### PR TITLE
Add renderer-flag infrastructure for the settings island (Phase 3, increment 1)

### DIFF
--- a/graphlink_app/graphlink_licensing.py
+++ b/graphlink_app/graphlink_licensing.py
@@ -254,6 +254,7 @@ class SettingsManager:
             "update_last_checked_at": "",
             "update_latest_version": "",
             "update_available": False,
+            "settings_renderer_override": "",
         }
         self._save_state(state)
         return state
@@ -343,6 +344,23 @@ class SettingsManager:
 
     def set_theme(self, theme_name):
         self.state['theme'] = theme_name
+        self._save_state()
+
+    def get_settings_renderer_override(self):
+        """Support-facing override for GRAPHLINK_SETTINGS_RENDERER (plan section 3.6).
+
+        Empty string means "no override" - resolve_renderer_flag() then falls
+        through to the env var or its own default.
+        """
+        return self.state.get("settings_renderer_override", "")
+
+    def set_settings_renderer_override(self, value: str):
+        from graphlink_renderer_flags import VALID_RENDERERS
+
+        normalized = (value or "").strip().lower()
+        if normalized and normalized not in VALID_RENDERERS:
+            raise ValueError(f"set_settings_renderer_override: value must be '' or one of {VALID_RENDERERS}, got {value!r}")
+        self.state['settings_renderer_override'] = normalized
         self._save_state()
 
     def get_show_token_counter(self):

--- a/graphlink_app/graphlink_renderer_flags.py
+++ b/graphlink_app/graphlink_renderer_flags.py
@@ -1,0 +1,40 @@
+"""Per-surface legacy/web renderer selection (migration plan section 3.6).
+
+A surface mid-migration to a web island needs to keep its legacy Qt
+implementation reachable while the web version is built out incrementally,
+without exposing an incomplete web UI to real usage in between. Precedence,
+highest first: an explicit GRAPHLINK_<SURFACE>_RENDERER environment
+variable, then a persisted settings override (so support can toggle a
+surface without shell access), then the caller's own default. An
+unrecognized value at any tier is treated as absent and falls through to
+the next tier rather than raising - a typo'd env var must not break
+startup, it should just be ignored.
+"""
+
+import os
+
+VALID_RENDERERS = ("legacy", "web")
+
+
+def resolve_renderer_flag(surface: str, default: str, settings_override: str | None = None) -> str:
+    """Resolve which renderer (``"legacy"`` or ``"web"``) a surface should use.
+
+    ``surface`` names the env var read as ``GRAPHLINK_<SURFACE>_RENDERER``
+    (e.g. ``"settings"`` -> ``GRAPHLINK_SETTINGS_RENDERER``). ``default`` is
+    returned when neither the env var nor ``settings_override`` supplies a
+    recognized value, and must itself be a recognized value.
+    """
+    if default not in VALID_RENDERERS:
+        raise ValueError(f"resolve_renderer_flag: default must be one of {VALID_RENDERERS}, got {default!r}")
+
+    env_var = f"GRAPHLINK_{surface.upper()}_RENDERER"
+    env_value = os.environ.get(env_var, "").strip().lower()
+    if env_value in VALID_RENDERERS:
+        return env_value
+
+    if settings_override:
+        normalized_override = settings_override.strip().lower()
+        if normalized_override in VALID_RENDERERS:
+            return normalized_override
+
+    return default

