### PR TITLE
Qt-removal R3.13/R3.14: real ThinkingNode + shared docked-child system

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -80,6 +80,9 @@ CHAT_TITLE_PREVIEW_LENGTH = 60
 # R3.5: code titles are a language label plus first line, not prose, so a
 # shorter preview than chat's 60 is plenty.
 CODE_TITLE_PREVIEW_LENGTH = 40
+# R3.13: thinking-node titles are prose (a preview of the reasoning text),
+# same as chat's, so it reuses chat's 60-char length rather than code's 40.
+THINKING_TITLE_PREVIEW_LENGTH = 60
 
 
 @dataclass
@@ -156,6 +159,12 @@ class SceneNode:
     duration_seconds: float | None = None
     byte_size: int | None = None
     preview_label: str = ""
+    # R3.13 (doc/QT_REMOVAL_PLAN.md): the ThinkingNode/docked-child increment -
+    # whether this node is currently docked into its parent's collapsed
+    # docked-child slot. A parent's set of docked children is derived at read
+    # time from this flag (scan nodes whose parent edge points at it), never
+    # stored on the parent itself. Unused (default) for every other kind.
+    is_docked: bool = False
 
 
 @dataclass
@@ -327,6 +336,45 @@ class SceneDocument:
         self.connect(parent_id, node_id)
         return node
 
+    def add_thinking_node(
+        self,
+        x: float,
+        y: float,
+        thinking_text: str,
+        parent_id: str,
+    ) -> SceneNode:
+        """R3.13's ThinkingNode equivalent of add_chat_node/add_code_node/
+        add_document_node: a real reasoning-panel node. Same as
+        add_document_node (and unlike chat/code), parent_id is REQUIRED, not
+        optional - a ThinkingNode never exists unparented - so this
+        unconditionally connects to its parent, no `if parent_id` guard.
+
+        Thinking text reuses the existing `content` field rather than a new
+        one - there is no separate thinking-text field. `is_docked` defaults
+        to False: a freshly-created thinking node is never pre-docked: dock()
+        is only ever invoked by explicit user action or on session-load
+        restore, never at construction time.
+
+        Thinking nodes are also NOT branch points (same as code/document):
+        there is no delete_thinking_node; deletion goes entirely through the
+        existing generic remove_nodes.
+        """
+        if parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        title = str(thinking_text)[:THINKING_TITLE_PREVIEW_LENGTH] or "Thinking"
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title=title,
+            kind="thinking",
+            content=str(thinking_text),
+        )
+        self.nodes[node_id] = node
+        self.connect(parent_id, node_id)
+        return node
+
     def delete_chat_node(self, node_id: str) -> None:
         """Delete one chat node WITHOUT orphaning its branch: children are
         re-parented to the deleted node's own parent (or become roots if it
@@ -377,6 +425,16 @@ class SceneDocument:
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
         node.is_collapsed = bool(collapsed)
+
+    def set_node_docked(self, node_id: str, docked: bool) -> None:
+        """R3.13: a single generic setter handling both dock (docked=True)
+        and undock (docked=False) - mirrors set_chat_collapsed's generic-
+        setter shape (despite its kind-specific name, it looks up ANY node by
+        id with no kind restriction)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.is_docked = bool(docked)
 
     def move_node(self, node_id: str, x: float, y: float) -> SceneNode:
         node = self.nodes.get(node_id)
@@ -462,6 +520,7 @@ class SceneDocument:
                     "durationSeconds": n.duration_seconds,
                     "byteSize": n.byte_size,
                     "previewLabel": n.preview_label,
+                    "isDocked": n.is_docked,
                 }
                 for n in self.nodes.values()
             ],
@@ -583,6 +642,15 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
         await publish_scene()
         return node.id
 
+    async def add_thinking_node(x, y, thinking_text, parent_id):
+        node = document.add_thinking_node(x, y, thinking_text, parent_id)
+        await publish_scene()
+        return node.id
+
+    async def set_node_docked(node_id, docked):
+        document.set_node_docked(node_id, docked)
+        await publish_scene()
+
     async def delete_chat_node(node_id):
         document.delete_chat_node(node_id)
         await publish_scene()
@@ -655,6 +723,8 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
     bus.register_intent("scene", "addChatNode", add_chat_node)
     bus.register_intent("scene", "addCodeNode", add_code_node)
     bus.register_intent("scene", "addDocumentNode", add_document_node)
+    bus.register_intent("scene", "addThinkingNode", add_thinking_node)
+    bus.register_intent("scene", "setNodeDocked", set_node_docked)
     bus.register_intent("scene", "deleteChatNode", delete_chat_node)
     bus.register_intent("scene", "setChatCollapsed", set_chat_collapsed)
     bus.register_intent("scene", "sendMessage", send_message)

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -326,6 +326,116 @@ def test_document_node_deletion_goes_through_the_generic_remove_nodes_path():
     assert not any(e.target == node.id or e.source == node.id for e in doc.edges.values())
 
 
