### PR TITLE
Embed current-theme --gl-* :root block into island HTML at construction time

### DIFF
--- a/graphlink_app/graphlink_styles.py
+++ b/graphlink_app/graphlink_styles.py
@@ -1074,7 +1074,7 @@ def css_custom_properties(theme_name: str) -> dict[str, str]:
     return properties
 
 
-_UNSAFE_CSS_VALUE_CHARS = (";", "{", "}", "\n", "\r")
+_UNSAFE_CSS_VALUE_CHARS = (";", "{", "}", "\n", "\r", "<", ">")
 
 
 def _assert_safe_css_declaration_value(property_name: str, value: str) -> None:
@@ -1082,7 +1082,18 @@ def _assert_safe_css_declaration_value(property_name: str, value: str) -> None:
     with no escaping - internal, self-authored data today (never user
     input), but a typo introducing one of these characters would silently
     produce syntactically broken or CSS-injected output otherwise. Loud
-    failure here beats a broken :root block discovered later at paint time."""
+    failure here beats a broken :root block discovered later at paint time.
+
+    `<`/`>` are included alongside the original CSS-breaking set because
+    css_root_block()'s output is no longer only ever consumed as CSS syntax -
+    graphlink_web_island_host.py's _inline_bundle() now embeds it directly
+    into an HTML <style> raw-text element. A value containing the literal
+    sequence `</style` there would prematurely close the style element in
+    HTML parsing, and this page's CSP (script-src 'unsafe-inline') would let
+    a broken-out inline <script> actually execute rather than render as
+    inert text. Blocking `<`/`>` entirely is simpler and safer than only
+    blocking the exact `</style` substring, and costs nothing today - no
+    THEME_TOKENS value has ever contained either character."""
     if any(char in value for char in _UNSAFE_CSS_VALUE_CHARS):
         raise ValueError(
             f"{property_name} = {value!r} contains a character that would break out "

--- a/graphlink_app/graphlink_web_island_host.py
+++ b/graphlink_app/graphlink_web_island_host.py
@@ -31,7 +31,9 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
+import graphlink_config as config
 from graphlink_paths import asset_path
+from graphlink_styles import css_root_block
 
 try:
     from PySide6.QtWebChannel import QWebChannel
@@ -46,7 +48,22 @@ except ImportError:
 
 
 def _inline_bundle(asset_root: Path) -> str:
-    """Inline the Vite output so the page has no file:// or network dependency."""
+    """Inline the Vite output so the page has no file:// or network dependency.
+
+    Also embeds a `:root { --gl-*: ...; }` block for the current app theme
+    (config.CURRENT_THEME) directly into <head>, ahead of the island's own
+    built stylesheet - so any var(--gl-*) reference in island CSS resolves to
+    a real value from first paint, before QWebChannel connects or the bridge
+    ever calls publish(). Without this, an island CSS rule referencing
+    var(--gl-*) would render unstyled (the property is simply undefined)
+    until some later JS-side mechanism sets it - a gap that still exists
+    separately (nothing today writes --gl-* onto document.documentElement at
+    runtime for live theme switching; this only covers the value present at
+    construction time). Same trust-CURRENT_THEME convention already used
+    throughout the app (e.g. graphlink_composer_bridge.py's _theme()) - not
+    defensive against an invalid theme name, since apply_theme() is the one
+    place that guarantees CURRENT_THEME is valid.
+    """
     index_path = asset_root / "index.html"
     if not index_path.is_file():
         return (
@@ -95,7 +112,8 @@ def _inline_bundle(asset_root: Path) -> str:
         'script-src \'unsafe-inline\' qrc:; style-src \'unsafe-inline\'; img-src data:; '
         'connect-src \'none\';">'
     )
-    document = document.replace("<head>", f"<head>{csp}", 1)
+    theme_root_style = f"<style>{css_root_block(config.CURRENT_THEME)}</style>"
+    document = document.replace("<head>", f"<head>{csp}{theme_root_style}", 1)
     channel_script = '<script src="qrc:///qtwebchannel/qwebchannel.js"></script>'
     document = document.replace("</head>", f"{channel_script}</head>", 1)
     return document

--- a/graphlink_app/tests/test_composer_bridge.py
+++ b/graphlink_app/tests/test_composer_bridge.py
@@ -17,6 +17,8 @@ from graphlink_composer_popups import (
     composer_picker_list_height,
     composer_picker_position,
 )
+import graphlink_config as config
+from graphlink_styles import css_root_block
 from graphlink_web_island_host import _inline_bundle, _rounded_region
 
 
@@ -272,3 +274,34 @@ def test_inline_bundle_is_self_contained_and_keeps_channel_local():
     assert "./assets/" not in document
     assert "qrc:///qtwebchannel/qwebchannel.js" in document
     assert "Content-Security-Policy" in document
+
+
+def test_inline_bundle_embeds_the_current_theme_root_block_byte_exact():
+    root = Path(__file__).resolve().parents[2] / "assets" / "composer"
+    document = _inline_bundle(root)
+
+    assert css_root_block(config.CURRENT_THEME) in document
+
+
+def test_inline_bundle_theme_root_block_precedes_the_built_stylesheet():
+    root = Path(__file__).resolve().parents[2] / "assets" / "composer"
+    document = _inline_bundle(root)
+
+    root_block_index = document.index(css_root_block(config.CURRENT_THEME))
+    built_stylesheet_index = document.index("<style>", root_block_index + 1)
+    assert root_block_index < built_stylesheet_index
+
+
+def test_inline_bundle_follows_current_theme_not_a_hardcoded_one(monkeypatch):
+    root = Path(__file__).resolve().parents[2] / "assets" / "composer"
+
+    monkeypatch.setattr(config, "CURRENT_THEME", "mono")
+    mono_document = _inline_bundle(root)
+
+    monkeypatch.setattr(config, "CURRENT_THEME", "muted")
+    muted_document = _inline_bundle(root)
+
+    assert css_root_block("mono") in mono_document
+    assert css_root_block("mono") not in muted_document
+    assert css_root_block("muted") in muted_document
+    assert css_root_block("muted") not in mono_document

--- a/graphlink_app/tests/test_css_custom_properties.py
+++ b/graphlink_app/tests/test_css_custom_properties.py
@@ -173,7 +173,7 @@ class TestSafetyGuards:
         }
         assert reordered_result == original_result
 
