### PR TITLE
Relocate PyCoderNode's PythonREPL ownership to PyCoderReplManager (Phase 7 prereq, increment 4)

### DIFF
--- a/graphlink_app/graphlink_agents.py
+++ b/graphlink_app/graphlink_agents.py
@@ -37,7 +37,8 @@ from graphlink_agents_pycoder import (
     PyCoderRepairAgent,
     PyCoderAnalysisAgent,
     PyCoderExecutionWorker,
-    PyCoderAgentWorker
+    PyCoderAgentWorker,
+    PyCoderReplManager
 )
 
 # --- Isolated Sandbox Execution Agents ---

--- a/graphlink_app/graphlink_agents_pycoder.py
+++ b/graphlink_app/graphlink_agents_pycoder.py
@@ -6,6 +6,7 @@ import re
 import json
 import base64
 import threading
+import weakref
 from enum import Enum
 from PySide6.QtCore import QThread, Signal
 import graphlink_config as config
@@ -91,6 +92,46 @@ while True:
             self.process.kill()
             self.process.wait()
             self.process = None
+
+
+class PyCoderReplManager:
+    """Owns the PythonREPL subprocess for each PyCoderNode, keyed by node
+    identity. PyCoderNode used to construct and stop its own REPL directly;
+    ownership moves here so the node no longer manages a live subprocess.
+
+    A weakref.finalize callback registered at REPL-creation time stops the
+    subprocess once the owning node is garbage collected, regardless of
+    whether stop()/dispose() was ever called first. This is load-bearing,
+    not just a safety net: ChatScene.clear() (the "New Chat"/chat-switch
+    path) never calls PyCoderNode.dispose() at all - only Python's own GC,
+    via this finalizer, stops the REPL on that path. dispose() (the
+    individual right-click-delete path) still calls stop() directly for
+    immediate, deterministic cleanup rather than waiting on GC.
+
+    A plain dict keyed by node would keep every node alive forever (the
+    dict entry itself would be a strong reference), which would prevent the
+    very GC this manager relies on - hence WeakKeyDictionary.
+    """
+
+    def __init__(self):
+        self._repls = weakref.WeakKeyDictionary()
+        self._finalizers = weakref.WeakKeyDictionary()
+
+    def get_repl(self, node):
+        repl = self._repls.get(node)
+        if repl is None:
+            repl = PythonREPL()
+            self._repls[node] = repl
+            self._finalizers[node] = weakref.finalize(node, repl.stop)
+        return repl
+
+    def stop(self, node):
+        finalizer = self._finalizers.pop(node, None)
+        if finalizer is not None:
+            finalizer.detach()
+        repl = self._repls.pop(node, None)
+        if repl is not None:
+            repl.stop()
 
 
 class CodeExecutionWorker(QThread):

--- a/graphlink_app/graphlink_pycoder.py
+++ b/graphlink_app/graphlink_pycoder.py
@@ -18,7 +18,7 @@ import qtawesome as qta
 from graphlink_config import canvas_font, get_current_palette, get_graph_node_colors, get_neutral_button_colors, get_semantic_color
 from graphlink_lod import draw_lod_card, preview_text, sync_proxy_render_state
 
-from graphlink_agents_pycoder import PyCoderStage, PyCoderStatus, PythonREPL
+from graphlink_agents_pycoder import PyCoderStage, PyCoderStatus
 from graphlink_canvas_items import HoverAnimationMixin
 from graphlink_plugins.graphlink_plugin_context_menu import PluginNodeContextMenu
 
@@ -351,7 +351,6 @@ class PyCoderNode(QGraphicsObject, HoverAnimationMixin):
         self.is_disposed = False
         self.is_collapsed = False
         self.collapse_button_rect = QRectF()
-        self.repl = PythonREPL()
         self.worker_thread = None
 
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable)
@@ -398,12 +397,15 @@ class PyCoderNode(QGraphicsObject, HoverAnimationMixin):
         if worker and worker.isRunning():
             worker.stop()
         self.worker_thread = None
-        if getattr(self, "repl", None):
-            self.repl.stop()
-
-    def __del__(self):
-        if hasattr(self, 'repl') and self.repl:
-            self.repl.stop()
+        # The REPL subprocess is owned by ChatWindow.pycoder_repl_manager, not this
+        # node - stop it here for immediate, deterministic cleanup on this (the
+        # right-click-delete) path. self.scene() is None for nodes never added to a
+        # scene (e.g. headless tests), so this is guarded rather than assumed.
+        scene = self.scene()
+        window = getattr(scene, "window", None) if scene is not None else None
+        manager = getattr(window, "pycoder_repl_manager", None) if window is not None else None
+        if manager is not None:
+            manager.stop(self)
 
     @property
     def width(self):

