### PR TITLE
Extract transport-agnostic IslandBridge base and fix ComposerBridge.dispose()

### DIFF
--- a/graphlink_app/graphlink_composer_bridge.py
+++ b/graphlink_app/graphlink_composer_bridge.py
@@ -16,6 +16,7 @@ from PySide6.QtCore import QObject, Signal, Slot
 import graphlink_config as config
 from graphlink_composer import ComposerController
 from graphlink_config import get_current_palette
+from graphlink_island_bridge import IslandBridge
 
 
 _MAX_DRAFT_CHARS = 100_000
@@ -70,45 +71,87 @@ def _model_option(
     }
 
 
-class ComposerBridge(QObject):
-    """QWebChannel object with a stable, versioned state contract."""
+class ComposerBridge(IslandBridge, QObject):
+    """QWebChannel object with a stable, versioned state contract.
+
+    State/lifecycle (publish/dispose, schemaVersion, revision) come from
+    IslandBridge and are transport-agnostic; this class supplies the composer's
+    own state payload plus the Qt-specific wiring QWebChannel requires
+    (Signals for outbound state, Slots for inbound intents).
+
+    IslandBridge only abstracts the outbound *state* channel (publish() ->
+    _transport_send()). It intentionally does not cover: inbound intent
+    dispatch (the @Slot methods below are 100% QWebChannel-shaped - a
+    non-Qt transport would expose the same plain methods with no decorator,
+    which is harmless, since the decorators are additive Qt metadata) or any
+    Qt Signal emitted directly from inside an intent handler rather than
+    through publish(). heightRequested is the one case of the latter with a
+    real consumer (ComposerWebHost.resize -> _apply_requested_height); it is
+    a second, Python-to-Python (not Python-to-JS) Qt-only channel a future
+    non-Qt host will need its own solution for (e.g. CSS/ResizeObserver-based
+    auto-sizing), not something IslandBridge should grow to cover. draftChanged
+    and contextReviewChanged below are unconsumed today (nothing connects to
+    them) but would have the same problem the moment something does.
+    Also out of scope here: ComposerController (self.controller) is itself a
+    QObject emitting Qt Signals - the republish *trigger*, not just the
+    publish path, still assumes Qt underneath this refactor.
+    """
 
     stateChanged = Signal(str)
-    draftChanged = Signal(str)
+    draftChanged = Signal(str)  # unconsumed; see class docstring
     contextReviewChanged = Signal(str)
     streamDelta = Signal(str)
     requestCompleted = Signal(str)
     requestFailed = Signal(str)
     routeChanged = Signal(str)
     themeChanged = Signal(str)
-    heightRequested = Signal(int)
+    heightRequested = Signal(int)  # Qt-only side channel; see class docstring
 
     def __init__(self, window, controller: ComposerController | None = None, parent=None):
-        super().__init__(parent)
+        QObject.__init__(self, parent)
+        IslandBridge.__init__(self)
         self.window = window
         self.controller = controller or getattr(window, "composer_controller", None)
         if self.controller is None:
             self.controller = ComposerController(self)
-        self._revision = 0
         self._attachment_paths: dict[str, str] = {}
         self._last_height = 0
         self.controller.draftChanged.connect(self._on_draft_changed)
         self.controller.stateChanged.connect(self._on_controller_state_changed)
 
+    def _transport_send(self, payload_json: str) -> None:
+        self.stateChanged.emit(payload_json)
+
+    def _after_publish(self, payload, serialized) -> None:
+        # Preserve today's theme broadcast (nothing on the JS side connects to
+        # it yet); scheduled for removal alongside the theme-token-table work,
+        # not this refactor.
+        self.themeChanged.emit(json.dumps(payload["theme"], sort_keys=True))
+
+    def _on_dispose(self) -> None:
+        try:
+            self.controller.draftChanged.disconnect(self._on_draft_changed)
+        except (RuntimeError, TypeError):
+            pass
+        try:
+            self.controller.stateChanged.disconnect(self._on_controller_state_changed)
+        except (RuntimeError, TypeError):
+            pass
+
     @Slot()
     def ready(self):
-        self._publish()
+        self.publish()
 
     @Slot(str)
     def updateDraft(self, text: str):
         normalized = str(text or "")[:_MAX_DRAFT_CHARS]
         self.controller.update_text(normalized)
         self.draftChanged.emit(normalized)
-        self._publish()
+        self.publish()
 
     @Slot()
     def send(self):
