### PR TITLE
Document git workflow and remove internal doc references from source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,17 @@ If you prefer Visual Studio, open `graphlink_app.sln`.
 - Treat top-level wrapper modules such as `graphlink_plugin_gitlink.py` as compatibility facades unless the change is specifically about import stability.
 - Keep changes focused. UI cleanup, plugin behavior, persistence updates, and provider changes should be easy to review independently.
 
+## Git & GitHub Workflow
+
+The standing branch → push → PR → merge process for this repository. It codifies what the commit history already does in practice, so it does not have to be re-derived each time.
+
+- **Never commit directly to `main`.** Every change gets a topic branch.
+- **Branch naming:** `agent/<short-kebab-slug>` for AI-agent-authored work (Claude Code, Codex, or similar), or a short descriptive kebab-case slug for human-authored branches. Examples from history: `agent/composer-react-qwebengine`, `agent/sota-model-settings`, `codex/navigation-pins-refactor`.
+- **Scope each branch to one reviewable unit of work** — the same "keep changes focused" rule from Development Rules, applied at the branch level. Large multi-part efforts should land as a sequence of scoped branches and PRs rather than one oversized branch.
+- **Push the branch to `origin`**, then open a pull request against `main` using `.github/pull_request_template.md`.
+- **Run local validation before opening the PR** (see Validation below). There is no automated CI — GitHub Actions and Dependabot were intentionally removed in commit `185143a` — so this local pass is the only gate.
+- **Merge strategy: squash-merge into `main`**, then delete the branch. Merged commit titles carry the PR number, e.g. `Refactor navigation pins and interaction surfaces (#17)`.
+
 ## Pull Request Expectations
 
 Please include:

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For a detailed, current map of where behavior lives in the codebase, see [GRAPHL
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, development conventions, and pull-request expectations. The repository has a `pytest` suite under `graphlink_app/tests/`; run it with `pytest` from the inner `graphlink_app/` directory, and a GitHub Actions workflow additionally runs a compile smoke check on every push.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, development conventions, branch/PR workflow, and pull-request expectations. The repository has a `pytest` suite under `graphlink_app/tests/`; run it with `pytest` from the inner `graphlink_app/` directory. There is currently no automated CI — validation is a manual local step before opening a PR (see CONTRIBUTING.md).
 
 ## Troubleshooting
 

--- a/graphlink_app/api_provider.py
+++ b/graphlink_app/api_provider.py
@@ -57,8 +57,8 @@ _LLAMA_CPP_CLIENT_LOCK = threading.RLock()
 # route the whole request through that snapshot. Previously a mode switch during an
 # in-flight request could interleave with the request's many separate global reads,
 # executing it against a half-swapped provider (e.g. the new provider type with the
-# old client/key) - see doc/ARCHITECTURE_REVIEW_FINDINGS.md #9. The module globals
-# stay authoritative (and monkeypatchable) - the snapshot is a per-request view.
+# old client/key). The module globals stay authoritative (and monkeypatchable) - the
+# snapshot is a per-request view.
 _PROVIDER_STATE_LOCK = threading.Lock()
 
 

--- a/graphlink_app/graphlink_agents_core.py
+++ b/graphlink_app/graphlink_agents_core.py
@@ -17,8 +17,8 @@ def resolve_branch_system_prompt(current_node, default_system_prompt):
     (``parent_node``/``scene()``/``system_prompt_connections``/``prompt_note.content``),
     so it MUST run on the GUI thread - QGraphicsScene is not thread-safe, and doing this
     walk from a worker thread races node deletion / scene.clear() and can crash or read
-    torn state (doc/ARCHITECTURE_REVIEW_FINDINGS.md #20). Callers resolve it here on the
-    UI thread and hand the resulting string to the worker, which never touches the scene.
+    torn state. Callers resolve it here on the UI thread and hand the resulting string
+    to the worker, which never touches the scene.
 
     Returns the final system prompt string (the default if nothing overrides it).
     """
@@ -290,8 +290,7 @@ class ChatAgent:
 def clean_agent_markdown_response(text, required_title, section_markers, reset_bullet_state_on_section_header=False):
     """Strip common markdown noise and normalize bullets/section spacing for a
     structured agent response (Explainer/KeyTakeaway/GroupSummary all used a
-    near-identical ~40-line clean_text() before this was extracted - see
-    doc/ARCHITECTURE_REVIEW_FINDINGS.md #58).
+    near-identical ~40-line clean_text() before this was extracted).
 
     Args:
         text (str): The raw text from the AI model.

--- a/graphlink_app/graphlink_agents_pycoder.py
+++ b/graphlink_app/graphlink_agents_pycoder.py
@@ -267,8 +267,8 @@ class PyCoderExecutionWorker(QThread):
     # Emitted with the generated code once it is ready but before anything executes in
     # the REPL. The receiver (main thread) must call approve() or deny() to unblock
     # run(), which is parked on _approval_event.wait(). Same contract as
-    # CodeSandboxExecutionWorker.approval_requested - see
-    # doc/ARCHITECTURE_REVIEW_FINDINGS.md #15 for why Py-Coder needs the same gate.
+    # CodeSandboxExecutionWorker.approval_requested: this path also runs model-generated
+    # code with full user privileges, so it needs the same gate.
     approval_requested = Signal(str)
 
     def __init__(self, user_prompt, conversation_history, repl):

--- a/graphlink_app/graphlink_crash.py
+++ b/graphlink_app/graphlink_crash.py
@@ -3,7 +3,7 @@ next-launch "did we crash last time" notice.
 
 Before this, a windowed app with no console meant every unhandled exception and every
 native Qt/llama.cpp fault was invisible - the user saw nothing, and the maintainer had no
-way to know a session died or why (see doc/PRODUCTION_ROADMAP.md #5 "Crash reporting").
+way to know a session died or why.
 
 Three capture channels, installed by install_crash_handlers() as the first thing
 graphlink_app.main() does (before QApplication exists):

--- a/graphlink_app/graphlink_html_view.py
+++ b/graphlink_app/graphlink_html_view.py
@@ -44,7 +44,7 @@ def preview_url_is_allowed(url):
     otherwise exfiltrate page content to a remote host or hit the user's localhost/intranet
     (SSRF/CSRF from their network position). We treat the preview as an offline sandbox:
     only local, self-contained schemes are permitted; any request that would leave the
-    machine is blocked. See doc/ARCHITECTURE_REVIEW_FINDINGS.md.
+    machine is blocked.
     """
     try:
         scheme = (url.scheme() or "").lower()

--- a/graphlink_app/graphlink_logging.py
+++ b/graphlink_app/graphlink_logging.py
@@ -3,9 +3,9 @@
 Nothing in the app ever configured Python's logging module - the one existing
 logging.exception() call (graphlink_session/content_codec.py, for corrupted image
 data during deserialization) went to Python's "handler of last resort" (stderr),
-which is invisible in a windowed app with no console (see
-doc/ARCHITECTURE_REVIEW_FINDINGS.md #63). This wires up a rotating log file instead so
-anything that does call logging.* has somewhere durable and inspectable to land.
+which is invisible in a windowed app with no console. This wires up a rotating log
+file instead so anything that does call logging.* has somewhere durable and
+inspectable to land.
 
 This is infrastructure only - it does not convert the app's print()/except: pass call
 sites to use logging. That's a much larger, more judgment-heavy change left open.

--- a/graphlink_app/graphlink_paths.py
+++ b/graphlink_app/graphlink_paths.py
@@ -6,7 +6,7 @@ several call sites previously hardcoded an absolute path to one developer's mach
 Also independent of whether the app is running from a source checkout or a PyInstaller
 freeze: __file__-based resolution (assets/ as a sibling of graphlink_app/) only holds in a
 checkout. A frozen onedir/onefile build extracts bundled `datas` under sys._MEIPASS
-instead, so ASSETS_DIR branches on sys.frozen. See doc/PRODUCTION_ROADMAP.md Section 4.
+instead, so ASSETS_DIR branches on sys.frozen.
 """
 
 import sys

--- a/graphlink_app/graphlink_plugins/common/__init__.py
+++ b/graphlink_app/graphlink_plugins/common/__init__.py
@@ -1,6 +1,5 @@
 """Shared, dependency-light infrastructure used by more than one plugin.
 
-Phase 3 of doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md: code that was independently
-duplicated across plugin files (see section 1.6) is extracted here so a fix in one
-place reaches every plugin that uses it, instead of drifting apart.
+Code that was independently duplicated across plugin files is extracted here so a
+fix in one place reaches every plugin that uses it, instead of drifting apart.
 """

--- a/graphlink_app/graphlink_plugins/common/github_client.py
+++ b/graphlink_app/graphlink_plugins/common/github_client.py
@@ -1,8 +1,7 @@
 """Shared GitHub REST client for plugins that read repository data.
 
 Extracted from near-identical code independently hand-rolled in
-graphlink_plugin_code_review.py and graphlink_plugin_gitlink.py (see
-doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 1.6/4.2/4.4): token retrieval, header
+graphlink_plugin_code_review.py and graphlink_plugin_gitlink.py: token retrieval, header
 construction, and HTTP-status-to-user-facing-error mapping were copy-pasted between
 the two files, so a fix (e.g. to rate-limit handling) in one would not reach the other.
 

--- a/graphlink_app/graphlink_plugins/common/llm_json.py
+++ b/graphlink_app/graphlink_plugins/common/llm_json.py
@@ -2,18 +2,16 @@
 
 Extracted from independently hand-rolled, near-identical code in
 graphlink_plugin_code_review.py, graphlink_plugin_quality_gate.py,
-graphlink_plugin_workflow.py, and graphlink_plugin_gitlink.py (see
-doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 1.6/3.5): all four independently
+graphlink_plugin_workflow.py, and graphlink_plugin_gitlink.py: all four independently
 implemented the exact same regex-based JSON-fence-stripping logic.
 
 This is deliberately a pair of plain functions rather than a shared base class with a
-get_response() template method (as originally sketched in the refactor plan). The three
-plugins that also share the "call the LLM, then parse JSON" shape turned out to differ
-in exactly where fallback/normalization happens relative to the try/except (see
-call_llm_and_parse_json's docstring) - forcing that into one template method would have
-meant parameterizing around the difference or risking a subtle behavior change, so each
-plugin keeps its own try/except/fallback control flow and just calls these functions
-instead of duplicating their bodies.
+get_response() template method. The three plugins that also share the "call the LLM,
+then parse JSON" shape turned out to differ in exactly where fallback/normalization
+happens relative to the try/except (see call_llm_and_parse_json's docstring) - forcing
+that into one template method would have meant parameterizing around the difference or
+risking a subtle behavior change, so each plugin keeps its own try/except/fallback
+control flow and just calls these functions instead of duplicating their bodies.
 """
 
 import json

--- a/graphlink_app/graphlink_plugins/gitlink/__init__.py
+++ b/graphlink_app/graphlink_plugins/gitlink/__init__.py
@@ -1,1 +1,2 @@
-"""Qt-free Gitlink helper package (see doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 4.4)."""
+"""Qt-free Gitlink helper package, split out so the agent and path-safety logic is
+testable without Qt."""

--- a/graphlink_app/graphlink_plugins/gitlink/agent.py
+++ b/graphlink_app/graphlink_plugins/gitlink/agent.py
@@ -1,6 +1,5 @@
 """Gitlink's Qt-free path-safety helpers, XML context formatting, and GitlinkAgent
-(the LLM change-proposal agent), extracted out of graphlink_plugin_gitlink.py - see
-doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 4.4.
+(the LLM change-proposal agent), extracted out of graphlink_plugin_gitlink.py.
 
 _normalize_repo_path / _safe_local_target are the security boundary between an
 LLM-proposed file path and a write to the user's local disk - keeping them Qt-free and
@@ -117,8 +116,8 @@ def _truncate_for_context(source_text, max_chars=MAX_FILE_CONTEXT_CHARS):
 
 
 def _extract_json_object(raw_text):
-    # Delegates to the shared regex (doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section
-    # 1.6/3.5) - kept as a wrapper so this function's existing call site is unchanged.
+    # Delegates to the regex shared with the other JSON-returning plugin agents - kept
+    # as a wrapper so this function's existing call site is unchanged.
     return extract_json_object(raw_text)
 
 

--- a/graphlink_app/graphlink_plugins/graphlink_plugin_artifact.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_artifact.py
@@ -441,9 +441,9 @@ class ArtifactNode(QGraphicsObject, HoverAnimationMixin):
             # Escape literal HTML before markdown-rendering it: the document content is
             # AI/user-controlled text, not trusted markup, so a literal "<img src=... />"
             # or "<div style=...>" typed/generated into the document must not be handed
-            # to QTextEdit.setHtml as real HTML (see doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md
-            # section 4.1). quote=False keeps quote characters literal so normal
-            # Markdown syntax (e.g. link titles) isn't mangled by entity-encoding them.
+            # to QTextEdit.setHtml as real HTML. quote=False keeps quote characters
+            # literal so normal Markdown syntax (e.g. link titles) isn't mangled by
+            # entity-encoding them.
             html = markdown.markdown(escape_html(content, quote=False), extensions=['fenced_code', 'tables'])
             self.preview_display.setHtml(html)
 
@@ -493,8 +493,8 @@ class ArtifactNode(QGraphicsObject, HoverAnimationMixin):
     def _handle_action_button(self):
         # Single dual-purpose button (mirrors ConversationNode._handle_action_button):
         # while a generation is running the icon/tooltip switch to "stop", and this is
-        # what makes that actually clickable - see doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md
-        # section 4.1, this used to stay disabled the whole time it showed a stop icon.
+        # what makes that actually clickable - the button used to stay disabled the
+        # whole time it showed a stop icon.
         if self.is_running:
             self.stop_requested.emit(self)
             return

--- a/graphlink_app/graphlink_plugins/graphlink_plugin_gitlink.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_gitlink.py
@@ -674,9 +674,9 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
         self.workspace_tabs.addTab(self.preview_editor, qta.icon("fa5s.columns", color="#CCCCCC"), "Preview")
 
     def _get_github_token(self):
-        # Delegates to the shared GitHubRestClient (doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md
-        # section 1.6/4.2) - kept as a thin wrapper so every existing call site in this
-        # file (load_github_repositories, _resolve_repo_and_branch, etc.) is unchanged.
+        # Delegates to the GitHubRestClient shared with Code Review - kept as a thin
+        # wrapper so every existing call site in this file (load_github_repositories,
+        # _resolve_repo_and_branch, etc.) is unchanged.
         return self._github_client.get_token()
 
     def _github_headers(self):

--- a/graphlink_app/graphlink_plugins/graphlink_plugin_portal.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_portal.py
@@ -23,15 +23,15 @@ from graphlink_memory import clone_history
 class PluginSpec:
     """Declarative metadata for one plugin node type.
 
-    Phase 1 of doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md: introduced additively, alongside the
-    existing hand-written `_register_plugin` calls and `_create_X_node` factories on
-    PluginPortal below, which are unchanged by this. Other hardcoded per-plugin metadata
-    scattered around the app (graphlink_plugin_quality_gate.py's `_node_label`,
-    graphlink_plugin_workflow.py's `WORKFLOW_PLUGIN_ICONS`/`WORKFLOW_ALLOWED_PLUGINS`,
-    graphlink_window_actions.py's `_seed_plugin_prompt` isinstance chain, the isinstance
-    chains in graphlink_scene.py/graphlink_window.py, etc.) are candidates to migrate onto
-    this table one plugin at a time in later phases - this phase only builds the table
-    and does not rewire any existing consumer.
+    Introduced additively, alongside the existing hand-written `_register_plugin` calls
+    and `_create_X_node` factories on PluginPortal below, which are unchanged by this.
+    Other hardcoded per-plugin metadata scattered around the app
+    (graphlink_plugin_quality_gate.py's `_node_label`, graphlink_plugin_workflow.py's
+    `WORKFLOW_PLUGIN_ICONS`/`WORKFLOW_ALLOWED_PLUGINS`, graphlink_window_actions.py's
+    `_seed_plugin_prompt` isinstance chain, the isinstance chains in
+    graphlink_scene.py/graphlink_window.py, etc.) are candidates to migrate onto this
+    table one plugin at a time - so far it only builds the table and does not rewire any
+    existing consumer.
     """
     key: str
     display_name: str
@@ -326,13 +326,13 @@ class PluginPortal:
         no_selection_message,
         invalid_parent_message=None,
     ):
-        """Generic single-parent plugin node factory (Phase 2 of doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md).
+        """Generic single-parent plugin node factory.
 
         Handles the ~15-line skeleton duplicated across most `_create_X_node` methods:
         resolve/validate the parent, construct the node, wire it into the parent's
         children, optionally clone conversation history, position it, and register both
-        the node and its connection with the scene's existing (still hardcoded, see
-        PLUGIN_SYSTEM_REFACTOR_PLAN.md section 3.3) node/connection lists.
+        the node and its connection with the scene's existing (still hardcoded
+        per-plugin) node/connection lists.
 
         Plugins with a genuinely different creation contract don't use this - e.g. System
         Prompt attaches to the graph root rather than branching from a selection - they
@@ -348,8 +348,8 @@ class PluginPortal:
         `scene.artifact_nodes`) rather than looked up by name, since the per-plugin scene
         attribute names don't consistently derive from the plugin's registry key (e.g.
         the "html_renderer" plugin's list is `scene.html_view_nodes`, named after the
-        node class instead) - see PLUGIN_SYSTEM_REFACTOR_PLAN.md section 3.3 for the
-        planned follow-up that would let this be looked up generically too.
+        node class instead). Keying those lists off the plugin key would let this be
+        looked up generically too, but that is a separate scene-wide change.
         """
         scene = self.main_window.chat_view.scene()
         selected_node = self.main_window.current_node

--- a/graphlink_app/graphlink_secrets.py
+++ b/graphlink_app/graphlink_secrets.py
@@ -1,9 +1,9 @@
 """Secret-at-rest protection for settings values.
 
 API keys and the GitHub token used to be stored as plaintext JSON in
-~/.graphlink/session.dat (doc/ARCHITECTURE_REVIEW_FINDINGS.md #14). This module wraps
-Windows DPAPI (CryptProtectData/CryptUnprotectData via ctypes - no new dependencies)
-so those values are encrypted at rest, bound to the current Windows user account.
+~/.graphlink/session.dat, world-readable by default. This module wraps Windows DPAPI
+(CryptProtectData/CryptUnprotectData via ctypes - no new dependencies) so those
+values are encrypted at rest, bound to the current Windows user account.
 
 Storage format: "dpapi:" + base64(DPAPI blob), kept in the same JSON string fields as
 before, so the settings file shape and the atomic-write machinery are unchanged.

--- a/graphlink_app/graphlink_session/database.py
+++ b/graphlink_app/graphlink_session/database.py
@@ -272,8 +272,7 @@ class ChatDatabase:
         """Persist the chat blob, notes, and pins as a single transaction.
 
         save_chat/update_chat/save_notes/save_pins each previously opened their own
-        connection and committed independently (see
-        doc/ARCHITECTURE_REVIEW_FINDINGS.md #52) - a crash between any two of those
+        connection and committed independently - a crash between any two of those
         steps left the chat row, notes, and pins inconsistent with each other. Here
         they share one connection, so Python's sqlite3 context manager commits all
         three together on success or rolls all three back together on any exception.
@@ -332,9 +331,8 @@ class ChatDatabase:
 
     def get_chat_title(self, chat_id):
         # Callers that only need the title (e.g. the window title bar) shouldn't pay
-        # for reading and json.loads()-ing the full chat payload - see
-        # doc/ARCHITECTURE_REVIEW_FINDINGS.md #45/#50 on how large that payload can get
-        # (every node, connection, and base64-inlined image in the chat).
+        # for reading and json.loads()-ing the full chat payload, which can be multiple
+        # megabytes (every node, connection, and base64-inlined image in the chat).
         with self._connect() as conn:
             result = conn.execute(
                 "SELECT title FROM chats WHERE id = ?",

--- a/graphlink_app/graphlink_session/manager.py
+++ b/graphlink_app/graphlink_session/manager.py
@@ -23,7 +23,7 @@ class ChatSessionManager:
         # and the next autosave would then overwrite the wrong chat's row (silent data
         # loss). `_context_epoch` bumps on every switch; `_saving_epoch` records the epoch
         # a save started under, and _on_save_finished only adopts the result if they still
-        # match. See doc/ARCHITECTURE_REVIEW_FINDINGS.md.
+        # match.
         self._context_epoch = 0
         self._saving_epoch = 0
         self.serializer = SceneSerializer(window) if window else None
@@ -51,7 +51,7 @@ class ChatSessionManager:
         the epoch lets _on_save_finished recognize its result as stale so it does not
         restore the previous chat_id over the newly-active one. Callers that reassign
         `current_chat_id` for a context switch (ChatWindow.new_chat, load_chat) must call
-        this. See doc/ARCHITECTURE_REVIEW_FINDINGS.md.
+        this.
         """
         self._context_epoch += 1
         if self.window and hasattr(self.window, "invalidate_chart_requests"):

--- a/graphlink_app/graphlink_session/scene_index.py
+++ b/graphlink_app/graphlink_session/scene_index.py
@@ -9,9 +9,8 @@ from graphlink_pycoder import PyCoderNode
 from graphlink_web import WebNode
 
 # Bumped whenever the saved chat payload's shape changes in a way future load code needs
-# to branch on. No migration logic reads this yet (see
-# doc/ARCHITECTURE_REVIEW_FINDINGS.md #49) - it's the version marker itself, not a
-# migration framework. Payloads saved before this field existed simply have no
+# to branch on. No migration logic reads this yet - it's the version marker itself, not
+# a migration framework. Payloads saved before this field existed simply have no
 # "schema_version" key; deserializers.py already tolerates missing/legacy shapes
 # (nodes/items/nested data.nodes) so this is purely additive.
 CURRENT_CHAT_SCHEMA_VERSION = 1

--- a/graphlink_app/graphlink_session/serializers.py
+++ b/graphlink_app/graphlink_session/serializers.py
@@ -40,7 +40,7 @@ class SceneSerializer:
 
         Graph references used to be serialized purely as list positions
         (all_nodes_list.index(node)), which silently corrupt when a load skips any
-        node and later positions shift (doc/ARCHITECTURE_REVIEW_FINDINGS.md #47).
+        node and later positions shift, silently reattaching links to wrong nodes.
         IDs are assigned lazily, stored on the node object so they stay stable across
         saves within a session, and restored from the payload on load so they stay
         stable across sessions too.

--- a/graphlink_app/graphlink_session/workers.py
+++ b/graphlink_app/graphlink_session/workers.py
@@ -56,7 +56,7 @@ class SaveWorkerThread(QThread):
             # Resolve (title, chat_id_for_save) first - chat_id_for_save is the id to
             # UPDATE, or None to INSERT a new chat - then make exactly one atomic call
             # that writes the chat blob, notes, and pins together (see
-            # save_chat_atomically's docstring / doc/ARCHITECTURE_REVIEW_FINDINGS.md #52).
+            # save_chat_atomically's docstring for why that has to be one transaction).
             chat_id_for_save = None
             if not self.current_chat_id:
                 title = self._generate_title()

--- a/graphlink_app/graphlink_window.py
+++ b/graphlink_app/graphlink_window.py
@@ -670,9 +670,9 @@ class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
 
     def _iter_shutdown_threads(self):
         # Artifact/Gitlink/Code Sandbox/PyCoder nodes each keep their running worker on
-        # their own node.worker_thread (see doc/ARCHITECTURE_REVIEW_FINDINGS.md #21/#24)
-        # - multiple nodes of the same plugin type can run concurrently, so there is no
-        # single shared main_window attribute to check for them anymore.
+        # their own node.worker_thread - multiple nodes of the same plugin type can run
+        # concurrently, so there is no single shared main_window attribute to check for
+        # them anymore.
         for attr_name, label in (
             ("chat_thread", "active chat request"),
             ("takeaway_thread", "takeaway generation"),
@@ -1128,8 +1128,8 @@ class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
         # Switching modes calls api_provider.initialize_* which swaps the provider
         # globals (USE_API_MODE, API_CLIENT, API_KEY, ...) that a running chat request
         # is reading from a worker thread - the request could execute against a
-        # half-swapped provider (doc/ARCHITECTURE_REVIEW_FINDINGS.md #9). Block the
-        # switch while a main request is in flight instead of racing it.
+        # half-swapped provider. Block the switch while a main request is in flight
+        # instead of racing it.
         if self._main_request_active and mode_text != previous_mode:
             self._set_mode_combo_silently(previous_mode)
             self.notification_banner.show_message(

--- a/graphlink_app/tests/test_api_key_env_fallback.py
+++ b/graphlink_app/tests/test_api_key_env_fallback.py
@@ -1,11 +1,10 @@
 """Tests for environment-variable API key fallback in api_provider.initialize_api().
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #37: Anthropic and Gemini
-both fall back to a GRAPHLINK_<PROVIDER>_API_KEY / vendor-standard env var when no key is
-passed in, but the OpenAI-compatible branch didn't - a user with OPENAI_API_KEY set in
-their environment (a very standard thing to have) but nothing saved in Graphlink's own
-Settings would get "API key not configured" instead of it just working, unlike every
-other provider.
+Regression coverage for the OpenAI env-var gap: Anthropic and Gemini both fall back to a
+GRAPHLINK_<PROVIDER>_API_KEY / vendor-standard env var when no key is passed in, but the
+OpenAI-compatible branch didn't - a user with OPENAI_API_KEY set in their environment (a
+very standard thing to have) but nothing saved in Graphlink's own Settings would get
+"API key not configured" instead of it just working, unlike every other provider.
 """
 
 import sys

--- a/graphlink_app/tests/test_artifact_bugs.py
+++ b/graphlink_app/tests/test_artifact_bugs.py
@@ -1,9 +1,8 @@
-"""Tests for three real Artifact plugin bugs fixed together (see
-doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 4.1):
+"""Tests for three real Artifact plugin bugs fixed together:
 
 1. The stop button was visibly a "stop" icon while running but stayed disabled the
-   whole time, so clicking it did nothing - stop_artifact_node (wired via task #26)
-   was never reachable from the UI.
+   whole time, so clicking it did nothing - stop_artifact_node was never reachable
+   from the UI.
 2. ArtifactAgent.get_response silently treated the ENTIRE raw LLM response as the new
    document body whenever the model forgot the <artifact> tags, corrupting the
    document with whatever conversational text the model wrote instead.

--- a/graphlink_app/tests/test_asset_paths.py
+++ b/graphlink_app/tests/test_asset_paths.py
@@ -3,8 +3,9 @@
 Regression coverage for hardcoded developer-machine absolute paths that used to be
 scattered across graphlink_window.py, graphlink_ui_components.py, graphlink_styles.py,
 graphlink_ui_dialogs/graphlink_settings_dialogs.py, and graphlink_widgets/controls.py -
-see doc/ARCHITECTURE_REVIEW_FINDINGS.md #65. Also covers check.png/down_arrow.png,
-which those hardcoded paths referenced but which never actually existed in the repo.
+on any other machine the window icon and checkbox/combo indicators silently vanished.
+Also covers check.png/down_arrow.png, which those hardcoded paths referenced but which
+never actually existed in the repo.
 """
 
 import sys

--- a/graphlink_app/tests/test_chat_database_get_title.py
+++ b/graphlink_app/tests/test_chat_database_get_title.py
@@ -1,14 +1,14 @@
 """Tests for ChatDatabase.get_chat_title().
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #45: update_title_bar()
-used to call db.load_chat(), which SELECTs both title and data and json.loads()-decodes
-the full chat payload (every node, connection, and base64-inlined image - see #50) just
-to read the title string, on every single save completion. get_chat_title() only SELECTs
-the title column and never touches `data` at all.
+Regression coverage for a synchronous full-payload read on the UI thread:
+update_title_bar() used to call db.load_chat(), which SELECTs both title and data and
+json.loads()-decodes the full chat payload (every node, connection, and base64-inlined
+image) just to read the title string, on every single save completion. get_chat_title()
+only SELECTs the title column and never touches `data` at all.
 
-Uses ChatDatabase(tmp_path / ...) - the constructor's db_path parameter (added by the
-#55 fix) - instead of the real constructor's hardcoded Path.home()/.graphlink/chats.db,
-so this never touches the developer's real chat database.
+Uses ChatDatabase(tmp_path / ...) - the constructor's injectable db_path parameter -
+instead of the real constructor's hardcoded Path.home()/.graphlink/chats.db, so this
+never touches the developer's real chat database.
 """
 
 import sys

--- a/graphlink_app/tests/test_chat_worker_scene_thread_safety.py
+++ b/graphlink_app/tests/test_chat_worker_scene_thread_safety.py
@@ -1,10 +1,10 @@
 """Tests that chat requests resolve the branch system prompt on the GUI thread.
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #20: ChatWorker.run used to
-walk live QGraphicsScene objects (current_node.parent_node -> .scene() ->
-system_prompt_connections -> prompt_note.content) from inside the worker thread. Since
-QGraphicsScene is not thread-safe, a concurrent node deletion / scene.clear() on the GUI
-thread could race that walk and crash or read torn state.
+Regression coverage for a cross-thread scene read: ChatWorker.run used to walk live
+QGraphicsScene objects (current_node.parent_node -> .scene() -> system_prompt_connections
+-> prompt_note.content) from inside the worker thread. Since QGraphicsScene is not
+thread-safe, a concurrent node deletion / scene.clear() on the GUI thread could race that
+walk and crash or read torn state.
 
 The fix resolves the branch system prompt via resolve_branch_system_prompt() on the GUI
 thread (in ChatWorkerThread.__init__, which runs on the caller's thread) and hands the
@@ -56,10 +56,10 @@ class _ExplodingNode:
     """Any scene access on this raises - proves the worker path never touches it."""
     @property
     def parent_node(self):
-        raise AssertionError("worker thread walked the scene graph (#20 regression)")
+        raise AssertionError("worker thread walked the scene graph (regression)")
 
     def scene(self):
-        raise AssertionError("worker thread called scene() (#20 regression)")
+        raise AssertionError("worker thread called scene() (regression)")
 
 
 class TestResolveBranchSystemPrompt:

--- a/graphlink_app/tests/test_clean_agent_markdown_response.py
+++ b/graphlink_app/tests/test_clean_agent_markdown_response.py
@@ -1,12 +1,12 @@
 """Tests for clean_agent_markdown_response() and the three agents that delegate to it.
 
-doc/ARCHITECTURE_REVIEW_FINDINGS.md #58: ExplainerAgent, KeyTakeawayAgent, and
-GroupSummaryAgent each carried a near-identical ~40-line clean_text() method. Extracted
-to one shared helper, verified behavior-preserving by capturing golden outputs from the
-three *original* clean_text() implementations against a battery of inputs (plain text,
-markdown noise, bullet lists, extra blank lines, an already-present title, unicode
-arrows/bullets, empty/whitespace-only input) and confirming the refactored delegating
-methods produce byte-identical output for every one of them.
+ExplainerAgent, KeyTakeawayAgent, and GroupSummaryAgent each carried a near-identical
+~40-line clean_text() method. Extracted to one shared helper, verified
+behavior-preserving by capturing golden outputs from the three *original* clean_text()
+implementations against a battery of inputs (plain text, markdown noise, bullet lists,
+extra blank lines, an already-present title, unicode arrows/bullets,
+empty/whitespace-only input) and confirming the refactored delegating methods produce
+byte-identical output for every one of them.
 
 That comparison surfaced one genuine (if narrow) behavioral difference between the three
 original implementations: GroupSummaryAgent explicitly reset its "currently inside a

--- a/graphlink_app/tests/test_code_sandbox_approval_gate.py
+++ b/graphlink_app/tests/test_code_sandbox_approval_gate.py
@@ -1,12 +1,12 @@
 """Tests for the Code Sandbox approval gate.
 
 Code Sandbox executes AI/user-generated Python with full host-user privileges and
-installs whatever packages are declared in requirements.txt (see
-doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 2.1). These tests cover the approval gate
-added to CodeSandboxExecutionWorker.run(): the worker must pause after code is ready
-and before it touches the venv/pip/subprocess, and must only proceed if the main
-thread calls approve() - a call to deny() (or stop()) must short-circuit the run
-without ever installing dependencies or executing code.
+installs whatever packages are declared in requirements.txt, unpinned and unverified.
+These tests cover the approval gate added to CodeSandboxExecutionWorker.run(): the
+worker must pause after code is ready and before it touches the venv/pip/subprocess,
+and must only proceed if the main thread calls approve() - a call to deny() (or
+stop()) must short-circuit the run without ever installing dependencies or executing
+code.
 """
 
 import sys

--- a/graphlink_app/tests/test_crash_reporting.py
+++ b/graphlink_app/tests/test_crash_reporting.py
@@ -1,8 +1,8 @@
 """Tests for graphlink_crash - crash capture, redaction, and the clean-shutdown sentinel.
 
-Regression coverage for doc/PRODUCTION_ROADMAP.md Section 5 "Crash reporting": a windowed
-app with no console previously made every unhandled exception and native fault invisible.
-This pins down two properties that matter most:
+Regression coverage for silent crashes: a windowed app with no console previously made
+every unhandled exception and native fault invisible. This pins down two properties that
+matter most:
 
 1. Redaction is structural: build_crash_report() only ever reads sys.exc_info()-shaped
    arguments plus an explicit `context` dict the caller passes - it never reaches into app

--- a/graphlink_app/tests/test_delete_chat_node_cascades_content.py
+++ b/graphlink_app/tests/test_delete_chat_node_cascades_content.py
@@ -1,18 +1,18 @@
 """Tests confirming ChatScene.delete_chat_node() cascades to attached content nodes.
 
-doc/ARCHITECTURE_REVIEW_FINDINGS.md #72 flagged send_message()'s attachment-failure path
-as a possible orphaned-node bug: if an early attachment (e.g. an image) succeeds and
-creates a child ImageNode/DocumentNode, then a *later* attachment in the same message
-fails to read, send_message() calls delete_chat_node(user_node) and returns - the worry
-was that the already-created child content nodes might be left behind since "whether
-those are cascaded depends on scene delete logic; the cleanup contract is implicit."
+send_message()'s attachment-failure path looked like a possible orphaned-node bug: if an
+early attachment (e.g. an image) succeeds and creates a child ImageNode/DocumentNode,
+then a *later* attachment in the same message fails to read, send_message() calls
+delete_chat_node(user_node) and returns - the worry was that the already-created child
+content nodes might be left behind, since whether they are cascaded depends on scene
+delete logic and the cleanup contract was only implicit.
 
 Traced the actual code: delete_chat_node() calls remove_associated_content_nodes() as
 its first step, which does remove any Code/Document/Image/Thinking node whose
 parent_content_node is the node being deleted (along with the connection linking it) -
-exactly the case send_message() creates. This was already correct; the finding's
-"whether cascaded" question is answered "yes" here, with a test, since it previously had
-none (finding #72's own point about the cleanup contract being implicit/unverified).
+exactly the case send_message() creates. This was already correct; the "whether
+cascaded" question is answered "yes" here, with a test, so the cleanup contract is no
+longer merely implicit and unverified.
 """
 
 import sys

--- a/graphlink_app/tests/test_gguf_scan_bounds.py
+++ b/graphlink_app/tests/test_gguf_scan_bounds.py
@@ -1,12 +1,11 @@
 """Tests for the bounded GGUF filesystem scan.
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #35: the "system" scan mode
-walks the user's entire Downloads/Documents/Desktop trees (see
-_iter_existing_llama_cpp_scan_roots) with a completely unbounded os.walk - a pathological
-or cloud-synced tree could make the scan run for a very long time. _collect_gguf_files_from_root
-now bails out once it has visited too many directories or spent too long, and reports
-that via a `truncated` flag instead of silently returning an incomplete list as if it
-were complete.
+Regression coverage for an unbounded model scan: the "system" scan mode walks the
+user's entire Downloads/Documents/Desktop trees (see _iter_existing_llama_cpp_scan_roots)
+with a completely unbounded os.walk - a pathological or cloud-synced tree could make the
+scan run for a very long time. _collect_gguf_files_from_root now bails out once it has
+visited too many directories or spent too long, and reports that via a `truncated` flag
+instead of silently returning an incomplete list as if it were complete.
 """
 
 import sys

--- a/graphlink_app/tests/test_github_client.py
+++ b/graphlink_app/tests/test_github_client.py
@@ -1,4 +1,4 @@
-"""Tests for the shared GitHubRestClient (Phase 3a of doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md).
+"""Tests for the shared GitHubRestClient.
 
 graphlink_plugin_code_review.py and graphlink_plugin_gitlink.py used to each hand-roll
 their own _get_github_token/_github_headers/_github_request with identical token

--- a/graphlink_app/tests/test_github_client_node_delegation.py
+++ b/graphlink_app/tests/test_github_client_node_delegation.py
@@ -3,7 +3,7 @@
 test_github_client.py covers the client's own logic in isolation; this file guards
 against the node class silently reverting to its own hand-rolled implementation (or the
 wrapper methods and the client instance drifting apart) since that would quietly
-reintroduce the exact duplication Phase 3a removed.
+reintroduce the exact duplication extracting the shared client removed.
 """
 
 import sys

--- a/graphlink_app/tests/test_gitlink_agent.py
+++ b/graphlink_app/tests/test_gitlink_agent.py
@@ -1,5 +1,5 @@
-"""Tests for graphlink_plugins/gitlink/agent.py (extracted from
-graphlink_plugin_gitlink.py - see doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 4.4).
+"""Tests for graphlink_plugins/gitlink/agent.py, the Qt-free half of the Gitlink plugin
+split out of the 1800-line graphlink_plugin_gitlink.py widget module.
 
 Path-safety helpers (_normalize_repo_path, _safe_local_target, _fingerprint_changes)
 already have dedicated coverage in tests/test_gitlink_path_safety.py - this file covers

--- a/graphlink_app/tests/test_gitlink_path_safety.py
+++ b/graphlink_app/tests/test_gitlink_path_safety.py
@@ -1,12 +1,12 @@
 """Tests for the Gitlink write-gate's security boundary.
 
 _normalize_repo_path / _safe_local_target are the only thing standing between an
-LLM-proposed file path and a write to the user's local disk (see
-doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 2.2 / 4.4).
+LLM-proposed file path and a write to the user's local disk, and they previously had
+zero test coverage despite being that entire security boundary.
 
 These now live in graphlink_plugins.gitlink.agent (extracted out of
-graphlink_plugin_gitlink.py along with GitlinkAgent - see section 4.4), which is what
-makes them directly importable here without any Qt widget or QApplication.
+graphlink_plugin_gitlink.py along with GitlinkAgent), which is what makes them directly
+importable here without any Qt widget or QApplication.
 """
 
 import sys

--- a/graphlink_app/tests/test_html_preview_sandbox.py
+++ b/graphlink_app/tests/test_html_preview_sandbox.py
@@ -1,11 +1,10 @@
 """Tests for the HTML Renderer network-egress sandbox (graphlink_html_view).
 
-Regression coverage for the HTML-Renderer arbitrary-egress issue
-(doc/ARCHITECTURE_REVIEW_FINDINGS.md): the HTML Renderer node auto-renders AI-generated
-and session-loaded markup in a QWebEngineView with JavaScript enabled and no restrictions,
-so an injected <script>/onerror payload could exfiltrate page content to a remote host or
-hit the user's localhost/intranet (SSRF/CSRF). A local-only request interceptor now blocks
-every request whose scheme would leave the machine.
+Regression coverage for the HTML-Renderer arbitrary-egress issue: the node auto-renders
+AI-generated and session-loaded markup in a QWebEngineView with JavaScript enabled and
+no restrictions, so an injected <script>/onerror payload could exfiltrate page content
+to a remote host or hit the user's localhost/intranet (SSRF/CSRF). A local-only request
+interceptor now blocks every request whose scheme would leave the machine.
 
 The block/allow decision is factored into the pure function preview_url_is_allowed(QUrl),
 tested here directly so coverage doesn't require a live QtWebEngine/GPU context (which

--- a/graphlink_app/tests/test_import_chain.py
+++ b/graphlink_app/tests/test_import_chain.py
@@ -1,7 +1,8 @@
-"""Import-chain regression tests (Phase 5).
+"""Import-chain regression tests.
 
 Guards against two classes of bug found while resolving the dual root-shim/package
-import paths (doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 1.5):
+import paths, where core files reached plugin classes through root-level shims while
+the portal imported the package directly:
 
 1. A real circular import surfaced when graphlink_plugin_context_menu.py moved into
    graphlink_plugins/: graphlink_plugins/__init__.py used to eagerly import every
@@ -46,7 +47,7 @@ def test_graphlink_plugins_package_has_no_eager_reexports():
     assert not hasattr(graphlink_plugins, "ArtifactNode"), (
         "graphlink_plugins/__init__.py appears to eagerly re-export plugin classes "
         "again - this previously caused a circular import via graphlink_pycoder.py. "
-        "See doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 1.5."
+        "The package __init__.py must stay import-free."
     )
 
 
@@ -67,8 +68,7 @@ def test_root_level_plugin_shim_files_are_gone():
         # rather than being a re-export left behind after a package move), but the
         # same "root-level plugin implementation file should no longer exist" check
         # applies now that Graphlink-Reasoning moved into graphlink_plugins/reasoning/
-        # and graphlink_plugins/graphlink_plugin_reasoning.py (see
-        # doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 4.10).
+        # and graphlink_plugins/graphlink_plugin_reasoning.py.
         "graphlink_reasoning.py",
         "graphlink_agents_reasoning.py",
     ]

--- a/graphlink_app/tests/test_is_configured.py
+++ b/graphlink_app/tests/test_is_configured.py
@@ -1,12 +1,11 @@
 """Tests for api_provider.is_configured().
 
-Written while investigating doc/ARCHITECTURE_REVIEW_FINDINGS.md #38, which claimed this
-function "falls off the end" and returns None for an unrecognized LOCAL_PROVIDER_TYPE.
-On re-reading the actual source, that claim was wrong: every branch already returns an
-explicit bool, including a catch-all `return False` for an unrecognized local provider.
-The finding was a misreading during the original review, not a real bug - corrected in
-the doc. This file locks in the (already-correct) behavior with tests, since it had no
-coverage at all before (see finding #68's "no tests for api_provider..." note).
+Written while investigating a claim that this function "falls off the end" and returns
+None for an unrecognized LOCAL_PROVIDER_TYPE. On re-reading the actual source, that
+claim was wrong: every branch already returns an explicit bool, including a catch-all
+`return False` for an unrecognized local provider. It was a misreading, not a real bug.
+This file locks in the (already-correct) behavior with tests, since it had no coverage
+at all before.
 """
 
 import sys

--- a/graphlink_app/tests/test_llama_cpp_reasoning_mode_default.py
+++ b/graphlink_app/tests/test_llama_cpp_reasoning_mode_default.py
@@ -1,6 +1,6 @@
 """Tests for the llama.cpp reasoning_mode default consistency.
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #12: api_provider.py had two
+Regression coverage for the reasoning_mode default drift: api_provider.py had two
 internal "Quick" placeholder defaults for reasoning_mode (the module-level
 LLAMA_CPP_SETTINGS dict, and _normalize_llama_cpp_settings()'s fallback for a missing
 key), while SettingsManager - the actual source of truth once a real settings dict flows
@@ -9,8 +9,7 @@ through initialize_local_provider() - has always defaulted to "Thinking" everywh
 get_llama_cpp_reasoning_mode()'s own fallback). Traced that this mismatch has no
 observable effect in the current codebase (the "Quick" defaults were always overwritten
 before a real llama.cpp request could read them), but it's still a real internal
-inconsistency worth aligning - so unlike #38/#69/#72, this one is a genuine (if very
-low-impact) fix, not a retraction.
+inconsistency worth aligning - a genuine, if very low-impact, fix.
 """
 
 import sys

--- a/graphlink_app/tests/test_llm_json.py
+++ b/graphlink_app/tests/test_llm_json.py
@@ -1,4 +1,5 @@
-"""Tests for the shared LLM-JSON helpers (Phase 3b of doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md).
+"""Tests for the shared LLM-JSON helpers, extracted so the plugins that each
+hand-rolled model-JSON parsing now share one implementation.
 
 graphlink_plugin_code_review.py, graphlink_plugin_quality_gate.py,
 graphlink_plugin_workflow.py, and graphlink_plugin_gitlink.py each independently

--- a/graphlink_app/tests/test_logging_setup.py
+++ b/graphlink_app/tests/test_logging_setup.py
@@ -1,6 +1,6 @@
 """Tests for graphlink_logging.configure_logging().
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #63: nothing in the app ever
+Regression coverage for the app's missing logging setup: nothing in the app ever
 configured Python's logging module, so the one existing logging.exception() call
 (content_codec.py, corrupted image data during deserialization) went to stderr's
 "handler of last resort" - invisible in a windowed app with no console. configure_logging()

--- a/graphlink_app/tests/test_mode_switch_guard.py
+++ b/graphlink_app/tests/test_mode_switch_guard.py
@@ -1,6 +1,6 @@
 """Tests for the mode-switch guard during an active main chat request.
 
-Partial coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #9: the provider runtime is
+Partial coverage for the unsynchronized provider globals: the provider runtime is
 module-level mutable global state in api_provider, swapped by initialize_* while worker
 threads read it. The most user-reachable race was simply changing the mode combo while
 a response was streaming in - nothing prevented it, so the in-flight request could

--- a/graphlink_app/tests/test_no_bom_in_widgets.py
+++ b/graphlink_app/tests/test_no_bom_in_widgets.py
@@ -1,6 +1,6 @@
-"""Regression test for doc/ARCHITECTURE_REVIEW_FINDINGS.md #8: eight files in
-graphlink_widgets/ carried a UTF-8 BOM, which trips up BOM-unaware tooling (naive
-open()/grep/patch flows). Guards against the BOM being reintroduced."""
+"""Regression test for UTF-8 BOMs in source files: eight files in graphlink_widgets/
+carried a UTF-8 BOM, which trips up BOM-unaware tooling (naive open()/grep/patch
+flows). Guards against the BOM being reintroduced."""
 
 import codecs
 import sys

--- a/graphlink_app/tests/test_ollama_capability_cache_invalidation.py
+++ b/graphlink_app/tests/test_ollama_capability_cache_invalidation.py
@@ -1,6 +1,6 @@
 """Tests for the Ollama capability cache and its invalidation.
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #39: _OLLAMA_CAPABILITY_CACHE
+Regression coverage for the never-invalidated capability cache: _OLLAMA_CAPABILITY_CACHE
 never expired or got cleared, so a model pulled/updated mid-session (e.g. gaining audio
 support in a newer build) kept whatever capability answer was cached the first time it
 was seen that session. invalidate_ollama_capability_cache() now exists, and

--- a/graphlink_app/tests/test_ollama_reasoning_retry.py
+++ b/graphlink_app/tests/test_ollama_reasoning_retry.py
@@ -7,10 +7,10 @@ configuration problem. Previously this raised immediately on the first occurrenc
 the identical request is retried up to 3 total attempts before surfacing an error, and
 only the terminal failure (all attempts exhausted) is raised to the caller.
 
-A short backoff now runs between attempts (see doc/ARCHITECTURE_REVIEW_FINDINGS.md #36 -
-previously attempts were re-sent with no delay at all). Every test here patches
-api_provider.time.sleep to a no-op so the suite doesn't actually pause for real -
-test_backoff_between_attempts specifically asserts the backoff is invoked.
+A short backoff now runs between attempts (previously they were re-sent with no delay
+at all). Every test here patches api_provider.time.sleep to a no-op so the suite
+doesn't actually pause for real - test_backoff_between_attempts specifically asserts
+the backoff is invoked.
 """
 
 import sys

--- a/graphlink_app/tests/test_per_node_worker_threads.py
+++ b/graphlink_app/tests/test_per_node_worker_threads.py
@@ -10,19 +10,18 @@ whatever main_window.sandbox_thread currently was - meaning clicking "stop" on o
 sandbox node could stop a *different*, more-recently-started concurrent sandbox node's
 execution instead of (or as well as) its own.
 
-Graphlink-Reasoning got the same fix later, as part of its full redesign (see
-doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 4.10): it predates graphlink_plugins/ entirely
-so it never got task #26's fix along with the other six - it had the shared
-main_window.reasoning_thread attribute AND no stop capability of any kind (no
-node.worker_thread, no stop_reasoning_node method at all).
+Graphlink-Reasoning got the same fix later, as part of its full redesign: it predates
+graphlink_plugins/ entirely, so it never got fixed along with the other six - it had
+the shared main_window.reasoning_thread attribute AND no stop capability of any kind
+(no node.worker_thread, no stop_reasoning_node method at all).
 
-PyCoderNode had the same bug and was still unfixed as of
-doc/ARCHITECTURE_REVIEW_FINDINGS.md #21: stop_pycoder_node(pycoder_node) took a specific
-node argument but stopped main_window.code_exec_thread/pycoder_exec_thread - single
-attributes shared across every PyCoderNode - so clicking "stop" on one node could stop a
-different, more-recently-started concurrent PyCoderNode's execution instead of (or as
-well as) its own. Fixed the same way as Code Sandbox: both CodeExecutionWorker (MANUAL
-mode) and PyCoderExecutionWorker (AI_DRIVEN mode) are now stored on the owning
+PyCoderNode had the same bug and was the last one still unfixed:
+stop_pycoder_node(pycoder_node) took a specific node argument but stopped
+main_window.code_exec_thread/pycoder_exec_thread - single attributes shared across every
+PyCoderNode - so clicking "stop" on one node could stop a different,
+more-recently-started concurrent PyCoderNode's execution instead of (or as well as) its
+own. Fixed the same way as Code Sandbox: both CodeExecutionWorker (MANUAL mode) and
+PyCoderExecutionWorker (AI_DRIVEN mode) are now stored on the owning
 pycoder_node.worker_thread instead.
 
 These tests use WindowActionsMixin directly (a bare mixin - the methods only need the

--- a/graphlink_app/tests/test_persistence_node_ids.py
+++ b/graphlink_app/tests/test_persistence_node_ids.py
@@ -1,6 +1,6 @@
 """Tests for stable node IDs and skip-safe index arithmetic in chat persistence.
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #47: graph references were
+Regression coverage for the index-shift graph corruption: graph references were
 serialized purely as list positions, and the load path re-derived several lookup maps
 from *survivor* counts instead of original payload positions. When any node was skipped
 during load (the documented behavior for node types whose plugins were removed - e.g. a

--- a/graphlink_app/tests/test_plugin_portal_create_node.py
+++ b/graphlink_app/tests/test_plugin_portal_create_node.py
@@ -1,11 +1,10 @@
 """Tests for PluginPortal.create_node() and its first consumer, _create_artifact_node.
 
-doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md Phase 2: create_node() is the generic single-parent
-plugin node factory meant to replace the ~15-line skeleton duplicated across most
-_create_X_node methods (resolve/validate parent, construct, wire into children,
-position, register with the scene). _create_artifact_node is migrated onto it here as
-the first proof; the other 12 _create_X_node methods are migrated one at a time in
-later phases, not all at once.
+create_node() is the generic single-parent plugin node factory meant to replace the
+~15-line skeleton duplicated across most _create_X_node methods (resolve/validate
+parent, construct, wire into children, position, register with the scene).
+_create_artifact_node is migrated onto it here as the first proof; the other 12
+_create_X_node methods are migrated one at a time later, not all at once.
 
 These tests use a lightweight fake scene/main_window rather than real Qt scene/window
 objects (which need a running app with a loaded chat) - only the handful of attributes
@@ -81,8 +80,8 @@ def test_create_artifact_node_wires_artifact_requested_to_main_window():
 
 def test_create_artifact_node_wires_stop_requested_to_main_window():
     # stop_requested is what makes the node's dual-purpose button's "stop" state
-    # actually do something (see doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 4.1/§31) -
-    # this locks in that _create_artifact_node wires it alongside artifact_requested.
+    # actually do something (before it existed, the stop icon was cosmetic) - this
+    # locks in that _create_artifact_node wires it alongside artifact_requested.
     portal, main_window, scene, parent = _make_portal_and_parent()
     result = portal._create_artifact_node()
 

--- a/graphlink_app/tests/test_plugin_portal_execute_plugin.py
+++ b/graphlink_app/tests/test_plugin_portal_execute_plugin.py
@@ -1,5 +1,4 @@
-"""Tests for PluginPortal.execute_plugin's not-found path (see
-doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 3.6/§4.8).
+"""Tests for PluginPortal.execute_plugin's not-found path.
 
 execute_plugin used to handle an unrecognized plugin_name with print() + return None -
 a real, silent failure, since instantiate_seeded_plugin() in graphlink_window_actions.py

--- a/graphlink_app/tests/test_plugin_portal_remaining_factories.py
+++ b/graphlink_app/tests/test_plugin_portal_remaining_factories.py
@@ -1,4 +1,4 @@
-"""Tests for the Phase 4 migration of the standard-shape plugin factories onto
+"""Tests for the standard-shape plugin factories now built on
 PluginPortal.create_node() (Py-Coder, Execution Sandbox, Gitlink, Graphlink-Web,
 Conversation Node, HTML Renderer).
 
@@ -235,8 +235,7 @@ class TestHtmlRendererValidateParent:
         # raising AttributeError instead. Confirmed via direct investigation of
         # graphlink_scene.py's deletion/connection-validity logic that CodeNode was
         # never part of the `.children`-based branch-visibility system anyway, so
-        # skipping that step for a CodeNode parent is safe - see
-        # doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md section 4.8/5.
+        # skipping that step for a CodeNode parent is safe.
         code_node = CodeNode(code="print(42)", language="python", parent_content_node=None)
         portal, main_window, scene = _make_portal(code_node)
 

--- a/graphlink_app/tests/test_plugin_registry.py
+++ b/graphlink_app/tests/test_plugin_registry.py
@@ -1,16 +1,16 @@
-"""Tests for the Phase 1 plugin registry (graphlink_plugin_portal.PLUGIN_REGISTRY).
+"""Tests for the plugin registry (graphlink_plugin_portal.PLUGIN_REGISTRY).
 
-doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md documents that plugin metadata is hand-copied in
-several independent places across the app (PluginPortal's _register_plugin calls,
-graphlink_plugin_quality_gate.py's _node_label, graphlink_plugin_workflow.py's
-WORKFLOW_PLUGIN_ICONS) and that this drift already caused a live bug (Workflow's
-allowlist silently omitted Code Review Agent). PLUGIN_REGISTRY is meant to become the
-single source of truth those should eventually read from - these tests cross-check it
-against the existing hand-maintained lists so registry/reality drift is caught
-immediately instead of being discovered by a future audit.
+Plugin metadata is hand-copied in several independent places across the app
+(PluginPortal's _register_plugin calls, graphlink_plugin_quality_gate.py's
+_node_label, graphlink_plugin_workflow.py's WORKFLOW_PLUGIN_ICONS) and that this
+drift already caused a live bug (Workflow's allowlist silently omitted Code Review
+Agent). PLUGIN_REGISTRY is meant to become the single source of truth those should
+eventually read from - these tests cross-check it against the existing
+hand-maintained lists so registry/reality drift is caught immediately instead of
+being discovered by a future audit.
 
-Note: graphlink_window_actions.py's former isinstance-chain dispatcher was replaced in
-Phase 2 by each node class implementing seed_prompt(text) itself (see
+Note: graphlink_window_actions.py's former isinstance-chain dispatcher was replaced
+by each node class implementing seed_prompt(text) itself (see
 tests/test_seed_prompt_protocol.py for the behavioral coverage of that). The
 seedable-flag-vs-reality cross-check below now asserts against that protocol directly
 instead of scraping the old isinstance chain out of the dispatcher's source.
@@ -44,11 +44,11 @@ def test_registry_names_match_the_live_portal_registration():
 
 def test_registry_descriptions_match_the_live_portal_registration():
     # Description text is hand-duplicated between PLUGIN_REGISTRY and
-    # PluginPortal._discover_plugins() (see doc/ARCHITECTURE_REVIEW_FINDINGS.md #61) -
+    # PluginPortal._discover_plugins(), two parallel registries that can drift -
     # this doesn't fix that duplication, but it does catch the two copies drifting out
-    # of sync, which is exactly what happened to Execution Sandbox's description before
-    # #16 was fixed (both copies had to be updated by hand to stay honest about the
-    # sandbox not isolating from the OS).
+    # of sync, which is exactly what happened to Execution Sandbox's description (both
+    # copies had to be updated by hand to stay honest about the sandbox not isolating
+    # from the OS).
     portal = PluginPortal(main_window=None)
     portal_descriptions_by_name = {p["name"]: p["description"] for p in portal.get_plugins()}
     for spec in PLUGIN_REGISTRY.values():
@@ -56,11 +56,11 @@ def test_registry_descriptions_match_the_live_portal_registration():
 
 
 def test_execution_sandbox_description_does_not_oversell_containment():
-    # See doc/ARCHITECTURE_REVIEW_FINDINGS.md #16: the description used to just say
-    # "isolated virtualenv" with no caveat, which a user could easily read as stronger
-    # containment than a venv actually provides. The approval dialog shown before every
-    # run has always been honest about this (_handle_code_sandbox_approval_request);
-    # the picker-level description should say the same thing, not oversell it.
+    # The description used to just say "isolated virtualenv" with no caveat, which a
+    # user could easily read as stronger containment than a venv actually provides. The
+    # approval dialog shown before every run has always been honest about this
+    # (_handle_code_sandbox_approval_request); the picker-level description should say
+    # the same thing, not oversell it.
     spec = get_plugin_spec("code_sandbox")
     assert "not the operating system" in spec.description
 

--- a/graphlink_app/tests/test_provider_state_snapshot.py
+++ b/graphlink_app/tests/test_provider_state_snapshot.py
@@ -1,8 +1,9 @@
 """Tests for the per-request provider-state snapshot in api_provider.
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #9's remainder: the provider
-runtime lives in module-level globals mutated by initialize_*() on the UI thread while
-chat()/generate_image() read them from worker threads. chat() and generate_image() now
+Regression coverage for the mid-request provider swap - the half of that race a UI-level
+mode-switch guard can't close, since background plugin requests aren't gated by the UI:
+the provider runtime lives in module-level globals mutated by initialize_*() on the UI
+thread while chat()/generate_image() read them from worker threads. Both functions now
 capture one consistent _ProviderSnapshot at entry (under _PROVIDER_STATE_LOCK, which all
 mutators also take) and route the ENTIRE request through it - branch selection, client,
 key, task models, llama.cpp settings, and, critically, the error-classification handler

--- a/graphlink_app/tests/test_pycoder_approval_gate.py
+++ b/graphlink_app/tests/test_pycoder_approval_gate.py
@@ -1,6 +1,6 @@
 """Tests for the Py-Coder execution approval gate.
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #15: Py-Coder's AI_DRIVEN
+Regression coverage for ungated AI-generated code execution: Py-Coder's AI_DRIVEN
 mode executed LLM-generated code in a completely unsandboxed REPL subprocess (full
 user-account privileges) with no approval step, while the newer Code Sandbox plugin has
 always had an explicit approval dialog for the same threat - an inconsistent trust model.

--- a/graphlink_app/tests/test_save_chat_atomically.py
+++ b/graphlink_app/tests/test_save_chat_atomically.py
@@ -1,6 +1,6 @@
 """Tests for ChatDatabase.save_chat_atomically().
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #52: save_chat/update_chat,
+Regression coverage for non-transactional cross-table saves: save_chat/update_chat,
 save_notes, and save_pins each previously opened their own connection and committed
 independently. A crash (or any exception) between two of those steps left the chat row,
 notes, and pins inconsistent with each other - e.g. a chat saved with notes that were

--- a/graphlink_app/tests/test_save_context_switch_guard.py
+++ b/graphlink_app/tests/test_save_context_switch_guard.py
@@ -1,12 +1,12 @@
 """Tests for the context-switch guard on background saves (ChatSessionManager).
 
-Regression coverage for the stale-chat_id save race (doc/ARCHITECTURE_REVIEW_FINDINGS.md):
-a background save serializes the chat that was active when it STARTED. If the user
-switches chats (New Chat, or loading another chat) while that save is in flight, the
-save's completion used to unconditionally do `current_chat_id = new_chat_id`, restoring
-the PREVIOUS chat as active. The next autosave then serialized the now-visible scene and
-UPDATE'd it into the previous chat's row - silently overwriting an unrelated conversation
-and never saving the new work under its own id.
+Regression coverage for the stale-chat_id save race: a background save serializes the
+chat that was active when it STARTED. If the user switches chats (New Chat, or loading
+another chat) while that save is in flight, the save's completion used to
+unconditionally do `current_chat_id = new_chat_id`, restoring the PREVIOUS chat as
+active. The next autosave then serialized the now-visible scene and UPDATE'd it into the
+previous chat's row - silently overwriting an unrelated conversation and never saving
+the new work under its own id.
 
 The fix: ChatSessionManager tracks a `_context_epoch` that bumps on every switch
 (mark_context_switch), records the epoch a save started under (`_saving_epoch`), and

--- a/graphlink_app/tests/test_save_worker_title_generation.py
+++ b/graphlink_app/tests/test_save_worker_title_generation.py
@@ -1,14 +1,13 @@
 """Tests for SaveWorkerThread's title generation on new-chat saves.
 
-Regression coverage for dead TitleGenerator wiring (see
-doc/ARCHITECTURE_REVIEW_FINDINGS.md #53): SaveWorkerThread received a title_generator
-constructor argument but never called it, always falling back to the first five words
-of the first message. TitleGenerator.generate_title() itself was fully implemented
-and already documented in GRAPHLINK_REPO_NAVIGATION.md's "Title generation flow" but had
-zero callers anywhere in the app. SaveWorkerThread.run() now calls it for new chats
-(current_chat_id is falsy, or the referenced chat_id no longer exists) and only drops
-to the plain fallback title if title generation is unavailable, raises, or returns
-nothing usable.
+Regression coverage for dead TitleGenerator wiring: SaveWorkerThread received a
+title_generator constructor argument but never called it, always falling back to the
+first five words of the first message. TitleGenerator.generate_title() itself was fully
+implemented and already documented in GRAPHLINK_REPO_NAVIGATION.md's "Title generation
+flow" but had zero callers anywhere in the app. SaveWorkerThread.run() now calls it for
+new chats (current_chat_id is falsy, or the referenced chat_id no longer exists) and
+only drops to the plain fallback title if title generation is unavailable, raises, or
+returns nothing usable.
 """
 
 import sys
@@ -98,10 +97,10 @@ class TestExistingChatDoesNotRegenerateTitle:
 
 
 class TestFallbackTitleIsUnicodeAware:
-    """Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #73: the fallback
-    title regex used to be r"[A-Za-z0-9']+", which strips non-ASCII text entirely -
-    every non-English first message (CJK, Cyrillic, accented Latin, ...) fell through
-    to a bare timestamp title instead of using any of the actual message content."""
+    """Regression coverage for the ASCII-only fallback title regex: it used to be
+    r"[A-Za-z0-9']+", which strips non-ASCII text entirely - every non-English first
+    message (CJK, Cyrillic, accented Latin, ...) fell through to a bare timestamp
+    title instead of using any of the actual message content."""
 
     def _fallback_title_for(self, message):
         worker = SaveWorkerThread(_make_db(), object(), {"nodes": []}, None, message)

--- a/graphlink_app/tests/test_scene_node_list_helpers.py
+++ b/graphlink_app/tests/test_scene_node_list_helpers.py
@@ -1,4 +1,4 @@
-"""Tests for ChatScene's node-list composition helpers (Phase 5).
+"""Tests for ChatScene's node-list composition helpers.
 
 graphlink_scene.py already defined _all_conversational_nodes()/_all_content_nodes()/
 _all_layout_nodes() (a union of the 12 plugin node lists plus self.nodes, content

--- a/graphlink_app/tests/test_schema_version.py
+++ b/graphlink_app/tests/test_schema_version.py
@@ -1,8 +1,8 @@
 """Tests for the schema_version field added to session.dat and saved chat payloads.
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #49: neither file carried a
-version field at all, so every future format change had no marker to branch a migration
-on. This adds the version field itself (SettingsManager.CURRENT_SCHEMA_VERSION,
+Neither file carried a version field at all, so every future format change had no marker
+to branch a migration on. This adds the version field itself
+(SettingsManager.CURRENT_SCHEMA_VERSION,
 graphlink_session.scene_index.CURRENT_CHAT_SCHEMA_VERSION) - not a migration framework,
 just the groundwork one would need.
 """

--- a/graphlink_app/tests/test_secrets_at_rest.py
+++ b/graphlink_app/tests/test_secrets_at_rest.py
@@ -1,9 +1,9 @@
 """Tests for secrets-at-rest encryption (graphlink_secrets + SettingsManager wiring).
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #14: API keys and the
-GitHub token were stored as plaintext JSON in session.dat. They are now DPAPI-protected
-("dpapi:" + base64 blob, bound to the Windows user account) with three hard
-requirements pinned down here:
+Regression coverage for secrets stored in plaintext: API keys and the GitHub token were
+stored as plaintext JSON in session.dat. They are now DPAPI-protected ("dpapi:" +
+base64 blob, bound to the Windows user account) with three hard requirements pinned
+down here:
 
 1. Roundtrip: what you set is what you get back, but the on-disk bytes never contain
    the plaintext.
@@ -180,7 +180,7 @@ class TestGracefulDegradationWithoutDpapi:
 
         assert manager.get_github_token() == "ghp_plain_fallback"
         raw = json.loads(state_file.read_text(encoding="utf-8"))
-        assert raw["github_access_token"] == "ghp_plain_fallback"  # plaintext, as before #14
+        assert raw["github_access_token"] == "ghp_plain_fallback"  # plaintext, as before
 
         # Reload with DPAPI still unavailable: no crash, no rewrite loop, same value.
         mtime_before = state_file.stat().st_mtime_ns

--- a/graphlink_app/tests/test_seed_prompt_protocol.py
+++ b/graphlink_app/tests/test_seed_prompt_protocol.py
@@ -1,4 +1,5 @@
-"""Tests for the seed_prompt() protocol (Phase 2 of doc/PLUGIN_SYSTEM_REFACTOR_PLAN.md).
+"""Tests for the seed_prompt() protocol - the shared contract that lets any plugin node
+be created pre-filled with a prompt.
 
 graphlink_window_actions.py's _seed_plugin_prompt used to be an 11-branch isinstance
 chain that had to be hand-edited every time a seedable plugin was added - each branch

--- a/graphlink_app/tests/test_settings_atomic_write.py
+++ b/graphlink_app/tests/test_settings_atomic_write.py
@@ -1,9 +1,9 @@
 """Tests for SettingsManager's atomic writes and corrupt-file recovery.
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #48: _save_state used to
-write directly to session.dat, so a crash mid-write left a truncated/corrupt file, and
-_load_state's JSONDecodeError handler then silently replaced it with defaults -
-destroying every saved API key and preference with no backup and no warning.
+Regression coverage for non-atomic settings writes: _save_state used to write directly
+to session.dat, so a crash mid-write left a truncated/corrupt file, and _load_state's
+JSONDecodeError handler then silently replaced it with defaults - destroying every
+saved API key and preference with no backup and no warning.
 
 _save_state now writes to a temp file (fsync'd) and atomically renames it into place, so
 state_file itself is always either the fully-old or fully-new version, never a partial

--- a/graphlink_app/tests/test_shutdown_thread_enumeration.py
+++ b/graphlink_app/tests/test_shutdown_thread_enumeration.py
@@ -1,11 +1,11 @@
 """Tests for ChatWindow._iter_shutdown_threads()/_shutdown_background_threads().
 
-Regression coverage for two related bugs (see doc/ARCHITECTURE_REVIEW_FINDINGS.md #24):
+Regression coverage for two related bugs in the hand-maintained shutdown thread list:
 
 1. The shutdown list still named main_window.X_thread attributes (reasoning_thread,
    workflow_thread, graph_diff_thread, quality_gate_thread, code_review_thread,
    sandbox_thread, artifact_thread, gitlink_thread, and - once PyCoder got the same
-   per-node fix, see #21 and test_per_node_worker_threads.py - code_exec_thread and
+   per-node fix, see test_per_node_worker_threads.py - code_exec_thread and
    pycoder_exec_thread) that were removed from the window entirely once those plugins
    moved to a per-node node.worker_thread attribute. They were harmless no-ops
    (getattr(self, name, None) always returned None) but misleading.

--- a/graphlink_app/tests/test_storage_path_injection.py
+++ b/graphlink_app/tests/test_storage_path_injection.py
@@ -1,10 +1,10 @@
 """Tests for optional path injection on ChatDatabase and SettingsManager.
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #55: both classes hardcoded
-Path.home()/.graphlink/... with no way to redirect them, forcing tests that needed an
-isolated instance to bypass __init__ entirely via __new__ (see
-test_chat_database_get_title.py's original _make_test_db helper). Both constructors now
-accept an optional path parameter; omitting it preserves the exact original behavior.
+Both classes used to hardcode Path.home()/.graphlink/... with no way to redirect them,
+forcing tests that needed an isolated instance to bypass __init__ entirely via __new__
+(see test_chat_database_get_title.py's original _make_test_db helper). Both
+constructors now accept an optional path parameter; omitting it preserves the exact
+original behavior.
 """
 
 import sys

--- a/graphlink_app/tests/test_temp_attachment_encoding.py
+++ b/graphlink_app/tests/test_temp_attachment_encoding.py
@@ -1,4 +1,4 @@
-"""Regression test for doc/ARCHITECTURE_REVIEW_FINDINGS.md #19: large-paste and
+"""Regression test for silent data mangling in temp attachments: large-paste and
 dropped-text attachments were written to temp files with errors="ignore", which
 silently drops any character Python can't encode to UTF-8 (e.g. an unpaired surrogate
 from a malformed Windows clipboard/drop payload) with no trace in the saved attachment.

--- a/graphlink_app/tests/test_token_accounting.py
+++ b/graphlink_app/tests/test_token_accounting.py
@@ -1,11 +1,11 @@
 """Tests for handle_response()'s input-token accounting.
 
-Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #41: handle_response() used
-to recompute input_tokens by parsing self.token_counter_widget.input_label.text() (a
-QLabel's *displayed* string, with formatting like "1,234" stripped by hand) instead of
-using the actual integer value already computed in send_message(). A display widget was
-the source of truth for a running token-total calculation. send_message() now passes
-that value straight through the finished-signal connection instead.
+Regression coverage for widget-derived token math: handle_response() used to recompute
+input_tokens by parsing self.token_counter_widget.input_label.text() (a QLabel's
+*displayed* string, with formatting like "1,234" stripped by hand) instead of using the
+actual integer value already computed in send_message(). A display widget was the
+source of truth for a running token-total calculation. send_message() now passes that
+value straight through the finished-signal connection instead.
 
 Uses a MagicMock as `self` for this unbound-method call (matching the pattern in
 test_shutdown_thread_enumeration.py) with token_counter_widget.input_label deliberately

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
 
 # llama-cpp-python is lazily imported (api_provider._load_llama_cpp_class) only when
 # Llama.cpp local mode is actually used - Ollama is the built-in local path, so it is an
-# opt-in extra rather than a hard dependency. See doc/PRODUCTION_ROADMAP.md Section 4.
+# opt-in extra rather than a hard dependency: it is a heavy native build with no wheels
+# for newer Python versions, so requiring it would break installs for most users.
 [project.optional-dependencies]
 llamacpp = ["llama-cpp-python"]
 dev = ["pytest"]


### PR DESCRIPTION
## Summary

Two related documentation cleanups. No behavior change — comments, docstrings, and markdown only.

First, the branch/PR/merge workflow is now written down. `CONTRIBUTING.md` covered what a PR should contain but never described branching or merge mechanics, even though the commit history has followed a consistent convention across 26 PRs. This records what was already practice rather than inventing anything new.

Second, and larger: 65 tracked files carried 79 citations pointing into `doc/`, which is gitignored. Those were dead links for anyone reading the repo, they exposed internal doc names along with their finding and section numbering, and they substituted a lookup key for the actual reasoning — so the reader most likely to need the explanation was the one who couldn't reach it. Each citation is now replaced with the substance it pointed at, stated inline.

## What Changed

- `CONTRIBUTING.md` — new "Git & GitHub Workflow" section: topic branches off `main`, `agent/<slug>` naming, push, PR via the existing template, squash-merge, delete branch.
- `README.md` — corrected a stale claim that a GitHub Actions workflow runs a compile check on every push. That automation was removed in `185143a`, so local validation is now the only gate.
- 65 source and test files — replaced every `doc/*.md` citation with the reasoning it referenced. Example: `Regression coverage for doc/ARCHITECTURE_REVIEW_FINDINGS.md #37: ...` became `Regression coverage for the OpenAI API-key env-var gap: ...`.
- Also removed three bare "Phase N" references, which leaked the same internal plan structure without a path.

## Why

`doc/` was deliberately made local-only in `79fc90e` ("Keep internal documentation local"), but the codebase kept citing it. That left the public repo full of references to files it doesn't contain. Inlining the reasoning fixes the disclosure and makes the comments genuinely useful to a reader who only has the repo.

## Validation

- [x] `python -m compileall -q .` passes
- [x] Full suite: **486 passed**
- [x] No `doc/` references remain in any tracked file
- [x] `doc/` confirmed still gitignored

## UI Notes

- [x] No screenshots needed — no user-visible change.

## Additional Context

The citation removal was mechanical in shape but needed care per site: where the surrounding prose already explained the issue, the citation was simply dropped; where the citation itself carried the meaning, it was replaced with a statement of the actual problem. A follow-up pass re-wrapped affected comment paragraphs whose line breaks had gone ragged — whitespace only, no wording changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)