### PR TITLE
Qt-removal R3.21-R3.24: ImageNode

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -34,6 +34,7 @@ from graphlink_licensing import SettingsManager
 
 from backend import BACKEND_VERSION
 from backend.about import register_about
+from backend.assets import register_assets
 from backend.canvas import register_canvas
 from backend.chat_library import register_chat_library
 from backend.composer import register_composer
@@ -71,7 +72,14 @@ def _configure_session(bus: SessionBus, settings_manager: SettingsManager, chat_
     notifications_state = register_notifications(bus)
 
     # R1 (doc/QT_REMOVAL_PLAN.md): scene document + grid topics.
-    register_canvas(bus, notifications_state)
+    # R3.21: stash the document on its own SessionBus so backend/assets.py's
+    # GET /api/assets/{id} route (registered once, globally, on the app) can
+    # reach the SAME per-session SceneDocument register_canvas() built here -
+    # there was previously no way to get from a session id back to its
+    # canvas document outside this closure. SessionBus has no fixed attribute
+    # set (no __slots__), so this is a plain, minimal bolt-on attribute, not
+    # a SessionBus API change.
+    bus.canvas_document = register_canvas(bus, notifications_state)
 
     # R2: composer draft/reasoning, token counter.
     token_counter = register_token_counter(bus)
@@ -102,6 +110,10 @@ def create_app(
     @app.get("/api/health")
     async def health() -> JSONResponse:
         return JSONResponse({"status": "ok", "app": "graphlink", "version": BACKEND_VERSION})
+
+    # R3.21: GET /api/assets/{id} - the image-node byte-serving route (see
+    # backend/assets.py's docstring for the transport decision behind it).
+    register_assets(app, bus)
 
     @app.websocket("/ws")
     async def ws_endpoint(websocket: WebSocket) -> None:

--- a/backend/assets.py
+++ b/backend/assets.py
@@ -1,0 +1,36 @@
+"""Binary asset serving for the new architecture (Qt-removal plan R3.21).
+
+Image-node bytes never travel over the WS scene snapshot - see the
+transport-decision comment on backend/canvas.py's SceneDocument.image_assets
+for why (scene_payload() resends every node on every publish_scene() call,
+so inlined bytes there would compound in size on every unrelated mutation).
+Instead the frontend fetches them on demand from this dedicated HTTP route,
+addressed by the opaque image_asset_id each image-kind SceneNode carries.
+
+This route needs to reach the SAME SceneDocument instance register_canvas()
+built for a given session - not a fresh one - so it goes through the same
+EventBus.session(session_id) lookup /ws already uses (and defaults to
+"default" the same way), then reads the document off the SessionBus. See
+backend/app.py's _configure_session for the (small) structural change that
+makes the document reachable there.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Response
+from fastapi.responses import JSONResponse
+
+from backend.events import EventBus
+
+
+def register_assets(app: FastAPI, bus: EventBus) -> None:
+    """Give the app its one asset route: GET /api/assets/{asset_id}."""
+
+    @app.get("/api/assets/{asset_id}")
+    async def get_asset(asset_id: str, session: str = "default") -> Response:
+        document = bus.session(session).canvas_document
+        asset = document.get_image_asset(asset_id)
+        if asset is None:
+            return JSONResponse({"error": "unknown asset"}, status_code=404)
+        image_bytes, mime_type = asset
+        return Response(content=image_bytes, media_type=mime_type)

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -20,8 +20,10 @@ document IS the source of truth the window can reload against.
 
 from __future__ import annotations
 
+import base64
 import itertools
 import math
+import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -87,6 +89,10 @@ THINKING_TITLE_PREVIEW_LENGTH = 60
 # text for truncation purposes (not code), so it reuses chat/thinking's
 # 60-char length rather than code's 40.
 HTML_TITLE_PREVIEW_LENGTH = 60
+# R3.21: image-node titles preview the generation prompt, which is prose
+# like chat/thinking/html, so it reuses their 60-char length rather than
+# code's 40.
+IMAGE_TITLE_PREVIEW_LENGTH = 60
 
 
 @dataclass
@@ -172,6 +178,11 @@ class SceneNode:
     # time from this flag (scan nodes whose parent edge points at it), never
     # stored on the parent itself. Unused (default) for every other kind.
     is_docked: bool = False
+    # R3.21 (doc/QT_REMOVAL_PLAN.md): the image node's real persisted shape -
+    # an opaque reference key into SceneDocument.image_assets. Image bytes
+    # never live on the node itself (see the transport-decision comment on
+    # image_assets below). Unused (default) for every other kind.
+    image_asset_id: str = ""
 
 
 @dataclass
@@ -201,6 +212,18 @@ class SceneDocument:
     # Qt-free stand-in for "the currently active branch" until real node
     # selection exists. None means the next message starts a fresh root.
     last_chat_node_id: str | None = None
+    # R3.21: in-memory, session-scoped store for image-node bytes, keyed by
+    # asset id (see SceneNode.image_asset_id) -> (raw_bytes, mime_type).
+    # TRANSPORT DECISION: images travel to the client via a dedicated GET
+    # /api/assets/{id} HTTP route (backend/assets.py), NEVER inlined into
+    # scene_payload(). scene_payload() resends every node on every
+    # publish_scene() call - roughly 20 different intents trigger it, none
+    # of them debounced - so inlining image bytes there would compound in
+    # size on every unrelated mutation for the rest of the session. No disk
+    # persistence yet: there is zero live creation trigger for this
+    # increment, same posture as every prior node-type increment before its
+    # real trigger landed.
+    image_assets: dict[str, tuple[bytes, str]] = field(default_factory=dict)
     _counter: itertools.count = field(default_factory=itertools.count, repr=False)
 
     # -- nodes -------------------------------------------------------------
@@ -424,6 +447,73 @@ class SceneDocument:
         self.connect(parent_id, node_id)
         return node
 
+    def add_image_node(
+        self,
+        x: float,
+        y: float,
+        image_bytes: bytes,
+        prompt: str,
+        parent_id: str,
+        *,
+        mime_type: str = "image/png",
+    ) -> SceneNode:
+        """R3.21's image-node equivalent of add_document_node/
+        add_thinking_node/add_html_node: a real generated-image node. Same as
+        document/thinking/html (and unlike chat/code), parent_id is
+        REQUIRED, not optional - an image node never exists unparented - so
+        this unconditionally connects to its parent, no `if parent_id` guard.
+
+        Image bytes do NOT live on SceneNode (see the transport-decision
+        comment on SceneDocument.image_assets) - they go into that
+        session-scoped store, keyed by a SEPARATE id. Unlike node/edge ids
+        (which only need to be unique within their own SceneDocument, since
+        nothing ever looks a node up across sessions), asset ids are read
+        back through GET /api/assets/{id}, a route that takes a bare id plus
+        an independent session query param - so a per-document counter here
+        would let two sessions mint the identical "imgN" id for unrelated
+        images (guaranteed, not just probabilistic, for sessions that create
+        nodes in the same order), and a caller that omits/mis-supplies the
+        session param would silently be served someone else's image instead
+        of a 404. A uuid4 hex keeps the id globally unique so cross-session
+        collision is not possible regardless of session query correctness.
+        image_asset_id on the node is just the opaque reference key into
+        that store.
+
+        There is no natural title-preview text for an image the way there is
+        for text-based kinds, so the title is the prompt (truncated, same
+        60-char convention as chat/thinking/html) when non-empty, else a
+        literal "Image".
+
+        Image nodes are also NOT branch points (same as code/document/
+        thinking/html): there is no delete_image_node; deletion goes
+        entirely through the existing generic remove_nodes, which
+        additionally evicts this node's image_assets entry so bytes never
+        outlive the node (see remove_nodes).
+        """
+        if parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        asset_id = f"img{uuid.uuid4().hex}"
+        self.image_assets[asset_id] = (image_bytes, mime_type)
+        title = str(prompt)[:IMAGE_TITLE_PREVIEW_LENGTH] or "Image"
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title=title,
+            kind="image",
+            content=str(prompt),
+            image_asset_id=asset_id,
+        )
+        self.nodes[node_id] = node
+        self.connect(parent_id, node_id)
+        return node
+
+    def get_image_asset(self, asset_id: str) -> tuple[bytes, str] | None:
+        """The read-side of image_assets - the same lookup backend/assets.py's
+        GET /api/assets/{id} route calls to serve the raw bytes + mime type."""
+        return self.image_assets.get(asset_id)
+
     def delete_chat_node(self, node_id: str) -> None:
         """Delete one chat node WITHOUT orphaning its branch: children are
         re-parented to the deleted node's own parent (or become roots if it
@@ -494,7 +584,8 @@ class SceneDocument:
 
     def remove_nodes(self, node_ids: list[str]) -> None:
         for node_id in node_ids:
-            if self.nodes.pop(node_id, None) is not None:
+            node = self.nodes.pop(node_id, None)
+            if node is not None:
                 # Edges die with either endpoint - same invariant ChatScene
                 # enforced on node removal.
                 self.edges = {
@@ -502,6 +593,11 @@ class SceneDocument:
                     for eid, e in self.edges.items()
                     if e.source != node_id and e.target != node_id
                 }
+                # R3.21: an image node's bytes must not outlive the node -
+                # evict its image_assets entry too, or a long session's
+                # deleted images would accumulate in memory forever.
+                if node.image_asset_id:
+                    self.image_assets.pop(node.image_asset_id, None)
 
     # -- edges -------------------------------------------------------------
 
@@ -570,6 +666,7 @@ class SceneDocument:
                     "byteSize": n.byte_size,
                     "previewLabel": n.preview_label,
                     "isDocked": n.is_docked,
+                    "imageAssetId": n.image_asset_id,
                 }
                 for n in self.nodes.values()
             ],
