### PR TITLE
Re-home TokenCounter + NotificationBanner onto overlay_coordinator (Phase 5, increment 4 - phase complete)

### DIFF
--- a/graphlink_app/graphlink_token_counter_web.py
+++ b/graphlink_app/graphlink_token_counter_web.py
@@ -1,0 +1,46 @@
+"""Web host for the token-counter island - Phase 5 increment 4.
+
+The phase-open recon flagged this as the one island with no dedicated host
+class at all: graphlink_window.py used to construct a bare, un-subclassed
+WebIslandHost directly, with its position computed inline inside
+ChatWindow._update_overlay_positions rather than via a self-owned
+reposition() method the way every other island (including NotificationWebHost,
+built in an earlier phase) already has. This isn't a new architectural idea -
+it just finishes applying the one pattern every other island already uses,
+needed so this island has a real reposition_fn to register with
+OverlayCoordinator alongside pin/search/composer-pickers/notification.
+
+Positioning math is unchanged from the inline version it replaces: bottom-left
+corner of the graph viewport, 10px padding, clamped so it never goes above the
+top edge on a very short viewport.
+"""
+
+from __future__ import annotations
+
+from graphlink_token_counter_bridge import TokenCounterBridge
+from graphlink_web_island_host import WebIslandHost
+
+TOKEN_COUNTER_UNAVAILABLE_MESSAGE = (
+    "Token counter unavailable because QtWebEngine failed to initialize."
+)
+
+TOKEN_COUNTER_WIDTH = 150
+TOKEN_COUNTER_HEIGHT = 90
+
+
+class TokenCounterWebHost(WebIslandHost):
+    def __init__(self, parent=None):
+        bridge = TokenCounterBridge()
+        super().__init__(
+            bridge=bridge,
+            asset_dir_name="token-counter",
+            bridge_object_name="tokenCounterBridge",
+            unavailable_message=TOKEN_COUNTER_UNAVAILABLE_MESSAGE,
+            parent=parent,
+        )
+        self.setFixedSize(TOKEN_COUNTER_WIDTH, TOKEN_COUNTER_HEIGHT)
+
+    def reposition(self, viewport) -> None:
+        padding = 10
+        target_y = viewport.height() - self.height() - padding
+        self.move(padding, max(padding, target_y))

--- a/graphlink_app/graphlink_window.py
+++ b/graphlink_app/graphlink_window.py
@@ -15,12 +15,12 @@ from graphlink_overlay_coordinator import OverlayCoordinator
 from graphlink_search_overlay_web import SearchOverlayHost
 from graphlink_pin_overlay_web import PinOverlayHost
 from graphlink_token_estimator import TokenEstimator
-from graphlink_token_counter_bridge import TokenCounterBridge
+from graphlink_token_counter_web import TokenCounterWebHost
 from graphlink_document_viewer_web import DocumentViewerWebHost
 from graphlink_notification_web import NotificationWebHost
 from graphlink_command_palette_web import CommandPaletteWebHost
 from graphlink_composer_web import ComposerWebHost
-from graphlink_web_island_host import AcceleratorForwardingFilter, WebIslandHost
+from graphlink_web_island_host import AcceleratorForwardingFilter
 from graphlink_canvas_items import Note, Frame, Container
 from graphlink_node import ChatNode, CodeNode, ThinkingNode
 from graphlink_pycoder import PyCoderNode
@@ -141,18 +141,30 @@ class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
         content_layout.addWidget(self.chat_view)
         self.navigation_pins_controller = NavigationPinsController(self.chat_view.scene(), self.chat_view)
 
-        # Notifications share the window overlay parent with the composer so
-        # their z-order is meaningful across the graph/content hierarchy.
-        # Keeping the banner under ChatView would leave it trapped below the
-        # fixed composer even when NotificationWebHost.raise_() is called.
-        self.notification_banner = NotificationWebHost(self, parent=self.composer_overlay_parent)
-
         # Phase 5 increment 1: the single arbiter for reposition/raise ordering
         # across the overlay hosts below, replacing the scattered raise_()
         # calls and duplicate positioning methods recon found. Registered
         # islands are re-homed onto it as each one migrates (see
         # graphlink_overlay_coordinator.py's own module docstring).
         self.overlay_coordinator = OverlayCoordinator()
