### PR TITLE
Qt-removal R3.9/R3.10: real DocumentNode on the React Flow canvas

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -100,6 +100,62 @@ class SceneNode:
     # every other kind.
     code: str = ""
     language: str = ""
+    # R3.9 (doc/QT_REMOVAL_PLAN.md): the document node's real persisted shape -
+    # graphlink_scene.py's add_document_node()/graphlink_node_document.py's
+    # DocumentNode.__init__ attachment metadata (title/content above, plus
+    # these six fields). The backend stores these VERBATIM, exactly as
+    # passed in - none of the legacy view-layer formatting below happens
+    # here; reproducing it is the frontend's job (same as the paint()/menu
+    # code it replaces). Formatting rules extracted from
+    # graphlink_nodes/graphlink_node_document.py + graphlink_audio.py, for
+    # the frontend to reproduce exactly in TypeScript:
+    #
+    # - Byte-size formatting (DocumentNode._format_byte_size): if byte_size
+    #   is falsy (None or 0) -> "Unknown". Else repeatedly divide by 1024.0
+    #   walking units ("B","KB","MB","GB","TB"), stopping at the first unit
+    #   where size < 1024.0 (or unit == "TB"); "B" formats as a bare integer
+    #   ("512 B"), every other unit formats with exactly one decimal place
+    #   ("1.5 MB").
+    # - Duration formatting (graphlink_audio.format_duration): None ->
+    #   "Unknown". Else round(seconds) to the nearest whole second, clamp
+    #   negative to 0, divmod into hours/minutes/seconds; if hours > 0 format
+    #   "H:MM:SS" (hours unpadded, minutes/seconds zero-padded to 2 digits),
+    #   else "M:SS" (minutes unpadded, seconds zero-padded).
+    # - Metadata rows (DocumentNode._build_metadata_rows), in this exact
+    #   order, each omitted entirely when its value is empty/None: Type
+    #   ("Audio file" if attachment_kind=="audio" else "Document", always
+    #   present) / Duration (formatted, only if duration_seconds is not
+    #   None) / Format (mime_type, only if truthy) / Size (formatted byte
+    #   size, only if byte_size is truthy) / Path (file_path, only if
+    #   truthy).
+    # - preview_label auto-fill (DocumentNode._build_preview_label), used
+    #   only when the caller didn't supply one: for attachment_kind=="audio"
+    #   -> "Audio | {duration formatted, or 'Audio' if duration_seconds is
+    #   None}"; otherwise derived from title's file extension via
+    #   os.path.splitext: ".pdf" -> "PDF", ".docx" -> "DOCX", any other
+    #   extension -> that extension uppercased without its dot, no extension
+    #   -> "Document".
+    # - Audio-preview-suppression heuristic
+    #   (DocumentNode._should_show_audio_preview): normalize both `content`
+    #   and the auto-built `audio_details` block the same way (join
+    #   right-stripped lines with "\n", strip the whole string, lowercase).
+    #   Hide the content-preview panel (show only the metadata table) when:
+    #   normalized content is empty; OR normalized content == normalized
+    #   audio_details (content is nothing but the auto-generated metadata
+    #   block); OR normalized content startswith "audio attachment" AND
+    #   contains "duration:" (catches legacy-saved sessions whose persisted
+    #   content is an older/differently-valued metadata block). Otherwise
+    #   show the preview. `audio_details` itself is the joined lines: "Audio
+    #   attachment", then "Duration: {formatted}" if duration_seconds is not
+    #   None, "Format: {mime_type}" if truthy, "Size: {formatted byte size}"
+    #   if byte_size truthy, "Path: {file_path}" if truthy - same
+    #   presence/order rules as the metadata rows above.
+    attachment_kind: str = ""
+    file_path: str = ""
+    mime_type: str = ""
+    duration_seconds: float | None = None
+    byte_size: int | None = None
+    preview_label: str = ""
 
 
 @dataclass
@@ -203,6 +259,72 @@ class SceneDocument:
         self.nodes[node_id] = node
         if parent_id is not None:
             self.connect(parent_id, node_id)
+        return node
+
+    def add_document_node(
+        self,
+        x: float,
+        y: float,
+        title: str,
+        content: str,
+        attachment_kind: str,
+        parent_id: str,
+        *,
+        file_path: str = "",
+        mime_type: str = "",
+        duration_seconds: float | None = None,
+        byte_size: int | None = None,
+        preview_label: str = "",
+    ) -> SceneNode:
+        """R3.9's document-node equivalent of add_chat_node/add_code_node: a
+        real file-attachment node (a document or an audio file), for the
+        legacy DocumentNode / ChatScene.add_document_node pair. UNLIKE
+        chat/code, parent_id is REQUIRED here, not optional: read fresh from
+        graphlink_scene.py, add_document_node(title, content,
+        parent_user_node, ...) takes parent_user_node as a plain required
+        positional with no default, and unconditionally constructs a
+        DocumentConnectionItem(parent_user_node, node) - there is no `if
+        parent_id` guard around that connection the way chat/code have
+        around theirs - so a DocumentNode can never exist unparented.
+        Document nodes are also NOT branch points (same as code): there is
+        no delete_document_node; deletion goes entirely through the
+        existing generic remove_nodes.
+
+        The six attachment fields are stored verbatim - no title-preview
+        truncation (DocumentNode.title in the legacy app is just whatever
+        descriptive title/filename was passed in, confirmed by reading
+        DocumentNode.__init__: `self.title = title`, no slicing), and none
+        of the legacy view-layer formatting (byte-size/duration strings,
+        preview_label auto-fill, audio-preview suppression) happens here -
+        see the R3.9 comment on the SceneNode dataclass fields for those
+        exact rules.
+        """
+        if parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        # Mirrors DocumentNode.__init__'s `(attachment_kind or
+        # "document").lower()` normalization - the attachment_kind param has
+        # no default in this signature (per spec), but an empty/None value
+        # still needs to fall back to "document" and casing still needs to
+        # normalize, since "audio" vs "Audio" is a real behavioral branch
+        # (metadata "Type" row, preview label, badge text all key off it).
+        normalized_kind = str(attachment_kind or "document").lower()
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title=str(title),
+            kind="document",
+            content=str(content),
+            attachment_kind=normalized_kind,
+            file_path=str(file_path),
+            mime_type=str(mime_type),
+            duration_seconds=duration_seconds,
+            byte_size=byte_size,
+            preview_label=str(preview_label),
+        )
+        self.nodes[node_id] = node
+        self.connect(parent_id, node_id)
         return node
 
     def delete_chat_node(self, node_id: str) -> None:
@@ -334,6 +456,12 @@ class SceneDocument:
                     "isCollapsed": n.is_collapsed,
                     "code": n.code,
                     "language": n.language,
+                    "attachmentKind": n.attachment_kind,
+                    "filePath": n.file_path,
+                    "mimeType": n.mime_type,
+                    "durationSeconds": n.duration_seconds,
+                    "byteSize": n.byte_size,
+                    "previewLabel": n.preview_label,
                 }
                 for n in self.nodes.values()
             ],
@@ -426,6 +554,35 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
         await publish_scene()
         return node.id
 
+    async def add_document_node(
+        x,
+        y,
+        title,
+        content,
+        attachment_kind,
+        parent_id,
+        file_path="",
+        mime_type="",
+        duration_seconds=None,
+        byte_size=None,
+        preview_label="",
+    ):
+        node = document.add_document_node(
+            x,
+            y,
+            title,
+            content,
+            attachment_kind,
+            parent_id,
+            file_path=file_path,
+            mime_type=mime_type,
+            duration_seconds=duration_seconds,
+            byte_size=byte_size,
+            preview_label=preview_label,
+        )
+        await publish_scene()
+        return node.id
+
     async def delete_chat_node(node_id):
         document.delete_chat_node(node_id)
         await publish_scene()
@@ -497,6 +654,7 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
     bus.register_intent("scene", "addNode", add_node)
     bus.register_intent("scene", "addChatNode", add_chat_node)
     bus.register_intent("scene", "addCodeNode", add_code_node)
+    bus.register_intent("scene", "addDocumentNode", add_document_node)
     bus.register_intent("scene", "deleteChatNode", delete_chat_node)
     bus.register_intent("scene", "setChatCollapsed", set_chat_collapsed)
     bus.register_intent("scene", "sendMessage", send_message)

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -201,6 +201,131 @@ def test_code_node_deletion_goes_through_the_generic_remove_nodes_path():
     assert not any(e.target == node.id or e.source == node.id for e in doc.edges.values())
 
 
+# -- R3.9: document nodes -----------------------------------------------------
+
+
+def test_add_document_node_creates_a_real_document_kind_node():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "the message that attached a file", True)
+    node = doc.add_document_node(
+        10,
+        20,
+        "report.pdf",
+        "some extracted text",
+        "document",
+        parent.id,
+        file_path="C:/files/report.pdf",
+        mime_type="application/pdf",
+        duration_seconds=None,
+        byte_size=2048,
+        preview_label="PDF",
+    )
+    assert node.kind == "document"
+    assert node.title == "report.pdf"
+    assert node.content == "some extracted text"
+    assert node.attachment_kind == "document"
+    assert node.file_path == "C:/files/report.pdf"
+    assert node.mime_type == "application/pdf"
+    assert node.duration_seconds is None
+    assert node.byte_size == 2048
+    assert node.preview_label == "PDF"
+    assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
+
+
+def test_add_document_node_normalizes_attachment_kind_casing():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_document_node(0, 0, "voice.wav", "", "Audio", parent.id)
+    assert node.attachment_kind == "audio"
+
+
+def test_add_document_node_requires_a_parent_id():
+    # Unlike chat/code, parent_id has no default in add_document_node's
+    # signature - the legacy DocumentNode can never exist unparented - so
+    # calling without one is a TypeError (missing required argument), same
+    # as any other required positional in this codebase.
+    doc = SceneDocument()
+    with pytest.raises(TypeError):
+        doc.add_document_node(0, 0, "file.txt", "content", "document")
+
+
+def test_add_document_node_rejects_unknown_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_document_node(0, 0, "file.txt", "content", "document", "ghost")
+
+
+def test_scene_payload_includes_document_fields_defaulted_for_other_kinds():
+    doc = SceneDocument()
+    doc.add_node(0, 0, "plain")
+    parent = doc.add_chat_node(1, 1, "parent message", True)
+    doc.add_document_node(
+        2,
+        2,
+        "notes.txt",
+        "hello",
+        "document",
+        parent.id,
+        file_path="/tmp/notes.txt",
+        mime_type="text/plain",
+        byte_size=512,
+        preview_label="TXT",
+    )
+    rows = {n["title"]: n for n in doc.scene_payload()["nodes"]}
+    plain_row = rows["plain"]
+    assert plain_row["kind"] == "placeholder"
+    assert plain_row["attachmentKind"] == ""
+    assert plain_row["filePath"] == ""
+    assert plain_row["mimeType"] == ""
+    assert plain_row["durationSeconds"] is None
+    assert plain_row["byteSize"] is None
+    assert plain_row["previewLabel"] == ""
+
+    doc_row = rows["notes.txt"]
+    assert doc_row["kind"] == "document"
+    assert doc_row["attachmentKind"] == "document"
+    assert doc_row["filePath"] == "/tmp/notes.txt"
+    assert doc_row["mimeType"] == "text/plain"
+    assert doc_row["byteSize"] == 512
+    assert doc_row["previewLabel"] == "TXT"
+
+
+def test_add_document_node_intent_creates_a_real_node_and_publishes():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addChatNode", [0, 0, "hi", True])
+        # dispatch_intent only ever forwards a positional args list (see
+        # SessionBus.dispatch_intent: `handler(*args)`), so every argument -
+        # including the wrapper's keyword-defaulted ones - is passed
+        # positionally here, in add_document_node's declared order.
+        node_id = await bus.dispatch_intent(
+            "scene",
+            "addDocumentNode",
+            [10, 10, "audio.mp3", "", "audio", parent_id, "", "audio/mpeg", 125.4, 4096, ""],
+        )
+        assert document.nodes[node_id].kind == "document"
+        assert document.nodes[node_id].attachment_kind == "audio"
+        assert document.nodes[node_id].mime_type == "audio/mpeg"
+        assert document.nodes[node_id].duration_seconds == 125.4
+        assert document.nodes[node_id].byte_size == 4096
+        assert any(
+            e.source == parent_id and e.target == node_id for e in document.edges.values()
+        )
+        assert recorder.topics_seen().count("scene") == 2, "both mutations publish"
+
+    asyncio.run(run())
+
+
+def test_document_node_deletion_goes_through_the_generic_remove_nodes_path():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_document_node(10, 10, "file.txt", "content", "document", parent.id)
+    assert not hasattr(doc, "delete_document_node"), "document nodes are not branch points - no special delete method"
+    doc.remove_nodes([node.id])
+    assert node.id not in doc.nodes
+    assert not any(e.target == node.id or e.source == node.id for e in doc.edges.values())
+
+
 def test_send_message_starts_a_root_branch():
     doc = SceneDocument()
     node = doc.send_message("hello there")

