### PR TITLE
Fix 6 app bugs from the survey re-investigation

### DIFF
--- a/graphlink_app/graphlink_canvas/graphlink_canvas_navigation_pin.py
+++ b/graphlink_app/graphlink_canvas/graphlink_canvas_navigation_pin.py
@@ -28,7 +28,6 @@ class NavigationPin(QGraphicsObject):
 
     editRequested = Signal(str)
     contextMenuRequested = Signal(str, object)
-    positionPreviewChanged = Signal(str, object)
     positionCommitted = Signal(str, object)
 
     def __init__(self, title="Waypoint", note="", parent=None, pin_id=None):
@@ -144,14 +143,6 @@ class NavigationPin(QGraphicsObject):
         super().mouseReleaseEvent(event)
         if was_dragging and event.button() == Qt.MouseButton.LeftButton:
             self.positionCommitted.emit(self.pin_id, self.pos())
-
-    def itemChange(self, change, value):
-        if (
-            change == QGraphicsItem.GraphicsItemChange.ItemPositionHasChanged
-            and self.scene() is not None
-        ):
-            self.positionPreviewChanged.emit(self.pin_id, value)
-        return super().itemChange(change, value)
 
     def apply_metadata(self, title, note):
         """Update display metadata after the store has accepted an edit."""

--- a/graphlink_app/graphlink_connections.py
+++ b/graphlink_app/graphlink_connections.py
@@ -29,6 +29,31 @@ def _sync_connection_visibility_mode(item):
     item.setOpacity(1.0 if (not _fade_connections_enabled(item) or is_active) else 0.08)
 
 
+def resolve_collapsed_endpoint(item):
+    """Return the effective endpoint for a connection touching `item`.
+
+    If `item` sits inside a collapsed Container OR Frame, the connection should
+    terminate at the OUTERMOST collapsed grouping ancestor (that's the one still
+    visible on the canvas; anything nested inside it is hidden), otherwise at
+    `item` itself. Walks the full ancestor chain.
+
+    This is the single source of truth for that rule. It exists because the
+    per-node *ConnectionItem classes each carried a copy-pasted version that had
+    drifted: they checked only `Container` (never `Frame`) and only the
+    immediate parent (not the full chain), so a connection into a node inside a
+    collapsed Frame drew to the node's stale, hidden position instead of the
+    Frame's collapsed edge. Every connection class now delegates here so those
+    copies can't diverge again.
+    """
+    effective = item
+    current = item
+    while current:
+        if isinstance(current, (Container, Frame)) and getattr(current, 'is_collapsed', False):
+            effective = current
+        current = current.parentItem()
+    return effective
+
+
 class Pin(QGraphicsItem):
     """
     A draggable point on a ConnectionItem that allows the user to curve the path.
@@ -336,24 +361,8 @@ class ConnectionItem(QGraphicsItem):
         return item.boundingRect()
 
     def _get_effective_endpoint(self, item):
-        """
-        Finds the "effective" endpoint for a connection. If an item is inside a
-        collapsed container or frame, the collapsed grouping item itself becomes
-        the endpoint for drawing.
-
-        Args:
-            item (QGraphicsItem): The original endpoint item.
-
-        Returns:
-            QGraphicsItem: The effective endpoint item (either the original or a parent container).
-        """
-        effective = item
-        current = item
-        while current:
-            if isinstance(current, (Container, Frame)) and getattr(current, 'is_collapsed', False):
-                effective = current
-            current = current.parentItem()
-        return effective
+        """Effective endpoint for drawing; see resolve_collapsed_endpoint()."""
+        return resolve_collapsed_endpoint(item)
 
     @staticmethod
     def _connection_signature(start_item, end_item):
@@ -775,14 +784,12 @@ class ContentConnectionItem(QGraphicsItem):
         return item.boundingRect()
 
     def _get_effective_endpoint(self, item):
-        """Helper to find the effective endpoint if inside a collapsed container."""
-        current = item
-        while current:
-            parent = current.parentItem()
-            if isinstance(parent, Container) and parent.is_collapsed:
-                return parent
-            current = parent
-        return item
+        """Effective endpoint for drawing; see resolve_collapsed_endpoint().
+
+        Previously a copy-paste that only honored collapsed Containers (not
+        Frames) and only the immediate parent - now delegates to the shared
+        helper so it can't drift from the other connection classes again."""
+        return resolve_collapsed_endpoint(item)
 
     def boundingRect(self):
         """Returns the bounding rectangle of the item."""
