### PR TITLE
Plugin-node execution hardening: structural REPL status, race-free sandbox output, live path guard (audit B-series)

### DIFF
--- a/graphlink_app/graphlink_agents_code_sandbox.py
+++ b/graphlink_app/graphlink_agents_code_sandbox.py
@@ -195,7 +195,15 @@ class VirtualEnvSandbox:
                 try:
                     line = output_queue.get(timeout=0.1)
                 except queue.Empty:
-                    if process.poll() is not None:
+                    if process.poll() is None:
+                        continue
+                    # The process has exited. The reader thread owns
+                    # process.stdout exclusively (audit finding B3: a direct
+                    # stdout.read() here used to race the reader's readline on
+                    # the same pipe, garbling/duplicating captured output) -
+                    # let it drain to EOF and post done_signal instead.
+                    reader_thread.join(timeout=5)
+                    if not reader_thread.is_alive() and output_queue.empty():
                         break
                     continue
 
@@ -206,23 +214,16 @@ class VirtualEnvSandbox:
                 if emit_line:
                     emit_line(line)
 
-            while True:
-                try:
-                    remaining_line = output_queue.get_nowait()
-                except queue.Empty:
-                    break
-
-                if remaining_line is done_signal:
-                    break
-                output_chunks.append(remaining_line)
-                if emit_line:
-                    emit_line(remaining_line)
-
-            remainder = process.stdout.read() if process.stdout else ""
-            if remainder:
-                output_chunks.append(remainder)
-                if emit_line:
-                    emit_line(remainder)
+            # done_signal received (or the reader finished with an empty
+            # queue): stdout has been consumed to EOF by the reader, so no
+            # direct read is needed - or safe - here. Reap the process so
+            # returncode is real rather than a still-None poll() snapshot.
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                # Pathological: the child closed stdout but kept running.
+                process.kill()
+                process.wait()
 
             return "".join(output_chunks), process.returncode
         except Exception:

--- a/graphlink_app/graphlink_agents_pycoder.py
+++ b/graphlink_app/graphlink_agents_pycoder.py
@@ -6,6 +6,7 @@ import re
 import json
 import base64
 import threading
+import uuid
 import weakref
 from enum import Enum
 from PySide6.QtCore import QThread, Signal
@@ -34,23 +35,39 @@ class PythonREPL:
     Variables and imports survive between executions.
     Communicates via base64-encoded strings over stdin/stdout (encoding for safe IPC
     framing, not a security mechanism).
+
+    After every execute() call, last_run_failed reports whether the executed
+    code raised - the wrapper reports it structurally on the boundary line, so
+    callers no longer scan stdout for English error keywords (which
+    misclassified correct programs that merely printed words like "failed";
+    audit finding B2). The boundary line carries a per-session nonce and is
+    matched as an exact full line, so program output that happens to contain
+    the marker text can no longer truncate the result or desync every
+    subsequent call (audit finding B4).
     """
     def __init__(self):
         self.process = None
+        self.last_run_failed = False
+        self._boundary_prefix = ""
 
     def start(self):
-        script = """
+        nonce = uuid.uuid4().hex
+        self._boundary_prefix = f"---GRAPHLINK_EXEC_BOUNDARY:{nonce}:"
+        script = f"""
 import sys, traceback, base64
-env = {}
+env = {{}}
 while True:
     line = sys.stdin.readline()
     if not line: break
+    failed = False
     try:
         code = base64.b64decode(line.strip()).decode('utf-8')
         exec(code, env)
     except Exception:
+        failed = True
         traceback.print_exc()
-    print("\\n---GRAPHLINK_EXEC_BOUNDARY---", flush=True)
+    status = "ERROR" if failed else "OK"
+    print("\\n---GRAPHLINK_EXEC_BOUNDARY:{nonce}:" + status + "---", flush=True)
 """
         kwargs = {}
         # Hide the console window on Windows
@@ -76,15 +93,31 @@ while True:
             self.process.stdin.write(encoded_code + "\n")
             self.process.stdin.flush()
         except Exception as e:
+            self.last_run_failed = True
             return f"Failed to send code to REPL: {e}"
 
         output = []
         while True:
             line = self.process.stdout.readline()
-            if not line or "---GRAPHLINK_EXEC_BOUNDARY---" in line:
+            if not line:
+                # EOF with no boundary line: the REPL process died mid-run
+                # (e.g. the executed code called sys.exit() or hard-crashed
+                # the interpreter). Reap it now - stdout EOF can arrive
+                # before poll() reports the exit, and without this the next
+                # execute() could write into the dying process's stdin
+                # (EINVAL) instead of restarting.
+                self.last_run_failed = True
+                self.stop()
+                break
+            stripped = line.strip()
+            if stripped == self._boundary_prefix + "OK---":
+                self.last_run_failed = False
+                break
+            if stripped == self._boundary_prefix + "ERROR---":
+                self.last_run_failed = True
                 break
             output.append(line)
-        
+
         return "".join(output).strip()
 
     def stop(self):
@@ -339,10 +372,6 @@ class PyCoderExecutionWorker(QThread):
         if self.repl:
             self.repl.stop()
 
-    def _is_error(self, output):
-        error_keywords = ["traceback (most recent call last)", "error:", "exception:", "failed"]
-        return any(keyword in output.lower() for keyword in error_keywords)
-
     def run(self):
         try:
             retry_count = 0
@@ -393,14 +422,22 @@ class PyCoderExecutionWorker(QThread):
                 if not self._is_running: return
                 self.log_update.emit(PyCoderStage.EXECUTE, PyCoderStatus.RUNNING)
                 
+                # Failure is reported structurally by the REPL wrapper
+                # (repl.last_run_failed) instead of keyword-scanning stdout,
+                # which used to mark correct programs that merely printed
+                # words like "failed" as errors and "repair" working code
+                # (audit finding B2). getattr keeps duck-typed test fakes
+                # without the attribute working.
                 execution_output = ""
                 try:
                     execution_output = self.repl.execute(current_code)
+                    execution_failed = getattr(self.repl, "last_run_failed", False)
                 except Exception as e:
                     execution_output = f"\n--- EXECUTION FAILED ---\n{type(e).__name__}: {e}"
+                    execution_failed = True
 
                 if not self._is_running: return
