### PR TITLE
Qt-removal R4.3: ConversationNode real reply + per-node cancel enablement

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -158,15 +158,26 @@ class AgentDispatcher:
         for entry in self._requests.values():
             entry["cancel_event"].set()
 
-    async def start_chat_reply(
+    async def _dispatch(
         self,
         *,
         bus: SessionBus,
         notifications_state,
-        composer_document,
         conversation_history,
         on_reply,
+        on_begin,
+        on_end,
+        state_topic: str,
     ) -> None:
+        """The shared real-dispatch pipeline behind both start_chat_reply
+        (Composer, state_topic="app-composer") and start_conversation_reply
+        (ConversationNode, state_topic="scene", R4.3) - one in-flight-request
+        slot per session regardless of which caller occupies it. `on_begin`/
+        `on_end` let each caller record the in-flight request_id on its own
+        state (ComposerDocument.begin_request/end_request, or a
+        ConversationNode's pending_request_id) without this method knowing
+        which; `state_topic` is the topic republished around that state
+        change so the right part of the UI refreshes."""
         if self._requests:
             # Single-request-per-session guard: never start a second
             # concurrent request while one is already in flight.
@@ -189,8 +200,8 @@ class AgentDispatcher:
         cancel_event = threading.Event()
 
         async def _run():
-            composer_document.begin_request(request_id)
-            await bus.publish("app-composer")
+            on_begin(request_id)
+            await bus.publish(state_topic)
             try:
                 reply_text = await asyncio.wait_for(
                     asyncio.to_thread(_call_chat_agent, conversation_history, self.persona(), cancel_event),
@@ -215,21 +226,65 @@ class AgentDispatcher:
                 await bus.publish("notification")
             finally:
                 # Unconditional on every exit path (success, timeout, cancel,
-                # other error) so the composer always returns to a usable
-                # idle state.
+                # other error) so the caller's state always returns to a
+                # usable idle state.
                 self._requests.pop(request_id, None)
-                composer_document.end_request()
-                await bus.publish("app-composer")
+                on_end()
+                await bus.publish(state_topic)
 
-        # NOT awaited here - start_chat_reply returns immediately after
-        # scheduling the task. This is load-bearing: the WS connection this
-        # session serves runs a plain sequential
+        # NOT awaited here - start_chat_reply/start_conversation_reply return
+        # immediately after scheduling the task. This is load-bearing: the WS
+        # connection this session serves runs a plain sequential
         # `while True: message = await websocket.receive_json(); ...` read
         # loop (backend/app.py) - if this handler awaited the full chat call
         # inline, no further message on that same socket (including a
         # cancelChatRequest intent) would even be read off the wire until the
         # handler returned, making cooperative cancellation impossible.
         self._requests[request_id] = {"cancel_event": cancel_event, "task": asyncio.create_task(_run())}
+
+    async def start_chat_reply(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        composer_document,
+        conversation_history,
+        on_reply,
+    ) -> None:
+        return await self._dispatch(
+            bus=bus,
+            notifications_state=notifications_state,
+            conversation_history=conversation_history,
+            on_reply=on_reply,
+            on_begin=composer_document.begin_request,
+            on_end=composer_document.end_request,
+            state_topic="app-composer",
+        )
+
+    async def start_conversation_reply(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        node,
+        conversation_history,
+        on_reply,
+    ) -> None:
+        """R4.3's ConversationNode equivalent of start_chat_reply: same
+        _dispatch pipeline, but the in-flight request_id lives on the
+        ConversationNode itself (`node.pending_request_id`, duck-typed - this
+        module does not import canvas.py's SceneNode) rather than on
+        ComposerDocument, and "scene" (not "app-composer") is republished
+        around that change so the node's own in-flight state refreshes."""
+        return await self._dispatch(
+            bus=bus,
+            notifications_state=notifications_state,
+            conversation_history=conversation_history,
+            on_reply=on_reply,
+            on_begin=lambda request_id: setattr(node, "pending_request_id", request_id),
+            on_end=lambda: setattr(node, "pending_request_id", None),
+            state_topic="scene",
+        )
 
 
 def _call_chat_agent(conversation_history, persona_text, cancel_event) -> str:

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -194,6 +194,13 @@ class SceneNode:
     # node; a conversation node instead owns a whole message history. Unused
     # (default empty list) for every other kind.
     history: list[dict[str, str]] = field(default_factory=list)
+    # R4.3 (doc/QT_REMOVAL_PLAN.md): transient per-node in-flight-request
+    # marker - the id of the AgentDispatcher request currently generating a
+    # reply for this node, or None when idle. Generic across any kind that
+    # ever gets its own real dispatch slot (not conversation-only, the same
+    # way is_docked/image_asset_id are generic fields even though today only
+    # one kind populates them); unused (default None) for every other kind.
+    pending_request_id: str | None = None
 
 
 @dataclass
@@ -787,6 +794,7 @@ class SceneDocument:
                     "history": [
                         {"role": m["role"], "content": m["content"]} for m in n.history
                     ],
+                    "pendingRequestId": n.pending_request_id,
                 }
                 for n in self.nodes.values()
             ],