-        state = self._state_payload()
+        state = self._build_state_payload()
         if state["request"]["state"] in _ACTIVE_STATES:
             return
         if not state["request"]["canSend"]:
@@ -116,7 +159,7 @@ class ComposerBridge(QObject):
         send_message = getattr(self.window, "send_message", None)
         if callable(send_message):
             send_message()
-            self._publish()
+            self.publish()
 
     @Slot()
     @Slot(str)
@@ -126,14 +169,14 @@ class ComposerBridge(QObject):
         callback = getattr(self.window, "_main_request_cancel_callback", None)
         if callable(callback):
             callback()
-            self._publish()
+            self.publish()
             return
         self.controller.cancel(request_id or None)
-        self._publish()
+        self.publish()
 
     @Slot()
     def reviewContext(self):
-        context = self._state_payload()["context"]
+        context = self._build_state_payload()["context"]
         open_context = getattr(self.window, "open_composer_context_popup", None)
         if callable(open_context):
             open_context(context)
@@ -152,7 +195,7 @@ class ComposerBridge(QObject):
         stage_paste = getattr(self.window, "_handle_large_paste_from_input", None)
         if callable(stage_paste):
             stage_paste(str(text or ""))
-            self._publish()
+            self.publish()
 
     @Slot(str)
     def removeContextItem(self, item_id: str):
@@ -160,12 +203,12 @@ class ComposerBridge(QObject):
         remove = getattr(self.window, "_handle_attachment_pill_removed", None)
         if path and callable(remove):
             remove(path)
-            self._publish()
+            self.publish()
 
     @Slot(str)
     def selectModel(self, model_id: str):
         """Persist and activate the chat model selected in the composer."""
-        if self._state_payload()["request"]["state"] in _ACTIVE_STATES:
+        if self._build_state_payload()["request"]["state"] in _ACTIVE_STATES:
             return
         model_id = str(model_id or "").strip()
         if not model_id:
@@ -197,14 +240,14 @@ class ComposerBridge(QObject):
                 )
 
             self._notify_settings_changed()
-            self._publish()
+            self.publish()
         except Exception as exc:
             self._show_configuration_error(f"Model selection failed: {exc}")
 
     @Slot(str)
     def setReasoningLevel(self, level: str):
         """Persist and activate the composer reasoning level."""
-        if self._state_payload()["request"]["state"] in _ACTIVE_STATES:
+        if self._build_state_payload()["request"]["state"] in _ACTIVE_STATES:
             return
 
         normalized = "Thinking" if str(level or "").strip().lower() == "thinking" else "Quick"
@@ -225,7 +268,7 @@ class ComposerBridge(QObject):
                 api_provider.set_ollama_reasoning_mode(normalized)
 
             self._notify_settings_changed()
-            self._publish()
+            self.publish()
         except Exception as exc:
             self._show_configuration_error(f"Reasoning setting failed: {exc}")
 
@@ -273,10 +316,10 @@ class ComposerBridge(QObject):
         self.heightRequested.emit(bounded)
 
     def _on_draft_changed(self, draft):
-        self._publish()
+        self.publish()
 
     def _on_controller_state_changed(self, state, message):
-        self._publish()
+        self.publish()
 
     def _context_anchor(self) -> dict[str, str] | None:
         node = getattr(self.window, "current_node", None)
@@ -519,7 +562,7 @@ class ComposerBridge(QObject):
             accent = "#A6A6A6"
         return {"mode": "dark", "accent": accent, "surface": "#1F1F1F"}
 
-    def _state_payload(self) -> dict[str, Any]:
+    def _build_state_payload(self) -> dict[str, Any]:
         draft = self.controller.draft
         anchor = self._context_anchor()
         items = self._context_items()
@@ -536,9 +579,8 @@ class ComposerBridge(QObject):
         # anchor. Attachments are valid input; an anchor alone is reviewable
         # context, not a sendable request.
         has_input = bool(str(draft.text or "").strip() or items)
+        # schemaVersion and revision are added by IslandBridge.publish().
         return {
-            "schemaVersion": 1,
-            "revision": self._revision,
             "draft": {
                 "id": draft.draft_id,
                 "text": draft.text,
@@ -567,10 +609,3 @@ class ComposerBridge(QObject):
             },
             "theme": self._theme(),
         }
-
-    def _publish(self):
-        self._revision += 1
-        payload = self._state_payload()
-        serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
-        self.stateChanged.emit(serialized)
-        self.themeChanged.emit(json.dumps(payload["theme"], sort_keys=True))

