### PR TITLE
Gitlink domain extraction to Qt-free repository.py (Phase 7 prereq, increment 6 - gate complete)

### DIFF
--- a/graphlink_app/graphlink_plugins/gitlink/repository.py
+++ b/graphlink_app/graphlink_plugins/gitlink/repository.py
@@ -111,7 +111,15 @@ def validate_pending_changes(pending_changes):
     # other write failure, rather than corrupting a file on disk.
     for file_item in pending_changes:
         operation = file_item.get("operation", "update")
-        if operation in ("update", "create"):
+        # Mirror apply_change_set's own dispatch exactly: it skips writing
+        # only when operation == "delete" and writes for every OTHER value,
+        # not just "update"/"create" by name. Enumerating "update"/"create"
+        # here instead of "not delete" let an unrecognized operation value
+        # (a typo, a stale schema value, or a hand-edited/corrupted saved
+        # session) skip this check entirely while still reaching
+        # apply_change_set's write branch below - reproduced end to end:
+        # such an item silently overwrote a real file with an empty string.
+        if operation != "delete":
             content = file_item.get("content")
             if not isinstance(content, str):
                 path_text = file_item.get("path", "<unknown path>")

--- a/graphlink_app/graphlink_plugins/gitlink/repository.py
+++ b/graphlink_app/graphlink_plugins/gitlink/repository.py
@@ -1,0 +1,327 @@
+"""Gitlink's Qt-free repository/context-building logic, extracted out of
+graphlink_plugin_gitlink.py (Phase 7 prerequisite increment 6).
+
+gitlink/agent.py's own module docstring documents that build_context_bundle/
+_resolve_scope_paths/_scan_local_repo_paths were the ORIGINAL target of that
+prior extraction and were deliberately left as GitlinkNode methods because
+they were judged "entangled with widget state... a redesign, not a refactor."
+This module revisits that punt: the state itself (repo/branch/local_root/
+scope_mode/task_prompt/selected_paths) stays exactly where it already lived
+correctly - as plain GitlinkNode attributes, kept in sync by the node's own
+textChanged/currentIndexChanged handlers, matching every other node type in
+this migration (WebNode.query, HtmlViewNode.html_content, etc.) - only the
+logic that doesn't need Qt at all moves here, taking that already-correct
+state as plain parameters instead of reading widgets directly.
+
+GitlinkRepository owns nothing but a GitHubRestClient reference, mirroring
+GitlinkNode's own pre-existing self._github_client pattern - it is a stateless
+helper, not a second source of truth for repo/branch/local_root.
+"""
+
+import base64
+import html
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import NamedTuple
+from urllib.parse import quote
+
+from graphlink_plugins.gitlink.agent import (
+    _clean_text,
+    _decode_text_bytes,
+    _is_repo_text_path,
+    _normalize_repo_path,
+    _safe_local_target,
+    _truncate_for_context,
+    _xml_file_block,
+)
+
+
+IGNORED_LOCAL_DIR_NAMES = {
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "node_modules",
+    "dist",
+    "build",
+}
+
+MAX_CONTEXT_CHARS = 180000
+MAX_MANIFEST_ENTRIES = 1200
+
+
+def default_import_root(repo_name, branch_name):
+    safe_repo = repo_name.replace("/", "__")
+    safe_branch = branch_name.replace("/", "__")
+    return Path.home() / ".graphlink" / "gitlink_repos" / safe_repo / safe_branch
+
+
+def scan_local_repo_paths(local_root):
+    root_path = Path(local_root).expanduser()
+    if not root_path.exists():
+        raise RuntimeError("The selected local repo path does not exist.")
+
+    collected = []
+    for file_path in root_path.rglob("*"):
+        if not file_path.is_file():
+            continue
+        relative = file_path.relative_to(root_path).as_posix()
+        if any(part in IGNORED_LOCAL_DIR_NAMES for part in PurePosixPath(relative).parts):
+            continue
+        if not _is_repo_text_path(relative):
+            continue
+        collected.append(relative)
+    return sorted(collected, key=str.lower)
+
+
+def resolve_scope_paths(scope_mode, selected_paths, repo_file_paths, local_root=None):
+    if scope_mode == "selected":
+        if not selected_paths:
+            raise RuntimeError("Select one or more files or switch to Full Repo Access.")
+        return list(selected_paths)
+
+    if repo_file_paths:
+        return list(repo_file_paths)
+    if local_root:
+        return scan_local_repo_paths(local_root)
+    raise RuntimeError("Load the file tree first so Gitlink knows which repository files to stitch together.")
+
+
+def read_local_repo_file(local_root, repo_path):
+    file_path = _safe_local_target(local_root, repo_path)
+    if not file_path.exists():
+        raise RuntimeError(f"Local checkout is missing `{repo_path}`.")
+    if file_path.is_dir():
+        raise RuntimeError(f"`{repo_path}` resolves to a directory, not a file.")
+    return _decode_text_bytes(file_path.read_bytes())
+
+
+def validate_pending_changes(pending_changes):
+    # Session-restored proposals skip GitlinkAgent._normalize_files (that
+    # normalization only runs for freshly-generated proposals, agent.py's
+    # get_response), so a restored change item is not guaranteed to have a
+    # 'content' key. Without this check, apply_change_set's original
+    # `file_item.get('content', '')` would silently write an EMPTY file over
+    # real content - failing loud here instead means the same caller's
+    # existing except-block revert-to-PREVIEWED path handles it like any
+    # other write failure, rather than corrupting a file on disk.
+    for file_item in pending_changes:
+        operation = file_item.get("operation", "update")
+        if operation in ("update", "create"):
+            content = file_item.get("content")
+            if not isinstance(content, str):
+                path_text = file_item.get("path", "<unknown path>")
+                raise RuntimeError(f"Proposed change for `{path_text}` is missing its file content.")
+
+
+def apply_change_set(local_root, pending_changes):
+    written_files = 0
+    for file_item in pending_changes:
+        path_text = file_item.get("path", "")
+        operation = file_item.get("operation", "update")
+        target_path = _safe_local_target(local_root, path_text)
+
+        if operation == "delete":
+            if target_path.exists():
+                target_path.unlink()
+                written_files += 1
+            continue
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(file_item.get("content", ""), encoding="utf-8")
+        written_files += 1
+
+    return written_files
+
+
+class ContextBundleResult(NamedTuple):
+    context_xml: str
+    context_stats: dict
+    context_summary: str
+    included_paths: list
+
+
+class GitlinkRepository:
+    """Stateless helper for the GitHub/filesystem operations GitlinkNode needs -
+    owns only a github_client reference, exactly like the node's own
+    self._github_client, not a second copy of repo/branch/local_root state."""
+
+    def __init__(self, github_client):
+        self.github_client = github_client
+
+    def fetch_github_file_text(self, repo_name, branch_name, repo_path):
+        content_payload = self.github_client.request(
+            f"https://api.github.com/repos/{repo_name}/contents/{quote(repo_path, safe='/')}",
+            params={"ref": branch_name},
+        )
+        if isinstance(content_payload, list):
+            raise RuntimeError(f"`{repo_path}` resolves to a directory, not a file.")
+
+        if content_payload.get("encoding") == "base64" and content_payload.get("content"):
+            return _decode_text_bytes(base64.b64decode(content_payload["content"]))
+
+        download_url = content_payload.get("download_url")
+        if download_url:
+            # Route through github_client rather than a raw requests.get: the
+            # bypassed call sent no Authorization header and got none of the
+            # client's 401/403/404 friendly-error mapping - a real gap for
+            # private-repo file fetches on this (rarer) fallback branch.
+            raw_bytes = self.github_client.request(download_url, expect_json=False, timeout=25)
+            return _decode_text_bytes(raw_bytes)
+
+        raise RuntimeError(f"GitHub did not return file contents for `{repo_path}`.")
+
+    def download_repository_snapshot(self, repo_name, branch_name, target_root):
+        if target_root.exists() and any(target_root.iterdir()):
+            return target_root
+
+        target_root.parent.mkdir(parents=True, exist_ok=True)
+        archive_bytes = self.github_client.request(
+            f"https://api.github.com/repos/{repo_name}/zipball/{quote(branch_name, safe='')}",
+            expect_json=False,
+            timeout=60,
+        )
+
+        with tempfile.TemporaryDirectory(prefix="gitlink_import_") as temp_dir:
+            temp_path = Path(temp_dir)
+            archive_path = temp_path / "repo.zip"
+            extract_root = temp_path / "extract"
+            extract_root.mkdir(parents=True, exist_ok=True)
+            archive_path.write_bytes(archive_bytes)
+
+            with zipfile.ZipFile(archive_path) as archive:
+                archive.extractall(extract_root)
+
+            extracted_dirs = [item for item in extract_root.iterdir() if item.is_dir()]
+            extracted_root = extracted_dirs[0] if extracted_dirs else extract_root
+
+            if target_root.exists():
+                return target_root
+
+            shutil.move(str(extracted_root), str(target_root))
+
+        return target_root
+
+    def build_context_bundle(self, *, repo_name, branch_name, scope_mode, selected_paths, repo_file_paths, local_root):
+        scope_paths = resolve_scope_paths(scope_mode, selected_paths, repo_file_paths, local_root=local_root)
+        records = []
+        included_file_count = 0
+        omitted_for_budget = 0
+        load_errors = 0
+
+        for repo_path in scope_paths:
+            normalized_path = _normalize_repo_path(repo_path)
+            source_origin = "github"
+            try:
+                if local_root is not None:
+                    source_text = read_local_repo_file(local_root, normalized_path)
+                    source_origin = "local"
+                else:
+                    source_text = self.fetch_github_file_text(repo_name, branch_name, normalized_path)
+                visible_text, source_truncated = _truncate_for_context(source_text)
+                records.append({
+                    "path": normalized_path,
+                    "source": source_origin,
+                    "content": visible_text,
+                    "original_chars": len(source_text),
+                    "source_truncated": source_truncated,
+                    "included": False,
+                })
+            except Exception as exc:
+                load_errors += 1
+                records.append({
+                    "path": normalized_path,
+                    "source": source_origin,
+                    "error": _clean_text(exc, limit=180) or "Unknown file load error.",
+                })
+
+        current_chars = 0
+        file_blocks = []
+        for record in records:
+            if record.get("error"):
+                continue
+            candidate_block = _xml_file_block(
+                record["path"],
+                record["content"],
+                truncated=record.get("source_truncated", False),
+                original_chars=record.get("original_chars", 0),
+            )
+            if file_blocks and (current_chars + len(candidate_block) > MAX_CONTEXT_CHARS):
+                omitted_for_budget += 1
+                continue
+            record["included"] = True
+            file_blocks.append(candidate_block)
+            current_chars += len(candidate_block)
+            included_file_count += 1
+
+        manifest_lines = []
+        for index, record in enumerate(records):
+            if index >= MAX_MANIFEST_ENTRIES:
+                break
+            attrs = [
+                f'path="{html.escape(record["path"], quote=True)}"',
+                f'source="{html.escape(record.get("source", "unknown"), quote=True)}"',
+            ]
+            if record.get("error"):
+                attrs.append(f'error="{html.escape(record["error"], quote=True)}"')
+            else:
+                attrs.append(f'included="{str(bool(record.get("included"))).lower()}"')
+                attrs.append(f'chars="{max(0, int(record.get("original_chars", 0)))}"')
+                attrs.append(f'truncated="{str(bool(record.get("source_truncated"))).lower()}"')
+                if not record.get("included"):
+                    attrs.append('omitted="true"')
+                    attrs.append('reason="context_budget"')
+            manifest_lines.append(f"    <file {' '.join(attrs)} />")
+
+        manifest_omitted = max(0, len(records) - MAX_MANIFEST_ENTRIES)
+        if manifest_omitted:
+            manifest_lines.append(f'    <more count="{manifest_omitted}" reason="manifest_budget" />')
+
+        scope_label = "full_repo" if scope_mode == "full" else "selected_files"
+        xml_parts = [
+            f'<gitlink_context repository="{html.escape(repo_name, quote=True)}" branch="{html.escape(branch_name, quote=True)}" scope="{scope_label}">',
+            f"  <summary scanned_files=\"{len(records)}\" loaded_files=\"{len(records) - load_errors}\" included_files=\"{included_file_count}\" load_errors=\"{load_errors}\" context_omissions=\"{omitted_for_budget}\" />",
+            "  <manifest>",
+            *manifest_lines,
+            "  </manifest>",
+            "  <files>",
+            *file_blocks,
+            "  </files>",
+            "</gitlink_context>",
+        ]
+        context_xml = "\n".join(xml_parts)
+
+        source_root = str(local_root) if local_root is not None else "github"
+        summary_parts = [
+            f"Scanned {len(records)} files",
+            f"loaded {len(records) - load_errors}",
+            f"included {included_file_count}",
+        ]
+        if omitted_for_budget:
+            summary_parts.append(f"omitted {omitted_for_budget} for context budget")
+        if load_errors:
+            summary_parts.append(f"hit {load_errors} load errors")
+        summary_parts.append(f"source={source_root}")
+        context_summary = ", ".join(summary_parts) + "."
+
+        context_stats = {
+            "scanned_files": len(records),
+            "loaded_files": len(records) - load_errors,
+            "included_files": included_file_count,
+            "load_errors": load_errors,
+            "context_omissions": omitted_for_budget,
+            "source_root": source_root,
+            "summary": context_summary,
+        }
+        included_paths = [record["path"] for record in records if record.get("included")]
+
+        return ContextBundleResult(
+            context_xml=context_xml,
+            context_stats=context_stats,
+            context_summary=context_summary,
+            included_paths=included_paths,
+        )

