### PR TITLE
Qt-removal R4.2: real agent-dispatch service - the first genuine LLM round trip

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -1,0 +1,267 @@
+"""Qt-removal plan R4: the agent-dispatch service.
+
+This is where the new FastAPI backend gets its first genuine LLM round trip.
+Two separate jobs live here:
+
+1. `bootstrap_provider_state()` - runs exactly ONCE per process, at app
+   startup (see backend/app.py's create_app()). It bootstraps api_provider.py's
+   module-level provider globals (USE_API_MODE/API_PROVIDER_TYPE/API_CLIENT/
+   LOCAL_PROVIDER_TYPE/...) from the SAME shared SettingsManager/session.dat
+   file the legacy Qt app reads and writes - so whichever provider/mode the
+   user last configured (Ollama, Llama.cpp, or a cloud API) is already live
+   the moment the first WS session connects, with no separate "initialize
+   the agent layer" step the frontend has to trigger.
+
+2. `AgentDispatcher` - one instance PER SESSION (never a module-level
+   singleton: two sessions must never share in-flight request state).
+   `start_chat_reply()` is the real Send-to-reply pipeline: it schedules the
+   blocking `api_provider.chat()` call off the FastAPI event loop (via
+   `asyncio.to_thread`), enforces a single fixed hard timeout
+   (`WATCHDOG_TIMEOUT_SECONDS`), and supports cooperative cancellation via a
+   `threading.Event` a client can trip mid-flight through the
+   `cancelChatRequest` intent this module registers.
+
+   Legacy has a two-tier watchdog for non-audio requests: a 35s "still
+   working..." stall notice, then a 420s hard timeout. This increment
+   deliberately ships only the hard 420s timeout via `asyncio.wait_for`,
+   cutting the intermediate stall-notice tier as an honest simplification -
+   the two-tier warning is a UX nicety, not a correctness requirement. Note
+   also that legacy itself does not kill the underlying call on timeout
+   either, it only stops waiting for it - same limitation here: the
+   worker-thread call to `api_provider.chat()` keeps running in its thread
+   pool slot after a timeout fires, it is simply no longer awaited.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import uuid
+
+import api_provider
+import graphlink_task_config as config
+from graphlink_chat_agent import ChatAgent
+from graphlink_licensing import SettingsManager  # type hint only
+from graphlink_prompts import BASE_SYSTEM_PROMPT
+
+from backend.events import SessionBus  # type hint only
+
+logger = logging.getLogger(__name__)
+
+# The single fixed hard timeout for this increment - see the module
+# docstring for why there is no intermediate stall-notice tier here.
+WATCHDOG_TIMEOUT_SECONDS = 420
+
+
+def bootstrap_provider_state(settings_manager: SettingsManager) -> None:
+    """Bootstrap api_provider's module-level provider state from persisted
+    settings. Call exactly ONCE per process (this is process-global state,
+    not session state) - see backend/app.py's create_app()."""
+    # Unconditional and first, regardless of active mode: resolves Auto/
+    # inherited Ollama task-model assignments against the cached scan, same
+    # as legacy does at startup.
+    config.sync_ollama_task_models(settings_manager)
+
+    mode_text = settings_manager.get_current_mode()
+    try:
+        _apply_mode(mode_text, settings_manager)
+        settings_manager.set_current_mode(mode_text)
+    except Exception:
+        # Funnels BOTH a real initialize_* failure (e.g. a persisted API key
+        # that no longer validates) AND a garbage/unrecognized persisted mode
+        # string through the same fallback - simpler than legacy's separate
+        # handling of those two cases, same practical outcome: the app always
+        # comes up in a usable state instead of failing to start.
+        logger.warning(
+            "failed to apply persisted provider mode %r; falling back to %s",
+            mode_text,
+            config.MODE_OLLAMA_LOCAL,
+            exc_info=True,
+        )
+        settings_manager.set_current_mode(config.MODE_OLLAMA_LOCAL)
+        api_provider.initialize_local_provider(config.LOCAL_PROVIDER_OLLAMA)
+
+
+def _apply_mode(mode_text: str, settings_manager: SettingsManager) -> None:
+    """Three-way dispatch mirroring the legacy mode-switch handlers. Raises
+    ValueError for any mode_text it does not recognize - see
+    bootstrap_provider_state's single fallback branch above."""
+    if mode_text == config.MODE_OLLAMA_LOCAL:
+        api_provider.initialize_local_provider(
+            config.LOCAL_PROVIDER_OLLAMA,
+            {"reasoning_mode": settings_manager.get_ollama_reasoning_mode()},
+        )
+    elif mode_text == config.MODE_LLAMACPP_LOCAL:
+        api_provider.initialize_local_provider(
+            config.LOCAL_PROVIDER_LLAMACPP,
+            settings_manager.get_llama_cpp_settings(),
+            preload_model=False,
+        )
+    elif mode_text == config.MODE_API_ENDPOINT:
+        provider = settings_manager.get_api_provider()
+        base_url = settings_manager.get_api_base_url()
+        for task, model in settings_manager.get_api_models(provider).items():
+            api_provider.set_task_model(task, model)
+        if provider == config.API_PROVIDER_OPENAI:
+            key = settings_manager.get_openai_key()
+        elif provider == config.API_PROVIDER_ANTHROPIC:
+            key = settings_manager.get_anthropic_key()
+        else:
+            key = settings_manager.get_gemini_key()
+        api_provider.initialize_api(provider, key, base_url)
+    else:
+        raise ValueError(f"unrecognized provider mode: {mode_text!r}")
+
+
+class AgentDispatcher:
+    """One instance per session - never a module-level singleton, since two
+    sessions must never share in-flight request state."""
+
+    def __init__(self, settings_manager: SettingsManager):
+        self._settings_manager = settings_manager
+        # request_id -> {"cancel_event": threading.Event, "task": asyncio.Task}
+        self._requests: dict[str, dict] = {}
+
+    def persona(self) -> str:
+        """Mirror legacy graphlink_window.py's `_get_current_system_prompt`:
+        fully suppressed (empty string) when the user has disabled the
+        system prompt in Settings, otherwise the base persona text.
+
+        Deliberate simplification vs legacy: legacy also prefixes
+        THINKING_INSTRUCTIONS_PROMPT ahead of BASE_SYSTEM_PROMPT when the
+        active provider's reasoning mode is "Thinking" (branching further on
+        Ollama's vs Llama.cpp's own reasoning-mode setting). That branch is
+        out of scope for this increment - see the final report."""
+        if not self._settings_manager.get_enable_system_prompt():
+            return ""
+        return BASE_SYSTEM_PROMPT
+
+    def cancel(self, request_id: str) -> bool:
+        entry = self._requests.get(request_id)
+        if entry is None:
+            return False
+        entry["cancel_event"].set()
+        return True
+
+    def cancel_all(self) -> None:
+        """Trip the cancel event on every in-flight request for this
+        session. Called when a session's last WS connection disconnects
+        (backend/app.py's ws_endpoint) - without this, a client that sends a
+        message and immediately closes the tab leaves the real outbound LLM
+        call (potentially a billed API request) running server-side,
+        untethered, for up to WATCHDOG_TIMEOUT_SECONDS with no way for the
+        client to ever cancel it (cancelChatRequest needs a live socket).
+        Same cooperative-cancellation semantics as cancel() - this does not
+        forcibly kill the in-flight thread, it only requests it stop at its
+        next checkpoint, same as the timeout path already does."""
+        for entry in self._requests.values():
+            entry["cancel_event"].set()
+
+    async def start_chat_reply(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        composer_document,
+        conversation_history,
+        on_reply,
+    ) -> None:
+        if self._requests:
+            # Single-request-per-session guard: never start a second
+            # concurrent request while one is already in flight.
+            notifications_state.show("A response is already being generated.", "info")
+            await bus.publish("notification")
+            return
+
+        if not api_provider.is_configured():
+            # Fail fast and clean, synchronously, before touching any thread -
+            # a never-configured install gets an honest, actionable error.
+            notifications_state.show(
+                "No AI provider is configured yet. Open Settings to choose Ollama, "
+                "Llama.cpp, or an API provider.",
+                "error",
+            )
+            await bus.publish("notification")
+            return
+
+        request_id = uuid.uuid4().hex
+        cancel_event = threading.Event()
+
+        async def _run():
+            composer_document.begin_request(request_id)
+            await bus.publish("app-composer")
+            try:
+                reply_text = await asyncio.wait_for(
+                    asyncio.to_thread(_call_chat_agent, conversation_history, self.persona(), cancel_event),
+                    timeout=WATCHDOG_TIMEOUT_SECONDS,
+                )
+                on_reply(reply_text)
+                await bus.publish("scene")
+            except asyncio.TimeoutError:
+                cancel_event.set()
+                notifications_state.show(
+                    "The model stopped responding before the request completed. "
+                    "Please try again or choose a faster model.",
+                    "error",
+                )
+                await bus.publish("notification")
+            except api_provider.RequestCancelledError:
+                notifications_state.show("Request cancelled.", "info")
+                await bus.publish("notification")
+            except Exception as exc:
+                logging.getLogger(__name__).exception("chat dispatch failed")
+                notifications_state.show(f"AI response failed: {exc}", "error")
+                await bus.publish("notification")
+            finally:
+                # Unconditional on every exit path (success, timeout, cancel,
+                # other error) so the composer always returns to a usable
+                # idle state.
+                self._requests.pop(request_id, None)
+                composer_document.end_request()
+                await bus.publish("app-composer")
+
+        # NOT awaited here - start_chat_reply returns immediately after
+        # scheduling the task. This is load-bearing: the WS connection this
+        # session serves runs a plain sequential
+        # `while True: message = await websocket.receive_json(); ...` read
+        # loop (backend/app.py) - if this handler awaited the full chat call
+        # inline, no further message on that same socket (including a
+        # cancelChatRequest intent) would even be read off the wire until the
+        # handler returned, making cooperative cancellation impossible.
+        self._requests[request_id] = {"cancel_event": cancel_event, "task": asyncio.create_task(_run())}
+
+
+def _call_chat_agent(conversation_history, persona_text, cancel_event) -> str:
+    """Runs inside asyncio.to_thread - a real OS thread, not the event loop."""
+    agent = ChatAgent("Graphlink Assistant", persona_text)
+    # KNOWN PRE-EXISTING LEGACY QUIRK, ported as-is (not fixed here - see the
+    # final report): ChatAgent.__init__ does
+    # `self.persona = persona or "(default persona)"`, so when persona_text
+    # is "" (system prompt disabled), self.persona becomes the literal
+    # "(default persona)" and system_prompt ends up
+    # "You are Graphlink Assistant. (default persona)." - not truly
+    # empty/suppressed the way disabling the setting is clearly meant to.
+    return agent.get_response(
+        conversation_history,
+        # current_node=None is never dereferenced: ChatWorker.run only walks
+        # current_node when resolved_system_prompt is None, and a real value
+        # (agent.system_prompt, NOT the raw persona_text - see below) is
+        # always supplied here.
+        current_node=None,
+        cancellation_event=cancel_event,
+        # Pass agent.system_prompt (the "You are {name}. {persona}." string
+        # ChatAgent always builds), NOT the raw persona_text - getting this
+        # backwards would silently drop the "You are Graphlink Assistant. "
+        # prefix.
+        resolved_system_prompt=agent.system_prompt,
+    )
+
+
+def register_agents(bus, composer_document, notifications_state, settings_manager) -> AgentDispatcher:
+    dispatcher = AgentDispatcher(settings_manager)
+    # dispatcher.cancel is synchronous (just sets an Event and returns a
+    # bool) - no publish/await needed here; the in-flight _run task's own
+    # finally block handles the resulting state transition.
+    bus.register_intent("app-composer", "cancelChatRequest", lambda request_id: dispatcher.cancel(request_id))
+    return dispatcher

