### PR TITLE
Qt-removal R4.3c: Regenerate Response (Chat/Code)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -35,6 +35,7 @@ Two separate jobs live here:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import threading
 import uuid
@@ -207,7 +208,10 @@ class AgentDispatcher:
                     asyncio.to_thread(_call_chat_agent, conversation_history, self.persona(), cancel_event),
                     timeout=WATCHDOG_TIMEOUT_SECONDS,
                 )
-                on_reply(reply_text)
+                if inspect.iscoroutinefunction(on_reply):
+                    await on_reply(reply_text)
+                else:
+                    on_reply(reply_text)
                 await bus.publish("scene")
             except asyncio.TimeoutError:
                 cancel_event.set()

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -689,6 +689,63 @@ class SceneDocument:
         history.reverse()
         return history
 
+    def regenerate_response(self, node_id: str) -> tuple[SceneNode, str]:
+        """Validate + resolve a regenerate target. Mirrors legacy's regenerate_node
+        single precondition (window_actions.py:512-514: no parent -> can't
+        regenerate), extended with two defensive checks legacy cannot hit (it
+        always holds a live scene-graph object, never a string id to resolve):
+        unknown node_id, and a non-chat-kind node_id (code/document/etc. can
+        never be regenerate targets directly - see Q2, the frontend always
+        resolves to a chat-node id before calling in). All three raise
+        SceneError; the WS-intent wrapper in register_canvas catches it and
+        shows ONE friendly notification for all three cases - see that wrapper
+        for why."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "chat":
+            raise SceneError(f"node is not a chat node: {node_id}")
+        parent_edge = next((e for e in self.edges.values() if e.target == node_id), None)
+        if parent_edge is None:
+            raise SceneError(f"node has no parent and cannot be regenerated: {node_id}")
+        return node, parent_edge.source
+
+    def update_chat_node_content(self, node_id: str, content: str) -> SceneNode:
+        """The regenerate primitive: mutate an EXISTING chat node's content in
+        place - the first in-place mutation of a content-bearing field in this
+        file (move_node/set_chat_collapsed/set_node_docked all mutate a
+        position/flag, never displayed text). Scope confirmed against legacy's
+        ChatNode.update_content (graphlink_nodes/graphlink_node_chat.py:677-686):
+        sets content ONLY. Does not touch title (legacy's update_content never
+        recomputes any title-like state either, and every other in-place mutator
+        here already leaves title untouched post-creation - consistent, not a
+        new carve-out). Does not touch is_user/is_collapsed/kind."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.content = str(content)
+        return node
+
+    def remove_associated_content_children(self, chat_node_id: str) -> None:
+        """The regenerate teardown: remove every code/document/image/thinking
+        node ONE HOP directly off chat_node_id. Built entirely on the existing
+        generic remove_nodes (edge cleanup + image-asset eviction come free).
+        Mirrors graphlink_scene.py's remove_associated_content_nodes exactly in
+        SCOPE (one-hop only, same four kinds, no cascade to any grandchild) but
+        resolved via this backend's one edge-encoded parent/child relationship
+        instead of legacy's four parallel per-kind lists. html/conversation
+        kinds are excluded on purpose - grep confirms neither ever has a
+        parent_content_node attribute in legacy, so they structurally can never
+        attach to a ChatNode this way."""
+        child_ids = []
+        for edge in self.edges.values():
+            if edge.source != chat_node_id:
+                continue
+            child = self.nodes.get(edge.target)
+            if child is not None and child.kind in ("code", "document", "image", "thinking"):
+                child_ids.append(child.id)
+        self.remove_nodes(child_ids)
+
     def set_chat_collapsed(self, node_id: str, collapsed: bool) -> None:
         node = self.nodes.get(node_id)
         if node is None:
@@ -1100,6 +1157,93 @@ def register_canvas(
         )
         return node.id
 
