### PR TITLE
Qt-removal R3.1-R3.4: real ChatNode on the React Flow canvas

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -66,13 +66,16 @@ def _configure_session(bus: SessionBus, settings_manager: SettingsManager, chat_
 
     bus.register_intent("system", "ping", ping)
 
-    # R1 (doc/QT_REMOVAL_PLAN.md): scene document + grid topics.
-    register_canvas(bus)
+    # R2: notifications, moved ahead of canvas - R3.3's sendMessage intent
+    # needs a real NotificationState to give an honest "lands in R4" notice.
+    notifications_state = register_notifications(bus)
 
-    # R2: composer draft/reasoning, token counter, notifications.
+    # R1 (doc/QT_REMOVAL_PLAN.md): scene document + grid topics.
+    register_canvas(bus, notifications_state)
+
+    # R2: composer draft/reasoning, token counter.
     token_counter = register_token_counter(bus)
     register_composer(bus, token_counter)
-    notifications_state = register_notifications(bus)
 
     # R2.5: about, plugins, settings, chat library.
     register_about(bus)

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -33,6 +33,7 @@ from graphlink_grid_view_settings import (
 from graphlink_navigation_pins import NavigationPinRecord, NavigationPinStore
 
 from backend.events import SessionBus
+from backend.notifications import NotificationState
 
 # Dark-theme grid swatches. The Qt bridge derived 3 of 5 from the live
 # QPalette; the backend is Qt-free by law (test_no_qt_anywhere.py), so until
@@ -64,10 +65,18 @@ FONT_SIZE_MAX = 16
 ORGANIZE_SPACING_X = 260
 ORGANIZE_SPACING_Y = 180
 
+# R3.3: the Composer's Send action stacks each new message below its parent
+# by this much - a simple deterministic layout, not the legacy
+# find_branch_position packing algorithm (a later refinement).
+MESSAGE_VERTICAL_SPACING = 160
+
 
 class SceneError(ValueError):
     """A scene intent referenced something that does not exist or is invalid.
     Raised so the WS layer reports it to the caller instead of crashing."""
+
+
+CHAT_TITLE_PREVIEW_LENGTH = 60
 
 
 @dataclass
@@ -77,6 +86,13 @@ class SceneNode:
     y: float
     title: str
     kind: str = "placeholder"
+    # R3.1 (doc/QT_REMOVAL_PLAN.md): the chat node's real persisted shape -
+    # graphlink_session/serializers.py's raw_content/is_user/is_collapsed,
+    # minus everything Qt-only (paint state, scroll position, docked-child
+    # widgets). Unused (default) for every other kind.
+    content: str = ""
+    is_user: bool = False
+    is_collapsed: bool = False
 
 
 @dataclass
@@ -102,6 +118,10 @@ class SceneDocument:
     font_family: str = "Segoe UI"
     font_size_pt: int = 9
     font_color: str = "#F0F0F0"
+    # R3.3: which chat node the Composer's next Send continues from - the
+    # Qt-free stand-in for "the currently active branch" until real node
+    # selection exists. None means the next message starts a fresh root.
+    last_chat_node_id: str | None = None
     _counter: itertools.count = field(default_factory=itertools.count, repr=False)
 
     # -- nodes -------------------------------------------------------------
@@ -111,6 +131,88 @@ class SceneDocument:
         node = SceneNode(id=node_id, x=float(x), y=float(y), title=title or f"Node {node_id[1:]}")
         self.nodes[node_id] = node
         return node
+
+    def add_chat_node(
+        self,
+        x: float,
+        y: float,
+        content: str,
+        is_user: bool,
+        parent_id: str | None = None,
+    ) -> SceneNode:
+        """The Qt-free ChatScene.add_chat_node equivalent: a real message-
+        bubble node, optionally connected to a parent (the branch it
+        continues). Mirrors add_node's id/dict bookkeeping; the only new
+        behavior is the parent-edge, ported from the legacy scene's own
+        ConnectionItem creation."""
+        if parent_id is not None and parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        title = content[:CHAT_TITLE_PREVIEW_LENGTH] or ("You" if is_user else "Assistant")
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title=title,
+            kind="chat",
+            content=str(content),
+            is_user=bool(is_user),
+        )
+        self.nodes[node_id] = node
+        if parent_id is not None:
+            self.connect(parent_id, node_id)
+        return node
+
+    def delete_chat_node(self, node_id: str) -> None:
+        """Delete one chat node WITHOUT orphaning its branch: children are
+        re-parented to the deleted node's own parent (or become roots if it
+        had none), mirroring ChatScene.delete_chat_node's load-bearing
+        reparent rule - a plain remove_nodes cascade-delete would sever every
+        child branch instead of splicing them back together."""
+        if node_id not in self.nodes:
+            raise SceneError(f"unknown node: {node_id}")
+        parent_edge = next((e for e in self.edges.values() if e.target == node_id), None)
+        parent_id = parent_edge.source if parent_edge is not None else None
+        child_edges = [e for e in self.edges.values() if e.source == node_id]
+
+        for edge in [parent_edge, *child_edges]:
+            if edge is not None:
+                self.edges.pop(edge.id, None)
+        if parent_id is not None:
+            for edge in child_edges:
+                self.connect(parent_id, edge.target)
+
+        if self.last_chat_node_id == node_id:
+            # The active branch continues from wherever it now ends: the
+            # deleted node's own parent (None if it had none either).
+            self.last_chat_node_id = parent_id
+
+        del self.nodes[node_id]
+
+    def send_message(self, text: str) -> SceneNode:
+        """The Composer's real Send action (R3.3): create a real user
+        ChatNode continuing the current branch (last_chat_node_id), or
+        start a fresh root if none exists yet. Positioning is a simple
+        deterministic stack, not the legacy find_branch_position packing
+        algorithm - real auto-layout is a later refinement; "Organize
+        Nodes" already exists as a fallback."""
+        parent_id = self.last_chat_node_id
+        if parent_id is not None and parent_id in self.nodes:
+            parent = self.nodes[parent_id]
+            x, y = parent.x, parent.y + MESSAGE_VERTICAL_SPACING
+        else:
+            parent_id = None
+            chat_node_count = sum(1 for n in self.nodes.values() if n.kind == "chat")
+            x, y = 0.0, chat_node_count * MESSAGE_VERTICAL_SPACING
+        node = self.add_chat_node(x, y, text, True, parent_id=parent_id)
+        self.last_chat_node_id = node.id
+        return node
+
+    def set_chat_collapsed(self, node_id: str, collapsed: bool) -> None:
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.is_collapsed = bool(collapsed)
 
     def move_node(self, node_id: str, x: float, y: float) -> SceneNode:
         node = self.nodes.get(node_id)
@@ -179,7 +281,16 @@ class SceneDocument:
     def scene_payload(self) -> dict[str, Any]:
         return {
             "nodes": [
-                {"id": n.id, "x": n.x, "y": n.y, "title": n.title, "kind": n.kind}
+                {
+                    "id": n.id,
+                    "x": n.x,
+                    "y": n.y,
+                    "title": n.title,
+                    "kind": n.kind,
+                    "content": n.content,
+                    "isUser": n.is_user,
+                    "isCollapsed": n.is_collapsed,
+                }
                 for n in self.nodes.values()
             ],
             "edges": [
@@ -218,7 +329,7 @@ class SceneDocument:
         }
 
 
-def register_canvas(bus: SessionBus) -> SceneDocument:
+def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneDocument:
     """Give a session its canvas document + the scene/grid topics and every
     R1 intent. Intent names for grid mirror GridControlBridge's @Slot names
     1:1 so the R2 island port is a transport swap, not a redesign."""
@@ -259,6 +370,31 @@ def register_canvas(bus: SessionBus) -> SceneDocument:
     async def add_node(x, y, title=""):
         node = document.add_node(x, y, title)
         await publish_scene()
+        return node.id
+
+    async def add_chat_node(x, y, content, is_user, parent_id=None):
+        node = document.add_chat_node(x, y, content, is_user, parent_id)
+        await publish_scene()
+        return node.id
+
+    async def delete_chat_node(node_id):
+        document.delete_chat_node(node_id)
+        await publish_scene()
+
+    async def set_chat_collapsed(node_id, collapsed):
+        document.set_chat_collapsed(node_id, collapsed)
+        await publish_scene()
+
+    async def send_message(text):
+        # R3.3: the real Send action - a real user ChatNode, continuing the
+        # active branch. The assistant's reply needs the agent layer
+        # (graphlink_config.py's Qt/non-Qt split is an R4 prerequisite - see
+        # doc/QT_REMOVAL_PLAN.md's R3 scoping note), so this is an honest
+        # deferred notice rather than a fake/stubbed response.
+        node = document.send_message(text)
+        await publish_scene()
+        notifications.show("AI response generation lands in R4.", "info")
+        await bus.publish("notification")
         return node.id
 
     async def move_node(node_id, x, y):
@@ -310,6 +446,10 @@ def register_canvas(bus: SessionBus) -> SceneDocument:
         await publish_scene()
 
     bus.register_intent("scene", "addNode", add_node)
+    bus.register_intent("scene", "addChatNode", add_chat_node)
+    bus.register_intent("scene", "deleteChatNode", delete_chat_node)
+    bus.register_intent("scene", "setChatCollapsed", set_chat_collapsed)
+    bus.register_intent("scene", "sendMessage", send_message)
     bus.register_intent("scene", "moveNode", move_node)
     bus.register_intent("scene", "removeNodes", remove_nodes)
     bus.register_intent("scene", "connectNodes", connect_nodes)

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -14,6 +14,7 @@ from backend.canvas import (
     register_canvas,
 )
 from backend.events import SessionBus
+from backend.notifications import NotificationState
 
 
 # -- document invariants ----------------------------------------------------
@@ -52,6 +53,118 @@ def test_removing_a_node_removes_its_edges():
     keep = doc.connect(b.id, c.id)
     doc.remove_nodes([a.id])
     assert list(doc.edges) == [keep.id], "edges die with either endpoint"
+
+
+# -- R3.1: chat nodes --------------------------------------------------------
+
+
+def test_add_chat_node_creates_a_real_chat_kind_node():
+    doc = SceneDocument()
+    node = doc.add_chat_node(10, 20, "Hello there, this is a real message", True)
+    assert node.kind == "chat"
+    assert node.content == "Hello there, this is a real message"
+    assert node.is_user is True
+    assert node.is_collapsed is False
+    assert node.title == "Hello there, this is a real message"[:60]
+
+
+def test_add_chat_node_falls_back_to_role_title_for_empty_content():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "", False)
+    assert node.title == "Assistant"
+
+
+def test_add_chat_node_connects_to_a_real_parent():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "question", True)
+    child = doc.add_chat_node(10, 10, "answer", False, parent_id=parent.id)
+    assert any(e.source == parent.id and e.target == child.id for e in doc.edges.values())
+
+
+def test_add_chat_node_rejects_unknown_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_chat_node(0, 0, "orphaned", True, parent_id="ghost")
+
+
+def test_delete_chat_node_reparents_children_to_the_deleted_nodes_parent():
+    doc = SceneDocument()
+    a = doc.add_chat_node(0, 0, "a", True)
+    b = doc.add_chat_node(1, 1, "b", False, parent_id=a.id)
+    c = doc.add_chat_node(2, 2, "c", True, parent_id=b.id)
+
+    doc.delete_chat_node(b.id)
+
+    assert b.id not in doc.nodes
+    assert any(e.source == a.id and e.target == c.id for e in doc.edges.values())
+    assert not any(e.target == b.id or e.source == b.id for e in doc.edges.values())
+
+
+def test_delete_chat_node_at_the_root_makes_children_new_roots():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    child = doc.add_chat_node(1, 1, "child", False, parent_id=root.id)
+
+    doc.delete_chat_node(root.id)
+
+    assert root.id not in doc.nodes
+    assert not any(e.target == child.id for e in doc.edges.values()), "child has no parent edge left"
+
+
+def test_delete_chat_node_unknown_raises():
+    with pytest.raises(SceneError):
+        SceneDocument().delete_chat_node("ghost")
+
+
+def test_set_chat_collapsed():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "hi", True)
+    doc.set_chat_collapsed(node.id, True)
+    assert doc.nodes[node.id].is_collapsed is True
+    with pytest.raises(SceneError):
+        doc.set_chat_collapsed("ghost", True)
+
+
+def test_scene_payload_includes_chat_fields_defaulted_for_placeholders():
+    doc = SceneDocument()
+    doc.add_node(0, 0, "plain")
+    doc.add_chat_node(1, 1, "real content", True)
+    rows = {n["title"]: n for n in doc.scene_payload()["nodes"]}
+    assert rows["plain"]["kind"] == "placeholder"
+    assert rows["plain"]["content"] == ""
+    assert rows["plain"]["isUser"] is False
+    assert rows["plain"]["isCollapsed"] is False
+    chat_row = rows["real content"]
+    assert chat_row["kind"] == "chat"
+    assert chat_row["content"] == "real content"
+    assert chat_row["isUser"] is True
+
+
+def test_send_message_starts_a_root_branch():
+    doc = SceneDocument()
+    node = doc.send_message("hello there")
+    assert node.kind == "chat"
+    assert node.is_user is True
+    assert node.content == "hello there"
+    assert doc.last_chat_node_id == node.id
+
+
+def test_send_message_continues_the_active_branch():
+    doc = SceneDocument()
+    first = doc.send_message("first message")
+    second = doc.send_message("second message")
+    assert any(e.source == first.id and e.target == second.id for e in doc.edges.values())
+    assert doc.last_chat_node_id == second.id
+
+
+def test_send_message_after_deleting_the_active_node_continues_from_its_parent():
+    doc = SceneDocument()
+    first = doc.send_message("first")
+    second = doc.send_message("second")
+    doc.delete_chat_node(second.id)
+    assert doc.last_chat_node_id == first.id
+    third = doc.send_message("third")
+    assert any(e.source == first.id and e.target == third.id for e in doc.edges.values())
 
 
 def test_drag_factor_is_bounded():