@@ -954,14 +961,12 @@ class DocumentConnectionItem(QGraphicsItem):
         return item.boundingRect()
 
     def _get_effective_endpoint(self, item):
-        """Helper to find the effective endpoint if inside a collapsed container."""
-        current = item
-        while current:
-            parent = current.parentItem()
-            if isinstance(parent, Container) and parent.is_collapsed:
-                return parent
-            current = parent
-        return item
+        """Effective endpoint for drawing; see resolve_collapsed_endpoint().
+
+        Previously a copy-paste that only honored collapsed Containers (not
+        Frames) and only the immediate parent - now delegates to the shared
+        helper so it can't drift from the other connection classes again."""
+        return resolve_collapsed_endpoint(item)
 
     def boundingRect(self):
         """Returns the bounding rectangle of the item."""
@@ -1136,14 +1141,12 @@ class ImageConnectionItem(QGraphicsItem):
         return item.boundingRect()
 
     def _get_effective_endpoint(self, item):
-        """Helper to find the effective endpoint if inside a collapsed container."""
-        current = item
-        while current:
-            parent = current.parentItem()
-            if isinstance(parent, Container) and parent.is_collapsed:
-                return parent
-            current = parent
-        return item
+        """Effective endpoint for drawing; see resolve_collapsed_endpoint().
+
+        Previously a copy-paste that only honored collapsed Containers (not
+        Frames) and only the immediate parent - now delegates to the shared
+        helper so it can't drift from the other connection classes again."""
+        return resolve_collapsed_endpoint(item)
 
     def boundingRect(self):
         """Returns the bounding rectangle of the item."""
@@ -1349,14 +1352,12 @@ class SystemPromptConnectionItem(QGraphicsItem):
         return item.boundingRect()
 
     def _get_effective_endpoint(self, item):
-        """Helper to find the effective endpoint if inside a collapsed container."""
-        current = item
-        while current:
-            parent = current.parentItem()
-            if isinstance(parent, Container) and parent.is_collapsed:
-                return parent
-            current = parent
-        return item
+        """Effective endpoint for drawing; see resolve_collapsed_endpoint().
+
+        Previously a copy-paste that only honored collapsed Containers (not
+        Frames) and only the immediate parent - now delegates to the shared
+        helper so it can't drift from the other connection classes again."""
+        return resolve_collapsed_endpoint(item)
 
     def boundingRect(self):
         """Returns the bounding rectangle of the item."""
@@ -1481,14 +1482,12 @@ class PyCoderConnectionItem(QGraphicsItem):
         return item.boundingRect()
 
     def _get_effective_endpoint(self, item):
-        """Helper to find the effective endpoint if inside a collapsed container."""
-        current = item
-        while current:
-            parent = current.parentItem()
-            if isinstance(parent, Container) and parent.is_collapsed:
-                return parent
-            current = parent
-        return item
+        """Effective endpoint for drawing; see resolve_collapsed_endpoint().
+
+        Previously a copy-paste that only honored collapsed Containers (not
+        Frames) and only the immediate parent - now delegates to the shared
+        helper so it can't drift from the other connection classes again."""
+        return resolve_collapsed_endpoint(item)
 
     def boundingRect(self):
         """Returns the bounding rectangle of the item."""

--- a/graphlink_app/graphlink_html_view.py
+++ b/graphlink_app/graphlink_html_view.py
@@ -391,12 +391,20 @@ class HtmlViewNode(QGraphicsObject, HoverAnimationMixin):
     def set_html_content(self, html_text):
         """
         Sets the HTML content of the input editor and automatically renders it.
-        
+
         Args:
             html_text (str): The HTML string to set.
         """
+        # setPlainText, NOT setHtml: html_input is a plain-text source editor
+        # (setAcceptRichText(False)). setHtml() would parse html_text as rich
+        # text, and the resulting textChanged -> _on_content_changed would
+        # overwrite self.html_content with the tag-stripped plain text, so
+        # render_html() below would render the mangled version instead of the
+        # real markup. setPlainText keeps the raw HTML as source verbatim
+        # (seed_prompt() already uses setPlainText for the same reason); its
+        # textChanged reassigns self.html_content to the identical string.
+        self.html_input.setPlainText(html_text)
         self.html_content = html_text
