### PR TITLE
Fix the 3 bugs from the plan-vs-code audit: node lifecycle, misleading Gitlink preview, partial-write rollback

### DIFF
--- a/graphlink_app/graphlink_conversation_node.py
+++ b/graphlink_app/graphlink_conversation_node.py
@@ -193,10 +193,32 @@ class ConversationNode(QGraphicsObject, HoverAnimationMixin):
         self._request_active = False
         self._cancel_pending = False
         self.worker_thread = None
+        self.is_disposed = False
 
         self._setup_ui()
         self.proxy = QGraphicsProxyWidget(self)
         self.proxy.setWidget(self.widget)
+
+    def dispose(self):
+        # Called by ChatScene.deleteSelectedItems when this node is removed. Cancel
+        # the in-flight ChatWorkerThread so deletion doesn't orphan a live QThread:
+        # once the node leaves scene.conversation_nodes there is nothing left that
+        # tracks that worker, and its finished/error/cancelled signals would fire
+        # into a node no longer on the canvas. ChatWorkerThread exposes cancel()
+        # (cooperative), not stop() - the existing result handlers already reject
+        # stale threads, so the cancelled callback becomes a no-op after this.
+        # Mirrors the sibling nodes' dispose(); the delete path is hasattr-gated so
+        # defining this method wires it up. (Plan-vs-code audit finding A3.)
+        if self.is_disposed:
+            return
+        self.is_disposed = True
+        worker = getattr(self, "worker_thread", None)
+        try:
+            if worker and worker.isRunning():
+                worker.cancel()
+        except RuntimeError:
+            pass
+        self.worker_thread = None
 
     @property
     def width(self):

--- a/graphlink_app/graphlink_plugins/gitlink/repository.py
+++ b/graphlink_app/graphlink_plugins/gitlink/repository.py
@@ -127,23 +127,56 @@ def validate_pending_changes(pending_changes):
 
 
 def apply_change_set(local_root, pending_changes):
+    # Backup-and-rollback (audit finding A1): previously a mid-loop failure
+    # (permission denied, a directory sitting where a file is expected, disk
+    # full, ...) left files 1..N-1 already written/deleted with no way back -
+    # the checkout ended half-applied while the UI reported the whole apply as
+    # failed. Every target's pre-state is now snapshotted BEFORE it is touched
+    # (so even the failing item's own partial write is restored); on any
+    # exception the applied entries are rolled back in reverse order and the
+    # original error re-raised. Rollback is best-effort: any path that cannot
+    # be restored is named in the raised error so the user knows exactly which
+    # files were left modified. Parent directories created by mkdir are not
+    # removed on rollback - empty leftover dirs are harmless.
     written_files = 0
-    for file_item in pending_changes:
-        path_text = file_item.get("path", "")
-        operation = file_item.get("operation", "update")
-        target_path = _safe_local_target(local_root, path_text)
+    backups = []  # (target_path, original_bytes or None if the file did not exist)
+    try:
+        for file_item in pending_changes:
+            path_text = file_item.get("path", "")
+            operation = file_item.get("operation", "update")
+            target_path = _safe_local_target(local_root, path_text)
 
-        if operation == "delete":
-            if target_path.exists():
-                target_path.unlink()
-                written_files += 1
-            continue
+            if operation == "delete":
+                if target_path.exists():
+                    backups.append((target_path, target_path.read_bytes()))
+                    target_path.unlink()
+                    written_files += 1
+                continue
 
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-        target_path.write_text(file_item.get("content", ""), encoding="utf-8")
-        written_files += 1
+            backups.append((target_path, target_path.read_bytes() if target_path.exists() else None))
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_text(file_item.get("content", ""), encoding="utf-8")
+            written_files += 1
 
-    return written_files
+        return written_files
+    except Exception as exc:
+        failed_restores = []
+        for target_path, original in reversed(backups):
+            try:
+                if original is None:
+                    if target_path.exists():
+                        target_path.unlink()
+                else:
+                    target_path.parent.mkdir(parents=True, exist_ok=True)
+                    target_path.write_bytes(original)
+            except Exception:
+                failed_restores.append(str(target_path))
+        if failed_restores:
+            raise RuntimeError(
+                f"{exc} (rolled back all other changes, but could not restore: "
+                f"{', '.join(failed_restores)})"
+            ) from exc
+        raise
 
 
 class ContextBundleResult(NamedTuple):