@@ -943,19 +951,26 @@ def register_canvas(
         return node.id
 
     async def send_conversation_message(node_id, text):
-        # R3.25: the real user-message-send action for a conversation node -
-        # appends a real user message. ConversationNode is deliberately NOT
-        # wired to agent_dispatcher this increment (R4 landed real dispatch
-        # for ChatNode's send_message only, above) - reserved for a
-        # follow-up increment, so this remains an honest deferred notice
-        # rather than a fake/stubbed response. The wording below was updated
-        # from "lands in R4" since R4 has now partially landed (just not for
-        # this node type yet) - leaving the old text unchanged would be
-        # actively misleading.
+        # R4.3: the real user-message-send action for a conversation node -
+        # appends a real user message, then dispatches a real agent reply
+        # through AgentDispatcher.start_conversation_reply, the ConversationNode
+        # counterpart of send_message's ChatNode dispatch above. The reply
+        # lands via _on_reply calling document.append_conversation_assistant_message
+        # directly - same established relationship as send_message's own
+        # _on_reply calling document.add_chat_node directly.
         node = document.send_conversation_message(node_id, text)
         await publish_scene()
-        notifications.show("AI response generation lands in a follow-up increment.", "info")
-        await bus.publish("notification")
+
+        def _on_reply(reply_text):
+            document.append_conversation_assistant_message(node_id, reply_text)
+
+        await agent_dispatcher.start_conversation_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            conversation_history=node.history,
+            on_reply=_on_reply,
+        )
         return node.id
 
     async def append_conversation_assistant_message(node_id, text):
