### PR TITLE
Add Python-side --gl-* CSS custom property export

### DIFF
--- a/graphlink_app/graphlink_styles.py
+++ b/graphlink_app/graphlink_styles.py
@@ -973,6 +973,130 @@ _FRAME_COLORS_BY_THEME = {
     "muted": MUTED_FRAME_COLORS,
 }
 
+# The one font-family value used everywhere it's explicit in the three QSS
+# templates above (confirmed via `grep -o "font-family:[^;]*;"` - a single
+# distinct declaration, byte-identical to what's already shipping; no
+# per-theme variation exists to preserve). Not every QSS rule sets
+# font-family explicitly (several inherit Qt's platform default instead),
+# so this is "the app's one explicit font choice," not "every font in use."
+FONT_FAMILY = "'Segoe UI', sans-serif"
+
+
+def css_custom_properties(theme_name: str) -> dict[str, str]:
+    """Flatten THEME_TOKENS + the frame-color presets + FONT_FAMILY into
+    --gl-*-named CSS custom properties, for web/Tailwind consumption
+    (section 3.4: "Tailwind preset maps every utility to var(--gl-*))".
+
+    Key names mirror THEME_TOKENS's own existing group/key names, mostly
+    mechanically (kebab-cased), not a redesigned semantic vocabulary (section
+    3.4's prose names one - surfaces bg-0/1/2, text tiers, accent, focus ring
+    - but inventing that naming now, with zero real web consumer to validate
+    it against, risks the exact "one example isn't enough to generalize
+    correctly from" mistake this migration has already avoided elsewhere:
+    see IslandBridge's id-not-path firewall, and the lib/ui/ deferral). Tried
+    the assignment exercise directly before deciding this: there is no clean
+    3-way "bg-0/1/2" split anywhere in the exported groups, and even counting
+    the excluded qss group there are only two distinct chrome-background
+    values per theme, not three - naming that vocabulary today would mean
+    inventing a value, not renaming one. ("Mostly" mechanical, not entirely:
+    the frame-color export does real, small interpretive work - deduping
+    "X"/"X Header" pairs into one token on the verified assumption their
+    colors match, and slugifying human-readable preset names - reasonable,
+    but worth being precise about rather than claiming zero judgment.)
+
+    Reshaping into a real semantic vocabulary is deferred to whichever
+    increment actually retrofits a real island onto it, with real usage to
+    design against. Until then, these mechanical --gl-* names should NOT
+    become a public surface island CSS/TSX consumes directly (nothing
+    currently stops that, e.g. via Tailwind's arbitrary-value syntax) - once
+    real usage depends on the mechanical names, the eventual semantic rename
+    becomes a breaking, repo-wide find-and-replace instead of an additive
+    layer on top of this function's output.
+
+    The "qss"/"qss_alpha" groups are deliberately excluded - those are
+    QSS-only literals for the hand-written Qt stylesheets (window chrome,
+    scrollbars, native widget states), not colors any island's own UI is
+    expected to reuse. Known real gap in that boundary, confirmed by
+    adversarial review, not fixed here: qlineedit_focus__border_color (in
+    the excluded qss group) is the only "focus ring" color anywhere in this
+    file, and qss also holds the only "surface bg"/"primary text" values -
+    two of section 3.4's named concepts have no source data outside the
+    group this function excludes. Whoever builds the semantic layer needs
+    new curated source data for those, not just a rename of what this
+    function already exports.
+    """
+    tokens = THEME_TOKENS[theme_name]
+    included_groups = ("palette", "semantic", "neutral_button", "graph_node")
+    excluded_groups = ("qss", "qss_alpha")
+    # Self-verifying rather than relying solely on a separate test file to
+    # catch drift: if a future edit adds a new top-level THEME_TOKENS group
+    # without deciding whether it belongs in this export, this raises
+    # immediately instead of silently omitting it forever.
+    assert set(tokens) == set(included_groups) | set(excluded_groups), (
+        f"THEME_TOKENS[{theme_name!r}] has group(s) "
+        f"{set(tokens) - set(included_groups) - set(excluded_groups)} that "
+        "css_custom_properties() doesn't know to include or deliberately "
+        "exclude - decide which before extending THEME_TOKENS further."
+    )
+
+    properties: dict[str, str] = {}
+
+    for group in included_groups:
+        group_slug = group.replace("_", "-")
+        for key, value in tokens[group].items():
+            properties[f"--gl-{group_slug}-{key.replace('_', '-')}"] = value
+
+    # Resolved explicitly from each base ("full"-type) entry, never from
+    # whichever of a "X"/"X Header" pair happens to be encountered first in
+    # dict iteration order - if the two ever diverge, this raises rather
+    # than silently exporting whichever one iteration order favored today.
+    frame_colors = _FRAME_COLORS_BY_THEME[theme_name]
+    frame_base_names = {name.removesuffix(" Header") for name in frame_colors}
+    for base_name in frame_base_names:
+        base_color = frame_colors[base_name]["color"]
+        header_name = f"{base_name} Header"
+        if header_name in frame_colors:
+            header_color = frame_colors[header_name]["color"]
+            assert header_color == base_color, (
+                f"{theme_name}: {header_name!r} color {header_color!r} differs from "
+                f"{base_name!r} color {base_color!r} - css_custom_properties()'s "
+                "dedup assumes these always match; decide which one should "
+                "actually be exported before extending this function to cover "
+                "the divergent case."
+            )
+        slug = base_name.lower().replace(" ", "-")
+        properties[f"--gl-frame-{slug}"] = base_color
+
+    properties["--gl-font-family"] = FONT_FAMILY
+
+    for name, value in properties.items():
+        _assert_safe_css_declaration_value(name, value)
+    return properties
+
+
+_UNSAFE_CSS_VALUE_CHARS = (";", "{", "}", "\n", "\r")
+
+
+def _assert_safe_css_declaration_value(property_name: str, value: str) -> None:
+    """css_root_block() interpolates values directly into a CSS text block
+    with no escaping - internal, self-authored data today (never user
+    input), but a typo introducing one of these characters would silently
+    produce syntactically broken or CSS-injected output otherwise. Loud
+    failure here beats a broken :root block discovered later at paint time."""
+    if any(char in value for char in _UNSAFE_CSS_VALUE_CHARS):
+        raise ValueError(
+            f"{property_name} = {value!r} contains a character that would break out "
+            f"of a CSS declaration ({_UNSAFE_CSS_VALUE_CHARS!r}) - fix the source value."
+        )
+
+
+def css_root_block(theme_name: str) -> str:
+    """Render css_custom_properties(theme_name) as a valid CSS `:root { ... }`
+    block, one declaration per line, sorted for a stable/reviewable diff."""
+    properties = css_custom_properties(theme_name)
+    lines = [f"  {name}: {value};" for name, value in sorted(properties.items())]
+    return ":root {\n" + "\n".join(lines) + "\n}\n"
+
 
 class ColorPalette:
     """

--- a/graphlink_app/tests/test_css_custom_properties.py
+++ b/graphlink_app/tests/test_css_custom_properties.py
@@ -1,0 +1,198 @@
+"""Coverage for graphlink_styles.css_custom_properties()/css_root_block()
+(Phase 1 checklist: Tailwind var(--gl-*) preset - Python-side token export,
+split out as its own first slice; see the master plan for the split
+rationale).
+
+This is purely additive - it reads THEME_TOKENS and the frame-color preset
+dicts without modifying either, and no existing function's behavior changes.
+There is no "golden baseline captured before this landed" the way earlier
+token-table increments needed one; the checks here are direct structural and
+round-trip correctness against the live source data instead.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+import graphlink_styles as gs
+
+THEMES = ("dark", "mono", "muted")
+HEX_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+CSS_VAR_NAME_RE = re.compile(r"^--gl-[a-z0-9]+(-[a-z0-9]+)*$")
+
+
+class TestCssCustomPropertiesStructure:
+    @pytest.mark.parametrize("theme_name", THEMES)
+    def test_every_key_is_a_well_formed_css_custom_property_name(self, theme_name):
+        props = gs.css_custom_properties(theme_name)
+        assert len(props) > 0
+        for key in props:
+            assert CSS_VAR_NAME_RE.match(key), f"{key!r} is not a valid --gl-* custom property name"
+
+    @pytest.mark.parametrize("theme_name", THEMES)
+    def test_key_set_is_identical_across_every_theme(self, theme_name):
+        # Different themes must expose the same *shape* (same token names),
+        # only differing in value - a Tailwind preset built against one
+        # theme's key set must work unmodified against every other.
+        assert set(gs.css_custom_properties(theme_name)) == set(gs.css_custom_properties("dark"))
+
+    @pytest.mark.parametrize("theme_name", THEMES)
+    def test_every_value_is_a_flat_hex_color_except_font_family(self, theme_name):
+        props = gs.css_custom_properties(theme_name)
+        for key, value in props.items():
+            if key == "--gl-font-family":
+                continue
+            assert HEX_RE.match(value), f"{key} = {value!r} is not a flat #RRGGBB hex color"
+
+    def test_qss_and_qss_alpha_groups_are_excluded(self):
+        # Those are QSS-only literals for the hand-written Qt stylesheets,
+        # not colors any web island's own UI is expected to reuse.
+        props = gs.css_custom_properties("dark")
+        assert not any(key.startswith("--gl-qss-") for key in props)
+
+
+class TestCssCustomPropertiesRoundTripAgainstThemeTokens:
+    @pytest.mark.parametrize("theme_name", THEMES)
+    @pytest.mark.parametrize("group", ["palette", "semantic", "neutral_button", "graph_node"])
+    def test_every_theme_tokens_value_is_reachable_unmodified(self, theme_name, group):
+        props = gs.css_custom_properties(theme_name)
+        tokens = gs.THEME_TOKENS[theme_name][group]
+        group_slug = group.replace("_", "-")
+        for key, value in tokens.items():
+            css_key = f"--gl-{group_slug}-{key.replace('_', '-')}"
+            assert props.get(css_key) == value, f"{theme_name}.{group}.{key} did not round-trip via {css_key}"
+
+    @pytest.mark.parametrize("theme_name", THEMES)
+    def test_frame_colors_are_deduplicated_by_base_name_not_by_full_or_header_type(self, theme_name):
+        # "X" and "X Header" share the same color in every theme (verified
+        # directly against the source dicts here, not assumed) - the CSS
+        # export should expose one token per base name, not two identical ones.
+        frame_colors = gs._FRAME_COLORS_BY_THEME[theme_name]
+        for name, entry in frame_colors.items():
+            if not name.endswith(" Header"):
+                continue
+            base_entry = frame_colors[name[: -len(" Header")]]
+            assert entry["color"] == base_entry["color"], (
+                f"{theme_name}: {name!r} and its base differ in color - "
+                "the CSS export's Header-dedup assumption doesn't hold here"
+            )
+
+        props = gs.css_custom_properties(theme_name)
+        frame_keys = {k for k in props if k.startswith("--gl-frame-")}
+        expected_base_names = {name.removesuffix(" Header") for name in frame_colors}
+        assert len(frame_keys) == len(expected_base_names)
+
+    @pytest.mark.parametrize("theme_name", THEMES)
+    def test_every_frame_color_value_matches_its_source_dict(self, theme_name):
+        props = gs.css_custom_properties(theme_name)
+        for name, entry in gs._FRAME_COLORS_BY_THEME[theme_name].items():
+            base = name.removesuffix(" Header")
+            slug = base.lower().replace(" ", "-")
+            assert props[f"--gl-frame-{slug}"] == entry["color"]
+
+    def test_font_family_matches_the_shared_constant(self):
+        for theme_name in THEMES:
+            assert gs.css_custom_properties(theme_name)["--gl-font-family"] == gs.FONT_FAMILY
+
+    @pytest.mark.parametrize("theme_name", THEMES)
+    def test_total_property_count_has_no_missing_or_extra_keys(self, theme_name):
+        tokens = gs.THEME_TOKENS[theme_name]
+        expected_group_count = sum(len(tokens[g]) for g in ("palette", "semantic", "neutral_button", "graph_node"))
+        expected_frame_count = len({name.removesuffix(" Header") for name in gs._FRAME_COLORS_BY_THEME[theme_name]})
+        expected_total = expected_group_count + expected_frame_count + 1  # +1 for --gl-font-family
+        assert len(gs.css_custom_properties(theme_name)) == expected_total
+
+
+class TestCssRootBlock:
+    @pytest.mark.parametrize("theme_name", THEMES)
+    def test_is_syntactically_a_single_root_block(self, theme_name):
+        block = gs.css_root_block(theme_name)
+        assert block.startswith(":root {\n")
+        assert block.rstrip().endswith("}")
+        assert block.count(":root") == 1
+        assert block.count("{") == 1
+        assert block.count("}") == 1
+
+    @pytest.mark.parametrize("theme_name", THEMES)
+    def test_every_property_appears_exactly_once_with_a_terminating_semicolon(self, theme_name):
+        props = gs.css_custom_properties(theme_name)
+        block = gs.css_root_block(theme_name)
+        assert block.count(";") == len(props)
+        for key, value in props.items():
+            assert f"{key}: {value};" in block
+
+    @pytest.mark.parametrize("theme_name", THEMES)
+    def test_is_deterministic_and_sorted(self, theme_name):
+        first = gs.css_root_block(theme_name)
+        second = gs.css_root_block(theme_name)
+        assert first == second
+
+        declared_names = re.findall(r"^\s*(--gl-[a-z0-9-]+):", first, re.MULTILINE)
+        assert declared_names == sorted(declared_names)
+
+    def test_different_themes_produce_different_blocks(self):
+        blocks = {theme_name: gs.css_root_block(theme_name) for theme_name in THEMES}
+        assert blocks["dark"] != blocks["mono"] != blocks["muted"] != blocks["dark"]
+
+
+class TestSafetyGuards:
+    """Regression coverage for three gaps an adversarial review found and
+    fixed in the same change: the frame-color dedup silently trusting dict
+    iteration order instead of asserting the assumption it depends on, no
+    validation against a CSS-breaking character in any exported value, and
+    no self-check that THEME_TOKENS's group set is fully accounted for
+    (included or deliberately excluded)."""
+
+    def test_frame_color_header_variant_diverging_from_base_raises(self, monkeypatch):
+        diverged = {
+            key: dict(value) for key, value in gs.DARK_FRAME_COLORS.items()
+        }
+        diverged["Green Header"] = {"color": "#ff00ff", "type": "header"}
+        monkeypatch.setitem(gs._FRAME_COLORS_BY_THEME, "dark", diverged)
+
+        with pytest.raises(AssertionError, match="Green Header"):
+            gs.css_custom_properties("dark")
+
+    def test_frame_color_dedup_is_independent_of_dict_iteration_order(self, monkeypatch):
+        # Same data, header entries listed first - must resolve to the exact
+        # same output as base-first order, not whichever is encountered first.
+        reordered = dict(reversed(list(gs.DARK_FRAME_COLORS.items())))
+        monkeypatch.setitem(gs._FRAME_COLORS_BY_THEME, "dark", reordered)
+        assert gs.css_custom_properties("dark") == gs.css_custom_properties("dark")
+        # And matches the un-reordered result's frame values exactly.
+        reordered_result = {
+            k: v for k, v in gs.css_custom_properties("dark").items() if k.startswith("--gl-frame-")
+        }
+        monkeypatch.setitem(gs._FRAME_COLORS_BY_THEME, "dark", gs.DARK_FRAME_COLORS)
+        original_result = {
+            k: v for k, v in gs.css_custom_properties("dark").items() if k.startswith("--gl-frame-")
+        }
+        assert reordered_result == original_result
+
+    @pytest.mark.parametrize("bad_char", [";", "{", "}", "\n", "\r"])
+    def test_a_css_breaking_character_in_a_token_value_raises(self, monkeypatch, bad_char):
+        tampered = dict(gs.THEME_TOKENS["dark"])
+        tampered_palette = dict(tampered["palette"])
+        tampered_palette["user_node"] = f"#838383{bad_char}injected"
+        tampered["palette"] = tampered_palette
+        monkeypatch.setitem(gs.THEME_TOKENS, "dark", tampered)
+
+        with pytest.raises(ValueError, match="injected"):
+            gs.css_custom_properties("dark")
+
+    def test_font_family_containing_a_css_breaking_character_raises(self, monkeypatch):
+        monkeypatch.setattr(gs, "FONT_FAMILY", "Segoe UI; } body { color: red")
+        with pytest.raises(ValueError):
+            gs.css_custom_properties("dark")
+
+    def test_an_unaccounted_theme_tokens_group_raises(self, monkeypatch):
+        tampered = dict(gs.THEME_TOKENS["dark"])
+        tampered["accent"] = {"primary": "#123456"}
+        monkeypatch.setitem(gs.THEME_TOKENS, "dark", tampered)
+
+        with pytest.raises(AssertionError, match="accent"):
+            gs.css_custom_properties("dark")