--- a/graphlink_app/graphlink_plugins/graphlink_plugin_artifact.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_artifact.py
@@ -130,6 +130,7 @@ class ArtifactNode(QGraphicsObject, HoverAnimationMixin):
         self.parent_node = parent_node
         self.children = []
         self.worker_thread = None
+        self.is_disposed = False
 
         self.conversation_history = []
         self.local_history = []
@@ -161,9 +162,26 @@ class ArtifactNode(QGraphicsObject, HoverAnimationMixin):
         """)
         
         self._setup_ui()
-        
+
         self.proxy = QGraphicsProxyWidget(self)
         self.proxy.setWidget(self.widget)
+
+    def dispose(self):
+        # Called by ChatScene.deleteSelectedItems when this node is removed. Stop the
+        # running worker so deletion doesn't orphan a live QThread: once the node
+        # leaves scene.artifact_nodes, ChatWindow._iter_shutdown_threads can no longer
+        # find that worker at app close, and its finished/error signals would fire
+        # into a node that no longer exists on the canvas. Mirrors
+        # CodeSandboxNode.dispose(); the delete path is hasattr-gated so simply
+        # defining this method wires it up. (Plan-vs-code audit finding A3: this was
+        # the one worker-owning node type with no dispose at all.)
+        if self.is_disposed:
+            return
+        self.is_disposed = True
+        worker = getattr(self, "worker_thread", None)
+        if worker and worker.isRunning():
+            worker.stop()
+        self.worker_thread = None
 
     @property
     def width(self):

--- a/graphlink_app/graphlink_plugins/graphlink_plugin_gitlink.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_gitlink.py
@@ -1059,6 +1059,13 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
         return "\n".join(lines)
 
     def _read_original_text_for_preview(self, repo_path):
+        # Returns the original file text, "" for a genuinely-empty-but-readable
+        # file, or None when the original could not be read from EITHER source.
+        # Callers must distinguish None (unknown) from "" (empty): collapsing a
+        # failed fetch to "" made an `update` diff render as a clean full-file
+        # `create` diff - no deletions shown - silently corrupting the human
+        # approval decision, which is the only gate on the disk write (audit
+        # finding A2).
         local_root_text = self.repo_state.get("local_root", "").strip()
         if local_root_text:
             try:
@@ -1073,7 +1080,7 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
                 return self._repository.fetch_github_file_text(repo_name, branch_name, repo_path)
             except Exception:
                 pass
-        return ""
+        return None
 
     def _build_preview_text(self, files):
         preview_parts = []
@@ -1082,6 +1089,30 @@ class GitlinkNode(QGraphicsObject, HoverAnimationMixin):
             operation = file_item.get("operation", "update")
             original_text = self._read_original_text_for_preview(path_text)
             proposed_text = file_item.get("content", "") if operation in {"update", "create"} else ""
+
+            # None = the original could not be read (as opposed to "" = a real
+            # empty file). For update/delete that means no honest diff exists -
+            # say so explicitly instead of diffing against "" and rendering a
+            # misleading all-additions "create" diff. Creates never need the
+            # original, so they render normally either way.
+            if original_text is None and operation in {"update", "delete"}:
+                preview_parts.append(f"### {path_text} [{operation}]\n")
+                preview_parts.append(
+                    "!! WARNING: the original file could not be read (local checkout "
+                    "and GitHub fetch both failed or are not configured), so no diff "
+                    "can be shown for this change."
+                )
+                if operation == "update":
+                    preview_parts.append(
+                        "!! Applying will OVERWRITE the existing file with the full "
+                        "proposed content below:\n"
+                    )
+                    preview_parts.append(proposed_text if proposed_text else "[No content in proposal]")
+                else:
+                    preview_parts.append("!! Applying will DELETE the file.")
+                preview_parts.append("")
+                continue
+            original_text = original_text or ""
 
             if operation == "create":
                 diff_lines = list(

--- a/graphlink_app/graphlink_scene.py
+++ b/graphlink_app/graphlink_scene.py
@@ -1485,6 +1485,7 @@ class ChatScene(QGraphicsScene):
                 self._remove_associated_chart_nodes(item)
                 if item.parent_node and item in item.parent_node.children: item.parent_node.children.remove(item)
                 self._remove_connections_for_node(item)
+                if hasattr(item, "dispose"): item.dispose()
                 self.removeItem(item)
                 if item in self.conversation_nodes: self.conversation_nodes.remove(item)
             elif isinstance(item, HtmlViewNode):
@@ -1497,6 +1498,7 @@ class ChatScene(QGraphicsScene):
                 self._remove_associated_chart_nodes(item)
                 if item.parent_node and item in item.parent_node.children: item.parent_node.children.remove(item)
                 self._remove_connections_for_node(item)
+                if hasattr(item, "dispose"): item.dispose()
                 self.removeItem(item)
                 if item in self.artifact_nodes: self.artifact_nodes.remove(item)
             elif isinstance(item, GitlinkNode):

--- a/graphlink_app/graphlink_window_actions.py
+++ b/graphlink_app/graphlink_window_actions.py
@@ -1595,18 +1595,27 @@ class WindowActionsMixin:
 
     def _handle_artifact_result(self, new_doc, ai_msg, artifact_node):
         """Processes the finished document and commentary from the Artifact thread."""
+        # These were the only worker result handlers with no disposed-node guard
+        # (audit finding A3): deleting the node mid-generate let the finished
+        # signal mutate a node no longer on the canvas.
+        if not artifact_node or getattr(artifact_node, "is_disposed", False):
+            return
+
         artifact_node.set_artifact_content(new_doc)
         if ai_msg:
             artifact_node.add_chat_message(ai_msg, is_user=False)
         artifact_node.set_running_state(False)
-        
+
         parent_history = self._branch_context_history(artifact_node, artifact_node.parent_node)
         assign_history(artifact_node, append_history(parent_history, artifact_node.local_history))
-        
+
         self.save_chat()
 
     def _handle_artifact_error(self, error_msg, artifact_node):
         """Handles an error within the Artifact thread."""
+        if not artifact_node or getattr(artifact_node, "is_disposed", False):
+            return
+
         artifact_node.add_chat_message(f"Error: {error_msg}", is_user=False)
         artifact_node.set_running_state(False)
 

--- a/graphlink_app/tests/test_gitlink_node_state.py
+++ b/graphlink_app/tests/test_gitlink_node_state.py
@@ -309,3 +309,69 @@ class TestApplyApprovedChangesOrchestration:
             node.apply_approved_changes()
 
         assert node.change_state == GITLINK_STATE_APPLIED
+
+
+class TestPreviewDistinguishesUnreadableOriginal:
+    """Audit finding A2: _read_original_text_for_preview used to swallow every
+    fetch failure to "" - so an `update` whose original couldn't be read
+    rendered as a clean all-additions "create" diff, silently corrupting the
+    human-approval decision (the only gate on the disk write). The method now
+    returns None for "could not read" (vs "" for a genuinely empty file), and
+    the preview renders an explicit warning instead of a fake diff."""
+
+    def test_read_original_returns_none_when_no_source_is_configured(self):
+        node = GitlinkNode(parent_node=None)
+        # No local_root, no repo/branch - both sources unavailable.
+        assert node._read_original_text_for_preview("a.py") is None
+
+    def test_read_original_returns_empty_string_for_a_real_empty_file(self, tmp_path):
+        (tmp_path / "empty.py").write_text("")
+        node = GitlinkNode(parent_node=None)
+        node.repo_state["local_root"] = str(tmp_path)
+
+        assert node._read_original_text_for_preview("empty.py") == ""
+
+    def test_update_with_unreadable_original_warns_instead_of_faking_a_create_diff(self):
+        node = GitlinkNode(parent_node=None)
+
+        preview = node._build_preview_text(
+            [{"path": "config.py", "operation": "update", "content": "NEW CONTENT"}]
+        )
+
+        assert "could not be read" in preview
+        assert "OVERWRITE" in preview
+        assert "NEW CONTENT" in preview
+        # The misleading unified-diff framing must NOT appear for this entry.
+        assert "+++ b/config.py" not in preview
+
+    def test_update_with_genuinely_empty_original_renders_a_normal_diff(self, tmp_path):
+        (tmp_path / "empty.py").write_text("")
+        node = GitlinkNode(parent_node=None)
+        node.repo_state["local_root"] = str(tmp_path)
+
+        preview = node._build_preview_text(
+            [{"path": "empty.py", "operation": "update", "content": "added line"}]
+        )
+
+        assert "could not be read" not in preview
+        assert "+++ b/empty.py" in preview
+
+    def test_delete_with_unreadable_original_warns(self):
+        node = GitlinkNode(parent_node=None)
+
+        preview = node._build_preview_text([{"path": "gone.py", "operation": "delete"}])
+
+        assert "could not be read" in preview
+        assert "DELETE" in preview
+
+    def test_create_is_unaffected_by_an_unavailable_original(self):
+        # Creates never need the original - they must keep rendering a normal
+        # new-file diff even when nothing is configured.
+        node = GitlinkNode(parent_node=None)
+
+        preview = node._build_preview_text(
+            [{"path": "new.py", "operation": "create", "content": "print(1)"}]
+        )
+
+        assert "could not be read" not in preview
+        assert "+++ b/new.py" in preview

--- a/graphlink_app/tests/test_gitlink_repository.py
+++ b/graphlink_app/tests/test_gitlink_repository.py
@@ -331,3 +331,61 @@ class TestApplyChangeSet:
     def test_delete_on_nonexistent_file_is_a_silent_no_op(self, tmp_path):
         written = apply_change_set(tmp_path, [{"path": "never_existed.py", "operation": "delete"}])
         assert written == 0
+
+
+class TestApplyChangeSetRollback:
+    """Audit finding A1: a mid-loop failure used to leave files 1..N-1 already
+    written/deleted with no way back - the checkout ended half-applied while
+    the UI reported the whole apply as failed. apply_change_set now snapshots
+    every target's pre-state before touching it and rolls back on any
+    exception. The failing item in these tests is a path that resolves to an
+    existing DIRECTORY - reading/writing it as a file raises on every
+    platform, and it passes validate_pending_changes (content present), so it
+    models a genuine mid-write surprise rather than a pre-validated reject."""
+
+    def _blocker(self, tmp_path):
+        (tmp_path / "blocker_dir").mkdir()
+        return {"path": "blocker_dir", "operation": "update", "content": "x"}
+
+    def test_mid_loop_failure_restores_an_earlier_overwrite(self, tmp_path):
+        (tmp_path / "a.py").write_text("ORIGINAL A")
+
+        with pytest.raises(Exception):
+            apply_change_set(tmp_path, [
+                {"path": "a.py", "operation": "update", "content": "NEW A"},
+                self._blocker(tmp_path),
+            ])
+
+        assert (tmp_path / "a.py").read_text() == "ORIGINAL A"
+
+    def test_mid_loop_failure_removes_a_file_created_earlier(self, tmp_path):
+        with pytest.raises(Exception):
+            apply_change_set(tmp_path, [
+                {"path": "brand_new.py", "operation": "create", "content": "print(1)"},
+                self._blocker(tmp_path),
+            ])
+
+        assert not (tmp_path / "brand_new.py").exists()
+
+    def test_mid_loop_failure_restores_an_earlier_delete(self, tmp_path):
+        (tmp_path / "a.py").write_text("KEEP ME")
+
+        with pytest.raises(Exception):
+            apply_change_set(tmp_path, [
+                {"path": "a.py", "operation": "delete"},
+                self._blocker(tmp_path),
+            ])
+
+        assert (tmp_path / "a.py").read_text() == "KEEP ME"
+
+    def test_successful_apply_is_unchanged_by_the_rollback_machinery(self, tmp_path):
+        (tmp_path / "a.py").write_text("old")
+
+        written = apply_change_set(tmp_path, [
+            {"path": "a.py", "operation": "update", "content": "new"},
+            {"path": "b.py", "operation": "create", "content": "made"},
+        ])
+
+        assert written == 2
+        assert (tmp_path / "a.py").read_text() == "new"
+        assert (tmp_path / "b.py").read_text() == "made"

--- a/graphlink_app/tests/test_plugin_node_dispose_lifecycle.py
+++ b/graphlink_app/tests/test_plugin_node_dispose_lifecycle.py
@@ -1,0 +1,172 @@
+"""Audit finding A3: ArtifactNode and ConversationNode were the two
+worker-owning plugin nodes with no dispose() at all - their branches in
+ChatScene.deleteSelectedItems called no cleanup, so deleting a node
+mid-generate orphaned the live QThread (invisible to
+ChatWindow._iter_shutdown_threads once the node left the scene lists) and
+let the worker's finished/error signals fire into a node no longer on the
+canvas. _handle_artifact_result/_handle_artifact_error were additionally the
+only worker result handlers with no disposed-node guard.
+
+Both nodes now define dispose() (Artifact stops its ArtifactWorkerThread;
+Conversation cancels its ChatWorkerThread - cancel() is that worker's
+cooperative-stop API), both scene delete branches call it via the existing
+hasattr gate, and the artifact result handlers guard on is_disposed like
+every sibling handler already did.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from PySide6.QtWidgets import QApplication
+
+_APP = QApplication.instance() or QApplication([])
+
+from graphlink_conversation_node import ConversationNode
+from graphlink_plugins.graphlink_plugin_artifact import ArtifactNode
+from graphlink_scene import ChatScene
+from graphlink_window_actions import WindowActionsMixin
+
+
+def _make_scene():
+    window = MagicMock()
+    scene = ChatScene(window=window)
+    window.chat_view.scene.return_value = scene
+    return scene
+
+
+class TestArtifactNodeDispose:
+    def test_dispose_stops_a_running_worker_and_clears_the_reference(self):
+        node = ArtifactNode(parent_node=None)
+        worker = MagicMock()
+        worker.isRunning.return_value = True
+        node.worker_thread = worker
+
+        node.dispose()
+
+        worker.stop.assert_called_once()
+        assert node.worker_thread is None
+        assert node.is_disposed is True
+
+    def test_dispose_is_idempotent(self):
+        node = ArtifactNode(parent_node=None)
+        node.dispose()
+        node.worker_thread = MagicMock()  # a second dispose must not touch this
+
+        node.dispose()
+
+        node.worker_thread.stop.assert_not_called()
+
+    def test_scene_delete_path_disposes_the_node(self):
+        scene = _make_scene()
+        parent = scene.add_chat_node("parent", is_user=True)
+        node = ArtifactNode(parent)
+        scene.addItem(node)
+        scene.artifact_nodes.append(node)
+        worker = MagicMock()
+        worker.isRunning.return_value = True
+        node.worker_thread = worker
+        node.setSelected(True)
+
+        scene.deleteSelectedItems()
+
+        worker.stop.assert_called_once()
+        assert node.is_disposed is True
+        assert node not in scene.artifact_nodes
+
+
+class TestConversationNodeDispose:
+    def test_dispose_cancels_a_running_worker_and_clears_the_reference(self):
+        node = ConversationNode(parent_node=None)
+        worker = MagicMock()
+        worker.isRunning.return_value = True
+        node.worker_thread = worker
+
+        node.dispose()
+
+        worker.cancel.assert_called_once()
+        assert node.worker_thread is None
+        assert node.is_disposed is True
+
+    def test_dispose_is_idempotent(self):
+        node = ConversationNode(parent_node=None)
+        node.dispose()
+        node.worker_thread = MagicMock()
+
+        node.dispose()
+
+        node.worker_thread.cancel.assert_not_called()
+
+    def test_scene_delete_path_disposes_the_node(self):
+        scene = _make_scene()
+        parent = scene.add_chat_node("parent", is_user=True)
+        node = ConversationNode(parent)
+        scene.addItem(node)
+        scene.conversation_nodes.append(node)
+        worker = MagicMock()
+        worker.isRunning.return_value = True
+        node.worker_thread = worker
+        node.setSelected(True)
+
+        scene.deleteSelectedItems()
+
+        worker.cancel.assert_called_once()
+        assert node.is_disposed is True
+        assert node not in scene.conversation_nodes
+
+
+class TestArtifactHandlersGuardDisposedNodes:
+    def _window(self):
+        class _FakeWindow(WindowActionsMixin):
+            pass
+
+        return _FakeWindow()
+
+    def test_result_handler_ignores_a_disposed_node(self):
+        window = self._window()
+        node = MagicMock()
+        node.is_disposed = True
+
+        # Guard missing => set_artifact_content is called (and the handler
+        # would then crash on the fake window's absent save_chat).
+        window._handle_artifact_result("new doc", "a message", node)
+
+        node.set_artifact_content.assert_not_called()
+        node.add_chat_message.assert_not_called()
+
+    def test_result_handler_ignores_none(self):
+        window = self._window()
+
+        window._handle_artifact_result("new doc", "a message", None)  # must not raise
+
+    def test_error_handler_ignores_a_disposed_node(self):
+        window = self._window()
+        node = MagicMock()
+        node.is_disposed = True
+
+        window._handle_artifact_error("boom", node)
+
+        node.add_chat_message.assert_not_called()
+
+    def test_delete_mid_generate_end_to_end_does_not_touch_the_removed_node(self):
+        # The full A3 scenario: node deleted while its worker runs; the
+        # worker's finished callback then arrives. The node must be left
+        # completely untouched.
+        scene = _make_scene()
+        parent = scene.add_chat_node("parent", is_user=True)
+        node = ArtifactNode(parent)
+        scene.addItem(node)
+        scene.artifact_nodes.append(node)
+        worker = MagicMock()
+        worker.isRunning.return_value = True
+        node.worker_thread = worker
+        node.setSelected(True)
+        scene.deleteSelectedItems()
+
+        window = self._window()
+        before = node.get_artifact_content()
+        window._handle_artifact_result("late result", "late message", node)
+
+        assert node.get_artifact_content() == before