@@ -95,7 +208,9 @@ class Recorder:
 
 def make_bus():
     bus = SessionBus("canvas-test")
-    document = register_canvas(bus)
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    document = register_canvas(bus, notifications)
     recorder = Recorder()
     bus.attach(recorder)
     return bus, document, recorder
@@ -112,6 +227,44 @@ def test_scene_intents_mutate_and_publish():
         await bus.dispatch_intent("scene", "moveNode", [node_id, 1, 2])
         assert (document.nodes[node_id].x, document.nodes[node_id].y) == (1, 2)
         assert recorder.topics_seen().count("scene") == 4, "every mutation publishes"
+
+    asyncio.run(run())
+
+
+def test_chat_node_intents_mutate_and_publish():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addChatNode", [0, 0, "hi", True])
+        child_id = await bus.dispatch_intent(
+            "scene", "addChatNode", [10, 10, "reply", False, parent_id]
+        )
+        assert document.nodes[child_id].kind == "chat"
+        assert any(
+            e.source == parent_id and e.target == child_id for e in document.edges.values()
+        )
+
+        await bus.dispatch_intent("scene", "setChatCollapsed", [child_id, True])
+        assert document.nodes[child_id].is_collapsed is True
+
+        await bus.dispatch_intent("scene", "deleteChatNode", [parent_id])
+        assert parent_id not in document.nodes
+        assert child_id in document.nodes, "deleting the parent must not cascade-delete the child"
+        assert recorder.topics_seen().count("scene") == 4, "every mutation publishes"
+
+    asyncio.run(run())
+
+
+def test_send_message_intent_creates_a_real_node_and_an_honest_deferred_notification():
+    async def run():
+        bus, document, recorder = make_bus()
+        node_id = await bus.dispatch_intent("scene", "sendMessage", ["what is this graph about?"])
+        assert document.nodes[node_id].content == "what is this graph about?"
+        assert document.nodes[node_id].is_user is True
+
+        notice = await bus.publish("notification")
+        assert notice["visible"] is True
+        assert notice["message"] == "AI response generation lands in R4."
+        assert recorder.topics_seen().count("scene") == 1
 
     asyncio.run(run())
 

