### PR TITLE
Extract shared graphlink_webengine.py hardening module

### DIFF
--- a/graphlink_app/graphlink_composer_web.py
+++ b/graphlink_app/graphlink_composer_web.py
@@ -23,7 +23,7 @@ try:
     from PySide6.QtWebChannel import QWebChannel
     from PySide6.QtWebEngineWidgets import QWebEngineView
 
-    from graphlink_html_view import WEBENGINE_AVAILABLE, _harden_preview_web_view
+    from graphlink_webengine import WEBENGINE_AVAILABLE, _harden_preview_web_view
 except ImportError:
     QWebChannel = None
     QWebEngineView = None

--- a/graphlink_app/graphlink_html_view.py
+++ b/graphlink_app/graphlink_html_view.py
@@ -13,102 +13,20 @@ from graphlink_plugins.graphlink_plugin_context_menu import PluginNodeContextMen
 import json
 
 try:
-    from PySide6.QtWidgets import QApplication
     from PySide6.QtWebEngineWidgets import QWebEngineView
-    from PySide6.QtWebEngineCore import (
-        QWebEnginePage,
-        QWebEngineProfile,
-        QWebEngineScript,
-        QWebEngineSettings,
-        QWebEngineUrlRequestInterceptor,
-    )
-    WEBENGINE_AVAILABLE = True
+    from PySide6.QtWebEngineCore import QWebEngineScript
+    _NODE_WEBENGINE_IMPORTS_OK = True
 except ImportError:
-    # Handle the case where WebEngine might not be installed but other parts of the app are
-    WEBENGINE_AVAILABLE = False
+    _NODE_WEBENGINE_IMPORTS_OK = False
 
+from graphlink_webengine import WEBENGINE_AVAILABLE as _SHARED_WEBENGINE_AVAILABLE
+from graphlink_webengine import _harden_preview_web_view
 
-# Schemes a self-contained local preview legitimately needs: the setHtml document itself
-# (about:), inline data: URIs, JS-created blob: URLs, and Qt's compiled-in qrc resources.
-# Everything else - http(s), file, ftp, ws(s) - would leave the machine or reach
-# localhost/intranet/disk.
-_LOCAL_PREVIEW_SCHEMES = frozenset({"about", "data", "blob", "qrc"})
-
-
-def preview_url_is_allowed(url):
-    """Whether a sub-resource/navigation request from the HTML preview may proceed.
-
-    The HTML Renderer previews AI-generated and session-loaded markup (see
-    graphlink_plugin_portal / deserializers, which auto-render it with no prompt). Its
-    QWebEngineView runs JavaScript, so an injected ``<script>``/``onerror`` payload could
-    otherwise exfiltrate page content to a remote host or hit the user's localhost/intranet
-    (SSRF/CSRF from their network position). We treat the preview as an offline sandbox:
-    only local, self-contained schemes are permitted; any request that would leave the
-    machine is blocked.
-    """
-    try:
-        scheme = (url.scheme() or "").lower()
-    except AttributeError:
-        return False
-    return scheme in _LOCAL_PREVIEW_SCHEMES
-
-
-if WEBENGINE_AVAILABLE:
-
-    class _LocalOnlyRequestInterceptor(QWebEngineUrlRequestInterceptor):
-        """Blocks every preview request whose scheme isn't local (see
-        preview_url_is_allowed). Applied to the preview profile so it covers <img>/<script>/
-        fetch/XHR/form-POST/navigation uniformly, regardless of how the payload was crafted.
-        """
-
-        def interceptRequest(self, info):
-            if not preview_url_is_allowed(info.requestUrl()):
-                info.block(True)
-
-    # One dedicated, process-wide preview profile carries the interceptor. Created lazily
-    # (never at import time - a QWebEngine QObject built before QApplication exists can
-    # crash) and cached, so we do NOT mutate the shared default profile on every view and
-    # do NOT create a new profile per view. Lifetime is the crux of QtWebEngine stability:
-    # - the profile is parented to the QApplication, so C++ owns it and it outlives every
-    #   preview page (a profile destroyed before its pages crashes);
-    # - the interceptor is parented to the profile, so C++ owns it too - the profile can
-    #   never call back into a Python object that GC already reclaimed.
-    _PREVIEW_PROFILE = None
-
-    def _get_preview_profile():
-        global _PREVIEW_PROFILE
-        if _PREVIEW_PROFILE is None:
-            app = QApplication.instance()
-            # Off-the-record profile: no on-disk cache/cookies for previewed content.
-            profile = QWebEngineProfile(app)
-            interceptor = _LocalOnlyRequestInterceptor(profile)
-            profile.setUrlRequestInterceptor(interceptor)
-            _PREVIEW_PROFILE = profile
-        return _PREVIEW_PROFILE
-
-    def _harden_preview_web_view(web_view):
-        """Lock a preview QWebEngineView down to an offline, self-contained sandbox.
-
-        The view is given its own page backed by the shared local-only profile, so every
-        request (``<img>``/``<script>``/fetch/XHR/form-POST/navigation) is filtered through
-        the interceptor regardless of how the payload was crafted.
-        """
-        profile = _get_preview_profile()
-        page = QWebEnginePage(profile, web_view)  # child of the view: destroyed with it
-        web_view.setPage(page)
-        settings = web_view.settings()
-        # Defense in depth alongside the interceptor: no disk reads, no remote pulls from
-        # local content, no clipboard access, no popups.
-        for attr, value in (
-            ("LocalContentCanAccessFileUrls", False),
-            ("LocalContentCanAccessRemoteUrls", False),
-            ("JavascriptCanAccessClipboard", False),
-            ("JavascriptCanPaste", False),
-            ("JavascriptCanOpenWindows", False),
-        ):
-            enum_val = getattr(QWebEngineSettings.WebAttribute, attr, None)
-            if enum_val is not None:
-                settings.setAttribute(enum_val, value)
+# Both this module's own imports (QWebEngineView, QWebEngineScript) and the shared
+# hardening module's imports must succeed - a partial PySide6 install where one set
+# imports and the other doesn't must not leave QWebEngineView referenced below while
+# WEBENGINE_AVAILABLE claims it's safe to do so.
+WEBENGINE_AVAILABLE = _SHARED_WEBENGINE_AVAILABLE and _NODE_WEBENGINE_IMPORTS_OK
 
 
 class HtmlPopoutWindow(QDialog):