-                if not self._is_error(execution_output):
+                if not execution_failed:
                     self.log_update.emit(PyCoderStage.EXECUTE, PyCoderStatus.SUCCESS)
                     self.log_update.emit(PyCoderStage.ANALYZE_RESULT, PyCoderStatus.RUNNING)
                     final_analysis = self.analysis_agent.get_response(

--- a/graphlink_app/graphlink_plugins/gitlink/agent.py
+++ b/graphlink_app/graphlink_plugins/gitlink/agent.py
@@ -72,10 +72,17 @@ def _is_repo_text_path(path_text):
 
 def _normalize_repo_path(path_text):
     raw_path = (path_text or "").strip().replace("\\", "/")
-    raw_path = raw_path.lstrip("/")
     if not raw_path:
         raise RuntimeError("Repository file path cannot be empty.")
 
+    # No lstrip("/") before this check: stripping first made the
+    # is_absolute() clause dead code, so absolute-looking input like
+    # "/etc/passwd" (or a UNC "//server/share") was silently reinterpreted as
+    # repo-relative and written INSIDE the repo instead of being rejected
+    # with the error this guard was written to raise (audit finding B1).
+    # Containment is still independently enforced downstream by
+    # _safe_local_target's resolve() check - this restores the loud,
+    # intended rejection at the semantic boundary.
     normalized = PurePosixPath(raw_path)
     if normalized.is_absolute() or ".." in normalized.parts:
         raise RuntimeError("Repository paths must stay inside the selected repository.")

--- a/graphlink_app/graphlink_plugins/graphlink_plugin_code_sandbox.py
+++ b/graphlink_app/graphlink_plugins/graphlink_plugin_code_sandbox.py
@@ -204,7 +204,19 @@ class CodeSandboxNode(QGraphicsObject, HoverAnimationMixin):
         self.proxy.setWidget(self.widget)
 
     def __del__(self):
-        self.dispose()
+        # GC-time last resort for the ChatScene.clear() path (New Chat /
+        # chat-switch), which never calls dispose() on plugin nodes - without
+        # this, a still-running sandbox worker would outlive its node with
+        # nothing left to stop it. Guarded because during interpreter
+        # shutdown the underlying C++ QThread/QObject may already be deleted,
+        # making dispose()'s worker.isRunning() raise inside __del__ (audit
+        # finding B5). Kept rather than dropped: unlike PyCoderNode (whose
+        # REPL manager registers a weakref.finalize), the sandbox worker has
+        # no other GC-time cleanup hook.
+        try:
+            self.dispose()
+        except Exception:
+            pass
 
     @property
     def width(self):

--- a/graphlink_app/tests/test_gitlink_path_safety.py
+++ b/graphlink_app/tests/test_gitlink_path_safety.py
@@ -46,16 +46,20 @@ class TestNormalizeRepoPath:
         with pytest.raises(RuntimeError):
             _normalize_repo_path("src/../../outside.py")
 
-    def test_leading_slash_is_stripped_to_a_relative_path(self):
-        # `lstrip("/")` runs before the PurePosixPath absolute-path check, so a
-        # leading-slash input never actually reaches that check as "absolute" -
-        # it's silently rewritten to a relative path instead of being rejected.
-        # That's still safe (containment is enforced downstream by
-        # _safe_local_target), but it means the `is_absolute()` guard in
-        # _normalize_repo_path is effectively unreachable for POSIX-style input.
-        # This test documents the real behavior so a future refactor doesn't
-        # accidentally rely on the dead branch.
-        assert _normalize_repo_path("/etc/passwd") == "etc/passwd"
+    def test_absolute_posix_path_is_rejected(self):
+        # Previously an lstrip("/") ran before the is_absolute() check, making
+        # that guard dead code: "/etc/passwd" was silently rewritten to the
+        # repo-relative "etc/passwd" and written INSIDE the repo instead of
+        # being rejected with the "must stay inside the repository" error the
+        # guard was written to raise (audit finding B1). Absolute-looking
+        # input now fails loud at the semantic boundary; byte-level
+        # containment remains independently enforced by _safe_local_target.
+        with pytest.raises(RuntimeError):
+            _normalize_repo_path("/etc/passwd")
+
+    def test_unc_style_path_is_rejected(self):
+        with pytest.raises(RuntimeError):
+            _normalize_repo_path("//server/share/evil.txt")
 
 
 class TestSafeLocalTarget:
@@ -74,10 +78,12 @@ class TestSafeLocalTarget:
         resolved_root = tmp_path.resolve()
         assert target == resolved_root or resolved_root in target.parents
 
-    def test_unc_style_path_stays_contained(self, tmp_path):
-        target = _safe_local_target(tmp_path, "//server/share/evil.txt")
-        resolved_root = tmp_path.resolve()
-        assert target == resolved_root or resolved_root in target.parents
+    def test_unc_style_path_is_rejected_at_normalization(self, tmp_path):
+        # _safe_local_target normalizes first, and normalization now rejects
+        # absolute-looking input outright (see TestNormalizeRepoPath) instead
+        # of silently rewriting it to a contained relative path.
+        with pytest.raises(RuntimeError):
+            _safe_local_target(tmp_path, "//server/share/evil.txt")
 
     def test_root_itself_is_a_valid_target(self, tmp_path):
         # repo_path resolving to the root exactly (e.g. a single-segment name)

--- a/graphlink_app/tests/test_pycoder_approval_gate.py
+++ b/graphlink_app/tests/test_pycoder_approval_gate.py
@@ -32,10 +32,13 @@ GENERATED_RESPONSE = "[TOOL:PYTHON]print('hello')[/TOOL]"
 
 
 class _FakeRepl:
-    def __init__(self, output="ok"):
+    def __init__(self, output="ok", last_run_failed=False):
         self.executed = []
         self.output = output
         self.stopped = False
+        # The worker reads failure structurally from this flag (audit B2) -
+        # NOT by scanning the output text for error keywords.
+        self.last_run_failed = last_run_failed
 
     def execute(self, code):
         self.executed.append(code)
@@ -113,7 +116,7 @@ class TestApprovalGateApproved:
     def test_repair_iterations_run_under_the_same_single_approval(self):
         # First execution fails, repair produces new code, which then executes without
         # a second approval prompt - the documented (sandbox-matching) behavior.
-        repl = _FakeRepl(output="Traceback (most recent call last): boom")
+        repl = _FakeRepl(output="Traceback (most recent call last): boom", last_run_failed=True)
         worker = _make_worker(repl)
         worker.repair_agent.get_response = lambda code, error, is_final: "print('repaired')"
 

--- a/graphlink_app/tests/test_pycoder_repl_hardening.py
+++ b/graphlink_app/tests/test_pycoder_repl_hardening.py
@@ -1,0 +1,138 @@
+"""Audit findings B2 + B4: PyCoder execution hardening.
+
+B2 - error detection was `_is_error()`, a substring scan of stdout for
+English keywords ("error:", "failed", ...): a correct program that merely
+printed one of those words was marked as a failure and handed to the repair
+agent, which could discard working code across up to 4 "fix" iterations. The
+REPL wrapper now reports success/failure structurally on its boundary line
+(PythonREPL.last_run_failed), and PyCoderExecutionWorker consumes that flag.
+
+B4 - the execution boundary was matched by SUBSTRING ("marker in line"): a
+program printing a line containing the marker truncated its own output and
+left the real boundary unread in the pipe, desyncing every subsequent
+execute() for the life of the REPL. The boundary now carries a per-session
+random nonce and is matched as an exact full line.
+
+The PythonREPL tests here run a REAL subprocess (that is the thing under
+test); each stops its REPL so no orphaned process survives the test run.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from graphlink_agents_pycoder import PythonREPL, PyCoderExecutionWorker
+
+
+@pytest.fixture
+def repl():
+    instance = PythonREPL()
+    yield instance
+    instance.stop()
+
+
+class TestStructuralStatus:
+    def test_successful_run_reports_ok(self, repl):
+        output = repl.execute("print('hello')")
+
+        assert output == "hello"
+        assert repl.last_run_failed is False
+
+    def test_raising_code_reports_error_structurally(self, repl):
+        output = repl.execute("raise ValueError('boom')")
+
+        assert repl.last_run_failed is True
+        assert "ValueError" in output
+
+    def test_printing_error_keywords_is_not_a_failure(self, repl):
+        # The exact B2 misclassification: correct output that merely contains
+        # the old keyword list ("failed", "error:", ...).
+        output = repl.execute("print('0 tests failed'); print('Error: none')")
+
+        assert repl.last_run_failed is False
+        assert "0 tests failed" in output
+        assert "Error: none" in output
+
+    def test_repl_death_reports_failure_and_next_execute_recovers(self, repl):
+        repl.execute("import sys; sys.exit(0)")
+        assert repl.last_run_failed is True
+
+        # The wrapper process died; execute() must transparently restart it.
+        output = repl.execute("print('back alive')")
+        assert output == "back alive"
+        assert repl.last_run_failed is False
+
+
+class TestBoundaryDesyncResistance:
+    def test_output_containing_the_marker_text_is_captured_not_truncated(self, repl):
+        # The exact B4 scenario: program output echoing the boundary framing.
+        # The old substring match would truncate here and desync the NEXT call.
+        output = repl.execute(
+            "print('---GRAPHLINK_EXEC_BOUNDARY---')\n"
+            "print('---GRAPHLINK_EXEC_BOUNDARY:deadbeef:OK---')\n"
+            "print('after the fakes')"
+        )
+
+        assert "---GRAPHLINK_EXEC_BOUNDARY---" in output
+        assert "after the fakes" in output
+        assert repl.last_run_failed is False
+
+        # And the stream is still in sync: the next call returns its own
+        # output, not stale leftovers from the previous run.
+        assert repl.execute("print('second call')") == "second call"
+
+    def test_boundary_nonce_differs_per_session(self):
+        a, b = PythonREPL(), PythonREPL()
+        try:
+            a.start()
+            b.start()
+            assert a._boundary_prefix != b._boundary_prefix
+        finally:
+            a.stop()
+            b.stop()
+
+
+class _FakeRepl:
+    def __init__(self, output, last_run_failed):
+        self._output = output
+        self.last_run_failed = last_run_failed
+
+    def execute(self, code):
+        return self._output
+
+    def stop(self):
+        pass
+
+
+def _run_worker(fake_repl):
+    worker = PyCoderExecutionWorker("do a thing", [], fake_repl)
+    worker.execution_agent = MagicMock()
+    worker.execution_agent.get_response.return_value = "[TOOL:PYTHON]print('x')[/TOOL]"
+    worker.repair_agent = MagicMock()
+    worker.repair_agent.get_response.return_value = "print('repaired')"
+    worker.analysis_agent = MagicMock()
+    worker.analysis_agent.get_response.return_value = "analysis text"
+    results = []
+    worker.finished.connect(results.append)
+    worker.approve()  # pre-approve so run() doesn't park on the gate
+    worker.run()
+    return worker, results
+
+
+class TestWorkerUsesTheStructuralFlag:
+    def test_benign_output_with_error_words_is_treated_as_success(self):
+        worker, results = _run_worker(_FakeRepl("0 tests failed", last_run_failed=False))
+
+        worker.repair_agent.get_response.assert_not_called()
+        assert results and results[0]["output"] == "0 tests failed"
+
+    def test_a_real_failure_with_benign_looking_output_triggers_repair(self):
+        # Inverse of B2: the flag says failed even though no keyword appears -
+        # the old keyword scan would have called this a success.
+        worker, results = _run_worker(_FakeRepl("exit status 1", last_run_failed=True))
+
+        worker.repair_agent.get_response.assert_called()


### PR DESCRIPTION
## Summary
The B-series latent hazards from the plan-vs-code audit, batched as one hardening pass:

- **B2** - PyCoder error detection is now structural: the REPL wrapper reports OK/ERROR on its boundary line (`PythonREPL.last_run_failed`) instead of the worker keyword-scanning stdout, which misclassified correct programs that merely printed words like "failed" and let the repair agent discard working code.
- **B4** - the execution boundary carries a per-session random nonce and is matched as an exact full line: program output containing the marker text can no longer truncate the result or desync every subsequent call. EOF-with-no-boundary also reaps the dead wrapper immediately so the next call restarts cleanly.
- **B3** - the sandbox's `_run_subprocess` no longer races its reader thread with a direct `stdout.read()` on the same pipe; the reader owns stdout exclusively and the process is reaped so `returncode` is real.
- **B5** - `CodeSandboxNode.__del__` is exception-guarded (Qt objects may be half-torn-down during GC). Kept rather than dropped: the `scene.clear()` path never calls `dispose()`, and the sandbox has no manager finalize to fall back on.
- **B1** - `_normalize_repo_path`'s dead `is_absolute()` guard is live again: absolute-looking input (`/etc/passwd`, UNC) is rejected loudly instead of silently rewritten to a repo-relative path. Containment via `_safe_local_target` unchanged.

## Test plan
- [x] 9 new tests in `test_pycoder_repl_hardening.py` against a REAL REPL subprocess (structural OK/ERROR, the exact keyword-misclassification scenario, boundary-desync resistance, per-session nonce, death-and-recover) + worker-level flag tests
- [x] Path-safety tests updated to assert the rejection they previously documented as a silent rewrite
- [x] Full suite: 1687 passed (was 1678), zero regressions; no orphaned subprocesses after the run