### PR DESCRIPTION
Adds `graphlink_styles.py::css_custom_properties(theme_name)` and
`css_root_block(theme_name)`, flattening `THEME_TOKENS`'s
`palette`/`semantic`/`neutral_button`/`graph_node` groups plus the three
`*_FRAME_COLORS` presets plus a new `FONT_FAMILY` constant into
`--gl-*`-named CSS custom properties, for eventual Tailwind/web consumption
(section 3.4: "Tailwind preset maps every utility to `var(--gl-*)`"). Purely
additive - no existing function's behavior changes; `StyleSheet`,
`THEME_TOKENS`, `ColorPalette`, and `graphlink_config.py`'s accessor
functions are all untouched.

Key names mirror `THEME_TOKENS`'s own existing names mechanically (kebab-
cased), not the "surfaces bg-0/1/2, text tiers, accent, focus ring" semantic
vocabulary the plan's prose describes. Verified directly before deciding
this - there is no clean 3-way "bg-0/1/2" split anywhere in the exported
groups, and even counting the excluded `qss` group there are only two
distinct chrome-background values per theme, not three, so naming that
vocabulary now would mean inventing a value, not renaming one. Deferred to
whichever change retrofits a real island onto it, with real usage to design
against.

Split out from the full "Tailwind installed, preset mapped to `var(--gl-*)`;
composer retrofitted to tokens+Tailwind; before/after screenshots" scope as
its dependency-free first slice - this piece has zero callers anywhere in
the app yet; it's the one piece of a five-piece pipeline (install, preset,
build-time embedding, composer retrofit, lint ban, screenshots) that needed
neither npm nor a design decision to build safely.