-        self.html_input.setHtml(html_text)
         self.render_html()
 
     def get_splitter_state(self):

--- a/graphlink_app/graphlink_nodes/graphlink_node_chat.py
+++ b/graphlink_app/graphlink_nodes/graphlink_node_chat.py
@@ -490,7 +490,11 @@ class ChatNode(QGraphicsItem, HoverAnimationMixin):
 
         painter.save()
         painter.setClipPath(path)
-        accent_fill = colors["accent"]
+        # Copy before mutating: colors["accent"] is reused at full opacity for
+        # the connection dots below (painter.setBrush(colors["accent"])), and
+        # setAlpha() mutates the QColor in place. Without the copy, the dots
+        # would inherit this strip's alpha=140 instead of being fully opaque.
+        accent_fill = QColor(colors["accent"])
         accent_fill.setAlpha(140)
         painter.setBrush(accent_fill)
         painter.setPen(Qt.PenStyle.NoPen)

--- a/graphlink_app/graphlink_nodes/graphlink_node_image.py
+++ b/graphlink_app/graphlink_nodes/graphlink_node_image.py
@@ -4,7 +4,7 @@ from PySide6.QtGui import QColor, QFont, QFontMetrics, QImage, QPainter, QPainte
 from PySide6.QtWidgets import QGraphicsItem
 
 from graphlink_canvas_items import Container, HoverAnimationMixin
-from graphlink_config import canvas_font, canvas_font_color, get_current_palette, get_graph_node_colors
+from graphlink_config import canvas_font, canvas_font_color, get_current_palette, get_graph_node_colors, get_semantic_color
 from graphlink_lod import draw_lod_card, lod_mode_for_item, preview_text
 
 
@@ -83,9 +83,17 @@ class ImageNode(QGraphicsItem, HoverAnimationMixin):
                 mode=lod_mode,
                 selected=self.isSelected() and not is_dragging,
                 hovered=self.hovered,
+                search_match=self.is_search_match,
             )
             return
         painter.drawPath(path)
+
+        if self.is_search_match:
+            highlight_pen = QPen(get_semantic_color("search_highlight"), 2.5)
+            highlight_pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
+            painter.setPen(highlight_pen)
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawPath(path)
 
         header_path = QPainterPath()
         header_rect = QRectF(0, 0, self.width, self.HEADER_HEIGHT)

--- a/graphlink_app/graphlink_nodes/graphlink_node_image.py
+++ b/graphlink_app/graphlink_nodes/graphlink_node_image.py
@@ -88,13 +88,6 @@ class ImageNode(QGraphicsItem, HoverAnimationMixin):
             return
         painter.drawPath(path)
 
-        if self.is_search_match:
-            highlight_pen = QPen(get_semantic_color("search_highlight"), 2.5)
-            highlight_pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
-            painter.setPen(highlight_pen)
-            painter.setBrush(Qt.BrushStyle.NoBrush)
-            painter.drawPath(path)
-
         header_path = QPainterPath()
         header_rect = QRectF(0, 0, self.width, self.HEADER_HEIGHT)
         header_path.addRoundedRect(header_rect, 10, 10)
@@ -142,6 +135,18 @@ class ImageNode(QGraphicsItem, HoverAnimationMixin):
             painter.setFont(canvas_font(self.scene(), delta=-1))
             painter.drawText(image_rect, Qt.AlignmentFlag.AlignCenter, "Image unavailable")
             painter.restore()
+
+        # Drawn LAST, on top of the header and content, so the search ring is
+        # exactly the node's outline and nothing else. ChatNode does the same
+        # (ring after the header); drawing it right after the body path instead
+        # would leave the search pen active for the header draw and paint a
+        # spurious tinted line under the header.
+        if self.is_search_match:
+            highlight_pen = QPen(get_semantic_color("search_highlight"), 2.5)
+            highlight_pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
+            painter.setPen(highlight_pen)
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawPath(path)
 
     def contextMenuEvent(self, event):
         from graphlink_nodes.graphlink_node_image_menu import ImageNodeContextMenu