--- a/backend/app.py
+++ b/backend/app.py
@@ -34,6 +34,7 @@ from graphlink_licensing import SettingsManager
 
 from backend import BACKEND_VERSION
 from backend.about import register_about
+from backend.agents import bootstrap_provider_state, register_agents
 from backend.assets import register_assets
 from backend.canvas import register_canvas
 from backend.chat_library import register_chat_library
@@ -68,8 +69,25 @@ def _configure_session(bus: SessionBus, settings_manager: SettingsManager, chat_
     bus.register_intent("system", "ping", ping)
 
     # R2: notifications, moved ahead of canvas - R3.3's sendMessage intent
-    # needs a real NotificationState to give an honest "lands in R4" notice.
+    # needs a real NotificationState to give an honest agent-dispatch notice.
     notifications_state = register_notifications(bus)
+
+    # R2: composer draft/reasoning, token counter. Moved ahead of canvas (R4):
+    # sendMessage's real agent dispatch needs a real ComposerDocument to flip
+    # into/out of "generating" state, and a real AgentDispatcher to hand off
+    # to - both must exist before register_canvas builds the sendMessage
+    # intent that calls them.
+    token_counter = register_token_counter(bus)
+    composer_document = register_composer(bus, token_counter)
+
+    # R4 (doc/QT_REMOVAL_PLAN.md): the agent-dispatch service - one
+    # AgentDispatcher per session (never a module-level singleton). Bolted
+    # onto the bus (same pattern as canvas_document below) so ws_endpoint's
+    # disconnect handler can reach it and cancel any in-flight request when
+    # this session's last connection drops - see AgentDispatcher.cancel_all's
+    # own docstring for why that matters.
+    agent_dispatcher = register_agents(bus, composer_document, notifications_state, settings_manager)
+    bus.agent_dispatcher = agent_dispatcher
 
     # R1 (doc/QT_REMOVAL_PLAN.md): scene document + grid topics.
     # R3.21: stash the document on its own SessionBus so backend/assets.py's
@@ -79,11 +97,7 @@ def _configure_session(bus: SessionBus, settings_manager: SettingsManager, chat_
     # canvas document outside this closure. SessionBus has no fixed attribute
     # set (no __slots__), so this is a plain, minimal bolt-on attribute, not
     # a SessionBus API change.
-    bus.canvas_document = register_canvas(bus, notifications_state)
-
-    # R2: composer draft/reasoning, token counter.
-    token_counter = register_token_counter(bus)
-    register_composer(bus, token_counter)
+    bus.canvas_document = register_canvas(bus, notifications_state, agent_dispatcher, composer_document)
 
     # R2.5: about, plugins, settings, chat library.
     register_about(bus)
@@ -102,6 +116,10 @@ def create_app(
     # ~/.graphlink/session.dat file), shared across every session rather
     # than reconstructed per-session - see backend/settings.py's docstring.
     settings_manager = SettingsManager(settings_state_file)
+    # R4: bootstrap api_provider's module-level provider state from that same
+    # SettingsManager exactly ONCE per process - process-global state, not
+    # session state (see backend/agents.py's docstring).
+    bootstrap_provider_state(settings_manager)
     bus = EventBus(
         configure_session=lambda session_bus: _configure_session(session_bus, settings_manager, chat_db_path)
     )
@@ -129,6 +147,16 @@ def create_app(
             pass
         finally:
             session.detach(websocket)
+            # Concurrency/security review finding (R4): a client that sends
+            # a message then immediately disconnects would otherwise leave
+            # the real outbound LLM call running server-side, untethered,
+            # for up to WATCHDOG_TIMEOUT_SECONDS with no way to ever cancel
+            # it - cancelChatRequest needs a live socket to arrive over.
+            # Only cancel once the LAST connection for this session drops:
+            # another tab/window on the same session should not lose its
+            # in-flight request just because a different tab closed.
+            if session.connection_count == 0:
+                session.agent_dispatcher.cancel_all()
 
     resolved_spa = SPA_DIST_DIR if spa_dir is None else spa_dir
     if resolved_spa.is_dir():

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -34,6 +34,8 @@ from graphlink_grid_view_settings import (
 )
 from graphlink_navigation_pins import NavigationPinRecord, NavigationPinStore
 
+from backend.agents import AgentDispatcher
+from backend.composer import ComposerDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 
@@ -651,6 +653,29 @@ class SceneDocument:
         self.last_chat_node_id = node.id
         return node
 
+    def chat_branch_history(self, node_id: str) -> list[dict]:
+        """Walk the branch from node_id up to its root, collecting one
+        {"role", "content"} entry per node visited (including node_id
+        itself), then reverse so the result reads root-to-leaf (oldest
+        message first) - the direct new-backend replacement for legacy
+        conversation_history built by walking the QGraphicsScene parent
+        chain. Follows edges generically (by target match) rather than
+        asserting a chat-kind node shape: the walk itself only ever visits
+        chat-kind nodes in practice given how they are the only kind chained
+        this way, but a bad/unknown node_id or a stray edge shape should
+        stop the walk quietly rather than raise."""
+        history: list[dict] = []
+        current_id: str | None = node_id
+        while current_id is not None:
+            node = self.nodes.get(current_id)
+            if node is None:
+                break
+            history.append({"role": "user" if node.is_user else "assistant", "content": node.content})
+            parent_edge = next((e for e in self.edges.values() if e.target == current_id), None)
+            current_id = parent_edge.source if parent_edge is not None else None
+        history.reverse()
+        return history
+
     def set_chat_collapsed(self, node_id: str, collapsed: bool) -> None:
         node = self.nodes.get(node_id)
         if node is None:
@@ -801,10 +826,19 @@ class SceneDocument:
         }
 
 
-def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneDocument:
+def register_canvas(
+    bus: SessionBus,
+    notifications: NotificationState,
+    agent_dispatcher: AgentDispatcher,
+    composer_document: ComposerDocument,
+) -> SceneDocument:
     """Give a session its canvas document + the scene/grid topics and every
     R1 intent. Intent names for grid mirror GridControlBridge's @Slot names
-    1:1 so the R2 island port is a transport swap, not a redesign."""
+    1:1 so the R2 island port is a transport swap, not a redesign.
+
+    R4: agent_dispatcher/composer_document are threaded through so
+    sendMessage's real Send action (below) can hand off to the real agent
+    dispatch pipeline instead of the R3-era deferred notice."""
 
     document = SceneDocument()
 
@@ -910,19 +944,24 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
 
     async def send_conversation_message(node_id, text):
         # R3.25: the real user-message-send action for a conversation node -
-        # appends a real user message. The assistant's reply needs the agent
-        # layer (same R4 prerequisite as ChatNode's send_message), so this is
-        # an honest deferred notice rather than a fake/stubbed response -
-        # same exact notification text/level/publish call as send_message.
+        # appends a real user message. ConversationNode is deliberately NOT
+        # wired to agent_dispatcher this increment (R4 landed real dispatch
+        # for ChatNode's send_message only, above) - reserved for a
+        # follow-up increment, so this remains an honest deferred notice
+        # rather than a fake/stubbed response. The wording below was updated
+        # from "lands in R4" since R4 has now partially landed (just not for
+        # this node type yet) - leaving the old text unchanged would be
+        # actively misleading.
         node = document.send_conversation_message(node_id, text)
         await publish_scene()
-        notifications.show("AI response generation lands in R4.", "info")
+        notifications.show("AI response generation lands in a follow-up increment.", "info")
         await bus.publish("notification")
         return node.id
 
     async def append_conversation_assistant_message(node_id, text):
         # Unlike send_conversation_message, this represents a real reply
-        # landing once R4 exists, not a deferral - so no notification fires.
+        # landing once ConversationNode gets real agent dispatch, not a
+        # deferral - so no notification fires.
         node = document.append_conversation_assistant_message(node_id, text)
         await publish_scene()
         return node.id
@@ -945,14 +984,25 @@ def register_canvas(bus: SessionBus, notifications: NotificationState) -> SceneD
 
     async def send_message(text):
         # R3.3: the real Send action - a real user ChatNode, continuing the
-        # active branch. The assistant's reply needs the agent layer
-        # (graphlink_config.py's Qt/non-Qt split is an R4 prerequisite - see
-        # doc/QT_REMOVAL_PLAN.md's R3 scoping note), so this is an honest
-        # deferred notice rather than a fake/stubbed response.
+        # active branch. R4: the assistant's reply is now a real agent
+        # dispatch call, not a deferred notice - see backend/agents.py.
         node = document.send_message(text)
         await publish_scene()
-        notifications.show("AI response generation lands in R4.", "info")
-        await bus.publish("notification")
+        history = document.chat_branch_history(node.id)
+
+        def _on_reply(reply_text):
+            reply_node = document.add_chat_node(
+                node.x, node.y + MESSAGE_VERTICAL_SPACING, reply_text, False, parent_id=node.id
+            )
+            document.last_chat_node_id = reply_node.id
+
+        await agent_dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=history,
+            on_reply=_on_reply,
+        )
         return node.id
 
     async def move_node(node_id, x, y):

--- a/backend/composer.py
+++ b/backend/composer.py
@@ -65,6 +65,11 @@ class ComposerDocument:
 
     draft: ComposerDraft = field(default_factory=ComposerDraft)
     reasoning_level: str = DEFAULT_REASONING_LEVEL
+    # R4: the in-flight agent-dispatch request, if any - set by
+    # backend/agents.py's AgentDispatcher around a real chat call so the
+    # composer UI can reflect generating/idle state and offer cancellation.
+    request_id: str | None = None
+    request_state: str = "idle"
 
     def update_draft_text(self, text: str) -> None:
         self.draft.text = str(text)
@@ -74,6 +79,14 @@ class ComposerDocument:
         if level not in valid_ids:
             raise ComposerError(f"unknown reasoning level: {level}")
         self.reasoning_level = level
+
+    def begin_request(self, request_id: str) -> None:
+        self.request_id = request_id
+        self.request_state = "generating"
+
+    def end_request(self) -> None:
+        self.request_id = None
+        self.request_state = "idle"
 
     def _reasoning_label(self) -> str:
         return next(o["label"] for o in REASONING_OPTIONS if o["id"] == self.reasoning_level)
@@ -109,11 +122,11 @@ class ComposerDocument:
                 "canChange": False,
             },
             "request": {
-                "id": None,
-                "state": "idle",
+                "id": self.request_id,
+                "state": self.request_state,
                 "message": "",
-                "canSend": False,
-                "canCancel": False,
+                "canSend": self.request_state == "idle",
+                "canCancel": self.request_state == "generating",
                 "canRetry": False,
             },
             "capabilities": {
@@ -123,7 +136,7 @@ class ComposerDocument:
                 "modelSelection": False,
                 "reasoningSelection": True,
                 "settingsShortcut": True,
-                "cancellation": False,
+                "cancellation": True,
             },
         }
 

--- a/backend/tests/test_agent_layer_qt_free.py
+++ b/backend/tests/test_agent_layer_qt_free.py
@@ -52,3 +52,14 @@ def test_api_provider_imports_qt_free():
     # any backend chat dispatch a Qt process. This is the machine-checked
     # fact that that chain is severed.
     _assert_import_is_qt_free("api_provider")
+
+
+def test_chat_agent_imports_qt_free():
+    # R4.2 prerequisite: graphlink_agents_core.py (home of ChatWorker/
+    # ChatAgent/resolve_branch_system_prompt before this split) has its own
+    # unconditional `from PySide6.QtCore import ...` at module level, needed
+    # only by its *WorkerThread classes - importing anything from it,
+    # including these three Qt-free symbols, pulled Qt in regardless. This
+    # is the machine-checked fact that the real chat-agent path backend/
+    # needs no longer does.
+    _assert_import_is_qt_free("graphlink_chat_agent")

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -1,0 +1,457 @@
+"""Agent-dispatch service tests (Qt-removal plan R4).
+
+Mocks `api_provider.chat` directly (mirroring
+graphlink_app/tests/test_provider_state_snapshot.py's monkeypatch-provider-
+globals pattern) rather than a deeper transport layer - this validates the
+real wiring end to end (event loop -> asyncio.to_thread -> ChatWorker ->
+api_provider.chat -> back through the WATCHDOG_TIMEOUT_SECONDS/cancellation
+plumbing) without ever needing a live Ollama daemon, a real API key, or real
+network access, while still catching a wiring bug in the new dispatch code
+itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+# Importing any backend.* submodule runs backend/__init__.py first, which
+# puts graphlink_app/ on sys.path - these must come before the bare
+# top-level graphlink_app imports below (api_provider, graphlink_task_config,
+# graphlink_licensing) for this module to import cleanly when run standalone.
+import backend.agents as agents_module
+from backend.agents import AgentDispatcher
+from backend.composer import ComposerDocument
+from backend.events import SessionBus
+from backend.notifications import NotificationState
+
+import api_provider
+import graphlink_task_config as config
+from graphlink_licensing import SettingsManager
+
+
+class _FakeSettingsManager:
+    """A minimal stand-in exposing only what AgentDispatcher.persona() reads -
+    the bootstrap_provider_state tests below use a real SettingsManager
+    instead, since they exercise its persistence surface directly."""
+
+    def __init__(self, enable_system_prompt: bool = True):
+        self._enable_system_prompt = enable_system_prompt
+
+    def get_enable_system_prompt(self) -> bool:
+        return self._enable_system_prompt
+
+
+def _make_dispatch_env(enable_system_prompt: bool = True):
+    bus = SessionBus("agents-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    composer_document = ComposerDocument()
+    bus.register_topic("app-composer", composer_document.payload)
+    # A real "scene" topic - the success path publishes it after on_reply.
+    bus.register_topic("scene", lambda: {})
+    dispatcher = AgentDispatcher(_FakeSettingsManager(enable_system_prompt))
+    return bus, notifications, composer_document, dispatcher
+
+
+def _configure_fake_ollama(monkeypatch, chat_fn, *, model="test-model"):
+    monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+    monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_OLLAMA)
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, model)
+    monkeypatch.setattr(api_provider, "chat", chat_fn)
+
+
+# -- 1. successful reply ------------------------------------------------------
+
+
+def test_successful_reply_calls_on_reply_with_the_agent_text(monkeypatch):
+    _configure_fake_ollama(monkeypatch, lambda task, messages, **kwargs: {"message": {"content": "canned reply"}})
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        replies = []
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=replies.append,
+        )
+        # The reply happens inside a scheduled (not awaited) task - grab the
+        # task reference start_chat_reply left in the registry and await it
+        # directly rather than assuming start_chat_reply itself blocks.
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assert replies == ["canned reply"]
+        assert dispatcher._requests == {}
+        assert composer_document.request_state == "idle"
+
+    asyncio.run(run())
+
+
+# -- 2. provider-not-configured clean error ----------------------------------
+
+
+def test_provider_not_configured_returns_quickly_with_an_error_notification(monkeypatch):
+    chat_calls = []
+    _configure_fake_ollama(
+        monkeypatch,
+        lambda task, messages, **kwargs: chat_calls.append(1),
+        model="",  # empty -> is_configured() is False
+    )
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[],
+            on_reply=lambda text: None,
+        )
+
+        assert dispatcher._requests == {}, "no task/thread work started"
+        assert chat_calls == [], "api_provider.chat was never reached"
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == (
+            "No AI provider is configured yet. Open Settings to choose Ollama, "
+            "Llama.cpp, or an API provider."
+        )
+
+    asyncio.run(run())
+
+
+# -- 3. cancellation mid-flight -----------------------------------------------
+
+
+def test_cancellation_mid_flight_fires_info_notification_and_clears_registry(monkeypatch):
+    started = threading.Event()
+
+    def blocking_then_cancelled(task, messages, cancellation_event=None, **kwargs):
+        started.set()
+        while not cancellation_event.is_set():
+            time.sleep(0.01)
+        raise api_provider.RequestCancelledError("Request cancelled.")
+
+    _configure_fake_ollama(monkeypatch, blocking_then_cancelled)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=lambda text: None,
+        )
+        request_id, entry = next(iter(dispatcher._requests.items()))
+
+        # Wait until the worker thread has actually entered chat() before
+        # cancelling, so this is a genuine mid-flight cancel.
+        await asyncio.to_thread(started.wait, 5)
+        assert dispatcher.cancel(request_id) is True
+
+        await entry["task"]
+
+        assert dispatcher._requests == {}
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert notifications.message == "Request cancelled."
+
+    asyncio.run(run())
+
+
+def test_cancel_returns_false_for_an_unknown_request_id():
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    assert dispatcher.cancel("no-such-request") is False
+
+
+# -- 4. timeout ---------------------------------------------------------------
+
+
+def test_timeout_fires_the_exact_message_and_clears_registry(monkeypatch):
+    monkeypatch.setattr(agents_module, "WATCHDOG_TIMEOUT_SECONDS", 0.05)
+
+    def slow_chat(task, messages, **kwargs):
+        time.sleep(0.3)
+        return {"message": {"content": "too late"}}
+
+    _configure_fake_ollama(monkeypatch, slow_chat)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=lambda text: None,
+        )
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assert dispatcher._requests == {}
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == (
+            "The model stopped responding before the request completed. "
+            "Please try again or choose a faster model."
+        )
+
+    asyncio.run(run())
+
+
+# -- 5. concurrent same-session guard -----------------------------------------
+
+
+def test_concurrent_calls_second_rejected_first_completes_third_succeeds(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_chat(task, messages, **kwargs):
+        started.set()
+        release.wait(5)
+        return {"message": {"content": "first reply"}}
+
+    _configure_fake_ollama(monkeypatch, blocking_chat)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        replies = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "first"}],
+            on_reply=replies.append,
+        )
+        await asyncio.to_thread(started.wait, 5)
+
+        # Second call while the first is still in flight must be rejected
+        # and must not disturb the first request.
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "second"}],
+            on_reply=replies.append,
+        )
+        assert notifications.visible is True
+        assert notifications.message == "A response is already being generated."
+        assert len(dispatcher._requests) == 1
+
+        release.set()
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+        assert replies == ["first reply"]
+        assert dispatcher._requests == {}
+
+        # Third call, after the first has fully completed, succeeds normally.
+        monkeypatch.setattr(api_provider, "chat", lambda task, messages, **kwargs: {"message": {"content": "third reply"}})
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "third"}],
+            on_reply=replies.append,
+        )
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+        assert replies == ["first reply", "third reply"]
+
+    asyncio.run(run())
+
+
+# -- persona() -----------------------------------------------------------------
+
+
+def test_persona_is_empty_when_system_prompt_disabled():
+    dispatcher = AgentDispatcher(_FakeSettingsManager(enable_system_prompt=False))
+    assert dispatcher.persona() == ""
+
+
+def test_persona_is_the_base_persona_text_when_enabled():
+    dispatcher = AgentDispatcher(_FakeSettingsManager(enable_system_prompt=True))
+    persona_text = dispatcher.persona()
+    assert persona_text
+    assert "Vertex" in persona_text  # BASE_SYSTEM_PROMPT's persona alias
+
+
+# -- 6. bootstrap_provider_state -----------------------------------------------
+
+
+def test_bootstrap_never_configured_settings_manager_does_not_raise(tmp_path):
+    settings_manager = SettingsManager(tmp_path / "session.dat")
+    agents_module.bootstrap_provider_state(settings_manager)  # must not raise
+
+
+def test_bootstrap_api_endpoint_mode_calls_initialize_api_with_provider_key_and_base_url(tmp_path, monkeypatch):
+    settings_manager = SettingsManager(tmp_path / "session.dat")
+    settings_manager.set_current_mode(config.MODE_API_ENDPOINT)
+    settings_manager.set_api_settings(
+        config.API_PROVIDER_OPENAI,
+        "https://example.test/v1",
+        "sk-fake-openai-key",
+        "",
+        "",
+    )
+    settings_manager.set_api_models({config.TASK_CHAT: "gpt-test"}, config.API_PROVIDER_OPENAI)
+
+    calls = []
+
+    def fake_initialize_api(provider, api_key, base_url=None):
+        calls.append((provider, api_key, base_url))
+        return {"provider": provider}
+
+    monkeypatch.setattr(api_provider, "initialize_api", fake_initialize_api)
+
+    agents_module.bootstrap_provider_state(settings_manager)
+
+    assert calls == [(config.API_PROVIDER_OPENAI, "sk-fake-openai-key", "https://example.test/v1")]
+    assert settings_manager.get_current_mode() == config.MODE_API_ENDPOINT
+
+
+def test_bootstrap_falls_back_to_ollama_when_apply_mode_raises(tmp_path, monkeypatch, caplog):
+    settings_manager = SettingsManager(tmp_path / "session.dat")
+    settings_manager.set_current_mode(config.MODE_API_ENDPOINT)
+    settings_manager.set_api_settings(config.API_PROVIDER_OPENAI, "https://example.test/v1", "sk-fake", "", "")
+    settings_manager.set_api_models({config.TASK_CHAT: "gpt-test"}, config.API_PROVIDER_OPENAI)
+
+    def raising_initialize_api(provider, api_key, base_url=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(api_provider, "initialize_api", raising_initialize_api)
+
+    with caplog.at_level("WARNING"):
+        agents_module.bootstrap_provider_state(settings_manager)  # must not raise
+
+    assert settings_manager.get_current_mode() == config.MODE_OLLAMA_LOCAL
+    assert settings_manager.get_current_mode() == "Ollama (Local)"
+    assert any(record.levelname == "WARNING" for record in caplog.records)
+
+
+def test_apply_mode_raises_value_error_for_an_unrecognized_mode(tmp_path):
+    settings_manager = SettingsManager(tmp_path / "session.dat")
+    with pytest.raises(ValueError):
+        agents_module._apply_mode("Some Nonsense Mode", settings_manager)
+
+
+# -- promoted from the R4 concurrency/security review's own adversarial probes -----
+
+
+def test_two_sessions_concurrent_inflight_no_cross_contamination(monkeypatch):
+    """Two DIFFERENT sessions (two separate AgentDispatcher/SceneDocument/
+    ComposerDocument instances) with in-flight chat requests at the same
+    time. Confirms no cross-contamination of replies/notifications/composer
+    state - the property the whole per-session-instance design exists to
+    guarantee, not previously exercised by any test with two REAL concurrent
+    in-flight dispatchers."""
+    a_started = threading.Event()
+    b_started = threading.Event()
+    a_release = threading.Event()
+    b_release = threading.Event()
+
+    def fake_chat(task, messages, **kwargs):
+        # Identify which session's request this is purely from the message
+        # content - if state ever leaked/crossed between the two
+        # dispatchers, this is where it would show up as the wrong reply
+        # landing on the wrong session.
+        user_texts = [m["content"] for m in messages if m.get("role") == "user"]
+        if "hello from A" in user_texts:
+            a_started.set()
+            a_release.wait(5)
+            return {"message": {"content": "reply for A"}}
+        if "hello from B" in user_texts:
+            b_started.set()
+            b_release.wait(5)
+            return {"message": {"content": "reply for B"}}
+        raise AssertionError(f"unexpected messages: {messages!r}")
+
+    _configure_fake_ollama(monkeypatch, chat_fn=fake_chat)
+
+    async def run():
+        bus_a, notif_a, composer_a, dispatcher_a = _make_dispatch_env()
+        bus_b, notif_b, composer_b, dispatcher_b = _make_dispatch_env()
+        replies_a: list[str] = []
+        replies_b: list[str] = []
+
+        # Kick off both sessions' requests - neither awaited to completion.
+        await dispatcher_a.start_chat_reply(
+            bus=bus_a, notifications_state=notif_a, composer_document=composer_a,
+            conversation_history=[{"role": "user", "content": "hello from A"}], on_reply=replies_a.append,
+        )
+        await dispatcher_b.start_chat_reply(
+            bus=bus_b, notifications_state=notif_b, composer_document=composer_b,
+            conversation_history=[{"role": "user", "content": "hello from B"}], on_reply=replies_b.append,
+        )
+
+        await asyncio.to_thread(a_started.wait, 5)
+        await asyncio.to_thread(b_started.wait, 5)
+        assert a_started.is_set() and b_started.is_set()
+
+        assert len(dispatcher_a._requests) == 1
+        assert len(dispatcher_b._requests) == 1
+        assert set(dispatcher_a._requests.keys()).isdisjoint(dispatcher_b._requests.keys())
+        assert composer_a.request_state == "generating"
+        assert composer_b.request_state == "generating"
+
+        # Release out of start order - completion order must not matter.
+        b_release.set()
+        await next(iter(dispatcher_b._requests.values()))["task"]
+        a_release.set()
+        await next(iter(dispatcher_a._requests.values()))["task"]
+
+        assert replies_a == ["reply for A"]
+        assert replies_b == ["reply for B"]
+        assert dispatcher_a._requests == {}
+        assert dispatcher_b._requests == {}
+        assert composer_a.request_state == "idle"
+        assert composer_b.request_state == "idle"
+        assert notif_a.visible is False
+        assert notif_b.visible is False
+
+    asyncio.run(run())
+
+
+def test_rapid_fire_double_send_same_session_second_is_rejected(monkeypatch):
+    """start_chat_reply has no `await` between the `if self._requests:`
+    emptiness check and the dict insertion at the bottom - so two calls
+    fired back-to-back on the same dispatcher, with no await of the first's
+    completion in between, must never both be admitted. This is the closest
+    this transport model gets to "two sendMessage frames arriving one right
+    after another" on the same WS connection."""
+    release = threading.Event()
+
+    def blocking_chat(task, messages, **kwargs):
+        release.wait(5)
+        return {"message": {"content": "first"}}
+
+    _configure_fake_ollama(monkeypatch, chat_fn=blocking_chat)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        replies: list[str] = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus, notifications_state=notifications, composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "one"}], on_reply=replies.append,
+        )
+        await dispatcher.start_chat_reply(
+            bus=bus, notifications_state=notifications, composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "two"}], on_reply=replies.append,
+        )
+
+        assert len(dispatcher._requests) == 1, "both calls must never be admitted concurrently"
+        assert notifications.message == "A response is already being generated."
+
+        release.set()
+        await next(iter(dispatcher._requests.values()))["task"]
+        assert replies == ["first"]
+
+    asyncio.run(run())

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -3,12 +3,20 @@ subscribe snapshots, the system/ping acceptance round-trip, and error paths.
 Runs the real ASGI app through Starlette's TestClient - no network, no Qt."""
 
 import tempfile