--- a/graphlink_app/graphlink_composer_web.py
+++ b/graphlink_app/graphlink_composer_web.py
@@ -234,16 +234,16 @@ class ComposerWebHost(QFrame):
 
     def set_context_items(self, items):
         self.controller.set_attachments(items or [])
-        self.bridge._publish()
+        self.bridge.publish()
 
     def set_context_anchor(self, node):
-        self.bridge._publish()
+        self.bridge.publish()
 
     def set_provider_status(self, text, tooltip=""):
         # Route is derived from SettingsManager in the bridge; this method is
         # retained for the legacy ChatWindow call site during migration.
         self._provider_status = str(text or "")
-        self.bridge._publish()
+        self.bridge.publish()
 
     def set_request_state(self, active=False, cancel_pending=False, message=""):
         self._request_message = str(message or "")
@@ -253,7 +253,7 @@ class ComposerWebHost(QFrame):
         self._editor_enabled = bool(enabled)
 
     def on_theme_changed(self):
-        self.bridge._publish()
+        self.bridge.publish()
 
     def prepare_for_shutdown(self):
         """Stop web content callbacks before Qt tears down the application."""

--- a/graphlink_app/graphlink_island_bridge.py
+++ b/graphlink_app/graphlink_island_bridge.py
@@ -1,0 +1,77 @@
+"""Transport-agnostic core for every desktop <-> web island bridge.
+
+A bridge owns exactly two responsibilities that never change across transports:
+building a JSON-serializable state snapshot, and running the publish/dispose
+lifecycle around it (schemaVersion, monotonic revision, sorted-keys JSON,
+idempotent teardown). How the serialized snapshot actually reaches the web
+side - a Qt Signal over QWebChannel today, something else if the desktop host
+ever changes - is a subclass concern, not this module's. Nothing here imports
+Qt, so this class is usable and testable independent of any GUI toolkit.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+class IslandBridge:
+    """Base class for every island's desktop-side state/intent bridge.
+
+    Subclasses provide two things:
+    - _build_state_payload() -> dict: the current state, without schemaVersion
+      or revision (publish() adds both, so every island gets them for free and
+      consistently).
+    - _transport_send(payload_json: str) -> None: hand the serialized snapshot
+      to whatever transport the concrete bridge uses.
+
+    Optional hooks:
+    - _after_publish(payload, serialized): side-channel emissions that piggyback
+      on a publish without becoming part of the core snapshot contract.
+    - _on_dispose(): real teardown work (disconnect signals, release
+      references). Called exactly once; publish() becomes a no-op afterward,
+      so a bridge that outlives its transport by a few event-loop ticks during
+      shutdown can't emit into a torn-down page.
+    """
+
+    SCHEMA_VERSION = 1
+
+    def __init__(self) -> None:
+        self._revision = 0
+        self._disposed = False
+
+    @property
+    def disposed(self) -> bool:
+        return self._disposed
+
+    def publish(self) -> None:
+        """Rebuild the full state snapshot and send it. A no-op after dispose()."""
+        if self._disposed:
+            return
+        self._revision += 1
+        payload = dict(self._build_state_payload())
+        payload["schemaVersion"] = self.SCHEMA_VERSION
+        payload["revision"] = self._revision
+        serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        self._transport_send(serialized)
+        self._after_publish(payload, serialized)
+
+    def dispose(self) -> None:
+        """Tear the bridge down. Idempotent - safe to call more than once."""
+        if self._disposed:
+            return
+        self._disposed = True
+        self._on_dispose()
+
+    def _build_state_payload(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _transport_send(self, payload_json: str) -> None:
+        raise NotImplementedError
+
+    def _after_publish(self, payload: dict[str, Any], serialized: str) -> None:
+        """Optional hook for side-channel emissions after the state channel
+        has sent. No-op by default."""
+
+    def _on_dispose(self) -> None:
+        """Optional hook for subclass teardown. No-op by default."""

--- a/graphlink_app/tests/test_composer_bridge.py
+++ b/graphlink_app/tests/test_composer_bridge.py
@@ -199,6 +199,55 @@ def test_bridge_clamps_compact_composer_height_requests():
     assert heights == [COMPOSER_MIN_HEIGHT, COMPOSER_MAX_HEIGHT]
 
 
+class TestDisposeIsRealAndIdempotent:
+    """Regression coverage for a known bug: ComposerWebHost.prepare_for_shutdown
+    called self.bridge.dispose(), but ComposerBridge defined no dispose() at all
+    - the AttributeError was silently swallowed by a broad except clause, so the
+    controller's draftChanged/stateChanged connections outlived the bridge with
+    nothing to ever disconnect them. dispose() now exists on the shared
+    IslandBridge base every future bridge subclasses too.
+    """
+
+    def test_dispose_runs_without_error_and_is_idempotent(self):
+        window = _Window()
+        controller = ComposerController()
+        bridge = ComposerBridge(window, controller)
+
+        assert bridge.disposed is False
+        bridge.dispose()
+        assert bridge.disposed is True
+        bridge.dispose()  # must not raise a second (or third) time
+        bridge.dispose()
+
+    def test_publish_is_a_no_op_after_dispose(self):
+        window = _Window()
+        controller = ComposerController()
+        bridge = ComposerBridge(window, controller)
+        states = []
+        bridge.stateChanged.connect(states.append)
+        bridge.ready()
+        count_before = len(states)
+
+        bridge.dispose()
+        bridge.publish()
+
+        assert len(states) == count_before
+
+    def test_dispose_disconnects_the_controller_so_it_cannot_republish(self):
+        window = _Window()
+        controller = ComposerController()
+        bridge = ComposerBridge(window, controller)
+        states = []
+        bridge.stateChanged.connect(states.append)
+        bridge.ready()
+        count_before = len(states)
+
+        bridge.dispose()
+        controller.update_text("late edit after teardown")
+
+        assert len(states) == count_before
+
+
 def test_composer_native_mask_has_rounded_corners():
     region = _rounded_region(QRect(0, 0, 100, 40), 12)
 

--- a/graphlink_app/tests/test_island_bridge.py
+++ b/graphlink_app/tests/test_island_bridge.py
@@ -1,0 +1,133 @@
+"""Tests for the transport-agnostic IslandBridge base class.
+
+graphlink_island_bridge.py has no Qt imports at all - deliberately, since it is
+meant to be the shared publish/dispose/schemaVersion/revision contract behind
+every future desktop<->web bridge, including ones that will eventually run over
+a non-Qt transport. These tests exercise it with a bare-minimum fake transport
+and no QApplication, no Qt event loop, and no other test in this file requiring
+the shared conftest.py QApplication fixture - if a future edit accidentally
+makes this module depend on Qt, these tests start needing that fixture and the
+regression is visible immediately.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import json
+
+from graphlink_island_bridge import IslandBridge
+
+
+class _RecordingBridge(IslandBridge):
+    """Minimal concrete bridge: a plain list stands in for a real transport."""
+
+    def __init__(self, state=None):
+        super().__init__()
+        self._state = dict(state or {"value": 0})
+        self.sent = []
+        self.after_publish_calls = []
+        self.disposed_calls = 0
+
+    def set_state(self, **kwargs):
+        self._state.update(kwargs)
+
+    def _build_state_payload(self):
+        return dict(self._state)
+
+    def _transport_send(self, payload_json):
+        self.sent.append(payload_json)
+
+    def _after_publish(self, payload, serialized):
+        self.after_publish_calls.append((payload, serialized))
+
+    def _on_dispose(self):
+        self.disposed_calls += 1
+
+
+def test_publish_sends_sorted_json_with_schema_version_and_revision():
+    bridge = _RecordingBridge(state={"b": 2, "a": 1})
+
+    bridge.publish()
+
+    assert len(bridge.sent) == 1
+    payload = json.loads(bridge.sent[0])
+    assert payload["schemaVersion"] == 1
+    assert payload["revision"] == 1
+    assert payload["a"] == 1 and payload["b"] == 2
+    # sort_keys=True: "a" before "b" before the injected keys alphabetically
+    assert bridge.sent[0].index('"a"') < bridge.sent[0].index('"b"')
+
+
+def test_revision_increments_monotonically_across_publishes():
+    bridge = _RecordingBridge()
+
+    bridge.publish()
+    bridge.publish()
+    bridge.publish()
+
+    revisions = [json.loads(payload)["revision"] for payload in bridge.sent]
+    assert revisions == [1, 2, 3]
+
+
+def test_build_state_payload_need_not_include_schema_or_revision():
+    # _build_state_payload() returns only domain state; publish() injects the
+    # envelope. A subclass accidentally including its own schemaVersion/revision
+    # keys gets overwritten, never doubled or left stale.
+    bridge = _RecordingBridge(state={"schemaVersion": 999, "revision": 999})
+
+    bridge.publish()
+
+    payload = json.loads(bridge.sent[0])
+    assert payload["schemaVersion"] == 1
+    assert payload["revision"] == 1
+
+
+def test_after_publish_hook_receives_the_full_envelope():
+    bridge = _RecordingBridge(state={"value": 42})
+
+    bridge.publish()
+
+    assert len(bridge.after_publish_calls) == 1
+    payload, serialized = bridge.after_publish_calls[0]
+    assert payload["value"] == 42
+    assert payload["revision"] == 1
+    assert serialized == bridge.sent[0]
+
+
+def test_dispose_is_idempotent_and_calls_the_hook_exactly_once():
+    bridge = _RecordingBridge()
+
+    assert bridge.disposed is False
+    bridge.dispose()
+    bridge.dispose()
+    bridge.dispose()
+
+    assert bridge.disposed is True
+    assert bridge.disposed_calls == 1
+
+
+def test_publish_is_a_no_op_after_dispose():
+    bridge = _RecordingBridge()
+    bridge.publish()
+    sent_before = len(bridge.sent)
+
+    bridge.dispose()
+    bridge.publish()
+    bridge.publish()
+
+    assert len(bridge.sent) == sent_before
+
+
+def test_unimplemented_hooks_raise_not_implemented_for_a_bare_subclass():
+    class _Bare(IslandBridge):
+        pass
+
+    bridge = _Bare()
+    try:
+        bridge.publish()
+    except NotImplementedError:
+        pass
+    else:
+        raise AssertionError("expected NotImplementedError from an unimplemented bridge")