--- a/graphlink_app/graphlink_webengine.py
+++ b/graphlink_app/graphlink_webengine.py
@@ -1,0 +1,106 @@
+"""Shared QtWebEngine hardening for every local preview/island surface.
+
+Both the HTML Renderer node's preview and the composer's React island render
+content inside a QWebEngineView, and both need the same guarantee: nothing they
+show may reach the network or the local disk. This module owns that guarantee in
+one place - the offline, local-only sandbox profile and interceptor - so it is
+proven once and every WebEngine surface inherits it instead of re-implementing
+its own escape hatch.
+"""
+
+try:
+    from PySide6.QtWidgets import QApplication
+    from PySide6.QtWebEngineCore import (
+        QWebEnginePage,
+        QWebEngineProfile,
+        QWebEngineSettings,
+        QWebEngineUrlRequestInterceptor,
+    )
+    WEBENGINE_AVAILABLE = True
+except ImportError:
+    # Handle the case where WebEngine might not be installed but other parts of the app are
+    WEBENGINE_AVAILABLE = False
+
+
+# Schemes a self-contained local surface legitimately needs: the setHtml document itself
+# (about:), inline data: URIs, JS-created blob: URLs, and Qt's compiled-in qrc resources.
+# Everything else - http(s), file, ftp, ws(s) - would leave the machine or reach
+# localhost/intranet/disk.
+_LOCAL_PREVIEW_SCHEMES = frozenset({"about", "data", "blob", "qrc"})
+
+
+def preview_url_is_allowed(url):
+    """Whether a sub-resource/navigation request from a hardened view may proceed.
+
+    Every surface that uses this module renders content that isn't fully trusted: the
+    HTML Renderer node auto-renders AI-generated and session-loaded markup, and the
+    composer island runs a bundled but still script-capable JS app. Either could
+    otherwise exfiltrate content to a remote host or hit the user's localhost/intranet
+    (SSRF/CSRF from their network position). We treat every hardened view as an offline
+    sandbox: only local, self-contained schemes are permitted; any request that would
+    leave the machine is blocked.
+    """
+    try:
+        scheme = (url.scheme() or "").lower()
+    except AttributeError:
+        return False
+    return scheme in _LOCAL_PREVIEW_SCHEMES
+
+
+if WEBENGINE_AVAILABLE:
+
+    class _LocalOnlyRequestInterceptor(QWebEngineUrlRequestInterceptor):
+        """Blocks every request whose scheme isn't local (see preview_url_is_allowed).
+        Applied to the shared profile so it covers <img>/<script>/fetch/XHR/form-POST/
+        navigation uniformly, regardless of how the payload was crafted.
+        """
+
+        def interceptRequest(self, info):
+            if not preview_url_is_allowed(info.requestUrl()):
+                info.block(True)
+
+    # One dedicated, process-wide profile carries the interceptor for every hardened view
+    # (HTML preview and composer alike). Created lazily (never at import time - a
+    # QWebEngine QObject built before QApplication exists can crash) and cached, so we do
+    # NOT mutate the shared default profile and do NOT create a new profile per view.
+    # Lifetime is the crux of QtWebEngine stability:
+    # - the profile is parented to the QApplication, so C++ owns it and it outlives every
+    #   hardened page (a profile destroyed before its pages crashes);
+    # - the interceptor is parented to the profile, so C++ owns it too - the profile can
+    #   never call back into a Python object that GC already reclaimed.
+    _PREVIEW_PROFILE = None
+
+    def _get_preview_profile():
+        global _PREVIEW_PROFILE
+        if _PREVIEW_PROFILE is None:
+            app = QApplication.instance()
+            # Off-the-record profile: no on-disk cache/cookies for hardened content.
+            profile = QWebEngineProfile(app)
+            interceptor = _LocalOnlyRequestInterceptor(profile)
+            profile.setUrlRequestInterceptor(interceptor)
+            _PREVIEW_PROFILE = profile
+        return _PREVIEW_PROFILE
+
+    def _harden_preview_web_view(web_view):
+        """Lock a QWebEngineView down to an offline, self-contained sandbox.
+
+        The view is given its own page backed by the shared local-only profile, so every
+        request (``<img>``/``<script>``/fetch/XHR/form-POST/navigation) is filtered
+        through the interceptor regardless of how the payload was crafted.
+        """
+        profile = _get_preview_profile()
+        page = QWebEnginePage(profile, web_view)  # child of the view: destroyed with it
+        web_view.setPage(page)
+        settings = web_view.settings()
+        # Defense in depth alongside the interceptor: no disk reads, no remote pulls from
+        # local content, no clipboard access, no popups.
+        for attr, value in (
+            ("LocalContentCanAccessFileUrls", False),
+            ("LocalContentCanAccessRemoteUrls", False),
+            ("JavascriptCanAccessClipboard", False),
+            ("JavascriptCanPaste", False),
+            ("JavascriptCanOpenWindows", False),
+        ):
+            enum_val = getattr(QWebEngineSettings.WebAttribute, attr, None)
+            if enum_val is not None:
+                settings.setAttribute(enum_val, value)

