### PR TITLE
Refresh navigation pin visuals

### DIFF
--- a/graphlink_app/graphlink_canvas/graphlink_canvas_navigation_pin.py
+++ b/graphlink_app/graphlink_canvas/graphlink_canvas_navigation_pin.py
@@ -7,9 +7,7 @@ scene/controller boundary rather than directly into a window or panel.
 
 from PySide6.QtWidgets import QGraphicsItem, QGraphicsObject
 from PySide6.QtCore import Qt, QRectF, Signal
-from PySide6.QtGui import QPainter, QColor, QPen, QFont, QPainterPath
-
-from graphlink_config import get_current_palette
+from PySide6.QtGui import QPainter, QColor, QPen, QFont, QFontMetrics, QPainterPath
 
 
 class NavigationPin(QGraphicsObject):
@@ -21,16 +19,19 @@ class NavigationPin(QGraphicsObject):
     # QGraphicsScene uses boundingRect() to calculate the dirty region when an
     # item moves.  Keep the text and the complete pin shape inside that region;
     # painting outside it leaves stale pixels behind with MinimalViewportUpdate.
-    # Includes the title, marker, and the comfortable triangle hit target.
-    _PAINT_RECT = QRectF(-52.0, -37.0, 104.0, 68.0)
-    _TITLE_RECT = QRectF(-50.0, -35.0, 100.0, 20.0)
+    # Includes the label, beacon, connector, and ground marker. Keeping the
+    # complete visual inside the dirty region prevents stale pixels while the
+    # pin is dragged with MinimalViewportUpdate.
+    _PAINT_RECT = QRectF(-90.0, -54.0, 180.0, 92.0)
+    _LABEL_RECT = QRectF(-82.0, -52.0, 164.0, 28.0)
+    _BEACON_RECT = QRectF(-15.0, -15.0, 30.0, 30.0)
 
     editRequested = Signal(str)
     contextMenuRequested = Signal(str, object)
     positionPreviewChanged = Signal(str, object)
     positionCommitted = Signal(str, object)
 
-    def __init__(self, title="New Pin", note="", parent=None, pin_id=None):
+    def __init__(self, title="Waypoint", note="", parent=None, pin_id=None):
         """
         Initializes the NavigationPin.
 
@@ -59,42 +60,69 @@ class NavigationPin(QGraphicsObject):
     def shape(self):
         """Return the comfortable hit target for the visible marker."""
         path = QPainterPath()
-        path.addEllipse(QRectF(-14.0, -14.0, 28.0, 28.0))
-        path.moveTo(0.0, 7.0)
-        path.lineTo(-12.0, 28.0)
-        path.lineTo(12.0, 28.0)
+        path.addRoundedRect(self._BEACON_RECT, 8.0, 8.0)
+        path.moveTo(-2.0, 13.0)
+        path.lineTo(-2.0, 30.0)
+        path.lineTo(2.0, 30.0)
+        path.lineTo(2.0, 13.0)
         path.closeSubpath()
+        path.addEllipse(QRectF(-6.0, 25.0, 12.0, 8.0))
         return path
         
     def paint(self, painter, option, widget=None):
         """Handles the custom painting of the pin icon."""
-        palette = get_current_palette()
         painter.save()
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-        
-        # Change color based on selection or hover state.
-        if self.isSelected(): pin_color = palette.SELECTION
-        elif self.hovered: pin_color = palette.AI_NODE
-        else: pin_color = palette.NAV_HIGHLIGHT
-            
+
+        selected = self.isSelected()
+        active = selected or self.hovered
+        marker_fill = QColor("#c8c8c8" if selected else "#a0a0a0" if self.hovered else "#777777")
+        marker_border = QColor("#f2f2f2" if selected else "#bdbdbd" if self.hovered else "#555555")
+        surface = QColor("#252525")
+
+        # A beacon-style marker makes navigation pins visually distinct from
+        # connection pins: rounded square body, inset waypoint core, stem, and
+        # ground contact. It deliberately uses grayscale only.
+        if active:
+            halo = QColor("#d8d8d8")
+            halo.setAlpha(35 if not selected else 55)
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(halo)
+            painter.drawEllipse(QRectF(-22.0, -22.0, 44.0, 44.0))
+
+        painter.setPen(QPen(marker_border, 2.0))
+        painter.setBrush(marker_fill)
+        painter.drawRoundedRect(self._BEACON_RECT, 8.0, 8.0)
+
+        painter.setPen(QPen(surface, 1.5))
+        painter.setBrush(surface)
+        painter.drawEllipse(QRectF(-5.0, -5.0, 10.0, 10.0))
+
+        painter.setPen(QPen(marker_border, 2.0, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap))
+        painter.drawLine(0.0, 15.0, 0.0, 28.0)
         painter.setPen(Qt.PenStyle.NoPen)
-        painter.setBrush(pin_color)
-        
-        # Draw the pin shape (a circle on top of a triangle).
-        head_rect = QRectF(-10, -10, 20, 20)
-        painter.drawEllipse(head_rect)
-        
-        path = QPainterPath()
-        path.moveTo(0, 10); path.lineTo(-8, 25); path.lineTo(8, 25); path.closeSubpath()
-        painter.setBrush(pin_color)
-        painter.drawPath(path)
-        
-        # Show the title on hover or selection.
-        if self.hovered or self.isSelected():
-            painter.setPen(QPen(QColor("#ffffff")))
+        painter.setBrush(marker_border)
+        painter.drawEllipse(QRectF(-5.0, 25.0, 10.0, 7.0))
+
+        if active:
+            label_surface = QColor("#242424")
+            label_border = QColor("#777777" if selected else "#555555")
+            painter.setPen(QPen(label_border, 1.0))
+            painter.setBrush(label_surface)
+            painter.drawRoundedRect(self._LABEL_RECT, 10.0, 10.0)
+
+            # Keep the label anchored without recreating the old triangle silhouette.
+            painter.setPen(QPen(label_border, 1.0))
+            painter.drawLine(0.0, self._LABEL_RECT.bottom(), 0.0, -15.0)
+
             font = QFont("Segoe UI", 8)
+            font.setWeight(QFont.Weight.DemiBold if selected else QFont.Weight.Normal)
             painter.setFont(font)
-            painter.drawText(self._TITLE_RECT, Qt.AlignmentFlag.AlignCenter, self.title)
+            painter.setPen(QColor("#f0f0f0"))
+            title = QFontMetrics(font).elidedText(
+                str(self.title or "Waypoint"), Qt.TextElideMode.ElideRight, 142
+            )
+            painter.drawText(self._LABEL_RECT, Qt.AlignmentFlag.AlignCenter, title)
 
         painter.restore()
             

--- a/graphlink_app/graphlink_navigation_pins.py
+++ b/graphlink_app/graphlink_navigation_pins.py
@@ -67,7 +67,7 @@ class NavigationPinRecord:
     def create(
         cls,
         *,
-        title: str = "Canvas location",
+        title: str = "Waypoint",
         note: str = "",
         x: float = 0.0,
         y: float = 0.0,
@@ -228,7 +228,7 @@ class NavigationPinsController:
         self.scene = scene
         self.view = view
 
-    def create_at(self, position, *, title="Canvas location", note="", anchor_item_id=None):
+    def create_at(self, position, *, title=None, note="", anchor_item_id=None):
         return self.scene.add_navigation_pin(
             position,
             title=title,

--- a/graphlink_app/graphlink_scene.py
+++ b/graphlink_app/graphlink_scene.py
@@ -567,7 +567,7 @@ class ChatScene(QGraphicsScene):
         self.pin_store.move(pin_id, position.x(), position.y())
         self._schedule_scene_changed()
 
-    def add_navigation_pin(self, pos, title="Canvas location", note="", pin_id=None, anchor_item_id=None):
+    def add_navigation_pin(self, pos, title=None, note="", pin_id=None, anchor_item_id=None):
         """
         Adds a new NavigationPin to the scene at the specified position.
 