@@ -1080,6 +1095,14 @@ def register_canvas(
     bus.register_intent("scene", "updatePin", update_pin)
     bus.register_intent("scene", "setSnapToGrid", set_snap_to_grid)
     bus.register_intent("scene", "setDragFactor", set_drag_factor)
+    # R4.3: per-node cancel for a ConversationNode's in-flight reply. Reuses
+    # the exact intent NAME "cancelChatRequest" already registered on the
+    # "app-composer" topic by R4.2 - SessionBus keys handlers by the
+    # (topic, intent) tuple (see backend/events.py), so this is a second,
+    # independent registration on a different topic, not a collision. It
+    # points at the same underlying agent_dispatcher.cancel, which is purely
+    # request_id-keyed and does not care which topic invoked it.
+    bus.register_intent("scene", "cancelChatRequest", lambda request_id: agent_dispatcher.cancel(request_id))
 
     async def organize_nodes():
         document.organize()

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -453,5 +454,357 @@ def test_rapid_fire_double_send_same_session_second_is_rejected(monkeypatch):
         release.set()
         await next(iter(dispatcher._requests.values()))["task"]
         assert replies == ["first"]
+
+    asyncio.run(run())
+
+
+# -- R4.3: start_conversation_reply (ConversationNode real reply + per-node
+# cancel) - mirrors the start_chat_reply tests above one-for-one, using a
+# small stand-in node object in place of composer_document. -----------------
+
+
+class _Recorder:
+    """Minimal connection stand-in recording which topics got published, in
+    order - used here to confirm start_conversation_reply republishes
+    "scene" (never "app-composer") around its state change, unlike
+    start_chat_reply's "app-composer"."""
+
+    def __init__(self):
+        self.topics: list[str] = []
+
+    async def send_json(self, data):
+        if data.get("kind") == "state":
+            self.topics.append(data["topic"])
+
+
+def _make_node():
+    return SimpleNamespace(pending_request_id=None)
+
+
+def test_conversation_reply_sets_then_clears_pending_request_id_and_calls_on_reply(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_chat(task, messages, **kwargs):
+        started.set()
+        release.wait(5)
+        return {"message": {"content": "canned reply"}}
+
+    _configure_fake_ollama(monkeypatch, blocking_chat)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        node = _make_node()
+        replies = []
+
+        await dispatcher.start_conversation_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=replies.append,
+        )
+        await asyncio.to_thread(started.wait, 5)
+        assert node.pending_request_id is not None, "set mid-flight, before the blocking call returns"
+
+        release.set()
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assert replies == ["canned reply"]
+        assert dispatcher._requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_conversation_reply_publishes_scene_not_app_composer_on_begin_and_end(monkeypatch):
+    _configure_fake_ollama(monkeypatch, lambda task, messages, **kwargs: {"message": {"content": "canned reply"}})
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        recorder = _Recorder()
+        bus.attach(recorder)
+        node = _make_node()
+
+        await dispatcher.start_conversation_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=lambda text: None,
+        )
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assert "app-composer" not in recorder.topics
+        # Once after on_begin, once after on_reply (hardcoded "scene" in
+        # _dispatch regardless of state_topic), once after on_end.
+        assert recorder.topics.count("scene") == 3
+        assert composer_document.request_state == "idle", "a conversation reply must never touch composer state"
+
+    asyncio.run(run())
+
+
+def test_conversation_reply_provider_not_configured_returns_quickly_with_an_error_notification(monkeypatch):
+    chat_calls = []
+    _configure_fake_ollama(
+        monkeypatch,
+        lambda task, messages, **kwargs: chat_calls.append(1),
+        model="",  # empty -> is_configured() is False
+    )
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        node = _make_node()
+
+        await dispatcher.start_conversation_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            conversation_history=[],
+            on_reply=lambda text: None,
+        )
+
+        assert dispatcher._requests == {}, "no task/thread work started"
+        assert chat_calls == [], "api_provider.chat was never reached"
+        assert node.pending_request_id is None, "never touched on the fail-fast path"
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == (
+            "No AI provider is configured yet. Open Settings to choose Ollama, "
+            "Llama.cpp, or an API provider."
+        )
+
+    asyncio.run(run())
+
+
+def test_conversation_reply_cancellation_mid_flight_fires_info_notification_and_clears_registry(monkeypatch):
+    started = threading.Event()
+
+    def blocking_then_cancelled(task, messages, cancellation_event=None, **kwargs):
+        started.set()
+        while not cancellation_event.is_set():
+            time.sleep(0.01)
+        raise api_provider.RequestCancelledError("Request cancelled.")
+
+    _configure_fake_ollama(monkeypatch, blocking_then_cancelled)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        node = _make_node()
+
+        await dispatcher.start_conversation_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=lambda text: None,
+        )
+        request_id, entry = next(iter(dispatcher._requests.items()))
+
+        await asyncio.to_thread(started.wait, 5)
+        assert dispatcher.cancel(request_id) is True
+
+        await entry["task"]
+
+        assert dispatcher._requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert notifications.message == "Request cancelled."
+
+    asyncio.run(run())
+
+
+def test_conversation_reply_timeout_fires_the_exact_message_and_clears_registry(monkeypatch):
+    monkeypatch.setattr(agents_module, "WATCHDOG_TIMEOUT_SECONDS", 0.05)
+
+    def slow_chat(task, messages, **kwargs):
+        time.sleep(0.3)
+        return {"message": {"content": "too late"}}
+
+    _configure_fake_ollama(monkeypatch, slow_chat)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        node = _make_node()
+
+        await dispatcher.start_conversation_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=lambda text: None,
+        )
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assert dispatcher._requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == (
+            "The model stopped responding before the request completed. "
+            "Please try again or choose a faster model."
+        )
+
+    asyncio.run(run())
+
+
+def test_conversation_on_reply_raising_still_clears_pending_request_id_and_frees_the_registry(monkeypatch):
+    """Simulates a node deleted mid-flight: on_reply (which in production
+    calls document.append_conversation_assistant_message) raises. This must
+    surface via the existing "AI response failed: ..." notification path
+    (same as any other _dispatch exception, e.g. api_provider.chat itself
+    raising), and the registry must still free up - node.pending_request_id
+    cleared, and a subsequent call admitted normally."""
+    _configure_fake_ollama(monkeypatch, lambda task, messages, **kwargs: {"message": {"content": "reply text"}})
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        node = _make_node()
+
+        def raising_on_reply(text):
+            raise KeyError("node deleted mid-flight")
+
+        await dispatcher.start_conversation_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=raising_on_reply,
+        )
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assert dispatcher._requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message.startswith("AI response failed:")
+
+        # The registry actually frees up: a subsequent call is admitted.
+        monkeypatch.setattr(
+            api_provider, "chat", lambda task, messages, **kwargs: {"message": {"content": "next reply"}}
+        )
+        replies = []
+        await dispatcher.start_conversation_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            conversation_history=[{"role": "user", "content": "hi again"}],
+            on_reply=replies.append,
+        )
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+        assert replies == ["next reply"]
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+# -- cross-channel guard: Composer and ConversationNode share ONE in-flight
+# slot per dispatcher - this locks in that shared-single-slot design
+# decision explicitly, not just implied by the same-channel tests above. ----
+
+
+def test_composer_call_in_flight_blocks_a_concurrent_conversation_call_on_the_same_dispatcher(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_chat(task, messages, **kwargs):
+        started.set()
+        release.wait(5)
+        return {"message": {"content": "composer reply"}}
+
+    _configure_fake_ollama(monkeypatch, blocking_chat)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        node = _make_node()
+        composer_replies = []
+        conversation_replies = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "composer msg"}],
+            on_reply=composer_replies.append,
+        )
+        await asyncio.to_thread(started.wait, 5)
+
+        await dispatcher.start_conversation_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            conversation_history=[{"role": "user", "content": "conversation msg"}],
+            on_reply=conversation_replies.append,
+        )
+
+        assert notifications.visible is True
+        assert notifications.message == "A response is already being generated."
+        assert node.pending_request_id is None, "the bounced call must never touch the node"
+        assert len(dispatcher._requests) == 1, "only the composer's original request stays in flight"
+
+        release.set()
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assert composer_replies == ["composer reply"]
+        assert conversation_replies == [], "the bounced call never ran at all"
+        assert dispatcher._requests == {}
+
+    asyncio.run(run())
+
+
+def test_conversation_call_in_flight_blocks_a_concurrent_composer_call_on_the_same_dispatcher(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_chat(task, messages, **kwargs):
+        started.set()
+        release.wait(5)
+        return {"message": {"content": "conversation reply"}}
+
+    _configure_fake_ollama(monkeypatch, blocking_chat)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        node = _make_node()
+        composer_replies = []
+        conversation_replies = []
+
+        await dispatcher.start_conversation_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            conversation_history=[{"role": "user", "content": "conversation msg"}],
+            on_reply=conversation_replies.append,
+        )
+        await asyncio.to_thread(started.wait, 5)
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "composer msg"}],
+            on_reply=composer_replies.append,
+        )
+
+        assert notifications.visible is True
+        assert notifications.message == "A response is already being generated."
+        assert composer_document.request_state == "idle", "the bounced call must never touch composer state"
+        assert len(dispatcher._requests) == 1, "only the conversation node's original request stays in flight"
+
+        release.set()
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assert conversation_replies == ["conversation reply"]
+        assert composer_replies == [], "the bounced call never ran at all"
+        assert dispatcher._requests == {}
+        assert node.pending_request_id is None
 
     asyncio.run(run())

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -4,6 +4,7 @@ shape, and snapshot publishing."""
 
 import asyncio
 import base64
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -804,6 +805,14 @@ def test_scene_payload_includes_history_defaulted_for_other_kinds():
         {"role": "user", "content": "hi"},
         {"role": "assistant", "content": "hello!"},
     ]
+    # R4.3: pendingRequestId defaults to None for every kind - including a
+    # conversation node with no in-flight dispatch (it is only ever set by
+    # AgentDispatcher.start_conversation_reply while a reply is generating -
+    # see test_agents.py and test_send_conversation_message_intent_dispatches_a_real_agent_reply
+    # below for the non-None in-flight case).
+    assert rows["n0"]["pendingRequestId"] is None
+    assert rows[parent.id]["pendingRequestId"] is None
+    assert rows[node.id]["pendingRequestId"] is None
 
 
 def test_add_conversation_node_intent_creates_a_real_node_and_publishes():
@@ -824,24 +833,90 @@ def test_add_conversation_node_intent_creates_a_real_node_and_publishes():
     asyncio.run(run())
 
 
-def test_send_conversation_message_intent_appends_and_fires_the_same_deferred_notice():
+def test_send_conversation_message_intent_dispatches_a_real_agent_reply():
+    # R4.3: sendConversationMessage's deferred "lands in a follow-up
+    # increment" notice is gone - the real intent now dispatches through
+    # AgentDispatcher.start_conversation_reply, same monkeypatch seam as
+    # test_send_message_intent_dispatches_a_real_agent_reply and
+    # test_agents.py (api_provider.chat directly). Uses a blocking fake chat
+    # (started/release threading.Events, same convention as test_agents.py's
+    # mid-flight tests) so the in-flight pendingRequestId state can actually
+    # be observed, not just the before/after idle states.
     async def run():
-        bus, document, recorder = make_bus()
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
         parent_id = await bus.dispatch_intent("scene", "addNode", [0, 0, "parent"])
         node_id = await bus.dispatch_intent("scene", "addConversationNode", [10, 10, parent_id])
 
-        returned_id = await bus.dispatch_intent(
-            "scene", "sendConversationMessage", [node_id, "what is this graph about?"]
-        )
-        assert returned_id == node_id
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_chat(task, messages, **kwargs):
+            started.set()
+            release.wait(5)
+            return {"message": {"content": "a real conversation reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", blocking_chat):
+            returned_id = await bus.dispatch_intent(
+                "scene", "sendConversationMessage", [node_id, "what is this graph about?"]
+            )
+            assert returned_id == node_id
+            assert document.nodes[node_id].history == [
+                {"role": "user", "content": "what is this graph about?"}
+            ]
+
+            await asyncio.to_thread(started.wait, 5)
+            # Mid-flight: pendingRequestId surfaces as non-None both on the
+            # domain node and in scene_payload.
+            assert document.nodes[node_id].pending_request_id is not None
+            rows = {n["id"]: n for n in document.scene_payload()["nodes"]}
+            assert rows[node_id]["pendingRequestId"] is not None
+            assert rows[node_id]["pendingRequestId"] == document.nodes[node_id].pending_request_id
+
+            release.set()
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
         assert document.nodes[node_id].history == [
-            {"role": "user", "content": "what is this graph about?"}
+            {"role": "user", "content": "what is this graph about?"},
+            {"role": "assistant", "content": "a real conversation reply"},
         ]
 
         notice = await bus.publish("notification")
-        assert notice["visible"] is True
-        assert notice["message"] == "AI response generation lands in a follow-up increment."
-        assert recorder.topics_seen().count("scene") == 3, "all three mutations publish (addNode, addConversationNode, sendConversationMessage)"
+        assert notice["visible"] is False, "a real reply landing is not a deferral - no notification fires"
+        assert document.nodes[node_id].pending_request_id is None, "cleared again once the reply lands"
+        rows = {n["id"]: n for n in document.scene_payload()["nodes"]}
+        assert rows[node_id]["pendingRequestId"] is None
+
+    asyncio.run(run())
+
+
+def test_cancel_chat_request_intent_on_scene_topic_calls_agent_dispatcher_cancel():
+    # A lightweight fake dispatcher is sufficient here - no real LLM call
+    # needed, this just confirms the intent forwards to cancel().
+    class _FakeDispatcher:
+        def __init__(self):
+            self.cancel_calls = []
+
+        def cancel(self, request_id):
+            self.cancel_calls.append(request_id)
+            return True
+
+    async def run():
+        bus = SessionBus("cancel-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        register_canvas(bus, notifications, fake_dispatcher, composer_document)
+
+        result = await bus.dispatch_intent("scene", "cancelChatRequest", ["req-123"])
+
+        assert result is True
+        assert fake_dispatcher.cancel_calls == ["req-123"]
 
     asyncio.run(run())
 

--- a/graphlink_app/graphlink_scene_payload.py
+++ b/graphlink_app/graphlink_scene_payload.py
@@ -37,6 +37,11 @@ R3.25 adds `history` (the ConversationNode increment): a growing list of
 role/content messages - the one R3 kind whose own field is a LIST rather
 than a scalar. Populated for kind=="conversation" rows, defaulted (empty
 list) for every other kind, same additive rule.
+
+R4.3 adds `pendingRequestId` (ConversationNode real-reply + per-node cancel):
+the id of the AgentDispatcher request currently generating a reply for a
+node, or None when idle. Generic across any kind that ever gets its own real
+dispatch slot, defaulted None for every other kind, same additive rule.
 """
 
 from __future__ import annotations