--- a/graphlink_app/tests/test_html_preview_sandbox.py
+++ b/graphlink_app/tests/test_html_preview_sandbox.py
@@ -1,10 +1,11 @@
-"""Tests for the HTML Renderer network-egress sandbox (graphlink_html_view).
+"""Tests for the shared QtWebEngine network-egress sandbox (graphlink_webengine).
 
 Regression coverage for the HTML-Renderer arbitrary-egress issue: the node auto-renders
 AI-generated and session-loaded markup in a QWebEngineView with JavaScript enabled and
 no restrictions, so an injected <script>/onerror payload could exfiltrate page content
 to a remote host or hit the user's localhost/intranet (SSRF/CSRF). A local-only request
-interceptor now blocks every request whose scheme would leave the machine.
+interceptor now blocks every request whose scheme would leave the machine. The composer
+island shares this same sandbox.
 
 The block/allow decision is factored into the pure function preview_url_is_allowed(QUrl),
 tested here directly so coverage doesn't require a live QtWebEngine/GPU context (which
@@ -21,7 +22,7 @@ import pytest
 
 from PySide6.QtCore import QUrl
 
-from graphlink_html_view import preview_url_is_allowed
+from graphlink_webengine import preview_url_is_allowed
 
 
 class TestLocalSchemesAreAllowed:
@@ -61,3 +62,34 @@ class TestDefensiveEdges:
     def test_a_non_url_object_is_blocked_not_crashed(self):
         # Fail closed: anything that doesn't look like a QUrl is treated as disallowed.
         assert preview_url_is_allowed(object()) is False
