### PR TITLE
Fix blank Chat Library on reopen after loading a chat

### DIFF
--- a/graphlink_app/graphlink_ui_dialogs/graphlink_library_dialog.py
+++ b/graphlink_app/graphlink_ui_dialogs/graphlink_library_dialog.py
@@ -219,11 +219,18 @@ class ChatLibraryDialog(QDialog):
 
     def closeEvent(self, event):
         self._drag_offset = None
-        # Construct-per-open (WA_DeleteOnClose): tear the embedded host down on
-        # close so each open/close cycle unregisters it from the shared
-        # shutdown registry instead of leaking a dead reference into _hosts.
-        if self.web_host is not None:
-            self.web_host.prepare_for_shutdown()
+        # CACHED lifecycle (P1): this dialog is constructed once and reused
+        # across opens - close() means HIDE, never teardown. The old
+        # construct-per-open comment here ("tear the embedded host down on
+        # close") survived the P1 switch away from WA_DeleteOnClose and was a
+        # real shipped bug: the chat-library bridge's load/new-chat success
+        # path calls dialog.close() directly, prepare_for_shutdown() then
+        # irreversibly disposed the embedded web host (bridge disposed, page
+        # stopped), and every REOPEN of the library showed a dead, blank
+        # panel for the rest of the session. The host stays registered in the
+        # shared registry and is torn down exactly once, at real application
+        # exit, by web_island_host.shutdown_all() - same as every other
+        # long-lived cached host.
         event.accept()
 
     def keyPressEvent(self, event):

--- a/graphlink_app/tests/test_overlay_manager.py
+++ b/graphlink_app/tests/test_overlay_manager.py
@@ -296,3 +296,40 @@ class TestRealChatWindowAcceptanceDrive:
         assert window.library_dialog is not None
         assert window.library_dialog.isVisible()
         manager.close("library")
+
+    def test_library_reopen_after_direct_close_is_not_a_dead_host(self, window):
+        # Regression (2026-07-23 user report, second symptom): the bridge's
+        # load-chat success path calls dialog.close() directly, and the
+        # cached dialog's closeEvent still ran the pre-P1 construct-per-open
+        # teardown (prepare_for_shutdown on the embedded web host) - so the
+        # NEXT open of the library showed a permanently dead, blank panel.
+        # close() must now mean hide for the cached dialog: the host stays
+        # alive and undisposed across open/close cycles.
+        manager = window.overlay_manager
+        manager.close_all()
+        manager.open("library")
+        dialog = window.library_dialog
+        assert dialog is not None and dialog.isVisible()
+        host = dialog.web_host
+        assert not host._shutdown_started
+
+        # The exact direct-close the bridge's _perform_load_chat issues.
+        dialog.close()
+        QApplication.processEvents()  # deferred scrim release tick
+        assert not dialog.isVisible()
+        assert not host._shutdown_started, (
+            "closing the cached library dialog must not dispose its web host"
+        )
+        assert not manager._scrim.isVisible()
+
+        # The reopen the user actually performs next - same dialog, same
+        # host, still alive.
+        manager.open("library")
+        assert dialog.isVisible()
+        assert dialog.web_host is host
+        assert not host._shutdown_started
+        assert not getattr(host.bridge, "disposed", False), (
+            "the bridge must still be live on reopen - a disposed bridge is "
+            "exactly the blank-dark-panel the user reported"
+        )
+        manager.close("library")


### PR DESCRIPTION
## Summary
Follow-up to #119, second half of the same user report: after loading a chat, the **next** open of the Chat Library showed a permanently dead, blank panel.

- `ChatLibraryDialog.closeEvent` still ran the pre-P1 construct-per-open teardown — calling `prepare_for_shutdown()` on the embedded web host, which irreversibly disposes the bridge and stops the page. P1 switched the dialog to cached-and-reused (`WA_DeleteOnClose` dropped) but this `closeEvent` was never updated.
- The Close-button path hides via the overlay manager (no `closeEvent`), which is why routine open/close cycles looked fine. Only the bridge's load/new-chat success path calls `dialog.close()` directly, firing the stale teardown and killing every subsequent reopen for the rest of the session.
- `closeEvent` now just hides (drag-state reset kept). The cached host stays registered and is disposed exactly once, at real application exit, via `web_island_host.shutdown_all()` — same as every other long-lived host. Grep confirmed no sibling dialog has this pattern.

## Verification
- New regression test in the real-ChatWindow acceptance-drive suite: open → direct `dialog.close()` (the load path's exact effect) → reopen → host undisposed, bridge live. 26/26 pass.
- End-to-end drive against a real `ChatWindow` and the real chats.db across the user's exact flow: load a chat → reopen the library (host undisposed, bridge live, all 19 chats listed, no error notice) → a second load from the reopened dialog also works (scene populates).
- Full suite: 2032 pytest green.