--- a/graphlink_app/graphlink_ui_dialogs/graphlink_settings_dialogs.py
+++ b/graphlink_app/graphlink_ui_dialogs/graphlink_settings_dialogs.py
@@ -1250,6 +1250,12 @@ class ApiSettingsWidget(QWidget):
         self.load_btn = QPushButton("Load Available Models")
         self.load_btn.clicked.connect(self.load_models_from_endpoint)
         layout.addWidget(self.load_btn)
+        # Whether the most recent load actually populated a catalog for the
+        # current provider. Drives the load_btn label in _clear_api_worker:
+        # "Refresh Available Models" only once something has been loaded, so a
+        # FAILED fetch no longer misleadingly relabels the button as if a
+        # catalog existed to refresh.
+        self._api_load_succeeded = False
         self.discovery_status_label = QLabel("Model catalog has not been refreshed yet.")
         self.discovery_status_label.setWordWrap(True)
         self.discovery_status_label.setStyleSheet("color: #A5A5A5;")
@@ -1420,6 +1426,7 @@ class ApiSettingsWidget(QWidget):
             QMessageBox.warning(self, "Missing Information", "Please enter the API Key.")
             return
 
+        self._api_load_succeeded = False
         self.load_btn.setEnabled(False)
         self.load_btn.setText("Loading catalog…")
         self.discovery_status_label.setText("Contacting the provider… You can keep editing other settings.")
@@ -1453,6 +1460,7 @@ class ApiSettingsWidget(QWidget):
             self.image_combo.clear()
             self.image_combo.addItems(api_provider.GEMINI_IMAGE_MODELS_STATIC)
         self.restore_saved_models()
+        self._api_load_succeeded = True
         self.discovery_status_label.setText(f"Catalog refreshed — {len(models)} model(s) available from {provider}.")
         self.discovery_status_label.setStyleSheet(f"color: {get_semantic_color('status_success').name()};")
 
@@ -1466,7 +1474,13 @@ class ApiSettingsWidget(QWidget):
 
     def _clear_api_worker(self, *_args):
         self.load_btn.setEnabled(True)
-        self.load_btn.setText("Refresh Available Models")
+        # Only advertise "Refresh" once a catalog was actually loaded for the
+        # current provider; a failed fetch (or a load whose result was
+        # discarded because the provider was switched mid-flight) leaves the
+        # button as "Load Available Models", since there is nothing to refresh.
+        self.load_btn.setText(
+            "Refresh Available Models" if self._api_load_succeeded else "Load Available Models"
+        )
         self.api_worker = None
         self.api_worker_provider = None
 

--- a/graphlink_app/tests/test_survey_bug_fixes.py
+++ b/graphlink_app/tests/test_survey_bug_fixes.py
@@ -178,7 +178,7 @@ def test_api_button_label_becomes_refresh_after_a_successful_load():
     assert widget.load_btn.text() == "Refresh Available Models"
 
 
-# --- Bug 2 & 3: paint-path fixes, smoke-level (no crash; correct code reached) ---
+# --- Bug 2 & 3: paint-path fixes, exercised through a real paint() that BITES ---
 
 def _paint_once(item):
     image = QImage(400, 400, QImage.Format.Format_ARGB32)
@@ -189,24 +189,60 @@ def _paint_once(item):
         painter.end()
 
 
-def test_image_node_paints_search_ring_without_error_when_matched():
-    from graphlink_nodes.graphlink_node_image import ImageNode
-
-    node = ImageNode(b"", None, prompt="a cat")
-    node.is_search_match = True
-    scene = QGraphicsScene()
-    scene.addItem(node)
-    _paint_once(node)  # must not raise; exercises the new is_search_match branch
-
-
-def test_chat_node_accent_copy_does_not_mutate_the_shared_dict_entry():
-    # The fix copies colors["accent"] before setAlpha(). Prove _surface_colors
-    # hands out an accent QColor whose later mutation can't corrupt a fresh call.
+def test_chat_node_paint_does_not_mutate_the_shared_accent_color(monkeypatch):
+    # Drives the REAL full-detail paint() and proves it no longer mutates the
+    # accent QColor in place. Against the pre-fix code (accent_fill =
+    # colors["accent"]; accent_fill.setAlpha(140)) this fails: the held accent
+    # object's alpha drops to 140.
+    from graphlink_nodes import graphlink_node_chat as chat_mod
     from graphlink_nodes.graphlink_node_chat import ChatNode
 