+import threading
+import time
 from pathlib import Path
 
 from fastapi.testclient import TestClient
 
 from backend import BACKEND_VERSION
 from backend.app import create_app
+
+# Importing any backend.* submodule (above) runs backend/__init__.py first,
+# which puts graphlink_app/ on sys.path - these bare top-level imports must
+# come after it, same ordering rule backend/tests/test_agents.py documents.
+import api_provider
+import graphlink_task_config as config
 
 
 def make_client(tmp_path: Path | None = None) -> TestClient:
@@ -128,3 +136,56 @@ def test_sessions_do_not_share_connections():
             ws_b.send_json({"kind": "subscribe", "topics": ["system"]})
             assert ws_a.receive_json()["payload"]["sessionId"] == "a"
             assert ws_b.receive_json()["payload"]["sessionId"] == "b"
+
+
+def test_disconnect_cancels_any_in_flight_chat_request(monkeypatch):
+    # R4 concurrency-review finding: a client that sends a message and then
+    # closes its tab must not leave the real outbound LLM call running
+    # server-side forever with no way to ever cancel it. ws_endpoint's
+    # disconnect handler should trip the session's AgentDispatcher cancel
+    # event once its last connection drops - this exercises that through the
+    # real ASGI app, not just AgentDispatcher in isolation (test_agents.py
+    # already covers cancel()/cancel_all() unit-level).
+    call_started = threading.Event()
+
+    def fake_chat(task, messages, cancellation_event=None, **kwargs):
+        call_started.set()
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if cancellation_event is not None and cancellation_event.is_set():
+                raise api_provider.RequestCancelledError("cancelled")
+            time.sleep(0.01)
+        raise AssertionError("cancel_event was never set after disconnect")
+
+    # make_client() -> create_app() runs bootstrap_provider_state() against
+    # a fresh (unconfigured) SettingsManager - monkeypatching BEFORE that
+    # would just get overwritten, so the client comes first.
+    client = make_client()
+    monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+    monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_OLLAMA)
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, "test-model")
+    monkeypatch.setattr(api_provider, "chat", fake_chat)
+
+    with client.websocket_connect("/ws?session=cancel-test") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["scene"]})
+        ws.receive_json()  # initial scene snapshot
+        ws.send_json({"kind": "intent", "topic": "scene", "intent": "sendMessage", "args": ["hello"]})
+        ws.receive_json()  # scene republish after the user node is created
+
+        deadline = time.monotonic() + 5
+        while not call_started.is_set() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert call_started.is_set(), "fake_chat never started - dispatch did not fire"
+
+        session = client.app.state.bus.session("cancel-test")
+        in_flight = list(session.agent_dispatcher._requests.values())
+        assert len(in_flight) == 1
+        cancel_event = in_flight[0]["cancel_event"]
+        assert not cancel_event.is_set()
+    # Exiting the `with` block closes the websocket, running ws_endpoint's
+    # finally - this is the disconnect this test exists to exercise.
+
+    deadline = time.monotonic() + 5
+    while not cancel_event.is_set() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert cancel_event.is_set()

