### PR TITLE
Fix: honor the explicit-defer convention on Chat/CodeNode menus

### DIFF
--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -56,14 +56,14 @@ describe("ChatNodeView", () => {
     expect(onToggleCollapse).toHaveBeenCalledOnce();
   });
 
-  it("right-click opens a menu with real Copy/Collapse/Delete and deferred Regenerate/Export", async () => {
+  it("right-click opens a menu with real Copy/Collapse/Delete and every deferred item honestly disabled+titled", async () => {
     const user = userEvent.setup();
-    const { onDelete } = renderChatNode();
+    const { onDelete } = renderChatNode({ isUser: false });
 
     const writeText = vi.fn();
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
 
-    const role = screen.getByText("You");
+    const role = screen.getByText("Assistant");
     fireEvent.contextMenu(role);
     expect(screen.getByRole("menu")).toBeInTheDocument();
 
@@ -73,6 +73,16 @@ describe("ChatNodeView", () => {
     const exportItem = screen.getByRole("menuitem", { name: "Export" });
     expect(exportItem).toBeDisabled();
     expect(exportItem).toHaveAttribute("title", "Export lands in R6");
+    const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
+    expect(hideBranches).toBeDisabled();
+    expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
+    const docView = screen.getByRole("menuitem", { name: "Open Document View" });
+    expect(docView).toBeDisabled();
+    for (const name of ["Generate Key Takeaway", "Generate Explainer Note", "Generate Chart", "Generate Image"]) {
+      const item = screen.getByRole("menuitem", { name });
+      expect(item).toBeDisabled();
+      expect(item).toHaveAttribute("title", "AI generation lands in R4");
+    }
 
     await user.click(screen.getByRole("menuitem", { name: "Copy Text" }));
     expect(writeText).toHaveBeenCalledWith("Hello **world**");
@@ -80,6 +90,12 @@ describe("ChatNodeView", () => {
     fireEvent.contextMenu(role);
     await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
     expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Regenerate Response only appears for assistant messages, matching the legacy is_user guard", () => {
+    renderChatNode({ isUser: true });
+    fireEvent.contextMenu(screen.getByText("You"));
+    expect(screen.queryByRole("menuitem", { name: "Regenerate Response" })).toBeNull();
   });
 
   it("Escape and outside-click both close the menu", async () => {

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -10,8 +10,20 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * a single message-bubble card, push-only (content arrives via the scene
  * document, never generated here). Real: render, collapse/expand, delete
  * (with the backend's reparent-children rule), copy. Deferred, with an
- * honest disabled+title label rather than a fake action: Regenerate (needs
- * the R4 agent layer) and Export (R6 session/export work).
+ * honest disabled+title label rather than a fake action or a silent drop
+ * (an R3.4 live-drive audit found several legacy ChatNode menu items had
+ * been dropped with zero acknowledgment - fixed here): Regenerate (assistant
+ * nodes only, needs the R4 agent layer), Key Takeaway/Explainer Note/Chart/
+ * Image generation (R4, same agent-layer blocker), Export (R6 session/export
+ * work), Open Document View (the document-viewer island isn't wired into the
+ * SPA overlay system yet), and Hide Other Branches (the legacy scene's
+ * branch-visibility toggle has no backend/frontend equivalent at all yet -
+ * unscoped, not owned by any R-phase). Two legacy items are deliberately NOT
+ * listed even as disabled: "Reveal Docked Items" and "Generate Group Summary"
+ * are themselves conditionally hidden in the legacy menu (only when docked
+ * children or a multi-selection exist), and neither precondition can occur
+ * yet in the new stack (no docking, no multi-select model) - showing them
+ * unconditionally would be a behavior regression, not parity.
  */
 
 export interface ChatNodeData extends Record<string, unknown> {
@@ -32,6 +44,7 @@ interface MenuPosition {
 function ChatNodeMenu({
   position,
   content,
+  isUser,
   isCollapsed,
   onToggleCollapse,
   onDelete,
@@ -39,6 +52,7 @@ function ChatNodeMenu({
 }: {
   position: MenuPosition;
   content: string;
+  isUser: boolean;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
   onDelete: () => void;
@@ -90,11 +104,26 @@ function ChatNodeMenu({
       >
         {isCollapsed ? "Expand" : "Collapse"}
       </button>
-      <button type="button" role="menuitem" disabled title="Agent regeneration lands in R4">
-        Regenerate Response
-      </button>
       <button type="button" role="menuitem" disabled title="Export lands in R6">
         Export
+      </button>
+      <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
+        Hide Other Branches
+      </button>
+      <button type="button" role="menuitem" disabled title="Document view integration isn't wired into the SPA yet">
+        Open Document View
+      </button>
+      <button type="button" role="menuitem" disabled title="AI generation lands in R4">
+        Generate Key Takeaway
+      </button>
+      <button type="button" role="menuitem" disabled title="AI generation lands in R4">
+        Generate Explainer Note
+      </button>
+      <button type="button" role="menuitem" disabled title="AI generation lands in R4">
+        Generate Chart
+      </button>
+      <button type="button" role="menuitem" disabled title="AI generation lands in R4">
+        Generate Image
       </button>
       <button
         type="button"
@@ -107,6 +136,11 @@ function ChatNodeMenu({
       >
         Delete Node
       </button>
+      {!isUser && (
+        <button type="button" role="menuitem" disabled title="Agent regeneration lands in R4">
+          Regenerate Response
+        </button>
+      )}
     </div>
   );
 }
@@ -149,6 +183,7 @@ export function ChatNodeView({ data, selected }: NodeProps<ChatFlowNode>) {
         <ChatNodeMenu
           position={menuPosition}
           content={data.content}
+          isUser={data.isUser}
           isCollapsed={data.isCollapsed}
           onToggleCollapse={data.onToggleCollapse}
           onDelete={data.onDelete}

--- a/web_ui/src/app/canvas/CodeNodeView.test.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.test.tsx
@@ -59,6 +59,9 @@ describe("CodeNodeView", () => {
     const exportItem = screen.getByRole("menuitem", { name: "Export" });
     expect(exportItem).toBeDisabled();
     expect(exportItem).toHaveAttribute("title", "Export lands in R6");
+    const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
+    expect(hideBranches).toBeDisabled();
+    expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
 
     await user.click(screen.getByRole("menuitem", { name: "Copy Code" }));
     expect(writeText).toHaveBeenCalledWith("def add(a, b):\n    return a + b");

--- a/web_ui/src/app/canvas/CodeNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.tsx
@@ -14,8 +14,12 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * via the same react-markdown + rehype-highlight pipeline chat nodes already
  * pull in - no new highlighter dependency), delete (generic cascade-delete;
  * code nodes are never branch points, so there's no reparent rule to honor),
- * copy. Deferred, with an honest disabled+title label: Regenerate (R4) and
- * Export (R6).
+ * copy. Deferred, with an honest disabled+title label rather than a silent
+ * drop (an R3.4 live-drive audit found the legacy CodeNode menu's branch-
+ * visibility item had been dropped with zero acknowledgment - fixed here):
+ * Regenerate (R4), Export (R6), and Hide Other Branches (the legacy scene's
+ * branch-visibility toggle has no backend/frontend equivalent at all yet -
+ * unscoped, not owned by any R-phase).
  */
 
 export interface CodeNodeData extends Record<string, unknown> {
@@ -85,11 +89,14 @@ function CodeNodeMenu({
       >
         Copy Code
       </button>
-      <button type="button" role="menuitem" disabled title="Agent regeneration lands in R4">
-        Regenerate Response
-      </button>
       <button type="button" role="menuitem" disabled title="Export lands in R6">
         Export
+      </button>
+      <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
+        Hide Other Branches
+      </button>
+      <button type="button" role="menuitem" disabled title="Agent regeneration lands in R4">
+        Regenerate Response
       </button>
       <button
         type="button"


### PR DESCRIPTION
## Summary
Prompted by an explicit "no room for error" directive - a zero-tolerance audit compared the shipped `ChatNodeView`/`CodeNodeView` context menus against their TRUE legacy Qt sources line-by-line (fresh reads, not prior summaries) and found real defects:

- **13 of 19 legacy ChatNode behaviors and 1 of 5 legacy CodeNode menu items had been silently dropped with zero acknowledgment** - no disabled button, no comment, nothing. This violates this project's own stated convention (`doc/QT_REMOVAL_PLAN.md` §0): anything not yet real must render `disabled` with a `title` naming why - never silently faked, and never silently omitted either.
- **A real correctness bug**: ChatNode's "Regenerate Response" rendered unconditionally instead of assistant-only. The legacy menu only shows it when `not self.node.is_user` - it makes no sense to offer to regenerate your own message. Fixed to `!isUser`, matching the legacy guard exactly, with a test for both branches.

## Fix
- `ChatNodeView.tsx`: added 6 honest disabled+titled placeholders - Hide Other Branches, Open Document View, Generate Key Takeaway, Generate Explainer Note, Generate Chart, Generate Image.
- `CodeNodeView.tsx`: added 1 - Hide Other Branches. Reordered to match the legacy Copy→Export→Hide-Branches→Regenerate→Delete sequence.
- Both components' doc comments now correctly enumerate every deferred item (the audit specifically caught `CodeNodeView`'s comment naming *some* deferred items while omitting others).
- Deliberately did **NOT** add stubs for "Reveal Docked Items" or "Generate Group Summary" - both are themselves conditionally hidden in the legacy menu (only when docked children or a multi-selection exist), and neither precondition can occur yet in the new stack. Showing them unconditionally would be a behavior regression, not parity - reasoning recorded in the component comments.
- Recorded 5 newly-surfaced, genuinely unscoped gaps in a new `doc/QT_REMOVAL_PLAN.md` §7a ("Known gaps surfaced by audits") rather than silently building partial versions as a side effect of this fix: a branch-visibility system, the docked-child badge system, three passive (non-button) legacy behaviors with no honest disabled-button form (long-hover ancestor-highlight, search-match highlight, nav/go-to highlight), and "Open Document View"'s real wiring path.

## Test plan
- [x] `npx vitest run` on both touched test files: 10/10 passed
- [x] `npx tsc --noEmit`: exit 0
- [x] Full `npm run check`: 606 vitest green (up from 605), 0 lint errors, clean build
- [x] `python -m pytest -q` (repo-wide, confirms the frontend-only fix didn't regress anything backend-side): 1861 passed
- [x] Independently adversarially re-reviewed by a second agent against the true legacy source, from scratch: **PASS**, zero remaining defects