### PR TITLE
Qt-removal R5.2: Artifact/Drafter plugin - real generate/refine loop

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -66,6 +66,7 @@ import uuid
 
 import api_provider
 import graphlink_task_config as config
+from graphlink_artifact_agent import ArtifactAgent
 from graphlink_chat_agent import ChatAgent
 from graphlink_licensing import SettingsManager  # type hint only
 from graphlink_plugins.web_research.domain import (
@@ -190,6 +191,13 @@ class AgentDispatcher:
         # independent from _requests. request_id -> {"cancel_token":
         # CancellationToken, "task": asyncio.Task}.
         self._web_research_requests: dict[str, dict] = {}
+        # R5.2: a FOURTH independent in-flight-request slot, separate from
+        # self._requests (chat/conversation), self._image_requests, and
+        # self._web_research_requests - an artifact-generation request must be
+        # able to run concurrently with any of those three, same reasoning as
+        # every prior independent slot above. request_id -> {"cancel_event":
+        # threading.Event, "task": asyncio.Task}.
+        self._artifact_requests: dict[str, dict] = {}
 
     def persona(self) -> str:
         """Mirror legacy graphlink_window.py's `_get_current_system_prompt`:
@@ -239,6 +247,13 @@ class AgentDispatcher:
         doesn't reset that node's progress/error fields only to be rejected
         a moment later by start_web_research's own busy check."""
         return bool(self._web_research_requests)
+
+    def cancel_artifact(self, request_id: str) -> bool:
+        entry = self._artifact_requests.get(request_id)
+        if entry is None:
+            return False
+        entry["cancel_event"].set()
+        return True
 
     async def _dispatch(
         self,
@@ -732,6 +747,88 @@ class AgentDispatcher:
             "cancel_token": cancel_token, "task": asyncio.create_task(_run())
         }
 
+    async def start_artifact_reply(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        node,
+        current_artifact: str,
+        history: list,
+        on_reply,
+    ) -> None:
+        """R5.2: the Artifact/Drafter independent-slot counterpart to
+        start_image_reply/start_web_research above - NOT a variant of
+        _dispatch, since _dispatch is hardcoded to a single-string on_reply
+        contract and a fixed driver function, while _call_artifact_agent
+        returns a two-element tuple and must run its own fail-closed
+        tag-parsing/raise (see ArtifactAgent.get_response) before any
+        mutation callback fires. Guarded by self._artifact_requests, a dict
+        kept fully SEPARATE from self._requests (chat/conversation),
+        self._image_requests, and self._web_research_requests - see that
+        field's own comment in __init__ for why this must stay independent.
+
+        Cooperative cancellation only, via a threading.Event (not the
+        CancellationToken web-research uses - ArtifactAgent has no such
+        primitive) - same honestly-documented limitation as every other
+        dispatch surface: ArtifactAgent.get_response has no cancellation
+        checkpoint of its own. The checkpoint is deliberately placed AFTER
+        the blocking call returns: if cancel_event is set by then, on_reply
+        is simply never called, so the document is left untouched.
+
+        Reuses WATCHDOG_TIMEOUT_SECONDS (420s), not a new constant:
+        ArtifactAgent.get_response makes exactly ONE blocking
+        api_provider.chat() call (see _call_artifact_agent below), the same
+        call-count as chat's own _call_chat_agent - Web Research's own 900s
+        bump exists specifically because WebResearchService.run chains ~10
+        sequential calls inside one outer timeout, which does not apply
+        here."""
+        if self._artifact_requests:
+            notifications_state.show("An artifact request is already running.", "info")
+            await bus.publish("notification")
+            return
+
+        request_id = uuid.uuid4().hex
+        cancel_event = threading.Event()
+
+        async def _run():
+            node.pending_request_id = request_id
+            await bus.publish("scene")
+            try:
+                new_content, ai_message = await asyncio.wait_for(
+                    asyncio.to_thread(_call_artifact_agent, current_artifact, history),
+                    timeout=WATCHDOG_TIMEOUT_SECONDS,
+                )
+                if cancel_event.is_set():
+                    notifications_state.show("Artifact generation cancelled.", "info")
+                    await bus.publish("notification")
+                else:
+                    if inspect.iscoroutinefunction(on_reply):
+                        await on_reply(new_content, ai_message)
+                    else:
+                        on_reply(new_content, ai_message)
+                    await bus.publish("scene")
+            except asyncio.TimeoutError:
+                cancel_event.set()
+                notifications_state.show(
+                    "Artifact generation stopped responding before the request completed. "
+                    "Please try again.",
+                    "error",
+                )
+                await bus.publish("notification")
+            except Exception as exc:
+                logger.exception("artifact dispatch failed")
+                notifications_state.show(f"Artifact generation failed: {exc}", "error")
+                await bus.publish("notification")
+            finally:
+                self._artifact_requests.pop(request_id, None)
+                node.pending_request_id = None
+                await bus.publish("scene")
+
+        self._artifact_requests[request_id] = {
+            "cancel_event": cancel_event, "task": asyncio.create_task(_run())
+        }
+
 
 def _call_chat_agent(conversation_history, persona_text, cancel_event) -> str:
     """Runs inside asyncio.to_thread - a real OS thread, not the event loop."""
@@ -784,6 +881,18 @@ def _call_chat_agent_stream(conversation_history, persona_text, cancel_event, on
         resolved_system_prompt=agent.system_prompt,
         on_chunk=on_chunk,
     )
+
+
+def _call_artifact_agent(current_artifact, history):
+    """Runs inside asyncio.to_thread - a real OS thread, not the event loop.
+    Reuses ArtifactAgent.get_response verbatim - same regex/raise
+    artifact-tag contract, completely unmodified. Returns
+    (new_document, ai_message); the tag-parsing RuntimeError, when raised,
+    propagates straight out of this call and is caught by
+    start_artifact_reply's own `except Exception` below - the document is
+    never touched in that case since mutation only happens in the success
+    branch."""
+    return ArtifactAgent().get_response(current_artifact, history)
 
 
 def register_agents(bus, composer_document, notifications_state, settings_manager) -> AgentDispatcher:

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -237,6 +237,15 @@ class SceneNode:
     # answer stays visible until this run replaces it on success, or
     # fails/cancels (leaving the stale result annotated by research_error).
     research_result: dict[str, Any] | None = None
+    # R5.2: the Artifact/Drafter node's real persisted shape - the model
+    # returns the WHOLE document every turn (whole-document replace, never a
+    # diff/patch - see complete_artifact_generation), so this field is
+    # bounded by the model's own per-turn output ceiling, not by session
+    # length. The turn-by-turn conversation reuses the existing generic
+    # `history` list field above (already used by ConversationNode) rather
+    # than a new list-typed field - only this one new scalar is needed.
+    # Unused (default) for every other kind.
+    artifact_content: str = ""
 
 
 @dataclass
@@ -737,6 +746,67 @@ class SceneDocument:
         node.research_active_source_id = None
         return node
 
+    # -- R5.2: artifact/drafter node -----------------------------------------
+
+    def add_artifact_node(self, x: float, y: float, parent_id: str) -> SceneNode:
+        """The Artifact/Drafter node's creation primitive - same required-
+        parent posture as document/thinking/html/image/conversation/
+        web_research nodes (never exists unparented). Title is always the
+        fixed literal "Artifact" (mirrors conversation/web_research's own
+        fixed titles - there is no meaningful single preview string before a
+        document has ever been drafted). artifact_content starts empty; the
+        document text only lands once complete_artifact_generation is
+        called."""
+        if parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title="Artifact",
+            kind="artifact",
+        )
+        self.nodes[node_id] = node
+        self.connect(parent_id, node_id)
+        return node
+
+    def append_artifact_user_message(self, node_id: str, text: str) -> SceneNode:
+        """Append a real user instruction to an artifact node's history -
+        mirrors append_conversation_user_message exactly (same shape, same
+        error-handling style)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.history.append({"role": "user", "content": str(text)})
+        return node
+
+    def send_artifact_message(self, node_id: str, text: str) -> SceneNode:
+        """The Artifact node's own Send action: a thin wrapper over
+        append_artifact_user_message, kept as a separate method (rather than
+        only calling append_artifact_user_message directly from the WS
+        wrapper) so the WS intent name lines up 1:1 with the domain method,
+        the same way send_conversation_message/append_conversation_user_message
+        already do for ConversationNode."""
+        return self.append_artifact_user_message(node_id, text)
+
+    def complete_artifact_generation(self, node_id: str, new_content, ai_message: str) -> SceneNode:
+        """Land a successful generation turn: WHOLE-DOCUMENT REPLACE (never an
+        append/merge - the model returns the entire document every turn, see
+        the artifact_content field's own comment on SceneNode), plus append a
+        real assistant turn to history. Raises SceneError if the node is
+        gone - this WS wrapper does NOT pre-check liveness before calling
+        this, same posture as send_conversation_message's own _on_reply, not
+        web_research's more defensive pre-check pattern (there is no
+        stage-stepper/persisted-error field here for a mid-flight delete to
+        race against)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.artifact_content = str(new_content)
+        node.history.append({"role": "assistant", "content": str(ai_message)})
+        return node
+
     def delete_chat_node(self, node_id: str) -> None:
         """Delete one chat node WITHOUT orphaning its branch: children are
         re-parented to the deleted node's own parent (or become roots if it
@@ -1070,6 +1140,7 @@ class SceneDocument:
                     "researchActiveSourceId": n.research_active_source_id,
                     "researchError": n.research_error,
                     "researchResult": n.research_result,
+                    "artifactContent": n.artifact_content,
                 }
                 for n in self.nodes.values()
             ],
@@ -1613,6 +1684,39 @@ def register_canvas(
     async def cancel_web_research_request(request_id):
         agent_dispatcher.cancel_web_research(request_id)
 
+    async def send_artifact_message(node_id, text):
+        # R5.2: the Artifact node's own Send action - appends a real user
+        # instruction, then dispatches a real agent reply through
+        # AgentDispatcher.start_artifact_reply. No try/except SceneError guard
+        # here (an unknown node_id propagates as a generic WS intent error) -
+        # same posture as send_conversation_message above, not
+        # run_web_research's defensive pre-check pattern: there is no
+        # persisted progress/error state on this node that an unguarded call
+        # could corrupt, so a stale click racing a delete has nothing
+        # destructive to protect against.
+        node = document.send_artifact_message(node_id, text)
+        await publish_scene()
+
+        parent_edge = next((e for e in document.edges.values() if e.target == node_id), None)
+        branch_history = document.chat_branch_history(parent_edge.source) if parent_edge else []
+        full_history = branch_history + node.history
+
+        def _on_reply(new_content, ai_message):
+            document.complete_artifact_generation(node_id, new_content, ai_message)
+
+        await agent_dispatcher.start_artifact_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            current_artifact=node.artifact_content,
+            history=full_history,
+            on_reply=_on_reply,
+        )
+        return node.id
+
+    async def cancel_artifact_request(request_id):
+        agent_dispatcher.cancel_artifact(request_id)
+
     async def move_node(node_id, x, y):
         document.move_node(node_id, x, y)
         await publish_scene()
@@ -1690,6 +1794,13 @@ def register_canvas(
     # here; these two intents drive an EXISTING web_research-kind node.
     bus.register_intent("scene", "runWebResearch", run_web_research)
     bus.register_intent("scene", "cancelWebResearchRequest", cancel_web_research_request)
+    # R5.2: Artifact/Drafter Send/cancel - node creation itself lives in
+    # backend/plugins.py's executePlugin (the "Artifact / Drafter" branch),
+    # not here; these two intents drive an EXISTING artifact-kind node, same
+    # posture as Web Research's own runWebResearch/cancelWebResearchRequest
+    # pair above.
+    bus.register_intent("scene", "sendArtifactMessage", send_artifact_message)
+    bus.register_intent("scene", "cancelArtifactRequest", cancel_artifact_request)
     bus.register_intent("scene", "moveNode", move_node)
     bus.register_intent("scene", "removeNodes", remove_nodes)
     bus.register_intent("scene", "connectNodes", connect_nodes)

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -146,6 +146,26 @@ def register_plugins(
             await bus.publish("scene")
             return node.id
 
+        if name == "Artifact / Drafter":
+            # R5.2: the second real node-creation plugin, same posture as
+            # Web Research above - an Artifact node is a branch-point child
+            # (same as thinking/html/image/conversation/web_research nodes),
+            # so it always requires a real, valid parent to branch from -
+            # there is no unparented/root form.
+            if not parent_node_id or parent_node_id not in canvas_document.nodes:
+                notifications.show(
+                    "Please select a valid node to branch from before adding an Artifact node.",
+                    "warning",
+                )
+                await bus.publish("notification")
+                return None
+            parent = canvas_document.nodes[parent_node_id]
+            node = canvas_document.add_artifact_node(
+                parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            )
+            await bus.publish("scene")
+            return node.id
+
         notifications.show(f'"{name}" node creation lands in R3/R5.', "info")
         await bus.publish("notification")
         return None

--- a/backend/tests/test_agent_layer_qt_free.py
+++ b/backend/tests/test_agent_layer_qt_free.py
@@ -63,3 +63,14 @@ def test_chat_agent_imports_qt_free():
     # is the machine-checked fact that the real chat-agent path backend/
     # needs no longer does.
     _assert_import_is_qt_free("graphlink_chat_agent")
+
+
+def test_artifact_agent_imports_qt_free():
+    # R5.2 prerequisite: graphlink_agents_artifact.py (home of ArtifactAgent
+    # before this split) has its own unconditional `from PySide6.QtCore
+    # import QThread, Signal` at module level, needed only by its
+    # ArtifactWorkerThread class - importing anything from it, including the
+    # Qt-free ArtifactAgent, pulled Qt in regardless. This is the
+    # machine-checked fact that the real artifact-agent path backend/ needs
+    # no longer does.
+    _assert_import_is_qt_free("graphlink_artifact_agent")

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -1907,6 +1907,420 @@ def test_start_web_research_constructs_web_research_service_with_no_override_the
     assert captured_kwargs == [{}]
 
 
+# -- R5.2: start_artifact_reply/_call_artifact_agent - the independent
+# artifact/drafter slot -------------------------------------------------------
+#
+# Mirrors the R5.1 web-research section's own structure: these tests never
+# touch Ollama/api_provider.chat plumbing (except the two dedicated
+# concurrency tests) - start_artifact_reply's only real dependency is
+# ArtifactAgent.get_response, monkeypatched directly on the class (agents.py
+# constructs a fresh ArtifactAgent() instance per call, so patching the class
+# method is the seam, mirroring how WebResearchService.run is patched as a
+# class-level seam for the research path).
+
+
+def _make_artifact_env():
+    bus = SessionBus("agents-artifact-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    bus.register_topic("scene", lambda: {})
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    return bus, notifications, dispatcher
+
+
+def test_call_artifact_agent_calls_get_response_and_returns_the_tuple(monkeypatch):
+    captured = []
+
+    def fake_get_response(self, current_artifact, history):
+        captured.append((current_artifact, history))
+        return "the new document", "an ai message"
+
+    monkeypatch.setattr(agents_module.ArtifactAgent, "get_response", fake_get_response)
+
+    result = agents_module._call_artifact_agent(
+        "the old document", [{"role": "user", "content": "add a section"}]
+    )
+
+    assert result == ("the new document", "an ai message")
+    assert captured == [("the old document", [{"role": "user", "content": "add a section"}])]
+
+
+def test_call_artifact_agent_propagates_the_missing_tag_runtime_error(monkeypatch):
+    # ArtifactAgent.get_response's own fail-closed contract (see
+    # graphlink_artifact_agent.py): a reply missing <artifact>...</artifact>
+    # tags raises RuntimeError rather than silently corrupting the document.
+    # _call_artifact_agent must let that propagate straight out, unmodified,
+    # for start_artifact_reply's own except Exception to catch.
+    def raising_get_response(self, current_artifact, history):
+        raise RuntimeError(
+            "The model's response did not include the required <artifact>...</artifact> tags, "
+            "so the document was left unchanged to avoid overwriting it with an unstructured reply."
+        )
+
+    monkeypatch.setattr(agents_module.ArtifactAgent, "get_response", raising_get_response)
+
+    with pytest.raises(RuntimeError, match="did not include the required"):
+        agents_module._call_artifact_agent("the old document", [])
+
+
+def test_start_artifact_reply_calls_on_reply_with_the_tuple_then_clears_the_slot(monkeypatch):
+    def fake_get_response(self, current_artifact, history):
+        return "the new document", "an ai message"
+
+    monkeypatch.setattr(agents_module.ArtifactAgent, "get_response", fake_get_response)
+
+    async def run():
+        bus, notifications, dispatcher = _make_artifact_env()
+        node = _make_node()
+        replies = []
+
+        await dispatcher.start_artifact_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            current_artifact="the old document",
+            history=[{"role": "user", "content": "add a section"}],
+            on_reply=lambda new_content, ai_message: replies.append((new_content, ai_message)),
+        )
+        entry = next(iter(dispatcher._artifact_requests.values()))
+        await entry["task"]
+
+        assert replies == [("the new document", "an ai message")]
+        assert dispatcher._artifact_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is False
+
+    asyncio.run(run())
+
+
+def test_start_artifact_reply_second_call_while_in_flight_is_rejected(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_get_response(self, current_artifact, history):
+        started.set()
+        release.wait(5)
+        return "first document", "first message"
+
+    monkeypatch.setattr(agents_module.ArtifactAgent, "get_response", blocking_get_response)
+
+    async def run():
+        bus, notifications, dispatcher = _make_artifact_env()
+        node1 = _make_node()
+        node2 = _make_node()
+        replies = []
+
+        await dispatcher.start_artifact_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node1,
+            current_artifact="doc1",
+            history=[],
+            on_reply=lambda new_content, ai_message: replies.append((new_content, ai_message)),
+        )
+        await asyncio.to_thread(started.wait, 5)
+
+        # Second call while the first is still in flight must be rejected and
+        # must not disturb the first request.
+        await dispatcher.start_artifact_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node2,
+            current_artifact="doc2",
+            history=[],
+            on_reply=lambda new_content, ai_message: replies.append((new_content, ai_message)),
+        )
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert notifications.message == "An artifact request is already running."
+        assert len(dispatcher._artifact_requests) == 1
+        assert node2.pending_request_id is None, "the bounced call must never touch node2"
+
+        release.set()
+        entry = next(iter(dispatcher._artifact_requests.values()))
+        await entry["task"]
+
+        assert replies == [("first document", "first message")]
+        assert dispatcher._artifact_requests == {}
+
+    asyncio.run(run())
+
+
+def test_start_artifact_reply_missing_tag_failure_shows_error_notification_and_never_calls_on_reply(monkeypatch):
+    """SECURITY-CRITICAL: on the fail-closed tag-parsing RuntimeError,
+    on_reply must NEVER be invoked - the document must be left completely
+    untouched rather than being replaced with anything derived from the
+    malformed reply."""
+    def raising_get_response(self, current_artifact, history):
+        raise RuntimeError(
+            "The model's response did not include the required <artifact>...</artifact> tags, "
+            "so the document was left unchanged to avoid overwriting it with an unstructured reply."
+        )
+
+    monkeypatch.setattr(agents_module.ArtifactAgent, "get_response", raising_get_response)
+
+    async def run():
+        bus, notifications, dispatcher = _make_artifact_env()
+        node = _make_node()
+        on_reply_calls = []
+
+        await dispatcher.start_artifact_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            current_artifact="the old document",
+            history=[],
+            on_reply=lambda new_content, ai_message: on_reply_calls.append((new_content, ai_message)),
+        )
+        entry = next(iter(dispatcher._artifact_requests.values()))
+        await entry["task"]
+
+        assert on_reply_calls == [], "on_reply must never be called on a tag-parsing failure"
+        assert dispatcher._artifact_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == (
+            "Artifact generation failed: The model's response did not include the required "
+            "<artifact>...</artifact> tags, so the document was left unchanged to avoid "
+            "overwriting it with an unstructured reply."
+        )
+
+    asyncio.run(run())
+
+
+def test_start_artifact_reply_timeout_fires_the_exact_message_and_clears_the_slot(monkeypatch):
+    monkeypatch.setattr(agents_module, "WATCHDOG_TIMEOUT_SECONDS", 0.05)
+
+    def slow_get_response(self, current_artifact, history):
+        time.sleep(0.3)
+        return "too late", "too late message"
+
+    monkeypatch.setattr(agents_module.ArtifactAgent, "get_response", slow_get_response)
+
+    async def run():
+        bus, notifications, dispatcher = _make_artifact_env()
+        node = _make_node()
+        replies = []
+
+        await dispatcher.start_artifact_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            current_artifact="doc",
+            history=[],
+            on_reply=lambda new_content, ai_message: replies.append((new_content, ai_message)),
+        )
+        entry = next(iter(dispatcher._artifact_requests.values()))
+        await entry["task"]
+
+        assert replies == []
+        assert dispatcher._artifact_requests == {}, "the slot must not leak/deadlock future requests"
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        expected_message = (
+            "Artifact generation stopped responding before the request completed. Please try again."
+        )
+        assert notifications.message == expected_message
+
+    asyncio.run(run())
+
+
+def test_cancel_artifact_drops_the_result_and_never_calls_on_reply_even_on_a_late_return(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_get_response(self, current_artifact, history):
+        started.set()
+        release.wait(5)
+        return "a document nobody should see", "a message nobody should see"
+
+    monkeypatch.setattr(agents_module.ArtifactAgent, "get_response", blocking_get_response)
+
+    async def run():
+        bus, notifications, dispatcher = _make_artifact_env()
+        node = _make_node()
+        replies = []
+
+        await dispatcher.start_artifact_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            current_artifact="doc",
+            history=[],
+            on_reply=lambda new_content, ai_message: replies.append((new_content, ai_message)),
+        )
+        await asyncio.to_thread(started.wait, 5)
+
+        request_id = next(iter(dispatcher._artifact_requests.keys()))
+        assert dispatcher.cancel_artifact(request_id) is True
+
+        release.set()
+        entry = next(iter(dispatcher._artifact_requests.values()))
+        await entry["task"]
+
+        assert replies == [], "on_reply must never be called once the request is cancelled"
+        assert dispatcher._artifact_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert notifications.message == "Artifact generation cancelled."
+
+    asyncio.run(run())
+
+
+def test_cancel_artifact_returns_false_for_an_unknown_request_id():
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    assert dispatcher.cancel_artifact("no-such-request") is False
+
+
+def test_artifact_request_and_chat_request_run_concurrently_both_dicts_non_empty(monkeypatch):
+    """THE key concurrency-slot regression guard (R5.2, mirrors R4.4a/R5.1's
+    own chat/image and chat/web-research guards): a chat/composer request
+    occupies self._requests while an artifact-generation request occupies the
+    SEPARATE self._artifact_requests dict at the same time - neither blocks
+    nor is blocked by the other, and both dicts are simultaneously non-empty
+    at least once."""
+    chat_started = threading.Event()
+    chat_release = threading.Event()
+    artifact_started = threading.Event()
+    artifact_release = threading.Event()
+
+    def blocking_chat(task, messages, **kwargs):
+        chat_started.set()
+        chat_release.wait(5)
+        return {"message": {"content": "chat reply"}}
+
+    def blocking_get_response(self, current_artifact, history):
+        artifact_started.set()
+        artifact_release.wait(5)
+        return "artifact document", "artifact message"
+
+    _configure_fake_ollama(monkeypatch, blocking_chat)
+    monkeypatch.setattr(agents_module.ArtifactAgent, "get_response", blocking_get_response)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        node = _make_node()
+        chat_replies = []
+        artifact_replies = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=chat_replies.append,
+        )
+        await dispatcher.start_artifact_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            current_artifact="doc",
+            history=[],
+            on_reply=lambda new_content, ai_message: artifact_replies.append((new_content, ai_message)),
+        )
+
+        await asyncio.to_thread(chat_started.wait, 5)
+        await asyncio.to_thread(artifact_started.wait, 5)
+
+        # THE key assertion: both slots are genuinely occupied at the same
+        # time - neither request bounced the other, and neither notification
+        # fired.
+        assert len(dispatcher._requests) == 1
+        assert len(dispatcher._artifact_requests) == 1
+        assert notifications.visible is False, "neither call should have been rejected"
+
+        chat_release.set()
+        chat_entry = next(iter(dispatcher._requests.values()))
+        await chat_entry["task"]
+        artifact_release.set()
+        artifact_entry = next(iter(dispatcher._artifact_requests.values()))
+        await artifact_entry["task"]
+
+        assert chat_replies == ["chat reply"]
+        assert artifact_replies == [("artifact document", "artifact message")]
+        assert dispatcher._requests == {}
+        assert dispatcher._artifact_requests == {}
+        assert composer_document.request_state == "idle"
+
+    asyncio.run(run())
+
+
+def test_artifact_request_and_web_research_request_run_concurrently(monkeypatch):
+    """Mirrors test_web_research_request_and_chat_request_run_concurrently_
+    both_dicts_non_empty: an artifact-generation request must also be able to
+    run concurrently with a web-research request - self._artifact_requests
+    and self._web_research_requests are two more genuinely independent slots,
+    neither blocking nor blocked by the other."""
+    research_started = threading.Event()
+    research_release = threading.Event()
+    artifact_started = threading.Event()
+    artifact_release = threading.Event()
+
+    def blocking_run(self, request, *, token=None, progress=None):
+        research_started.set()
+        research_release.wait(5)
+        return SimpleNamespace(answer_markdown="research result")
+
+    def blocking_get_response(self, current_artifact, history):
+        artifact_started.set()
+        artifact_release.wait(5)
+        return "artifact document", "artifact message"
+
+    monkeypatch.setattr(agents_module.WebResearchService, "run", blocking_run)
+    monkeypatch.setattr(agents_module.ArtifactAgent, "get_response", blocking_get_response)
+
+    async def run():
+        bus, notifications, dispatcher = _make_web_research_env()
+        research_node = _make_node()
+        artifact_node = _make_node()
+        research_successes = []
+        artifact_replies = []
+
+        await dispatcher.start_web_research(
+            bus=bus,
+            notifications_state=notifications,
+            node=research_node,
+            node_id="n1",
+            query="q",
+            branch_history=[],
+            on_progress=lambda event: None,
+            on_success=research_successes.append,
+            on_failure=lambda exc: None,
+        )
+        await dispatcher.start_artifact_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=artifact_node,
+            current_artifact="doc",
+            history=[],
+            on_reply=lambda new_content, ai_message: artifact_replies.append((new_content, ai_message)),
+        )
+
+        await asyncio.to_thread(research_started.wait, 5)
+        await asyncio.to_thread(artifact_started.wait, 5)
+
+        assert len(dispatcher._web_research_requests) == 1
+        assert len(dispatcher._artifact_requests) == 1
+        assert notifications.visible is False, "neither call should have been rejected"
+
+        research_release.set()
+        research_entry = next(iter(dispatcher._web_research_requests.values()))
+        await research_entry["task"]
+        artifact_release.set()
+        artifact_entry = next(iter(dispatcher._artifact_requests.values()))
+        await artifact_entry["task"]
+
+        assert research_successes == [SimpleNamespace(answer_markdown="research result")]
+        assert artifact_replies == [("artifact document", "artifact message")]
+        assert dispatcher._web_research_requests == {}
+        assert dispatcher._artifact_requests == {}
+
+    asyncio.run(run())
+
+
 def test_agents_never_imports_qt():
     # This is the regression gate for Step 0's providers.py fix - mirrors
     # test_plugins.py's own test_plugins_never_imports_qt's exact

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -2866,3 +2866,196 @@ def test_run_web_research_on_a_different_node_while_one_is_busy_does_not_clobber
         assert node_a.research_result["answerMarkdown"] == "node a's result"
 
     asyncio.run(run())
+
+
+# -- R5.2: artifact/drafter node ----------------------------------------------
+
+
+def test_add_artifact_node_creates_a_real_artifact_kind_node():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "draft this for me", True)
+    node = doc.add_artifact_node(10, 20, parent.id)
+    assert node.kind == "artifact"
+    assert node.title == "Artifact"
+    assert node.artifact_content == ""
+    assert node.history == []
+    assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
+
+
+def test_add_artifact_node_rejects_unknown_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_artifact_node(0, 0, "ghost")
+
+
+def test_add_artifact_node_requires_a_parent_id():
+    # Same as add_document_node/add_thinking_node/add_html_node/add_image_node/
+    # add_conversation_node/add_web_research_node - parent_id has no default in
+    # add_artifact_node's signature, so calling without one is a TypeError
+    # (missing required argument), not a SceneError.
+    doc = SceneDocument()
+    with pytest.raises(TypeError):
+        doc.add_artifact_node(0, 0)
+
+
+def test_artifact_node_deletion_goes_through_the_generic_remove_nodes_path():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_artifact_node(10, 10, parent.id)
+    assert not hasattr(doc, "delete_artifact_node"), (
+        "artifact nodes are not branch points - no special delete method"
+    )
+    doc.remove_nodes([node.id])
+    assert node.id not in doc.nodes
+    assert not any(e.target == node.id or e.source == node.id for e in doc.edges.values())
+
+
+def test_append_artifact_user_message_appends_a_user_turn():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_artifact_node(0, 0, parent.id)
+    returned = doc.append_artifact_user_message(node.id, "add a conclusion section")
+    assert returned is node
+    assert node.history == [{"role": "user", "content": "add a conclusion section"}]
+
+
+def test_append_artifact_user_message_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().append_artifact_user_message("ghost", "hi")
+
+
+def test_send_artifact_message_is_a_thin_wrapper_over_append_artifact_user_message():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_artifact_node(0, 0, parent.id)
+    returned = doc.send_artifact_message(node.id, "start drafting")
+    assert returned is node
+    assert node.history == [{"role": "user", "content": "start drafting"}]
+
+
+def test_complete_artifact_generation_replaces_content_and_appends_assistant_turn():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_artifact_node(0, 0, parent.id)
+    doc.append_artifact_user_message(node.id, "draft a project brief")
+
+    returned = doc.complete_artifact_generation(
+        node.id, "# Project Brief\n\nDraft content.", "Here's a first draft."
+    )
+
+    assert returned is node
+    assert node.artifact_content == "# Project Brief\n\nDraft content."
+    assert node.history == [
+        {"role": "user", "content": "draft a project brief"},
+        {"role": "assistant", "content": "Here's a first draft."},
+    ]
+
+
+def test_complete_artifact_generation_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().complete_artifact_generation("ghost", "doc", "message")
+
+
+def test_scene_payload_includes_artifact_content_for_artifact_kind_rows():
+    doc = SceneDocument()
+    doc.add_node(0, 0, "plain")
+    parent = doc.add_node(1, 1, "parent")
+    node = doc.add_artifact_node(2, 2, parent.id)
+
+    rows = {n["id"]: n for n in doc.scene_payload()["nodes"]}
+    assert rows["n0"]["artifactContent"] == ""
+
+    doc.complete_artifact_generation(node.id, "the drafted document", "done")
+    row = {n["id"]: n for n in doc.scene_payload()["nodes"]}[node.id]
+    assert row["kind"] == "artifact"
+    assert row["artifactContent"] == "the drafted document"
+
+
+# -- R5.2: artifact/drafter node - WS-intent level ----------------------------
+#
+# Beyond the spec's enumerated SceneDocument-level tests above, these two
+# exercise register_canvas's own sendArtifactMessage/cancelArtifactRequest
+# closures - the new production code path in canvas.py itself - mirroring
+# Web Research's own WS-intent-level coverage
+# (test_run_web_research_intent_publishes_scene_and_calls_start_web_research_with_correct_branch_history/
+# test_cancel_web_research_request_intent_calls_agent_dispatcher_cancel_web_research)
+# so that wiring is not left untested just because it wasn't spelled out
+# alongside the SceneDocument-level list.
+
+
+def test_send_artifact_message_intent_dispatches_a_real_agent_reply_with_correct_branch_history():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.calls = []
+
+        async def start_artifact_reply(self, **kwargs):
+            self.calls.append(kwargs)
+
+        def cancel_artifact(self, request_id):
+            return False
+
+    async def run():
+        bus = SessionBus("send-artifact-message-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        document = register_canvas(bus, notifications, fake_dispatcher, composer_document)
+        recorder = Recorder()
+        bus.attach(recorder)
+
+        root = await bus.dispatch_intent("scene", "addChatNode", [0, 0, "draft me a brief", True])
+        # add_artifact_node itself always requires a real parent - here we
+        # parent the artifact node off the CHAT node so branch_history is
+        # meaningfully non-trivial (mirrors run_web_research's own test).
+        art_node = document.add_artifact_node(0, 0, root)
+        recorder.messages.clear()  # only care about messages from sendArtifactMessage below
+
+        result = await bus.dispatch_intent(
+            "scene", "sendArtifactMessage", [art_node.id, "draft the introduction"]
+        )
+
+        assert result == art_node.id
+        assert document.nodes[art_node.id].history == [
+            {"role": "user", "content": "draft the introduction"}
+        ]
+        assert recorder.topics_seen().count("scene") == 1, "send_artifact_message publishes scene once"
+        assert len(fake_dispatcher.calls) == 1
+        call = fake_dispatcher.calls[0]
+        assert call["bus"] is bus
+        assert call["notifications_state"] is notifications
+        assert call["node"] is art_node
+        assert call["current_artifact"] == ""
+        assert call["history"] == document.chat_branch_history(root) + [
+            {"role": "user", "content": "draft the introduction"}
+        ]
+        assert callable(call["on_reply"])
+
+    asyncio.run(run())
+
+
+def test_cancel_artifact_request_intent_calls_agent_dispatcher_cancel_artifact():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.cancel_calls = []
+
+        def cancel_artifact(self, request_id):
+            self.cancel_calls.append(request_id)
+            return True
+
+    async def run():
+        bus = SessionBus("cancel-artifact-request-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        register_canvas(bus, notifications, fake_dispatcher, composer_document)
+
+        result = await bus.dispatch_intent("scene", "cancelArtifactRequest", ["req-123"])
+
+        assert result is None
+        assert fake_dispatcher.cancel_calls == ["req-123"]
+
+    asyncio.run(run())

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -187,12 +187,77 @@ def test_execute_plugin_web_research_with_a_valid_parent_creates_a_real_node_and
     assert "scene" in recorder.topics_seen()
 
 
-# -- R5.1: non-regression - every OTHER plugin name is still an honest,
+# -- R5.2: "Artifact / Drafter" - the second real node-creation plugin ------
+
+
+def test_execute_plugin_artifact_drafter_requires_a_selected_parent():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Artifact / Drafter"]))
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == (
+        "Please select a valid node to branch from before adding an Artifact node."
+    )
+    assert not any(n.kind == "artifact" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_artifact_drafter_rejects_unknown_parent_id():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Artifact / Drafter", "ghost-node-id"])
+    )
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == (
+        "Please select a valid node to branch from before adding an Artifact node."
+    )
+    assert not any(n.kind == "artifact" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_artifact_drafter_creates_a_real_artifact_node():
+    bus, notifications, canvas_document = _make_plugins_bus()
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    class Recorder:
+        def __init__(self):
+            self.messages = []
+
+        async def send_json(self, data):
+            self.messages.append(data)
+
+        def topics_seen(self):
+            return [m["topic"] for m in self.messages if m["kind"] == "state"]
+
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Artifact / Drafter", parent.id])
+    )
+
+    assert result is not None
+    node = canvas_document.nodes[result]
+    assert node.kind == "artifact"
+    assert node.title == "Artifact"
+    assert any(
+        e.source == parent.id and e.target == node.id for e in canvas_document.edges.values()
+    )
+    assert notifications.visible is False, "success is not a deferral - no notification fires"
+    assert "scene" in recorder.topics_seen()
+
+
+# -- R5.1/R5.2: non-regression - every OTHER plugin name is still an honest,
 # unchanged deferred notice ---------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "name", [n for n in (p[0] for p in _PLUGINS) if n != "Web Research"]
+    "name", [n for n in (p[0] for p in _PLUGINS) if n not in ("Web Research", "Artifact / Drafter")]
 )
 def test_execute_plugin_every_other_plugin_name_still_shows_the_unchanged_deferred_notice(name):
     bus, notifications, canvas_document = _make_plugins_bus()

--- a/graphlink_app/graphlink_agents_artifact.py
+++ b/graphlink_app/graphlink_agents_artifact.py
@@ -1,68 +1,29 @@
-"""Artifact's LLM agent + background worker thread (Phase 7 prerequisite,
-increment 2) - extracted from graphlink_plugins/graphlink_plugin_artifact.py,
-mirroring the same split graphlink_agents_pycoder.py already did for PyCoder.
+"""Artifact's background worker thread (Phase 7 prerequisite, increment 2;
+Qt-removal plan R5.2 split) - extracted from
+graphlink_plugins/graphlink_plugin_artifact.py, mirroring the same split
+graphlink_agents_pycoder.py already did for PyCoder.
 
-Both classes were already Qt-free/Qt-only-for-threading and self-contained -
-this is a pure relocation, not a rewrite. ArtifactNode never referenced
-either class by name in its own body (confirmed by grep); the only
-production caller is graphlink_window_actions.py's execute_artifact_node,
-which constructs an ArtifactWorkerThread and assigns it onto the node
-(node.worker_thread) - that ownership shape is unchanged, only the import
-path moves.
+R5.2: `ArtifactAgent` itself has since moved OUT of this file into
+graphlink_artifact_agent.py, for the exact same reason R4.2 moved
+`ChatAgent`/`ChatWorker`/`resolve_branch_system_prompt` out of
+graphlink_agents_core.py into graphlink_chat_agent.py (see that module's own
+docstring): this file's unconditional `from PySide6.QtCore import QThread,
+Signal` - needed only by `ArtifactWorkerThread` below - meant importing
+anything from it, including the Qt-free `ArtifactAgent`, pulled PySide6 into
+the process. That made `ArtifactAgent` unimportable from backend/ despite
+containing zero Qt code itself. `ArtifactAgent` is re-exported here unchanged
+so `ArtifactWorkerThread` (which constructs one internally) and the one
+legacy production call site (graphlink_window_actions.py's
+execute_artifact_node, which constructs an `ArtifactWorkerThread` and assigns
+it onto the node as `node.worker_thread`) keep working unmodified - only the
+class's true home moved.
 """
 