@@ -701,6 +798,16 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
         await publish_scene()
         return node.id
 
+    async def add_image_node(x, y, image_bytes_base64, prompt, parent_id, mime_type="image/png"):
+        # Unlike every prior wrapper, the WS intent transport is JSON, which
+        # cannot carry raw bytes - the caller sends base64 text, decoded here
+        # before it ever reaches SceneDocument (which only ever deals in real
+        # bytes, same as the HTTP asset route on the read side).
+        image_bytes = base64.b64decode(image_bytes_base64)
+        node = document.add_image_node(x, y, image_bytes, prompt, parent_id, mime_type=mime_type)
+        await publish_scene()
+        return node.id
+
     async def set_node_docked(node_id, docked):
         document.set_node_docked(node_id, docked)
         await publish_scene()
@@ -779,6 +886,7 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
     bus.register_intent("scene", "addDocumentNode", add_document_node)
     bus.register_intent("scene", "addThinkingNode", add_thinking_node)
     bus.register_intent("scene", "addHtmlNode", add_html_node)
+    bus.register_intent("scene", "addImageNode", add_image_node)
     bus.register_intent("scene", "setNodeDocked", set_node_docked)
     bus.register_intent("scene", "deleteChatNode", delete_chat_node)
     bus.register_intent("scene", "setChatCollapsed", set_chat_collapsed)