--- a/graphlink_app/graphlink_window.py
+++ b/graphlink_app/graphlink_window.py
@@ -41,7 +41,7 @@ from graphlink_session import ChatSessionManager
 from graphlink_command_palette import CommandManager
 from graphlink_plugins.graphlink_plugin_portal import PluginPortal
 from graphlink_plugin_picker_web import PluginPickerHost
-from graphlink_agents import ChatAgent
+from graphlink_agents import ChatAgent, PyCoderReplManager
 from graphlink_audio import (
     AudioValidationError,
     SUPPORTED_AUDIO_EXTENSIONS,
@@ -115,6 +115,7 @@ class ChatWindow(QMainWindow, WindowActionsMixin, WindowNavigationMixin):
         self.setWindowIcon(QIcon(str(asset_path("graphlink.ico"))))
 
         self.session_manager = ChatSessionManager(self)
+        self.pycoder_repl_manager = PyCoderReplManager()
         self.plugin_portal = PluginPortal(self)
         self.update_title_bar()
         self.reinitialize_agent()

--- a/graphlink_app/graphlink_window_actions.py
+++ b/graphlink_app/graphlink_window_actions.py
@@ -1005,6 +1005,12 @@ class WindowActionsMixin:
             self._clear_loading_animation()
 
     def execute_pycoder_node(self, pycoder_node):
+        # The `node=pycoder_node` capture on the finished/error lambdas below (both
+        # branches) is load-bearing beyond cleanup: it keeps pycoder_node reachable
+        # for as long as this worker_thread is alive, which in turn keeps
+        # PyCoderReplManager's weakref.finalize for this node from firing mid-execution
+        # - do not drop that capture without another way to keep the node alive for
+        # the run's duration.
         if pycoder_node.is_running:
             self.stop_pycoder_node(pycoder_node)
             return

--- a/graphlink_app/graphlink_window_actions.py
+++ b/graphlink_app/graphlink_window_actions.py
@@ -1016,7 +1016,7 @@ class WindowActionsMixin:
                 pycoder_node.set_output("[No code to run]")
                 pycoder_node.set_running_state(False)
                 return
-            worker_thread = CodeExecutionWorker(code, pycoder_node.repl)
+            worker_thread = CodeExecutionWorker(code, self.pycoder_repl_manager.get_repl(pycoder_node))
             pycoder_node.worker_thread = worker_thread
             worker_thread.finished.connect(
                 lambda output, history=self._branch_context_history(pycoder_node, pycoder_node.parent_node): self._handle_code_execution_result(output, pycoder_node, history)
@@ -1035,7 +1035,7 @@ class WindowActionsMixin:
             context_node = pycoder_node.parent_node
             if isinstance(context_node, CodeNode): context_node = context_node.parent_content_node
             history = self._branch_context_history(pycoder_node, context_node)
-            worker_thread = PyCoderExecutionWorker(prompt, history, pycoder_node.repl)
+            worker_thread = PyCoderExecutionWorker(prompt, history, self.pycoder_repl_manager.get_repl(pycoder_node))
             pycoder_node.worker_thread = worker_thread
             worker_thread.log_update.connect(pycoder_node.update_status)
             worker_thread.approval_requested.connect(

--- a/graphlink_app/tests/test_pycoder_repl_ownership.py
+++ b/graphlink_app/tests/test_pycoder_repl_ownership.py
@@ -1,0 +1,216 @@
+"""Phase 7 prerequisite increment 4: PyCoderNode's PythonREPL subprocess moves
+from being owned/constructed directly by the node to being owned by a new
+PyCoderReplManager, held on ChatWindow (self.pycoder_repl_manager).
+
+The reason this needed its own manager rather than just staying a plain
+per-node attribute: reading graphlink_scene.py's ChatScene.clear() (the "New
+Chat" / chat-switch path, also used by graphlink_session/deserializers.py's
+restore_chat()) directly shows it NEVER calls PyCoderNode.dispose() -
+_teardown_items_before_clear() only stops hover-animation timers for
+pycoder_nodes, nothing else. Before this increment, only Python's own
+__del__ (fired once the node's last reference was dropped and GC ran) ever
+stopped the REPL subprocess on that path; dispose() (the individual
+right-click-delete path) was the only *deterministic* stop.
+
+PyCoderReplManager preserves both guarantees without an explicit
+__del__: a weakref.finalize registered at REPL-creation time stops the
+subprocess when the node is garbage collected regardless of whether
+stop()/dispose() was ever called (covering the clear()-only path), and
+dispose() still calls manager.stop() directly for immediate, deterministic
+cleanup on the right-click-delete path.
+"""
+
+import gc
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from PySide6.QtWidgets import QApplication
+
+_APP = QApplication.instance() or QApplication([])
+
+from graphlink_agents_pycoder import PyCoderReplManager, PythonREPL
+from graphlink_pycoder import PyCoderNode
+from graphlink_scene import ChatScene
+
+
+class _StandinNode:
+    """A minimal hashable object - the manager only needs identity-based keying,
+    so most cases below don't need a real (expensive-to-construct) PyCoderNode."""
+
+
+class TestGetReplCachesPerNode:
+    def test_same_node_reuses_the_same_repl(self):
+        manager = PyCoderReplManager()
+        node = _StandinNode()
+
+        assert manager.get_repl(node) is manager.get_repl(node)
+
+    def test_different_nodes_get_different_repls(self):
+        manager = PyCoderReplManager()
+        node_a, node_b = _StandinNode(), _StandinNode()
+
+        assert manager.get_repl(node_a) is not manager.get_repl(node_b)
+
+    def test_get_repl_returns_a_real_python_repl_instance(self):
+        manager = PyCoderReplManager()
+
+        assert isinstance(manager.get_repl(_StandinNode()), PythonREPL)
+
+
+class TestStopReleasesAndAllowsRecreation:
+    def test_stop_calls_repl_stop(self):
+        manager = PyCoderReplManager()
+        node = _StandinNode()
+        repl = manager.get_repl(node)
+        repl.stop = MagicMock()
+
+        manager.stop(node)
+
+        repl.stop.assert_called_once()
+
+    def test_stop_is_a_no_op_for_a_node_with_no_repl(self):
+        manager = PyCoderReplManager()
+
+        manager.stop(_StandinNode())  # must not raise
+
+    def test_stop_then_get_repl_creates_a_fresh_instance(self):
+        manager = PyCoderReplManager()
+        node = _StandinNode()
+        first = manager.get_repl(node)
+        manager.stop(node)
+
+        assert manager.get_repl(node) is not first
+
+
+class TestFinalizerFiresOnGarbageCollectionAlone:
+    """The load-bearing guarantee described in the module docstring: a REPL must
+    stop even if manager.stop()/node.dispose() is never called at all."""
+
+    def test_finalizer_stops_the_repl_once_the_node_is_collected(self):
+        with patch.object(PythonREPL, "stop") as mock_stop:
+            manager = PyCoderReplManager()
+            node = _StandinNode()
+            manager.get_repl(node)
+
+            del node
+            gc.collect()
+
+            mock_stop.assert_called_once()
+
+    def test_an_explicit_stop_detaches_the_finalizer_so_it_does_not_fire_twice(self):
+        with patch.object(PythonREPL, "stop") as mock_stop:
+            manager = PyCoderReplManager()
+            node = _StandinNode()
+            manager.get_repl(node)
+
+            manager.stop(node)
+            del node
+            gc.collect()
+
+            mock_stop.assert_called_once()
+
+
+class TestRealPyCoderNodeIntegration:
+    def test_manager_accepts_a_real_pycoder_node_as_its_key(self):
+        # Confirms PyCoderNode has no custom __eq__/__hash__ that would break
+        # WeakKeyDictionary keying (verified directly: grep found neither defined).
+        manager = PyCoderReplManager()
+        node = PyCoderNode(parent_node=None)
+
+        repl = manager.get_repl(node)
+
+        assert isinstance(repl, PythonREPL)
+        assert manager.get_repl(node) is repl
+
+    def test_pycoder_node_init_no_longer_constructs_its_own_repl(self):
+        node = PyCoderNode(parent_node=None)
+
+        assert not hasattr(node, "repl")
+
+    def test_pycoder_node_has_no_del_method_of_its_own(self):
+        # __del__'s only content was self.repl.stop() - now dead once ownership
+        # moved to the manager, so it was deleted rather than left as a no-op.
+        assert "__del__" not in PyCoderNode.__dict__
+
+    def test_dispose_calls_through_to_the_real_manager_via_scene_window(self):
+        window = MagicMock()
+        window.pycoder_repl_manager = PyCoderReplManager()
+        scene = ChatScene(window=window)
+        node = PyCoderNode(parent_node=None)
+        scene.addItem(node)
+        scene.pycoder_nodes.append(node)
+        repl = window.pycoder_repl_manager.get_repl(node)
+        repl.stop = MagicMock()
+
+        node.dispose()
+
+        repl.stop.assert_called_once()
+
+    def test_dispose_does_not_raise_for_a_node_never_added_to_a_scene(self):
+        node = PyCoderNode(parent_node=None)
+
+        node.dispose()  # self.scene() is None here - must not raise
+
+    def test_dispose_is_a_no_op_on_the_manager_when_no_repl_was_ever_created(self):
+        window = MagicMock()
+        window.pycoder_repl_manager = PyCoderReplManager()
+        scene = ChatScene(window=window)
+        node = PyCoderNode(parent_node=None)
+        scene.addItem(node)
+        scene.pycoder_nodes.append(node)
+
+        node.dispose()  # must not raise even though get_repl() was never called
+
+
+class TestClearPathReliesOnTheFinalizerNotDispose:
+    """Directly proves the pivotal recon finding behind this whole increment:
+    ChatScene.clear() does not call dispose(), so only the finalizer protects
+    the New Chat / chat-switch path."""
+
+    def test_scene_clear_skips_dispose_but_gc_afterwards_still_stops_the_repl(self):
+        with patch.object(PythonREPL, "stop") as mock_stop:
+            window = MagicMock()
+            window.pycoder_repl_manager = PyCoderReplManager()
+            scene = ChatScene(window=window)
+            parent = scene.add_chat_node("parent", is_user=True)
+            node = PyCoderNode(parent_node=parent)
+            scene.addItem(node)
+            scene.pycoder_nodes.append(node)
+            window.pycoder_repl_manager.get_repl(node)
+            node.dispose = MagicMock()
+
+            scene.clear()
+
+            node.dispose.assert_not_called()
+            mock_stop.assert_not_called()  # not yet - node/parent are still referenced locally
+
+            del node
+            del parent
+            gc.collect()
+
+            mock_stop.assert_called_once()
+
+
+class TestWindowActionsUsesTheManager:
+    def test_execute_pycoder_node_manual_mode_fetches_repl_through_the_manager(self):
+        from graphlink_pycoder import PyCoderMode
+        from graphlink_window_actions import WindowActionsMixin
+
+        class _FakeWindow(WindowActionsMixin):
+            pass
+
+        window = _FakeWindow()
+        window.pycoder_repl_manager = PyCoderReplManager()
+        node = PyCoderNode(parent_node=None, mode=PyCoderMode.MANUAL)
+        node.set_code("print(1)")
+        node.is_running = False
+
+        with patch("graphlink_window_actions.CodeExecutionWorker") as mock_worker_cls:
+            mock_worker_cls.return_value = MagicMock()
+            window.execute_pycoder_node(node)
+
+        used_repl = mock_worker_cls.call_args[0][1]
+        assert used_repl is window.pycoder_repl_manager.get_repl(node)


### PR DESCRIPTION
## Summary
- `ChatScene.clear()` (New Chat / chat-switch) never calls `PyCoderNode.dispose()` - `__del__` was the only thing stopping a REPL subprocess on that path. A new `PyCoderReplManager` (owned by `ChatWindow`) takes over construction/lookup via a `weakref.WeakKeyDictionary`, using `weakref.finalize` to guarantee cleanup on GC alone while `dispose()` still stops it deterministically on right-click delete.
- `PyCoderNode.__init__` no longer constructs `self.repl`; `__del__` (whose only content was the now-moot repl-stop call) is deleted outright. `graphlink_window_actions.py` fetches the REPL via `self.pycoder_repl_manager.get_repl(pycoder_node)` at both worker-construction sites instead of reading `pycoder_node.repl` directly.
- 2-agent adversarial review (reference-completeness + GC/finalizer-timing safety) came back CLEAN with zero blockers; one nitpick (a GC-reachability invariant worth codifying, not a defect) is now documented inline in `execute_pycoder_node`.

## Test plan
- [x] 16 new tests in `test_pycoder_repl_ownership.py` (get/reuse-per-node, stop/recreate, finalizer-fires-on-GC-alone, explicit-stop-detaches-finalizer, real-`PyCoderNode` integration, `dispose()`'s scene-window reach-through, `scene.clear()` skipping `dispose()` while the finalizer still fires)
- [x] Full suite: 1575 passed (was 1559), zero regressions
- [x] Real `ChatWindow` drive script (7 cases) against a REAL subprocess: spawn/execute via the manager, real `dispose()` killing the subprocess immediately, and real `scene.clear()` + `gc.collect()` triggering the finalizer to kill the subprocess afterward
- [x] Adversarial Workflow review: 2 independent reviewers, both CLEAN, zero blockers