-import re
 from PySide6.QtCore import QThread, Signal
-import graphlink_config as config
-import api_provider
 
+from graphlink_artifact_agent import ArtifactAgent
 
-class ArtifactAgent:
-    """
-    An agent specialized in iteratively creating and refining a living document.
-    """
-    def __init__(self):
-        self.system_prompt = """You are an expert Document Drafting Assistant (Artifacts).
-Your primary task is to create, update, or refine a 'living document' based on user instructions and the context of the conversation.
-
-RULES:
-1. You will receive the conversation history, and your system instructions contain the CURRENT state of the document.
-2. You must output the ENTIRE updated document enclosed exactly within <artifact> and </artifact> tags. Do NOT truncate or abbreviate the document. If you are changing one paragraph, you must still output the whole document with that change applied.
-3. After the </artifact> tag, provide a brief conversational response acknowledging the changes, explaining your thought process, or asking for clarification.
-4. If the document is currently empty, create the first draft based entirely on the instruction.
-5. Always use Markdown formatting for the document content.
-"""
-
-    def get_response(self, current_artifact, history):
-        # We inject the document state directly into the system prompt to maintain clean alternating history
-        system_with_doc = self.system_prompt + f"\n\n--- CURRENT DOCUMENT STATE ---\n{current_artifact if current_artifact else '(Document is currently empty)'}\n"
-
-        messages = [{'role': 'system', 'content': system_with_doc}]
-        for msg in history:
-            messages.append(msg)
-
-        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
-        raw_text = response['message']['content']
-
-        # Parse out the artifact and the conversational response
-        artifact_match = re.search(r'<artifact>(.*?)</artifact>', raw_text, re.DOTALL)
-        if not artifact_match:
-            # Previously fell back to treating the ENTIRE raw response - including any
-            # conversational preamble/explanation the model wrote outside the tags - as
-            # the new document body, silently corrupting the document on any tag-format
-            # miss. Raising here instead routes through ArtifactWorkerThread's existing
-            # except/error.emit path, which surfaces "Error: ..." in the node's chat and
-            # leaves the previous document content untouched (see
-            # _handle_artifact_error in graphlink_window_actions.py) rather than
-            # overwriting it with something that was never meant to be the document.
-            raise RuntimeError(
-                "The model's response did not include the required <artifact>...</artifact> tags, "
-                "so the document was left unchanged to avoid overwriting it with an unstructured reply."
-            )
-
-        new_artifact = artifact_match.group(1).strip()
-        ai_message = raw_text.replace(artifact_match.group(0), "").strip()
-        return new_artifact, ai_message
+__all__ = ["ArtifactAgent", "ArtifactWorkerThread"]
 
 
 class ArtifactWorkerThread(QThread):