### PR DESCRIPTION
## Summary

Second slice of the frontend platform effort (first was #28): extract the shared state-snapshot lifecycle every desktop-to-web bridge needs into its own base class, and fix a known bug along the way. No behavior change to the composer from any existing caller's perspective, verified two independent ways.

## What Changed

- New `graphlink_app/graphlink_island_bridge.py`: `IslandBridge`, a Qt-free base class owning publish/dispose lifecycle, monotonic revision, `schemaVersion` injection, and sorted-keys JSON serialization.
- `graphlink_composer_bridge.py`: `ComposerBridge` now built as `class ComposerBridge(IslandBridge, QObject)`. Every internal `_publish()`/`_state_payload()` call site renamed to the new public `publish()`/`_build_state_payload()`.
- `graphlink_composer_web.py`: the 4 external `self.bridge._publish()` call sites updated to the new public `publish()`.
- `tests/test_island_bridge.py` (new): 7 tests exercising `IslandBridge` directly with a fake in-memory transport — no Qt fixture required at all.
- `tests/test_composer_bridge.py`: 3 new tests for the `dispose()` fix.

## The bug this also fixes

`ComposerWebHost.prepare_for_shutdown()` has always called `self.bridge.dispose()`, but `ComposerBridge` never defined a `dispose()` method — the resulting `AttributeError` was silently swallowed by a broad `except` clause, so shutdown teardown was a no-op. `dispose()` now genuinely exists on the shared base, is idempotent, disconnects the controller's Qt signal connections, and makes `publish()` a no-op afterward. I reproduced the original failure and confirmed the fix closes it before writing it up as a permanent regression test.

## Verification

I sent two independent reviews (fresh context, no prior involvement in this change) at the diff in parallel, each with a different adversarial angle:

- **"Disprove zero behavior change."** Found nothing beyond the intended `dispose()` fix — payload key set, `themeChanged` emission order, revision-increment count, and every external call site all confirmed identical to before.
- **"Disprove this is genuinely swappable, not just a rename."** Found a real, worth-keeping finding: three Qt Signals fire directly from inside intent handlers, bypassing `publish()` entirely. One of them, `heightRequested`, has a real production consumer (`ComposerWebHost._apply_requested_height`) and is a second, structurally different Qt-only channel that nothing had previously flagged as follow-up work. I didn't try to fix that in this change — it's a legitimate scope boundary, not a defect — but documented it inline at the `Signal` declarations and class docstring so it's visible to whoever touches this code next, rather than a fact that only existed in a review transcript.

- [x] `python -m compileall -q .` passes
- [x] Full suite: **497 passed** (487 existing + 10 new), zero existing tests needed modification
- [x] `IslandBridge` proven Qt-free: its own test suite constructs zero Qt objects and needs no fixture

## UI Notes

- [x] No screenshots needed — no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)