--- a/graphlink_app/graphlink_scene_payload.py
+++ b/graphlink_app/graphlink_scene_payload.py
@@ -17,6 +17,11 @@ other kind, so the schema stays additive-only as new kinds land.
 
 R3.5 adds the `code` kind's fields (code/language): populated for kind=="code"
 rows, defaulted (empty string) for every other kind, same additive rule.
+
+R3.9 adds the `document` kind's fields (attachmentKind/filePath/mimeType/
+durationSeconds/byteSize/previewLabel - the DocumentNode attachment
+metadata): populated for kind=="document" rows, defaulted (empty
+string/None) for every other kind, same additive rule.
 """
 
 from __future__ import annotations
@@ -38,6 +43,15 @@ class SceneNodeRow:
     # rows, defaulted (empty string) for every other kind.
     code: str = ""
     language: str = ""
+    # R3.9: the document node's real persisted shape (attachment metadata) -
+    # populated for kind=="document" rows, defaulted (empty string/None) for
+    # every other kind.
+    attachmentKind: str = ""
+    filePath: str = ""
+    mimeType: str = ""
+    durationSeconds: float | None = None
+    byteSize: int | None = None
+    previewLabel: str = ""
 
 
 @dataclass

--- a/web_ui/src/app/canvas/DocumentNodeView.test.tsx
+++ b/web_ui/src/app/canvas/DocumentNodeView.test.tsx
@@ -1,0 +1,263 @@
+import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DocumentNodeView,
+  formatByteSize,
+  formatDuration,
+  shouldShowAudioPreview,
+  type DocumentFlowNode,
+} from "./DocumentNodeView";
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
+// ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too.
+function renderDocumentNode(overrides: Partial<DocumentFlowNode["data"]> = {}) {
+  const onToggleCollapse = vi.fn();
+  const onDelete = vi.fn();
+  const props = {
+    id: "n0",
+    selected: false,
+    data: {
+      title: "notes.pdf",
+      content: "Quarterly figures attached.",
+      attachmentKind: "document",
+      filePath: "",
+      mimeType: "",
+      durationSeconds: null,
+      byteSize: null,
+      previewLabel: "",
+      isCollapsed: false,
+      onToggleCollapse,
+      onDelete,
+      ...overrides,
+    },
+  } as unknown as NodeProps<DocumentFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <DocumentNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return { onToggleCollapse, onDelete };
+}
+
+describe("formatByteSize (ported DocumentNode._format_byte_size)", () => {
+  it("is Unknown for null/zero", () => {
+    expect(formatByteSize(null)).toBe("Unknown");
+    expect(formatByteSize(0)).toBe("Unknown");
+  });
+
+  it("renders whole bytes with no decimal", () => {
+    expect(formatByteSize(512)).toBe("512 B");
+  });
+
+  it("renders KB/MB with one decimal place", () => {
+    expect(formatByteSize(2048)).toBe("2.0 KB");
+    expect(formatByteSize(5 * 1024 * 1024)).toBe("5.0 MB");
+  });
+});
+
+describe("formatDuration (ported graphlink_audio.format_duration)", () => {
+  it("is Unknown for null", () => {
+    expect(formatDuration(null)).toBe("Unknown");
+  });
+
+  it("renders M:SS under an hour", () => {
+    expect(formatDuration(65)).toBe("1:05");
+  });
+
+  it("renders H:MM:SS once an hour is reached", () => {
+    expect(formatDuration(3725)).toBe("1:02:05");
+  });
+});
+
+describe("shouldShowAudioPreview (ported DocumentNode._should_show_audio_preview)", () => {
+  it("shows a real transcript that differs from the audio-details block", () => {
+    const audioDetails = "Audio attachment\nDuration: 1:05\nFormat: audio/mpeg";
+    expect(shouldShowAudioPreview("Here is what the speaker said...", audioDetails)).toBe(true);
+  });
+
+  it("suppresses when content is empty", () => {
+    expect(shouldShowAudioPreview("   ", "Audio attachment")).toBe(false);
+  });
+
+  it("suppresses when content exactly matches the freshly-built audio details", () => {
+    const audioDetails = "Audio attachment\nDuration: 1:05";
+    expect(shouldShowAudioPreview(audioDetails, audioDetails)).toBe(false);
+  });
+
+  it("legacy-compat: suppresses an old saved session's persisted metadata block even if it no longer matches verbatim", () => {
+    // Old session persisted just "Audio attachment\nDuration: 0:45" as
+    // content; today's freshly-built details string has grown a Format
+    // line the old session never recorded, so they no longer match
+    // byte-for-byte - the special-case rule must still catch this.
+    const legacyContent = "Audio attachment\nDuration: 0:45";
+    const freshAudioDetails = "Audio attachment\nDuration: 0:45\nFormat: audio/wav";
+    expect(shouldShowAudioPreview(legacyContent, freshAudioDetails)).toBe(false);
+  });
+});
+
+describe("DocumentNodeView", () => {
+  it("renders the title and correctly formatted metadata rows", () => {
+    renderDocumentNode({
+      title: "quarterly-report.pdf",
+      attachmentKind: "document",
+      mimeType: "application/pdf",
+      byteSize: 2048,
+      filePath: "C:/docs/quarterly-report.pdf",
+      durationSeconds: null,
+    });
+    expect(screen.getByText("quarterly-report.pdf")).toBeInTheDocument();
+    expect(screen.getByText("Document")).toBeInTheDocument();
+    expect(screen.getByText("application/pdf")).toBeInTheDocument();
+    expect(screen.getByText("2.0 KB")).toBeInTheDocument();
+    expect(screen.getByText("C:/docs/quarterly-report.pdf")).toBeInTheDocument();
+    // Duration is gated on durationSeconds being populated, not on kind.
+    expect(screen.queryByText("Duration")).toBeNull();
+  });
+
+  it("shows Duration and Audio file type for audio metadata", () => {
+    renderDocumentNode({
+      title: "clip.mp3",
+      attachmentKind: "audio",
+      content: "Full transcript of the recording goes here.",
+      durationSeconds: 65,
+      mimeType: "audio/mpeg",
+    });
+    expect(screen.getByText("Audio file")).toBeInTheDocument();
+    expect(screen.getByText("1:05")).toBeInTheDocument();
+  });
+
+  it("shows the content preview panel for document kind", () => {
+    renderDocumentNode({ attachmentKind: "document", content: "Quarterly figures attached." });
+    expect(screen.getByText("Contents")).toBeInTheDocument();
+    expect(screen.getByText("Quarterly figures attached.")).toBeInTheDocument();
+  });
+
+  it("shows the content preview for audio kind when content is a real transcript", () => {
+    renderDocumentNode({
+      attachmentKind: "audio",
+      content: "Speaker: hello, this is the actual transcript.",
+      durationSeconds: 65,
+    });
+    expect(screen.getByText("Contents")).toBeInTheDocument();
+    expect(screen.getByText("Speaker: hello, this is the actual transcript.")).toBeInTheDocument();
+  });
+
+  it("suppresses the content preview for audio kind per the legacy-compat rule", () => {
+    renderDocumentNode({
+      attachmentKind: "audio",
+      // Old saved session persisted just the bare legacy metadata block as
+      // content; today's freshly-built audio-details string has since grown
+      // a Format line the old session never recorded (mimeType below), so a
+      // plain equality check would NOT catch this - only the startsWith
+      // "audio attachment" + "duration:" special-case rule does.
+      content: "Audio attachment\nDuration: 1:05",
+      durationSeconds: 65,
+      mimeType: "audio/mpeg",
+    });
+    expect(screen.queryByText("Contents")).toBeNull();
+  });
+
+  it("the inline collapse button calls onToggleCollapse", async () => {
+    const user = userEvent.setup();
+    const { onToggleCollapse } = renderDocumentNode();
+    await user.click(screen.getByRole("button", { name: "Collapse" }));
+    expect(onToggleCollapse).toHaveBeenCalledOnce();
+  });
+
+  it("hides the body when isCollapsed is true", () => {
+    renderDocumentNode({ isCollapsed: true, content: "Quarterly figures attached." });
+    expect(screen.queryByText("Quarterly figures attached.")).toBeNull();
+  });
+
+  it("right-click opens a menu with real Copy Details/Collapse/Delete Attachment and honest disabled placeholders", async () => {
+    const user = userEvent.setup();
+    const { onDelete } = renderDocumentNode({ attachmentKind: "document", filePath: "" });
+
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    const title = screen.getByText("notes.pdf");
+    fireEvent.contextMenu(title);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    const dock = screen.getByRole("menuitem", { name: "Dock into Parent Node" });
+    expect(dock).toBeDisabled();
+    expect(dock).toHaveAttribute("title", "Docking into the parent node's badge isn't built yet");
+
+    const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
+    expect(hideBranches).toBeDisabled();
+    expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
+
+    const exportItem = screen.getByRole("menuitem", { name: "Export" });
+    expect(exportItem).toBeDisabled();
+    expect(exportItem).toHaveAttribute("title", "Export lands in R6");
+
+    // filePath is empty -> Open File must be entirely absent, matching the
+    // legacy menu's own conditional (only added when file_path is set).
+    expect(screen.queryByRole("menuitem", { name: "Open File" })).toBeNull();
+
+    await user.click(screen.getByRole("menuitem", { name: "Copy Details" }));
+    expect(writeText).toHaveBeenCalledWith("Quarterly figures attached.");
+
+    fireEvent.contextMenu(title);
+    await user.click(screen.getByRole("menuitem", { name: "Collapse to Pill" }));
+    expect(screen.queryByRole("menu")).toBeNull(); // the menu closes after any item fires
+
+    fireEvent.contextMenu(title);
+    await user.click(screen.getByRole("menuitem", { name: "Delete Attachment" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("shows Open File when filePath is set, and reads 'Delete Audio Attachment' + no Export for audio kind", async () => {
+    const user = userEvent.setup();
+    const { onDelete } = renderDocumentNode({
+      attachmentKind: "audio",
+      filePath: "C:/audio/clip.mp3",
+      content: "Speaker: a real transcript.",
+      durationSeconds: 65,
+    });
+
+    const title = screen.getByText("notes.pdf");
+    fireEvent.contextMenu(title);
+
+    const openFile = screen.getByRole("menuitem", { name: "Open File" });
+    expect(openFile).toBeDisabled();
+    expect(openFile).toHaveAttribute(
+      "title",
+      "Opening local files needs a new backend endpoint - browsers can't open arbitrary local paths",
+    );
+
+    // attachmentKind "audio" -> Export must be entirely absent, matching the
+    // legacy menu's own conditional (export submenu only added for "document").
+    expect(screen.queryByRole("menuitem", { name: "Export" })).toBeNull();
+
+    await user.click(screen.getByRole("menuitem", { name: "Delete Audio Attachment" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("hides Export for a non-audio, non-document kind (legacy gate is `== \"document\"`, not `!= \"audio\"`)", async () => {
+    renderDocumentNode({ attachmentKind: "unknown", filePath: "" });
+    const title = screen.getByText("notes.pdf");
+    fireEvent.contextMenu(title);
+    expect(screen.queryByRole("menuitem", { name: "Export" })).toBeNull();
+  });
+
+  it("Escape and outside-click both close the menu", async () => {
+    const user = userEvent.setup();
+    renderDocumentNode();
+    const title = screen.getByText("notes.pdf");
+
+    fireEvent.contextMenu(title);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(title);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/DocumentNodeView.tsx
+++ b/web_ui/src/app/canvas/DocumentNodeView.tsx
@@ -1,0 +1,357 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+
+/**
+ * The document node (Qt-removal plan R3.9/R3.10) - graphlink_node_document.py's
+ * React successor: an uploaded-file-attachment card (document or audio),
+ * push-only same as chat/code. Unlike code, DocumentNode has a real manual
+ * collapse toggle (mirrors ChatNode's LOD-OR-manual pattern). Unlike both
+ * chat and code, a document node can never exist without a parent - the
+ * backend's add_document_node requires parent_id.
+ *
+ * Real: render (metadata rows + gated content preview), collapse/expand,
+ * delete, copy. Deferred, with an honest disabled+title label rather than a
+ * silently-dropped action (see the R3.7-era audit this increment is
+ * following up on): Dock into Parent Node (needs the shared parent-badge/
+ * docking mechanism - not built), Open File (needs a new backend endpoint;
+ * browsers cannot open arbitrary local paths), Export (R6, document-kind
+ * only - matches the legacy menu's own conditional), Hide Other Branches
+ * (branch visibility isn't built yet).
+ */
+
+export interface DocumentNodeData extends Record<string, unknown> {
+  title: string;
+  content: string;
+  /** "document" | "audio" (freeform string on the wire, same convention as
+   * every other scene-node "kind"-like field). */
+  attachmentKind: string;
+  filePath: string;
+  mimeType: string;
+  durationSeconds: number | null;
+  byteSize: number | null;
+  /** Carried through from the backend contract (graphlink_node_document.py's
+   * preview_label - the collapsed-pill subtitle / future docked-badge text
+   * upstream). Not yet surfaced in this increment's render: the spec's
+   * header requirement is "just a title label", and docking (the feature
+   * that would consume it) is still a disabled placeholder below. Kept on
+   * the data shape rather than dropped, so nothing here is a silent field
+   * omission - it is simply unused by the UI *yet*. */
+  previewLabel: string;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+}
+
+export type DocumentFlowNode = Node<DocumentNodeData, "document">;
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+// -- ported legacy formatting/heuristic rules (graphlink_node_document.py) --
+
+/** Ports DocumentNode._format_byte_size() verbatim: falsy byte_size (None or
+ * 0) is "Unknown"; whole bytes have no decimal; every larger unit is one
+ * decimal place; TB is the terminal unit regardless of magnitude. */
+export function formatByteSize(byteSize: number | null): string {
+  if (!byteSize) return "Unknown";
+  let size = byteSize;
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  for (const unit of units) {
+    if (size < 1024 || unit === "TB") {
+      return unit === "B" ? `${Math.trunc(size)} ${unit}` : `${size.toFixed(1)} ${unit}`;
+    }
+    size /= 1024;
+  }
+  return `${Math.trunc(byteSize)} B`; // unreachable - mirrors the legacy fallback line
+}
+
+/** Ports graphlink_audio.format_duration() verbatim: H:MM:SS once an hour is
+ * reached, otherwise M:SS (no leading zero on the leftmost unit). */
+export function formatDuration(seconds: number | null): string {
+  if (seconds === null) return "Unknown";
+  const totalSeconds = Math.max(0, Math.round(seconds));
+  const hours = Math.floor(totalSeconds / 3600);
+  const remainder = totalSeconds % 3600;
+  const minutes = Math.floor(remainder / 60);
+  const secs = remainder % 60;
+  const pad2 = (n: number) => String(n).padStart(2, "0");
+  return hours ? `${hours}:${pad2(minutes)}:${pad2(secs)}` : `${minutes}:${pad2(secs)}`;
+}
+
+/** Ports DocumentNode._normalize_preview_text() verbatim: strip the whole
+ * string, split into lines, rstrip each line, rejoin, strip again, lowercase. */
+function normalizePreviewText(value: string): string {
+  const stripped = (value || "").trim();
+  const lines = stripped.split(/\r\n|\r|\n/).map((line) => line.replace(/\s+$/, ""));
+  return lines.join("\n").trim().toLowerCase();
+}
+
+/** Ports DocumentNode._build_audio_details() verbatim: the freshly-built
+ * "what this attachment is" string the content gets compared against. */
+function buildAudioDetails(fields: {
+  durationSeconds: number | null;
+  mimeType: string;
+  byteSize: number | null;
+  filePath: string;
+}): string {
+  const lines = ["Audio attachment"];
+  if (fields.durationSeconds !== null) lines.push(`Duration: ${formatDuration(fields.durationSeconds)}`);
+  if (fields.mimeType) lines.push(`Format: ${fields.mimeType}`);
+  if (fields.byteSize) lines.push(`Size: ${formatByteSize(fields.byteSize)}`);
+  if (fields.filePath) lines.push(`Path: ${fields.filePath}`);
+  return lines.join("\n");
+}
+
+/** Ports DocumentNode._should_show_audio_preview() verbatim, including the
+ * legacy-compat special case: older saved sessions persisted the metadata
+ * block itself as the node's content, and that shape must still suppress
+ * the preview even though today's freshly-built audio-details string might
+ * not be a byte-for-byte match (e.g. a mime type the old session lacked). */
+export function shouldShowAudioPreview(content: string, audioDetails: string): boolean {
+  const normalizedContent = normalizePreviewText(content);
+  if (!normalizedContent) return false;
+
+  const normalizedDetails = normalizePreviewText(audioDetails);
+  if (normalizedContent === normalizedDetails) return false;
+
+  if (normalizedContent.startsWith("audio attachment") && normalizedContent.includes("duration:")) {
+    return false;
+  }
+
+  return true;
+}
+
+/** Combines the legacy's two gates for whether the "Contents" preview panel
+ * renders at all: content must be non-empty after trimming (true for both
+ * kinds - DocumentNode._show_preview_content defaults True for "document"
+ * but an empty preview_text still suppresses the panel), and for "audio"
+ * kind specifically, the suppression heuristic above must also pass. */
+export function shouldShowContentPreview(attachmentKind: string, content: string, audioDetails: string): boolean {
+  if (!content.trim()) return false;
+  if (attachmentKind !== "audio") return true;
+  return shouldShowAudioPreview(content, audioDetails);
+}
+
+/** Ports DocumentNode._build_metadata_rows() verbatim: Type always first,
+ * then Duration/Format/Size/Path each gated on its own field being
+ * populated (falsy-checked exactly like the Python, not gated on kind). */
+export function buildMetadataRows(fields: {
+  attachmentKind: string;
+  durationSeconds: number | null;
+  mimeType: string;
+  byteSize: number | null;
+  filePath: string;
+}): Array<{ label: string; value: string }> {
+  const rows: Array<{ label: string; value: string }> = [
+    { label: "Type", value: fields.attachmentKind === "audio" ? "Audio file" : "Document" },
+  ];
+  if (fields.durationSeconds !== null) rows.push({ label: "Duration", value: formatDuration(fields.durationSeconds) });
+  if (fields.mimeType) rows.push({ label: "Format", value: fields.mimeType });
+  if (fields.byteSize) rows.push({ label: "Size", value: formatByteSize(fields.byteSize) });
+  if (fields.filePath) rows.push({ label: "Path", value: fields.filePath });
+  return rows;
+}
+
+// -- menu --------------------------------------------------------------
+
+function DocumentNodeMenu({
+  position,
+  content,
+  attachmentKind,
+  filePath,
+  isCollapsed,
+  onToggleCollapse,
+  onDelete,
+  onClose,
+}: {
+  position: MenuPosition;
+  content: string;
+  attachmentKind: string;
+  filePath: string;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
+      // type-only import above shadows the bare name for casts like this).
+      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [onClose]);
+
+  const isAudio = attachmentKind === "audio";
+  // Legacy gate is `attachment_kind == "document"` (a strict allow-list), not
+  // "not audio" - the two diverge for any other/malformed kind value (e.g. a
+  // corrupted saved session). Keep the same strict check here rather than
+  // `!isAudio`, which would show the Export placeholder for a kind the
+  // legacy menu would never have added it for.
+  const isDocumentKind = attachmentKind === "document";
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      {/* Order verified against graphlink_node_document_menu.py's own
+          construction order: Copy Details, Collapse/Expand, Dock, Open File
+          (conditional), separator, Export (conditional), Hide Other
+          Branches, Delete. */}
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          navigator.clipboard.writeText(content);
+          onClose();
+        }}
+      >
+        Copy Details
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleCollapse();
+          onClose();
+        }}
+      >
+        {isCollapsed ? "Expand Attachment" : "Collapse to Pill"}
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        disabled
+        title="Docking into the parent node's badge isn't built yet"
+      >
+        Dock into Parent Node
+      </button>
+      {filePath && (
+        <button
+          type="button"
+          role="menuitem"
+          disabled
+          title="Opening local files needs a new backend endpoint - browsers can't open arbitrary local paths"
+        >
+          Open File
+        </button>
+      )}
+      <div className="chat-node-menu-separator" role="separator" />
+      {isDocumentKind && (
+        <button type="button" role="menuitem" disabled title="Export lands in R6">
+          Export
+        </button>
+      )}
+      <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
+        Hide Other Branches
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        {isAudio ? "Delete Audio Attachment" : "Delete Attachment"}
+      </button>
+    </div>
+  );
+}
+
+// -- view ----------------------------------------------------------------
+
+export function DocumentNodeView({ data, selected }: NodeProps<DocumentFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const collapsed = data.isCollapsed || lodCollapsed;
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+
+  const isAudio = data.attachmentKind === "audio";
+  const audioDetails = buildAudioDetails({
+    durationSeconds: data.durationSeconds,
+    mimeType: data.mimeType,
+    byteSize: data.byteSize,
+    filePath: data.filePath,
+  });
+  const showPreview = shouldShowContentPreview(data.attachmentKind, data.content, audioDetails);
+  const metadataRows = buildMetadataRows({
+    attachmentKind: data.attachmentKind,
+    durationSeconds: data.durationSeconds,
+    mimeType: data.mimeType,
+    byteSize: data.byteSize,
+    filePath: data.filePath,
+  });
+  const fallbackTitle = isAudio ? "Audio Attachment" : "File Attachment";
+
+  return (
+    <div
+      className={`scene-node document-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title chat-node-role">
+        <span>{data.title || fallbackTitle}</span>
+        <button
+          type="button"
+          className="chat-node-collapse-btn"
+          aria-label={data.isCollapsed ? "Expand" : "Collapse"}
+          onClick={data.onToggleCollapse}
+        >
+          {data.isCollapsed ? "▸" : "▾"}
+        </button>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body document-node-content">
+          <dl className="document-node-metadata">
+            {metadataRows.map((row) => (
+              <div className="document-node-metadata-row" key={row.label}>
+                <dt>{row.label}</dt>
+                <dd>{row.value}</dd>
+              </div>
+            ))}
+          </dl>
+          {showPreview && (
+            <div className="document-node-preview">
+              <p className="document-node-preview-label">Contents</p>
+              <pre className="document-node-preview-text">{data.content.trim()}</pre>
+            </div>
+          )}
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+      {menuPosition && (
+        <DocumentNodeMenu
+          position={menuPosition}
+          content={data.content}
+          attachmentKind={data.attachmentKind}
+          filePath={data.filePath}
+          isCollapsed={data.isCollapsed}
+          onToggleCollapse={data.onToggleCollapse}
+          onDelete={data.onDelete}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
 import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
 import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
+import { DocumentNodeView, type DocumentFlowNode } from "./DocumentNodeView";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { SceneStore, scaleDragPosition } from "./sceneStore";
 
@@ -38,7 +39,7 @@ const GRID_VARIANTS: Record<string, BackgroundVariant> = {
 };
 
 type PlaceholderNode = Node<{ title: string }, "placeholder">;
-type SceneFlowNode = PlaceholderNode | ChatFlowNode | CodeFlowNode;
+type SceneFlowNode = PlaceholderNode | ChatFlowNode | CodeFlowNode | DocumentFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   const zoom = useStore((s) => s.transform[2]);
@@ -56,7 +57,12 @@ function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   );
 }
 
-const NODE_TYPES = { placeholder: PlaceholderNodeView, chat: ChatNodeView, code: CodeNodeView };
+const NODE_TYPES = {
+  placeholder: PlaceholderNodeView,
+  chat: ChatNodeView,
+  code: CodeNodeView,
+  document: DocumentNodeView,
+};
 
 function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
   return scene.nodes.map((n) => {
@@ -82,6 +88,37 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
         data: {
           code: n.code,
           language: n.language,
+          onDelete: () => store.removeNodes([n.id]),
+        },
+      };
+    }
+    if (n.kind === "document") {
+      return {
+        id: n.id,
+        type: "document" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          title: n.title,
+          content: n.content,
+          attachmentKind: n.attachmentKind,
+          filePath: n.filePath,
+          mimeType: n.mimeType,
+          // Generated SceneNodeRow marks these `?: number | null` (optional
+          // Python field), so the read can be `undefined`; DocumentNodeData
+          // is strictly `number | null` (matches the wire value, which is
+          // always present - the backend dataclass always serializes both
+          // keys). Coalesce here rather than loosening DocumentNodeData.
+          durationSeconds: n.durationSeconds ?? null,
+          byteSize: n.byteSize ?? null,
+          previewLabel: n.previewLabel,
+          isCollapsed: n.isCollapsed,
+          // setChatCollapsed's backend handler (backend/canvas.py) looks up
+          // ANY node by id and sets is_collapsed - it does not special-case
+          // "chat" kind despite the intent's name - so it is reused here
+          // as-is rather than inventing a setDocumentCollapsed intent the
+          // backend doesn't register. See this increment's report for the
+          // full reasoning.
+          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
           onDelete: () => store.removeNodes([n.id]),
         },
       };

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -36,6 +36,10 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         isCollapsed: false,
         code: "",
         language: "",
+        attachmentKind: "",
+        filePath: "",
+        mimeType: "",
+        previewLabel: "",
       },
     ],
     edges: [],
@@ -137,6 +141,43 @@ describe("SceneStore", () => {
     expect(intents).toEqual([
       { topic: "scene", intent: "addCodeNode", args: [10, 20, "print('hi')", "python"] },
       { topic: "scene", intent: "addCodeNode", args: [30, 40, "console.log('hi')", "javascript", "n1"] },
+    ]);
+  });
+
+  it("sends document-node intents with the backend's registered names and shapes", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.addDocumentNode(10, 20, "notes.pdf", "some content", "document", "n1");
+    store.addDocumentNode(30, 40, "clip.mp3", "", "audio", "n1", {
+      filePath: "C:/audio/clip.mp3",
+      mimeType: "audio/mpeg",
+      durationSeconds: 125,
+      byteSize: 48000,
+      previewLabel: "Audio | 2:05",
+    });
+    expect(intents).toEqual([
+      {
+        topic: "scene",
+        intent: "addDocumentNode",
+        args: [10, 20, "notes.pdf", "some content", "document", "n1", "", "", null, null, ""],
+      },
+      {
+        topic: "scene",
+        intent: "addDocumentNode",
+        args: [
+          30,
+          40,
+          "clip.mp3",
+          "",
+          "audio",
+          "n1",
+          "C:/audio/clip.mp3",
+          "audio/mpeg",
+          125,
+          48000,
+          "Audio | 2:05",
+        ],
+      },
     ]);
   });
 

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -145,6 +145,58 @@ export class SceneStore {
     this.transport.intent("scene", "setChatCollapsed", [id, collapsed]);
   }
 
+  // R3.9/R3.10: real document nodes (attachments). Unlike chat/code,
+  // parentId is REQUIRED - the backend's add_document_node signature has no
+  // default for it (a document node can never exist without a parent chat
+  // node in the legacy app). The five backend keyword-only fields
+  // (file_path/mime_type/duration_seconds/byte_size/preview_label) are
+  // bundled into one optional `options` object rather than five trailing
+  // optional parameters: unlike addChatNode/addCodeNode's single optional
+  // trailing parentId (conditionally omitted from the wire args so the
+  // backend's own default kicks in), omitting only SOME of five trailing
+  // positional slots while supplying a later one is not well-formed over
+  // dispatch_intent's plain `handler(*args)` positional call - so this
+  // always sends the full 11-arg positional list, filling any field the
+  // caller didn't supply with the exact same default the backend method
+  // itself uses. Same intent name reused for collapse - see setChatCollapsed
+  // below this method's call sites in SceneCanvas.tsx for why.
+  addDocumentNode(
+    x: number,
+    y: number,
+    title: string,
+    content: string,
+    attachmentKind: string,
+    parentId: string,
+    options: {
+      filePath?: string;
+      mimeType?: string;
+      durationSeconds?: number | null;
+      byteSize?: number | null;
+      previewLabel?: string;
+    } = {},
+  ): void {
+    const {
+      filePath = "",
+      mimeType = "",
+      durationSeconds = null,
+      byteSize = null,
+      previewLabel = "",
+    } = options;
+    this.transport.intent("scene", "addDocumentNode", [
+      x,
+      y,
+      title,
+      content,
+      attachmentKind,
+      parentId,
+      filePath,
+      mimeType,
+      durationSeconds,
+      byteSize,
+      previewLabel,
+    ]);
+  }
+
   // R3.3: the Composer's real Send action - a real user ChatNode. The
   // assistant's reply is deferred to R4 (graphlink_config.py's Qt/non-Qt
   // split is a prerequisite for calling the real agent layer); the backend

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -581,6 +581,91 @@ body,
   margin-bottom: 0;
 }
 
+/* -- R3.9/R3.10 document node ---------------------------------------------- */
+
+.document-node {
+  width: 420px;
+  max-height: 640px;
+  min-height: 110px;
+}
+
+.document-node.collapsed {
+  width: 290px;
+  min-height: 58px;
+}
+
+.document-node-content {
+  max-height: 560px;
+  overflow-y: auto;
+}
+
+/* Label/value pairs, 2-column grid (dt/dd) - the 88px label column mirrors
+   the legacy scene's own td.meta-label width (graphlink_node_document.py's
+   _setup_document stylesheet). */
+.document-node-metadata {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 0 10px 0;
+}
+
+.document-node-metadata-row {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: 10px;
+}
+
+.document-node-metadata-row dt {
+  margin: 0;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--gl-surface-text-muted);
+  white-space: nowrap;
+}
+
+.document-node-metadata-row dd {
+  margin: 0;
+  color: var(--gl-surface-text);
+  word-break: break-word;
+}
+
+/* The gated "Contents" preview panel - a plain preformatted block (not
+   markdown), so it does not reuse .chat-node-content's markdown-body rules;
+   colors/spacing still reuse the shared surface tokens. */
+.document-node-preview-label {
+  margin: 0 0 6px 0;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--gl-surface-text-muted);
+}
+
+.document-node-preview {
+  padding: 10px 12px;
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 10px;
+}
+
+.document-node-preview-text {
+  margin: 0;
+  color: var(--gl-surface-text-muted);
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Reuses .chat-node-menu/-danger (see the R3.1/R3.2 section above) - this
+   adds only the separator DocumentNodeMenu needs that chat/code's menus
+   never did (their menus have no grouped sections). */
+.chat-node-menu-separator {
+  height: 1px;
+  margin: 4px 2px;
+  background-color: var(--gl-surface-border);
+}
+
 /* -- R2 app bar + overlay system ----------------------------------------- */
 
 .app-topbar {

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -44,10 +44,22 @@
       "items": {
         "additionalProperties": false,
         "properties": {
+          "attachmentKind": {
+            "type": "string"
+          },
+          "byteSize": {
+            "type": "integer"
+          },
           "code": {
             "type": "string"
           },
           "content": {
+            "type": "string"
+          },
+          "durationSeconds": {
+            "type": "number"
+          },
+          "filePath": {
             "type": "string"
           },
           "id": {
@@ -63,6 +75,12 @@
             "type": "string"
           },
           "language": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "previewLabel": {
             "type": "string"
           },
           "title": {
@@ -85,7 +103,11 @@
           "isUser",
           "isCollapsed",
           "code",
-          "language"
+          "language",
+          "attachmentKind",
+          "filePath",
+          "mimeType",
+          "previewLabel"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -13,6 +13,12 @@ export interface SceneNodeRow {
   isCollapsed: boolean;
   code: string;
   language: string;
+  attachmentKind: string;
+  filePath: string;
+  mimeType: string;
+  durationSeconds?: number | null;
+  byteSize?: number | null;
+  previewLabel: string;
 }
 
 export interface SceneEdgeRow {
@@ -109,6 +115,34 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["language"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.language: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.language` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["attachmentKind"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.attachmentKind: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.attachmentKind` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["filePath"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.filePath: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.filePath` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["mimeType"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.mimeType: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.mimeType` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["durationSeconds"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.durationSeconds` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["byteSize"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.byteSize` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["previewLabel"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.previewLabel: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.previewLabel` + ": expected string"); }
   }
 }
 


### PR DESCRIPTION
## Summary
- Backend: `SceneNode`/`SceneNodeRow` gain six additive attachment fields (`attachment_kind`/`file_path`/`mime_type`/`duration_seconds`/`byte_size`/`preview_label`). `SceneDocument.add_document_node` **requires** `parent_id` (unlike chat/code's optional parent) - a legacy `DocumentNode` can never exist without a parent chat node, confirmed against `graphlink_scene.py`'s only construction call site. No `delete_document_node` - document nodes are never branch points, deletion goes through the existing generic `remove_nodes`.
- Frontend: `DocumentNodeView.tsx` ports three pieces of legacy logic **verbatim** into TypeScript rather than approximating them: byte-size formatting, duration formatting, and the audio-preview-suppression heuristic (including its legacy-compat special case for old saved sessions whose content string starts with "audio attachment" and contains "duration:"). This is the first node type whose rendering correctness depends on faithfully reproducing old-session data quirks. Manual collapse (OR'd with LOD, like chat) reuses the existing `setChatCollapsed` intent generically - confirmed by reading the backend method directly, it looks up any node by id regardless of kind despite its name.
- Menu: Copy Details/Collapse-Expand/Delete real (delete label switches "Delete Attachment"/"Delete Audio Attachment" per the legacy conditional); Dock into Parent/Open File/Export/Hide Other Branches disabled+titled, with Open File and Export each conditionally rendered only when the legacy's own preconditions hold (a real file path present; document-kind only, never audio).
- **Built with a dedicated legacy-menu-parity audit baked into the review process from the start** this time - a separate fix earlier today ([#106](https://github.com/dovvnloading/Graphlink/pull/106)) found ChatNode/CodeNode had silently dropped several legacy menu items without honest disabled+title acknowledgment. This time the same check ran *before* ship, as a 4th dedicated reviewer alongside backend/frontend/integration reviews, and caught + fixed a real gap: the Export menu item was gated on `!isAudio` ("show unless audio") instead of the legacy's exact `attachment_kind === "document"` allow-list - functionally identical today (only "document"/"audio" values exist) but an approximation gap that would misbehave on a malformed/corrupted saved session with any other stored value. Fixed with a regression test.
- A separate integration-review pass also caught and fixed a `tsc` type mismatch (generated `durationSeconds`/`byteSize` are optional; the component's props were declared strict non-optional).

## Test plan
- [x] `python -m pytest -q` (repo-wide): 1868 passed
- [x] `npm run check` (schema/typecheck/lint/test/build): all green, 627 vitest passing
- [x] Live drive against the real running backend: created a real parent ChatNode then a real DocumentNode attached to it via direct WS intents (no UI trigger exists yet, same reasoning as CodeNode - real creation needs a native file-picker attachment flow, not yet built), confirmed the SPA rendered the correct title, metadata grid (Type/Format/Size/Path, correctly formatted - "448.0 KB" for 458752 bytes), and content preview; fired `setChatCollapsed` against the node and confirmed the real backend-authoritative collapse round-tripped into the DOM; fired `removeNodes` and confirmed the SPA reflected the deletion
- [x] Context-menu/click interaction covered by `DocumentNodeView.test.tsx`'s direct-render unit tests - not exercised live this round due to the same browser-pane compositing limitation documented in the prior two node-type PRs

Remaining in R3 (not this PR): thinking/HTML-view/image node types, and the `ConversationNode` fast-follow.