--- a/graphlink_app/graphlink_artifact_agent.py
+++ b/graphlink_app/graphlink_artifact_agent.py
@@ -1,0 +1,71 @@
+"""Qt-free artifact-agent core (Qt-removal plan R5.2 prerequisite).
+
+`ArtifactAgent` moved out of graphlink_agents_artifact.py: that module's
+unconditional `from PySide6.QtCore import QThread, Signal` (needed only by
+its `ArtifactWorkerThread` class) meant importing anything from it -
+including this Qt-free class - pulled PySide6 into the process. That made it
+unimportable from backend/ despite containing zero Qt code itself, exactly
+the same problem R4.2 fixed for chat by splitting graphlink_chat_agent.py out
+of graphlink_agents_core.py (see that module's own docstring).
+
+graphlink_agents_artifact.py re-exports this class unchanged for its own
+ArtifactWorkerThread (which constructs one internally) and the legacy Qt call
+site (graphlink_window_actions.py's execute_artifact_node) - see its own
+import line.
+
+This file must stay Qt-free forever - it exists to be importable from
+backend/, which test_no_qt_anywhere.py holds to zero tolerance.
+"""
+
+import re
+
+import graphlink_task_config as config
+import api_provider
+
+
+class ArtifactAgent:
+    """
+    An agent specialized in iteratively creating and refining a living document.
+    """
+    def __init__(self):
+        self.system_prompt = """You are an expert Document Drafting Assistant (Artifacts).
+Your primary task is to create, update, or refine a 'living document' based on user instructions and the context of the conversation.
+
+RULES:
+1. You will receive the conversation history, and your system instructions contain the CURRENT state of the document.
+2. You must output the ENTIRE updated document enclosed exactly within <artifact> and </artifact> tags. Do NOT truncate or abbreviate the document. If you are changing one paragraph, you must still output the whole document with that change applied.
+3. After the </artifact> tag, provide a brief conversational response acknowledging the changes, explaining your thought process, or asking for clarification.
+4. If the document is currently empty, create the first draft based entirely on the instruction.
+5. Always use Markdown formatting for the document content.
+"""
+
+    def get_response(self, current_artifact, history):
+        # We inject the document state directly into the system prompt to maintain clean alternating history
+        system_with_doc = self.system_prompt + f"\n\n--- CURRENT DOCUMENT STATE ---\n{current_artifact if current_artifact else '(Document is currently empty)'}\n"
+
+        messages = [{'role': 'system', 'content': system_with_doc}]
+        for msg in history:
+            messages.append(msg)
+
+        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
+        raw_text = response['message']['content']
+
+        # Parse out the artifact and the conversational response
+        artifact_match = re.search(r'<artifact>(.*?)</artifact>', raw_text, re.DOTALL)
+        if not artifact_match:
+            # Previously fell back to treating the ENTIRE raw response - including any
+            # conversational preamble/explanation the model wrote outside the tags - as
+            # the new document body, silently corrupting the document on any tag-format
+            # miss. Raising here instead routes through ArtifactWorkerThread's existing
+            # except/error.emit path, which surfaces "Error: ..." in the node's chat and
+            # leaves the previous document content untouched (see
+            # _handle_artifact_error in graphlink_window_actions.py) rather than
+            # overwriting it with something that was never meant to be the document.
+            raise RuntimeError(
+                "The model's response did not include the required <artifact>...</artifact> tags, "
+                "so the document was left unchanged to avoid overwriting it with an unstructured reply."
+            )
+
+        new_artifact = artifact_match.group(1).strip()
+        ai_message = raw_text.replace(artifact_match.group(0), "").strip()
+        return new_artifact, ai_message

