### PR TITLE
Fix crash: unparented QTimer/QVariantAnimation outliving QGraphicsItem on chat-switch

### DIFF
--- a/graphlink_app/graphlink_canvas/graphlink_canvas_base.py
+++ b/graphlink_app/graphlink_canvas/graphlink_canvas_base.py
@@ -19,11 +19,26 @@ class HoverAnimationMixin:
     def __init__(self):
         """Initializes the HoverAnimationMixin."""
         self.incoming_connection = None # The connection leading *to* this node.
+        self._hover_animation_disposed = False
         # A single-shot timer to detect a "long hover".
         self.long_hover_timer = QTimer()
         self.long_hover_timer.setSingleShot(True)
         self.long_hover_timer.setInterval(750) # 750ms delay before triggering.
         self.long_hover_timer.timeout.connect(self.trigger_ancestor_animation)
+
+    def _stop_hover_animation_timer(self):
+        """Stops long_hover_timer so it can't fire after the host item's C++
+        side is destroyed - QGraphicsItem isn't a QObject, so nothing else
+        parents or auto-cleans up this timer. Idempotent; each host class's
+        itemChange calls this on ItemSceneHasChanged/value is None."""
+        if self._hover_animation_disposed:
+            return
+        self._hover_animation_disposed = True
+        self.long_hover_timer.stop()
+        try:
+            self.long_hover_timer.timeout.disconnect()
+        except (TypeError, RuntimeError):
+            pass
 
     def trigger_ancestor_animation(self):
         """

--- a/graphlink_app/graphlink_canvas/graphlink_canvas_note.py
+++ b/graphlink_app/graphlink_canvas/graphlink_canvas_note.py
@@ -77,7 +77,8 @@ class Note(QGraphicsItem):
         
         self.hovered = False
         self.color_button_hovered = False
-        
+        self._disposed = False
+
         self.cursor_timer = QTimer()
         self.cursor_timer.timeout.connect(self.toggle_cursor)
         self.cursor_timer.setInterval(500)
@@ -181,8 +182,26 @@ class Note(QGraphicsItem):
         
     def toggle_cursor(self):
         """Toggles the visibility of the text editing cursor."""
+        if self._disposed:
+            return
         self.cursor_visible = not self.cursor_visible
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
+
+    def _teardown_async_helpers(self):
+        """Stops cursor_timer so it can't fire after this item's C++ side is
+        destroyed - QGraphicsItem isn't a QObject, so nothing else parents
+        or auto-cleans up this timer. Idempotent."""
+        if self._disposed:
+            return
+        self._disposed = True
+        self.cursor_timer.stop()
+        try:
+            self.cursor_timer.timeout.disconnect()
+        except (TypeError, RuntimeError):
+            pass
 
     def paint(self, painter, option, widget=None):
         """Handles the custom painting of the note."""
@@ -644,6 +663,9 @@ class Note(QGraphicsItem):
         
     def itemChange(self, change, value):
         """Handles item changes."""
+        if change == QGraphicsItem.ItemSceneHasChanged and value is None:
+            self._teardown_async_helpers()
+
         if change == QGraphicsItem.ItemPositionChange and self.scene() and self.scene().is_dragging_item:
             parent = self.parentItem()
             from .graphlink_canvas_container import Container

--- a/graphlink_app/graphlink_connections.py
+++ b/graphlink_app/graphlink_connections.py
@@ -195,12 +195,13 @@ class ConnectionItem(QGraphicsItem):
         self.click_tolerance = 20.0 # Increased hitbox for easier clicking
         self.hover_path = None # Cached path for hover detection
         self.is_selected = False
-        
+        self._disposed = False
+
         # Timer to delay the start of the arrow animation on long hover
         self.hover_start_timer = QTimer()
         self.hover_start_timer.setSingleShot(True)
         self.hover_start_timer.timeout.connect(self.startArrowAnimation)
-        
+
         # Timer to drive the arrow animation frames
         self.animation_timer = QTimer()
         self.animation_timer.timeout.connect(self.updateArrows)
@@ -242,8 +243,24 @@ class ConnectionItem(QGraphicsItem):
 
     def itemChange(self, change, value):
         if change == QGraphicsItem.GraphicsItemChange.ItemSceneHasChanged:
+            if value is None:
+                self._teardown_async_helpers()
             self.sync_visibility_mode()
         return super().itemChange(change, value)
+
+    def _teardown_async_helpers(self):
+        """Stops both timers so they can't fire after this item's C++ side
+        is destroyed - QGraphicsItem isn't a QObject, so nothing else
+        parents or auto-cleans up these timers. Idempotent."""
+        if self._disposed:
+            return
+        self._disposed = True
+        for timer in (self.hover_start_timer, self.animation_timer):
+            timer.stop()
+            try:
+                timer.timeout.disconnect()
+            except (TypeError, RuntimeError):
+                pass
 
     def create_hover_path(self):
         """
@@ -501,6 +518,8 @@ class ConnectionItem(QGraphicsItem):
 
     def startArrowAnimation(self):
         """Starts the animated arrow flow along the connection path."""
+        if self._disposed:
+            return
         if not self.is_animating:
             self.is_animating = True
             self.arrows = []
@@ -508,7 +527,7 @@ class ConnectionItem(QGraphicsItem):
             if path_length <= 0:
                 self.is_animating = False
                 return
-            
+
             # Pre-populate arrows along the path
             current_distance = 0
             while current_distance < path_length:
@@ -518,39 +537,47 @@ class ConnectionItem(QGraphicsItem):
                     'distance': current_distance
                 })
                 current_distance += self.arrow_spacing
-            
+
             self.animation_timer.start(16) # ~60 FPS
-            self.update()
+            try:
+                self.update()
+            except RuntimeError:
+                self._teardown_async_helpers()
 
     def stopArrowAnimation(self):
         """Stops the arrow animation and clears the arrows."""
+        if self._disposed:
+            return
         self.is_animating = False
         self.animation_timer.stop()
         self.arrows.clear()
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
 
     def updateArrows(self):
         """Updates the position of each arrow for the next animation frame."""
-        if not self.is_animating:
+        if self._disposed or not self.is_animating:
             return