--- a/backend/tests/test_assets.py
+++ b/backend/tests/test_assets.py
@@ -1,0 +1,115 @@
+"""Asset-serving route tests (Qt-removal plan R3.21): GET /api/assets/{id}
+against the real ASGI app through FastAPI's TestClient - no network, no Qt.
+
+Image nodes are created directly through the session's SceneDocument (not
+through the WS layer) so these tests stay focused on the HTTP route itself;
+the WS addImageNode intent (base64 decode -> real node) is already covered
+in backend/tests/test_canvas.py."""
+
+import tempfile
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+
+
+def make_client(tmp_path: Path | None = None) -> TestClient:
+    # Same isolation convention as test_app_ws.py's make_client: a fresh temp
+    # dir per client so tests never touch the developer's real
+    # ~/.graphlink/session.dat or ~/.graphlink/chats.db.
+    spa = tmp_path if tmp_path is not None else Path("__no_such_dir__")
+    state_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    state_path = Path(state_dir.name)
+    client = TestClient(
+        create_app(
+            spa_dir=spa,
+            settings_state_file=state_path / "session.dat",
+            chat_db_path=state_path / "chats.db",
+        )
+    )
+    client._state_tmpdir = state_dir  # type: ignore[attr-defined]
+    return client
+
+
+def test_get_asset_returns_exact_bytes_and_stored_mime_type():
+    client = make_client()
+    bus = client.app.state.bus
+    document = bus.session("default").canvas_document
+    parent = document.add_node(0, 0, "parent")
+    node = document.add_image_node(
+        0, 0, b"\x89PNG\r\n\x1a\nsome raw image bytes", "a test image", parent.id, mime_type="image/png"
+    )
+
+    response = client.get(f"/api/assets/{node.image_asset_id}")
+
+    assert response.status_code == 200
+    assert response.content == b"\x89PNG\r\n\x1a\nsome raw image bytes"
+    assert response.headers["content-type"] == "image/png"
+
+
+def test_get_asset_respects_the_mime_type_it_was_stored_with():
+    client = make_client()
+    bus = client.app.state.bus
+    document = bus.session("default").canvas_document
+    parent = document.add_node(0, 0, "parent")
+    node = document.add_image_node(0, 0, b"jpeg-ish bytes", "prompt", parent.id, mime_type="image/jpeg")
+
+    response = client.get(f"/api/assets/{node.image_asset_id}")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+
+
+def test_get_asset_for_unknown_id_returns_404_json():
+    client = make_client()
+
+    response = client.get("/api/assets/nope-not-real")
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "unknown asset"}
+
+
+def test_get_asset_scopes_by_session_query_param():
+    client = make_client()
+    bus = client.app.state.bus
+    document_a = bus.session("session-a").canvas_document
+    parent = document_a.add_node(0, 0, "parent")
+    node = document_a.add_image_node(0, 0, b"session-a bytes", "prompt", parent.id)
+
+    # The default session has no such asset.
+    default_response = client.get(f"/api/assets/{node.image_asset_id}")
+    assert default_response.status_code == 404
+
+    # The session it was actually created under does.
+    scoped_response = client.get(f"/api/assets/{node.image_asset_id}?session=session-a")
+    assert scoped_response.status_code == 200
+    assert scoped_response.content == b"session-a bytes"
+
+
+def test_asset_ids_do_not_collide_across_sessions_with_identical_creation_order():
+    # Regression: asset ids must be globally unique, not just unique within
+    # one SceneDocument. Two sessions performing the identical sequence of
+    # operations (one parent node, then one image node) used to mint the
+    # exact same "imgN" id from each document's own fresh counter - not a
+    # rare fluke, the deterministic median case. That let a request missing
+    # or mis-supplying its session query param be silently served a
+    # different session's real image instead of a 404.
+    client = make_client()
+    bus = client.app.state.bus
+
+    document_a = bus.session("session-a").canvas_document
+    parent_a = document_a.add_node(0, 0, "parent")
+    node_a = document_a.add_image_node(0, 0, b"session-a bytes", "prompt", parent_a.id)
+
+    document_b = bus.session("session-b").canvas_document
+    parent_b = document_b.add_node(0, 0, "parent")
+    node_b = document_b.add_image_node(0, 0, b"session-b bytes", "prompt", parent_b.id)
+
+    assert node_a.image_asset_id != node_b.image_asset_id
+
+    response_a = client.get(f"/api/assets/{node_a.image_asset_id}?session=session-b")
+    assert response_a.status_code == 404
+
+    response_b = client.get(f"/api/assets/{node_b.image_asset_id}?session=session-a")
+    assert response_b.status_code == 404

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -3,6 +3,7 @@ intent surface, grid payload compatibility with the generated validator's
 shape, and snapshot publishing."""
 
 import asyncio
+import base64
 
 import pytest
 
@@ -513,6 +514,120 @@ def test_add_html_node_intent_creates_a_real_node_and_publishes():
         )
         assert document.nodes[node_id].kind == "html"
         assert document.nodes[node_id].content == "<h1>preview</h1>"
+        assert any(
+            e.source == parent_id and e.target == node_id for e in document.edges.values()
+        )
+        assert recorder.topics_seen().count("scene") == 2, "both mutations publish"
+
+    asyncio.run(run())
+
+
+# -- R3.21: image nodes -------------------------------------------------------
+
+
+def test_add_image_node_creates_a_real_image_kind_node():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "generate a picture of a cat", True)
+    node = doc.add_image_node(10, 20, b"\x89PNG raw bytes", "a cat wearing a hat", parent.id)
+    assert node.kind == "image"
+    assert node.content == "a cat wearing a hat"
+    assert node.title == "a cat wearing a hat"
+    assert node.image_asset_id != ""
+    assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
+
+
+def test_add_image_node_falls_back_to_image_title_for_empty_prompt():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_image_node(0, 0, b"bytes", "", parent.id)
+    assert node.title == "Image"
+
+
+def test_add_image_node_stores_the_asset_retrievable_with_correct_bytes_and_mime_type():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_image_node(0, 0, b"raw-png-bytes", "prompt", parent.id, mime_type="image/png")
+    asset = doc.get_image_asset(node.image_asset_id)
+    assert asset == (b"raw-png-bytes", "image/png")
+
+
+def test_get_image_asset_returns_none_for_unknown_id():
+    doc = SceneDocument()
+    assert doc.get_image_asset("ghost") is None
+
+
+def test_add_image_node_rejects_unknown_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_image_node(0, 0, b"bytes", "orphaned image", "ghost")
+
+
+def test_add_image_node_requires_a_parent_id():
+    # Same as add_document_node/add_thinking_node/add_html_node - parent_id
+    # has no default in add_image_node's signature, so calling without one is
+    # a TypeError (missing required argument), not a SceneError.
+    doc = SceneDocument()
+    with pytest.raises(TypeError):
+        doc.add_image_node(0, 0, b"bytes", "orphaned image")
+
+
+def test_scene_payload_includes_image_asset_id_defaulted_for_other_kinds():
+    doc = SceneDocument()
+    doc.add_node(0, 0, "plain")
+    parent = doc.add_node(1, 1, "parent")
+    image_node = doc.add_image_node(2, 2, b"bytes", "a real prompt", parent.id)
+    rows = {n["id"]: n for n in doc.scene_payload()["nodes"]}
+    assert rows["n0"]["imageAssetId"] == ""
+    assert rows[parent.id]["imageAssetId"] == ""
+    assert rows[image_node.id]["imageAssetId"] == image_node.image_asset_id
+    assert rows[image_node.id]["imageAssetId"] != ""
+
+
+def test_image_node_deletion_goes_through_remove_nodes_and_evicts_the_asset():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_image_node(10, 10, b"doomed bytes", "doomed image", parent.id)
+    asset_id = node.image_asset_id
+    assert not hasattr(doc, "delete_image_node"), "image nodes are not branch points - no special delete method"
+
+    assert doc.get_image_asset(asset_id) is not None
+    doc.remove_nodes([node.id])
+
+    assert node.id not in doc.nodes
+    assert not any(e.target == node.id or e.source == node.id for e in doc.edges.values())
+    assert doc.get_image_asset(asset_id) is None, "deleting the node must evict its asset-store entry too"
+    assert doc.image_assets == {}, "no leftover entries linger after the owning node is gone"
+
+
+def test_non_image_node_deletion_does_not_touch_image_assets():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    image_node = doc.add_image_node(0, 0, b"keep me", "keep this image", parent.id)
+    code_node = doc.add_code_node(1, 1, "x = 1", "python", parent_id=parent.id)
+
+    doc.remove_nodes([code_node.id])
+
+    assert code_node.id not in doc.nodes
+    assert doc.get_image_asset(image_node.image_asset_id) == (b"keep me", "image/png"), (
+        "deleting a node with no image_asset_id must not touch image_assets at all"
+    )
+
+
+def test_add_image_node_intent_creates_a_real_node_and_publishes():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addChatNode", [0, 0, "hi", True])
+        image_bytes = b"\x89PNG\r\n\x1a\nfake-but-real-bytes"
+        encoded = base64.b64encode(image_bytes).decode("ascii")
+        node_id = await bus.dispatch_intent(
+            "scene",
+            "addImageNode",
+            [10, 10, encoded, "a generated image", parent_id, "image/jpeg"],
+        )
+        assert document.nodes[node_id].kind == "image"
+        assert document.nodes[node_id].content == "a generated image"
+        asset = document.get_image_asset(document.nodes[node_id].image_asset_id)
+        assert asset == (image_bytes, "image/jpeg"), "base64 payload must decode back to the exact original bytes"
         assert any(
             e.source == parent_id and e.target == node_id for e in document.edges.values()
         )

--- a/graphlink_app/graphlink_scene_payload.py
+++ b/graphlink_app/graphlink_scene_payload.py
@@ -27,6 +27,11 @@ R3.13 adds `isDocked` (the ThinkingNode/docked-child increment): true when a
 node is currently docked into its parent's docked-child slot, populated for
 any kind that has been docked, defaulted false otherwise - same additive
 rule.
+
+R3.21 adds `imageAssetId` (the ImageNode increment): the opaque asset-store
+key an image-kind node's bytes live under (fetched separately over HTTP,
+never inlined here), populated for kind=="image" rows, defaulted (empty
+string) for every other kind, same additive rule.
 """
 
 from __future__ import annotations