+
+        # Notifications share the window overlay parent with the composer so
+        # their z-order is meaningful across the graph/content hierarchy.
+        # Keeping the banner under ChatView would leave it trapped below the
+        # fixed composer even when NotificationWebHost.raise_() is called.
+        # Phase 5 increment 4: registered with the coordinator at the highest
+        # z_priority of the group - a notification's whole point is to
+        # interrupt and stay readable over every other transient overlay.
+        # update_position() takes no arguments, so it registers directly as
+        # the reposition_fn with no wrapping lambda needed. The composer's
+        # own raise_() still runs in a separate, always-later method
+        # (_update_composer_overlay), so that method keeps its own explicit
+        # notification_banner.raise_() reassert - the coordinator's raise
+        # pass alone can't guarantee ordering relative to the composer.
+        self.notification_banner = NotificationWebHost(self, parent=self.composer_overlay_parent)
+        self.overlay_coordinator.register(
+            self.notification_banner, self.notification_banner.update_position, z_priority=40
+        )
 
         # Parented to self (ChatWindow), not chat_view, exactly matching the
         # legacy PinOverlay's own parenting - reposition()'s clamping math
@@ -165,16 +177,18 @@ class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
 
         self.token_estimator = TokenEstimator()
         self.total_session_tokens = 0
-        self.token_counter_bridge = TokenCounterBridge()
-        self.token_counter_widget = WebIslandHost(
-            bridge=self.token_counter_bridge,
-            asset_dir_name="token-counter",
-            bridge_object_name="tokenCounterBridge",
-            unavailable_message="Token counter unavailable: QtWebEngine failed to initialize.",
-            parent=self.chat_view,
-        )
-        self.token_counter_widget.setFixedSize(150, 90)
+        # Phase 5 increment 4: TokenCounterWebHost gives this island the same
+        # self-owned reposition() shape every other island already has (see
+        # graphlink_token_counter_web.py's module docstring). Lowest
+        # z_priority of the group - a passive corner HUD never meant to
+        # render above anything else.
+        self.token_counter_widget = TokenCounterWebHost(parent=self.chat_view)
         self.token_counter_widget.setVisible(self.settings_manager.get_show_token_counter())
+        self.overlay_coordinator.register(
+            self.token_counter_widget,
+            lambda: self.token_counter_widget.reposition(self.chat_view.viewport()),
+            z_priority=5,
+        )
 
         self.toolbar = QToolBar()
         container_layout.addWidget(self.toolbar)
@@ -385,24 +399,21 @@ class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
         self._update_overlay_positions()
 
     def _update_overlay_positions(self):
-        token_counter_widget = getattr(self, 'token_counter_widget', None)
-        notification_banner = getattr(self, 'notification_banner', None)
         command_palette_host = getattr(self, 'command_palette_host', None)
-        padding = 10
-        viewport = self.chat_view.viewport()
-
-        if notification_banner and notification_banner.isVisible():
-            notification_banner.update_position()
         if command_palette_host and command_palette_host.isVisible():
             command_palette_host.update_position()
-        if token_counter_widget and token_counter_widget.isVisible():
-            token_y = viewport.height() - token_counter_widget.height() - padding
-            token_counter_widget.move(padding, max(padding, token_y))
 
-        # search_overlay and pin_overlay are both registered with
-        # overlay_coordinator (Phase 5 increment 1) - it positions and raises
-        # each in one pass, replacing what used to be inline .move() calls
-        # here plus a separate pin_overlay.reposition() call.
+        # search_overlay, pin_overlay, composer_picker_host,
+        # composer_context_host, token_counter_widget, and notification_banner
+        # are all registered with overlay_coordinator (Phase 5 increments
+        # 1-4) - it positions and raises each in one pass, replacing what
+        # used to be inline .move() calls and hand-called
+        # .update_position()/.raise_() here. command_palette_host stays
+        # hand-managed above deliberately - it predates Phase 5 entirely
+        # (Phase 2) and already had its own correct open-time
+        # position+raise pattern (show_command_palette() calls
+        # update_position()+raise_() itself), unlike the newly-added
+        # surfaces this phase's own recon found dueling over positioning.
         self.overlay_coordinator.reposition_all()
 
         # ChatView stacks control_widget/grid_control/font_control/
