### PR TITLE
Add live dev-server-in-window path; fix fail-open WebEngine interceptor

### DIFF
--- a/graphlink_app/graphlink_frontend_bootstrap.py
+++ b/graphlink_app/graphlink_frontend_bootstrap.py
@@ -17,13 +17,17 @@ hard no-op the moment sys.frozen is set, checked before anything else here
 runs.
 """
 
+import logging
 import os
 import subprocess
 import shutil
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from graphlink_paths import ASSETS_DIR, REPO_ROOT
+
+logger = logging.getLogger(__name__)
 
 WEB_UI_DIR = REPO_ROOT / "web_ui"
 
@@ -52,6 +56,34 @@ _STALENESS_IGNORED_FILENAME_MARKERS = (
 
 DEV_MODE_ENV_VAR = "GRAPHLINK_FRONTEND_DEV"
 
+# Second, independent opt-in for the live dev-server-in-window path: the exact
+# origin (e.g. "http://127.0.0.1:5173") WebIslandHost should load instead of
+# the offline inlined bundle. Deliberately a SEPARATE variable from
+# DEV_MODE_ENV_VAR rather than derived from it: "skip npm orchestration" and
+# "point the app's own webview at a live local server" are different trust
+# decisions (the second relaxes the WebEngine network sandbox), and a single
+# leaked/inherited env var must never activate both. Both must be set for the
+# live path to engage - see resolve_dev_server_origin().
+DEV_SERVER_URL_ENV_VAR = "GRAPHLINK_FRONTEND_DEV_URL"
+
+# The live path only ever targets a loopback Vite dev server; anything else is
+# a misconfiguration (or an attempt to point the sandboxed webview somewhere
+# it must never go) and fails closed.
+_DEV_SERVER_ALLOWED_HOSTS = frozenset({"127.0.0.1", "localhost"})
+
+# One-shot guard for resolve_dev_server_origin()'s misconfiguration warnings:
+# the WebEngine request interceptor re-resolves the origin on every
+# intercepted request (see graphlink_webengine.py), so an unguarded
+# logger.warning here would repeat once per subresource request.
+_warned_dev_url_issues: set[str] = set()
+
+
+def _warn_once(key: str, message: str, *args) -> None:
+    if key in _warned_dev_url_issues:
+        return
+    _warned_dev_url_issues.add(key)
+    logger.warning(message, *args)
+
 
 class FrontendBootstrapError(RuntimeError):
     """An actionable, user-facing frontend bootstrap failure.
