### PR TITLE
Repair navigation pin list icons

### DIFF
--- a/graphlink_app/graphlink_widgets/pins.py
+++ b/graphlink_app/graphlink_widgets/pins.py
@@ -138,6 +138,11 @@ class NavigationPinDelegate(QStyledItemDelegate):
     ROW_HEIGHT = 58
     NOTE_ROW_HEIGHT = 72
 
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._pin_icon = qta.icon("fa5s.map-pin", color="#858585")
+        self._selected_pin_icon = qta.icon("fa5s.map-pin", color="#d0d0d0")
+
     def sizeHint(self, option, index):
         note = str(index.data(PIN_NOTE_ROLE) or "")
         height = self.NOTE_ROW_HEIGHT if note else self.ROW_HEIGHT
@@ -152,12 +157,9 @@ class NavigationPinDelegate(QStyledItemDelegate):
         painter.drawRoundedRect(rect, 10, 10)
 
         marker_rect = QRect(rect.left() + 12, rect.center().y() - 10, 20, 20)
-        painter.setPen(QColor("#d0d0d0" if selected else "#686868"))
-        painter.setBrush(QColor("#b8b8b8" if selected else "#858585"))
-        painter.drawRoundedRect(marker_rect, 6, 6)
-        painter.setPen(Qt.PenStyle.NoPen)
-        painter.setBrush(QColor("#2b2b2b"))
-        painter.drawEllipse(marker_rect.adjusted(6, 6, -6, -6))
+        (self._selected_pin_icon if selected else self._pin_icon).paint(
+            painter, marker_rect, Qt.AlignmentFlag.AlignCenter
+        )
 
         title = str(index.data(Qt.ItemDataRole.DisplayRole) or "")
         note = str(index.data(PIN_NOTE_ROLE) or "")

--- a/graphlink_app/tests/test_navigation_pins.py
+++ b/graphlink_app/tests/test_navigation_pins.py
@@ -49,6 +49,8 @@ def test_navigation_pin_list_rows_keep_consistent_vertical_rhythm():
     assert plain_height == NavigationPinDelegate.ROW_HEIGHT
     assert noted_height == NavigationPinDelegate.NOTE_ROW_HEIGHT
     assert noted_height > plain_height
+    assert not delegate._pin_icon.isNull()
+    assert not delegate._selected_pin_icon.isNull()
     model.dispose()
 
 


### PR DESCRIPTION
## What changed

- Replaced the hand-painted rounded-square list marker with the shared aspect-ratio-safe `fa5s.map-pin` glyph.
- Added distinct grayscale normal and selected icon variants.
- Added regression assertions that both delegate icons are valid.

## Why

The list marker was being rendered as a square body plus circular center. At small sizes it visually collapsed into a deformed donut and did not read as a navigation pin. The shared map-pin glyph preserves its intended silhouette and matches the add-pin control.

## Validation

- `python -m pytest graphlink_app/tests/test_navigation_pins.py -q --basetemp .pytest-tmp-nav-icons` — 5 passed
- `python -m pytest graphlink_app/tests -q --basetemp .pytest-tmp-nav-icons-full-2` — 485 passed, `PYTEST_EXIT=0`
- `python -m py_compile graphlink_app/graphlink_widgets/pins.py graphlink_app/tests/test_navigation_pins.py` — passed
- `git diff --check` — passed