+    from graphlink_scene import ChatScene
+
+    monkeypatch.setattr(chat_mod, "lod_mode_for_item", lambda item: "full")
     node = ChatNode("hi", is_user=False)
+    # ChatScene (not a bare QGraphicsScene): ChatNode.itemChange reads
+    # scene().font_family on add. Held so it doesn't GC-delete the node.
+    scene = ChatScene(MagicMock())
+    scene.addItem(node)
+
     colors = node._surface_colors()
     accent = colors["accent"]
-    before = accent.alpha()
-    QColor(accent).setAlpha(140)  # mutating a COPY (the fix's shape)
-    assert accent.alpha() == before  # original untouched
+    assert accent.alpha() == 255  # precondition
+    # Make paint() operate on THIS dict (and this accent object) so an in-place
+    # mutation would be observable here.
+    monkeypatch.setattr(node, "_surface_colors", lambda: colors)
+
+    _paint_once(node)
+
+    assert accent.alpha() == 255, "paint() mutated the shared accent QColor in place"
+
+
+def test_image_node_paint_requests_the_search_highlight_only_when_matched(monkeypatch):
+    # Proves the new full-detail search-ring branch actually EXECUTES: it is the
+    # only thing in ImageNode.paint that asks for the "search_highlight" color.
+    # Against the pre-fix code (no ring) this color is never requested even when
+    # matched, so the assertion below fails.
+    from graphlink_nodes import graphlink_node_image as image_mod
+    from graphlink_nodes.graphlink_node_image import ImageNode
+
+    monkeypatch.setattr(image_mod, "lod_mode_for_item", lambda item: "full")
+    real_get = image_mod.get_semantic_color
+    requested = []
+    monkeypatch.setattr(
+        image_mod, "get_semantic_color",
+        lambda name: (requested.append(name), real_get(name))[1],
+    )
+
+    node = ImageNode(b"", None, prompt="a cat")
+    scene = QGraphicsScene()  # held so it doesn't GC-delete the node's C++ object
+    scene.addItem(node)
+
+    node.is_search_match = False
+    _paint_once(node)
+    assert "search_highlight" not in requested  # no ring when not matched
+
+    requested.clear()
+    node.is_search_match = True
+    _paint_once(node)
+    assert "search_highlight" in requested, "matched ImageNode did not draw the search ring"