--- a/backend/tests/test_backend_composer.py
+++ b/backend/tests/test_backend_composer.py
@@ -40,7 +40,7 @@ def test_default_payload_matches_generated_validator_shape():
     assert set(payload["draft"]) == {"id", "text", "contextMode", "sendMode", "restored"}
     assert payload["capabilities"]["reasoningSelection"] is True
     assert payload["capabilities"]["attachments"] is False, "attachment staging is deferred, not faked"
-    assert payload["request"]["canSend"] is False, "send needs R4 agents"
+    assert payload["request"]["canSend"] is True, "idle state can send now that R4 agent dispatch has landed"
 
 
 def test_update_draft_intent_updates_text_and_publishes_composer_and_tokens():
@@ -66,6 +66,61 @@ def test_set_reasoning_level_intent_updates_and_rejects_unknown():
             await bus.dispatch_intent("app-composer", "setReasoningLevel", ["nonsense"])
 
     asyncio.run(run())
+
+
+# -- R4: request lifecycle (begin_request/end_request) ------------------------
+
+
+def test_request_defaults_to_idle_and_can_send():
+    document = ComposerDocument()
+    request = document.payload()["request"]
+    assert request == {
+        "id": None,
+        "state": "idle",
+        "message": "",
+        "canSend": True,
+        "canCancel": False,
+        "canRetry": False,
+    }
+
+
+def test_begin_request_flips_to_generating():
+    document = ComposerDocument()
+    document.begin_request("req-1")
+
+    assert document.request_id == "req-1"
+    assert document.request_state == "generating"
+
+    request = document.payload()["request"]
+    assert request["id"] == "req-1"
+    assert request["state"] == "generating"
+    assert request["canSend"] is False
+    assert request["canCancel"] is True
+    assert request["canRetry"] is False
+
+
+def test_end_request_returns_to_idle():
+    document = ComposerDocument()
+    document.begin_request("req-1")
+    document.end_request()
+
+    assert document.request_id is None
+    assert document.request_state == "idle"
+
+    request = document.payload()["request"]
+    assert request == {
+        "id": None,
+        "state": "idle",
+        "message": "",
+        "canSend": True,
+        "canCancel": False,
+        "canRetry": False,
+    }
+
+
+def test_capabilities_cancellation_is_a_genuine_permanent_capability():
+    document = ComposerDocument()
+    assert document.payload()["capabilities"]["cancellation"] is True
 
 
 # -- token counter -------------------------------------------------------------

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -4,9 +4,16 @@ shape, and snapshot publishing."""
 
 import asyncio
 import base64
+from unittest.mock import patch
 
 import pytest
 
+# Importing any backend.* submodule runs backend/__init__.py first, which
+# puts graphlink_app/ on sys.path - these must come before the bare
+# top-level graphlink_app imports below (api_provider, graphlink_task_config)
+# for this module to import cleanly when run standalone, not just as part of
+# a larger session where some earlier-collected module already did this.
+from backend.agents import AgentDispatcher
 from backend.canvas import (
     DRAG_FACTOR_MAX,
     DRAG_FACTOR_MIN,
@@ -14,8 +21,12 @@ from backend.canvas import (
     SceneError,
     register_canvas,
 )
+from backend.composer import ComposerDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
+
+import api_provider
+import graphlink_task_config as task_config
 
 
 # -- document invariants ----------------------------------------------------
@@ -829,7 +840,7 @@ def test_send_conversation_message_intent_appends_and_fires_the_same_deferred_no
 
         notice = await bus.publish("notification")
         assert notice["visible"] is True
-        assert notice["message"] == "AI response generation lands in R4."
+        assert notice["message"] == "AI response generation lands in a follow-up increment."
         assert recorder.topics_seen().count("scene") == 3, "all three mutations publish (addNode, addConversationNode, sendConversationMessage)"
 
     asyncio.run(run())
@@ -922,6 +933,35 @@ def test_send_message_after_deleting_the_active_node_continues_from_its_parent()
     assert any(e.source == first.id and e.target == third.id for e in doc.edges.values())
 
 
+# -- R4: chat_branch_history --------------------------------------------------
+
+
+def test_chat_branch_history_returns_root_to_leaf_for_a_multi_hop_branch():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root question", True)
+    reply = doc.add_chat_node(0, 160, "root answer", False, parent_id=root.id)
+    follow_up = doc.add_chat_node(0, 320, "follow up", True, parent_id=reply.id)
+
+    history = doc.chat_branch_history(follow_up.id)
+
+    assert history == [
+        {"role": "user", "content": "root question"},
+        {"role": "assistant", "content": "root answer"},
+        {"role": "user", "content": "follow up"},
+    ]
+
+
+def test_chat_branch_history_for_a_single_root_node_returns_one_entry():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "only message", True)
+    assert doc.chat_branch_history(root.id) == [{"role": "user", "content": "only message"}]
+
+
+def test_chat_branch_history_does_not_error_on_an_unknown_node_id():
+    doc = SceneDocument()
+    assert doc.chat_branch_history("ghost") == []
+
+
 def test_drag_factor_is_bounded():
     doc = SceneDocument()
     doc.set_drag_factor(99)
@@ -961,13 +1001,29 @@ class Recorder:
         return [m["topic"] for m in self.messages if m["kind"] == "state"]
 
 
-def make_bus():
+class _FakeSettingsManager:
+    """Stand-in for AgentDispatcher's settings_manager - canvas tests only
+    need persona() to resolve, not real settings persistence."""
+
+    def get_enable_system_prompt(self):
+        return True
+
+
+def make_bus_with_dispatcher():
     bus = SessionBus("canvas-test")
     notifications = NotificationState()
     bus.register_topic("notification", notifications.payload)
-    document = register_canvas(bus, notifications)
+    composer_document = ComposerDocument()
+    bus.register_topic("app-composer", composer_document.payload)
+    agent_dispatcher = AgentDispatcher(_FakeSettingsManager())
+    document = register_canvas(bus, notifications, agent_dispatcher, composer_document)
     recorder = Recorder()
     bus.attach(recorder)
+    return bus, document, recorder, agent_dispatcher
+
+
+def make_bus():
+    bus, document, recorder, _ = make_bus_with_dispatcher()
     return bus, document, recorder
 
 
@@ -1023,17 +1079,39 @@ def test_add_code_node_intent_creates_a_real_node_and_publishes():
     asyncio.run(run())
 
 
-def test_send_message_intent_creates_a_real_node_and_an_honest_deferred_notification():
+def test_send_message_intent_dispatches_a_real_agent_reply():
+    # R4: sendMessage's deferred "lands in R4" notice is gone - the real
+    # intent now dispatches through AgentDispatcher. Same monkeypatch seam as
+    # test_agents.py (api_provider.chat directly), validating the real
+    # wiring end to end through the WS intent layer.
     async def run():
-        bus, document, recorder = make_bus()
-        node_id = await bus.dispatch_intent("scene", "sendMessage", ["what is this graph about?"])
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def fake_chat(task, messages, **kwargs):
+            return {"message": {"content": "a real agent reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", fake_chat):
+            node_id = await bus.dispatch_intent("scene", "sendMessage", ["what is this graph about?"])
+            # The reply lands inside a scheduled (not awaited) background
+            # task - grab it from the dispatcher's registry and await it
+            # directly rather than assuming the intent itself blocks for it.
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
         assert document.nodes[node_id].content == "what is this graph about?"
         assert document.nodes[node_id].is_user is True
 
-        notice = await bus.publish("notification")
-        assert notice["visible"] is True
-        assert notice["message"] == "AI response generation lands in R4."
-        assert recorder.topics_seen().count("scene") == 1
+        reply_nodes = [n for n in document.nodes.values() if n.kind == "chat" and n.id != node_id]
+        assert len(reply_nodes) == 1
+        reply_node = reply_nodes[0]
+        assert reply_node.content == "a real agent reply"
+        assert reply_node.is_user is False
+        assert any(e.source == node_id and e.target == reply_node.id for e in document.edges.values())
+        assert document.last_chat_node_id == reply_node.id
+        assert recorder.topics_seen().count("scene") >= 2, "user node + reply node both publish scene"
 
     asyncio.run(run())
 

--- a/graphlink_app/graphlink_agents_core.py
+++ b/graphlink_app/graphlink_agents_core.py
@@ -1,46 +1,17 @@
-import json
 import re
 import threading
 import time
 from PySide6.QtCore import QThread, Signal, QPointF
-# Qt-removal plan R4.1: only the Qt-free task-config half is needed here.
+# Qt-removal plan R4.2: resolve_branch_system_prompt/ChatWorker/ChatAgent
+# moved to the Qt-free graphlink_chat_agent so backend/ can call the real
+# chat layer - this module's own PySide6 import (needed only by the
+# *WorkerThread classes below) would otherwise pull Qt into any importer.
+# Still needed here directly: ExplainerAgent/KeyTakeawayAgent/GroupSummaryAgent
+# (below) call api_provider.chat(task=config.TASK_CHAT, ...) themselves.
 import graphlink_task_config as config
 import api_provider
-from graphlink_token_estimator import TokenEstimator
-from graphlink_memory import trim_history
+from graphlink_chat_agent import resolve_branch_system_prompt, ChatWorker, ChatAgent
 
-
-def resolve_branch_system_prompt(current_node, default_system_prompt):
-    """Resolve the effective system prompt for a chat branch.
-
-    Walks up to the branch root and, if a system-prompt note is attached there, uses its
-    content instead of the default. This reads live QGraphicsScene objects
-    (``parent_node``/``scene()``/``system_prompt_connections``/``prompt_note.content``),
-    so it MUST run on the GUI thread - QGraphicsScene is not thread-safe, and doing this
-    walk from a worker thread races node deletion / scene.clear() and can crash or read
-    torn state. Callers resolve it here on the UI thread and hand the resulting string
-    to the worker, which never touches the scene.
-
-    Returns the final system prompt string (the default if nothing overrides it).
-    """
-    final_system_prompt = default_system_prompt
-    if not (default_system_prompt or "").strip():
-        return default_system_prompt
-    if not current_node:
-        return final_system_prompt
-
-    root_node = current_node
-    while root_node.parent_node:
-        root_node = root_node.parent_node
-
-    if root_node.scene():
-        for conn in root_node.scene().system_prompt_connections:
-            if conn.end_node == root_node:
-                prompt_note = conn.start_node
-                if prompt_note.content:
-                    final_system_prompt = prompt_note.content
-                break
-    return final_system_prompt
 
 class ChatWorkerThread(QThread):
     """
