### PR TITLE
Fix stuck scrim + dead input after loading a chat from the Library

### DIFF
--- a/graphlink_app/graphlink_overlay_manager.py
+++ b/graphlink_app/graphlink_overlay_manager.py
@@ -38,7 +38,7 @@ OverlayCoordinator, it holds behavior, not chrome.
 
 from __future__ import annotations
 
-from PySide6.QtCore import QEvent, QObject, Qt, Signal
+from PySide6.QtCore import QEvent, QObject, Qt, QTimer, Signal
 from PySide6.QtGui import QColor, QPainter
 from PySide6.QtWidgets import QApplication, QWidget
 
@@ -205,6 +205,23 @@ class OverlayManager(QObject):
         if name is not None:
             self.close(name)
 
+    def _release_orphaned_surface(self):
+        """Deferred cleanup after a surface was hidden behind the manager's
+        back (see the Hide handling in eventFilter). By this tick, a
+        manager-driven close() has already cleared _open_name - so a
+        remaining _open_name whose surface is no longer genuinely open means
+        an external close: release the scrim and emit the chip-off signal
+        the direct close path never fired (audit B6 - without this, the
+        toolbar chip stays latched active too, not just the scrim)."""
+        if self._open_name is None:
+            return
+        if self.is_open(self._open_name):
+            return  # re-shown between the hide and this tick - still open
+        name = self._open_name
+        self._open_name = None
+        self._scrim.setVisible(False)
+        self.visibility_changed.emit(name, False)
+
     # -- global dismissal (audit B2 + popover outside-click) ---------------
 
     def eventFilter(self, watched, event):
@@ -213,6 +230,22 @@ class OverlayManager(QObject):
         # _open_name from here races the very methods that own it (the P1
         # acceptance tests caught exactly that). open_surface_name() already
         # re-derives from real visibility for reads.
+
+        # Behind-the-back hides: several legacy paths close a surface's
+        # widget DIRECTLY (e.g. the chat-library bridge's load/new-chat
+        # success path calls dialog.close() itself), never going through
+        # this manager's close(). open_surface_name() self-corrects for
+        # reads, but the scrim is only ever hidden inside close() - so a
+        # dialog closed behind our back left a full-window, press-absorbing
+        # scrim up forever: the whole app dimmed and input-dead. Detect the
+        # hide here, but DEFER the release one tick (same no-sync-mutation
+        # rule as above); keyed on the cached _open_name, since the
+        # re-derived name is already None by the time this Hide arrives.
+        if event.type() == QEvent.Type.Hide and self._open_name is not None:
+            surface = self._surfaces.get(self._open_name)
+            if surface is not None and watched is surface.widget_fn():
+                QTimer.singleShot(0, self._release_orphaned_surface)
+
         name = self.open_surface_name()
         if name is None:
             return False

--- a/graphlink_app/tests/test_overlay_manager.py
+++ b/graphlink_app/tests/test_overlay_manager.py
@@ -129,6 +129,54 @@ class TestDialogScrim:
         manager.reposition_for_resize()
         assert manager._scrim.geometry() == window.rect()
 
+    def test_dialog_hidden_behind_the_managers_back_releases_the_scrim(self, rig):
+        # Regression (2026-07-23 user report): the chat-library bridge's
+        # load/new-chat success path calls dialog.close() DIRECTLY, never
+        # manager.close("library") - the scrim (which absorbs every mouse
+        # press) stayed visible forever, leaving the whole app dimmed and
+        # input-dead after loading a saved chat. The manager must notice a
+        # behind-the-back hide of the open dialog and release the scrim on
+        # the next event-loop tick.
+        _, manager, surfaces = rig
+        manager.open("dlg_a")
+        assert manager._scrim.isVisible()
+
+        # A direct hide, exactly like ChatLibraryBridge._close_dialog().
+        surfaces["dlg_a"].widget.setVisible(False)
+        QApplication.processEvents()  # let the deferred release tick run
+
+        assert not manager._scrim.isVisible(), (
+            "scrim must be released when the open dialog is closed outside "
+            "the manager (e.g. the chat-library load path)"
+        )
+        assert manager.open_surface_name() is None
+        assert manager._open_name is None, "cached name must be cleared too"
+
+    def test_behind_the_back_hide_emits_chip_off_signal(self, rig):
+        # Same regression's second symptom (audit B6): the toolbar chip
+        # binds to visibility_changed - a direct close never emitted the
+        # (name, False) edge, so the Library chip stayed latched active.
+        _, manager, surfaces = rig
+        received = []
+        manager.visibility_changed.connect(lambda name, is_open: received.append((name, is_open)))
+        manager.open("dlg_a")
+        surfaces["dlg_a"].widget.setVisible(False)
+        QApplication.processEvents()
+        assert ("dlg_a", False) in received
+
+    def test_manager_driven_close_does_not_double_fire_the_deferred_release(self, rig):
+        # The ordinary close() path also delivers a Hide event through the
+        # filter; the deferred release must then no-op (close() already
+        # cleaned up), not emit a second visibility_changed(False).
+        _, manager, surfaces = rig
+        received = []
+        manager.visibility_changed.connect(lambda name, is_open: received.append((name, is_open)))
+        manager.open("dlg_a")
+        manager.close("dlg_a")
+        QApplication.processEvents()
+        assert received.count(("dlg_a", False)) == 1
+        assert not manager._scrim.isVisible()
+
 
 class TestVisibilityChangedSignal:
     def test_emits_true_on_open_and_false_on_close(self, rig):


### PR DESCRIPTION
## Summary
- Loading a saved chat (or starting a new one) from the Chat Library left the whole legacy app dimmed and input-dead. Root cause: the chat-library bridge's success path closes the dialog directly (`dialog.close()`), never through `OverlayManager.close()` — and the full-window, press-absorbing `DialogScrim` is only ever hidden inside `close()`. Nothing released the scrim, so every mouse press after a load was swallowed forever.
- `OverlayManager` now notices a Hide event for the currently-open surface's widget in its application event filter and defers the release one event-loop tick (respecting the same no-synchronous-mutation rule the P1 acceptance tests established). The deferred release no-ops when a manager-driven close already cleaned up; otherwise it hides the scrim, clears the cached name, and emits the `visibility_changed(name, False)` edge the direct-close path never fired — fixing the latched-active toolbar chip too.
- One fix covers loadChat, newChat, and any other legacy direct-close path.

## Verification
- 3 new regression tests in `test_overlay_manager.py` (behind-the-back hide releases scrim; chip-off signal fires; manager-driven close doesn't double-fire) — 25/25 pass.
- End-to-end repro against a real `ChatWindow` driving the real `ChatLibraryBridge._perform_load_chat` with the real chats.db: dialog closes, scrim releases, scene populates (12 items), and a subsequent surface opens normally (input genuinely unblocked).
- Full suite: 2031 pytest green.