### PR TITLE
Fix QSS golden-diff test to compare text, not raw bytes

### DIFF
--- a/graphlink_app/tests/test_qss_generation.py
+++ b/graphlink_app/tests/test_qss_generation.py
@@ -3,13 +3,17 @@ token work: the three StyleSheet.*_THEME strings are now generated from
 THEME_TOKENS[theme]["qss"] / ["qss_alpha"] filled into a *_THEME_TEMPLATE,
 instead of being hand-maintained literals.
 
-The fixtures under tests/fixtures/qss_golden_*.txt are byte-for-byte copies
-of StyleSheet.DARK_THEME / MONOCHROMATIC_THEME / MUTED_THEME captured from
-the running app BEFORE this refactor (via a script, not retyped by hand) -
-this is the "generated == current, diffs reviewed" golden test called for
-in the master plan's Phase 1 checklist and section 3.4. A future edit that
-silently changes a resolved color fails this test with an actual text diff,
-not just a bespoke hash comparison.
+The fixtures under tests/fixtures/qss_golden_*.txt are copies of
+StyleSheet.DARK_THEME / MONOCHROMATIC_THEME / MUTED_THEME captured from the
+running app BEFORE this refactor (via a script, not retyped by hand) - this
+is the "generated == current, diffs reviewed" golden test called for in the
+master plan's Phase 1 checklist and section 3.4. Compared as text (universal
+newlines), not raw bytes: repo-root .gitattributes forces `*.txt eol=crlf`,
+so a fresh checkout is free to rewrite this file's line endings regardless
+of what was committed, while the generated StyleSheet.* strings are always
+\n-only (Python normalizes source line endings when parsing a string
+literal). A future edit that silently changes a resolved color still fails
+this test with an actual text diff, not just a bespoke hash comparison.
 """
 
 import re
@@ -38,9 +42,20 @@ PLACEHOLDER_RE = re.compile(r"\{\{([a-z0-9_]+)\}\}")
 
 
 def _read_fixture(filename):
-    # newline="" mirrors how the fixture was written: no universal-newline
-    # translation, so the comparison is truly byte-for-byte.
-    with open(FIXTURES / filename, "r", encoding="utf-8", newline="") as f:
+    # Universal-newline text mode (the default - no newline= override), NOT
+    # newline="" byte-exact mode: repo-root .gitattributes forces `*.txt
+    # text eol=crlf`, so a checkout can legitimately materialize this file
+    # with \r\n regardless of what was written or committed. StyleSheet.
+    # DARK_THEME etc. are always \n-only (Python's tokenizer normalizes
+    # source line endings when parsing a string literal, regardless of the
+    # .py file's own on-disk line endings). Comparing raw bytes against a
+    # fixture whose line endings git is free to rewrite was the actual bug
+    # here, caught when this test failed after nothing but a routine
+    # `git checkout`/`git merge --ff-only` re-materialized the fixture as
+    # CRLF. Reading in text mode normalizes \r\n -> \n on the way in, so the
+    # comparison is diff-worthy on real content changes and indifferent to
+    # a line-ending convention neither side of the comparison controls.
+    with open(FIXTURES / filename, "r", encoding="utf-8") as f:
         return f.read()
 
 


### PR DESCRIPTION
`tests/test_qss_generation.py`'s golden-diff test read its fixture files with
`newline=""` (byte-exact, no line-ending translation) and compared that
directly against `StyleSheet.DARK_THEME`/`MONOCHROMATIC_THEME`/`MUTED_THEME`,
which are always `\n`-only (Python normalizes source line endings when parsing
a string literal, regardless of the `.py` file's own on-disk line endings).

Repo-root `.gitattributes` forces `*.txt text eol=crlf`, so any checkout - not
just one particular machine's - is free to re-materialize those fixtures with
`\r\n` regardless of what was committed, deterministically breaking a
byte-exact comparison against a string that is guaranteed to never contain
`\r`. This was caught when a routine `git checkout` / `git merge --ff-only`
(pulling in the already-merged #32) re-materialized the fixtures as CRLF and
the full suite started failing on three parametrized cases.

Fixed by reading the fixture in ordinary universal-newline text mode instead
of `newline=""` - `\r\n` normalizes to `\n` on read, matching what
`StyleSheet.*` always produces. This is the correct comparison level for this
test (content-identical, line-ending-convention-agnostic) rather than fighting
a line-ending policy that neither side of the comparison owns. A real content
change to a resolved color still fails the test with a genuine text diff.

## Test plan

- [x] The 3 previously-failing parametrized cases in
      `TestGeneratedQssMatchesGoldenByteForByte` now pass
- [x] `graphlink_app/tests/test_qss_generation.py`: 30 passed
- [x] Full pytest suite: 571 passed
- [x] `python -m compileall` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>