@@ -1402,7 +1413,7 @@ class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
         return None
 
     def reset_token_counter(self, total_tokens=0):
-        self.total_session_tokens = total_tokens; self.token_counter_bridge.reset(); self.token_counter_bridge.update_counts(total_tokens=self.total_session_tokens)
+        self.total_session_tokens = total_tokens; self.token_counter_widget.bridge.reset(); self.token_counter_widget.bridge.update_counts(total_tokens=self.total_session_tokens)
 
     def new_chat(self, parent_for_dialog=None):
         scene = self.chat_view.scene()

--- a/graphlink_app/graphlink_window_actions.py
+++ b/graphlink_app/graphlink_window_actions.py
@@ -363,7 +363,7 @@ class WindowActionsMixin:
             system_prompt_estimate=500 if self.settings_manager.get_enable_system_prompt() else 0,
             reserve_tokens=input_tokens,
         )
-        self.token_counter_bridge.update_counts(input_tokens=input_tokens, context_tokens=context_tokens)
+        self.token_counter_widget.bridge.update_counts(input_tokens=input_tokens, context_tokens=context_tokens)
 
         history_for_worker = append_history(trimmed_history, [input_msg_for_token])
         assign_history(user_node, history_for_worker)
@@ -415,7 +415,7 @@ class WindowActionsMixin:
         
         output_tokens = self.token_estimator.count_tokens(response_text)
         self.total_session_tokens += input_tokens + output_tokens
-        self.token_counter_bridge.update_counts(output_tokens=output_tokens, total_tokens=self.total_session_tokens)
+        self.token_counter_widget.bridge.update_counts(output_tokens=output_tokens, total_tokens=self.total_session_tokens)
 
         parsed_parts = self._parse_response(response_text)
         text_content_parts = [part['content'] for part in parsed_parts if part['type'] == 'text']

--- a/graphlink_app/tests/test_overlay_positioning.py
+++ b/graphlink_app/tests/test_overlay_positioning.py
@@ -23,6 +23,14 @@ graphlink_overlay_coordinator.py) - ChatView still needs search_overlay's
 height/visibility to stack control_widget/grid_control/font_control below it,
 now via a direct reference (_search_overlay_host) instead of a findChild()
 probe, but no longer repositions it a second time itself.