+    async def regenerate_response(node_id):
+        try:
+            node_to_regenerate, parent_id = document.regenerate_response(node_id)
+        except SceneError:
+            # Deliberate: ALL THREE of regenerate_response's SceneErrors funnel
+            # into this ONE legacy-parity message. app.py's _handle_message
+            # would otherwise turn a raised SceneError into a generic
+            # "intent failed" WS error - and transport.ts's intent() is
+            # fire-and-forget (no id), so that error is ONLY ever
+            # console.error'd, never shown to the user (confirmed by reading
+            # transport.ts's handleMessage). A stale click racing a delete, or
+            # a future caller passing a bad kind, must never go silently to the
+            # console when legacy's real, reachable case shows a visible
+            # banner - so this is the one deliberate divergence from every
+            # other register_canvas wrapper's convention of letting SceneError
+            # bubble to the generic WS error path.
+            notifications.show("This node has no parent and cannot be regenerated.", "warning")
+            await bus.publish("notification")
+            return None
+
+        history = document.chat_branch_history(parent_id)
+
+        async def _on_reply(reply_text):
+            # (1) Empty/whitespace reply: keep ORIGINAL content, notify, stop.
+            # Checked FIRST - exact legacy order (window_actions.py:544-546),
+            # even before the liveness check below (see its own comment).
+            if not reply_text or not reply_text.strip():
+                notifications.show(
+                    "The model returned an empty response. The original response has been kept.",
+                    "warning",
+                )
+                await bus.publish("notification")
+                return
+
+            # (2) Deleted mid-flight: silent no-op, matches
+            # window_actions.py:548 (`if not old_node or not old_node.scene():
+            # return` - no notification_banner call there either).
+            if node_to_regenerate.id not in document.nodes:
+                return
+
+            # (3) Teardown BEFORE parse/mutate - exact legacy step order.
+            # Runs unconditionally on any non-empty, still-alive reply, even if
+            # the new reply has no code/thinking parts at all - this is why
+            # document/image children are deleted but never recreated
+            # (parse_response structurally only emits thinking/text/code).
+            document.remove_associated_content_children(node_to_regenerate.id)
+
+            parsed_parts = parse_response(reply_text)
+            text_parts = [p["content"] for p in parsed_parts if p["type"] == "text"]
+            text_content = "\n\n".join(text_parts)
+
+            # THE SIMPLE 1-WAY TERNARY - NOT send_message's 3-way priority
+            # chain. PLACEHOLDER_ASSISTANT_REASONING is NEVER touched by this
+            # path. Exact match to legacy line 561:
+            # `text_content if text_content else "[Generated Content]"`.
+            placeholder_text = text_content if text_content else PLACEHOLDER_GENERATED_CONTENT
+            document.update_chat_node_content(node_to_regenerate.id, placeholder_text)
+
+            # NOTE: `document.` prefix is REQUIRED - bare add_code_node/
+            # add_thinking_node would silently resolve to this same
+            # register_canvas scope's own WS-intent wrapper closures instead of
+            # raising (identical hazard already documented on send_message's
+            # own _on_reply above this function).
+            bx, by = node_to_regenerate.x, node_to_regenerate.y
+            for part in parsed_parts:
+                if part["type"] == "thinking":
+                    document.add_thinking_node(
+                        bx - MESSAGE_VERTICAL_SPACING, by + MESSAGE_VERTICAL_SPACING,
+                        part["content"], parent_id=node_to_regenerate.id,
+                    )
+                elif part["type"] == "code":
+                    document.add_code_node(
+                        bx + MESSAGE_VERTICAL_SPACING, by + MESSAGE_VERTICAL_SPACING,
+                        part["content"], part["language"], parent_id=node_to_regenerate.id,
+                    )
+
+            # last_chat_node_id: DELIBERATELY untouched. See §5.
+
+        await agent_dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=history,
+            on_reply=_on_reply,
+        )
+        return node_to_regenerate.id
+
     async def move_node(node_id, x, y):
         document.move_node(node_id, x, y)
         await publish_scene()
@@ -1165,6 +1309,7 @@ def register_canvas(
     bus.register_intent("scene", "deleteChatNode", delete_chat_node)
     bus.register_intent("scene", "setChatCollapsed", set_chat_collapsed)
     bus.register_intent("scene", "sendMessage", send_message)
+    bus.register_intent("scene", "regenerateResponse", regenerate_response)
     bus.register_intent("scene", "moveNode", move_node)
     bus.register_intent("scene", "removeNodes", remove_nodes)
     bus.register_intent("scene", "connectNodes", connect_nodes)

--- a/backend/response_parsing.py
+++ b/backend/response_parsing.py
@@ -10,11 +10,12 @@ thinking-kind and code-kind CHILD nodes for the rest - instead of dumping the
 model's raw, unprocessed reply (complete with <think> tags, <code_block>
 wrappers, and/or ```fenced``` code) into a single flat node.
 
