### PR TITLE
Extract mode-switch guard predicate, remove native modals (Phase 6, increment 2)

### DIFF
--- a/graphlink_app/graphlink_window.py
+++ b/graphlink_app/graphlink_window.py
@@ -71,6 +71,27 @@ logger = logging.getLogger(__name__)
 
 from graphlink_utility import UtilityOperationController
 
+
+def mode_switch_rejection_reason(*, request_active: bool, requested_mode: str, current_mode: str) -> str | None:
+    """Pure predicate: why a mode-switch request should be rejected, or None
+    if it's allowed to proceed - Phase 6 increment 2's own named "guard logic
+    extracted from the combo handler first" requirement. Directly unit-
+    testable with no Qt/mock machinery at all, unlike the inline check it
+    replaces inside on_mode_changed().
+
+    Switching modes calls api_provider.initialize_* which swaps the provider
+    globals (USE_API_MODE, API_CLIENT, API_KEY, ...) that a running chat
+    request is reading from a worker thread - the request could execute
+    against a half-swapped provider. Blocking while a request is active
+    avoids racing it. Re-selecting the CURRENT mode is deliberately not a
+    switch and must never be rejected, even while busy - it's a no-op either
+    way (see test_mode_switch_guard.py's own "no-op not a warning" case).
+    """
+    if request_active and requested_mode != current_mode:
+        return "busy"
+    return None
+
+
 class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
     def __init__(self, settings_manager):
         super().__init__()
@@ -983,22 +1004,22 @@ class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
             return True
 
         if show_dialogs:
-            QMessageBox.warning(
-                self,
-                "Unknown Mode",
+            self.notification_banner.show_message(
                 f"Graphlink does not recognize the saved mode '{mode_text}'.",
+                6000,
+                "error",
             )
         return False
-    
+
     def on_mode_changed(self, mode_text):
         previous_mode = self.settings_manager.get_current_mode()
 
-        # Switching modes calls api_provider.initialize_* which swaps the provider
-        # globals (USE_API_MODE, API_CLIENT, API_KEY, ...) that a running chat request
-        # is reading from a worker thread - the request could execute against a
-        # half-swapped provider. Block the switch while a main request is in flight
-        # instead of racing it.
-        if self._main_request_active and mode_text != previous_mode:
+        rejection = mode_switch_rejection_reason(
+            request_active=self._main_request_active,
+            requested_mode=mode_text,
+            current_mode=previous_mode,
+        )
+        if rejection == "busy":
             self.notification_banner.show_message(
                 "Can't switch modes while a response is being generated. "
                 "Cancel the request or wait for it to finish, then switch.",
@@ -1014,7 +1035,16 @@ class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
             return
 
         try:
-            self._initialize_mode(mode_text, show_dialogs=True)
+            # A real, pre-existing gap caught while removing the QMessageBox
+            # this branch used to pop: _initialize_mode's own True/False
+            # return (False only for an unrecognized mode_text, which
+            # doesn't raise) was never checked here, so an unknown mode still
+            # got persisted via set_current_mode below regardless of the
+            # warning shown. Bail out before persisting/reinitializing
+            # anything when initialization explicitly reported failure.
+            if not self._initialize_mode(mode_text, show_dialogs=True):
+                self.toolbar_host.bridge.publish()
+                return
             self.settings_manager.set_current_mode(mode_text)
             self.reinitialize_agent()
             self._refresh_composer_provider_status()
@@ -1025,6 +1055,9 @@ class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
                     "info",
                 )
         except Exception as e:
+            # Roll back to the pre-switch snapshot (previous_mode, captured
+            # before any mutation above) rather than leaving persisted state
+            # pointing at a mode that never actually initialized.
             if previous_mode and previous_mode != mode_text:
                 self.settings_manager.set_current_mode(previous_mode)
                 try:
@@ -1032,17 +1065,17 @@ class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
                     self.reinitialize_agent()
                 except Exception:
                     pass
-            title = (
-                "Llama.cpp Configuration Required"
+            label = (
+                "Llama.cpp"
                 if mode_text == config.MODE_LLAMACPP_LOCAL
-                else "API Configuration Required"
+                else "API"
                 if mode_text == config.MODE_API_ENDPOINT
-                else "Ollama Initialization Error"
+                else "Ollama"
             )
-            QMessageBox.warning(
-                self,
-                title,
-                f"{mode_text} could not be initialized:\n\n{str(e)}"
+            self.notification_banner.show_message(
+                f"{label} configuration failed - {mode_text} could not be initialized:\n\n{str(e)}",
+                8000,
+                "error",
             )
         self.toolbar_host.bridge.publish()
 

--- a/graphlink_app/tests/test_mode_switch_guard.py
+++ b/graphlink_app/tests/test_mode_switch_guard.py
@@ -9,24 +9,20 @@ _main_request_active, reverts the toolbar's displayed mode, and tells the user w
 encapsulation of the provider globals remains open - this closes the one race a user can
 trigger from the toolbar with no special timing.)
 
-Phase 6 increment 1: on_mode_changed() now takes the mode text directly (there is no more
-QComboBox to call .itemText(index) on - the toolbar island reports the mode string chosen
-by the user straight from its own bridge Slot). "Reverting" no longer means silently
-resetting a native widget's selection - the toolbar's mode selector is a controlled
-element that only ever displays settings_manager.get_current_mode()'s own value, so a
-rejected switch reverts for free simply by republishing that unchanged value via
-toolbar_host.bridge.publish(). The busy-guard predicate/behavior itself is otherwise
-UNCHANGED this increment - the full request/confirm/reject protocol upgrade and this
-file's own deeper rewrite are deferred to increment 2, per the plan doc's own recorded
-scope.
-
-Uses a MagicMock as `self` for the unbound-method call, with the small set of real
-attributes the guard reads set explicitly.
+Phase 6 increment 2: the busy/no-op predicate on_mode_changed() used to check inline is
+now graphlink_window.mode_switch_rejection_reason() - a pure function taking primitives
+and returning a rejection reason or None, directly unit-tested below with zero Qt/mock
+machinery. The 2 remaining QMessageBox.warning calls in mode-switching (unknown mode,
+init failure) are gone too - both now route through notification_banner.show_message(),
+matching the exact non-modal pattern the busy-guard case already used, so the ENTIRE
+mode-switch flow is now free of native modal popups. The previously-uncovered rollback
+branch (a real gap the module docstring's own "rollback" framing didn't actually test)
+gets real coverage here for the first time.
 """
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -35,6 +31,33 @@ from PySide6.QtWidgets import QApplication
 _APP = QApplication.instance() or QApplication([])
 
 import graphlink_window
+from graphlink_window import mode_switch_rejection_reason
+
+
+class TestModeSwitchRejectionReasonIsAPureFunction:
+    """The extracted guard predicate itself - no window, no mocks, just
+    primitives in and a reason (or None) out."""
+
+    def test_rejects_a_real_switch_while_a_request_is_active(self):
+        reason = mode_switch_rejection_reason(
+            request_active=True, requested_mode="API Endpoint", current_mode="Ollama (Local)"
+        )
+
+        assert reason == "busy"
+
+    def test_allows_reselecting_the_current_mode_even_while_active(self):
+        reason = mode_switch_rejection_reason(
+            request_active=True, requested_mode="Ollama (Local)", current_mode="Ollama (Local)"
+        )
+
+        assert reason is None
+
+    def test_allows_any_switch_while_idle(self):
+        reason = mode_switch_rejection_reason(
+            request_active=False, requested_mode="API Endpoint", current_mode="Ollama (Local)"
+        )
+
+        assert reason is None
 
 
 def _make_window(active, current_mode="Ollama (Local)"):
@@ -53,8 +76,9 @@ class TestSwitchBlockedWhileRequestActive:
         window._initialize_mode.assert_not_called()
         window.settings_manager.set_current_mode.assert_not_called()
         window.notification_banner.show_message.assert_called_once()
-        message = window.notification_banner.show_message.call_args[0][0]
+        message, _duration, level = window.notification_banner.show_message.call_args[0]
         assert "switch" in message.lower()
+        assert level == "warning"
         # No native combo to revert anymore - republishing the toolbar's
         # unchanged currentMode is what "reverts" the displayed selection.
         window.toolbar_host.bridge.publish.assert_called_once()
@@ -81,3 +105,47 @@ class TestSwitchAllowedWhenIdle:
         window.settings_manager.set_current_mode.assert_called_once_with("API Endpoint")
         window.reinitialize_agent.assert_called_once()
         window.toolbar_host.bridge.publish.assert_called_once()
+
+
+class TestInitFailureRollsBackToTheSnapshot:
+    """Previously uncovered entirely: the except-block rollback path. No
+    QMessageBox is popped anymore - init failures surface through the same
+    notification_banner the busy-guard case already uses, so the toolbar's
+    own currentMode is the only thing that ever needs reverting."""
+
+    def test_a_failed_initialize_reverts_settings_to_the_previous_mode(self):
+        window = _make_window(active=False, current_mode="Ollama (Local)")
+        window._initialize_mode.side_effect = [RuntimeError("boom"), True]
+
+        graphlink_window.ChatWindow.on_mode_changed(window, "API Endpoint")
+
+        # First call attempts the requested mode; second call is the rollback
+        # re-initializing the previous (snapshotted) mode.
+        assert window._initialize_mode.call_args_list == [
+            call("API Endpoint", show_dialogs=True),
+            call("Ollama (Local)", show_dialogs=False),
+        ]
+        window.settings_manager.set_current_mode.assert_called_once_with("Ollama (Local)")
+        window.notification_banner.show_message.assert_called_once()
+        message, _duration, level = window.notification_banner.show_message.call_args[0]
+        assert "API Endpoint" in message
+        assert level == "error"
+        window.toolbar_host.bridge.publish.assert_called_once()
+
+    def test_a_failed_rollback_is_swallowed_and_still_notifies_once(self):
+        window = _make_window(active=False, current_mode="Ollama (Local)")
+        window._initialize_mode.side_effect = RuntimeError("boom")
+
+        graphlink_window.ChatWindow.on_mode_changed(window, "API Endpoint")  # must not raise
+
+        window.notification_banner.show_message.assert_called_once()
+        window.toolbar_host.bridge.publish.assert_called_once()
+
+    def test_no_rollback_is_attempted_when_the_requested_mode_equals_the_current_one(self):
+        window = _make_window(active=False, current_mode="Ollama (Local)")
+        window._initialize_mode.side_effect = RuntimeError("boom")
+
+        graphlink_window.ChatWindow.on_mode_changed(window, "Ollama (Local)")
+
+        window._initialize_mode.assert_called_once_with("Ollama (Local)", show_dialogs=True)
+        window.settings_manager.set_current_mode.assert_not_called()


### PR DESCRIPTION
## Summary
- Extracts `on_mode_changed`'s inline busy-check into a pure, module-level `mode_switch_rejection_reason()` function - directly unit-testable with no Qt/mock machinery, per the checklist's own "guard logic extracted first" ordering.
- Both remaining `QMessageBox.warning` calls in mode-switching (unknown-mode, init-failure) are replaced with `notification_banner.show_message()`, matching the non-modal pattern the adjacent busy-guard case already used. The whole mode-switch flow is now free of native popups - verified by poisoning `QMessageBox.warning` itself in the real drive.
- "Roll back init failure via snapshot" needed no new mechanism - `previous_mode` (captured before any mutation) already **is** the snapshot the existing rollback restores.
- **Real, pre-existing bug fixed in passing**: `on_mode_changed` never checked `_initialize_mode`'s own `True`/`False` return, so an unrecognized mode string was persisted via `set_current_mode` anyway even though initialization explicitly reported failure without raising.
- `test_mode_switch_guard.py` substantially rewritten: the extracted predicate gets isolated unit tests, and the previously **zero-coverage** rollback branch gets real tests for the first time.

## Test plan
- [x] 1388 pytest passed (+6 net)
- [x] 445 vitest passed (unchanged - no React touched)
- [x] ESLint/tsc/schema-check/builds unaffected, reconfirmed clean
- [x] 4-case real `ChatWindow` drive with `QMessageBox.warning` poisoned for the whole run - covering a real busy-guard rejection, same-mode reselection producing zero notifications, a full successful idle switch, and a real unknown-mode failure correctly rolling back to the pre-switch snapshot