### PR TITLE
Qt-removal R5.1: Web Research plugin - real search+fetch+cite pipeline

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -68,6 +68,14 @@ import api_provider
 import graphlink_task_config as config
 from graphlink_chat_agent import ChatAgent
 from graphlink_licensing import SettingsManager  # type hint only
+from graphlink_plugins.web_research.domain import (
+    CancellationToken,
+    ProgressEvent,
+    RequestCancelled,
+    ResearchFailure,
+    WebResearchRequest,
+)
+from graphlink_plugins.web_research.service import WebResearchService
 from graphlink_prompts import BASE_SYSTEM_PROMPT
 
 from backend.events import SessionBus  # type hint only
@@ -77,6 +85,15 @@ logger = logging.getLogger(__name__)
 # The single fixed hard timeout for this increment - see the module
 # docstring for why there is no intermediate stall-notice tier here.
 WATCHDOG_TIMEOUT_SECONDS = 420
+
+# R5.1: Web Research gets its own, longer watchdog rather than reusing
+# WATCHDOG_TIMEOUT_SECONDS=420 - a research run can involve up to 4
+# sequential source fetches (each individually capped by
+# FetchPolicy.total_timeout_seconds, ~30s) plus up to 6 sequential LLM round
+# trips (refine_query + up to 4x assess_source + summarize), none of which
+# has its own outer timeout beyond this one. Realistic worst-case legitimate
+# duration is roughly 660s, so 900s gives headroom without being unbounded.
+WEB_RESEARCH_WATCHDOG_TIMEOUT_SECONDS = 900
 
 
 def bootstrap_provider_state(settings_manager: SettingsManager) -> None:
@@ -166,6 +183,13 @@ class AgentDispatcher:
         # "cancel_event" key here, unlike self._requests: image generation
         # has no cancellation at all (see start_image_reply's own docstring).
         self._image_requests: dict[str, dict] = {}
+        # R5.1: a THIRD independent in-flight-request slot, separate from both
+        # self._requests (chat/conversation) and self._image_requests - a web
+        # research run and a chat/image request must be able to run
+        # concurrently, same reasoning R4.4a used for _image_requests being
+        # independent from _requests. request_id -> {"cancel_token":
+        # CancellationToken, "task": asyncio.Task}.
+        self._web_research_requests: dict[str, dict] = {}
 
     def persona(self) -> str:
         """Mirror legacy graphlink_window.py's `_get_current_system_prompt`:
@@ -201,6 +225,20 @@ class AgentDispatcher:
         next checkpoint, same as the timeout path already does."""
         for entry in self._requests.values():
             entry["cancel_event"].set()
+
+    def cancel_web_research(self, request_id: str) -> bool:
+        entry = self._web_research_requests.get(request_id)
+        if entry is None:
+            return False
+        entry["cancel_token"].cancel()
+        return True
+
+    def is_web_research_busy(self) -> bool:
+        """Lets callers check the single-slot guard before mutating scene
+        state, so a Run click on a node other than the one already running
+        doesn't reset that node's progress/error fields only to be rejected
+        a moment later by start_web_research's own busy check."""
+        return bool(self._web_research_requests)
 
     async def _dispatch(
         self,
@@ -561,6 +599,138 @@ class AgentDispatcher:
         # keep reading further messages on this same socket while a
         # generation is in flight.
         self._image_requests[request_id] = {"task": asyncio.create_task(_run())}
+
+    async def start_web_research(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        node,
+        node_id: str,
+        query: str,
+        branch_history: list,
+        on_progress,
+        on_success,
+        on_failure,
+    ) -> None:
+        """R5.1: the Web Research independent-slot counterpart to
+        start_image_reply above - NOT a variant of _dispatch, since there is
+        exactly one caller (backend/canvas.py's run_web_research), so
+        on_begin/on_end are inlined here directly rather than taking
+        _dispatch's generic parameters. Guarded by self._web_research_requests,
+        a dict kept fully SEPARATE from both self._requests (chat/
+        conversation) and self._image_requests - see that field's own
+        comment in __init__ for why this must stay independent.
+
+        Cooperative cancellation only, via a CancellationToken (not a
+        threading.Event, since WebResearchService.run's own pipeline stages
+        already accept `token: CancellationToken` - see
+        graphlink_plugins/web_research/domain.py) - same honestly-documented
+        limitation as existing chat/image dispatch: this does not force-kill
+        a call already blocked inside a single blocking call with no
+        checkpoint until it returns."""
+        if self._web_research_requests:
+            notifications_state.show("A web research request is already running.", "info")
+            await bus.publish("notification")
+            return
+
+        request_id = uuid.uuid4().hex
+        cancel_token = CancellationToken()
+        request = WebResearchRequest(
+            request_id=request_id,
+            node_id=node_id,
+            chat_epoch=0,
+            original_query=query,
+            branch_history=list(branch_history),
+        )
+
+        async def _invoke(fn, *a):
+            if inspect.iscoroutinefunction(fn):
+                await fn(*a)
+            else:
+                fn(*a)
+
+        async def _run():
+            node.pending_request_id = request_id
+            await bus.publish("scene")
+            loop = asyncio.get_running_loop()
+            service = WebResearchService()
+
+            async def _guarded_progress(event) -> None:
+                # asyncio.to_thread's underlying thread is NOT actually
+                # killed by wait_for's timeout (Future.cancel() on an
+                # already-running thread is a no-op - see the watchdog
+                # comment on WATCHDOG_TIMEOUT_SECONDS above for the chat
+                # path's identical limitation), so a slow service.run() can
+                # keep calling progress() well after this request's own
+                # finally block has already popped _web_research_requests
+                # and cleared node.pending_request_id. Re-check liveness here
+                # (on the loop thread, so no race with the pop above) and
+                # drop the event if this request is no longer the active one
+                # - otherwise a stale progress tick can resurrect a
+                # since-failed/cancelled node's stage, or clobber a brand
+                # new run started on the same node in the meantime.
+                if request_id not in self._web_research_requests:
+                    return
+                await _invoke(on_progress, event)
+
+            def _thread_on_progress(event) -> None:
+                # Runs on the WORKER THREAD (inside asyncio.to_thread). Given
+                # the low event frequency (<=16 events per run), this
+                # deliberately does NOT need the token-streaming pipeline's
+                # Queue+_pump batching machinery - a single
+                # run_coroutine_threadsafe per event is simpler and still
+                # correctly ordered, because service.run() calls progress()
+                # synchronously and single-threaded, and each event's
+                # coroutine mutates SceneNode fields synchronously before its
+                # first await, so asyncio's FIFO call_soon scheduling
+                # preserves emission order even if the subsequent
+                # bus.publish("scene") awaits interleave.
+                asyncio.run_coroutine_threadsafe(_guarded_progress(event), loop)
+
+            try:
+                result = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        service.run, request, token=cancel_token, progress=_thread_on_progress
+                    ),
+                    timeout=WEB_RESEARCH_WATCHDOG_TIMEOUT_SECONDS,
+                )
+                await _invoke(on_success, result)
+                await bus.publish("scene")
+            except asyncio.TimeoutError:
+                cancel_token.cancel()
+                message = (
+                    "Web research stopped responding before the request completed. "
+                    "Please try again."
+                )
+                await _invoke(on_failure, ResearchFailure(message, code="watchdog_timeout"))
+                notifications_state.show(message, "error")
+                await bus.publish("notification")
+                await bus.publish("scene")
+            except RequestCancelled as exc:
+                await _invoke(on_failure, exc)
+                notifications_state.show("Web research cancelled.", "info")
+                await bus.publish("notification")
+                await bus.publish("scene")
+            except ResearchFailure as exc:
+                await _invoke(on_failure, exc)
+                notifications_state.show(f"Web research failed: {exc}", "error")
+                await bus.publish("notification")
+                await bus.publish("scene")
+            except Exception as exc:
+                logger.exception("web research dispatch failed")
+                await _invoke(on_failure, exc)
+                notifications_state.show(f"Web research failed: {exc}", "error")
+                await bus.publish("notification")
+                await bus.publish("scene")
+            finally:
+                self._web_research_requests.pop(request_id, None)
+                node.pending_request_id = None
+                await bus.publish("scene")
+
+        self._web_research_requests[request_id] = {
+            "cancel_token": cancel_token, "task": asyncio.create_task(_run())
+        }
 
 
 def _call_chat_agent(conversation_history, persona_text, cancel_event) -> str:

--- a/backend/app.py
+++ b/backend/app.py
@@ -101,7 +101,10 @@ def _configure_session(bus: SessionBus, settings_manager: SettingsManager, chat_
 
     # R2.5: about, plugins, settings, chat library.
     register_about(bus)
-    register_plugins(bus, notifications_state)
+    # R5.1: register_plugins needs the same session's canvas_document (built
+    # just above) so "Web Research" can create a real node - this ordering
+    # (canvas_document exists before register_plugins runs) is load-bearing.
+    register_plugins(bus, notifications_state, bus.canvas_document)
     register_settings(bus, settings_manager)
     register_chat_library(bus, chat_db_path)
 

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -216,6 +216,27 @@ class SceneNode:
     # way is_docked/image_asset_id are generic fields even though today only
     # one kind populates them); unused (default None) for every other kind.
     pending_request_id: str | None = None
+    # R5.1: the Web Research node's real persisted shape - `content` (reused,
+    # same pattern as code/thinking/html) holds the query text; these six
+    # fields track one research run's live progress/outcome. Unused
+    # (default) for every other kind.
+    #
+    # research_stage is one of the empty-string sentinel ("" - never run) or
+    # the 9 ResearchStage enum values from
+    # graphlink_plugins/web_research/domain.py's own .value strings:
+    # "preparing" | "searching" | "fetching" | "extracting" | "validating" |
+    # "synthesizing" | "completed" | "cancelled" | "failed".
+    research_stage: str = ""
+    research_completed: int = 0
+    research_total: int = 0
+    research_active_source_id: str | None = None
+    research_error: str = ""
+    # The wire-shaped (camelCase) ResearchResult, or None before the first
+    # run ever completes. Deliberate stale-while-revalidate: a NEW run does
+    # NOT clear this on start (see start_web_research_run) - the previous
+    # answer stays visible until this run replaces it on success, or
+    # fails/cancels (leaving the stale result annotated by research_error).
+    research_result: dict[str, Any] | None = None
 
 
 @dataclass
@@ -630,6 +651,92 @@ class SceneDocument:
         ChatNode."""
         return self.append_conversation_user_message(node_id, text)
 
+    # -- R5.1: web research node ---------------------------------------------
+
+    def add_web_research_node(self, x: float, y: float, parent_id: str) -> SceneNode:
+        """The Web Research node's creation primitive - same required-parent
+        posture as document/thinking/html/image/conversation nodes (never
+        exists unparented). Title is always the fixed literal "Web Research"
+        (mirrors conversation node's own fixed "Conversation" title - there
+        is no meaningful single preview string before a query has ever been
+        run). Content starts empty; the query text only lands once
+        start_web_research_run is called."""
+        if parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title="Web Research",
+            kind="web_research",
+        )
+        self.nodes[node_id] = node
+        self.connect(parent_id, node_id)
+        return node
+
+    def start_web_research_run(self, node_id: str, query: str) -> SceneNode:
+        """Begin one research run: stores the query text and resets this
+        run's progress fields. Deliberately does NOT clear research_result -
+        stale-while-revalidate: the previous run's answer stays visible until
+        this run replaces it on success, or fails/cancels (leaving the stale
+        result annotated by the new research_error)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "web_research":
+            raise SceneError(f"node is not a web_research node: {node_id}")
+        node.content = str(query)
+        node.research_stage = ""
+        node.research_completed = 0
+        node.research_total = 0
+        node.research_active_source_id = None
+        node.research_error = ""
+        return node
+
+    def apply_web_research_progress(self, node_id: str, event) -> SceneNode | None:
+        """Apply one duck-typed ProgressEvent-shaped update (.stage/.completed/
+        .total/.source_id) - canvas.py deliberately does NOT import anything
+        from graphlink_plugins.web_research (mirrors how
+        start_conversation_reply's node param is duck-typed without
+        agents.py importing backend.canvas.SceneNode). Silent no-op (returns
+        None, never raises) if node_id is no longer in self.nodes - the node
+        may have been deleted while a background run was still in flight."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            return None
+        node.research_stage = event.stage.value
+        node.research_completed = event.completed
+        node.research_total = event.total
+        node.research_active_source_id = event.source_id
+        return node
+
+    def complete_web_research_run(self, node_id: str, result_wire: dict) -> SceneNode:
+        """Land a successful run's result. Raises SceneError if the node is
+        gone - the WS wrapper's own liveness check (in register_canvas)
+        guards the actual mid-flight-delete race; this stays a hard
+        precondition here, same posture as update_chat_node_content."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.research_stage = "completed"
+        node.research_error = ""
+        node.research_active_source_id = None
+        node.research_result = result_wire
+        return node
+
+    def fail_web_research_run(self, node_id: str, *, cancelled: bool, message: str) -> SceneNode:
+        """Land a failed or cancelled run. research_result is deliberately
+        left untouched (stale-while-revalidate - see start_web_research_run's
+        own docstring)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.research_stage = "cancelled" if cancelled else "failed"
+        node.research_error = message
+        node.research_active_source_id = None
+        return node
+
     def delete_chat_node(self, node_id: str) -> None:
         """Delete one chat node WITHOUT orphaning its branch: children are
         re-parented to the deleted node's own parent (or become roots if it
@@ -957,6 +1064,12 @@ class SceneDocument:
                         {"role": m["role"], "content": m["content"]} for m in n.history
                     ],
                     "pendingRequestId": n.pending_request_id,
+                    "researchStage": n.research_stage,
+                    "researchCompleted": n.research_completed,
+                    "researchTotal": n.research_total,
+                    "researchActiveSourceId": n.research_active_source_id,
+                    "researchError": n.research_error,
+                    "researchResult": n.research_result,
                 }
                 for n in self.nodes.values()
             ],
@@ -994,6 +1107,45 @@ class SceneDocument:
             "stylePresets": list(GRID_STYLE_PRESETS),
             "colorPresets": list(GRID_COLOR_PRESETS),
         }
