### PR TITLE
Normalize HtmlViewNode to the request-signal contract; fix save/load corruption (Phase 7 prereq, increment 1)

### DIFF
--- a/graphlink_app/graphlink_html_view.py
+++ b/graphlink_app/graphlink_html_view.py
@@ -97,6 +97,18 @@ class HtmlViewNode(QGraphicsObject, HoverAnimationMixin):
     A specialized QGraphicsItem that provides an interface for rendering HTML code.
     This node features a resizable splitter to adjust the code and preview panes.
     """
+    # Phase 7 prerequisite (increment 1): the user-initiated render is now a
+    # request Signal the window connects to (execute_html_view_node), matching
+    # every other plugin node's request-signal contract (WebNode.run_clicked,
+    # CodeSandboxNode.sandbox_requested, etc.). The node no longer wires its
+    # Render button straight to render_html - it emits, and the window slot
+    # drives the work. This is the seam a future web island's "Render" intent
+    # will land on. The programmatic set_html_content() restore/seed path still
+    # renders directly (not a user "request"), matching WebNode.set_result's
+    # own "restore writes directly, only the button goes through the signal"
+    # precedent.
+    render_requested = Signal(object)
+
     NODE_WIDTH = 600
     NODE_HEIGHT = 850
     COLLAPSED_WIDTH = 250
@@ -219,7 +231,7 @@ class HtmlViewNode(QGraphicsObject, HoverAnimationMixin):
         self.html_input.textChanged.connect(self._on_content_changed)
         input_layout.addWidget(self.html_input)
         self.render_button = QPushButton("Render")
-        self.render_button.clicked.connect(self.render_html)
+        self.render_button.clicked.connect(self._handle_render_button)
         input_layout.addWidget(self.render_button)
         self.splitter.addWidget(input_container)
 
@@ -372,6 +384,13 @@ class HtmlViewNode(QGraphicsObject, HoverAnimationMixin):
 
     def _on_content_changed(self):
         self.html_content = self.html_input.toPlainText()
+
+    def _handle_render_button(self):
+        """Render-button click handler: emits the request Signal the window
+        connects to, matching WebNode._handle_run_button's own emit-helper
+        shape. The window slot (execute_html_view_node) calls back into
+        render_html() to do the work."""
+        self.render_requested.emit(self)
 
     def render_html(self):
         """Renders the current HTML content in the web view."""

--- a/graphlink_app/graphlink_plugins/graphlink_plugin_portal.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_portal.py
@@ -526,6 +526,7 @@ class PluginPortal:
         valid_parents = (ChatNode, CodeNode, PyCoderNode, CodeSandboxNode, WebNode, ConversationNode, GitlinkNode)
 
         def _wire(node):
+            node.render_requested.connect(self.main_window.execute_html_view_node)
             if isinstance(selected_node, CodeNode):
                 node.set_html_content(selected_node.code)
 

--- a/graphlink_app/graphlink_session/deserializers.py
+++ b/graphlink_app/graphlink_session/deserializers.py
@@ -356,6 +356,11 @@ class SceneDeserializer:
                 node.conversation_history = deserialize_history(data.get("conversation_history", []))
                 if data.get("is_collapsed", False):
                     node.set_collapsed(True)
+                # Phase 7 prerequisite (increment 1): wire the render-request
+                # signal on restore, matching every other node type's own
+                # _connect_if_available call in this function (html was the one
+                # branch that connected nothing).
+                self._connect_if_available(node.render_requested, "execute_html_view_node")
                 scene.addItem(node)
                 scene.html_view_nodes.append(node)
 

--- a/graphlink_app/graphlink_session/serializers.py
+++ b/graphlink_app/graphlink_session/serializers.py
@@ -250,7 +250,17 @@ class SceneSerializer:
             return {
                 "node_type": "html",
                 "position": {"x": node.pos().x(), "y": node.pos().y()},
-                "html_content": node.html_input.toHtml(),
+                # Phase 7 prerequisite (increment 1): read the raw-source model
+                # attribute (get_html_content() -> self.html_content), NOT the
+                # widget's toHtml(). toHtml() on this setAcceptRichText(False)
+                # editor returns a full Qt rich-text DOCUMENT wrapper with the
+                # user's markup HTML-ESCAPED (<h1> -> &lt;h1&gt;); on reload
+                # set_html_content(setPlainText) then rendered that wrapper
+                # instead of the user's HTML, corrupting the node on the first
+                # save/reload cycle (verified empirically). Reading the model
+                # mirror both fixes that round-trip bug and clears one of the
+                # 14 widget-reads the Phase 7 gate exists to eliminate.
+                "html_content": node.get_html_content(),
                 "splitter_state": node.get_splitter_state(),
                 "conversation_history": serialize_history(getattr(node, "conversation_history", [])),
                 "is_collapsed": node.is_collapsed,

--- a/graphlink_app/graphlink_window_actions.py
+++ b/graphlink_app/graphlink_window_actions.py
@@ -1302,6 +1302,17 @@ class WindowActionsMixin:
         sandbox_node.set_running_state(False)
         sandbox_node.set_error(error_message)
 
+    def execute_html_view_node(self, html_node):
+        """Window slot for HtmlViewNode.render_requested (Phase 7 prerequisite,
+        increment 1). Unlike the other execute_* handlers, HTML rendering needs
+        no worker thread or window-owned resource - the work is pure in-node
+        Qt (web_view.setHtml). So this slot simply calls back into the node's
+        own render_html(); the value is the request-signal SEAM itself (a
+        window-mediated entry point a future web island's "Render" intent can
+        target), not access to a window-only capability."""
+        if html_node is not None and hasattr(html_node, "render_html"):
+            html_node.render_html()
+
     def execute_web_node(self, web_node):
         if not web_node or getattr(web_node, "is_disposed", False):
             return

--- a/graphlink_app/tests/test_html_view_request_signal.py
+++ b/graphlink_app/tests/test_html_view_request_signal.py
@@ -1,0 +1,153 @@
+"""Phase 7 prerequisite increment 1: HtmlViewNode normalized to the
+request-signal contract, plus the serializer round-trip corruption fix
+that fell out of the state-ownership recon.
+
+Two things under test:
+1. The USER-initiated render now goes through a `render_requested = Signal(object)`
+   seam the window connects to (execute_html_view_node), matching every other
+   plugin node's request-signal contract - the seam a future web island's
+   "Render" intent will target. The programmatic set_html_content() restore
+   path still renders directly (not a "request"), matching WebNode.set_result.
+2. The serializer now reads the raw-source model attribute (get_html_content)
+   instead of html_input.toHtml(). toHtml() on the setAcceptRichText(False)
+   editor returned a Qt rich-text DOCUMENT wrapper with the user's markup
+   HTML-escaped, which set_html_content then rendered verbatim on reload -
+   corrupting the node on the first save/reload cycle. The decisive test is a
+   full serialize->deserialize round-trip preserving raw markup.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from PySide6.QtWidgets import QApplication
+
+_APP = QApplication.instance() or QApplication([])
+
+from graphlink_html_view import HtmlViewNode
+from graphlink_scene import ChatScene
+from graphlink_session.deserializers import SceneDeserializer
+from graphlink_session.serializers import SceneSerializer
+
+_RAW_MARKUP = "<html><body><h1>Title</h1><p>Some <b>bold</b> markup &amp; entities</p></body></html>"
+
+
+def _make_window_and_scene():
+    window = MagicMock()
+    scene = ChatScene(window=window)
+    window.chat_view.scene.return_value = scene
+    return window, scene
+
+
+class TestRequestSignalContract:
+    def test_node_declares_the_render_request_signal(self):
+        node = HtmlViewNode(None)
+
+        assert hasattr(node, "render_requested")
+
+    def test_render_button_emits_the_request_signal_with_the_node(self):
+        node = HtmlViewNode(None)
+        node.set_html_content("<p>hi</p>")
+        received = []
+        node.render_requested.connect(received.append)
+
+        node._handle_render_button()
+
+        assert received == [node]
+
+    def test_render_button_handler_does_not_render_directly(self):
+        # The button must go through the signal, not call render_html itself -
+        # otherwise the web-island seam this increment exists to create would be
+        # bypassed. render_html stays callable (the window slot calls it), but
+        # the button handler must not.
+        node = HtmlViewNode(None)
+        node.render_html = MagicMock()
+
+        node._handle_render_button()
+
+        node.render_html.assert_not_called()
+
+    def test_execute_html_view_node_slot_calls_render_html(self):
+        # The window slot's whole job is to call back into the node's render.
+        from graphlink_window_actions import WindowActionsMixin
+
+        node = MagicMock()
+        # Bind the real method to a bare object so we exercise the actual slot.
+        WindowActionsMixin.execute_html_view_node(MagicMock(), node)
+
+        node.render_html.assert_called_once_with()
+
+    def test_execute_html_view_node_slot_tolerates_none_and_missing_render(self):
+        from graphlink_window_actions import WindowActionsMixin
+
+        # Must not raise on a None node or a node lacking render_html.
+        WindowActionsMixin.execute_html_view_node(MagicMock(), None)
+        WindowActionsMixin.execute_html_view_node(MagicMock(), object())
+
+
+class TestSerializerReadsModelStateNotWidget:
+    def test_serializer_writes_the_raw_source_not_the_toHtml_wrapper(self):
+        window, scene = _make_window_and_scene()
+        parent = scene.add_chat_node("parent", is_user=True)
+        node = HtmlViewNode(parent)
+        node.set_html_content(_RAW_MARKUP)
+        scene.addItem(node)
+        scene.html_view_nodes.append(node)
+
+        payload = SceneSerializer(window).serialize_node(node, [parent, node])
+
+        # The core assertion: the persisted value IS the raw source, with real
+        # markup, not a Qt rich-text document wrapper with escaped tags.
+        assert payload["html_content"] == _RAW_MARKUP
+        assert "<h1>" in payload["html_content"]
+        assert "&lt;h1&gt;" not in payload["html_content"]
+        assert "<!DOCTYPE HTML" not in payload["html_content"]
+
+    def test_full_serialize_deserialize_round_trip_preserves_raw_markup(self):
+        # The decisive regression test for the save/reload corruption: a real
+        # round-trip through both the serializer and the deserializer must
+        # return the exact raw source the user typed.
+        window, scene = _make_window_and_scene()
+        parent = scene.add_chat_node("parent", is_user=True)
+        node = HtmlViewNode(parent)
+        node.set_html_content(_RAW_MARKUP)
+        scene.addItem(node)
+        scene.html_view_nodes.append(node)
+
+        parent_payload = SceneSerializer(window).serialize_node(parent, [parent, node])
+        html_payload = SceneSerializer(window).serialize_node(node, [parent, node])
+
+        target_window, target_scene = _make_window_and_scene()
+        deserializer = SceneDeserializer(target_window)
+        restored_parent = deserializer.deserialize_node(0, parent_payload, {})
+        deserializer.deserialize_node(1, html_payload, {0: restored_parent})
+
+        assert len(target_scene.html_view_nodes) == 1
+        restored = target_scene.html_view_nodes[0]
+        assert restored.get_html_content() == _RAW_MARKUP
+
+
+class TestDeserializerWiresTheSignal:
+    def test_restored_node_has_render_requested_connected_to_the_window_slot(self):
+        window, scene = _make_window_and_scene()
+        parent = scene.add_chat_node("parent", is_user=True)
+        node = HtmlViewNode(parent)
+        node.set_html_content(_RAW_MARKUP)
+        scene.addItem(node)
+        scene.html_view_nodes.append(node)
+        html_payload = SceneSerializer(window).serialize_node(node, [parent, node])
+        parent_payload = SceneSerializer(window).serialize_node(parent, [parent, node])
+
+        target_window, target_scene = _make_window_and_scene()
+        # A real callable slot on the window so _connect_if_available connects.
+        target_window.execute_html_view_node = MagicMock()
+        deserializer = SceneDeserializer(target_window)
+        restored_parent = deserializer.deserialize_node(0, parent_payload, {})
+        deserializer.deserialize_node(1, html_payload, {0: restored_parent})
+
+        restored = target_scene.html_view_nodes[0]
+        restored.render_requested.emit(restored)
+
+        target_window.execute_html_view_node.assert_called_once_with(restored)


