### PR TITLE
Qt-removal R3.17/R3.18: real HtmlViewNode with a sandboxed iframe

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -83,6 +83,10 @@ CODE_TITLE_PREVIEW_LENGTH = 40
 # R3.13: thinking-node titles are prose (a preview of the reasoning text),
 # same as chat's, so it reuses chat's 60-char length rather than code's 40.
 THINKING_TITLE_PREVIEW_LENGTH = 60
+# R3.17: html-node titles preview the raw HTML source, which is prose-like
+# text for truncation purposes (not code), so it reuses chat/thinking's
+# 60-char length rather than code's 40.
+HTML_TITLE_PREVIEW_LENGTH = 60
 
 
 @dataclass
@@ -96,6 +100,9 @@ class SceneNode:
     # graphlink_session/serializers.py's raw_content/is_user/is_collapsed,
     # minus everything Qt-only (paint state, scroll position, docked-child
     # widgets). Unused (default) for every other kind.
+    # R3.17: also reused verbatim as the html node's raw HTML source string -
+    # no separate field, same reuse pattern as R3.5's code text and R3.13's
+    # thinking text living in this same field.
     content: str = ""
     is_user: bool = False
     is_collapsed: bool = False
@@ -375,6 +382,48 @@ class SceneDocument:
         self.connect(parent_id, node_id)
         return node
 
