### PR TITLE
Qt-removal R3.5/R3.6: real CodeNode on the React Flow canvas

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -77,6 +77,9 @@ class SceneError(ValueError):
 
 
 CHAT_TITLE_PREVIEW_LENGTH = 60
+# R3.5: code titles are a language label plus first line, not prose, so a
+# shorter preview than chat's 60 is plenty.
+CODE_TITLE_PREVIEW_LENGTH = 40
 
 
 @dataclass
@@ -93,6 +96,10 @@ class SceneNode:
     content: str = ""
     is_user: bool = False
     is_collapsed: bool = False
+    # R3.5: the code node's real persisted shape - unused/defaulted for
+    # every other kind.
+    code: str = ""
+    language: str = ""
 
 
 @dataclass
@@ -157,6 +164,41 @@ class SceneDocument:
             kind="chat",
             content=str(content),
             is_user=bool(is_user),
+        )
+        self.nodes[node_id] = node
+        if parent_id is not None:
+            self.connect(parent_id, node_id)
+        return node
+
+    def add_code_node(
+        self,
+        x: float,
+        y: float,
+        code: str,
+        language: str,
+        parent_id: str | None = None,
+    ) -> SceneNode:
+        """R3.5's code-node equivalent of add_chat_node: a real code-block
+        node, optionally connected to a parent. Mirrors add_chat_node's
+        id/dict bookkeeping and parent-edge behavior exactly. Code nodes are
+        NOT branch points - nothing ever gets reparented through them - so
+        unlike chat there is no delete_code_node; deletion goes entirely
+        through the existing generic remove_nodes."""
+        if parent_id is not None and parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        label = str(language) or "code"
+        first_line = str(code).split("\n", 1)[0]
+        preview = first_line[:CODE_TITLE_PREVIEW_LENGTH]
+        title = f"{label}: {preview}" if preview else label
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title=title,
+            kind="code",
+            code=str(code),
+            language=str(language),
         )
         self.nodes[node_id] = node
         if parent_id is not None:
@@ -290,6 +332,8 @@ class SceneDocument:
                     "content": n.content,
                     "isUser": n.is_user,
                     "isCollapsed": n.is_collapsed,
+                    "code": n.code,
+                    "language": n.language,
                 }
                 for n in self.nodes.values()
             ],
@@ -377,6 +421,11 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
         await publish_scene()
         return node.id
 
+    async def add_code_node(x, y, code, language, parent_id=None):
+        node = document.add_code_node(x, y, code, language, parent_id)
+        await publish_scene()
+        return node.id
+
     async def delete_chat_node(node_id):
         document.delete_chat_node(node_id)
         await publish_scene()
@@ -447,6 +496,7 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
 
     bus.register_intent("scene", "addNode", add_node)
     bus.register_intent("scene", "addChatNode", add_chat_node)
+    bus.register_intent("scene", "addCodeNode", add_code_node)
     bus.register_intent("scene", "deleteChatNode", delete_chat_node)
     bus.register_intent("scene", "setChatCollapsed", set_chat_collapsed)
     bus.register_intent("scene", "sendMessage", send_message)

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -140,6 +140,67 @@ def test_scene_payload_includes_chat_fields_defaulted_for_placeholders():
     assert chat_row["isUser"] is True
 
 