@@ -174,118 +145,6 @@ class ChatWorkerThread(QThread):
             "The model stopped responding before the request completed.\n\n"
             "Please try again or choose a faster model."
         )
-
-
-class ChatWorker:
-    """
-    A stateless worker class that encapsulates the logic for a single chat API call.
-    It determines the correct system prompt to use based on the conversation context.
-    """
-    def __init__(self, system_prompt):
-        """
-        Initializes the ChatWorker.
-
-        Args:
-            system_prompt (str): The default system prompt to use if no custom one is found.
-        """
-        self.system_prompt = system_prompt
-        self.token_estimator = TokenEstimator()
-        self.MAX_TOKENS = 8000
-        
-    def run(self, conversation_history, current_node, cancellation_event=None, resolved_system_prompt=None):
-        """
-        Executes the chat logic for a single turn.
-
-        Args:
-            conversation_history (list): The list of messages in the conversation.
-            current_node (QGraphicsItem): The current node context. Only used to resolve the
-                branch system prompt when `resolved_system_prompt` is not supplied.
-            resolved_system_prompt (str, optional): The branch system prompt already
-                resolved on the GUI thread. When provided, the scene is NOT walked here -
-                this is how the worker-thread path avoids touching QGraphicsScene (#20).
-
-        Returns:
-            str: The AI-generated response text.
-
-        Raises:
-            Exception: Propagates exceptions from the API provider.
-        """
-        if resolved_system_prompt is not None:
-            final_system_prompt = resolved_system_prompt
-        else:
-            # Legacy/direct path (no pre-resolution): safe only on the GUI thread.
-            final_system_prompt = resolve_branch_system_prompt(current_node, self.system_prompt)
-        use_system_prompt = bool((final_system_prompt or "").strip())
-
-        try:
-            sys_tokens = 0
-            messages = []
-            if use_system_prompt:
-                system_msg = {'role': 'system', 'content': final_system_prompt}
-                sys_tokens = self.token_estimator.count_tokens(json.dumps(system_msg))
-                messages.append(system_msg)
-            trimmed_history, _ = trim_history(
-                conversation_history,
-                self.token_estimator,
-                max_tokens=self.MAX_TOKENS,
-                system_prompt_estimate=sys_tokens,
-            )
-
-            messages.extend(trimmed_history)
-            
-            response = api_provider.chat(
-                task=config.TASK_CHAT,
-                messages=messages,
-                cancellation_event=cancellation_event,
-            )
-            ai_message = response['message']['content']
-            return ai_message
-        except Exception as e:
-            print(f"  [LOG-CHATWORKER] API call failed: {e}")
-            raise e
-
-
-class ChatAgent:
-    """
-    The primary agent for handling general-purpose chat conversations.
-    This agent is stateless; it relies on the conversation history passed to it for context.
-    """
-    def __init__(self, name, persona):
-        """
-        Initializes the ChatAgent.
-
-        Args:
-            name (str): The name of the AI assistant.
-            persona (str): The detailed system prompt defining the AI's behavior and knowledge.
-        """
-        self.name = name or "AI Assistant"
-        self.persona = persona or "(default persona)"
-        self.system_prompt = f"You are {self.name}. {self.persona}"
-        
-    def get_response(self, conversation_history, current_node, cancellation_event=None, resolved_system_prompt=None):
-        """
-        Gets an AI response for a given conversation history.
-
-        Args:
-            conversation_history (list): The list of messages in the conversation.
-            current_node (QGraphicsItem): The current node context.
-            resolved_system_prompt (str, optional): Branch system prompt already resolved
-                on the GUI thread; passed straight through so the worker never walks the
-                scene itself (#20).
-
-        Returns:
-            str: The AI-generated response text.
-        """
-        # This agent is stateless. It does not store conversation_history.
-        # It creates a temporary ChatWorker to handle the API call.
-        chat_worker = ChatWorker(self.system_prompt)
-        ai_response = chat_worker.run(
-            conversation_history,
-            current_node,
-            cancellation_event=cancellation_event,
-            resolved_system_prompt=resolved_system_prompt,
-        )
-        return ai_response
 
 
 def clean_agent_markdown_response(text, required_title, section_markers, reset_bullet_state_on_section_header=False):

