### PR TITLE
Harden combo popup teardown

### DIFF
--- a/graphlink_app/graphlink_plugins/common/combo.py
+++ b/graphlink_app/graphlink_plugins/common/combo.py
@@ -32,6 +32,17 @@ from PySide6.QtWidgets import (
     QListWidgetItem,
     QVBoxLayout,
 )
+from shiboken6 import isValid as _is_qt_object_valid
+
+
+def _qt_object_is_alive(obj):
+    """Return whether a Qt wrapper still owns a live C++ object."""
+    if obj is None:
+        return False
+    try:
+        return bool(_is_qt_object_valid(obj))
+    except (RuntimeError, TypeError):
+        return False
 
 
 class ComboPopup(QFrame):
@@ -284,28 +295,49 @@ class PopupComboBox(QComboBox):
         self._popup.item_selected.connect(self._apply_popup_selection)
         self._popup.popup_closed.connect(self._handle_popup_closed)
         self._popup_closing = False
+        self._shutting_down = False
         self.destroyed.connect(self._cleanup_popup)
+        app = QApplication.instance()
+        if app is not None:
+            app.aboutToQuit.connect(self._begin_shutdown)
 
     def apply_popup_style(self, accent_color):
         self._popup.apply_style(accent_color)
 
     def showPopup(self):
+        if self._shutting_down or not _qt_object_is_alive(self):
+            return
         self.about_to_show_popup.emit()
-        if self._popup is not None and self._popup.isVisible():
+        popup = self._live_popup()
+        if popup is not None and popup.isVisible():
             self.hidePopup()
             return
         if not self.isEnabled() or self.count() == 0:
             return
-        self._popup.show_for_combo(self)
+        popup = self._live_popup()
+        if popup is not None:
+            popup.show_for_combo(self)
 
     def hidePopup(self):
-        if self._popup is not None and self._popup.isVisible():
+        if self._shutting_down or not _qt_object_is_alive(self):
+            return
+        popup = self._live_popup()
+        if popup is not None and popup.isVisible():
             self._popup_closing = True
-            self._popup.hide()
-            self._popup_closing = False
-        super().hidePopup()
+            try:
+                popup.hide()
+            finally:
+                self._popup_closing = False
+        try:
+            super().hidePopup()
+        except RuntimeError:
+            # Qt can enter the virtual override after the C++ wrapper begins
+            # teardown. There is no native popup left to close in that state.
+            return
 
     def _apply_popup_selection(self, index, text):
+        if self._shutting_down or not _qt_object_is_alive(self):
+            return
         if 0 <= index < self.count():
             self.setCurrentIndex(index)
         else:
@@ -314,11 +346,35 @@ class PopupComboBox(QComboBox):
         self.setFocus()
 
     def _handle_popup_closed(self):
+        if self._shutting_down or not _qt_object_is_alive(self):
+            return
         if not self._popup_closing:
-            super().hidePopup()
+            try:
+                super().hidePopup()
+            except RuntimeError:
+                return
+
+    def _live_popup(self):
+        popup = getattr(self, "_popup", None)
+        return popup if _qt_object_is_alive(popup) else None
+
+    def _begin_shutdown(self):
+        self._shutting_down = True
+        self._dispose_popup()
+
+    def _dispose_popup(self):
+        popup = getattr(self, "_popup", None)
+        self._popup = None
+        if not _qt_object_is_alive(popup):
+            return
+        try:
+            popup.hide()
+            popup.deleteLater()
+        except RuntimeError:
+            # A parent window may have deleted the popup first. Shiboken has
+            # already told us it is stale; cleanup must remain idempotent.
+            return
 
     def _cleanup_popup(self):
-        if self._popup is not None:
-            self._popup.hide()
-            self._popup.deleteLater()
-            self._popup = None
+        self._shutting_down = True
+        self._dispose_popup()

--- a/graphlink_app/tests/test_popup_combo_lifecycle.py
+++ b/graphlink_app/tests/test_popup_combo_lifecycle.py
@@ -1,0 +1,25 @@
+"""Regression coverage for custom combo popup teardown on Windows/Qt."""
+
+from PySide6.QtCore import QEvent
+from PySide6.QtWidgets import QApplication
+from shiboken6 import isValid
+
+from graphlink_plugins.common.combo import PopupComboBox
+
+
+def test_popup_combo_ignores_a_popup_deleted_before_combo_cleanup():
+    combo = PopupComboBox()
+    combo.addItems(["First", "Second"])
+    popup = combo._popup
+
+    popup.deleteLater()
+    QApplication.sendPostedEvents(popup, QEvent.Type.DeferredDelete)
+    QApplication.processEvents()
+
+    assert not isValid(popup)
+    combo.hidePopup()
+    combo._cleanup_popup()
+    assert combo._popup is None
+
+    combo.deleteLater()
+    QApplication.sendPostedEvents(combo, QEvent.Type.DeferredDelete)


### PR DESCRIPTION
## What changed

- Added Shiboken-backed Qt wrapper validity checks around the custom `PopupComboBox` popup lifecycle.
- Made popup cleanup idempotent when the popup C++ object is deleted before its Python wrapper.
- Added an explicit `aboutToQuit` shutdown path that closes and schedules the popup before Qt destroys parent windows.
- Guarded virtual `hidePopup`, selection, and popup-closed callbacks during teardown.
- Added a regression test for calling `hidePopup()` and cleanup after the popup has already been deleted.

## Root cause

The custom popup could be destroyed by Qt before `PopupComboBox.hidePopup()` or `_cleanup_popup()` ran. Those methods then called `isVisible()` on a stale Shiboken wrapper, producing the recurring `Internal C++ object (ComboPopup) already deleted` warning and risking a native Windows memory-read crash during test shutdown.

## Validation

- Targeted popup/context-menu lifecycle tests — 6 passed
- Full suite — 486 passed, `PYTEST_EXIT=0`
- `py_compile` on touched modules — passed
- `git diff --check` — passed