+# -- R3.13: thinking nodes + docking -----------------------------------------
+
+
+def test_add_thinking_node_creates_a_real_thinking_kind_node():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "the message that triggered reasoning", True)
+    node = doc.add_thinking_node(10, 20, "step one, then step two, then a conclusion", parent.id)
+    assert node.kind == "thinking"
+    assert node.content == "step one, then step two, then a conclusion"
+    assert node.title == "step one, then step two, then a conclusion"[:60]
+    assert node.is_docked is False
+    assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
+
+
+def test_add_thinking_node_falls_back_to_thinking_title_for_empty_text():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_thinking_node(0, 0, "", parent.id)
+    assert node.title == "Thinking"
+
+
+def test_add_thinking_node_rejects_unknown_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_thinking_node(0, 0, "orphaned reasoning", "ghost")
+
+
+def test_add_thinking_node_requires_a_parent_id():
+    # Same as add_document_node - parent_id has no default in
+    # add_thinking_node's signature, so calling without one is a TypeError
+    # (missing required argument), not a SceneError.
+    doc = SceneDocument()
+    with pytest.raises(TypeError):
+        doc.add_thinking_node(0, 0, "orphaned reasoning")
+
+
+def test_set_node_docked_toggles_true_then_false():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_thinking_node(1, 1, "reasoning", parent.id)
+
+    doc.set_node_docked(node.id, True)
+    assert doc.nodes[node.id].is_docked is True
+    row = {n["id"]: n for n in doc.scene_payload()["nodes"]}[node.id]
+    assert row["isDocked"] is True
+
+    doc.set_node_docked(node.id, False)
+    assert doc.nodes[node.id].is_docked is False
+    row = {n["id"]: n for n in doc.scene_payload()["nodes"]}[node.id]
+    assert row["isDocked"] is False
+
+
+def test_set_node_docked_unknown_node_raises():
+    with pytest.raises(SceneError):
+        SceneDocument().set_node_docked("ghost", True)
+
+
+def test_scene_payload_includes_is_docked_defaulted_for_other_kinds():
+    doc = SceneDocument()
+    doc.add_node(0, 0, "plain")
+    doc.add_chat_node(1, 1, "a chat message", True)
+    rows = {n["title"]: n for n in doc.scene_payload()["nodes"]}
+    assert rows["plain"]["isDocked"] is False
+    assert rows["a chat message"]["isDocked"] is False
+
+
+def test_thinking_node_deletion_goes_through_the_generic_remove_nodes_path():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_thinking_node(10, 10, "reasoning", parent.id)
+    assert not hasattr(doc, "delete_thinking_node"), "thinking nodes are not branch points - no special delete method"
+    doc.remove_nodes([node.id])
+    assert node.id not in doc.nodes
+    assert not any(e.target == node.id or e.source == node.id for e in doc.edges.values())
+
+
+def test_add_thinking_node_intent_creates_a_real_node_and_publishes():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addChatNode", [0, 0, "hi", True])
+        node_id = await bus.dispatch_intent(
+            "scene", "addThinkingNode", [10, 10, "reasoning text", parent_id]
+        )
+        assert document.nodes[node_id].kind == "thinking"
+        assert document.nodes[node_id].content == "reasoning text"
+        assert document.nodes[node_id].is_docked is False
+        assert any(
+            e.source == parent_id and e.target == node_id for e in document.edges.values()
+        )
+        assert recorder.topics_seen().count("scene") == 2, "both mutations publish"
+
+    asyncio.run(run())
+
+
+def test_set_node_docked_intent_flips_is_docked_and_publishes():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addNode", [0, 0, "parent"])
+        node_id = await bus.dispatch_intent(
+            "scene", "addThinkingNode", [10, 10, "reasoning", parent_id]
+        )
+        await bus.dispatch_intent("scene", "setNodeDocked", [node_id, True])
+        assert document.nodes[node_id].is_docked is True
+        await bus.dispatch_intent("scene", "setNodeDocked", [node_id, False])
+        assert document.nodes[node_id].is_docked is False
+        assert recorder.topics_seen().count("scene") == 4, "every mutation publishes"
+
+    asyncio.run(run())
+
+
 def test_send_message_starts_a_root_branch():
     doc = SceneDocument()
     node = doc.send_message("hello there")

--- a/graphlink_app/graphlink_scene_payload.py
+++ b/graphlink_app/graphlink_scene_payload.py
@@ -22,6 +22,11 @@ R3.9 adds the `document` kind's fields (attachmentKind/filePath/mimeType/
 durationSeconds/byteSize/previewLabel - the DocumentNode attachment
 metadata): populated for kind=="document" rows, defaulted (empty
 string/None) for every other kind, same additive rule.