-    @pytest.mark.parametrize("bad_char", [";", "{", "}", "\n", "\r"])
+    @pytest.mark.parametrize("bad_char", [";", "{", "}", "\n", "\r", "<", ">"])
     def test_a_css_breaking_character_in_a_token_value_raises(self, monkeypatch, bad_char):
         tampered = dict(gs.THEME_TOKENS["dark"])
         tampered_palette = dict(tampered["palette"])


### PR DESCRIPTION
`_inline_bundle()` now injects `css_root_block(config.CURRENT_THEME)` into
every `WebIslandHost`'s inlined `<head>`, ahead of the island's own built
stylesheet, so any `var(--gl-*)` reference resolves to a real value from
first paint rather than the property's undefined initial value. Placed at
the generic host layer rather than composer-specifically, matching the
module's own stated design ("owns... asset loading... every current and
future island needs") - composer is simply the only island that exists yet.

This is the build-time half of the token pipeline the two prior PRs (#37's
`css_custom_properties()` export, #38's Tailwind `@theme` preset) set up.
It needed **no new Python-to-Vite build integration point** - the planning
note that assumed one was written before anyone had read `_inline_bundle()`,
which already does exactly this kind of `<head>` injection for the CSP meta
tag and the QWebChannel script tag. The change is a ~3-line addition to an
existing function.

Zero visual change today: composer's CSS contains no `var(--gl-*)`
reference yet (verified by grep), so nothing consumes the embedded block.
It becomes load-bearing the moment the composer CSS retrofit adds the first
one - without it, every such reference would render unstyled.

Deliberately **not** included: runtime live-theme-switch wiring (nothing
writes `--gl-*` onto `document.documentElement` when the theme changes
while running). Confirmed safe to defer by tracing the full
`apply_theme()` → `on_theme_changed()` → `bridge.publish()` chain:
composer has **zero live theme-reactivity today** - its CSS is entirely
hardcoded hex, independent of the active theme - so there is no existing
behavior for this gap to regress. It is a separate, later increment.

## Safety-net gap found by review and fixed here

`_assert_safe_css_declaration_value()`'s injection guard was written when
`css_root_block()`'s output was only ever consumed as CSS syntax; it blocks
`;` `{` `}` `\n` `\r` but not `<` or `>`. That output now also flows into an
HTML `<style>` raw-text element, where a value containing `</style` would
prematurely close the tag - and since this page's CSP permits
`script-src 'unsafe-inline'`, a broken-out `<script>` would actually
execute rather than render as inert text. Not exploitable with any current
value (every `THEME_TOKENS` entry and `FONT_FAMILY` is a static hex /
`rgba()` / font-name literal, never user input, and none contains `<` or
`>`), but a real dormant gap in a guard now implicitly relied on for a
context it wasn't written to cover. Fixed by widening
`_UNSAFE_CSS_VALUE_CHARS`, extending the existing parametrized regression
test rather than adding a parallel one.

## Verification

Zero behavior change to existing paths was proven empirically, not by
inspection: the pre-change and post-change `_inline_bundle()` outputs were
generated against the real `assets/composer` bundle, the new `:root` block
string stripped back out of the latter, and the remainders compared -
byte-identical (158207 bytes both sides). This rules out any shift in the
CSP tag, channel script, or composer's own inlined CSS/JS as a side effect
of the combined `.replace()` call.

## Test plan

- [x] `python -m compileall` clean
- [x] Full pytest suite: 672 passed (667 + 3 new + 2 new parametrized cases)
- [x] New tests run against the real built `assets/composer`, not a mock
- [x] Document order verified (theme block precedes the built stylesheet)
- [x] `CURRENT_THEME` responsiveness verified across dark/mono/muted
- [x] Real generated `<head>` inspected directly, not only asserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>