--- a/graphlink_app/graphlink_scene_payload.py
+++ b/graphlink_app/graphlink_scene_payload.py
@@ -49,6 +49,14 @@ kind=="web_research" rows, defaulted (empty string/0/None) for every other
 kind, same additive rule. `researchResult`, when present, is a nested
 ResearchResultRow - the one field here (besides R3.25's `history`) whose
 shape is a structured object rather than a scalar.
+
+R5.2 adds `artifactContent` (the Artifact/Drafter node's real persisted
+shape): the model returns the WHOLE document every turn (whole-document
+replace, never a diff/patch), so this single scalar always holds the latest
+full document text. Populated for kind=="artifact" rows, defaulted (empty
+string) for every other kind, same additive rule. The turn-by-turn
+conversation reuses the existing `history` field (R3.25) rather than a new
+list-typed field.
 """
 
 from __future__ import annotations
@@ -170,6 +178,11 @@ class SceneNodeRow:
     researchActiveSourceId: str | None = None
     researchError: str = ""
     researchResult: ResearchResultRow | None = None
+    # R5.2: the Artifact/Drafter node's real persisted shape - the latest
+    # full document text (whole-document replace every turn, never a
+    # diff/patch). Populated for kind=="artifact" rows, defaulted (empty
+    # string) for every other kind.
+    artifactContent: str = ""
 
 
 @dataclass

--- a/graphlink_app/tests/test_artifact_agent_extraction.py
+++ b/graphlink_app/tests/test_artifact_agent_extraction.py
@@ -3,13 +3,22 @@ extracted out of graphlink_plugins/graphlink_plugin_artifact.py into a new
 graphlink_agents_artifact.py, mirroring the split graphlink_agents_pycoder.py
 already did for PyCoder.
 
+R5.2: ArtifactAgent has since moved AGAIN, out of graphlink_agents_artifact.py
+into a Qt-free graphlink_artifact_agent.py (mirroring R4.2's chat-agent
+split), because graphlink_agents_artifact.py's own `from PySide6.QtCore
+import QThread, Signal` (needed only by ArtifactWorkerThread) pulled Qt into
+any importer, including ArtifactAgent despite it containing zero Qt code.
+graphlink_agents_artifact.py re-exports ArtifactAgent unchanged for backward
+compatibility.
+
 A pure relocation, not a rewrite - both classes were already Qt-free/
 Qt-only-for-threading and self-contained; ArtifactNode never referenced
 either by name. This file proves the module boundary landed exactly where
-the recon said it would: the new module holds both classes with the
-underlying import graph intact, the old module holds neither, and the one
-production construction site (graphlink_window_actions.execute_artifact_node)
-still gets a real, working ArtifactWorkerThread from the new location.
+the recon said it would: graphlink_artifact_agent.py holds ArtifactAgent's
+real home, graphlink_agents_artifact.py holds ArtifactWorkerThread plus a
+re-export, the old plugin module holds neither, and the one production
+construction site (graphlink_window_actions.execute_artifact_node) still gets
+a real, working ArtifactWorkerThread from the re-exporting location.
 """
 
 import sys
@@ -18,6 +27,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import graphlink_agents_artifact
+import graphlink_artifact_agent
 import graphlink_plugins.graphlink_plugin_artifact as plugin_artifact_module
 from graphlink_agents_artifact import ArtifactAgent, ArtifactWorkerThread
 
@@ -27,13 +37,20 @@ class TestModuleBoundary:
         assert graphlink_agents_artifact.ArtifactAgent is ArtifactAgent
         assert graphlink_agents_artifact.ArtifactWorkerThread is ArtifactWorkerThread
 
+    def test_artifact_agent_real_home_is_the_qt_free_module_and_the_old_module_only_re_exports_it(self):
+        # R5.2: ArtifactAgent's real home is now graphlink_artifact_agent.py
+        # (Qt-free forever); graphlink_agents_artifact.py's own ArtifactAgent
+        # name is the SAME object, re-exported for backward compatibility,
+        # not a second independent class.
+        assert graphlink_agents_artifact.ArtifactAgent is graphlink_artifact_agent.ArtifactAgent
+
     def test_the_worker_threads_own_class_attribute_still_resolves_to_the_new_module(self):
         # ArtifactWorkerThread constructs its own ArtifactAgent internally -
-        # confirm that reference resolves within the new module, not a stale
-        # import of the old (now nonexistent) location.
+        # confirm that reference resolves to ArtifactAgent's real (Qt-free)
+        # home, not a stale import of an old (now nonexistent) location.
         worker = ArtifactWorkerThread("doc", [])
         assert isinstance(worker.agent, ArtifactAgent)
-        assert type(worker.agent).__module__ == "graphlink_agents_artifact"
+        assert type(worker.agent).__module__ == "graphlink_artifact_agent"
 
     def test_neither_class_remains_on_the_plugin_module(self):
         assert not hasattr(plugin_artifact_module, "ArtifactAgent")

--- a/graphlink_app/tests/test_artifact_bugs.py
+++ b/graphlink_app/tests/test_artifact_bugs.py
@@ -27,7 +27,7 @@ from PySide6.QtWidgets import QApplication
 
 _APP = QApplication.instance() or QApplication([])
 
-from graphlink_agents_artifact import ArtifactAgent
+from graphlink_artifact_agent import ArtifactAgent
 from graphlink_plugins.graphlink_plugin_artifact import ArtifactNode
 
 
@@ -37,7 +37,7 @@ class TestArtifactAgentTagParsing:
         raw_text = "<artifact>\n# Title\n\nBody text.\n</artifact>\nHere's the update."
 
         with patch(
-            "graphlink_agents_artifact.api_provider.chat",
+            "graphlink_artifact_agent.api_provider.chat",
             return_value={"message": {"content": raw_text}},
         ):
             new_doc, ai_message = agent.get_response("old doc", [])
@@ -50,7 +50,7 @@ class TestArtifactAgentTagParsing:
         raw_text = "Sorry, I can't help with that right now."
 
         with patch(
-            "graphlink_agents_artifact.api_provider.chat",
+            "graphlink_artifact_agent.api_provider.chat",
             return_value={"message": {"content": raw_text}},
         ):
             with pytest.raises(RuntimeError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ py-modules = [
     "api_provider",
     "graphlink_agents",
     "graphlink_agents_artifact",
+    "graphlink_artifact_agent",
     "graphlink_agents_code_sandbox",
     "graphlink_agents_core",
     "graphlink_agents_pycoder",

--- a/web_ui/src/app/canvas/ArtifactNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ArtifactNodeView.test.tsx
@@ -1,0 +1,282 @@
+import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ArtifactNodeView, type ArtifactFlowNode } from "./ArtifactNodeView";
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
+// ChatNodeView.test.tsx / ConversationNodeView.test.tsx / WebResearchNodeView.test.tsx
+// for why a bare ReactFlowProvider is enough here too.
+
+function baseData(overrides: Partial<ArtifactFlowNode["data"]> = {}): ArtifactFlowNode["data"] {
+  return {
+    artifactContent: "",
+    history: [],
+    isCollapsed: false,
+    pendingRequestId: null,
+    onToggleCollapse: vi.fn(),
+    onDelete: vi.fn(),
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderArtifactNode(overrides: Partial<ArtifactFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "n0", selected: false, data } as unknown as NodeProps<ArtifactFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <ArtifactNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return data;
+}
+
+// Directly sets the React Flow internal Zustand store's transform/zoom value
+// - same technique WebResearchNodeView.test.tsx / ConversationNodeView.test.tsx's
+// own ZoomSetter uses (a mounted panZoom instance doesn't exist in this
+// direct-render test setup).
+function ZoomSetter({ zoom }: { zoom: number }) {
+  const store = useStoreApi();
+  useEffect(() => {
+    store.setState({ transform: [0, 0, zoom] });
+  }, [zoom, store]);
+  return null;
+}
+
+function renderArtifactNodeAtZoom(zoom: number, overrides: Partial<ArtifactFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "n0", selected: false, data } as unknown as NodeProps<ArtifactFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <ZoomSetter zoom={zoom} />
+      <ArtifactNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return data;
+}
+
+describe("ArtifactNodeView", () => {
+  // -- document preview -----------------------------------------------------
+
+  it("renders the empty-document placeholder when artifactContent is an empty string", () => {
+    renderArtifactNode({ artifactContent: "" });
+    expect(screen.getByText("Document is currently empty.")).toBeInTheDocument();
+  });
+
+  it("renders real rendered Markdown (heading, bold text, a GFM table) for non-empty artifactContent", () => {
+    renderArtifactNode({
+      artifactContent:
+        "# Project Proposal\n\nThis is **very important**.\n\n| Item | Cost |\n| --- | --- |\n| Widget | $5 |\n",
+    });
+    expect(screen.queryByText("Document is currently empty.")).toBeNull();
+    expect(screen.getByRole("heading", { name: "Project Proposal" })).toBeInTheDocument();
+    expect(screen.getByText("very important")).toBeInTheDocument(); // bold text still renders as text
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByText("Widget")).toBeInTheDocument();
+  });
+
+  // -- turn history -----------------------------------------------------------
+
+  it("renders one bubble per history entry with the correct user/assistant styling class", () => {
+    renderArtifactNode({
+      history: [
+        { role: "user", content: "Draft a **proposal**" },
+        { role: "assistant", content: "Here is a draft." },
+      ],
+    });
+    const userBubble = screen.getByText("proposal").closest(".artifact-node-bubble");
+    const assistantBubble = screen.getByText("Here is a draft.").closest(".artifact-node-bubble");
+    expect(userBubble).toHaveClass("artifact-node-bubble", "user");
+    expect(assistantBubble).toHaveClass("artifact-node-bubble", "assistant");
+  });
+
+  it("renders no turn-history section at all when history is empty", () => {
+    renderArtifactNode({ history: [] });
+    expect(document.querySelector(".artifact-node-messages")).toBeNull();
+  });
+
+  // -- collapse/expand + LOD -------------------------------------------------
+
+  it("manual collapse hides the body and shows only the header", () => {
+    renderArtifactNode({ isCollapsed: true, artifactContent: "hello" });
+    expect(screen.getByText("Artifact")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("the inline collapse chevron calls onToggleCollapse", async () => {
+    const user = userEvent.setup();
+    const data = renderArtifactNode();
+    await user.click(screen.getByRole("button", { name: "Collapse" }));
+    expect(data.onToggleCollapse).toHaveBeenCalledOnce();
+  });
+
+  it("LOD auto-collapse (zoom below threshold) also hides the body, even when isCollapsed is false", () => {
+    renderArtifactNodeAtZoom(0.2, { isCollapsed: false, artifactContent: "hello" });
+    expect(screen.getByText("Artifact")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("stays expanded above the LOD threshold when isCollapsed is false", () => {
+    renderArtifactNodeAtZoom(1, { isCollapsed: false });
+    expect(screen.getByRole("textbox", { name: "Instruction" })).toBeInTheDocument();
+  });
+
+  // -- submit label + disabled state ------------------------------------------
+
+  it("the submit button reads Generate when artifactContent is empty", () => {
+    renderArtifactNode({ artifactContent: "" });
+    expect(screen.getByRole("button", { name: "Generate" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Refine" })).toBeNull();
+  });
+
+  it("the submit button reads Refine once artifactContent is non-empty", () => {
+    renderArtifactNode({ artifactContent: "# Existing draft" });
+    expect(screen.getByRole("button", { name: "Refine" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Generate" })).toBeNull();
+  });
+
+  it("treats whitespace-only artifactContent the same as empty (Generate, not Refine)", () => {
+    renderArtifactNode({ artifactContent: "   \n  " });
+    expect(screen.getByRole("button", { name: "Generate" })).toBeInTheDocument();
+  });
+
+  it("the submit button is disabled when the draft is empty or whitespace-only", async () => {
+    const user = userEvent.setup();
+    renderArtifactNode();
+    const input = screen.getByRole("textbox", { name: "Instruction" });
+    const submitButton = screen.getByRole("button", { name: "Generate" });
+
+    expect(submitButton).toBeDisabled();
+    await user.type(input, "   ");
+    expect(submitButton).toBeDisabled();
+    await user.type(input, "real text");
+    expect(submitButton).toBeEnabled();
+  });
+
+  it("the submit button is disabled while pendingRequestId is set, even with non-empty draft", async () => {
+    const user = userEvent.setup();
+    renderArtifactNode({ pendingRequestId: "req-1" });
+    const input = screen.getByRole("textbox", { name: "Instruction" });
+    await user.type(input, "real text");
+    expect(screen.getByRole("button", { name: "Generate" })).toBeDisabled();
+  });
+
+  // -- submit / Enter / Shift+Enter -------------------------------------------
+
+  it("typing text and pressing Enter calls onSubmit with the trimmed text and clears the input", async () => {
+    const user = userEvent.setup();
+    const data = renderArtifactNode();
+    const input = screen.getByRole("textbox", { name: "Instruction" });
+
+    await user.type(input, "  draft a proposal  {Enter}");
+    expect(data.onSubmit).toHaveBeenCalledWith("draft a proposal");
+    expect(input).toHaveValue("");
+  });
+
+  it("Shift+Enter does not submit and instead allows a newline", async () => {
+    const user = userEvent.setup();
+    const data = renderArtifactNode();
+    const input = screen.getByRole("textbox", { name: "Instruction" });
+
+    await user.type(input, "line one{Shift>}{Enter}{/Shift}line two");
+    expect(data.onSubmit).not.toHaveBeenCalled();
+    expect(input).toHaveValue("line one\nline two");
+  });
+
+  it("clicking the submit button calls onSubmit with the trimmed text and clears the input", async () => {
+    const user = userEvent.setup();
+    const data = renderArtifactNode();
+    const input = screen.getByRole("textbox", { name: "Instruction" });
+
+    await user.type(input, "click to submit");
+    await user.click(screen.getByRole("button", { name: "Generate" }));
+    expect(data.onSubmit).toHaveBeenCalledWith("click to submit");
+    expect(input).toHaveValue("");
+  });
+
+  // -- Cancel -----------------------------------------------------------------
+
+  it("the Cancel button is absent when pendingRequestId is null", () => {
+    renderArtifactNode({ pendingRequestId: null });
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+
+  it("the Cancel button is present and calls onCancel when pendingRequestId is set", async () => {
+    const user = userEvent.setup();
+    const data = renderArtifactNode({ pendingRequestId: "req-42" });
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    expect(cancelButton).toBeInTheDocument();
+    await user.click(cancelButton);
+    expect(data.onCancel).toHaveBeenCalledOnce();
+  });
+
+  // -- card-level menu ----------------------------------------------------
+
+  it("the node-level right-click menu shows exactly Collapse/Expand + Delete Node - no dock action", async () => {
+    const user = userEvent.setup();
+    const data = renderArtifactNode();
+
+    fireEvent.contextMenu(screen.getByText("Artifact"));
+    const menu = screen.getByRole("menu");
+    expect(menu).toBeInTheDocument();
+
+    const items = screen.getAllByRole("menuitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("Collapse");
+    expect(items[1]).toHaveTextContent("Delete Node");
+    expect(screen.queryByRole("menuitem", { name: /Dock/ })).toBeNull();
+
+    await user.click(items[0]);
+    expect(data.onToggleCollapse).toHaveBeenCalledOnce();
+
+    fireEvent.contextMenu(screen.getByText("Artifact"));
+    await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
+    expect(data.onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("the menu's Collapse/Expand label flips when isCollapsed is true", () => {
+    renderArtifactNode({ isCollapsed: true });
+    fireEvent.contextMenu(screen.getByText("Artifact"));
+    expect(screen.getByRole("menuitem", { name: "Expand" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Collapse" })).toBeNull();
+  });
+
+  it("Escape and outside-click both close the node-level menu", async () => {
+    const user = userEvent.setup();
+    renderArtifactNode();
+    const header = screen.getByText("Artifact");
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  // -- security: no raw-HTML passthrough ---------------------------------
+
+  it("SECURITY: a document string containing a literal <img onerror> tag never becomes a real rendered img element", () => {
+    renderArtifactNode({
+      artifactContent: 'Look at this: <img src="x" onerror="alert(1)"> nothing happened.',
+    });
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("SECURITY: a turn-history entry containing a literal <img onerror> tag never becomes a real rendered img element", () => {
+    renderArtifactNode({
+      history: [{ role: "assistant", content: '<img src="x" onerror="alert(1)"> as requested.' }],
+    });
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/ArtifactNodeView.tsx
+++ b/web_ui/src/app/canvas/ArtifactNodeView.tsx
@@ -1,0 +1,278 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+
+/**
+ * The artifact node (Qt-removal plan R5.2) - the Artifact/Drafter plugin's
+ * React card. One vertical card, same overall shell as its plugin-node
+ * siblings (ConversationNodeView/WebResearchNodeView): collapse/expand OR-ed
+ * with LOD, a card menu with outside-click/Escape dismiss, the shared
+ * react-markdown + remarkGfm + rehypeHighlight pipeline. Deliberately NOT a
+ * literal two-pane split-view clone of the legacy widget - every prior
+ * node/plugin port in this codebase re-composes the legacy widget's layout
+ * into one card instead, and this follows that same convention: a document
+ * preview on top, the instruction turn history below it, then the
+ * instruction input at the bottom.
+ *
+ * Security note, not a style preference: this reuses react-markdown/
+ * remarkGfm/rehypeHighlight UNCHANGED - no rehype-raw, no
+ * dangerouslySetInnerHTML anywhere in this file. Without rehype-raw,
+ * react-markdown never interprets embedded HTML in either the document
+ * preview or a turn bubble as live markup; it renders as inert text. That is
+ * the same raw-text-can-never-become-a-live-DOM-element guarantee the legacy
+ * app's escape-then-render pipeline gave, achieved here by construction
+ * instead of an explicit escape step.
+ *
+ * Card menu mirrors WebResearchNodeMenu's own posture: Collapse/Expand +
+ * Delete Node only - no "Open Document View" placeholder (that is a legacy
+ * ConversationNode-specific leftover, not a convention every node kind
+ * repeats) and no dock-to-parent action (this node kind is never docked,
+ * same posture as html/image/conversation/web_research above it).
+ *
+ * The submit button's label ("Generate" vs "Refine") is derived purely from
+ * whether data.artifactContent is non-empty after trimming - it is not a
+ * flag from the wire, since ArtifactAgent.get_response(current_artifact,
+ * history) itself always treats "was there prior content" as an empty-string
+ * check, not a separate mode.
+ */
+
+export interface ArtifactMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface ArtifactNodeData extends Record<string, unknown> {
+  artifactContent: string;
+  history: ArtifactMessage[];
+  isCollapsed: boolean;
+  pendingRequestId: string | null;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  onSubmit: (text: string) => void;
+  onCancel: () => void;
+}
+
+export type ArtifactFlowNode = Node<ArtifactNodeData, "artifact">;
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+/** Same outside-click/Escape dismiss pattern every sibling node menu uses
+ * (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu/ConversationNodeMenu/
+ * WebResearchNodeMenu). */
+function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
+      // type-only import above shadows the bare name for casts like this).
+      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [menuRef, onClose]);
+}
+
+// -- card-level menu -------------------------------------------------------
+
+function ArtifactNodeMenu({
+  position,
+  isCollapsed,
+  onToggleCollapse,
+  onDelete,
+  onClose,
+}: {
+  position: MenuPosition;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useMenuDismiss(menuRef, onClose);
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleCollapse();
+          onClose();
+        }}
+      >
+        {isCollapsed ? "Expand" : "Collapse"}
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        Delete Node
+      </button>
+    </div>
+  );
+}
+
+// -- turn bubble ------------------------------------------------------------
+
+function ArtifactBubble({ message }: { message: ArtifactMessage }) {
+  return (
+    <div className={`artifact-node-bubble${message.role === "user" ? " user" : " assistant"}`}>
+      {/* Reuses .chat-node-content's markdown-body rule set verbatim - same
+          shared-class convention ConversationBubble's own -content div
+          establishes across every sibling node kind. */}
+      <div className="chat-node-content artifact-node-bubble-content">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+          {message.content}
+        </ReactMarkdown>
+      </div>
+    </div>
+  );
+}
+
+// -- view ----------------------------------------------------------------
+
+export function ArtifactNodeView({ data, selected }: NodeProps<ArtifactFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const collapsed = data.isCollapsed || lodCollapsed;
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+  // Local, ephemeral instruction draft - starts empty and is never re-synced
+  // from props after mount, same non-clobbering posture ConversationNodeView's
+  // own message draft follows (there is no wire field this could even be
+  // re-synced from - unlike WebResearchNodeView's query input, an
+  // instruction is a one-shot message, not persisted node state).
+  const [draft, setDraft] = useState("");
+
+  function submit() {
+    const text = draft.trim();
+    if (!text) return;
+    data.onSubmit(text);
+    setDraft("");
+  }
+
+  const hasContent = data.artifactContent.trim().length > 0;
+  const submitLabel = hasContent ? "Refine" : "Generate";
+
+  return (
+    <div
+      className={`scene-node artifact-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title chat-node-role">
+        <span>Artifact</span>
+        <button
+          type="button"
+          className="chat-node-collapse-btn"
+          aria-label={data.isCollapsed ? "Expand" : "Collapse"}
+          onClick={data.onToggleCollapse}
+        >
+          {data.isCollapsed ? "▸" : "▾"}
+        </button>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body artifact-node-content">
+          <div className="artifact-node-document">
+            {hasContent ? (
+              <div className="chat-node-content artifact-node-document-content">
+                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                  {data.artifactContent}
+                </ReactMarkdown>
+              </div>
+            ) : (
+              <p className="artifact-node-empty">Document is currently empty.</p>
+            )}
+          </div>
+
+          {data.history.length > 0 && (
+            <div className="artifact-node-messages">
+              {data.history.map((message, index) => (
+                // No per-message id on the wire shape - render order is
+                // always the true history order, so index is a correct and
+                // sufficient key here (same posture as ConversationBubble's
+                // own key).
+                <ArtifactBubble key={index} message={message} />
+              ))}
+            </div>
+          )}
+
+          <div className="artifact-node-input-row">
+            <textarea
+              className="artifact-node-input"
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                // Enter-to-submit / Shift+Enter-for-newline - same convention
+                // ConversationNodeView's own input (and the Composer's own
+                // onKeyDown handler) already use.
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  submit();
+                }
+              }}
+              placeholder="Describe what to generate or refine…"
+              aria-label="Instruction"
+              rows={1}
+              spellCheck
+            />
+            <div className="artifact-node-input-actions">
+              <button
+                type="button"
+                className="artifact-node-submit-btn"
+                disabled={!draft.trim() || !!data.pendingRequestId}
+                onClick={submit}
+              >
+                {submitLabel}
+              </button>
+              {data.pendingRequestId && (
+                <button
+                  type="button"
+                  className="artifact-node-cancel-btn"
+                  onClick={() => data.onCancel()}
+                  title="Cancel response"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+      {menuPosition && (
+        <ArtifactNodeMenu
+          position={menuPosition}
+          isCollapsed={data.isCollapsed}
+          onToggleCollapse={data.onToggleCollapse}
+          onDelete={data.onDelete}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -42,6 +42,7 @@ function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
     researchActiveSourceId: null,
     researchError: "",
     researchResult: null,
+    artifactContent: "",
     ...overrides,
   };
 }
@@ -288,6 +289,106 @@ describe("toFlowNodes (R5.1 web_research node)", () => {
 
     (wrFlowNode!.data as { onDelete: () => void }).onDelete();
     expect(removeSpy).toHaveBeenCalledWith(["wr-1"]);
+  });
+});
+
+describe("toFlowNodes (R5.2 artifact node)", () => {
+  it("maps an artifact scene node's artifactContent/history/isCollapsed onto the flow node's data", () => {
+    const history = [
+      { role: "user" as const, content: "Draft a project proposal" },
+      { role: "assistant" as const, content: "# Proposal\n\nHere is a draft." },
+    ];
+    const scene = baseScene({
+      nodes: [
+        baseNode({
+          id: "art-1",
+          kind: "artifact",
+          artifactContent: "# Proposal\n\nHere is a draft.",
+          history,
+          isCollapsed: true,
+          pendingRequestId: "req-1",
+        }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const artifactFlowNode = flowNodes.find((n) => n.id === "art-1");
+    expect(artifactFlowNode).toBeDefined();
+    expect(artifactFlowNode!.type).toBe("artifact");
+    expect(artifactFlowNode!.data).toMatchObject({
+      artifactContent: "# Proposal\n\nHere is a draft.",
+      history,
+      isCollapsed: true,
+      pendingRequestId: "req-1",
+    });
+  });
+
+  it("coalesces a null-ish pendingRequestId to null", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "art-2", kind: "artifact", artifactContent: "", history: [] })],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const artifactFlowNode = flowNodes.find((n) => n.id === "art-2");
+    expect(artifactFlowNode).toBeDefined();
+    expect(artifactFlowNode!.data).toMatchObject({ pendingRequestId: null });
+  });
+
+  it("onSubmit calls store.sendArtifactMessage with this node's id and the given text", () => {
+    const scene = baseScene({ nodes: [baseNode({ id: "art-1", kind: "artifact" })], edges: [] });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "sendArtifactMessage");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const artifactFlowNode = flowNodes.find((n) => n.id === "art-1");
+
+    (artifactFlowNode!.data as { onSubmit: (text: string) => void }).onSubmit("Refine the intro");
+    expect(intentSpy).toHaveBeenCalledWith("art-1", "Refine the intro");
+  });
+
+  it("onCancel fires cancelArtifactRequest with pendingRequestId when set, and is a no-op otherwise", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "art-pending", kind: "artifact", pendingRequestId: "req-77" }),
+        baseNode({ id: "art-idle", kind: "artifact", pendingRequestId: null }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "cancelArtifactRequest");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const pendingNode = flowNodes.find((n) => n.id === "art-pending");
+    const idleNode = flowNodes.find((n) => n.id === "art-idle");
+
+    (pendingNode!.data as { onCancel: () => void }).onCancel();
+    expect(intentSpy).toHaveBeenCalledWith("req-77");
+
+    (idleNode!.data as { onCancel: () => void }).onCancel();
+    expect(intentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("onToggleCollapse/onDelete reuse the generic setChatCollapsed/removeNodes intents", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "art-1", kind: "artifact", isCollapsed: false })],
+      edges: [],
+    });
+    const store = makeStore();
+    const collapseSpy = vi.spyOn(store, "setChatCollapsed");
+    const removeSpy = vi.spyOn(store, "removeNodes");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const artifactFlowNode = flowNodes.find((n) => n.id === "art-1");
+
+    (artifactFlowNode!.data as { onToggleCollapse: () => void }).onToggleCollapse();
+    expect(collapseSpy).toHaveBeenCalledWith("art-1", true);
+
+    (artifactFlowNode!.data as { onDelete: () => void }).onDelete();
+    expect(removeSpy).toHaveBeenCalledWith(["art-1"]);
   });
 });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -17,6 +17,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
+import { ArtifactNodeView, type ArtifactFlowNode } from "./ArtifactNodeView";
 import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
 import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
 import { ConversationNodeView, type ConversationFlowNode } from "./ConversationNodeView";
@@ -53,7 +54,8 @@ type SceneFlowNode =
   | HtmlFlowNode
   | ImageFlowNode
   | ConversationFlowNode
-  | WebResearchFlowNode;
+  | WebResearchFlowNode
+  | ArtifactFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   const zoom = useStore((s) => s.transform[2]);
@@ -81,6 +83,7 @@ const NODE_TYPES = {
   image: ImageNodeView,
   conversation: ConversationNodeView,
   web_research: WebResearchNodeView,
+  artifact: ArtifactNodeView,
 };
 
 // Exported standalone for direct unit testing (same posture as
@@ -316,6 +319,37 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
           // genuinely a non-null request id to target.
           onCancel: () => {
             if (n.pendingRequestId) store.cancelWebResearchRequest(n.pendingRequestId);
+          },
+        },
+      });
+      continue;
+    }
+    if (n.kind === "artifact") {
+      // No onDock here either (same reasoning as the html/image/conversation/
+      // web_research branches above) - ArtifactNodeView never offers a
+      // dock-into-parent action; the generic `if (n.isDocked) continue` guard
+      // above still covers it correctly if it were ever docked via a direct
+      // WS call.
+      flowNodes.push({
+        id: n.id,
+        type: "artifact" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          artifactContent: n.artifactContent,
+          history: n.history,
+          isCollapsed: n.isCollapsed,
+          pendingRequestId: n.pendingRequestId ?? null,
+          // Reuses the existing generic setChatCollapsed intent - same
+          // reasoning as every other non-chat node kind's onToggleCollapse
+          // above (the backend handler looks up ANY node by id).
+          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
+          onDelete: () => store.removeNodes([n.id]),
+          onSubmit: (text: string) => store.sendArtifactMessage(n.id, text),
+          // Same null-guard pattern as the conversation/web_research nodes'
+          // own analogous cancel call sites above - only fire the intent if
+          // there is genuinely a non-null request id to target.
+          onCancel: () => {
+            if (n.pendingRequestId) store.cancelArtifactRequest(n.pendingRequestId);
           },
         },
       });

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -47,6 +47,7 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         researchCompleted: 0,
         researchTotal: 0,
         researchError: "",
+        artifactContent: "",
       },
     ],
     edges: [],
@@ -287,6 +288,24 @@ describe("SceneStore", () => {
     store.cancelWebResearchRequest("req-99");
     expect(intents).toEqual([
       { topic: "scene", intent: "cancelWebResearchRequest", args: ["req-99"] },
+    ]);
+  });
+
+  it("sendArtifactMessage sends the scene-topic sendArtifactMessage intent with [nodeId, text]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.sendArtifactMessage("n1", "Draft a project proposal");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "sendArtifactMessage", args: ["n1", "Draft a project proposal"] },
+    ]);
+  });
+
+  it("cancelArtifactRequest sends the scene-topic cancelArtifactRequest intent with the requestId", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.cancelArtifactRequest("req-13");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "cancelArtifactRequest", args: ["req-13"] },
     ]);
   });
 

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -335,6 +335,20 @@ export class SceneStore {
     this.transport.intent("scene", "cancelWebResearchRequest", [requestId]);
   }
 
+  // R5.2: real Artifact/Drafter plugin - sendArtifactMessage appends a real
+  // user instruction AND triggers ArtifactAgent.get_response(current_artifact,
+  // history) for an existing artifact node; cancelArtifactRequest targets it
+  // by its own in-flight requestId, the same requestId-not-nodeId shape
+  // cancelConversationRequest/cancelWebResearchRequest above already
+  // established for their own per-node cancel.
+  sendArtifactMessage(nodeId: string, text: string): void {
+    this.transport.intent("scene", "sendArtifactMessage", [nodeId, text]);
+  }
+
+  cancelArtifactRequest(requestId: string): void {
+    this.transport.intent("scene", "cancelArtifactRequest", [requestId]);
+  }
+
   // R3.3: the Composer's real Send action - a real user ChatNode. The
   // assistant's reply is deferred to R4 (graphlink_config.py's Qt/non-Qt
   // split is a prerequisite for calling the real agent layer); the backend

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2755,3 +2755,142 @@ body,
 .web-research-node-source-status-fetching {
   color: var(--gl-semantic-status-info, currentColor);
 }
+
+/* -- R5.2 artifact node ------------------------------------------------- */
+
+.artifact-node {
+  width: 420px;
+  max-height: 640px;
+  min-height: 110px;
+}
+
+.artifact-node.collapsed {
+  width: 290px;
+  min-height: 58px;
+}
+
+.artifact-node-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 560px;
+  overflow-y: auto;
+}
+
+.artifact-node-document {
+  display: flex;
+  flex-direction: column;
+}
+
+.artifact-node-empty {
+  margin: 0;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--gl-surface-text-muted);
+}
+
+/* Reuses .chat-node-content's full markdown-body rule set (headings, lists,
+   code, tables, hljs) verbatim - same shared-class convention
+   .conversation-node-bubble-content/.web-research-node-answer already
+   establish for this pipeline. Only overrides the max-height/overflow-y a
+   nested preview pane should never take on its own (the outer
+   .artifact-node-content already scrolls). */
+.artifact-node-document-content {
+  max-height: none;
+  overflow: visible;
+}
+
+/* The turn history - same scrollable-list posture as
+   .conversation-node-messages, applied here below the document preview
+   rather than as the node's only content region. */
+.artifact-node-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Per-turn bubble - reuses conversation-node-bubble's own role-modifier
+   convention (var(--gl-neutral-button-hover) for the user variant) under
+   this node kind's own class name. */
+.artifact-node-bubble {
+  padding: 8px 10px;
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 8px;
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+}
+
+.artifact-node-bubble.user {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.artifact-node-bubble-content {
+  max-height: none;
+  overflow: visible;
+}
+
+.artifact-node-input-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.artifact-node-input {
+  box-sizing: border-box;
+  width: 100%;
+  resize: none;
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 8px 10px;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.artifact-node-input:focus {
+  outline: none;
+  border-color: var(--gl-surface-text-muted);
+}
+
+.artifact-node-input-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+/* Reuses conversation-node/web-research-node's send/cancel button chrome
+   verbatim (same shared-token convention already established across sibling
+   node views) rather than duplicating the two declarations under a new
+   name. */
+.artifact-node-submit-btn,
+.artifact-node-cancel-btn {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 5px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.artifact-node-submit-btn {
+  color: var(--gl-surface-window);
+  background-color: var(--gl-surface-text-muted);
+  border: none;
+}
+
+.artifact-node-submit-btn:hover:enabled {
+  filter: brightness(1.1);
+}
+
+.artifact-node-submit-btn:disabled,
+.artifact-node-cancel-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.artifact-node-cancel-btn {
+  color: var(--gl-surface-text);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+}

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -44,6 +44,9 @@
       "items": {
         "additionalProperties": false,
         "properties": {
+          "artifactContent": {
+            "type": "string"
+          },
           "attachmentKind": {
             "type": "string"
           },
@@ -291,7 +294,8 @@
           "researchStage",
           "researchCompleted",
           "researchTotal",
-          "researchError"
+          "researchError",
+          "artifactContent"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -29,6 +29,7 @@ export interface SceneNodeRow {
   researchActiveSourceId?: string | null;
   researchError: string;
   researchResult?: ResearchResultRow | null;
+  artifactContent: string;
 }
 
 export interface ConversationMessageRow {
@@ -240,6 +241,11 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
   {
     const fieldValue = value["researchResult"];
     if (fieldValue !== undefined && fieldValue !== null) { checkResearchResultRow(fieldValue, `${path}.researchResult`, errors); }
+  }
+  {
+    const fieldValue = value["artifactContent"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.artifactContent: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.artifactContent` + ": expected string"); }
   }
 }
 


### PR DESCRIPTION
## Summary
- Second R5 (Plugins) increment: replaces the "lands in R3/R5" placeholder with a real Artifact/Drafter node - a living-document generate/refine loop backed by the existing ArtifactAgent LLM logic, dispatched on a fourth independent AgentDispatcher slot concurrent with chat, image, and web-research.
- A real Qt-free file split (not a one-line import swap): `graphlink_agents_artifact.py` had an unconditional `PySide6.QtCore` import that would otherwise enter the FastAPI process the moment this plugin is imported - the same bug class R4.2 already fixed for chat. `ArtifactAgent` moves verbatim into a new `graphlink_artifact_agent.py`; the legacy file keeps only `ArtifactWorkerThread` + a re-export, confirmed zero-behavior-change for the still-running legacy Qt app by a dedicated legacy-safety review.
- One additive `SceneNode` field (`artifact_content`, whole-document-replace) reuses the already-generic `history` list `ConversationNode` established - no parallel state store needed.
- New `ArtifactNodeView` reuses the exact `ReactMarkdown`/`remarkGfm`/`rehypeHighlight` configuration already established elsewhere (no `rehype-raw`, no `dangerouslySetInnerHTML`) - same raw-HTML-safety guarantee by construction. `PluginPicker` needed zero changes.
- 5-way adversarial review (backend/frontend/integration/XSS/legacy-safety) found **zero confirmed bugs**. Two real regressions (stale mock-patch targets in a pre-existing test, a missing `pyproject.toml` entry) were caught and fixed before review.

## Test plan
- [x] `python -m pytest backend/tests/ graphlink_app/tests/ -q` — 2122 passed
- [x] `npx tsc --noEmit -p .` — 0 errors
- [x] `npx vitest run` — 781 passed (70 files)
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run check:schema` — 25 generated artifact sets up to date, no drift
- [x] Live-driven against the real backend + a real Ollama model in a browser: node creation via plugin picker, 4 full generate/refine round trips, whole-document-replace confirmed genuine across 3 refine calls, cross-node concurrency (chat message completing independently while an Artifact refine was in flight), and WS-reconnect persistence (state survives a full page reload)
- [x] One honest finding recorded in the ledger (not a regression): this sandbox's small reasoning-mode test model occasionally writes draft `<artifact>` tag examples inside its own chain-of-thought, which the legacy-inherited, unmodified tag-parsing regex can match instead of the final answer - reproduces identically against the legacy Qt app's own identical regex, flagged for a future increment