+
+
+class TestHtmlViewNodeWebengineAvailabilityIsAtomic:
+    """graphlink_html_view.WEBENGINE_AVAILABLE gates `QWebEngineView(...)` construction
+    in HtmlViewNode. QWebEngineView lives in a separate compiled module
+    (PySide6.QtWebEngineWidgets) from the classes graphlink_webengine's own
+    availability check imports (QtWebEngineCore, QtWidgets), so the flag must combine
+    both: True only when the node's own QWebEngineView/QWebEngineScript imports AND
+    the shared hardening module's imports both succeeded. A gap here would let
+    WEBENGINE_AVAILABLE be True while QWebEngineView is unbound, crashing HtmlViewNode
+    with NameError instead of falling back to its "module not found" placeholder UI.
+
+    This deliberately does not simulate the partial-import-failure case by reloading
+    graphlink_html_view: 11 other modules cache `HtmlViewNode` at their own import
+    time, and reloading would fork class identity between this test and them for the
+    rest of the shared-process test session.
+    """
+
+    def test_true_and_shared_when_both_import_cleanly(self):
+        import graphlink_composer_web
+        import graphlink_html_view
+        import graphlink_webengine
+
+        assert graphlink_html_view.WEBENGINE_AVAILABLE is True
+        assert graphlink_html_view.WEBENGINE_AVAILABLE is graphlink_webengine.WEBENGINE_AVAILABLE
+        assert graphlink_html_view._harden_preview_web_view is (
+            graphlink_webengine._harden_preview_web_view
+        )
+        assert graphlink_composer_web._harden_preview_web_view is (
+            graphlink_webengine._harden_preview_web_view
+        )


### PR DESCRIPTION
## Summary

First slice of a larger frontend platform effort: extract the WebEngine sandboxing that the HTML Renderer node and the composer's React island both rely on into its own shared module. No behavior change to either surface — this is a pure extraction plus one narrow bug fix uncovered while verifying that claim.

## What Changed

- New `graphlink_app/graphlink_webengine.py`: the off-the-record profile, the local-only request interceptor, `preview_url_is_allowed` (the egress allowlist), and the defense-in-depth `QWebEngineSettings` — moved out of `graphlink_html_view.py` verbatim.
- `graphlink_html_view.py` and `graphlink_composer_web.py` both now import the hardening from the new module directly, instead of the composer reaching into the HTML-preview node's file to get it.
- `graphlink_app/tests/test_html_preview_sandbox.py`: repointed its import, plus a new regression test for the availability-atomicity fix below.

## Why

Every future web-embedded surface in this app is going to need this same sandbox. Extracting it now — before a second and third consumer show up — means it gets hardened and tested once, in one place, instead of being copy-pasted or reached-into again.

## A bug found during review, not before it

I had an independent agent (fresh context, no prior involvement) adversarially review the diff with instructions to try to disprove "zero behavior change." It found a real gap: splitting `graphlink_html_view.py`'s WebEngine import block broke the atomicity between `WEBENGINE_AVAILABLE` and whether `QWebEngineView` was actually a bound name. Under a partial PySide6 install (`QtWebEngineCore` importable, `QtWebEngineWidgets` not), `WEBENGINE_AVAILABLE` could read `True` while `QWebEngineView` stayed unbound — `HtmlViewNode` would crash with `NameError` instead of falling back to its "module not found" placeholder. I reproduced the exact failure with an import hook, fixed it by ANDing the shared module's availability with the node's own local import success, and re-verified the fix closes it.

The new regression test checks the resulting shared-state invariant directly rather than reloading `graphlink_html_view` mid-session — 11 other files cache `HtmlViewNode` at their own import time, and reloading it would fork class identity for the rest of that test run.

## Validation

- [x] `python -m compileall -q .` passes
- [x] Full suite: **487 passed** (486 existing + 1 new)
- [x] Confirmed by direct import that both consumers share the exact same profile/interceptor/hardening-function objects (one singleton, not two)
- [x] Reproduced the partial-install failure mode against the fix and confirmed it's closed

## UI Notes

- [x] No screenshots needed — no user-visible change.

## Additional Context

This is increment 1 of a larger, locally-planned frontend platform effort (tracked in a gitignored planning doc, not part of this PR). Later increments build a shared bridge base and host widget on top of this module; none of that is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)