--- a/graphlink_app/tests/test_renderer_flags.py
+++ b/graphlink_app/tests/test_renderer_flags.py
@@ -1,0 +1,71 @@
+"""Tests for resolve_renderer_flag (migration plan section 3.6).
+
+Precedence: explicit GRAPHLINK_<SURFACE>_RENDERER env var, then a settings
+override, then the caller's default. An unrecognized value at any tier is
+treated as absent (falls through), never raises.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from graphlink_renderer_flags import resolve_renderer_flag
+
+
+class TestResolveRendererFlag:
+    def test_unset_env_and_no_override_returns_default(self, monkeypatch):
+        monkeypatch.delenv("GRAPHLINK_SETTINGS_RENDERER", raising=False)
+
+        assert resolve_renderer_flag("settings", "legacy") == "legacy"
+
+    def test_explicit_env_value_wins(self, monkeypatch):
+        monkeypatch.setenv("GRAPHLINK_SETTINGS_RENDERER", "web")
+
+        assert resolve_renderer_flag("settings", "legacy") == "web"
+
+    def test_env_value_is_case_and_whitespace_insensitive(self, monkeypatch):
+        monkeypatch.setenv("GRAPHLINK_SETTINGS_RENDERER", "  WEB  ")
+
+        assert resolve_renderer_flag("settings", "legacy") == "web"
+
+    def test_garbage_env_value_falls_through_to_default(self, monkeypatch):
+        monkeypatch.setenv("GRAPHLINK_SETTINGS_RENDERER", "nonsense")
+
+        assert resolve_renderer_flag("settings", "legacy") == "legacy"
+
+    def test_garbage_env_value_falls_through_to_settings_override(self, monkeypatch):
+        monkeypatch.setenv("GRAPHLINK_SETTINGS_RENDERER", "nonsense")
+
+        assert resolve_renderer_flag("settings", "legacy", settings_override="web") == "web"
+
+    def test_settings_override_used_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("GRAPHLINK_SETTINGS_RENDERER", raising=False)
+
+        assert resolve_renderer_flag("settings", "legacy", settings_override="web") == "web"
+
+    def test_env_wins_over_settings_override(self, monkeypatch):
+        monkeypatch.setenv("GRAPHLINK_SETTINGS_RENDERER", "legacy")
+
+        assert resolve_renderer_flag("settings", "legacy", settings_override="web") == "legacy"
+
+    def test_empty_settings_override_falls_through_to_default(self, monkeypatch):
+        monkeypatch.delenv("GRAPHLINK_SETTINGS_RENDERER", raising=False)
+
+        assert resolve_renderer_flag("settings", "legacy", settings_override="") == "legacy"
+
+    def test_garbage_settings_override_falls_through_to_default(self, monkeypatch):
+        monkeypatch.delenv("GRAPHLINK_SETTINGS_RENDERER", raising=False)
+
+        assert resolve_renderer_flag("settings", "legacy", settings_override="nonsense") == "legacy"
+
+    def test_surface_name_maps_to_uppercase_env_var(self, monkeypatch):
+        monkeypatch.setenv("GRAPHLINK_COMPOSER_RENDERER", "web")
+
+        assert resolve_renderer_flag("composer", "legacy") == "web"
+
+    def test_invalid_default_raises(self):
+        with pytest.raises(ValueError):
+            resolve_renderer_flag("settings", "not-a-real-renderer")

--- a/graphlink_app/tests/test_settings_renderer_override.py
+++ b/graphlink_app/tests/test_settings_renderer_override.py
@@ -1,0 +1,65 @@
+"""Tests for SettingsManager's settings_renderer_override field (plan section 3.6).
+
+The support-facing mirror of GRAPHLINK_SETTINGS_RENDERER - lets a user flip
+the settings island's renderer without shell access. resolve_renderer_flag()
+(tests/test_renderer_flags.py) covers the precedence logic; these tests only
+cover SettingsManager's own storage/validation of the value.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from graphlink_licensing import SettingsManager
+
+
+class TestSettingsRendererOverride:
+    def test_default_is_empty_string(self, tmp_path):
+        manager = SettingsManager(tmp_path / "session.dat")
+
+        assert manager.get_settings_renderer_override() == ""
+
+    def test_round_trips_and_persists_across_reload(self, tmp_path):
+        state_file = tmp_path / "session.dat"
+        manager = SettingsManager(state_file)
+
+        manager.set_settings_renderer_override("web")
+
+        reloaded = SettingsManager(state_file)
+        assert reloaded.get_settings_renderer_override() == "web"
+
+    def test_value_is_normalized_to_lowercase(self, tmp_path):
+        manager = SettingsManager(tmp_path / "session.dat")
+
+        manager.set_settings_renderer_override("  WEB  ")
+
+        assert manager.get_settings_renderer_override() == "web"
+
+    def test_empty_string_clears_the_override(self, tmp_path):
+        manager = SettingsManager(tmp_path / "session.dat")
+        manager.set_settings_renderer_override("web")
+
+        manager.set_settings_renderer_override("")
+
+        assert manager.get_settings_renderer_override() == ""
+
+    def test_invalid_value_raises_and_does_not_persist(self, tmp_path):
+        manager = SettingsManager(tmp_path / "session.dat")
+
+        with pytest.raises(ValueError):
+            manager.set_settings_renderer_override("nonsense")
+
+        assert manager.get_settings_renderer_override() == ""
+
+    def test_an_older_state_file_missing_the_key_defaults_to_empty(self, tmp_path):
+        state_file = tmp_path / "session.dat"
+        manager = SettingsManager(state_file)
+        del manager.state["settings_renderer_override"]
+        manager._save_state()
+
+        reloaded = SettingsManager(state_file)
+
+        assert reloaded.get_settings_renderer_override() == ""


### PR DESCRIPTION
## Summary
- First increment of Phase 3 (Settings dialog -> web island). Adds the flag mechanism the whole phase will build behind: `resolve_renderer_flag()`, `GRAPHLINK_SETTINGS_RENDERER` env var, and a mirrored `SettingsManager` override for support to toggle without shell access.
- Default is `legacy` everywhere. Nothing in `SettingsDialog` is touched - this increment only adds the plumbing, no behavior change to the running app.

## Test plan
- [x] 17 new tests (renderer flag precedence + SettingsManager storage/validation)
- [x] Full pytest suite: 975 passed, 0 failed
- [x] `compileall` clean