+
+
+def _research_result_wire(result) -> dict[str, Any]:
+    """Camel-cases a ResearchResult (graphlink_plugins/web_research/domain.py)
+    for the wire - a pure mapping function, NOT a SceneDocument method.
+    Duck-typed on purpose: canvas.py imports nothing from
+    graphlink_plugins.web_research (same posture as apply_web_research_progress
+    above)."""
+    return {
+        "requestId": result.request_id,
+        "originalQuery": result.original_query,
+        "effectiveQuery": result.effective_query,
+        "answerMarkdown": result.answer_markdown,
+        "sources": [
+            {
+                "sourceId": s.source_id,
+                "title": s.title,
+                "url": s.url,
+                "canonicalUrl": s.canonical_url,
+                "snippet": s.snippet,
+                "rank": s.rank,
+                "provider": s.provider,
+                "finalUrl": s.final_url,
+                "status": s.status,
+                "errorCode": s.error_code,
+                "errorMessage": s.error_message,
+                "truncated": s.truncated,
+                "contentHash": s.content_hash,
+                "citationCount": s.citation_count,
+            }
+            for s in result.sources
+        ],
+        "citations": [
+            {"sourceId": c.source_id, "marker": c.marker, "claimContext": c.claim_context}
+            for c in result.citations
+        ],
+        "warnings": list(result.warnings),
+        "providerSnapshot": dict(result.provider_snapshot),
+    }
 
 
 def register_canvas(
@@ -1404,6 +1556,63 @@ def register_canvas(
         await _dispatch_image(parent_chat_node_id, prompt)
         return None
 
+    async def run_web_research(node_id, query_text):
+        if agent_dispatcher.is_web_research_busy():
+            # Checked BEFORE touching document state: start_web_research_run
+            # resets a node's progress/error fields unconditionally, and the
+            # dispatcher only allows one web-research run at a time anyway -
+            # without this early check, clicking Run on a different node
+            # while one is already in flight would silently wipe that node's
+            # prior result/error banner even though no new run actually starts.
+            notifications.show("A web research request is already running.", "info")
+            await bus.publish("notification")
+            return None
+        try:
+            node = document.start_web_research_run(node_id, query_text)
+        except SceneError:
+            notifications.show("This node no longer exists.", "warning")
+            await bus.publish("notification")
+            return None
+        await publish_scene()
+
+        parent_edge = next((e for e in document.edges.values() if e.target == node_id), None)
+        branch_history = document.chat_branch_history(parent_edge.source) if parent_edge else []
+
+        async def _on_progress(event):
+            if node_id not in document.nodes:
+                return
+            document.apply_web_research_progress(node_id, event)
+            await bus.publish("scene")
+
+        async def _on_success(result):
+            if node_id not in document.nodes:
+                return
+            document.complete_web_research_run(node_id, _research_result_wire(result))
+            await bus.publish("scene")
+
+        async def _on_failure(exc):
+            if node_id not in document.nodes:
+                return
+            cancelled = type(exc).__name__ == "RequestCancelled"
+            document.fail_web_research_run(node_id, cancelled=cancelled, message=str(exc))
+            await bus.publish("scene")
+
+        await agent_dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            node_id=node_id,
+            query=query_text,
+            branch_history=branch_history,
+            on_progress=_on_progress,
+            on_success=_on_success,
+            on_failure=_on_failure,
+        )
+        return node_id
+
+    async def cancel_web_research_request(request_id):
+        agent_dispatcher.cancel_web_research(request_id)
+
     async def move_node(node_id, x, y):
         document.move_node(node_id, x, y)
         await publish_scene()
@@ -1476,6 +1685,11 @@ def register_canvas(
     # both funneling through the shared _dispatch_image helper above.
     bus.register_intent("scene", "generateImage", generate_image)
     bus.register_intent("scene", "regenerateImage", regenerate_image)
+    # R5.1: Web Research node run/cancel - node creation itself lives in
+    # backend/plugins.py's executePlugin (the "Web Research" branch), not
+    # here; these two intents drive an EXISTING web_research-kind node.
+    bus.register_intent("scene", "runWebResearch", run_web_research)
+    bus.register_intent("scene", "cancelWebResearchRequest", cancel_web_research_request)
     bus.register_intent("scene", "moveNode", move_node)
     bus.register_intent("scene", "removeNodes", remove_nodes)
     bus.register_intent("scene", "connectNodes", connect_nodes)

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 
@@ -108,20 +109,45 @@ def plugins_payload() -> dict[str, Any]:
     return {"categories": get_plugin_categories()}
 
 
-def register_plugins(bus: SessionBus, notifications: NotificationState) -> None:
+def register_plugins(
+    bus: SessionBus, notifications: NotificationState, canvas_document: SceneDocument
+) -> None:
     # Topic name "app-plugins" (matching the codegen artifact's derived
     # name - same reasoning as "app-composer"/"app-about"): no existing
     # "plugins" schema collision today, but the pattern is now consistent
     # across every R2.3-R2.5 topic that has a distinct SPA payload.
     bus.register_topic("app-plugins", plugins_payload)
 
-    async def execute_plugin(plugin_name: str):
+    async def execute_plugin(plugin_name: str, parent_node_id: str | None = None):
         name = str(plugin_name).strip()
         valid_names = {p[0] for p in _PLUGINS}
-        if name in valid_names:
-            notifications.show(f'"{name}" node creation lands in R3/R5.', "info")
-        else:
+        if name not in valid_names:
             notifications.show(f'Unknown plugin: "{name}"', "warning")
+            await bus.publish("notification")
+            return None
+
+        if name == "Web Research":
+            # R5.1: the first real node-creation plugin - every other plugin
+            # name below is still an honest deferred notice. A Web Research
+            # node is a branch-point child (same posture as thinking/html/
+            # image/conversation nodes), so it always requires a real, valid
+            # parent to branch from - there is no unparented/root form.
+            if not parent_node_id or parent_node_id not in canvas_document.nodes:
+                notifications.show(
+                    "Please select a valid node to branch from before adding a Web Node.",
+                    "warning",
+                )
+                await bus.publish("notification")
+                return None
+            parent = canvas_document.nodes[parent_node_id]
+            node = canvas_document.add_web_research_node(
+                parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            )
+            await bus.publish("scene")
+            return node.id
+
+        notifications.show(f'"{name}" node creation lands in R3/R5.', "info")
         await bus.publish("notification")
+        return None
 
     bus.register_intent("app-plugins", "executePlugin", execute_plugin)

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -33,6 +33,7 @@ from backend.notifications import NotificationState
 import api_provider
 import graphlink_task_config as config
 from graphlink_licensing import SettingsManager
+from graphlink_plugins.web_research.domain import RequestCancelled, ResearchFailure
 
 
 class _FakeSettingsManager:
@@ -1412,3 +1413,519 @@ def test_image_request_runs_independently_while_a_chat_stream_is_paused_mid_flig
         assert recorder.frames[-1]["done"] is True, "stream frames kept recording throughout the image request"
 
     asyncio.run(run())
+
+
+# -- R5.1: start_web_research - the independent web-research slot ------------
+#
+# Unlike start_chat_reply/start_conversation_reply above, these tests never
+# touch Ollama/api_provider.chat plumbing (except the two dedicated
+# concurrency tests) - start_web_research's only real dependency is
+# WebResearchService.run, monkeypatched directly on the class (agents.py
+# constructs a fresh WebResearchService() instance per call, so patching the
+# class method is the seam, mirroring how api_provider.chat/chat_stream are
+# patched as module-level seams for the chat path).
+
+
+def _make_web_research_env():
+    bus = SessionBus("agents-web-research-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    bus.register_topic("scene", lambda: {})
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    return bus, notifications, dispatcher
+
+
+def test_start_web_research_calls_on_success_with_the_result_then_clears_the_slot(monkeypatch):
+    fake_result = SimpleNamespace(answer_markdown="the answer")
+
+    def fake_run(self, request, *, token=None, progress=None):
+        return fake_result
+
+    monkeypatch.setattr(agents_module.WebResearchService, "run", fake_run)
+
+    async def run():
+        bus, notifications, dispatcher = _make_web_research_env()
+        node = _make_node()
+        successes = []
+
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            node_id="n1",
+            query="what is this about?",
+            branch_history=[],
+            on_progress=lambda event: None,
+            on_success=successes.append,
+            on_failure=lambda exc: None,
+        )
+        entry = next(iter(dispatcher._web_research_requests.values()))
+        await entry["task"]
+
+        assert successes == [fake_result]
+        assert dispatcher._web_research_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is False
+
+    asyncio.run(run())
+
+
+def test_start_web_research_second_call_while_in_flight_is_rejected_first_still_completes(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_run(self, request, *, token=None, progress=None):
+        started.set()
+        release.wait(5)
+        return SimpleNamespace(answer_markdown="first result")
+
+    monkeypatch.setattr(agents_module.WebResearchService, "run", blocking_run)
+
+    async def run():
+        bus, notifications, dispatcher = _make_web_research_env()
+        node1 = _make_node()
+        node2 = _make_node()
+        successes = []
+
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node1,
+            node_id="n1",
+            query="first query",
+            branch_history=[],
+            on_progress=lambda event: None,
+            on_success=successes.append,
+            on_failure=lambda exc: None,
+        )
+        await asyncio.to_thread(started.wait, 5)
+
+        # Second call while the first is still in flight must be rejected and
+        # must not disturb the first request.
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node2,
+            node_id="n2",
+            query="second query",
+            branch_history=[],
+            on_progress=lambda event: None,
+            on_success=successes.append,
+            on_failure=lambda exc: None,
+        )
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert notifications.message == "A web research request is already running."
+        assert len(dispatcher._web_research_requests) == 1
+        assert node2.pending_request_id is None, "the bounced call must never touch node2"
+
+        release.set()
+        entry = next(iter(dispatcher._web_research_requests.values()))
+        await entry["task"]
+
+        assert successes == [SimpleNamespace(answer_markdown="first result")]
+        assert dispatcher._web_research_requests == {}
+
+    asyncio.run(run())
+
+
+def test_start_web_research_research_failure_forwards_via_on_failure_and_shows_error_notification(monkeypatch):
+    failure = ResearchFailure("The search provider failed.", code="search_failed")
+
+    def raising_run(self, request, *, token=None, progress=None):
+        raise failure
+
+    monkeypatch.setattr(agents_module.WebResearchService, "run", raising_run)
+
+    async def run():
+        bus, notifications, dispatcher = _make_web_research_env()
+        node = _make_node()
+        failures = []
+
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            node_id="n1",
+            query="q",
+            branch_history=[],
+            on_progress=lambda event: None,
+            on_success=lambda result: None,
+            on_failure=failures.append,
+        )
+        entry = next(iter(dispatcher._web_research_requests.values()))
+        await entry["task"]
+
+        assert failures == [failure]
+        assert dispatcher._web_research_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == "Web research failed: The search provider failed."
+
+    asyncio.run(run())
+
+
+def test_start_web_research_request_cancelled_forwards_via_on_failure_and_shows_info_notification(monkeypatch):
+    cancelled_exc = RequestCancelled("Web research was cancelled.")
+
+    def raising_run(self, request, *, token=None, progress=None):
+        raise cancelled_exc
+
+    monkeypatch.setattr(agents_module.WebResearchService, "run", raising_run)
+
+    async def run():
+        bus, notifications, dispatcher = _make_web_research_env()
+        node = _make_node()
+        failures = []
+
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            node_id="n1",
+            query="q",
+            branch_history=[],
+            on_progress=lambda event: None,
+            on_success=lambda result: None,
+            on_failure=failures.append,
+        )
+        entry = next(iter(dispatcher._web_research_requests.values()))
+        await entry["task"]
+
+        assert failures == [cancelled_exc]
+        assert dispatcher._web_research_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert notifications.message == "Web research cancelled."
+
+    asyncio.run(run())
+
+
+def test_start_web_research_generic_exception_forwards_via_on_failure_and_shows_error_notification(monkeypatch):
+    def raising_run(self, request, *, token=None, progress=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(agents_module.WebResearchService, "run", raising_run)
+
+    async def run():
+        bus, notifications, dispatcher = _make_web_research_env()
+        node = _make_node()
+        failures = []
+
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            node_id="n1",
+            query="q",
+            branch_history=[],
+            on_progress=lambda event: None,
+            on_success=lambda result: None,
+            on_failure=failures.append,
+        )
+        entry = next(iter(dispatcher._web_research_requests.values()))
+        await entry["task"]
+
+        assert len(failures) == 1
+        assert isinstance(failures[0], RuntimeError)
+        assert str(failures[0]) == "boom"
+        assert dispatcher._web_research_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == "Web research failed: boom"
+
+    asyncio.run(run())
+
+
+def test_start_web_research_timeout_fires_the_exact_message_and_clears_the_slot(monkeypatch):
+    monkeypatch.setattr(agents_module, "WEB_RESEARCH_WATCHDOG_TIMEOUT_SECONDS", 0.05)
+
+    def slow_run(self, request, *, token=None, progress=None):
+        time.sleep(0.3)
+        return SimpleNamespace(answer_markdown="too late")
+
+    monkeypatch.setattr(agents_module.WebResearchService, "run", slow_run)
+
+    async def run():
+        bus, notifications, dispatcher = _make_web_research_env()
+        node = _make_node()
+        failures = []
+
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            node_id="n1",
+            query="q",
+            branch_history=[],
+            on_progress=lambda event: None,
+            on_success=lambda result: None,
+            on_failure=failures.append,
+        )
+        entry = next(iter(dispatcher._web_research_requests.values()))
+        await entry["task"]
+
+        assert len(failures) == 1
+        assert isinstance(failures[0], ResearchFailure)
+        expected_message = (
+            "Web research stopped responding before the request completed. Please try again."
+        )
+        assert str(failures[0]) == expected_message
+        assert failures[0].code == "watchdog_timeout"
+        assert dispatcher._web_research_requests == {}, "the slot must not leak/deadlock future requests"
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == expected_message
+
+    asyncio.run(run())
+
+
+def test_start_web_research_stale_progress_event_after_timeout_is_dropped(monkeypatch):
+    """Review-found regression guard: asyncio.to_thread's underlying thread is
+    not actually killed when wait_for's timeout fires (Future.cancel() on an
+    already-running thread is a no-op), so a slow WebResearchService.run()
+    can keep calling progress() well after this request's own finally block
+    has already popped _web_research_requests and cleared
+    node.pending_request_id. That stale event must be dropped, not delivered
+    to on_progress - otherwise it can resurrect a since-failed node's stage
+    or clobber a new run started on the same node afterward."""
+    monkeypatch.setattr(agents_module, "WEB_RESEARCH_WATCHDOG_TIMEOUT_SECONDS", 0.05)
+    late_event = SimpleNamespace(
+        stage=SimpleNamespace(value="fetching"), completed=1, total=4, source_id="s1"
+    )
+
+    def slow_run(self, request, *, token=None, progress=None):
+        time.sleep(0.3)  # past the watchdog timeout, so the timeout branch already ran
+        progress(late_event)  # the "zombie" thread still calling back afterward
+        return SimpleNamespace(answer_markdown="too late")
+
+    monkeypatch.setattr(agents_module.WebResearchService, "run", slow_run)
+
+    async def run():
+        bus, notifications, dispatcher = _make_web_research_env()
+        node = _make_node()
+        progress_events = []
+
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            node_id="n1",
+            query="q",
+            branch_history=[],
+            on_progress=progress_events.append,
+            on_success=lambda result: None,
+            on_failure=lambda exc: None,
+        )
+        entry = next(iter(dispatcher._web_research_requests.values()))
+        await entry["task"]
+        assert dispatcher._web_research_requests == {}, "slot must already be cleared by the timeout branch"
+
+        # Give the still-running background thread time to reach its
+        # progress() call and for run_coroutine_threadsafe's scheduled
+        # coroutine to actually execute on this loop.
+        await asyncio.sleep(0.4)
+
+        assert progress_events == [], (
+            "a progress event emitted after this request's slot was cleared "
+            "must be dropped, not delivered to on_progress"
+        )
+
+    asyncio.run(run())
+
+
+def test_cancel_web_research_returns_false_for_an_unknown_request_id():
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    assert dispatcher.cancel_web_research("no-such-request") is False
+
+
+def test_web_research_request_and_chat_request_run_concurrently_both_dicts_non_empty(monkeypatch):
+    """THE key concurrency-slot regression guard (R5.1, mirrors R4.4a's own
+    chat/image guard test): a chat/composer request occupies self._requests
+    while a web-research request occupies the SEPARATE
+    self._web_research_requests dict at the same time - neither blocks nor is
+    blocked by the other, and both dicts are simultaneously non-empty at
+    least once."""
+    chat_started = threading.Event()
+    chat_release = threading.Event()
+    research_started = threading.Event()
+    research_release = threading.Event()
+
+    def blocking_chat(task, messages, **kwargs):
+        chat_started.set()
+        chat_release.wait(5)
+        return {"message": {"content": "chat reply"}}
+
+    def blocking_run(self, request, *, token=None, progress=None):
+        research_started.set()
+        research_release.wait(5)
+        return SimpleNamespace(answer_markdown="research result")
+
+    _configure_fake_ollama(monkeypatch, blocking_chat)
+    monkeypatch.setattr(agents_module.WebResearchService, "run", blocking_run)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        node = _make_node()
+        chat_replies = []
+        research_successes = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=chat_replies.append,
+        )
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            node_id="n1",
+            query="q",
+            branch_history=[],
+            on_progress=lambda event: None,
+            on_success=research_successes.append,
+            on_failure=lambda exc: None,
+        )
+
+        await asyncio.to_thread(chat_started.wait, 5)
+        await asyncio.to_thread(research_started.wait, 5)
+
+        # THE key assertion: both slots are genuinely occupied at the same
+        # time - neither request bounced the other, and neither notification
+        # fired.
+        assert len(dispatcher._requests) == 1
+        assert len(dispatcher._web_research_requests) == 1
+        assert notifications.visible is False, "neither call should have been rejected"
+
+        chat_release.set()
+        chat_entry = next(iter(dispatcher._requests.values()))
+        await chat_entry["task"]
+        research_release.set()
+        research_entry = next(iter(dispatcher._web_research_requests.values()))
+        await research_entry["task"]
+
+        assert chat_replies == ["chat reply"]
+        assert research_successes == [SimpleNamespace(answer_markdown="research result")]
+        assert dispatcher._requests == {}
+        assert dispatcher._web_research_requests == {}
+        assert composer_document.request_state == "idle"
+
+    asyncio.run(run())
+
+
+def test_start_web_research_progress_ordering_on_progress_invoked_in_the_same_order(monkeypatch):
+    """Validates the run_coroutine_threadsafe handoff preserves emission
+    order (see start_web_research's own docstring for why this holds even
+    though on_progress is invoked from a worker thread)."""
+    events = [
+        SimpleNamespace(stage=SimpleNamespace(value=f"stage{i}"), completed=i, total=5, source_id=None)
+        for i in range(5)
+    ]
+
+    def fake_run(self, request, *, token=None, progress=None):
+        for event in events:
+            progress(event)
+        return SimpleNamespace(answer_markdown="done")
+
+    monkeypatch.setattr(agents_module.WebResearchService, "run", fake_run)
+
+    async def run():
+        bus, notifications, dispatcher = _make_web_research_env()
+        node = _make_node()
+        progress_calls = []
+
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            node_id="n1",
+            query="q",
+            branch_history=[],
+            on_progress=progress_calls.append,
+            on_success=lambda result: None,
+            on_failure=lambda exc: None,
+        )
+        entry = next(iter(dispatcher._web_research_requests.values()))
+        await entry["task"]
+
+        assert progress_calls == events
+
+    asyncio.run(run())
+
+
+def test_start_web_research_constructs_web_research_service_with_no_override_the_ssrf_safety_default(monkeypatch):
+    """Confirms AgentDispatcher.start_web_research always constructs a
+    default WebResearchService() - no fetcher/policy override - so the
+    SSRF-safe RequestsDocumentFetcher()/FetchPolicy() defaults are always in
+    effect for every dispatch. The dedicated SSRF/redirect/byte-cap tests
+    themselves live in graphlink_app/tests/test_web_research_service.py and
+    test_web_research_lifecycle.py (unchanged, untouched by this increment) -
+    this is only the construction-site confirmation."""
+    captured_args = []
+    captured_kwargs = []
+    original_init = agents_module.WebResearchService.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured_args.append(args)
+        captured_kwargs.append(kwargs)
+        return original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(agents_module.WebResearchService, "__init__", spy_init)
+    monkeypatch.setattr(
+        agents_module.WebResearchService,
+        "run",
+        lambda self, request, *, token=None, progress=None: SimpleNamespace(answer_markdown="x"),
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_web_research_env()
+        node = _make_node()
+
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            node_id="n1",
+            query="q",
+            branch_history=[],
+            on_progress=lambda event: None,
+            on_success=lambda result: None,
+            on_failure=lambda exc: None,
+        )
+        entry = next(iter(dispatcher._web_research_requests.values()))
+        await entry["task"]
+
+    asyncio.run(run())
+
+    assert captured_args == [()]
+    assert captured_kwargs == [{}]
+
+
+def test_agents_never_imports_qt():
+    # This is the regression gate for Step 0's providers.py fix - mirrors
+    # test_plugins.py's own test_plugins_never_imports_qt's exact
+    # subprocess-invocation style (a plain in-process assert is meaningless
+    # once anything else in a shared pytest run has already imported
+    # PySide6; only a fresh subprocess importing ONLY backend.agents actually
+    # answers "does this transitively pull in Qt"). Before Step 0's fix,
+    # `import backend.agents` -> WebResearchService -> providers.py ->
+    # `import graphlink_config as config` -> PySide6.QtGui/QtWidgets at
+    # module scope - a real regression this test would have caught.
+    import subprocess
+    import sys as _sys
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [_sys.executable, "-c", "import backend.agents, sys; assert 'PySide6' not in sys.modules"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -5,6 +5,7 @@ shape, and snapshot publishing."""
 import asyncio
 import base64
 import threading
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +15,7 @@ import pytest
 # top-level graphlink_app imports below (api_provider, graphlink_task_config)
 # for this module to import cleanly when run standalone, not just as part of
 # a larger session where some earlier-collected module already did this.
+import backend.agents as agents_module
 from backend.agents import AgentDispatcher
 from backend.canvas import (
     DRAG_FACTOR_MAX,
@@ -21,6 +23,7 @@ from backend.canvas import (
     SceneDocument,
     SceneEmptyPromptError,
     SceneError,
+    _research_result_wire,
     register_canvas,
 )
 from backend.composer import ComposerDocument
@@ -29,6 +32,7 @@ from backend.notifications import NotificationState
 
 import api_provider
 import graphlink_task_config as task_config
+from graphlink_plugins.web_research.domain import ResearchCitation, ResearchResult, ResearchSource
 
 
 # -- document invariants ----------------------------------------------------
@@ -2378,5 +2382,487 @@ def test_dispatch_image_mid_flight_delete_of_the_parent_is_a_silent_noop():
         assert dispatcher._image_requests == {}
         notice = await bus.publish("notification")
         assert notice["visible"] is False, "deleted-mid-flight is a silent no-op - no notification fires"
+
+    asyncio.run(run())
+
+
+# -- R5.1: web research node - domain-level ----------------------------------
+
+
+def test_add_web_research_node_creates_a_real_web_research_kind_node():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "research this for me", True)
+    node = doc.add_web_research_node(10, 20, parent.id)
+    assert node.kind == "web_research"
+    assert node.title == "Web Research"
+    assert node.content == ""
+    assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
+
+
+def test_add_web_research_node_rejects_unknown_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_web_research_node(0, 0, "ghost")
+
+
+def test_add_web_research_node_requires_a_parent_id():
+    # Same as add_document_node/add_thinking_node/add_html_node/add_image_node/
+    # add_conversation_node - parent_id has no default in add_web_research_node's
+    # signature, so calling without one is a TypeError (missing required
+    # argument), not a SceneError.
+    doc = SceneDocument()
+    with pytest.raises(TypeError):
+        doc.add_web_research_node(0, 0)
+
+
+def test_web_research_node_deletion_goes_through_the_generic_remove_nodes_path():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_web_research_node(10, 10, parent.id)
+    assert not hasattr(doc, "delete_web_research_node"), (
+        "web_research nodes are not branch points - no special delete method"
+    )
+    doc.remove_nodes([node.id])
+    assert node.id not in doc.nodes
+    assert not any(e.target == node.id or e.source == node.id for e in doc.edges.values())
+
+
+def test_start_web_research_run_sets_content_and_resets_progress_fields():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_web_research_node(0, 0, parent.id)
+    # Simulate a previous run's leftover progress state.
+    node.research_stage = "fetching"
+    node.research_completed = 2
+    node.research_total = 4
+    node.research_active_source_id = "s1-old"
+    node.research_error = "stale error"
+
+    returned = doc.start_web_research_run(node.id, "what is the capital of France?")
+
+    assert returned is node
+    assert node.content == "what is the capital of France?"
+    assert node.research_stage == ""
+    assert node.research_completed == 0
+    assert node.research_total == 0
+    assert node.research_active_source_id is None
+    assert node.research_error == ""
+
+
+def test_start_web_research_run_does_not_clear_a_stale_previous_result():
+    # Deliberate stale-while-revalidate (see the method's own docstring): the
+    # previous run's answer stays visible until THIS run replaces it on
+    # success, or fails/cancels (leaving the stale result annotated by the
+    # new research_error).
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_web_research_node(0, 0, parent.id)
+    node.research_result = {"answerMarkdown": "a previous stale answer"}
+
+    doc.start_web_research_run(node.id, "a follow-up question")
+
+    assert node.research_result == {"answerMarkdown": "a previous stale answer"}
+
+
+def test_start_web_research_run_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().start_web_research_run("ghost", "a query")
+
+
+def test_start_web_research_run_wrong_kind_raises_scene_error():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "not a web research node", True)
+    with pytest.raises(SceneError):
+        doc.start_web_research_run(chat.id, "a query")
+
+
+def test_apply_web_research_progress_updates_stage_completed_total_source_id_from_a_duck_typed_event():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_web_research_node(0, 0, parent.id)
+    fake_event = SimpleNamespace(
+        stage=SimpleNamespace(value="fetching"), completed=1, total=4, source_id="s1-abc123"
+    )
+
+    returned = doc.apply_web_research_progress(node.id, fake_event)
+
+    assert returned is node
+    assert node.research_stage == "fetching"
+    assert node.research_completed == 1
+    assert node.research_total == 4
+    assert node.research_active_source_id == "s1-abc123"
+
+
+def test_apply_web_research_progress_is_a_silent_noop_for_a_deleted_or_unknown_node():
+    doc = SceneDocument()
+    fake_event = SimpleNamespace(
+        stage=SimpleNamespace(value="searching"), completed=0, total=1, source_id=None
+    )
+    assert doc.apply_web_research_progress("ghost", fake_event) is None
+
+
+def test_complete_web_research_run_sets_result_and_clears_error_and_active_source():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_web_research_node(0, 0, parent.id)
+    node.research_error = "a previous error"
+    node.research_active_source_id = "s1-still-active"
+    result_wire = {"answerMarkdown": "the answer", "sources": []}
+
+    returned = doc.complete_web_research_run(node.id, result_wire)
+
+    assert returned is node
+    assert node.research_stage == "completed"
+    assert node.research_error == ""
+    assert node.research_active_source_id is None
+    assert node.research_result == result_wire
+
+
+def test_complete_web_research_run_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().complete_web_research_run("ghost", {"answerMarkdown": "x"})
+
+
+def test_fail_web_research_run_sets_cancelled_stage_and_message():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_web_research_node(0, 0, parent.id)
+    node.research_active_source_id = "s1-in-flight"
+
+    returned = doc.fail_web_research_run(node.id, cancelled=True, message="Web research cancelled.")
+
+    assert returned is node
+    assert node.research_stage == "cancelled"
+    assert node.research_error == "Web research cancelled."
+    assert node.research_active_source_id is None
+
+
+def test_fail_web_research_run_sets_failed_stage_and_message():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_web_research_node(0, 0, parent.id)
+
+    returned = doc.fail_web_research_run(node.id, cancelled=False, message="The search provider failed.")
+
+    assert returned is node
+    assert node.research_stage == "failed"
+    assert node.research_error == "The search provider failed."
+
+
+def test_fail_web_research_run_does_not_clear_a_stale_previous_result():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_web_research_node(0, 0, parent.id)
+    node.research_result = {"answerMarkdown": "a previous stale answer"}
+
+    doc.fail_web_research_run(node.id, cancelled=False, message="boom")
+
+    assert node.research_result == {"answerMarkdown": "a previous stale answer"}
+
+
+def test_fail_web_research_run_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().fail_web_research_run("ghost", cancelled=False, message="boom")
+
+
+def test_scene_payload_includes_research_fields_defaulted_for_other_kinds():
+    doc = SceneDocument()
+    doc.add_node(0, 0, "plain")
+    parent = doc.add_node(1, 1, "parent")
+    node = doc.add_web_research_node(2, 2, parent.id)
+
+    rows = {n["id"]: n for n in doc.scene_payload()["nodes"]}
+    assert rows["n0"]["researchStage"] == ""
+    assert rows["n0"]["researchCompleted"] == 0
+    assert rows["n0"]["researchTotal"] == 0
+    assert rows["n0"]["researchActiveSourceId"] is None
+    assert rows["n0"]["researchError"] == ""
+    assert rows["n0"]["researchResult"] is None
+
+    doc.start_web_research_run(node.id, "a query")
+    fake_event = SimpleNamespace(
+        stage=SimpleNamespace(value="fetching"), completed=1, total=2, source_id="s1-x"
+    )
+    doc.apply_web_research_progress(node.id, fake_event)
+    row = {n["id"]: n for n in doc.scene_payload()["nodes"]}[node.id]
+    assert row["kind"] == "web_research"
+    assert row["content"] == "a query"
+    assert row["researchStage"] == "fetching"
+    assert row["researchCompleted"] == 1
+    assert row["researchTotal"] == 2
+    assert row["researchActiveSourceId"] == "s1-x"
+
+
+def test_research_result_wire_camel_cases_a_research_result():
+    result = ResearchResult(
+        request_id="req-1",
+        original_query="what is the capital of France?",
+        effective_query="capital of France",
+        answer_markdown="Paris is the capital of France [s1-abc].",
+        sources=[
+            ResearchSource(
+                source_id="s1-abc",
+                title="France - Wikipedia",
+                url="https://example.test/france",
+                canonical_url="https://example.test/france",
+                snippet="France is a country...",
+                rank=1,
+                provider="DuckDuckGo",
+                final_url="https://example.test/france",
+                status="accepted",
+                error_code="",
+                error_message="",
+                truncated=False,
+                content_hash="deadbeef",
+                citation_count=1,
+            )
+        ],
+        citations=[ResearchCitation(source_id="s1-abc", marker="[s1-abc]", claim_context="")],
+        warnings=["Source 2 was not used (low_quality)."],
+        provider_snapshot={},
+    )
+
+    wire = _research_result_wire(result)
+
+    assert wire == {
+        "requestId": "req-1",
+        "originalQuery": "what is the capital of France?",
+        "effectiveQuery": "capital of France",
+        "answerMarkdown": "Paris is the capital of France [s1-abc].",
+        "sources": [
+            {
+                "sourceId": "s1-abc",
+                "title": "France - Wikipedia",
+                "url": "https://example.test/france",
+                "canonicalUrl": "https://example.test/france",
+                "snippet": "France is a country...",
+                "rank": 1,
+                "provider": "DuckDuckGo",
+                "finalUrl": "https://example.test/france",
+                "status": "accepted",
+                "errorCode": "",
+                "errorMessage": "",
+                "truncated": False,
+                "contentHash": "deadbeef",
+                "citationCount": 1,
+            }
+        ],
+        "citations": [{"sourceId": "s1-abc", "marker": "[s1-abc]", "claimContext": ""}],
+        "warnings": ["Source 2 was not used (low_quality)."],
+        "providerSnapshot": {},
+    }
+
+
+# -- R5.1: web research node - WS-intent level -------------------------------
+
+
+def test_run_web_research_intent_publishes_scene_and_calls_start_web_research_with_correct_branch_history():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.calls = []
+
+        async def start_web_research(self, **kwargs):
+            self.calls.append(kwargs)
+
+        def cancel_web_research(self, request_id):
+            return False
+
+        def is_web_research_busy(self):
+            return False
+
+    async def run():
+        bus = SessionBus("run-web-research-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        document = register_canvas(bus, notifications, fake_dispatcher, composer_document)
+        recorder = Recorder()
+        bus.attach(recorder)
+
+        root = await bus.dispatch_intent("scene", "addChatNode", [0, 0, "root question", True])
+        # add_web_research_node itself always requires a real parent - here we
+        # parent the web_research node off the CHAT node so branch_history is
+        # meaningfully non-trivial (mirrors how a real Web Research node
+        # branches from a chat node in production).
+        wr_node = document.add_web_research_node(0, 0, root)
+        recorder.messages.clear()  # only care about messages from runWebResearch below
+
+        result = await bus.dispatch_intent(
+            "scene", "runWebResearch", [wr_node.id, "what is this about?"]
+        )
+
+        assert result == wr_node.id
+        assert document.nodes[wr_node.id].content == "what is this about?"
+        assert recorder.topics_seen().count("scene") == 1, "start_web_research_run publishes scene once"
+
+        assert len(fake_dispatcher.calls) == 1
+        call = fake_dispatcher.calls[0]
+        assert call["bus"] is bus
+        assert call["notifications_state"] is notifications
+        assert call["node"] is wr_node
+        assert call["node_id"] == wr_node.id
+        assert call["query"] == "what is this about?"
+        assert call["branch_history"] == document.chat_branch_history(root)
+        assert callable(call["on_progress"])
+        assert callable(call["on_success"])
+        assert callable(call["on_failure"])
+
+    asyncio.run(run())
+
+
+def test_run_web_research_intent_unknown_node_shows_notification_not_a_crash():
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        result = await bus.dispatch_intent("scene", "runWebResearch", ["ghost", "a query"])
+
+        assert result is None
+        assert dispatcher._web_research_requests == {}
+        notice = await bus.publish("notification")
+        assert notice["visible"] is True
+        assert notice["msgType"] == "warning"
+        assert notice["message"] == "This node no longer exists."
+
+    asyncio.run(run())
+
+
+def test_cancel_web_research_request_intent_calls_agent_dispatcher_cancel_web_research():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.cancel_calls = []
+
+        def cancel_web_research(self, request_id):
+            self.cancel_calls.append(request_id)
+            return True
+
+        def is_web_research_busy(self):
+            return False
+
+    async def run():
+        bus = SessionBus("cancel-web-research-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        register_canvas(bus, notifications, fake_dispatcher, composer_document)
+
+        result = await bus.dispatch_intent("scene", "cancelWebResearchRequest", ["req-123"])
+
+        assert result is None
+        assert fake_dispatcher.cancel_calls == ["req-123"]
+
+    asyncio.run(run())
+
+
+def test_run_web_research_mid_flight_delete_of_the_node_is_a_silent_noop():
+    # Mirrors test_dispatch_image_mid_flight_delete_of_the_parent_is_a_silent_noop's
+    # own pattern: block the underlying call with threading Events, delete the
+    # node between dispatch and callback invocation, and confirm _on_progress/
+    # _on_success/_on_failure inside run_web_research's closure all no-op
+    # silently rather than raising or recreating anything.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_chat_node(0, 0, "research this please", True)
+        node = document.add_web_research_node(0, 160, parent.id)
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_run(self, request, *, token=None, progress=None):
+            started.set()
+            release.wait(5)
+            return SimpleNamespace()  # never actually read - node is gone by then
+
+        with patch.object(agents_module.WebResearchService, "run", blocking_run):
+            result = await bus.dispatch_intent(
+                "scene", "runWebResearch", [node.id, "what is this about?"]
+            )
+            assert result == node.id
+
+            await asyncio.to_thread(started.wait, 5)
+            document.remove_nodes([node.id])
+
+            release.set()
+            entry = next(iter(dispatcher._web_research_requests.values()))
+            await entry["task"]
+
+        assert node.id not in document.nodes
+        assert dispatcher._web_research_requests == {}
+        notice = await bus.publish("notification")
+        assert notice["visible"] is False, "deleted-mid-flight is a silent no-op - no notification fires"
+
+    asyncio.run(run())
+
+
+def test_run_web_research_on_a_different_node_while_one_is_busy_does_not_clobber_its_state():
+    # Review-found regression guard: run_web_research used to call
+    # start_web_research_run (which unconditionally resets research_stage/
+    # research_error/progress fields and republishes scene) BEFORE checking
+    # whether AgentDispatcher's single in-flight slot was already busy - so
+    # clicking Run on node B while node A was mid-research would silently wipe
+    # B's existing failure/cancelled banner even though no new run for B ever
+    # actually started. The busy check must happen first.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_chat_node(0, 0, "research this please", True)
+        node_a = document.add_web_research_node(0, 160, parent.id)
+        node_b = document.add_web_research_node(200, 160, parent.id)
+
+        # Give node_b a pre-existing failed state to prove it survives.
+        document.start_web_research_run(node_b.id, "node b's original query")
+        document.fail_web_research_run(node_b.id, cancelled=False, message="node b failed earlier")
+        assert node_b.research_stage == "failed"
+        assert node_b.research_error == "node b failed earlier"
+
+        started = threading.Event()
+        release = threading.Event()
+        fake_result = ResearchResult(
+            request_id="req-a",
+            original_query="node a's query",
+            effective_query="node a's query",
+            answer_markdown="node a's result",
+            sources=[],
+            citations=[],
+            warnings=[],
+            provider_snapshot={},
+        )
+
+        def blocking_run(self, request, *, token=None, progress=None):
+            started.set()
+            release.wait(5)
+            return fake_result
+
+        with patch.object(agents_module.WebResearchService, "run", blocking_run):
+            result_a = await bus.dispatch_intent(
+                "scene", "runWebResearch", [node_a.id, "node a's query"]
+            )
+            assert result_a == node_a.id
+            await asyncio.to_thread(started.wait, 5)
+
+            # node_a is now in flight (the single web-research slot is busy).
+            # Clicking Run on node_b must be rejected up front, WITHOUT
+            # touching node_b's stage/error/content at all.
+            result_b = await bus.dispatch_intent(
+                "scene", "runWebResearch", [node_b.id, "a brand new query for b"]
+            )
+            assert result_b is None
+            assert node_b.research_stage == "failed", "node_b's terminal state must survive the bounce"
+            assert node_b.research_error == "node b failed earlier"
+            assert node_b.content == "node b's original query", "node_b's content must not be overwritten"
+
+            notice = await bus.publish("notification")
+            assert notice["visible"] is True
+            assert notice["msgType"] == "info"
+            assert notice["message"] == "A web research request is already running."
+
+            release.set()
+            entry = next(iter(dispatcher._web_research_requests.values()))
+            await entry["task"]
+
+        assert node_a.research_stage == "completed"
+        assert node_a.research_result["answerMarkdown"] == "node a's result"
 
     asyncio.run(run())

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -1,7 +1,10 @@
-"""Plugin picker topic tests (Qt-removal plan R2.5)."""
+"""Plugin picker topic tests (Qt-removal plan R2.5, extended R5.1)."""
 
 import asyncio
 
+import pytest
+
+from backend.canvas import SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.plugins import _CATEGORY_META, _PLUGINS, get_plugin_categories, plugins_payload, register_plugins
@@ -68,7 +71,7 @@ def test_plugins_never_imports_qt():
 def test_register_plugins_publishes_on_the_app_plugins_topic():
     bus = SessionBus("plugins-test")
     notifications = NotificationState()
-    register_plugins(bus, notifications)
+    register_plugins(bus, notifications, SceneDocument())
 
     class Recorder:
         def __init__(self):
@@ -88,7 +91,7 @@ def test_execute_plugin_shows_info_notification_for_known_plugin():
     bus = SessionBus("plugins-exec-test")
     notifications = NotificationState()
     bus.register_topic("notification", notifications.payload)
-    register_plugins(bus, notifications)
+    register_plugins(bus, notifications, SceneDocument())
 
     asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Gitlink"]))
     assert notifications.visible is True
@@ -101,9 +104,103 @@ def test_execute_plugin_shows_warning_notification_for_unknown_plugin():
     bus = SessionBus("plugins-exec-unknown-test")
     notifications = NotificationState()
     bus.register_topic("notification", notifications.payload)
-    register_plugins(bus, notifications)
+    register_plugins(bus, notifications, SceneDocument())
 
     asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Not A Real Plugin"]))
     assert notifications.visible is True
     assert notifications.msg_type == "warning"
     assert "Not A Real Plugin" in notifications.message
+
+
+# -- R5.1: "Web Research" - the first real node-creation plugin --------------
+
+
+def _make_plugins_bus():
+    bus = SessionBus("plugins-web-research-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    canvas_document = SceneDocument()
+    bus.register_topic("scene", canvas_document.scene_payload)
+    register_plugins(bus, notifications, canvas_document)
+    return bus, notifications, canvas_document
+
+
+def test_execute_plugin_web_research_with_no_parent_shows_the_exact_warning():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Web Research"]))
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == (
+        "Please select a valid node to branch from before adding a Web Node."
+    )
+    assert not any(n.kind == "web_research" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_web_research_with_unknown_parent_shows_the_same_warning():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Web Research", "ghost-node-id"])
+    )
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == (
+        "Please select a valid node to branch from before adding a Web Node."
+    )
+    assert not any(n.kind == "web_research" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_web_research_with_a_valid_parent_creates_a_real_node_and_publishes_scene():
+    bus, notifications, canvas_document = _make_plugins_bus()
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    class Recorder:
+        def __init__(self):
+            self.messages = []
+
+        async def send_json(self, data):
+            self.messages.append(data)
+
+        def topics_seen(self):
+            return [m["topic"] for m in self.messages if m["kind"] == "state"]
+
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Web Research", parent.id])
+    )
+
+    assert result is not None
+    node = canvas_document.nodes[result]
+    assert node.kind == "web_research"
+    assert node.title == "Web Research"
+    assert any(
+        e.source == parent.id and e.target == node.id for e in canvas_document.edges.values()
+    )
+    assert notifications.visible is False, "success is not a deferral - no notification fires"
+    assert "scene" in recorder.topics_seen()
+
+
+# -- R5.1: non-regression - every OTHER plugin name is still an honest,
+# unchanged deferred notice ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name", [n for n in (p[0] for p in _PLUGINS) if n != "Web Research"]
+)
+def test_execute_plugin_every_other_plugin_name_still_shows_the_unchanged_deferred_notice(name):
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", [name]))
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "info"
+    assert notifications.message == f'"{name}" node creation lands in R3/R5.'
+    assert not any(n.kind == "web_research" for n in canvas_document.nodes.values())

--- a/graphlink_app/graphlink_plugins/web_research/providers.py
+++ b/graphlink_app/graphlink_plugins/web_research/providers.py
@@ -12,7 +12,7 @@ from typing import Sequence
 from urllib.parse import urljoin, urlsplit
 
 import api_provider
-import graphlink_config as config
+import graphlink_task_config as config
 
 from .domain import (
     CancellationToken,

--- a/graphlink_app/graphlink_scene_payload.py
+++ b/graphlink_app/graphlink_scene_payload.py
@@ -42,6 +42,13 @@ R4.3 adds `pendingRequestId` (ConversationNode real-reply + per-node cancel):
 the id of the AgentDispatcher request currently generating a reply for a
 node, or None when idle. Generic across any kind that ever gets its own real
 dispatch slot, defaulted None for every other kind, same additive rule.
+
+R5.1 adds the Web Research node's six `research*` fields (query text reuses
+the existing `content` field, same as code/thinking/html): populated for
+kind=="web_research" rows, defaulted (empty string/0/None) for every other
+kind, same additive rule. `researchResult`, when present, is a nested
+ResearchResultRow - the one field here (besides R3.25's `history`) whose
+shape is a structured object rather than a scalar.
 """
 
 from __future__ import annotations
@@ -54,6 +61,58 @@ from typing import Literal
 class ConversationMessageRow:
     role: Literal["user", "assistant"]
     content: str
+
+
+@dataclass
+class ResearchSourceRow:
+    sourceId: str
+    title: str
+    url: str
+    canonicalUrl: str
+    snippet: str
+    rank: int
+    provider: str
+    finalUrl: str
+    status: str
+    errorCode: str
+    errorMessage: str
+    truncated: bool
+    contentHash: str
+    citationCount: int
+
+
+@dataclass
+class ResearchCitationRow:
+    sourceId: str
+    marker: str
+    claimContext: str
+
+
+@dataclass
+class ResearchResultRow:
+    requestId: str
+    originalQuery: str
+    effectiveQuery: str
+    answerMarkdown: str
+    sources: list[ResearchSourceRow]
+    citations: list[ResearchCitationRow]
+    warnings: list[str]
+    # DEVIATION from the R5.1 spec text (which said a bare `dict`): the
+    # codegen's schema generator (graphlink_island_schema.py) has a closed,
+    # deliberately-narrow supported-type set that does NOT include a bare
+    # `dict` or `dict[str, Any]` (there is no catch-all/`Any` case - see that
+    # module's own docstring) - only `dict[str, X]` for X itself in the
+    # supported set. provider_snapshot is genuinely free-form diagnostics at
+    # the domain layer (graphlink_plugins/web_research/domain.py's
+    # WebResearchRequest/ResearchResult.provider_snapshot: dict[str, Any]),
+    # but nothing in this increment ever populates it (agents.py's
+    # WebResearchRequest(...) call site never passes provider_snapshot, so it
+    # is always {} at runtime here) - dict[str, str] is the narrowest
+    # accurate supertype of "empty dict" that the generator supports, so it
+    # is used here rather than blocking codegen. A future increment that
+    # starts populating this with non-string values needs its own explicit
+    # schema-generator extension, not a silent workaround here.
+    providerSnapshot: dict[str, str]
 
 
 @dataclass
@@ -100,6 +159,17 @@ class SceneNodeRow:
     # dispatch slot (not conversation-only), defaulted None for every other
     # kind.
     pendingRequestId: str | None = None
+    # R5.1: the Web Research node's real persisted shape - query text reuses
+    # `content` above (same pattern as code/thinking/html); these six fields
+    # track one research run's live progress/outcome, populated for
+    # kind=="web_research" rows, defaulted (empty string/0/None) for every
+    # other kind.
+    researchStage: str = ""
+    researchCompleted: int = 0
+    researchTotal: int = 0
+    researchActiveSourceId: str | None = None
+    researchError: str = ""
+    researchResult: ResearchResultRow | None = None
 
 
 @dataclass

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -131,7 +131,7 @@ function App() {
               <ViewPopover store={sceneStore} />
             </div>
             <div className="app-plugins-layer">
-              <PluginPicker transport={transport} />
+              <PluginPicker transport={transport} store={sceneStore} />
             </div>
             {settingsVisibility.showTokenCounter !== false && (
               <div className="app-token-counter-layer">

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { toFlowNodes } from "./SceneCanvas";
+import { handleSelectionChange, toFlowNodes } from "./SceneCanvas";
 import { SceneStore, initialSceneState } from "./sceneStore";
 import type { WsTransport } from "../../lib/ws/transport";
 import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
@@ -36,6 +36,12 @@ function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
     imageAssetId: "",
     history: [],
     pendingRequestId: null,
+    researchStage: "",
+    researchCompleted: 0,
+    researchTotal: 0,
+    researchActiveSourceId: null,
+    researchError: "",
+    researchResult: null,
     ...overrides,
   };
 }
@@ -136,5 +142,167 @@ describe("toFlowNodes (R4.4a Generate/Regenerate Image wiring)", () => {
 
     (imageFlowNode!.data as { onRegenerate: () => void }).onRegenerate();
     expect(intentSpy).toHaveBeenCalledWith("image-1");
+  });
+});
+
+describe("toFlowNodes (R5.1 web_research node)", () => {
+  it("maps a web_research scene node's all 6 new fields onto the flow node's data", () => {
+    const researchResult = {
+      requestId: "req-1",
+      originalQuery: "who won the 2019 world series",
+      effectiveQuery: "2019 world series winner",
+      answerMarkdown: "The **Washington Nationals** won.",
+      sources: [
+        {
+          sourceId: "src-1",
+          title: "2019 World Series",
+          url: "https://example.com/2019-ws",
+          canonicalUrl: "https://example.com/2019-ws",
+          snippet: "...",
+          rank: 1,
+          provider: "search",
+          finalUrl: "https://example.com/2019-ws",
+          status: "accepted",
+          errorCode: "",
+          errorMessage: "",
+          truncated: false,
+          contentHash: "abc",
+          citationCount: 1,
+        },
+      ],
+      citations: [{ sourceId: "src-1", marker: "[1]", claimContext: "won the series" }],
+      warnings: ["One source was truncated."],
+      providerSnapshot: {},
+    };
+    const scene = baseScene({
+      nodes: [
+        baseNode({
+          id: "wr-1",
+          kind: "web_research",
+          content: "who won the 2019 world series",
+          isCollapsed: true,
+          pendingRequestId: "req-1",
+          researchStage: "fetching",
+          researchCompleted: 2,
+          researchTotal: 5,
+          researchActiveSourceId: "src-2",
+          researchError: "",
+          researchResult,
+        }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const wrFlowNode = flowNodes.find((n) => n.id === "wr-1");
+    expect(wrFlowNode).toBeDefined();
+    expect(wrFlowNode!.type).toBe("web_research");
+    expect(wrFlowNode!.data).toMatchObject({
+      query: "who won the 2019 world series",
+      isCollapsed: true,
+      pendingRequestId: "req-1",
+      researchStage: "fetching",
+      researchCompleted: 2,
+      researchTotal: 5,
+      researchActiveSourceId: "src-2",
+      researchError: "",
+      researchResult,
+    });
+  });
+
+  it("coalesces null-ish optional fields (pendingRequestId/researchActiveSourceId/researchResult) to null", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({
+          id: "wr-2",
+          kind: "web_research",
+          content: "a fresh query",
+          researchStage: "",
+          researchCompleted: 0,
+          researchTotal: 0,
+        }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const wrFlowNode = flowNodes.find((n) => n.id === "wr-2");
+    expect(wrFlowNode).toBeDefined();
+    expect(wrFlowNode!.data).toMatchObject({
+      pendingRequestId: null,
+      researchActiveSourceId: null,
+      researchResult: null,
+    });
+  });
+
+  it("onRun calls store.runWebResearch with this node's id and the given query", () => {
+    const scene = baseScene({ nodes: [baseNode({ id: "wr-1", kind: "web_research" })], edges: [] });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "runWebResearch");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const wrFlowNode = flowNodes.find((n) => n.id === "wr-1");
+
+    (wrFlowNode!.data as { onRun: (query: string) => void }).onRun("a new question");
+    expect(intentSpy).toHaveBeenCalledWith("wr-1", "a new question");
+  });
+
+  it("onCancel fires cancelWebResearchRequest with pendingRequestId when set, and is a no-op otherwise", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "wr-pending", kind: "web_research", pendingRequestId: "req-77" }),
+        baseNode({ id: "wr-idle", kind: "web_research", pendingRequestId: null }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "cancelWebResearchRequest");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const pendingNode = flowNodes.find((n) => n.id === "wr-pending");
+    const idleNode = flowNodes.find((n) => n.id === "wr-idle");
+
+    (pendingNode!.data as { onCancel: () => void }).onCancel();
+    expect(intentSpy).toHaveBeenCalledWith("req-77");
+
+    (idleNode!.data as { onCancel: () => void }).onCancel();
+    expect(intentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("onToggleCollapse/onDelete reuse the generic setChatCollapsed/removeNodes intents", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "wr-1", kind: "web_research", isCollapsed: false })],
+      edges: [],
+    });
+    const store = makeStore();
+    const collapseSpy = vi.spyOn(store, "setChatCollapsed");
+    const removeSpy = vi.spyOn(store, "removeNodes");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const wrFlowNode = flowNodes.find((n) => n.id === "wr-1");
+
+    (wrFlowNode!.data as { onToggleCollapse: () => void }).onToggleCollapse();
+    expect(collapseSpy).toHaveBeenCalledWith("wr-1", true);
+
+    (wrFlowNode!.data as { onDelete: () => void }).onDelete();
+    expect(removeSpy).toHaveBeenCalledWith(["wr-1"]);
+  });
+});
+
+describe("handleSelectionChange (R5.1 onSelectionChange wiring)", () => {
+  it("calls store.setSelectedNodeId with the first selected node's id", () => {
+    const store = makeStore();
+    const spy = vi.spyOn(store, "setSelectedNodeId");
+    handleSelectionChange(store, [{ id: "n1" }, { id: "n2" }]);
+    expect(spy).toHaveBeenCalledWith("n1");
+  });
+
+  it("calls store.setSelectedNodeId with null when nothing is selected", () => {
+    const store = makeStore();
+    const spy = vi.spyOn(store, "setSelectedNodeId");
+    handleSelectionChange(store, []);
+    expect(spy).toHaveBeenCalledWith(null);
   });
 });

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -24,6 +24,7 @@ import { DocumentNodeView, type DocumentFlowNode } from "./DocumentNodeView";
 import { HtmlNodeView, type HtmlFlowNode } from "./HtmlNodeView";
 import { ImageNodeView, type ImageFlowNode } from "./ImageNodeView";
 import { ThinkingNodeView, type ThinkingFlowNode } from "./ThinkingNodeView";
