### PR TITLE
Qt-removal R4.1: Qt-free config split - the agent-layer unblock

### DIFF
--- a/backend/tests/test_agent_layer_qt_free.py
+++ b/backend/tests/test_agent_layer_qt_free.py
@@ -1,0 +1,54 @@
+"""R4.1's load-bearing guarantee: the agent layer's imports are Qt-free.
+
+The whole point of the graphlink_task_config split is that backend/ can
+import api_provider (and through it the task/provider/model config) without
+PySide6 ever loading. A same-process assertion would be unreliable - some
+earlier test may already have imported Qt - so each check runs a fresh
+python subprocess and asserts PySide6 never entered sys.modules.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _assert_import_is_qt_free(module_name: str) -> None:
+    code = (
+        "import sys\n"
+        f"import {module_name}\n"
+        "qt = [m for m in sys.modules if m.startswith('PySide6')]\n"
+        "assert not qt, f'importing {module_name} pulled Qt: {{qt}}'\n"
+        f"print('{module_name} imported qt-free')\n"
+    )
+    # The legacy modules live in graphlink_app/ and are importable as
+    # top-level names (pyproject py-modules); a fresh subprocess needs that
+    # directory on its path the same way conftest arranges it in-process.
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT / "graphlink_app") + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        f"importing {module_name} in a fresh process failed or pulled Qt:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_task_config_imports_qt_free():
+    _assert_import_is_qt_free("graphlink_task_config")
+
+
+def test_api_provider_imports_qt_free():
+    # THE R4 unblock: before the split, api_provider's
+    # `import graphlink_config` chained to PySide6.QtGui/QtWidgets, making
+    # any backend chat dispatch a Qt process. This is the machine-checked
+    # fact that that chain is severed.
+    _assert_import_is_qt_free("api_provider")

--- a/graphlink_app/api_provider.py
+++ b/graphlink_app/api_provider.py
@@ -19,7 +19,9 @@ except ImportError:
     requests = None
     REQUESTS_AVAILABLE = False
 
-import graphlink_config as config
+# Qt-removal plan R4.1: import the Qt-free split, not graphlink_config -
+# this module must be importable from backend/ without PySide6 loading.
+import graphlink_task_config as config
 from graphlink_audio import guess_audio_mime_type
 from graphlink_model_catalog import ModelDescriptor, ollama_descriptor, sort_descriptors
 

--- a/graphlink_app/graphlink_agents_core.py
+++ b/graphlink_app/graphlink_agents_core.py
@@ -3,7 +3,8 @@ import re
 import threading
 import time
 from PySide6.QtCore import QThread, Signal, QPointF
-import graphlink_config as config
+# Qt-removal plan R4.1: only the Qt-free task-config half is needed here.
+import graphlink_task_config as config
 import api_provider
 from graphlink_token_estimator import TokenEstimator
 from graphlink_memory import trim_history

--- a/graphlink_app/graphlink_config.py
+++ b/graphlink_app/graphlink_config.py
@@ -149,77 +149,41 @@ def apply_theme(app: QApplication, theme_name: str):
     import graphlink_web_island_host
     graphlink_web_island_host.theme_changed_all()
 
-TASK_TITLE = "task_title"
-TASK_CHAT = "task_chat"
-TASK_CHART = "task_chart"
-TASK_IMAGE_GEN = "task_image_gen"
-TASK_WEB_VALIDATE = "task_web_validate"
-TASK_WEB_SUMMARIZE = "task_web_summarize"
-
-API_PROVIDER_OPENAI = "OpenAI-Compatible"
-API_PROVIDER_ANTHROPIC = "Anthropic Claude"
-API_PROVIDER_GEMINI = "Google Gemini"
-
-LOCAL_PROVIDER_OLLAMA = "Ollama"
-LOCAL_PROVIDER_LLAMACPP = "Llama.cpp"
-
-MODE_OLLAMA_LOCAL = "Ollama (Local)"
-MODE_LLAMACPP_LOCAL = "Llama.cpp (Local)"
-MODE_API_ENDPOINT = "API Endpoint"
-
-OLLAMA_MODELS = {
-    # These are runtime-resolved selections, not product defaults.  An empty
-    # value means the user has not selected a ready local model yet.
-    TASK_TITLE: '',
-    TASK_CHAT: '',
-    TASK_CHART: '',
-    TASK_WEB_VALIDATE: '',
-    TASK_WEB_SUMMARIZE: ''
-}
-
-CURRENT_MODEL = ''
-
-def set_current_model(model_name: str):
-    global CURRENT_MODEL
-    if model_name:
-        CURRENT_MODEL = model_name
-        OLLAMA_MODELS[TASK_CHAT] = model_name
+# Qt-removal plan R4.1: the task/provider/model half of this module moved to
+# the Qt-free graphlink_task_config so api_provider and the new backend can
+# import it without pulling PySide6 into the process. Legacy call sites keep
+# reading everything through this module unchanged:
+# - the constants are immutable strings (safe to re-export by from-import),
+# - OLLAMA_MODELS is the SAME dict object (mutations flow both ways),
+# - set_current_model/sync_ollama_task_models are the same function objects
+#   and mutate graphlink_task_config's own globals,
+# - CURRENT_MODEL is a rebound str global, so a from-import would go stale
+#   the moment set_current_model reassigns it; the module __getattr__ below
+#   delegates reads live instead. (PEP 562 __getattr__ only fires for names
+#   missing from this module's dict - do not from-import CURRENT_MODEL here.)
+from graphlink_task_config import (
+    TASK_TITLE,
+    TASK_CHAT,
+    TASK_CHART,
+    TASK_IMAGE_GEN,
+    TASK_WEB_VALIDATE,
+    TASK_WEB_SUMMARIZE,
+    API_PROVIDER_OPENAI,
+    API_PROVIDER_ANTHROPIC,
+    API_PROVIDER_GEMINI,
+    LOCAL_PROVIDER_OLLAMA,
+    LOCAL_PROVIDER_LLAMACPP,
+    MODE_OLLAMA_LOCAL,
+    MODE_LLAMACPP_LOCAL,
+    MODE_API_ENDPOINT,
+    OLLAMA_MODELS,
+    set_current_model,
+    sync_ollama_task_models,
+)
 
 
-def sync_ollama_task_models(settings_manager):
-    """Populate runtime selections from explicit/inherited/Auto settings.
-
-    The compatibility table remains for callers that already pass a task to
-    :func:`api_provider.chat`, but it no longer contains product-authored model
-    IDs.  Cached discovery is intentionally best-effort; an empty result leaves
-    an Auto task unconfigured until the provider is reachable and the user picks
-    or discovers a model.
-    """
-    from graphlink_model_catalog import ModelDescriptor, resolve_task_model
-
-    if hasattr(settings_manager, "get_ollama_model_assignments"):
-        assignments = settings_manager.get_ollama_model_assignments()
-    else:
-        assignments = {
-            TASK_CHAT: settings_manager.get_ollama_chat_model(),
-            TASK_TITLE: settings_manager.get_ollama_title_model(),
-            TASK_CHART: settings_manager.get_ollama_chart_model(),
-            TASK_WEB_VALIDATE: settings_manager.get_ollama_web_validate_model(),
-            TASK_WEB_SUMMARIZE: settings_manager.get_ollama_web_summarize_model(),
-        }
-
-    cached_models = []
-    if hasattr(settings_manager, "get_ollama_scanned_models"):
-        cached_models = settings_manager.get_ollama_scanned_models()
-    catalog = [ModelDescriptor(model_id=model, provider=LOCAL_PROVIDER_OLLAMA) for model in cached_models]
-    chat_model = resolve_task_model(TASK_CHAT, assignments, catalog)
-    for task in (TASK_CHAT, TASK_TITLE, TASK_CHART, TASK_WEB_VALIDATE, TASK_WEB_SUMMARIZE):
-        OLLAMA_MODELS[task] = resolve_task_model(
-            task,
-            assignments,
-            catalog,
-            chat_model=chat_model,
-        )
-
-    global CURRENT_MODEL
-    CURRENT_MODEL = OLLAMA_MODELS[TASK_CHAT]
+def __getattr__(name):
+    if name == "CURRENT_MODEL":
+        import graphlink_task_config
+        return graphlink_task_config.CURRENT_MODEL
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/graphlink_app/graphlink_task_config.py
+++ b/graphlink_app/graphlink_task_config.py
@@ -1,0 +1,91 @@
+"""Qt-free task/provider/model configuration (Qt-removal plan R4.1).
+
+The agent layer's half of what used to live in graphlink_config.py: task
+identifiers, provider/mode names, and the runtime model-selection state
+(OLLAMA_MODELS/CURRENT_MODEL). Split out so api_provider and the new
+backend can import all of it without pulling PySide6 into the process -
+graphlink_config.py's module-level Qt imports made every consumer a Qt
+process even when it only needed these plain constants.
+
+graphlink_config.py re-exports everything here for the legacy Qt call
+sites, so nothing legacy changes behavior; new code (backend/) imports
+this module directly and must never import graphlink_config.
+
+This file must stay Qt-free forever - it exists to be importable from
+backend/, which test_no_qt_anywhere.py holds to zero tolerance.
+"""
+
+TASK_TITLE = "task_title"
+TASK_CHAT = "task_chat"
+TASK_CHART = "task_chart"
+TASK_IMAGE_GEN = "task_image_gen"
+TASK_WEB_VALIDATE = "task_web_validate"
+TASK_WEB_SUMMARIZE = "task_web_summarize"
+
+API_PROVIDER_OPENAI = "OpenAI-Compatible"
+API_PROVIDER_ANTHROPIC = "Anthropic Claude"
+API_PROVIDER_GEMINI = "Google Gemini"
+
+LOCAL_PROVIDER_OLLAMA = "Ollama"
+LOCAL_PROVIDER_LLAMACPP = "Llama.cpp"
+
+MODE_OLLAMA_LOCAL = "Ollama (Local)"
+MODE_LLAMACPP_LOCAL = "Llama.cpp (Local)"
+MODE_API_ENDPOINT = "API Endpoint"
+
+OLLAMA_MODELS = {
+    # These are runtime-resolved selections, not product defaults.  An empty
+    # value means the user has not selected a ready local model yet.
+    TASK_TITLE: '',
+    TASK_CHAT: '',
+    TASK_CHART: '',
+    TASK_WEB_VALIDATE: '',
+    TASK_WEB_SUMMARIZE: ''
+}
+
+CURRENT_MODEL = ''
+
+def set_current_model(model_name: str):
+    global CURRENT_MODEL
+    if model_name:
+        CURRENT_MODEL = model_name
+        OLLAMA_MODELS[TASK_CHAT] = model_name
+
+
+def sync_ollama_task_models(settings_manager):
+    """Populate runtime selections from explicit/inherited/Auto settings.
+
+    The compatibility table remains for callers that already pass a task to
+    :func:`api_provider.chat`, but it no longer contains product-authored model
+    IDs.  Cached discovery is intentionally best-effort; an empty result leaves
+    an Auto task unconfigured until the provider is reachable and the user picks
+    or discovers a model.
+    """
+    from graphlink_model_catalog import ModelDescriptor, resolve_task_model
+
+    if hasattr(settings_manager, "get_ollama_model_assignments"):
+        assignments = settings_manager.get_ollama_model_assignments()
+    else:
+        assignments = {
+            TASK_CHAT: settings_manager.get_ollama_chat_model(),
+            TASK_TITLE: settings_manager.get_ollama_title_model(),
+            TASK_CHART: settings_manager.get_ollama_chart_model(),
+            TASK_WEB_VALIDATE: settings_manager.get_ollama_web_validate_model(),
+            TASK_WEB_SUMMARIZE: settings_manager.get_ollama_web_summarize_model(),
+        }
+
+    cached_models = []
+    if hasattr(settings_manager, "get_ollama_scanned_models"):
+        cached_models = settings_manager.get_ollama_scanned_models()
+    catalog = [ModelDescriptor(model_id=model, provider=LOCAL_PROVIDER_OLLAMA) for model in cached_models]
+    chat_model = resolve_task_model(TASK_CHAT, assignments, catalog)
+    for task in (TASK_CHAT, TASK_TITLE, TASK_CHART, TASK_WEB_VALIDATE, TASK_WEB_SUMMARIZE):
+        OLLAMA_MODELS[task] = resolve_task_model(
+            task,
+            assignments,
+            catalog,
+            chat_model=chat_model,
+        )
+
+    global CURRENT_MODEL
+    CURRENT_MODEL = OLLAMA_MODELS[TASK_CHAT]

--- a/graphlink_app/tests/test_ollama_task_model_settings.py
+++ b/graphlink_app/tests/test_ollama_task_model_settings.py
@@ -31,6 +31,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import pytest
 
 import graphlink_config as config
+import graphlink_task_config
 from graphlink_licensing import SettingsManager
 
 
@@ -45,12 +46,15 @@ def _restore_ollama_globals():
     # its own default-state assertion failed only when run after this file,
     # tracing back to test_auto_tasks_stay_unconfigured_until_discovery's
     # unprotected config.sync_ollama_task_models(manager) call.
-    original_models = dict(config.OLLAMA_MODELS)
-    original_current_model = config.CURRENT_MODEL
+    # R4.1: the state itself now lives in graphlink_task_config; restore it
+    # THERE - assigning graphlink_config.CURRENT_MODEL would only create a
+    # shadowing attribute on the re-export shim, not restore the real global.
+    original_models = dict(graphlink_task_config.OLLAMA_MODELS)
+    original_current_model = graphlink_task_config.CURRENT_MODEL
     yield
-    config.OLLAMA_MODELS.clear()
-    config.OLLAMA_MODELS.update(original_models)
-    config.CURRENT_MODEL = original_current_model
+    graphlink_task_config.OLLAMA_MODELS.clear()
+    graphlink_task_config.OLLAMA_MODELS.update(original_models)
+    graphlink_task_config.CURRENT_MODEL = original_current_model
 
 
 def _make_settings_manager(tmp_path):

--- a/graphlink_app/tests/test_settings_bridge_ollama_page.py
+++ b/graphlink_app/tests/test_settings_bridge_ollama_page.py
@@ -26,12 +26,16 @@ def _restore_ollama_globals():
     # config.set_current_model()/sync_ollama_task_models(), same class of
     # leak test_theme_tokens.py's own save/restore convention already
     # guards against for config.CURRENT_THEME.
-    original_models = dict(config.OLLAMA_MODELS)
-    original_current_model = config.CURRENT_MODEL
+    # R4.1: the state itself now lives in graphlink_task_config; restore it
+    # THERE - assigning graphlink_config.CURRENT_MODEL would only create a
+    # shadowing attribute on the re-export shim, not restore the real global.
+    import graphlink_task_config
+    original_models = dict(graphlink_task_config.OLLAMA_MODELS)
+    original_current_model = graphlink_task_config.CURRENT_MODEL
     yield
-    config.OLLAMA_MODELS.clear()
-    config.OLLAMA_MODELS.update(original_models)
-    config.CURRENT_MODEL = original_current_model
+    graphlink_task_config.OLLAMA_MODELS.clear()
+    graphlink_task_config.OLLAMA_MODELS.update(original_models)
+    graphlink_task_config.CURRENT_MODEL = original_current_model
 
 
 def _bridge(tmp_path) -> SettingsBridge:

--- a/graphlink_app/tests/test_task_config_split.py
+++ b/graphlink_app/tests/test_task_config_split.py
@@ -1,0 +1,59 @@
+"""R4.1: the graphlink_config -> graphlink_task_config re-export shim.
+
+The split moved mutable module state (OLLAMA_MODELS/CURRENT_MODEL) into
+graphlink_task_config while every legacy Qt call site keeps reading through
+graphlink_config. These tests pin the two sharp edges of that arrangement:
+the dict must be the SAME object through both modules, and CURRENT_MODEL -
+a rebound str global that a plain from-import would freeze at import time -
+must stay live through graphlink_config's module __getattr__ delegation.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import graphlink_config
+import graphlink_task_config
+
+
+@pytest.fixture(autouse=True)
+def _restore_ollama_globals():
+    original_models = dict(graphlink_task_config.OLLAMA_MODELS)
+    original_current_model = graphlink_task_config.CURRENT_MODEL
+    yield
+    graphlink_task_config.OLLAMA_MODELS.clear()
+    graphlink_task_config.OLLAMA_MODELS.update(original_models)
+    graphlink_task_config.CURRENT_MODEL = original_current_model
+
+
+def test_ollama_models_is_the_same_object_through_both_modules():
+    assert graphlink_config.OLLAMA_MODELS is graphlink_task_config.OLLAMA_MODELS
+
+
+def test_current_model_reads_stay_live_through_graphlink_config():
+    # set_current_model rebinds graphlink_task_config.CURRENT_MODEL; a stale
+    # from-import re-export would keep returning the old value here.
+    graphlink_config.set_current_model("split-proof-model")
+    assert graphlink_task_config.CURRENT_MODEL == "split-proof-model"
+    assert graphlink_config.CURRENT_MODEL == "split-proof-model"
+
+
+def test_current_model_is_not_shadowed_on_the_shim():
+    # If anything ever assigns graphlink_config.CURRENT_MODEL directly, the
+    # module attribute would permanently shadow the __getattr__ delegation
+    # and reads through the shim would silently go stale. Keep it absent.
+    assert "CURRENT_MODEL" not in vars(graphlink_config)
+
+
+def test_task_constants_match_through_both_modules():
+    for name in (
+        "TASK_TITLE", "TASK_CHAT", "TASK_CHART", "TASK_IMAGE_GEN",
+        "TASK_WEB_VALIDATE", "TASK_WEB_SUMMARIZE",
+        "API_PROVIDER_OPENAI", "API_PROVIDER_ANTHROPIC", "API_PROVIDER_GEMINI",
+        "LOCAL_PROVIDER_OLLAMA", "LOCAL_PROVIDER_LLAMACPP",
+        "MODE_OLLAMA_LOCAL", "MODE_LLAMACPP_LOCAL", "MODE_API_ENDPOINT",
+    ):
+        assert getattr(graphlink_config, name) == getattr(graphlink_task_config, name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ py-modules = [
     "graphlink_composer_popup_positioning",
     "graphlink_composer_web",
     "graphlink_config",
+    "graphlink_task_config",
     "graphlink_context_menu",
     "graphlink_connections",
     "graphlink_conversation_node",


### PR DESCRIPTION
## Summary
- Extracts the task/provider/model half of `graphlink_config.py` into a new Qt-free `graphlink_task_config.py`. The old module's top-level PySide6 imports made every consumer a Qt process even when it only needed plain constants - this was the single blocker keeping the new backend from calling `api_provider.chat()`, i.e. the thing every "lands in R4" placeholder across R3's node types is waiting on.
- `graphlink_config` re-exports everything for legacy call sites unchanged: constants/functions by from-import, `OLLAMA_MODELS` as the same shared dict, and `CURRENT_MODEL` (a rebound global that a from-import would freeze stale) via a PEP 562 module `__getattr__` delegating reads live.
- `api_provider.py` and `graphlink_agents_core.py` now import the Qt-free module directly. The two test fixtures that save/restore `CURRENT_MODEL` were repointed at the owning module - assigning through the shim would have created a shadowing attribute breaking both delegation and restore.
- New machine-checked proof: fresh-subprocess tests assert `import api_provider` never pulls PySide6 into `sys.modules`.

## Test plan
- [x] `python -m pytest -q` (repo-wide): 1928 passed (up 6, all new tests), zero regressions
- [x] Burn-down gate green at the unchanged 168 pin (new module is Qt-free; `graphlink_config` keeps its Qt styling half until R7 cutover)
- [x] Shim edge-case tests: same-dict identity, live `CURRENT_MODEL` delegation, no shadowing attribute