--- a/graphlink_app/graphlink_scene_payload.py
+++ b/graphlink_app/graphlink_scene_payload.py
@@ -9,6 +9,11 @@ JSON shape and generates the TS type + runtime validator the SPA consumes.
 
 R1 nodes are placeholders (`kind: "placeholder"`); R3 extends `kind` per
 migrated node type - additive only, per the schema-versioning contract.
+
+R3.1 adds the `chat` kind's fields (content/isUser/isCollapsed - the real
+persisted shape from the legacy ChatNode's serializer, minus everything
+Qt-only): populated for kind=="chat" rows, defaulted (empty/false) for every
+other kind, so the schema stays additive-only as new kinds land.
 """
 
 from __future__ import annotations
@@ -23,6 +28,9 @@ class SceneNodeRow:
     y: float
     title: str
     kind: str
+    content: str = ""
+    isUser: bool = False
+    isCollapsed: bool = False
 
 
 @dataclass

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -149,7 +149,7 @@ function App() {
           </main>
 
           <footer className="app-composer-region">
-            <Composer store={composerStore} />
+            <Composer store={composerStore} sceneStore={sceneStore} />
           </footer>
         </div>
       </ReactFlowProvider>

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -1,0 +1,100 @@
+import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount): RF's
+// own node wrapper stays `visibility: hidden` in jsdom until its
+// ResizeObserver-driven measurement pass completes, and forcing that pass
+// hits jsdom gaps deep in RF's internals (missing DOMMatrixReadOnly). Since
+// ChatNodeView only needs a ReactFlowProvider ancestor for its own
+// useStore(zoom) read - not RF's node-mounting/measurement pipeline - a
+// bare ReactFlowProvider is enough, and the component renders immediately
+// visible with no jsdom polyfills required.
+function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
+  const onToggleCollapse = vi.fn();
+  const onDelete = vi.fn();
+  const props = {
+    id: "n0",
+    selected: false,
+    data: {
+      content: "Hello **world**",
+      isUser: true,
+      isCollapsed: false,
+      onToggleCollapse,
+      onDelete,
+      ...overrides,
+    },
+  } as unknown as NodeProps<ChatFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <ChatNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return { onToggleCollapse, onDelete };
+}
+
+describe("ChatNodeView", () => {
+  it("renders the role and markdown content", () => {
+    renderChatNode();
+    expect(screen.getByText("You")).toBeInTheDocument();
+    expect(screen.getByText("world")).toBeInTheDocument(); // bold text still renders as text
+  });
+
+  it("shows Assistant for a non-user message and hides content when collapsed", () => {
+    renderChatNode({ isUser: false, isCollapsed: true });
+    expect(screen.getByText("Assistant")).toBeInTheDocument();
+    expect(screen.queryByText(/Hello/)).toBeNull();
+  });
+
+  it("the inline collapse button calls onToggleCollapse", async () => {
+    const user = userEvent.setup();
+    const { onToggleCollapse } = renderChatNode();
+    await user.click(screen.getByRole("button", { name: "Collapse" }));
+    expect(onToggleCollapse).toHaveBeenCalledOnce();
+  });
+
+  it("right-click opens a menu with real Copy/Collapse/Delete and deferred Regenerate/Export", async () => {
+    const user = userEvent.setup();
+    const { onDelete } = renderChatNode();
+
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    const role = screen.getByText("You");
+    fireEvent.contextMenu(role);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    const regenerate = screen.getByRole("menuitem", { name: "Regenerate Response" });
+    expect(regenerate).toBeDisabled();
+    expect(regenerate).toHaveAttribute("title", "Agent regeneration lands in R4");
+    const exportItem = screen.getByRole("menuitem", { name: "Export" });
+    expect(exportItem).toBeDisabled();
+    expect(exportItem).toHaveAttribute("title", "Export lands in R6");
+
+    await user.click(screen.getByRole("menuitem", { name: "Copy Text" }));
+    expect(writeText).toHaveBeenCalledWith("Hello **world**");
+
+    fireEvent.contextMenu(role);
+    await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Escape and outside-click both close the menu", async () => {
+    const user = userEvent.setup();
+    renderChatNode();
+    const role = screen.getByText("You");
+
+    fireEvent.contextMenu(role);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(role);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -1,0 +1,160 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+
+/**
+ * The chat node (Qt-removal plan R3.1/R3.2) - ChatNode's React successor:
+ * a single message-bubble card, push-only (content arrives via the scene
+ * document, never generated here). Real: render, collapse/expand, delete
+ * (with the backend's reparent-children rule), copy. Deferred, with an
+ * honest disabled+title label rather than a fake action: Regenerate (needs
+ * the R4 agent layer) and Export (R6 session/export work).
+ */
+
+export interface ChatNodeData extends Record<string, unknown> {
+  content: string;
+  isUser: boolean;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+}
+
+export type ChatFlowNode = Node<ChatNodeData, "chat">;
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+function ChatNodeMenu({
+  position,
+  content,
+  isCollapsed,
+  onToggleCollapse,
+  onDelete,
+  onClose,
+}: {
+  position: MenuPosition;
+  content: string;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
+      // type-only import above shadows the bare name for casts like this).
+      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          navigator.clipboard.writeText(content);
+          onClose();
+        }}
+      >
+        Copy Text
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleCollapse();
+          onClose();
+        }}
+      >
+        {isCollapsed ? "Expand" : "Collapse"}
+      </button>
+      <button type="button" role="menuitem" disabled title="Agent regeneration lands in R4">
+        Regenerate Response
+      </button>
+      <button type="button" role="menuitem" disabled title="Export lands in R6">
+        Export
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        Delete Node
+      </button>
+    </div>
+  );
+}
+
+export function ChatNodeView({ data, selected }: NodeProps<ChatFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const collapsed = data.isCollapsed || lodCollapsed;
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+
+  return (
+    <div
+      className={`scene-node chat-node${data.isUser ? " user" : " assistant"}${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title chat-node-role">
+        <span>{data.isUser ? "You" : "Assistant"}</span>
+        <button
+          type="button"
+          className="chat-node-collapse-btn"
+          aria-label={data.isCollapsed ? "Expand" : "Collapse"}
+          onClick={data.onToggleCollapse}
+        >
+          {data.isCollapsed ? "▸" : "▾"}
+        </button>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body chat-node-content">
+          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+            {data.content}
+          </ReactMarkdown>
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+      {menuPosition && (
+        <ChatNodeMenu
+          position={menuPosition}
+          content={data.content}
+          isCollapsed={data.isCollapsed}
+          onToggleCollapse={data.onToggleCollapse}
+          onDelete={data.onDelete}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -17,19 +17,17 @@ import {
 import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
+import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { SceneStore, scaleDragPosition } from "./sceneStore";
 
 /**
  * The React Flow canvas (Qt-removal plan R1) - the QGraphicsScene/ChatView
  * successor. R1 scope: pan/zoom, model-driven grid (size/style/color/opacity
  * + snap), node drag with the drag-speed factor, edges, selection + delete,
- * minimap, an LOD threshold, navigation pins. Placeholder nodes only; real
- * node types land per-increment in R3.
+ * minimap, an LOD threshold, navigation pins. R3.1/R3.2 add the first real
+ * node type (chat); every other kind still renders as a placeholder.
  */
-
-// Below this zoom the node body collapses to its title bar - the R1 seed of
-// the Qt canvas's LOD thresholds (full LOD tiers return with real nodes).
-const LOD_ZOOM_THRESHOLD = 0.5;
 
 const GRID_VARIANTS: Record<string, BackgroundVariant> = {
   Dots: BackgroundVariant.Dots,
@@ -38,6 +36,7 @@ const GRID_VARIANTS: Record<string, BackgroundVariant> = {
 };
 
 type PlaceholderNode = Node<{ title: string }, "placeholder">;
+type SceneFlowNode = PlaceholderNode | ChatFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   const zoom = useStore((s) => s.transform[2]);
@@ -55,15 +54,31 @@ function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   );
 }
 
-const NODE_TYPES = { placeholder: PlaceholderNodeView };
+const NODE_TYPES = { placeholder: PlaceholderNodeView, chat: ChatNodeView };
 
-function toFlowNodes(scene: SceneState): PlaceholderNode[] {
-  return scene.nodes.map((n) => ({
-    id: n.id,
-    type: "placeholder" as const,
-    position: { x: n.x, y: n.y },
-    data: { title: n.title },
-  }));
+function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
+  return scene.nodes.map((n) => {
+    if (n.kind === "chat") {
+      return {
+        id: n.id,
+        type: "chat" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          content: n.content,
+          isUser: n.isUser,
+          isCollapsed: n.isCollapsed,
+          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
+          onDelete: () => store.deleteChatNode(n.id),
+        },
+      };
+    }
+    return {
+      id: n.id,
+      type: "placeholder" as const,
+      position: { x: n.x, y: n.y },
+      data: { title: n.title },
+    };
+  });
 }
 
 function toFlowEdges(scene: SceneState): Edge[] {
@@ -77,18 +92,18 @@ function CanvasInner({ store }: { store: SceneStore }) {
   // Local node state exists so dragging is fluid; backend snapshots are the
   // truth and reconcile in whenever nothing is being dragged. dragStartRef
   // powers the drag-speed scaling contract (see scaleDragPosition).
-  const [nodes, setNodes] = useState<PlaceholderNode[]>([]);
+  const [nodes, setNodes] = useState<SceneFlowNode[]>([]);
   const dragStartRef = useRef<Map<string, { x: number; y: number }>>(new Map());
   const draggingRef = useRef(false);
 
   useEffect(() => {
-    if (!draggingRef.current) setNodes(toFlowNodes(scene));
-  }, [scene]);
+    if (!draggingRef.current) setNodes(toFlowNodes(scene, store));
+  }, [scene, store]);
 
   const edges = useMemo(() => toFlowEdges(scene), [scene]);
 
   const onNodesChange = useCallback(
-    (changes: NodeChange<PlaceholderNode>[]) => {
+    (changes: NodeChange<SceneFlowNode>[]) => {
       const scaled = changes.map((change) => {
         if (change.type !== "position" || !change.position) return change;
         if (change.dragging) {
@@ -127,14 +142,27 @@ function CanvasInner({ store }: { store: SceneStore }) {
 
   const onDelete = useCallback(
     ({ nodes: deletedNodes, edges: deletedEdges }: { nodes: Node[]; edges: Edge[] }) => {
-      store.removeNodes(deletedNodes.map((n) => n.id));
-      // Skip edges an already-deleted node takes with it server-side.
+      // Chat nodes delete through their own reparent-preserving intent
+      // (backend/canvas.py's delete_chat_node) so the Delete key matches the
+      // context menu's "Delete Node" exactly - a plain cascade-delete would
+      // orphan every child branch instead of splicing it back to the
+      // grandparent. Every other kind still uses the generic cascade-delete.
+      const chatNodeIds: string[] = [];
+      const otherNodeIds: string[] = [];
+      for (const deleted of deletedNodes) {
+        const flowNode = nodes.find((n) => n.id === deleted.id);
+        (flowNode?.type === "chat" ? chatNodeIds : otherNodeIds).push(deleted.id);
+      }
+      for (const id of chatNodeIds) store.deleteChatNode(id);
+      store.removeNodes(otherNodeIds);
+      // Skip edges an already-deleted node takes with it server-side
+      // (cascade-delete or the chat reparent both manage their own edges).
       const dying = new Set(deletedNodes.map((n) => n.id));
       store.removeEdges(
         deletedEdges.filter((e) => !dying.has(e.source) && !dying.has(e.target)).map((e) => e.id),
       );
     },
-    [store],
+    [store, nodes],
   );
 
   const { screenToFlowPosition } = useReactFlow();

--- a/web_ui/src/app/canvas/canvasConstants.ts
+++ b/web_ui/src/app/canvas/canvasConstants.ts
@@ -1,0 +1,4 @@
+/** Below this zoom, node bodies collapse to their title bar - the R1 seed of
+ * the Qt canvas's LOD thresholds. Shared by every custom node view so they
+ * all collapse at the same zoom level. */
+export const LOD_ZOOM_THRESHOLD = 0.5;

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -24,7 +24,9 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
     schemaVersion: 1,
     minCompatibleSchemaVersion: 1,
     revision: 3,
-    nodes: [{ id: "n0", x: 1, y: 2, title: "A", kind: "placeholder" }],
+    nodes: [
+      { id: "n0", x: 1, y: 2, title: "A", kind: "placeholder", content: "", isUser: false, isCollapsed: false },
+    ],
     edges: [],
     pins: [],
     snapToGrid: true,
@@ -98,6 +100,21 @@ describe("SceneStore", () => {
       { topic: "scene", intent: "addPin", args: ["P", 5, 6, "note"] },
       { topic: "scene", intent: "setSnapToGrid", args: [true] },
       { topic: "scene", intent: "setDragFactor", args: [0.25] },
+    ]);
+  });
+
+  it("sends chat-node intents with the backend's registered names and shapes", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.addChatNode(10, 20, "hello", true);
+    store.addChatNode(30, 40, "hi back", false, "n1");
+    store.setChatCollapsed("n1", true);
+    store.deleteChatNode("n1");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "addChatNode", args: [10, 20, "hello", true] },
+      { topic: "scene", intent: "addChatNode", args: [30, 40, "hi back", false, "n1"] },
+      { topic: "scene", intent: "setChatCollapsed", args: ["n1", true] },
+      { topic: "scene", intent: "deleteChatNode", args: ["n1"] },
     ]);
   });
 

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -119,6 +119,32 @@ export class SceneStore {
     this.transport.intent("scene", "addNode", [x, y, title]);
   }
 
+  // R3.1: real chat nodes - createChatNode/deleteChatNode/setChatCollapsed
+  // mirror backend/canvas.py's intent names 1:1 (same convention as every
+  // other scene intent above).
+  addChatNode(x: number, y: number, content: string, isUser: boolean, parentId?: string): void {
+    const args: unknown[] = [x, y, content, isUser];
+    if (parentId !== undefined) args.push(parentId);
+    this.transport.intent("scene", "addChatNode", args);
+  }
+
+  deleteChatNode(id: string): void {
+    this.transport.intent("scene", "deleteChatNode", [id]);
+  }
+
+  setChatCollapsed(id: string, collapsed: boolean): void {
+    this.transport.intent("scene", "setChatCollapsed", [id, collapsed]);
+  }
+
+  // R3.3: the Composer's real Send action - a real user ChatNode. The
+  // assistant's reply is deferred to R4 (graphlink_config.py's Qt/non-Qt
+  // split is a prerequisite for calling the real agent layer); the backend
+  // surfaces that honestly via the existing notification topic, no fake
+  // response synthesized here.
+  sendMessage(text: string): void {
+    this.transport.intent("scene", "sendMessage", [text]);
+  }
+
   moveNode(id: string, x: number, y: number): void {
     this.transport.intent("scene", "moveNode", [id, x, y]);
   }

--- a/web_ui/src/app/chrome/Composer.test.tsx
+++ b/web_ui/src/app/chrome/Composer.test.tsx
@@ -32,6 +32,11 @@ function makeStore(overrides: { composer?: object; tokenCounter?: object; notifi
   return { store, updateDraft, setReasoningLevel, dismissNotification };
 }
 
+function makeSceneStore() {
+  const sendMessage = vi.fn();
+  return { sceneStore: { sendMessage }, sendMessage };
+}
+
 describe("Composer", () => {
   it("renders the draft text and forwards edits", async () => {
     const user = userEvent.setup();
@@ -39,7 +44,7 @@ describe("Composer", () => {
     render(
       <OverlayProvider>
         {/* @ts-expect-error - test double, not the real ComposerStore class */}
-        <Composer store={store} />
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
       </OverlayProvider>,
     );
     const input = screen.getByLabelText("Message composer") as HTMLTextAreaElement;
@@ -48,17 +53,63 @@ describe("Composer", () => {
     expect(updateDraft).toHaveBeenCalledWith("hi!");
   });
 
-  it("send/attach/model controls are visibly disabled with their deferred phase named", () => {
+  it("attach/model controls stay visibly disabled with their deferred phase named; Send starts disabled on an empty draft", () => {
     const { store } = makeStore();
     render(
       <OverlayProvider>
         {/* @ts-expect-error - test double */}
-        <Composer store={store} />
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
       </OverlayProvider>,
     );
     expect(screen.getByLabelText("Send message")).toBeDisabled();
     expect(screen.getByLabelText("Attach context")).toBeDisabled();
     expect(screen.getByTitle("Model/provider selection lands in R4")).toBeDisabled();
+  });
+
+  it("Send is enabled once there's text, calls sceneStore.sendMessage, and clears the draft", async () => {
+    const user = userEvent.setup();
+    const { store, updateDraft } = makeStore({ composer: { draft: { ...initialComposerState.draft, text: "hi" } } });
+    const { sceneStore, sendMessage } = makeSceneStore();
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={sceneStore} />
+      </OverlayProvider>,
+    );
+    const sendButton = screen.getByLabelText("Send message");
+    expect(sendButton).not.toBeDisabled();
+    await user.click(sendButton);
+    expect(sendMessage).toHaveBeenCalledWith("hi");
+    expect(updateDraft).toHaveBeenCalledWith("");
+  });
+
+  it("Enter sends (and clears the draft); Shift+Enter does not", async () => {
+    const user = userEvent.setup();
+    const { store, updateDraft } = makeStore({ composer: { draft: { ...initialComposerState.draft, text: "hi" } } });
+    const { sceneStore, sendMessage } = makeSceneStore();
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={sceneStore} />
+      </OverlayProvider>,
+    );
+    const input = screen.getByLabelText("Message composer");
+    await user.type(input, "{Shift>}{Enter}{/Shift}");
+    expect(sendMessage).not.toHaveBeenCalled();
+    await user.type(input, "{Enter}");
+    expect(sendMessage).toHaveBeenCalledWith("hi");
+    expect(updateDraft).toHaveBeenCalledWith("");
+  });
+
+  it("whitespace-only text does not enable Send", () => {
+    const { store } = makeStore({ composer: { draft: { ...initialComposerState.draft, text: "   " } } });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(screen.getByLabelText("Send message")).toBeDisabled();
   });
 
   it("opens the reasoning popover and selecting an option calls the intent and closes it", async () => {

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -1,18 +1,23 @@
 import { useLayoutEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import type { SceneStore } from "../canvas/sceneStore";
 import { Popover, useOverlays } from "../overlays/overlays";
 import type { ComposerStore } from "./composerStore";
 
 /**
- * The composer dock (Qt-removal plan R2.3) - ComposerApp's SPA successor.
+ * The composer dock (Qt-removal plan R2.3/R3.3) - ComposerApp's SPA
+ * successor.
  *
  * Real here: draft text editing, reasoning-level selection (a stored
  * preference popover, reusing the overlay system rather than a dedicated
- * picker island). Visibly deferred, per backend/composer.py's capability
+ * picker island), and (R3.3) Send - a real user ChatNode via
+ * sceneStore.sendMessage. The assistant's reply is NOT generated here (see
+ * backend/canvas.py's send_message docstring): the backend gives an honest
+ * "lands in R4" notice over the existing notification topic instead of a
+ * fake response. Visibly deferred, per backend/composer.py's capability
  * flags: attach (file-staging pipeline is an R4 concern), context review
  * (nothing to review until attachments exist), model/provider selection
- * (R4 - needs real provider wiring), send/cancel (R4 - needs the agent
- * layer). Each renders disabled with a title naming its phase, exactly the
- * app bar's Save/provider-select precedent.
+ * (R4 - needs real provider wiring). Each renders disabled with a title
+ * naming its phase, exactly the app bar's Save/provider-select precedent.
  *
  * Theme is NOT read from this payload (see backend/composer.py's docstring
  * for why) - the SPA's tokens are already global CSS.
@@ -32,7 +37,7 @@ function Icon({ name }: { name: "attach" | "send" | "chevron" }) {
   );
 }
 
-export function Composer({ store }: { store: ComposerStore }) {
+export function Composer({ store, sceneStore }: { store: ComposerStore; sceneStore: SceneStore }) {
   const composer = useSyncExternalStore(store.subscribe, store.getComposer);
   const overlays = useOverlays();
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -46,6 +51,13 @@ export function Composer({ store }: { store: ComposerStore }) {
 
   const modelLabel = composer.route.modelLabel || composer.route.modelId || "Select a model";
 
+  function send() {
+    const text = composer.draft.text.trim();
+    if (!text) return;
+    sceneStore.sendMessage(text);
+    store.updateDraft("");
+  }
+
   return (
     <div className="composer-dock">
       <div className="composer-input-wrap">
@@ -54,6 +66,12 @@ export function Composer({ store }: { store: ComposerStore }) {
           className="composer-input"
           value={composer.draft.text}
           onChange={(e) => store.updateDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              send();
+            }
+          }}
           placeholder="Ask about this graph…"
           aria-label="Message composer"
           rows={1}
@@ -103,9 +121,10 @@ export function Composer({ store }: { store: ComposerStore }) {
         <button
           type="button"
           className="composer-send-button"
-          disabled
-          title="Send lands in R4 (agent layer)"
+          disabled={!composer.draft.text.trim()}
+          title="Sends a real message; the AI response lands in R4 (agent layer)"
           aria-label="Send message"
+          onClick={send}
         >
           <Icon name="send" />
         </button>

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -328,6 +328,227 @@ body,
   background-color: var(--gl-neutral-button-hover);
 }
 
+/* -- R3.1/R3.2 chat node --------------------------------------------------- */
+
+.chat-node {
+  width: 420px;
+  max-height: 640px;
+  min-height: 110px;
+}
+
+.chat-node.collapsed {
+  width: 290px;
+  min-height: 58px;
+}
+
+.chat-node.user .scene-node-title {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.chat-node-role {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.chat-node-collapse-btn {
+  font-size: 10px;
+  line-height: 1;
+  padding: 2px 6px;
+  color: var(--gl-surface-text-muted);
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.chat-node-collapse-btn:hover {
+  color: var(--gl-surface-text);
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.chat-node-content {
+  max-height: 560px;
+  overflow-y: auto;
+}
+
+.chat-node-content > :first-child {
+  margin-top: 0;
+}
+
+.chat-node-content > :last-child {
+  margin-bottom: 0;
+}
+
+/* Markdown body inside a chat bubble - the same rule set as the document
+   viewer's own .document-viewer-markdown, duplicated here since that island
+   builds to a separate bundle and isn't importable into the SPA. */
+.chat-node-content h1,
+.chat-node-content h2,
+.chat-node-content h3,
+.chat-node-content h4,
+.chat-node-content h5,
+.chat-node-content h6 {
+  margin: 0 0 8px 0;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.chat-node-content h1 { font-size: 15px; }
+.chat-node-content h2 { font-size: 14px; }
+.chat-node-content h3 { font-size: 13px; }
+.chat-node-content h4,
+.chat-node-content h5,
+.chat-node-content h6 { font-size: 12px; }
+
+.chat-node-content p {
+  margin: 0 0 10px 0;
+}
+
+.chat-node-content ul,
+.chat-node-content ol {
+  margin: 0 0 10px 0;
+  padding-left: 20px;
+}
+
+.chat-node-content li {
+  margin: 0 0 4px 0;
+}
+
+.chat-node-content a {
+  color: var(--gl-palette-selection, var(--gl-surface-text));
+}
+
+.chat-node-content blockquote {
+  margin: 0 0 10px 0;
+  padding-left: 10px;
+  border-left: 3px solid var(--gl-surface-border);
+  color: var(--gl-surface-text-muted);
+}
+
+.chat-node-content hr {
+  margin: 16px 0;
+  border: 0;
+  border-top: 1px solid var(--gl-surface-border);
+}
+
+.chat-node-content code {
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 0.9em;
+  background-color: var(--gl-neutral-button-hover);
+  border-radius: 3px;
+  padding: 2px 4px;
+}
+
+.chat-node-content pre {
+  margin: 0 0 10px 0;
+  padding: 10px;
+  overflow-x: auto;
+  background-color: var(--gl-neutral-button-hover);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.chat-node-content pre code {
+  background-color: transparent;
+  border-radius: 0;
+  padding: 0;
+  font-size: 0.85em;
+}
+
+.chat-node-content table {
+  width: 100%;
+  margin: 0 0 10px 0;
+  border-collapse: collapse;
+}
+
+.chat-node-content th,
+.chat-node-content td {
+  padding: 6px 8px;
+  text-align: left;
+  border: 1px solid var(--gl-surface-border);
+}
+
+.chat-node-content th {
+  font-weight: 700;
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.chat-node-content .hljs {
+  color: var(--gl-surface-text);
+  background: transparent;
+}
+
+.chat-node-content .hljs-comment,
+.chat-node-content .hljs-quote {
+  color: var(--gl-surface-text-muted);
+  font-style: italic;
+}
+
+.chat-node-content .hljs-keyword,
+.chat-node-content .hljs-selector-tag,
+.chat-node-content .hljs-literal,
+.chat-node-content .hljs-string,
+.chat-node-content .hljs-number,
+.chat-node-content .hljs-title,
+.chat-node-content .hljs-section,
+.chat-node-content .hljs-name,
+.chat-node-content .hljs-type,
+.chat-node-content .hljs-attribute,
+.chat-node-content .hljs-symbol,
+.chat-node-content .hljs-built_in,
+.chat-node-content .hljs-variable,
+.chat-node-content .hljs-template-tag,
+.chat-node-content .hljs-template-variable {
+  color: var(--gl-palette-selection, var(--gl-surface-text));
+}
+
+.chat-node-content .hljs-emphasis {
+  font-style: italic;
+}
+
+.chat-node-content .hljs-strong {
+  font-weight: 700;
+}
+
+.chat-node-menu {
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  min-width: 170px;
+  padding: 6px;
+  gap: 2px;
+  background-color: var(--gl-surface-node-body);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+}
+
+.chat-node-menu button {
+  padding: 7px 10px;
+  text-align: left;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--gl-surface-text);
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.chat-node-menu button:hover:not(:disabled) {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.chat-node-menu button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.chat-node-menu-danger {
+  color: var(--gl-semantic-status-error, currentColor);
+}
+
 /* -- R2 app bar + overlay system ----------------------------------------- */
 
 .app-topbar {

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -44,8 +44,17 @@
       "items": {
         "additionalProperties": false,
         "properties": {
+          "content": {
+            "type": "string"
+          },
           "id": {
             "type": "string"
+          },
+          "isCollapsed": {
+            "type": "boolean"
+          },
+          "isUser": {
+            "type": "boolean"
           },
           "kind": {
             "type": "string"
@@ -65,7 +74,10 @@
           "x",
           "y",
           "title",
-          "kind"
+          "kind",
+          "content",
+          "isUser",
+          "isCollapsed"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -8,6 +8,9 @@ export interface SceneNodeRow {
   y: number;
   title: string;
   kind: string;
+  content: string;
+  isUser: boolean;
+  isCollapsed: boolean;
 }
 
 export interface SceneEdgeRow {
@@ -79,6 +82,21 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["kind"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.kind: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.kind` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["content"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.content: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.content` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["isUser"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isUser: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isUser` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["isCollapsed"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isCollapsed: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isCollapsed` + ": expected boolean"); }
   }
 }
 

--- a/web_ui/src/lib/ws/transport.test.ts
+++ b/web_ui/src/lib/ws/transport.test.ts
@@ -160,6 +160,29 @@ describe("WsTransport", () => {
     expect(FakeSocket.instances).toHaveLength(1);
   });
 
+  it("connect() after dispose() re-arms the transport (StrictMode remount safety)", () => {
+    const t = makeTransport();
+    t.subscribe("system", () => {});
+    t.connect();
+    const first = FakeSocket.instances[0];
+    t.dispose();
+    expect(first.closed).toBe(true);
+
+    t.connect();
+    expect(FakeSocket.instances).toHaveLength(2);
+    const second = FakeSocket.instances[1];
+    second.open();
+    expect(t.getStatus()).toBe("open");
+    expect(second.lastSent()).toEqual({ kind: "subscribe", topics: ["system"] });
+
+    // The first socket's close was already delivered synchronously by
+    // dispose() above; simulate it arriving again (a real WebSocket can
+    // still fire a queued close event after .close() was called) and
+    // confirm it doesn't clobber the second, live connection.
+    first.onclose?.();
+    expect(t.getStatus()).toBe("open");
+  });
+
   it("notifies status listeners through the lifecycle", () => {
     const t = makeTransport();
     const statuses: string[] = [];

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -71,13 +71,25 @@ export class WsTransport {
     this.requestTimeout = options.requestTimeoutMs ?? 10_000;
   }
 
+  // Calling connect() always re-arms a disposed transport rather than
+  // leaving it permanently inert. React 18 StrictMode's dev-only
+  // mount->cleanup->mount cycle calls dispose() then connect() again on the
+  // SAME memoized instance to check the component survives a remount; a
+  // one-way disposed flag would leave the app stuck "closed" forever after
+  // the very first render.
   connect(): void {
-    if (this.disposed || this.socket) return;
+    if (this.socket) return;
+    this.disposed = false;
     this.setStatus("connecting");
     const socket = this.factory(this.url);
     this.socket = socket;
 
+    // Every handler checks it's still the current socket before touching
+    // shared state - a superseded socket's belated close/message (e.g. the
+    // one dispose() just closed, right before this same connect() call
+    // re-armed and opened a fresh one) must not clobber the live connection.
     socket.onopen = () => {
+      if (this.socket !== socket) return;
       this.attempts = 0;
       this.setStatus("open");
       const topics = [...this.stateListeners.keys()];
@@ -85,11 +97,15 @@ export class WsTransport {
         socket.send(JSON.stringify({ kind: "subscribe", topics }));
       }
     };
-    socket.onmessage = (event) => this.handleMessage(event.data);
+    socket.onmessage = (event) => {
+      if (this.socket !== socket) return;
+      this.handleMessage(event.data);
+    };
     socket.onerror = () => {
       // onclose always follows; reconnect logic lives there.
     };
     socket.onclose = () => {
+      if (this.socket !== socket) return;
       this.socket = null;
       this.setStatus("closed");
       this.failAllPending(new Error("connection closed"));


### PR DESCRIPTION
## Summary
- Backend chat-node model in `backend/canvas.py`: create/delete (with parent-reparenting so deleting a mid-chain node splices its children back to the grandparent), collapse, and `send_message` tracking the active linear branch (`last_chat_node_id`).
- `ChatNodeView.tsx`: real React Flow node — role label, markdown + syntax-highlighted content, LOD collapse, context menu (Copy/Collapse/Delete real; Regenerate/Export explicitly disabled + titled for R4/R6).
- Composer's Send now creates a real user `ChatNode` (Enter to send, Shift+Enter for a newline). The assistant's reply is an honest "AI response generation lands in R4" notification, not a fake response — `graphlink_config.py`'s Qt import blocks the real agent call until R4's de-Qt pass (already catalogued in the local plan doc's Appendix A).
- **Real bug found and fixed during the live drive**: `WsTransport.dispose()` set a one-way flag that permanently blocked future `connect()` calls. React 18 StrictMode's dev-only mount→cleanup→remount cycle calls dispose() then connect() again on the same memoized transport instance, which left the dev server's WS connection stuck "closed" forever after the very first render. Fixed by having `connect()` re-arm the transport and guarding every socket handler against a stale/superseded socket. Regression test added.
- Investigated and ruled out a false alarm: newly-created nodes (both this ChatNode and R1's existing placeholder type) appeared stuck `visibility:hidden` in the live-drive browser tab. Root-caused to the tab's `document.hidden` / non-composited state suppressing all `ResizeObserver` callbacks (confirmed with a bare vanilla `ResizeObserver` that also never fired) — that's what React Flow's own node-visibility gate depends on. Not a product bug; doesn't reproduce in a real focused window.

## Test plan
- [x] `python -m pytest -q` (repo-wide): 1853 passed
- [x] `npm run check` (schema/typecheck/lint/test/build): all green, 600 vitest passing
- [x] Live drive against the real running backend: real WS round-trip, Send created a real user ChatNode with correct content and the honest R4-deferred notification appeared
- [x] Collapse/delete-via-UI-click covered by `ChatNodeView.test.tsx`'s direct-render unit tests (not exercised live this round — see browser-pane limitation above)

Remaining in R3 (not this PR): thinking/code/document/image/HTML-view node types, and the `ConversationNode` fast-follow.