## Review findings addressed

Two adversarial reviews found and fixed three real issues by simulating
failure conditions rather than only reading code:

- The `"X"`/`"X Header"` frame-color dedup relied on dict iteration order
  with no explicit tie-break (simulating a value divergence produced a
  silently wrong export).
- Zero CSS-injection safety in the root-block renderer (simulating an
  injected value produced broken/injected CSS with nothing catching it).
- No self-check that `THEME_TOKENS`'s full group set was accounted for.

All three fixed with explicit assertions and covered by 9 new regression
tests that reproduce each failure condition directly.

The reviews also traced real ground truth for the deferred composer
retrofit (diffing composer's 19 distinct hex colors against every token this
migration has ever produced: only 2 match anything, meaning that work is a
design/reconciliation pass, not a mechanical swap) and flagged a real gap in
the `qss`/`qss_alpha` exclusion (it excludes the only source data for "focus
ring" and "surface bg," two concepts the plan names) plus a future-breakage
risk if island CSS is ever allowed to consume the mechanical names directly
before a semantic layer exists - both recorded in the function's docstring
for whoever builds the preset next.

## Test plan

- [x] `python -m compileall` clean
- [x] Full pytest suite: 662 passed (653 + 9 new)
- [x] Independent hand-derivation of the full "dark" theme output matched
      the real function output byte-for-byte
- [x] Diff confirmed zero changes to `StyleSheet`, `THEME_TOKENS`,
      `ColorPalette`, or `graphlink_config.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>