-            
+
         path_length = self.path.length()
         if path_length <= 0:
             self.stopArrowAnimation()
             return
         arrows_to_remove = []
-        
+
         for arrow in self.arrows:
             arrow['distance'] += self.animation_speed
             arrow['pos'] = arrow['distance'] / path_length
-            
+
             # Mark arrows that have reached the end of the path for removal
             if arrow['pos'] >= 1:
                 arrows_to_remove.append(arrow)
-                
+
         for arrow in arrows_to_remove:
             self.arrows.remove(arrow)
-            
+
         # Add a new arrow at the start if there's space
         if not self.arrows or self.arrows[0]['distance'] >= self.arrow_spacing:
             self.arrows.insert(0, {
@@ -558,8 +585,11 @@ class ConnectionItem(QGraphicsItem):
                 'opacity': 1.0,
                 'distance': 0
             })
-        
-        self.update()
+
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
 
     def drawArrow(self, painter, pos, opacity):
         """
@@ -751,12 +781,13 @@ class ContentConnectionItem(QGraphicsItem):
         self.path = QPainterPath()
         self.setAcceptHoverEvents(True)
         self.hover = False
-        
+        self._disposed = False
+
         # Timers for hover animation
         self.hover_start_timer = QTimer()
         self.hover_start_timer.setSingleShot(True)
         self.hover_start_timer.timeout.connect(self.startArrowAnimation)
-        
+
         self.animation_timer = QTimer()
         self.animation_timer.timeout.connect(self.updateArrows)
         
@@ -797,8 +828,24 @@ class ContentConnectionItem(QGraphicsItem):
 
     def itemChange(self, change, value):
         if change == QGraphicsItem.GraphicsItemChange.ItemSceneHasChanged:
+            if value is None:
+                self._teardown_async_helpers()
             self.sync_visibility_mode()
         return super().itemChange(change, value)
+
+    def _teardown_async_helpers(self):
+        """Stops both timers so they can't fire after this item's C++ side
+        is destroyed - QGraphicsItem isn't a QObject, so nothing else
+        parents or auto-cleans up these timers. Idempotent."""
+        if self._disposed:
+            return
+        self._disposed = True
+        for timer in (self.hover_start_timer, self.animation_timer):
+            timer.stop()
+            try:
+                timer.timeout.disconnect()
+            except (TypeError, RuntimeError):
+                pass
 
     def update_path(self):
         """Recalculates the path, which is a straight line from bottom-center to top-center."""
@@ -833,29 +880,39 @@ class ContentConnectionItem(QGraphicsItem):
 
     def startArrowAnimation(self):
         """Starts the animated arrow flow."""
+        if self._disposed:
+            return
         if not self.is_animating:
             self.is_animating = True
             self.arrows = []
             path_length = self.path.length()
-            
+
             current_distance = 0
             while current_distance < path_length:
                 self.arrows.append({'pos': current_distance / path_length, 'distance': current_distance})
                 current_distance += self.arrow_spacing
-            
+
             self.animation_timer.start(16)
-            self.update()
+            try:
+                self.update()
+            except RuntimeError:
+                self._teardown_async_helpers()
 
     def stopArrowAnimation(self):
         """Stops the animated arrow flow."""
+        if self._disposed:
+            return
         self.is_animating = False
         self.animation_timer.stop()
         self.arrows.clear()
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
 
     def updateArrows(self):
         """Updates arrow positions for animation."""
-        if not self.is_animating: return
+        if self._disposed or not self.is_animating: return
         path_length = self.path.length()
         for arrow in self.arrows:
             arrow['distance'] += self.animation_speed
@@ -863,7 +920,10 @@ class ContentConnectionItem(QGraphicsItem):
         self.arrows = [a for a in self.arrows if a['pos'] < 1]
         if not self.arrows or self.arrows[0]['distance'] >= self.arrow_spacing:
             self.arrows.insert(0, {'pos': 0, 'distance': 0})
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
 
     def drawArrow(self, painter, pos, color):
         """Draws a single arrow on the path."""
@@ -930,11 +990,12 @@ class DocumentConnectionItem(QGraphicsItem):
         self.path = QPainterPath()
         self.setAcceptHoverEvents(True)
         self.hover = False
-        
+        self._disposed = False
+
         self.hover_start_timer = QTimer()
         self.hover_start_timer.setSingleShot(True)
         self.hover_start_timer.timeout.connect(self.startArrowAnimation)
-        
+
         self.animation_timer = QTimer()
         self.animation_timer.timeout.connect(self.updateArrows)
         
@@ -974,8 +1035,24 @@ class DocumentConnectionItem(QGraphicsItem):
 
     def itemChange(self, change, value):
         if change == QGraphicsItem.GraphicsItemChange.ItemSceneHasChanged:
+            if value is None:
+                self._teardown_async_helpers()
             self.sync_visibility_mode()
         return super().itemChange(change, value)
+
+    def _teardown_async_helpers(self):
+        """Stops both timers so they can't fire after this item's C++ side
+        is destroyed - QGraphicsItem isn't a QObject, so nothing else
+        parents or auto-cleans up these timers. Idempotent."""
+        if self._disposed:
+            return
+        self._disposed = True
+        for timer in (self.hover_start_timer, self.animation_timer):
+            timer.stop()
+            try:
+                timer.timeout.disconnect()
+            except (TypeError, RuntimeError):
+                pass
 
     def update_path(self):
         """Recalculates the path as a straight line."""
@@ -1013,6 +1090,8 @@ class DocumentConnectionItem(QGraphicsItem):
 
     def startArrowAnimation(self):
         """Starts the arrow animation."""
+        if self._disposed:
+            return
         if not self.is_animating:
             self.is_animating = True
             self.arrows = []
@@ -1022,18 +1101,26 @@ class DocumentConnectionItem(QGraphicsItem):
                 self.arrows.append({'pos': current_distance / path_length, 'distance': current_distance})
                 current_distance += self.arrow_spacing
             self.animation_timer.start(16)
-            self.update()
+            try:
+                self.update()
+            except RuntimeError:
+                self._teardown_async_helpers()
 
     def stopArrowAnimation(self):
         """Stops the arrow animation."""
+        if self._disposed:
+            return
         self.is_animating = False
         self.animation_timer.stop()
         self.arrows.clear()
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
 
     def updateArrows(self):
         """Updates arrow positions for animation."""
-        if not self.is_animating: return
+        if self._disposed or not self.is_animating: return
         path_length = self.path.length()
         for arrow in self.arrows:
             arrow['distance'] += self.animation_speed
@@ -1041,7 +1128,10 @@ class DocumentConnectionItem(QGraphicsItem):
         self.arrows = [a for a in self.arrows if a['pos'] < 1]
         if not self.arrows or self.arrows[0]['distance'] >= self.arrow_spacing:
             self.arrows.insert(0, {'pos': 0, 'distance': 0})
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
 
     def drawArrow(self, painter, pos, color):
         """Draws a single arrow on the path."""
@@ -1110,11 +1200,12 @@ class ImageConnectionItem(QGraphicsItem):
         self.path = QPainterPath()
         self.setAcceptHoverEvents(True)
         self.hover = False
-        
+        self._disposed = False
+
         self.hover_start_timer = QTimer()
         self.hover_start_timer.setSingleShot(True)
         self.hover_start_timer.timeout.connect(self.startArrowAnimation)
-        
+
         self.animation_timer = QTimer()
         self.animation_timer.timeout.connect(self.updateArrows)
         
@@ -1154,8 +1245,24 @@ class ImageConnectionItem(QGraphicsItem):
 
     def itemChange(self, change, value):
         if change == QGraphicsItem.GraphicsItemChange.ItemSceneHasChanged:
+            if value is None:
+                self._teardown_async_helpers()
             self.sync_visibility_mode()
         return super().itemChange(change, value)
+
+    def _teardown_async_helpers(self):
+        """Stops both timers so they can't fire after this item's C++ side
+        is destroyed - QGraphicsItem isn't a QObject, so nothing else
+        parents or auto-cleans up these timers. Idempotent."""
+        if self._disposed:
+            return
+        self._disposed = True
+        for timer in (self.hover_start_timer, self.animation_timer):
+            timer.stop()
+            try:
+                timer.timeout.disconnect()
+            except (TypeError, RuntimeError):
+                pass
 
     def update_path(self):
         """Recalculates the path as a straight line."""
@@ -1189,6 +1296,8 @@ class ImageConnectionItem(QGraphicsItem):
 
     def startArrowAnimation(self):
         """Starts the arrow animation."""
+        if self._disposed:
+            return
         if not self.is_animating:
             self.is_animating = True
             self.arrows = []
@@ -1198,18 +1307,26 @@ class ImageConnectionItem(QGraphicsItem):
                 self.arrows.append({'pos': current_distance / path_length, 'distance': current_distance})
                 current_distance += self.arrow_spacing
             self.animation_timer.start(16)
-            self.update()
+            try:
+                self.update()
+            except RuntimeError:
+                self._teardown_async_helpers()
 
     def stopArrowAnimation(self):
         """Stops the arrow animation."""
+        if self._disposed:
+            return
         self.is_animating = False
         self.animation_timer.stop()
         self.arrows.clear()
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
 
     def updateArrows(self):
         """Updates arrow positions for animation."""
-        if not self.is_animating: return
+        if self._disposed or not self.is_animating: return
         path_length = self.path.length()
         for arrow in self.arrows:
             arrow['distance'] += self.animation_speed
@@ -1217,7 +1334,10 @@ class ImageConnectionItem(QGraphicsItem):
         self.arrows = [a for a in self.arrows if a['pos'] < 1]
         if not self.arrows or self.arrows[0]['distance'] >= self.arrow_spacing:
             self.arrows.insert(0, {'pos': 0, 'distance': 0})
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
 
     def drawArrow(self, painter, pos, color):
         """Draws a single arrow on the path."""
@@ -1310,6 +1430,7 @@ class SystemPromptConnectionItem(QGraphicsItem):
         self.path = QPainterPath()
         self.hovered = False
         self._pulse_value = 0.0
+        self._disposed = False
 
         # Animation for the pulsing effect
         self.pulse_animation = QVariantAnimation()
@@ -1329,16 +1450,34 @@ class SystemPromptConnectionItem(QGraphicsItem):
 
     def _on_pulse_update(self, value):
         """Slot to update the pulse value from the animation and trigger a repaint."""
+        if self._disposed:
+            return
         self._pulse_value = value
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
 
     def itemChange(self, change, value):
         """Stops the animation when the item is removed from the scene."""
         if change == QGraphicsItem.ItemSceneHasChanged:
-            if self.pulse_animation:
-                self.pulse_animation.stop()
+            if value is None:
+                self._teardown_async_helpers()
             self.sync_visibility_mode()
         return super().itemChange(change, value)
+
+    def _teardown_async_helpers(self):
+        """Stops the pulse animation so it can't fire after this item's C++
+        side is destroyed - QGraphicsItem isn't a QObject, so nothing else
+        parents or auto-cleans up this QVariantAnimation. Idempotent."""
+        if self._disposed:
+            return
+        self._disposed = True
+        self.pulse_animation.stop()
+        try:
+            self.pulse_animation.valueChanged.disconnect()
+        except (TypeError, RuntimeError):
+            pass
 
     def _get_visual_rect(self, item):
         """Helper to get the visual rectangle of an item."""
@@ -1451,11 +1590,12 @@ class PyCoderConnectionItem(QGraphicsItem):
         self.path = QPainterPath()
         self.setAcceptHoverEvents(True)
         self.hover = False
-        
+        self._disposed = False
+
         self.hover_start_timer = QTimer()
         self.hover_start_timer.setSingleShot(True)
         self.hover_start_timer.timeout.connect(self.startArrowAnimation)
-        
+
         self.animation_timer = QTimer()
         self.animation_timer.timeout.connect(self.updateArrows)
         
@@ -1495,8 +1635,24 @@ class PyCoderConnectionItem(QGraphicsItem):
 
     def itemChange(self, change, value):
         if change == QGraphicsItem.GraphicsItemChange.ItemSceneHasChanged:
+            if value is None:
+                self._teardown_async_helpers()
             self.sync_visibility_mode()
         return super().itemChange(change, value)
+
+    def _teardown_async_helpers(self):
+        """Stops both timers so they can't fire after this item's C++ side
+        is destroyed - QGraphicsItem isn't a QObject, so nothing else
+        parents or auto-cleans up these timers. Idempotent."""
+        if self._disposed:
+            return
+        self._disposed = True
+        for timer in (self.hover_start_timer, self.animation_timer):
+            timer.stop()
+            try:
+                timer.timeout.disconnect()
+            except (TypeError, RuntimeError):
+                pass
 
     def update_path(self):
         """Recalculates the path of the connection."""
@@ -1547,6 +1703,8 @@ class PyCoderConnectionItem(QGraphicsItem):
 
     def startArrowAnimation(self):
         """Starts the arrow animation."""
+        if self._disposed:
+            return
         if not self.is_animating:
             self.is_animating = True
             self.arrows = []
@@ -1556,18 +1714,26 @@ class PyCoderConnectionItem(QGraphicsItem):
                 self.arrows.append({'pos': current_distance / path_length, 'distance': current_distance})
                 current_distance += self.arrow_spacing
             self.animation_timer.start(16)
-            self.update()
+            try:
+                self.update()
+            except RuntimeError:
+                self._teardown_async_helpers()
 
     def stopArrowAnimation(self):
         """Stops the arrow animation."""
+        if self._disposed:
+            return
         self.is_animating = False
         self.animation_timer.stop()
         self.arrows.clear()
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
 
     def updateArrows(self):
         """Updates arrow positions for animation."""
-        if not self.is_animating: return
+        if self._disposed or not self.is_animating: return
         path_length = self.path.length()
         for arrow in self.arrows:
             arrow['distance'] += self.animation_speed
@@ -1575,7 +1741,10 @@ class PyCoderConnectionItem(QGraphicsItem):
         self.arrows = [a for a in self.arrows if a['pos'] < 1]
         if not self.arrows or self.arrows[0]['distance'] >= self.arrow_spacing:
             self.arrows.insert(0, {'pos': 0, 'distance': 0})
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
 
     def drawArrow(self, painter, pos, color):
         """Draws a single arrow on the path."""

--- a/graphlink_app/graphlink_conversation_node.py
+++ b/graphlink_app/graphlink_conversation_node.py
@@ -96,16 +96,40 @@ class TypingIndicatorItem(QGraphicsObject):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._dot_opacity = [1.0, 1.0, 1.0]
+        self._disposed = False
         self._timer = QTimer()
         self._timer.timeout.connect(self._animate)
         self._timer.start(300)
         self._counter = 0
 
     def _animate(self):
+        if self._disposed:
+            return
         self._counter = (self._counter + 1) % 4
         for i in range(3):
             self._dot_opacity[i] = 1.0 if self._counter == i + 1 else 0.3
-        self.update()
+        try:
+            self.update()
+        except RuntimeError:
+            self._teardown_async_helpers()
+
+    def itemChange(self, change, value):
+        if change == QGraphicsObject.GraphicsItemChange.ItemSceneHasChanged and value is None:
+            self._teardown_async_helpers()
+        return super().itemChange(change, value)
+
+    def _teardown_async_helpers(self):
+        """Stops _timer so it can't fire after this item's C++ side is
+        destroyed - QGraphicsItem isn't a QObject, so nothing else parents
+        or auto-cleans up this timer. Idempotent."""
+        if self._disposed:
+            return
+        self._disposed = True
+        self._timer.stop()
+        try:
+            self._timer.timeout.disconnect()
+        except (TypeError, RuntimeError):
+            pass
 
     def boundingRect(self):
         return QRectF(0, 0, 60, 30)
@@ -527,6 +551,8 @@ class ConversationNode(QGraphicsObject, HoverAnimationMixin):
         super().mouseReleaseEvent(event)
 
     def itemChange(self, change, value):
+        if change == QGraphicsObject.GraphicsItemChange.ItemSceneHasChanged and value is None:
+            self._stop_hover_animation_timer()
         if change == QGraphicsObject.GraphicsItemChange.ItemPositionChange and self.scene() and self.scene().is_dragging_item:
             return self.scene().snap_position(self, value)
         if change == QGraphicsObject.GraphicsItemChange.ItemPositionHasChanged and self.scene():

--- a/graphlink_app/graphlink_html_view.py
+++ b/graphlink_app/graphlink_html_view.py
@@ -520,9 +520,10 @@ class HtmlViewNode(QGraphicsObject, HoverAnimationMixin):
 
     def itemChange(self, change, value):
         if change == self.GraphicsItemChange.ItemSceneHasChanged and not self.scene():
+            self._stop_hover_animation_timer()
             if self.popout_window:
                 self.popout_window.close()
-        
+
         if change == QGraphicsObject.GraphicsItemChange.ItemPositionChange and self.scene() and self.scene().is_dragging_item:
             return self.scene().snap_position(self, value)
         if change == QGraphicsObject.GraphicsItemChange.ItemPositionHasChanged and self.scene():

--- a/graphlink_app/graphlink_nodes/graphlink_node_chat.py
+++ b/graphlink_app/graphlink_nodes/graphlink_node_chat.py
@@ -657,8 +657,11 @@ class ChatNode(QGraphicsItem, HoverAnimationMixin):
         super().hoverLeaveEvent(event)
 
     def itemChange(self, change, value):
-        if change == QGraphicsItem.ItemSceneHasChanged and self.scene():
-            self._setup_document()
+        if change == QGraphicsItem.ItemSceneHasChanged:
+            if self.scene():
+                self._setup_document()
+            else:
+                self._stop_hover_animation_timer()
         if change == QGraphicsItem.ItemPositionChange and self.scene():
             parent = self.parentItem()
             if parent and isinstance(parent, Container):

--- a/graphlink_app/graphlink_nodes/graphlink_node_code.py
+++ b/graphlink_app/graphlink_nodes/graphlink_node_code.py
@@ -261,6 +261,8 @@ class CodeNode(QGraphicsItem, HoverAnimationMixin):
         super().hoverLeaveEvent(event)
 
     def itemChange(self, change, value):
+        if change == QGraphicsItem.ItemSceneHasChanged and value is None:
+            self._stop_hover_animation_timer()
         if change == QGraphicsItem.ItemPositionChange and self.scene():
             parent = self.parentItem()
             if parent and isinstance(parent, Container):

--- a/graphlink_app/graphlink_nodes/graphlink_node_document.py
+++ b/graphlink_app/graphlink_nodes/graphlink_node_document.py
@@ -573,10 +573,13 @@ class DocumentNode(QGraphicsItem, HoverAnimationMixin):
         super().hoverLeaveEvent(event)
 
     def itemChange(self, change, value):
-        if change == QGraphicsItem.ItemSceneHasChanged and self.scene():
-            self._setup_document()
-            if not self.is_collapsed:
-                self._recalculate_geometry()
+        if change == QGraphicsItem.ItemSceneHasChanged:
+            if self.scene():
+                self._setup_document()
+                if not self.is_collapsed:
+                    self._recalculate_geometry()
+            else:
+                self._stop_hover_animation_timer()
         if change == QGraphicsItem.ItemPositionChange and self.scene():
             parent = self.parentItem()
             if parent and isinstance(parent, Container):

--- a/graphlink_app/graphlink_nodes/graphlink_node_image.py
+++ b/graphlink_app/graphlink_nodes/graphlink_node_image.py
@@ -174,6 +174,8 @@ class ImageNode(QGraphicsItem, HoverAnimationMixin):
         super().hoverLeaveEvent(event)
 
     def itemChange(self, change, value):
+        if change == QGraphicsItem.ItemSceneHasChanged and value is None:
+            self._stop_hover_animation_timer()
         if change == QGraphicsItem.ItemPositionChange and self.scene():
             parent = self.parentItem()
             if parent and isinstance(parent, Container):

--- a/graphlink_app/graphlink_nodes/graphlink_node_thinking.py
+++ b/graphlink_app/graphlink_nodes/graphlink_node_thinking.py
@@ -302,8 +302,11 @@ class ThinkingNode(QGraphicsItem, HoverAnimationMixin):
         super().hoverLeaveEvent(event)
 
     def itemChange(self, change, value):
-        if change == QGraphicsItem.ItemSceneHasChanged and self.scene():
-            self._setup_document()
+        if change == QGraphicsItem.ItemSceneHasChanged:
+            if self.scene():
+                self._setup_document()
+            else:
+                self._stop_hover_animation_timer()
         if change == QGraphicsItem.ItemPositionChange and self.scene():
             parent = self.parentItem()
             if parent and isinstance(parent, Container):

--- a/graphlink_app/graphlink_plugins/graphlink_plugin_artifact.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_artifact.py
@@ -624,6 +624,8 @@ class ArtifactNode(QGraphicsObject, HoverAnimationMixin):
         super().mouseReleaseEvent(event)
 
     def itemChange(self, change, value):
+        if change == QGraphicsObject.GraphicsItemChange.ItemSceneHasChanged and value is None:
+            self._stop_hover_animation_timer()
         if change == QGraphicsObject.GraphicsItemChange.ItemPositionChange and self.scene() and self.scene().is_dragging_item:
             return self.scene().snap_position(self, value)
         if change == QGraphicsObject.GraphicsItemChange.ItemPositionHasChanged and self.scene():

--- a/graphlink_app/graphlink_plugins/graphlink_plugin_code_sandbox.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_code_sandbox.py
@@ -704,6 +704,8 @@ class CodeSandboxNode(QGraphicsObject, HoverAnimationMixin):
         super().mouseReleaseEvent(event)
 
     def itemChange(self, change, value):
+        if change == QGraphicsItem.GraphicsItemChange.ItemSceneHasChanged and value is None:
+            self._stop_hover_animation_timer()
         if change == QGraphicsItem.GraphicsItemChange.ItemPositionChange and self.scene() and self.scene().is_dragging_item:
             return self.scene().snap_position(self, value)
         if change == QGraphicsItem.GraphicsItemChange.ItemPositionHasChanged and self.scene():

--- a/graphlink_app/graphlink_plugins/graphlink_plugin_gitlink.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_gitlink.py
@@ -1668,6 +1668,8 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
         super().mouseReleaseEvent(event)
 
     def itemChange(self, change, value):
+        if change == QGraphicsObject.GraphicsItemChange.ItemSceneHasChanged and value is None:
+            self._stop_hover_animation_timer()
         if change == QGraphicsObject.GraphicsItemChange.ItemPositionChange and self.scene() and self.scene().is_dragging_item:
             return self.scene().snap_position(self, value)
         if change == QGraphicsObject.GraphicsItemChange.ItemPositionHasChanged and self.scene():

--- a/graphlink_app/graphlink_pycoder.py
+++ b/graphlink_app/graphlink_pycoder.py
@@ -746,6 +746,8 @@ class PyCoderNode(QGraphicsItem, HoverAnimationMixin):
         super().mouseReleaseEvent(event)
 
     def itemChange(self, change, value):
+        if change == QGraphicsItem.ItemSceneHasChanged and value is None:
+            self._stop_hover_animation_timer()
         if change == QGraphicsItem.ItemPositionChange and self.scene() and self.scene().is_dragging_item:
             return self.scene().snap_position(self, value)
         if change == QGraphicsItem.ItemPositionHasChanged and self.scene():

--- a/graphlink_app/graphlink_scene.py
+++ b/graphlink_app/graphlink_scene.py
@@ -1652,10 +1652,68 @@ class ChatScene(QGraphicsScene):
                 
         return snapped_pos
 
+    def _teardown_items_before_clear(self):
+        """Stops every tracked item's unparented async timers/animations
+        BEFORE super().clear() deletes their C++ objects.
+
+        QGraphicsScene.clear() does NOT call itemChange(ItemSceneHasChanged,
+        None) for the items it removes - confirmed empirically against this
+        project's PySide6 build: only QGraphicsScene.removeItem() (the
+        individual-delete path, e.g. right-click delete) fires that
+        notification. clear() deletes each item's C++ side directly. Since
+        QGraphicsItem isn't a QObject, nothing else stops a plain QTimer/
+        QVariantAnimation created inside one - the itemChange-based teardown
+        hooks on these classes are correct and necessary for the
+        removeItem() path, but are never invoked for clear(), which is
+        exactly the path chat-switching uses (see
+        graphlink_session/deserializers.py's restore_chat()). This walk is
+        the only way to stop them before clear() destroys the items.
+        """
+        def _try_teardown(item, method_name):
+            method = getattr(item, method_name, None)
+            if callable(method):
+                try:
+                    method()
+                except RuntimeError:
+                    pass
+
+        connection_lists = (
+            self.connections, self.content_connections, self.document_connections,
+            self.image_connections, self.thinking_connections, self.system_prompt_connections,
+            self.pycoder_connections, self.code_sandbox_connections, self.web_connections,
+            self.conversation_connections, self.group_summary_connections, self.html_connections,
+            self.artifact_connections, self.gitlink_connections, self.chart_connections,
+        )
+        for conn_list in connection_lists:
+            for conn in conn_list:
+                _try_teardown(conn, "_teardown_async_helpers")
+
+        hover_animation_node_lists = (
+            self.nodes, self.code_nodes, self.document_nodes, self.image_nodes,
+            self.thinking_nodes, self.pycoder_nodes, self.code_sandbox_nodes,
+            self.web_nodes, self.conversation_nodes, self.html_view_nodes,
+            self.artifact_nodes, self.gitlink_nodes,
+        )
+        for node_list in hover_animation_node_lists:
+            for node in node_list:
+                _try_teardown(node, "_stop_hover_animation_timer")
+
+        for node in self.conversation_nodes:
+            typing_indicator = getattr(node, "_typing_indicator", None)
+            if typing_indicator is not None:
+                _try_teardown(typing_indicator, "_teardown_async_helpers")
+
+        for item in list(self.notes) + list(self.containers) + list(self.frames):
+            _try_teardown(item, "_teardown_async_helpers")
+
+        for chart in self.chart_nodes:
+            _try_teardown(chart, "dispose")  # ChartItem.dispose() is timer/figure-only
+
     def clear(self):
         """
         Clears the entire scene, removing all items and resetting all tracking lists.
         """
+        self._teardown_items_before_clear()
         super().clear()
         self.nodes.clear()
         self.connections.clear()

--- a/graphlink_app/graphlink_web.py
+++ b/graphlink_app/graphlink_web.py
@@ -586,6 +586,8 @@ class WebNode(QGraphicsObject, HoverAnimationMixin):
         Returns:
             The modified value or the result of the superclass implementation.
         """
+        if change == QGraphicsItem.ItemSceneHasChanged and value is None:
+            self._stop_hover_animation_timer()
         if change == QGraphicsItem.ItemPositionChange and self.scene() and self.scene().is_dragging_item:
             return self.scene().snap_position(self, value)
         if change == QGraphicsItem.ItemPositionHasChanged and self.scene():

--- a/graphlink_app/tests/test_connection_timer_lifecycle.py
+++ b/graphlink_app/tests/test_connection_timer_lifecycle.py
@@ -1,0 +1,355 @@
+"""Regression coverage for the timer-outlives-item crash class:
+
+    RuntimeError: Internal C++ object (ThinkingConnectionItem) already deleted.
+
+QGraphicsItem is not a QObject, so a QTimer/QVariantAnimation created inside a
+QGraphicsItem.__init__ is never auto-parented or auto-cleaned-up. Several
+classes across graphlink_connections.py, graphlink_canvas_base.py
+(HoverAnimationMixin), graphlink_canvas_note.py (Note), and
+graphlink_conversation_node.py (TypingIndicatorItem) created such timers with
+no teardown hook, so the timer kept firing after ChatScene.clear() (used by
+chat-switching, see graphlink_session/deserializers.py's restore_chat())
+deleted the item's C++ side - the timer's callback then touched self.update()
+on a dead object.
+
+Two real bugs were found and fixed while building this, not just the one
+reported: (1) each affected class got an itemChange(ItemSceneHasChanged,
+value is None) hook to stop its own timers - correct and necessary for
+QGraphicsScene.removeItem() (individual delete, e.g. right-click delete),
+confirmed via a live diagnostic to fire reliably for that path; (2) but a
+SECOND diagnostic proved QGraphicsScene.clear() - the actual path chat-
+switching uses - never calls itemChange at all for the items it bulk-deletes,
+even for the pre-existing "proven" Container/ChartItem precedent this fix
+was modeled on (its ghost_frame_timer was still active after scene.clear()
+too, confirmed empirically). So ChatScene.clear() (graphlink_scene.py) now
+explicitly walks every tracked item and tears its timers down BEFORE calling
+super().clear() - that pre-clear walk is what these tests exercise, using a
+REAL ChatScene (not a bare QGraphicsScene, which has no such override and
+would not exercise this fix at all).
+
+Verification approach: once an item's C++ side is deleted, shiboken blocks
+ALL further attribute access on it (confirmed empirically) - even reading a
+plain instance attribute raises "Internal C++ object already deleted". So
+every test captures a reference to the timer/animation OBJECT ITSELF before
+triggering deletion, then inspects that independent QObject afterward, never
+the (by-then) dead item.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from PySide6.QtCore import QPointF, QRectF, QTimer
+from PySide6.QtWidgets import QGraphicsItem, QGraphicsScene
+from shiboken6 import isValid
+
+from graphlink_canvas.graphlink_canvas_base import HoverAnimationMixin
+from graphlink_canvas.graphlink_canvas_container import Container
+from graphlink_canvas.graphlink_canvas_frame import Frame
+from graphlink_canvas.graphlink_canvas_note import Note
+from graphlink_connections import ConnectionItem, SystemPromptConnectionItem, ThinkingConnectionItem
+from graphlink_conversation_node import ConversationNode, TypingIndicatorItem
+from graphlink_nodes.graphlink_node_chat import ChatNode
+from graphlink_scene import ChatScene
+
+
+def _scene():
+    return ChatScene(MagicMock())
+
+
+class _FakeNode(QGraphicsItem):
+    """Minimal connection endpoint matching the real contract every
+    ConnectionItem subclass's _get_visual_rect() expects: plain int/float
+    width/height attributes - NOT QGraphicsRectItem, whose built-in .rect()
+    is a method, which _get_visual_rect's hasattr(item, 'rect') branch
+    would misinterpret as the QRectF attribute Frame/Container expose."""
+
+    def __init__(self, w=50, h=50):
+        super().__init__()
+        self.width = w
+        self.height = h
+
+    def boundingRect(self):
+        return QRectF(0, 0, self.width, self.height)
+
+    def paint(self, painter, option, widget=None):
+        pass
+
+
+def _make_endpoints(scene):
+    start = _FakeNode()
+    end = _FakeNode()
+    start.setPos(0, 0)
+    end.setPos(0, 100)
+    scene.addItem(start)
+    scene.addItem(end)
+    return start, end
+
+
+class TestUnderlyingVulnerabilityIsReal:
+    def test_an_unparented_timer_left_running_crashes_on_a_deleted_item(self):
+        """Standalone reproduction of the exact bug class (deliberately NOT
+        using any already-fixed production class): a QGraphicsRectItem with
+        a plain, unparented QTimer wired straight to self.update(), started,
+        then the item is deleted out from under it via scene.clear() while
+        the timer is still running. Calling the timer's connected slot
+        afterward (the same call scene.clear() would leave a live QTimer
+        free to make later) reproduces the reported RuntimeError, proving
+        the danger this fix closes is real, not theoretical. Uses a bare
+        QGraphicsScene deliberately, to isolate the vulnerability from
+        ChatScene's fix. Note: Qt's signal/slot dispatch swallows exceptions
+        raised inside a slot during real signal emission (prints to stderr
+        instead of propagating) - calling the slot directly, as done here,
+        is what actually surfaces the RuntimeError to a test."""
+        from PySide6.QtWidgets import QGraphicsRectItem
+
+        scene = QGraphicsScene()
+        item = QGraphicsRectItem(QRectF(0, 0, 10, 10))
+        scene.addItem(item)
+
+        timer = QTimer()  # unparented - the exact root-cause pattern
+        timer.timeout.connect(item.update)
+        timer.start(16)
+        assert timer.isActive()
+
+        scene.clear()  # deletes item's C++ side; timer is untouched, still active
+        assert timer.isActive()
+
+        with pytest.raises(RuntimeError, match="already deleted"):
+            item.update()  # what the timer's next tick would have done
+
+
+class TestConnectionItemTimerLifecycle:
+    def test_stops_timers_on_chat_scene_clear(self):
+        scene = _scene()
+        start, end = _make_endpoints(scene)
+        conn = ConnectionItem(start, end)
+        scene.addItem(conn)
+        scene.connections.append(conn)
+
+        conn.startArrowAnimation()
+        animation_timer = conn.animation_timer
+        hover_timer = conn.hover_start_timer
+        assert animation_timer.isActive()
+
+        scene.clear()
+
+        assert not animation_timer.isActive()
+        assert not hover_timer.isActive()
+
+    def test_stops_timers_on_scene_removeitem(self):
+        """The itemChange-based hook's own path: removeItem() does NOT
+        delete the C++ object (ownership just returns to the caller), but
+        it DOES fire itemChange(ItemSceneHasChanged, None) - unlike clear().
+        """
+        scene = _scene()
+        start, end = _make_endpoints(scene)
+        conn = ConnectionItem(start, end)
+        scene.addItem(conn)
+        conn.startArrowAnimation()
+        assert conn.animation_timer.isActive()
+
+        scene.removeItem(conn)
+
+        assert not conn.animation_timer.isActive()
+
+
+class TestThinkingConnectionItemTimerLifecycle:
+    def test_stops_timers_on_chat_scene_clear(self):
+        """The exact class from the reported traceback."""
+        scene = _scene()
+        start, end = _make_endpoints(scene)
+        conn = ThinkingConnectionItem(start, end)
+        scene.addItem(conn)
+        scene.thinking_connections.append(conn)
+
+        conn.startArrowAnimation()
+        animation_timer = conn.animation_timer
+        assert animation_timer.isActive()
+
+        scene.clear()
+
+        assert not animation_timer.isActive()
+
+
+class TestSystemPromptConnectionItemTimerLifecycle:
+    def test_stops_pulse_animation_on_chat_scene_clear(self):
+        scene = _scene()
+        start, end = _make_endpoints(scene)
+        conn = SystemPromptConnectionItem(start, end)
+        scene.addItem(conn)
+        scene.system_prompt_connections.append(conn)
+        pulse = conn.pulse_animation
+        assert pulse.state() == pulse.State.Running
+
+        scene.clear()
+
+        assert pulse.state() != pulse.State.Running
+
+    def test_pulse_animation_survives_being_added_to_a_scene(self):
+        """Found while fixing the crash: the old itemChange stopped
+        pulse_animation on EVERY ItemSceneHasChanged, including being added
+        (not just removed) - so the pulsing border never actually animated.
+        Only the removal case should stop it now."""
+        scene = _scene()
+        start, end = _make_endpoints(scene)
+        conn = SystemPromptConnectionItem(start, end)
+        pulse = conn.pulse_animation
+
+        assert pulse.state() == pulse.State.Running
+        scene.addItem(conn)
+        assert pulse.state() == pulse.State.Running
+
+
+class _MixinHost(QGraphicsItem, HoverAnimationMixin):
+    """Minimal concrete host used to test HoverAnimationMixin's own teardown
+    logic in isolation, independent of any of its 12 real production hosts."""
+
+    def __init__(self):
+        QGraphicsItem.__init__(self)
+        HoverAnimationMixin.__init__(self)
+
+    def boundingRect(self):
+        return QRectF(0, 0, 10, 10)
+
+    def paint(self, painter, option, widget=None):
+        pass
+
+
+class TestHoverAnimationMixinTimerLifecycle:
+    def test_stop_hover_animation_timer_is_idempotent_and_stops_the_timer(self):
+        host = _MixinHost()
+        host.long_hover_timer.start()
+        assert host.long_hover_timer.isActive()
+
+        host._stop_hover_animation_timer()
+        assert not host.long_hover_timer.isActive()
+        assert host._hover_animation_disposed is True
+
+        host._stop_hover_animation_timer()  # must not raise a second time
+
+
+class TestChatNodeTimerLifecycle:
+    def test_real_host_stops_hover_timer_on_chat_scene_clear(self):
+        """Spot-checks a real production HoverAnimationMixin host end to
+        end, through ChatScene.clear()'s pre-clear teardown walk - not just
+        the mixin in isolation and not just the itemChange wiring."""
+        scene = _scene()
+        node = ChatNode("hello")
+        scene.addItem(node)
+        scene.nodes.append(node)
+
+        node.long_hover_timer.start()
+        timer = node.long_hover_timer
+        assert timer.isActive()
+
+        scene.clear()
+
+        assert not timer.isActive()
+
+
+class TestNoteTimerLifecycle:
+    def test_stops_cursor_timer_on_chat_scene_clear(self):
+        scene = _scene()
+        note = Note(QPointF(0, 0))
+        scene.addItem(note)
+        scene.notes.append(note)
+
+        note.cursor_timer.start()
+        timer = note.cursor_timer
+        assert timer.isActive()
+
+        scene.clear()
+
+        assert not timer.isActive()
+
+
+class TestContainerTimerLifecycle:
+    def test_stops_ghost_frame_timer_on_chat_scene_clear(self):
+        """Container's own _teardown_async_helpers is pre-existing code this
+        fix did not need to change - only ChatScene.clear() now actually
+        calls it for the bulk-clear path, which it never did before."""
+        scene = _scene()
+        container = Container(items=[])
+        scene.addItem(container)
+        scene.containers.append(container)
+
+        container.ghost_frame_timer.start(5000)
+        timer = container.ghost_frame_timer
+        assert timer.isActive()
+
+        scene.clear()
+
+        assert not timer.isActive()
+
+
+class TestFrameTimerLifecycle:
+    def test_stops_outline_animation_on_chat_scene_clear(self):
+        """Found by adversarial review: the first version of the pre-clear
+        walk covered notes/containers but missed self.frames entirely.
+        Frame.outline_animation (started by toggle_lock()/toggle_collapse())
+        is the identical unparented-QVariantAnimation pattern as Container's
+        pulse/ghost-frame timers. It happened not to crash only because
+        Frame._on_outline_animation_tick has its own pre-existing, unrelated
+        try/except RuntimeError self-heal - exactly the fragile, reactive-
+        only protection this fix's whole rationale exists to not rely on."""
+        scene = _scene()
+        frame = Frame(nodes=[])
+        scene.addItem(frame)
+        scene.frames.append(frame)
+
+        frame.outline_animation.start()
+        animation = frame.outline_animation
+        assert animation.state() == animation.State.Running
+
+        scene.clear()
+
+        assert animation.state() != animation.State.Running
+
+
+class TestConversationNodeTypingIndicatorTimerLifecycle:
+    def test_stops_own_hover_timer_and_nested_typing_indicator_on_chat_scene_clear(self):
+        scene = _scene()
+        node = ConversationNode(parent_node=None)
+        scene.addItem(node)
+        scene.conversation_nodes.append(node)
+
+        node.long_hover_timer.start()
+        hover_timer = node.long_hover_timer
+
+        indicator = TypingIndicatorItem()
+        node.internal_scene.addItem(indicator)
+        node._typing_indicator = indicator
+        typing_timer = indicator._timer
+        assert typing_timer.isActive()  # starts running unconditionally in __init__
+
+        scene.clear()
+
+        assert not hover_timer.isActive()
+        assert not typing_timer.isActive()
+
+
+class TestTypingIndicatorItemTimerLifecycle:
+    def test_real_qobject_deletion_confirms_the_cpp_side_is_actually_gone(self):
+        """TypingIndicatorItem is a QGraphicsObject (a real QObject, unlike
+        the plain-QGraphicsItem classes above) - shiboken6.isValid() can
+        directly confirm its C++ side is gone after scene.removeItem(), the
+        same introspection this codebase's own test_popup_combo_lifecycle.py
+        already uses for the analogous QWidget case. (This exercises the
+        itemChange path directly: TypingIndicatorItem lives in its owning
+        ConversationNode's nested internal_scene, not a top-level ChatScene
+        list, so it's outside ChatScene's pre-clear walk and relies on its
+        own itemChange hook, which DOES fire for removeItem().)"""
+        scene = QGraphicsScene()
+        indicator = TypingIndicatorItem()
+        scene.addItem(indicator)
+        assert isValid(indicator)
+
+        timer = indicator._timer
+        assert timer.isActive()
+        scene.removeItem(indicator)
+
+        assert not timer.isActive()


### PR DESCRIPTION
## Summary
Fixes the reported crash: `RuntimeError: Internal C++ object (ThinkingConnectionItem) already deleted.` in `updateArrows()`'s `self.update()`, hit when opening an old chat.

- **Root cause**: `QGraphicsItem` isn't a `QObject`, so an unparented `QTimer`/`QVariantAnimation` created in `__init__` is never auto-cleaned-up. Confirmed systemic — present in the whole `ConnectionItem` family, `SystemPromptConnectionItem`, `HoverAnimationMixin` (12 node classes), `Note`, `Frame`, `TypingIndicatorItem`.
- **Two fix layers, both needed**: `itemChange(ItemSceneHasChanged, value is None)` hooks stop each class's own timer (correct for individual delete via `removeItem()`) — but a live diagnostic proved `QGraphicsScene.clear()` (the actual chat-switch path) **never fires `itemChange`** for bulk-deleted items in this PySide6 build, so `ChatScene.clear()` now explicitly tears down every tracked item's timers *before* calling `super().clear()`.
- Adversarial review caught one real gap (`Frame.outline_animation` was missed by the first pass) — fixed and covered by a new test.

## Note on a bundled behavior change
`SystemPromptConnectionItem`'s pulse animation previously stopped itself the moment it was added to a scene (a pre-existing bug in the old `itemChange`), so it was very likely always inert in production. It now animates for the item's full on-screen lifetime — a real, intentional, tested visual change riding inside this crash fix. Flagging explicitly rather than letting it ride silently.

## Test plan
- [x] 13 new regression tests (`test_connection_timer_lifecycle.py`) using a real `ChatScene`, including the exact reported class (`ThinkingConnectionItem`) and a standalone reproduction proving the underlying vulnerability is real
- [x] Full pytest suite: 881 passed (868 baseline + 13 new)
- [x] `compileall` clean
- [x] Adversarial review (2 parallel reviewers, correctness + regression/scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)