### PR TITLE
R2 review fixes: off-loop persistence writes, closed sqlite handles, validated payloads, picker close-on-select

### DIFF
--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -22,6 +22,8 @@ as disabled controls with an explicit R6 label rather than faking them.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import sqlite3
 from datetime import datetime
 from pathlib import Path
@@ -71,7 +73,10 @@ def _ensure_chats_table(conn: sqlite3.Connection) -> None:
 
 
 def get_all_chats(db_path: Path) -> list[dict[str, Any]]:
-    with _connect(db_path) as conn:
+    # closing() + the connection's own transaction context: sqlite3's
+    # `with conn:` commits/rolls back but does NOT close the connection -
+    # without closing() the handle would linger until garbage collection.
+    with contextlib.closing(_connect(db_path)) as conn, conn:
         _ensure_chats_table(conn)
         rows = conn.execute(
             "SELECT id, title, created_at, updated_at FROM chats ORDER BY updated_at DESC"
@@ -88,7 +93,7 @@ def get_all_chats(db_path: Path) -> list[dict[str, Any]]:
 
 
 def rename_chat(db_path: Path, chat_id: int, new_title: str) -> None:
-    with _connect(db_path) as conn:
+    with contextlib.closing(_connect(db_path)) as conn, conn:
         _ensure_chats_table(conn)
         conn.execute(
             "UPDATE chats SET title = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
@@ -97,7 +102,7 @@ def rename_chat(db_path: Path, chat_id: int, new_title: str) -> None:
 
 
 def delete_chat(db_path: Path, chat_id: int) -> None:
-    with _connect(db_path) as conn:
+    with contextlib.closing(_connect(db_path)) as conn, conn:
         _ensure_chats_table(conn)
         conn.execute("DELETE FROM chats WHERE id = ?", (chat_id,))
 
@@ -120,6 +125,13 @@ def register_chat_library(bus: SessionBus, db_path: Path | None = None) -> None:
 
     bus.register_topic("app-chat-library", lambda: chat_library_payload(resolved_path))
 
+    # Writes run in worker threads (asyncio.to_thread) so a slow disk/WAL
+    # commit never stalls the event loop. No Python-side lock is needed:
+    # each call opens, uses, and closes its own connection inside one thread
+    # (satisfying check_same_thread), and sqlite's file locking (timeout=30
+    # in _connect) serializes concurrent writers. The topic builder's read
+    # stays on the loop - a few-row SELECT, negligible.
+
     async def rename(chat_id: int, new_title: str):
         # Non-empty guard matches the legacy `if ok and new_title:` - an
         # empty/whitespace title is ignored, no mutation, no error (the SPA
@@ -127,13 +139,13 @@ def register_chat_library(bus: SessionBus, db_path: Path | None = None) -> None:
         title = str(new_title or "").strip()
         if not title:
             return
-        rename_chat(resolved_path, int(chat_id), title)
+        await asyncio.to_thread(rename_chat, resolved_path, int(chat_id), title)
         await bus.publish("app-chat-library")
 
     async def delete(chat_id: int):
         # The SPA only calls this after its own two-step confirm, so no
         # confirmation happens here - same contract as the legacy bridge.
-        delete_chat(resolved_path, int(chat_id))
+        await asyncio.to_thread(delete_chat, resolved_path, int(chat_id))
         await bus.publish("app-chat-library")
 
     bus.register_intent("app-chat-library", "renameChat", rename)

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -25,11 +25,28 @@ independently and stomp on each other's in-memory copy.
 
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+import threading
+from typing import Any, Callable
 
 from graphlink_licensing import SettingsManager
 
 from backend.events import SessionBus
+
+# Every persistence-touching mutation runs in a worker thread
+# (asyncio.to_thread) so SettingsManager._save_state's json-dump + fsync +
+# atomic-replace never stalls the event loop (and with it, every session's
+# WS traffic). The manager's mutations are unsynchronized read-modify-writes
+# on shared state, so this lock restores the serialization that running them
+# on the single-threaded loop used to provide for free. Module-level rather
+# than per-manager: a real process has exactly one manager, and the
+# throwaway managers tests create can share it harmlessly.
+_manager_lock = threading.Lock()
+
+
+def _apply(mutation: Callable[..., None], *args: Any) -> None:
+    with _manager_lock:
+        mutation(*args)
 
 
 def settings_payload(manager: SettingsManager) -> dict[str, Any]:
@@ -60,28 +77,34 @@ def register_settings(bus: SessionBus, manager: SettingsManager) -> None:
         active_section["value"] = str(section)
         await bus.publish("app-settings")
 
+    # The topic builder (read path) stays on the loop, unlocked: field reads
+    # are GIL-atomic, and every mutation republishes on completion, so a
+    # snapshot that races a write is immediately superseded by a settled one.
+
     async def set_theme(theme: str):
-        manager.set_theme(str(theme))
+        await asyncio.to_thread(_apply, manager.set_theme, str(theme))
         await bus.publish("app-settings")
 
     async def set_show_token_counter(enabled: bool):
-        manager.set_show_token_counter(bool(enabled))
+        await asyncio.to_thread(_apply, manager.set_show_token_counter, bool(enabled))
         await bus.publish("app-settings")
 
     async def set_enable_system_prompt(enabled: bool):
-        manager.set_enable_system_prompt(bool(enabled))
+        await asyncio.to_thread(_apply, manager.set_enable_system_prompt, bool(enabled))
         await bus.publish("app-settings")
 
     async def set_notification_preference(notification_type: str, enabled: bool):
-        manager.set_notification_preferences({str(notification_type): bool(enabled)})
+        await asyncio.to_thread(
+            _apply, manager.set_notification_preferences, {str(notification_type): bool(enabled)}
+        )
         await bus.publish("app-settings")
 
     async def set_github_token(token: str):
-        manager.set_github_token(str(token))
+        await asyncio.to_thread(_apply, manager.set_github_token, str(token))
         await bus.publish("app-settings")
 
     async def clear_github_token():
-        manager.set_github_token("")
+        await asyncio.to_thread(_apply, manager.set_github_token, "")
         await bus.publish("app-settings")
 
     bus.register_intent("app-settings", "setActiveSection", set_active_section)

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -18,15 +18,21 @@ def make_client(tmp_path: Path | None = None) -> TestClient:
     # R2.5d/e: create_app() now builds a real SettingsManager and a real
     # chats.db path - always point both at a fresh temp dir so tests never
     # read or mutate the developer's actual ~/.graphlink/session.dat or
-    # ~/.graphlink/chats.db.
-    temp_dir = Path(tempfile.mkdtemp())
-    return TestClient(
+    # ~/.graphlink/chats.db. TemporaryDirectory (not mkdtemp) so its
+    # finalizer removes the dir when the client is garbage collected instead
+    # of accumulating litter in %TEMP% run after run; pinned to the client
+    # so it lives exactly as long as the app that writes into it.
+    state_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    state_path = Path(state_dir.name)
+    client = TestClient(
         create_app(
             spa_dir=spa,
-            settings_state_file=temp_dir / "session.dat",
-            chat_db_path=temp_dir / "chats.db",
+            settings_state_file=state_path / "session.dat",
+            chat_db_path=state_path / "chats.db",
         )
     )
+    client._state_tmpdir = state_dir  # type: ignore[attr-defined]
+    return client
 
 
 def test_health_reports_ok_and_version():

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -1,5 +1,7 @@
 import { ReactFlowProvider } from "@xyflow/react";
 import { useEffect, useMemo, useState } from "react";
+import { TOPIC_VALIDATORS } from "../lib/api-contract/topics";
+import type { AppSettingsState } from "../lib/bridge-core/generated/app-settings-state";
 import { ConnectionStatus, WsTransport, defaultWsUrl } from "../lib/ws/transport";
 import { SceneCanvas } from "./canvas/SceneCanvas";
 import { SceneStore } from "./canvas/sceneStore";
@@ -81,7 +83,15 @@ function App() {
       setSystem(payload as SystemState);
     });
     const offSettings = transport.subscribe("app-settings", (payload) => {
-      setSettingsVisibility(payload as SettingsVisibilityState);
+      // Same validate-before-trust discipline as every other subscriber -
+      // this one only reads a single boolean, but an unvalidated cast here
+      // was the one inconsistent gap in the pattern.
+      const validated = TOPIC_VALIDATORS["app-settings"](payload);
+      if (validated.ok) {
+        setSettingsVisibility({ showTokenCounter: (validated.value as AppSettingsState).showTokenCounter });
+      } else {
+        console.error("[app-settings] rejected snapshot:", validated.errors);
+      }
     });
     sceneStore.connect();
     composerStore.connect();

--- a/web_ui/src/app/chrome/PluginPicker.test.tsx
+++ b/web_ui/src/app/chrome/PluginPicker.test.tsx
@@ -1,0 +1,96 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { PluginPicker } from "./PluginPicker";
+import { OverlayProvider, useOverlays } from "../overlays/overlays";
+import type { WsTransport } from "../../lib/ws/transport";
+
+const snapshot = {
+  schemaVersion: 1,
+  minCompatibleSchemaVersion: 1,
+  revision: 1,
+  categories: [
+    {
+      name: "Branch Foundations",
+      description: "Core branch scaffolding.",
+      plugins: [
+        { name: "System Prompt", description: "Adds a system-prompt node." },
+        { name: "Conversation Node", description: "Adds a linear chat node." },
+      ],
+    },
+    {
+      name: "Build & Execution",
+      description: "Code generation and execution.",
+      plugins: [{ name: "Py-Coder", description: "Python workspace." }],
+    },
+  ],
+};
+
+function makeTransport() {
+  const intents: unknown[][] = [];
+  let listener: ((payload: Record<string, unknown>) => void) | null = null;
+  const transport = {
+    subscribe: (_topic: string, l: (payload: Record<string, unknown>) => void) => {
+      listener = l;
+      return () => {
+        listener = null;
+      };
+    },
+    intent: (topic: string, intent: string, args: unknown[]) => {
+      intents.push([topic, intent, args]);
+    },
+  } as unknown as WsTransport;
+  return {
+    transport,
+    intents,
+    push: (payload: Record<string, unknown>) => listener?.(payload),
+  };
+}
+
+function OpenPluginsButton() {
+  const overlays = useOverlays();
+  return (
+    <button type="button" onClick={() => overlays.toggle("plugins", "popover")}>
+      open plugins
+    </button>
+  );
+}
+
+function setup() {
+  const user = userEvent.setup();
+  const fake = makeTransport();
+  render(
+    <OverlayProvider>
+      <OpenPluginsButton />
+      <PluginPicker transport={fake.transport} />
+    </OverlayProvider>,
+  );
+  act(() => fake.push(snapshot));
+  return { user, ...fake };
+}
+
+describe("PluginPicker", () => {
+  it("renders backend categories and plugins once the popover opens", async () => {
+    const { user } = setup();
+    expect(screen.queryByText("Categories")).toBeNull();
+
+    await user.click(screen.getByText("open plugins"));
+    // The active category's name appears twice by design: rail button + pane title.
+    expect(screen.getByRole("button", { name: "Branch Foundations" })).toBeInTheDocument();
+    expect(screen.getByText("System Prompt")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Build & Execution/ }));
+    expect(screen.getByText("Py-Coder")).toBeInTheDocument();
+  });
+
+  it("selecting a plugin fires executePlugin and closes the popover", async () => {
+    const { user, intents } = setup();
+    await user.click(screen.getByText("open plugins"));
+
+    await user.click(screen.getByText("System Prompt"));
+    expect(intents).toContainEqual(["app-plugins", "executePlugin", ["System Prompt"]]);
+    // Close-on-select: the popover dismisses so the resulting notification
+    // banner is seen unobstructed (matching the legacy popup's behavior).
+    expect(screen.queryByText("Categories")).toBeNull();
+  });
+});

