### PR TITLE
Hotfix: stop the startup npm rebuild storm (write-if-changed codegen + hardened bootstrap)

### DIFF
--- a/graphlink_app/graphlink_frontend_bootstrap.py
+++ b/graphlink_app/graphlink_frontend_bootstrap.py
@@ -94,6 +94,24 @@ class FrontendBootstrapError(RuntimeError):
     """
 
 
+# Generous ceilings so a wedged npm can never hang startup forever with no
+# window and no error - `subprocess.run` without a timeout blocks
+# indefinitely, which presented as the app "looping" at launch. A clean
+# `vite build` is sub-second per island; `npm ci` is minutes at worst.
+_NPM_INSTALL_TIMEOUT_SECONDS = 600
+_NPM_BUILD_TIMEOUT_SECONDS = 180
+
+
+def _subprocess_no_window_kwargs() -> dict:
+    # A windowed (pythonw / desktop-shortcut) launch otherwise flashes one
+    # visible console window PER subprocess call - with every island stale
+    # that strobed 19 consoles in a row before any app window appeared,
+    # which read as the app stuck in an npm loop.
+    if sys.platform == "win32":
+        return {"creationflags": subprocess.CREATE_NO_WINDOW}
+    return {}
+
+
 def _is_frozen() -> bool:
     return bool(getattr(sys, "frozen", False))
 
@@ -264,8 +282,9 @@ def _require_node_and_npm() -> tuple[str, str]:
     try:
         version_output = subprocess.run(
             [node_path, "--version"], capture_output=True, text=True, check=True,
+            timeout=30, **_subprocess_no_window_kwargs(),
         ).stdout.strip()
-    except (subprocess.CalledProcessError, OSError) as exc:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
         raise FrontendBootstrapError(
             f"Found Node.js at {node_path} but `node --version` failed: {exc}"
         ) from exc
@@ -289,17 +308,42 @@ def _require_node_and_npm() -> tuple[str, str]:
     return node_path, npm_path
 
 
-def _run_npm(npm_path: str, args: list[str], *, extra_env: dict[str, str] | None = None) -> None:
+def _run_npm(
+    npm_path: str,
+    args: list[str],
+    *,
+    extra_env: dict[str, str] | None = None,
+    timeout_seconds: int = _NPM_BUILD_TIMEOUT_SECONDS,
+) -> None:
     env = os.environ.copy()
     if extra_env:
         env.update(extra_env)
+    command = " ".join(["npm", *args])
     try:
         subprocess.run(
             [npm_path, *args], cwd=WEB_UI_DIR, env=env, check=True,
-            capture_output=True, text=True,
+            capture_output=True, text=True, timeout=timeout_seconds,
+            **_subprocess_no_window_kwargs(),
         )
+    except subprocess.TimeoutExpired as exc:
+        # Without this, a wedged npm blocked startup forever with no window
+        # and no error. Decode captured output defensively - TimeoutExpired
+        # can carry bytes or None even in text mode.
+        def _as_text(stream) -> str:
+            if stream is None:
+                return ""
+            return stream.decode("utf-8", errors="replace") if isinstance(stream, bytes) else str(stream)
+
+        raise FrontendBootstrapError(
+            f"`{command}` did not finish within {timeout_seconds}s while building "
+            f"Graphlink's frontend in {WEB_UI_DIR} - npm appears hung.\n\n"
+            f"Try running the command manually in web_ui/ (deleting node_modules/ "
+            f"and re-running often clears a wedged install), or set "
+            f"{DEV_MODE_ENV_VAR}=1 to skip build orchestration if you manage the "
+            f"frontend build yourself.\n\n--- partial stdout ---\n{_as_text(exc.stdout)}"
+            f"\n--- partial stderr ---\n{_as_text(exc.stderr)}"
+        ) from exc
     except subprocess.CalledProcessError as exc:
-        command = " ".join(["npm", *args])
         raise FrontendBootstrapError(
             f"`{command}` failed (exit code {exc.returncode}) while building Graphlink's "
             f"frontend in {WEB_UI_DIR}.\n\n--- stdout ---\n{exc.stdout}\n--- stderr ---\n{exc.stderr}"
@@ -328,8 +372,17 @@ def ensure_frontend_built() -> None:
 
     node_path, npm_path = _require_node_and_npm()
 
-    if _node_modules_needs_install():
-        _run_npm(npm_path, ["ci"])
+    logger.info(
+        "Frontend bootstrap: rebuilding %d stale island(s): %s",
+        len(stale), ", ".join(stale),
+    )
 
-    for island in stale:
+    if _node_modules_needs_install():
+        logger.info("Frontend bootstrap: running `npm ci` first (node_modules missing or outdated)")
+        _run_npm(npm_path, ["ci"], timeout_seconds=_NPM_INSTALL_TIMEOUT_SECONDS)
+
+    for index, island in enumerate(stale, start=1):
+        logger.info("Frontend bootstrap: building island %d/%d: %s", index, len(stale), island)
         _run_npm(npm_path, ["run", "build"], extra_env={"GRAPHLINK_ISLAND": island})
+
+    logger.info("Frontend bootstrap: all %d island build(s) finished", len(stale))

--- a/graphlink_app/graphlink_island_codegen.py
+++ b/graphlink_app/graphlink_island_codegen.py
@@ -508,8 +508,16 @@ def _main(argv: list[str]) -> int:
         fresh_ts = typescript_for(dataclass_type, source=entry["source"])
 
         if mode == "--write":
-            entry["schema_path"].write_text(fresh_schema, encoding="utf-8", newline="\n")
-            entry["ts_path"].write_text(fresh_ts, encoding="utf-8", newline="\n")
+            # Write-if-changed, not unconditional: rewriting a byte-identical
+            # file still bumps its mtime, and graphlink_frontend_bootstrap's
+            # staleness check is mtime-based - an unconditional rewrite of all
+            # ~38 generated files marked EVERY island stale, so one full
+            # pytest run (whose CLI tests invoke --write) turned the next app
+            # launch into a 19-island npm rebuild storm that looked like the
+            # app hanging in a npm loop before any window appeared.
+            for path, fresh in ((entry["schema_path"], fresh_schema), (entry["ts_path"], fresh_ts)):
+                if not path.is_file() or path.read_text(encoding="utf-8") != fresh:
+                    path.write_text(fresh, encoding="utf-8", newline="\n")
             continue
 
         for path, fresh in ((entry["schema_path"], fresh_schema), (entry["ts_path"], fresh_ts)):

--- a/graphlink_app/tests/test_composer_payload_schema.py
+++ b/graphlink_app/tests/test_composer_payload_schema.py
@@ -19,6 +19,7 @@ still match reality is exactly the drift this whole pipeline exists to stop.
 """
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -264,6 +265,18 @@ class TestCheckCliClosesTheNpmRunCheckDriftGap:
             cwd=_REPO_ROOT,
         )
 