@@ -577,6 +577,9 @@ class ChatScene(QGraphicsScene):
         Returns:
             NavigationPin: The created pin item.
         """
+        if title is None or not str(title).strip():
+            title = f"Waypoint {len(self.pin_store.records) + 1}"
+
         record = self.pin_store.add(
             title=title,
             note=note,

--- a/graphlink_app/graphlink_widgets/pins.py
+++ b/graphlink_app/graphlink_widgets/pins.py
@@ -181,7 +181,7 @@ class NavigationPinDelegate(QStyledItemDelegate):
 class NavigationPinEditor(QDialog):
     """Shared, validated editor for creating and editing a navigation pin."""
 
-    def __init__(self, title="Canvas location", note="", parent=None, creating=False):
+    def __init__(self, title="Waypoint", note="", parent=None, creating=False):
         super().__init__(parent)
         self.setWindowTitle("Add navigation pin" if creating else "Edit navigation pin")
         self.setModal(True)

--- a/graphlink_app/tests/test_navigation_pins.py
+++ b/graphlink_app/tests/test_navigation_pins.py
@@ -14,14 +14,23 @@ def test_navigation_pin_dirty_rect_covers_everything_it_paints():
     pin = NavigationPin()
     rect = pin.boundingRect()
 
-    # The pin body reaches y=25 and the hover/selection title is painted in a
-    # 100px-wide rectangle starting at (-50, -35).  The dirty region must cover
-    # both so moving/panning cannot leave a frame-sized trail behind.
-    assert rect.left() <= -50
-    assert rect.top() <= -35
-    assert rect.right() >= 50
-    assert rect.bottom() >= 25
-    assert rect.contains(QPointF(0, 25))
+    # The beacon reaches y=33 and the hover/selection label spans 164px from
+    # x=-82. The dirty region must cover the complete visual so moving/panning
+    # cannot leave a frame-sized trail behind.
+    assert rect.left() <= -82
+    assert rect.top() <= -52
+    assert rect.right() >= 82
+    assert rect.bottom() >= 33
+    assert rect.contains(QPointF(0, 32))
+
+
+def test_navigation_pin_uses_the_new_beacon_visual_and_waypoint_default():
+    pin = NavigationPin()
+
+    assert pin.title == "Waypoint"
+    assert pin.shape().contains(QPointF(0, 0))
+    assert pin.shape().contains(QPointF(0, 30))
+    assert pin.boundingRect().width() > 160
 
 
 def test_pin_store_preserves_explicit_order_and_reindexes_after_remove():


### PR DESCRIPTION
## What changed

- Replaced the legacy circle-and-triangle navigation pin painter with a distinct grayscale beacon/waypoint marker.
- Added a rounded marker body, inset core, connector, ground contact, hover/selection halo, and bounded label pill.
- Defaulted newly created pins to numbered `Waypoint N` titles while preserving legacy persisted titles during deserialization.
- Updated dirty-region regression coverage for the full visual footprint.

## Why

The previous navigation-pin refactor changed the data and management layers but left the canvas renderer unchanged. New pins therefore looked identical to the old widget and still used the generic `Canvas location` label.

## Validation

- `python -m pytest graphlink_app/tests/test_navigation_pins.py -q --basetemp .pytest-tmp-nav-pin` — 4 passed
- `python -m pytest graphlink_app/tests -q --basetemp .pytest-tmp-nav-pin-full` — 484 passed
- `python -m compileall -q graphlink_app` — passed
- `git diff --check` — passed