--- a/web_ui/src/app/chrome/PluginPicker.tsx
+++ b/web_ui/src/app/chrome/PluginPicker.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import type { WsTransport } from "../../lib/ws/transport";
 import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
 import type { AppPluginsState } from "../../lib/bridge-core/generated/app-plugins-state";
-import { Popover } from "../overlays/overlays";
+import { Popover, useOverlays } from "../overlays/overlays";
 
 /**
  * The plugin picker popover (Qt-removal plan R2.5) - plugin-picker island's
@@ -20,6 +20,7 @@ const initialState: AppPluginsState = {
 };
 
 export function PluginPicker({ transport }: { transport: WsTransport }) {
+  const overlays = useOverlays();
   const [state, setState] = useState<AppPluginsState>(initialState);
   const [activeCategoryName, setActiveCategoryName] = useState<string | null>(null);
 
@@ -75,7 +76,13 @@ export function PluginPicker({ transport }: { transport: WsTransport }) {
                   <button
                     type="button"
                     className="plugin-picker-row"
-                    onClick={() => transport.intent("app-plugins", "executePlugin", [plugin.name])}
+                    onClick={() => {
+                      transport.intent("app-plugins", "executePlugin", [plugin.name]);
+                      // Close on select, matching the legacy popup's own
+                      // post-execute dismiss - and so the resulting
+                      // notification banner is seen unobstructed.
+                      overlays.close();
+                    }}
                   >
                     <span className="plugin-picker-row-copy">
                       <span className="plugin-picker-row-label">{plugin.name}</span>


### PR DESCRIPTION
## Summary

Fixes the five findings from the post-ship code review of the R2 chrome consolidation. Stacked on `qt-removal/r2-chrome` (#101) so it contains exactly the fixes.

- **Settings writes off the event loop** (`backend/settings.py`): every persistence-touching mutation runs via `asyncio.to_thread`, so `SettingsManager._save_state`'s json-dump + `fsync` + atomic-replace no longer stalls the loop (and all sessions' WS traffic) on every toggle. A module-level lock restores the serialization for the manager's unsynchronized read-modify-write mutations that the single-threaded loop used to provide implicitly. The read path stays on the loop, unlocked — field reads are GIL-atomic and every mutation republishes on completion.
- **Chat-library writes off the loop + deterministic connection close** (`backend/chat_library.py`): rename/delete offload to worker threads (no Python lock needed — each call owns its connection end-to-end, sqlite file locking serializes writers), and all DB helpers now wrap connections in `contextlib.closing` — sqlite3's `with conn:` commits but never closes, so handles previously lingered until GC.
- **Validated `app-settings` subscription** (`App.tsx`): the token-counter-visibility subscriber now runs the generated validator like every other subscriber instead of a blind cast.
- **Plugin picker closes on select** (`PluginPicker.tsx`): matches the legacy popup's post-execute dismiss and lets the "lands in R3/R5" notification be seen unobstructed. Added `PluginPicker.test.tsx` (the component previously had no test) covering snapshot rendering, category switching, and the executePlugin + close-on-select path.
- **Test temp-dir cleanup** (`test_app_ws.py`): `make_client`'s `mkdtemp` (never removed — litter in `%TEMP%` every run) replaced with a `TemporaryDirectory` pinned to the client so its finalizer cleans up.

## Test plan
- [x] `python -m pytest` (full repo-wide, offscreen): 1839 passed
- [x] `npm run check`: 590 vitest passed (588 + 2 new), 0 lint errors, build clean
- [x] SPA app target (`GRAPHLINK_ISLAND=app`) builds clean