### PR TITLE
Qt-removal R3.25-R3.28: ConversationNode - closes out R3

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -183,6 +183,15 @@ class SceneNode:
     # never live on the node itself (see the transport-decision comment on
     # image_assets below). Unused (default) for every other kind.
     image_asset_id: str = ""
+    # R3.25 (doc/QT_REMOVAL_PLAN.md): the ConversationNode's real persisted
+    # shape - graphlink_conversation_node.py's conversation_history, a
+    # growing list of {"role": "user"|"assistant", "content": text} dicts
+    # rendered as multiple bubbles inside one node card. This is the one R3
+    # kind whose OWN field is a LIST rather than a scalar - every prior kind
+    # (chat/code/document/thinking/html/image) stores one scalar value per
+    # node; a conversation node instead owns a whole message history. Unused
+    # (default empty list) for every other kind.
+    history: list[dict[str, str]] = field(default_factory=list)
 
 
 @dataclass
@@ -514,6 +523,89 @@ class SceneDocument:
         GET /api/assets/{id} route calls to serve the raw bytes + mime type."""
         return self.image_assets.get(asset_id)
 
+    def add_conversation_node(self, x: float, y: float, parent_id: str) -> SceneNode:
+        """R3.25's ConversationNode equivalent of add_document_node/
+        add_thinking_node/add_html_node/add_image_node: a real multi-message
+        conversation node. Same as document/thinking/html/image (and unlike
+        chat/code), parent_id is REQUIRED, not optional - a ConversationNode
+        never exists unparented - so this unconditionally connects to its
+        parent, no `if parent_id` guard.
+
+        Title is always the fixed literal "Conversation" - never derived or
+        truncated from any content, unlike every scalar-content kind before
+        it (chat/thinking/html/image all preview their own text). There is
+        no natural single preview string for a node whose content is a
+        growing LIST of messages, so the title never changes as messages are
+        appended (see append_conversation_user_message/
+        append_conversation_assistant_message below - neither touches
+        title). Mirrors graphlink_conversation_node.py's `title_label =
+        QLabel("Conversation")`, a hardcoded literal, not derived state.
+
+        `history` starts empty - a freshly-created conversation node has no
+        messages yet, same posture as `is_docked` defaulting False on a
+        freshly-created thinking node.
+
+        Conversation nodes are also NOT branch points (same as code/document/
+        thinking/html/image): there is no delete_conversation_node; deletion
+        goes entirely through the existing generic remove_nodes.
+        """
+        if parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title="Conversation",
+            kind="conversation",
+        )
+        self.nodes[node_id] = node
+        self.connect(parent_id, node_id)
+        return node
+
+    def append_conversation_user_message(self, node_id: str, text: str) -> SceneNode:
+        """Append a real user message to a conversation node's history -
+        mirrors graphlink_conversation_node.py's add_user_message, minus the
+        view-layer bubble creation (the frontend's job)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.history.append({"role": "user", "content": str(text)})
+        return node
+
+    def append_conversation_assistant_message(self, node_id: str, text: str) -> SceneNode:
+        """Append a real assistant message to a conversation node's history -
+        mirrors graphlink_conversation_node.py's add_ai_message, minus the
+        view-layer bubble creation. No live caller yet in this increment -
+        this exists for R4 to call once real agent dispatch lands, same
+        posture as every prior kind's method built ahead of its trigger."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.history.append({"role": "assistant", "content": str(text)})
+        return node
+
+    def delete_conversation_message(self, node_id: str, message_index: int) -> None:
+        """Prune one message out of a conversation node's history by index -
+        mirrors graphlink_conversation_node.py's _remove_message's index-
+        synced pop, minus the view-layer bubble removal/re-layout (the
+        frontend's job)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if message_index < 0 or message_index >= len(node.history):
+            raise SceneError(f"message index out of range: {message_index}")
+        node.history.pop(message_index)
+
+    def send_conversation_message(self, node_id: str, text: str) -> SceneNode:
+        """The Conversation node's own Send action (R3.25): a thin wrapper
+        over append_conversation_user_message, kept as a separate method
+        (rather than only calling append_conversation_user_message directly
+        from the WS wrapper) so the WS intent name lines up 1:1 with the
+        domain method, the same way sendMessage/send_message already do for
+        ChatNode."""
+        return self.append_conversation_user_message(node_id, text)
+
     def delete_chat_node(self, node_id: str) -> None:
         """Delete one chat node WITHOUT orphaning its branch: children are
         re-parented to the deleted node's own parent (or become roots if it
@@ -667,6 +759,9 @@ class SceneDocument:
                     "previewLabel": n.preview_label,
                     "isDocked": n.is_docked,
                     "imageAssetId": n.image_asset_id,
+                    "history": [
+                        {"role": m["role"], "content": m["content"]} for m in n.history
+                    ],
                 }
                 for n in self.nodes.values()
             ],
@@ -808,6 +903,34 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
         await publish_scene()
         return node.id
 
+    async def add_conversation_node(x, y, parent_id):
+        node = document.add_conversation_node(x, y, parent_id)
+        await publish_scene()
+        return node.id
+
+    async def send_conversation_message(node_id, text):
+        # R3.25: the real user-message-send action for a conversation node -
+        # appends a real user message. The assistant's reply needs the agent
+        # layer (same R4 prerequisite as ChatNode's send_message), so this is
+        # an honest deferred notice rather than a fake/stubbed response -
+        # same exact notification text/level/publish call as send_message.
+        node = document.send_conversation_message(node_id, text)
+        await publish_scene()
+        notifications.show("AI response generation lands in R4.", "info")
+        await bus.publish("notification")
+        return node.id
+
+    async def append_conversation_assistant_message(node_id, text):
+        # Unlike send_conversation_message, this represents a real reply
+        # landing once R4 exists, not a deferral - so no notification fires.
+        node = document.append_conversation_assistant_message(node_id, text)
+        await publish_scene()
+        return node.id
+
+    async def delete_conversation_message(node_id, message_index):
+        document.delete_conversation_message(node_id, message_index)
+        await publish_scene()
+
     async def set_node_docked(node_id, docked):
         document.set_node_docked(node_id, docked)
         await publish_scene()
@@ -887,6 +1010,12 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
     bus.register_intent("scene", "addThinkingNode", add_thinking_node)
     bus.register_intent("scene", "addHtmlNode", add_html_node)
     bus.register_intent("scene", "addImageNode", add_image_node)
+    bus.register_intent("scene", "addConversationNode", add_conversation_node)
+    bus.register_intent("scene", "sendConversationMessage", send_conversation_message)
+    bus.register_intent(
+        "scene", "appendConversationAssistantMessage", append_conversation_assistant_message
+    )
+    bus.register_intent("scene", "deleteConversationMessage", delete_conversation_message)
     bus.register_intent("scene", "setNodeDocked", set_node_docked)
     bus.register_intent("scene", "deleteChatNode", delete_chat_node)
     bus.register_intent("scene", "setChatCollapsed", set_chat_collapsed)

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -636,6 +636,265 @@ def test_add_image_node_intent_creates_a_real_node_and_publishes():
     asyncio.run(run())
 
 
+# -- R3.25: conversation nodes -----------------------------------------------
+
+
+def test_add_conversation_node_creates_a_real_conversation_kind_node():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "let's have a back-and-forth", True)
+    node = doc.add_conversation_node(10, 20, parent.id)
+    assert node.kind == "conversation"
+    assert node.title == "Conversation"
+    assert node.history == []
+    assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
+
+
+def test_add_conversation_node_title_never_changes_after_messages_are_appended():
+    # Unlike every scalar-content kind before it (chat/thinking/html/image all
+    # preview their own text), a conversation node's title is a fixed literal
+    # - there is no natural single preview string for a growing message list.
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_conversation_node(0, 0, parent.id)
+    doc.append_conversation_user_message(node.id, "hello there, a whole essay of text")
+    doc.append_conversation_assistant_message(node.id, "a long reply that would have been truncated as a title")
+    assert node.title == "Conversation"
+
+
+def test_add_conversation_node_rejects_unknown_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_conversation_node(0, 0, "ghost")
+
+
+def test_add_conversation_node_requires_a_parent_id():
+    # Same as add_document_node/add_thinking_node/add_html_node/
+    # add_image_node - parent_id has no default in add_conversation_node's
+    # signature, so calling without one is a TypeError (missing required
+    # argument), not a SceneError.
+    doc = SceneDocument()
+    with pytest.raises(TypeError):
+        doc.add_conversation_node(0, 0)
+
+
+def test_append_conversation_user_message_appends_role_and_content():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_conversation_node(0, 0, parent.id)
+    returned = doc.append_conversation_user_message(node.id, "hi there")
+    assert returned is node
+    assert node.history == [{"role": "user", "content": "hi there"}]
+
+
+def test_append_conversation_assistant_message_appends_role_and_content():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_conversation_node(0, 0, parent.id)
+    returned = doc.append_conversation_assistant_message(node.id, "hello, how can I help?")
+    assert returned is node
+    assert node.history == [{"role": "assistant", "content": "hello, how can I help?"}]
+
+
+def test_append_conversation_message_unknown_node_raises():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.append_conversation_user_message("ghost", "hi")
+    with pytest.raises(SceneError):
+        doc.append_conversation_assistant_message("ghost", "hi")
+
+
+def test_send_conversation_message_is_equivalent_to_append_conversation_user_message():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_conversation_node(0, 0, parent.id)
+    returned = doc.send_conversation_message(node.id, "what's up")
+    assert returned is node
+    assert node.history == [{"role": "user", "content": "what's up"}]
+
+
+def test_delete_conversation_message_removes_the_correct_index():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_conversation_node(0, 0, parent.id)
+    doc.append_conversation_user_message(node.id, "first")
+    doc.append_conversation_assistant_message(node.id, "second")
+    doc.append_conversation_user_message(node.id, "third")
+
+    doc.delete_conversation_message(node.id, 1)
+
+    assert node.history == [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "third"},
+    ]
+
+
+def test_delete_conversation_message_out_of_range_raises():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_conversation_node(0, 0, parent.id)
+    doc.append_conversation_user_message(node.id, "only message")
+    with pytest.raises(SceneError):
+        doc.delete_conversation_message(node.id, 5)
+    with pytest.raises(SceneError):
+        doc.delete_conversation_message(node.id, -1)
+
+
+def test_delete_conversation_message_unknown_node_raises():
+    with pytest.raises(SceneError):
+        SceneDocument().delete_conversation_message("ghost", 0)
+
+
+def test_conversation_node_deletion_goes_through_the_generic_remove_nodes_path():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_conversation_node(10, 10, parent.id)
+    doc.append_conversation_user_message(node.id, "doomed message")
+    assert not hasattr(doc, "delete_conversation_node"), (
+        "conversation nodes are not branch points - no special delete method"
+    )
+    doc.remove_nodes([node.id])
+    assert node.id not in doc.nodes
+    assert not any(e.target == node.id or e.source == node.id for e in doc.edges.values())
+
+
+def test_set_chat_collapsed_works_generically_against_a_conversation_node():
+    # setChatCollapsed is already fully generic (looks up any node by id
+    # regardless of kind) - ConversationNode reuses it with zero backend
+    # change, same as document/html already do.
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_conversation_node(0, 0, parent.id)
+    doc.set_chat_collapsed(node.id, True)
+    assert doc.nodes[node.id].is_collapsed is True
+
+
+def test_no_bulk_replace_or_cancel_methods_exist_this_increment():
+    # Deliberate omissions, documented the same way other kinds' tests
+    # document intentional gaps: no set_history (no clone-on-create/session
+    # persistence call site yet) and no delete_conversation_node (leaf
+    # deletion goes through the generic remove_nodes).
+    doc = SceneDocument()
+    assert not hasattr(doc, "set_history")
+    assert not hasattr(doc, "delete_conversation_node")
+
+
+def test_scene_payload_includes_history_defaulted_for_other_kinds():
+    doc = SceneDocument()
+    doc.add_node(0, 0, "plain")
+    parent = doc.add_node(1, 1, "parent")
+    node = doc.add_conversation_node(2, 2, parent.id)
+    doc.append_conversation_user_message(node.id, "hi")
+    doc.append_conversation_assistant_message(node.id, "hello!")
+
+    rows = {n["id"]: n for n in doc.scene_payload()["nodes"]}
+    assert rows["n0"]["history"] == []
+    assert rows[parent.id]["history"] == []
+    assert rows[node.id]["history"] == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello!"},
+    ]
+
+
+def test_add_conversation_node_intent_creates_a_real_node_and_publishes():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addChatNode", [0, 0, "hi", True])
+        node_id = await bus.dispatch_intent(
+            "scene", "addConversationNode", [10, 10, parent_id]
+        )
+        assert document.nodes[node_id].kind == "conversation"
+        assert document.nodes[node_id].title == "Conversation"
+        assert document.nodes[node_id].history == []
+        assert any(
+            e.source == parent_id and e.target == node_id for e in document.edges.values()
+        )
+        assert recorder.topics_seen().count("scene") == 2, "both mutations publish"
+
+    asyncio.run(run())
+
+
+def test_send_conversation_message_intent_appends_and_fires_the_same_deferred_notice():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addNode", [0, 0, "parent"])
+        node_id = await bus.dispatch_intent("scene", "addConversationNode", [10, 10, parent_id])
+
+        returned_id = await bus.dispatch_intent(
+            "scene", "sendConversationMessage", [node_id, "what is this graph about?"]
+        )
+        assert returned_id == node_id
+        assert document.nodes[node_id].history == [
+            {"role": "user", "content": "what is this graph about?"}
+        ]
+
+        notice = await bus.publish("notification")
+        assert notice["visible"] is True
+        assert notice["message"] == "AI response generation lands in R4."
+        assert recorder.topics_seen().count("scene") == 3, "all three mutations publish (addNode, addConversationNode, sendConversationMessage)"
+
+    asyncio.run(run())
+
+
+def test_append_conversation_assistant_message_intent_publishes_with_no_notification():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addNode", [0, 0, "parent"])
+        node_id = await bus.dispatch_intent("scene", "addConversationNode", [10, 10, parent_id])
+
+        returned_id = await bus.dispatch_intent(
+            "scene", "appendConversationAssistantMessage", [node_id, "here is my answer"]
+        )
+        assert returned_id == node_id
+        assert document.nodes[node_id].history == [
+            {"role": "assistant", "content": "here is my answer"}
+        ]
+
+        notice = await bus.publish("notification")
+        assert notice["visible"] is False, "a real reply landing is not a deferral - no notification fires"
+        assert recorder.topics_seen().count("scene") == 3, "all three mutations publish (addNode, addConversationNode, appendConversationAssistantMessage)"
+
+    asyncio.run(run())
+
+
+def test_delete_conversation_message_intent_mutates_and_publishes():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addNode", [0, 0, "parent"])
+        node_id = await bus.dispatch_intent("scene", "addConversationNode", [10, 10, parent_id])
+        await bus.dispatch_intent("scene", "sendConversationMessage", [node_id, "first"])
+        await bus.dispatch_intent(
+            "scene", "appendConversationAssistantMessage", [node_id, "second"]
+        )
+
+        result = await bus.dispatch_intent("scene", "deleteConversationMessage", [node_id, 0])
+        assert result is None
+        assert document.nodes[node_id].history == [{"role": "assistant", "content": "second"}]
+
+    asyncio.run(run())
+
+
+def test_conversation_node_removed_generically_through_remove_nodes_intent():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addNode", [0, 0, "parent"])
+        node_id = await bus.dispatch_intent("scene", "addConversationNode", [10, 10, parent_id])
+        await bus.dispatch_intent("scene", "removeNodes", [[node_id]])
+        assert node_id not in document.nodes
+
+    asyncio.run(run())
+
+
+def test_set_chat_collapsed_intent_works_generically_against_a_conversation_node():
+    async def run():
+        bus, document, recorder = make_bus()
+        parent_id = await bus.dispatch_intent("scene", "addNode", [0, 0, "parent"])
+        node_id = await bus.dispatch_intent("scene", "addConversationNode", [10, 10, parent_id])
+        await bus.dispatch_intent("scene", "setChatCollapsed", [node_id, True])
+        assert document.nodes[node_id].is_collapsed is True
+
+    asyncio.run(run())
+
+
 def test_send_message_starts_a_root_branch():
     doc = SceneDocument()
     node = doc.send_message("hello there")

--- a/graphlink_app/graphlink_scene_payload.py
+++ b/graphlink_app/graphlink_scene_payload.py
@@ -32,11 +32,23 @@ R3.21 adds `imageAssetId` (the ImageNode increment): the opaque asset-store
 key an image-kind node's bytes live under (fetched separately over HTTP,
 never inlined here), populated for kind=="image" rows, defaulted (empty
 string) for every other kind, same additive rule.
+
+R3.25 adds `history` (the ConversationNode increment): a growing list of
+role/content messages - the one R3 kind whose own field is a LIST rather
+than a scalar. Populated for kind=="conversation" rows, defaulted (empty
+list) for every other kind, same additive rule.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+@dataclass
+class ConversationMessageRow:
+    role: Literal["user", "assistant"]
+    content: str
 
 
 @dataclass
@@ -72,6 +84,11 @@ class SceneNodeRow:
     # themselves never appear in this payload - see the transport-decision
     # comment on backend/canvas.py's SceneDocument.image_assets.
     imageAssetId: str = ""
+    # R3.25: the ConversationNode's real persisted shape - a growing list of
+    # role/content messages, populated for kind=="conversation" rows,
+    # defaulted (empty list) for every other kind. The one R3 kind whose own
+    # field is a list rather than a scalar.
+    history: list[ConversationMessageRow] = field(default_factory=list)
 
 
 @dataclass

--- a/web_ui/src/app/canvas/ConversationNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.test.tsx
@@ -1,0 +1,308 @@
+import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ConversationNodeView, type ConversationFlowNode } from "./ConversationNodeView";
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
+// ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too.
+function renderConversationNode(overrides: Partial<ConversationFlowNode["data"]> = {}) {
+  const onToggleCollapse = vi.fn();
+  const onDelete = vi.fn();
+  const onSend = vi.fn();
+  const onDeleteMessage = vi.fn();
+  const props = {
+    id: "n0",
+    selected: false,
+    data: {
+      history: [
+        { role: "user" as const, content: "Hello **world**" },
+        { role: "assistant" as const, content: "Hi there" },
+      ],
+      isCollapsed: false,
+      onToggleCollapse,
+      onDelete,
+      onSend,
+      onDeleteMessage,
+      ...overrides,
+    },
+  } as unknown as NodeProps<ConversationFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <ConversationNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return { onToggleCollapse, onDelete, onSend, onDeleteMessage };
+}
+
+// Directly sets the React Flow internal Zustand store's transform/zoom
+// value - useReactFlow()'s own setViewport requires a mounted panZoom
+// instance (a real <ReactFlow> viewport element), which doesn't exist in
+// this direct-render test setup (see the comment above renderConversationNode
+// / ChatNodeView.test.tsx). Writing directly to the store via useStoreApi()
+// is the same store useStore(s => s.transform[2]) reads from, so this is a
+// faithful way to drive the LOD threshold in a test.
+function ZoomSetter({ zoom }: { zoom: number }) {
+  const store = useStoreApi();
+  useEffect(() => {
+    store.setState({ transform: [0, 0, zoom] });
+  }, [zoom, store]);
+  return null;
+}
+
+function renderConversationNodeAtZoom(zoom: number, overrides: Partial<ConversationFlowNode["data"]> = {}) {
+  const onToggleCollapse = vi.fn();
+  const onDelete = vi.fn();
+  const onSend = vi.fn();
+  const onDeleteMessage = vi.fn();
+  const props = {
+    id: "n0",
+    selected: false,
+    data: {
+      history: [{ role: "user" as const, content: "Hello" }],
+      isCollapsed: false,
+      onToggleCollapse,
+      onDelete,
+      onSend,
+      onDeleteMessage,
+      ...overrides,
+    },
+  } as unknown as NodeProps<ConversationFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <ZoomSetter zoom={zoom} />
+      <ConversationNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return { onToggleCollapse, onDelete, onSend, onDeleteMessage };
+}
+
+describe("ConversationNodeView", () => {
+  it("renders a bubble per history entry with correct per-role styling and content", () => {
+    renderConversationNode();
+    expect(screen.getByText("world")).toBeInTheDocument(); // bold text still renders as text
+    expect(screen.getByText("Hi there")).toBeInTheDocument();
+
+    const userBubble = screen.getByText("world").closest(".conversation-node-bubble");
+    const assistantBubble = screen.getByText("Hi there").closest(".conversation-node-bubble");
+    expect(userBubble).toHaveClass("conversation-node-bubble", "user");
+    expect(assistantBubble).toHaveClass("conversation-node-bubble", "assistant");
+  });
+
+  it("manual collapse hides the body and shows only the header", () => {
+    renderConversationNode({ isCollapsed: true });
+    expect(screen.getByText("Conversation")).toBeInTheDocument();
+    expect(screen.queryByText("Hi there")).toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("the inline collapse chevron calls onToggleCollapse", async () => {
+    const user = userEvent.setup();
+    const { onToggleCollapse } = renderConversationNode();
+    await user.click(screen.getByRole("button", { name: "Collapse" }));
+    expect(onToggleCollapse).toHaveBeenCalledOnce();
+  });
+
+  it("LOD auto-collapse (zoom below threshold) also hides the body, even when isCollapsed is false", () => {
+    renderConversationNodeAtZoom(0.2, { isCollapsed: false });
+    expect(screen.getByText("Conversation")).toBeInTheDocument();
+    expect(screen.queryByText("Hello")).toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("stays expanded above the LOD threshold when isCollapsed is false", () => {
+    renderConversationNodeAtZoom(1, { isCollapsed: false });
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("each bubble's right-click menu shows exactly Copy Message and Delete from History, both real", async () => {
+    const user = userEvent.setup();
+    const { onDeleteMessage } = renderConversationNode();
+
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    const userBubble = screen.getByText("world").closest(".conversation-node-bubble") as HTMLElement;
+    fireEvent.contextMenu(userBubble);
+    const menu = screen.getByRole("menu");
+    expect(menu).toBeInTheDocument();
+
+    const items = screen.getAllByRole("menuitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("Copy Message");
+    expect(items[1]).toHaveTextContent("Delete from History");
+    expect(items[0]).toBeEnabled();
+    expect(items[1]).toBeEnabled();
+
+    await user.click(screen.getByRole("menuitem", { name: "Copy Message" }));
+    expect(writeText).toHaveBeenCalledWith("Hello **world**");
+
+    fireEvent.contextMenu(userBubble);
+    await user.click(screen.getByRole("menuitem", { name: "Delete from History" }));
+    expect(onDeleteMessage).toHaveBeenCalledOnce();
+    expect(onDeleteMessage).toHaveBeenCalledWith(0);
+  });
+
+  it("clicking Copy Message on the second bubble copies its own exact content", async () => {
+    const user = userEvent.setup();
+    renderConversationNode();
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    const assistantBubble = screen.getByText("Hi there").closest(".conversation-node-bubble") as HTMLElement;
+    fireEvent.contextMenu(assistantBubble);
+    await user.click(screen.getByRole("menuitem", { name: "Copy Message" }));
+    expect(writeText).toHaveBeenCalledWith("Hi there");
+  });
+
+  it("clicking Delete from History on the second bubble calls onDeleteMessage with index 1", async () => {
+    const user = userEvent.setup();
+    const { onDeleteMessage } = renderConversationNode();
+
+    const assistantBubble = screen.getByText("Hi there").closest(".conversation-node-bubble") as HTMLElement;
+    fireEvent.contextMenu(assistantBubble);
+    await user.click(screen.getByRole("menuitem", { name: "Delete from History" }));
+    expect(onDeleteMessage).toHaveBeenCalledWith(1);
+  });
+
+  it("a bubble right-click does not also open the node-level menu", () => {
+    renderConversationNode();
+    const userBubble = screen.getByText("world").closest(".conversation-node-bubble") as HTMLElement;
+    fireEvent.contextMenu(userBubble);
+    expect(screen.getAllByRole("menu")).toHaveLength(1);
+    expect(screen.queryByRole("menuitem", { name: "Delete Node" })).toBeNull();
+  });
+
+  it("the node-level right-click menu shows exactly 3 items: Open Document View (disabled, exact title), Collapse/Expand (real), Delete Node (real)", async () => {
+    const user = userEvent.setup();
+    const { onDelete, onToggleCollapse } = renderConversationNode();
+
+    const header = screen.getByText("Conversation");
+    fireEvent.contextMenu(header);
+    const menu = screen.getByRole("menu");
+    expect(menu).toBeInTheDocument();
+
+    const items = screen.getAllByRole("menuitem");
+    expect(items).toHaveLength(3);
+
+    const docView = screen.getByRole("menuitem", { name: "Open Document View" });
+    expect(docView).toBeDisabled();
+    // Copied verbatim from ChatNodeView.tsx's own disabled "Open Document
+    // View" menu item title string.
+    expect(docView).toHaveAttribute("title", "Document view integration isn't wired into the SPA yet");
+
+    const collapseItem = screen.getByRole("menuitem", { name: "Collapse" });
+    expect(collapseItem).toBeEnabled();
+
+    const deleteItem = screen.getByRole("menuitem", { name: "Delete Node" });
+    expect(deleteItem).toBeEnabled();
+
+    // Explicitly absent: neither of these belongs to this node kind's menu.
+    expect(screen.queryByRole("menuitem", { name: "Include Previous Branch Context" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Hide Other Branches" })).toBeNull();
+    expect(screen.queryByText("Include Previous Branch Context")).toBeNull();
+    expect(screen.queryByText("Hide Other Branches")).toBeNull();
+
+    await user.click(collapseItem);
+    expect(onToggleCollapse).toHaveBeenCalledOnce();
+
+    fireEvent.contextMenu(header);
+    await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("the node-level menu's Collapse/Expand label flips when isCollapsed is true", () => {
+    renderConversationNode({ isCollapsed: true });
+    // isCollapsed alone collapses the body, so use the header label to open
+    // the node-level menu (still visible while collapsed).
+    fireEvent.contextMenu(screen.getByText("Conversation"));
+    expect(screen.getByRole("menuitem", { name: "Expand" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Collapse" })).toBeNull();
+  });
+
+  it("typing text and pressing Enter calls onSend with the trimmed text and clears the input", async () => {
+    const user = userEvent.setup();
+    const { onSend } = renderConversationNode();
+    const input = screen.getByRole("textbox", { name: "Message" });
+
+    await user.type(input, "  hello there  {Enter}");
+    expect(onSend).toHaveBeenCalledWith("hello there");
+    expect(input).toHaveValue("");
+  });
+
+  it("Shift+Enter does not send and instead allows a newline", async () => {
+    const user = userEvent.setup();
+    const { onSend } = renderConversationNode();
+    const input = screen.getByRole("textbox", { name: "Message" });
+
+    await user.type(input, "line one{Shift>}{Enter}{/Shift}line two");
+    expect(onSend).not.toHaveBeenCalled();
+    expect(input).toHaveValue("line one\nline two");
+  });
+
+  it("the Send button is disabled when the input is empty or whitespace-only", async () => {
+    const user = userEvent.setup();
+    renderConversationNode();
+    const input = screen.getByRole("textbox", { name: "Message" });
+    const sendButton = screen.getByRole("button", { name: "Send" });
+
+    expect(sendButton).toBeDisabled();
+    await user.type(input, "   ");
+    expect(sendButton).toBeDisabled();
+    await user.type(input, "real text");
+    expect(sendButton).toBeEnabled();
+  });
+
+  it("clicking the Send button calls onSend and clears the input", async () => {
+    const user = userEvent.setup();
+    const { onSend } = renderConversationNode();
+    const input = screen.getByRole("textbox", { name: "Message" });
+
+    await user.type(input, "click to send");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+    expect(onSend).toHaveBeenCalledWith("click to send");
+    expect(input).toHaveValue("");
+  });
+
+  it("the Cancel button is always disabled with the exact R4 title string", () => {
+    renderConversationNode();
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    expect(cancelButton).toBeDisabled();
+    expect(cancelButton).toHaveAttribute("title", "Agent cancellation lands in R4");
+  });
+
+  it("Escape and outside-click both close the node-level menu", async () => {
+    const user = userEvent.setup();
+    renderConversationNode();
+    const header = screen.getByText("Conversation");
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("Escape and outside-click both close a bubble's menu", async () => {
+    const user = userEvent.setup();
+    renderConversationNode();
+    const userBubble = screen.getByText("world").closest(".conversation-node-bubble") as HTMLElement;
+
+    fireEvent.contextMenu(userBubble);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(userBubble);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/ConversationNodeView.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.tsx
@@ -1,0 +1,337 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+
+/**
+ * The conversation node (Qt-removal plan R3.25/R3.26) - ConversationNode's
+ * React successor. Different in kind from every prior R3 node view: instead
+ * of one scalar content field, this node holds a growing LIST of messages
+ * (data.history), each rendered as its own bubble inside the one node card -
+ * the only R3 kind shaped like a real message list rather than one flat text
+ * block.
+ *
+ * Real: render (one ConversationBubble per history entry, same react-markdown
+ * + remarkGfm + rehypeHighlight pipeline every other text-bearing node view
+ * in this codebase already uses), collapse/expand (manual toggle OR-ed with
+ * LOD auto-collapse, same as Chat/Document), delete (generic - a conversation
+ * node is never a branch point/reparented, same as code/thinking/html/image),
+ * per-bubble copy + delete-from-history, and Send (appends a real user
+ * message; the assistant's reply is deferred to R4 - see sendConversationMessage's
+ * own backend docstring - the backend surfaces that honestly over the
+ * existing notification topic, no fake response synthesized here, matching
+ * the Composer's own sendMessage precedent). Deferred, with an honest
+ * disabled+title label rather than a silent drop (same audit convention
+ * every prior node kind in this plan has followed): Open Document View (the
+ * document-viewer island isn't wired into the SPA overlay system yet - same
+ * reason ChatNodeView's own menu defers it) and Cancel (there is no in-flight
+ * request concept anywhere in this frontend yet for it to ever act on -
+ * agent cancellation lands in R4 alongside the agent layer itself).
+ *
+ * Card menu deliberately does NOT include "Hide Other Branches" or "Include
+ * Previous Branch Context": the legacy PluginNodeContextMenu for this node
+ * kind only ever shows Open Document View / Collapse-Expand / Delete Node -
+ * "Include Previous Branch Context" is gated on an attribute ConversationNode
+ * never defines, and branch-visibility toggling is a distinct legacy menu
+ * class entirely, not this one.
+ */
+
+export interface ConversationMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface ConversationNodeData extends Record<string, unknown> {
+  history: ConversationMessage[];
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  onSend: (text: string) => void;
+  onDeleteMessage: (index: number) => void;
+}
+
+export type ConversationFlowNode = Node<ConversationNodeData, "conversation">;
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+/** Shared outside-click/Escape dismiss behavior - identical pattern to every
+ * sibling menu component (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu). */
+function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
+      // type-only import above shadows the bare name for casts like this).
+      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [menuRef, onClose]);
+}
+
+// -- card-level menu -------------------------------------------------------
+
+function ConversationNodeMenu({
+  position,
+  isCollapsed,
+  onToggleCollapse,
+  onDelete,
+  onClose,
+}: {
+  position: MenuPosition;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useMenuDismiss(menuRef, onClose);
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      {/* Order verified against the legacy PluginNodeContextMenu's own
+          construction order for this node kind: Open Document View,
+          Collapse/Expand, Delete Node - nothing else. */}
+      <button type="button" role="menuitem" disabled title="Document view integration isn't wired into the SPA yet">
+        Open Document View
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleCollapse();
+          onClose();
+        }}
+      >
+        {isCollapsed ? "Expand" : "Collapse"}
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        Delete Node
+      </button>
+    </div>
+  );
+}
+
+// -- per-bubble menu ---------------------------------------------------------
+
+function ConversationBubbleMenu({
+  position,
+  content,
+  onDeleteMessage,
+  onClose,
+}: {
+  position: MenuPosition;
+  content: string;
+  onDeleteMessage: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useMenuDismiss(menuRef, onClose);
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          navigator.clipboard.writeText(content);
+          onClose();
+        }}
+      >
+        Copy Message
+      </button>
+      <div className="chat-node-menu-separator" role="separator" />
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDeleteMessage();
+          onClose();
+        }}
+      >
+        Delete from History
+      </button>
+    </div>
+  );
+}
+
+// -- bubble ------------------------------------------------------------------
+
+function ConversationBubble({
+  message,
+  index,
+  onDeleteMessage,
+}: {
+  message: ConversationMessage;
+  index: number;
+  onDeleteMessage: (index: number) => void;
+}) {
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+
+  return (
+    <div
+      className={`conversation-node-bubble${message.role === "user" ? " user" : " assistant"}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        // Stops this from also bubbling up into the card-level onContextMenu
+        // handler below - a bubble right-click opens exactly one menu (its
+        // own), never both.
+        event.stopPropagation();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      {/* Reuses .chat-node-content's markdown-body rule set (headings,
+          lists, code, tables, hljs) - the same shared-class convention
+          .chat-node-menu already establishes across every sibling node's
+          menu, applied here to markdown styling instead. */}
+      <div className="chat-node-content conversation-node-bubble-content">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+          {message.content}
+        </ReactMarkdown>
+      </div>
+      {menuPosition && (
+        <ConversationBubbleMenu
+          position={menuPosition}
+          content={message.content}
+          onDeleteMessage={() => onDeleteMessage(index)}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+// -- view ----------------------------------------------------------------
+
+export function ConversationNodeView({ data, selected }: NodeProps<ConversationFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const collapsed = data.isCollapsed || lodCollapsed;
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+  const [draft, setDraft] = useState("");
+
+  function send() {
+    const text = draft.trim();
+    if (!text) return;
+    data.onSend(text);
+    setDraft("");
+  }
+
+  return (
+    <div
+      className={`scene-node conversation-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title chat-node-role">
+        <span>Conversation</span>
+        <button
+          type="button"
+          className="chat-node-collapse-btn"
+          aria-label={data.isCollapsed ? "Expand" : "Collapse"}
+          onClick={data.onToggleCollapse}
+        >
+          {data.isCollapsed ? "▸" : "▾"}
+        </button>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body conversation-node-content">
+          <div className="conversation-node-messages">
+            {data.history.map((message, index) => (
+              // No per-message id on the wire shape - render order is
+              // always the true history order, so index is a correct and
+              // sufficient key here.
+              <ConversationBubble
+                key={index}
+                message={message}
+                index={index}
+                onDeleteMessage={data.onDeleteMessage}
+              />
+            ))}
+          </div>
+          <div className="conversation-node-input-row">
+            <textarea
+              className="conversation-node-input"
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                // Enter-to-send / Shift+Enter-for-newline - same convention
+                // the existing Composer already uses (Composer.tsx's own
+                // onKeyDown handler).
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  send();
+                }
+              }}
+              placeholder="Send a message…"
+              aria-label="Message"
+              rows={1}
+              spellCheck
+            />
+            <div className="conversation-node-input-actions">
+              <button
+                type="button"
+                className="conversation-node-send-btn"
+                disabled={!draft.trim()}
+                onClick={send}
+              >
+                Send
+              </button>
+              <button
+                type="button"
+                className="conversation-node-cancel-btn"
+                disabled
+                title="Agent cancellation lands in R4"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+      {menuPosition && (
+        <ConversationNodeMenu
+          position={menuPosition}
+          isCollapsed={data.isCollapsed}
+          onToggleCollapse={data.onToggleCollapse}
+          onDelete={data.onDelete}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
 import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
 import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
+import { ConversationNodeView, type ConversationFlowNode } from "./ConversationNodeView";
 import { DocumentNodeView, type DocumentFlowNode } from "./DocumentNodeView";
 import { HtmlNodeView, type HtmlFlowNode } from "./HtmlNodeView";
 import { ImageNodeView, type ImageFlowNode } from "./ImageNodeView";
@@ -49,7 +50,8 @@ type SceneFlowNode =
   | DocumentFlowNode
   | ThinkingFlowNode
   | HtmlFlowNode
-  | ImageFlowNode;
+  | ImageFlowNode
+  | ConversationFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   const zoom = useStore((s) => s.transform[2]);
@@ -75,6 +77,7 @@ const NODE_TYPES = {
   thinking: ThinkingNodeView,
   html: HtmlNodeView,
   image: ImageNodeView,
+  conversation: ConversationNodeView,
 };
 
 function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
@@ -223,6 +226,30 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
           imageAssetId: n.imageAssetId,
           prompt: n.content,
           onDelete: () => store.removeNodes([n.id]),
+        },
+      });
+      continue;
+    }
+    if (n.kind === "conversation") {
+      // No onDock here either (same reasoning as the html/image branches
+      // above) - ConversationNodeView never offers a dock-into-parent
+      // action, so this kind never sets isDocked=true through any UI path
+      // of its own; the generic `if (n.isDocked) continue` guard above still
+      // covers it correctly if it were ever docked via a direct WS call.
+      flowNodes.push({
+        id: n.id,
+        type: "conversation" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          history: n.history,
+          isCollapsed: n.isCollapsed,
+          // Reuses the existing generic setChatCollapsed intent - same
+          // reasoning as every other non-chat node kind's onToggleCollapse
+          // above (the backend handler looks up ANY node by id).
+          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
+          onDelete: () => store.removeNodes([n.id]),
+          onSend: (text: string) => store.sendConversationMessage(n.id, text),
+          onDeleteMessage: (index: number) => store.deleteConversationMessage(n.id, index),
         },
       });
       continue;

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -42,6 +42,7 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         previewLabel: "",
         isDocked: false,
         imageAssetId: "",
+        history: [],
       },
     ],
     edges: [],
@@ -221,6 +222,21 @@ describe("SceneStore", () => {
         intent: "addImageNode",
         args: [30, 40, "base64bytes2==", "a mountain lake", "n1", "image/jpeg"],
       },
+    ]);
+  });
+
+  it("sends conversation-node intents with the backend's registered names and shapes", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.addConversationNode(10, 20, "n1");
+    store.sendConversationMessage("n2", "hello there");
+    store.appendConversationAssistantMessage("n2", "hi back");
+    store.deleteConversationMessage("n2", 0);
+    expect(intents).toEqual([
+      { topic: "scene", intent: "addConversationNode", args: [10, 20, "n1"] },
+      { topic: "scene", intent: "sendConversationMessage", args: ["n2", "hello there"] },
+      { topic: "scene", intent: "appendConversationAssistantMessage", args: ["n2", "hi back"] },
+      { topic: "scene", intent: "deleteConversationMessage", args: ["n2", 0] },
     ]);
   });
 

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -236,6 +236,40 @@ export class SceneStore {
     this.transport.intent("scene", "addImageNode", [x, y, imageBytesBase64, prompt, parentId, mimeType]);
   }
 
+  // R3.25/R3.26: real conversation nodes - the only R3 kind shaped like a
+  // growing message LIST (data.history) rather than one scalar content
+  // field. addConversationNode has no real UI creation trigger yet, same
+  // posture as addThinkingNode/addHtmlNode/addImageNode before it. Deletion
+  // has no dedicated intent (a conversation node is never a branch
+  // point/reparented, so the generic removeNodes intent below already
+  // covers it, same as code/thinking/html/image); collapse reuses the
+  // existing generic setChatCollapsed intent below (see its own comment)
+  // rather than inventing a setConversationCollapsed the backend doesn't
+  // register.
+  addConversationNode(x: number, y: number, parentId: string): void {
+    this.transport.intent("scene", "addConversationNode", [x, y, parentId]);
+  }
+
+  // sendConversationMessage appends a real user message AND triggers the
+  // existing app-wide deferred notification ("AI response generation lands
+  // in R4.") over the same notification WS topic the Composer/ChatNode's
+  // own sendMessage already flows through - nothing new to wire on the
+  // frontend for that half of it.
+  sendConversationMessage(id: string, text: string): void {
+    this.transport.intent("scene", "sendConversationMessage", [id, text]);
+  }
+
+  // No live caller yet this increment (same posture as addThinkingNode when
+  // it first landed) - exists so the intent shape is testable now. Will
+  // back the real agent reply once R4's agent layer can call it.
+  appendConversationAssistantMessage(id: string, text: string): void {
+    this.transport.intent("scene", "appendConversationAssistantMessage", [id, text]);
+  }
+
+  deleteConversationMessage(id: string, messageIndex: number): void {
+    this.transport.intent("scene", "deleteConversationMessage", [id, messageIndex]);
+  }
+
   setNodeDocked(id: string, docked: boolean): void {
     this.transport.intent("scene", "setNodeDocked", [id, docked]);
   }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2391,3 +2391,126 @@ body,
   font-size: 11px;
   color: var(--gl-surface-text-muted);
 }
+
+/* -- R3.25/R3.26 conversation node ------------------------------------------ */
+
+.conversation-node {
+  width: 420px;
+  max-height: 640px;
+  min-height: 110px;
+}
+
+.conversation-node.collapsed {
+  width: 290px;
+  min-height: 58px;
+}
+
+.conversation-node-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 560px;
+}
+
+/* The scrollable message list - only this scrolls, not the input row below
+   it (unlike every scalar-content sibling's single `-content` block, this
+   node's body is two stacked regions: a growing list, then a fixed input
+   row that must stay put). */
+.conversation-node-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+/* Per-message bubble - the role modifier reuses ChatNodeView's own
+   `.chat-node.user` token (var(--gl-neutral-button-hover)), applied here per
+   bubble instead of per node: ConversationNode is the only R3 kind shaped
+   like a message list rather than one flat text block. */
+.conversation-node-bubble {
+  padding: 8px 10px;
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 8px;
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+}
+
+.conversation-node-bubble.user {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+/* Reuses .chat-node-content's full markdown-body rule set (headings, lists,
+   code, tables, hljs) verbatim rather than duplicating it - the same
+   shared-class convention .chat-node-menu already establishes across every
+   sibling node's context menu, applied here to markdown styling instead.
+   Only overrides the max-height/overflow-y a single bubble should never
+   take on its own - the message LIST scrolls (.conversation-node-messages
+   above), not each bubble individually. */
+.conversation-node-bubble-content {
+  max-height: none;
+  overflow: visible;
+}
+
+.conversation-node-input-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.conversation-node-input {
+  box-sizing: border-box;
+  width: 100%;
+  resize: none;
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 8px 10px;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.conversation-node-input:focus {
+  outline: none;
+  border-color: var(--gl-surface-text-muted);
+}
+
+.conversation-node-input-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.conversation-node-send-btn,
+.conversation-node-cancel-btn {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 5px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.conversation-node-send-btn {
+  color: var(--gl-surface-window);
+  background-color: var(--gl-surface-text-muted);
+  border: none;
+}
+
+.conversation-node-send-btn:hover:enabled {
+  filter: brightness(1.1);
+}
+
+.conversation-node-send-btn:disabled,
+.conversation-node-cancel-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.conversation-node-cancel-btn {
+  color: var(--gl-surface-text);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+}

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -62,6 +62,29 @@
           "filePath": {
             "type": "string"
           },
+          "history": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "content": {
+                  "type": "string"
+                },
+                "role": {
+                  "enum": [
+                    "user",
+                    "assistant"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "role",
+                "content"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "id": {
             "type": "string"
           },
@@ -115,7 +138,8 @@
           "mimeType",
           "previewLabel",
           "isDocked",
-          "imageAssetId"
+          "imageAssetId",
+          "history"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -21,6 +21,12 @@ export interface SceneNodeRow {
   previewLabel: string;
   isDocked: boolean;
   imageAssetId: string;
+  history: ConversationMessageRow[];
+}
+
+export interface ConversationMessageRow {
+  role: "user" | "assistant";
+  content: string;
 }
 
 export interface SceneEdgeRow {
@@ -155,6 +161,26 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["imageAssetId"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.imageAssetId: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.imageAssetId` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["history"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.history: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.history` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { checkConversationMessageRow(item, `${path}.history` + `[${i}]`, errors); }); }
+  }
+}
+
+function checkConversationMessageRow(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["role"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.role: missing required field`);
+    else { if (!["user", "assistant"].includes(fieldValue as string)) errors.push(`${path}.role` + `: ${JSON.stringify(fieldValue)} is not one of [` + "user, assistant" + `]`); }
+  }
+  {
+    const fieldValue = value["content"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.content: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.content` + ": expected string"); }
   }
 }
 


### PR DESCRIPTION
## Summary
- The last of R3's six node types, and structurally the odd one out: every prior kind is one flat row with a scalar text field, but `ConversationNode` owns its own growing list of role/content messages, each rendered as its own bubble with its own menu inside one node card.
- Ran a full fresh recon+cross-check+design pass before any code was written, given the structural mismatch. The cross-check surfaced two real legacy findings (a multimodal-content cloning bug, and a deserializer asymmetry) - both deliberately scoped out rather than ported or silently dropped, since neither has a live call site in this stack yet, and flagged for whoever picks up those phases (Plugin-Picker parity / R6 persistence).
- Backend: `history` is an additive list field directly on the same flat `SceneNode`/`SceneNodeRow` every other kind uses, reasoned explicitly against a separate-store design. New methods: `add_conversation_node` (required parent, fixed title), `append_conversation_user_message`/`append_conversation_assistant_message`, `delete_conversation_message` (bounds-checked). `sendConversationMessage` reuses ChatNode's own deferred-notice pattern verbatim - a real intent, not a disabled button. No `set_history`/bulk-replace and no cancel-related backend code at all - deliberately, both would be dead code with no real call site yet.
- Frontend: `ConversationNodeView.tsx` renders a bubble per history entry, each with its own Copy Message/Delete from History menu; the card-level menu matches the true legacy shared `PluginNodeContextMenu` class exactly (3 items - not copied from a sibling's distinct menu by analogy). Manual-OR-LOD collapse, real Send, permanently disabled Cancel.
- 4-way adversarial review (backend/frontend/integration/legacy-parity) returned a clean PASS with zero defects - the first R3 node-type increment to do so.
- **This closes R3 in full: all six node types (Chat/Code/Document/Thinking/HtmlView/Image/Conversation) are now shipped.**

## Test plan
- [x] `python -m pytest -q` (repo-wide): 1922 passed
- [x] `npx vitest run` (web_ui): 679 passed, 67 files
- [x] `npx tsc --noEmit`: clean
- [x] `python graphlink_app/graphlink_island_codegen.py --check`: up to date
- [x] Live WS drive against the real running backend: real send + deferred R4 notification, assistant-message append, message deletion with correct reindexing, clean error handling for an out-of-range delete index, generic `setChatCollapsed`/`removeNodes` reuse
- [x] Burn-down gate (`qt_burndown.json`) unchanged at 168 - no legacy Qt node class deleted yet, by design (real agent dispatch is R4)