### PR TITLE
Qt-removal R4.3b: response-parsing retrofit - legacy-parity fix to shipped R4.2/R4.3 work

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -38,6 +38,12 @@ from backend.agents import AgentDispatcher
 from backend.composer import ComposerDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
+from backend.response_parsing import (
+    parse_response,
+    PLACEHOLDER_GENERATED_CONTENT,
+    PLACEHOLDER_ASSISTANT_REASONING,
+    PLACEHOLDER_EMPTY_RESPONSE,
+)
 
 # Dark-theme grid swatches. The Qt bridge derived 3 of 5 from the live
 # QPalette; the backend is Qt-free by law (test_no_qt_anywhere.py), so until
@@ -962,6 +968,17 @@ def register_canvas(
         await publish_scene()
 
         def _on_reply(reply_text):
+            # R4.3b: deliberate, confirmed-correct omission, NOT an oversight -
+            # ConversationNode is exempt from the response_parsing retrofit
+            # applied to send_message's _on_reply above. The true legacy
+            # handler for a conversation node's reply is
+            # graphlink_window_actions.py's WindowActionsMixin.
+            # handle_conversation_node_response (NOT handle_response), which
+            # just calls target_node.add_ai_message(response_text) directly -
+            # it never calls self._parse_response and never creates any
+            # child node. A ConversationNode is a self-contained mega-node
+            # with a flat plain-text-only history and no child-node concept
+            # at all in legacy.
             document.append_conversation_assistant_message(node_id, reply_text)
 
         await agent_dispatcher.start_conversation_reply(
@@ -1006,10 +1023,73 @@ def register_canvas(
         history = document.chat_branch_history(node.id)
 
         def _on_reply(reply_text):
-            reply_node = document.add_chat_node(
-                node.x, node.y + MESSAGE_VERTICAL_SPACING, reply_text, False, parent_id=node.id
-            )
-            document.last_chat_node_id = reply_node.id
+            # R4.3b: port legacy handle_response's _parse_response retrofit -
+            # split the flat reply into thinking/text/code parts and create
+            # separate thinking-kind/code-kind CHILD nodes instead of
+            # dumping the raw, unparsed reply into one flat node.
+            parsed_parts = parse_response(reply_text)
+            if not parsed_parts:
+                # Mirrors legacy handle_response's own outer gate
+                # (`if text_content or parsed_parts:`) - a genuinely empty/
+                # whitespace-only reply creates NO node at all, not a
+                # "[Empty Response]" placeholder node. Currently unreachable
+                # in practice (api_provider._compose_reasoned_response raises
+                # rather than returning blank content), but the gate is kept
+                # so a future provider path can never silently diverge from
+                # legacy here. last_chat_node_id is deliberately left
+                # untouched - it already points at the user's own message
+                # node (set by send_message just above), matching legacy's
+                # own fallback of leaving current_node at user_node when no
+                # assistant node gets created.
+                return
+
+            text_parts = [p["content"] for p in parsed_parts if p["type"] == "text"]
+            text_content = "\n\n".join(text_parts)
+
+            placeholder_text = text_content
+            if not placeholder_text:
+                if any(p["type"] == "code" for p in parsed_parts):
+                    placeholder_text = PLACEHOLDER_GENERATED_CONTENT
+                elif any(p["type"] == "thinking" for p in parsed_parts):
+                    placeholder_text = PLACEHOLDER_ASSISTANT_REASONING
+                else:
+                    # Unreachable given parse_response's own invariants (a
+                    # non-empty parts list with no text/code part must
+                    # contain a thinking part) - legacy's handle_response has
+                    # this exact same dead branch; kept verbatim for
+                    # structural parity rather than optimized away.
+                    placeholder_text = PLACEHOLDER_EMPTY_RESPONSE
+
+            ax, ay = node.x, node.y + MESSAGE_VERTICAL_SPACING
+            ai_node = document.add_chat_node(ax, ay, placeholder_text, False, parent_id=node.id)
+
+            # NOTE: these two calls MUST use the `document.` prefix. Bare
+            # `add_code_node(...)` / `add_thinking_node(...)` would silently
+            # resolve to this enclosing register_canvas scope's own async WS-
+            # intent wrapper closures of the same name (defined earlier,
+            # above send_message) instead of raising a NameError - producing
+            # an unawaited coroutine that never runs and never errors, so no
+            # node would be created and nothing would look wrong until the
+            # scene state was actually inspected.
+            for part in parsed_parts:
+                if part["type"] == "thinking":
+                    document.add_thinking_node(
+                        ax - MESSAGE_VERTICAL_SPACING, ay + MESSAGE_VERTICAL_SPACING,
+                        part["content"], parent_id=ai_node.id,
+                    )
+                elif part["type"] == "code":
+                    document.add_code_node(
+                        ax + MESSAGE_VERTICAL_SPACING, ay + MESSAGE_VERTICAL_SPACING,
+                        part["content"], part["language"], parent_id=ai_node.id,
+                    )
+
+            # Always the real chat node's id, never a code/thinking child's -
+            # add_code_node/add_thinking_node are documented above (see their
+            # own docstrings) as NOT branch points, and last_chat_node_id
+            # specifically drives the next real send's branch-continuation
+            # (chat_branch_history), which only makes sense pointed at a real
+            # chat node.
+            document.last_chat_node_id = ai_node.id
 
         await agent_dispatcher.start_chat_reply(
             bus=bus,

--- a/backend/response_parsing.py
+++ b/backend/response_parsing.py
@@ -1,0 +1,89 @@
+"""Qt-free port of graphlink_app/graphlink_window_actions.py's _parse_response.
+
+This is the shared parsing routine legacy uses for every REAL chat reply -
+both the ordinary send path (WindowActionsMixin.handle_response) and the
+regenerate path (WindowActionsMixin.handle_regenerated_response) both call
+`self._parse_response(response_text)` before creating any node. It splits a
+flat LLM response string into an ordered list of thinking/text/code parts, so
+the caller can create a real chat node for the text plus separate real
+thinking-kind and code-kind CHILD nodes for the rest - instead of dumping the
+model's raw, unprocessed reply (complete with <think> tags, <code_block>
+wrappers, and/or ```fenced``` code) into a single flat node.
+
+Only the ordinary send path (backend/canvas.py's send_message) is retrofitted
+onto this module for now; the regenerate path and ConversationNode remain
+out of scope for this increment (ConversationNode never called
+_parse_response in legacy either - see backend/canvas.py's
+send_conversation_message for that confirmed exemption).
+"""
+
+from __future__ import annotations
+
+import re
+
+import api_provider
+
+# Compiled once at module import instead of once per call (legacy's own
+# _parse_response re-compiles both patterns on every invocation) - a harmless
+# efficiency improvement over legacy, not a behavior change.
+CODE_BLOCK_TAG_PATTERN = re.compile(r"<code_block>([\s\S]*?)</code_block>", re.IGNORECASE)
+CODE_FENCE_PATTERN = re.compile(r"```(\w*)\s*\n?([\s\S]*?)\s*```")
+
+PLACEHOLDER_GENERATED_CONTENT = "[Generated Content]"
+PLACEHOLDER_ASSISTANT_REASONING = "[Assistant Reasoning]"
+PLACEHOLDER_EMPTY_RESPONSE = "[Empty Response]"
+
+
+def parse_response(response_text: str) -> list[dict]:
+    """Split a flat LLM reply into ordered thinking/text/code parts.
+
+    Exact port of graphlink_window_actions.py's WindowActionsMixin._parse_response.
+    The returned list, when multiple types are present, is always ordered
+    thinking (if any), then text (if any), then code (if any) - never
+    interleaved, never more than one of each type. The "language" key exists
+    ONLY on code-type parts; thinking/text parts have exactly the two keys
+    {"type", "content"}.
+    """
+    parts: list[dict] = []
+
+    thinking_content, remaining_text = api_provider.split_reasoning_and_content(response_text)
+    if thinking_content:
+        parts.append({"type": "thinking", "content": thinking_content})
+
+    text_content = ""
+    code_snippets: list[str] = []
+    language = ""
+
+    code_block_match = CODE_BLOCK_TAG_PATTERN.search(remaining_text)
+    if code_block_match:
+        code_content_raw = code_block_match.group(1).strip()
+        text_content = (
+            remaining_text[: code_block_match.start()] + remaining_text[code_block_match.end() :]
+        ).strip()
+        inner_matches = list(CODE_FENCE_PATTERN.finditer(code_content_raw))
+        if inner_matches:
+            language = inner_matches[0].group(1).strip()
+            code_snippets = [m.group(2).strip() for m in inner_matches]
+        else:
+            code_snippets = [code_content_raw]
+    else:
+        matches = list(CODE_FENCE_PATTERN.finditer(remaining_text))
+        if matches:
+            language = matches[0].group(1).strip()
+            code_snippets = [m.group(2).strip() for m in matches]
+            text_content = CODE_FENCE_PATTERN.sub("", remaining_text).strip()
+        else:
+            text_content = remaining_text.strip()
+
+    if text_content:
+        parts.append({"type": "text", "content": text_content})
+
+    if code_snippets:
+        combined_code = "\n\n# --- Next Code Block ---\n\n".join(code_snippets).strip()
+        if combined_code:
+            parts.append({"type": "code", "language": language, "content": combined_code})
+
+    if not parts and response_text.strip():
+        return [{"type": "text", "content": response_text.strip()}]
+
+    return parts

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -893,6 +893,43 @@ def test_send_conversation_message_intent_dispatches_a_real_agent_reply():
     asyncio.run(run())
 
 
+def test_send_conversation_message_reply_with_code_fence_lands_raw_and_unparsed():
+    # R4.3b: ConversationNode is EXEMPT from the response_parsing retrofit -
+    # this is the machine-checked proof, not just the documenting comment in
+    # backend/canvas.py's send_conversation_message _on_reply. A reply
+    # containing a fenced code block must land verbatim in the conversation
+    # node's plain-text history, with no code/thinking child node created.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        parent_id = await bus.dispatch_intent("scene", "addNode", [0, 0, "parent"])
+        node_id = await bus.dispatch_intent("scene", "addConversationNode", [10, 10, parent_id])
+
+        raw_reply = "Sure thing:\n\n```python\nprint('unparsed')\n```"
+
+        def fake_chat(task, messages, **kwargs):
+            return {"message": {"content": raw_reply}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", fake_chat):
+            await bus.dispatch_intent(
+                "scene", "sendConversationMessage", [node_id, "show me some code"]
+            )
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assert document.nodes[node_id].history == [
+            {"role": "user", "content": "show me some code"},
+            {"role": "assistant", "content": raw_reply},
+        ], "the raw reply (fences and all) lands verbatim - no parsing happened"
+        assert not any(n.kind in ("code", "thinking") for n in document.nodes.values()), (
+            "no child node of any kind was created for this reply"
+        )
+
+    asyncio.run(run())
+
+
 def test_cancel_chat_request_intent_on_scene_topic_calls_agent_dispatcher_cancel():
     # A lightweight fake dispatcher is sufficient here - no real LLM call
     # needed, this just confirms the intent forwards to cancel().
@@ -1187,6 +1224,176 @@ def test_send_message_intent_dispatches_a_real_agent_reply():
         assert any(e.source == node_id and e.target == reply_node.id for e in document.edges.values())
         assert document.last_chat_node_id == reply_node.id
         assert recorder.topics_seen().count("scene") >= 2, "user node + reply node both publish scene"
+
+    asyncio.run(run())
+
+
+def test_send_message_reply_that_is_genuinely_empty_creates_no_assistant_node():
+    # R4.3b regression: mirrors legacy handle_response's own outer gate
+    # (`if text_content or parsed_parts:`) - a reply that parse_response
+    # reduces to an empty parts list (whitespace-only) must create NO
+    # assistant node at all, not a "[Empty Response]" placeholder node, and
+    # must leave last_chat_node_id pointed at the user's own message (set by
+    # send_message's domain method), not touch it again.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def fake_chat(task, messages, **kwargs):
+            return {"message": {"content": "   \n\n   "}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", fake_chat):
+            node_id = await bus.dispatch_intent("scene", "sendMessage", ["hello"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        reply_nodes = [n for n in document.nodes.values() if n.id != node_id]
+        assert reply_nodes == [], "a genuinely empty reply must create no assistant/child nodes at all"
+        assert document.last_chat_node_id == node_id
+
+    asyncio.run(run())
+
+
+def test_send_message_reply_with_code_fence_creates_code_child_and_edge():
+    # R4.3b: a reply with leading text plus a fenced code block must split
+    # into a real code-kind child node (correct language/content) connected
+    # to the assistant node by a real edge - the assistant node's own
+    # content is just the text portion, not the raw unparsed reply.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def fake_chat(task, messages, **kwargs):
+            return {"message": {"content": "Here is the fix:\n\n```python\nprint('hi')\n```"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", fake_chat):
+            user_node_id = await bus.dispatch_intent("scene", "sendMessage", ["write me a hello world"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_nodes = [
+            n for n in document.nodes.values() if n.kind == "chat" and n.id != user_node_id
+        ]
+        assert len(assistant_nodes) == 1
+        assistant_node = assistant_nodes[0]
+        assert assistant_node.content == "Here is the fix:"
+
+        code_nodes = [n for n in document.nodes.values() if n.kind == "code"]
+        assert len(code_nodes) == 1
+        code_node = code_nodes[0]
+        assert code_node.language == "python"
+        assert code_node.code == "print('hi')"
+
+        assert any(
+            e.source == assistant_node.id and e.target == code_node.id
+            for e in document.edges.values()
+        ), "a real edge connects the assistant node to its code child"
+        assert document.last_chat_node_id == assistant_node.id
+
+    asyncio.run(run())
+
+
+def test_send_message_reply_that_is_only_thinking_uses_reasoning_placeholder():
+    # R4.3b: a reply that is nothing but a <think> block has no text
+    # content at all - the assistant node's content must fall back to the
+    # literal "[Assistant Reasoning]" placeholder, with the actual reasoning
+    # text living on a real thinking-kind child node instead.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def fake_chat(task, messages, **kwargs):
+            return {"message": {"content": "<think>pondering deeply</think>"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", fake_chat):
+            user_node_id = await bus.dispatch_intent("scene", "sendMessage", ["what are you thinking?"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_nodes = [
+            n for n in document.nodes.values() if n.kind == "chat" and n.id != user_node_id
+        ]
+        assert len(assistant_nodes) == 1
+        assistant_node = assistant_nodes[0]
+        assert assistant_node.content == "[Assistant Reasoning]"
+
+        thinking_nodes = [n for n in document.nodes.values() if n.kind == "thinking"]
+        assert len(thinking_nodes) == 1
+        thinking_node = thinking_nodes[0]
+        assert thinking_node.content == "pondering deeply"
+        assert any(
+            e.source == assistant_node.id and e.target == thinking_node.id
+            for e in document.edges.values()
+        )
+
+        code_nodes = [n for n in document.nodes.values() if n.kind == "code"]
+        assert code_nodes == [], "no code node was created"
+
+    asyncio.run(run())
+
+
+def test_send_message_reply_with_thinking_text_and_code_creates_both_children_on_same_parent():
+    # R4.3b: thinking + surrounding text + one code fence must produce
+    # exactly one thinking child and one code child, both parented to the
+    # SAME assistant node (never chained to each other), with the assistant
+    # node's own content being the real text portion, not a placeholder.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def fake_chat(task, messages, **kwargs):
+            return {
+                "message": {
+                    "content": (
+                        "<think>working it out</think>\n"
+                        "Here's the plan.\n"
+                        "```python\nprint('plan')\n```"
+                    )
+                }
+            }
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", fake_chat):
+            user_node_id = await bus.dispatch_intent("scene", "sendMessage", ["plan it out"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_nodes = [
+            n for n in document.nodes.values() if n.kind == "chat" and n.id != user_node_id
+        ]
+        assert len(assistant_nodes) == 1
+        assistant_node = assistant_nodes[0]
+        assert assistant_node.content == "Here's the plan."
+
+        thinking_nodes = [n for n in document.nodes.values() if n.kind == "thinking"]
+        code_nodes = [n for n in document.nodes.values() if n.kind == "code"]
+        assert len(thinking_nodes) == 1
+        assert len(code_nodes) == 1
+
+        assert any(
+            e.source == assistant_node.id and e.target == thinking_nodes[0].id
+            for e in document.edges.values()
+        )
+        assert any(
+            e.source == assistant_node.id and e.target == code_nodes[0].id
+            for e in document.edges.values()
+        )
+        assert not any(
+            e.source == thinking_nodes[0].id and e.target == code_nodes[0].id
+            for e in document.edges.values()
+        ), "thinking and code children are not chained to each other"
+        assert not any(
+            e.source == code_nodes[0].id and e.target == thinking_nodes[0].id
+            for e in document.edges.values()
+        )
+        assert document.last_chat_node_id == assistant_node.id
 
     asyncio.run(run())
 

--- a/backend/tests/test_response_parsing.py
+++ b/backend/tests/test_response_parsing.py
@@ -1,0 +1,115 @@
+"""Isolated unit tests for backend/response_parsing.py's parse_response().
+
+No SceneDocument, no dispatcher, no WS bus - just the pure parsing function,
+verified against the exact behaviors ported from legacy's
+WindowActionsMixin._parse_response (graphlink_app/graphlink_window_actions.py).
+"""
+
+from backend.response_parsing import parse_response
+
+
+def test_empty_input_returns_empty_list():
+    assert parse_response("") == []
+
+
+def test_whitespace_only_input_returns_empty_list():
+    assert parse_response("   \n\t  ") == []
+
+
+def test_plain_text_with_no_code_or_thinking_returns_one_text_part():
+    result = parse_response("  Hello, just plain text.  ")
+    assert result == [{"type": "text", "content": "Hello, just plain text."}]
+
+
+def test_single_fenced_code_block_with_language_produces_text_then_code():
+    response = "Here is the answer:\n\n```python\nprint('hi')\n```"
+    result = parse_response(response)
+    assert result == [
+        {"type": "text", "content": "Here is the answer:"},
+        {"type": "code", "language": "python", "content": "print('hi')"},
+    ]
+
+
+def test_two_fenced_code_blocks_collapse_into_one_combined_code_part():
+    response = (
+        "Two snippets:\n"
+        "```python\nprint('one')\n```\n"
+        "and\n"
+        "```javascript\nconsole.log('two')\n```"
+    )
+    result = parse_response(response)
+    text_parts = [p for p in result if p["type"] == "text"]
+    code_parts = [p for p in result if p["type"] == "code"]
+    assert len(code_parts) == 1
+    code_part = code_parts[0]
+    assert code_part["language"] == "python", "language comes from the FIRST fence only"
+    assert code_part["content"] == (
+        "print('one')\n\n# --- Next Code Block ---\n\nconsole.log('two')"
+    )
+    assert len(text_parts) == 1
+    assert "```" not in text_parts[0]["content"]
+
+
+def test_code_block_tag_with_nested_fences_takes_the_inner_fence_branch():
+    response = (
+        "<code_block>\n"
+        "```python\n"
+        "print('nested')\n"
+        "```\n"
+        "</code_block>"
+    )
+    result = parse_response(response)
+    code_parts = [p for p in result if p["type"] == "code"]
+    assert len(code_parts) == 1
+    assert code_parts[0]["language"] == "python"
+    assert code_parts[0]["content"] == "print('nested')"
+
+
+def test_code_block_tag_with_no_inner_fences_produces_one_raw_blob_with_empty_language():
+    response = "<code_block>raw code, no fences here</code_block>"
+    result = parse_response(response)
+    code_parts = [p for p in result if p["type"] == "code"]
+    assert len(code_parts) == 1
+    assert code_parts[0]["language"] == ""
+    assert code_parts[0]["content"] == "raw code, no fences here"
+
+
+def test_think_tag_with_trailing_text_and_code_fence_produces_fixed_order():
+    response = (
+        "<think>reasoning about the problem</think>\n"
+        "Here's the answer.\n"
+        "```python\nprint('done')\n```"
+    )
+    result = parse_response(response)
+    assert [p["type"] for p in result] == ["thinking", "text", "code"]
+    assert result[0]["content"] == "reasoning about the problem"
+    assert result[1]["content"] == "Here's the answer."
+    assert result[2]["language"] == "python"
+    assert result[2]["content"] == "print('done')"
+    # thinking/text parts carry exactly {"type", "content"} - no "language" key.
+    assert set(result[0].keys()) == {"type", "content"}
+    assert set(result[1].keys()) == {"type", "content"}
+    assert set(result[2].keys()) == {"type", "language", "content"}
+
+
+def test_fallback_reasoning_marker_format_is_recognized_as_thinking():
+    # Proves the real api_provider.split_reasoning_and_content is genuinely
+    # being called (a <think>-tag-only reimplementation would miss this
+    # fallback marker format entirely).
+    response = (
+        "--- REASONING ---\n"
+        "stepping through the fallback format\n"
+        "--- END REASONING ---\n"
+        "The final answer."
+    )
+    result = parse_response(response)
+    assert result[0] == {"type": "thinking", "content": "stepping through the fallback format"}
+    assert result[1] == {"type": "text", "content": "The final answer."}
+
+
+def test_whitespace_only_around_otherwise_empty_content_returns_empty_list():
+    # Mixed whitespace (tabs/newlines/spaces) with nothing else - must not
+    # produce a spurious text part from the "if not parts and
+    # response_text.strip()" fallback (that fallback only fires when the
+    # raw response has non-whitespace content left after stripping).
+    assert parse_response("\n\t  \r\n   \t\n") == []


### PR DESCRIPTION
## Summary
- **Found while scoping the next increment, not a planned deliverable:** legacy's ordinary (non-regenerate) send-completion handler always splits the flat LLM reply into thinking/text/code parts and creates separate child nodes for the non-text parts. R4.2's and R4.3's shipped real reply paths just created one flat node with the raw reply text - a genuine fidelity gap in already live-drive-verified work.
- New Qt-free `backend/response_parsing.py`'s `parse_response()` is a character-for-character port of legacy's `_parse_response`, critically calling the **real** `api_provider.split_reasoning_and_content` rather than reimplementing a `<think>`-only subset (the real function handles 4 distinct reasoning encodings; a naive port would have silently regressed 3 of them).
- `send_message`'s reply now fans out into a real assistant node plus at most one real thinking/code child, both parented to the same assistant node (matching legacy exactly); `last_chat_node_id` always points at the assistant node.
- ConversationNode is confirmed genuinely exempt - independently verified by both reviewers against the true legacy source.
- Both reviewers independently caught the same real gap (legacy skips node creation entirely for a truly empty reply; the first pass didn't) - fixed before shipping with a matching gate and regression test.
- A real hazard was flagged and confirmed avoided: the enclosing scope already has async closures literally named `add_code_node`/`add_thinking_node` - a missing `document.` prefix would have silently swallowed child-node creation with no error.

## Test plan
- [x] `python -m pytest -q` (repo-wide): 1975 passed
- [x] `python graphlink_app/graphlink_island_codegen.py --check`: up to date (no wire-schema change)
- [x] Backend-only - zero frontend files touched
- [x] Live acceptance against a real Ollama model: a real reasoning-trace-plus-code-fence reply split correctly into a clean placeholder assistant node (zero raw markup leaking through) plus real thinking/code children; a follow-up send confirmed branch continuation targets the assistant node
- [x] Burn-down gate unchanged at the pin