### PR TITLE
Fix Ctrl+K command palette NameError crash

### DIFF
--- a/graphlink_app/graphlink_command_palette.py
+++ b/graphlink_app/graphlink_command_palette.py
@@ -117,34 +117,34 @@ class CommandPaletteDialog(QDialog):
         self.canvas.setGraphicsEffect(shadow)
 
         self.setStyleSheet(f"""
-            QDialog {
+            QDialog {{
                 background: transparent;
-            }
-            QWidget#commandPaletteCanvas {
+            }}
+            QWidget#commandPaletteCanvas {{
                 background-color: #252525;
                 color: #FFFFFF;
                 border-radius: 8px;
-            }
-            QLineEdit {
+            }}
+            QLineEdit {{
                 padding: 10px;
                 font-size: 14px;
                 background-color: #1E1E1E;
                 border: 1px solid #3F3F3F;
                 border-radius: 4px;
-            }
-            QListWidget {
+            }}
+            QListWidget {{
                 border: 1px solid #3F3F3F;
                 background-color: #2D2D2D;
                 font-size: 13px;
                 border-radius: 4px;
-            }
-            QListWidget::item {
+            }}
+            QListWidget::item {{
                 padding: 10px;
-            }
-            QListWidget::item:selected {
+            }}
+            QListWidget::item:selected {{
                 background-color: {get_semantic_color("status_success").name()};
                 color: white;
-            }
+            }}
         """)
 
         # Initially populate the list with all available commands.

--- a/graphlink_app/tests/test_command_palette.py
+++ b/graphlink_app/tests/test_command_palette.py
@@ -1,0 +1,53 @@
+"""Regression coverage for the Ctrl+K command palette crash (Phase 1 hot-fix,
+see doc/FRONTEND_WEB_MIGRATION_MASTER_PLAN.md section 2.4).
+
+CommandPaletteDialog.__init__ builds its stylesheet from an f-string
+containing literal QSS braces (`QDialog { ... }`) alongside one real
+substitution (`{get_semantic_color(...).name()}`). Python's f-string parser
+reads every unescaped `{` as the start of a replacement field, so a literal
+`QDialog {` was parsed as an expression `background` (the first bare name
+inside the braces) followed by a `: ...` format spec - raising
+`NameError: name 'background' is not defined` the moment the dialog was
+constructed, i.e. every time a user pressed Ctrl+K. Verified live before
+the fix (2026-07-19): constructing CommandPaletteDialog([]) raised exactly
+that NameError. Fixed by doubling every literal brace ({{ / }}), leaving
+only the one real substitution single-braced.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from graphlink_command_palette import CommandManager, CommandPaletteDialog
+
+
+class TestCommandPaletteDialogConstructs:
+    def test_constructs_with_no_commands_without_raising(self):
+        # This is the exact reproduction of the pre-fix crash: construction
+        # alone (before .exec(), before any user interaction) used to raise
+        # NameError unconditionally.
+        dialog = CommandPaletteDialog([])
+        assert dialog is not None
+
+    def test_constructs_with_real_registered_commands(self):
+        manager = CommandManager()
+        manager.register_command("Test Command", ["tc"], callback=lambda: None)
+        dialog = CommandPaletteDialog(manager.get_available_commands())
+        assert dialog.results_list.count() == 1
+
+
+class TestStylesheetRendersCorrectly:
+    def test_rendered_stylesheet_has_balanced_single_braces(self):
+        dialog = CommandPaletteDialog([])
+        qss = dialog.styleSheet()
+        assert "{{" not in qss and "}}" not in qss, "escaped double-braces leaked into the rendered QSS"
+        assert qss.count("{") == qss.count("}") == 6, "expected exactly 6 QSS rule blocks"
+
+    def test_semantic_color_substitution_resolves_to_a_hex_color(self):
+        dialog = CommandPaletteDialog([])
+        qss = dialog.styleSheet()
+        assert "QListWidget::item:selected {" in qss
+        # The one real f-string substitution: get_semantic_color("status_success").name()
+        selected_block = qss.split("QListWidget::item:selected {")[1]
+        assert "background-color: #" in selected_block


### PR DESCRIPTION
`CommandPaletteDialog.__init__` built its stylesheet via
`self.setStyleSheet(f"""...""")`, mixing 6 literal, unescaped QSS rule blocks
(`QDialog { ... }`, `QWidget#commandPaletteCanvas { ... }`, etc.) with exactly
one real f-string substitution
(`{get_semantic_color("status_success").name()}`). Python's f-string parser
treats every unescaped `{` as a replacement-field opener, so the first
literal block was parsed as the bare expression `background` (the first
token after the brace) followed by a `: transparent;` format spec - raising
`NameError: name 'background' is not defined` the instant the dialog was
constructed, i.e. on every Ctrl+K press. Reproduced live before any change to
confirm the exact failure mode.

Fixed by doubling all 12 literal braces (`{{` / `}}`) across the 6 rule
blocks, leaving only the one real substitution single-braced - a pure
escaping change; the diff touches nothing else.

Added `tests/test_command_palette.py`: construction with no commands (the
exact pre-fix crash reproduction, now a permanent regression guard),
construction with real registered commands, a balanced-brace + exact
rule-count assertion on the rendered stylesheet, and confirmation the one
real substitution resolves to an actual color rather than leaking template
text.

## Review findings addressed

Two independent adversarial reviews ran against this diff:

- One confirmed the fix produces byte-for-byte the *intended* pre-bug QSS
  text - zero visual drift, not just zero crash - verified end-to-end through
  the real Ctrl+K shortcut wiring on a genuinely constructed `ChatWindow` with
  real registered commands.
- The other scanned all 14 other files in this codebase that build QSS via
  f-strings, using an AST check for this bug's exact mechanical signature
  (an f-string `FormattedValue` node with a non-`None` `format_spec` - a bare
  identifier followed by `:` inside unescaped braces). Found nowhere else -
  this was the only live instance of this bug class.

## Test plan

- [x] Reproduced the exact pre-fix crash (`NameError: name 'background' is
      not defined`) before making any change
- [x] `graphlink_app/tests/test_command_palette.py`: 4 passed
- [x] Full pytest suite: 575 passed
- [x] `python -m compileall` clean
- [x] Real `ChatWindow` boot in offscreen mode confirming the actual Ctrl+K
      shortcut wiring and real registered commands construct the dialog
      without exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>