@@ -89,6 +94,12 @@ class SceneNodeRow:
     # defaulted (empty list) for every other kind. The one R3 kind whose own
     # field is a list rather than a scalar.
     history: list[ConversationMessageRow] = field(default_factory=list)
+    # R4.3: transient per-node in-flight-request marker - the id of the
+    # AgentDispatcher request currently generating a reply for this node, or
+    # None when idle. Generic across any kind that ever gets its own real
+    # dispatch slot (not conversation-only), defaulted None for every other
+    # kind.
+    pendingRequestId: str | None = None
 
 
 @dataclass

--- a/web_ui/src/app/canvas/ConversationNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.test.tsx
@@ -12,6 +12,7 @@ function renderConversationNode(overrides: Partial<ConversationFlowNode["data"]>
   const onDelete = vi.fn();
   const onSend = vi.fn();
   const onDeleteMessage = vi.fn();
+  const onCancel = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -21,10 +22,12 @@ function renderConversationNode(overrides: Partial<ConversationFlowNode["data"]>
         { role: "assistant" as const, content: "Hi there" },
       ],
       isCollapsed: false,
+      pendingRequestId: null,
       onToggleCollapse,
       onDelete,
       onSend,
       onDeleteMessage,
+      onCancel,
       ...overrides,
     },
   } as unknown as NodeProps<ConversationFlowNode>;