+# -- R3.5: code nodes --------------------------------------------------------
+
+
+def test_add_code_node_creates_a_real_code_kind_node():
+    doc = SceneDocument()
+    node = doc.add_code_node(10, 20, "print('hi')", "python")
+    assert node.kind == "code"
+    assert node.code == "print('hi')"
+    assert node.language == "python"
+    assert node.title == "python: print('hi')"
+
+
+def test_add_code_node_falls_back_to_language_only_title_for_empty_code():
+    doc = SceneDocument()
+    node = doc.add_code_node(0, 0, "", "python")
+    assert node.title == "python"
+
+
+def test_add_code_node_falls_back_to_code_label_when_language_and_code_are_empty():
+    doc = SceneDocument()
+    node = doc.add_code_node(0, 0, "", "")
+    assert node.title == "code"
+
+
+def test_add_code_node_connects_to_a_real_parent():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    child = doc.add_code_node(10, 10, "x = 1", "python", parent_id=parent.id)
+    assert any(e.source == parent.id and e.target == child.id for e in doc.edges.values())
+
+
+def test_add_code_node_rejects_unknown_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_code_node(0, 0, "x = 1", "python", parent_id="ghost")
+
+
+def test_scene_payload_includes_code_fields_defaulted_for_other_kinds():
+    doc = SceneDocument()
+    doc.add_node(0, 0, "plain")
+    doc.add_code_node(1, 1, "x = 1", "python")
+    rows = {n["title"]: n for n in doc.scene_payload()["nodes"]}
+    assert rows["plain"]["kind"] == "placeholder"
+    assert rows["plain"]["code"] == ""
+    assert rows["plain"]["language"] == ""
+    code_row = rows["python: x = 1"]
+    assert code_row["kind"] == "code"
+    assert code_row["code"] == "x = 1"
+    assert code_row["language"] == "python"
+
+
+def test_code_node_deletion_goes_through_the_generic_remove_nodes_path():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_code_node(10, 10, "x = 1", "python", parent_id=parent.id)
+    assert not hasattr(doc, "delete_code_node"), "code nodes are not branch points - no special delete method"
+    doc.remove_nodes([node.id])
+    assert node.id not in doc.nodes
+    assert not any(e.target == node.id or e.source == node.id for e in doc.edges.values())
+
+
 def test_send_message_starts_a_root_branch():
     doc = SceneDocument()
     node = doc.send_message("hello there")
@@ -250,6 +311,20 @@ def test_chat_node_intents_mutate_and_publish():
         assert parent_id not in document.nodes
         assert child_id in document.nodes, "deleting the parent must not cascade-delete the child"
         assert recorder.topics_seen().count("scene") == 4, "every mutation publishes"
+
+    asyncio.run(run())
+
+
+def test_add_code_node_intent_creates_a_real_node_and_publishes():
+    async def run():
+        bus, document, recorder = make_bus()
+        node_id = await bus.dispatch_intent(
+            "scene", "addCodeNode", [0, 0, "def f(): pass", "python"]
+        )
+        assert document.nodes[node_id].kind == "code"
+        assert document.nodes[node_id].code == "def f(): pass"
+        assert document.nodes[node_id].language == "python"
+        assert recorder.topics_seen().count("scene") == 1, "the mutation publishes"
 
     asyncio.run(run())
 

--- a/graphlink_app/graphlink_scene_payload.py
+++ b/graphlink_app/graphlink_scene_payload.py
@@ -14,6 +14,9 @@ R3.1 adds the `chat` kind's fields (content/isUser/isCollapsed - the real
 persisted shape from the legacy ChatNode's serializer, minus everything
 Qt-only): populated for kind=="chat" rows, defaulted (empty/false) for every
 other kind, so the schema stays additive-only as new kinds land.
