### PR TITLE
Qt-removal R4.4a: Generate Image from Text + Regenerate Image

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -123,6 +123,25 @@ class AgentDispatcher:
         self._settings_manager = settings_manager
         # request_id -> {"cancel_event": threading.Event, "task": asyncio.Task}
         self._requests: dict[str, dict] = {}
+        # R4.4a: an INDEPENDENT in-flight slot for image generation, separate
+        # from self._requests (chat/conversation). Preserves legacy's real,
+        # verified concurrent capability - graphlink_window.py's
+        # self.chat_thread/self.image_gen_thread are separate, never-aliased
+        # attributes, so a chat request and an image-generation request
+        # genuinely run concurrently today. Reusing self._requests for image
+        # generation too would be a real, visible behavior regression (a user
+        # could no longer send a chat message while an image generates), so
+        # this stays a second, independent dict rather than a new key inside
+        # the existing one. Still single-slot PER KIND (one image request at
+        # a time, same as chat): legacy's generate_image() silently
+        # overwrites self.image_gen_thread with no guard if fired twice (a
+        # latent bug - the orphaned old QThread keeps running unreferenced),
+        # not a deliberate concurrent-multi-image feature; start_image_reply
+        # below gives an honest "already generating" refusal instead of
+        # replicating that hazard. request_id -> {"task": asyncio.Task} - no
+        # "cancel_event" key here, unlike self._requests: image generation
+        # has no cancellation at all (see start_image_reply's own docstring).
+        self._image_requests: dict[str, dict] = {}
 
     def persona(self) -> str:
         """Mirror legacy graphlink_window.py's `_get_current_system_prompt`:
@@ -289,6 +308,94 @@ class AgentDispatcher:
             on_end=lambda: setattr(node, "pending_request_id", None),
             state_topic="scene",
         )
+
+    async def start_image_reply(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        prompt: str,
+        on_reply,  # on_reply(image_bytes: bytes) -> None | Awaitable
+    ) -> None:
+        """R4.4a: the independent-slot counterpart to _dispatch, NOT a
+        variant of it - image generation has no conversation_history/
+        persona/on_begin/on_end/state_topic shape (there is no per-node
+        "generating" flag to toggle the way ComposerDocument.request_state or
+        a ConversationNode's pending_request_id do; the frontend shows a
+        transient "Generating image..." notification instead of a per-node
+        spinner). Guarded by self._image_requests, a dict kept fully
+        SEPARATE from self._requests (chat/conversation) - see that field's
+        own comment in __init__ for why this must stay independent rather
+        than reusing the existing single-slot guard.
+
+        No cancel_event is constructed or passed - api_provider.generate_image
+        has no cancellation_event parameter at all and its body has no
+        checkpoint to insert one at (it is one blocking network POST), and
+        legacy itself has zero real cancel affordance for image generation
+        either (ImageGenerationWorkerThread.stop() exists but is never called
+        from any UI path). The WATCHDOG_TIMEOUT_SECONDS ceiling IS still
+        applied here even though legacy has none for image generation - a
+        deliberate, explicitly-flagged improvement (leaving this as the only
+        dispatch surface with no ceiling against a hung external HTTP call
+        would be an unforced gap, not considered legacy design), not silent
+        parity.
+        """
+        if self._image_requests:
+            # Single in-flight-image-request-per-session guard, mirroring
+            # _dispatch's own "A response is already being generated." guard
+            # in shape but tracked on the independent self._image_requests
+            # dict, never self._requests.
+            notifications_state.show("An image is already being generated.", "info")
+            await bus.publish("notification")
+            return
+
+        request_id = uuid.uuid4().hex
+
+        async def _run():
+            try:
+                image_bytes = await asyncio.wait_for(
+                    asyncio.to_thread(api_provider.generate_image, prompt),
+                    timeout=WATCHDOG_TIMEOUT_SECONDS,
+                )
+                if inspect.iscoroutinefunction(on_reply):
+                    await on_reply(image_bytes)
+                else:
+                    on_reply(image_bytes)
+                # Unlike _dispatch, "scene" is NOT published here on success -
+                # on_reply itself (canvas.py's _dispatch_image._on_reply)
+                # already publishes "scene" after mutating the document, so a
+                # second unconditional publish here would be redundant.
+            except asyncio.TimeoutError:
+                notifications_state.show(
+                    "Image generation stopped responding before the request "
+                    "completed. Please try again.",
+                    "error",
+                )
+                await bus.publish("notification")
+            except Exception as exc:
+                # Catches api_provider.generate_image's real gating
+                # RuntimeErrors (not API mode / no client / Anthropic
+                # unsupported / no model configured / quota exceeded) and any
+                # other failure the same way, matching _dispatch's own
+                # generic "AI response failed: {exc}" catch-all shape - exc's
+                # own text is forwarded verbatim after one shared prefix so
+                # api_provider.py's distinct messages stay distinguishable to
+                # the user without the WS layer duplicating that gating
+                # knowledge.
+                logger.exception("image generation dispatch failed")
+                notifications_state.show(f"Image generation failed: {exc}", "error")
+                await bus.publish("notification")
+            finally:
+                # Unconditional on every exit path so the slot never leaks -
+                # a future request must always be admitted once this one is
+                # done, success or failure.
+                self._image_requests.pop(request_id, None)
+
+        # NOT awaited here, same load-bearing reason _dispatch's own _run
+        # task is not awaited inline - the WS connection's read loop must
+        # keep reading further messages on this same socket while a
+        # generation is in flight.
+        self._image_requests[request_id] = {"task": asyncio.create_task(_run())}
 
 
 def _call_chat_agent(conversation_history, persona_text, cancel_event) -> str:

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -86,6 +86,15 @@ class SceneError(ValueError):
     Raised so the WS layer reports it to the caller instead of crashing."""
 
 
+class SceneEmptyPromptError(SceneError):
+    """R4.4a: a distinct SceneError subclass carrying one extra bit of
+    information - the resolved node had no non-whitespace text to use as an
+    image-generation prompt. Kept as a real subclass (not a shared message
+    string on the base SceneError) so the WS wrapper in register_canvas can
+    tell "empty prompt" apart from "wrong kind/unknown node" via isinstance,
+    without string-sniffing exception text in production code."""
+
+
 CHAT_TITLE_PREVIEW_LENGTH = 60
 # R3.5: code titles are a language label plus first line, not prose, so a
 # shorter preview than chat's 60 is plenty.
@@ -746,6 +755,96 @@ class SceneDocument:
                 child_ids.append(child.id)
         self.remove_nodes(child_ids)
 