+
+R3.13 adds `isDocked` (the ThinkingNode/docked-child increment): true when a
+node is currently docked into its parent's docked-child slot, populated for
+any kind that has been docked, defaulted false otherwise - same additive
+rule.
 """
 
 from __future__ import annotations
@@ -52,6 +57,10 @@ class SceneNodeRow:
     durationSeconds: float | None = None
     byteSize: int | None = None
     previewLabel: str = ""
+    # R3.13: the ThinkingNode/docked-child increment - populated for any node
+    # that has been docked into its parent's docked-child slot, defaulted
+    # false for every other node.
+    isDocked: bool = False
 
 
 @dataclass

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -15,6 +15,7 @@ import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
 function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   const onToggleCollapse = vi.fn();
   const onDelete = vi.fn();
+  const onUndockChild = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -22,8 +23,10 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
       content: "Hello **world**",
       isUser: true,
       isCollapsed: false,
+      dockedChildren: [],
       onToggleCollapse,
       onDelete,
+      onUndockChild,
       ...overrides,
     },
   } as unknown as NodeProps<ChatFlowNode>;
@@ -33,7 +36,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
       <ChatNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onToggleCollapse, onDelete };
+  return { onToggleCollapse, onDelete, onUndockChild };
 }
 
 describe("ChatNodeView", () => {
@@ -112,5 +115,46 @@ describe("ChatNodeView", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
     await user.click(document.body);
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("hides the docked-count badge when dockedChildren is empty (the default)", () => {
+    renderChatNode();
+    expect(screen.queryByTitle("Docked items")).toBeNull();
+  });
+
+  it("shows the docked-count badge with the correct count when dockedChildren has entries", () => {
+    renderChatNode({
+      dockedChildren: [
+        { id: "t1", label: "Thinking" },
+        { id: "t2", label: "Thinking" },
+      ],
+    });
+    expect(screen.getByTitle("Docked items")).toHaveTextContent("2");
+  });
+
+  it("omits the 'Reveal Docked Items' menu section entirely when dockedChildren is empty", () => {
+    renderChatNode();
+    fireEvent.contextMenu(screen.getByText("You"));
+    expect(screen.queryByText("Reveal Docked Items")).toBeNull();
+  });
+
+  it("shows one labeled 'Reveal Docked Items' entry per docked child, and clicking one calls onUndockChild with its id", async () => {
+    const user = userEvent.setup();
+    const { onUndockChild } = renderChatNode({
+      dockedChildren: [
+        { id: "t1", label: "Thinking" },
+        { id: "t2", label: "Thinking" },
+      ],
+    });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    expect(screen.getByText("Reveal Docked Items")).toBeInTheDocument();
+    const entries = screen.getAllByRole("menuitem", { name: "Thinking" });
+    expect(entries).toHaveLength(2);
+
+    await user.click(entries[0]);
+    expect(onUndockChild).toHaveBeenCalledOnce();
+    expect(onUndockChild).toHaveBeenCalledWith("t1");
+    expect(screen.queryByRole("menu")).toBeNull(); // the menu closes after any item fires
   });
 });

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -18,20 +18,27 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * work), Open Document View (the document-viewer island isn't wired into the
  * SPA overlay system yet), and Hide Other Branches (the legacy scene's
  * branch-visibility toggle has no backend/frontend equivalent at all yet -
- * unscoped, not owned by any R-phase). Two legacy items are deliberately NOT
- * listed even as disabled: "Reveal Docked Items" and "Generate Group Summary"
- * are themselves conditionally hidden in the legacy menu (only when docked
- * children or a multi-selection exist), and neither precondition can occur
- * yet in the new stack (no docking, no multi-select model) - showing them
- * unconditionally would be a behavior regression, not parity.
+ * unscoped, not owned by any R-phase). One legacy item is still deliberately
+ * NOT listed even as disabled: "Generate Group Summary" is itself
+ * conditionally hidden in the legacy menu (only when a multi-selection
+ * exists), and that precondition can't occur yet in the new stack (no
+ * multi-select model) - showing it unconditionally would be a behavior
+ * regression, not parity. "Reveal Docked Items" WAS in that same boat until
+ * R3.13/R3.14 (ThinkingNode + generic docking): its precondition - one or
+ * more docked children - can now be real (a thinking node docks via its own
+ * "Dock to Parent Node" action), so it's implemented for real below, gated
+ * on dockedChildren.length > 0 exactly like the legacy's own `if
+ * docked_children:` guard.
  */
 
 export interface ChatNodeData extends Record<string, unknown> {
   content: string;
   isUser: boolean;
   isCollapsed: boolean;
+  dockedChildren: { id: string; label: string }[];
   onToggleCollapse: () => void;
   onDelete: () => void;
+  onUndockChild: (childId: string) => void;
 }
 
 export type ChatFlowNode = Node<ChatNodeData, "chat">;
@@ -46,16 +53,20 @@ function ChatNodeMenu({
   content,
   isUser,
   isCollapsed,
+  dockedChildren,
   onToggleCollapse,
   onDelete,
+  onUndockChild,
   onClose,
 }: {
   position: MenuPosition;
   content: string;
   isUser: boolean;
   isCollapsed: boolean;
+  dockedChildren: { id: string; label: string }[];
   onToggleCollapse: () => void;
   onDelete: () => void;
+  onUndockChild: (childId: string) => void;
   onClose: () => void;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
@@ -110,6 +121,28 @@ function ChatNodeMenu({
       <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
         Hide Other Branches
       </button>
+      {/* Real (not disabled) - matches the legacy's own `if docked_children:`
+          guard exactly. One button per docked child, each undocking that
+          specific child back onto the canvas via the shared setNodeDocked
+          intent (docked=false). */}
+      {dockedChildren.length > 0 && (
+        <>
+          <div className="chat-node-menu-section-label">Reveal Docked Items</div>
+          {dockedChildren.map((child) => (
+            <button
+              key={child.id}
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                onUndockChild(child.id);
+                onClose();
+              }}
+            >
+              {child.label}
+            </button>
+          ))}
+        </>
+      )}
       <button type="button" role="menuitem" disabled title="Document view integration isn't wired into the SPA yet">
         Open Document View
       </button>
@@ -161,7 +194,14 @@ export function ChatNodeView({ data, selected }: NodeProps<ChatFlowNode>) {
     >
       <Handle type="target" position={Position.Top} className="scene-node-handle" />
       <div className="scene-node-title chat-node-role">
-        <span>{data.isUser ? "You" : "Assistant"}</span>
+        <span className="chat-node-role-group">
+          <span>{data.isUser ? "You" : "Assistant"}</span>
+          {data.dockedChildren.length > 0 && (
+            <span className="chat-node-docked-badge" title="Docked items">
+              {data.dockedChildren.length}
+            </span>
+          )}
+        </span>
         <button
           type="button"
           className="chat-node-collapse-btn"
@@ -185,8 +225,10 @@ export function ChatNodeView({ data, selected }: NodeProps<ChatFlowNode>) {
           content={data.content}
           isUser={data.isUser}
           isCollapsed={data.isCollapsed}
+          dockedChildren={data.dockedChildren}
           onToggleCollapse={data.onToggleCollapse}
           onDelete={data.onDelete}
+          onUndockChild={data.onUndockChild}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/DocumentNodeView.test.tsx
+++ b/web_ui/src/app/canvas/DocumentNodeView.test.tsx
@@ -14,6 +14,7 @@ import {
 // ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too.
 function renderDocumentNode(overrides: Partial<DocumentFlowNode["data"]> = {}) {
   const onToggleCollapse = vi.fn();
+  const onDock = vi.fn();
   const onDelete = vi.fn();
   const props = {
     id: "n0",
@@ -29,6 +30,7 @@ function renderDocumentNode(overrides: Partial<DocumentFlowNode["data"]> = {}) {
       previewLabel: "",
       isCollapsed: false,
       onToggleCollapse,
+      onDock,
       onDelete,
       ...overrides,
     },
@@ -39,7 +41,7 @@ function renderDocumentNode(overrides: Partial<DocumentFlowNode["data"]> = {}) {
       <DocumentNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onToggleCollapse, onDelete };
+  return { onToggleCollapse, onDock, onDelete };
 }
 
 describe("formatByteSize (ported DocumentNode._format_byte_size)", () => {
@@ -172,9 +174,9 @@ describe("DocumentNodeView", () => {
     expect(screen.queryByText("Quarterly figures attached.")).toBeNull();
   });
 
-  it("right-click opens a menu with real Copy Details/Collapse/Delete Attachment and honest disabled placeholders", async () => {
+  it("right-click opens a menu with real Copy Details/Dock/Collapse/Delete Attachment and honest disabled placeholders", async () => {
     const user = userEvent.setup();
-    const { onDelete } = renderDocumentNode({ attachmentKind: "document", filePath: "" });
+    const { onDelete, onDock } = renderDocumentNode({ attachmentKind: "document", filePath: "" });
 
     const writeText = vi.fn();
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
@@ -183,10 +185,10 @@ describe("DocumentNodeView", () => {
     fireEvent.contextMenu(title);
     expect(screen.getByRole("menu")).toBeInTheDocument();
 
-    const dock = screen.getByRole("menuitem", { name: "Dock into Parent Node" });
-    expect(dock).toBeDisabled();
-    expect(dock).toHaveAttribute("title", "Docking into the parent node's badge isn't built yet");
+    await user.click(screen.getByRole("menuitem", { name: "Dock into Parent Node" }));
+    expect(onDock).toHaveBeenCalledOnce();
 
+    fireEvent.contextMenu(title);
     const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
     expect(hideBranches).toBeDisabled();
     expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");

--- a/web_ui/src/app/canvas/DocumentNodeView.tsx
+++ b/web_ui/src/app/canvas/DocumentNodeView.tsx
@@ -11,13 +11,17 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * backend's add_document_node requires parent_id.
  *
  * Real: render (metadata rows + gated content preview), collapse/expand,
- * delete, copy. Deferred, with an honest disabled+title label rather than a
+ * delete, copy, and (as of R3.13's shared docked-child mechanism) dock -
+ * "Dock into Parent Node" now calls the same generic setNodeDocked(id, true)
+ * intent ThinkingNodeView uses; SceneCanvas.tsx's node/edge filtering and
+ * ChatNodeView's badge/"Reveal Docked Items" are already kind-agnostic, so
+ * no further wiring was needed beyond this file and SceneCanvas's document
+ * branch. Deferred, with an honest disabled+title label rather than a
  * silently-dropped action (see the R3.7-era audit this increment is
- * following up on): Dock into Parent Node (needs the shared parent-badge/
- * docking mechanism - not built), Open File (needs a new backend endpoint;
- * browsers cannot open arbitrary local paths), Export (R6, document-kind
- * only - matches the legacy menu's own conditional), Hide Other Branches
- * (branch visibility isn't built yet).
+ * following up on): Open File (needs a new backend endpoint; browsers
+ * cannot open arbitrary local paths), Export (R6, document-kind only -
+ * matches the legacy menu's own conditional), Hide Other Branches (branch
+ * visibility isn't built yet).
  */
 
 export interface DocumentNodeData extends Record<string, unknown> {
@@ -40,6 +44,7 @@ export interface DocumentNodeData extends Record<string, unknown> {
   previewLabel: string;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
+  onDock: () => void;
   onDelete: () => void;
 }
 
@@ -164,6 +169,7 @@ function DocumentNodeMenu({
   filePath,
   isCollapsed,
   onToggleCollapse,
+  onDock,
   onDelete,
   onClose,
 }: {
@@ -173,6 +179,7 @@ function DocumentNodeMenu({
   filePath: string;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
+  onDock: () => void;
   onDelete: () => void;
   onClose: () => void;
 }) {
@@ -237,8 +244,10 @@ function DocumentNodeMenu({
       <button
         type="button"
         role="menuitem"
-        disabled
-        title="Docking into the parent node's badge isn't built yet"
+        onClick={() => {
+          onDock();
+          onClose();
+        }}
       >
         Dock into Parent Node
       </button>
@@ -348,6 +357,7 @@ export function DocumentNodeView({ data, selected }: NodeProps<DocumentFlowNode>
           filePath={data.filePath}
           isCollapsed={data.isCollapsed}
           onToggleCollapse={data.onToggleCollapse}
+          onDock={data.onDock}
           onDelete={data.onDelete}
           onClose={() => setMenuPosition(null)}
         />

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -20,6 +20,7 @@ import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
 import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
 import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
 import { DocumentNodeView, type DocumentFlowNode } from "./DocumentNodeView";
+import { ThinkingNodeView, type ThinkingFlowNode } from "./ThinkingNodeView";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { SceneStore, scaleDragPosition } from "./sceneStore";
 
@@ -39,7 +40,7 @@ const GRID_VARIANTS: Record<string, BackgroundVariant> = {
 };
 
 type PlaceholderNode = Node<{ title: string }, "placeholder">;
-type SceneFlowNode = PlaceholderNode | ChatFlowNode | CodeFlowNode | DocumentFlowNode;
+type SceneFlowNode = PlaceholderNode | ChatFlowNode | CodeFlowNode | DocumentFlowNode | ThinkingFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   const zoom = useStore((s) => s.transform[2]);
@@ -62,12 +63,39 @@ const NODE_TYPES = {
   chat: ChatNodeView,
   code: CodeNodeView,
   document: DocumentNodeView,
+  thinking: ThinkingNodeView,
 };
 
 function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
-  return scene.nodes.map((n) => {
+  // Looked up per-chat-node below to build dockedChildren - a docked node is
+  // omitted from the returned array entirely (see the "thinking" branch), so
+  // this is the only remaining way a chat node's dock badge/menu can find it.
+  const nodesById = new Map(scene.nodes.map((n) => [n.id, n]));
+  const flowNodes: SceneFlowNode[] = [];
+
+  for (const n of scene.nodes) {
+    // A docked node (any kind) is fully removed from the canvas (mirrors the
+    // legacy scene's own behavior for both ThinkingNode and DocumentNode,
+    // which the legacy code lets dock via the same attachment_kind-routed
+    // mechanism) - not rendered-but-hidden. This check is deliberately
+    // generic rather than "thinking"-only: backend/canvas.py's
+    // setNodeDocked has no kind restriction, and toFlowEdges below already
+    // filters a docked node's edges generically - a kind-specific check here
+    // would leave a docked non-thinking node rendered with no edge to it the
+    // moment any future node type wires up a real onDock action.
+    if (n.isDocked) continue;
     if (n.kind === "chat") {
-      return {
+      // dockedChildren: this chat node's own edges whose target is currently
+      // docked - the new stack's equivalent of the legacy scene's per-node
+      // docked-children list. title is the closest faithful stand-in for a
+      // per-node-type "docked label" concept (none exists in the new stack).
+      const dockedChildren: { id: string; label: string }[] = [];
+      for (const e of scene.edges) {
+        if (e.source !== n.id) continue;
+        const target = nodesById.get(e.target);
+        if (target?.isDocked) dockedChildren.push({ id: target.id, label: target.title });
+      }
+      flowNodes.push({
         id: n.id,
         type: "chat" as const,
         position: { x: n.x, y: n.y },
@@ -75,13 +103,16 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
           content: n.content,
           isUser: n.isUser,
           isCollapsed: n.isCollapsed,
+          dockedChildren,
           onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
           onDelete: () => store.deleteChatNode(n.id),
+          onUndockChild: (childId: string) => store.setNodeDocked(childId, false),
         },
-      };
+      });
+      continue;
     }
     if (n.kind === "code") {
-      return {
+      flowNodes.push({
         id: n.id,
         type: "code" as const,
         position: { x: n.x, y: n.y },
@@ -90,10 +121,11 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
           language: n.language,
           onDelete: () => store.removeNodes([n.id]),
         },
-      };
+      });
+      continue;
     }
     if (n.kind === "document") {
-      return {
+      flowNodes.push({
         id: n.id,
         type: "document" as const,
         position: { x: n.x, y: n.y },
@@ -119,21 +151,46 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
           // backend doesn't register. See this increment's report for the
           // full reasoning.
           onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
+          onDock: () => store.setNodeDocked(n.id, true),
           onDelete: () => store.removeNodes([n.id]),
         },
-      };
+      });
+      continue;
     }
-    return {
+    if (n.kind === "thinking") {
+      // Docked-hiding is handled by the generic check above; once undocked,
+      // it resurfaces as a badge + "Reveal Docked Items" entry on its parent
+      // chat node (dockedChildren above).
+      flowNodes.push({
+        id: n.id,
+        type: "thinking" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          thinkingText: n.content,
+          onDock: () => store.setNodeDocked(n.id, true),
+          onDelete: () => store.removeNodes([n.id]),
+        },
+      });
+      continue;
+    }
+    flowNodes.push({
       id: n.id,
       type: "placeholder" as const,
       position: { x: n.x, y: n.y },
       data: { title: n.title },
-    };
-  });
+    });
+  }
+
+  return flowNodes;
 }
 
 function toFlowEdges(scene: SceneState): Edge[] {
-  return scene.edges.map((e) => ({ id: e.id, source: e.source, target: e.target }));
+  // An edge pointing at a docked node must not render either - mirrors the
+  // legacy connection-item self-suppression when its end node is docked.
+  const dockedNodeIds = new Set(scene.nodes.filter((n) => n.isDocked).map((n) => n.id));
+  return scene.edges
+    .filter((e) => !dockedNodeIds.has(e.target))
+    .map((e) => ({ id: e.id, source: e.source, target: e.target }));
 }
 
 function CanvasInner({ store }: { store: SceneStore }) {

--- a/web_ui/src/app/canvas/ThinkingNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ThinkingNodeView.test.tsx
@@ -1,0 +1,85 @@
+import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ThinkingNodeView, type ThinkingFlowNode } from "./ThinkingNodeView";
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
+// ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too.
+function renderThinkingNode(overrides: Partial<ThinkingFlowNode["data"]> = {}) {
+  const onDock = vi.fn();
+  const onDelete = vi.fn();
+  const props = {
+    id: "n0",
+    selected: false,
+    data: {
+      thinkingText: "Considering **several** approaches before answering.",
+      onDock,
+      onDelete,
+      ...overrides,
+    },
+  } as unknown as NodeProps<ThinkingFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <ThinkingNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return { onDock, onDelete };
+}
+
+describe("ThinkingNodeView", () => {
+  it("renders the markdown thinking text", () => {
+    renderThinkingNode();
+    expect(screen.getByText("several")).toBeInTheDocument(); // bold text still renders as text
+  });
+
+  it("right-click opens a menu with real Copy Content/Dock to Parent Node/Delete Node and honest disabled Hide Other Branches", async () => {
+    const user = userEvent.setup();
+    const { onDock, onDelete } = renderThinkingNode();
+
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    const label = screen.getByText("Thinking");
+    fireEvent.contextMenu(label);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    const copyItem = screen.getByRole("menuitem", { name: "Copy Content" });
+    const dockItem = screen.getByRole("menuitem", { name: "Dock to Parent Node" });
+    const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
+    const deleteItem = screen.getByRole("menuitem", { name: "Delete Node" });
+    expect(copyItem).toBeEnabled();
+    expect(dockItem).toBeEnabled();
+    expect(deleteItem).toBeEnabled();
+    expect(hideBranches).toBeDisabled();
+    expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
+
+    await user.click(copyItem);
+    expect(writeText).toHaveBeenCalledWith("Considering **several** approaches before answering.");
+
+    fireEvent.contextMenu(label);
+    await user.click(screen.getByRole("menuitem", { name: "Dock to Parent Node" }));
+    expect(onDock).toHaveBeenCalledOnce();
+
+    fireEvent.contextMenu(label);
+    await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Escape and outside-click both close the menu", async () => {
+    const user = userEvent.setup();
+    renderThinkingNode();
+    const label = screen.getByText("Thinking");
+
+    fireEvent.contextMenu(label);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(label);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/ThinkingNodeView.tsx
+++ b/web_ui/src/app/canvas/ThinkingNodeView.tsx
@@ -1,0 +1,166 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+
+/**
+ * The thinking node (Qt-removal plan R3.13/R3.14) - graphlink_node_thinking.py's
+ * React successor: a scratch/reasoning card that always requires a parent
+ * (same as DocumentNode - the backend's add_thinking_node has no default for
+ * parent_id). Unlike ChatNode/DocumentNode, ThinkingNode has no manual
+ * collapse toggle at all in the legacy app - only the shared zoom-based LOD
+ * auto-collapse applies (mirrors CodeNodeView's collapsed-from-LOD-alone
+ * pattern, not Chat/Document's manual-OR-LOD pattern).
+ *
+ * This increment also introduces the first REAL docking mechanic: "Dock to
+ * Parent Node" calls the new generic setNodeDocked(id, true) intent, which
+ * removes this node from the canvas entirely (SceneCanvas.tsx's toFlowNodes
+ * filters out any node with isDocked===true, and toFlowEdges drops any edge
+ * pointing at it) and surfaces it instead as a badge + menu entry on its
+ * parent chat node (see ChatNodeView.tsx's dockedChildren / "Reveal Docked
+ * Items"). Undocking is the parent's action, not this node's - there is no
+ * "Undock" item here, matching the legacy menu (only ChatNode's menu offers
+ * the reverse direction).
+ *
+ * Real: render (markdown thinking text, same react-markdown + rehype-
+ * highlight pipeline every other node kind pulls in), delete (generic
+ * cascade-delete - a thinking node is never a branch point/reparented, same
+ * as CodeNode), copy, dock. Deferred, with an honest disabled+title label
+ * rather than a silent drop (same audit convention every prior node kind in
+ * this plan has followed): Hide Other Branches (the legacy scene's branch-
+ * visibility toggle has no backend/frontend equivalent at all yet - unscoped,
+ * not owned by any R-phase).
+ */
+
+export interface ThinkingNodeData extends Record<string, unknown> {
+  thinkingText: string;
+  onDock: () => void;
+  onDelete: () => void;
+}
+
+export type ThinkingFlowNode = Node<ThinkingNodeData, "thinking">;
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+function ThinkingNodeMenu({
+  position,
+  thinkingText,
+  onDock,
+  onDelete,
+  onClose,
+}: {
+  position: MenuPosition;
+  thinkingText: string;
+  onDock: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
+      // type-only import above shadows the bare name for casts like this).
+      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      {/* Order verified against graphlink_node_thinking_menu.py's own
+          construction order: Copy Content, Dock to Parent Node, Hide Other
+          Branches, Delete Node. */}
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          navigator.clipboard.writeText(thinkingText);
+          onClose();
+        }}
+      >
+        Copy Content
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onDock();
+          onClose();
+        }}
+      >
+        Dock to Parent Node
+      </button>
+      <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
+        Hide Other Branches
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        Delete Node
+      </button>
+    </div>
+  );
+}
+
+export function ThinkingNodeView({ data, selected }: NodeProps<ThinkingFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const collapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+
+  return (
+    <div
+      className={`scene-node thinking-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title thinking-node-label">
+        <span>Thinking</span>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body thinking-node-content">
+          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+            {data.thinkingText}
+          </ReactMarkdown>
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+      {menuPosition && (
+        <ThinkingNodeMenu
+          position={menuPosition}
+          thinkingText={data.thinkingText}
+          onDock={data.onDock}
+          onDelete={data.onDelete}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -40,6 +40,7 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         filePath: "",
         mimeType: "",
         previewLabel: "",
+        isDocked: false,
       },
     ],
     edges: [],
@@ -178,6 +179,19 @@ describe("SceneStore", () => {
           "Audio | 2:05",
         ],
       },
+    ]);
+  });
+
+  it("sends thinking-node and docking intents with the backend's registered names and shapes", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.addThinkingNode(10, 20, "Weighing the options...", "n1");
+    store.setNodeDocked("n2", true);
+    store.setNodeDocked("n2", false);
+    expect(intents).toEqual([
+      { topic: "scene", intent: "addThinkingNode", args: [10, 20, "Weighing the options...", "n1"] },
+      { topic: "scene", intent: "setNodeDocked", args: ["n2", true] },
+      { topic: "scene", intent: "setNodeDocked", args: ["n2", false] },
     ]);
   });
 

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -197,6 +197,21 @@ export class SceneStore {
     ]);
   }
 
+  // R3.13/R3.14: real thinking nodes + generic docking. addThinkingNode has
+  // no real UI creation trigger yet - same situation addCodeNode/
+  // addDocumentNode were in when they landed; real creation is R4's agent
+  // layer. setNodeDocked is intentionally generic (any node kind, either
+  // direction) rather than a thinking-node-specific intent - it backs both
+  // ThinkingNodeView's "Dock to Parent Node" and ChatNodeView's per-child
+  // "Reveal Docked Items" undock action.
+  addThinkingNode(x: number, y: number, thinkingText: string, parentId: string): void {
+    this.transport.intent("scene", "addThinkingNode", [x, y, thinkingText, parentId]);
+  }
+
+  setNodeDocked(id: string, docked: boolean): void {
+    this.transport.intent("scene", "setNodeDocked", [id, docked]);
+  }
+
   // R3.3: the Composer's real Send action - a real user ChatNode. The
   // assistant's reply is deferred to R4 (graphlink_config.py's Qt/non-Qt
   // split is a prerequisite for calling the real agent layer); the backend

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -666,6 +666,75 @@ body,
   background-color: var(--gl-surface-border);
 }
 
+/* Small uppercase divider label ChatNodeMenu's "Reveal Docked Items" section
+   uses ahead of its per-child buttons (R3.13/R3.14). */
+.chat-node-menu-section-label {
+  padding: 6px 10px 2px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--gl-surface-text-muted);
+}
+
+/* -- R3.13/R3.14 thinking node + docked-child badge ------------------------ */
+
+.thinking-node {
+  width: 420px;
+  max-height: 640px;
+  min-height: 110px;
+}
+
+.thinking-node.collapsed {
+  width: 290px;
+  min-height: 58px;
+}
+
+.thinking-node-label {
+  font-style: italic;
+  color: var(--gl-surface-text-muted);
+}
+
+.thinking-node-content {
+  max-height: 560px;
+  overflow-y: auto;
+}
+
+.thinking-node-content > :first-child {
+  margin-top: 0;
+}
+
+.thinking-node-content > :last-child {
+  margin-bottom: 0;
+}
+
+/* Groups the role label with its docked-count badge so the pair sits
+   together on the left of .chat-node-role's space-between layout, instead
+   of the badge landing in the middle (a 3rd flex child would otherwise get
+   pushed to the center by space-between). */
+.chat-node-role-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Small pill on ChatNodeView showing how many thinking-node children are
+   currently docked to this chat node - only rendered when count > 0. */
+.chat-node-docked-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--gl-surface-window);
+  background-color: var(--gl-surface-text-muted);
+  border-radius: 999px;
+}
+
 /* -- R2 app bar + overlay system ----------------------------------------- */
 
 .app-topbar {

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -68,6 +68,9 @@
           "isCollapsed": {
             "type": "boolean"
           },
+          "isDocked": {
+            "type": "boolean"
+          },
           "isUser": {
             "type": "boolean"
           },
@@ -107,7 +110,8 @@
           "attachmentKind",
           "filePath",
           "mimeType",
-          "previewLabel"
+          "previewLabel",
+          "isDocked"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -19,6 +19,7 @@ export interface SceneNodeRow {
   durationSeconds?: number | null;
   byteSize?: number | null;
   previewLabel: string;
+  isDocked: boolean;
 }
 
 export interface SceneEdgeRow {
@@ -143,6 +144,11 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["previewLabel"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.previewLabel: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.previewLabel` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["isDocked"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isDocked: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isDocked` + ": expected boolean"); }
   }
 }
 


### PR DESCRIPTION
## Summary
Per the R3-scoping note, ThinkingNode couldn't ship standalone - it needed the dock↔badge contract shared with ChatNode built alongside it. This PR does both, via a fresh recon+cross-check+design pass covering ThinkingNode's legacy source AND ChatNode's docked-child tracking mechanism (`docked_thinking_nodes`/`add_docked_child`/`get_docked_child_nodes`), then implements both together.

- **Backend**: `SceneNode`/`SceneNodeRow` gain exactly one new field, `is_docked` (thinking text reuses the existing `content` field). `SceneDocument.add_thinking_node` requires `parent_id`, matching `add_document_node`'s pattern (not chat/code's optional one - a legacy ThinkingNode can never exist without a parent). A single generic `set_node_docked(node_id, docked)` setter - not two separate dock/undock methods - works on **any** node kind by design, mirroring how `set_chat_collapsed` already worked generically despite its name. Deliberately **no new field on the parent** to track docked children - that would duplicate the edge `connect()` already creates; docked children are derived at read time by scanning edges.
- **Frontend**: `ThinkingNodeView.tsx` (LOD-only collapse, no manual toggle - legacy has none). `ChatNodeView.tsx` gains a real docked-count badge and a real "Reveal Docked Items" menu section, promoted from the R2.6-era menu-parity fix's "deliberately absent since the precondition can never be true" placeholder to a genuinely working feature now that the precondition can occur. `SceneCanvas.tsx` omits any docked node from the rendered array entirely (not CSS-hidden) and filters its edge, mirroring the legacy's real `hide()`/connection-suppression behavior.
- **The 4-way adversarial review** (now standard process, including a dedicated legacy-parity audit) caught and fixed a real defect *before* ship: the `isDocked` omission check was implemented only inside the `kind === "thinking"` branch of `toFlowNodes`, not generically - since the backend setter and the edge filter were both already fully kind-agnostic, a docked non-thinking node would have had its edge hidden but stayed rendered as an orphan. Fixed by moving the check to the top of the loop.
- The same review also flagged that `DocumentNodeView.tsx`'s "Dock into Parent Node" placeholder (shipped disabled in the prior PR, before this mechanism existed) was now stale. Since wiring it up needed **zero backend changes** - the architecture was already fully generic - completed it for real within this same increment rather than leaving a now-pointless disabled button.
- `doc/QT_REMOVAL_PLAN.md` §7a updated: the docked-child system entry is closed out as built; the passive hover-animation gap note now confirms ThinkingNode also inherits it (same already-tracked gap, not new).

## Test plan
- [x] `python -m pytest -q` (repo-wide): 1878 passed
- [x] `npm run check` (schema/typecheck/lint/test/build): all green, 636 vitest passing
- [x] Live drive against the real running backend: created a real chat node, a real thinking node parented to it, and a real document node parented to it, via direct WS intents; docking either child node made it disappear from the canvas entirely while the parent's badge count correctly incremented (confirmed both individually and together - badge read "2" with both docked); undocking restored the thinking node with its edge intact
- [x] Context-menu/click interaction covered by `ThinkingNodeView.test.tsx`/updated `ChatNodeView.test.tsx` direct-render unit tests

Remaining in R3 (not this PR): HTML-view/image node types, and the `ConversationNode` fast-follow.