### PR TITLE
Normalize PyCoderNode's run-dispatch to the request-signal contract (Phase 7 prereq, increment 3)

### DIFF
--- a/graphlink_app/graphlink_plugins/graphlink_plugin_portal.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_portal.py
@@ -429,11 +429,16 @@ class PluginPortal:
 
     def _create_pycoder_node(self):
         scene = self.main_window.chat_view.scene()
+
+        def _wire(node):
+            node.run_clicked.connect(self.main_window.execute_pycoder_node)
+
         return self.create_node(
             node_cls=PyCoderNode,
             connection_cls=PyCoderConnectionItem,
             scene_nodes=scene.pycoder_nodes,
             scene_connections=scene.pycoder_connections,
+            wire=_wire,
             no_selection_message="Please select a node to branch from before adding Py-Coder.",
             invalid_parent_message="Py-Coder can only branch from a valid conversational node.",
         )

--- a/graphlink_app/graphlink_pycoder.py
+++ b/graphlink_app/graphlink_pycoder.py
@@ -8,11 +8,11 @@ import markdown
 from enum import Enum
 
 from PySide6.QtWidgets import (
-    QGraphicsItem, QGraphicsProxyWidget, QWidget, QVBoxLayout,
+    QGraphicsItem, QGraphicsObject, QGraphicsProxyWidget, QWidget, QVBoxLayout,
     QTextEdit, QPushButton, QLabel, QFrame, QHBoxLayout, QGridLayout,
     QTabWidget, QPlainTextEdit
 )
-from PySide6.QtCore import QRectF, Qt, Property, QPropertyAnimation, QEasingCurve, QPointF, QRegularExpression, QSize, QRect
+from PySide6.QtCore import QRectF, Qt, Signal, Property, QPropertyAnimation, QEasingCurve, QPointF, QRegularExpression, QSize, QRect
 from PySide6.QtGui import QPainter, QColor, QBrush, QPen, QPainterPath, QIcon, QSyntaxHighlighter, QTextCharFormat, QFont
 import qtawesome as qta
 from graphlink_config import canvas_font, get_current_palette, get_graph_node_colors, get_neutral_button_colors, get_semantic_color
@@ -309,11 +309,26 @@ class StatusTrackerWidget(QWidget):
             stage_widget.set_status(PyCoderStatus.PENDING)
 
 
-class PyCoderNode(QGraphicsItem, HoverAnimationMixin):
+class PyCoderNode(QGraphicsObject, HoverAnimationMixin):
     """
     A specialized QGraphicsItem that provides a UI for both AI-driven code generation
     and manual code execution, styled like a modern IDE pane.
     """
+    # Phase 7 prerequisite (increment 3): the run/generate dispatch is now a
+    # request Signal the window connects to (matching WebNode.run_clicked and
+    # every other plugin node's request-signal contract), instead of the
+    # direct scene().window.execute_pycoder_node(self) reach-through this node
+    # used to be the one exception for. A plain Signal class attribute
+    # requires the base class to be QGraphicsObject (a QObject), not the
+    # plain QGraphicsItem this class used before - every OTHER plugin node
+    # already extends QGraphicsObject for exactly this reason; PyCoderNode was
+    # the one inconsistency, discovered while implementing this increment
+    # (the initial recon assumed a bare Signal(object) would just work).
+    # QGraphicsItem stays imported below for the itemChange()/GraphicsItemFlag
+    # enum references, which resolve identically regardless of which of the
+    # two classes this node itself extends.
+    run_clicked = Signal(object)
+
     supports_branch_context_toggle = True
 
     NODE_WIDTH = 550
@@ -635,10 +650,9 @@ class PyCoderNode(QGraphicsItem, HoverAnimationMixin):
             self.tabs.setCurrentIndex(1) # Default to Terminal tab
 
     def _on_run_clicked(self):
-        if self.scene() and hasattr(self.scene(), 'window'):
-            if not self.is_running:
-                self.tabs.setCurrentIndex(1 if self.mode == PyCoderMode.MANUAL else 0)
-            self.scene().window.execute_pycoder_node(self)
+        if not self.is_running:
+            self.tabs.setCurrentIndex(1 if self.mode == PyCoderMode.MANUAL else 0)
+        self.run_clicked.emit(self)
 
     def boundingRect(self):
         padding = self.CONNECTION_DOT_OFFSET + self.CONNECTION_DOT_RADIUS

--- a/graphlink_app/graphlink_session/deserializers.py
+++ b/graphlink_app/graphlink_session/deserializers.py
@@ -286,6 +286,11 @@ class SceneDeserializer:
                 node.include_branch_context = data.get("include_branch_context", True)
                 if data.get("is_collapsed", False):
                     node.set_collapsed(True)
+                # Phase 7 prerequisite (increment 3): wire the run-request
+                # signal on restore, matching every other node type's own
+                # _connect_if_available call in this function (pycoder was the
+                # one branch connecting nothing).
+                self._connect_if_available(node.run_clicked, "execute_pycoder_node")
                 scene.addItem(node)
                 scene.pycoder_nodes.append(node)
 