+    def add_html_node(
+        self,
+        x: float,
+        y: float,
+        html_content: str,
+        parent_id: str,
+    ) -> SceneNode:
+        """R3.17's HtmlViewNode equivalent of add_document_node/
+        add_thinking_node: a real raw-HTML-source node. Same as
+        add_document_node/add_thinking_node (and unlike chat/code), parent_id
+        is REQUIRED, not optional - an HtmlViewNode never exists unparented -
+        so this unconditionally connects to its parent, no `if parent_id`
+        guard.
+
+        The raw HTML source reuses the existing `content` field rather than a
+        new one - there is no separate html-content field, same reuse pattern
+        as R3.5's code text and R3.13's thinking text. The backend stores it
+        VERBATIM as an opaque string: it never parses, sanitizes, validates,
+        or otherwise interprets the HTML - that is the frontend's job (the
+        preview render is a 100% client-side action that never round-trips
+        here).
+
+        Html nodes are also NOT branch points (same as code/document/
+        thinking): there is no delete_html_node; deletion goes entirely
+        through the existing generic remove_nodes.
+        """
+        if parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        title = str(html_content)[:HTML_TITLE_PREVIEW_LENGTH] or "HTML"
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title=title,
+            kind="html",
+            content=str(html_content),
+        )
+        self.nodes[node_id] = node
+        self.connect(parent_id, node_id)
+        return node
+
     def delete_chat_node(self, node_id: str) -> None:
         """Delete one chat node WITHOUT orphaning its branch: children are
         re-parented to the deleted node's own parent (or become roots if it
@@ -647,6 +696,11 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
         await publish_scene()
         return node.id
 
+    async def add_html_node(x, y, html_content, parent_id):
+        node = document.add_html_node(x, y, html_content, parent_id)
+        await publish_scene()
+        return node.id
+
     async def set_node_docked(node_id, docked):
         document.set_node_docked(node_id, docked)
         await publish_scene()
@@ -724,6 +778,7 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
     bus.register_intent("scene", "addCodeNode", add_code_node)
     bus.register_intent("scene", "addDocumentNode", add_document_node)
     bus.register_intent("scene", "addThinkingNode", add_thinking_node)
+    bus.register_intent("scene", "addHtmlNode", add_html_node)
     bus.register_intent("scene", "setNodeDocked", set_node_docked)
     bus.register_intent("scene", "deleteChatNode", delete_chat_node)
     bus.register_intent("scene", "setChatCollapsed", set_chat_collapsed)

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -436,6 +436,91 @@ def test_set_node_docked_intent_flips_is_docked_and_publishes():
     asyncio.run(run())
 
 
+# -- R3.17: html nodes --------------------------------------------------------
+
+
+def test_add_html_node_creates_a_real_html_kind_node():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "show me a preview", True)
+    node = doc.add_html_node(10, 20, "<h1>Hello</h1><p>world</p>", parent.id)
+    assert node.kind == "html"
+    assert node.content == "<h1>Hello</h1><p>world</p>"
+    assert node.title == "<h1>Hello</h1><p>world</p>"[:60]
+    assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
+
+
+def test_add_html_node_stores_script_content_as_an_opaque_string():
+    # The backend never parses, sanitizes, or interprets HTML content - it is
+    # stored verbatim, exactly like any other opaque text field.
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    raw = "<script>alert(1)</script>"
+    node = doc.add_html_node(0, 0, raw, parent.id)
+    assert node.content == raw
+    assert node.title == raw
+
+
+def test_add_html_node_falls_back_to_html_title_for_empty_content():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_html_node(0, 0, "", parent.id)
+    assert node.title == "HTML"
+
+
+def test_add_html_node_rejects_unknown_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_html_node(0, 0, "<div>orphan</div>", "ghost")
+
+
+def test_add_html_node_requires_a_parent_id():
+    # Same as add_document_node/add_thinking_node - parent_id has no default
+    # in add_html_node's signature, so calling without one is a TypeError
+    # (missing required argument), not a SceneError.
+    doc = SceneDocument()
+    with pytest.raises(TypeError):
+        doc.add_html_node(0, 0, "<div>orphan</div>")
+
+
+def test_html_node_scene_payload_needs_no_new_key():
+    # The raw HTML source reuses the existing `content` field - scene_payload
+    # gets no html-specific key at all.
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    doc.add_html_node(1, 1, "<b>bold</b>", parent.id)
+    rows = {n["kind"]: n for n in doc.scene_payload()["nodes"]}
+    html_row = rows["html"]
+    assert html_row["content"] == "<b>bold</b>"
+    assert "html" not in html_row, "no html-specific key - content already carries it"
+
+
+def test_html_node_deletion_goes_through_the_generic_remove_nodes_path():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_html_node(10, 10, "<p>doomed</p>", parent.id)
+    assert not hasattr(doc, "delete_html_node"), "html nodes are not branch points - no special delete method"
+    doc.remove_nodes([node.id])
+    assert node.id not in doc.nodes
+    assert not any(e.target == node.id or e.source == node.id for e in doc.edges.values())
+
+
+def test_add_html_node_intent_creates_a_real_node_and_publishes():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addChatNode", [0, 0, "hi", True])
+        node_id = await bus.dispatch_intent(
+            "scene", "addHtmlNode", [10, 10, "<h1>preview</h1>", parent_id]
+        )
+        assert document.nodes[node_id].kind == "html"
+        assert document.nodes[node_id].content == "<h1>preview</h1>"
+        assert any(
+            e.source == parent_id and e.target == node_id for e in document.edges.values()
+        )
+        assert recorder.topics_seen().count("scene") == 2, "both mutations publish"
+
+    asyncio.run(run())
+
+
 def test_send_message_starts_a_root_branch():
     doc = SceneDocument()
     node = doc.send_message("hello there")

--- a/web_ui/src/app/canvas/HtmlNodeView.test.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.test.tsx
@@ -1,0 +1,198 @@
+import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { buildSandboxedHtmlDocument, HtmlNodeView, type HtmlFlowNode } from "./HtmlNodeView";
+
+const EXACT_CSP =
+  "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; base-uri 'none'; frame-src 'none'; object-src 'none'; form-action 'none'";
+const EXACT_CSP_META = `<meta http-equiv="Content-Security-Policy" content="${EXACT_CSP}">`;
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
+// ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too.
+function renderHtmlNode(overrides: Partial<HtmlFlowNode["data"]> = {}) {
+  const onToggleCollapse = vi.fn();
+  const onDelete = vi.fn();
+  const props = {
+    id: "n0",
+    selected: false,
+    data: {
+      htmlContent: "<p>hello</p>",
+      isCollapsed: false,
+      onToggleCollapse,
+      onDelete,
+      ...overrides,
+    },
+  } as unknown as NodeProps<HtmlFlowNode>;
+
+  const { container } = render(
+    <ReactFlowProvider>
+      <HtmlNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return { onToggleCollapse, onDelete, container };
+}
+
+function getIframe(container: HTMLElement): HTMLIFrameElement {
+  const iframe = container.querySelector("iframe.html-node-preview");
+  expect(iframe).not.toBeNull();
+  return iframe as HTMLIFrameElement;
+}
+
+function getSourceTextarea(container: HTMLElement): HTMLTextAreaElement {
+  const textarea = container.querySelector("textarea.html-node-source");
+  expect(textarea).not.toBeNull();
+  return textarea as HTMLTextAreaElement;
+}
+
+describe("buildSandboxedHtmlDocument", () => {
+  it("wraps raw content verbatim in the exact fixed structure with the exact CSP string", () => {
+    const result = buildSandboxedHtmlDocument("<p>hi</p>");
+    expect(result).toBe(
+      `<!DOCTYPE html><html><head>${EXACT_CSP_META}</head><body>\n<p>hi</p>\n</body></html>`,
+    );
+  });
+
+  it("never branches on adversarial content trying to inject a competing head/CSP", () => {
+    const attacker =
+      '</body></html><html><head><meta http-equiv="Content-Security-Policy" content="script-src *"></head><body>' +
+      "<script>evil()</script>";
+    const result = buildSandboxedHtmlDocument(attacker);
+
+    // Our CSP meta tag is still the very first meta tag in the document,
+    // positioned before any byte of the attacker's payload - not merged
+    // with, replaced by, or reordered around the attacker's own competing
+    // head/meta content. Assert exact indices, not mere substring presence.
+    const ourMetaIndex = result.indexOf(EXACT_CSP_META);
+    const attackerMetaIndex = result.indexOf('content="script-src *"');
+    expect(ourMetaIndex).toBeGreaterThan(-1);
+    expect(attackerMetaIndex).toBeGreaterThan(-1);
+    expect(ourMetaIndex).toBeLessThan(attackerMetaIndex);
+
+    // The wrapper's own head/body scaffolding is untouched: exactly one
+    // <!DOCTYPE html>, exactly one wrapper <head>...</head> holding only our
+    // meta tag, and the attacker's entire string appears intact and
+    // unmodified inside the body position.
+    expect(result.startsWith(`<!DOCTYPE html><html><head>${EXACT_CSP_META}</head><body>\n`)).toBe(true);
+    expect(result.endsWith(`${attacker}\n</body></html>`)).toBe(true);
+    expect(result).toBe(`<!DOCTYPE html><html><head>${EXACT_CSP_META}</head><body>\n${attacker}\n</body></html>`);
+  });
+});
+
+describe("HtmlNodeView", () => {
+  it("typing in the source textarea does NOT change the iframe's srcdoc at all", () => {
+    const { container } = renderHtmlNode({ htmlContent: "<p>original</p>" });
+    const iframe = getIframe(container);
+    const initialSrcDoc = iframe.srcdoc;
+    expect(initialSrcDoc).toBe(buildSandboxedHtmlDocument("<p>original</p>"));
+
+    const textarea = getSourceTextarea(container);
+    fireEvent.change(textarea, { target: { value: "<script>alert(1)</script>" } });
+
+    expect(textarea.value).toBe("<script>alert(1)</script>");
+    // The iframe must be byte-for-byte unchanged after typing.
+    expect(getIframe(container).srcdoc).toBe(initialSrcDoc);
+  });
+
+  it("clicking Render updates the iframe to reflect the current textarea value, wrapped correctly", async () => {
+    const user = userEvent.setup();
+    const { container } = renderHtmlNode({ htmlContent: "<p>original</p>" });
+    const textarea = getSourceTextarea(container);
+
+    fireEvent.change(textarea, { target: { value: "<p>updated</p>" } });
+    expect(getIframe(container).srcdoc).toBe(buildSandboxedHtmlDocument("<p>original</p>")); // still unchanged pre-Render
+
+    await user.click(screen.getByRole("button", { name: "Render" }));
+
+    expect(getIframe(container).srcdoc).toBe(buildSandboxedHtmlDocument("<p>updated</p>"));
+  });
+
+  it("the iframe's sandbox attribute is EXACTLY 'allow-scripts', nothing more", () => {
+    const { container } = renderHtmlNode();
+    const iframe = getIframe(container);
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+  });
+
+  it("the rendered srcdoc contains the exact CSP meta tag string, verbatim", () => {
+    const { container } = renderHtmlNode({ htmlContent: "<p>x</p>" });
+    const iframe = getIframe(container);
+    expect(iframe.srcdoc).toContain(EXACT_CSP_META);
+    expect(iframe.srcdoc.indexOf(EXACT_CSP_META)).toBe(iframe.srcdoc.indexOf("<meta"));
+  });
+
+  it("adversarial: content containing <head>/</head>/<html>/</html>/a competing CSP meta tag never displaces our CSP or breaks the wrapper", async () => {
+    const user = userEvent.setup();
+    const attacker =
+      "</head></html><html><head>" +
+      '<meta http-equiv="Content-Security-Policy" content="script-src *">' +
+      "<title>hijacked</title></head><body><h1>pwned</h1>";
+    const { container } = renderHtmlNode({ htmlContent: "" });
+    const textarea = getSourceTextarea(container);
+
+    fireEvent.change(textarea, { target: { value: attacker } });
+    await user.click(screen.getByRole("button", { name: "Render" }));
+
+    const srcDoc = getIframe(container).srcdoc;
+
+    // Our wrapper's own head/CSP is still the first thing in the document.
+    expect(srcDoc.startsWith(`<!DOCTYPE html><html><head>${EXACT_CSP_META}</head><body>\n`)).toBe(true);
+    const ourMetaIndex = srcDoc.indexOf(EXACT_CSP_META);
+    const attackerMetaIndex = srcDoc.indexOf('content="script-src *"');
+    expect(ourMetaIndex).toBe(0 + "<!DOCTYPE html><html><head>".length);
+    expect(attackerMetaIndex).toBeGreaterThan(-1);
+    expect(ourMetaIndex).toBeLessThan(attackerMetaIndex);
+
+    // Only ONE occurrence of our exact CSP meta tag exists (it wasn't
+    // duplicated, and the attacker's competing one - a different string,
+    // "script-src *" not our policy - doesn't collide with it).
+    const occurrences = srcDoc.split(EXACT_CSP_META).length - 1;
+    expect(occurrences).toBe(1);
+
+    // The attacker's payload made it through unparsed/unmodified, verbatim,
+    // entirely within the body position after our fixed prefix.
+    expect(srcDoc).toBe(`<!DOCTYPE html><html><head>${EXACT_CSP_META}</head><body>\n${attacker}\n</body></html>`);
+  });
+
+  it("the Popout button is present, disabled, and wired to nothing observable", async () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const user = userEvent.setup();
+    renderHtmlNode();
+
+    const popout = screen.getByRole("button", { name: "Popout" });
+    expect(popout).toBeDisabled();
+    expect(popout).toHaveAttribute(
+      "title",
+      "Popout view isn't built yet - see the R3 plan doc for why a naive window.open() would be unsafe for untrusted HTML",
+    );
+
+    await user.click(popout); // disabled - fires nothing
+    expect(openSpy).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it("Collapse/Expand toggle calls onToggleCollapse", async () => {
+    const user = userEvent.setup();
+    const { onToggleCollapse } = renderHtmlNode({ isCollapsed: false });
+    await user.click(screen.getByRole("button", { name: "Collapse" }));
+    expect(onToggleCollapse).toHaveBeenCalledOnce();
+  });
+
+  it("shows 'Expand' label when isCollapsed is true", () => {
+    renderHtmlNode({ isCollapsed: true });
+    expect(screen.getByRole("button", { name: "Expand" })).toBeInTheDocument();
+  });
+
+  it("Delete calls onDelete", async () => {
+    const user = userEvent.setup();
+    const { onDelete } = renderHtmlNode();
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("collapse hides the source/preview area entirely", () => {
+    const { container } = renderHtmlNode({ isCollapsed: true });
+    expect(container.querySelector("textarea.html-node-source")).toBeNull();
+    expect(container.querySelector("iframe.html-node-preview")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Render" })).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/HtmlNodeView.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.tsx
@@ -1,0 +1,155 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useState } from "react";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+
+/**
+ * The HTML view node (Qt-removal plan R3.17/R3.18) - graphlink_node_htmlview.py's
+ * React successor: a card that holds arbitrary, untrusted HTML (user-authored
+ * today, plugin/AI-authored eventually) and previews it inside a sandboxed
+ * iframe. Unlike ChatNode/CodeNode/DocumentNode/ThinkingNode, this node's
+ * source string is content the LEGACY app itself renders unsafely (a bare
+ * QWebEngineView with full JS + same-origin + navigation), so this rewrite
+ * takes the opportunity to close that hole rather than port it faithfully:
+ * the wire shape is unchanged (the html source travels on the existing
+ * `content` field, exactly like ChatNode/ThinkingNode's content column - see
+ * addHtmlNode below), but the render posture is deliberately much stricter
+ * than the legacy widget ever was. See buildSandboxedHtmlDocument's own
+ * comment for the specific security reasoning.
+ *
+ * Real: render (manual, source-then-Render-button - never live-on-keystroke,
+ * see the state split below), collapse/expand (a real per-node toggle, same
+ * ChatNode/DocumentNode manual-OR-LOD pattern - unlike CodeNode/ThinkingNode,
+ * which have no manual collapse at all), delete. Deliberately, permanently
+ * NOT wired (not a temporary stub - see the Popout button below): Popout /
+ * standalone window view. Also deliberately not present even as a disabled
+ * placeholder: "Open Document View" - there is no clear SPA equivalent for it
+ * yet (matches this increment's own scope decision, not carried over from
+ * any sibling node's menu).
+ *
+ * Card controls, not a context menu: every sibling node view above uses a
+ * right-click dropdown for its actions, but this node's action surface is
+ * small enough (Collapse/Expand, Popout placeholder, Delete) that it renders
+ * as a plain inline button row in the header instead - no menu component,
+ * no onContextMenu handler, nothing to dismiss.
+ */
+
+export interface HtmlNodeData extends Record<string, unknown> {
+  htmlContent: string;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+}
+
+export type HtmlFlowNode = Node<HtmlNodeData, "html">;
+
+/**
+ * buildSandboxedHtmlDocument is the ONLY place in the codebase allowed to
+ * construct the iframe's srcdoc string, and it must NEVER parse, sniff, or
+ * branch on what `raw` contains - no checking for an existing <head>,
+ * <html>, or <body> tag in `raw`, no detecting or stripping a competing
+ * <meta http-equiv="Content-Security-Policy"> tag an attacker might have
+ * embedded, nothing conditional on `raw`'s bytes at all. `raw` always lands
+ * verbatim in the body position of this fixed wrapper, even when `raw` is
+ * itself a complete HTML document with its own head/script tags.
+ *
+ * This is deliberate, not an oversight: the moment this function tried to be
+ * "smart" about `raw` - e.g. merging into an existing <head> it found, or
+ * removing a CSP meta tag it decided was the attacker's rather than ours -
+ * it would become a second HTML parser that disagrees with the browser's
+ * real one about where tag boundaries fall on attacker-controlled bytes.
+ * That disagreement IS the injection primitive (the same shape as every
+ * mXSS / sanitizer-bypass bug: two parsers, one input, different
+ * conclusions). A dumb, unconditional wrapper has no such gap - the srcdoc
+ * value the browser receives is always exactly this fixed prefix, then
+ * `raw` byte-for-byte unchanged, then this fixed suffix. That guarantees our
+ * CSP <meta> tag is unconditionally the first thing the browser's HTML
+ * parser sees, before a single byte of untrusted content, which is what
+ * makes the CSP actually enforceable rather than something the untrusted
+ * content could race, override, or bypass by supplying its own competing
+ * <head>/<meta> first.
+ */
+export function buildSandboxedHtmlDocument(raw: string): string {
+  return `<!DOCTYPE html><html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; base-uri 'none'; frame-src 'none'; object-src 'none'; form-action 'none'"></head><body>
+${raw}
+</body></html>`;
+}
+
+export function HtmlNodeView({ data, selected }: NodeProps<HtmlFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const collapsed = data.isCollapsed || lodCollapsed;
+
+  // Two separate pieces of local state, per the R3.18 spec: `sourceText`
+  // tracks every keystroke in the textarea (fine - it never touches the
+  // iframe), while `renderedDoc` is only ever reassigned by the Render
+  // button's onClick below, via buildSandboxedHtmlDocument. The iframe's
+  // srcDoc is bound to `renderedDoc` alone, never to `sourceText` - typing
+  // literally cannot reach the iframe through any path in this component.
+  const [sourceText, setSourceText] = useState(data.htmlContent);
+  const [renderedDoc, setRenderedDoc] = useState(() => buildSandboxedHtmlDocument(data.htmlContent));
+
+  return (
+    <div className={`scene-node html-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}>
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title html-node-header">
+        <span>HTML</span>
+        <div className="html-node-controls">
+          <button type="button" className="html-node-header-btn" onClick={data.onToggleCollapse}>
+            {data.isCollapsed ? "Expand" : "Collapse"}
+          </button>
+          <button
+            type="button"
+            className="html-node-header-btn"
+            disabled
+            title="Popout view isn't built yet - see the R3 plan doc for why a naive window.open() would be unsafe for untrusted HTML"
+          >
+            Popout
+          </button>
+          <button
+            type="button"
+            className="html-node-header-btn html-node-delete-btn"
+            onClick={data.onDelete}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body html-node-content">
+          <div className="html-node-section">
+            <p className="html-node-section-label">Source</p>
+            <textarea
+              className="html-node-source"
+              value={sourceText}
+              onChange={(event) => setSourceText(event.target.value)}
+              spellCheck={false}
+            />
+          </div>
+          <button
+            type="button"
+            className="html-node-render-btn"
+            onClick={() => setRenderedDoc(buildSandboxedHtmlDocument(sourceText))}
+          >
+            Render
+          </button>
+          <div className="html-node-section">
+            <p className="html-node-section-label">Preview</p>
+            {/* sandbox is EXACTLY "allow-scripts" - no allow-same-origin (no
+                access to this app's origin/storage/parent DOM), no
+                allow-popups, no allow-top-navigation, no allow-forms, no
+                allow-modals. srcDoc (never a blob: URL, never `src`, never
+                dangerouslySetInnerHTML) is the only content-delivery path,
+                and it only ever holds buildSandboxedHtmlDocument's output. */}
+            <iframe
+              className="html-node-preview"
+              sandbox="allow-scripts"
+              srcDoc={renderedDoc}
+              title="HTML preview"
+            />
+          </div>
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -20,6 +20,7 @@ import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
 import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
 import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
 import { DocumentNodeView, type DocumentFlowNode } from "./DocumentNodeView";
+import { HtmlNodeView, type HtmlFlowNode } from "./HtmlNodeView";
 import { ThinkingNodeView, type ThinkingFlowNode } from "./ThinkingNodeView";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { SceneStore, scaleDragPosition } from "./sceneStore";
@@ -40,7 +41,13 @@ const GRID_VARIANTS: Record<string, BackgroundVariant> = {
 };
 
 type PlaceholderNode = Node<{ title: string }, "placeholder">;
-type SceneFlowNode = PlaceholderNode | ChatFlowNode | CodeFlowNode | DocumentFlowNode | ThinkingFlowNode;
+type SceneFlowNode =
+  | PlaceholderNode
+  | ChatFlowNode
+  | CodeFlowNode
+  | DocumentFlowNode
+  | ThinkingFlowNode
+  | HtmlFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   const zoom = useStore((s) => s.transform[2]);
@@ -64,6 +71,7 @@ const NODE_TYPES = {
   code: CodeNodeView,
   document: DocumentNodeView,
   thinking: ThinkingNodeView,
+  html: HtmlNodeView,
 };
 
 function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
@@ -168,6 +176,31 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
         data: {
           thinkingText: n.content,
           onDock: () => store.setNodeDocked(n.id, true),
+          onDelete: () => store.removeNodes([n.id]),
+        },
+      });
+      continue;
+    }
+    if (n.kind === "html") {
+      // No onDock here (unlike thinking/document) - HtmlNodeView never
+      // offers a "dock into parent" action, so this kind never sets
+      // isDocked=true through any UI path of its own. It still passes
+      // through the generic `if (n.isDocked) continue` guard above
+      // untouched: that check is is_docked-field-generic, not kind-gated,
+      // so an html node docked via a direct WS call (setNodeDocked has no
+      // kind restriction backend-side) would still be omitted correctly -
+      // it would just have no UI-driven way back (no "Reveal Docked Items"
+      // entry exists on this node's own header, and ChatNodeView's own
+      // dockedChildren/undock badge is kind-agnostic already, so undocking
+      // it is still possible from the parent chat node's side).
+      flowNodes.push({
+        id: n.id,
+        type: "html" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          htmlContent: n.content,
+          isCollapsed: n.isCollapsed,
+          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
           onDelete: () => store.removeNodes([n.id]),
         },
       });

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -195,6 +195,15 @@ describe("SceneStore", () => {
     ]);
   });
 
+  it("sends html-node intents with the backend's registered names and shapes", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.addHtmlNode(10, 20, "<p>hello</p>", "n1");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "addHtmlNode", args: [10, 20, "<p>hello</p>", "n1"] },
+    ]);
+  });
+
   it("suppresses empty removal intents", () => {
     const { transport, intents } = makeFakeTransport();
     const store = new SceneStore(transport);

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -208,6 +208,15 @@ export class SceneStore {
     this.transport.intent("scene", "addThinkingNode", [x, y, thinkingText, parentId]);
   }
 
+  // R3.17/R3.18: real HTML view nodes. Same posture as addThinkingNode/
+  // addDocumentNode - parentId is REQUIRED (the backend's add_html_node has
+  // no default for it), and there is no real UI creation trigger yet (R4's
+  // agent/plugin layer). The html source string rides the same `content`
+  // field every other node kind's text lives in - no new wire field.
+  addHtmlNode(x: number, y: number, htmlContent: string, parentId: string): void {
+    this.transport.intent("scene", "addHtmlNode", [x, y, htmlContent, parentId]);
+  }
+
   setNodeDocked(id: string, docked: boolean): void {
     this.transport.intent("scene", "setNodeDocked", [id, docked]);
   }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -735,6 +735,140 @@ body,
   border-radius: 999px;
 }
 
+/* -- R3.17/R3.18 html view node -------------------------------------------- */
+
+.html-node {
+  width: 420px;
+  max-height: 640px;
+  min-height: 110px;
+}
+
+.html-node.collapsed {
+  width: 290px;
+  min-height: 58px;
+}
+
+/* Card controls live inline in the header (no context menu for this node -
+   see HtmlNodeView.tsx's doc comment for why). Reuses .chat-node-role's
+   space-between layout so the label sits left and the button row sits
+   right, same as every sibling node's title bar. */
+.html-node-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.html-node-controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.html-node-header-btn {
+  font-size: 10px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 3px 7px;
+  color: var(--gl-surface-text-muted);
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.html-node-header-btn:hover:not(:disabled) {
+  color: var(--gl-surface-text);
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.html-node-header-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.html-node-delete-btn {
+  color: var(--gl-semantic-status-error, currentColor);
+}
+
+.html-node-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.html-node-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.html-node-section-label {
+  margin: 0;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--gl-surface-text-muted);
+}
+
+/* Fixed-height source/preview panes, deliberately not resizable by drag in
+   either direction. Legacy graphlink_html_view.py's QSplitter (splitter_state)
+   was pure Qt UI state with no domain meaning - never in scene_payload/the DB
+   row (confirmed by backend/tests/test_canvas.py's
+   test_html_node_scene_payload_needs_no_new_key) - so it's a scope cut here,
+   not an oversight. `resize: none` on the textarea keeps the browser from
+   offering its own native drag handle as an accidental substitute. */
+.html-node-source {
+  box-sizing: border-box;
+  width: 100%;
+  height: 140px;
+  resize: none;
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 11px;
+  padding: 8px 10px;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.html-node-source:focus {
+  outline: none;
+  border-color: var(--gl-surface-text-muted);
+}
+
+.html-node-render-btn {
+  align-self: flex-start;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 4px 10px;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.html-node-render-btn:hover {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+/* A visible border matters here specifically - it's the visual cue that
+   this rectangle is a distinct, sandboxed embedded document, not part of
+   the card's own chrome. */
+.html-node-preview {
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  height: 140px;
+  background-color: var(--gl-surface-window);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
 /* -- R2 app bar + overlay system ----------------------------------------- */
 
 .app-topbar {


### PR DESCRIPTION
## Summary
The first security-sensitive node type in this rewrite - renders arbitrary/untrusted HTML inside the app. Given the stakes, this increment ran a security-focused variant of the standard process.

**Design phase**: dug into the legacy Qt hardening (`graphlink_webengine.py::_harden_preview_web_view`) before any code was written. Finding: the legacy `QWebEngineView` never disables JavaScript - isolation comes entirely from a profile-level `QWebEngineUrlRequestInterceptor` blocking every non-local network scheme. That set the exact target posture for the SPA: `<iframe sandbox="allow-scripts">` and nothing else (no `allow-same-origin` - the iframe gets an opaque origin with zero access to the parent's cookies/localStorage/DOM even though its own JS runs), with a CSP `<meta>` tag doing the interceptor's network-blocking job - correctly identified as **load-bearing, not "defense-in-depth"**, since sandbox flags govern capability, not network egress.

- **Backend**: `SceneNode` gets **zero new fields** - the HTML source reuses the existing `content` field, same as chat/thinking. `add_html_node` requires `parent_id` (legacy never allows unparented creation). No delete method, no content-mutation intent - Render is 100% client-local and never round-trips to the backend at all.
- **Frontend**: `buildSandboxedHtmlDocument(raw)` is the single function allowed to construct the sandboxed document - a deliberately dumb, unconditional template. `raw` is substituted verbatim into a fixed wrapper with the CSP meta tag always positioned first, with an explicit rule (and a matching adversarial test) that this function must **never** parse, detect, or branch on what `raw` contains - that's exactly the class of bug that would let attacker content race the CSP into place first. Render is gated behind two separate state variables with no `useEffect` linking them - typing in the source textarea can never reach the iframe, only a real button click can.
- **The popout button was decisively cut from this increment's scope** rather than built unsafely: a naive `window.open()` + raw HTML would not inherit the iframe's sandboxing at all (full origin privilege, real cookies, no CSP). Shipped as a genuine, permanently-disabled placeholder with a title explaining why, with the safe follow-up design recorded (a same-origin popout route re-embedding the same sandboxed iframe, content passed by node id + WS lookup, never by URL).
- **Review added a 5th role** to the now-standard 4-way process (backend/frontend/integration/legacy-parity): a dedicated adversarial security reviewer whose only job was to try to break the isolation. It constructed real exfiltration/CSP-override payloads by hand, traced them through the actual code, wrote and ran its own additional adversarial tests reusing the attack strings, and returned a definitive **SAFE** verdict.

## Test plan
- [x] `python -m pytest -q` (repo-wide): 1886 passed
- [x] `npm run check` (schema/typecheck/lint/test/build): all green, 649 vitest passing, **zero codegen/schema drift** confirmed explicitly (no new backend field was needed)
- [x] **Live security smoke test against the real running backend and browser** (not just unit tests): created a real chat node then a real HtmlViewNode parented to it via direct WS intents, with content set to an actual exfiltration payload - a `<script>` attempting `window.parent.document.title = "PWNED"`, `window.top.location = "http://evil.example/"`, and leaking a marker global onto `window`. After the node rendered live: the parent page's real `document.title` was unchanged ("Graphlink"), `window.location` had not navigated, no marker global leaked onto the parent's `window`, and the parent could not read into the iframe's `contentDocument` either - confirming opaque-origin isolation holds in both directions, in a real browser
- [x] Confirmed the sandbox attribute's live DOM value is the exact string `"allow-scripts"`
- [x] Confirmed collapse/expand/delete round-trip through the real backend correctly

Remaining in R3 (not this PR): the image node type, and the `ConversationNode` fast-follow.