--- a/graphlink_app/tests/test_survey_bug_fixes.py
+++ b/graphlink_app/tests/test_survey_bug_fixes.py
@@ -1,0 +1,212 @@
+"""Regression coverage for the 6 survey-reported bugs fixed together.
+
+Each was independently re-verified (4 confirmed as reported, 2 partially true)
+before fixing; these tests pin the fixed behavior so it can't silently regress.
+The two paint-internal fixes (ChatNode's in-place QColor mutation, ImageNode's
+missing search ring) are exercised as "paint runs without error in the buggy
+code path" smoke tests plus, for ImageNode, that the search-highlight code is
+actually reached - a full pixel assertion would be brittle and is not worth it
+for a one-line copy / mirror-the-sibling fix.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from PySide6.QtGui import QColor, QImage, QPainter
+from PySide6.QtWidgets import QGraphicsRectItem, QGraphicsScene, QStyleOptionGraphicsItem
+
+from graphlink_canvas.graphlink_canvas_frame import Frame
+from graphlink_canvas.graphlink_canvas_container import Container
+from graphlink_canvas.graphlink_canvas_navigation_pin import NavigationPin
+from graphlink_connections import (
+    ContentConnectionItem,
+    DocumentConnectionItem,
+    ImageConnectionItem,
+    PyCoderConnectionItem,
+    SystemPromptConnectionItem,
+    ConnectionItem,
+    resolve_collapsed_endpoint,
+)
+
+
+# --- Bug 1: HtmlViewNode.set_html_content corrupted markup via setHtml round-trip ---
+
+def test_html_view_set_html_content_preserves_raw_markup():
+    from graphlink_html_view import HtmlViewNode
+
+    node = HtmlViewNode(None)
+    markup = "<html><body><h1>Title</h1><p>Some <b>bold</b> markup &amp; entities</p></body></html>"
+    node.set_html_content(markup)
+
+    # Before the fix, setHtml() parsed the markup as rich text and the
+    # textChanged handler overwrote html_content with the tag-stripped plain
+    # text ("Title\nSome bold markup & entities"). The source must stay verbatim.
+    assert node.get_html_content() == markup
+    assert "<h1>" in node.get_html_content()
+
+
+# --- Bug 4: NavigationPin.positionPreviewChanged was an orphaned dead signal ---
+
+def test_navigation_pin_dead_preview_signal_removed():
+    assert not hasattr(NavigationPin, "positionPreviewChanged"), (
+        "positionPreviewChanged was emitted every drag step but connected "
+        "nowhere; it should be gone"
+    )
+    # The signals that ARE wired must remain.
+    for kept in ("editRequested", "contextMenuRequested", "positionCommitted"):
+        assert hasattr(NavigationPin, kept)
+
+
+def test_navigation_pin_still_constructs_and_moves_without_the_signal():
+    scene = QGraphicsScene()
+    pin = NavigationPin(title="wp", note="", pin_id="p1")
+    scene.addItem(pin)
+    # Removing the itemChange override (its only purpose was emitting the dead
+    # signal) must not break dragging the pin around.
+    pin.setPos(10, 20)
+    pin.setPos(30, 40)
+    assert pin.pos().x() == 30 and pin.pos().y() == 40
+
+
+# --- Bug 5: connection collapsed-endpoint semantics (Frame ignored; innermost) ---
+
+_ALL_ENDPOINT_CLASSES = [
+    ConnectionItem,
+    ContentConnectionItem,
+    DocumentConnectionItem,
+    ImageConnectionItem,
+    SystemPromptConnectionItem,
+    PyCoderConnectionItem,
+]
+
+
+def _child_in(parent):
+    child = QGraphicsRectItem()
+    child.setParentItem(parent)
+    return child
+
+
+def test_resolve_collapsed_endpoint_honors_collapsed_frame():
+    frame = Frame([])
+    frame.is_collapsed = True
+    child = _child_in(frame)
+    assert resolve_collapsed_endpoint(child) is frame
+
+
+def test_resolve_collapsed_endpoint_honors_collapsed_container():
+    container = Container([])
+    container.is_collapsed = True
+    child = _child_in(container)
+    assert resolve_collapsed_endpoint(child) is container
+
+
+def test_resolve_collapsed_endpoint_returns_outermost_when_nested():
+    outer = Frame([])
+    outer.is_collapsed = True
+    inner = Container([])
+    inner.is_collapsed = True
+    inner.setParentItem(outer)
+    child = _child_in(inner)
+    # The outermost collapsed grouping is the one still visible on the canvas.
+    assert resolve_collapsed_endpoint(child) is outer
+
+
+def test_resolve_collapsed_endpoint_returns_item_when_nothing_collapsed():
+    frame = Frame([])
+    frame.is_collapsed = False
+    child = _child_in(frame)
+    assert resolve_collapsed_endpoint(child) is child
+
+
+def test_every_connection_class_delegates_endpoint_to_the_shared_helper():
+    # All 6 classes' _get_effective_endpoint ignore self, so an arbitrary
+    # stand-in self is fine. This proves none of the previously-duplicated
+    # variants still carries its own Frame-blind copy.
+    frame = Frame([])
+    frame.is_collapsed = True
+    child = _child_in(frame)
+    for cls in _ALL_ENDPOINT_CLASSES:
+        assert cls._get_effective_endpoint(object(), child) is frame, (
+            f"{cls.__name__}._get_effective_endpoint did not clamp to the "
+            "collapsed Frame"
+        )
+
+
+# --- Bug 6: ApiSettingsWidget button label never reverted after a failed load ---
+
+def _make_api_settings_widget():
+    from graphlink_ui_dialogs.graphlink_settings_dialogs import ApiSettingsWidget
+
+    # __init__ feeds several settings getters straight into Qt widgets that
+    # reject non-str/-list values, so stub the ones it reads with real types.
+    settings = MagicMock()
+    settings.get_api_base_url.return_value = ""
+    settings.get_api_provider.return_value = ""
+    settings.get_api_models.return_value = {}
+    settings.get_openai_key.return_value = ""
+    settings.get_anthropic_key.return_value = ""
+    settings.get_gemini_key.return_value = ""
+    return ApiSettingsWidget(settings)
+
+
+def test_api_button_label_stays_load_after_a_failed_fetch():
+    widget = _make_api_settings_widget()
+    assert widget.load_btn.text() == "Load Available Models"
+
+    # Simulate a load attempt that fails: load_models_from_endpoint resets the
+    # flag, the error handler does NOT set it, and _clear_api_worker runs.
+    widget._api_load_succeeded = False
+    widget._clear_api_worker()
+
+    assert widget.load_btn.text() == "Load Available Models", (
+        "a failed fetch must not relabel the button as if a catalog exists"
+    )
+    assert widget.load_btn.isEnabled()
+
+
+def test_api_button_label_becomes_refresh_after_a_successful_load():
+    widget = _make_api_settings_widget()
+
+    # Simulate a successful load: handle_models_loaded sets the flag True, then
+    # _clear_api_worker (connected after it) reads it.
+    widget._api_load_succeeded = True
+    widget._clear_api_worker()
+
+    assert widget.load_btn.text() == "Refresh Available Models"
+
+
+# --- Bug 2 & 3: paint-path fixes, smoke-level (no crash; correct code reached) ---
+
+def _paint_once(item):
+    image = QImage(400, 400, QImage.Format.Format_ARGB32)
+    painter = QPainter(image)
+    try:
+        item.paint(painter, QStyleOptionGraphicsItem(), None)
+    finally:
+        painter.end()
+
+
+def test_image_node_paints_search_ring_without_error_when_matched():
+    from graphlink_nodes.graphlink_node_image import ImageNode
+
+    node = ImageNode(b"", None, prompt="a cat")
+    node.is_search_match = True
+    scene = QGraphicsScene()
+    scene.addItem(node)
+    _paint_once(node)  # must not raise; exercises the new is_search_match branch
+
+
+def test_chat_node_accent_copy_does_not_mutate_the_shared_dict_entry():
+    # The fix copies colors["accent"] before setAlpha(). Prove _surface_colors
+    # hands out an accent QColor whose later mutation can't corrupt a fresh call.
+    from graphlink_nodes.graphlink_node_chat import ChatNode
+
+    node = ChatNode("hi", is_user=False)
+    colors = node._surface_colors()
+    accent = colors["accent"]
+    before = accent.alpha()
+    QColor(accent).setAlpha(140)  # mutating a COPY (the fix's shape)
+    assert accent.alpha() == before  # original untouched


### PR DESCRIPTION
Six independent PySide6 correctness fixes, each verified and (for the non-trivial ones) covered by a biting, mutation-checked regression test in `graphlink_app/tests/test_survey_bug_fixes.py`. Went through a two-reviewer adversarial pass before this PR; the corrections it surfaced are in the second commit.

## Fixes
- **HtmlViewNode.set_html_content** corrupted markup on load/session-restore — `setHtml()` on the plain-text source editor round-tripped through `textChanged` and stripped all tags. Use `setPlainText` (verbatim).
- **ChatNode.paint** mutated `colors["accent"]` in place (`setAlpha(140)`), so the connection dots reused it at 55% opacity. Copy before mutating.
- **ImageNode.paint** never drew the search-match highlight ring; added it (full + LOD paths), drawn last so it doesn't leave a tinted line under the header.
- **NavigationPin.positionPreviewChanged** — a signal emitted every drag step but connected nowhere; removed it and the `itemChange` override that only existed to emit it.
- **Connection endpoints** — 5 copy-pasted `_get_effective_endpoint` overrides ignored collapsed Frames and only checked the immediate parent, drawing connections to hidden positions. Extracted one `resolve_collapsed_endpoint()` helper that base + all 5 variants delegate to.
- **ApiSettingsWidget** relabeled its button "Refresh Available Models" even after a failed fetch; gate the label on a per-attempt success flag.

## Test plan
- [x] `compileall` clean; full suite **853 passed** (841 + 12 new)
- [x] The 4 non-trivial fixes (HTML, nav-pin signal, connection endpoint, API button) + the 2 rewritten paint tests are all mutation-checked — each fails against the pre-fix code
- [x] ImageNode ring-last verified by pixel count (no header scanline)
- [x] Python-only; `web_ui/` untouched
- [ ] CI validates on push

## Note
`CodeNode` has the identical (pre-existing) search-ring header-scanline; left out of scope here and flagged as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)