+    def resolve_generate_image(self, chat_node_id: str) -> tuple[str, str]:
+        """'Generate Image from Text' target resolution (R4.4a). Returns
+        (parent_chat_node_id, prompt) = (chat_node_id, node.content) - the
+        selected ChatNode's own id becomes the new image's parent chat node,
+        and its own text becomes the prompt, mirroring legacy's real
+        "Generate Image from Text" entry point (window_actions.py's
+        generate_image(chat_node), called with node.text as the prompt).
+        Raises SceneError for an unknown node id or a non-chat kind
+        (defensive - the frontend always resolves this from a real ChatNode's
+        own menu, same posture as regenerate_response's own defensive checks
+        above), and the SceneEmptyPromptError subclass specifically for
+        empty/whitespace content - mirrors legacy's own "no text to use as a
+        prompt" guard (window_actions.py:989-991), kept as a DISTINCT
+        SceneError subclass (not a plain SceneError) so the WS wrapper in
+        register_canvas can show a distinct message for this case without
+        string-sniffing."""
+        node = self.nodes.get(chat_node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {chat_node_id}")
+        if node.kind != "chat":
+            raise SceneError(f"node is not a chat node: {chat_node_id}")
+        if not node.content or not node.content.strip():
+            raise SceneEmptyPromptError(f"node has no text to use as a prompt: {chat_node_id}")
+        return chat_node_id, node.content
+
+    def resolve_regenerate_image(self, image_node_id: str) -> tuple[str, str]:
+        """'Regenerate Image' target resolution (R4.4a). Returns
+        (parent_chat_node_id, prompt) = (the ImageNode's own parent chat node
+        id via one-hop edge lookup, node.content - the ImageNode's OWN stored
+        prompt). This is the deliberate improvement over legacy's real
+        regenerate mechanism, which instead re-derives the prompt from the
+        parent ChatNode's live .text - a real, reproducible legacy quirk that
+        re-wraps its own wrapped "Generated image for prompt: ..." string on
+        every subsequent regenerate. Raises SceneError for an unknown node
+        id, a non-image kind, or a missing parent edge (defensive only -
+        add_image_node requires parent_id, so an unparented image node can
+        never actually be constructed; this exists purely so a future bug
+        elsewhere fails loud instead of crashing downstream), and the
+        SceneEmptyPromptError subclass for empty/whitespace content
+        (defensive - mirrors legacy's own conditional-visibility guard `if
+        parent_content_node and prompt` around showing the menu action at
+        all)."""
+        node = self.nodes.get(image_node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {image_node_id}")
+        if node.kind != "image":
+            raise SceneError(f"node is not an image node: {image_node_id}")
+        parent_edge = next((e for e in self.edges.values() if e.target == image_node_id), None)
+        if parent_edge is None:
+            raise SceneError(f"image node has no parent: {image_node_id}")
+        if not node.content or not node.content.strip():
+            raise SceneEmptyPromptError(f"image node has no prompt to regenerate from: {image_node_id}")
+        return parent_edge.source, node.content
+
+    def add_generated_image_reply(
+        self,
+        parent_chat_node_id: str,
+        prompt: str,
+        image_bytes: bytes,
+        mime_type: str = "image/png",
+    ) -> tuple[SceneNode, SceneNode]:
+        """The Generate/Regenerate Image success primitive (R4.4a) - mirrors
+        legacy's handle_image_response exactly: unconditionally creates a NEW
+        assistant ChatNode (content=f'Generated image for prompt: "{prompt}"',
+        is_user=False, parent_id=parent_chat_node_id) then a NEW ImageNode
+        (content=prompt, parent_id=<the new ChatNode's id>) - built entirely
+        from the existing add_chat_node/add_image_node primitives, zero new
+        mutation-in-place logic, matching this feature's create-new-nodes
+        scope decision. Positions via the same MESSAGE_VERTICAL_SPACING
+        offset convention send_message/regenerate_response's own new-child
+        placement already uses. last_chat_node_id is DELIBERATELY untouched
+        - mirrors legacy: handle_image_response never assigns
+        self.current_node either, since image generation is side content,
+        not a branch-continuation point (same posture as
+        regenerate_response's own documented "last_chat_node_id:
+        DELIBERATELY untouched"). Raises SceneError if parent_chat_node_id is
+        unknown - defensive: a delete could race the in-flight generation
+        request (see the mid-flight-delete handling in the WS wrapper in
+        register_canvas)."""
+        parent = self.nodes.get(parent_chat_node_id)
+        if parent is None:
+            raise SceneError(f"unknown parent node: {parent_chat_node_id}")
+        ax, ay = parent.x, parent.y + MESSAGE_VERTICAL_SPACING
+        chat_node = self.add_chat_node(
+            ax, ay, f'Generated image for prompt: "{prompt}"', False, parent_id=parent_chat_node_id,
+        )
+        ix, iy = ax, ay + MESSAGE_VERTICAL_SPACING
+        image_node = self.add_image_node(ix, iy, image_bytes, prompt, chat_node.id, mime_type=mime_type)
+        return chat_node, image_node
+
     def set_chat_collapsed(self, node_id: str, collapsed: bool) -> None:
         node = self.nodes.get(node_id)
         if node is None:
@@ -1244,6 +1343,60 @@ def register_canvas(
         )
         return node_to_regenerate.id
 
+    async def _dispatch_image(parent_chat_node_id, prompt):
+        # R4.4a: shared internal path for both generateImage and
+        # regenerateImage below - each resolves its own (parent_chat_node_id,
+        # prompt) pair from a different source-node kind, then both funnel
+        # through this one dispatch + success-primitive call. Runs on
+        # agent_dispatcher's INDEPENDENT self._image_requests slot, never
+        # self._requests - see backend/agents.py's AgentDispatcher docstring
+        # for why chat and image generation must be able to run concurrently.
+        async def _on_reply(image_bytes):
+            if parent_chat_node_id not in document.nodes:
+                # Mid-flight delete, silent no-op - same posture as
+                # regenerate_response's own liveness check above.
+                return
+            document.add_generated_image_reply(parent_chat_node_id, prompt, image_bytes)
+            await bus.publish("scene")
+
+        await agent_dispatcher.start_image_reply(
+            bus=bus,
+            notifications_state=notifications,
+            prompt=prompt,
+            on_reply=_on_reply,
+        )
+
+    async def generate_image(chat_node_id):
+        try:
+            parent_chat_node_id, prompt = document.resolve_generate_image(chat_node_id)
+        except SceneError as exc:
+            # Two genuinely distinct SceneErrors here, NOT collapsed into one
+            # generic message: SceneEmptyPromptError lets this wrapper tell
+            # "empty prompt" apart from "wrong kind/unknown node" via
+            # isinstance, without string-sniffing exc's own text.
+            if isinstance(exc, SceneEmptyPromptError):
+                notifications.show("The selected node has no text to use as a prompt.", "warning")
+            else:
+                notifications.show("This node can't be used to generate an image.", "warning")
+            await bus.publish("notification")
+            return None
+        await _dispatch_image(parent_chat_node_id, prompt)
+        return None
+
+    async def regenerate_image(image_node_id):
+        try:
+            parent_chat_node_id, prompt = document.resolve_regenerate_image(image_node_id)
+        except SceneError:
+            # Unlike generate_image above, both of resolve_regenerate_image's
+            # SceneErrors (unknown/wrong-kind/no-parent, and the
+            # SceneEmptyPromptError empty-content variant) share ONE message
+            # here - the exact wording this feature's design spec settled on.
+            notifications.show("This image has no prompt to regenerate from.", "warning")
+            await bus.publish("notification")
+            return None
+        await _dispatch_image(parent_chat_node_id, prompt)
+        return None
+
     async def move_node(node_id, x, y):
         document.move_node(node_id, x, y)
         await publish_scene()
@@ -1310,6 +1463,12 @@ def register_canvas(
     bus.register_intent("scene", "setChatCollapsed", set_chat_collapsed)
     bus.register_intent("scene", "sendMessage", send_message)
     bus.register_intent("scene", "regenerateResponse", regenerate_response)
+    # R4.4a: "Generate Image from Text" (ChatNode) and "Regenerate Image"
+    # (ImageNode) - two intents because the two entry points resolve from
+    # genuinely different source-node kinds with different validation rules,
+    # both funneling through the shared _dispatch_image helper above.
+    bus.register_intent("scene", "generateImage", generate_image)
+    bus.register_intent("scene", "regenerateImage", regenerate_image)
     bus.register_intent("scene", "moveNode", move_node)
     bus.register_intent("scene", "removeNodes", remove_nodes)
     bus.register_intent("scene", "connectNodes", connect_nodes)

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -808,3 +808,246 @@ def test_conversation_call_in_flight_blocks_a_concurrent_composer_call_on_the_sa
         assert node.pending_request_id is None
 
     asyncio.run(run())
+
+
+# -- R4.4a: start_image_reply - the independent image-generation slot --------
+#
+# Unlike start_chat_reply/start_conversation_reply above, these tests never
+# touch Ollama/api_provider.chat plumbing at all - start_image_reply's only
+# real dependency is api_provider.generate_image, monkeypatched directly.
+
+
+def _make_image_env():
+    bus = SessionBus("agents-image-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    bus.register_topic("scene", lambda: {})
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    return bus, notifications, dispatcher
+
+
+def test_start_image_reply_calls_on_reply_with_the_image_bytes(monkeypatch):
+    monkeypatch.setattr(api_provider, "generate_image", lambda prompt, **kwargs: b"canned-image-bytes")
+
+    async def run():
+        bus, notifications, dispatcher = _make_image_env()
+        replies = []
+        await dispatcher.start_image_reply(
+            bus=bus, notifications_state=notifications, prompt="a cat", on_reply=replies.append,
+        )
+        entry = next(iter(dispatcher._image_requests.values()))
+        await entry["task"]
+
+        assert replies == [b"canned-image-bytes"]
+        assert dispatcher._image_requests == {}
+        assert notifications.visible is False
+
+    asyncio.run(run())
+
+
+def test_start_image_reply_second_call_while_in_flight_is_rejected_with_info_notification(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_generate_image(prompt, **kwargs):
+        started.set()
+        release.wait(5)
+        return b"first-image-bytes"
+
+    monkeypatch.setattr(api_provider, "generate_image", blocking_generate_image)
+
+    async def run():
+        bus, notifications, dispatcher = _make_image_env()
+        replies = []
+
+        await dispatcher.start_image_reply(
+            bus=bus, notifications_state=notifications, prompt="first prompt", on_reply=replies.append,
+        )
+        await asyncio.to_thread(started.wait, 5)
+
+        # Second call while the first is still in flight must be rejected
+        # and must not disturb the first request.
+        await dispatcher.start_image_reply(
+            bus=bus, notifications_state=notifications, prompt="second prompt", on_reply=replies.append,
+        )
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert notifications.message == "An image is already being generated."
+        assert len(dispatcher._image_requests) == 1
+
+        release.set()
+        entry = next(iter(dispatcher._image_requests.values()))
+        await entry["task"]
+        assert replies == [b"first-image-bytes"]
+        assert dispatcher._image_requests == {}
+
+    asyncio.run(run())
+
+
+def test_image_request_and_chat_request_run_concurrently_both_dicts_non_empty(monkeypatch):
+    """THE key concurrency-slot regression guard (R4.4a): a chat/composer
+    request occupies self._requests while an image-generation request
+    occupies the SEPARATE self._image_requests dict at the same time -
+    neither blocks nor is blocked by the other, and both dicts are
+    simultaneously non-empty at least once, proving these are two genuinely
+    independent slots rather than aliases of the same guard (the whole point
+    of AgentDispatcher._image_requests existing as its own field - see its
+    comment in backend/agents.py)."""
+    chat_started = threading.Event()
+    chat_release = threading.Event()
+    image_started = threading.Event()
+    image_release = threading.Event()
+
+    def blocking_chat(task, messages, **kwargs):
+        chat_started.set()
+        chat_release.wait(5)
+        return {"message": {"content": "chat reply"}}
+
+    def blocking_generate_image(prompt, **kwargs):
+        image_started.set()
+        image_release.wait(5)
+        return b"image-bytes"
+
+    _configure_fake_ollama(monkeypatch, blocking_chat)
+    monkeypatch.setattr(api_provider, "generate_image", blocking_generate_image)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        chat_replies = []
+        image_replies = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=chat_replies.append,
+        )
+        await dispatcher.start_image_reply(
+            bus=bus, notifications_state=notifications, prompt="a cat", on_reply=image_replies.append,
+        )
+
+        await asyncio.to_thread(chat_started.wait, 5)
+        await asyncio.to_thread(image_started.wait, 5)
+
+        # THE key assertion: both slots are genuinely occupied at the same
+        # time - neither request bounced the other, and neither notification
+        # fired.
+        assert len(dispatcher._requests) == 1
+        assert len(dispatcher._image_requests) == 1
+        assert notifications.visible is False, "neither call should have been rejected"
+
+        chat_release.set()
+        chat_entry = next(iter(dispatcher._requests.values()))
+        await chat_entry["task"]
+        image_release.set()
+        image_entry = next(iter(dispatcher._image_requests.values()))
+        await image_entry["task"]
+
+        assert chat_replies == ["chat reply"]
+        assert image_replies == [b"image-bytes"]
+        assert dispatcher._requests == {}
+        assert dispatcher._image_requests == {}
+        assert composer_document.request_state == "idle"
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("error_message", [
+    "Image generation is only available in API Endpoint mode.",
+    "API client not initialized. Configure API settings first.",
+    "Image generation is not available for Anthropic Claude in Graphlink yet.",
+    "No image generation model configured.\nPlease select one in API Settings.",
+    "Image generation quota exceeded.\n\nPlease use a lower-cost image model or "
+    "verify billing is enabled for the selected provider.",
+])
+def test_start_image_reply_runtime_error_cases_forward_the_exact_message_verbatim(monkeypatch, error_message):
+    """Each of api_provider.generate_image's real RuntimeError gating
+    messages (not API mode / no client / Anthropic unsupported / no model
+    configured / quota exceeded) must be forwarded to the user VERBATIM
+    after one shared "Image generation failed: " prefix - the WS/dispatch
+    layer never duplicates api_provider.py's own gating knowledge."""
+    def raising_generate_image(prompt, **kwargs):
+        raise RuntimeError(error_message)
+
+    monkeypatch.setattr(api_provider, "generate_image", raising_generate_image)
+
+    async def run():
+        bus, notifications, dispatcher = _make_image_env()
+        await dispatcher.start_image_reply(
+            bus=bus, notifications_state=notifications, prompt="a cat", on_reply=lambda image_bytes: None,
+        )
+        entry = next(iter(dispatcher._image_requests.values()))
+        await entry["task"]
+
+        assert dispatcher._image_requests == {}
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == f"Image generation failed: {error_message}"
+
+    asyncio.run(run())
+
+
+def test_start_image_reply_timeout_fires_the_exact_message_and_clears_the_slot(monkeypatch):
+    monkeypatch.setattr(agents_module, "WATCHDOG_TIMEOUT_SECONDS", 0.05)
+
+    def slow_generate_image(prompt, **kwargs):
+        time.sleep(0.3)
+        return b"too-late-bytes"
+
+    monkeypatch.setattr(api_provider, "generate_image", slow_generate_image)
+
+    async def run():
+        bus, notifications, dispatcher = _make_image_env()
+        await dispatcher.start_image_reply(
+            bus=bus, notifications_state=notifications, prompt="a cat", on_reply=lambda image_bytes: None,
+        )
+        entry = next(iter(dispatcher._image_requests.values()))
+        await entry["task"]
+
+        assert dispatcher._image_requests == {}, "the slot must not leak/deadlock future requests"
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == (
+            "Image generation stopped responding before the request completed. Please try again."
+        )
+
+    asyncio.run(run())
+
+
+def test_start_image_reply_slot_does_not_leak_a_subsequent_request_is_admitted_after_failure(monkeypatch):
+    def raising_generate_image(prompt, **kwargs):
+        raise RuntimeError("No image generation model configured.")
+
+    monkeypatch.setattr(api_provider, "generate_image", raising_generate_image)
+
+    async def run():
+        bus, notifications, dispatcher = _make_image_env()
+        await dispatcher.start_image_reply(
+            bus=bus, notifications_state=notifications, prompt="a cat", on_reply=lambda image_bytes: None,
+        )
+        entry = next(iter(dispatcher._image_requests.values()))
+        await entry["task"]
+        assert dispatcher._image_requests == {}
+
+        monkeypatch.setattr(api_provider, "generate_image", lambda prompt, **kwargs: b"next-bytes")
+        replies = []
+        await dispatcher.start_image_reply(
+            bus=bus, notifications_state=notifications, prompt="a dog", on_reply=replies.append,
+        )
+        entry = next(iter(dispatcher._image_requests.values()))
+        await entry["task"]
+        assert replies == [b"next-bytes"]
+
+    asyncio.run(run())
+
+
+def test_no_cancel_image_method_or_intent_exists():
+    """Deliberate absence-of-API test (R4.4a design spec §3): image
+    generation has zero cancellation, matching legacy's real, complete
+    absence of a working cancel affordance for image generation
+    (ImageGenerationWorkerThread.stop() exists but is never called from any
+    UI path). A cancel_image method/intent must never be added for as long
+    as this design decision holds."""
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    assert not hasattr(dispatcher, "cancel_image")

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -19,6 +19,7 @@ from backend.canvas import (
     DRAG_FACTOR_MAX,
     DRAG_FACTOR_MIN,
     SceneDocument,
+    SceneEmptyPromptError,
     SceneError,
     register_canvas,
 )
@@ -2037,5 +2038,302 @@ def test_snap_and_drag_factor_intents_publish_scene():
         payload = document.scene_payload()
         assert payload["snapToGrid"] is True
         assert payload["dragFactor"] == 0.5
+
+    asyncio.run(run())
+
+
+# -- R4.4a: Generate/Regenerate Image - domain-level resolvers ---------------
+
+
+def test_resolve_generate_image_returns_chat_node_id_and_its_own_content():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "a cat wearing a wizard hat", True)
+    parent_id, prompt = doc.resolve_generate_image(chat.id)
+    assert parent_id == chat.id
+    assert prompt == "a cat wearing a wizard hat"
+
+
+def test_resolve_generate_image_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().resolve_generate_image("ghost")
+
+
+def test_resolve_generate_image_non_chat_node_raises_scene_error():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "question", True)
+    code_node = doc.add_code_node(10, 10, "x = 1", "python", parent_id=parent.id)
+    with pytest.raises(SceneError):
+        doc.resolve_generate_image(code_node.id)
+
+
+def test_resolve_generate_image_empty_content_raises_the_empty_prompt_variant():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "   ", True)
+    with pytest.raises(SceneEmptyPromptError):
+        doc.resolve_generate_image(chat.id)
+    # The empty-prompt variant IS a SceneError too - callers that only check
+    # for the base class must still catch it.
+    with pytest.raises(SceneError):
+        doc.resolve_generate_image(chat.id)
+
+
+def test_resolve_regenerate_image_returns_parent_id_and_the_image_nodes_own_content_not_the_parents():
+    doc = SceneDocument()
+    # The parent chat node's content is deliberately DIFFERENT from the
+    # image's own stored prompt - regression-guards the R4.4a fix: regenerate
+    # must read the ImageNode's OWN content, never the parent ChatNode's,
+    # even though legacy's real mechanism reuses the (wrapped) parent text.
+    chat = doc.add_chat_node(0, 0, 'Generated image for prompt: "a cat"', False)
+    image_node = doc.add_image_node(0, 160, b"bytes", "a cat", chat.id)
+    parent_id, prompt = doc.resolve_regenerate_image(image_node.id)
+    assert parent_id == chat.id
+    assert prompt == "a cat"
+    assert prompt != chat.content
+
+
+def test_resolve_regenerate_image_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().resolve_regenerate_image("ghost")
+
+
+def test_resolve_regenerate_image_non_image_node_raises_scene_error():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "question", True)
+    with pytest.raises(SceneError):
+        doc.resolve_regenerate_image(chat.id)
+
+
+def test_resolve_regenerate_image_empty_content_raises_the_empty_prompt_variant():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "assistant reply", False)
+    image_node = doc.add_image_node(0, 160, b"bytes", "", chat.id)
+    with pytest.raises(SceneEmptyPromptError):
+        doc.resolve_regenerate_image(image_node.id)
+
+
+# -- R4.4a: Generate/Regenerate Image - the success primitive -----------------
+
+
+def test_add_generated_image_reply_creates_two_new_nodes_with_the_correct_parent_chain():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "draw a cat", True)
+    node_count_before = len(doc.nodes)
+
+    new_chat_node, new_image_node = doc.add_generated_image_reply(chat.id, "a cat", b"png-bytes")
+
+    assert len(doc.nodes) == node_count_before + 2
+    assert new_chat_node.kind == "chat"
+    assert new_image_node.kind == "image"
+
+    def parent_of(node_id):
+        edge = next((e for e in doc.edges.values() if e.target == node_id), None)
+        return edge.source if edge is not None else None
+
+    assert parent_of(new_image_node.id) == new_chat_node.id
+    assert parent_of(new_chat_node.id) == chat.id
+
+
+def test_add_generated_image_reply_new_chat_node_content_is_the_exact_wrapper_string():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "draw a cat", True)
+    new_chat_node, new_image_node = doc.add_generated_image_reply(chat.id, "a cat wearing a hat", b"png-bytes")
+    assert new_chat_node.content == 'Generated image for prompt: "a cat wearing a hat"'
+    assert new_chat_node.is_user is False
+    assert new_image_node.content == "a cat wearing a hat"
+
+
+def test_add_generated_image_reply_gains_exactly_one_image_asset_entry():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "draw a cat", True)
+    assets_before = dict(doc.image_assets)
+    _, new_image_node = doc.add_generated_image_reply(chat.id, "a cat", b"png-bytes", mime_type="image/jpeg")
+    assert len(doc.image_assets) == len(assets_before) + 1
+    assert doc.get_image_asset(new_image_node.image_asset_id) == (b"png-bytes", "image/jpeg")
+
+
+def test_add_generated_image_reply_leaves_last_chat_node_id_untouched():
+    doc = SceneDocument()
+    node = doc.send_message("hello")
+    assert doc.last_chat_node_id == node.id
+    doc.add_generated_image_reply(node.id, "a cat", b"png-bytes")
+    assert doc.last_chat_node_id == node.id, "image generation is side content, not a branch-continuation point"
+
+
+def test_add_generated_image_reply_unknown_parent_raises_scene_error():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_generated_image_reply("ghost", "a cat", b"png-bytes")
+
+
+# -- R4.4a: Generate/Regenerate Image - WS-intent level -----------------------
+
+
+def test_generate_image_intent_empty_content_shows_warning_and_never_dispatches():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        chat = document.add_chat_node(0, 0, "   ", True)
+
+        calls = []
+
+        def recording_generate_image(prompt, **kwargs):
+            calls.append(prompt)
+            return b"bytes"
+
+        with patch.object(api_provider, "generate_image", recording_generate_image):
+            result = await bus.dispatch_intent("scene", "generateImage", [chat.id])
+
+        assert result is None
+        assert calls == [], "api_provider.generate_image must never be reached"
+        assert dispatcher._image_requests == {}
+        notice = await bus.publish("notification")
+        assert notice["visible"] is True
+        assert notice["msgType"] == "warning"
+        assert notice["message"] == "The selected node has no text to use as a prompt."
+
+    asyncio.run(run())
+
+
+def test_generate_image_intent_unknown_node_shows_the_wrong_kind_message():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        result = await bus.dispatch_intent("scene", "generateImage", ["ghost"])
+        assert result is None
+        assert dispatcher._image_requests == {}
+        notice = await bus.publish("notification")
+        assert notice["visible"] is True
+        assert notice["msgType"] == "warning"
+        assert notice["message"] == "This node can't be used to generate an image."
+
+    asyncio.run(run())
+
+
+def test_generate_image_intent_non_chat_node_shows_the_wrong_kind_message():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_chat_node(0, 0, "question", True)
+        code_node = document.add_code_node(10, 10, "x = 1", "python", parent_id=parent.id)
+        result = await bus.dispatch_intent("scene", "generateImage", [code_node.id])
+        assert result is None
+        notice = await bus.publish("notification")
+        assert notice["message"] == "This node can't be used to generate an image."
+
+    asyncio.run(run())
+
+
+def test_regenerate_image_intent_unknown_node_shows_the_no_prompt_message():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        result = await bus.dispatch_intent("scene", "regenerateImage", ["ghost"])
+        assert result is None
+        assert dispatcher._image_requests == {}
+        notice = await bus.publish("notification")
+        assert notice["visible"] is True
+        assert notice["msgType"] == "warning"
+        assert notice["message"] == "This image has no prompt to regenerate from."
+
+    asyncio.run(run())
+
+
+def test_regenerate_image_intent_non_image_node_shows_the_no_prompt_message():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        chat = document.add_chat_node(0, 0, "a chat node", True)
+        result = await bus.dispatch_intent("scene", "regenerateImage", [chat.id])
+        assert result is None
+        notice = await bus.publish("notification")
+        assert notice["message"] == "This image has no prompt to regenerate from."
+
+    asyncio.run(run())
+
+
+def test_regenerate_image_intent_empty_content_shows_the_no_prompt_message():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        chat = document.add_chat_node(0, 0, "assistant reply", False)
+        image_node = document.add_image_node(0, 160, b"bytes", "", chat.id)
+        result = await bus.dispatch_intent("scene", "regenerateImage", [image_node.id])
+        assert result is None
+        notice = await bus.publish("notification")
+        assert notice["message"] == "This image has no prompt to regenerate from."
+
+    asyncio.run(run())
+
+
+def test_generate_image_intent_full_success_round_trip_creates_two_nodes_and_republishes_scene():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        chat = document.add_chat_node(0, 0, "a cat wearing a hat", True)
+        node_count_before = len(document.nodes)
+        scene_publishes_before = recorder.topics_seen().count("scene")
+
+        with patch.object(api_provider, "generate_image", lambda prompt, **kwargs: b"real-png-bytes"):
+            result = await bus.dispatch_intent("scene", "generateImage", [chat.id])
+            assert result is None
+            entry = next(iter(dispatcher._image_requests.values()))
+            await entry["task"]
+
+        assert len(document.nodes) == node_count_before + 2
+        new_chat = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != chat.id)
+        new_image = next(n for n in document.nodes.values() if n.kind == "image")
+        assert new_chat.content == 'Generated image for prompt: "a cat wearing a hat"'
+        assert new_image.content == "a cat wearing a hat"
+        assert document.get_image_asset(new_image.image_asset_id) == (b"real-png-bytes", "image/png")
+        assert recorder.topics_seen().count("scene") > scene_publishes_before
+        assert dispatcher._image_requests == {}
+
+    asyncio.run(run())
+
+
+def test_regenerate_image_intent_full_success_round_trip_creates_two_nodes_using_the_image_nodes_own_prompt():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        chat = document.add_chat_node(0, 0, 'Generated image for prompt: "a cat"', False)
+        old_image = document.add_image_node(0, 160, b"old-bytes", "a cat", chat.id)
+        node_count_before = len(document.nodes)
+
+        with patch.object(api_provider, "generate_image", lambda prompt, **kwargs: b"new-png-bytes"):
+            result = await bus.dispatch_intent("scene", "regenerateImage", [old_image.id])
+            assert result is None
+            entry = next(iter(dispatcher._image_requests.values()))
+            await entry["task"]
+
+        assert len(document.nodes) == node_count_before + 2, "old image node is left untouched, not replaced"
+        assert old_image.id in document.nodes
+        new_image = next(n for n in document.nodes.values() if n.kind == "image" and n.id != old_image.id)
+        assert new_image.content == "a cat"
+        assert document.get_image_asset(new_image.image_asset_id) == (b"new-png-bytes", "image/png")
+
+    asyncio.run(run())
+
+
+def test_dispatch_image_mid_flight_delete_of_the_parent_is_a_silent_noop():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        chat = document.add_chat_node(0, 0, "a cat wearing a hat", True)
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_generate_image(prompt, **kwargs):
+            started.set()
+            release.wait(5)
+            return b"png-bytes"
+
+        with patch.object(api_provider, "generate_image", blocking_generate_image):
+            result = await bus.dispatch_intent("scene", "generateImage", [chat.id])
+            assert result is None
+
+            await asyncio.to_thread(started.wait, 5)
+            document.remove_nodes([chat.id])
+
+            release.set()
+            entry = next(iter(dispatcher._image_requests.values()))
+            await entry["task"]
+
+        assert chat.id not in document.nodes
+        assert not any(n.kind == "image" for n in document.nodes.values()), "no new nodes were created"
+        assert dispatcher._image_requests == {}
+        notice = await bus.publish("notification")
+        assert notice["visible"] is False, "deleted-mid-flight is a silent no-op - no notification fires"
 
     asyncio.run(run())

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -17,6 +17,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   const onDelete = vi.fn();
   const onUndockChild = vi.fn();
   const onRegenerate = vi.fn();