### PR DESCRIPTION
First increment of Phase 7's prerequisite "state-ownership inversion" gate (Python-only; no panels move yet). Lowest-risk, self-contained change that proves the process.

## Summary
- **Request-signal normalization**: `HtmlViewNode` was the only plugin node with no request signal — its Render button called `render_html()` in-node. It now emits `render_requested = Signal(object)` (using the previously-dead `Signal` import), serviced by a new `WindowActionsMixin.execute_html_view_node` slot, wired in the two standard places every other node uses (`plugin_portal._wire` + the deserializer `html` branch, which connected nothing before). The slot is deliberately thin — HTML render is pure in-node Qt with no window-owned resource — its value is the window-mediated **seam** a future web island's Render intent will target. The programmatic `set_html_content()` restore/seed path still renders directly (matches `WebNode.set_result`).
- **Real save/load corruption bug fixed inline**: the serializer read `html_input.toHtml()`, which on a `setAcceptRichText(False)` editor returns a Qt rich-text document wrapper with the user's markup HTML-**escaped** (`<h1>` → `&lt;h1&gt;`). On reload that wrapper was rendered instead of the user's HTML — corrupting the node on the **first** save/reload cycle (verified empirically). Repointed to the raw-source model attribute `get_html_content()`, which fixes the corruption *and* clears one of the 14 widget-reads the Phase 7 gate targets (12 remain, in later increments).

## Test plan
- [x] `pytest` — 1541 passed (+8 new in `test_html_view_request_signal.py`: signal seam, window-slot call-through + None-tolerance, decisive full serialize→deserialize round-trip preserving raw markup, deserializer re-wiring on restore)
- [x] Zero web_ui files touched (schema check reconfirmed clean, 19 artifact sets; no frontend re-run needed)
- [x] 5-case real `ChatWindow` drive: real portal wiring (`render_requested` → real `execute_html_view_node` → render), real Render-button `.click()` through the seam, real `web_view.setHtml`, real serialize→deserialize round-trip across two real `ChatWindow`s preserving raw markup, and signal re-wired on the restored node

Note: the new round-trip test caught a self-inflicted regression during development (an accidentally-dropped `"position"` line in the serializer edit) — exactly why it tests the real save/load path, not `set_html_content` in isolation.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>