--- a/graphlink_app/tests/test_plugin_portal_remaining_factories.py
+++ b/graphlink_app/tests/test_plugin_portal_remaining_factories.py
@@ -67,7 +67,7 @@ def _make_portal(current_node):
 # (factory_method, node_cls, connection_cls, scene_node_attr, scene_connection_attr,
 #  signal_name, handler_name, clones_history)
 STANDARD_CASES = [
-    ("_create_pycoder_node", PyCoderNode, PyCoderConnectionItem, "pycoder_nodes", "pycoder_connections", None, None, False),
+    ("_create_pycoder_node", PyCoderNode, PyCoderConnectionItem, "pycoder_nodes", "pycoder_connections", "run_clicked", "execute_pycoder_node", False),
     ("_create_code_sandbox_node", CodeSandboxNode, CodeSandboxConnectionItem, "code_sandbox_nodes", "code_sandbox_connections", "sandbox_requested", "execute_code_sandbox_node", True),
     ("_create_gitlink_node", GitlinkNode, GitlinkConnectionItem, "gitlink_nodes", "gitlink_connections", "gitlink_requested", "execute_gitlink_node", True),
     ("_create_web_node", WebNode, WebConnectionItem, "web_nodes", "web_connections", "run_clicked", "execute_web_node", False),

--- a/graphlink_app/tests/test_pycoder_run_signal.py
+++ b/graphlink_app/tests/test_pycoder_run_signal.py
@@ -1,0 +1,144 @@
+"""Phase 7 prerequisite increment 3: PyCoderNode's run-dispatch normalized to
+the request-signal contract.
+
+PyCoderNode was the ONE plugin node whose run/generate dispatch reached
+directly through the canvas (`self.scene().window.execute_pycoder_node(self)`)
+instead of emitting a Signal like every other node (WebNode.run_clicked,
+CodeSandboxNode.sandbox_requested, ConversationNode.ai_request_sent,
+GitlinkNode.gitlink_requested, ArtifactNode.artifact_requested). A real,
+material correction to the original recon surfaced while implementing this:
+a bare `Signal` class attribute requires the class to be a QObject, which
+`QGraphicsItem` (PyCoderNode's old base class) is NOT - every other plugin
+node already extends `QGraphicsObject` (QGraphicsItem + QObject) for exactly
+this reason. This increment therefore also changes PyCoderNode's base class
+from QGraphicsItem to QGraphicsObject, matching the other 6 node types
+exactly, before it can declare `run_clicked = Signal(object)` at all.
+
+The `setCurrentNode` reach-through in mousePressEvent is a separate,
+codebase-wide idiom on every node type and is explicitly OUT of scope here -
+only the run/generate dispatch changes.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from PySide6.QtWidgets import QApplication, QGraphicsObject
+
+_APP = QApplication.instance() or QApplication([])
+
+from graphlink_pycoder import PyCoderMode, PyCoderNode
+from graphlink_scene import ChatScene
+from graphlink_session.deserializers import SceneDeserializer
+from graphlink_session.serializers import SceneSerializer
+
+
+def _make_window_and_scene():
+    window = MagicMock()
+    scene = ChatScene(window=window)
+    window.chat_view.scene.return_value = scene
+    return window, scene
+
+
+class TestBaseClassPrerequisite:
+    def test_pycoder_node_is_now_a_qgraphicsobject_matching_every_other_plugin_node(self):
+        node = PyCoderNode(parent_node=None)
+
+        assert isinstance(node, QGraphicsObject)
+
+    def test_pycoder_node_declares_the_run_clicked_signal(self):
+        node = PyCoderNode(parent_node=None)
+
+        assert hasattr(node, "run_clicked")
+
+
+class TestRunDispatchContract:
+    def test_run_click_emits_the_signal_with_the_node(self):
+        node = PyCoderNode(parent_node=None)
+        received = []
+        node.run_clicked.connect(received.append)
+
+        node._on_run_clicked()
+
+        assert received == [node]
+
+    def test_run_click_handler_does_not_reach_through_the_scene_directly(self):
+        # Regression guard for the exact bug this increment fixes: if a scene
+        # is present with a `window` attribute, _on_run_clicked must NOT call
+        # anything on it directly - it must go through the signal only.
+        node = PyCoderNode(parent_node=None)
+        fake_window = MagicMock()
+        fake_scene = MagicMock()
+        fake_scene.window = fake_window
+        node.scene = MagicMock(return_value=fake_scene)
+
+        node._on_run_clicked()
+
+        fake_window.execute_pycoder_node.assert_not_called()
+
+    def test_run_click_switches_to_the_terminal_tab_when_manual_and_idle(self):
+        node = PyCoderNode(parent_node=None, mode=PyCoderMode.MANUAL)
+        node.is_running = False
+        node.tabs.setCurrentIndex = MagicMock()
+
+        node._on_run_clicked()
+
+        node.tabs.setCurrentIndex.assert_called_once_with(1)
+
+    def test_run_click_switches_to_the_code_tab_when_ai_driven_and_idle(self):
+        node = PyCoderNode(parent_node=None, mode=PyCoderMode.AI_DRIVEN)
+        node.is_running = False
+        node.tabs.setCurrentIndex = MagicMock()
+
+        node._on_run_clicked()
+
+        node.tabs.setCurrentIndex.assert_called_once_with(0)
+
+    def test_run_click_does_not_switch_tabs_while_already_running(self):
+        # Preserves the exact pre-existing side-effect condition (not self.is_running) -
+        # only the dispatch mechanism changed, not this behavior.
+        node = PyCoderNode(parent_node=None)
+        node.is_running = True
+        node.tabs.setCurrentIndex = MagicMock()
+
+        node._on_run_clicked()
+
+        node.tabs.setCurrentIndex.assert_not_called()
+
+    def test_run_click_still_emits_while_running_so_the_window_can_stop_it(self):
+        # execute_pycoder_node's own existing branch (stop if already running)
+        # depends on the signal still firing even when is_running is True.
+        node = PyCoderNode(parent_node=None)
+        node.is_running = True
+        received = []
+        node.run_clicked.connect(received.append)
+
+        node._on_run_clicked()
+
+        assert received == [node]
+
+
+class TestDeserializerWiresTheSignal:
+    def test_restored_node_has_run_clicked_connected_to_the_window_slot(self):
+        window, scene = _make_window_and_scene()
+        parent = scene.add_chat_node("parent", is_user=True)
+        node = PyCoderNode(parent, mode=PyCoderMode.MANUAL)
+        node.set_code("print('hi')")
+        scene.addItem(node)
+        scene.pycoder_nodes.append(node)
+        parent_payload = SceneSerializer(window).serialize_node(parent, [parent, node])
+        node_payload = SceneSerializer(window).serialize_node(node, [parent, node])
+
+        target_window, target_scene = _make_window_and_scene()
+        target_window.execute_pycoder_node = MagicMock()
+        deserializer = SceneDeserializer(target_window)
+        restored_parent = deserializer.deserialize_node(0, parent_payload, {})
+        deserializer.deserialize_node(1, node_payload, {0: restored_parent})
+
+        assert len(target_scene.pycoder_nodes) == 1
+        restored = target_scene.pycoder_nodes[0]
+        restored.run_clicked.emit(restored)
+
+        target_window.execute_pycoder_node.assert_called_once_with(restored)


### PR DESCRIPTION
Third increment of Phase 7's prerequisite "state-ownership inversion" gate. Turned out riskier than scoped — a real complication the original recon missed.

## Summary
- `PyCoderNode` was the only plugin node whose run/generate dispatch reached directly through the canvas (`self.scene().window.execute_pycoder_node(self)`) instead of emitting a Signal like every other node.
- **The complication**: a bare `Signal` class attribute requires the owning class to be a `QObject`. `PyCoderNode`'s base class was plain `QGraphicsItem`, NOT `QGraphicsObject` (`QGraphicsItem` + `QObject`) — which every one of the other 6 plugin node types already extends for exactly this reason. The recon assumed adding a `Signal` would just work; it wouldn't have. Verified this empirically (constructed a bare `QGraphicsObject`/`QGraphicsItem` comparison) before touching any real file.
- `PyCoderNode(QGraphicsItem, HoverAnimationMixin)` → `PyCoderNode(QGraphicsObject, HoverAnimationMixin)`, matching every other node's own base-class shape exactly (not a new one-off mechanism). `run_clicked = Signal(object)` added; `_on_run_clicked` now emits it as its last line (tab-switch side effect preserved verbatim). Wired at both standard sites — the portal's `wire=` callback and the deserializer restore branch, neither of which wired anything before.
- Confirmed via repo-wide grep that zero production code branches on `QGraphicsObject`-vs-`QGraphicsItem` class identity, closing off the one plausible way this reclassification could silently change behavior elsewhere.
- `mousePressEvent`'s own `setCurrentNode` reach-through is untouched — a separate, codebase-wide idiom, explicitly out of scope.

## Verification
Given the genuinely elevated risk of a base-class change (not just a signal wire), ran a 2-agent adversarial review specifically targeting Qt base-class-change safety (geometry/painting/event-handling/memory-ownership/sibling-system interaction) in addition to reference-completeness, explicitly told not to assume "6 other nodes already do this so it's fine": **both CLEAN, zero blockers**. One reviewer independently constructed a real `PyCoderNode` under offscreen QPA, confirmed `parentItem()` (QGraphicsItem scene-graph parent) and `QObject.parent()` (the separate Qt ownership hierarchy) never cross-wire, confirmed no signal-name collisions, and confirmed `dispose()`+`del`+`gc.collect()` completes cleanly.

- [x] `pytest` — 1559 passed (+10 net: 9 new in `test_pycoder_run_signal.py`, +1 previously-filtered parametrized case activated for free)
- [x] Zero web_ui files touched
- [x] 7-case real `ChatWindow` drive: real portal-created node confirmed as a real `QGraphicsObject`, real emit reaching the real slot, real position/selection/`itemChange` under the new base class, real parent/child bookkeeping unaffected, real `dispose()`, a real session round-trip re-wiring the signal, and source-level confirmation `mousePressEvent` is unchanged

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>