+  const onGenerateImage = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -29,6 +30,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
       onDelete,
       onUndockChild,
       onRegenerate,
+      onGenerateImage,
       ...overrides,
     },
   } as unknown as NodeProps<ChatFlowNode>;
@@ -38,7 +40,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
       <ChatNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onToggleCollapse, onDelete, onUndockChild, onRegenerate };
+  return { onToggleCollapse, onDelete, onUndockChild, onRegenerate, onGenerateImage };
 }
 
 describe("ChatNodeView", () => {
@@ -80,11 +82,12 @@ describe("ChatNodeView", () => {
     expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
     const docView = screen.getByRole("menuitem", { name: "Open Document View" });
     expect(docView).toBeDisabled();
-    for (const name of ["Generate Key Takeaway", "Generate Explainer Note", "Generate Chart", "Generate Image"]) {
+    for (const name of ["Generate Key Takeaway", "Generate Explainer Note", "Generate Chart"]) {
       const item = screen.getByRole("menuitem", { name });
       expect(item).toBeDisabled();
       expect(item).toHaveAttribute("title", "AI generation lands in R4");
     }
+    expect(screen.getByRole("menuitem", { name: "Generate Image" })).not.toBeDisabled();
 
     await user.click(screen.getByRole("menuitem", { name: "Copy Text" }));
     expect(writeText).toHaveBeenCalledWith("Hello **world**");
@@ -111,6 +114,19 @@ describe("ChatNodeView", () => {
     await user.click(regenerate);
     expect(onRegenerate).toHaveBeenCalledOnce();
     expect(screen.queryByRole("menu")).toBeNull(); // onClose fires after onRegenerate
+  });
+
+  it("Generate Image is a real, enabled item (unconditional, unlike Regenerate Response) that calls onGenerateImage then closes the menu", async () => {
+    const user = userEvent.setup();
+    const { onGenerateImage } = renderChatNode({ isUser: true });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    const generateImage = screen.getByRole("menuitem", { name: "Generate Image" });
+    expect(generateImage).not.toBeDisabled();
+
+    await user.click(generateImage);
+    expect(onGenerateImage).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull(); // onClose fires after onGenerateImage
   });
 
   it("Escape and outside-click both close the menu", async () => {

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -30,7 +30,11 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * on dockedChildren.length > 0 exactly like the legacy's own `if
  * docked_children:` guard. "Regenerate Response" is likewise no longer
  * deferred as of R4.3c: it now calls the real regenerateResponse intent,
- * still gated on !isUser (matching the legacy is_user guard).
+ * still gated on !isUser (matching the legacy is_user guard). "Generate
+ * Image" is likewise no longer deferred as of R4.4a: it now calls the real
+ * generateImage intent, with no visibility/enablement gating beyond what
+ * already existed - matches legacy's own unconditional enablement (the
+ * empty-content case is caught server-side with a warning banner instead).
  */
 
 export interface ChatNodeData extends Record<string, unknown> {
@@ -42,6 +46,7 @@ export interface ChatNodeData extends Record<string, unknown> {
   onDelete: () => void;
   onUndockChild: (childId: string) => void;
   onRegenerate: () => void;
+  onGenerateImage: () => void;
 }
 
 export type ChatFlowNode = Node<ChatNodeData, "chat">;
@@ -61,6 +66,7 @@ function ChatNodeMenu({
   onDelete,
   onUndockChild,
   onRegenerate,
+  onGenerateImage,
   onClose,
 }: {
   position: MenuPosition;
@@ -72,6 +78,7 @@ function ChatNodeMenu({
   onDelete: () => void;
   onUndockChild: (childId: string) => void;
   onRegenerate: () => void;
+  onGenerateImage: () => void;
   onClose: () => void;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
@@ -160,7 +167,14 @@ function ChatNodeMenu({
       <button type="button" role="menuitem" disabled title="AI generation lands in R4">
         Generate Chart
       </button>
-      <button type="button" role="menuitem" disabled title="AI generation lands in R4">
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onGenerateImage();
+          onClose();
+        }}
+      >
         Generate Image
       </button>
       <button
@@ -242,6 +256,7 @@ export function ChatNodeView({ data, selected }: NodeProps<ChatFlowNode>) {
           onDelete={data.onDelete}
           onUndockChild={data.onUndockChild}
           onRegenerate={data.onRegenerate}
+          onGenerateImage={data.onGenerateImage}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/ImageNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ImageNodeView.test.tsx
@@ -8,6 +8,7 @@ import { ImageNodeView, type ImageFlowNode } from "./ImageNodeView";
 // ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too.
 function renderImageNode(overrides: Partial<ImageFlowNode["data"]> = {}, id = "n0") {
   const onDelete = vi.fn();
+  const onRegenerate = vi.fn();
   const props = {
     id,
     selected: false,
@@ -15,6 +16,7 @@ function renderImageNode(overrides: Partial<ImageFlowNode["data"]> = {}, id = "n
       imageAssetId: "asset-123",
       prompt: "a red fox in the snow",
       onDelete,
+      onRegenerate,
       ...overrides,
     },
   } as unknown as NodeProps<ImageFlowNode>;
@@ -24,7 +26,7 @@ function renderImageNode(overrides: Partial<ImageFlowNode["data"]> = {}, id = "n
       <ImageNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onDelete, container };
+  return { onDelete, onRegenerate, container };
 }
 
 // jsdom implements neither URL.createObjectURL/revokeObjectURL nor
@@ -87,7 +89,7 @@ describe("ImageNodeView", () => {
     expect(container.querySelector("img")).toBeNull();
   });
 
-  it("right-click opens a menu with real Copy Image/Export Image/Delete Image and disabled Hide Other Branches/Regenerate Image", async () => {
+  it("right-click opens a menu with real Copy Image/Export Image/Regenerate Image/Delete Image and disabled Hide Other Branches", async () => {
     const user = userEvent.setup();
     const { onDelete } = renderImageNode({ prompt: "a red fox in the snow" });
 
@@ -102,12 +104,37 @@ describe("ImageNodeView", () => {
     expect(hideBranches).toBeDisabled();
     expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
 
-    const regenerate = screen.getByRole("menuitem", { name: "Regenerate Image" });
-    expect(regenerate).toBeDisabled();
-    expect(regenerate).toHaveAttribute("title", "Agent regeneration lands in R4");
+    expect(screen.getByRole("menuitem", { name: "Regenerate Image" })).toBeEnabled();
 
     await user.click(screen.getByRole("menuitem", { name: "Delete Image" }));
     expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Regenerate Image is a real, enabled item that calls onRegenerate then closes the menu", async () => {
+    const user = userEvent.setup();
+    const { onRegenerate } = renderImageNode({ prompt: "a red fox in the snow" });
+
+    fireEvent.contextMenu(screen.getByText("a red fox in the snow"));
+    const regenerate = screen.getByRole("menuitem", { name: "Regenerate Image" });
+    expect(regenerate).not.toBeDisabled();
+
+    await user.click(regenerate);
+    expect(onRegenerate).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull(); // onClose fires after onRegenerate
+  });
+
+  it("Regenerate Image is absent from the menu entirely for a prompt-less image node", () => {
+    // Mirrors legacy's own menu-build-time gate (graphlink_node_image_menu.py:
+    // `if self.node.parent_content_node and self.node.prompt:` - the action is
+    // never added to the menu at all when prompt is falsy), reachable via a
+    // user-attached image with no caption text. Absent from the DOM, not
+    // merely disabled - same convention CodeNodeView's own parent-gated
+    // Regenerate Response item uses.
+    renderImageNode({ prompt: "" }, "n7");
+
+    fireEvent.contextMenu(screen.getByText("Image"));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Regenerate Image" })).toBeNull();
   });
 
   it("clicking Copy Image fetches the asset and writes it to the clipboard as a ClipboardItem", async () => {

--- a/web_ui/src/app/canvas/ImageNodeView.tsx
+++ b/web_ui/src/app/canvas/ImageNodeView.tsx
@@ -30,17 +30,20 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * -> navigator.clipboard.write with a real ClipboardItem - NOT a data URI or
  * an <img>, Clipboard API image writes require an actual Blob), Export Image
  * (fetch -> blob -> object URL -> a temporary anchor's programmatic download,
- * revoked immediately after). Deferred, with an honest disabled+title label
- * rather than a silent drop (same posture every sibling node menu takes):
- * Hide Other Branches (branch visibility isn't built yet - unscoped, not
- * owned by any R-phase) and Regenerate Image (R4's agent layer - same
- * agent-layer-blocked semantics as Chat's "Regenerate Response").
+ * revoked immediately after). "Regenerate Image" is likewise no longer
+ * deferred as of R4.4a: it now calls the real regenerateImage intent -
+ * unlike CodeNodeView's own onRegenerate, no client-side parent-lookup/
+ * null-guard is needed here, since the backend resolves the ImageNode's
+ * parent chat node internally (see sceneStore.ts's regenerateImage). Still
+ * deferred, with an honest disabled+title label: Hide Other Branches (branch
+ * visibility isn't built yet - unscoped, not owned by any R-phase).
  */
 
 export interface ImageNodeData extends Record<string, unknown> {
   imageAssetId: string;
   prompt: string;
   onDelete: () => void;
+  onRegenerate: () => void;
 }
 
 export type ImageFlowNode = Node<ImageNodeData, "image">;
@@ -112,13 +115,17 @@ function ImageNodeMenu({
   position,
   imageAssetId,
   filename,
+  prompt,
   onDelete,
+  onRegenerate,
   onClose,
 }: {
   position: MenuPosition;
   imageAssetId: string;
   filename: string;
+  prompt: string;
   onDelete: () => void;
+  onRegenerate: () => void;
   onClose: () => void;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
@@ -173,9 +180,18 @@ function ImageNodeMenu({
       <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
         Hide Other Branches
       </button>
-      <button type="button" role="menuitem" disabled title="Agent regeneration lands in R4">
-        Regenerate Image
-      </button>
+      {prompt.trim() && (
+        <button
+          type="button"
+          role="menuitem"
+          onClick={() => {
+            onRegenerate();
+            onClose();
+          }}
+        >
+          Regenerate Image
+        </button>
+      )}
       <button
         type="button"
         role="menuitem"
@@ -231,7 +247,9 @@ export function ImageNodeView({ id, data, selected }: NodeProps<ImageFlowNode>) 
           position={menuPosition}
           imageAssetId={data.imageAssetId}
           filename={buildDownloadFilename(id, data.prompt)}
+          prompt={data.prompt}
           onDelete={data.onDelete}
+          onRegenerate={data.onRegenerate}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -101,3 +101,40 @@ describe("toFlowNodes (R4.3c parentChatNodeId derivation)", () => {
     expect(intentSpy).toHaveBeenCalledWith("chat-1");
   });
 });
+
+describe("toFlowNodes (R4.4a Generate/Regenerate Image wiring)", () => {
+  it("a chat node's onGenerateImage calls generateImage with its own id", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hello", isUser: true })],
+      edges: [],
+    });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "generateImage");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    expect(chatFlowNode).toBeDefined();
+
+    (chatFlowNode!.data as { onGenerateImage: () => void }).onGenerateImage();
+    expect(intentSpy).toHaveBeenCalledWith("chat-1");
+  });
+
+  it("an image node's onRegenerate calls regenerateImage with its own id - no client-side parent lookup, unlike CodeNode's onRegenerate", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "chat-1", kind: "chat", content: "Hello" }),
+        baseNode({ id: "image-1", kind: "image", imageAssetId: "asset-1", content: "a red fox" }),
+      ],
+      edges: [{ id: "e1", source: "chat-1", target: "image-1" }],
+    });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "regenerateImage");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const imageFlowNode = flowNodes.find((n) => n.id === "image-1");
+    expect(imageFlowNode).toBeDefined();
+
+    (imageFlowNode!.data as { onRegenerate: () => void }).onRegenerate();
+    expect(intentSpy).toHaveBeenCalledWith("image-1");
+  });
+});

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -125,6 +125,7 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
           onDelete: () => store.deleteChatNode(n.id),
           onUndockChild: (childId: string) => store.setNodeDocked(childId, false),
           onRegenerate: () => store.regenerateResponse(n.id),
+          onGenerateImage: () => store.generateImage(n.id),
         },
       });
       continue;
@@ -242,6 +243,11 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
           imageAssetId: n.imageAssetId,
           prompt: n.content,
           onDelete: () => store.removeNodes([n.id]),
+          // R4.4a: unlike CodeNodeView's onRegenerate, no client-side parent
+          // lookup/null-guard is needed here - the backend resolves the
+          // image's parent chat node internally (see sceneStore.ts's
+          // regenerateImage / backend/canvas.py's resolve_regenerate_image).
+          onRegenerate: () => store.regenerateImage(n.id),
         },
       });
       continue;

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -254,6 +254,20 @@ describe("SceneStore", () => {
     expect(intents).toEqual([{ topic: "scene", intent: "regenerateResponse", args: ["n1"] }]);
   });
 
+  it("generateImage sends the scene-topic generateImage intent with the chat node id", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.generateImage("n1");
+    expect(intents).toEqual([{ topic: "scene", intent: "generateImage", args: ["n1"] }]);
+  });
+
+  it("regenerateImage sends the scene-topic regenerateImage intent with the image node id", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.regenerateImage("img1");
+    expect(intents).toEqual([{ topic: "scene", intent: "regenerateImage", args: ["img1"] }]);
+  });
+
   it("suppresses empty removal intents", () => {
     const { transport, intents } = makeFakeTransport();
     const store = new SceneStore(transport);

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -291,6 +291,22 @@ export class SceneStore {
     this.transport.intent("scene", "regenerateResponse", [chatNodeId]);
   }
 
+  // R4.4a: real "Generate Image from Text", for ChatNodeView's own menu -
+  // resolves purely from the ChatNode's id (backend reads its own .content
+  // as the prompt, mirroring legacy's node.text).
+  generateImage(chatNodeId: string): void {
+    this.transport.intent("scene", "generateImage", [chatNodeId]);
+  }
+
+  // R4.4a: real "Regenerate Image", for ImageNodeView's own menu - resolves
+  // purely from the ImageNode's id (backend reads ITS OWN .content as the
+  // prompt and its parent chat node as the new sibling's parent - see
+  // backend/canvas.py's resolve_regenerate_image docstring for why this is a
+  // deliberate improvement over legacy's parent-.text reuse).
+  regenerateImage(imageNodeId: string): void {
+    this.transport.intent("scene", "regenerateImage", [imageNodeId]);
+  }
+
   // R3.3: the Composer's real Send action - a real user ChatNode. The
   // assistant's reply is deferred to R4 (graphlink_config.py's Qt/non-Qt
   // split is a prerequisite for calling the real agent layer); the backend


### PR DESCRIPTION
## Summary
- Ports legacy's `generate_image`/`handle_image_response` - the single mechanism behind BOTH "Generate Image from Text" (ChatNode's menu) and "Regenerate Image" (ImageNode's own context menu, wired outside the command palette). An initial recon pass concluded legacy had no working regenerate mechanism at all; the independent cross-check pass caught the real one (`graphlink_node_image_menu.py`), and the design phase re-verified it before adjudicating - a genuine catch of an analysis error before it reached implementation.
- Both entry points are unconditionally create-new-nodes in legacy (new assistant ChatNode + new ImageNode); there is zero legacy precedent for in-place ImageNode mutation. Both new WS intents (`generateImage`, `regenerateImage`) funnel through one shared `add_generated_image_reply` primitive built entirely from the existing `add_chat_node`/`add_image_node` methods.
- One deliberate, explicit fix vs legacy: regenerate reads the ImageNode's own stored prompt, not the parent ChatNode's live text (which for an AI-generated image is a wrapped string that legacy's real mechanism re-wraps further on every click - a real legacy bug, not ported).
- `AgentDispatcher` gained an independent `_image_requests` slot, separate from the existing chat/regenerate/ConversationNode guard, since legacy genuinely lets a chat request and an image-generation request run concurrently (`self.chat_thread`/`self.image_gen_thread` are separate, never-aliased attributes). Reusing the shared guard would have been an unstated behavior regression.
- No cancellation support, matching legacy's real and complete absence of one. A 420s watchdog timeout is added where legacy has none - a stated, deliberate improvement, not silent parity.

## Process
- Fresh recon+cross-check+design pass (3 agents) - the cross-check corrected the recon's headline finding, and the design phase independently re-verified before ruling in its favor.
- Parallel backend+frontend implementation, each independently green (177/177 + 255/255 full backend suite; 700/700 vitest + clean `tsc`).
- 4-way adversarial review returned 3 clean PASSes and one real legacy-parity gap: the new ImageNodeView always rendered "Regenerate Image" enabled, but legacy's real menu conditionally omits it entirely for a prompt-less image node (a real, reachable case - a user-attached image with no caption). Fixed before shipping with a conditional render matching CodeNode's own established convention, plus a regression test.
- Live-drive made a real, user-authorized paid API call against Google Gemini (on a scratch copy of `session.dat`, never touching the real persisted settings) - it correctly reached Gemini and was rejected for a genuine, account-level zero image-gen quota, proving the exact `RuntimeError`-forwarding path end-to-end against a real external failure. The full happy path remains verified by passing mocked tests only, not a live external call - stated plainly in the PR and the plan doc ledger, not glossed over as full parity.

## Test plan
- [x] `python -m pytest -q` — 2028 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 701 passed
- [x] `python graphlink_island_codegen.py --check` — up to date
- [x] Live WS drive against the real backend with a real Gemini credential (real API call, real error-path verification; happy path covered by mocked tests only)