### PR TITLE
Qt-removal R4.4: true token streaming (closes R4)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -30,6 +30,30 @@ Two separate jobs live here:
    either, it only stops waiting for it - same limitation here: the
    worker-thread call to `api_provider.chat()` keeps running in its thread
    pool slot after a timeout fires, it is simply no longer awaited.
+
+R4.4 ("true token streaming") adds a `stream: bool` keyword-only parameter to
+`_dispatch`, used ONLY by `start_chat_reply` (the Composer/ChatNode reply
+path - see backend/composer.py's `app-composer` topic).
+`start_conversation_reply` (ConversationNode) is completely unchanged: it
+passes no `stream` kwarg at all and keeps calling the plain blocking
+`_call_chat_agent` driver, exactly as R4.3 shipped it - streaming that
+surface is a deliberately deferred follow-up (see the R4.4 design spec).
+
+When streaming, `_run()` hands raw `on_chunk(delta, reset)` callbacks arriving
+on a worker OS thread (inside `asyncio.to_thread`) back to the event loop via
+`loop.call_soon_threadsafe(queue.put_nowait, ...)` feeding an `asyncio.Queue`
+- the only safe way to cross that thread boundary. A `_pump()` coroutine
+drains that queue and batches deltas into `bus.publish_stream(...)` calls
+(new sibling to `bus.publish()` on `backend.events.SessionBus`, see that
+module) under a fixed flush policy: every ~60ms if anything is buffered, or
+immediately once 40 characters have accumulated, whichever comes first - plus
+an unconditional final flush the instant the underlying call finishes, on
+EVERY exit path (success, cancel, timeout, or any other exception), so the
+pump can never leave a stream hanging without its final `done: true` frame.
+The completion hand-off (`on_reply(reply_text)` with the full accumulated
+text, then `await bus.publish("scene")`) is byte-identical to the
+non-streaming path - callers never know or care whether their reply arrived
+in one blocking call or was assembled from many small chunks.
 """
 
 from __future__ import annotations
@@ -188,6 +212,7 @@ class AgentDispatcher:
         on_begin,
         on_end,
         state_topic: str,
+        stream: bool = False,
     ) -> None:
         """The shared real-dispatch pipeline behind both start_chat_reply
         (Composer, state_topic="app-composer") and start_conversation_reply
@@ -197,7 +222,18 @@ class AgentDispatcher:
         state (ComposerDocument.begin_request/end_request, or a
         ConversationNode's pending_request_id) without this method knowing
         which; `state_topic` is the topic republished around that state
-        change so the right part of the UI refreshes."""
+        change so the right part of the UI refreshes.
+
+        `stream` (R4.4, keyword-only, default False): when True, the reply is
+        assembled from incremental `on_chunk` callbacks - see `_run`'s own
+        streaming branch below - and broadcast live via
+        `bus.publish_stream(...)` as it arrives, instead of waiting for one
+        blocking call to return the full text. start_chat_reply is the ONLY
+        caller that passes stream=True; start_conversation_reply omits the
+        kwarg entirely and is completely unchanged by this addition. Either
+        way, the completion hand-off below (`on_reply(reply_text)` then
+        `await bus.publish("scene")`) is identical - callers never see a
+        difference once the reply is ready."""
         if self._requests:
             # Single-request-per-session guard: never start a second
             # concurrent request while one is already in flight.
@@ -223,10 +259,118 @@ class AgentDispatcher:
             on_begin(request_id)
             await bus.publish(state_topic)
             try:
-                reply_text = await asyncio.wait_for(
-                    asyncio.to_thread(_call_chat_agent, conversation_history, self.persona(), cancel_event),
-                    timeout=WATCHDOG_TIMEOUT_SECONDS,
-                )
+                if stream:
+                    loop = asyncio.get_running_loop()
+                    queue: asyncio.Queue = asyncio.Queue()
+                    _STREAM_DONE = object()
+
+                    def _thread_on_chunk(delta: str, reset: bool) -> None:
+                        # Runs on the WORKER THREAD inside asyncio.to_thread -
+                        # this is the only safe way to hand data to the event
+                        # loop from another OS thread; never touch
+                        # `queue`/`bus` directly here, only via
+                        # call_soon_threadsafe.
+                        loop.call_soon_threadsafe(queue.put_nowait, (delta, reset))
+
+                    async def _pump() -> None:
+                        # Batches raw on_chunk deltas into WS "stream" frames:
+                        # flush every FLUSH_INTERVAL_S if anything is
+                        # buffered, or immediately once FLUSH_CHARS is
+                        # reached, whichever comes first. A `reset` item
+                        # (discarding a failed reasoning-retry attempt) always
+                        # flushes whatever is buffered first, then emits its
+                        # own reset frame immediately - never batched away.
+                        seq = 0
+                        buffer = ""
+                        FLUSH_INTERVAL_S, FLUSH_CHARS = 0.06, 40
+                        finished = False
+                        last_flush = loop.time()
+
+                        async def _emit(text: str, *, done: bool = False, reset: bool = False) -> None:
+                            nonlocal seq
+                            await bus.publish_stream(
+                                topic=state_topic,
+                                request_id=request_id,
+                                seq=seq,
+                                delta=text,
+                                done=done,
+                                reset=reset,
+                            )
+                            seq += 1
+
+                        while not finished:
+                            got = False
+                            try:
+                                item = await asyncio.wait_for(queue.get(), timeout=FLUSH_INTERVAL_S)
+                                got = True
+                            except asyncio.TimeoutError:
+                                pass
+                            if got:
+                                pending = [item]
+                                while not queue.empty():  # drain a burst without waiting
+                                    pending.append(queue.get_nowait())
+                                for it in pending:
+                                    if finished:
+                                        # A delta queued essentially
+                                        # concurrently with _STREAM_DONE (the
+                                        # background thread is never actually
+                                        # interrupted on timeout - see this
+                                        # module's own docstring) could still
+                                        # land in the same drained burst AFTER
+                                        # the done marker. Discard it rather
+                                        # than buffering a stray, cosmetic
+                                        # trailing update that would arrive
+                                        # after the request already ended.
+                                        continue
+                                    if it is _STREAM_DONE:
+                                        finished = True
+                                    else:
+                                        delta, reset = it
+                                        if reset:
+                                            if buffer:
+                                                await _emit(buffer)
+                                                buffer = ""
+                                            await _emit("", reset=True)
+                                            last_flush = loop.time()
+                                        else:
+                                            buffer += delta
+                            now = loop.time()
+                            if buffer and (
+                                finished or len(buffer) >= FLUSH_CHARS or (now - last_flush) >= FLUSH_INTERVAL_S
+                            ):
+                                await _emit(buffer)
+                                buffer = ""
+                                last_flush = now
+                        # Guaranteed final flush, unconditional and always
+                        # last, on EVERY exit path (success, cancel, timeout,
+                        # other error) - see the `finally` below that always
+                        # queues _STREAM_DONE before awaiting this task.
+                        await _emit("", done=True)
+
+                    pump_task = asyncio.create_task(_pump())
+                    try:
+                        reply_text = await asyncio.wait_for(
+                            asyncio.to_thread(
+                                _call_chat_agent_stream,
+                                conversation_history,
+                                self.persona(),
+                                cancel_event,
+                                _thread_on_chunk,
+                            ),
+                            timeout=WATCHDOG_TIMEOUT_SECONDS,
+                        )
+                    finally:
+                        # Guarantees the pump always terminates and sends its
+                        # final done:true frame, on EVERY exit path - success,
+                        # timeout, cancel, or any other exception raised out
+                        # of the to_thread call above.
+                        queue.put_nowait(_STREAM_DONE)
+                        await pump_task
+                else:
+                    reply_text = await asyncio.wait_for(
+                        asyncio.to_thread(_call_chat_agent, conversation_history, self.persona(), cancel_event),
+                        timeout=WATCHDOG_TIMEOUT_SECONDS,
+                    )
                 if inspect.iscoroutinefunction(on_reply):
                     await on_reply(reply_text)
                 else:
@@ -273,7 +417,21 @@ class AgentDispatcher:
         composer_document,
         conversation_history,
         on_reply,
+        stream: bool = True,
     ) -> None:
+        # R4.4: defaults to True for send_message's Composer-send call site
+        # (the only surface this increment's design intends to stream), but
+        # is a real, caller-controlled parameter, NOT hardcoded - regenerate_
+        # response's own call site below passes stream=False explicitly,
+        # since it REPLACES an existing node's content rather than creating
+        # a new one, and the design spec's own deferral list explicitly
+        # scoped Regenerate Response streaming out of this increment ("a
+        # small follow-up once this mechanism is proven"). Hardcoding
+        # stream=True here would have silently activated the Composer's live
+        # preview UI for every Regenerate click too, with no way for the
+        # frontend to distinguish "a send is in flight" from "a regenerate
+        # elsewhere in the canvas is in flight" - a real, confusing surprise
+        # this parameter exists specifically to prevent.
         return await self._dispatch(
             bus=bus,
             notifications_state=notifications_state,
@@ -282,6 +440,7 @@ class AgentDispatcher:
             on_begin=composer_document.begin_request,
             on_end=composer_document.end_request,
             state_topic="app-composer",
+            stream=stream,
         )
 
     async def start_conversation_reply(
@@ -298,7 +457,13 @@ class AgentDispatcher:
         ConversationNode itself (`node.pending_request_id`, duck-typed - this
         module does not import canvas.py's SceneNode) rather than on
         ComposerDocument, and "scene" (not "app-composer") is republished
-        around that change so the node's own in-flight state refreshes."""
+        around that change so the node's own in-flight state refreshes.
+
+        R4.4: deliberately UNCHANGED by the new streaming addition - no
+        `stream` kwarg is passed here, so _dispatch's default (False) applies
+        and this keeps calling the plain blocking `_call_chat_agent` driver
+        exactly as before. Streaming ConversationNode replies is an explicit,
+        separate deferral (see the R4.4 design spec)."""
         return await self._dispatch(
             bus=bus,
             notifications_state=notifications_state,
@@ -421,6 +586,33 @@ def _call_chat_agent(conversation_history, persona_text, cancel_event) -> str:
         # backwards would silently drop the "You are Graphlink Assistant. "
         # prefix.
         resolved_system_prompt=agent.system_prompt,
+    )
+
+
+def _call_chat_agent_stream(conversation_history, persona_text, cancel_event, on_chunk) -> str:
+    """Runs inside asyncio.to_thread - a real OS thread, not the event loop.
+    Streaming counterpart to _call_chat_agent (R4.4) - same persona/
+    current_node/resolved_system_prompt quirks and guarantees as that
+    function (see its own docstring for the "(default persona)" note, which
+    applies identically here since both build the ChatAgent the same way).
+
+    The only difference is the trailing `on_chunk` argument, forwarded
+    straight through to ChatAgent.get_response's additive `on_chunk` kwarg
+    (see graphlink_app/graphlink_chat_agent.py): when non-None, get_response
+    routes the call through api_provider.chat_stream instead of
+    api_provider.chat, invoking `on_chunk(delta, reset)` zero or more times
+    before returning the same full-text shape `_call_chat_agent` returns.
+    `on_chunk` itself is `_dispatch`'s `_thread_on_chunk` closure - a plain
+    callable safe to invoke from this worker thread, since it only ever does
+    `loop.call_soon_threadsafe(...)` internally rather than touching the
+    event loop directly."""
+    agent = ChatAgent("Graphlink Assistant", persona_text)
+    return agent.get_response(
+        conversation_history,
+        current_node=None,
+        cancellation_event=cancel_event,
+        resolved_system_prompt=agent.system_prompt,
+        on_chunk=on_chunk,
     )
 
 

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -1340,6 +1340,13 @@ def register_canvas(
             composer_document=composer_document,
             conversation_history=history,
             on_reply=_on_reply,
+            # R4.4: deliberately NOT streamed - see the design spec's own
+            # deferral list. Regenerate replaces an EXISTING node's content
+            # rather than creating a new one, and streaming it would light
+            # up the Composer dock's live preview for a click on some other
+            # node in the canvas, with no way for the frontend to tell that
+            # apart from an actual Composer send.
+            stream=False,
         )
         return node_to_regenerate.id
 

--- a/backend/events.py
+++ b/backend/events.py
@@ -132,6 +132,46 @@ class SessionBus:
             raise UnknownTopicError(topic)
         await conn.send_json({"kind": "state", "topic": topic, "payload": t.snapshot()})
 
+    async def publish_stream(
+        self,
+        *,
+        topic: str,
+        request_id: str,
+        seq: int,
+        delta: str,
+        done: bool,
+        reset: bool = False,
+    ) -> None:
+        """Broadcast one streaming delta chunk (Qt-removal plan R4.4).
+        Sibling to publish()/send_snapshot(), deliberately NOT a topic
+        snapshot: bypasses _Topic entirely - no revision bump, no
+        schemaVersion stamp. This is a brand-new `kind: "stream"` wire
+        message living outside the versioned-snapshot contract, for a
+        15-17Hz delta channel that would otherwise force `_Topic.snapshot()`
+        to falsely bump `revision` dozens of times per reply.
+
+        `topic` is informational only (which UI surface's request this is) -
+        unlike publish()/send_snapshot(), it is never looked up in
+        self._topics, so an unregistered/arbitrary topic name here is not an
+        error. Same broadcast/dead-connection-detach shape as publish()."""
+        message = {
+            "kind": "stream",
+            "topic": topic,
+            "requestId": request_id,
+            "seq": seq,
+            "delta": delta,
+            "done": done,
+            "reset": reset,
+        }
+        # Snapshot the set: a failed send detaches the connection mid-loop -
+        # same defensive shape as publish() above.
+        for conn in list(self._connections):
+            try:
+                await conn.send_json(message)
+            except Exception:
+                logger.warning("dropping dead connection on session %s", self.session_id)
+                self.detach(conn)
+
     def topic_names(self) -> list[str]:
         return sorted(self._topics)
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,38 @@
+import pytest
+
+import backend  # noqa: F401 - side effect: backend/__init__.py's own import
+# puts graphlink_app/ on sys.path - this must come before the bare
+# `import api_provider` below, matching the same convention every other
+# file in this test package already follows (see test_canvas.py/
+# test_agents.py/test_app_ws.py's own identical comment).
+import api_provider
+
+
+@pytest.fixture(autouse=True)
+def _chat_stream_delegates_to_patched_chat(monkeypatch):
+    """R4.4: send_message's reply path now always calls api_provider.chat_stream
+    (AgentDispatcher.start_chat_reply passes stream=True unconditionally), not
+    api_provider.chat. Every existing test in this suite fakes only chat() via
+    patch.object(api_provider, "chat", fake_chat) - without this fixture,
+    chat_stream's real Ollama branch runs instead (these tests configure Ollama
+    mode to match production), attempting a genuine network call.
+
+    This generic chat_stream fake looks up api_provider.chat AT CALL TIME (a
+    fresh module-attribute read, not a captured reference), so it transparently
+    picks up whatever fake_chat a given test has patched into api_provider.chat
+    for the duration of its own `with patch.object(...)` block, and forwards it
+    through on_chunk as a single synthetic chunk - the exact shape
+    chat_stream's own documented non-Ollama fallback already uses. This tests
+    send_message's downstream logic (node creation, parsing, cancellation),
+    which is unaffected by whether the reply arrived in one chunk or many -
+    real incremental chunking is covered separately by
+    graphlink_app/tests/test_api_provider_chat_stream.py and this suite's own
+    dedicated streaming tests in test_agents.py."""
+
+    def _generic_chat_stream(task, messages, on_chunk, **kwargs):
+        response = api_provider.chat(task, messages, **kwargs)
+        on_chunk(response["message"].get("content", ""), False)
+        return response
+
+    monkeypatch.setattr(api_provider, "chat_stream", _generic_chat_stream)
+    yield

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -25,6 +25,7 @@ import pytest
 # graphlink_licensing) for this module to import cleanly when run standalone.
 import backend.agents as agents_module
 from backend.agents import AgentDispatcher
+from backend.canvas import register_canvas
 from backend.composer import ComposerDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -63,6 +64,50 @@ def _configure_fake_ollama(monkeypatch, chat_fn, *, model="test-model"):
     monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_OLLAMA)
     monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, model)
     monkeypatch.setattr(api_provider, "chat", chat_fn)
+
+    # R4.4: start_chat_reply now always streams (backend/agents.py's
+    # _call_chat_agent_stream always passes a non-None on_chunk), so
+    # ChatWorker.run always calls api_provider.chat_stream, never
+    # api_provider.chat, for that path. Every pre-existing test in this file
+    # built around mocking api_provider.chat alone - most of which predate
+    # R4.4 - would otherwise fall through to chat_stream's REAL Ollama
+    # branch (since these fixtures also set LOCAL_PROVIDER_TYPE to Ollama)
+    # and attempt a genuine network call. This fake mirrors
+    # api_provider.chat_stream's own documented non-streaming-provider
+    # fallback shape exactly (one blocking call plus one synthetic
+    # full-text on_chunk), just delegating the blocking call to chat_fn
+    # instead of the real chat() - so chat_fn's return value/exception/
+    # cancellation behavior is preserved unchanged for both the streaming
+    # and non-streaming dispatch paths. Tests that care about the streaming
+    # semantics THEMSELVES (batching, reset events, ...) monkeypatch
+    # api_provider.chat_stream directly instead - see the "R4.4: true token
+    # streaming" section below.
+    #
+    # Calls api_provider.chat (the module attribute, looked up fresh on
+    # every invocation) rather than closing over chat_fn directly - this
+    # matters for tests that re-monkeypatch api_provider.chat again later
+    # (e.g. simulating a third, different reply after the first call
+    # completes): this fallback must see that later reassignment too, same
+    # as the real chat_stream's own fallback branch would.
+    def _fallback_chat_stream(task, messages, on_chunk, **kwargs):
+        response = api_provider.chat(task, messages, **kwargs)
+        on_chunk(response["message"].get("content", ""), False)
+        return response
+
+    monkeypatch.setattr(api_provider, "chat_stream", _fallback_chat_stream)
+
+
+def _configure_fake_chat_stream(monkeypatch, chat_stream_fn, *, model="test-model"):
+    """Sibling of _configure_fake_ollama for tests that care about the
+    streaming semantics THEMSELVES (batching, cancel-mid-stream, reset
+    events, ...) rather than delegating through a plain chat_fn - sets the
+    same is_configured()-satisfying provider state, then installs
+    chat_stream_fn directly as api_provider.chat_stream (no synthetic
+    fallback wrapper in between, unlike _configure_fake_ollama's own)."""
+    monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+    monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_OLLAMA)
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, model)
+    monkeypatch.setattr(api_provider, "chat_stream", chat_stream_fn)
 
 
 # -- 1. successful reply ------------------------------------------------------
@@ -1051,3 +1096,319 @@ def test_no_cancel_image_method_or_intent_exists():
     as this design decision holds."""
     dispatcher = AgentDispatcher(_FakeSettingsManager())
     assert not hasattr(dispatcher, "cancel_image")
+
+
+# -- R4.4: true token streaming (dispatcher half) -----------------------------
+#
+# These tests monkeypatch graphlink_app.api_provider.chat_stream directly
+# (the same seam graphlink_chat_agent.py's ChatWorker.run calls when
+# on_chunk is not None), so they exercise the REAL _call_chat_agent_stream ->
+# ChatAgent.get_response -> ChatWorker.run -> api_provider.chat_stream chain,
+# not just a fake standing in for backend/agents.py's own driver function -
+# the dispatcher-side pump/thread-to-loop-handoff logic in _dispatch's _run()
+# is what is actually under test here.
+
+
+class _StreamRecorderConnection:
+    """Connection double recording every 'stream'-kind frame broadcast to
+    it, in order - lets tests assert the pump's batching/flush behavior end
+    to end without a real WebSocket. (Distinct from _Recorder above, which
+    only tracks 'state'-kind topic names.)"""
+
+    def __init__(self):
+        self.frames: list[dict] = []
+
+    async def send_json(self, data):
+        if data.get("kind") == "stream":
+            self.frames.append(data)
+
+
+def test_streaming_happy_path_recorder_receives_ordered_stream_frames_and_on_reply_once(monkeypatch):
+    def fake_chat_stream(task, messages, on_chunk, **kwargs):
+        on_chunk("Hel", False)
+        on_chunk("lo", False)
+        return {"message": {"content": "Hello"}}
+
+    _configure_fake_chat_stream(monkeypatch, fake_chat_stream)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        recorder = _StreamRecorderConnection()
+        bus.attach(recorder)
+        replies = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=replies.append,
+        )
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assert replies == ["Hello"]
+        assert dispatcher._requests == {}
+        assert composer_document.request_state == "idle"
+
+        assert recorder.frames, "must have received at least one stream frame"
+        assert recorder.frames[-1]["done"] is True
+        assert recorder.frames[-1]["delta"] == ""
+        concatenated = "".join(f["delta"] for f in recorder.frames if not f["done"])
+        assert concatenated == "Hello"
+        assert all(f["topic"] == "app-composer" for f in recorder.frames)
+        request_ids = {f["requestId"] for f in recorder.frames}
+        assert len(request_ids) == 1 and next(iter(request_ids))
+        seqs = [f["seq"] for f in recorder.frames]
+        assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs), "seq must be strictly increasing"
+
+    asyncio.run(run())
+
+
+def test_cancel_mid_stream_no_on_reply_and_stream_frames_still_end_with_done_true(monkeypatch):
+    started = threading.Event()
+
+    def fake_chat_stream(task, messages, on_chunk, cancellation_event=None, **kwargs):
+        on_chunk("a", False)
+        on_chunk("b", False)
+        started.set()
+        while not cancellation_event.is_set():
+            time.sleep(0.01)
+        raise api_provider.RequestCancelledError("Request cancelled.")
+
+    _configure_fake_chat_stream(monkeypatch, fake_chat_stream)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        recorder = _StreamRecorderConnection()
+        bus.attach(recorder)
+        replies = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=replies.append,
+        )
+        request_id, entry = next(iter(dispatcher._requests.items()))
+
+        await asyncio.to_thread(started.wait, 5)
+        assert dispatcher.cancel(request_id) is True
+
+        await entry["task"]
+
+        assert replies == [], "cancel discards everything - no partial-text on_reply, matching R4.2 precedent"
+        assert dispatcher._requests == {}
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert notifications.message == "Request cancelled."
+
+        assert recorder.frames, "the pump must still have flushed something before terminating"
+        assert recorder.frames[-1]["done"] is True, "the pump never hangs - it always sends its final frame"
+
+    asyncio.run(run())
+
+
+def test_stream_error_mid_way_generic_notification_and_stream_frames_still_end_done_true(monkeypatch):
+    def fake_chat_stream(task, messages, on_chunk, **kwargs):
+        on_chunk("partial", False)
+        raise RuntimeError("boom")
+
+    _configure_fake_chat_stream(monkeypatch, fake_chat_stream)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        recorder = _StreamRecorderConnection()
+        bus.attach(recorder)
+        replies = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=replies.append,
+        )
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assert replies == []
+        assert dispatcher._requests == {}
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == "AI response failed: boom"
+
+        assert recorder.frames, "the pump must still have flushed the partial chunk before terminating"
+        assert recorder.frames[-1]["done"] is True
+
+    asyncio.run(run())
+
+
+def test_throttle_batches_many_small_chunks_into_materially_fewer_publish_stream_calls(monkeypatch):
+    chars = [chr(ord("a") + (i % 26)) for i in range(200)]
+    expected = "".join(chars)
+
+    def fake_chat_stream(task, messages, on_chunk, **kwargs):
+        for c in chars:
+            on_chunk(c, False)
+        return {"message": {"content": expected}}
+
+    _configure_fake_chat_stream(monkeypatch, fake_chat_stream)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        recorder = _StreamRecorderConnection()
+        bus.attach(recorder)
+        replies = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=replies.append,
+        )
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assert replies == [expected]
+        assert len(recorder.frames) < 100, (
+            "200 one-character on_chunk calls fired with no delay must batch into "
+            "materially fewer publish_stream calls than input chunks"
+        )
+        concatenated = "".join(f["delta"] for f in recorder.frames if not f["done"])
+        assert concatenated == expected
+        assert recorder.frames[-1]["done"] is True
+
+    asyncio.run(run())
+
+
+def test_completion_handoff_parity_streaming_send_message_creates_identical_nodes(monkeypatch):
+    """R4.4 spec section 6, item 7: re-run the R4.3b thinking+text+code
+    send_message fixture (test_canvas.py's own
+    test_send_message_reply_with_thinking_text_and_code_creates_both_children_on_same_parent)
+    through the real streaming dispatch path (api_provider.chat_stream
+    monkeypatched instead of api_provider.chat) via the real "sendMessage"
+    scene intent, and assert IDENTICAL ChatNode/ThinkingNode/CodeNode
+    creation results to the non-streaming fixture for the same canned full
+    text - proves the completion hand-off (on_reply -> parse_response ->
+    add_chat_node/add_thinking_node/add_code_node, all in backend/canvas.py,
+    untouched by this increment) is truly unchanged by streaming."""
+    canned_text = (
+        "<think>working it out</think>\n"
+        "Here's the plan.\n"
+        "```python\nprint('plan')\n```"
+    )
+
+    def fake_chat_stream(task, messages, on_chunk, **kwargs):
+        on_chunk(canned_text, False)
+        return {"message": {"content": canned_text}}
+
+    _configure_fake_chat_stream(monkeypatch, fake_chat_stream)
+
+    async def run():
+        bus = SessionBus("agents-stream-parity-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+        document = register_canvas(bus, notifications, dispatcher, composer_document)
+
+        user_node_id = await bus.dispatch_intent("scene", "sendMessage", ["plan it out"])
+        entry = next(iter(dispatcher._requests.values()))
+        await entry["task"]
+
+        assistant_nodes = [
+            n for n in document.nodes.values() if n.kind == "chat" and n.id != user_node_id
+        ]
+        assert len(assistant_nodes) == 1
+        assistant_node = assistant_nodes[0]
+        assert assistant_node.content == "Here's the plan."
+
+        thinking_nodes = [n for n in document.nodes.values() if n.kind == "thinking"]
+        code_nodes = [n for n in document.nodes.values() if n.kind == "code"]
+        assert len(thinking_nodes) == 1
+        assert len(code_nodes) == 1
+
+        assert any(
+            e.source == assistant_node.id and e.target == thinking_nodes[0].id
+            for e in document.edges.values()
+        )
+        assert any(
+            e.source == assistant_node.id and e.target == code_nodes[0].id
+            for e in document.edges.values()
+        )
+        assert not any(
+            e.source == thinking_nodes[0].id and e.target == code_nodes[0].id
+            for e in document.edges.values()
+        ), "thinking and code children are not chained to each other"
+        assert document.last_chat_node_id == assistant_node.id
+
+    asyncio.run(run())
+
+
+def test_image_request_runs_independently_while_a_chat_stream_is_paused_mid_flight(monkeypatch):
+    """R4.4 spec section 6, item 8: cross-slot concurrency during an active
+    stream. A chat stream paused mid-flight (self._requests) must not block,
+    or be blocked by, a concurrent image-generation request
+    (self._image_requests) - the two independent slots this dispatcher
+    already guarantees (R4.4a) must keep holding under streaming too."""
+    chat_started = threading.Event()
+    chat_release = threading.Event()
+
+    def fake_chat_stream(task, messages, on_chunk, **kwargs):
+        on_chunk("partial chat text", False)
+        chat_started.set()
+        chat_release.wait(5)
+        return {"message": {"content": "final chat reply"}}
+
+    _configure_fake_chat_stream(monkeypatch, fake_chat_stream)
+    monkeypatch.setattr(api_provider, "generate_image", lambda prompt, **kwargs: b"image-bytes")
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        recorder = _StreamRecorderConnection()
+        bus.attach(recorder)
+        chat_replies = []
+        image_replies = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=chat_replies.append,
+        )
+        await asyncio.to_thread(chat_started.wait, 5)
+        # chat_started only guarantees on_chunk queued its delta - give the
+        # pump's own flush timer (FLUSH_INTERVAL_S=0.06s) a moment to
+        # actually broadcast it before asserting.
+        await asyncio.sleep(0.15)
+
+        assert len(dispatcher._requests) == 1
+        assert recorder.frames, "at least the first buffered delta should have flushed by now"
+
+        await dispatcher.start_image_reply(
+            bus=bus, notifications_state=notifications, prompt="a cat", on_reply=image_replies.append,
+        )
+        image_entry = next(iter(dispatcher._image_requests.values()))
+        await image_entry["task"]
+
+        # The image request completed independently, without waiting on the
+        # still-paused chat stream.
+        assert image_replies == [b"image-bytes"]
+        assert dispatcher._image_requests == {}
+        assert len(dispatcher._requests) == 1, "the chat stream is still in flight, untouched by the image request"
+        assert notifications.visible is False, "neither request was rejected"
+
+        chat_release.set()
+        chat_entry = next(iter(dispatcher._requests.values()))
+        await chat_entry["task"]
+
+        assert chat_replies == ["final chat reply"]
+        assert dispatcher._requests == {}
+        assert recorder.frames[-1]["done"] is True, "stream frames kept recording throughout the image request"
+
+    asyncio.run(run())

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -1220,6 +1220,49 @@ def test_regenerate_response_intent_mutates_the_existing_node_in_place_not_a_new
     asyncio.run(run())
 
 
+def test_regenerate_response_does_not_stream_unlike_an_ordinary_send():
+    # R4.4 regression: start_chat_reply's stream=True default is for
+    # send_message's Composer-send surface only. regenerate_response passes
+    # stream=False explicitly (see canvas.py's own call site) - an
+    # adversarial reviewer found the first R4.4 cut hardcoded stream=True
+    # unconditionally, silently activating the Composer dock's live preview
+    # for a Regenerate click on some unrelated node in the canvas, with no
+    # way for the frontend to distinguish that from a real Send in flight.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "original reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["hi"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
+        recorder.messages.clear()  # only care about messages from the regenerate call below
+
+        def regenerated_reply(task, messages, **kwargs):
+            return {"message": {"content": "regenerated reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", regenerated_reply):
+            await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        stream_frames = [m for m in recorder.messages if m.get("kind") == "stream"]
+        assert stream_frames == [], "regenerate_response must never emit stream frames"
+        assert document.nodes[assistant_node.id].content == "regenerated reply"
+
+    asyncio.run(run())
+
+
 def test_regenerate_response_replaces_code_child_not_accumulates():
     async def run():
         bus, document, recorder, dispatcher = make_bus_with_dispatcher()

--- a/graphlink_app/api_provider.py
+++ b/graphlink_app/api_provider.py
@@ -8,7 +8,7 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import NamedTuple
+from typing import Callable, NamedTuple
 from urllib.parse import urlparse
 
 import ollama
@@ -2040,86 +2040,211 @@ def chat(task: str, messages: list, **kwargs) -> dict:
         raise RuntimeError(f"Unsupported API provider: {state.api_provider_type}")
 
     except Exception as exc:
-        if isinstance(exc, RequestCancelledError):
-            raise
+        _translate_chat_exception(exc, state, messages)
 
-        error_str = str(exc).lower()
-        status_code = getattr(exc, "status_code", None)
 
-        if "timed out" in error_str or "timeout" in error_str:
-            if _message_contains_audio(messages):
-                raise TimeoutError(
-                    "The request timed out while processing audio.\n\n"
-                    "Please try again. If this keeps happening, use a shorter clip or switch to an audio-capable Gemini or Ollama model."
-                ) from exc
+def _translate_chat_exception(exc: Exception, state, messages: list) -> None:
+    """Shared exception-normalization for chat()/chat_stream(): translates raw
+    provider/network exceptions into actionable, user-facing messages. Always
+    raises - either a translated exception (chained `from exc`) or the
+    original `exc` unchanged - never returns normally. Extracted as its own
+    function (R4.4) so chat_stream()'s live-streaming branch gets the exact
+    same error-translation behavior chat() already has, rather than letting
+    raw provider/network exceptions (connection-refused, timeout, quota, ...)
+    propagate unfriendly and untranslated on the now-exclusively-streaming
+    Composer chat path."""
+    if isinstance(exc, RequestCancelledError):
+        raise exc
+
+    error_str = str(exc).lower()
+    status_code = getattr(exc, "status_code", None)
+
+    if "timed out" in error_str or "timeout" in error_str:
+        if _message_contains_audio(messages):
             raise TimeoutError(
-                "The model request timed out.\n\n"
-                "Please try again or choose a faster model."
+                "The request timed out while processing audio.\n\n"
+                "Please try again. If this keeps happening, use a shorter clip or switch to an audio-capable Gemini or Ollama model."
             ) from exc
+        raise TimeoutError(
+            "The model request timed out.\n\n"
+            "Please try again or choose a faster model."
+        ) from exc
 
-        if "429" in error_str or "quota" in error_str or "resourceexhausted" in error_str:
-            if state.api_provider_type == config.API_PROVIDER_OPENAI:
-                raise RuntimeError(
-                    "OpenAI-compatible API quota exceeded or rate limited.\n\n"
-                    "Please verify billing, rate limits, and the selected model for your endpoint."
-                ) from exc
-            if state.api_provider_type == config.API_PROVIDER_ANTHROPIC:
-                raise RuntimeError(
-                    "Anthropic API quota exceeded or rate limited.\n\n"
-                    "Please verify billing, rate limits, and the selected Claude model."
-                ) from exc
+    if "429" in error_str or "quota" in error_str or "resourceexhausted" in error_str:
+        if state.api_provider_type == config.API_PROVIDER_OPENAI:
             raise RuntimeError(
-                "Google Gemini API Quota Exceeded.\n\n"
-                "Note: Google does not offer a free tier for their 'Pro' models. "
-                "Please switch your default task models to a 'Flash' model in the API Settings, "
-                "or link a billing account in Google AI Studio."
+                "OpenAI-compatible API quota exceeded or rate limited.\n\n"
+                "Please verify billing, rate limits, and the selected model for your endpoint."
+            ) from exc
+        if state.api_provider_type == config.API_PROVIDER_ANTHROPIC:
+            raise RuntimeError(
+                "Anthropic API quota exceeded or rate limited.\n\n"
+                "Please verify billing, rate limits, and the selected Claude model."
+            ) from exc
+        raise RuntimeError(
+            "Google Gemini API Quota Exceeded.\n\n"
+            "Note: Google does not offer a free tier for their 'Pro' models. "
+            "Please switch your default task models to a 'Flash' model in the API Settings, "
+            "or link a billing account in Google AI Studio."
+        ) from exc
+
+    if state.use_api_mode and state.api_provider_type == config.API_PROVIDER_ANTHROPIC:
+        if status_code in (401, 403) or "authentication" in error_str or "invalid x-api-key" in error_str:
+            raise RuntimeError(
+                "Anthropic API authentication failed.\n\n"
+                "Please verify your Anthropic API key in Settings."
             ) from exc
 
-        if state.use_api_mode and state.api_provider_type == config.API_PROVIDER_ANTHROPIC:
-            if status_code in (401, 403) or "authentication" in error_str or "invalid x-api-key" in error_str:
-                raise RuntimeError(
-                    "Anthropic API authentication failed.\n\n"
-                    "Please verify your Anthropic API key in Settings."
-                ) from exc
-
-        if (
-            "connection refused" in error_str
-            or "connecterror" in error_str
-            or "connection error" in error_str
-            or "all connection attempts failed" in error_str
-        ):
-            if not state.use_api_mode:
-                raise ConnectionError(
-                    "Failed to connect to local Ollama server. Please ensure the Ollama app is running and accessible."
-                ) from exc
-            if state.api_provider_type == config.API_PROVIDER_ANTHROPIC:
-                raise ConnectionError(
-                    "Failed to connect to the Anthropic API. Please verify your network connection and try again.\n\n"
-                    f"Details: {exc}"
-                ) from exc
+    if (
+        "connection refused" in error_str
+        or "connecterror" in error_str
+        or "connection error" in error_str
+        or "all connection attempts failed" in error_str
+    ):
+        if not state.use_api_mode:
             raise ConnectionError(
-                "Failed to connect to the API endpoint. Please verify your Base URL in settings and your network connection.\n\n"
+                "Failed to connect to local Ollama server. Please ensure the Ollama app is running and accessible."
+            ) from exc
+        if state.api_provider_type == config.API_PROVIDER_ANTHROPIC:
+            raise ConnectionError(
+                "Failed to connect to the Anthropic API. Please verify your network connection and try again.\n\n"
                 f"Details: {exc}"
             ) from exc
+        raise ConnectionError(
+            "Failed to connect to the API endpoint. Please verify your Base URL in settings and your network connection.\n\n"
+            f"Details: {exc}"
+        ) from exc
 
-        if _message_contains_audio(messages):
-            audio_error_fragments = (
-                "audio input",
-                "audio support",
-                "unsupported audio",
-                "input_audio",
-                "modality",
-                "capabilit",
-                "transcription",
-                "decode audio",
-            )
-            if any(fragment in error_str for fragment in audio_error_fragments):
-                raise RuntimeError(
-                    f"{exc}\n\n"
-                    "Please try again with an audio-capable model, or retry after confirming the file opens correctly."
-                ) from exc
+    if _message_contains_audio(messages):
+        audio_error_fragments = (
+            "audio input",
+            "audio support",
+            "unsupported audio",
+            "input_audio",
+            "modality",
+            "capabilit",
+            "transcription",
+            "decode audio",
+        )
+        if any(fragment in error_str for fragment in audio_error_fragments):
+            raise RuntimeError(
+                f"{exc}\n\n"
+                "Please try again with an audio-capable model, or retry after confirming the file opens correctly."
+            ) from exc
 
-        raise
+    raise exc
+
+
+def chat_stream(task: str, messages: list, on_chunk: Callable[[str, bool], None], **kwargs) -> dict:
+    """Streaming sibling of chat() (Qt-removal R4.4: true token streaming).
+
+    Only the Ollama local provider streams real incremental chunks. Every other
+    provider/task combination (API mode, Llama.cpp local) silently falls back to one
+    ordinary blocking chat() call plus exactly one synthetic full-text chunk - an
+    intentional, explicit R4.4 scope decision, not a gap (see the design spec).
+
+    `on_chunk(delta, reset)` is called zero or more times with `reset=False` and
+    incremental DELTAS (never cumulative text - Ollama's streamed `message.content`
+    fragments must be concatenated, not replaced). It is called once with `("", True)`
+    immediately before a reasoning-retry attempt discards the prior attempt's partial
+    text.
+
+    Returns the exact same shape chat() returns: {"message": {"content": <full text>,
+    "role": "assistant"}}. `**kwargs` behaves identically to chat()'s kwargs (including
+    `cancellation_event`).
+    """
+    cancel_event = kwargs.get("cancellation_event")
+    state = _snapshot_provider_state()
+
+    # Silent fallback: every provider/local-type this increment doesn't cover
+    # degenerates to one blocking chat() call + one synthetic chunk.
+    if state.use_api_mode or state.local_provider_type != config.LOCAL_PROVIDER_OLLAMA:
+        response = chat(task, messages, **kwargs)
+        on_chunk(response["message"].get("content", ""), False)
+        return response
+
+    try:
+        _raise_if_cancelled(cancel_event)
+        model = config.OLLAMA_MODELS.get(task)
+        if not model:
+            raise ValueError(f"No Ollama model configured for task: {task}")
+        _assert_ollama_audio_support(model, messages)
+        ollama_messages = _prepare_ollama_messages(messages)
+
+        ollama_kwargs = {k: v for k, v in kwargs.items() if k != "cancellation_event"}
+        if task == config.TASK_CHAT and ("qwen3" in model.lower() or "deepseek" in model.lower()):
+            ollama_kwargs["think"] = state.ollama_reasoning_mode == "Thinking"
+
+        # Same 3-attempt reasoning-retry loop as chat() (see ReasoningWithoutAnswerError):
+        # each attempt streams live, and if an attempt is discarded, the caller is told via
+        # one on_chunk("", True) reset event before the next attempt's deltas start
+        # arriving.
+        max_attempts = 3
+        last_reasoning_error = None
+        full_response_content = None
+        for attempt in range(max_attempts):
+            if attempt > 0:
+                _raise_if_cancelled(cancel_event)
+                time.sleep(_OLLAMA_REASONING_RETRY_BACKOFF_SECONDS)
+                _raise_if_cancelled(cancel_event)
+                on_chunk("", True)  # tell the caller: discard the last attempt's partial text
+
+            content_parts: list[str] = []
+            thinking_parts: list[str] = []
+            stream = ollama.chat(model=model, messages=ollama_messages, stream=True, **ollama_kwargs)
+            try:
+                for part in stream:
+                    if cancel_event is not None and cancel_event.is_set():
+                        stream.close()  # unwinds ollama/_client.py's `with self._client.stream(...)`
+                    _raise_if_cancelled(cancel_event)  # raises RequestCancelledError if just closed above
+
+                    delta_content = part["message"].get("content") or ""
+                    if delta_content:
+                        content_parts.append(delta_content)
+                        on_chunk(delta_content, False)
+                    delta_thinking = part["message"].get("thinking") or ""
+                    if delta_thinking:
+                        thinking_parts.append(delta_thinking)  # never forwarded to on_chunk
+                    if part.get("done"):
+                        break
+            finally:
+                stream.close()  # idempotent on an already-exhausted generator
+
+            raw_response_content = "".join(content_parts)
+            embedded_reasoning, visible_response_content = split_reasoning_and_content(raw_response_content)
+            reasoning_parts: list[str] = []
+            reasoning_seen: set[str] = set()
+            _append_unique_text_segment(reasoning_parts, "".join(thinking_parts), reasoning_seen)
+            _append_unique_text_segment(reasoning_parts, embedded_reasoning, reasoning_seen)
+
+            try:
+                full_response_content = _compose_reasoned_response(
+                    visible_response_content,
+                    "\n\n".join(reasoning_parts).strip(),
+                    "Ollama",
+                )
+                break
+            except ReasoningWithoutAnswerError as exc:
+                last_reasoning_error = exc
+                continue
+        else:
+            raise RuntimeError(
+                f"Ollama returned reasoning but no final answer after {max_attempts} attempts. "
+                "Retry in Quick mode or choose a different chat format/model."
+            ) from last_reasoning_error
+
+        return {
+            "message": {
+                "content": full_response_content,
+                "role": "assistant",
+            }
+        }
+    except Exception as exc:
+        # Same translation chat()'s Ollama branch gets - a real connection-
+        # refused/timeout/quota failure here must show the same friendly,
+        # actionable message as the non-streaming path, not raw exception
+        # text (this is now the ONLY code path Composer send uses).
+        _translate_chat_exception(exc, state, messages)
 
 
 def initialize_api(provider: str, api_key: str, base_url: str = None):

--- a/graphlink_app/graphlink_chat_agent.py
+++ b/graphlink_app/graphlink_chat_agent.py
@@ -74,7 +74,8 @@ class ChatWorker:
         self.token_estimator = TokenEstimator()
         self.MAX_TOKENS = 8000
 
-    def run(self, conversation_history, current_node, cancellation_event=None, resolved_system_prompt=None):
+    def run(self, conversation_history, current_node, cancellation_event=None, resolved_system_prompt=None,
+            on_chunk=None):
         """
         Executes the chat logic for a single turn.
 
@@ -85,6 +86,11 @@ class ChatWorker:
             resolved_system_prompt (str, optional): The branch system prompt already
                 resolved on the GUI thread. When provided, the scene is NOT walked here -
                 this is how the worker-thread path avoids touching QGraphicsScene (#20).
+            on_chunk (callable, optional): Qt-removal R4.4 token streaming. When provided,
+                routes through api_provider.chat_stream(...) instead of api_provider.chat(...),
+                invoking on_chunk(delta, reset) as incremental text arrives. Additive and
+                default-None: every existing call site (this legacy Qt path included) that
+                omits it gets byte-identical behavior via the unchanged chat() call below.
 
         Returns:
             str: The AI-generated response text.
@@ -115,11 +121,19 @@ class ChatWorker:
 
             messages.extend(trimmed_history)
 
-            response = api_provider.chat(
-                task=config.TASK_CHAT,
-                messages=messages,
-                cancellation_event=cancellation_event,
-            )
+            if on_chunk is not None:
+                response = api_provider.chat_stream(
+                    task=config.TASK_CHAT,
+                    messages=messages,
+                    on_chunk=on_chunk,
+                    cancellation_event=cancellation_event,
+                )
+            else:
+                response = api_provider.chat(
+                    task=config.TASK_CHAT,
+                    messages=messages,
+                    cancellation_event=cancellation_event,
+                )
             ai_message = response['message']['content']
             return ai_message
         except Exception as e:
@@ -144,7 +158,8 @@ class ChatAgent:
         self.persona = persona or "(default persona)"
         self.system_prompt = f"You are {self.name}. {self.persona}"
 
-    def get_response(self, conversation_history, current_node, cancellation_event=None, resolved_system_prompt=None):
+    def get_response(self, conversation_history, current_node, cancellation_event=None, resolved_system_prompt=None,
+                      on_chunk=None):
         """
         Gets an AI response for a given conversation history.
 
@@ -154,6 +169,8 @@ class ChatAgent:
             resolved_system_prompt (str, optional): Branch system prompt already resolved
                 on the GUI thread; passed straight through so the worker never walks the
                 scene itself (#20).
+            on_chunk (callable, optional): Qt-removal R4.4 token streaming; passed straight
+                through to ChatWorker.run (see its docstring). Additive, default-None.
 
         Returns:
             str: The AI-generated response text.
@@ -166,5 +183,6 @@ class ChatAgent:
             current_node,
             cancellation_event=cancellation_event,
             resolved_system_prompt=resolved_system_prompt,
+            on_chunk=on_chunk,
         )
         return ai_response

--- a/graphlink_app/tests/test_api_provider_chat_stream.py
+++ b/graphlink_app/tests/test_api_provider_chat_stream.py
@@ -1,0 +1,373 @@
+"""Tests for api_provider.chat_stream() (Qt-removal R4.4: true token streaming).
+
+chat_stream() is an additive, wholly new function alongside chat() - it must never
+change chat()'s own behavior (see test_import_chain.py / test_no_qt_anywhere.py, run
+unmodified as part of the same increment's verification: chat_stream/on_chunk add zero
+new import edges).
+
+This file covers exactly the two backend-only items from the R4.4 design spec's test
+plan (section 6) that fall entirely inside api_provider.py:
+
+1. Fallback path unchanged for non-streaming providers - every provider/local-type this
+   increment doesn't cover (API mode, or a non-Ollama local provider) degenerates to one
+   blocking chat() call plus exactly one synthetic on_chunk(full_text, False) call, and
+   returns the exact value chat() alone would for the same fixture.
+6. Reset-on-retry - driving the real chat_stream against a monkeypatched ollama.chat
+   that raises ReasoningWithoutAnswerError-triggering content on attempt 1 and real
+   content on attempt 2: on_chunk("", True) fires exactly once between attempts, and all
+   deltas after that reset concatenate to attempt 2's raw content.
+
+(Items 2-5, 7-9 of the spec's test list live in backend/tests/test_agents.py and are out
+of scope for this file - this file only exercises the provider layer.)
+"""
+
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+import api_provider
+import graphlink_task_config as config
+
+
+def _set_ollama_model(monkeypatch, model_name="test-model"):
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, model_name)
+    monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+    monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_OLLAMA)
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep(monkeypatch):
+    # Same convention as test_ollama_reasoning_retry.py: keep the retry-backoff path
+    # fast/deterministic in tests that exercise more than one attempt.
+    monkeypatch.setattr(api_provider.time, "sleep", lambda seconds: None)
+
+
+class _FakeStream:
+    """Stand-in for the generator ollama.chat(..., stream=True) returns.
+
+    Real ollama.chat(stream=True) returns a plain Python generator (see
+    ollama/_client.py's Client._request -> inner(), which `yield`s), so `.close()` is
+    always available on it for free - chat_stream's `finally: stream.close()` relies on
+    exactly that. This fake exposes the same iterate+close() shape explicitly, and
+    records whether close() was ever invoked so tests can assert on it.
+    """
+
+    def __init__(self, chunks):
+        self._iter = iter(chunks)
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._iter)
+
+    def close(self):
+        self.closed = True
+
+
+class TestFallbackPathUnchangedForNonStreamingProviders:
+    """Spec section 6 item 1."""
+
+    @staticmethod
+    def _fixture_response():
+        return {"message": {"content": "The full non-streamed answer.", "role": "assistant"}}
+
+    def test_api_mode_falls_back_to_one_chat_call_and_one_synthetic_chunk(self, monkeypatch):
+        monkeypatch.setattr(api_provider, "USE_API_MODE", True)
+        fixture = self._fixture_response()
+        received = []
+
+        with patch("api_provider.chat", return_value=fixture) as mock_chat:
+            result = api_provider.chat_stream(
+                task=config.TASK_CHAT,
+                messages=[{"role": "user", "content": "hi"}],
+                on_chunk=lambda delta, reset: received.append((delta, reset)),
+            )
+
+        mock_chat.assert_called_once_with(config.TASK_CHAT, [{"role": "user", "content": "hi"}])
+        assert result == fixture
+        assert received == [("The full non-streamed answer.", False)]
+
+    def test_non_ollama_local_provider_falls_back_identically(self, monkeypatch):
+        monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+        monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_LLAMACPP)
+        fixture = self._fixture_response()
+        received = []
+
+        with patch("api_provider.chat", return_value=fixture) as mock_chat:
+            result = api_provider.chat_stream(
+                task=config.TASK_CHAT,
+                messages=[{"role": "user", "content": "hi"}],
+                on_chunk=lambda delta, reset: received.append((delta, reset)),
+            )
+
+        assert mock_chat.call_count == 1
+        assert result == fixture
+        assert received == [("The full non-streamed answer.", False)]
+
+    def test_fallback_return_value_is_identical_to_calling_chat_directly(self, monkeypatch):
+        # Proves chat_stream's fallback returns the exact same value chat() alone would
+        # produce for the identical fixture, not merely "a dict shaped like it".
+        monkeypatch.setattr(api_provider, "USE_API_MODE", True)
+        fixture = self._fixture_response()
+
+        with patch("api_provider.chat", return_value=fixture):
+            direct_result = api_provider.chat(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}])
+        with patch("api_provider.chat", return_value=fixture):
+            streamed_result = api_provider.chat_stream(
+                task=config.TASK_CHAT,
+                messages=[{"role": "user", "content": "hi"}],
+                on_chunk=lambda delta, reset: None,
+            )
+
+        assert streamed_result == direct_result
+
+    def test_cancellation_kwarg_still_flows_through_to_the_underlying_chat_call(self, monkeypatch):
+        monkeypatch.setattr(api_provider, "USE_API_MODE", True)
+        cancel_event = threading.Event()
+        fixture = self._fixture_response()
+
+        with patch("api_provider.chat", return_value=fixture) as mock_chat:
+            api_provider.chat_stream(
+                task=config.TASK_CHAT,
+                messages=[{"role": "user", "content": "hi"}],
+                on_chunk=lambda delta, reset: None,
+                cancellation_event=cancel_event,
+            )
+
+        assert mock_chat.call_args.kwargs.get("cancellation_event") is cancel_event
+
+
+class TestResetOnRetryPreservesTheReasoningRetryLoop:
+    """Spec section 6 item 6."""
+
+    def test_reset_emitted_once_between_attempts_and_post_reset_deltas_match_attempt_two(self, monkeypatch):
+        _set_ollama_model(monkeypatch)
+
+        # Attempt 1: entirely wrapped in <think>...</think> with nothing else -
+        # split_reasoning_and_content yields reasoning but an empty visible answer,
+        # which _compose_reasoned_response turns into ReasoningWithoutAnswerError.
+        attempt_one_chunks = [
+            {"message": {"content": "<think>some reasoning"}, "done": False},
+            {"message": {"content": " only</think>"}, "done": True},
+        ]
+        # Attempt 2: a plain final answer, no reasoning wrapper - succeeds.
+        attempt_two_chunks = [
+            {"message": {"content": "This is "}, "done": False},
+            {"message": {"content": "the final real answer."}, "done": True},
+        ]
+        attempt_two_raw_content = "This is the final real answer."
+
+        events = []  # (delta, reset) in call order
+
+        with patch(
+            "api_provider.ollama.chat",
+            side_effect=[_FakeStream(attempt_one_chunks), _FakeStream(attempt_two_chunks)],
+        ) as mock_chat:
+            result = api_provider.chat_stream(
+                task=config.TASK_CHAT,
+                messages=[{"role": "user", "content": "hi"}],
+                on_chunk=lambda delta, reset: events.append((delta, reset)),
+            )
+
+        assert mock_chat.call_count == 2
+        assert result["message"]["content"] == attempt_two_raw_content
+
+        reset_events = [e for e in events if e[1] is True]
+        assert len(reset_events) == 1
+        assert reset_events[0] == ("", True)
+
+        reset_index = events.index(("", True))
+        deltas_before_reset = [delta for delta, reset in events[:reset_index] if not reset]
+        deltas_after_reset = [delta for delta, reset in events[reset_index + 1:] if not reset]
+
+        assert "".join(deltas_before_reset) == "<think>some reasoning only</think>"
+        assert "".join(deltas_after_reset) == attempt_two_raw_content
+
+    def test_succeeds_immediately_with_no_reset_when_the_first_attempt_has_a_real_answer(self, monkeypatch):
+        _set_ollama_model(monkeypatch)
+        chunks = [
+            {"message": {"content": "Immediate "}, "done": False},
+            {"message": {"content": "answer."}, "done": True},
+        ]
+        events = []
+
+        with patch("api_provider.ollama.chat", side_effect=[_FakeStream(chunks)]) as mock_chat:
+            result = api_provider.chat_stream(
+                task=config.TASK_CHAT,
+                messages=[{"role": "user", "content": "hi"}],
+                on_chunk=lambda delta, reset: events.append((delta, reset)),
+            )
+
+        assert mock_chat.call_count == 1
+        assert result["message"]["content"] == "Immediate answer."
+        assert all(reset is False for _, reset in events)
+        assert "".join(delta for delta, _ in events) == "Immediate answer."
+
+    def test_raises_after_exhausting_all_three_attempts_with_two_resets(self, monkeypatch):
+        # Parity with test_ollama_reasoning_retry.py's
+        # test_raises_after_exhausting_all_three_attempts, but through the streaming path:
+        # 3 attempts all reasoning-only -> RuntimeError, with a reset event before
+        # attempt 2 and before attempt 3 (2 total), never before attempt 1.
+        _set_ollama_model(monkeypatch)
+        reasoning_only_chunks = [
+            {"message": {"content": "<think>still thinking</think>"}, "done": True},
+        ]
+        events = []
+
+        with patch(
+            "api_provider.ollama.chat",
+            side_effect=[
+                _FakeStream(list(reasoning_only_chunks)),
+                _FakeStream(list(reasoning_only_chunks)),
+                _FakeStream(list(reasoning_only_chunks)),
+            ],
+        ) as mock_chat:
+            with pytest.raises(RuntimeError, match="Ollama returned reasoning but no final answer"):
+                api_provider.chat_stream(
+                    task=config.TASK_CHAT,
+                    messages=[{"role": "user", "content": "hi"}],
+                    on_chunk=lambda delta, reset: events.append((delta, reset)),
+                )
+
+        assert mock_chat.call_count == 3
+        reset_events = [e for e in events if e[1] is True]
+        assert reset_events == [("", True), ("", True)]
+
+
+class _CancellableFakeStream:
+    """Like _FakeStream, but flips `cancel_event` after yielding a fixed
+    number of chunks - drives the REAL per-chunk cancel-check-and-close
+    ordering inside chat_stream's own loop (`if cancel_event.is_set():
+    stream.close()` then `_raise_if_cancelled(...)`), rather than a fake
+    chat_stream that reimplements cancellation itself."""
+
+    def __init__(self, chunks, cancel_event, cancel_after):
+        self._chunks = list(chunks)
+        self._cancel_event = cancel_event
+        self._cancel_after = cancel_after
+        self._yielded = 0
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._yielded >= len(self._chunks):
+            raise StopIteration
+        part = self._chunks[self._yielded]
+        self._yielded += 1
+        if self._yielded == self._cancel_after:
+            self._cancel_event.set()
+        return part
+
+    def close(self):
+        self.closed = True
+
+
+class TestCancelMidStream:
+    """Spec section 6 item 3, driven against the REAL chat_stream (not a
+    fake chat_stream) - proves the exact per-chunk ordering: stream.close()
+    is called, no further chunks are consumed/forwarded after the cancel
+    point, and RequestCancelledError propagates (not swallowed, not
+    translated into a different exception)."""
+
+    def test_cancel_mid_stream_closes_the_generator_and_raises_request_cancelled(self, monkeypatch):
+        _set_ollama_model(monkeypatch)
+        cancel_event = threading.Event()
+        chunks = [
+            {"message": {"content": "one "}, "done": False},
+            {"message": {"content": "two "}, "done": False},  # cancel_event flips right after this
+            {"message": {"content": "three "}, "done": False},
+            {"message": {"content": "four"}, "done": True},
+        ]
+        fake_stream = _CancellableFakeStream(chunks, cancel_event, cancel_after=2)
+        received = []
+
+        with patch("api_provider.ollama.chat", return_value=fake_stream):
+            with pytest.raises(api_provider.RequestCancelledError):
+                api_provider.chat_stream(
+                    task=config.TASK_CHAT,
+                    messages=[{"role": "user", "content": "hi"}],
+                    on_chunk=lambda delta, reset: received.append(delta),
+                    cancellation_event=cancel_event,
+                )
+
+        assert fake_stream.closed, "cancel must close the live ollama generator"
+        # The cancel_event flips INSIDE the generator's own __next__, before
+        # control returns to chat_stream's loop body - so even the chunk
+        # that coincides with the flip is caught by the cancel check before
+        # its content is ever forwarded to on_chunk. Only "one " (yielded
+        # strictly before the flip) gets through; "two "/"three "/"four"
+        # never reach on_chunk - tight cancellation, nothing trickles past
+        # the cancel point.
+        assert received == ["one "]
+
+    def test_cancel_checked_before_the_stream_is_first_touched(self, monkeypatch):
+        # _raise_if_cancelled(cancel_event) at the top of chat_stream's
+        # Ollama branch must fire even if the event was already set before
+        # any chunk ever arrives - ollama.chat itself must never be called.
+        _set_ollama_model(monkeypatch)
+        cancel_event = threading.Event()
+        cancel_event.set()
+
+        with patch("api_provider.ollama.chat") as mock_chat:
+            with pytest.raises(api_provider.RequestCancelledError):
+                api_provider.chat_stream(
+                    task=config.TASK_CHAT,
+                    messages=[{"role": "user", "content": "hi"}],
+                    on_chunk=lambda delta, reset: None,
+                    cancellation_event=cancel_event,
+                )
+
+        mock_chat.assert_not_called()
+
+
+class TestErrorTranslationMatchesChat:
+    """Regression for an adversarial-review finding: chat_stream's live
+    Ollama branch must translate raw connection/timeout/etc. exceptions into
+    the exact same friendly, actionable messages chat() already does for its
+    own Ollama branch - not let raw provider/network exception text
+    propagate on what is now the ONLY code path the Composer send surface
+    uses."""
+
+    def test_connection_refused_gets_the_same_friendly_message_chat_would_raise(self, monkeypatch):
+        _set_ollama_model(monkeypatch)
+
+        with patch("api_provider.ollama.chat", side_effect=ConnectionError("Connection refused")):
+            with pytest.raises(ConnectionError, match="Failed to connect to local Ollama server"):
+                api_provider.chat_stream(
+                    task=config.TASK_CHAT,
+                    messages=[{"role": "user", "content": "hi"}],
+                    on_chunk=lambda delta, reset: None,
+                )
+
+    def test_timeout_gets_the_same_friendly_message_chat_would_raise(self, monkeypatch):
+        _set_ollama_model(monkeypatch)
+
+        with patch("api_provider.ollama.chat", side_effect=TimeoutError("Read timed out")):
+            with pytest.raises(TimeoutError, match="The model request timed out"):
+                api_provider.chat_stream(
+                    task=config.TASK_CHAT,
+                    messages=[{"role": "user", "content": "hi"}],
+                    on_chunk=lambda delta, reset: None,
+                )
+
+    def test_request_cancelled_error_passes_through_untranslated(self, monkeypatch):
+        # The translation helper's own first check (isinstance RequestCancelledError)
+        # must re-raise unchanged, never wrap it as some other exception type.
+        _set_ollama_model(monkeypatch)
+
+        with patch("api_provider.ollama.chat", side_effect=api_provider.RequestCancelledError("cancelled")):
+            with pytest.raises(api_provider.RequestCancelledError):
+                api_provider.chat_stream(
+                    task=config.TASK_CHAT,
+                    messages=[{"role": "user", "content": "hi"}],
+                    on_chunk=lambda delta, reset: None,
+                )

--- a/web_ui/src/app/chrome/Composer.test.tsx
+++ b/web_ui/src/app/chrome/Composer.test.tsx
@@ -7,12 +7,15 @@ import { NotificationBanner } from "./NotificationBanner";
 import { initialComposerState, initialNotificationState, initialTokenCounterState } from "./composerStore";
 import { OverlayProvider } from "../overlays/overlays";
 
-function makeStore(overrides: { composer?: object; tokenCounter?: object; notification?: object } = {}) {
+function makeStore(
+  overrides: { composer?: object; tokenCounter?: object; notification?: object; streamText?: string } = {},
+) {
   const listeners = new Set<() => void>();
   const state = {
     composer: { ...initialComposerState, ...overrides.composer },
     tokenCounter: { ...initialTokenCounterState, ...overrides.tokenCounter },
     notification: { ...initialNotificationState, ...overrides.notification },
+    streamText: overrides.streamText ?? "",
   };
   const updateDraft = vi.fn();
   const setReasoningLevel = vi.fn();
@@ -26,6 +29,7 @@ function makeStore(overrides: { composer?: object; tokenCounter?: object; notifi
     getComposer: () => state.composer,
     getTokenCounter: () => state.tokenCounter,
     getNotification: () => state.notification,
+    getStreamText: () => state.streamText,
     updateDraft,
     setReasoningLevel,
     cancelChatRequest,
@@ -172,11 +176,12 @@ describe("Composer", () => {
     expect(cancelChatRequest).toHaveBeenCalledWith("req-42");
   });
 
-  it("shows the generating indicator only when request.state is 'generating'", () => {
+  it("shows 'Thinking…' while generating and streamText is still empty", () => {
     const { store } = makeStore({
       composer: {
         request: { id: "req-1", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false },
       },
+      streamText: "",
     });
     render(
       <OverlayProvider>
@@ -184,10 +189,27 @@ describe("Composer", () => {
         <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
       </OverlayProvider>,
     );
-    expect(screen.getByText("Generating…")).toBeInTheDocument();
+    expect(screen.getByText("Thinking…")).toBeInTheDocument();
   });
 
-  it("hides the generating indicator when request.state is 'idle'", () => {
+  it("shows the raw growing stream text once streamText is non-empty", () => {
+    const { store } = makeStore({
+      composer: {
+        request: { id: "req-1", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false },
+      },
+      streamText: "Hello, wor",
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(screen.getByText("Hello, wor")).toBeInTheDocument();
+    expect(screen.queryByText("Thinking…")).toBeNull();
+  });
+
+  it("hides the stream preview when request.state is 'idle'", () => {
     const { store } = makeStore({
       composer: { request: { ...initialComposerState.request, state: "idle" } },
     });
@@ -197,7 +219,8 @@ describe("Composer", () => {
         <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
       </OverlayProvider>,
     );
-    expect(screen.queryByText("Generating…")).toBeNull();
+    expect(screen.queryByText("Thinking…")).toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
   });
 
   it("opens the reasoning popover and selecting an option calls the intent and closes it", async () => {

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -43,6 +43,7 @@ function Icon({ name }: { name: "attach" | "send" | "chevron" | "stop" }) {
 
 export function Composer({ store, sceneStore }: { store: ComposerStore; sceneStore: SceneStore }) {
   const composer = useSyncExternalStore(store.subscribe, store.getComposer);
+  const streamText = useSyncExternalStore(store.subscribe, store.getStreamText);
   const overlays = useOverlays();
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -85,9 +86,9 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
 
       <div className="composer-controls">
         {composer.request.state === "generating" && (
-          <span className="composer-generating-indicator" role="status">
-            Generating…
-          </span>
+          <div className="composer-stream-preview" role="status" aria-live="polite">
+            {streamText || "Thinking…"}
+          </div>
         )}
 
         <button

--- a/web_ui/src/app/chrome/composerStore.test.ts
+++ b/web_ui/src/app/chrome/composerStore.test.ts
@@ -3,10 +3,21 @@ import { ComposerStore, initialComposerState } from "./composerStore";
 import type { WsTransport } from "../../lib/ws/transport";
 
 type StateListener = (payload: Record<string, unknown>) => void;
+type StreamListener = (delta: string, done: boolean, reset: boolean, seq: number) => void;
 
 function makeFakeTransport() {
   const listeners = new Map<string, StateListener>();
   const intents: Array<{ topic: string; intent: string; args: unknown[] }> = [];
+  const streamListeners = new Map<string, StreamListener>();
+  const streamUnsubFns = new Map<string, ReturnType<typeof vi.fn>>();
+  const subscribeStream = vi.fn((requestId: string, listener: StreamListener) => {
+    streamListeners.set(requestId, listener);
+    const unsub = vi.fn(() => {
+      streamListeners.delete(requestId);
+    });
+    streamUnsubFns.set(requestId, unsub);
+    return unsub;
+  });
   const transport = {
     subscribe: vi.fn((topic: string, listener: StateListener) => {
       listeners.set(topic, listener);
@@ -15,8 +26,9 @@ function makeFakeTransport() {
     intent: vi.fn((topic: string, intent: string, args: unknown[] = []) => {
       intents.push({ topic, intent, args });
     }),
+    subscribeStream,
   } as unknown as WsTransport;
-  return { transport, listeners, intents };
+  return { transport, listeners, intents, subscribeStream, streamListeners, streamUnsubFns };
 }
 
 function validComposerPayload(overrides: Record<string, unknown> = {}) {
@@ -121,5 +133,111 @@ describe("ComposerStore", () => {
     expect(listeners.size).toBe(3);
     store.dispose();
     expect(listeners.size).toBe(0);
+  });
+});
+
+describe("ComposerStore stream subscription lifecycle (R4.4)", () => {
+  it("subscribes to the stream exactly when request.id transitions from null to a real id", () => {
+    const { transport, listeners, subscribeStream } = makeFakeTransport();
+    const store = new ComposerStore(transport);
+    store.connect();
+    listeners.get("app-composer")!(validComposerPayload());
+    expect(subscribeStream).not.toHaveBeenCalled();
+
+    listeners.get("app-composer")!(
+      validComposerPayload({ request: { id: "req-1", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false } }),
+    );
+    expect(subscribeStream).toHaveBeenCalledTimes(1);
+    expect(subscribeStream).toHaveBeenCalledWith("req-1", expect.any(Function));
+
+    // Same id republished (e.g. an unrelated field changed) - no re-subscribe.
+    listeners.get("app-composer")!(
+      validComposerPayload({ request: { id: "req-1", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false } }),
+    );
+    expect(subscribeStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("getStreamText() accumulates deltas in order", () => {
+    const { transport, listeners, streamListeners } = makeFakeTransport();
+    const store = new ComposerStore(transport);
+    store.connect();
+    listeners.get("app-composer")!(
+      validComposerPayload({ request: { id: "req-1", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false } }),
+    );
+    const streamListener = streamListeners.get("req-1")!;
+    streamListener("Hel", false, false, 0);
+    streamListener("lo", false, false, 1);
+    expect(store.getStreamText()).toBe("Hello");
+  });
+
+  it("a reset:true frame clears the buffer before further deltas append", () => {
+    const { transport, listeners, streamListeners } = makeFakeTransport();
+    const store = new ComposerStore(transport);
+    store.connect();
+    listeners.get("app-composer")!(
+      validComposerPayload({ request: { id: "req-1", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false } }),
+    );
+    const streamListener = streamListeners.get("req-1")!;
+    streamListener("abc", false, false, 0);
+    expect(store.getStreamText()).toBe("abc");
+    streamListener("", false, true, 1);
+    expect(store.getStreamText()).toBe("");
+    streamListener("xyz", false, false, 2);
+    expect(store.getStreamText()).toBe("xyz");
+  });
+
+  it("unsubscribes and clears streamText when request.id flips back to null", () => {
+    const { transport, listeners, streamListeners, streamUnsubFns } = makeFakeTransport();
+    const store = new ComposerStore(transport);
+    store.connect();
+    listeners.get("app-composer")!(
+      validComposerPayload({ request: { id: "req-1", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false } }),
+    );
+    streamListeners.get("req-1")!("Hello", false, false, 0);
+    expect(store.getStreamText()).toBe("Hello");
+
+    listeners.get("app-composer")!(validComposerPayload());
+    expect(streamUnsubFns.get("req-1")).toHaveBeenCalledTimes(1);
+    expect(store.getStreamText()).toBe("");
+  });
+
+  it("a fresh request.id (e.g. immediately re-sending) resubscribes and starts streamText from empty", () => {
+    const { transport, listeners, streamListeners, subscribeStream } = makeFakeTransport();
+    const store = new ComposerStore(transport);
+    store.connect();
+    listeners.get("app-composer")!(
+      validComposerPayload({ request: { id: "req-1", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false } }),
+    );
+    streamListeners.get("req-1")!("first reply", false, false, 0);
+
+    listeners.get("app-composer")!(
+      validComposerPayload({ request: { id: "req-2", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false } }),
+    );
+    expect(subscribeStream).toHaveBeenCalledTimes(2);
+    expect(store.getStreamText()).toBe("");
+    streamListeners.get("req-2")!("second reply", false, false, 0);
+    expect(store.getStreamText()).toBe("second reply");
+  });
+
+  it("dispose() unsubscribes the active stream without double-invoking", () => {
+    const { transport, listeners, streamUnsubFns } = makeFakeTransport();
+    const store = new ComposerStore(transport);
+    store.connect();
+    listeners.get("app-composer")!(
+      validComposerPayload({ request: { id: "req-1", state: "generating", message: "", canSend: false, canCancel: true, canRetry: false } }),
+    );
+    store.dispose();
+    expect(streamUnsubFns.get("req-1")).toHaveBeenCalledTimes(1);
+    // dispose() is not re-entrant/double-firing on the same unsub reference.
+    store.dispose();
+    expect(streamUnsubFns.get("req-1")).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose() with no active stream does not throw", () => {
+    const { transport, listeners } = makeFakeTransport();
+    const store = new ComposerStore(transport);
+    store.connect();
+    listeners.get("app-composer")!(validComposerPayload());
+    expect(() => store.dispose()).not.toThrow();
   });
 });

--- a/web_ui/src/app/chrome/composerStore.ts
+++ b/web_ui/src/app/chrome/composerStore.ts
@@ -65,6 +65,8 @@ export class ComposerStore {
   private composer: AppComposerState = initialComposerState;
   private tokenCounter: TokenCounterState = initialTokenCounterState;
   private notification: NotificationState = initialNotificationState;
+  private streamText = "";
+  private streamUnsub: (() => void) | null = null;
   private readonly listeners = new Set<Listener>();
   private readonly unsubscribers: Array<() => void> = [];
 
@@ -84,7 +86,11 @@ export class ComposerStore {
 
   connect(): void {
     this.unsubscribers.push(
-      this.bind<AppComposerState>("app-composer", (v) => (this.composer = v)),
+      this.bind<AppComposerState>("app-composer", (v) => {
+        const prevId = this.composer.request.id;
+        this.composer = v;
+        this.syncStream(prevId, v.request.id);
+      }),
       this.bind<TokenCounterState>("token-counter", (v) => (this.tokenCounter = v)),
       this.bind<NotificationState>("notification", (v) => (this.notification = v)),
     );
@@ -93,6 +99,26 @@ export class ComposerStore {
   dispose(): void {
     for (const unsubscribe of this.unsubscribers) unsubscribe();
     this.unsubscribers.length = 0;
+    this.streamUnsub?.();
+    this.streamUnsub = null;
+  }
+
+  /** Keeps `streamText` bound to whichever request is currently in flight -
+   * a fresh request.id subscribes to its own stream frames; the id
+   * dropping back to null (idle/cancelled/errored) unsubscribes and clears
+   * the buffer. See transport.ts's subscribeStream()/`kind:"stream"`. */
+  private syncStream(prevId: string | null | undefined, nextId: string | null | undefined): void {
+    if (nextId === prevId) return;
+    this.streamUnsub?.();
+    this.streamUnsub = null;
+    this.streamText = "";
+    if (nextId) {
+      this.streamUnsub = this.transport.subscribeStream(nextId, (delta, _done, reset) => {
+        if (reset) this.streamText = "";
+        else this.streamText += delta;
+        this.emit();
+      });
+    }
   }
 
   subscribe = (listener: Listener): (() => void) => {
@@ -103,6 +129,7 @@ export class ComposerStore {
   getComposer = (): AppComposerState => this.composer;
   getTokenCounter = (): TokenCounterState => this.tokenCounter;
   getNotification = (): NotificationState => this.notification;
+  getStreamText = (): string => this.streamText;
 
   private emit(): void {
     for (const listener of [...this.listeners]) listener();

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1285,10 +1285,28 @@ body,
   gap: 1px;
 }
 
-.composer-generating-indicator {
-  font-size: 11px;
-  font-weight: 600;
+/* R4.4 token-streaming preview - replaces the old static
+   .composer-generating-indicator span. Absolutely positioned against
+   .composer-dock's `position: relative` so it floats above the input
+   instead of pushing the controls row around as it grows. */
+.composer-stream-preview {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 100%;
+  margin-bottom: 8px;
+  max-height: 160px;
+  overflow-y: auto;
+  padding: 8px 12px;
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.4;
   color: var(--gl-surface-text-muted);
+  background-color: var(--gl-surface-inset, var(--gl-surface-node-body));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .composer-send-group {

--- a/web_ui/src/lib/ws/transport.test.ts
+++ b/web_ui/src/lib/ws/transport.test.ts
@@ -183,6 +183,70 @@ describe("WsTransport", () => {
     expect(t.getStatus()).toBe("open");
   });
 
+  it("a truly unrecognized kind still logs the existing 'unknown message kind' error (contrast with stream's silent drop)", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    socket.receive({ kind: "not-a-real-kind" });
+    expect(consoleError).toHaveBeenCalledWith("[ws] unknown message kind:", "not-a-real-kind");
+    consoleError.mockRestore();
+  });
+
+  it("subscribeStream: a stream frame with no matching requestId subscriber is silently dropped", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    socket.receive({ kind: "stream", topic: "app-composer", requestId: "no-such-request", seq: 0, delta: "hi", done: false, reset: false });
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("subscribeStream: routes deltas only to the matching requestId and fans out to every listener on it", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const forA1: unknown[] = [];
+    const forA2: unknown[] = [];
+    const forB: unknown[] = [];
+    t.subscribeStream("req-a", (delta, done, reset, seq) => forA1.push({ delta, done, reset, seq }));
+    t.subscribeStream("req-a", (delta, done, reset, seq) => forA2.push({ delta, done, reset, seq }));
+    t.subscribeStream("req-b", (delta, done, reset, seq) => forB.push({ delta, done, reset, seq }));
+
+    socket.receive({ kind: "stream", topic: "app-composer", requestId: "req-a", seq: 0, delta: "Hel", done: false, reset: false });
+    socket.receive({ kind: "stream", topic: "app-composer", requestId: "req-a", seq: 1, delta: "lo", done: true, reset: false });
+
+    expect(forA1).toEqual([
+      { delta: "Hel", done: false, reset: false, seq: 0 },
+      { delta: "lo", done: true, reset: false, seq: 1 },
+    ]);
+    expect(forA2).toEqual(forA1);
+    expect(forB).toEqual([]);
+  });
+
+  it("subscribeStream: the returned unsubscribe stops further delivery and cleans up an empty requestId entry", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const seen: unknown[] = [];
+    const unsub = t.subscribeStream("req-a", (delta) => seen.push(delta));
+    socket.receive({ kind: "stream", topic: "app-composer", requestId: "req-a", seq: 0, delta: "one", done: false, reset: false });
+    unsub();
+    socket.receive({ kind: "stream", topic: "app-composer", requestId: "req-a", seq: 1, delta: "two", done: false, reset: false });
+    expect(seen).toEqual(["one"]);
+
+    // Now that no listener remains, this must silently drop (not error).
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    socket.receive({ kind: "stream", topic: "app-composer", requestId: "req-a", seq: 2, delta: "three", done: true, reset: false });
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
   it("notifies status listeners through the lifecycle", () => {
     const t = makeTransport();
     const statuses: string[] = [];

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -8,6 +8,10 @@
  * Server -> client: {kind:"state", topic, payload}   (versioned envelope)
  *                   {kind:"result", id, value}
  *                   {kind:"error", id?, error}
+ *                   {kind:"stream", topic, requestId, seq, delta, done, reset}
+ *                     (R4.4 token streaming - a sibling delta channel outside
+ *                     the topic/revision system; addressed by requestId, not
+ *                     subscribed like a topic. See subscribeStream().)
  * Client -> server: {kind:"subscribe", topics}
  *                   {kind:"intent", topic, intent, args, id?}
  *
@@ -20,6 +24,7 @@ export type ConnectionStatus = "connecting" | "open" | "closed";
 
 export type StateListener = (payload: Record<string, unknown>) => void;
 export type StatusListener = (status: ConnectionStatus) => void;
+export type StreamListener = (delta: string, done: boolean, reset: boolean, seq: number) => void;
 
 interface WsLike {
   send(data: string): void;
@@ -58,6 +63,9 @@ export class WsTransport {
 
   private readonly stateListeners = new Map<string, Set<StateListener>>();
   private readonly statusListeners = new Set<StatusListener>();
+  /** Keyed by requestId - stream deltas are addressed to a specific in-flight
+   * request, not a topic. See handleMessage()'s "stream" branch. */
+  private readonly streamListeners = new Map<string, Set<StreamListener>>();
   private readonly pending = new Map<
     number,
     { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
@@ -144,6 +152,24 @@ export class WsTransport {
     };
   }
 
+  /** Listen for one in-flight request's streaming deltas (`kind:"stream"`
+   * frames), addressed by requestId rather than topic. No subscribe message
+   * is sent to the server - the server broadcasts stream frames to every
+   * connection unconditionally, and this only filters/fans them out
+   * client-side. */
+  subscribeStream(requestId: string, listener: StreamListener): () => void {
+    let set = this.streamListeners.get(requestId);
+    if (!set) {
+      set = new Set();
+      this.streamListeners.set(requestId, set);
+    }
+    set.add(listener);
+    return () => {
+      set.delete(listener);
+      if (set.size === 0) this.streamListeners.delete(requestId);
+    };
+  }
+
   onStatus(listener: StatusListener): () => void {
     this.statusListeners.add(listener);
     listener(this.status);
@@ -204,6 +230,20 @@ export class WsTransport {
         else entry.reject(new Error(String(message.error)));
       } else if (kind === "error") {
         console.error("[ws] server error:", message.error);
+      }
+      return;
+    }
+    if (kind === "stream") {
+      // A stream frame with no matching requestId subscriber is silently
+      // dropped - unlike a truly unrecognized kind below, this is an
+      // expected, routine occurrence (e.g. a request already completed and
+      // unsubscribed a moment before a straggling frame arrives).
+      const requestId = message.requestId as string;
+      const listeners = this.streamListeners.get(requestId);
+      if (listeners) {
+        for (const listener of [...listeners]) {
+          listener(message.delta as string, Boolean(message.done), Boolean(message.reset), message.seq as number);
+        }
       }
       return;
     }


### PR DESCRIPTION
## Summary
Legacy never streamed at all - one blocking `chat()` call, one complete reply - so this is a new capability, not a port. Every decision here is a fresh architectural call rather than an inherited one.

- Only the Ollama local provider streams real incremental chunks; every other provider/task combination falls back to one blocking `chat()` call plus one synthetic full-text chunk - an explicit, stated scope cut.
- New `api_provider.chat_stream()` reuses every one of `chat()`'s existing Ollama-branch helpers verbatim and preserves the exact 3-attempt reasoning-retry loop. `chat()` itself is untouched; `graphlink_chat_agent.py` gained one additive, default-`None` `on_chunk` parameter. Every real legacy call site across `graphlink_app/` was grepped to confirm none references it - the still-running legacy Qt app's own chat functionality is unchanged (the first R4 increment to touch files the legacy app depends on).
- Token deltas travel over a brand-new WS message kind (`"stream"`) living entirely outside the codegen/generated-contract system, since the existing topic-snapshot machinery's revision/schema-version stamping is wrong semantics for a 15-17Hz delta channel.
- Only the Composer's `send_message` reply streams; `ConversationNode`'s reply is deliberately not streamed this increment (its content lives inside `scene_payload()`'s full resend on every publish, with no cheap path around that cost).
- `AgentDispatcher._dispatch` gained a `stream` keyword-only parameter and a thread-to-event-loop handoff built from scratch (`call_soon_threadsafe` + `asyncio.Queue`, drained by a batching pump), the same unchanged 420s watchdog, and cancel-mid-stream semantics that discard partial text entirely via the existing `RequestCancelledError` path.

## Process
- 3-agent recon+cross-check+design pass (the first attempt failed on a model usage-limit error mid-run and resumed cleanly with zero rework via per-agent caching).
- Parallel implementation across 3 file groups (provider layer / dispatcher / frontend), which surfaced one ordering hazard (14 pre-existing tests only mocking `api_provider.chat` directly) - fixed with one new autouse `conftest.py` fixture rather than touching each test body.
- 4-way adversarial review (backend/frontend/integration + a **dedicated legacy-safety audit**, since this is the first R4 increment touching legacy-shared files) found two real majors, both fixed before shipping:
  - `chat_stream` lacked `chat()`'s exception-translation wrapper (raw connection/timeout errors instead of friendly messages) - fixed by extracting a shared `_translate_chat_exception` helper both functions call.
  - `start_chat_reply` hardcoded `stream=True` unconditionally, silently making `regenerate_response` stream too and lighting up the Composer's live preview for an unrelated Regenerate click - fixed by making `stream` a real caller-controlled parameter, with `regenerate_response` now passing `stream=False` explicitly plus a regression test.
- Live-drive verified against the real backend and real, locally-installed Ollama model across three drives: 47 distinct, strictly-sequenced stream frames over 3 real seconds with the final ChatNode content matching the streamed text; a clean cancel-mid-stream with the exact "Request cancelled." notification and no node created; and a cross-slot concurrency drive proving a chat stream keeps flowing while a concurrent image-generation request fails independently without disrupting it.

**This closes R4 in full**: R4.1, R4.2, R4.3, R4.3b, R4.3c, R4.4a, and R4.4 have all shipped.

## Test plan
- [x] `python -m pytest -q` — 2051 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 713 passed
- [x] `python graphlink_island_codegen.py --check` — up to date
- [x] Live WS drive against the real backend + real Ollama model (incremental streaming proof, cancel-mid-stream, cross-slot concurrency)