@@ -70,14 +102,71 @@ def _dev_mode_requested() -> bool:
     """True if GRAPHLINK_FRONTEND_DEV is set to a truthy value.
 
     Opt-in escape hatch for a developer already running `npm run dev`
-    themselves in a separate terminal (real HMR, via a real browser tab
-    today - WebIslandHost has no live-dev-server loading mode yet, only
-    the inlined-bundle path `_inline_bundle()` reads from disk). Setting
-    this skips the build-orchestration below entirely, so the app launches
-    immediately against whatever assets/ already has, without this module
-    fighting the developer's own build loop.
+    themselves in a separate terminal. Setting this skips the
+    build-orchestration below entirely, so the app launches immediately
+    against whatever assets/ already has, without this module fighting the
+    developer's own build loop. Set ALONE, the app still loads the offline
+    inlined bundle; additionally setting GRAPHLINK_FRONTEND_DEV_URL points
+    the app's own window at the live dev server for in-app HMR - see
+    resolve_dev_server_origin().
     """
     return os.environ.get(DEV_MODE_ENV_VAR, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def resolve_dev_server_origin() -> str | None:
+    """The exact origin ("http://host:port") a live WebIslandHost load may
+    target, or None if the live-URL path is inactive.
+
+    Requires BOTH env vars: GRAPHLINK_FRONTEND_DEV (its meaning above is
+    unchanged - build-orchestration skip) and GRAPHLINK_FRONTEND_DEV_URL.
+    GRAPHLINK_FRONTEND_DEV alone is today's normal dev loop and stays
+    silent; GRAPHLINK_FRONTEND_DEV_URL alone is a likely misconfiguration
+    and is warned about (once), not guessed at. The URL itself must be a
+    plain http origin on a loopback host with an explicit port - anything
+    else fails closed with a warning. A missing port is invalid rather than
+    defaulted to 80: Vite is never on port 80, so guessing there would fail
+    closed permanently and silently instead of surfacing the real mistake.
+
+    Never returns non-None in a frozen build - checked first, before any
+    env var is even read, mirroring ensure_frontend_built()'s hard bypass.
+    graphlink_webengine.preview_url_is_allowed() independently re-checks
+    sys.frozen on its own side as well; neither module trusts the other to
+    have gated this (same defense-in-depth convention as graphlink_paths'
+    local frozen re-derivation).
+    """
+    if _is_frozen():
+        return None
+    raw_url = os.environ.get(DEV_SERVER_URL_ENV_VAR, "").strip()
+    if not raw_url:
+        return None
+    if not _dev_mode_requested():
+        _warn_once(
+            "url-without-flag",
+            "%s is set but %s is not; both are required to load the live dev "
+            "server in-window. The offline bundle will load instead.",
+            DEV_SERVER_URL_ENV_VAR,
+            DEV_MODE_ENV_VAR,
+        )
+        return None
+    try:
+        parsed = urlsplit(raw_url)
+        host = (parsed.hostname or "").lower()
+        port = parsed.port
+        scheme = parsed.scheme
+    except ValueError:
+        host, port, scheme = "", None, ""
+    # port 0 is not a real listen port; treat it as "no explicit port" so a
+    # stray http://127.0.0.1:0 fails closed rather than yielding a dead origin.
+    if scheme != "http" or host not in _DEV_SERVER_ALLOWED_HOSTS or not port:
+        _warn_once(
+            f"invalid-url:{raw_url}",
+            "%s=%r is not a valid http://127.0.0.1:<port> origin. The offline "
+            "bundle will load instead.",
+            DEV_SERVER_URL_ENV_VAR,
+            raw_url,
+        )
+        return None
+    return f"http://{host}:{port}"
 
 
 def discover_islands() -> list[str]:

--- a/graphlink_app/graphlink_web_island_host.py
+++ b/graphlink_app/graphlink_web_island_host.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from PySide6.QtCore import QRect, QUrl, Qt, Signal
+from PySide6.QtCore import QFile, QIODevice, QRect, QUrl, Qt, Signal
 from PySide6.QtGui import QColor, QRegion
 from PySide6.QtWidgets import (
     QApplication,
@@ -32,16 +32,19 @@ from PySide6.QtWidgets import (
 )
 
 import graphlink_config as config
+from graphlink_frontend_bootstrap import resolve_dev_server_origin
 from graphlink_paths import asset_path
 from graphlink_styles import css_root_block
 
 try:
     from PySide6.QtWebChannel import QWebChannel
+    from PySide6.QtWebEngineCore import QWebEngineScript
     from PySide6.QtWebEngineWidgets import QWebEngineView
 
     from graphlink_webengine import WEBENGINE_AVAILABLE, _harden_preview_web_view
 except ImportError:
     QWebChannel = None
+    QWebEngineScript = None
     QWebEngineView = None
     WEBENGINE_AVAILABLE = False
     _harden_preview_web_view = None
@@ -174,6 +177,49 @@ def _inline_bundle(asset_root: Path) -> str:
     channel_script = '<script src="qrc:///qtwebchannel/qwebchannel.js"></script>'
     document = document.replace("</head>", f"{channel_script}</head>", 1)
     return document
+
+
+def _qwebchannel_injection_script():
+    """Live-URL equivalent of _inline_bundle()'s injected
+    <script src="qrc:///qtwebchannel/qwebchannel.js"> tag.
+
+    Vite's own served index.html has no such tag and must not gain one -
+    web_ui/ stays Qt-agnostic. The injection point must be DocumentCreation
+    (before ANY page script runs, including deferred module scripts): the
+    island's bridge.ts checks isQWebChannelAvailable() exactly once,
+    synchronously, when main.tsx's module script executes, and permanently
+    falls back to its mock bridge if window.QWebChannel is absent at that
+    moment. Injecting later (e.g. runJavaScript after loadFinished) would
+    "work" without error while the composer silently ran disconnected from
+    Python forever.
+
+    Returned script must be added to the PAGE's script collection
+    (page().scripts()), never the shared profile's - _PREVIEW_PROFILE is
+    shared with the HTML-renderer node preview, which renders untrusted
+    markup and must never be handed a QWebChannel bootstrap it didn't ask
+    for. Each WebIslandHost constructs its own QWebEnginePage, so
+    page-scoped scripts can't leak across surfaces.
+    """
+    qfile = QFile(":/qtwebchannel/qwebchannel.js")
+    if not qfile.open(QIODevice.OpenModeFlag.ReadOnly):
+        raise RuntimeError(
+            "qrc:///qtwebchannel/qwebchannel.js could not be read from Qt's "
+            "resource system - QtWebChannel appears not to be loaded. The "
+            "live dev-server page cannot be wired to the Python bridge "
+            "without it, and proceeding would silently run the island on "
+            "its mock bridge instead."
+        )
+    try:
+        source = bytes(qfile.readAll()).decode("utf-8")
+    finally:
+        qfile.close()
+    script = QWebEngineScript()
+    script.setName("qwebchannel-bootstrap")
+    script.setSourceCode(source)
+    script.setInjectionPoint(QWebEngineScript.InjectionPoint.DocumentCreation)
+    script.setWorldId(QWebEngineScript.ScriptWorldId.MainWorld)
+    script.setRunsOnSubFrames(False)
+    return script
 
 
 def _rounded_region(rect: QRect, radius: int) -> QRegion:
@@ -311,6 +357,11 @@ class WebIslandHost(QFrame):
         self._min_height = min_height
         self._max_height = max_height
         self._shutdown_started = False
+        # Resolved once at construction (unlike the request interceptor's
+        # per-request re-resolution): a host is not a forever-cached
+        # singleton, and its load mode must not change out from under an
+        # already-loaded page.
+        self._dev_origin = resolve_dev_server_origin()
 
         self.setObjectName(f"{bridge_object_name}Host")
         if min_height is not None:
@@ -338,14 +389,29 @@ class WebIslandHost(QFrame):
             self.web_view = QWebEngineView(self)
             self.web_view.setStyleSheet("background: transparent; border: 0;")
             self.web_view.page().setBackgroundColor(QColor(0, 0, 0, 0))
-            _harden_preview_web_view(self.web_view)
+            # Live-dev hosts get the dedicated dev-server profile; every other
+            # surface (offline composer, HTML-renderer preview) stays on the
+            # unconditionally-offline profile. self._dev_origin is None unless
+            # both opt-in env vars are set and this isn't a frozen build, so a
+            # shipped build always takes the offline profile here.
+            _harden_preview_web_view(
+                self.web_view, allow_dev_server=self._dev_origin is not None
+            )
             channel = QWebChannel(self.web_view.page())
             channel.registerObject(bridge_object_name, self.bridge)
             self.web_view.page().setWebChannel(channel)
-            self.web_view.loadFinished.connect(lambda _ok: self.bridge.publish())
-            self.web_view.setHtml(
-                _inline_bundle(asset_path(asset_dir_name)), QUrl("about:blank")
-            )
+            self.web_view.loadFinished.connect(self._on_load_finished)
+            if self._dev_origin is not None:
+                # Live dev-server mode (developer opt-in, double-gated - see
+                # resolve_dev_server_origin). The request interceptor
+                # independently allowlists exactly this origin; everything
+                # else stays blocked as in the offline path.
+                self.web_view.page().scripts().insert(_qwebchannel_injection_script())
+                self.web_view.setUrl(QUrl(self._dev_origin))
+            else:
+                self.web_view.setHtml(
+                    _inline_bundle(asset_path(asset_dir_name)), QUrl("about:blank")
+                )
             layout.addWidget(self.web_view)
         else:
             fallback = QLabel(unavailable_message, self)
@@ -375,6 +441,40 @@ class WebIslandHost(QFrame):
         return self.web_view or super().focusWidget()
 
     def on_theme_changed(self):
+        self.bridge.publish()
+
+    def _on_load_finished(self, ok: bool) -> None:
+        """Publish on load, or - in live dev-server mode only - replace
+        Chromium's generic error page with an actionable one when the dev
+        server isn't answering.
+
+        Deliberately does NOT exit the process the way a
+        FrontendBootstrapError does: that failure is pre-window and
+        unrecoverable, while this one is mid-session and fixed by starting
+        the server - exiting would make the live path strictly worse than
+        the separate-browser-tab workflow it replaces. No pre-flight TCP
+        probe either; loadFinished is Qt's own single source of truth for
+        whether the load worked. The offline path's behavior is unchanged:
+        publish regardless of ok, exactly as before.
+        """
+        # prepare_for_shutdown() calls web_view.stop(), which aborts an
+        # in-flight load and fires loadFinished(False). Without this guard a
+        # teardown mid-load would kick off a brand-new setHtml() during
+        # shutdown - starting work exactly when the host is being torn down.
+        if self._shutdown_started:
+            return
+        if not ok and self._dev_origin is not None:
+            self.web_view.setHtml(
+                "<!doctype html><html><body style=\"font-family:sans-serif;"
+                "padding:2rem\">"
+                f"<h2>Could not reach {self._dev_origin}</h2>"
+                "<p>GRAPHLINK_FRONTEND_DEV_URL is set but nothing answered "
+                "there. Run <code>npm run dev</code> in web_ui/, then reopen "
+                "this window - or unset GRAPHLINK_FRONTEND_DEV_URL to load "
+                "the offline bundle instead.</p></body></html>",
+                QUrl("about:blank"),
+            )
+            return
         self.bridge.publish()
 
     def apply_requested_height(self, height: int) -> None:

--- a/graphlink_app/graphlink_webengine.py
+++ b/graphlink_app/graphlink_webengine.py
@@ -6,7 +6,37 @@ show may reach the network or the local disk. This module owns that guarantee in
 one place - the offline, local-only sandbox profile and interceptor - so it is
 proven once and every WebEngine surface inherits it instead of re-implementing
 its own escape hatch.
+
+One narrow, developer-only exception exists: when BOTH GRAPHLINK_FRONTEND_DEV
+and GRAPHLINK_FRONTEND_DEV_URL are set (see
+graphlink_frontend_bootstrap.resolve_dev_server_origin), requests to that one
+exact loopback origin (http and its ws HMR upgrade, nothing else) are also
+allowed, so WebIslandHost can load the live Vite dev server in-window.
+
+That exception lives on a SEPARATE profile (_get_dev_server_profile), used
+only by a WebIslandHost that is actually in live mode. The shared offline
+profile (_get_offline_profile) - which backs the composer's normal offline
+mode AND the HTML-renderer node preview, the latter rendering untrusted
+AI-generated markup - never consults the dev origin at all: its interceptor is
+constructed with allow_dev_server=False and is unconditionally offline. This is
+structural, not a per-request heuristic: an untrusted surface cannot reach the
+dev server because its profile's interceptor never even asks whether a dev
+origin exists. (A single shared profile can't express this - a
+QWebEngineUrlRequestInterceptor can only block, never un-block, so a per-page
+interceptor cannot re-add a permission the profile interceptor denied.)
+
+The exception is additionally gated on sys.frozen three ways over:
+resolve_dev_server_origin() refuses to produce an origin in a frozen build; a
+live host therefore never opts into the dev profile when frozen; and
+preview_url_is_allowed() below independently ignores any dev_origin it is
+handed while frozen. No caller mistake can reopen the sandbox in a shipped
+build.
 """
+
+import sys
+from urllib.parse import urlsplit
+
+from graphlink_frontend_bootstrap import resolve_dev_server_origin
 
 try:
     from PySide6.QtWidgets import QApplication
@@ -28,8 +58,14 @@ except ImportError:
 # localhost/intranet/disk.
 _LOCAL_PREVIEW_SCHEMES = frozenset({"about", "data", "blob", "qrc"})
 
+# The only schemes the developer-opt-in live path may add on top: plain http to
+# the dev server, plus the WebSocket upgrade Vite's HMR client opens against
+# that same origin (without which nothing tells the page a file changed and
+# "hot reload" silently degrades to "stale until manually reloaded").
+_DEV_SERVER_SCHEMES = frozenset({"http", "ws"})
 
-def preview_url_is_allowed(url):
+
+def preview_url_is_allowed(url, dev_origin=None):
     """Whether a sub-resource/navigation request from a hardened view may proceed.
 
     Every surface that uses this module renders content that isn't fully trusted: the
@@ -39,56 +75,151 @@ def preview_url_is_allowed(url):
     (SSRF/CSRF from their network position). We treat every hardened view as an offline
     sandbox: only local, self-contained schemes are permitted; any request that would
     leave the machine is blocked.
+
+    dev_origin, when not None, is the ONE exact extra origin ("http://host:port",
+    from resolve_dev_server_origin()) whose http/ws requests are additionally
+    allowed - an exact scheme+host+port match, never a host- or port-wildcard, so
+    a compromised process on another loopback port (or Vite silently drifting to
+    5174 when 5173 is taken - prevented separately by strictPort in
+    vite.config.ts) gains nothing. The default None is byte-for-byte the
+    pre-existing offline behavior. Ignored entirely in a frozen build regardless
+    of what the caller passes - this module does not trust its callers to have
+    gated that.
     """
     try:
         scheme = (url.scheme() or "").lower()
     except AttributeError:
         return False
-    return scheme in _LOCAL_PREVIEW_SCHEMES
+    if scheme in _LOCAL_PREVIEW_SCHEMES:
+        return True
+    if not dev_origin or getattr(sys, "frozen", False):
+        return False
+    if scheme not in _DEV_SERVER_SCHEMES:
+        return False
+    try:
+        host = (url.host() or "").lower()
+        port = url.port(-1)
+    except AttributeError:
+        return False
+    # dev_origin's shape is not trusted (the docstring says so): a malformed
+    # value must fail CLOSED, never raise. urlsplit(...).port raises
+    # ValueError on a bad port, and this runs on the interceptor's IO thread
+    # where an unhandled exception is swallowed-and-printed by PySide and the
+    # request would proceed unblocked - the exact fail-open shape this module
+    # exists to prevent.
+    try:
+        dev = urlsplit(dev_origin)
+        dev_host = (dev.hostname or "").lower()
+        dev_port = dev.port
+    except ValueError:
+        return False
+    return host == dev_host and port == dev_port
+
+
+def _request_should_be_blocked(url, *, allow_dev_server: bool = False) -> bool:
+    """The interceptor's actual per-request decision, factored out of the Qt
+    class so the full env-var-to-verdict chain is testable without a live
+    WebEngine context (QWebEngineUrlRequestInfo can't be constructed by hand).
+
+    allow_dev_server distinguishes the two profiles: the offline profile's
+    interceptor passes False and can NEVER reach the dev server (it doesn't
+    even resolve the origin); only the dedicated dev-server profile's
+    interceptor passes True. When True the dev origin is re-resolved on EVERY
+    call, deliberately: the profile and its interceptor are a lazily-created,
+    forever-cached process-wide singleton, so anything baked in at
+    construction time would never re-evaluate for the process's lifetime.
+    """
+    dev_origin = resolve_dev_server_origin() if allow_dev_server else None
+    return not preview_url_is_allowed(url, dev_origin)
 
 
 if WEBENGINE_AVAILABLE:
 
     class _LocalOnlyRequestInterceptor(QWebEngineUrlRequestInterceptor):
         """Blocks every request whose scheme isn't local (see preview_url_is_allowed).
-        Applied to the shared profile so it covers <img>/<script>/fetch/XHR/form-POST/
-        navigation uniformly, regardless of how the payload was crafted.
+
+        allow_dev_server is fixed per interceptor instance, not per request: the
+        offline profile's interceptor is constructed with False and can never
+        reach the dev server; the dedicated dev-server profile's is constructed
+        with True. Applied at profile level so it covers <img>/<script>/fetch/
+        XHR/form-POST/navigation uniformly, regardless of how the payload was
+        crafted.
         """
+
+        def __init__(self, parent=None, *, allow_dev_server: bool = False):
+            super().__init__(parent)
+            self._allow_dev_server = allow_dev_server
 
         def interceptRequest(self, info):
-            if not preview_url_is_allowed(info.requestUrl()):
+            if _request_should_be_blocked(
+                info.requestUrl(), allow_dev_server=self._allow_dev_server
+            ):
                 info.block(True)
 
-    # One dedicated, process-wide profile carries the interceptor for every hardened view
-    # (HTML preview and composer alike). Created lazily (never at import time - a
-    # QWebEngine QObject built before QApplication exists can crash) and cached, so we do
-    # NOT mutate the shared default profile and do NOT create a new profile per view.
+    # Two dedicated, process-wide profiles, each carrying its own interceptor.
+    # Created lazily (never at import time - a QWebEngine QObject built before
+    # QApplication exists can crash) and cached, so we do NOT mutate the shared
+    # default profile and do NOT create a new profile per view.
+    #
+    # _OFFLINE_PROFILE is the unconditional offline sandbox: the composer's
+    # normal mode and the untrusted HTML-renderer preview both use it, and its
+    # interceptor (allow_dev_server=False) can never reach the network.
+    # _DEV_SERVER_PROFILE exists only so a live-mode WebIslandHost can reach the
+    # one dev origin; nothing untrusted is ever put on it. Splitting the two is
+    # what keeps the dev-server relaxation off the untrusted preview surface
+    # structurally (see module docstring).
+    #
     # Lifetime is the crux of QtWebEngine stability:
-    # - the profile is parented to the QApplication, so C++ owns it and it outlives every
-    #   hardened page (a profile destroyed before its pages crashes);
-    # - the interceptor is parented to the profile, so C++ owns it too - the profile can
-    #   never call back into a Python object that GC already reclaimed.
-    _PREVIEW_PROFILE = None
+    # - each profile is parented to the QApplication, so C++ owns it and it
+    #   outlives every hardened page (a profile destroyed before its pages crashes);
+    # - each interceptor MUST be kept alive by a strong Python reference (the
+    #   module globals below), NOT just Qt parenting. An earlier version relied
+    #   on parenting alone ("C++ owns it") and that was empirically wrong in the
+    #   way that matters most: C++ ownership keeps the C++ object installed on
+    #   the profile, but once the Python wrapper is garbage-collected its
+    #   interceptRequest override is gone, and Qt silently dispatches to the C++
+    #   base no-op instead - every request PROCEEDS, fail-open, with zero errors
+    #   anywhere. Reproduced directly on PySide6 6.11.1: an interceptor held only
+    #   by parenting logged 0 interceptions; the identical interceptor held by a
+    #   module global intercepted every request. test_html_preview_sandbox.py's
+    #   TestInterceptorIsAliveAndBlocking guards the references' existence.
+    _OFFLINE_PROFILE = None
+    _OFFLINE_INTERCEPTOR = None
+    _DEV_SERVER_PROFILE = None
+    _DEV_SERVER_INTERCEPTOR = None
 
-    def _get_preview_profile():
-        global _PREVIEW_PROFILE
-        if _PREVIEW_PROFILE is None:
-            app = QApplication.instance()
-            # Off-the-record profile: no on-disk cache/cookies for hardened content.
-            profile = QWebEngineProfile(app)
-            interceptor = _LocalOnlyRequestInterceptor(profile)
-            profile.setUrlRequestInterceptor(interceptor)
-            _PREVIEW_PROFILE = profile
-        return _PREVIEW_PROFILE
+    def _make_hardened_profile(*, allow_dev_server: bool):
+        app = QApplication.instance()
+        # Off-the-record profile: no on-disk cache/cookies for hardened content.
+        profile = QWebEngineProfile(app)
+        interceptor = _LocalOnlyRequestInterceptor(profile, allow_dev_server=allow_dev_server)
+        profile.setUrlRequestInterceptor(interceptor)
+        return profile, interceptor
 
-    def _harden_preview_web_view(web_view):
-        """Lock a QWebEngineView down to an offline, self-contained sandbox.
+    def _get_offline_profile():
+        global _OFFLINE_PROFILE, _OFFLINE_INTERCEPTOR
+        if _OFFLINE_PROFILE is None:
+            _OFFLINE_PROFILE, _OFFLINE_INTERCEPTOR = _make_hardened_profile(allow_dev_server=False)
+        return _OFFLINE_PROFILE
 
-        The view is given its own page backed by the shared local-only profile, so every
-        request (``<img>``/``<script>``/fetch/XHR/form-POST/navigation) is filtered
-        through the interceptor regardless of how the payload was crafted.
+    def _get_dev_server_profile():
+        global _DEV_SERVER_PROFILE, _DEV_SERVER_INTERCEPTOR
+        if _DEV_SERVER_PROFILE is None:
+            _DEV_SERVER_PROFILE, _DEV_SERVER_INTERCEPTOR = _make_hardened_profile(allow_dev_server=True)
+        return _DEV_SERVER_PROFILE
+
+    def _harden_preview_web_view(web_view, *, allow_dev_server: bool = False):
+        """Lock a QWebEngineView down to a self-contained sandbox.
+
+        The view is given its own page backed by a shared local-only profile, so
+        every request (``<img>``/``<script>``/fetch/XHR/form-POST/navigation) is
+        filtered through the interceptor regardless of how the payload was
+        crafted. allow_dev_server picks the dev-server profile - passed True ONLY
+        by a WebIslandHost that resolved a live dev origin (which a frozen build
+        never does); every other caller, including the untrusted HTML-renderer
+        preview, takes the default and stays unconditionally offline.
         """
-        profile = _get_preview_profile()
+        profile = _get_dev_server_profile() if allow_dev_server else _get_offline_profile()
         page = QWebEnginePage(profile, web_view)  # child of the view: destroyed with it
         web_view.setPage(page)
         settings = web_view.settings()

--- a/graphlink_app/tests/test_composer_web_host.py
+++ b/graphlink_app/tests/test_composer_web_host.py
@@ -9,12 +9,29 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import pytest
+
 from PySide6.QtWidgets import QPushButton
 
+import graphlink_frontend_bootstrap as gfb
+import graphlink_webengine
 from graphlink_composer import ComposerController
 from graphlink_composer_bridge import COMPOSER_MAX_HEIGHT, COMPOSER_MIN_HEIGHT
 from graphlink_composer_web import ComposerWebHost
 import graphlink_web_island_host as wih
+
+
+@pytest.fixture(autouse=True)
+def _force_offline_unless_test_opts_in(monkeypatch):
+    # Without this, a developer running the suite with both live-dev env vars
+    # exported (this feature's own target workflow) would silently construct
+    # every host below in LIVE mode - pointing real QWebEngineViews at a dev
+    # server and swapping which profile they use. Clear both vars so the
+    # default for every test here is deterministically the offline branch;
+    # the two branch-selection tests opt back in by monkeypatching
+    # resolve_dev_server_origin directly.
+    monkeypatch.delenv(gfb.DEV_MODE_ENV_VAR, raising=False)
+    monkeypatch.delenv(gfb.DEV_SERVER_URL_ENV_VAR, raising=False)
 
 
 class _Window:
@@ -26,6 +43,10 @@ class _Window:
 
 def _make_host(window=None, controller=None):
     return ComposerWebHost(window or _Window(), controller or ComposerController(), None)
+
+
+def _dev_scripts(host):
+    return host.web_view.page().scripts().find("qwebchannel-bootstrap")
 
 
 def _clear_registry():
@@ -147,3 +168,48 @@ def test_registry_shutdown_all_tears_down_every_composer_host():
     assert host_b not in wih._hosts
     assert host_a.bridge.disposed is True
     assert host_b.bridge.disposed is True
+
+
+class TestLiveDevServerBranchSelection:
+    """The host's actual load-mode decision - the one thing neither the pure
+    resolve_dev_server_origin tests nor the pure interceptor tests exercise.
+    Proves a frozen/no-env build takes the offline branch (offline profile, no
+    injected script) and a live build takes the dev branch (dedicated dev
+    profile + injected qwebchannel bootstrap)."""
+
+    def test_offline_branch_uses_the_offline_profile_and_injects_no_script(self, monkeypatch):
+        # The default with both env vars cleared; also the exact shape a frozen
+        # build hits (resolve_dev_server_origin returns None when frozen).
+        monkeypatch.setattr(wih, "resolve_dev_server_origin", lambda: None)
+        host = _make_host()
+        if host.web_view is None:
+            pytest.skip("WebEngine unavailable in this environment")
+
+        assert host._dev_origin is None
+        assert host.web_view.page().profile() is graphlink_webengine._get_offline_profile()
+        assert _dev_scripts(host) == []
+
+    def test_live_branch_uses_the_dev_profile_and_injects_the_qwebchannel_bootstrap(self, monkeypatch):
+        monkeypatch.setattr(wih, "resolve_dev_server_origin", lambda: "http://127.0.0.1:5173")
+        host = _make_host()
+        if host.web_view is None:
+            pytest.skip("WebEngine unavailable in this environment")
+
+        assert host._dev_origin == "http://127.0.0.1:5173"
+        assert host.web_view.page().profile() is graphlink_webengine._get_dev_server_profile()
+        # Exactly one qwebchannel bootstrap script, on the PAGE's collection...
+        assert len(_dev_scripts(host)) == 1
+        # ...and never on the shared profile (the isolation invariant the
+        # injection-script docstring leans on - a future move onto the profile
+        # would hand the untrusted HTML-renderer preview the same bootstrap).
+        assert graphlink_webengine._get_dev_server_profile().scripts().find("qwebchannel-bootstrap") == []
+
+    def test_offline_and_live_branches_use_genuinely_different_profiles(self, monkeypatch):
+        monkeypatch.setattr(wih, "resolve_dev_server_origin", lambda: None)
+        offline_host = _make_host()
+        monkeypatch.setattr(wih, "resolve_dev_server_origin", lambda: "http://127.0.0.1:5173")
+        live_host = _make_host()
+        if offline_host.web_view is None or live_host.web_view is None:
+            pytest.skip("WebEngine unavailable in this environment")
+
+        assert offline_host.web_view.page().profile() is not live_host.web_view.page().profile()

--- a/graphlink_app/tests/test_frontend_bootstrap.py
+++ b/graphlink_app/tests/test_frontend_bootstrap.py
@@ -23,9 +23,12 @@ import graphlink_frontend_bootstrap as gfb
 
 @pytest.fixture(autouse=True)
 def _clean_dev_env(monkeypatch):
-    # Never let a real GRAPHLINK_FRONTEND_DEV in the test-runner's environment
-    # leak into these tests' expectations.
+    # Never let a real GRAPHLINK_FRONTEND_DEV / GRAPHLINK_FRONTEND_DEV_URL in
+    # the test-runner's environment leak into these tests' expectations, and
+    # reset the warn-once dedup so each test observes its own warnings.
     monkeypatch.delenv(gfb.DEV_MODE_ENV_VAR, raising=False)
+    monkeypatch.delenv(gfb.DEV_SERVER_URL_ENV_VAR, raising=False)
+    gfb._warned_dev_url_issues.clear()
 
 
 @pytest.fixture
@@ -188,6 +191,79 @@ class TestBypassPaths:
         monkeypatch.setattr(gfb, "WEB_UI_DIR", tmp_path / "empty_web_ui")
         monkeypatch.setattr(gfb, "ASSETS_DIR", tmp_path / "assets")
         gfb.ensure_frontend_built()  # must not raise
+
+
+class TestResolveDevServerOrigin:
+    """resolve_dev_server_origin() - the trigger for the live
+    dev-server-in-window path. Pure env-var/frozen logic, no QApplication,
+    matching this file's existing convention."""
+
+    def test_neither_var_set_is_none(self):
+        assert gfb.resolve_dev_server_origin() is None
+
+    def test_dev_flag_alone_is_none_and_silent(self, monkeypatch, caplog):
+        # GRAPHLINK_FRONTEND_DEV alone is today's normal, intentional dev
+        # loop (build-skip only) - it must stay warning-free.
+        monkeypatch.setenv(gfb.DEV_MODE_ENV_VAR, "1")
+        with caplog.at_level("WARNING"):
+            assert gfb.resolve_dev_server_origin() is None
+        assert caplog.records == []
+
+    def test_url_alone_is_none_with_a_warning_naming_both_vars(self, monkeypatch, caplog):
+        monkeypatch.setenv(gfb.DEV_SERVER_URL_ENV_VAR, "http://127.0.0.1:5173")
+        with caplog.at_level("WARNING"):
+            assert gfb.resolve_dev_server_origin() is None
+        assert len(caplog.records) == 1
+        assert gfb.DEV_SERVER_URL_ENV_VAR in caplog.text
+        assert gfb.DEV_MODE_ENV_VAR in caplog.text
+
+    def test_misconfiguration_warning_is_logged_once_not_per_call(self, monkeypatch, caplog):
+        # The request interceptor re-resolves on every intercepted request;
+        # an unguarded warning would repeat once per subresource.
+        monkeypatch.setenv(gfb.DEV_SERVER_URL_ENV_VAR, "http://127.0.0.1:5173")
+        with caplog.at_level("WARNING"):
+            for _ in range(5):
+                assert gfb.resolve_dev_server_origin() is None
+        assert len(caplog.records) == 1
+
+    def test_both_set_validly_returns_exactly_that_origin(self, monkeypatch):
+        monkeypatch.setenv(gfb.DEV_MODE_ENV_VAR, "1")
+        monkeypatch.setenv(gfb.DEV_SERVER_URL_ENV_VAR, "http://127.0.0.1:5173")
+        assert gfb.resolve_dev_server_origin() == "http://127.0.0.1:5173"
+
+    def test_localhost_hostname_is_accepted_and_preserved(self, monkeypatch):
+        monkeypatch.setenv(gfb.DEV_MODE_ENV_VAR, "1")
+        monkeypatch.setenv(gfb.DEV_SERVER_URL_ENV_VAR, "http://localhost:5173")
+        assert gfb.resolve_dev_server_origin() == "http://localhost:5173"
+
+    def test_a_path_suffix_is_normalized_away(self, monkeypatch):
+        monkeypatch.setenv(gfb.DEV_MODE_ENV_VAR, "1")
+        monkeypatch.setenv(gfb.DEV_SERVER_URL_ENV_VAR, "http://127.0.0.1:5173/index.html")
+        assert gfb.resolve_dev_server_origin() == "http://127.0.0.1:5173"
+
+    @pytest.mark.parametrize("bad_url", [
+        "http://evil.example.com:5173",   # non-loopback host
+        "http://192.168.1.50:5173",       # intranet host
+        "https://127.0.0.1:5173",         # wrong scheme
+        "ws://127.0.0.1:5173",            # wrong scheme
+        "file:///C:/x",                   # wrong scheme
+        "http://127.0.0.1",               # missing port - invalid, never defaulted to 80
+        "http://127.0.0.1:0",             # port 0 is not a real listen port
+        "not a url",                       # unparseable
+        "http://127.0.0.1:notaport",      # invalid port digits
+    ])
+    def test_invalid_or_disallowed_urls_fail_closed_with_a_warning(self, monkeypatch, caplog, bad_url):
+        monkeypatch.setenv(gfb.DEV_MODE_ENV_VAR, "1")
+        monkeypatch.setenv(gfb.DEV_SERVER_URL_ENV_VAR, bad_url)
+        with caplog.at_level("WARNING"):
+            assert gfb.resolve_dev_server_origin() is None
+        assert len(caplog.records) == 1
+
+    def test_frozen_build_is_none_even_with_both_vars_validly_set(self, monkeypatch):
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setenv(gfb.DEV_MODE_ENV_VAR, "1")
+        monkeypatch.setenv(gfb.DEV_SERVER_URL_ENV_VAR, "http://127.0.0.1:5173")
+        assert gfb.resolve_dev_server_origin() is None
 
 
 class TestNodeAndNpmDetection:

--- a/graphlink_app/tests/test_html_preview_sandbox.py
+++ b/graphlink_app/tests/test_html_preview_sandbox.py
@@ -22,7 +22,9 @@ import pytest
 
 from PySide6.QtCore import QUrl
 
-from graphlink_webengine import preview_url_is_allowed
+import graphlink_frontend_bootstrap as gfb
+import graphlink_webengine
+from graphlink_webengine import _request_should_be_blocked, preview_url_is_allowed
 
 
 class TestLocalSchemesAreAllowed:
@@ -62,6 +64,164 @@ class TestDefensiveEdges:
     def test_a_non_url_object_is_blocked_not_crashed(self):
         # Fail closed: anything that doesn't look like a QUrl is treated as disallowed.
         assert preview_url_is_allowed(object()) is False
+
+
+_DEV_ORIGIN = "http://127.0.0.1:5173"
+
+
+class TestDevServerOriginRelaxation:
+    """The one developer-opt-in exception to the offline sandbox: an exact
+    dev-server origin. Every existing test above calls preview_url_is_allowed
+    with NO second argument - their continued passing is itself the regression
+    proof that the default (dev_origin=None) is byte-for-byte the pre-existing
+    offline behavior."""
+
+    @pytest.mark.parametrize("url", [
+        "http://127.0.0.1:5173/",
+        "http://127.0.0.1:5173/src/islands/composer/main.tsx",
+        "ws://127.0.0.1:5173/",                   # Vite's HMR websocket
+        "ws://127.0.0.1:5173/@vite/client",
+    ])
+    def test_exact_origin_http_and_ws_are_allowed(self, url):
+        assert preview_url_is_allowed(QUrl(url), _DEV_ORIGIN) is True
+
+    @pytest.mark.parametrize("url", [
+        "http://127.0.0.1:5174/",                 # port drift (Vite auto-increment)
+        "http://127.0.0.1:8080/admin/shutdown",   # another loopback service
+        "http://localhost:5173/",                  # host string mismatch vs 127.0.0.1
+        "http://192.168.1.50:5173/",               # non-loopback, matching port
+        "http://attacker.example:5173/",           # remote, matching port
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata - the key regression proof
+        "https://127.0.0.1:5173/",                 # right authority, wrong scheme
+        "wss://127.0.0.1:5173/",                   # right authority, wrong scheme
+        "file:///C:/Windows/win.ini",
+    ])
+    def test_everything_but_the_exact_origin_stays_blocked(self, url):
+        assert preview_url_is_allowed(QUrl(url), _DEV_ORIGIN) is False
+
+    def test_no_dev_origin_still_blocks_the_dev_server_url_itself(self):
+        assert preview_url_is_allowed(QUrl("http://127.0.0.1:5173/")) is False
+
+    def test_frozen_build_ignores_a_dev_origin_regardless_of_caller(self, monkeypatch):
+        # graphlink_webengine's own side of the double sys.frozen gate: even a
+        # validly-formed dev_origin passed straight in is discarded.
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        assert preview_url_is_allowed(QUrl("http://127.0.0.1:5173/"), _DEV_ORIGIN) is False
+
+
+class TestOfflineProfileIsUnconditionallyOffline:
+    """The security invariant the two-profile split exists to guarantee: the
+    OFFLINE profile's decision (allow_dev_server=False) can never reach the dev
+    server, even with both opt-in env vars set. This is the surface the
+    untrusted HTML-renderer preview shares, so it must stay offline no matter
+    what a developer set for the composer's benefit."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_dev_env(self, monkeypatch):
+        monkeypatch.delenv(gfb.DEV_MODE_ENV_VAR, raising=False)
+        monkeypatch.delenv(gfb.DEV_SERVER_URL_ENV_VAR, raising=False)
+        gfb._warned_dev_url_issues.clear()
+
+    def test_offline_decision_blocks_the_dev_origin_even_with_both_vars_set(self, monkeypatch):
+        monkeypatch.setenv(gfb.DEV_MODE_ENV_VAR, "1")
+        monkeypatch.setenv(gfb.DEV_SERVER_URL_ENV_VAR, _DEV_ORIGIN)
+        # allow_dev_server=False is the offline profile's fixed setting.
+        assert _request_should_be_blocked(QUrl("http://127.0.0.1:5173/")) is True
+        assert _request_should_be_blocked(QUrl("ws://127.0.0.1:5173/")) is True
+
+    def test_offline_decision_never_resolves_the_origin(self, monkeypatch):
+        # Even if resolve_dev_server_origin somehow returned an origin, the
+        # offline path must not consult it - prove it's never called.
+        called = {"n": 0}
+        monkeypatch.setattr(
+            graphlink_webengine, "resolve_dev_server_origin",
+            lambda: (called.__setitem__("n", called["n"] + 1) or _DEV_ORIGIN),
+        )
+        assert _request_should_be_blocked(QUrl("http://127.0.0.1:5173/")) is True
+        assert called["n"] == 0
+
+    def test_local_schemes_still_allowed_offline(self):
+        assert _request_should_be_blocked(QUrl("qrc:///qtwebchannel/qwebchannel.js")) is False
+
+
+class TestDevServerProfileDecisionWiring:
+    """The dedicated dev-server profile's decision (allow_dev_server=True) -
+    the ONLY path that may reach the dev origin, and only when both env vars
+    are set. Proves the env-var-to-verdict chain re-resolves per request."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_dev_env(self, monkeypatch):
+        monkeypatch.delenv(gfb.DEV_MODE_ENV_VAR, raising=False)
+        monkeypatch.delenv(gfb.DEV_SERVER_URL_ENV_VAR, raising=False)
+        gfb._warned_dev_url_issues.clear()
+
+    def test_dev_server_request_blocked_without_the_env_vars(self):
+        assert _request_should_be_blocked(QUrl("http://127.0.0.1:5173/"), allow_dev_server=True) is True
+
+    def test_dev_server_request_allowed_once_both_vars_are_set(self, monkeypatch):
+        monkeypatch.setenv(gfb.DEV_MODE_ENV_VAR, "1")
+        monkeypatch.setenv(gfb.DEV_SERVER_URL_ENV_VAR, _DEV_ORIGIN)
+        assert _request_should_be_blocked(QUrl("http://127.0.0.1:5173/"), allow_dev_server=True) is False
+        assert _request_should_be_blocked(QUrl("ws://127.0.0.1:5173/"), allow_dev_server=True) is False
+
+    def test_unrelated_egress_stays_blocked_even_with_both_vars_set(self, monkeypatch):
+        monkeypatch.setenv(gfb.DEV_MODE_ENV_VAR, "1")
+        monkeypatch.setenv(gfb.DEV_SERVER_URL_ENV_VAR, _DEV_ORIGIN)
+        assert _request_should_be_blocked(QUrl("http://attacker.example/x"), allow_dev_server=True) is True
+        assert _request_should_be_blocked(QUrl("http://127.0.0.1:8080/"), allow_dev_server=True) is True
+
+    def test_local_schemes_stay_allowed(self, monkeypatch):
+        assert _request_should_be_blocked(QUrl("qrc:///qtwebchannel/qwebchannel.js"), allow_dev_server=True) is False
+
+
+class TestInterceptorIsAliveAndBlocking:
+    """Regression guard for a real, empirically-confirmed fail-open bug: the
+    interceptor was originally kept alive ONLY by Qt parenting, and PySide's
+    wrapper for it could be garbage-collected - the C++ object stayed
+    installed on the profile, but its interceptRequest silently dispatched to
+    the C++ no-op base instead of the Python override, so every request
+    PROCEEDED. Nothing errored anywhere; the offline sandbox held for the
+    composer only because _inline_bundle()'s CSP meta tag did the real work,
+    and the HTML-renderer node preview (no CSP) had no working egress block
+    at all. Fixed by the module-level strong references; these tests pin BOTH
+    profiles' interceptors and prove the Python override is the one reachable."""
+
+    def test_both_profiles_pin_a_strong_interceptor_reference(self):
+        import gc
+
+        offline = graphlink_webengine._get_offline_profile()
+        dev = graphlink_webengine._get_dev_server_profile()
+        gc.collect()
+
+        assert offline is graphlink_webengine._OFFLINE_PROFILE
+        assert dev is graphlink_webengine._DEV_SERVER_PROFILE
+        assert offline is not dev  # genuinely separate profiles
+        for interceptor in (
+            graphlink_webengine._OFFLINE_INTERCEPTOR,
+            graphlink_webengine._DEV_SERVER_INTERCEPTOR,
+        ):
+            assert isinstance(interceptor, graphlink_webengine._LocalOnlyRequestInterceptor)
+        assert graphlink_webengine._OFFLINE_INTERCEPTOR._allow_dev_server is False
+        assert graphlink_webengine._DEV_SERVER_INTERCEPTOR._allow_dev_server is True
+
+    def test_the_pinned_offline_interceptor_runs_the_real_python_override(self):
+        # Drive interceptRequest directly with a duck-typed info object (a
+        # real QWebEngineUrlRequestInfo can't be constructed by hand). If the
+        # Python override were lost, this call would still "work" via the
+        # base class and never touch block() - asserting the block call is
+        # what proves the override is the live code path.
+        graphlink_webengine._get_offline_profile()
+        blocked = []
+
+        class _FakeInfo:
+            def requestUrl(self):
+                return QUrl("http://attacker.example/exfil")
+
+            def block(self, value):
+                blocked.append(value)
+
+        graphlink_webengine._OFFLINE_INTERCEPTOR.interceptRequest(_FakeInfo())
+        assert blocked == [True]
 
 
 class TestHtmlViewNodeWebengineAvailabilityIsAtomic:

--- a/web_ui/vite.config.ts
+++ b/web_ui/vite.config.ts
@@ -25,6 +25,17 @@ export default defineConfig({
   plugins: [tailwindcss(), react()],
   base: "./",
   root: resolve(__dirname, "src/islands", island),
+  // The desktop app's live dev-server mode (GRAPHLINK_FRONTEND_DEV_URL)
+  // allowlists ONE exact origin in its WebEngine request interceptor. These
+  // three settings keep the real served origin pinned to that expectation:
+  // the literal IP avoids localhost's IPv4/IPv6 resolution split, and
+  // strictPort makes a taken port fail loud at startup instead of silently
+  // drifting to 5174+ where the interceptor would block everything.
+  server: {
+    host: "127.0.0.1",
+    port: 5173,
+    strictPort: true,
+  },
   build: {
     outDir: resolve(__dirname, "../assets", island),
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
Adds an opt-in live dev-server-in-window path (Phase 1 checklist item) and — as a direct consequence of empirically testing it — fixes a **pre-existing fail-open bug** in the shared WebEngine egress sandbox.

### Live dev-server path
When BOTH `GRAPHLINK_FRONTEND_DEV` and `GRAPHLINK_FRONTEND_DEV_URL` are set, `WebIslandHost` loads the live Vite dev server in-window (real in-app HMR) instead of the offline inlined bundle. The request interceptor additionally allows exactly one loopback origin (http + its `ws` HMR upgrade), on a **dedicated profile** so the shared offline profile — used by the untrusted HTML-renderer node preview — can never reach it. Triple-gated on `sys.frozen`. `qwebchannel.js` is injected via a `DocumentCreation` `QWebEngineScript` (the island's `bridge.ts` checks `isQWebChannelAvailable()` once, synchronously, so later injection would permanently fall back to the mock). Loud in-window diagnostic when the server is down. `vite.config.ts` gains `server: { host: "127.0.0.1", port: 5173, strictPort: true }`.

### Security fix (found by this increment's live smoke test, not the survey)
The egress interceptor was kept alive only by Qt parenting, so its PySide wrapper was garbage-collected and `interceptRequest` silently dispatched to the C++ no-op base — **nothing was ever intercepted**. The composer was incidentally covered by `_inline_bundle`'s CSP; the HTML-renderer preview (arbitrary AI/session markup, no CSP) had **no working egress block at all**. Fixed with a module-level strong reference (`_OFFLINE_INTERCEPTOR` / `_DEV_SERVER_INTERCEPTOR`), pinned by regression tests. Reproduced + fix confirmed on PySide6 6.11.1.

### Review-driven fixes (2 adversarial reviewers)
- **Cross-surface widening**: dev-origin relaxation moved off the shared profile onto a dedicated one — the untrusted preview surface is now structurally unable to reach the dev origin (an interceptor can only block, never un-block, so a shared profile can't express this).
- Malformed `dev_origin` now fails closed instead of raising on the IO thread (latent fail-open).
- `_on_load_finished` guarded against starting a new load during shutdown.
- Port 0 rejected.

## Test plan
- [x] Full Python suite: **841 passed** (44 new)
- [x] `npm run check` green (schema/typecheck/lint/77 vitest/build; 1 pre-existing unrelated warning)
- [x] Empirical, against a real Vite dev server: live composer reaches the dev origin + wires QWebChannel/`composerBridge`; an untrusted `setHtml` preview surface is **blocked** from the same origin with the same env vars set; offline mode blocks all egress; dev-server-down diagnostic renders
- [x] Correctness reviewer mutation-tested the strong-ref and port-match guards; file restored sha-identical

## Reviewer note
This carries a real security fix to the shared egress sandbox — worth a closer look than a typical migration increment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)