-Only the ordinary send path (backend/canvas.py's send_message) is retrofitted
-onto this module for now; the regenerate path and ConversationNode remain
-out of scope for this increment (ConversationNode never called
-_parse_response in legacy either - see backend/canvas.py's
-send_conversation_message for that confirmed exemption).
+Both real paths now depend on this module: the ordinary send path
+(backend/canvas.py's send_message, R4.3b) and the regenerate path
+(backend/canvas.py's regenerate_response, R4.3c) each call parse_response
+directly. ConversationNode remains the one confirmed exemption -
+ConversationNode never called _parse_response in legacy either, see
+backend/canvas.py's send_conversation_message for that.
 """
 
 from __future__ import annotations

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -1074,6 +1074,538 @@ def test_chat_branch_history_does_not_error_on_an_unknown_node_id():
     assert doc.chat_branch_history("ghost") == []
 
 
+# -- R4.3c: regenerate response (domain-level) --------------------------------
+
+
+def test_regenerate_response_returns_node_and_parent_id_for_a_valid_chat_node():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "question", True)
+    child = doc.add_chat_node(0, 160, "answer", False, parent_id=parent.id)
+    node, parent_id = doc.regenerate_response(child.id)
+    assert node is child
+    assert parent_id == parent.id
+
+
+def test_regenerate_response_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().regenerate_response("ghost")
+
+
+def test_regenerate_response_non_chat_node_raises_scene_error():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "question", True)
+    code_node = doc.add_code_node(10, 10, "x = 1", "python", parent_id=parent.id)
+    with pytest.raises(SceneError):
+        doc.regenerate_response(code_node.id)
+
+
+def test_regenerate_response_node_without_parent_raises_scene_error():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root question", True)
+    with pytest.raises(SceneError):
+        doc.regenerate_response(root.id)
+
+
+def test_update_chat_node_content_mutates_content_only_leaves_title_and_flags_untouched():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "original content", False)
+    original_title = node.title
+    returned = doc.update_chat_node_content(node.id, "new content")
+    assert returned is node
+    assert node.content == "new content"
+    assert node.title == original_title
+    assert node.is_user is False
+    assert node.is_collapsed is False
+    assert node.kind == "chat"
+
+
+def test_update_chat_node_content_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().update_chat_node_content("ghost", "text")
+
+
+def test_remove_associated_content_children_removes_direct_code_document_image_thinking_children():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "assistant reply", False)
+    code = doc.add_code_node(10, 10, "x = 1", "python", parent_id=chat.id)
+    document_node = doc.add_document_node(20, 20, "file.txt", "content", "document", chat.id)
+    image_node = doc.add_image_node(30, 30, b"bytes", "prompt", chat.id)
+    thinking = doc.add_thinking_node(40, 40, "reasoning", chat.id)
+    sibling = doc.add_chat_node(50, 50, "sibling", True)
+
+    doc.remove_associated_content_children(chat.id)
+
+    assert code.id not in doc.nodes
+    assert document_node.id not in doc.nodes
+    assert image_node.id not in doc.nodes
+    assert thinking.id not in doc.nodes
+    assert sibling.id in doc.nodes, "an unrelated sibling chat node must survive"
+    assert chat.id in doc.nodes, "the chat node itself must survive"
+
+
+def test_remove_associated_content_children_evicts_image_assets_via_remove_nodes():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "assistant reply", False)
+    image_node = doc.add_image_node(10, 10, b"doomed bytes", "prompt", chat.id)
+    asset_id = image_node.image_asset_id
+    assert doc.get_image_asset(asset_id) is not None
+
+    doc.remove_associated_content_children(chat.id)
+
+    assert doc.get_image_asset(asset_id) is None, (
+        "built on top of remove_nodes - asset eviction must come free, not be reimplemented"
+    )
+
+
+def test_remove_associated_content_children_is_one_hop_only():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "assistant reply", False)
+    code_child = doc.add_code_node(10, 10, "x = 1", "python", parent_id=chat.id)
+    grandchild = doc.add_code_node(20, 20, "y = 2", "python")
+    doc.connect(code_child.id, grandchild.id)
+
+    doc.remove_associated_content_children(chat.id)
+
+    assert code_child.id not in doc.nodes
+    assert grandchild.id in doc.nodes, "no cascade past the direct one-hop children"
+
+
+def test_remove_associated_content_children_noop_when_no_content_children_exist():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "assistant reply", False)
+    before_nodes = dict(doc.nodes)
+    doc.remove_associated_content_children(chat.id)
+    assert doc.nodes == before_nodes
+
+
+# -- R4.3c: regenerate response (WS-intent level) -----------------------------
+
+
+def test_regenerate_response_intent_mutates_the_existing_node_in_place_not_a_new_one():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "original reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["hi"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
+        assert assistant_node.content == "original reply"
+        node_count_before = len(document.nodes)
+
+        def regenerated_reply(task, messages, **kwargs):
+            return {"message": {"content": "regenerated reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", regenerated_reply):
+            returned_id = await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assert returned_id == assistant_node.id, "the same node id, never a new node"
+        assert assistant_node.id in document.nodes
+        assert document.nodes[assistant_node.id].content == "regenerated reply"
+        assert len(document.nodes) == node_count_before, "no new node was created"
+
+    asyncio.run(run())
+
+
+def test_regenerate_response_replaces_code_child_not_accumulates():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "Here:\n\n```python\nprint('one')\n```"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["write code"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
+        assert len([n for n in document.nodes.values() if n.kind == "code"]) == 1
+
+        def second_reply(task, messages, **kwargs):
+            return {"message": {"content": "Now:\n\n```python\nprint('two')\n```"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", second_reply):
+            await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        code_nodes = [n for n in document.nodes.values() if n.kind == "code"]
+        assert len(code_nodes) == 1, "the old code child must be replaced, not accumulated"
+        assert code_nodes[0].code == "print('two')"
+
+    asyncio.run(run())
+
+
+def test_regenerate_response_document_and_image_children_torn_down_but_never_recreated():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "original reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["attach files"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
+        # Simulate a prior real attachment - manually attached, since
+        # send_message's own _on_reply never creates document/image children.
+        document_node = document.add_document_node(0, 0, "file.txt", "content", "document", assistant_node.id)
+        image_node = document.add_image_node(0, 0, b"bytes", "prompt", assistant_node.id)
+
+        def plain_reply(task, messages, **kwargs):
+            return {"message": {"content": "just plain text, no attachments"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", plain_reply):
+            await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assert document_node.id not in document.nodes
+        assert image_node.id not in document.nodes
+        assert not any(n.kind in ("document", "image") for n in document.nodes.values()), (
+            "torn down but never recreated - parse_response structurally never emits document/image parts"
+        )
+
+    asyncio.run(run())
+
+
+def test_regenerate_response_empty_reply_keeps_original_content_and_notifies():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "Here's code:\n\n```python\nprint('original')\n```"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["show me code"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
+        assert assistant_node.content == "Here's code:"
+        node_ids_before = set(document.nodes)
+
+        def empty_reply(task, messages, **kwargs):
+            return {"message": {"content": "   \n\n  "}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", empty_reply):
+            await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assert document.nodes[assistant_node.id].content == "Here's code:", "original content is kept"
+        assert set(document.nodes) == node_ids_before, "existing children must be untouched"
+        notice = await bus.publish("notification")
+        assert notice["visible"] is True
+        assert notice["msgType"] == "warning"
+        assert notice["message"] == (
+            "The model returned an empty response. The original response has been kept."
+        )
+
+    asyncio.run(run())
+
+
+def test_regenerate_response_reasoning_only_reply_uses_generated_content_not_reasoning_placeholder():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "original reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["think about it"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
+
+        def reasoning_only_reply(task, messages, **kwargs):
+            return {"message": {"content": "<think>pondering deeply</think>"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", reasoning_only_reply):
+            await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        # The critical differentiator: regenerate's ternary is 1-way, unlike
+        # send_message's 3-way priority chain - a reasoning-only reply must
+        # fall back to the GENERATED-content placeholder, never the
+        # reasoning-specific one.
+        assert document.nodes[assistant_node.id].content == "[Generated Content]"
+        assert document.nodes[assistant_node.id].content != "[Assistant Reasoning]"
+
+        thinking_nodes = [n for n in document.nodes.values() if n.kind == "thinking"]
+        assert len(thinking_nodes) == 1
+        assert thinking_nodes[0].content == "pondering deeply"
+
+    asyncio.run(run())
+
+
+def test_regenerate_response_node_deleted_mid_flight_is_a_silent_noop():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "original reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["hi"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_chat(task, messages, **kwargs):
+            started.set()
+            release.wait(5)
+            return {"message": {"content": "regenerated reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", blocking_chat):
+            returned_id = await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
+            assert returned_id == assistant_node.id
+
+            await asyncio.to_thread(started.wait, 5)
+            document.remove_nodes([assistant_node.id])
+
+            release.set()
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assert assistant_node.id not in document.nodes
+        notice = await bus.publish("notification")
+        assert notice["visible"] is False, "deleted-mid-flight is a silent no-op - no notification fires"
+
+    asyncio.run(run())
+
+
+def test_regenerate_response_unknown_node_id_shows_notification_not_a_crash():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        result = await bus.dispatch_intent("scene", "regenerateResponse", ["ghost"])
+
+        assert result is None
+        assert dispatcher._requests == {}, "no dispatch was ever scheduled"
+        notice = await bus.publish("notification")
+        assert notice["visible"] is True
+        assert notice["msgType"] == "warning"
+        assert notice["message"] == "This node has no parent and cannot be regenerated."
+
+    asyncio.run(run())
+
+
+def test_regenerate_response_shares_the_single_in_flight_guard():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "original reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["hi"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_chat(task, messages, **kwargs):
+            started.set()
+            release.wait(5)
+            return {"message": {"content": "second message reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", blocking_chat):
+            # Occupy the single in-flight slot with an ordinary sendMessage.
+            await bus.dispatch_intent("scene", "sendMessage", ["second message"])
+            await asyncio.to_thread(started.wait, 5)
+            assert len(dispatcher._requests) == 1
+
+            returned = await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
+            # Validation (a real chat node with a parent) still succeeds - the
+            # guard lives one layer deeper, inside AgentDispatcher._dispatch.
+            assert returned == assistant_node.id
+            assert len(dispatcher._requests) == 1, "still just the original sendMessage in flight"
+
+            notice = await bus.publish("notification")
+            assert notice["visible"] is True
+            assert notice["message"] == "A response is already being generated."
+
+            release.set()
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+    asyncio.run(run())
+
+
+def test_regenerate_response_of_a_non_tip_node_leaves_last_chat_node_id_untouched():
+    # R4.3c design spec section 5's load-bearing rule: regenerating an OLDER,
+    # non-tip node must never rewind last_chat_node_id back to it - only
+    # send_message (creating a brand-new node) or delete_chat_node (removing
+    # the tip itself) ever move that pointer. A regenerate mutates
+    # node_to_regenerate in place without changing its id, so if it is not
+    # already the tip, it must not become the tip just by being regenerated.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "first reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            user1_id = await bus.dispatch_intent("scene", "sendMessage", ["first"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        old_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user1_id)
+
+        def second_reply(task, messages, **kwargs):
+            return {"message": {"content": "second reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", second_reply):
+            await bus.dispatch_intent("scene", "sendMessage", ["second"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        tip_id = document.last_chat_node_id
+        assert tip_id != old_node.id, "the branch must have advanced past old_node by now"
+
+        def regenerated_reply(task, messages, **kwargs):
+            return {"message": {"content": "regenerated content"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", regenerated_reply):
+            await bus.dispatch_intent("scene", "regenerateResponse", [old_node.id])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assert document.last_chat_node_id == tip_id, \
+            "regenerating an older node must never rewind the active branch tip"
+        assert old_node.content == "regenerated content"
+
+    asyncio.run(run())
+
+
+def test_regenerate_response_shares_the_single_in_flight_guard_in_reverse():
+    # Mirror of test_regenerate_response_shares_the_single_in_flight_guard:
+    # this occupies the slot with a regenerateResponse first, then asserts a
+    # concurrent ordinary sendMessage is bounced. Both directions exercise
+    # the exact same AgentDispatcher._dispatch guard (`if self._requests:`),
+    # caller-agnostic - see backend/tests/test_agents.py's own cross-channel
+    # guard tests for the underlying primitive this is layered on top of.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "original reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["hi"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_chat(task, messages, **kwargs):
+            started.set()
+            release.wait(5)
+            return {"message": {"content": "regenerated reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", blocking_chat):
+            # Occupy the single in-flight slot with a regenerateResponse this time.
+            await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
+            await asyncio.to_thread(started.wait, 5)
+            assert len(dispatcher._requests) == 1
+
+            returned = await bus.dispatch_intent("scene", "sendMessage", ["second message"])
+            # sendMessage's own domain mutation (a new user ChatNode) still
+            # happens unconditionally - the guard lives one layer deeper,
+            # inside AgentDispatcher._dispatch, same as the forward direction.
+            assert returned is not None
+            assert len(dispatcher._requests) == 1, "still just the original regenerateResponse in flight"
+
+            notice = await bus.publish("notification")
+            assert notice["visible"] is True
+            assert notice["message"] == "A response is already being generated."
+
+            release.set()
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+    asyncio.run(run())
+
+
 def test_drag_factor_is_bounded():
     doc = SceneDocument()
     doc.set_drag_factor(99)

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -16,6 +16,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   const onToggleCollapse = vi.fn();
   const onDelete = vi.fn();
   const onUndockChild = vi.fn();
+  const onRegenerate = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -27,6 +28,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
       onToggleCollapse,
       onDelete,
       onUndockChild,
+      onRegenerate,
       ...overrides,
     },
   } as unknown as NodeProps<ChatFlowNode>;
@@ -36,7 +38,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
       <ChatNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onToggleCollapse, onDelete, onUndockChild };
+  return { onToggleCollapse, onDelete, onUndockChild, onRegenerate };
 }
 
 describe("ChatNodeView", () => {
@@ -70,9 +72,6 @@ describe("ChatNodeView", () => {
     fireEvent.contextMenu(role);
     expect(screen.getByRole("menu")).toBeInTheDocument();
 
-    const regenerate = screen.getByRole("menuitem", { name: "Regenerate Response" });
-    expect(regenerate).toBeDisabled();
-    expect(regenerate).toHaveAttribute("title", "Agent regeneration lands in R4");
     const exportItem = screen.getByRole("menuitem", { name: "Export" });
     expect(exportItem).toBeDisabled();
     expect(exportItem).toHaveAttribute("title", "Export lands in R6");
@@ -99,6 +98,19 @@ describe("ChatNodeView", () => {
     renderChatNode({ isUser: true });
     fireEvent.contextMenu(screen.getByText("You"));
     expect(screen.queryByRole("menuitem", { name: "Regenerate Response" })).toBeNull();
+  });
+
+  it("Regenerate Response is a real, enabled item for an assistant message that calls onRegenerate then closes the menu", async () => {
+    const user = userEvent.setup();
+    const { onRegenerate } = renderChatNode({ isUser: false });
+
+    fireEvent.contextMenu(screen.getByText("Assistant"));
+    const regenerate = screen.getByRole("menuitem", { name: "Regenerate Response" });
+    expect(regenerate).not.toBeDisabled();
+
+    await user.click(regenerate);
+    expect(onRegenerate).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull(); // onClose fires after onRegenerate
   });
 
   it("Escape and outside-click both close the menu", async () => {

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -28,7 +28,9 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * more docked children - can now be real (a thinking node docks via its own
  * "Dock to Parent Node" action), so it's implemented for real below, gated
  * on dockedChildren.length > 0 exactly like the legacy's own `if
- * docked_children:` guard.
+ * docked_children:` guard. "Regenerate Response" is likewise no longer
+ * deferred as of R4.3c: it now calls the real regenerateResponse intent,
+ * still gated on !isUser (matching the legacy is_user guard).
  */
 
 export interface ChatNodeData extends Record<string, unknown> {
@@ -39,6 +41,7 @@ export interface ChatNodeData extends Record<string, unknown> {
   onToggleCollapse: () => void;
   onDelete: () => void;
   onUndockChild: (childId: string) => void;
+  onRegenerate: () => void;
 }
 
 export type ChatFlowNode = Node<ChatNodeData, "chat">;
@@ -57,6 +60,7 @@ function ChatNodeMenu({
   onToggleCollapse,
   onDelete,
   onUndockChild,
+  onRegenerate,
   onClose,
 }: {
   position: MenuPosition;
@@ -67,6 +71,7 @@ function ChatNodeMenu({
   onToggleCollapse: () => void;
   onDelete: () => void;
   onUndockChild: (childId: string) => void;
+  onRegenerate: () => void;
   onClose: () => void;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
@@ -170,7 +175,14 @@ function ChatNodeMenu({
         Delete Node
       </button>
       {!isUser && (
-        <button type="button" role="menuitem" disabled title="Agent regeneration lands in R4">
+        <button
+          type="button"
+          role="menuitem"
+          onClick={() => {
+            onRegenerate();
+            onClose();
+          }}
+        >
           Regenerate Response
         </button>
       )}
@@ -229,6 +241,7 @@ export function ChatNodeView({ data, selected }: NodeProps<ChatFlowNode>) {
           onToggleCollapse={data.onToggleCollapse}
           onDelete={data.onDelete}
           onUndockChild={data.onUndockChild}
+          onRegenerate={data.onRegenerate}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/CodeNodeView.test.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.test.tsx
@@ -8,12 +8,15 @@ import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
 // ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too.
 function renderCodeNode(overrides: Partial<CodeFlowNode["data"]> = {}) {
   const onDelete = vi.fn();
+  const onRegenerate = vi.fn();
   const props = {
     id: "n0",
     selected: false,
     data: {
       code: "def add(a, b):\n    return a + b",
       language: "python",
+      parentChatNodeId: "chat-1",
+      onRegenerate,
       onDelete,
       ...overrides,
     },
@@ -24,7 +27,7 @@ function renderCodeNode(overrides: Partial<CodeFlowNode["data"]> = {}) {
       <CodeNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onDelete, container };
+  return { onDelete, onRegenerate, container };
 }
 
 describe("CodeNodeView", () => {
@@ -42,7 +45,7 @@ describe("CodeNodeView", () => {
     expect(screen.getByText("code")).toBeInTheDocument();
   });
 
-  it("right-click opens a menu with real Copy Code/Delete Code Block and deferred Regenerate/Export", async () => {
+  it("right-click opens a menu with real Copy Code/Delete Code Block and deferred Export", async () => {
     const user = userEvent.setup();
     const { onDelete } = renderCodeNode();
 
@@ -53,9 +56,6 @@ describe("CodeNodeView", () => {
     fireEvent.contextMenu(label);
     expect(screen.getByRole("menu")).toBeInTheDocument();
 
-    const regenerate = screen.getByRole("menuitem", { name: "Regenerate Response" });
-    expect(regenerate).toBeDisabled();
-    expect(regenerate).toHaveAttribute("title", "Agent regeneration lands in R4");
     const exportItem = screen.getByRole("menuitem", { name: "Export" });
     expect(exportItem).toBeDisabled();
     expect(exportItem).toHaveAttribute("title", "Export lands in R6");
@@ -69,6 +69,25 @@ describe("CodeNodeView", () => {
     fireEvent.contextMenu(label);
     await user.click(screen.getByRole("menuitem", { name: "Delete Code Block" }));
     expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Regenerate Response renders enabled and fires onRegenerate then closes the menu when parentChatNodeId is non-null", async () => {
+    const user = userEvent.setup();
+    const { onRegenerate } = renderCodeNode({ parentChatNodeId: "chat-1" });
+
+    fireEvent.contextMenu(screen.getByText("python"));
+    const regenerate = screen.getByRole("menuitem", { name: "Regenerate Response" });
+    expect(regenerate).not.toBeDisabled();
+
+    await user.click(regenerate);
+    expect(onRegenerate).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("Regenerate Response is absent from the DOM entirely (not merely disabled) when parentChatNodeId is null", () => {
+    renderCodeNode({ parentChatNodeId: null });
+    fireEvent.contextMenu(screen.getByText("python"));
+    expect(screen.queryByRole("menuitem", { name: "Regenerate Response" })).toBeNull();
   });
 
   it("Escape and outside-click both close the menu", async () => {

--- a/web_ui/src/app/canvas/CodeNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.tsx
@@ -14,10 +14,13 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * via the same react-markdown + rehype-highlight pipeline chat nodes already
  * pull in - no new highlighter dependency), delete (generic cascade-delete;
  * code nodes are never branch points, so there's no reparent rule to honor),
- * copy. Deferred, with an honest disabled+title label rather than a silent
+ * copy, and (as of R4.3c) Regenerate Response - conditionally rendered
+ * (not merely disabled) on parentChatNodeId being non-null, matching
+ * legacy's own menu-build-time `if self.node.parent_content_node:` gate.
+ * Deferred, with an honest disabled+title label rather than a silent
  * drop (an R3.4 live-drive audit found the legacy CodeNode menu's branch-
  * visibility item had been dropped with zero acknowledgment - fixed here):
- * Regenerate (R4), Export (R6), and Hide Other Branches (the legacy scene's
+ * Export (R6) and Hide Other Branches (the legacy scene's
  * branch-visibility toggle has no backend/frontend equivalent at all yet -
  * unscoped, not owned by any R-phase).
  */
@@ -25,6 +28,13 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 export interface CodeNodeData extends Record<string, unknown> {
   code: string;
   language: string;
+  // R4.3c: parentChatNodeId is the one-hop-derived parent (see SceneCanvas's
+  // toFlowNodes) - null for a parentless code node. Drives whether the
+  // Regenerate Response menu item renders at all (see CodeNodeMenu below),
+  // matching legacy's own menu-build-time `if self.node.parent_content_node:`
+  // gate rather than merely disabling the item.
+  parentChatNodeId: string | null;
+  onRegenerate: () => void;
   onDelete: () => void;
 }
 
@@ -45,11 +55,15 @@ function toFencedCodeBlock(code: string, language: string): string {
 function CodeNodeMenu({
   position,
   code,
+  parentChatNodeId,
+  onRegenerate,
   onDelete,
   onClose,
 }: {
   position: MenuPosition;
   code: string;
+  parentChatNodeId: string | null;
+  onRegenerate: () => void;
   onDelete: () => void;
   onClose: () => void;
 }) {
@@ -95,9 +109,18 @@ function CodeNodeMenu({
       <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
         Hide Other Branches
       </button>
-      <button type="button" role="menuitem" disabled title="Agent regeneration lands in R4">
-        Regenerate Response
-      </button>
+      {parentChatNodeId && (
+        <button
+          type="button"
+          role="menuitem"
+          onClick={() => {
+            onRegenerate();
+            onClose();
+          }}
+        >
+          Regenerate Response
+        </button>
+      )}
       <button
         type="button"
         role="menuitem"
@@ -142,6 +165,8 @@ export function CodeNodeView({ data, selected }: NodeProps<CodeFlowNode>) {
         <CodeNodeMenu
           position={menuPosition}
           code={data.code}
+          parentChatNodeId={data.parentChatNodeId}
+          onRegenerate={data.onRegenerate}
           onDelete={data.onDelete}
           onClose={() => setMenuPosition(null)}
         />

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { toFlowNodes } from "./SceneCanvas";
+import { SceneStore, initialSceneState } from "./sceneStore";
+import type { WsTransport } from "../../lib/ws/transport";
+import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
+
+// toFlowNodes is exported standalone specifically so this doesn't need a
+// full <ReactFlow> mount (same reasoning as sceneStore.test.ts's direct
+// scaleDragPosition coverage) - see SceneCanvas.tsx's own comment on the
+// export.
+
+function makeStore(): SceneStore {
+  const transport = { subscribe: vi.fn(), intent: vi.fn() } as unknown as WsTransport;
+  return new SceneStore(transport);
+}
+
+function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
+  return {
+    id: "n0",
+    x: 0,
+    y: 0,
+    title: "",
+    kind: "placeholder",
+    content: "",
+    isUser: false,
+    isCollapsed: false,
+    code: "",
+    language: "",
+    attachmentKind: "",
+    filePath: "",
+    mimeType: "",
+    durationSeconds: null,
+    byteSize: null,
+    previewLabel: "",
+    isDocked: false,
+    imageAssetId: "",
+    history: [],
+    pendingRequestId: null,
+    ...overrides,
+  };
+}
+
+function baseScene(overrides: Partial<SceneState> = {}): SceneState {
+  return {
+    ...initialSceneState,
+    ...overrides,
+  };
+}
+
+describe("toFlowNodes (R4.3c parentChatNodeId derivation)", () => {
+  it("a code node with a parent edge yields the correct parentChatNodeId, and its onRegenerate calls regenerateResponse with that id", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "chat-1", kind: "chat", content: "Hello" }),
+        baseNode({ id: "code-1", kind: "code", code: "print(1)", language: "python" }),
+      ],
+      edges: [{ id: "e1", source: "chat-1", target: "code-1" }],
+    });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "regenerateResponse");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const codeFlowNode = flowNodes.find((n) => n.id === "code-1");
+    expect(codeFlowNode).toBeDefined();
+    expect((codeFlowNode!.data as { parentChatNodeId: string | null }).parentChatNodeId).toBe("chat-1");
+
+    (codeFlowNode!.data as { onRegenerate: () => void }).onRegenerate();
+    expect(intentSpy).toHaveBeenCalledWith("chat-1");
+  });
+
+  it("a code node with no parent edge yields parentChatNodeId: null, and its onRegenerate is a no-op", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "code-orphan", kind: "code", code: "print(1)", language: "python" })],
+      edges: [],
+    });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "regenerateResponse");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const codeFlowNode = flowNodes.find((n) => n.id === "code-orphan");
+    expect(codeFlowNode).toBeDefined();
+    expect((codeFlowNode!.data as { parentChatNodeId: string | null }).parentChatNodeId).toBeNull();
+
+    (codeFlowNode!.data as { onRegenerate: () => void }).onRegenerate();
+    expect(intentSpy).not.toHaveBeenCalled();
+  });
+
+  it("a chat node's onRegenerate calls regenerateResponse with its own id", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hello", isUser: false })],
+      edges: [],
+    });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "regenerateResponse");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    expect(chatFlowNode).toBeDefined();
+
+    (chatFlowNode!.data as { onRegenerate: () => void }).onRegenerate();
+    expect(intentSpy).toHaveBeenCalledWith("chat-1");
+  });
+});

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -80,7 +80,10 @@ const NODE_TYPES = {
   conversation: ConversationNodeView,
 };
 
-function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
+// Exported standalone for direct unit testing (same posture as
+// scaleDragPosition in sceneStore.ts) - covers the parentChatNodeId
+// derivation below without needing a full <ReactFlow> mount.
+export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
   // Looked up per-chat-node below to build dockedChildren - a docked node is
   // omitted from the returned array entirely (see the "thinking" branch), so
   // this is the only remaining way a chat node's dock badge/menu can find it.
@@ -121,11 +124,20 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
           onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
           onDelete: () => store.deleteChatNode(n.id),
           onUndockChild: (childId: string) => store.setNodeDocked(childId, false),
+          onRegenerate: () => store.regenerateResponse(n.id),
         },
       });
       continue;
     }
     if (n.kind === "code") {
+      // parentChatNodeId: this code node's own one-hop parent lookup - the
+      // new stack's equivalent of legacy's CodeNode.parent_content_node,
+      // resolved client-side (same one-hop-via-edges style as
+      // dockedChildren above) since the backend never kind-sniffs a code
+      // node id back to its parent chat node (see regenerateResponse's own
+      // comment above and SceneCanvas's regenerate-response design notes).
+      const parentEdge = scene.edges.find((e) => e.target === n.id);
+      const parentChatNodeId = parentEdge ? parentEdge.source : null;
       flowNodes.push({
         id: n.id,
         type: "code" as const,
@@ -133,6 +145,10 @@ function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
         data: {
           code: n.code,
           language: n.language,
+          parentChatNodeId,
+          onRegenerate: () => {
+            if (parentChatNodeId) store.regenerateResponse(parentChatNodeId);
+          },
           onDelete: () => store.removeNodes([n.id]),
         },
       });

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -247,6 +247,13 @@ describe("SceneStore", () => {
     expect(intents).toEqual([{ topic: "scene", intent: "cancelChatRequest", args: ["req-42"] }]);
   });
 
+  it("regenerateResponse sends the scene-topic regenerateResponse intent with the chat node id", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.regenerateResponse("n1");
+    expect(intents).toEqual([{ topic: "scene", intent: "regenerateResponse", args: ["n1"] }]);
+  });
+
   it("suppresses empty removal intents", () => {
     const { transport, intents } = makeFakeTransport();
     const store = new SceneStore(transport);

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -284,6 +284,13 @@ export class SceneStore {
     this.transport.intent("scene", "setNodeDocked", [id, docked]);
   }
 
+  // R4.3c: real Regenerate Response, for both ChatNodeView's own menu and
+  // CodeNodeView's menu (which resolves to its parent chat node's id before
+  // calling this - see toFlowNodes below; the backend never kind-sniffs).
+  regenerateResponse(chatNodeId: string): void {
+    this.transport.intent("scene", "regenerateResponse", [chatNodeId]);
+  }
+
   // R3.3: the Composer's real Send action - a real user ChatNode. The
   // assistant's reply is deferred to R4 (graphlink_config.py's Qt/non-Qt
   // split is a prerequisite for calling the real agent layer); the backend


### PR DESCRIPTION
## Summary
- Ports legacy's `regenerate_node`/`handle_regenerated_response`: real in-place regeneration of an existing assistant ChatNode, reachable from both ChatNode's own "Regenerate Response" menu item and CodeNode's (which resolves to its owning chat node client-side first).
- Three new `SceneDocument` methods (`regenerate_response`, `update_chat_node_content` — the first in-place content mutation in `backend/canvas.py` — and `remove_associated_content_children`, a one-hop teardown built on the existing generic `remove_nodes`), plus a `regenerateResponse` WS intent that reuses `AgentDispatcher.start_chat_reply` completely unchanged (legacy already shares its single dispatch slot between ordinary send and regenerate — this is a port of that sharing, not a new simplification).
- Three distinct empty/edge-case behaviors kept unconflated, each matching the true legacy source: an empty/whitespace reply keeps the original content and children untouched with a "kept" notification; a node deleted mid-flight is a silent no-op; a normal reply tears down old code/document/image/thinking children before reparsing and mutating content in place, using the simpler 1-way placeholder rule regenerate actually uses (not `send_message`'s 3-way priority chain).
- `last_chat_node_id` is deliberately never written by this feature, in either direction — regenerating an older, non-tip node must never rewind the active branch.
- One small, precedented shared-pipeline change: `AgentDispatcher._dispatch` now supports an async `on_reply` (needed so the empty-reply case can await a notification publish), via the same `iscoroutinefunction` idiom already used in `backend/events.py`. Zero behavior change for existing sync callers (`send_message`, `ConversationNode`).

## Process
- Fresh recon+cross-check+design pass (3 agents) resolved every open question decisively, including a real scope reduction: `chat_branch_history(parent_id)` already substitutes for legacy's parent-anchored history with zero new method needed.
- Parallel backend+frontend implementation, each independently green (142/142 + 220/220 full backend suite; 694/694 vitest + clean `tsc`).
- 4-way adversarial review (backend-correctness/frontend-correctness/cross-boundary-integration/legacy-parity-audit) returned all PASS with zero blockers or majors — the cleanest review pass this session. One minor (stale docstring) and two test-coverage nits (protecting the `last_chat_node_id` invariant and the reverse single-in-flight-guard direction) were fixed before shipping.
- Live-drive verified against a real, locally-installed Ollama model across two consecutive regenerate cycles: same assistant node id throughout (in-place mutation, not a new node), old code/thinking children genuinely torn down, fresh node ids minted for the recreated ones, node count held steady with no orphaned nodes, and a follow-up ordinary send correctly continued from the regenerated node.

## Test plan
- [x] `python -m pytest -q` — 1995 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 694 passed
- [x] `python graphlink_island_codegen.py --check` — up to date
- [x] Live WS drive against the real backend + real Ollama model (two regenerate cycles + branch-continuation check)