@@ -61,6 +66,12 @@ class SceneNodeRow:
     # that has been docked into its parent's docked-child slot, defaulted
     # false for every other node.
     isDocked: bool = False
+    # R3.21: the image node's opaque reference key into the asset store
+    # (backend/assets.py's GET /api/assets/{id}) - populated for kind=="image"
+    # rows, defaulted (empty string) for every other kind. The image bytes
+    # themselves never appear in this payload - see the transport-decision
+    # comment on backend/canvas.py's SceneDocument.image_assets.
+    imageAssetId: str = ""
 
 
 @dataclass

--- a/web_ui/src/app/canvas/ImageNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ImageNodeView.test.tsx
@@ -1,0 +1,229 @@
+import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ImageNodeView, type ImageFlowNode } from "./ImageNodeView";
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
+// ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too.
+function renderImageNode(overrides: Partial<ImageFlowNode["data"]> = {}, id = "n0") {
+  const onDelete = vi.fn();
+  const props = {
+    id,
+    selected: false,
+    data: {
+      imageAssetId: "asset-123",
+      prompt: "a red fox in the snow",
+      onDelete,
+      ...overrides,
+    },
+  } as unknown as NodeProps<ImageFlowNode>;
+
+  const { container } = render(
+    <ReactFlowProvider>
+      <ImageNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return { onDelete, container };
+}
+
+// jsdom implements neither URL.createObjectURL/revokeObjectURL nor
+// ClipboardItem nor navigator.clipboard - every test that exercises Copy
+// Image/Export Image has to hand-install its own fakes for the run. These
+// are plain property assignments (not vi.spyOn) because vi.spyOn requires
+// the property to already exist on the object, and none of the above do in
+// this jsdom version.
+// A real `class`, not vi.fn().mockImplementation(arrow) - ClipboardItem is
+// invoked with `new` in the component, and an arrow-function mock can't be a
+// constructor (vitest surfaces that as a silent-looking TypeError caught by
+// handleCopyImage's own try/catch, which made the failure confusing until
+// traced: `write` was never reached because construction itself threw).
+class FakeClipboardItem {
+  items: Record<string, Blob>;
+  constructor(items: Record<string, Blob>) {
+    this.items = items;
+  }
+}
+
+beforeEach(() => {
+  URL.createObjectURL = vi.fn().mockReturnValue("blob:fake-object-url");
+  URL.revokeObjectURL = vi.fn();
+  (globalThis as unknown as { ClipboardItem: unknown }).ClipboardItem = FakeClipboardItem;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("ImageNodeView", () => {
+  it("renders the img with the correct src pointing at the asset endpoint", () => {
+    const { container } = renderImageNode({ imageAssetId: "asset-123" });
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute("src", "/api/assets/asset-123");
+  });
+
+  it("falls back to 'Generated image' alt text when prompt is empty", () => {
+    const { container } = renderImageNode({ prompt: "" });
+    const img = container.querySelector("img");
+    expect(img).toHaveAttribute("alt", "Generated image");
+  });
+
+  it("uses the prompt as alt text when present", () => {
+    const { container } = renderImageNode({ prompt: "a red fox in the snow" });
+    const img = container.querySelector("img");
+    expect(img).toHaveAttribute("alt", "a red fox in the snow");
+  });
+
+  it("onError shows the 'Image unavailable' placeholder and hides the broken img", () => {
+    const { container } = renderImageNode();
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+
+    fireEvent.error(img!);
+
+    expect(screen.getByText("Image unavailable")).toBeInTheDocument();
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("right-click opens a menu with real Copy Image/Export Image/Delete Image and disabled Hide Other Branches/Regenerate Image", async () => {
+    const user = userEvent.setup();
+    const { onDelete } = renderImageNode({ prompt: "a red fox in the snow" });
+
+    const title = screen.getByText("a red fox in the snow");
+    fireEvent.contextMenu(title);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    expect(screen.getByRole("menuitem", { name: "Copy Image" })).toBeEnabled();
+    expect(screen.getByRole("menuitem", { name: "Export Image" })).toBeEnabled();
+
+    const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
+    expect(hideBranches).toBeDisabled();
+    expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
+
+    const regenerate = screen.getByRole("menuitem", { name: "Regenerate Image" });
+    expect(regenerate).toBeDisabled();
+    expect(regenerate).toHaveAttribute("title", "Agent regeneration lands in R4");
+
+    await user.click(screen.getByRole("menuitem", { name: "Delete Image" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("clicking Copy Image fetches the asset and writes it to the clipboard as a ClipboardItem", async () => {
+    const user = userEvent.setup();
+    renderImageNode({ imageAssetId: "asset-abc", prompt: "sunset over the bay" });
+
+    const fakeBlob = { type: "image/png" } as Blob;
+    const fetchMock = vi.fn().mockResolvedValue({ blob: () => Promise.resolve(fakeBlob) } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const write = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { write }, configurable: true });
+
+    fireEvent.contextMenu(screen.getByText("sunset over the bay"));
+    await user.click(screen.getByRole("menuitem", { name: "Copy Image" }));
+
+    await waitFor(() => expect(write).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith("/api/assets/asset-abc");
+    expect(write).toHaveBeenCalledWith([new FakeClipboardItem({ "image/png": fakeBlob })]);
+  });
+
+  it("does not throw when the clipboard write fails", async () => {
+    const user = userEvent.setup();
+    renderImageNode({ imageAssetId: "asset-abc", prompt: "sunset over the bay" });
+
+    const fakeBlob = { type: "image/png" } as Blob;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ blob: () => Promise.resolve(fakeBlob) } as unknown as Response),
+    );
+    const write = vi.fn().mockRejectedValue(new Error("permission denied"));
+    Object.defineProperty(navigator, "clipboard", { value: { write }, configurable: true });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    fireEvent.contextMenu(screen.getByText("sunset over the bay"));
+    await user.click(screen.getByRole("menuitem", { name: "Copy Image" }));
+
+    await waitFor(() => expect(write).toHaveBeenCalled());
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    consoleError.mockRestore();
+  });
+
+  it("clicking Export Image fetches the asset, creates an object URL, and clicks a temporary download anchor", async () => {
+    const user = userEvent.setup();
+    renderImageNode({ imageAssetId: "asset-xyz", prompt: "mountain lake" }, "n7");
+
+    const fakeBlob = { type: "image/png" } as Blob;
+    const fetchMock = vi.fn().mockResolvedValue({ blob: () => Promise.resolve(fakeBlob) } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    // jsdom has no navigation implementation, so letting a real anchor.click()
+    // run its default download/navigate behavior would either no-op silently
+    // or spam "Not implemented: navigation" to the virtual console depending
+    // on jsdom's version - neither tells us anything useful. Instead, spy on
+    // HTMLAnchorElement.prototype.click itself (rather than document.
+    // createElement) so we capture the exact anchor instance our code built,
+    // without ever letting jsdom attempt real navigation.
+    // A plain `let` reassigned only from inside the mockImplementation
+    // closure below type-checks its later reads as `never` (TS can't narrow
+    // a closure-captured let back to its declared type across the
+    // intervening `await`) - an object wrapper sidesteps that entirely.
+    const captured: { anchor: HTMLAnchorElement | null } = { anchor: null };
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        captured.anchor = this;
+      });
+
+    fireEvent.contextMenu(screen.getByText("mountain lake"));
+    await user.click(screen.getByRole("menuitem", { name: "Export Image" }));
+
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith("/api/assets/asset-xyz");
+    expect(URL.createObjectURL).toHaveBeenCalledWith(fakeBlob);
+    expect(captured.anchor?.getAttribute("href")).toBe("blob:fake-object-url");
+    expect(captured.anchor?.getAttribute("download")).toBe("mountain-lake.png");
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:fake-object-url");
+  });
+
+  it("falls back to the node id for the download filename when prompt is empty", async () => {
+    const user = userEvent.setup();
+    renderImageNode({ imageAssetId: "asset-xyz", prompt: "" }, "n7");
+
+    const fakeBlob = { type: "image/png" } as Blob;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ blob: () => Promise.resolve(fakeBlob) } as unknown as Response),
+    );
+
+    const captured: { anchor: HTMLAnchorElement | null } = { anchor: null };
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        captured.anchor = this;
+      });
+
+    fireEvent.contextMenu(screen.getByText("Image"));
+    await user.click(screen.getByRole("menuitem", { name: "Export Image" }));
+
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled());
+    expect(captured.anchor?.getAttribute("download")).toBe("n7.png");
+  });
+
+  it("Escape and outside-click both close the menu", async () => {
+    const user = userEvent.setup();
+    renderImageNode({ prompt: "a red fox in the snow" });
+    const title = screen.getByText("a red fox in the snow");
+
+    fireEvent.contextMenu(title);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(title);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/ImageNodeView.tsx
+++ b/web_ui/src/app/canvas/ImageNodeView.tsx
@@ -1,0 +1,240 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+
+/**
+ * The image node (Qt-removal plan R3.21/R3.22) - graphlink_node_image.py's
+ * React successor: a card holding a single generated/attached image,
+ * push-only same as chat/code/document/thinking/html (content arrives via
+ * the scene document; the WS-side addImageNode intent has no live UI
+ * trigger yet - same posture addCodeNode/addDocumentNode/addThinkingNode/
+ * addHtmlNode were in when they first shipped - see sceneStore.ts). Unlike
+ * ChatNode/DocumentNode/HtmlNode, ImageNode has no manual collapse toggle at
+ * all - like CodeNode/ThinkingNode, it only ever auto-collapses on zoom
+ * (LOD), since the legacy ImageNode has no collapse concept whatsoever
+ * (confirmed during R3.21/R3.22 design).
+ *
+ * The image bytes themselves NEVER ride the scene WS topic - only a small
+ * imageAssetId reference string does (backend/canvas.py's SceneNodeRow gains
+ * this field for every kind, empty string for non-image rows). The actual
+ * bytes are fetched over a plain HTTP GET to /api/assets/{assetId}, a normal
+ * browser-fetchable URL (not a WS topic, unlike every other node's content) -
+ * both the <img src> below and the Copy/Export menu actions hit that same
+ * endpoint via assetUrl() so all three call sites can never drift from one
+ * another.
+ *
+ * Real: render (via <img src>, with an onError-driven "Image unavailable"
+ * placeholder - the legacy app's own verbatim text - for a broken/unknown
+ * asset id), delete (generic cascade-delete; image nodes are never branch
+ * points, so there's no reparent rule to honor), Copy Image (fetch -> blob
+ * -> navigator.clipboard.write with a real ClipboardItem - NOT a data URI or
+ * an <img>, Clipboard API image writes require an actual Blob), Export Image
+ * (fetch -> blob -> object URL -> a temporary anchor's programmatic download,
+ * revoked immediately after). Deferred, with an honest disabled+title label
+ * rather than a silent drop (same posture every sibling node menu takes):
+ * Hide Other Branches (branch visibility isn't built yet - unscoped, not
+ * owned by any R-phase) and Regenerate Image (R4's agent layer - same
+ * agent-layer-blocked semantics as Chat's "Regenerate Response").
+ */
+
+export interface ImageNodeData extends Record<string, unknown> {
+  imageAssetId: string;
+  prompt: string;
+  onDelete: () => void;
+}
+
+export type ImageFlowNode = Node<ImageNodeData, "image">;
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+/** The one place this file turns an asset id into a URL - the <img> render
+ * below and both menu actions (Copy Image, Export Image) all call this, so
+ * they can never disagree with each other about the endpoint shape. */
+function assetUrl(imageAssetId: string): string {
+  return `/api/assets/${imageAssetId}`;
+}
+
+/** A reasonable download filename for Export Image: the prompt, slugified,
+ * falling back to the node id when there's no prompt to work with. Kept
+ * deliberately simple - the asset endpoint's Content-Type is the real source
+ * of truth for what the bytes are, and browsers don't require a "correct"
+ * extension to accept a download. */
+function buildDownloadFilename(nodeId: string, prompt: string): string {
+  const base = prompt.trim() || nodeId;
+  const slug = base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-+|-+$)/g, "");
+  return `${slug || nodeId}.png`;
+}
+
+/** Fetch the asset, then hand the browser's Clipboard API a real Blob via
+ * ClipboardItem (not a data URI, not an <img> element - navigator.clipboard.
+ * write's image path requires an actual Blob). Any failure here (missing
+ * Clipboard API, a permissions prompt the user denied, an insecure context)
+ * is swallowed rather than thrown - a best-effort menu action should never
+ * crash the node, it should just silently not have copied anything. */
+async function handleCopyImage(imageAssetId: string): Promise<void> {
+  try {
+    const response = await fetch(assetUrl(imageAssetId));
+    const blob = await response.blob();
+    await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+  } catch (error) {
+    console.error("[image-node] Copy Image failed:", error);
+  }
+}
+
+/** Fetch the asset, wrap it in an object URL, and drive a temporary,
+ * never-attached-to-view anchor's download through a programmatic click -
+ * the standard "save this blob as a file" browser pattern. The object URL is
+ * revoked immediately after the click to avoid leaking it (the click itself
+ * is synchronous, so the browser has already captured what it needs from the
+ * URL by the time revokeObjectURL runs on the next line). */
+async function handleExportImage(imageAssetId: string, filename: string): Promise<void> {
+  try {
+    const response = await fetch(assetUrl(imageAssetId));
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = objectUrl;
+    anchor.download = filename;
+    anchor.click();
+    URL.revokeObjectURL(objectUrl);
+  } catch (error) {
+    console.error("[image-node] Export Image failed:", error);
+  }
+}
+
+function ImageNodeMenu({
+  position,
+  imageAssetId,
+  filename,
+  onDelete,
+  onClose,
+}: {
+  position: MenuPosition;
+  imageAssetId: string;
+  filename: string;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
+      // type-only import above shadows the bare name for casts like this).
+      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      {/* Legacy order: Copy Image, Export Image, separator, Hide Other
+          Branches, Regenerate Image, Delete Image. */}
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          void handleCopyImage(imageAssetId);
+          onClose();
+        }}
+      >
+        Copy Image
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          void handleExportImage(imageAssetId, filename);
+          onClose();
+        }}
+      >
+        Export Image
+      </button>
+      <div className="chat-node-menu-separator" role="separator" />
+      <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
+        Hide Other Branches
+      </button>
+      <button type="button" role="menuitem" disabled title="Agent regeneration lands in R4">
+        Regenerate Image
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        Delete Image
+      </button>
+    </div>
+  );
+}
+
+export function ImageNodeView({ id, data, selected }: NodeProps<ImageFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const collapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+  const [imageFailed, setImageFailed] = useState(false);
+
+  const altText = data.prompt || "Generated image";
+
+  return (
+    <div
+      className={`scene-node image-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title image-node-title">
+        <span>{data.prompt || "Image"}</span>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body image-node-content">
+          {imageFailed ? (
+            <div className="image-node-placeholder">Image unavailable</div>
+          ) : (
+            <img
+              className="image-node-img"
+              src={assetUrl(data.imageAssetId)}
+              alt={altText}
+              onError={() => setImageFailed(true)}
+            />
+          )}
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+      {menuPosition && (
+        <ImageNodeMenu
+          position={menuPosition}
+          imageAssetId={data.imageAssetId}
+          filename={buildDownloadFilename(id, data.prompt)}
+          onDelete={data.onDelete}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -21,6 +21,7 @@ import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
 import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
 import { DocumentNodeView, type DocumentFlowNode } from "./DocumentNodeView";
 import { HtmlNodeView, type HtmlFlowNode } from "./HtmlNodeView";
+import { ImageNodeView, type ImageFlowNode } from "./ImageNodeView";
 import { ThinkingNodeView, type ThinkingFlowNode } from "./ThinkingNodeView";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { SceneStore, scaleDragPosition } from "./sceneStore";
@@ -47,7 +48,8 @@ type SceneFlowNode =
   | CodeFlowNode
   | DocumentFlowNode
   | ThinkingFlowNode
-  | HtmlFlowNode;
+  | HtmlFlowNode
+  | ImageFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   const zoom = useStore((s) => s.transform[2]);
@@ -72,6 +74,7 @@ const NODE_TYPES = {
   document: DocumentNodeView,
   thinking: ThinkingNodeView,
   html: HtmlNodeView,
+  image: ImageNodeView,
 };
 
 function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
@@ -201,6 +204,24 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
           htmlContent: n.content,
           isCollapsed: n.isCollapsed,
           onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
+          onDelete: () => store.removeNodes([n.id]),
+        },
+      });
+      continue;
+    }
+    if (n.kind === "image") {
+      // No onDock here either (same reasoning as the html branch above) -
+      // ImageNodeView never offers a "dock into parent" action, so this kind
+      // never sets isDocked=true through any UI path of its own. The generic
+      // `if (n.isDocked) continue` guard above still covers it correctly if
+      // it were ever docked via a direct WS call, same as html.
+      flowNodes.push({
+        id: n.id,
+        type: "image" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          imageAssetId: n.imageAssetId,
+          prompt: n.content,
           onDelete: () => store.removeNodes([n.id]),
         },
       });

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -41,6 +41,7 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         mimeType: "",
         previewLabel: "",
         isDocked: false,
+        imageAssetId: "",
       },
     ],
     edges: [],
@@ -201,6 +202,25 @@ describe("SceneStore", () => {
     store.addHtmlNode(10, 20, "<p>hello</p>", "n1");
     expect(intents).toEqual([
       { topic: "scene", intent: "addHtmlNode", args: [10, 20, "<p>hello</p>", "n1"] },
+    ]);
+  });
+
+  it("sends image-node intents with the backend's registered names and shapes", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.addImageNode(10, 20, "base64bytes==", "a red fox in the snow", "n1");
+    store.addImageNode(30, 40, "base64bytes2==", "a mountain lake", "n1", "image/jpeg");
+    expect(intents).toEqual([
+      {
+        topic: "scene",
+        intent: "addImageNode",
+        args: [10, 20, "base64bytes==", "a red fox in the snow", "n1", "image/png"],
+      },
+      {
+        topic: "scene",
+        intent: "addImageNode",
+        args: [30, 40, "base64bytes2==", "a mountain lake", "n1", "image/jpeg"],
+      },
     ]);
   });
 

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -217,6 +217,25 @@ export class SceneStore {
     this.transport.intent("scene", "addHtmlNode", [x, y, htmlContent, parentId]);
   }
 
+  // R3.21/R3.22: real image nodes. Same posture as addThinkingNode/
+  // addHtmlNode - no real UI creation trigger yet (R4's agent/plugin layer);
+  // this method exists so the intent shape is testable now. The image bytes
+  // themselves are never sent over this (or any) WS topic - only the small
+  // imageAssetId reference string SceneNodeRow carries rides the wire; the
+  // caller is responsible for having already uploaded/generated the bytes
+  // and obtained imageBytesBase64 some other way (out of scope here).
+  // mimeType defaults to "image/png" to match the backend's own default.
+  addImageNode(
+    x: number,
+    y: number,
+    imageBytesBase64: string,
+    prompt: string,
+    parentId: string,
+    mimeType = "image/png",
+  ): void {
+    this.transport.intent("scene", "addImageNode", [x, y, imageBytesBase64, prompt, parentId, mimeType]);
+  }
+
   setNodeDocked(id: string, docked: boolean): void {
     this.transport.intent("scene", "setNodeDocked", [id, docked]);
   }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -869,6 +869,56 @@ body,
   border-radius: 6px;
 }
 
+/* -- R3.21/R3.22 image node ------------------------------------------------ */
+
+.image-node {
+  width: 420px;
+  max-height: 640px;
+  min-height: 110px;
+}
+
+.image-node.collapsed {
+  width: 290px;
+  min-height: 58px;
+}
+
+.image-node-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-height: 560px;
+  overflow: hidden;
+}
+
+/* max-width/max-height + object-fit: contain so a large source image never
+   blows out the card layout - it scales down to fit the card, never up. */
+.image-node-img {
+  display: block;
+  max-width: 100%;
+  max-height: 480px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: 6px;
+}
+
+/* The broken/unknown-asset fallback (onError-driven, see ImageNodeView.tsx) -
+   a dashed box is the deliberate visual cue that this is a "missing content"
+   placeholder, not real card chrome. */
+.image-node-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 120px;
+  padding: 16px;
+  color: var(--gl-surface-text-muted);
+  font-size: 11px;
+  text-align: center;
+  border: 1px dashed var(--gl-surface-border);
+  border-radius: 8px;
+}
+
 /* -- R2 app bar + overlay system ----------------------------------------- */
 
 .app-topbar {

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -65,6 +65,9 @@
           "id": {
             "type": "string"
           },
+          "imageAssetId": {
+            "type": "string"
+          },
           "isCollapsed": {
             "type": "boolean"
           },
@@ -111,7 +114,8 @@
           "filePath",
           "mimeType",
           "previewLabel",
-          "isDocked"
+          "isDocked",
+          "imageAssetId"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -20,6 +20,7 @@ export interface SceneNodeRow {
   byteSize?: number | null;
   previewLabel: string;
   isDocked: boolean;
+  imageAssetId: string;
 }
 
 export interface SceneEdgeRow {
@@ -149,6 +150,11 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["isDocked"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isDocked: missing required field`);
     else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isDocked` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["imageAssetId"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.imageAssetId: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.imageAssetId` + ": expected string"); }
   }
 }
 