+
+R3.5 adds the `code` kind's fields (code/language): populated for kind=="code"
+rows, defaulted (empty string) for every other kind, same additive rule.
 """
 
 from __future__ import annotations
@@ -31,6 +34,10 @@ class SceneNodeRow:
     content: str = ""
     isUser: bool = False
     isCollapsed: bool = False
+    # R3.5: the code node's real persisted shape - populated for kind=="code"
+    # rows, defaulted (empty string) for every other kind.
+    code: str = ""
+    language: str = ""
 
 
 @dataclass

--- a/web_ui/src/app/canvas/CodeNodeView.test.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.test.tsx
@@ -1,0 +1,86 @@
+import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
+// ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too.
+function renderCodeNode(overrides: Partial<CodeFlowNode["data"]> = {}) {
+  const onDelete = vi.fn();
+  const props = {
+    id: "n0",
+    selected: false,
+    data: {
+      code: "def add(a, b):\n    return a + b",
+      language: "python",
+      onDelete,
+      ...overrides,
+    },
+  } as unknown as NodeProps<CodeFlowNode>;
+
+  const { container } = render(
+    <ReactFlowProvider>
+      <CodeNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return { onDelete, container };
+}
+
+describe("CodeNodeView", () => {
+  it("renders the language label and syntax-highlighted code content", () => {
+    const { container } = renderCodeNode();
+    expect(screen.getByText("python")).toBeInTheDocument();
+    // Proves the fenced-code-block-through-ReactMarkdown+rehype-highlight
+    // pipeline actually ran (not just plain-text rendering of the raw code).
+    expect(container.querySelector(".hljs")).not.toBeNull();
+    expect(container.textContent).toContain("return a + b");
+  });
+
+  it("falls back to the word 'code' when language is empty", () => {
+    renderCodeNode({ language: "" });
+    expect(screen.getByText("code")).toBeInTheDocument();
+  });
+
+  it("right-click opens a menu with real Copy Code/Delete Code Block and deferred Regenerate/Export", async () => {
+    const user = userEvent.setup();
+    const { onDelete } = renderCodeNode();
+
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    const label = screen.getByText("python");
+    fireEvent.contextMenu(label);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    const regenerate = screen.getByRole("menuitem", { name: "Regenerate Response" });
+    expect(regenerate).toBeDisabled();
+    expect(regenerate).toHaveAttribute("title", "Agent regeneration lands in R4");
+    const exportItem = screen.getByRole("menuitem", { name: "Export" });
+    expect(exportItem).toBeDisabled();
+    expect(exportItem).toHaveAttribute("title", "Export lands in R6");
+
+    await user.click(screen.getByRole("menuitem", { name: "Copy Code" }));
+    expect(writeText).toHaveBeenCalledWith("def add(a, b):\n    return a + b");
+
+    fireEvent.contextMenu(label);
+    await user.click(screen.getByRole("menuitem", { name: "Delete Code Block" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Escape and outside-click both close the menu", async () => {
+    const user = userEvent.setup();
+    renderCodeNode();
+    const label = screen.getByText("python");
+
+    fireEvent.contextMenu(label);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(label);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/CodeNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.tsx
@@ -1,0 +1,144 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+
+/**
+ * The code node (Qt-removal plan R3.5/R3.6) - a card holding a single code
+ * block (push-only, same as chat: content arrives via the scene document,
+ * never generated here). Unlike ChatNodeView, code nodes have no manual
+ * collapse toggle - they only ever auto-collapse on zoom (LOD), since there's
+ * no per-node state worth toggling by hand. Real: render (syntax-highlighted,
+ * via the same react-markdown + rehype-highlight pipeline chat nodes already
+ * pull in - no new highlighter dependency), delete (generic cascade-delete;
+ * code nodes are never branch points, so there's no reparent rule to honor),
+ * copy. Deferred, with an honest disabled+title label: Regenerate (R4) and
+ * Export (R6).
+ */
+
+export interface CodeNodeData extends Record<string, unknown> {
+  code: string;
+  language: string;
+  onDelete: () => void;
+}
+
+export type CodeFlowNode = Node<CodeNodeData, "code">;
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+/** Wraps raw code in a markdown fenced code block so ReactMarkdown +
+ * rehype-highlight can syntax-highlight it for free - no Shiki/Prism/
+ * CodeMirror needed, zero bundle growth over what chat nodes already ship. */
+function toFencedCodeBlock(code: string, language: string): string {
+  return "```" + language + "\n" + code + "\n```";
+}
+
+function CodeNodeMenu({
+  position,
+  code,
+  onDelete,
+  onClose,
+}: {
+  position: MenuPosition;
+  code: string;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
+      // type-only import above shadows the bare name for casts like this).
+      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          navigator.clipboard.writeText(code);
+          onClose();
+        }}
+      >
+        Copy Code
+      </button>
+      <button type="button" role="menuitem" disabled title="Agent regeneration lands in R4">
+        Regenerate Response
+      </button>
+      <button type="button" role="menuitem" disabled title="Export lands in R6">
+        Export
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        Delete Code Block
+      </button>
+    </div>
+  );
+}
+
+export function CodeNodeView({ data, selected }: NodeProps<CodeFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const collapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+
+  return (
+    <div
+      className={`scene-node code-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title code-node-language">
+        <span>{data.language || "code"}</span>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body code-node-content">
+          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+            {toFencedCodeBlock(data.code, data.language)}
+          </ReactMarkdown>
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+      {menuPosition && (
+        <CodeNodeMenu
+          position={menuPosition}
+          code={data.code}
+          onDelete={data.onDelete}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -18,6 +18,7 @@ import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
 import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
+import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { SceneStore, scaleDragPosition } from "./sceneStore";
 
@@ -26,7 +27,8 @@ import { SceneStore, scaleDragPosition } from "./sceneStore";
  * successor. R1 scope: pan/zoom, model-driven grid (size/style/color/opacity
  * + snap), node drag with the drag-speed factor, edges, selection + delete,
  * minimap, an LOD threshold, navigation pins. R3.1/R3.2 add the first real
- * node type (chat); every other kind still renders as a placeholder.
+ * node type (chat); R3.5/R3.6 add code. Every other kind still renders as a
+ * placeholder.
  */
 
 const GRID_VARIANTS: Record<string, BackgroundVariant> = {
@@ -36,7 +38,7 @@ const GRID_VARIANTS: Record<string, BackgroundVariant> = {
 };
 
 type PlaceholderNode = Node<{ title: string }, "placeholder">;
-type SceneFlowNode = PlaceholderNode | ChatFlowNode;
+type SceneFlowNode = PlaceholderNode | ChatFlowNode | CodeFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   const zoom = useStore((s) => s.transform[2]);
@@ -54,7 +56,7 @@ function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   );
 }
 
-const NODE_TYPES = { placeholder: PlaceholderNodeView, chat: ChatNodeView };
+const NODE_TYPES = { placeholder: PlaceholderNodeView, chat: ChatNodeView, code: CodeNodeView };
 
 function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
   return scene.nodes.map((n) => {
@@ -69,6 +71,18 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
           isCollapsed: n.isCollapsed,
           onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
           onDelete: () => store.deleteChatNode(n.id),
+        },
+      };
+    }
+    if (n.kind === "code") {
+      return {
+        id: n.id,
+        type: "code" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          code: n.code,
+          language: n.language,
+          onDelete: () => store.removeNodes([n.id]),
         },
       };
     }

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -25,7 +25,18 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
     minCompatibleSchemaVersion: 1,
     revision: 3,
     nodes: [
-      { id: "n0", x: 1, y: 2, title: "A", kind: "placeholder", content: "", isUser: false, isCollapsed: false },
+      {
+        id: "n0",
+        x: 1,
+        y: 2,
+        title: "A",
+        kind: "placeholder",
+        content: "",
+        isUser: false,
+        isCollapsed: false,
+        code: "",
+        language: "",
+      },
     ],
     edges: [],
     pins: [],
@@ -115,6 +126,17 @@ describe("SceneStore", () => {
       { topic: "scene", intent: "addChatNode", args: [30, 40, "hi back", false, "n1"] },
       { topic: "scene", intent: "setChatCollapsed", args: ["n1", true] },
       { topic: "scene", intent: "deleteChatNode", args: ["n1"] },
+    ]);
+  });
+
+  it("sends code-node intents with the backend's registered names and shapes", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.addCodeNode(10, 20, "print('hi')", "python");
+    store.addCodeNode(30, 40, "console.log('hi')", "javascript", "n1");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "addCodeNode", args: [10, 20, "print('hi')", "python"] },
+      { topic: "scene", intent: "addCodeNode", args: [30, 40, "console.log('hi')", "javascript", "n1"] },
     ]);
   });
 

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -132,6 +132,15 @@ export class SceneStore {
     this.transport.intent("scene", "deleteChatNode", [id]);
   }
 
+  // R3.5: real code nodes - deletion has no dedicated intent (code nodes are
+  // never branch points/reparented, so the generic removeNodes intent below
+  // already covers it).
+  addCodeNode(x: number, y: number, code: string, language: string, parentId?: string): void {
+    const args: unknown[] = [x, y, code, language];
+    if (parentId !== undefined) args.push(parentId);
+    this.transport.intent("scene", "addCodeNode", args);
+  }
+
   setChatCollapsed(id: string, collapsed: boolean): void {
     this.transport.intent("scene", "setChatCollapsed", [id, collapsed]);
   }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -549,6 +549,38 @@ body,
   color: var(--gl-semantic-status-error, currentColor);
 }
 
+/* -- R3.5/R3.6 code node --------------------------------------------------- */
+
+.chat-node,
+.code-node {
+  width: 420px;
+  max-height: 640px;
+  min-height: 110px;
+}
+
+.code-node.collapsed {
+  width: 290px;
+  min-height: 58px;
+}
+
+.code-node-language {
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  text-transform: lowercase;
+}
+
+.code-node-content {
+  max-height: 560px;
+  overflow-y: auto;
+}
+
+.code-node-content > :first-child {
+  margin-top: 0;
+}
+
+.code-node-content > :last-child {
+  margin-bottom: 0;
+}
+
 /* -- R2 app bar + overlay system ----------------------------------------- */
 
 .app-topbar {

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -44,6 +44,9 @@
       "items": {
         "additionalProperties": false,
         "properties": {
+          "code": {
+            "type": "string"
+          },
           "content": {
             "type": "string"
           },
@@ -57,6 +60,9 @@
             "type": "boolean"
           },
           "kind": {
+            "type": "string"
+          },
+          "language": {
             "type": "string"
           },
           "title": {
@@ -77,7 +83,9 @@
           "kind",
           "content",
           "isUser",
-          "isCollapsed"
+          "isCollapsed",
+          "code",
+          "language"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -11,6 +11,8 @@ export interface SceneNodeRow {
   content: string;
   isUser: boolean;
   isCollapsed: boolean;
+  code: string;
+  language: string;
 }
 
 export interface SceneEdgeRow {
@@ -97,6 +99,16 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["isCollapsed"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isCollapsed: missing required field`);
     else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isCollapsed` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["code"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.code: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.code` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["language"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.language: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.language` + ": expected string"); }
   }
 }
 


### PR DESCRIPTION
## Summary
- Backend: `SceneNode`/`SceneNodeRow` gain `code`/`language` fields (additive, same pattern as chat's `content`/`isUser`/`isCollapsed`). `SceneDocument.add_code_node` mirrors `add_chat_node` exactly - parent-linkage reuses the existing edge mechanism, no new field needed. Deliberately no `delete_code_node`: code nodes are never branch points, so deletion goes entirely through the existing generic `remove_nodes`/`removeNodes` intent.
- Frontend: `CodeNodeView.tsx` reuses the exact `react-markdown` + `rehype-highlight` pipeline chat nodes already ship, by wrapping raw code in a synthetic markdown fenced code block, instead of adding a new syntax-highlighting dependency (no Shiki/Prism/CodeMirror) - avoids further growing the already-flagged main-bundle size. LOD-only auto-collapse (no manual toggle, unlike chat). Context menu: Copy Code/Delete Code Block real; Regenerate/Export disabled with the exact same R4/R6 title strings as ChatNode's, for cross-node consistency.
- CodeNode has **no UI creation trigger yet, by design** - its real-world trigger (regex-parsing a code block out of an AI reply) is blocked on the same `graphlink_config.py` Qt split that blocks ChatNode's real reply (R4). So `addCodeNode` ships as a tested, WS-callable intent with no UI entry point yet - the same role R1's placeholder nodes played before real kinds existed.
- Scoped the rest of R3 while here: recon'd and cross-checked every remaining node type (Thinking/Document/Image/HTML-View/Conversation) against the legacy Qt implementation and the plan's own Appendix A disposition table, producing a dependency-ordered build plan (recorded in the local plan doc) - Code first (this PR, zero cross-cutting new state), then Document, then Thinking (needs a new dock↔badge contract shared with ChatNode), then HTML View, then Image (blocked on a new asset-serving endpoint), then `ConversationNode` last (L effort, needs a new non-flat backend shape).
- Built via 2 parallel implementation agents against a precisely-specified shared contract, then 3 independent adversarial reviews (backend correctness, frontend correctness, cross-boundary integration) - all 3 **PASSED**, zero defects found, no fixes needed.

## Test plan
- [x] `python -m pytest -q` (repo-wide): 1861 passed
- [x] `npm run check` (schema/typecheck/lint/test/build): all green, 605 vitest passing
- [x] Live drive against the real running backend: fired the `addCodeNode` WS intent directly (no UI trigger exists yet), confirmed a real code-kind node appears in the SPA with correct title/code/language and **genuine client-side syntax highlighting** (`hljs language-python` classes present in the live DOM, not just in tests); fired `removeNodes` and confirmed the SPA reflected the deletion
- [x] Context-menu/click interaction (Copy Code, Delete-via-menu) covered by `CodeNodeView.test.tsx`'s direct-render unit tests - not exercised live this round due to a browser-pane compositing limitation in this environment (documented in the local plan doc, same as the prior ChatNode PR)

Remaining in R3 (not this PR): document/thinking/HTML-view/image node types, and the `ConversationNode` fast-follow.