+    @staticmethod
+    def _restore(path: Path, original_text: str, stat_before: os.stat_result) -> None:
+        """Restore a generated file's content AND its mtime. The restore
+        write alone bumps mtime, and graphlink_frontend_bootstrap's island
+        staleness check is mtime-based - a suite run that leaves generated
+        files looking newer than the built assets makes the next real app
+        launch rebuild islands for no reason (the 19-island npm storm that
+        presented as the app looping at startup without ever showing a
+        window)."""
+        path.write_text(original_text, encoding="utf-8", newline="\n")
+        os.utime(path, ns=(stat_before.st_atime_ns, stat_before.st_mtime_ns))
+
     def test_check_passes_and_exits_zero_when_artifacts_are_current(self):
         result = self._run("--check")
 
@@ -272,6 +285,7 @@ class TestCheckCliClosesTheNpmRunCheckDriftGap:
 
     def test_check_fails_and_exits_nonzero_when_a_generated_file_is_hand_edited(self):
         original = _read(_TS_FILE)
+        stat_before = _TS_FILE.stat()
         try:
             _TS_FILE.write_text(original + "\n// hand-edited\n", encoding="utf-8", newline="\n")
             result = self._run("--check")
@@ -280,10 +294,11 @@ class TestCheckCliClosesTheNpmRunCheckDriftGap:
             assert "stale" in result.stderr.lower()
             assert str(_TS_FILE.name) in result.stderr
         finally:
-            _TS_FILE.write_text(original, encoding="utf-8", newline="\n")
+            self._restore(_TS_FILE, original, stat_before)
 
     def test_check_fails_when_a_generated_file_is_missing(self):
         original = _read(_SCHEMA_FILE)
+        stat_before = _SCHEMA_FILE.stat()
         try:
             _SCHEMA_FILE.unlink()
             result = self._run("--check")
@@ -291,10 +306,11 @@ class TestCheckCliClosesTheNpmRunCheckDriftGap:
             assert result.returncode == 1
             assert "missing" in result.stderr.lower()
         finally:
-            _SCHEMA_FILE.write_text(original, encoding="utf-8", newline="\n")
+            self._restore(_SCHEMA_FILE, original, stat_before)
 
     def test_write_regenerates_a_hand_edited_file_back_to_the_real_contract(self):
         original = _read(_TS_FILE)
+        stat_before = _TS_FILE.stat()
         try:
             _TS_FILE.write_text("// corrupted\n", encoding="utf-8", newline="\n")
 
@@ -303,7 +319,21 @@ class TestCheckCliClosesTheNpmRunCheckDriftGap:
             assert result.returncode == 0, result.stderr
             assert _read(_TS_FILE) == original
         finally:
-            _TS_FILE.write_text(original, encoding="utf-8", newline="\n")
+            self._restore(_TS_FILE, original, stat_before)
+
+    def test_write_leaves_up_to_date_files_untouched(self):
+        # The root cause of the rebuild storm: --write used to rewrite every
+        # generated file for every island unconditionally, bumping ~38 mtimes
+        # per run even when the content was byte-identical. It must now leave
+        # an already-current file's mtime alone.
+        mtime_before = _TS_FILE.stat().st_mtime_ns
+        schema_mtime_before = _SCHEMA_FILE.stat().st_mtime_ns
+
+        result = self._run("--write")
+
+        assert result.returncode == 0, result.stderr
+        assert _TS_FILE.stat().st_mtime_ns == mtime_before
+        assert _SCHEMA_FILE.stat().st_mtime_ns == schema_mtime_before
 
     def test_schema_is_valid_json_and_declares_its_draft(self):
         schema = json.loads(_read(_SCHEMA_FILE))

--- a/graphlink_app/tests/test_frontend_bootstrap.py
+++ b/graphlink_app/tests/test_frontend_bootstrap.py
@@ -338,7 +338,7 @@ class TestBuildOrchestration:
 
         calls = []
 
-        def fake_run_npm(npm_path, args, *, extra_env=None):
+        def fake_run_npm(npm_path, args, *, extra_env=None, timeout_seconds=None):
             calls.append((args, extra_env))
 
         monkeypatch.setattr(gfb, "_run_npm", fake_run_npm)


### PR DESCRIPTION
## Summary
Fixes the "app won't start - loops between npm and a window frame" incident.

**Root cause:** codegen `--write` rewrote all ~38 generated schema/TS files unconditionally (byte-identical, mtimes bumped). The pytest suite invokes `--write`, so every full test run marked **all 19 islands stale** under the bootstrap's mtime-based staleness check - the next desktop launch then rebuilt 19 islands sequentially, each npm call flashing a console window, minutes of strobing with no app window. The orphaned `running.lock` shows the run was killed 12 islands in; every retry replayed the stale tail.

**Fixes:**
- codegen `--write` is now write-if-changed (+ regression test: an up-to-date file's mtime survives `--write`)
- payload-schema tests restore generated files **with their original mtimes** - suite runs leave zero staleness behind
- bootstrap hardening: `CREATE_NO_WINDOW` on Windows subprocess calls (no console strobing from desktop launches), timeouts on `npm ci`/build (a wedged npm raises an actionable error instead of hanging startup forever - the log shows `npm ci` failures already hit this machine on Jul 19), per-island progress logging to `~/.graphlink/graphlink.log`

## Verification
- [x] Full suite: 1679 passed
- [x] Decisive proof: snapshot of all 38 generated-file mtimes before/after a complete suite run - **zero changes**
- [x] Real desktop launch: bootstrap rebuilt the 6 remaining stale islands in 10s (logged, no console flashing), Graphlink window up and running