### PR DESCRIPTION
## Summary
- Backend: `image_asset_id` + in-memory asset store on `SceneDocument`; `add_image_node` (required parent); a dedicated `GET /api/assets/{id}` HTTP route serves image bytes instead of inlining them in the WS scene payload (every one of ~20 intents triggers an undebounced full scene rebroadcast, so inlining would compound on every unrelated future mutation); generic `remove_nodes` now also evicts an image's asset-store entry on delete.
- Frontend: `ImageNodeView.tsx` - LOD-only collapse, verbatim "Image unavailable" placeholder matching the legacy decode-failure text, real Copy Image (Clipboard API `ClipboardItem`) and Export Image (blob → object URL → anchor download), Hide Other Branches/Regenerate Image honestly disabled+titled.
- 4-way adversarial review caught and fixed two real issues before ship: a TS control-flow-narrowing bug in a test file, and a genuine cross-session asset-id collision hazard (asset ids were minted from a per-document counter, so two sessions with identical creation order could mint the same id and the asset route could silently serve the wrong session's image) - fixed by switching to uuid4-based asset ids, with a regression test.
- Live-drive verified end-to-end against the real running backend: byte-for-byte round-trip through the new HTTP endpoint, clean 404 for unknown assets, and asset eviction confirmed after node deletion.

## Test plan
- [x] `python -m pytest -q` (repo-wide): 1901 passed
- [x] `npx vitest run` (web_ui): 660 passed, 66 files
- [x] `npx tsc --noEmit`: clean
- [x] `python graphlink_app/graphlink_island_codegen.py --check`: up to date
- [x] Live WS drive against the real running backend: image node creation, byte-exact asset fetch, 404 for unknown/deleted assets
- [x] Burn-down gate (`qt_burndown.json`) unchanged at 168 - no legacy Qt node class deleted yet, by design