@@ -34,7 +37,7 @@ function renderConversationNode(overrides: Partial<ConversationFlowNode["data"]>
       <ConversationNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onToggleCollapse, onDelete, onSend, onDeleteMessage };
+  return { onToggleCollapse, onDelete, onSend, onDeleteMessage, onCancel };
 }
 
 // Directly sets the React Flow internal Zustand store's transform/zoom
@@ -57,16 +60,19 @@ function renderConversationNodeAtZoom(zoom: number, overrides: Partial<Conversat
   const onDelete = vi.fn();
   const onSend = vi.fn();
   const onDeleteMessage = vi.fn();
+  const onCancel = vi.fn();
   const props = {
     id: "n0",
     selected: false,
     data: {
       history: [{ role: "user" as const, content: "Hello" }],
       isCollapsed: false,
+      pendingRequestId: null,
       onToggleCollapse,
       onDelete,
       onSend,
       onDeleteMessage,
+      onCancel,
       ...overrides,
     },
   } as unknown as NodeProps<ConversationFlowNode>;
@@ -267,11 +273,28 @@ describe("ConversationNodeView", () => {
     expect(input).toHaveValue("");
   });
 
-  it("the Cancel button is always disabled with the exact R4 title string", () => {
-    renderConversationNode();
+  it("the Cancel button is absent when pendingRequestId is null", () => {
+    renderConversationNode({ pendingRequestId: null });
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+
+  it("the Cancel button is present and calls onCancel when pendingRequestId is set", async () => {
+    const user = userEvent.setup();
+    const { onCancel } = renderConversationNode({ pendingRequestId: "req-42" });
     const cancelButton = screen.getByRole("button", { name: "Cancel" });
-    expect(cancelButton).toBeDisabled();
-    expect(cancelButton).toHaveAttribute("title", "Agent cancellation lands in R4");
+    expect(cancelButton).toBeInTheDocument();
+    await user.click(cancelButton);
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("the Send button is disabled while pendingRequestId is set, even with non-empty draft text", async () => {
+    const user = userEvent.setup();
+    renderConversationNode({ pendingRequestId: "req-42" });
+    const input = screen.getByRole("textbox", { name: "Message" });
+    const sendButton = screen.getByRole("button", { name: "Send" });
+
+    await user.type(input, "real text");
+    expect(sendButton).toBeDisabled();
   });
 
   it("Escape and outside-click both close the node-level menu", async () => {

--- a/web_ui/src/app/canvas/ConversationNodeView.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.tsx
@@ -18,17 +18,20 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * in this codebase already uses), collapse/expand (manual toggle OR-ed with
  * LOD auto-collapse, same as Chat/Document), delete (generic - a conversation
  * node is never a branch point/reparented, same as code/thinking/html/image),
- * per-bubble copy + delete-from-history, and Send (appends a real user
- * message; the assistant's reply is deferred to R4 - see sendConversationMessage's
- * own backend docstring - the backend surfaces that honestly over the
- * existing notification topic, no fake response synthesized here, matching
- * the Composer's own sendMessage precedent). Deferred, with an honest
- * disabled+title label rather than a silent drop (same audit convention
- * every prior node kind in this plan has followed): Open Document View (the
- * document-viewer island isn't wired into the SPA overlay system yet - same
- * reason ChatNodeView's own menu defers it) and Cancel (there is no in-flight
- * request concept anywhere in this frontend yet for it to ever act on -
- * agent cancellation lands in R4 alongside the agent layer itself).
+ * per-bubble copy + delete-from-history, Send (appends a real user message
+ * and triggers the real agent reply via the backend agent layer - see
+ * sendConversationMessage's own backend docstring), and (R4.3) Cancel: a
+ * real per-node cancel affordance, the exact same conditional-render pattern
+ * as the Composer's own Cancel button (Composer.tsx) applied one level down
+ * - per-node instead of per-session. Cancel is rendered only while this
+ * node's own data.pendingRequestId is non-null (this node has an in-flight
+ * reply of its own), and Send is additionally disabled while that same
+ * field is set, so a second send can't be issued mid-flight for this node.
+ * Still deferred, with an honest disabled+title label rather than a silent
+ * drop (same audit convention every prior node kind in this plan has
+ * followed): Open Document View (the document-viewer island isn't wired
+ * into the SPA overlay system yet - same reason ChatNodeView's own menu
+ * defers it).
  *
  * Card menu deliberately does NOT include "Hide Other Branches" or "Include
  * Previous Branch Context": the legacy PluginNodeContextMenu for this node
@@ -46,10 +49,12 @@ export interface ConversationMessage {
 export interface ConversationNodeData extends Record<string, unknown> {
   history: ConversationMessage[];
   isCollapsed: boolean;
+  pendingRequestId: string | null;
   onToggleCollapse: () => void;
   onDelete: () => void;
   onSend: (text: string) => void;
   onDeleteMessage: (index: number) => void;
+  onCancel: () => void;
 }
 
 export type ConversationFlowNode = Node<ConversationNodeData, "conversation">;
@@ -305,19 +310,21 @@ export function ConversationNodeView({ data, selected }: NodeProps<ConversationF
               <button
                 type="button"
                 className="conversation-node-send-btn"
-                disabled={!draft.trim()}
+                disabled={!draft.trim() || !!data.pendingRequestId}
                 onClick={send}
               >
                 Send
               </button>
-              <button
-                type="button"
-                className="conversation-node-cancel-btn"
-                disabled
-                title="Agent cancellation lands in R4"
-              >
-                Cancel
-              </button>
+              {data.pendingRequestId && (
+                <button
+                  type="button"
+                  className="conversation-node-cancel-btn"
+                  onClick={() => data.onCancel()}
+                  title="Cancel response"
+                >
+                  Cancel
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -243,6 +243,7 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
         data: {
           history: n.history,
           isCollapsed: n.isCollapsed,
+          pendingRequestId: n.pendingRequestId ?? null,
           // Reuses the existing generic setChatCollapsed intent - same
           // reasoning as every other non-chat node kind's onToggleCollapse
           // above (the backend handler looks up ANY node by id).
@@ -250,6 +251,12 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
           onDelete: () => store.removeNodes([n.id]),
           onSend: (text: string) => store.sendConversationMessage(n.id, text),
           onDeleteMessage: (index: number) => store.deleteConversationMessage(n.id, index),
+          // Same null-guard pattern as Composer.tsx's own analogous cancel
+          // call site - only fire the intent if there is genuinely a
+          // non-null request id to target.
+          onCancel: () => {
+            if (n.pendingRequestId) store.cancelConversationRequest(n.pendingRequestId);
+          },
         },
       });
       continue;

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -240,6 +240,13 @@ describe("SceneStore", () => {
     ]);
   });
 
+  it("cancelConversationRequest fires the scene-topic cancelChatRequest intent", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.cancelConversationRequest("req-42");
+    expect(intents).toEqual([{ topic: "scene", intent: "cancelChatRequest", args: ["req-42"] }]);
+  });
+
   it("suppresses empty removal intents", () => {
     const { transport, intents } = makeFakeTransport();
     const store = new SceneStore(transport);

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -270,6 +270,16 @@ export class SceneStore {
     this.transport.intent("scene", "deleteConversationMessage", [id, messageIndex]);
   }
 
+  // R4.3: real per-node Cancel for a conversation node's own in-flight reply.
+  // A second, independent registration of the same "cancelChatRequest" intent
+  // name the Composer already sends on the "app-composer" topic (see
+  // composerStore.ts's own cancelChatRequest) - not the same call site, just
+  // two topics sharing one action name, so this is named distinctly
+  // (cancelConversationRequest) to avoid implying otherwise.
+  cancelConversationRequest(requestId: string): void {
+    this.transport.intent("scene", "cancelChatRequest", [requestId]);
+  }
+
   setNodeDocked(id: string, docked: boolean): void {
     this.transport.intent("scene", "setNodeDocked", [id, docked]);
   }

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -109,6 +109,9 @@
           "mimeType": {
             "type": "string"
           },
+          "pendingRequestId": {
+            "type": "string"
+          },
           "previewLabel": {
             "type": "string"
           },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -22,6 +22,7 @@ export interface SceneNodeRow {
   isDocked: boolean;
   imageAssetId: string;
   history: ConversationMessageRow[];
+  pendingRequestId?: string | null;
 }
 
 export interface ConversationMessageRow {
@@ -167,6 +168,10 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.history: missing required field`);
     else { if (!Array.isArray(fieldValue)) errors.push(`${path}.history` + ": expected array");
     else (fieldValue as unknown[]).forEach((item, i) => { checkConversationMessageRow(item, `${path}.history` + `[${i}]`, errors); }); }
+  }
+  {
+    const fieldValue = value["pendingRequestId"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.pendingRequestId` + ": expected string"); }
   }
 }
 


### PR DESCRIPTION
## Summary
- A fresh recon+cross-check+design pass sized the three items the original R4 scoping bundled into "R4.3" and decisively shipped only the bounded one: ConversationNode's real reply. `SceneNode.history` already lives in the exact role/content shape the chat layer expects - no new subsystem needed.
- **Explicitly deferred, with reasoning recorded, not force-fit in:** Regenerate Response (Chat/Code) - legacy mutates a node's content in place and tears down/recreates dependent code/document/image/thinking children, a pattern with zero precedent in `backend/canvas.py` today, and depends on a response-parsing/auto-child-creation pipeline that has never been built for any reply path. Regenerate Image - needs a wholly separate, unbuilt image-generation dispatch subsystem. Both frontend placeholders stay untouched and honestly disabled.
- `backend/agents.py`'s `AgentDispatcher.start_chat_reply` was refactored into a private generic `_dispatch` primitive plus two thin wrappers - the original (byte-for-byte unchanged behavior, every pre-existing test passes unmodified) and a new `start_conversation_reply` that sets/clears a transient `pending_request_id` on the `SceneNode` itself and publishes `scene` instead of `app-composer`.
- A genuine product-behavior fork was decided explicitly: legacy's `ConversationNode` dispatch is truly concurrent with the main Composer; this backend deliberately keeps a single shared session-wide dispatch slot instead, the same class of honest simplification R4.2 used for its watchdog cut.
- Per-node cancel needed one new additive `SceneNode.pending_request_id` field plus reusing the existing `cancelChatRequest` intent name on a second topic - the cancel mechanism itself needed zero new logic.
- `ConversationNodeView.tsx`'s Cancel button goes from permanently-disabled to a genuine conditional render, mirroring the Composer's own R4.2 pattern one level down.
- The 3-way review found and fixed one real bug: the generated `pendingRequestId` field is optional, breaking `tsc` against `ConversationNodeData`'s narrower type - fixed with a `?? null` coercion.

## Test plan
- [x] `python -m pytest -q` (repo-wide): 1960 passed
- [x] `npx vitest run` (web_ui): 687 passed, 67 files
- [x] `npx tsc --noEmit`: clean
- [x] Live acceptance against a real Ollama model on the node-level surface: real send with `pendingRequestId` tracked while generating, real reply landing in the node's history
- [x] Live cancel-mid-flight on the same node: real in-flight request id captured, cancelled via the `scene`-topic intent, exact `"Request cancelled."` notification confirmed, no assistant reply added
- [x] Burn-down gate unchanged at the pin