+import { WebResearchNodeView, type WebResearchFlowNode } from "./WebResearchNodeView";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { SceneStore, scaleDragPosition } from "./sceneStore";
 
@@ -51,7 +52,8 @@ type SceneFlowNode =
   | ThinkingFlowNode
   | HtmlFlowNode
   | ImageFlowNode
-  | ConversationFlowNode;
+  | ConversationFlowNode
+  | WebResearchFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   const zoom = useStore((s) => s.transform[2]);
@@ -78,6 +80,7 @@ const NODE_TYPES = {
   html: HtmlNodeView,
   image: ImageNodeView,
   conversation: ConversationNodeView,
+  web_research: WebResearchNodeView,
 };
 
 // Exported standalone for direct unit testing (same posture as
@@ -283,6 +286,41 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
       });
       continue;
     }
+    if (n.kind === "web_research") {
+      // No onDock here either (same reasoning as the html/image/conversation
+      // branches above) - WebResearchNodeView never offers a dock-into-parent
+      // action; the generic `if (n.isDocked) continue` guard above still
+      // covers it correctly if it were ever docked via a direct WS call.
+      flowNodes.push({
+        id: n.id,
+        type: "web_research" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          query: n.content,
+          isCollapsed: n.isCollapsed,
+          pendingRequestId: n.pendingRequestId ?? null,
+          researchStage: n.researchStage,
+          researchCompleted: n.researchCompleted,
+          researchTotal: n.researchTotal,
+          researchActiveSourceId: n.researchActiveSourceId ?? null,
+          researchError: n.researchError,
+          researchResult: n.researchResult ?? null,
+          // Reuses the existing generic setChatCollapsed intent - same
+          // reasoning as every other non-chat node kind's onToggleCollapse
+          // above (the backend handler looks up ANY node by id).
+          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
+          onDelete: () => store.removeNodes([n.id]),
+          onRun: (query: string) => store.runWebResearch(n.id, query),
+          // Same null-guard pattern as the conversation node's own analogous
+          // cancel call site above - only fire the intent if there is
+          // genuinely a non-null request id to target.
+          onCancel: () => {
+            if (n.pendingRequestId) store.cancelWebResearchRequest(n.pendingRequestId);
+          },
+        },
+      });
+      continue;
+    }
     flowNodes.push({
       id: n.id,
       type: "placeholder" as const,
@@ -292,6 +330,15 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
   }
 
   return flowNodes;
+}
+
+// R5.1: the onSelectionChange callback's actual logic, pulled out standalone
+// for direct unit testing (same posture as toFlowNodes/scaleDragPosition
+// above) - a full <ReactFlow> mount's own drag-select interaction isn't
+// something this codebase drives in tests anywhere else, so this is what
+// gets covered instead of the mount.
+export function handleSelectionChange(store: SceneStore, nodes: { id: string }[]): void {
+  store.setSelectedNodeId(nodes[0]?.id ?? null);
 }
 
 function toFlowEdges(scene: SceneState): Edge[] {
@@ -406,6 +453,10 @@ function CanvasInner({ store }: { store: SceneStore }) {
         onNodesChange={onNodesChange}
         onConnect={onConnect}
         onDelete={onDelete}
+        // R5.1: mirrors React Flow's own selection state into the store so
+        // PluginPicker can attach "which node was selected" to executePlugin
+        // without either component reaching into the other's internals.
+        onSelectionChange={({ nodes: sel }) => handleSelectionChange(store, sel)}
         snapToGrid={scene.snapToGrid}
         snapGrid={[grid.gridSize, grid.gridSize]}
         // Double-click is the R1 create-node gesture (wrapper onDoubleClick);

--- a/web_ui/src/app/canvas/WebResearchNodeView.test.tsx
+++ b/web_ui/src/app/canvas/WebResearchNodeView.test.tsx
@@ -1,0 +1,380 @@
+import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  WebResearchNodeView,
+  type WebResearchFlowNode,
+  type WebResearchResultRow,
+} from "./WebResearchNodeView";
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
+// ChatNodeView.test.tsx / ConversationNodeView.test.tsx for why a bare
+// ReactFlowProvider is enough here too.
+
+function baseData(overrides: Partial<WebResearchFlowNode["data"]> = {}): WebResearchFlowNode["data"] {
+  return {
+    query: "",
+    isCollapsed: false,
+    pendingRequestId: null,
+    researchStage: "",
+    researchCompleted: 0,
+    researchTotal: 0,
+    researchActiveSourceId: null,
+    researchError: "",
+    researchResult: null,
+    onToggleCollapse: vi.fn(),
+    onDelete: vi.fn(),
+    onRun: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderWebResearchNode(overrides: Partial<WebResearchFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "n0", selected: false, data } as unknown as NodeProps<WebResearchFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <WebResearchNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return data;
+}
+
+// Directly sets the React Flow internal Zustand store's transform/zoom value
+// - same technique ConversationNodeView.test.tsx's own ZoomSetter uses (a
+// mounted panZoom instance doesn't exist in this direct-render test setup).
+function ZoomSetter({ zoom }: { zoom: number }) {
+  const store = useStoreApi();
+  useEffect(() => {
+    store.setState({ transform: [0, 0, zoom] });
+  }, [zoom, store]);
+  return null;
+}
+
+function renderWebResearchNodeAtZoom(zoom: number, overrides: Partial<WebResearchFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "n0", selected: false, data } as unknown as NodeProps<WebResearchFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <ZoomSetter zoom={zoom} />
+      <WebResearchNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return data;
+}
+
+function makeResult(overrides: Partial<WebResearchResultRow> = {}): WebResearchResultRow {
+  return {
+    requestId: "req-1",
+    originalQuery: "who won the 2019 world series",
+    effectiveQuery: "2019 world series winner",
+    answerMarkdown: "The Nationals won.",
+    sources: [],
+    citations: [],
+    warnings: [],
+    providerSnapshot: {},
+    ...overrides,
+  };
+}
+
+describe("WebResearchNodeView", () => {
+  it("renders the query in the input and the header label", () => {
+    renderWebResearchNode({ query: "who won the 2019 world series" });
+    expect(screen.getByText("Web Research")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Research query" })).toHaveValue(
+      "who won the 2019 world series",
+    );
+  });
+
+  it("manual collapse hides the body and shows only the header", () => {
+    renderWebResearchNode({ isCollapsed: true, query: "hello" });
+    expect(screen.getByText("Web Research")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("the inline collapse chevron calls onToggleCollapse", async () => {
+    const user = userEvent.setup();
+    const data = renderWebResearchNode();
+    await user.click(screen.getByRole("button", { name: "Collapse" }));
+    expect(data.onToggleCollapse).toHaveBeenCalledOnce();
+  });
+
+  it("LOD auto-collapse (zoom below threshold) also hides the body, even when isCollapsed is false", () => {
+    renderWebResearchNodeAtZoom(0.2, { isCollapsed: false, query: "hello" });
+    expect(screen.getByText("Web Research")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("stays expanded above the LOD threshold when isCollapsed is false", () => {
+    renderWebResearchNodeAtZoom(1, { isCollapsed: false, query: "hello" });
+    expect(screen.getByRole("textbox", { name: "Research query" })).toBeInTheDocument();
+  });
+
+  // -- Run/Cancel ------------------------------------------------------------
+
+  it("the Run button is disabled when the query is empty or whitespace-only", async () => {
+    const user = userEvent.setup();
+    renderWebResearchNode({ query: "" });
+    const input = screen.getByRole("textbox", { name: "Research query" });
+    const runButton = screen.getByRole("button", { name: "Run" });
+
+    expect(runButton).toBeDisabled();
+    await user.type(input, "   ");
+    expect(runButton).toBeDisabled();
+    await user.type(input, "real query");
+    expect(runButton).toBeEnabled();
+  });
+
+  it("clicking Run calls onRun with the trimmed draft text", async () => {
+    const user = userEvent.setup();
+    const data = renderWebResearchNode({ query: "" });
+    const input = screen.getByRole("textbox", { name: "Research query" });
+
+    await user.type(input, "  who won the 2019 world series  ");
+    await user.click(screen.getByRole("button", { name: "Run" }));
+    expect(data.onRun).toHaveBeenCalledWith("who won the 2019 world series");
+  });
+
+  it("the Run button is disabled while pendingRequestId is set, even with non-empty query", async () => {
+    const user = userEvent.setup();
+    renderWebResearchNode({ query: "", pendingRequestId: "req-1" });
+    const input = screen.getByRole("textbox", { name: "Research query" });
+    await user.type(input, "real query");
+    expect(screen.getByRole("button", { name: "Run" })).toBeDisabled();
+  });
+
+  it("the Cancel button is absent when pendingRequestId is null", () => {
+    renderWebResearchNode({ pendingRequestId: null });
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+
+  it("the Cancel button is present and calls onCancel when pendingRequestId is set", async () => {
+    const user = userEvent.setup();
+    const data = renderWebResearchNode({ pendingRequestId: "req-42" });
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    expect(cancelButton).toBeInTheDocument();
+    await user.click(cancelButton);
+    expect(data.onCancel).toHaveBeenCalledOnce();
+  });
+
+  // -- stage stepper ----------------------------------------------------------
+
+  it("highlights the correct step as active, marks earlier steps done, and leaves later ones pending", () => {
+    renderWebResearchNode({ researchStage: "extracting" });
+    expect(screen.getByText("Preparing")).toHaveClass("web-research-node-step", "done");
+    expect(screen.getByText("Searching")).toHaveClass("web-research-node-step", "done");
+    expect(screen.getByText("Fetching")).toHaveClass("web-research-node-step", "done");
+    expect(screen.getByText("Extracting")).toHaveClass("web-research-node-step", "active");
+    expect(screen.getByText("Validating")).toHaveClass("web-research-node-step", "pending");
+    expect(screen.getByText("Synthesizing")).toHaveClass("web-research-node-step", "pending");
+  });
+
+  it("shows no stepper before any run has started (empty researchStage)", () => {
+    renderWebResearchNode({ researchStage: "" });
+    expect(screen.queryByText("Preparing")).toBeNull();
+  });
+
+  it("shows the fetching-source progress line built from researchCompleted/researchTotal, never a per-source highlight", () => {
+    renderWebResearchNode({
+      researchStage: "fetching",
+      researchCompleted: 2,
+      researchTotal: 5,
+      researchActiveSourceId: "opaque-source-id",
+    });
+    expect(screen.getByText(/Fetching source 3 of 5/)).toBeInTheDocument();
+    // The opaque active-source id itself must never appear as rendered text.
+    expect(screen.queryByText("opaque-source-id")).toBeNull();
+  });
+
+  it("shows no progress line when researchTotal is 0", () => {
+    renderWebResearchNode({ researchStage: "searching", researchCompleted: 0, researchTotal: 0 });
+    expect(screen.queryByText(/Fetching source/)).toBeNull();
+  });
+
+  it("completed collapses the stepper in favor of the answer", () => {
+    renderWebResearchNode({
+      researchStage: "completed",
+      researchResult: makeResult({ answerMarkdown: "Final answer text." }),
+    });
+    expect(screen.queryByText("Preparing")).toBeNull();
+    expect(screen.getByText("Final answer text.")).toBeInTheDocument();
+  });
+
+  it("shows a red failed banner with the researchError text instead of continuing the stepper", () => {
+    renderWebResearchNode({ researchStage: "failed", researchError: "Search provider unavailable." });
+    expect(screen.queryByText("Preparing")).toBeNull();
+    const banner = screen.getByText("Search provider unavailable.");
+    expect(banner).toHaveClass("web-research-node-banner", "web-research-node-banner-failed");
+  });
+
+  it("shows a gray cancelled banner, defaulting the text when researchError is empty", () => {
+    renderWebResearchNode({ researchStage: "cancelled", researchError: "" });
+    expect(screen.queryByText("Preparing")).toBeNull();
+    const banner = screen.getByText("Research was cancelled.");
+    expect(banner).toHaveClass("web-research-node-banner", "web-research-node-banner-cancelled");
+  });
+
+  // -- result: answer/warnings/sources -----------------------------------------
+
+  it("renders the answer markdown, warnings, and per-source status chips from a completed result", () => {
+    renderWebResearchNode({
+      researchStage: "completed",
+      researchResult: makeResult({
+        answerMarkdown: "The **Nationals** won.",
+        warnings: ["One source was truncated."],
+        sources: [
+          {
+            sourceId: "src-1",
+            title: "2019 World Series - Wikipedia",
+            url: "https://example.com/ws",
+            canonicalUrl: "https://example.com/ws",
+            snippet: "",
+            rank: 1,
+            provider: "search",
+            finalUrl: "https://example.com/ws",
+            status: "accepted",
+            errorCode: "",
+            errorMessage: "",
+            truncated: false,
+            contentHash: "abc",
+            citationCount: 1,
+          },
+          {
+            sourceId: "src-2",
+            title: "",
+            url: "https://example.com/rejected",
+            canonicalUrl: "",
+            snippet: "",
+            rank: 2,
+            provider: "search",
+            finalUrl: "",
+            status: "rejected",
+            errorCode: "",
+            errorMessage: "",
+            truncated: false,
+            contentHash: "",
+            citationCount: 0,
+          },
+        ],
+      }),
+    });
+
+    expect(screen.getByText("Nationals")).toBeInTheDocument(); // bold text still renders as text
+    expect(screen.getByText("One source was truncated.")).toBeInTheDocument();
+
+    expect(screen.getByText("2019 World Series - Wikipedia")).toBeInTheDocument();
+    expect(screen.getByText("accepted")).toHaveClass("web-research-node-source-status-accepted");
+
+    expect(screen.getByText("https://example.com/rejected")).toBeInTheDocument();
+    expect(screen.getByText("rejected")).toHaveClass("web-research-node-source-status-rejected");
+  });
+
+  it("renders nothing for the result section when researchResult is null", () => {
+    renderWebResearchNode({ researchResult: null });
+    expect(screen.queryByText(/accepted|rejected|fetching|discovered|failed/)).toBeNull();
+  });
+
+  // -- markdown link safety ------------------------------------------------
+
+  it("opens a real http(s) link via window.open on click", async () => {
+    const user = userEvent.setup();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    renderWebResearchNode({
+      researchStage: "completed",
+      researchResult: makeResult({
+        answerMarkdown: "[real link](https://example.com/page)",
+      }),
+    });
+
+    await user.click(screen.getByText("real link"));
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith("https://example.com/page", "_blank", "noopener,noreferrer");
+    openSpy.mockRestore();
+  });
+
+  it("never calls window.open for a javascript: href", async () => {
+    const user = userEvent.setup();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    renderWebResearchNode({
+      researchStage: "completed",
+      researchResult: makeResult({
+        answerMarkdown: "[bad link](javascript:alert(1))",
+      }),
+    });
+
+    await user.click(screen.getByText("bad link"));
+    expect(openSpy).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it("renders a non-http(s) link with no href at all, so middle-click/context-menu has no raw href to bypass onClick with", () => {
+    // Review-found regression guard: an onClick-only guard (preventDefault +
+    // scheme check) leaves the raw href on the DOM node, which the browser's
+    // native middle-click (auxclick) and "open link in new tab"/"copy link
+    // address" context-menu actions read directly - bypassing onClick
+    // entirely. The fix omits href on the anchor altogether for any
+    // non-http(s) scheme, so there is nothing for those native gestures to act on.
+    renderWebResearchNode({
+      researchStage: "completed",
+      researchResult: makeResult({
+        answerMarkdown: "[bad link](javascript:alert(1))",
+      }),
+    });
+
+    const badLink = screen.getByText("bad link");
+    expect(badLink.tagName).not.toBe("A");
+    expect(document.querySelector("a[href]")).toBeNull();
+  });
+
+  // -- card-level menu ----------------------------------------------------
+
+  it("the node-level right-click menu shows exactly Collapse/Expand + Delete Node - no dock action", async () => {
+    const user = userEvent.setup();
+    const data = renderWebResearchNode();
+
+    fireEvent.contextMenu(screen.getByText("Web Research"));
+    const menu = screen.getByRole("menu");
+    expect(menu).toBeInTheDocument();
+
+    const items = screen.getAllByRole("menuitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("Collapse");
+    expect(items[1]).toHaveTextContent("Delete Node");
+    expect(screen.queryByRole("menuitem", { name: /Dock/ })).toBeNull();
+
+    await user.click(items[0]);
+    expect(data.onToggleCollapse).toHaveBeenCalledOnce();
+
+    fireEvent.contextMenu(screen.getByText("Web Research"));
+    await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
+    expect(data.onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("the menu's Collapse/Expand label flips when isCollapsed is true", () => {
+    renderWebResearchNode({ isCollapsed: true });
+    fireEvent.contextMenu(screen.getByText("Web Research"));
+    expect(screen.getByRole("menuitem", { name: "Expand" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Collapse" })).toBeNull();
+  });
+
+  it("Escape and outside-click both close the node-level menu", async () => {
+    const user = userEvent.setup();
+    renderWebResearchNode();
+    const header = screen.getByText("Web Research");
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/WebResearchNodeView.tsx
+++ b/web_ui/src/app/canvas/WebResearchNodeView.tsx
@@ -1,0 +1,397 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+
+/**
+ * The web-research node (Qt-removal plan R5.1) - the Web Research plugin's
+ * React card. Same overall shape as ConversationNodeView (collapse/expand
+ * OR-ed with LOD, a card menu with outside-click/Escape dismiss, the shared
+ * react-markdown + remarkGfm + rehypeHighlight pipeline), but instead of a
+ * growing message list this node drives ONE research run at a time and
+ * renders it as: a query input + Run/Cancel, an in-progress stage stepper,
+ * and - once a result exists - the synthesized answer, its warnings, and its
+ * source list.
+ *
+ * Honest scoping, called out because it is easy to get wrong: mid-run,
+ * data.researchActiveSourceId is an OPAQUE id string - the backend has not
+ * yet resolved a title/URL for whatever it is currently fetching (that only
+ * exists once a ResearchSource is attached to a completed/stale
+ * data.researchResult). So this view never tries to look that id up or
+ * highlight a chip for it; instead it shows a plain
+ * "Fetching source N of total…" progress line built from
+ * researchCompleted/researchTotal alone. Per-source chips render ONLY from
+ * data.researchResult.sources - which may be THIS run's finished result, or
+ * a stale result left over from a previous run while a new one is already
+ * back in progress (the two are independent: the stepper reflects
+ * data.researchStage, the result section reflects data.researchResult, and
+ * both can be visible at once).
+ *
+ * Card menu deliberately mirrors ConversationNodeMenu's dismiss/positioning
+ * plumbing but carries only Collapse/Expand + Delete Node - no "Open
+ * Document View" placeholder (that is a legacy ConversationNode-specific
+ * leftover, not a convention every node kind repeats) and no dock-to-parent
+ * action (this node kind is never docked, same posture as html/image/
+ * conversation nodes above it).
+ */
+
+export interface WebResearchSourceRow {
+  sourceId: string;
+  title: string;
+  url: string;
+  canonicalUrl: string;
+  snippet: string;
+  rank: number;
+  provider: string;
+  finalUrl: string;
+  status: string;
+  errorCode: string;
+  errorMessage: string;
+  truncated: boolean;
+  contentHash: string;
+  citationCount: number;
+}
+
+export interface WebResearchCitationRow {
+  sourceId: string;
+  marker: string;
+  claimContext: string;
+}
+
+export interface WebResearchResultRow {
+  requestId: string;
+  originalQuery: string;
+  effectiveQuery: string;
+  answerMarkdown: string;
+  sources: WebResearchSourceRow[];
+  citations: WebResearchCitationRow[];
+  warnings: string[];
+  providerSnapshot: Record<string, unknown>;
+}
+
+export interface WebResearchNodeData extends Record<string, unknown> {
+  query: string;
+  isCollapsed: boolean;
+  pendingRequestId: string | null;
+  researchStage: string;
+  researchCompleted: number;
+  researchTotal: number;
+  researchActiveSourceId: string | null;
+  researchError: string;
+  researchResult: WebResearchResultRow | null;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  onRun: (query: string) => void;
+  onCancel: () => void;
+}
+
+export type WebResearchFlowNode = Node<WebResearchNodeData, "web_research">;
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+/** Same outside-click/Escape dismiss pattern every sibling node menu uses
+ * (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu/ConversationNodeMenu). */
+function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
+      // type-only import above shadows the bare name for casts like this).
+      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [menuRef, onClose]);
+}
+
+// -- card-level menu -------------------------------------------------------
+
+function WebResearchNodeMenu({
+  position,
+  isCollapsed,
+  onToggleCollapse,
+  onDelete,
+  onClose,
+}: {
+  position: MenuPosition;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useMenuDismiss(menuRef, onClose);
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleCollapse();
+          onClose();
+        }}
+      >
+        {isCollapsed ? "Expand" : "Collapse"}
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        Delete Node
+      </button>
+    </div>
+  );
+}
+
+// -- stage stepper ----------------------------------------------------------
+
+/** The 6 in-progress stages, in order - "completed"/"failed"/"cancelled" are
+ * terminal states rendered separately (see the banner/result branches in the
+ * view below), never as a 7th/8th/9th step here. */
+const STAGE_STEPS = [
+  { key: "preparing", label: "Preparing" },
+  { key: "searching", label: "Searching" },
+  { key: "fetching", label: "Fetching" },
+  { key: "extracting", label: "Extracting" },
+  { key: "validating", label: "Validating" },
+  { key: "synthesizing", label: "Synthesizing" },
+] as const;
+
+// -- per-source chip ---------------------------------------------------------
+
+/** Colored purely by source.status, reusing the existing app-wide semantic
+ * status tokens (--gl-semantic-status-success/warning/error/info) rather than
+ * inventing a new palette - accepted reads as success, rejected/failed as
+ * error, fetching as info (in progress), discovered as neutral/muted (not
+ * yet attempted). */
+function WebResearchSourceChip({ source }: { source: WebResearchSourceRow }) {
+  return (
+    <div className="web-research-node-source">
+      <span
+        className={`web-research-node-source-status web-research-node-source-status-${source.status}`}
+      >
+        {source.status}
+      </span>
+      <span className="web-research-node-source-title">
+        {source.title || source.finalUrl || source.url || source.sourceId}
+      </span>
+    </div>
+  );
+}
+
+// -- view ----------------------------------------------------------------
+
+export function WebResearchNodeView({ data, selected }: NodeProps<WebResearchFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const collapsed = data.isCollapsed || lodCollapsed;
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+  // Initialized once from persisted content and never re-synced on a later
+  // scene snapshot - same non-clobbering rationale ConversationNodeView's own
+  // draft-input state follows (a remote update mid-type must never stomp
+  // what the user is currently typing).
+  const [draft, setDraft] = useState(data.query);
+
+  function run() {
+    const query = draft.trim();
+    if (!query) return;
+    data.onRun(query);
+  }
+
+  const stageIndex = STAGE_STEPS.findIndex((step) => step.key === data.researchStage);
+  const showStepper = stageIndex !== -1;
+  const isFailed = data.researchStage === "failed";
+  const isCancelled = data.researchStage === "cancelled";
+  const showProgress = showStepper && data.researchTotal > 0;
+
+  return (
+    <div
+      className={`scene-node web-research-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title chat-node-role">
+        <span>Web Research</span>
+        <button
+          type="button"
+          className="chat-node-collapse-btn"
+          aria-label={data.isCollapsed ? "Expand" : "Collapse"}
+          onClick={data.onToggleCollapse}
+        >
+          {data.isCollapsed ? "▸" : "▾"}
+        </button>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body web-research-node-content">
+          <div className="web-research-node-query-row">
+            <input
+              type="text"
+              className="web-research-node-query-input"
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  run();
+                }
+              }}
+              placeholder="Research a question…"
+              aria-label="Research query"
+            />
+            <div className="web-research-node-query-actions">
+              <button
+                type="button"
+                className="web-research-node-run-btn"
+                disabled={!draft.trim() || !!data.pendingRequestId}
+                onClick={run}
+              >
+                Run
+              </button>
+              {data.pendingRequestId && (
+                <button
+                  type="button"
+                  className="web-research-node-cancel-btn"
+                  onClick={() => data.onCancel()}
+                  title="Cancel research"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          </div>
+
+          {showStepper && (
+            <div className="web-research-node-stepper">
+              {STAGE_STEPS.map((step, index) => (
+                <span
+                  key={step.key}
+                  className={
+                    "web-research-node-step" +
+                    (index < stageIndex ? " done" : index === stageIndex ? " active" : " pending")
+                  }
+                >
+                  {step.label}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {showProgress && (
+            <p className="web-research-node-progress">
+              Fetching source {Math.min(data.researchCompleted + 1, data.researchTotal)} of{" "}
+              {data.researchTotal}…
+            </p>
+          )}
+
+          {isFailed && (
+            <div className="web-research-node-banner web-research-node-banner-failed">
+              {data.researchError || "Research failed."}
+            </div>
+          )}
+          {isCancelled && (
+            <div className="web-research-node-banner web-research-node-banner-cancelled">
+              {data.researchError || "Research was cancelled."}
+            </div>
+          )}
+
+          {data.researchResult && (
+            <div className="web-research-node-result">
+              {/* Reuses .chat-node-content's full markdown-body rule set
+                  verbatim (same shared-class convention
+                  ConversationBubble's own -content div establishes), with a
+                  custom anchor renderer: answerMarkdown is LLM-generated from
+                  untrusted web evidence, so a javascript:/file: scheme must
+                  never be allowed to navigate - only a real http(s) link ever
+                  reaches window.open, everything else is inert. The href
+                  attribute itself is only set for http(s) links - an
+                  onClick-only guard leaves the raw (unsafe) href on the DOM
+                  node, which the browser's own middle-click/auxclick and
+                  "open link in new tab"/"copy link" context-menu actions read
+                  directly, bypassing onClick entirely. Omitting href for
+                  every other scheme removes that native escape hatch. */}
+              <div className="chat-node-content web-research-node-answer">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeHighlight]}
+                  components={{
+                    a: ({ href, children }) => {
+                      const isHttpUrl = !!href && /^https?:\/\//i.test(href.trim());
+                      if (!isHttpUrl) {
+                        // No href at all - nothing for middle-click/context-menu to act on.
+                        return <>{children}</>;
+                      }
+                      return (
+                        <a
+                          href={href}
+                          onClick={(event) => {
+                            event.preventDefault();
+                            window.open(href, "_blank", "noopener,noreferrer");
+                          }}
+                        >
+                          {children}
+                        </a>
+                      );
+                    },
+                  }}
+                >
+                  {data.researchResult.answerMarkdown}
+                </ReactMarkdown>
+              </div>
+
+              {data.researchResult.warnings.length > 0 && (
+                <ul className="web-research-node-warnings">
+                  {data.researchResult.warnings.map((warning, index) => (
+                    <li key={index}>{warning}</li>
+                  ))}
+                </ul>
+              )}
+
+              {data.researchResult.sources.length > 0 && (
+                <div className="web-research-node-sources">
+                  {data.researchResult.sources.map((source) => (
+                    <WebResearchSourceChip key={source.sourceId} source={source} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+      {menuPosition && (
+        <WebResearchNodeMenu
+          position={menuPosition}
+          isCollapsed={data.isCollapsed}
+          onToggleCollapse={data.onToggleCollapse}
+          onDelete={data.onDelete}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -43,6 +43,10 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         isDocked: false,
         imageAssetId: "",
         history: [],
+        researchStage: "",
+        researchCompleted: 0,
+        researchTotal: 0,
+        researchError: "",
       },
     ],
     edges: [],
@@ -268,12 +272,65 @@ describe("SceneStore", () => {
     expect(intents).toEqual([{ topic: "scene", intent: "regenerateImage", args: ["img1"] }]);
   });
 
+  it("runWebResearch sends the scene-topic runWebResearch intent with [nodeId, queryText]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.runWebResearch("n1", "who won the 2019 world series");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "runWebResearch", args: ["n1", "who won the 2019 world series"] },
+    ]);
+  });
+
+  it("cancelWebResearchRequest sends the scene-topic cancelWebResearchRequest intent with the requestId", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.cancelWebResearchRequest("req-99");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "cancelWebResearchRequest", args: ["req-99"] },
+    ]);
+  });
+
   it("suppresses empty removal intents", () => {
     const { transport, intents } = makeFakeTransport();
     const store = new SceneStore(transport);
     store.removeNodes([]);
     store.removeEdges([]);
     expect(intents).toEqual([]);
+  });
+
+  it("setSelectedNodeId/getSelectedNodeId update state and notify listeners", () => {
+    const { transport } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    const seen = vi.fn();
+    store.subscribe(seen);
+
+    expect(store.getSelectedNodeId()).toBeNull();
+    store.setSelectedNodeId("n1");
+    expect(store.getSelectedNodeId()).toBe("n1");
+    expect(seen).toHaveBeenCalledTimes(1);
+
+    store.setSelectedNodeId(null);
+    expect(store.getSelectedNodeId()).toBeNull();
+    expect(seen).toHaveBeenCalledTimes(2);
+  });
+
+  it("setSelectedNodeId is a no-op (no re-emit) when the id is unchanged", () => {
+    const { transport } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    const seen = vi.fn();
+
+    // Baseline no-op: already null -> null, before subscribing even matters.
+    store.setSelectedNodeId(null);
+    expect(store.getSelectedNodeId()).toBeNull();
+
+    store.subscribe(seen);
+    store.setSelectedNodeId("n1");
+    expect(seen).toHaveBeenCalledTimes(1);
+
+    // Re-selecting the SAME id must not re-emit.
+    store.setSelectedNodeId("n1");
+    expect(seen).toHaveBeenCalledTimes(1);
+    expect(store.getSelectedNodeId()).toBe("n1");
   });
 
   it("dispose() unsubscribes every topic", () => {

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -70,6 +70,12 @@ export class SceneStore {
   private fontConfig: FontControlState = initialFontControlState;
   private readonly listeners = new Set<Listener>();
   private readonly unsubscribers: Array<() => void> = [];
+  // R5.1: the currently-selected canvas node id, mirrored from React Flow's
+  // own onSelectionChange (see SceneCanvas.tsx) - local UI state only, never
+  // sent over the wire on its own. Exists so PluginPicker can attach "which
+  // node was selected when a plugin was launched" to executePlugin without
+  // either component reaching into the other's internals.
+  private selectedNodeId: string | null = null;
 
   constructor(private readonly transport: WsTransport) {}
 
@@ -108,6 +114,15 @@ export class SceneStore {
   getGrid = (): GridControlState => this.grid;
   getDragConfig = (): DragSpeedState => this.dragConfig;
   getFontConfig = (): FontControlState => this.fontConfig;
+  getSelectedNodeId = (): string | null => this.selectedNodeId;
+
+  // R5.1: no-op-if-unchanged, same discipline as every other setter here that
+  // guards a redundant assignment before paying for an emit() fan-out.
+  setSelectedNodeId(id: string | null): void {
+    if (id === this.selectedNodeId) return;
+    this.selectedNodeId = id;
+    this.emit();
+  }
 
   private emit(): void {
     for (const listener of [...this.listeners]) listener();
@@ -305,6 +320,19 @@ export class SceneStore {
   // deliberate improvement over legacy's parent-.text reuse).
   regenerateImage(imageNodeId: string): void {
     this.transport.intent("scene", "regenerateImage", [imageNodeId]);
+  }
+
+  // R5.1: real Web Research plugin - runWebResearch starts (or restarts) a
+  // research run for an existing web_research node; cancelWebResearchRequest
+  // targets it by its own in-flight requestId, the same
+  // requestId-not-nodeId shape cancelConversationRequest above already
+  // established for the conversation node's own per-node cancel.
+  runWebResearch(nodeId: string, query: string): void {
+    this.transport.intent("scene", "runWebResearch", [nodeId, query]);
+  }
+
+  cancelWebResearchRequest(requestId: string): void {
+    this.transport.intent("scene", "cancelWebResearchRequest", [requestId]);
   }
 
   // R3.3: the Composer's real Send action - a real user ChatNode. The

--- a/web_ui/src/app/chrome/PluginPicker.test.tsx
+++ b/web_ui/src/app/chrome/PluginPicker.test.tsx
@@ -1,8 +1,9 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { PluginPicker } from "./PluginPicker";
 import { OverlayProvider, useOverlays } from "../overlays/overlays";
+import { SceneStore } from "../canvas/sceneStore";
 import type { WsTransport } from "../../lib/ws/transport";
 
 const snapshot = {
@@ -56,17 +57,17 @@ function OpenPluginsButton() {
   );
 }
 
-function setup() {
+function setup(store: SceneStore = new SceneStore({ subscribe: vi.fn(), intent: vi.fn() } as unknown as WsTransport)) {
   const user = userEvent.setup();
   const fake = makeTransport();
   render(
     <OverlayProvider>
       <OpenPluginsButton />
-      <PluginPicker transport={fake.transport} />
+      <PluginPicker transport={fake.transport} store={store} />
     </OverlayProvider>,
   );
   act(() => fake.push(snapshot));
-  return { user, ...fake };
+  return { user, store, ...fake };
 }
 
 describe("PluginPicker", () => {
@@ -83,14 +84,35 @@ describe("PluginPicker", () => {
     expect(screen.getByText("Py-Coder")).toBeInTheDocument();
   });
 
-  it("selecting a plugin fires executePlugin and closes the popover", async () => {
+  it("selecting a plugin fires executePlugin with [name, null] when nothing is selected, and closes the popover", async () => {
     const { user, intents } = setup();
     await user.click(screen.getByText("open plugins"));
 
     await user.click(screen.getByText("System Prompt"));
-    expect(intents).toContainEqual(["app-plugins", "executePlugin", ["System Prompt"]]);
+    expect(intents).toContainEqual(["app-plugins", "executePlugin", ["System Prompt", null]]);
     // Close-on-select: the popover dismisses so the resulting notification
     // banner is seen unobstructed (matching the legacy popup's behavior).
     expect(screen.queryByText("Categories")).toBeNull();
+  });
+
+  it("selecting a plugin fires executePlugin with the currently-selected node id", async () => {
+    const store = new SceneStore({ subscribe: vi.fn(), intent: vi.fn() } as unknown as WsTransport);
+    store.setSelectedNodeId("node-42");
+    const { user, intents } = setup(store);
+    await user.click(screen.getByText("open plugins"));
+
+    await user.click(screen.getByText("System Prompt"));
+    expect(intents).toContainEqual(["app-plugins", "executePlugin", ["System Prompt", "node-42"]]);
+  });
+
+  it("every plugin's click sends the selected node id, not just Web Research's", async () => {
+    const store = new SceneStore({ subscribe: vi.fn(), intent: vi.fn() } as unknown as WsTransport);
+    store.setSelectedNodeId("node-7");
+    const { user, intents } = setup(store);
+    await user.click(screen.getByText("open plugins"));
+    await user.click(screen.getByRole("button", { name: /Build & Execution/ }));
+
+    await user.click(screen.getByText("Py-Coder"));
+    expect(intents).toContainEqual(["app-plugins", "executePlugin", ["Py-Coder", "node-7"]]);
   });
 });

--- a/web_ui/src/app/chrome/PluginPicker.tsx
+++ b/web_ui/src/app/chrome/PluginPicker.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { WsTransport } from "../../lib/ws/transport";
 import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
 import type { AppPluginsState } from "../../lib/bridge-core/generated/app-plugins-state";
+import type { SceneStore } from "../canvas/sceneStore";
 import { Popover, useOverlays } from "../overlays/overlays";
 
 /**
@@ -10,6 +11,14 @@ import { Popover, useOverlays } from "../overlays/overlays";
  * backend (backend/plugins.py); selecting a plugin fires the real
  * `executePlugin` intent, which surfaces an honest "lands in R3/R5"
  * notification instead of creating a node - node types don't exist yet.
+ *
+ * R5.1: every plugin's click now also sends the canvas's currently-selected
+ * node id (store.getSelectedNodeId()) as executePlugin's second argument -
+ * future plugin-node-creation wiring built once, here, rather than
+ * special-cased per plugin. Most plugins (including Web Research itself)
+ * don't read this argument yet; it rides along regardless, same posture the
+ * backend's own execute_plugin(plugin_name, parent_node_id=None) already
+ * takes.
  */
 
 const initialState: AppPluginsState = {
@@ -19,7 +28,7 @@ const initialState: AppPluginsState = {
   categories: [],
 };
 
-export function PluginPicker({ transport }: { transport: WsTransport }) {
+export function PluginPicker({ transport, store }: { transport: WsTransport; store: SceneStore }) {
   const overlays = useOverlays();
   const [state, setState] = useState<AppPluginsState>(initialState);
   const [activeCategoryName, setActiveCategoryName] = useState<string | null>(null);
@@ -77,7 +86,10 @@ export function PluginPicker({ transport }: { transport: WsTransport }) {
                     type="button"
                     className="plugin-picker-row"
                     onClick={() => {
-                      transport.intent("app-plugins", "executePlugin", [plugin.name]);
+                      transport.intent("app-plugins", "executePlugin", [
+                        plugin.name,
+                        store.getSelectedNodeId(),
+                      ]);
                       // Close on select, matching the legacy popup's own
                       // post-execute dismiss - and so the resulting
                       // notification banner is seen unobstructed.

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2548,3 +2548,210 @@ body,
   background-color: var(--gl-neutral-button-background);
   border: 1px solid var(--gl-neutral-button-border);
 }
+
+/* -- R5.1 web research node -------------------------------------------------- */
+
+.web-research-node {
+  width: 420px;
+  max-height: 640px;
+  min-height: 110px;
+}
+
+.web-research-node.collapsed {
+  width: 290px;
+  min-height: 58px;
+}
+
+.web-research-node-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 560px;
+  overflow-y: auto;
+}
+
+.web-research-node-query-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.web-research-node-query-input {
+  box-sizing: border-box;
+  width: 100%;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 8px 10px;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.web-research-node-query-input:focus {
+  outline: none;
+  border-color: var(--gl-surface-text-muted);
+}
+
+.web-research-node-query-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+/* Reuses conversation-node's send/cancel button chrome verbatim (same
+   shared-token convention .chat-node-content's markdown rules already
+   establish across sibling node views) rather than duplicating the two
+   declarations under a new name. */
+.web-research-node-run-btn,
+.web-research-node-cancel-btn {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 5px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.web-research-node-run-btn {
+  color: var(--gl-surface-window);
+  background-color: var(--gl-surface-text-muted);
+  border: none;
+}
+
+.web-research-node-run-btn:hover:enabled {
+  filter: brightness(1.1);
+}
+
+.web-research-node-run-btn:disabled,
+.web-research-node-cancel-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.web-research-node-cancel-btn {
+  color: var(--gl-surface-text);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+}
+
+/* Stage stepper - pending/active/done, one pill per STAGE_STEPS entry. */
+.web-research-node-stepper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.web-research-node-step {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--gl-surface-border);
+  color: var(--gl-surface-text-muted);
+}
+
+.web-research-node-step.active {
+  color: var(--gl-surface-text);
+  border-color: var(--gl-semantic-status-info, currentColor);
+}
+
+.web-research-node-step.done {
+  color: var(--gl-semantic-status-success, currentColor);
+  border-color: var(--gl-semantic-status-success, currentColor);
+}
+
+.web-research-node-progress {
+  margin: 0;
+  font-size: 11px;
+  color: var(--gl-surface-text-muted);
+}
+
+/* Terminal-state banner - failed reuses the same error token every other
+   danger surface in this file uses; cancelled is deliberately neutral/muted
+   rather than error-colored (a user-initiated cancel is not a failure). */
+.web-research-node-banner {
+  padding: 8px 10px;
+  font-size: 11px;
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 8px;
+}
+
+.web-research-node-banner-failed {
+  color: var(--gl-semantic-status-error, currentColor);
+  border-color: var(--gl-semantic-status-error, currentColor);
+}
+
+.web-research-node-banner-cancelled {
+  color: var(--gl-surface-text-muted);
+}
+
+.web-research-node-result {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Reuses .chat-node-content's full markdown-body rule set (headings, lists,
+   code, tables, hljs) verbatim - same shared-class convention
+   .conversation-node-bubble-content already establishes for this pipeline.
+   Only overrides the max-height/overflow-y a nested answer pane should never
+   take on its own (the outer .web-research-node-content already scrolls). */
+.web-research-node-answer {
+  max-height: none;
+  overflow: visible;
+}
+
+.web-research-node-warnings {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 11px;
+  color: var(--gl-semantic-status-warning, currentColor);
+}
+
+.web-research-node-sources {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.web-research-node-source {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  font-size: 11px;
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.web-research-node-source-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--gl-surface-text);
+}
+
+.web-research-node-source-status {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--gl-surface-text-muted);
+}
+
+.web-research-node-source-status-accepted {
+  color: var(--gl-semantic-status-success, currentColor);
+}
+
+.web-research-node-source-status-rejected,
+.web-research-node-source-status-failed {
+  color: var(--gl-semantic-status-error, currentColor);
+}
+
+.web-research-node-source-status-fetching {
+  color: var(--gl-semantic-status-info, currentColor);
+}

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -115,6 +115,151 @@
           "previewLabel": {
             "type": "string"
           },
+          "researchActiveSourceId": {
+            "type": "string"
+          },
+          "researchCompleted": {
+            "type": "integer"
+          },
+          "researchError": {
+            "type": "string"
+          },
+          "researchResult": {
+            "additionalProperties": false,
+            "properties": {
+              "answerMarkdown": {
+                "type": "string"
+              },
+              "citations": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "claimContext": {
+                      "type": "string"
+                    },
+                    "marker": {
+                      "type": "string"
+                    },
+                    "sourceId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "sourceId",
+                    "marker",
+                    "claimContext"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "effectiveQuery": {
+                "type": "string"
+              },
+              "originalQuery": {
+                "type": "string"
+              },
+              "providerSnapshot": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "requestId": {
+                "type": "string"
+              },
+              "sources": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "canonicalUrl": {
+                      "type": "string"
+                    },
+                    "citationCount": {
+                      "type": "integer"
+                    },
+                    "contentHash": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    },
+                    "errorMessage": {
+                      "type": "string"
+                    },
+                    "finalUrl": {
+                      "type": "string"
+                    },
+                    "provider": {
+                      "type": "string"
+                    },
+                    "rank": {
+                      "type": "integer"
+                    },
+                    "snippet": {
+                      "type": "string"
+                    },
+                    "sourceId": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "truncated": {
+                      "type": "boolean"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "sourceId",
+                    "title",
+                    "url",
+                    "canonicalUrl",
+                    "snippet",
+                    "rank",
+                    "provider",
+                    "finalUrl",
+                    "status",
+                    "errorCode",
+                    "errorMessage",
+                    "truncated",
+                    "contentHash",
+                    "citationCount"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "warnings": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "requestId",
+              "originalQuery",
+              "effectiveQuery",
+              "answerMarkdown",
+              "sources",
+              "citations",
+              "warnings",
+              "providerSnapshot"
+            ],
+            "type": "object"
+          },
+          "researchStage": {
+            "type": "string"
+          },
+          "researchTotal": {
+            "type": "integer"
+          },
           "title": {
             "type": "string"
           },
@@ -142,7 +287,11 @@
           "previewLabel",
           "isDocked",
           "imageAssetId",
-          "history"
+          "history",
+          "researchStage",
+          "researchCompleted",
+          "researchTotal",
+          "researchError"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -23,11 +23,51 @@ export interface SceneNodeRow {
   imageAssetId: string;
   history: ConversationMessageRow[];
   pendingRequestId?: string | null;
+  researchStage: string;
+  researchCompleted: number;
+  researchTotal: number;
+  researchActiveSourceId?: string | null;
+  researchError: string;
+  researchResult?: ResearchResultRow | null;
 }
 
 export interface ConversationMessageRow {
   role: "user" | "assistant";
   content: string;
+}
+
+export interface ResearchResultRow {
+  requestId: string;
+  originalQuery: string;
+  effectiveQuery: string;
+  answerMarkdown: string;
+  sources: ResearchSourceRow[];
+  citations: ResearchCitationRow[];
+  warnings: string[];
+  providerSnapshot: Record<string, string>;
+}
+
+export interface ResearchSourceRow {
+  sourceId: string;
+  title: string;
+  url: string;
+  canonicalUrl: string;
+  snippet: string;
+  rank: number;
+  provider: string;
+  finalUrl: string;
+  status: string;
+  errorCode: string;
+  errorMessage: string;
+  truncated: boolean;
+  contentHash: string;
+  citationCount: number;
+}
+
+export interface ResearchCitationRow {
+  sourceId: string;
+  marker: string;
+  claimContext: string;
 }
 
 export interface SceneEdgeRow {
@@ -173,6 +213,34 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["pendingRequestId"];
     if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.pendingRequestId` + ": expected string"); }
   }
+  {
+    const fieldValue = value["researchStage"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.researchStage: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.researchStage` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["researchCompleted"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.researchCompleted: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.researchCompleted` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["researchTotal"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.researchTotal: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.researchTotal` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["researchActiveSourceId"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.researchActiveSourceId` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["researchError"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.researchError: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.researchError` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["researchResult"];
+    if (fieldValue !== undefined && fieldValue !== null) { checkResearchResultRow(fieldValue, `${path}.researchResult`, errors); }
+  }
 }
 
 function checkConversationMessageRow(value: unknown, path: string, errors: string[]): void {
@@ -186,6 +254,147 @@ function checkConversationMessageRow(value: unknown, path: string, errors: strin
     const fieldValue = value["content"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.content: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.content` + ": expected string"); }
+  }
+}
+
+function checkResearchResultRow(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["requestId"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.requestId: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.requestId` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["originalQuery"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.originalQuery: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.originalQuery` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["effectiveQuery"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.effectiveQuery: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.effectiveQuery` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["answerMarkdown"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.answerMarkdown: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.answerMarkdown` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["sources"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.sources: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.sources` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { checkResearchSourceRow(item, `${path}.sources` + `[${i}]`, errors); }); }
+  }
+  {
+    const fieldValue = value["citations"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.citations: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.citations` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { checkResearchCitationRow(item, `${path}.citations` + `[${i}]`, errors); }); }
+  }
+  {
+    const fieldValue = value["warnings"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.warnings: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.warnings` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "string") errors.push(`${path}.warnings` + `[${i}]` + ": expected string"); }); }
+  }
+  {
+    const fieldValue = value["providerSnapshot"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.providerSnapshot: missing required field`);
+    else { if (!isRecord(fieldValue)) errors.push(`${path}.providerSnapshot` + ": expected object");
+    else Object.entries(fieldValue as Record<string, unknown>).forEach(([k, v]) => { if (typeof v !== "string") errors.push(`${path}.providerSnapshot` + `[${JSON.stringify(k)}]` + ": expected string"); }); }
+  }
+}
+
+function checkResearchSourceRow(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["sourceId"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.sourceId: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.sourceId` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["title"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.title: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.title` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["url"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.url: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.url` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["canonicalUrl"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.canonicalUrl: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.canonicalUrl` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["snippet"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.snippet: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.snippet` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["rank"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.rank: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.rank` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["provider"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.provider: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.provider` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["finalUrl"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.finalUrl: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.finalUrl` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["status"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.status: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.status` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["errorCode"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.errorCode: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.errorCode` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["errorMessage"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.errorMessage: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.errorMessage` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["truncated"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.truncated: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.truncated` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["contentHash"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.contentHash: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.contentHash` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["citationCount"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.citationCount: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.citationCount` + ": expected number"); }
+  }
+}
+
+function checkResearchCitationRow(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["sourceId"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.sourceId: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.sourceId` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["marker"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.marker: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.marker` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["claimContext"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.claimContext: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.claimContext` + ": expected string"); }
   }
 }
 


### PR DESCRIPTION
## Summary
- First R5 (Plugins) increment: replaces the "lands in R3/R5" placeholder with a real, network-backed Web Research node (DuckDuckGo search -> SSRF-policy-guarded fetch -> LLM validation -> cited summary), dispatched on a third independent `AgentDispatcher` slot concurrent with chat and image generation.
- New `WebResearchNodeView` renders a 6-stage live progress stepper, per-source status chips, warnings, and an http(s)-only external-link guard on the LLM-generated answer markdown.
- One-line Step-0 fix removes a transitive PySide6 import that would otherwise enter the FastAPI process the moment this plugin is imported, guarded by a new subprocess Qt-import test.
- 5-way adversarial review (backend/frontend/integration/SSRF/legacy-safety) found and fixed 3 real bugs before shipping: a watchdog-timeout zombie-thread progress race, a node-state-reset ordering bug that could wipe a different node's terminal banner, and a markdown link-guard gap exploitable via native middle-click/context-menu actions.
- Deliberate design call: `ResearchResult` is stored as inline `SceneNode` fields (not a parallel store like `image_assets`), since it's small and bounded — this sets the reusable template for future plugin increments.

## Test plan
- [x] `python -m pytest backend/tests/ -q` — 307 passed
- [x] `npx tsc --noEmit -p .` — 0 errors
- [x] `npx vitest run` — 751 passed (69 files)
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run check:schema` — 25 generated artifact sets up to date, no drift
- [x] Live-driven against the real backend + a real Ollama model + real internet search/fetch traffic in a browser: plugin-picker node creation (parent-required validation both paths), 6-stage progress stepper observed live, terminal failure banner rendering for two distinct real backend failure codes, re-run behavior, and concurrency (a chat message and a research run dispatched at the same instant both completed independently)