+
+Phase 5 increment 4: notification_banner and token_counter_widget are also
+now registered with overlay_coordinator (see graphlink_window.py's __init__),
+so ChatWindow._update_overlay_positions() no longer touches either directly -
+only command_palette_host stays hand-managed here (it predates Phase 5 and
+already had its own correct open-time position+raise pattern). That one
+remaining direct call was previously never asserted on by this file at all -
+closed below by test_command_palette_is_repositioned_directly_when_visible.
 """
 
 import sys
@@ -114,3 +122,26 @@ def test_visible_notification_is_raised_above_composer():
     graphlink_window.ChatWindow._update_composer_overlay(mock_self)
 
     mock_self.notification_banner.raise_.assert_called_once()
+
+
+def test_command_palette_is_repositioned_directly_when_visible():
+    """command_palette_host stays hand-managed in _update_overlay_positions
+    (Phase 5 increment 4 deliberately left it out of overlay_coordinator -
+    see the module docstring) - this was never actually asserted on before,
+    a real gap a refactor could have silently broken without any test
+    noticing."""
+    mock_self = _make_mock_window()
+    mock_self.command_palette_host.isVisible.return_value = True
+
+    graphlink_window.ChatWindow._update_overlay_positions(mock_self)
+
+    mock_self.command_palette_host.update_position.assert_called_once()
+
+
+def test_command_palette_is_not_repositioned_when_hidden():
+    mock_self = _make_mock_window()
+    mock_self.command_palette_host.isVisible.return_value = False
+
+    graphlink_window.ChatWindow._update_overlay_positions(mock_self)
+
+    mock_self.command_palette_host.update_position.assert_not_called()

--- a/graphlink_app/tests/test_token_counter_web_host.py
+++ b/graphlink_app/tests/test_token_counter_web_host.py
@@ -1,0 +1,98 @@
+"""Integration tests for TokenCounterWebHost - Phase 5 increment 4.
+
+Phase-open recon flagged the token counter as the one island with no
+dedicated host class at all - a bare, un-subclassed WebIslandHost was
+constructed directly in graphlink_window.py, with its position computed
+inline rather than via a self-owned reposition() method. This class finishes
+applying the pattern every other island already has.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from PySide6.QtWidgets import QWidget
+from PySide6.QtCore import Qt
+
+import graphlink_web_island_host as wih
+from graphlink_token_counter_web import (
+    TOKEN_COUNTER_HEIGHT,
+    TOKEN_COUNTER_WIDTH,
+    TokenCounterWebHost,
+)
+
+
+def _clear_registry():
+    wih._hosts.clear()
+
+
+def _make_host(parent=None) -> TokenCounterWebHost:
+    return TokenCounterWebHost(parent=parent)
+
+
+def test_construction_registers_with_the_shared_shutdown_registry():
+    _clear_registry()
+    host = _make_host()
+
+    assert host in wih._hosts
+
+
+def test_construction_has_no_window_flag_it_is_an_embedded_child():
+    parent = QWidget()
+    host = _make_host(parent)
+
+    assert not (host.windowFlags() & Qt.WindowType.Tool)
+    assert not (host.windowFlags() & Qt.WindowType.Window)
+
+
+def test_construction_sizes_to_the_fixed_150x90():
+    host = _make_host()
+
+    assert (host.width(), host.height()) == (TOKEN_COUNTER_WIDTH, TOKEN_COUNTER_HEIGHT) == (150, 90)
+
+
+def test_on_theme_changed_is_inherited_and_republishes():
+    host = _make_host()
+    states = []
+    host.bridge.stateChanged.connect(states.append)
+    count_before = len(states)
+
+    host.on_theme_changed()
+
+    assert len(states) == count_before + 1
+
+
+def test_prepare_for_shutdown_disposes_bridge_and_unregisters():
+    _clear_registry()
+    host = _make_host()
+
+    host.prepare_for_shutdown()
+
+    assert host not in wih._hosts
+    assert host.bridge.disposed is True
+
+
+class TestReposition:
+    def test_positions_bottom_left_with_padding(self):
+        host = _make_host()
+
+        class _FakeViewport:
+            def height(self):
+                return 800
+
+        host.reposition(_FakeViewport())
+
+        assert host.pos().x() == 10
+        assert host.pos().y() == 800 - 90 - 10
+
+    def test_clamps_to_the_top_padding_on_a_very_short_viewport(self):
+        host = _make_host()
+
+        class _FakeViewport:
+            def height(self):
+                return 50
+
+        host.reposition(_FakeViewport())
+
+        assert host.pos().y() == 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ py-modules = [
     "graphlink_styles",
     "graphlink_token_counter_bridge",
     "graphlink_token_counter_payload",
+    "graphlink_token_counter_web",
     "graphlink_token_estimator",
     "graphlink_ui_components",
     "graphlink_utility",


### PR DESCRIPTION
## Summary
- Both `TokenCounterWebHost` (new - the one island with no dedicated host class at all, per the phase-open recon) and `NotificationWebHost` are now registered with `overlay_coordinator`, replacing hand-written positioning/raise_ checks in `ChatWindow._update_overlay_positions()`.
- `command_palette_host` is deliberately **out of scope** - it predates Phase 5 (Phase 2), was never named in any of the phase's increments, and already had its own correct open-time position+raise pattern.
- The composer's own `bottom_inset`-avoidance read of the token counter's geometry (a layout concern, not z-order) is left untouched.
- Removed the redundant top-level `self.token_counter_bridge` attribute; 3 real call sites now go through `self.token_counter_widget.bridge`, matching every other island's access pattern.
- **This completes Phase 5** - all 4 increments shipped; the coordinator now arbitrates 5 real overlay surfaces.

## Test plan
- [x] 1354 pytest passed (+9 new)
- [x] 424 vitest passed (unchanged - no React touched)
- [x] ESLint / `tsc --noEmit` / schema check / single-chunk builds unaffected, reconfirmed clean
- [x] 9-case real `ChatWindow` drive: both new registrations present, `command_palette_host` confirmed absent from the coordinator, real token-accounting round-trips through `window_actions.py`, real positioning + z-order (raise_ call-order spy) for the notification-above-composer reassert, real settings-toggle show/hide, and confirmation `command_palette_host`'s own untouched pathway still works