--- a/graphlink_app/graphlink_chat_agent.py
+++ b/graphlink_app/graphlink_chat_agent.py
@@ -1,0 +1,170 @@
+"""Qt-free chat-agent core (Qt-removal plan R4.2 prerequisite).
+
+`resolve_branch_system_prompt`/`ChatWorker`/`ChatAgent` moved out of
+graphlink_agents_core.py: that module's unconditional
+`from PySide6.QtCore import QThread, Signal, QPointF` (needed only by its
+`*WorkerThread` classes) meant importing anything from it - including these
+three Qt-free symbols - pulled PySide6 into the process. That made them
+unimportable from backend/ despite containing zero Qt code themselves,
+exactly the R4.1 problem R4.1 itself didn't reach (it only split
+graphlink_config.py).
+
+graphlink_agents_core.py re-exports all three unchanged for its own
+ChatWorkerThread (which calls resolve_branch_system_prompt) and every
+legacy Qt call site - see its own import line.
+
+This file must stay Qt-free forever - it exists to be importable from
+backend/, which test_no_qt_anywhere.py holds to zero tolerance.
+"""
+
+import json
+
+import graphlink_task_config as config
+import api_provider
+from graphlink_token_estimator import TokenEstimator
+from graphlink_memory import trim_history
+
+
+def resolve_branch_system_prompt(current_node, default_system_prompt):
+    """Resolve the effective system prompt for a chat branch.
+
+    Walks up to the branch root and, if a system-prompt note is attached there, uses its
+    content instead of the default. This reads live QGraphicsScene objects
+    (``parent_node``/``scene()``/``system_prompt_connections``/``prompt_note.content``),
+    so it MUST run on the GUI thread - QGraphicsScene is not thread-safe, and doing this
+    walk from a worker thread races node deletion / scene.clear() and can crash or read
+    torn state. Callers resolve it here on the UI thread and hand the resulting string
+    to the worker, which never touches the scene.
+
+    Returns the final system prompt string (the default if nothing overrides it).
+    """
+    final_system_prompt = default_system_prompt
+    if not (default_system_prompt or "").strip():
+        return default_system_prompt
+    if not current_node:
+        return final_system_prompt
+
+    root_node = current_node
+    while root_node.parent_node:
+        root_node = root_node.parent_node
+
+    if root_node.scene():
+        for conn in root_node.scene().system_prompt_connections:
+            if conn.end_node == root_node:
+                prompt_note = conn.start_node
+                if prompt_note.content:
+                    final_system_prompt = prompt_note.content
+                break
+    return final_system_prompt
+
+
+class ChatWorker:
+    """
+    A stateless worker class that encapsulates the logic for a single chat API call.
+    It determines the correct system prompt to use based on the conversation context.
+    """
+    def __init__(self, system_prompt):
+        """
+        Initializes the ChatWorker.
+
+        Args:
+            system_prompt (str): The default system prompt to use if no custom one is found.
+        """
+        self.system_prompt = system_prompt
+        self.token_estimator = TokenEstimator()
+        self.MAX_TOKENS = 8000
+
+    def run(self, conversation_history, current_node, cancellation_event=None, resolved_system_prompt=None):
+        """
+        Executes the chat logic for a single turn.
+
+        Args:
+            conversation_history (list): The list of messages in the conversation.
+            current_node (QGraphicsItem): The current node context. Only used to resolve the
+                branch system prompt when `resolved_system_prompt` is not supplied.
+            resolved_system_prompt (str, optional): The branch system prompt already
+                resolved on the GUI thread. When provided, the scene is NOT walked here -
+                this is how the worker-thread path avoids touching QGraphicsScene (#20).
+
+        Returns:
+            str: The AI-generated response text.
+
+        Raises:
+            Exception: Propagates exceptions from the API provider.
+        """
+        if resolved_system_prompt is not None:
+            final_system_prompt = resolved_system_prompt
+        else:
+            # Legacy/direct path (no pre-resolution): safe only on the GUI thread.
+            final_system_prompt = resolve_branch_system_prompt(current_node, self.system_prompt)
+        use_system_prompt = bool((final_system_prompt or "").strip())
+
+        try:
+            sys_tokens = 0
+            messages = []
+            if use_system_prompt:
+                system_msg = {'role': 'system', 'content': final_system_prompt}
+                sys_tokens = self.token_estimator.count_tokens(json.dumps(system_msg))
+                messages.append(system_msg)
+            trimmed_history, _ = trim_history(
+                conversation_history,
+                self.token_estimator,
+                max_tokens=self.MAX_TOKENS,
+                system_prompt_estimate=sys_tokens,
+            )
+
+            messages.extend(trimmed_history)
+
+            response = api_provider.chat(
+                task=config.TASK_CHAT,
+                messages=messages,
+                cancellation_event=cancellation_event,
+            )
+            ai_message = response['message']['content']
+            return ai_message
+        except Exception as e:
+            print(f"  [LOG-CHATWORKER] API call failed: {e}")
+            raise e
+
+
+class ChatAgent:
+    """
+    The primary agent for handling general-purpose chat conversations.
+    This agent is stateless; it relies on the conversation history passed to it for context.
+    """
+    def __init__(self, name, persona):
+        """
+        Initializes the ChatAgent.
+
+        Args:
+            name (str): The name of the AI assistant.
+            persona (str): The detailed system prompt defining the AI's behavior and knowledge.
+        """
+        self.name = name or "AI Assistant"
+        self.persona = persona or "(default persona)"
+        self.system_prompt = f"You are {self.name}. {self.persona}"
+
+    def get_response(self, conversation_history, current_node, cancellation_event=None, resolved_system_prompt=None):
+        """
+        Gets an AI response for a given conversation history.
+
+        Args:
+            conversation_history (list): The list of messages in the conversation.
+            current_node (QGraphicsItem): The current node context.
+            resolved_system_prompt (str, optional): Branch system prompt already resolved
+                on the GUI thread; passed straight through so the worker never walks the
+                scene itself (#20).
+
+        Returns:
+            str: The AI-generated response text.
+        """
+        # This agent is stateless. It does not store conversation_history.
+        # It creates a temporary ChatWorker to handle the API call.
+        chat_worker = ChatWorker(self.system_prompt)
+        ai_response = chat_worker.run(
+            conversation_history,
+            current_node,
+            cancellation_event=cancellation_event,
+            resolved_system_prompt=resolved_system_prompt,
+        )
+        return ai_response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ py-modules = [
     "graphlink_composer_web",
     "graphlink_config",
     "graphlink_task_config",
+    "graphlink_chat_agent",
     "graphlink_context_menu",
     "graphlink_connections",
     "graphlink_conversation_node",

--- a/web_ui/src/app/chrome/Composer.test.tsx
+++ b/web_ui/src/app/chrome/Composer.test.tsx
@@ -16,6 +16,7 @@ function makeStore(overrides: { composer?: object; tokenCounter?: object; notifi
   };
   const updateDraft = vi.fn();
   const setReasoningLevel = vi.fn();
+  const cancelChatRequest = vi.fn();
   const dismissNotification = vi.fn();
   const store = {
     subscribe: (listener: () => void) => {
@@ -27,9 +28,10 @@ function makeStore(overrides: { composer?: object; tokenCounter?: object; notifi
     getNotification: () => state.notification,
     updateDraft,
     setReasoningLevel,
+    cancelChatRequest,
     dismissNotification,
   };
-  return { store, updateDraft, setReasoningLevel, dismissNotification };
+  return { store, updateDraft, setReasoningLevel, cancelChatRequest, dismissNotification };
 }
 
 function makeSceneStore() {
@@ -68,7 +70,12 @@ describe("Composer", () => {
 
   it("Send is enabled once there's text, calls sceneStore.sendMessage, and clears the draft", async () => {
     const user = userEvent.setup();
-    const { store, updateDraft } = makeStore({ composer: { draft: { ...initialComposerState.draft, text: "hi" } } });
+    const { store, updateDraft } = makeStore({
+      composer: {
+        draft: { ...initialComposerState.draft, text: "hi" },
+        request: { ...initialComposerState.request, canSend: true },
+      },
+    });
     const { sceneStore, sendMessage } = makeSceneStore();
     render(
       <OverlayProvider>
@@ -85,7 +92,12 @@ describe("Composer", () => {
 
   it("Enter sends (and clears the draft); Shift+Enter does not", async () => {
     const user = userEvent.setup();
-    const { store, updateDraft } = makeStore({ composer: { draft: { ...initialComposerState.draft, text: "hi" } } });
+    const { store, updateDraft } = makeStore({
+      composer: {
+        draft: { ...initialComposerState.draft, text: "hi" },
+        request: { ...initialComposerState.request, canSend: true },
+      },
+    });
     const { sceneStore, sendMessage } = makeSceneStore();
     render(
       <OverlayProvider>
@@ -110,6 +122,82 @@ describe("Composer", () => {
       </OverlayProvider>,
     );
     expect(screen.getByLabelText("Send message")).toBeDisabled();
+  });
+
+  it("Send stays disabled when request.canSend is false even with non-empty draft text", () => {
+    const { store } = makeStore({
+      composer: {
+        draft: { ...initialComposerState.draft, text: "hi" },
+        request: { ...initialComposerState.request, canSend: false },
+      },
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(screen.getByLabelText("Send message")).toBeDisabled();
+  });
+
+  it("Cancel control is absent when request.canCancel is false", () => {
+    const { store } = makeStore({
+      composer: { request: { ...initialComposerState.request, canCancel: false } },
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(screen.queryByLabelText("Cancel response")).toBeNull();
+  });
+
+  it("Cancel control is present when request.canCancel is true and calls cancelChatRequest with the request id", async () => {
+    const user = userEvent.setup();
+    const { store, cancelChatRequest } = makeStore({
+      composer: {
+        request: { id: "req-42", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false },
+      },
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+    const cancelButton = screen.getByLabelText("Cancel response");
+    expect(cancelButton).toBeInTheDocument();
+    await user.click(cancelButton);
+    expect(cancelChatRequest).toHaveBeenCalledWith("req-42");
+  });
+
+  it("shows the generating indicator only when request.state is 'generating'", () => {
+    const { store } = makeStore({
+      composer: {
+        request: { id: "req-1", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false },
+      },
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(screen.getByText("Generating…")).toBeInTheDocument();
+  });
+
+  it("hides the generating indicator when request.state is 'idle'", () => {
+    const { store } = makeStore({
+      composer: { request: { ...initialComposerState.request, state: "idle" } },
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(screen.queryByText("Generating…")).toBeNull();
   });
 
   it("opens the reasoning popover and selecting an option calls the intent and closes it", async () => {

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -4,31 +4,35 @@ import { Popover, useOverlays } from "../overlays/overlays";
 import type { ComposerStore } from "./composerStore";
 
 /**
- * The composer dock (Qt-removal plan R2.3/R3.3) - ComposerApp's SPA
+ * The composer dock (Qt-removal plan R2.3/R3.3/R4.3) - ComposerApp's SPA
  * successor.
  *
  * Real here: draft text editing, reasoning-level selection (a stored
  * preference popover, reusing the overlay system rather than a dedicated
- * picker island), and (R3.3) Send - a real user ChatNode via
- * sceneStore.sendMessage. The assistant's reply is NOT generated here (see
- * backend/canvas.py's send_message docstring): the backend gives an honest
- * "lands in R4" notice over the existing notification topic instead of a
- * fake response. Visibly deferred, per backend/composer.py's capability
- * flags: attach (file-staging pipeline is an R4 concern), context review
- * (nothing to review until attachments exist), model/provider selection
- * (R4 - needs real provider wiring). Each renders disabled with a title
- * naming its phase, exactly the app bar's Save/provider-select precedent.
+ * picker island), Send - a real user ChatNode via sceneStore.sendMessage,
+ * and (R4.3) the agent-dispatch request lifecycle: the assistant's reply
+ * is generated asynchronously by the backend agent layer and lands over
+ * the existing scene topic republish, exactly like any other node-creation
+ * path this app already handles. Send is gated on request.canSend (so a
+ * second send can't be issued mid-flight) and Cancel is rendered only
+ * while request.canCancel is true, per backend/composer.py's request
+ * capability flags. Still visibly deferred, per those same flags: attach
+ * (file-staging pipeline), context review (nothing to review until
+ * attachments exist), model/provider selection (needs real provider
+ * wiring). Each renders disabled with a title naming its phase, exactly
+ * the app bar's Save/provider-select precedent.
  *
  * Theme is NOT read from this payload (see backend/composer.py's docstring
  * for why) - the SPA's tokens are already global CSS.
  */
 
-function Icon({ name }: { name: "attach" | "send" | "chevron" }) {
+function Icon({ name }: { name: "attach" | "send" | "chevron" | "stop" }) {
   const paths: Record<string, string> = {
     attach:
       "M12 5.5 6.4 11.1a3.6 3.6 0 0 0 5.1 5.1l6-6a2.5 2.5 0 0 0-3.5-3.5l-6.1 6.1a1.35 1.35 0 0 0 1.9 1.9l5.5-5.5",
     send: "M3.5 4.6 20.5 12 3.5 19.4l2.2-6.2L15 12 5.7 10.8 3.5 4.6Z",
     chevron: "m7 10 5 5 5-5",
+    stop: "M7 7h10v10H7z",
   };
   return (
     <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
@@ -53,7 +57,7 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
 
   function send() {
     const text = composer.draft.text.trim();
-    if (!text) return;
+    if (!text || !composer.request.canSend) return;
     sceneStore.sendMessage(text);
     store.updateDraft("");
   }
@@ -80,6 +84,12 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
       </div>
 
       <div className="composer-controls">
+        {composer.request.state === "generating" && (
+          <span className="composer-generating-indicator" role="status">
+            Generating…
+          </span>
+        )}
+
         <button
           type="button"
           className="composer-icon-button"
@@ -118,16 +128,32 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
           <Icon name="chevron" />
         </button>
 
-        <button
-          type="button"
-          className="composer-send-button"
-          disabled={!composer.draft.text.trim()}
-          title="Sends a real message; the AI response lands in R4 (agent layer)"
-          aria-label="Send message"
-          onClick={send}
-        >
-          <Icon name="send" />
-        </button>
+        <div className="composer-send-group">
+          {composer.request.canCancel && (
+            <button
+              type="button"
+              className="composer-icon-button composer-cancel-button"
+              onClick={() => {
+                if (composer.request.id) store.cancelChatRequest(composer.request.id);
+              }}
+              title="Cancel response"
+              aria-label="Cancel response"
+            >
+              <Icon name="stop" />
+            </button>
+          )}
+
+          <button
+            type="button"
+            className="composer-send-button"
+            disabled={!composer.draft.text.trim() || !composer.request.canSend}
+            title="Send message"
+            aria-label="Send message"
+            onClick={send}
+          >
+            <Icon name="send" />
+          </button>
+        </div>
       </div>
 
       <Reasoning store={store} />

--- a/web_ui/src/app/chrome/composerStore.test.ts
+++ b/web_ui/src/app/chrome/composerStore.test.ts
@@ -104,10 +104,12 @@ describe("ComposerStore", () => {
     const store = new ComposerStore(transport);
     store.updateDraft("hello world");
     store.setReasoningLevel("thinking");
+    store.cancelChatRequest("req-42");
     store.dismissNotification();
     expect(intents).toEqual([
       { topic: "app-composer", intent: "updateDraft", args: ["hello world"] },
       { topic: "app-composer", intent: "setReasoningLevel", args: ["thinking"] },
+      { topic: "app-composer", intent: "cancelChatRequest", args: ["req-42"] },
       { topic: "notification", intent: "dismiss", args: [] },
     ]);
   });

--- a/web_ui/src/app/chrome/composerStore.ts
+++ b/web_ui/src/app/chrome/composerStore.ts
@@ -118,6 +118,10 @@ export class ComposerStore {
     this.transport.intent("app-composer", "setReasoningLevel", [level]);
   }
 
+  cancelChatRequest(requestId: string): void {
+    this.transport.intent("app-composer", "cancelChatRequest", [requestId]);
+  }
+
   dismissNotification(): void {
     this.transport.intent("notification", "dismiss", []);
   }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1285,8 +1285,24 @@ body,
   gap: 1px;
 }
 
-.composer-send-button {
+.composer-generating-indicator {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--gl-surface-text-muted);
+}
+
+.composer-send-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin-left: auto;
+}
+
+.composer-cancel-button {
+  color: var(--gl-status-error, var(--gl-neutral-button-icon));
+}
+
+.composer-send-button {
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- `backend/agents.py`'s `bootstrap_provider_state()` ports legacy's exact Ollama/Llama.cpp/API mode-dispatch from the same shared `SettingsManager`/`session.dat` file the legacy app already reads and writes - whichever provider a user configured previously is already live the moment the new backend starts, no new Settings UI needed this increment.
- `AgentDispatcher` (one instance per session, never a module-level singleton) wraps the fully-synchronous `api_provider.chat()` in `asyncio.to_thread` with a `threading.Event` cooperative-cancel contract mirroring legacy's own `_cancel_event`, a single fixed 420s hard timeout, and a one-in-flight-request-per-session guard.
- The load-bearing design constraint, found by tracing the actual WS read loop: the intent handler must never `await` the chat call inline, since `ws_endpoint`'s read loop is strictly sequential per connection - it schedules `asyncio.create_task` and returns immediately so `cancelChatRequest` stays reachable.
- `sendMessage`'s deferred-notice closure is replaced with the real dispatch; `sendConversationMessage` is untouched except a one-line notification-text tweak (ConversationNode's real reply stays R4.3, per the plan).
- Frontend: Composer gains a real Cancel control (a true conditional render) and a generating-state indicator.
- Prerequisite shipped separately ([#113](https://github.com/dovvnloading/Graphlink/pull/113)): `graphlink_agents_core.py`'s own unconditional PySide6 import made `ChatWorker`/`ChatAgent`/`resolve_branch_system_prompt` unimportable from `backend/` despite being Qt-free themselves - split into `graphlink_chat_agent.py`.
- The 4-way adversarial review (backend/frontend/integration + a dedicated concurrency/security reviewer) found one genuine gap: a client disconnecting mid-request left the real LLM call running server-side untethered for up to 420s with no way to ever cancel it. Fixed before shipping: `AgentDispatcher.cancel_all()` fires when a session's last connection drops, with a regression test driving the real ASGI app through a genuine WS disconnect.

## Test plan
- [x] `python -m pytest -q` (repo-wide): 1951 passed
- [x] `npx vitest run` (web_ui): 684 passed, 67 files
- [x] `npx tsc --noEmit`: clean
- [x] Live acceptance against a real, locally-installed Ollama model (not mocked): sent a real message, watched the composer go to `"generating"`, received a genuine model-generated reply as a real new assistant `ChatNode`, composer settled back to `"idle"`
- [x] Live cancel-mid-flight against the same real model: fired `cancelChatRequest` on a real in-flight request id, confirmed the exact `"Request cancelled."` notification, no assistant node added, composer returned to idle
- [x] Burn-down gate unchanged at the pin