--- a/graphlink_app/graphlink_plugins/graphlink_plugin_gitlink.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_gitlink.py
@@ -1,14 +1,8 @@
-import base64
 import difflib
-import html
-import shutil
-import tempfile
-import zipfile
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from urllib.parse import quote
 
 import qtawesome as qta
-import requests
 from PySide6.QtCore import QRect, QRectF, Qt, QThread, Signal
 from PySide6.QtGui import QColor, QFont, QPainter, QPainterPath, QPen
 from PySide6.QtWidgets import (
@@ -43,13 +37,16 @@ from graphlink_plugins.gitlink.agent import (
     GitlinkAgent,
     _clean_text,
     _compact_label_text,
-    _decode_text_bytes,
     _fingerprint_changes,
     _is_repo_text_path,
     _normalize_repo_path,
-    _safe_local_target,
-    _truncate_for_context,
-    _xml_file_block,
+)
+from graphlink_plugins.gitlink.repository import (
+    GitlinkRepository,
+    apply_change_set,
+    default_import_root,
+    read_local_repo_file,
+    validate_pending_changes,
 )
 from graphlink_plugins.common.combo import PopupComboBox
 
@@ -99,20 +96,6 @@ GITLINK_SCROLLBAR_STYLE = """
     }
 """
 
-IGNORED_LOCAL_DIR_NAMES = {
-    ".git",
-    ".hg",
-    ".svn",
-    "__pycache__",
-    ".venv",
-    "venv",
-    "node_modules",
-    "dist",
-    "build",
-}
-
-MAX_CONTEXT_CHARS = 180000
-MAX_MANIFEST_ENTRIES = 1200
 MAX_REPO_PAGES = 5
 
 
@@ -207,6 +190,7 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
         self.parent_node = parent_node
         self.settings_manager = settings_manager
         self._github_client = GitHubRestClient(settings_manager)
+        self._repository = GitlinkRepository(self._github_client)
         self.children = []
         self.is_user = False
         self.conversation_history = []
@@ -814,13 +798,18 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
             self.set_status(f"Error: {exc}")
 
     def _resolve_repo_and_branch(self):
-        repo_name = self.repo_input.text().strip() or self.repo_combo.currentText().strip()
+        # repo_combo has no mirror of its own (it's a convenience dropdown, not
+        # one of the source-of-truth fields), so it stays a direct widget read;
+        # repo/branch themselves now read repo_state, which every write path
+        # (the textChanged handler below and this method's own writeback) keeps
+        # in lockstep with the widgets.
+        repo_name = self.repo_state.get("repo", "").strip() or self.repo_combo.currentText().strip()
         if not repo_name or "/" not in repo_name:
             raise RuntimeError("Enter a repository as `owner/repo`.")
 
         repo_payload = self._github_request(f"https://api.github.com/repos/{repo_name}")
         default_branch = repo_payload.get("default_branch", "")
-        branch_name = self.branch_input.text().strip() or default_branch
+        branch_name = self.repo_state.get("branch", "").strip() or default_branch
         if not branch_name:
             raise RuntimeError("GitHub did not provide a default branch for this repository.")
 
@@ -919,45 +908,9 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
             self.repo_state["local_root"] = chosen_dir
             self._mark_context_dirty()
 
-    def _default_import_root(self, repo_name, branch_name):
-        safe_repo = repo_name.replace("/", "__")
-        safe_branch = branch_name.replace("/", "__")
-        return Path.home() / ".graphlink" / "gitlink_repos" / safe_repo / safe_branch
-
-    def _download_repository_snapshot(self, repo_name, branch_name, target_root):
-        if target_root.exists() and any(target_root.iterdir()):
-            return target_root
-
-        target_root.parent.mkdir(parents=True, exist_ok=True)
-        archive_bytes = self._github_request(
-            f"https://api.github.com/repos/{repo_name}/zipball/{quote(branch_name, safe='')}",
-            expect_json=False,
-            timeout=60,
-        )
-
-        with tempfile.TemporaryDirectory(prefix="gitlink_import_") as temp_dir:
-            temp_path = Path(temp_dir)
-            archive_path = temp_path / "repo.zip"
-            extract_root = temp_path / "extract"
-            extract_root.mkdir(parents=True, exist_ok=True)
-            archive_path.write_bytes(archive_bytes)
-
-            with zipfile.ZipFile(archive_path) as archive:
-                archive.extractall(extract_root)
-
-            extracted_dirs = [item for item in extract_root.iterdir() if item.is_dir()]
-            extracted_root = extracted_dirs[0] if extracted_dirs else extract_root
-
-            if target_root.exists():
-                return target_root
-
-            shutil.move(str(extracted_root), str(target_root))
-
-        return target_root
-
     def _ensure_repository_snapshot(self):
         repo_name, branch_name = self._resolve_repo_and_branch()
-        local_root_text = self.local_root_input.text().strip()
+        local_root_text = self.repo_state.get("local_root", "").strip()
         if local_root_text:
             root_path = Path(local_root_text).expanduser()
             if root_path.exists():
@@ -974,8 +927,8 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
                 self.repo_state["local_root"] = str(imported_path)
                 return imported_path
 
-        target_root = self._default_import_root(repo_name, branch_name)
-        target_path = self._download_repository_snapshot(repo_name, branch_name, target_root)
+        target_root = default_import_root(repo_name, branch_name)
+        target_path = self._repository.download_repository_snapshot(repo_name, branch_name, target_root)
         self.repo_state["imported_root"] = str(target_path)
         self.repo_state["local_root"] = str(target_path)
         self._suppress_ui_updates = True
@@ -991,193 +944,43 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
         except Exception as exc:
             self.set_status(f"Error: {exc}")
 
-    def _read_local_repo_file(self, local_root, repo_path):
-        file_path = _safe_local_target(local_root, repo_path)
-        if not file_path.exists():
-            raise RuntimeError(f"Local checkout is missing `{repo_path}`.")
-        if file_path.is_dir():
-            raise RuntimeError(f"`{repo_path}` resolves to a directory, not a file.")
-        return _decode_text_bytes(file_path.read_bytes())
-
-    def _fetch_github_file_text(self, repo_name, branch_name, repo_path):
-        content_payload = self._github_request(
-            f"https://api.github.com/repos/{repo_name}/contents/{quote(repo_path, safe='/')}",
-            params={"ref": branch_name},
-        )
-        if isinstance(content_payload, list):
-            raise RuntimeError(f"`{repo_path}` resolves to a directory, not a file.")
-
-        if content_payload.get("encoding") == "base64" and content_payload.get("content"):
-            return _decode_text_bytes(base64.b64decode(content_payload["content"]))
-
-        download_url = content_payload.get("download_url")
-        if download_url:
-            response = requests.get(download_url, timeout=25)
-            response.raise_for_status()
-            return response.text
-
-        raise RuntimeError(f"GitHub did not return file contents for `{repo_path}`.")
-
-    def _scan_local_repo_paths(self, local_root):
-        root_path = Path(local_root).expanduser()
-        if not root_path.exists():
-            raise RuntimeError("The selected local repo path does not exist.")
-
-        collected = []
-        for file_path in root_path.rglob("*"):
-            if not file_path.is_file():
-                continue
-            relative = file_path.relative_to(root_path).as_posix()
-            if any(part in IGNORED_LOCAL_DIR_NAMES for part in PurePosixPath(relative).parts):
-                continue
-            if not _is_repo_text_path(relative):
-                continue
-            collected.append(relative)
-        return sorted(collected, key=str.lower)
-
-    def _resolve_scope_paths(self, local_root=None):
-        scope_mode = self.scope_combo.currentData() or "selected"
-        if scope_mode == "selected":
-            selected_paths = self.get_selected_paths()
-            if not selected_paths:
-                raise RuntimeError("Select one or more files or switch to Full Repo Access.")
-            return selected_paths
-
-        if self.repo_file_paths:
-            return list(self.repo_file_paths)
-        if local_root:
-            return self._scan_local_repo_paths(local_root)
-        raise RuntimeError("Load the file tree first so Gitlink knows which repository files to stitch together.")
-
     def build_context_bundle(self):
+        # Phase 7 prerequisite (increment 6): the ~130-line pure file-loading/
+        # budget-trimming/XML-assembly core now lives Qt-free in
+        # gitlink/repository.py's GitlinkRepository.build_context_bundle - this
+        # method is left as the thin Qt-facing wrapper: resolve repo/branch,
+        # read the now-consistently-authoritative repo_state mirror for
+        # local_root/scope_mode (and self.selected_paths/self.repo_file_paths,
+        # both already correctly synced), delegate, then push the result into
+        # widgets.
         repo_name, branch_name = self._resolve_repo_and_branch()
-        local_root_text = self.local_root_input.text().strip()
+        local_root_text = self.repo_state.get("local_root", "").strip()
         local_root = Path(local_root_text).expanduser() if local_root_text else None
         if local_root and not local_root.exists():
             raise RuntimeError("The selected local repo path does not exist.")
 
-        if (self.scope_combo.currentData() or "selected") == "full" and local_root is None:
+        scope_mode = self.repo_state.get("scope_mode") or "selected"
+        if scope_mode == "full" and local_root is None:
             local_root = self._ensure_repository_snapshot()
 
-        scope_paths = self._resolve_scope_paths(local_root=local_root)
-        records = []
-        included_file_count = 0
-        omitted_for_budget = 0
-        load_errors = 0
+        result = self._repository.build_context_bundle(
+            repo_name=repo_name,
+            branch_name=branch_name,
+            scope_mode=scope_mode,
+            selected_paths=self.selected_paths,
+            repo_file_paths=self.repo_file_paths,
+            local_root=local_root,
+        )
 
-        for repo_path in scope_paths:
-            normalized_path = _normalize_repo_path(repo_path)
-            source_origin = "github"
-            try:
-                if local_root is not None:
-                    source_text = self._read_local_repo_file(local_root, normalized_path)
-                    source_origin = "local"
-                else:
-                    source_text = self._fetch_github_file_text(repo_name, branch_name, normalized_path)
-                visible_text, source_truncated = _truncate_for_context(source_text)
-                records.append({
-                    "path": normalized_path,
-                    "source": source_origin,
-                    "content": visible_text,
-                    "original_chars": len(source_text),
-                    "source_truncated": source_truncated,
-                    "included": False,
-                })
-            except Exception as exc:
-                load_errors += 1
-                records.append({
-                    "path": normalized_path,
-                    "source": source_origin,
-                    "error": _clean_text(exc, limit=180) or "Unknown file load error.",
-                })
-
-        current_chars = 0
-        file_blocks = []
-        for record in records:
-            if record.get("error"):
-                continue
-            candidate_block = _xml_file_block(
-                record["path"],
-                record["content"],
-                truncated=record.get("source_truncated", False),
-                original_chars=record.get("original_chars", 0),
-            )
-            if file_blocks and (current_chars + len(candidate_block) > MAX_CONTEXT_CHARS):
-                omitted_for_budget += 1
-                continue
-            record["included"] = True
-            file_blocks.append(candidate_block)
-            current_chars += len(candidate_block)
-            included_file_count += 1
-
-        manifest_lines = []
-        for index, record in enumerate(records):
-            if index >= MAX_MANIFEST_ENTRIES:
-                break
-            attrs = [
-                f'path="{html.escape(record["path"], quote=True)}"',
-                f'source="{html.escape(record.get("source", "unknown"), quote=True)}"',
-            ]
-            if record.get("error"):
-                attrs.append(f'error="{html.escape(record["error"], quote=True)}"')
-            else:
-                attrs.append(f'included="{str(bool(record.get("included"))).lower()}"')
-                attrs.append(f'chars="{max(0, int(record.get("original_chars", 0)))}"')
-                attrs.append(f'truncated="{str(bool(record.get("source_truncated"))).lower()}"')
-                if not record.get("included"):
-                    attrs.append('omitted="true"')
-                    attrs.append('reason="context_budget"')
-            manifest_lines.append(f"    <file {' '.join(attrs)} />")
-
-        manifest_omitted = max(0, len(records) - MAX_MANIFEST_ENTRIES)
-        if manifest_omitted:
-            manifest_lines.append(f'    <more count="{manifest_omitted}" reason="manifest_budget" />')
-
-        scope_mode = self.scope_combo.currentData() or "selected"
-        scope_label = "full_repo" if scope_mode == "full" else "selected_files"
-        xml_parts = [
-            f'<gitlink_context repository="{html.escape(repo_name, quote=True)}" branch="{html.escape(branch_name, quote=True)}" scope="{scope_label}">',
-            f"  <summary scanned_files=\"{len(records)}\" loaded_files=\"{len(records) - load_errors}\" included_files=\"{included_file_count}\" load_errors=\"{load_errors}\" context_omissions=\"{omitted_for_budget}\" />",
-            "  <manifest>",
-            *manifest_lines,
-            "  </manifest>",
-            "  <files>",
-            *file_blocks,
-            "  </files>",
-            "</gitlink_context>",
-        ]
-        context_xml = "\n".join(xml_parts)
-
-        source_root = str(local_root) if local_root is not None else "github"
-        summary_parts = [
-            f"Scanned {len(records)} files",
-            f"loaded {len(records) - load_errors}",
-            f"included {included_file_count}",
-        ]
-        if omitted_for_budget:
-            summary_parts.append(f"omitted {omitted_for_budget} for context budget")
-        if load_errors:
-            summary_parts.append(f"hit {load_errors} load errors")
-        summary_parts.append(f"source={source_root}")
-        context_summary = ", ".join(summary_parts) + "."
-
-        self.context_xml = context_xml
-        self.context_stats = {
-            "scanned_files": len(records),
-            "loaded_files": len(records) - load_errors,
-            "included_files": included_file_count,
-            "load_errors": load_errors,
-            "context_omissions": omitted_for_budget,
-            "source_root": source_root,
-            "summary": context_summary,
-        }
-        self.context_summary = context_summary
-        self.last_context_paths = [record["path"] for record in records if record.get("included")]
-        self.context_editor.setPlainText(context_xml)
+        self.context_xml = result.context_xml
+        self.context_stats = result.context_stats
+        self.context_summary = result.context_summary
+        self.last_context_paths = result.included_paths
+        self.context_editor.setPlainText(result.context_xml)
         self.workspace_tabs.setCurrentIndex(1)
         self._context_dirty = False
         self._update_badges()
-        return context_xml
+        return result.context_xml
 
     def build_context_preview(self):
         try:
@@ -1187,15 +990,20 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
             self.set_status(f"Error: {exc}")
 
     def get_task_prompt(self):
-        return self.task_input.toPlainText()
+        # Phase 7 prerequisite (increment 6): self.task_prompt was already a
+        # correctly-synced mirror (kept in sync by _on_task_changed/seed_prompt/
+        # restore_saved_state) - this getter simply bypassed it and re-read the
+        # widget every time. Matches the identical fix already applied to every
+        # other node type's get_prompt()/get_code()/etc. in increments 1/5.
+        return self.task_prompt
 
     def build_change_request(self):
         if not self.context_xml.strip():
             raise RuntimeError("Build the XML context before generating a change set.")
         return {
-            "repo": self.repo_state.get("repo") or self.repo_input.text().strip(),
-            "branch": self.repo_state.get("branch") or self.branch_input.text().strip(),
-            "scope_label": "Full Repo Access" if (self.scope_combo.currentData() == "full") else "Selected Files",
+            "repo": self.repo_state.get("repo", ""),
+            "branch": self.repo_state.get("branch", ""),
+            "scope_label": "Full Repo Access" if (self.repo_state.get("scope_mode") == "full") else "Selected Files",
             "task_prompt": self.get_task_prompt(),
             "context_xml": self.context_xml,
             "context_summary": self.context_summary,
@@ -1214,8 +1022,8 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
             self.set_error(str(exc))
 
     def _build_proposal_markdown(self, proposal):
-        repo_name = self.repo_state.get("repo") or self.repo_input.text().strip()
-        branch_name = self.repo_state.get("branch") or self.branch_input.text().strip()
+        repo_name = self.repo_state.get("repo", "")
+        branch_name = self.repo_state.get("branch", "")
         summary = _clean_text(proposal.get("summary"), limit=500)
         rationale = _clean_text(proposal.get("rationale"), limit=1200)
         notes = proposal.get("notes", []) if isinstance(proposal.get("notes"), list) else []
@@ -1251,18 +1059,18 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
         return "\n".join(lines)
 
     def _read_original_text_for_preview(self, repo_path):
-        local_root_text = self.local_root_input.text().strip()
+        local_root_text = self.repo_state.get("local_root", "").strip()
         if local_root_text:
             try:
-                return self._read_local_repo_file(local_root_text, repo_path)
+                return read_local_repo_file(local_root_text, repo_path)
             except Exception:
                 pass
 
-        repo_name = self.repo_state.get("repo") or self.repo_input.text().strip()
-        branch_name = self.repo_state.get("branch") or self.branch_input.text().strip()
+        repo_name = self.repo_state.get("repo", "")
+        branch_name = self.repo_state.get("branch", "")
         if repo_name and branch_name:
             try:
-                return self._fetch_github_file_text(repo_name, branch_name, repo_path)
+                return self._repository.fetch_github_file_text(repo_name, branch_name, repo_path)
             except Exception:
                 pass
         return ""
@@ -1394,7 +1202,7 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
             self.set_error("There is no approved change set to write.")
             return
 
-        local_root_text = self.local_root_input.text().strip()
+        local_root_text = self.repo_state.get("local_root", "").strip()
         if not local_root_text:
             self.set_error("Select or import a local repository path before applying changes.")
             return
@@ -1431,23 +1239,18 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
             self.set_error("The proposed change set changed after approval. Review it again before applying.")
             return
 
-        written_files = 0
         try:
-            for file_item in self.pending_changes:
-                path_text = file_item.get("path", "")
-                operation = file_item.get("operation", "update")
-                target_path = _safe_local_target(local_root, path_text)
-
-                if operation == "delete":
-                    if target_path.exists():
-                        target_path.unlink()
-                        written_files += 1
-                    continue
-
-                target_path.parent.mkdir(parents=True, exist_ok=True)
-                target_path.write_text(file_item.get("content", ""), encoding="utf-8")
-                written_files += 1
-
+            # validate_pending_changes is a new pre-flight guard (Phase 7
+            # prerequisite increment 6): a session-restored proposal skips
+            # GitlinkAgent._normalize_files' content-key validation (that only
+            # runs for freshly-generated proposals), so a restored change item
+            # could otherwise reach apply_change_set's write_text(content, "")
+            # and silently write an EMPTY file over real content. This fails
+            # loud instead, caught by the same except block below that already
+            # handles every other write failure - it cannot weaken the gate,
+            # only surface one more failure mode as a reported error.
+            validate_pending_changes(self.pending_changes)
+            written_files = apply_change_set(local_root, self.pending_changes)
             self.change_state = GITLINK_STATE_APPLIED
             self.set_status(f"Applied {written_files} file changes.")
         except Exception as exc:

--- a/graphlink_app/tests/test_gitlink_node_state.py
+++ b/graphlink_app/tests/test_gitlink_node_state.py
@@ -1,0 +1,289 @@
+"""Phase 7 prerequisite increment 6: GitlinkNode's source-of-truth inversion
+(repo/branch/local_root/scope_mode become consistently authoritative on read,
+not just on write; task_prompt's already-correct mirror gets a getter that
+actually uses it) plus regression coverage for the write-approval flow
+(the fingerprint gate, restore_saved_state's "approval never survives a
+reload" invariant, and apply_approved_changes itself) - none of which had any
+test coverage before this increment (confirmed via repo-wide grep).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from PySide6.QtWidgets import QApplication, QMessageBox
+
+_APP = QApplication.instance() or QApplication([])
+
+from graphlink_plugins.graphlink_plugin_gitlink import (
+    GITLINK_STATE_APPLIED,
+    GITLINK_STATE_APPROVED,
+    GITLINK_STATE_DRAFT,
+    GITLINK_STATE_PREVIEWED,
+    GitlinkNode,
+)
+from graphlink_scene import ChatScene
+from graphlink_session.deserializers import SceneDeserializer
+from graphlink_session.serializers import SceneSerializer
+
+
+def _make_window_and_scene():
+    window = MagicMock()
+    scene = ChatScene(window=window)
+    window.chat_view.scene.return_value = scene
+    return window, scene
+
+
+def _desynced_widget_value(widget, mirror_getter):
+    """Sets the widget's text WITHOUT firing textChanged (blockSignals), then
+    confirms the getter still returns the pre-existing mirror value - proof a
+    getter reads the mirror and not the live widget."""
+    before = mirror_getter()
+    widget.blockSignals(True)
+    widget.setPlainText("SHOULD NOT BE VISIBLE THROUGH THE GETTER")
+    widget.blockSignals(False)
+    after = mirror_getter()
+    return before, after
+
+
+class TestTaskPromptMirrorAuthority:
+    def test_get_task_prompt_reads_the_mirror_not_the_live_widget(self):
+        node = GitlinkNode(parent_node=None)
+        node.seed_prompt("original prompt")
+
+        before, after = _desynced_widget_value(node.task_input, node.get_task_prompt)
+
+        assert before == after == "original prompt"
+
+    def test_seed_prompt_keeps_widget_and_mirror_in_sync(self):
+        node = GitlinkNode(parent_node=None)
+        node.seed_prompt("seeded")
+        assert node.get_task_prompt() == "seeded"
+        assert node.task_input.toPlainText() == "seeded"
+
+
+class TestRepoStateReadAuthority:
+    def test_resolve_repo_and_branch_reads_repo_state_not_the_widget(self):
+        node = GitlinkNode(parent_node=None)
+        # Deliberately desync: repo_state has real values, the widgets are
+        # still blank (never touched) - if _resolve_repo_and_branch fell back
+        # to reading the widgets, this would raise "Enter a repository..."
+        node.repo_state["repo"] = "owner/repo"
+        node.repo_state["branch"] = "main"
+        node._github_request = MagicMock(return_value={"default_branch": "main"})
+
+        repo_name, branch_name = node._resolve_repo_and_branch()
+
+        assert repo_name == "owner/repo"
+        assert branch_name == "main"
+
+    def test_ensure_repository_snapshot_reads_local_root_from_repo_state(self, tmp_path):
+        node = GitlinkNode(parent_node=None)
+        node._resolve_repo_and_branch = MagicMock(return_value=("owner/repo", "main"))
+        node.repo_state["local_root"] = str(tmp_path)
+
+        result = node._ensure_repository_snapshot()
+
+        assert result == tmp_path
+
+    def test_apply_approved_changes_reads_local_root_from_repo_state(self, tmp_path):
+        node = GitlinkNode(parent_node=None)
+        node.pending_changes = [{"path": "a.py", "operation": "create", "content": "print(1)"}]
+        node.repo_state["local_root"] = str(tmp_path)
+
+        with patch.object(QMessageBox, "question", return_value=QMessageBox.StandardButton.Yes):
+            node.apply_approved_changes()
+
+        assert (tmp_path / "a.py").read_text() == "print(1)"
+        assert node.change_state == GITLINK_STATE_APPLIED
+
+    def test_build_context_bundle_reads_scope_mode_from_repo_state(self, tmp_path):
+        (tmp_path / "a.py").write_text("print(1)")
+        node = GitlinkNode(parent_node=None)
+        node._resolve_repo_and_branch = MagicMock(return_value=("owner/repo", "main"))
+        node.repo_state["local_root"] = str(tmp_path)
+        node.repo_state["scope_mode"] = "full"
+        node.repo_file_paths = ["a.py"]
+
+        context_xml = node.build_context_bundle()
+
+        assert "a.py" in context_xml
+        assert node.context_stats["scanned_files"] == 1
+
+
+class TestSelectedPathsMirrorAuthority:
+    def test_build_context_bundle_selected_mode_uses_the_mirror_not_the_widget(self, tmp_path):
+        # file_list is deliberately left empty (no QListWidgetItems at all) -
+        # if build_context_bundle's scope resolution called get_selected_paths()
+        # (which reads file_list.selectedItems() live) instead of trusting
+        # self.selected_paths, this would raise "Select one or more files...".
+        (tmp_path / "fake.py").write_text("print(1)")
+        node = GitlinkNode(parent_node=None)
+        node._resolve_repo_and_branch = MagicMock(return_value=("owner/repo", "main"))
+        node.repo_state["local_root"] = str(tmp_path)
+        node.repo_state["scope_mode"] = "selected"
+        node.selected_paths = ["fake.py"]
+
+        context_xml = node.build_context_bundle()
+
+        assert "fake.py" in context_xml
+
+
+class TestSerializerRoundTrip:
+    def test_full_round_trip_preserves_repo_state_and_task_prompt(self):
+        window, scene = _make_window_and_scene()
+        parent = scene.add_chat_node("parent", is_user=True)
+        node = GitlinkNode(parent, settings_manager=None)
+        node.seed_prompt("fix the bug")
+        node.repo_state["repo"] = "owner/repo"
+        node.repo_state["branch"] = "main"
+        node.repo_state["scope_mode"] = "full"
+        node.repo_state["local_root"] = "/tmp/somewhere"
+        # selected_paths can only be restored as a subset of repo_file_paths -
+        # _populate_file_list (called by restore_saved_state) only creates
+        # QListWidgetItems for paths in repo_file_paths, so a selected path
+        # outside that list has no item to mark selected on restore.
+        node.repo_file_paths = ["a.py", "b.py", "c.py"]
+        node.selected_paths = ["a.py", "b.py"]
+        node.context_xml = "<gitlink_context></gitlink_context>"
+        scene.addItem(node)
+        scene.gitlink_nodes.append(node)
+
+        parent_payload = SceneSerializer(window).serialize_node(parent, [parent, node])
+        node_payload = SceneSerializer(window).serialize_node(node, [parent, node])
+
+        assert node_payload["task_prompt"] == "fix the bug"
+        assert node_payload["repo_state"]["repo"] == "owner/repo"
+        assert node_payload["repo_state"]["scope_mode"] == "full"
+        assert node_payload["selected_paths"] == ["a.py", "b.py"]
+
+        target_window, target_scene = _make_window_and_scene()
+        deserializer = SceneDeserializer(target_window)
+        restored_parent = deserializer.deserialize_node(0, parent_payload, {})
+        restored_node = deserializer.deserialize_node(1, node_payload, {0: restored_parent})
+
+        assert restored_node.get_task_prompt() == "fix the bug"
+        assert restored_node.repo_state["repo"] == "owner/repo"
+        assert restored_node.selected_paths == ["a.py", "b.py"]
+
+    def test_gitlink_requested_is_wired_on_restore(self):
+        window, scene = _make_window_and_scene()
+        parent = scene.add_chat_node("parent", is_user=True)
+        node = GitlinkNode(parent, settings_manager=None)
+        scene.addItem(node)
+        scene.gitlink_nodes.append(node)
+        parent_payload = SceneSerializer(window).serialize_node(parent, [parent, node])
+        node_payload = SceneSerializer(window).serialize_node(node, [parent, node])
+
+        target_window, target_scene = _make_window_and_scene()
+        target_window.execute_gitlink_node = MagicMock()
+        deserializer = SceneDeserializer(target_window)
+        restored_parent = deserializer.deserialize_node(0, parent_payload, {})
+        restored_node = deserializer.deserialize_node(1, node_payload, {0: restored_parent})
+
+        restored_node.gitlink_requested.emit(restored_node)
+        target_window.execute_gitlink_node.assert_called_once_with(restored_node)
+
+
+class TestApprovalNeverSurvivesReload:
+    def test_restoring_a_proposal_never_exceeds_previewed(self):
+        node = GitlinkNode(parent_node=None)
+
+        node.restore_saved_state(
+            proposal_data={"files": [{"path": "a.py", "operation": "update", "content": "x"}]},
+        )
+
+        assert node.change_state in (GITLINK_STATE_DRAFT, GITLINK_STATE_PREVIEWED)
+        assert node.change_state != GITLINK_STATE_APPROVED
+        assert node.change_state != GITLINK_STATE_APPLIED
+        assert node._approved_fingerprint is None
+
+    def test_restoring_after_a_real_applied_state_still_resets_to_at_most_previewed(self, tmp_path):
+        node = GitlinkNode(parent_node=None)
+        node.pending_changes = [{"path": "a.py", "operation": "create", "content": "x"}]
+        node.repo_state["local_root"] = str(tmp_path)
+        with patch.object(QMessageBox, "question", return_value=QMessageBox.StandardButton.Yes):
+            node.apply_approved_changes()
+        assert node.change_state == GITLINK_STATE_APPLIED
+
+        node.restore_saved_state(
+            proposal_data={"files": [{"path": "b.py", "operation": "update", "content": "y"}]},
+        )
+
+        assert node.change_state in (GITLINK_STATE_DRAFT, GITLINK_STATE_PREVIEWED)
+        assert node._approved_fingerprint is None
+
+
+class TestApplyApprovedChangesOrchestration:
+    def test_happy_path_approve_writes_files_and_reaches_applied(self, tmp_path):
+        node = GitlinkNode(parent_node=None)
+        node.pending_changes = [{"path": "a.py", "operation": "create", "content": "print(1)"}]
+        node.repo_state["local_root"] = str(tmp_path)
+
+        with patch.object(QMessageBox, "question", return_value=QMessageBox.StandardButton.Yes):
+            node.apply_approved_changes()
+
+        assert (tmp_path / "a.py").read_text() == "print(1)"
+        assert node.change_state == GITLINK_STATE_APPLIED
+
+    def test_user_cancelling_leaves_everything_unchanged(self, tmp_path):
+        node = GitlinkNode(parent_node=None)
+        node.pending_changes = [{"path": "a.py", "operation": "create", "content": "print(1)"}]
+        node.repo_state["local_root"] = str(tmp_path)
+
+        with patch.object(QMessageBox, "question", return_value=QMessageBox.StandardButton.No):
+            node.apply_approved_changes()
+
+        assert not (tmp_path / "a.py").exists()
+        assert node.change_state != GITLINK_STATE_APPLIED
+
+    def test_simulated_race_mutates_pending_changes_during_the_dialog_and_is_caught(self, tmp_path):
+        # Reproduces the exact scenario the fingerprint gate exists for: a
+        # background worker's finished signal calls set_proposal() (which
+        # unconditionally overwrites pending_changes) while the confirmation
+        # dialog is open. Here the monkeypatched QMessageBox.question mutates
+        # pending_changes itself as a stand-in for that race, then returns Yes.
+        node = GitlinkNode(parent_node=None)
+        node.pending_changes = [{"path": "a.py", "operation": "create", "content": "print(1)"}]
+        node.repo_state["local_root"] = str(tmp_path)
+
+        def _mutate_then_approve(*args, **kwargs):
+            node.pending_changes = [{"path": "b.py", "operation": "create", "content": "print(2)"}]
+            return QMessageBox.StandardButton.Yes
+
+        with patch.object(QMessageBox, "question", side_effect=_mutate_then_approve):
+            node.apply_approved_changes()
+
+        assert not (tmp_path / "a.py").exists()
+        assert not (tmp_path / "b.py").exists()
+        assert node.change_state == GITLINK_STATE_PREVIEWED
+        assert node._approved_fingerprint is None
+
+    def test_missing_content_key_aborts_with_no_partial_writes(self, tmp_path):
+        node = GitlinkNode(parent_node=None)
+        node.pending_changes = [
+            {"path": "a.py", "operation": "create", "content": "print(1)"},
+            {"path": "b.py", "operation": "update"},  # missing 'content'
+        ]
+        node.repo_state["local_root"] = str(tmp_path)
+
+        with patch.object(QMessageBox, "question", return_value=QMessageBox.StandardButton.Yes):
+            node.apply_approved_changes()
+
+        # validate_pending_changes runs before any writes in the try block, so
+        # a.py (which would have written fine) must NOT exist either.
+        assert not (tmp_path / "a.py").exists()
+        assert not (tmp_path / "b.py").exists()
+        assert node.change_state == GITLINK_STATE_PREVIEWED
+
+    def test_delete_of_nonexistent_file_is_a_no_op_within_the_full_flow(self, tmp_path):
+        node = GitlinkNode(parent_node=None)
+        node.pending_changes = [{"path": "never_existed.py", "operation": "delete"}]
+        node.repo_state["local_root"] = str(tmp_path)
+
+        with patch.object(QMessageBox, "question", return_value=QMessageBox.StandardButton.Yes):
+            node.apply_approved_changes()
+
+        assert node.change_state == GITLINK_STATE_APPLIED

--- a/graphlink_app/tests/test_gitlink_node_state.py
+++ b/graphlink_app/tests/test_gitlink_node_state.py
@@ -278,6 +278,28 @@ class TestApplyApprovedChangesOrchestration:
         assert not (tmp_path / "b.py").exists()
         assert node.change_state == GITLINK_STATE_PREVIEWED
 
+    def test_unrecognized_operation_value_does_not_silently_wipe_a_real_file(self, tmp_path):
+        # Adversarial-review finding: validate_pending_changes originally
+        # enumerated "update"/"create" by name, but apply_change_set's real
+        # dispatch treats ANY non-"delete" operation as a write. A
+        # session-restored proposal with a corrupted/unrecognized operation
+        # value (here "modify" - a plausible typo/stale-schema value) used to
+        # sail past validation and reach the write branch, which defaults
+        # missing content to "" and overwrote a real file's real content.
+        important_file = tmp_path / "important.py"
+        important_file.write_text("REAL CONTENT THAT MUST SURVIVE")
+        node = GitlinkNode(parent_node=None)
+        node.restore_saved_state(
+            proposal_data={"files": [{"path": "important.py", "operation": "modify"}]},
+        )
+        node.repo_state["local_root"] = str(tmp_path)
+
+        with patch.object(QMessageBox, "question", return_value=QMessageBox.StandardButton.Yes):
+            node.apply_approved_changes()
+
+        assert important_file.read_text() == "REAL CONTENT THAT MUST SURVIVE"
+        assert node.change_state == GITLINK_STATE_PREVIEWED
+
     def test_delete_of_nonexistent_file_is_a_no_op_within_the_full_flow(self, tmp_path):
         node = GitlinkNode(parent_node=None)
         node.pending_changes = [{"path": "never_existed.py", "operation": "delete"}]

--- a/graphlink_app/tests/test_gitlink_repository.py
+++ b/graphlink_app/tests/test_gitlink_repository.py
@@ -1,0 +1,322 @@
+"""Phase 7 prerequisite increment 6: GitlinkNode's tangled domain logic
+(GitHub tree/file loading, local-repo scanning, context-bundle assembly, and
+the write-approval loop) moves to a new Qt-free module,
+graphlink_plugins/gitlink/repository.py - a peer of gitlink/agent.py and
+common/github_client.py, following the exact same "revisit the previously
+punted extraction" reasoning gitlink/agent.py's own docstring already
+documents. This module has never had any test coverage before this increment
+(confirmed via repo-wide grep for build_context_bundle/apply_approved_changes/
+etc. before this increment landed) - this is the decisive new coverage for
+the one part of the app that writes AI-generated content to the user's local
+disk.
+
+No QApplication needed anywhere in this file - repository.py is Qt-free by
+construction, matching test_gitlink_agent.py/test_gitlink_path_safety.py's
+own precedent for the other two Qt-free gitlink modules.
+"""
+
+import base64
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from graphlink_plugins.gitlink.repository import (
+    ContextBundleResult,
+    GitlinkRepository,
+    apply_change_set,
+    default_import_root,
+    read_local_repo_file,
+    resolve_scope_paths,
+    scan_local_repo_paths,
+    validate_pending_changes,
+)
+
+
+class _FakeGithubClient:
+    """Duck-typed stand-in for GitHubRestClient.request(url, params=None, *,
+    expect_json=True, timeout=25) - records every call so bugfix-regression
+    tests can assert on exactly what was requested and how."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def request(self, url, params=None, *, expect_json=True, timeout=25):
+        self.calls.append({"url": url, "params": params, "expect_json": expect_json, "timeout": timeout})
+        if not self.responses:
+            raise AssertionError("_FakeGithubClient ran out of queued responses")
+        return self.responses.pop(0)
+
+
+class TestDefaultImportRoot:
+    def test_replaces_slashes_in_repo_and_branch(self):
+        result = default_import_root("owner/repo", "feature/x")
+        assert result.name == "feature__x"
+        assert result.parent.name == "owner__repo"
+
+
+class TestScanLocalRepoPaths:
+    def test_finds_nested_text_files(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("print(1)")
+        (tmp_path / "README.md").write_text("hi")
+
+        paths = scan_local_repo_paths(tmp_path)
+
+        assert "src/main.py" in paths
+        assert "README.md" in paths
+
+    def test_excludes_ignored_directory_names(self, tmp_path):
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "node_modules" / "pkg.js").write_text("x")
+        (tmp_path / "app.py").write_text("x")
+
+        paths = scan_local_repo_paths(tmp_path)
+
+        assert "app.py" in paths
+        assert not any("node_modules" in p for p in paths)
+
+    def test_excludes_binary_suffixes(self, tmp_path):
+        (tmp_path / "image.png").write_bytes(b"\x89PNG")
+        (tmp_path / "app.py").write_text("x")
+
+        paths = scan_local_repo_paths(tmp_path)
+
+        assert "app.py" in paths
+        assert "image.png" not in paths
+
+    def test_missing_root_raises(self, tmp_path):
+        with pytest.raises(RuntimeError):
+            scan_local_repo_paths(tmp_path / "does_not_exist")
+
+
+class TestResolveScopePaths:
+    def test_selected_mode_returns_selected_paths(self):
+        assert resolve_scope_paths("selected", ["a.py", "b.py"], []) == ["a.py", "b.py"]
+
+    def test_selected_mode_raises_when_nothing_selected(self):
+        with pytest.raises(RuntimeError):
+            resolve_scope_paths("selected", [], [])
+
+    def test_full_mode_prefers_repo_file_paths(self):
+        result = resolve_scope_paths("full", [], ["a.py", "b.py"])
+        assert result == ["a.py", "b.py"]
+
+    def test_full_mode_falls_back_to_scanning_local_root(self, tmp_path):
+        (tmp_path / "app.py").write_text("x")
+
+        result = resolve_scope_paths("full", [], [], local_root=tmp_path)
+
+        assert result == ["app.py"]
+
+    def test_full_mode_raises_with_nothing_available(self):
+        with pytest.raises(RuntimeError):
+            resolve_scope_paths("full", [], [])
+
+
+class TestReadLocalRepoFile:
+    def test_happy_path(self, tmp_path):
+        (tmp_path / "a.py").write_text("print(1)")
+        assert read_local_repo_file(tmp_path, "a.py") == "print(1)"
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(RuntimeError):
+            read_local_repo_file(tmp_path, "missing.py")
+
+    def test_directory_raises(self, tmp_path):
+        (tmp_path / "a_dir").mkdir()
+        with pytest.raises(RuntimeError):
+            read_local_repo_file(tmp_path, "a_dir")
+
+
+class TestFetchGithubFileText:
+    def test_base64_branch_decodes_correctly(self):
+        encoded = base64.b64encode(b"print(1)").decode("ascii")
+        client = _FakeGithubClient([{"encoding": "base64", "content": encoded}])
+        repo = GitlinkRepository(client)
+
+        result = repo.fetch_github_file_text("owner/repo", "main", "a.py")
+
+        assert result == "print(1)"
+
+    def test_download_url_fallback_routes_through_the_client_not_raw_requests(self):
+        # The bugfix regression test: this fallback used to call requests.get()
+        # directly, bypassing GitHubRestClient's auth header and error mapping
+        # entirely. Now it must go through the same client.request(...) as
+        # every other GitHub call, with expect_json=False (raw bytes).
+        client = _FakeGithubClient([
+            {"download_url": "https://raw.example/a.py"},
+            b"print(2)",
+        ])
+        repo = GitlinkRepository(client)
+
+        result = repo.fetch_github_file_text("owner/repo", "main", "a.py")
+
+        assert result == "print(2)"
+        assert client.calls[1]["url"] == "https://raw.example/a.py"
+        assert client.calls[1]["expect_json"] is False
+
+    def test_directory_response_raises(self):
+        client = _FakeGithubClient([[{"name": "a.py"}, {"name": "b.py"}]])
+        repo = GitlinkRepository(client)
+
+        with pytest.raises(RuntimeError):
+            repo.fetch_github_file_text("owner/repo", "main", "some_dir")
+
+    def test_neither_content_nor_download_url_raises(self):
+        client = _FakeGithubClient([{}])
+        repo = GitlinkRepository(client)
+
+        with pytest.raises(RuntimeError):
+            repo.fetch_github_file_text("owner/repo", "main", "a.py")
+
+
+class TestDownloadRepositorySnapshot:
+    def test_already_populated_target_short_circuits_with_no_request(self, tmp_path):
+        target_root = tmp_path / "existing"
+        target_root.mkdir()
+        (target_root / "a.py").write_text("x")
+        client = _FakeGithubClient([])
+        repo = GitlinkRepository(client)
+
+        result = repo.download_repository_snapshot("owner/repo", "main", target_root)
+
+        assert result == target_root
+        assert client.calls == []
+
+    def test_fresh_download_extracts_a_zip(self, tmp_path):
+        zip_bytes_path = tmp_path / "src.zip"
+        with zipfile.ZipFile(zip_bytes_path, "w") as archive:
+            archive.writestr("repo-main/app.py", "print(1)")
+        archive_bytes = zip_bytes_path.read_bytes()
+
+        client = _FakeGithubClient([archive_bytes])
+        repo = GitlinkRepository(client)
+        target_root = tmp_path / "extracted" / "owner__repo" / "main"
+
+        result = repo.download_repository_snapshot("owner/repo", "main", target_root)
+
+        assert result == target_root
+        assert (target_root / "app.py").read_text() == "print(1)"
+        assert client.calls[0]["expect_json"] is False
+
+
+class TestBuildContextBundle:
+    def test_all_local_happy_path(self, tmp_path):
+        (tmp_path / "a.py").write_text("print(1)")
+        (tmp_path / "b.py").write_text("print(2)")
+        repo = GitlinkRepository(_FakeGithubClient([]))
+
+        result = repo.build_context_bundle(
+            repo_name="owner/repo",
+            branch_name="main",
+            scope_mode="selected",
+            selected_paths=["a.py", "b.py"],
+            repo_file_paths=[],
+            local_root=tmp_path,
+        )
+
+        assert isinstance(result, ContextBundleResult)
+        assert result.context_stats["scanned_files"] == 2
+        assert result.context_stats["loaded_files"] == 2
+        assert result.context_stats["load_errors"] == 0
+        assert "a.py" in result.context_xml
+        assert "print(1)" in result.context_xml
+
+    def test_one_file_load_error_is_recorded_not_raised(self, tmp_path):
+        (tmp_path / "a.py").write_text("print(1)")
+        repo = GitlinkRepository(_FakeGithubClient([]))
+
+        result = repo.build_context_bundle(
+            repo_name="owner/repo",
+            branch_name="main",
+            scope_mode="selected",
+            selected_paths=["a.py", "missing.py"],
+            repo_file_paths=[],
+            local_root=tmp_path,
+        )
+
+        assert result.context_stats["load_errors"] == 1
+        assert result.context_stats["loaded_files"] == 1
+
+    def test_context_budget_omission(self, tmp_path, monkeypatch):
+        (tmp_path / "a.py").write_text("x" * 100)
+        (tmp_path / "b.py").write_text("y" * 100)
+        monkeypatch.setattr("graphlink_plugins.gitlink.repository.MAX_CONTEXT_CHARS", 50)
+        repo = GitlinkRepository(_FakeGithubClient([]))
+
+        result = repo.build_context_bundle(
+            repo_name="owner/repo",
+            branch_name="main",
+            scope_mode="selected",
+            selected_paths=["a.py", "b.py"],
+            repo_file_paths=[],
+            local_root=tmp_path,
+        )
+
+        assert result.context_stats["context_omissions"] >= 1
+        assert result.context_stats["included_files"] < 2
+
+    def test_scope_resolution_failure_propagates(self, tmp_path):
+        repo = GitlinkRepository(_FakeGithubClient([]))
+
+        with pytest.raises(RuntimeError):
+            repo.build_context_bundle(
+                repo_name="owner/repo",
+                branch_name="main",
+                scope_mode="selected",
+                selected_paths=[],
+                repo_file_paths=[],
+                local_root=tmp_path,
+            )
+
+
+class TestValidatePendingChanges:
+    def test_well_formed_changes_pass(self):
+        validate_pending_changes([
+            {"path": "a.py", "operation": "update", "content": "x"},
+            {"path": "b.py", "operation": "create", "content": ""},
+            {"path": "c.py", "operation": "delete"},
+        ])  # must not raise
+
+    def test_missing_content_on_update_raises_naming_the_path(self):
+        with pytest.raises(RuntimeError, match="missing_content.py"):
+            validate_pending_changes([{"path": "missing_content.py", "operation": "update"}])
+
+    def test_missing_content_on_create_raises(self):
+        with pytest.raises(RuntimeError):
+            validate_pending_changes([{"path": "new.py", "operation": "create"}])
+
+    def test_delete_needs_no_content(self):
+        validate_pending_changes([{"path": "gone.py", "operation": "delete"}])  # must not raise
+
+
+class TestApplyChangeSet:
+    def test_create_writes_file_and_parent_dirs(self, tmp_path):
+        written = apply_change_set(tmp_path, [
+            {"path": "nested/new.py", "operation": "create", "content": "print(1)"},
+        ])
+        assert written == 1
+        assert (tmp_path / "nested" / "new.py").read_text() == "print(1)"
+
+    def test_update_overwrites_existing_content(self, tmp_path):
+        (tmp_path / "a.py").write_text("old")
+        written = apply_change_set(tmp_path, [
+            {"path": "a.py", "operation": "update", "content": "new"},
+        ])
+        assert written == 1
+        assert (tmp_path / "a.py").read_text() == "new"
+
+    def test_delete_removes_file_and_counts(self, tmp_path):
+        (tmp_path / "a.py").write_text("x")
+        written = apply_change_set(tmp_path, [{"path": "a.py", "operation": "delete"}])
+        assert written == 1
+        assert not (tmp_path / "a.py").exists()
+
+    def test_delete_on_nonexistent_file_is_a_silent_no_op(self, tmp_path):
+        written = apply_change_set(tmp_path, [{"path": "never_existed.py", "operation": "delete"}])
+        assert written == 0

--- a/graphlink_app/tests/test_gitlink_repository.py
+++ b/graphlink_app/tests/test_gitlink_repository.py
@@ -294,6 +294,17 @@ class TestValidatePendingChanges:
     def test_delete_needs_no_content(self):
         validate_pending_changes([{"path": "gone.py", "operation": "delete"}])  # must not raise
 
+    def test_unrecognized_operation_value_still_requires_content(self):
+        # Adversarial-review finding: apply_change_set's real dispatch skips
+        # writing ONLY for operation == "delete" and writes for every other
+        # value - not just "update"/"create" by name. A guard that enumerated
+        # "update"/"create" specifically let an unrecognized value (a typo, a
+        # stale schema value, a hand-edited/corrupted saved session) skip
+        # validation while still reaching the write branch, silently
+        # overwriting a real file with an empty string.
+        with pytest.raises(RuntimeError, match="weird.py"):
+            validate_pending_changes([{"path": "weird.py", "operation": "modify"}])
+
 
 class TestApplyChangeSet:
     def test_create_writes_file_and_parent_dirs(self, tmp_path):


### PR DESCRIPTION
## Summary
- The largest and last of the 6-increment prerequisite gate. Moves GitlinkNode's GitHub/filesystem domain logic (file/tree loading, context-bundle assembly, the write-approval loop) out of the 1685-line node into a new `graphlink_plugins/gitlink/repository.py`, a Qt-free peer of `gitlink/agent.py` and `common/github_client.py` - revisiting an extraction `agent.py`'s own docstring had previously punted as "a redesign, not a refactor."
- Inverts source-of-truth for repo/branch/local_root/scope_mode so `repo_state` is authoritative on read as well as write, fixes `get_task_prompt()` to read its own already-correct `self.task_prompt` mirror instead of re-reading the widget, and lets `selected_paths` become read-authoritative as a structural consequence of the extraction.
- Fixes two real bugs found during recon: a raw `requests.get()` call bypassing `GitHubRestClient`'s auth header and error mapping, and a missing-content-key hazard where a session-restored proposal could silently write an empty file over real content. The fingerprint-gate/QMessageBox orchestration is left byte-for-byte untouched to preserve the "approval never survives a reload" invariant.
- **A 3-reviewer adversarial pass (scaled up given this is the only disk-write path in the app) found one real blocker**: the new `validate_pending_changes` guard checked `operation in ("update", "create")` by name, but `apply_change_set`'s real dispatch treats anything that isn't `"delete"` as a write - an unrecognized operation value slipped past validation and still got written, reproduced end-to-end through a real node destroying a real file's content. Fixed by mirroring the sibling function's actual dispatch logic, with a unit test and an end-to-end regression test reproducing the exact repro.

## Test plan
- [x] 49 new tests: `test_gitlink_repository.py` (31, pure-function/class coverage for the new Qt-free module) + `test_gitlink_node_state.py` (16, mirror-authority, serializer round-trip, reload invariant, fingerprint-gate race simulation) + 2 more added in response to the adversarial-review finding
- [x] Full suite: 1658 passed (was 1609), zero regressions
- [x] Real `ChatWindow` drive script (6 cases, re-run clean after the fix): real task_prompt mirror behavior, a real all-local context-bundle build, a real serialize/deserialize round-trip, the real complete apply-approved-changes flow writing a real file, the real fingerprint-gate race defense, and the reload invariant from a real APPLIED state
- [x] Adversarial Workflow review: 3 independent reviewers (reference-completeness, safety-critical-path, state-inversion-completeness) - 2 CLEAN, 1 found a real blocker, fixed and re-verified before push

Closes Phase 7's prerequisite-refactor gate (6/6 increments done).