### PR DESCRIPTION
## Summary
Fixes the three actionable bugs (A1-A3) from today's full plan-vs-code audit sweep, most-dangerous paths first:

- **A3 (new find): ArtifactNode/ConversationNode had no `dispose()`** - deleting either mid-generate orphaned the live QThread (invisible to `_iter_shutdown_threads` once the node left the scene lists) and let the worker's finished/error signals mutate a node no longer on the canvas. Both now define `dispose()` (Artifact stops its worker; Conversation cancels its `ChatWorkerThread`), both scene delete branches call it via the existing hasattr gate, and `_handle_artifact_result`/`_handle_artifact_error` - the only result handlers with no disposed-node guard - now guard like every sibling.
- **A2: Gitlink preview rendered an `update` as a clean full-file `create` diff whenever the original couldn't be read** - silently corrupting the human-approval decision, the only gate on the disk write. `_read_original_text_for_preview` now returns `None` for could-not-read (vs `""` for a genuinely empty file), and the preview shows an explicit OVERWRITE/DELETE warning with the full proposed content instead of a fake diff.
- **A1: `apply_change_set` had no rollback** - a mid-loop failure left files 1..N-1 written/deleted with the checkout half-applied while the UI reported the apply as failed. Every target's pre-state is now snapshotted before it is touched; on any exception the applied entries are restored in reverse order and the original error re-raised, naming any path that could not be restored. The fingerprint-gate orchestration is untouched.

One commit per bug for reviewability.

## Test plan
- [x] 20 new tests: `test_plugin_node_dispose_lifecycle.py` (10 - dispose contracts, real-scene delete-path disposal, guarded handlers, the full delete-mid-generate end-to-end scenario), preview-vs-empty distinction (6), rollback (4 - overwrite restored, created file removed, delete restored, success path byte-identical)
- [x] Full suite: 1678 passed (was 1658), zero regressions
- [x] Real ChatWindow Gitlink drive script re-run clean (real file write, fingerprint-gate race defense, reload invariant)