### PR TITLE
Qt-removal R5.3: Gitlink plugin - repo browse/context/generate/apply pipeline

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -59,16 +59,28 @@ in one blocking call or was assembled from many small chunks.
 from __future__ import annotations
 
 import asyncio
+import difflib
 import inspect
 import logging
 import threading
 import uuid
+from pathlib import Path
+from urllib.parse import quote
 
 import api_provider
 import graphlink_task_config as config
 from graphlink_artifact_agent import ArtifactAgent
 from graphlink_chat_agent import ChatAgent
 from graphlink_licensing import SettingsManager  # type hint only
+from graphlink_plugins.common.github_client import GitHubRestClient
+from graphlink_plugins.gitlink.agent import GitlinkAgent, _fingerprint_changes, _is_repo_text_path
+from graphlink_plugins.gitlink.repository import (
+    GitlinkRepository,
+    apply_change_set,
+    default_import_root,
+    read_local_repo_file,
+    validate_pending_changes,
+)
 from graphlink_plugins.web_research.domain import (
     CancellationToken,
     ProgressEvent,
@@ -95,6 +107,47 @@ WATCHDOG_TIMEOUT_SECONDS = 420
 # has its own outer timeout beyond this one. Realistic worst-case legitimate
 # duration is roughly 660s, so 900s gives headroom without being unbounded.
 WEB_RESEARCH_WATCHDOG_TIMEOUT_SECONDS = 900
+
+# R5.3: Gitlink's six timeout constants, each independently reasoned rather
+# than reused from an existing constant whose justification doesn't apply
+# here.
+#
+# One LLM completion (same call-count shape as chat/artifact, whose 420s
+# already covers that shape) but can carry up to 180,000 chars of input
+# context (repository.py's MAX_CONTEXT_CHARS) - an order of magnitude more
+# prompt than typical, measurably increasing processing/queueing latency even
+# at identical call-count. A deliberate bump over 420s for THIS reason alone -
+# NOT web research's 900s reasoning (which exists because that service chains
+# ~10 sequential calls inside one outer timeout; Gitlink's run is one call).
+GITLINK_WATCHDOG_TIMEOUT_SECONDS = 600
+# Local disk I/O only, no network - generous headroom, short enough to fail
+# fast.
+GITLINK_APPLY_TIMEOUT_SECONDS = 30
+# Up to 5 sequential paginated GET /user/repos calls (MAX_REPO_PAGES).
+GITLINK_REPO_LIST_TIMEOUT_SECONDS = 150
+# One branch-resolve GET (GET /repos/{repo}) + one recursive tree GET.
+GITLINK_TREE_TIMEOUT_SECONDS = 60
+# One zipball GET (network-timeout-capped at 60s by
+# GitlinkRepository.download_repository_snapshot itself) + local
+# extract/move.
+GITLINK_IMPORT_TIMEOUT_SECONDS = 90
+# Bounded by selected-file count when no local_root is set (one GitHub file
+# fetch per selected path); local-root-backed builds are pure disk I/O and
+# finish well under this.
+GITLINK_CONTEXT_TIMEOUT_SECONDS = 300
+
+# R5.3 post-review FIX 4(b): the sentinel value backend/canvas.py's
+# run_gitlink_change_set stores into node.pending_request_id SYNCHRONOUSLY,
+# in the same stretch as its own busy pre-check, immediately before ever
+# calling start_gitlink_run below - this closes the real await-spanning gap
+# between that pre-check and start_gitlink_run's own synchronous claim
+# (spanning run_gitlink_change_set's own `await publish_scene()`). See
+# start_gitlink_run's own docstring and run_gitlink_change_set's own comment
+# for the full race this closes. start_gitlink_run recognizes ONLY this
+# exact value as "already claimed by my own caller, safe to overwrite" - any
+# OTHER truthy pending_request_id is still a genuine busy node and is
+# rejected exactly as before.
+_GITLINK_RUN_CLAIM_PLACEHOLDER = "pending"
 
 
 def bootstrap_provider_state(settings_manager: SettingsManager) -> None:
@@ -198,6 +251,31 @@ class AgentDispatcher:
         # every prior independent slot above. request_id -> {"cancel_event":
         # threading.Event, "task": asyncio.Task}.
         self._artifact_requests: dict[str, dict] = {}
+        # R5.3: a FIFTH independent in-flight-request slot, separate from
+        # self._requests/self._image_requests/self._web_research_requests/
+        # self._artifact_requests - a Gitlink Generate Change Set run must be
+        # able to run concurrently with any of those four, same reasoning as
+        # every prior independent slot above. request_id -> {"cancel_event":
+        # threading.Event, "task": asyncio.Task} - Run is cancellable,
+        # mirrors self._web_research_requests' exact shape.
+        self._gitlink_requests: dict[str, dict] = {}
+        # R5.3: a SIXTH independent in-flight-request slot - Gitlink's Apply
+        # (the disk-write step) must be able to run concurrently with a
+        # Gitlink Run on a DIFFERENT node, or with any other kind's dispatch.
+        # request_id -> {"task": asyncio.Task} - NO "cancel_event" key here,
+        # matching self._image_requests' shape: legacy has zero cancel
+        # affordance for the disk-write step either. (Same-node concurrent
+        # Run+Apply is additionally blocked by node.pending_request_id - see
+        # register_canvas's own busy checks in backend/canvas.py - this dict
+        # split is about cross-request bookkeeping, not the same-node guard.)
+        self._gitlink_apply_requests: dict[str, dict] = {}
+
+    def cancel_gitlink(self, request_id: str) -> bool:
+        entry = self._gitlink_requests.get(request_id)
+        if entry is None:
+            return False
+        entry["cancel_event"].set()
+        return True
 
     def persona(self) -> str:
         """Mirror legacy graphlink_window.py's `_get_current_system_prompt`:
@@ -829,6 +907,430 @@ class AgentDispatcher:
             "cancel_event": cancel_event, "task": asyncio.create_task(_run())
         }
 
+    # -- R5.3: Gitlink ------------------------------------------------------
+    #
+    # Four PLAIN async methods below (fetch_gitlink_repositories/
+    # load_gitlink_repo_tree/import_gitlink_snapshot/build_gitlink_context) -
+    # NO dict-tracking: the caller (backend/canvas.py's register_canvas) already
+    # guards busy-state via node.pending_request_id directly before calling,
+    # and each of these is awaited DIRECTLY by that caller (not scheduled via
+    # asyncio.create_task the way start_chat_reply/start_web_research/
+    # start_artifact_reply/start_gitlink_run/start_gitlink_apply are) - there
+    # is no natural intermediate UI state beyond "loading" for a one-shot
+    # listing/import/context-build action, and the caller needs the result
+    # back in the same round trip. node.pending_request_id is still the busy
+    # marker for the duration (see AgentDispatcher.__init__'s own comment on
+    # why every Gitlink action - including these four - shares that one
+    # field); it is set/cleared inline here rather than via a background task.
+
+    async def fetch_gitlink_repositories(self, *, bus: SessionBus, notifications_state, node) -> list[str]:
+        request_id = uuid.uuid4().hex
+        node.pending_request_id = request_id
+        await bus.publish("scene")
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(_list_github_repositories, self._settings_manager),
+                timeout=GITLINK_REPO_LIST_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            notifications_state.show(
+                "Loading GitHub repositories stopped responding before the request completed. "
+                "Please try again.",
+                "error",
+            )
+            await bus.publish("notification")
+            return []
+        except Exception as exc:
+            logger.exception("gitlink repository listing failed")
+            notifications_state.show(f"Failed to load GitHub repositories: {exc}", "error")
+            await bus.publish("notification")
+            return []
+        finally:
+            node.pending_request_id = None
+            await bus.publish("scene")
+
+    async def load_gitlink_repo_tree(self, *, bus: SessionBus, notifications_state, node, repo: str, branch: str):
+        request_id = uuid.uuid4().hex
+        node.pending_request_id = request_id
+        await bus.publish("scene")
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(_load_gitlink_tree, self._settings_manager, repo, branch),
+                timeout=GITLINK_TREE_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            notifications_state.show(
+                "Loading the repository file tree stopped responding before the request "
+                "completed. Please try again.",
+                "error",
+            )
+            await bus.publish("notification")
+            return None
+        except Exception as exc:
+            logger.exception("gitlink repo tree load failed")
+            notifications_state.show(f"Failed to load the repository file tree: {exc}", "error")
+            await bus.publish("notification")
+            return None
+        finally:
+            node.pending_request_id = None
+            await bus.publish("scene")
+
+    async def import_gitlink_snapshot(
+        self, *, bus: SessionBus, notifications_state, node, repo: str, branch: str,
+        local_root_hint: str, imported_root_hint: str,
+    ):
+        request_id = uuid.uuid4().hex
+        node.pending_request_id = request_id
+        await bus.publish("scene")
+        try:
+            resolved_repo, resolved_branch, local_root_path = await asyncio.wait_for(
+                asyncio.to_thread(
+                    _ensure_gitlink_snapshot, self._settings_manager, repo, branch,
+                    local_root_hint, imported_root_hint,
+                ),
+                timeout=GITLINK_IMPORT_TIMEOUT_SECONDS,
+            )
+            return resolved_repo, resolved_branch, str(local_root_path)
+        except asyncio.TimeoutError:
+            notifications_state.show(
+                "Importing the repository snapshot stopped responding before the request "
+                "completed. Please try again.",
+                "error",
+            )
+            await bus.publish("notification")
+            return None
+        except Exception as exc:
+            logger.exception("gitlink snapshot import failed")
+            notifications_state.show(f"Failed to import the repository snapshot: {exc}", "error")
+            await bus.publish("notification")
+            return None
+        finally:
+            node.pending_request_id = None
+            await bus.publish("scene")
+
+    async def build_gitlink_context(
+        self, *, bus: SessionBus, notifications_state, node, scope_mode: str, selected_paths: list[str],
+    ):
+        request_id = uuid.uuid4().hex
+        node.pending_request_id = request_id
+        await bus.publish("scene")
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(
+                    _build_gitlink_context_bundle,
+                    self._settings_manager,
+                    repo=node.gitlink_repo,
+                    branch=node.gitlink_branch,
+                    scope_mode=scope_mode,
+                    selected_paths=selected_paths,
+                    repo_file_paths=list(node.gitlink_repo_file_paths),
+                    local_root_hint=node.gitlink_local_root,
+                    imported_root_hint=node.gitlink_imported_root,
+                ),
+                timeout=GITLINK_CONTEXT_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            notifications_state.show(
+                "Building the repository context stopped responding before the request "
+                "completed. Please try again.",
+                "error",
+            )
+            await bus.publish("notification")
+            return None
+        except Exception as exc:
+            logger.exception("gitlink context build failed")
+            notifications_state.show(f"Failed to build the repository context: {exc}", "error")
+            await bus.publish("notification")
+            return None
+        finally:
+            node.pending_request_id = None
+            await bus.publish("scene")
+
+    async def start_gitlink_run(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        node,
+        node_id: str,
+        repo: str,
+        branch: str,
+        scope_mode: str,
+        task_prompt: str,
+        context_xml: str,
+        context_summary: str,
+        local_root: str,
+        on_success,
+        on_failure,
+    ) -> None:
+        """R5.3: Gitlink's Generate Change Set action - the independent
+        Gitlink Run slot, mirroring start_web_research/start_artifact_reply's
+        own fire-and-forget shape: the caller (register_canvas's
+        run_gitlink_change_set) returns immediately after this schedules its
+        background task; the eventual result lands via on_success/on_failure
+        plus a "scene" republish, same as every other kind's real dispatch.
+
+        Cooperative cancellation only, via a threading.Event
+        (GitlinkAgent.get_response has no cancellation primitive of its own)
+        - same honestly-documented limitation as every other dispatch
+        surface: the checkpoint is placed AFTER the blocking call returns, so
+        a cancel requested while the model call is already in flight discards
+        the result rather than truly interrupting the underlying network
+        call.
+
+        The fingerprint is computed over the EXACT change set about to be
+        shown - mirrors legacy's own shown_fingerprint, computed immediately
+        before display, never a value captured earlier or later.
+
+        DEFENSE-IN-DEPTH busy guard, checked here too (not only by
+        register_canvas's own run_gitlink_change_set pre-check): node.
+        pending_request_id is the shared busy marker for EVERY Gitlink
+        action on this node, and the whole point of that field is making the
+        Run-cannot-start-while-an-Apply-is-in-flight (and vice versa)
+        guarantee hold regardless of call site. Checking it again here means
+        a future caller that skips the canvas.py pre-check can never
+        accidentally start a second concurrent Gitlink action on the same
+        node. The ONE exception is _GITLINK_RUN_CLAIM_PLACEHOLDER (see that
+        constant's own comment): run_gitlink_change_set stores that exact
+        sentinel into node.pending_request_id, synchronously, immediately
+        before calling this method - this method recognizes it as "already
+        claimed by my own caller" and overwrites it, rather than rejecting a
+        request its own caller just admitted.
+
+        R5.3 post-review FIX 4(a): node.pending_request_id is now claimed
+        SYNCHRONOUSLY here, immediately after the busy check and BEFORE
+        asyncio.create_task(_run()) below - mirroring start_gitlink_apply's
+        own claim exactly. Before this fix, the slot stayed empty until
+        _run() actually got a turn on the event loop, leaving a real gap
+        between "Run was requested" and "Run's sub-task actually started"
+        during which a second concurrent Run or an Apply for the same node
+        could slip past the busy check above."""
+        if node.pending_request_id and node.pending_request_id != _GITLINK_RUN_CLAIM_PLACEHOLDER:
+            notifications_state.show("Gitlink is already busy for this node.", "info")
+            await bus.publish("notification")
+            return
+
+        request_id = uuid.uuid4().hex
+        node.pending_request_id = request_id
+        cancel_event = threading.Event()
+        await bus.publish("scene")
+
+        async def _run():
+            try:
+                payload = {
+                    "task_prompt": task_prompt,
+                    "context_xml": context_xml,
+                    "repo": repo,
+                    "branch": branch,
+                    "scope_label": "Full Repo Access" if scope_mode == "full" else "Selected Files",
+                    "context_summary": context_summary,
+                    "branch_transcript": "",
+                }
+                result = await asyncio.wait_for(
+                    asyncio.to_thread(_call_gitlink_agent, payload),
+                    timeout=GITLINK_WATCHDOG_TIMEOUT_SECONDS,
+                )
+                if cancel_event.is_set():
+                    notifications_state.show("Gitlink generation cancelled.", "info")
+                    await bus.publish("notification")
+                else:
+                    proposal_markdown = _build_gitlink_proposal_markdown(repo, branch, result)
+                    preview_text = _build_gitlink_preview_text(result["files"], local_root, repo, branch)
+                    fingerprint = _fingerprint_changes(result["files"]) if result["files"] else None
+                    # R5.3 post-review FIX 2: local_root is now forwarded to
+                    # on_success too, so document.complete_gitlink_run can
+                    # record exactly which local_root THIS run used (see that
+                    # method's own docstring) - the write-destination binding
+                    # start_gitlink_apply's fourth check enforces.
+                    on_success(proposal_markdown, result["files"], preview_text, fingerprint, local_root)
+                    await bus.publish("scene")
+            except asyncio.TimeoutError:
+                cancel_event.set()
+                notifications_state.show(
+                    "Gitlink generation stopped responding before the request completed. "
+                    "Please try again.",
+                    "error",
+                )
+                await bus.publish("notification")
+            except Exception as exc:
+                logger.exception("gitlink dispatch failed")
+                on_failure(f"Gitlink generation failed: {exc}")
+                notifications_state.show(f"Gitlink generation failed: {exc}", "error")
+                await bus.publish("notification")
+            finally:
+                self._gitlink_requests.pop(request_id, None)
+                # R5.3 post-review FIX 4(c): only clear if this task's OWN
+                # request_id is still the one recorded - a stale,
+                # already-superseded task finishing late must never clobber
+                # a newer legitimate busy marker.
+                if node.pending_request_id == request_id:
+                    node.pending_request_id = None
+                await bus.publish("scene")
+
+        self._gitlink_requests[request_id] = {
+            "cancel_event": cancel_event, "task": asyncio.create_task(_run())
+        }
+
+    async def start_gitlink_apply(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        node,
+        node_id: str,
+        client_fingerprint: str,
+        local_root: str,
+        on_success,
+        on_failure,
+    ) -> None:
+        """R5.3: Gitlink's Apply action - THE code the whole increment hinges
+        on. The fingerprint check and the freeze of the data that will
+        actually be written happen in the SAME synchronous stretch of this
+        coroutine, with ZERO await between them. Python asyncio is
+        single-threaded; only an await yields control - so it is IMPOSSIBLE
+        (not merely unlikely) for node.gitlink_pending_changes to be mutated
+        between the recompute and the freeze immediately after it. This is a
+        STRONGER guarantee than legacy's own check, because legacy's
+        confirmation dialog is a real blocking call that pumps the Qt event
+        loop (letting a background thread's finished signal run mid-dialog) -
+        this coroutine has no equivalent yield point until deliberately
+        introduced AFTER the freeze.
+
+        R5.3 post-review FIX 5: node.pending_request_id is now claimed
+        SYNCHRONOUSLY here, immediately after the busy check above and
+        BEFORE the local_root_text validation - mirroring start_gitlink_run's
+        own early synchronous claim (see that method's own docstring). Before
+        this fix, the busy slot stayed unclaimed all the way through the
+        local_root_text validation, the `await asyncio.to_thread(local_root_
+        path.exists)` call below (a real yield point), and the entire atomic
+        fingerprint/local_root section, only ever being set at the very end,
+        just before scheduling _run(). Two genuinely concurrent Apply calls
+        for the SAME node (two different WebSocket connections on the same
+        session, e.g. two browser tabs - not a single connection's
+        sequential message loop) could both read node.pending_request_id as
+        falsy before either claimed it, both proceed through the exists()
+        await and the atomic section, and both end up scheduling a write via
+        apply_change_set concurrently - a real write-safety issue, since two
+        concurrent writers touching the same files' backup/rollback
+        bookkeeping is not something apply_change_set was designed to
+        tolerate. Every early-return failure path BELOW this claim (empty
+        pending_changes, empty local_root, nonexistent local_root,
+        fingerprint mismatch, local_root mismatch) now ALSO clears
+        node.pending_request_id back to None before returning, since none of
+        those paths ever reach _run()'s own finally block - without that
+        clear, a legitimately-rejected Apply would leave the node
+        permanently stuck "busy"."""
+        if node.pending_request_id:
+            notifications_state.show("Gitlink is already busy for this node.", "info")
+            await bus.publish("notification")
+            return
+
+        request_id = uuid.uuid4().hex
+        node.pending_request_id = request_id
+
+        if not node.gitlink_pending_changes:
+            node.pending_request_id = None
+            on_failure("There is no approved change set to write.")
+            await bus.publish("scene")
+            return
+
+        local_root_text = (local_root or "").strip()
+        if not local_root_text:
+            node.pending_request_id = None
+            on_failure("Select or import a local repository path before applying changes.")
+            await bus.publish("scene")
+            return
+        local_root_path = Path(local_root_text).expanduser()
+        # R5.3 post-review FIX 3: wrapped in asyncio.to_thread, like every
+        # other filesystem check in this file - this was the sole exception,
+        # running synchronously directly on the shared event loop. Placed
+        # BEFORE the atomic check-and-freeze section below, so this await
+        # does not touch that section's own zero-await guarantee (which only
+        # covers the fingerprint-check-through-snapshot-freeze part). R5.3
+        # post-review FIX 5: this await is now the reason the busy claim
+        # above had to move earlier - a second concurrent call could
+        # otherwise slip past the busy check while this await has yielded
+        # control.
+        local_root_exists = await asyncio.to_thread(local_root_path.exists)
+        if not local_root_exists:
+            node.pending_request_id = None
+            on_failure("The selected local repository path does not exist.")
+            await bus.publish("scene")
+            return
+
+        # --- Atomic check-and-freeze: NO await between these statements. ---
+        current_fingerprint = _fingerprint_changes(node.gitlink_pending_changes)
+        if (
+            client_fingerprint != current_fingerprint
+            or current_fingerprint != node.gitlink_change_fingerprint
+        ):
+            node.pending_request_id = None
+            on_failure("The proposed change set changed after approval. Review it again before applying.")
+            await bus.publish("scene")
+            return
+        # R5.3 post-review FIX 2: the fingerprint above says nothing about
+        # WHERE the content is written - _fingerprint_changes only hashes
+        # file content/paths/operations, never local_root (deliberately not
+        # modified here - it is reused verbatim from gitlink/agent.py, shared
+        # with the legacy Qt app). Without this separate check, a
+        # gitlink_local_root edited after Run but before Apply would let
+        # previously-reviewed content be written into a directory that was
+        # never diffed or shown to the user. Compared as raw trimmed text,
+        # consistent with how local_root_text itself is derived just above
+        # and how document.complete_gitlink_run records
+        # gitlink_change_local_root.
+        if local_root_text != (node.gitlink_change_local_root or ""):
+            node.pending_request_id = None
+            on_failure(
+                "The local repository path changed since this proposal was generated. "
+                "Regenerate the change set before applying."
+            )
+            await bus.publish("scene")
+            return
+        changes_snapshot = [dict(item) for item in node.gitlink_pending_changes]
+        # --- End atomic section. Everything past this point operates ONLY on
+        # changes_snapshot, never on node.gitlink_pending_changes again. ---
+
+        # R5.3 post-review FIX 5: request_id was already generated and
+        # claimed into node.pending_request_id right after the busy check
+        # above - NOT re-generated here. Only the change_state transition and
+        # publish happen at this point now.
+        node.gitlink_change_state = "applying"
+        await bus.publish("scene")
+
+        async def _run():
+            try:
+                written_files = await asyncio.wait_for(
+                    asyncio.to_thread(_call_gitlink_apply, local_root_path, changes_snapshot),
+                    timeout=GITLINK_APPLY_TIMEOUT_SECONDS,
+                )
+                on_success(written_files)
+                notifications_state.show(f"Applied {written_files} file changes.", "info")
+                await bus.publish("notification")
+            except asyncio.TimeoutError:
+                on_failure(
+                    "Applying changes stopped responding before the request completed. "
+                    "Some files may have been partially written - check the repository "
+                    "before retrying."
+                )
+                notifications_state.show("Gitlink apply timed out.", "error")
+                await bus.publish("notification")
+            except Exception as exc:
+                logger.exception("gitlink apply failed")
+                on_failure(f"Failed to write approved changes: {exc}")
+                notifications_state.show(f"Gitlink apply failed: {exc}", "error")
+                await bus.publish("notification")
+            finally:
+                self._gitlink_apply_requests.pop(request_id, None)
+                # R5.3 post-review FIX 4(c): only clear if this task's OWN
+                # request_id is still the one recorded - same stale-task
+                # guard as start_gitlink_run's own finally block above.
+                if node.pending_request_id == request_id:
+                    node.pending_request_id = None
+                await bus.publish("scene")
+
+        self._gitlink_apply_requests[request_id] = {"task": asyncio.create_task(_run())}
+
 
 def _call_chat_agent(conversation_history, persona_text, cancel_event) -> str:
     """Runs inside asyncio.to_thread - a real OS thread, not the event loop."""
@@ -893,6 +1395,307 @@ def _call_artifact_agent(current_artifact, history):
     never touched in that case since mutation only happens in the success
     branch."""
     return ArtifactAgent().get_response(current_artifact, history)
+
+
+# -- R5.3: Gitlink - blocking helpers, each runs inside asyncio.to_thread ----
+#
+# These replicate the exact GitHub REST call shapes graphlink_plugin_gitlink.py's
+# legacy GitlinkNode uses (load_github_repositories/load_repository_tree/
+# _resolve_repo_and_branch/_ensure_repository_snapshot/build_context_bundle),
+# confirmed by reading that file directly, as new plain functions here using
+# GitHubRestClient.request() directly - repo-listing and tree-loading were
+# never extracted into the Qt-free gitlink package, so there is no existing
+# Qt-free surface to import for them.
+
+# Up to 5 sequential pages of GET /user/repos, matching legacy's own
+# MAX_REPO_PAGES constant.
+_GITLINK_MAX_REPO_PAGES = 5
+
+
+def _list_github_repositories(settings_manager):
+    """Replicates load_github_repositories exactly: GET /user/repos with
+    per_page=100, sort=updated, visibility=all,
+    affiliation=owner,collaborator,organization_member, looped while
+    page <= 5, collecting each page's item full_name, stopping early on a
+    short/empty page. Returns the sorted, deduplicated list of repo
+    full_names."""
+    client = GitHubRestClient(settings_manager)
+    repos: list[str] = []
+    page = 1
+    while page <= _GITLINK_MAX_REPO_PAGES:
+        page_payload = client.request(
+            "https://api.github.com/user/repos",
+            params={
+                "per_page": 100,
+                "page": page,
+                "sort": "updated",
+                "visibility": "all",
+                "affiliation": "owner,collaborator,organization_member",
+            },
+        )
+        if not page_payload:
+            break
+        repos.extend(item.get("full_name", "") for item in page_payload if item.get("full_name"))
+        if len(page_payload) < 100:
+            break
+        page += 1
+    return sorted(set(repos), key=str.lower)
+
+
+def _resolve_gitlink_branch(client, repo_name, branch_hint):
+    """Replicates the branch-resolution half of _resolve_repo_and_branch: an
+    explicit branch_hint wins outright; otherwise GET /repos/{repo_name} and
+    read default_branch."""
+    branch_name = (branch_hint or "").strip()
+    if branch_name:
+        return branch_name
+    repo_payload = client.request(f"https://api.github.com/repos/{repo_name}")
+    default_branch = repo_payload.get("default_branch", "")
+    if not default_branch:
+        raise RuntimeError("GitHub did not provide a default branch for this repository.")
+    return default_branch
+
+
+def _load_gitlink_tree(settings_manager, repo, branch):
+    """Replicates load_repository_tree exactly: resolve repo/branch, GET the
+    recursive git tree, keep only blob entries whose path passes
+    _is_repo_text_path. Returns (repo, resolved_branch, sorted_file_paths)."""
+    if not repo or "/" not in repo:
+        raise RuntimeError("Enter a repository as `owner/repo`.")
+    client = GitHubRestClient(settings_manager)
+    resolved_branch = _resolve_gitlink_branch(client, repo, branch)
+    tree_payload = client.request(
+        f"https://api.github.com/repos/{repo}/git/trees/{quote(resolved_branch, safe='')}",
+        params={"recursive": 1},
+    )
+    tree_items = tree_payload.get("tree", [])
+    file_paths = sorted(
+        (
+            item.get("path", "")
+            for item in tree_items
+            if item.get("type") == "blob" and item.get("path") and _is_repo_text_path(item.get("path", ""))
+        ),
+        key=str.lower,
+    )
+    return repo, resolved_branch, file_paths
+
+
+def _ensure_gitlink_snapshot(settings_manager, repo, branch, local_root_hint, imported_root_hint):
+    """Replicates _ensure_repository_snapshot exactly: an existing
+    local_root_hint wins outright (error if it does not exist); else an
+    existing imported_root_hint is reused if it still exists; else a fresh
+    snapshot is downloaded to default_import_root(repo, branch) (itself
+    short-circuiting if that target already exists non-empty). Returns
+    (repo, resolved_branch, local_root_path). Shared by both
+    import_gitlink_snapshot and build_gitlink_context's own full-scope path -
+    factored out once here rather than duplicated, per the design spec."""
+    client = GitHubRestClient(settings_manager)
+    resolved_branch = _resolve_gitlink_branch(client, repo, branch)
+
+    local_root_text = (local_root_hint or "").strip()
+    if local_root_text:
+        root_path = Path(local_root_text).expanduser()
+        if root_path.exists():
+            return repo, resolved_branch, root_path
+        raise RuntimeError("The selected local repo path does not exist.")
+
+    imported_root_text = (imported_root_hint or "").strip()
+    if imported_root_text:
+        imported_path = Path(imported_root_text)
+        if imported_path.exists():
+            return repo, resolved_branch, imported_path
+
+    target_root = default_import_root(repo, resolved_branch)
+    repository = GitlinkRepository(client)
+    target_path = repository.download_repository_snapshot(repo, resolved_branch, target_root)
+    return repo, resolved_branch, target_path
+
+
+def _build_gitlink_context_bundle(
+    settings_manager, *, repo, branch, scope_mode, selected_paths, repo_file_paths,
+    local_root_hint, imported_root_hint,
+):
+    """Replicates the build_context_bundle wrapper: resolve local_root from
+    local_root_hint (None if blank; error if set but does not exist); if
+    scope_mode is "full" and local_root is still None, ensure a snapshot
+    first (reusing _ensure_gitlink_snapshot rather than duplicating it); then
+    delegate to GitlinkRepository.build_context_bundle. Returns a dict with
+    context_xml/context_stats/context_summary keys, matching
+    store_gitlink_context(node_id, scope_mode=..., selected_paths=...,
+    **result)'s call shape in backend/canvas.py.
+
+    DEVIATION from a strict line-for-line legacy replication, noted
+    explicitly: legacy's own build_context_bundle wrapper unconditionally
+    calls _resolve_repo_and_branch() at its very top (one GET
+    /repos/{repo_name} every time, even for a purely local-root/selected-
+    files build). This function only resolves the branch via GitHub when a
+    snapshot actually needs to be ensured (scope_mode == "full" and no
+    local_root) - matching the design spec's own literal parameter passing
+    (`branch_name=node.gitlink_branch`) rather than legacy's more eager
+    resolution. A local-root-backed build with a blank branch therefore
+    proceeds using an empty branch string (harmless: build_context_bundle
+    only reads files from local_root in that case, never from GitHub, and
+    branch only ends up in cosmetic XML attributes)."""
+    local_root_text = (local_root_hint or "").strip()
+    local_root = None
+    if local_root_text:
+        local_root = Path(local_root_text).expanduser()
+        if not local_root.exists():
+            raise RuntimeError("The selected local repo path does not exist.")
+
+    resolved_branch = branch
+    if scope_mode == "full" and local_root is None:
+        _, resolved_branch, local_root = _ensure_gitlink_snapshot(
+            settings_manager, repo, branch, local_root_hint, imported_root_hint
+        )
+
+    client = GitHubRestClient(settings_manager)
+    repository = GitlinkRepository(client)
+    result = repository.build_context_bundle(
+        repo_name=repo,
+        branch_name=resolved_branch,
+        scope_mode=scope_mode,
+        selected_paths=selected_paths,
+        repo_file_paths=repo_file_paths,
+        local_root=local_root,
+    )
+    return {
+        "context_xml": result.context_xml,
+        "context_stats": dict(result.context_stats),
+        "context_summary": result.context_summary,
+    }
+
+
+def _call_gitlink_agent(payload):
+    """Runs inside asyncio.to_thread. Reuses GitlinkAgent.get_response
+    verbatim - same defensive-by-construction dict-in/dict-out contract,
+    completely unmodified."""
+    return GitlinkAgent().get_response(payload)
+
+
+def _build_gitlink_proposal_markdown(repo, branch, result):
+    """Replicates _build_proposal_markdown exactly, as a plain function
+    operating on GitlinkAgent.get_response's own result dict instead of a
+    widget's repo_state."""
+    summary = result.get("summary") or "No summary returned."
+    rationale = result.get("rationale") or "No rationale returned."
+    notes = result.get("notes") or []
+    write_intent = result.get("write_intent", "blocked")
+    files = result.get("files") or []
+
+    lines = [
+        "## Gitlink Proposal",
+        "",
+        f"- Repository: {repo or 'Unknown repo'}",
+        f"- Branch: {branch or 'Unknown branch'}",
+        f"- Intent: {str(write_intent).replace('_', ' ').title()}",
+        f"- Files Returned: {len(files)}",
+        "",
+        "### Summary",
+        summary,
+        "",
+        "### Rationale",
+        rationale,
+    ]
+
+    if notes:
+        lines.extend(["", "### Notes"])
+        lines.extend(f"- {note}" for note in notes)
+
+    if files:
+        lines.extend(["", "### Proposed File Writes"])
+        for file_item in files:
+            lines.append(
+                f"- `{file_item.get('path', '')}` [{file_item.get('operation', 'update')}] - "
+                f"{file_item.get('reason', 'No reason supplied.')}"
+            )
+
+    return "\n".join(lines)
+
+
+def _build_gitlink_preview_text(files, local_root, repo, branch):
+    """Replicates _build_preview_text's diff-building shape, reusing
+    read_local_repo_file for the original-content side of each update/delete
+    diff. DEVIATION from legacy, noted explicitly: legacy's own
+    _read_original_text_for_preview falls back to a live GitHub fetch when no
+    local_root is configured; this function does NOT - it degrades
+    gracefully (shows the proposed content with an explicit warning banner
+    instead of a diff) rather than spending a GitHub API call per changed
+    file purely for a preview render. `repo`/`branch` are used only in that
+    warning's text, never for a network fetch."""
+    preview_parts = []
+    for file_item in files:
+        path_text = file_item.get("path", "")
+        operation = file_item.get("operation", "update")
+        original_text = None
+        if local_root:
+            try:
+                original_text = read_local_repo_file(local_root, path_text)
+            except Exception:
+                original_text = None
+        proposed_text = file_item.get("content", "") if operation in {"update", "create"} else ""
+
+        # None = the original could not be read (as opposed to "" = a real
+        # empty file). For update/delete that means no honest diff exists -
+        # say so explicitly instead of diffing against "" and rendering a
+        # misleading all-additions "create" diff. Creates never need the
+        # original, so they render normally either way. Mirrors the A2 fix
+        # already shipped for the legacy widget's own preview builder.
+        if original_text is None and operation in {"update", "delete"}:
+            preview_parts.append(f"### {path_text} [{operation}]\n")
+            preview_parts.append(
+                "!! WARNING: the original file could not be read (no local checkout is "
+                f"configured for {repo or 'this repository'}@{branch or 'unknown branch'}), "
+                "so no diff can be shown for this change."
+            )
+            if operation == "update":
+                preview_parts.append(
+                    "!! Applying will OVERWRITE the existing file with the full "
+                    "proposed content below:\n"
+                )
+                preview_parts.append(proposed_text if proposed_text else "[No content in proposal]")
+            else:
+                preview_parts.append("!! Applying will DELETE the file.")
+            preview_parts.append("")
+            continue
+        original_text = original_text or ""
+
+        if operation == "create":
+            diff_lines = list(
+                difflib.unified_diff(
+                    [], proposed_text.splitlines(), fromfile=f"a/{path_text}", tofile=f"b/{path_text}", lineterm="",
+                )
+            )
+        elif operation == "delete":
+            diff_lines = list(
+                difflib.unified_diff(
+                    original_text.splitlines(), [], fromfile=f"a/{path_text}", tofile=f"b/{path_text}", lineterm="",
+                )
+            )
+        else:
+            diff_lines = list(
+                difflib.unified_diff(
+                    original_text.splitlines(), proposed_text.splitlines(),
+                    fromfile=f"a/{path_text}", tofile=f"b/{path_text}", lineterm="",
+                )
+            )
+
+        preview_parts.append(f"### {path_text} [{operation}]\n")
+        if diff_lines:
+            preview_parts.append("\n".join(diff_lines))
+        else:
+            preview_parts.append("No textual diff available.")
+        preview_parts.append("")
+
+    return "\n".join(preview_parts).strip()
+
+
+def _call_gitlink_apply(local_root, pending_changes):
+    """Runs inside asyncio.to_thread. Reuses validate_pending_changes/
+    apply_change_set UNMODIFIED, verbatim - the path-safety boundary is never
+    reimplemented, only invoked."""
+    validate_pending_changes(pending_changes)
+    return apply_change_set(local_root, pending_changes)
 
 
 def register_agents(bus, composer_document, notifications_state, settings_manager) -> AgentDispatcher:

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -34,7 +34,7 @@ from graphlink_grid_view_settings import (
 )
 from graphlink_navigation_pins import NavigationPinRecord, NavigationPinStore
 
-from backend.agents import AgentDispatcher
+from backend.agents import _GITLINK_RUN_CLAIM_PLACEHOLDER, AgentDispatcher
 from backend.composer import ComposerDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -246,6 +246,85 @@ class SceneNode:
     # than a new list-typed field - only this one new scalar is needed.
     # Unused (default) for every other kind.
     artifact_content: str = ""
+    # R5.3: the Gitlink node's real persisted shape - reads a GitHub repo (or
+    # a local checkout) into structured XML context, proposes an LLM change
+    # set, and only writes to disk after an explicit, fingerprint-verified
+    # approval. Unused (default) for every other kind.
+    gitlink_repo: str = ""
+    gitlink_branch: str = ""
+    gitlink_scope_mode: str = "selected"
+    gitlink_local_root: str = ""
+    # Mirrors legacy repo_state["imported_root"] - remembers which local path
+    # a prior Import Repo Snapshot produced, so a later run can reuse it
+    # without re-downloading. Server-side bookkeeping ONLY: deliberately
+    # absent from scene_payload()/SceneNodeRow - there is no wire field for
+    # it, nothing on the frontend ever needs to read it directly (gitlink_
+    # local_root is what's shown/edited).
+    gitlink_imported_root: str = ""
+    gitlink_repo_file_paths: list[str] = field(default_factory=list)
+    gitlink_selected_paths: list[str] = field(default_factory=list)
+    gitlink_task_prompt: str = ""
+    # DESIGNED ceiling of 180,000 chars (repository.py's MAX_CONTEXT_CHARS) -
+    # an order of magnitude above this node's other fields' implicit
+    # ceilings. scene_payload() resends every node on roughly 20 undebounced
+    # triggers (see the image_assets comment above) - inlining a 180KB text
+    # blob there would reproduce that exact cost on every unrelated
+    # mutation for the rest of the session. EXCLUDED from scene_payload() on
+    # purpose; served on demand via the read-only fetchGitlinkContext intent
+    # instead (see fetch_gitlink_context_xml below). Deleted automatically
+    # when the node is deleted - no separate eviction bookkeeping needed
+    # (unlike image_assets, this never leaves this dataclass instance).
+    gitlink_context_xml: str = ""
+    # repository.py's build_context_bundle returns a mixed int/str dict
+    # (scanned_files/loaded_files/included_files/load_errors/
+    # context_omissions are ints; source_root/summary are strings) -
+    # store_gitlink_context stringifies every value before assigning here so
+    # the wire field this feeds (scene_payload()'s "gitlinkContextStats") stays
+    # honestly dict[str, str] end to end, matching how graphlink_scene_payload.py's
+    # SceneNodeRow types it for codegen. DEVIATION from a literal-verbatim
+    # forward: unlike R5.1's providerSnapshot (typed dict[str, str] but always
+    # populated as {} at runtime, so the type is never really exercised),
+    # gitlink_context_stats IS genuinely populated with int values at
+    # runtime - forwarding it unmodified would make the generated
+    # validateSceneState() reject every real context-build result. The
+    # str-coercion here is load-bearing, not a defensive formality.
+    gitlink_context_stats: dict[str, str] = field(default_factory=dict)
+    gitlink_context_summary: str = ""
+    # R5.3 post-review FIX 6: a genuine MONOTONIC per-node counter,
+    # incremented unconditionally every time store_gitlink_context lands a
+    # successful Build Context result (see that method below) - unlike
+    # gitlink_context_summary (built purely from aggregate file counts, per
+    # repository.py's build_context_bundle - never from paths/content), this
+    # can never collide. Without this field, two DIFFERENT Build Context
+    # results (e.g. selecting a different single file each time) could
+    # produce an IDENTICAL summary string, tricking the frontend's
+    # lazy-fetch-once guard (keyed on data.gitlinkContextSummary) into
+    # skipping a real refetch and showing stale XML. UNLIKE
+    # gitlink_context_xml/gitlink_change_local_root, this DOES need to be on
+    # the wire (see scene_payload() below) - the frontend reads it to detect
+    # "a new build landed" even when the summary text happens to repeat.
+    gitlink_context_version: int = 0
+    gitlink_proposal_markdown: str = ""
+    gitlink_pending_changes: list[dict[str, Any]] = field(default_factory=list)
+    gitlink_preview_text: str = ""
+    gitlink_change_fingerprint: str | None = None
+    # R5.3 post-review FIX 2: the local_root the approved change set's WRITE
+    # DESTINATION was bound to at Run time (see complete_gitlink_run below).
+    # _fingerprint_changes only hashes file content/paths/operations, never
+    # local_root - deliberately NOT modified, since it is reused verbatim
+    # from gitlink/agent.py, shared with the legacy Qt app. Without this
+    # separate binding, a still-valid fingerprint would let previously-
+    # reviewed content be written into a directory that was never diffed or
+    # shown to the user, if gitlink_local_root changes between Run and
+    # Apply (see start_gitlink_apply's fourth check in backend/agents.py).
+    # Plain internal bookkeeping field, like gitlink_context_xml: NEVER
+    # added to scene_payload()/the codegen dataclass source - the frontend
+    # never reads this directly, only the backend enforces it.
+    gitlink_change_local_root: str | None = None
+    # draft | previewed | applying | applied - see complete_gitlink_run/
+    # fail_gitlink_apply below for the transitions.
+    gitlink_change_state: str = "draft"
+    gitlink_error: str = ""
 
 
 @dataclass
@@ -807,6 +886,241 @@ class SceneDocument:
         node.history.append({"role": "assistant", "content": str(ai_message)})
         return node
 
+    # -- R5.3: gitlink node --------------------------------------------------
+    #
+    # canvas.py imports NOTHING from graphlink_plugins.gitlink - every method
+    # below is pure state mutation on plain fields, matching how
+    # apply_web_research_progress already does duck-typed mutation without
+    # importing the domain package. The fingerprint mechanism itself
+    # (_fingerprint_changes) lives in backend/agents.py, which DOES import
+    # from graphlink_plugins.gitlink - same precedent as ArtifactAgent/
+    # web_research.domain already being imported there, not here.
+
+    def add_gitlink_node(self, x: float, y: float, parent_id: str) -> SceneNode:
+        """The Gitlink node's creation primitive - same required-parent
+        posture as document/thinking/html/image/conversation/web_research/
+        artifact nodes (never exists unparented - confirmed against
+        graphlink_plugin_portal.py's own no_selection_message/
+        invalid_parent_message for Gitlink, there is no unparented/root form
+        in the domain model). Title is always the fixed literal "Gitlink"
+        (mirrors conversation/web_research/artifact's own fixed titles)."""
+        if parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title="Gitlink",
+            kind="gitlink",
+        )
+        self.nodes[node_id] = node
+        self.connect(parent_id, node_id)
+        return node
+
+    def set_gitlink_local_root(self, node_id: str, local_root: str) -> SceneNode:
+        """The one dedicated config setter Gitlink needs (see the design
+        rationale on every other config field being passed as a direct
+        action parameter instead): the user may type/paste a local checkout
+        path BEFORE ever clicking Import/Build Context, with no other action
+        call site to piggyback on."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.gitlink_local_root = str(local_root)
+        return node
+
+    def store_gitlink_repo_tree(self, node_id: str, repo: str, branch: str, file_paths: list[str]) -> SceneNode:
+        """Lands a successful loadGitlinkRepoTree result: repo, branch
+        (resolved server-side, including any default-branch lookup), and the
+        scanned text-file path list."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.gitlink_repo = str(repo)
+        node.gitlink_branch = str(branch)
+        node.gitlink_repo_file_paths = list(file_paths)
+        return node
+
+    def store_gitlink_snapshot_root(self, node_id: str, repo: str, branch: str, local_root: str) -> SceneNode:
+        """Lands a successful importGitlinkSnapshot result - sets
+        repo/branch/local_root AND gitlink_imported_root (so a later run
+        knows this path came from an import, matching legacy repo_state's
+        imported_root concept)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.gitlink_repo = str(repo)
+        node.gitlink_branch = str(branch)
+        node.gitlink_local_root = str(local_root)
+        node.gitlink_imported_root = str(local_root)
+        return node
+
+    def store_gitlink_context(
+        self,
+        node_id: str,
+        *,
+        scope_mode: str,
+        selected_paths: list[str],
+        context_xml: str,
+        context_stats: dict[str, Any],
+        context_summary: str,
+    ) -> SceneNode:
+        """Lands a successful buildGitlinkContext result: scope_mode,
+        selected_paths, and all three context_* fields. context_stats is
+        stringified value-by-value here - repository.py's
+        build_context_bundle returns a mixed int/str dict, but the wire field
+        this feeds (scene_payload()'s "gitlinkContextStats") must stay
+        honestly dict[str, str] for the codegen'd validator (see the field's
+        own comment on SceneNode).
+
+        R5.3 post-review FIX 6: gitlink_context_version is incremented
+        UNCONDITIONALLY every time this method runs - a genuine monotonic
+        counter, never reset, never skipped - closing a real bug
+        gitlink_context_summary alone could not: two different Build Context
+        results (e.g. selecting a different single file each time) can
+        produce an IDENTICAL summary string (see that field's own comment on
+        SceneNode), which was tricking the frontend's lazy-fetch-once guard
+        into skipping a real refetch and showing stale XML."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.gitlink_scope_mode = str(scope_mode)
+        node.gitlink_selected_paths = list(selected_paths)
+        node.gitlink_context_xml = str(context_xml)
+        node.gitlink_context_stats = {str(k): str(v) for k, v in (context_stats or {}).items()}
+        node.gitlink_context_summary = str(context_summary)
+        node.gitlink_context_version += 1
+        return node
+
+    def fetch_gitlink_context_xml(self, node_id: str) -> str:
+        """The read-side of the lazy fetch: gitlink_context_xml is EXCLUDED
+        from scene_payload() (see the field's own comment on SceneNode) - this
+        is the only way the frontend ever gets the full text, via the
+        read-only fetchGitlinkContext intent."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        return node.gitlink_context_xml
+
+    def start_gitlink_run(self, node_id: str, task_prompt: str) -> SceneNode:
+        """Begin one Generate Change Set run: stores the task prompt and
+        clears any previous error. Deliberately does NOT touch
+        gitlink_pending_changes/gitlink_proposal_markdown/
+        gitlink_change_fingerprint here - those only change once
+        complete_gitlink_run lands a real result, same stale-while-revalidate
+        posture web research's own start_web_research_run documents for
+        research_result."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "gitlink":
+            raise SceneError(f"node is not a gitlink node: {node_id}")
+        node.gitlink_task_prompt = str(task_prompt)
+        node.gitlink_error = ""
+        return node
+
+    def complete_gitlink_run(
+        self,
+        node_id: str,
+        proposal_markdown: str,
+        pending_changes: list[dict[str, Any]],
+        preview_text: str,
+        fingerprint: str | None,
+        local_root: str,
+    ) -> SceneNode:
+        """Land a successful run. proposal_markdown/pending_changes/
+        preview_text are always set. If pending_changes is non-empty:
+        change_state becomes "previewed", fingerprint is recorded, AND
+        (R5.3 post-review FIX 2) gitlink_change_local_root records the
+        EXACT local_root this run used - the write-destination binding
+        start_gitlink_apply's fourth check enforces, since the fingerprint
+        alone says nothing about where the content is written. If
+        pending_changes is empty (the agent's own write_intent came back
+        no_changes or blocked): change_state becomes "draft" and both
+        fingerprint and local_root are cleared - mirrors legacy
+        set_proposal's own unconditional `change_state = PREVIEWED if
+        pending_changes else DRAFT` exactly (an empty proposal is never
+        something to approve), extended so an empty proposal never leaves a
+        dangling local_root binding behind either.
+
+        `local_root` is compared as raw trimmed text against
+        start_gitlink_apply's own local_root_text - stored stripped here so
+        that comparison lines up exactly."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.gitlink_proposal_markdown = str(proposal_markdown)
+        node.gitlink_pending_changes = list(pending_changes or [])
+        node.gitlink_preview_text = str(preview_text)
+        if node.gitlink_pending_changes:
+            node.gitlink_change_state = "previewed"
+            node.gitlink_change_fingerprint = fingerprint
+            node.gitlink_change_local_root = str(local_root).strip()
+        else:
+            node.gitlink_change_state = "draft"
+            node.gitlink_change_fingerprint = None
+            node.gitlink_change_local_root = None
+        return node
+
+    def fail_gitlink_run(self, node_id: str, message: str) -> SceneNode | None:
+        """No-op (return None without raising) if the node is gone - a
+        background failure landing after node deletion should be silent,
+        matching the more defensive posture used for other failure-only
+        paths in this file (e.g. apply_web_research_progress). Deliberately
+        does NOT clear any existing pending_changes/proposal_markdown/
+        change_state - a failed re-run must never wipe out a previously
+        staged, still-valid proposal; only the error banner reflects the
+        new failure."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            return None
+        node.gitlink_error = str(message)
+        return node
+
+    def complete_gitlink_apply(self, node_id: str, written_files: int) -> SceneNode:
+        """Land a successful apply: change_state becomes "applied", error is
+        cleared.
+
+        R5.3 post-review FIX 1 (CRITICAL): ALSO clears gitlink_pending_changes
+        and gitlink_change_fingerprint - a successful Apply must invalidate
+        the approval it just consumed, or the exact same already-applied
+        change set could be replayed via a second applyGitlinkChanges call
+        (start_gitlink_apply's fingerprint check would still pass, since
+        nothing here previously changed after a successful write).
+        gitlink_change_local_root is cleared alongside them (R5.3 post-review
+        FIX 2) - a cleared approval must have no dangling bound fields.
+        gitlink_proposal_markdown/gitlink_preview_text are DELIBERATELY left
+        untouched - they remain visible as a historical record of what was
+        applied."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.gitlink_change_state = "applied"
+        node.gitlink_error = ""
+        node.gitlink_pending_changes = []
+        node.gitlink_change_fingerprint = None
+        node.gitlink_change_local_root = None
+        return node
+
+    def fail_gitlink_apply(self, node_id: str, message: str) -> SceneNode | None:
+        """No-op if the node is gone. Reverts change_state to "previewed"
+        (NEVER silently "applied"), CLEARS gitlink_change_fingerprint (so a
+        stale approval can never be replayed) and gitlink_change_local_root
+        (R5.3 post-review FIX 2 - a cleared approval must have no dangling
+        bound fields), and sets gitlink_error verbatim. Handles BOTH the
+        fingerprint-mismatch refusal path, the local_root-mismatch refusal
+        path, and the write-failure path identically - all three are "the
+        apply did not happen, here is why"."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            return None
+        node.gitlink_change_state = "previewed"
+        node.gitlink_change_fingerprint = None
+        node.gitlink_change_local_root = None
+        node.gitlink_error = str(message)
+        return node
+
     def delete_chat_node(self, node_id: str) -> None:
         """Delete one chat node WITHOUT orphaning its branch: children are
         re-parented to the deleted node's own parent (or become roots if it
@@ -1141,6 +1455,30 @@ class SceneDocument:
                     "researchError": n.research_error,
                     "researchResult": n.research_result,
                     "artifactContent": n.artifact_content,
+                    "gitlinkRepo": n.gitlink_repo,
+                    "gitlinkBranch": n.gitlink_branch,
+                    "gitlinkScopeMode": n.gitlink_scope_mode,
+                    "gitlinkLocalRoot": n.gitlink_local_root,
+                    "gitlinkRepoFilePaths": list(n.gitlink_repo_file_paths),
+                    "gitlinkSelectedPaths": list(n.gitlink_selected_paths),
+                    "gitlinkTaskPrompt": n.gitlink_task_prompt,
+                    # gitlinkContextXml is DELIBERATELY OMITTED - see the
+                    # field's own comment on SceneNode. Served on demand via
+                    # the fetchGitlinkContext intent instead.
+                    "gitlinkContextStats": dict(n.gitlink_context_stats),
+                    "gitlinkContextSummary": n.gitlink_context_summary,
+                    # R5.3 post-review FIX 6: UNLIKE gitlinkContextXml (and
+                    # unlike gitlink_change_local_root, never on the wire at
+                    # all), this genuinely needs to be here - see the field's
+                    # own comment on SceneNode for why gitlinkContextSummary
+                    # alone cannot be trusted as a lazy-fetch-once cache key.
+                    "gitlinkContextVersion": n.gitlink_context_version,
+                    "gitlinkProposalMarkdown": n.gitlink_proposal_markdown,
+                    "gitlinkPendingChanges": [dict(c) for c in n.gitlink_pending_changes],
+                    "gitlinkPreviewText": n.gitlink_preview_text,
+                    "gitlinkChangeFingerprint": n.gitlink_change_fingerprint,
+                    "gitlinkChangeState": n.gitlink_change_state,
+                    "gitlinkError": n.gitlink_error,
                 }
                 for n in self.nodes.values()
             ],
@@ -1716,6 +2054,164 @@ def register_canvas(
 
     async def cancel_artifact_request(request_id):
         agent_dispatcher.cancel_artifact(request_id)
+
+    # -- R5.3: Gitlink node --------------------------------------------------
+    #
+    # Reuses the existing generic pending_request_id field as the busy/
+    # in-flight marker for every Gitlink action (list repos, load tree,
+    # import, build context, run, apply) - this is exactly that field's
+    # documented purpose, and critically it is what makes the
+    # fingerprint-recheck race-proof: a Run cannot start while an Apply
+    # request_id occupies this node's slot, and vice versa.
+
+    async def fetch_gitlink_repositories(node_id):
+        node = document.nodes.get(node_id)
+        if node is None or node.pending_request_id:
+            notifications.show("Gitlink is busy for this node.", "info")
+            await bus.publish("notification")
+            return []
+        return await agent_dispatcher.fetch_gitlink_repositories(
+            bus=bus, notifications_state=notifications, node=node,
+        )
+
+    async def load_gitlink_repo_tree(node_id, repo, branch):
+        node = document.nodes.get(node_id)
+        if node is None or node.pending_request_id:
+            notifications.show("Gitlink is busy for this node.", "info")
+            await bus.publish("notification")
+            return None
+        result = await agent_dispatcher.load_gitlink_repo_tree(
+            bus=bus, notifications_state=notifications, node=node, repo=repo, branch=branch,
+        )
+        if result is not None:
+            document.store_gitlink_repo_tree(node_id, *result)
+            await publish_scene()
+        return node_id
+
+    async def set_gitlink_local_root(node_id, local_root):
+        document.set_gitlink_local_root(node_id, local_root)
+        await publish_scene()
+
+    async def import_gitlink_snapshot(node_id, repo, branch):
+        node = document.nodes.get(node_id)
+        if node is None or node.pending_request_id:
+            notifications.show("Gitlink is busy for this node.", "info")
+            await bus.publish("notification")
+            return None
+        result = await agent_dispatcher.import_gitlink_snapshot(
+            bus=bus, notifications_state=notifications, node=node, repo=repo, branch=branch,
+            local_root_hint=node.gitlink_local_root, imported_root_hint=node.gitlink_imported_root,
+        )
+        if result is not None:
+            document.store_gitlink_snapshot_root(node_id, *result)
+            await publish_scene()
+        return node_id
+
+    async def build_gitlink_context(node_id, scope_mode, selected_paths):
+        node = document.nodes.get(node_id)
+        if node is None or node.pending_request_id:
+            notifications.show("Gitlink is busy for this node.", "info")
+            await bus.publish("notification")
+            return None
+        result = await agent_dispatcher.build_gitlink_context(
+            bus=bus, notifications_state=notifications, node=node,
+            scope_mode=scope_mode, selected_paths=list(selected_paths),
+        )
+        if result is not None:
+            document.store_gitlink_context(node_id, scope_mode=scope_mode,
+                                            selected_paths=selected_paths, **result)
+            await publish_scene()
+        return node_id
+
+    async def fetch_gitlink_context(node_id):
+        return document.fetch_gitlink_context_xml(node_id)
+
+    async def run_gitlink_change_set(node_id, task_prompt):
+        node_for_check = document.nodes.get(node_id)
+        if node_for_check is not None and node_for_check.pending_request_id:
+            notifications.show("Gitlink is already busy for this node.", "info")
+            await bus.publish("notification")
+            return None
+        # R5.3 post-review FIX 4(b): claim the busy slot with a placeholder
+        # SYNCHRONOUSLY, in the same stretch as the busy pre-check just
+        # above - before document.start_gitlink_run or any await - so a
+        # second concurrent call for this SAME node_id can never pass that
+        # same pre-check during the `await publish_scene()` gap below.
+        # agent_dispatcher.start_gitlink_run (the ONLY caller of this dict
+        # entry for this node_id, invoked just below) recognizes this exact
+        # placeholder and overwrites it with the real request_id, still
+        # synchronously - see that method's own docstring.
+        if node_for_check is not None:
+            node_for_check.pending_request_id = _GITLINK_RUN_CLAIM_PLACEHOLDER
+        try:
+            node = document.start_gitlink_run(node_id, task_prompt)
+        except SceneError:
+            # Node deleted (or wrong-kind) concurrently with the claim above -
+            # the placeholder must not linger on a node this handler is
+            # about to give up on.
+            if node_for_check is not None:
+                node_for_check.pending_request_id = None
+            notifications.show("This node no longer exists.", "warning")
+            await bus.publish("notification")
+            return None
+        await publish_scene()
+
+        def _on_success(proposal_markdown, pending_changes, preview_text, fingerprint, local_root):
+            document.complete_gitlink_run(node_id, proposal_markdown, pending_changes,
+                                           preview_text, fingerprint, local_root)
+
+        def _on_failure(message):
+            document.fail_gitlink_run(node_id, message)
+
+        await agent_dispatcher.start_gitlink_run(
+            bus=bus, notifications_state=notifications, node=node, node_id=node_id,
+            repo=node.gitlink_repo, branch=node.gitlink_branch,
+            scope_mode=node.gitlink_scope_mode, task_prompt=task_prompt,
+            context_xml=node.gitlink_context_xml, context_summary=node.gitlink_context_summary,
+            local_root=node.gitlink_local_root,
+            on_success=_on_success, on_failure=_on_failure,
+        )
+        return node_id
+
+    async def cancel_gitlink_request(request_id):
+        agent_dispatcher.cancel_gitlink(request_id)
+
+    async def apply_gitlink_changes(node_id, fingerprint):
+        node = document.nodes.get(node_id)
+        if node is None:
+            notifications.show("This node no longer exists.", "warning")
+            await bus.publish("notification")
+            return None
+
+        def _on_success(written_files):
+            document.complete_gitlink_apply(node_id, written_files)
+
+        def _on_failure(message):
+            document.fail_gitlink_apply(node_id, message)
+
+        await agent_dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id=node_id,
+            client_fingerprint=fingerprint, local_root=node.gitlink_local_root,
+            on_success=_on_success, on_failure=_on_failure,
+        )
+        return node_id
+
+    bus.register_intent("scene", "fetchGitlinkRepositories", fetch_gitlink_repositories)
+    bus.register_intent("scene", "loadGitlinkRepoTree", load_gitlink_repo_tree)
+    bus.register_intent("scene", "setGitlinkLocalRoot", set_gitlink_local_root)
+    bus.register_intent("scene", "importGitlinkSnapshot", import_gitlink_snapshot)
+    bus.register_intent("scene", "buildGitlinkContext", build_gitlink_context)
+    bus.register_intent("scene", "fetchGitlinkContext", fetch_gitlink_context)
+    bus.register_intent("scene", "runGitlinkChangeSet", run_gitlink_change_set)
+    bus.register_intent("scene", "cancelGitlinkRequest", cancel_gitlink_request)
+    # CRITICAL, load-bearing property: applyGitlinkChanges takes ONLY
+    # (node_id, fingerprint) as WS intent arguments - there must be NO
+    # changes/pending_changes parameter anywhere in this signature or the
+    # dispatcher method it calls. This closes the most obvious
+    # content-injection bypass by construction, not by a runtime check: the
+    # only content that ever reaches apply_change_set is server-held,
+    # already-normalized node.gitlink_pending_changes.
+    bus.register_intent("scene", "applyGitlinkChanges", apply_gitlink_changes)
 
     async def move_node(node_id, x, y):
         document.move_node(node_id, x, y)

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -146,6 +146,28 @@ def register_plugins(
             await bus.publish("scene")
             return node.id
 
+        if name == "Gitlink":
+            # R5.3: the third real node-creation plugin, same posture as Web
+            # Research/Artifact above - Gitlink is a branch-point child (same
+            # as thinking/html/image/conversation/web_research/artifact
+            # nodes), so it always requires a real, valid parent to branch
+            # from - there is no unparented/root form (confirmed against
+            # graphlink_plugin_portal.py's own no_selection_message/
+            # invalid_parent_message for Gitlink).
+            if not parent_node_id or parent_node_id not in canvas_document.nodes:
+                notifications.show(
+                    "Please select a valid node to branch from before adding a Gitlink node.",
+                    "warning",
+                )
+                await bus.publish("notification")
+                return None
+            parent = canvas_document.nodes[parent_node_id]
+            node = canvas_document.add_gitlink_node(
+                parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            )
+            await bus.publish("scene")
+            return node.id
+
         if name == "Artifact / Drafter":
             # R5.2: the second real node-creation plugin, same posture as
             # Web Research above - an Artifact node is a branch-point child

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -13,8 +13,10 @@ itself.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import threading
 import time
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -25,7 +27,7 @@ import pytest
 # graphlink_licensing) for this module to import cleanly when run standalone.
 import backend.agents as agents_module
 from backend.agents import AgentDispatcher
-from backend.canvas import register_canvas
+from backend.canvas import SceneDocument, register_canvas
 from backend.composer import ComposerDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -2317,6 +2319,883 @@ def test_artifact_request_and_web_research_request_run_concurrently(monkeypatch)
         assert artifact_replies == [("artifact document", "artifact message")]
         assert dispatcher._web_research_requests == {}
         assert dispatcher._artifact_requests == {}
+
+    asyncio.run(run())
+
+
+# -- R5.3: Gitlink -------------------------------------------------------
+#
+# The data-integrity core of this whole increment: the fingerprint
+# check-and-freeze in start_gitlink_apply must be provably atomic (no await
+# between recompute and freeze), the client-supplied fingerprint must be
+# checked against BOTH a fresh recompute AND the server's own last-recorded
+# fingerprint (a three-way check), and applyGitlinkChanges/start_gitlink_apply
+# must never accept a changes/pending_changes payload from the caller.
+
+
+def _make_gitlink_node(**overrides):
+    defaults = dict(
+        pending_request_id=None,
+        gitlink_repo="octocat/hello-world",
+        gitlink_branch="main",
+        gitlink_scope_mode="selected",
+        gitlink_local_root="",
+        gitlink_imported_root="",
+        gitlink_repo_file_paths=[],
+        gitlink_selected_paths=[],
+        gitlink_task_prompt="",
+        gitlink_context_xml="<gitlink_context/>",
+        gitlink_context_stats={},
+        gitlink_context_summary="",
+        gitlink_proposal_markdown="",
+        gitlink_pending_changes=[],
+        gitlink_preview_text="",
+        gitlink_change_fingerprint=None,
+        gitlink_change_local_root=None,
+        gitlink_change_state="draft",
+        gitlink_error="",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_gitlink_env():
+    bus = SessionBus("agents-gitlink-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    bus.register_topic("scene", lambda: {})
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    return bus, notifications, dispatcher
+
+
+def test_call_gitlink_agent_calls_get_response(monkeypatch):
+    captured = []
+    fake_result = {
+        "summary": "s", "write_intent": "changes_ready", "rationale": "r",
+        "notes": [], "files": [], "change_count": 0, "raw_response": "{}",
+    }
+
+    def fake_get_response(self, payload):
+        captured.append(payload)
+        return fake_result
+
+    monkeypatch.setattr(agents_module.GitlinkAgent, "get_response", fake_get_response)
+
+    payload = {"task_prompt": "do x", "context_xml": "<x/>", "repo": "o/r", "branch": "main"}
+    result = agents_module._call_gitlink_agent(payload)
+
+    assert result is fake_result
+    assert captured == [payload]
+
+
+# -- start_gitlink_run --------------------------------------------------------
+
+
+def test_start_gitlink_run_with_changes_calls_on_success_with_fingerprint(monkeypatch):
+    fake_result = {
+        "summary": "add a health check", "write_intent": "changes_ready", "rationale": "r",
+        "notes": [], "change_count": 1,
+        "files": [{"path": "a.py", "operation": "update", "reason": "x", "content": "y"}],
+        "raw_response": "{}",
+    }
+    monkeypatch.setattr(agents_module.GitlinkAgent, "get_response", lambda self, payload: fake_result)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        node = _make_gitlink_node()
+        successes = []
+
+        await dispatcher.start_gitlink_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            repo="octocat/hello-world", branch="main", scope_mode="selected",
+            task_prompt="add a health check", context_xml="<x/>", context_summary="s",
+            local_root="",
+            on_success=lambda *args: successes.append(args),
+            on_failure=lambda message: None,
+        )
+        entry = next(iter(dispatcher._gitlink_requests.values()))
+        await entry["task"]
+
+        assert len(successes) == 1
+        proposal_markdown, files, preview_text, fingerprint, local_root = successes[0]
+        assert files == fake_result["files"]
+        assert fingerprint == agents_module._fingerprint_changes(fake_result["files"])
+        assert "octocat/hello-world" in proposal_markdown
+        assert local_root == "", "the exact local_root this run used must be forwarded to on_success (FIX 2)"
+        assert dispatcher._gitlink_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is False
+
+    asyncio.run(run())
+
+
+def test_start_gitlink_run_no_changes_calls_on_success_with_empty_files_and_none_fingerprint(monkeypatch):
+    fake_result = {
+        "summary": "nothing to change", "write_intent": "no_changes", "rationale": "r",
+        "notes": ["no changes needed"], "files": [], "change_count": 0, "raw_response": "{}",
+    }
+    monkeypatch.setattr(agents_module.GitlinkAgent, "get_response", lambda self, payload: fake_result)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        node = _make_gitlink_node()
+        successes = []
+
+        await dispatcher.start_gitlink_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            repo="o/r", branch="main", scope_mode="selected", task_prompt="do nothing",
+            context_xml="<x/>", context_summary="s", local_root="",
+            on_success=lambda *args: successes.append(args),
+            on_failure=lambda message: None,
+        )
+        entry = next(iter(dispatcher._gitlink_requests.values()))
+        await entry["task"]
+
+        assert len(successes) == 1
+        _proposal_markdown, files, _preview_text, fingerprint, _local_root = successes[0]
+        assert files == []
+        assert fingerprint is None
+
+    asyncio.run(run())
+
+
+def test_start_gitlink_run_timeout_fires_the_exact_message_and_clears_the_slot(monkeypatch):
+    monkeypatch.setattr(agents_module, "GITLINK_WATCHDOG_TIMEOUT_SECONDS", 0.05)
+
+    def slow_get_response(self, payload):
+        time.sleep(0.3)
+        return {
+            "summary": "s", "write_intent": "no_changes", "rationale": "r",
+            "notes": [], "files": [], "change_count": 0, "raw_response": "",
+        }
+
+    monkeypatch.setattr(agents_module.GitlinkAgent, "get_response", slow_get_response)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        node = _make_gitlink_node()
+        successes = []
+
+        await dispatcher.start_gitlink_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            repo="o/r", branch="main", scope_mode="selected", task_prompt="x",
+            context_xml="<x/>", context_summary="s", local_root="",
+            on_success=lambda *args: successes.append(args),
+            on_failure=lambda message: None,
+        )
+        entry = next(iter(dispatcher._gitlink_requests.values()))
+        await entry["task"]
+
+        assert successes == []
+        assert dispatcher._gitlink_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert notifications.message == (
+            "Gitlink generation stopped responding before the request completed. Please try again."
+        )
+
+    asyncio.run(run())
+
+
+def test_start_gitlink_run_cancel_mid_flight_fires_info_notification_and_never_calls_on_success(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_get_response(self, payload):
+        started.set()
+        release.wait(5)
+        return {
+            "summary": "s", "write_intent": "changes_ready", "rationale": "r", "notes": [],
+            "files": [{"path": "a.py", "operation": "update", "reason": "x", "content": "y"}],
+            "change_count": 1, "raw_response": "{}",
+        }
+
+    monkeypatch.setattr(agents_module.GitlinkAgent, "get_response", blocking_get_response)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        node = _make_gitlink_node()
+        successes = []
+
+        await dispatcher.start_gitlink_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            repo="o/r", branch="main", scope_mode="selected", task_prompt="x",
+            context_xml="<x/>", context_summary="s", local_root="",
+            on_success=lambda *args: successes.append(args),
+            on_failure=lambda message: None,
+        )
+        request_id, entry = next(iter(dispatcher._gitlink_requests.items()))
+
+        await asyncio.to_thread(started.wait, 5)
+        assert dispatcher.cancel_gitlink(request_id) is True
+        release.set()
+        await entry["task"]
+
+        assert successes == [], "a cancelled run must never call on_success, even on a late return"
+        assert dispatcher._gitlink_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert notifications.message == "Gitlink generation cancelled."
+
+    asyncio.run(run())
+
+
+def test_cancel_gitlink_returns_false_for_an_unknown_request_id():
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    assert dispatcher.cancel_gitlink("no-such-request") is False
+
+
+def test_start_gitlink_run_busy_node_refuses_immediately_without_creating_a_request_entry():
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        node = _make_gitlink_node(pending_request_id="already-busy")
+
+        await dispatcher.start_gitlink_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            repo="o/r", branch="main", scope_mode="selected", task_prompt="x",
+            context_xml="<x/>", context_summary="s", local_root="",
+            on_success=lambda *args: None, on_failure=lambda message: None,
+        )
+
+        assert dispatcher._gitlink_requests == {}
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+
+    asyncio.run(run())
+
+
+# -- start_gitlink_apply: the data-integrity core -----------------------------
+
+
+def test_gitlink_apply_rejects_client_fingerprint_mismatch(monkeypatch):
+    def raising_apply_change_set(local_root, pending_changes):
+        raise AssertionError("apply_change_set must never be reached on a fingerprint mismatch")
+
+    monkeypatch.setattr(agents_module, "apply_change_set", raising_apply_change_set)
+
+    async def run(tmp_path):
+        bus, notifications, dispatcher = _make_gitlink_env()
+        changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+        real_fingerprint = agents_module._fingerprint_changes(changes)
+        node = _make_gitlink_node(
+            gitlink_pending_changes=changes,
+            gitlink_change_fingerprint=real_fingerprint,
+            gitlink_local_root=str(tmp_path),
+        )
+        failures = []
+        successes = []
+
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            client_fingerprint="deliberately-wrong-fingerprint", local_root=str(tmp_path),
+            on_success=successes.append, on_failure=failures.append,
+        )
+
+        assert failures == [
+            "The proposed change set changed after approval. Review it again before applying."
+        ]
+        assert successes == []
+        assert dispatcher._gitlink_apply_requests == {}, "no apply task must ever have been scheduled"
+
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        asyncio.run(run(Path(tmp)))
+
+
+def test_gitlink_apply_rejects_when_pending_changes_mutated_between_generation_and_apply(monkeypatch, tmp_path):
+    def raising_apply_change_set(local_root, pending_changes):
+        raise AssertionError("apply_change_set must never be reached when the recorded fingerprint is stale")
+
+    monkeypatch.setattr(agents_module, "apply_change_set", raising_apply_change_set)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        changes_a = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+        changes_b = [{"path": "b.py", "operation": "update", "reason": "r2", "content": "y"}]
+        fingerprint_for_a = agents_module._fingerprint_changes(changes_a)
+        # Simulates a second Run landing (mutating pending_changes) WITHOUT
+        # going through complete_gitlink_run's own fingerprint-recording -
+        # node.gitlink_change_fingerprint is left stale, still pointing at A.
+        node = _make_gitlink_node(
+            gitlink_pending_changes=changes_b,
+            gitlink_change_fingerprint=fingerprint_for_a,
+            gitlink_local_root=str(tmp_path),
+        )
+        failures = []
+
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            client_fingerprint=fingerprint_for_a, local_root=str(tmp_path),
+            on_success=lambda written_files: None, on_failure=failures.append,
+        )
+
+        assert failures == [
+            "The proposed change set changed after approval. Review it again before applying."
+        ]
+        assert dispatcher._gitlink_apply_requests == {}
+
+    asyncio.run(run())
+
+
+def test_gitlink_apply_freezes_changes_before_await(monkeypatch, tmp_path):
+    changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "original"}]
+    fingerprint = agents_module._fingerprint_changes(changes)
+    node = _make_gitlink_node(
+        gitlink_pending_changes=changes,
+        gitlink_change_fingerprint=fingerprint,
+        gitlink_local_root=str(tmp_path),
+        gitlink_change_local_root=str(tmp_path),
+    )
+    captured = {}
+
+    def mutating_apply_change_set(local_root, pending_changes):
+        # Proves the write uses a DISTINCT, already-frozen list/copy - not
+        # node.gitlink_pending_changes itself.
+        assert pending_changes is not node.gitlink_pending_changes
+        captured["frozen_content"] = pending_changes[0]["content"]
+        # Mutate the LIVE node list from inside this patched function, to
+        # prove the write still used the original frozen snapshot's content,
+        # not whatever the live list is mutated to afterward.
+        node.gitlink_pending_changes[0]["content"] = "mutated-after-freeze"
+        return 1
+
+    monkeypatch.setattr(agents_module, "apply_change_set", mutating_apply_change_set)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        successes = []
+
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            client_fingerprint=fingerprint, local_root=str(tmp_path),
+            on_success=successes.append, on_failure=lambda message: None,
+        )
+        entry = next(iter(dispatcher._gitlink_apply_requests.values()))
+        await entry["task"]
+
+        assert successes == [1]
+        assert captured["frozen_content"] == "original", (
+            "the write must use the frozen snapshot's content, unaffected by the later mutation"
+        )
+        assert node.gitlink_pending_changes[0]["content"] == "mutated-after-freeze"
+
+    asyncio.run(run())
+
+
+def test_gitlink_apply_busy_guard_blocks_concurrent_run_and_apply(tmp_path):
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+        fingerprint = agents_module._fingerprint_changes(changes)
+        node = _make_gitlink_node(
+            pending_request_id="an-in-flight-request",
+            gitlink_pending_changes=changes,
+            gitlink_change_fingerprint=fingerprint,
+            gitlink_local_root=str(tmp_path),
+        )
+
+        await dispatcher.start_gitlink_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            repo="o/r", branch="main", scope_mode="selected", task_prompt="x",
+            context_xml="<x/>", context_summary="s", local_root="",
+            on_success=lambda *args: None, on_failure=lambda message: None,
+        )
+        assert dispatcher._gitlink_requests == {}, "Run must refuse immediately for a busy node"
+
+        failures = []
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            client_fingerprint=fingerprint, local_root=str(tmp_path),
+            on_success=lambda written_files: None, on_failure=failures.append,
+        )
+        assert dispatcher._gitlink_apply_requests == {}, "Apply must refuse immediately for a busy node"
+        assert failures == [], "the busy guard shows a notification, not an on_failure call"
+        assert notifications.visible is True
+        assert notifications.message == "Gitlink is already busy for this node."
+
+    asyncio.run(run())
+
+
+def test_gitlink_apply_no_pending_changes_calls_on_failure_without_touching_apply_change_set(monkeypatch, tmp_path):
+    def raising_apply_change_set(local_root, pending_changes):
+        raise AssertionError("apply_change_set must never be reached with no pending changes")
+
+    monkeypatch.setattr(agents_module, "apply_change_set", raising_apply_change_set)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        node = _make_gitlink_node(gitlink_local_root=str(tmp_path))
+        failures = []
+
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            client_fingerprint="whatever", local_root=str(tmp_path),
+            on_success=lambda written_files: None, on_failure=failures.append,
+        )
+
+        assert failures == ["There is no approved change set to write."]
+        assert dispatcher._gitlink_apply_requests == {}
+
+    asyncio.run(run())
+
+
+def test_gitlink_apply_missing_local_root_calls_on_failure(monkeypatch):
+    changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+    fingerprint = agents_module._fingerprint_changes(changes)
+    node = _make_gitlink_node(
+        gitlink_pending_changes=changes, gitlink_change_fingerprint=fingerprint, gitlink_local_root="",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        failures = []
+
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            client_fingerprint=fingerprint, local_root="",
+            on_success=lambda written_files: None, on_failure=failures.append,
+        )
+
+        assert failures == ["Select or import a local repository path before applying changes."]
+        assert dispatcher._gitlink_apply_requests == {}
+
+    asyncio.run(run())
+
+
+def test_gitlink_apply_nonexistent_local_root_calls_on_failure(monkeypatch):
+    changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+    fingerprint = agents_module._fingerprint_changes(changes)
+    missing_root = "C:/this/path/does/not/exist/for/sure/gitlink-test"
+    node = _make_gitlink_node(
+        gitlink_pending_changes=changes, gitlink_change_fingerprint=fingerprint, gitlink_local_root=missing_root,
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        failures = []
+
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            client_fingerprint=fingerprint, local_root=missing_root,
+            on_success=lambda written_files: None, on_failure=failures.append,
+        )
+
+        assert failures == ["The selected local repository path does not exist."]
+        assert dispatcher._gitlink_apply_requests == {}
+
+    asyncio.run(run())
+
+
+def test_gitlink_apply_success_calls_on_success_with_written_files_count(monkeypatch, tmp_path):
+    changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+    fingerprint = agents_module._fingerprint_changes(changes)
+    node = _make_gitlink_node(
+        gitlink_pending_changes=changes, gitlink_change_fingerprint=fingerprint, gitlink_local_root=str(tmp_path),
+        gitlink_change_local_root=str(tmp_path),
+    )
+    monkeypatch.setattr(agents_module, "apply_change_set", lambda local_root, pending_changes: 3)
+    monkeypatch.setattr(agents_module, "validate_pending_changes", lambda pending_changes: None)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        successes = []
+
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            client_fingerprint=fingerprint, local_root=str(tmp_path),
+            on_success=successes.append, on_failure=lambda message: None,
+        )
+        entry = next(iter(dispatcher._gitlink_apply_requests.values()))
+        await entry["task"]
+
+        assert successes == [3]
+        assert dispatcher._gitlink_apply_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert notifications.message == "Applied 3 file changes."
+
+    asyncio.run(run())
+
+
+def test_gitlink_apply_rollback_message_surfaced_verbatim(monkeypatch, tmp_path):
+    changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+    fingerprint = agents_module._fingerprint_changes(changes)
+    node = _make_gitlink_node(
+        gitlink_pending_changes=changes, gitlink_change_fingerprint=fingerprint, gitlink_local_root=str(tmp_path),
+        gitlink_change_local_root=str(tmp_path),
+    )
+    # The exact rollback RuntimeError shape repository.py's own apply_change_set
+    # produces on a failed restore (see its own docstring/comment).
+    rollback_message = (
+        "disk full (rolled back all other changes, but could not restore: "
+        f"{tmp_path}/a.py)"
+    )
+
+    def raising_apply_change_set(local_root, pending_changes):
+        raise RuntimeError(rollback_message)
+
+    monkeypatch.setattr(agents_module, "apply_change_set", raising_apply_change_set)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        failures = []
+
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            client_fingerprint=fingerprint, local_root=str(tmp_path),
+            on_success=lambda written_files: None, on_failure=failures.append,
+        )
+        entry = next(iter(dispatcher._gitlink_apply_requests.values()))
+        await entry["task"]
+
+        assert failures == [f"Failed to write approved changes: {rollback_message}"]
+        assert dispatcher._gitlink_apply_requests == {}
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+
+    asyncio.run(run())
+
+
+def test_gitlink_apply_timeout_fires_the_exact_message_and_clears_the_slot(monkeypatch, tmp_path):
+    monkeypatch.setattr(agents_module, "GITLINK_APPLY_TIMEOUT_SECONDS", 0.05)
+    changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+    fingerprint = agents_module._fingerprint_changes(changes)
+    node = _make_gitlink_node(
+        gitlink_pending_changes=changes, gitlink_change_fingerprint=fingerprint, gitlink_local_root=str(tmp_path),
+        gitlink_change_local_root=str(tmp_path),
+    )
+
+    def slow_apply_change_set(local_root, pending_changes):
+        time.sleep(0.3)
+        return 1
+
+    monkeypatch.setattr(agents_module, "apply_change_set", slow_apply_change_set)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        failures = []
+
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            client_fingerprint=fingerprint, local_root=str(tmp_path),
+            on_success=lambda written_files: None, on_failure=failures.append,
+        )
+        entry = next(iter(dispatcher._gitlink_apply_requests.values()))
+        await entry["task"]
+
+        assert len(failures) == 1
+        assert "stopped responding" in failures[0]
+        assert dispatcher._gitlink_apply_requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+# -- R5.3 post-review FIX 1/FIX 2 ---------------------------------------------
+
+
+def test_gitlink_apply_rejects_when_local_root_changed_since_generation(monkeypatch, tmp_path):
+    """R5.3 post-review FIX 2 (HIGH): _fingerprint_changes only hashes file
+    content/paths/operations, never local_root - so an unchanged, still-valid
+    fingerprint must NOT be enough to authorize a write once the local_root
+    binding recorded at Run time no longer matches the local_root passed to
+    Apply. Both checkout paths must actually exist on disk (the exists()
+    check runs BEFORE this new check), so this uses two real tmp_path
+    subdirectories rather than illustrative non-existent paths."""
+    def raising_apply_change_set(local_root, pending_changes):
+        raise AssertionError("apply_change_set must never be reached when local_root changed since generation")
+
+    monkeypatch.setattr(agents_module, "apply_change_set", raising_apply_change_set)
+
+    checkout_a = tmp_path / "checkout-a"
+    checkout_a.mkdir()
+    checkout_b = tmp_path / "checkout-b"
+    checkout_b.mkdir()
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+        fingerprint = agents_module._fingerprint_changes(changes)
+        # The change set was generated (Run) against checkout_a, but
+        # gitlink_local_root has since been edited to checkout_b - the
+        # fingerprint itself is still perfectly valid (nothing about the
+        # CONTENT changed), which is exactly why FIX 2 exists.
+        node = _make_gitlink_node(
+            gitlink_pending_changes=changes,
+            gitlink_change_fingerprint=fingerprint,
+            gitlink_change_local_root=str(checkout_a),
+            gitlink_local_root=str(checkout_b),
+        )
+        failures = []
+
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            client_fingerprint=fingerprint, local_root=str(checkout_b),
+            on_success=lambda written_files: None, on_failure=failures.append,
+        )
+
+        assert failures == [
+            "The local repository path changed since this proposal was generated. "
+            "Regenerate the change set before applying."
+        ]
+        assert dispatcher._gitlink_apply_requests == {}, "no apply task must ever have been scheduled"
+
+    asyncio.run(run())
+
+
+def test_gitlink_apply_cannot_be_replayed_after_success(monkeypatch, tmp_path):
+    """R5.3 post-review FIX 1 (CRITICAL): a successful Apply must invalidate
+    the approval it just consumed. Exercises the REAL
+    canvas.SceneDocument.complete_gitlink_apply/complete_gitlink_run wiring
+    (not a bespoke test stub) since that is where the fix actually lives -
+    on_success below is exactly what backend/canvas.py's
+    apply_gitlink_changes wires up in production. Runs start_gitlink_apply
+    to a successful completion once, then attempts calling it AGAIN with the
+    SAME original fingerprint, and asserts the replay is refused with the
+    "no approved change set" message and apply_change_set is never invoked
+    the second time."""
+    changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+    fingerprint = agents_module._fingerprint_changes(changes)
+    apply_calls = []
+
+    def counting_apply_change_set(local_root, pending_changes):
+        apply_calls.append(list(pending_changes))
+        return 1
+
+    monkeypatch.setattr(agents_module, "apply_change_set", counting_apply_change_set)
+    monkeypatch.setattr(agents_module, "validate_pending_changes", lambda pending_changes: None)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        document = SceneDocument()
+        parent = document.add_chat_node(0, 0, "root", True)
+        node = document.add_gitlink_node(0, 0, parent.id)
+        document.complete_gitlink_run(node.id, "## Gitlink Proposal", changes, "diff", fingerprint, str(tmp_path))
+
+        def _on_success(written_files):
+            document.complete_gitlink_apply(node.id, written_files)
+
+        def _on_failure(message):
+            document.fail_gitlink_apply(node.id, message)
+
+        # First Apply: succeeds, consuming the approval.
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id=node.id,
+            client_fingerprint=fingerprint, local_root=str(tmp_path),
+            on_success=_on_success, on_failure=_on_failure,
+        )
+        entry = next(iter(dispatcher._gitlink_apply_requests.values()))
+        await entry["task"]
+
+        assert len(apply_calls) == 1
+        assert node.gitlink_change_state == "applied"
+        assert node.gitlink_pending_changes == [], "the approval must be cleared on success (FIX 1)"
+        assert node.gitlink_change_fingerprint is None, "a consumed approval must never be replayable"
+        assert node.pending_request_id is None
+
+        # Second Apply attempt with the SAME original fingerprint: must be
+        # refused, and apply_change_set must never be invoked again.
+        failures = []
+        await dispatcher.start_gitlink_apply(
+            bus=bus, notifications_state=notifications, node=node, node_id=node.id,
+            client_fingerprint=fingerprint, local_root=str(tmp_path),
+            on_success=_on_success, on_failure=failures.append,
+        )
+
+        assert failures == ["There is no approved change set to write."]
+        assert len(apply_calls) == 1, "apply_change_set must NOT be invoked on the replay attempt"
+        assert dispatcher._gitlink_apply_requests == {}
+
+    asyncio.run(run())
+
+
+# -- R5.3 post-review FIX 5: real concurrent interleaving for Apply-vs-Apply,
+# not a pre-set busy flag -----------------------------------------------------
+
+
+def test_two_concurrent_start_gitlink_apply_calls_for_the_same_node_only_one_reaches_the_write_path(
+    monkeypatch, tmp_path,
+):
+    """R5.3 post-review FIX 5: before this fix, node.pending_request_id was
+    only claimed at the very END of start_gitlink_apply - AFTER the
+    local_root_text validation, the `await asyncio.to_thread(local_root_
+    path.exists)` yield point, and the entire atomic fingerprint/local_root
+    check-and-freeze section - so two genuinely concurrent Apply calls for
+    the SAME node (two different WebSocket connections on the same session,
+    e.g. two browser tabs - not a single connection's sequential message
+    loop) could both read node.pending_request_id as falsy before either
+    claimed it, both pass every check, and both end up scheduling a write via
+    apply_change_set concurrently.
+
+    This drives TWO REAL coroutines through a genuine asyncio interleaving -
+    both dispatcher.start_gitlink_apply(...) calls are fired via
+    asyncio.gather without either being awaited to completion first, exactly
+    the scenario the fix spec calls for - not the trivial
+    pre-set-pending_request_id case
+    test_gitlink_apply_busy_guard_blocks_concurrent_run_and_apply above
+    already covers. Mirrors
+    test_two_concurrent_run_gitlink_change_set_calls_for_the_same_node_only_one_reaches_the_agent's
+    own mechanism in test_canvas.py (asyncio.gather, a call-counting patch,
+    then draining the one admitted background task afterward). apply_change_set
+    is ALSO patched to actually sleep (a real blocking sleep inside the
+    asyncio.to_thread-wrapped worker call) so there is a genuine interleaving
+    opportunity even if some future change removed the already-real
+    `local_root_path.exists()` await this test also relies on."""
+    call_count = {"n": 0}
+
+    def slow_counting_apply_change_set(local_root, pending_changes):
+        call_count["n"] += 1
+        time.sleep(0.05)
+        return len(pending_changes)
+
+    monkeypatch.setattr(agents_module, "apply_change_set", slow_counting_apply_change_set)
+    monkeypatch.setattr(agents_module, "validate_pending_changes", lambda pending_changes: None)
+
+    async def run():
+        bus, notifications, dispatcher = _make_gitlink_env()
+        changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+        fingerprint = agents_module._fingerprint_changes(changes)
+        node = _make_gitlink_node(
+            gitlink_pending_changes=changes,
+            gitlink_change_fingerprint=fingerprint,
+            gitlink_change_local_root=str(tmp_path),
+            gitlink_local_root=str(tmp_path),
+        )
+        successes = []
+        failures = []
+
+        await asyncio.gather(
+            dispatcher.start_gitlink_apply(
+                bus=bus, notifications_state=notifications, node=node, node_id="n1",
+                client_fingerprint=fingerprint, local_root=str(tmp_path),
+                on_success=successes.append, on_failure=failures.append,
+            ),
+            dispatcher.start_gitlink_apply(
+                bus=bus, notifications_state=notifications, node=node, node_id="n1",
+                client_fingerprint=fingerprint, local_root=str(tmp_path),
+                on_success=successes.append, on_failure=failures.append,
+            ),
+        )
+
+        # Deterministic here, same reasoning as the Run-vs-Run test in
+        # test_canvas.py: neither coroutine's own body has a genuine
+        # suspension point before the busy claim, so asyncio's FIFO task
+        # scheduling always lets the FIRST-created call win the claim; the
+        # second one sees a truthy node.pending_request_id immediately and
+        # is rejected via the plain "already busy" notification branch (no
+        # on_failure call for that branch - see start_gitlink_apply's own
+        # busy-check at the very top).
+        assert len(dispatcher._gitlink_apply_requests) == 1, (
+            "only ONE Apply may ever be admitted for this node at a time"
+        )
+        entry = next(iter(dispatcher._gitlink_apply_requests.values()))
+        await entry["task"]
+
+        assert call_count["n"] == 1, "only ONE of the two concurrent calls may ever reach the write path"
+        assert successes == [1], "the admitted call's on_success must fire exactly once"
+        assert failures == [], "the rejected call is refused via the busy notification, not on_failure"
+        assert dispatcher._gitlink_apply_requests == {}
+        assert node.pending_request_id is None, (
+            "the busy slot must be fully released once the admitted Apply finishes"
+        )
+
+    asyncio.run(run())
+
+
+def test_gitlink_apply_no_changes_payload_in_intent_signature():
+    """Signature-inspection regression guard: the registered
+    applyGitlinkChanges WS intent handler must take EXACTLY two parameters
+    (node_id, fingerprint) - guards against a future regression that adds a
+    changes/pending_changes argument, which would let a client inject
+    arbitrary file content into the write path."""
+    bus = SessionBus("gitlink-signature-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    composer_document = ComposerDocument()
+    bus.register_topic("app-composer", composer_document.payload)
+
+    class _FakeDispatcher:
+        async def start_gitlink_apply(self, **kwargs):
+            pass
+
+    register_canvas(bus, notifications, _FakeDispatcher(), composer_document)
+
+    handler = bus._intents[("scene", "applyGitlinkChanges")]
+    signature = inspect.signature(handler)
+    assert list(signature.parameters) == ["node_id", "fingerprint"], (
+        "applyGitlinkChanges must take ONLY (node_id, fingerprint) - no changes/pending_changes param"
+    )
+
+
+def test_gitlink_request_and_other_kind_request_run_concurrently(monkeypatch):
+    """Mirrors the other cross-kind concurrency tests: a Gitlink Run request
+    must run concurrently with (neither blocking nor blocked by) a chat/
+    composer request - self._gitlink_requests and self._requests are two
+    genuinely independent slots."""
+    chat_started = threading.Event()
+    chat_release = threading.Event()
+    gitlink_started = threading.Event()
+    gitlink_release = threading.Event()
+
+    def blocking_chat(task, messages, **kwargs):
+        chat_started.set()
+        chat_release.wait(5)
+        return {"message": {"content": "chat reply"}}
+
+    def blocking_get_response(self, payload):
+        gitlink_started.set()
+        gitlink_release.wait(5)
+        return {
+            "summary": "s", "write_intent": "changes_ready", "rationale": "r", "notes": [],
+            "files": [{"path": "a.py", "operation": "update", "reason": "x", "content": "y"}],
+            "change_count": 1, "raw_response": "{}",
+        }
+
+    _configure_fake_ollama(monkeypatch, blocking_chat)
+    monkeypatch.setattr(agents_module.GitlinkAgent, "get_response", blocking_get_response)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        chat_replies = []
+        gitlink_successes = []
+        gitlink_node = _make_gitlink_node()
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=chat_replies.append,
+        )
+        await dispatcher.start_gitlink_run(
+            bus=bus, notifications_state=notifications, node=gitlink_node, node_id="n1",
+            repo="o/r", branch="main", scope_mode="selected", task_prompt="x",
+            context_xml="<x/>", context_summary="s", local_root="",
+            on_success=lambda *args: gitlink_successes.append(args),
+            on_failure=lambda message: None,
+        )
+
+        await asyncio.to_thread(chat_started.wait, 5)
+        await asyncio.to_thread(gitlink_started.wait, 5)
+
+        assert len(dispatcher._requests) == 1
+        assert len(dispatcher._gitlink_requests) == 1
+        assert notifications.visible is False, "neither call should have been rejected"
+
+        chat_release.set()
+        chat_entry = next(iter(dispatcher._requests.values()))
+        await chat_entry["task"]
+        gitlink_release.set()
+        gitlink_entry = next(iter(dispatcher._gitlink_requests.values()))
+        await gitlink_entry["task"]
+
+        assert chat_replies == ["chat reply"]
+        assert len(gitlink_successes) == 1
+        assert dispatcher._requests == {}
+        assert dispatcher._gitlink_requests == {}
 
     asyncio.run(run())
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -3059,3 +3059,657 @@ def test_cancel_artifact_request_intent_calls_agent_dispatcher_cancel_artifact()
         assert fake_dispatcher.cancel_calls == ["req-123"]
 
     asyncio.run(run())
+
+
+# -- R5.3: gitlink node -------------------------------------------------------
+
+
+def test_add_gitlink_node_requires_valid_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_gitlink_node(0, 0, "ghost")
+
+
+def test_add_gitlink_node_creates_child():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "wire up gitlink", True)
+    node = doc.add_gitlink_node(10, 20, parent.id)
+    assert node.kind == "gitlink"
+    assert node.title == "Gitlink"
+    assert node.gitlink_repo == ""
+    assert node.gitlink_change_state == "draft"
+    assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
+
+
+def test_add_gitlink_node_requires_a_parent_id():
+    # Same TypeError-not-SceneError posture as every other required-parent
+    # node kind (document/thinking/html/image/conversation/web_research/
+    # artifact) - parent_id has no default in add_gitlink_node's signature.
+    doc = SceneDocument()
+    with pytest.raises(TypeError):
+        doc.add_gitlink_node(0, 0)
+
+
+def test_gitlink_node_deletion_goes_through_the_generic_remove_nodes_path():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(10, 10, parent.id)
+    assert not hasattr(doc, "delete_gitlink_node"), (
+        "gitlink nodes are not branch points - no special delete method"
+    )
+    doc.remove_nodes([node.id])
+    assert node.id not in doc.nodes
+
+
+def test_set_gitlink_local_root_sets_the_field():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    returned = doc.set_gitlink_local_root(node.id, "C:/checkout/repo")
+    assert returned is node
+    assert node.gitlink_local_root == "C:/checkout/repo"
+
+
+def test_set_gitlink_local_root_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().set_gitlink_local_root("ghost", "C:/checkout")
+
+
+def test_store_gitlink_repo_tree():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    returned = doc.store_gitlink_repo_tree(node.id, "octocat/hello-world", "main", ["a.py", "b.py"])
+    assert returned is node
+    assert node.gitlink_repo == "octocat/hello-world"
+    assert node.gitlink_branch == "main"
+    assert node.gitlink_repo_file_paths == ["a.py", "b.py"]
+
+
+def test_store_gitlink_repo_tree_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().store_gitlink_repo_tree("ghost", "o/r", "main", [])
+
+
+def test_store_gitlink_snapshot_root_sets_repo_branch_local_root_and_imported_root():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    returned = doc.store_gitlink_snapshot_root(node.id, "octocat/hello-world", "main", "C:/tmp/snapshot")
+    assert returned is node
+    assert node.gitlink_repo == "octocat/hello-world"
+    assert node.gitlink_branch == "main"
+    assert node.gitlink_local_root == "C:/tmp/snapshot"
+    assert node.gitlink_imported_root == "C:/tmp/snapshot"
+
+
+def test_store_gitlink_context_excluded_from_scene_payload():
+    # Security/cost-boundary test: gitlinkContextXml must NEVER appear in
+    # scene_payload() (see the field's own comment on SceneNode), while
+    # gitlinkContextSummary/gitlinkContextStats - small, cheap status-badge
+    # fields - ARE present.
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    huge_xml = "<gitlink_context>" + ("x" * 5000) + "</gitlink_context>"
+
+    doc.store_gitlink_context(
+        node.id,
+        scope_mode="selected",
+        selected_paths=["a.py"],
+        context_xml=huge_xml,
+        context_stats={"scanned_files": 3, "loaded_files": 3, "source_root": "github"},
+        context_summary="Scanned 3 files.",
+    )
+
+    assert node.gitlink_context_xml == huge_xml, "the domain object DOES hold the full text"
+
+    row = {n["id"]: n for n in doc.scene_payload()["nodes"]}[node.id]
+    assert "gitlinkContextXml" not in row
+    assert row["gitlinkContextSummary"] == "Scanned 3 files."
+    assert row["gitlinkScopeMode"] == "selected"
+    assert row["gitlinkSelectedPaths"] == ["a.py"]
+    # context_stats' mixed int/str values are stringified end to end.
+    assert row["gitlinkContextStats"] == {
+        "scanned_files": "3", "loaded_files": "3", "source_root": "github",
+    }
+
+
+def test_store_gitlink_context_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().store_gitlink_context(
+            "ghost", scope_mode="selected", selected_paths=[], context_xml="",
+            context_stats={}, context_summary="",
+        )
+
+
+def test_store_gitlink_context_increments_version_even_with_an_identical_summary():
+    """R5.3 post-review FIX 6: gitlink_context_version is a genuine
+    MONOTONIC counter, incremented unconditionally on every call - unlike
+    gitlink_context_summary (built purely from aggregate file counts, see
+    repository.py's build_context_bundle), which can collide across two
+    DIFFERENT Build Context results (e.g. selecting a different single file
+    each time produces the exact same "Scanned 1 files." summary). Two
+    successive store_gitlink_context calls for the SAME node, with
+    IDENTICAL summary/stats (same file count from two different
+    single-file selections), must still produce two DIFFERENT version
+    values - this is what lets the frontend's lazy-fetch-once guard detect
+    the second build actually happened."""
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    assert node.gitlink_context_version == 0, "a fresh node starts at 0"
+
+    doc.store_gitlink_context(
+        node.id,
+        scope_mode="selected",
+        selected_paths=["a.py"],
+        context_xml="<gitlink_context>a.py content</gitlink_context>",
+        context_stats={"scanned_files": 1, "loaded_files": 1},
+        context_summary="Scanned 1 files.",
+    )
+    assert node.gitlink_context_version == 1
+
+    # A second, genuinely DIFFERENT Build Context result (a different single
+    # file selected) that happens to produce an IDENTICAL summary string.
+    doc.store_gitlink_context(
+        node.id,
+        scope_mode="selected",
+        selected_paths=["b.py"],
+        context_xml="<gitlink_context>b.py content</gitlink_context>",
+        context_stats={"scanned_files": 1, "loaded_files": 1},
+        context_summary="Scanned 1 files.",
+    )
+    assert node.gitlink_context_version == 2, (
+        "the version must increase even when the summary string is identical to the prior build"
+    )
+    assert node.gitlink_context_xml == "<gitlink_context>b.py content</gitlink_context>", (
+        "the second build's own content must have actually landed"
+    )
+
+    row = {n["id"]: n for n in doc.scene_payload()["nodes"]}[node.id]
+    assert row["gitlinkContextVersion"] == 2, "scene_payload() must reflect the current version"
+
+
+def test_fetch_gitlink_context_xml_returns_full_text_not_in_payload():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    doc.store_gitlink_context(
+        node.id, scope_mode="full", selected_paths=[], context_xml="<gitlink_context>full text</gitlink_context>",
+        context_stats={}, context_summary="done",
+    )
+
+    fetched = doc.fetch_gitlink_context_xml(node.id)
+
+    assert fetched == "<gitlink_context>full text</gitlink_context>"
+    row = {n["id"]: n for n in doc.scene_payload()["nodes"]}[node.id]
+    assert "gitlinkContextXml" not in row
+
+
+def test_fetch_gitlink_context_xml_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().fetch_gitlink_context_xml("ghost")
+
+
+def test_start_gitlink_run_sets_task_prompt_and_clears_error():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    node.gitlink_error = "a previous error"
+
+    returned = doc.start_gitlink_run(node.id, "add a health check endpoint")
+
+    assert returned is node
+    assert node.gitlink_task_prompt == "add a health check endpoint"
+    assert node.gitlink_error == ""
+
+
+def test_start_gitlink_run_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().start_gitlink_run("ghost", "do something")
+
+
+def test_start_gitlink_run_wrong_kind_raises_scene_error():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "not a gitlink node", True)
+    with pytest.raises(SceneError):
+        doc.start_gitlink_run(chat.id, "do something")
+
+
+def test_complete_gitlink_run_no_changes_stays_draft():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+
+    returned = doc.complete_gitlink_run(node.id, "## Gitlink Proposal\n\nNo changes needed.", [], "", None, "")
+
+    assert returned is node
+    assert node.gitlink_proposal_markdown == "## Gitlink Proposal\n\nNo changes needed."
+    assert node.gitlink_pending_changes == []
+    assert node.gitlink_change_state == "draft"
+    assert node.gitlink_change_fingerprint is None
+    assert node.gitlink_change_local_root is None, "an empty proposal must never leave a dangling local_root binding"
+
+
+def test_complete_gitlink_run_with_changes_becomes_previewed_with_fingerprint():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    changes = [{"path": "a.py", "operation": "update", "reason": "fix bug", "content": "x = 1"}]
+
+    returned = doc.complete_gitlink_run(
+        node.id, "## Gitlink Proposal", changes, "diff text", "abc123fingerprint", "C:/checkout/repo",
+    )
+
+    assert returned is node
+    assert node.gitlink_pending_changes == changes
+    assert node.gitlink_preview_text == "diff text"
+    assert node.gitlink_change_state == "previewed"
+    assert node.gitlink_change_fingerprint == "abc123fingerprint"
+    assert node.gitlink_change_local_root == "C:/checkout/repo", (
+        "R5.3 post-review FIX 2: the local_root this run used must be bound to the approval"
+    )
+
+
+def test_complete_gitlink_run_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().complete_gitlink_run("ghost", "proposal", [], "", None, "")
+
+
+def test_fail_gitlink_run_sets_error_and_is_a_silent_noop_for_a_deleted_node():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+
+    returned = doc.fail_gitlink_run(node.id, "Gitlink generation failed: boom")
+    assert returned is node
+    assert node.gitlink_error == "Gitlink generation failed: boom"
+
+    assert doc.fail_gitlink_run("ghost", "too late") is None
+
+
+def test_fail_gitlink_run_does_not_clear_a_previously_staged_proposal():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+    doc.complete_gitlink_run(node.id, "## Gitlink Proposal", changes, "diff", "fp1", "C:/checkout")
+
+    doc.fail_gitlink_run(node.id, "a later re-run failed")
+
+    assert node.gitlink_pending_changes == changes, "a failed re-run must not wipe a valid staged proposal"
+    assert node.gitlink_change_state == "previewed"
+    assert node.gitlink_change_fingerprint == "fp1"
+    assert node.gitlink_error == "a later re-run failed"
+
+
+def test_complete_gitlink_apply_sets_applied_and_clears_error():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    node.gitlink_change_state = "applying"
+    node.gitlink_error = "stale"
+
+    returned = doc.complete_gitlink_apply(node.id, 2)
+
+    assert returned is node
+    assert node.gitlink_change_state == "applied"
+    assert node.gitlink_error == ""
+
+
+def test_complete_gitlink_apply_clears_pending_changes_and_fingerprint_to_prevent_replay():
+    """R5.3 post-review FIX 1 (CRITICAL): a successful Apply must invalidate
+    the approval it just consumed - otherwise start_gitlink_apply's own
+    fingerprint check would still pass on a second, replayed call, since
+    nothing about the (already-applied) content changed. proposal_markdown/
+    preview_text stay intact as a historical record of what was applied."""
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+    doc.complete_gitlink_run(node.id, "## Gitlink Proposal", changes, "diff text", "fp1", "C:/checkout")
+    node.gitlink_change_state = "applying"
+
+    returned = doc.complete_gitlink_apply(node.id, 1)
+
+    assert returned is node
+    assert node.gitlink_change_state == "applied"
+    assert node.gitlink_pending_changes == [], "the approval must be cleared so it cannot be replayed"
+    assert node.gitlink_change_fingerprint is None
+    assert node.gitlink_change_local_root is None, "a cleared approval must have no dangling bound fields"
+    # Historical record of what was applied - deliberately left untouched.
+    assert node.gitlink_proposal_markdown == "## Gitlink Proposal"
+    assert node.gitlink_preview_text == "diff text"
+
+
+def test_complete_gitlink_apply_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().complete_gitlink_apply("ghost", 1)
+
+
+def test_fail_gitlink_apply_reverts_to_previewed_and_clears_fingerprint():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+    doc.complete_gitlink_run(node.id, "## Gitlink Proposal", changes, "diff", "fp1", "C:/checkout")
+    node.gitlink_change_state = "applying"
+
+    returned = doc.fail_gitlink_apply(
+        node.id, "The proposed change set changed after approval. Review it again before applying."
+    )
+
+    assert returned is node
+    assert node.gitlink_change_state == "previewed"
+    assert node.gitlink_change_fingerprint is None, "a stale approval must never be replayable"
+    assert node.gitlink_change_local_root is None, "a cleared approval must have no dangling bound fields"
+    assert node.gitlink_error == (
+        "The proposed change set changed after approval. Review it again before applying."
+    )
+    # pending_changes/proposal_markdown themselves stay put - only the
+    # fingerprint is invalidated, so the user can review and re-approve.
+    assert node.gitlink_pending_changes == changes
+
+
+def test_fail_gitlink_apply_is_a_silent_noop_for_a_deleted_node():
+    assert SceneDocument().fail_gitlink_apply("ghost", "too late") is None
+
+
+def test_scene_payload_gitlink_fields_default_correctly_for_a_fresh_node():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+
+    row = {n["id"]: n for n in doc.scene_payload()["nodes"]}[node.id]
+
+    assert row["gitlinkRepo"] == ""
+    assert row["gitlinkBranch"] == ""
+    assert row["gitlinkScopeMode"] == "selected"
+    assert row["gitlinkLocalRoot"] == ""
+    assert row["gitlinkRepoFilePaths"] == []
+    assert row["gitlinkSelectedPaths"] == []
+    assert row["gitlinkTaskPrompt"] == ""
+    assert row["gitlinkContextStats"] == {}
+    assert row["gitlinkContextSummary"] == ""
+    # R5.3 post-review FIX 6: a fresh node's monotonic counter starts at 0.
+    assert row["gitlinkContextVersion"] == 0
+    assert row["gitlinkProposalMarkdown"] == ""
+    assert row["gitlinkPendingChanges"] == []
+    assert row["gitlinkPreviewText"] == ""
+    assert row["gitlinkChangeFingerprint"] is None
+    assert row["gitlinkChangeState"] == "draft"
+    assert row["gitlinkError"] == ""
+    # R5.3 post-review FIX 2: gitlink_change_local_root is plain internal
+    # backend bookkeeping, like gitlink_context_xml/gitlink_imported_root -
+    # it must NEVER appear on the wire.
+    assert "gitlinkChangeLocalRoot" not in row
+
+
+def test_scene_payload_gitlink_pending_changes_is_a_copy_not_the_live_list():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    changes = [{"path": "a.py", "operation": "update", "reason": "r", "content": "x"}]
+    doc.complete_gitlink_run(node.id, "proposal", changes, "diff", "fp1", "C:/checkout")
+
+    row = {n["id"]: n for n in doc.scene_payload()["nodes"]}[node.id]
+    row["gitlinkPendingChanges"][0]["path"] = "mutated.py"
+
+    assert node.gitlink_pending_changes[0]["path"] == "a.py", (
+        "mutating the payload copy must never mutate the live domain state"
+    )
+
+
+# -- R5.3: gitlink node - WS-intent level -------------------------------------
+
+
+def _make_gitlink_plugins_bus():
+    bus = SessionBus("gitlink-canvas-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    composer_document = ComposerDocument()
+    bus.register_topic("app-composer", composer_document.payload)
+
+    class _FakeDispatcher:
+        pass
+
+    fake_dispatcher = _FakeDispatcher()
+    document = register_canvas(bus, notifications, fake_dispatcher, composer_document)
+    return bus, notifications, document, fake_dispatcher
+
+
+def test_set_gitlink_local_root_intent_publishes_scene():
+    async def run():
+        bus, notifications, document, _dispatcher = _make_gitlink_plugins_bus()
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_gitlink_node(0, 0, parent.id)
+
+        await bus.dispatch_intent("scene", "setGitlinkLocalRoot", [node.id, "C:/checkout"])
+
+        assert document.nodes[node.id].gitlink_local_root == "C:/checkout"
+
+    asyncio.run(run())
+
+
+def test_fetch_gitlink_context_intent_returns_full_text():
+    async def run():
+        bus, notifications, document, _dispatcher = _make_gitlink_plugins_bus()
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_gitlink_node(0, 0, parent.id)
+        document.store_gitlink_context(
+            node.id, scope_mode="selected", selected_paths=["a.py"],
+            context_xml="<gitlink_context>full</gitlink_context>", context_stats={}, context_summary="s",
+        )
+
+        result = await bus.dispatch_intent("scene", "fetchGitlinkContext", [node.id])
+
+        assert result == "<gitlink_context>full</gitlink_context>"
+
+    asyncio.run(run())
+
+
+def test_fetch_gitlink_repositories_intent_busy_guard_returns_empty_list_without_calling_dispatcher():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.called = False
+
+        async def fetch_gitlink_repositories(self, **kwargs):
+            self.called = True
+            return ["should-not-be-reached/repo"]
+
+    async def run():
+        bus = SessionBus("gitlink-busy-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        document = register_canvas(bus, notifications, fake_dispatcher, composer_document)
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_gitlink_node(0, 0, parent.id)
+        node.pending_request_id = "already-busy"
+
+        result = await bus.dispatch_intent("scene", "fetchGitlinkRepositories", [node.id])
+
+        assert result == []
+        assert fake_dispatcher.called is False
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+
+    asyncio.run(run())
+
+
+def test_run_gitlink_change_set_intent_dispatches_with_correct_node_fields():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.calls = []
+
+        async def start_gitlink_run(self, **kwargs):
+            self.calls.append(kwargs)
+
+    async def run():
+        bus = SessionBus("gitlink-run-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        document = register_canvas(bus, notifications, fake_dispatcher, composer_document)
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_gitlink_node(0, 0, parent.id)
+        document.store_gitlink_repo_tree(node.id, "octocat/hello-world", "main", ["a.py"])
+        document.store_gitlink_context(
+            node.id, scope_mode="selected", selected_paths=["a.py"], context_xml="<x/>",
+            context_stats={}, context_summary="s",
+        )
+
+        result = await bus.dispatch_intent("scene", "runGitlinkChangeSet", [node.id, "add a feature"])
+
+        assert result == node.id
+        assert document.nodes[node.id].gitlink_task_prompt == "add a feature"
+        assert len(fake_dispatcher.calls) == 1
+        call = fake_dispatcher.calls[0]
+        assert call["repo"] == "octocat/hello-world"
+        assert call["branch"] == "main"
+        assert call["scope_mode"] == "selected"
+        assert call["task_prompt"] == "add a feature"
+        assert call["context_xml"] == "<x/>"
+        assert call["context_summary"] == "s"
+        assert callable(call["on_success"])
+        assert callable(call["on_failure"])
+
+    asyncio.run(run())
+
+
+def test_apply_gitlink_changes_intent_calls_dispatcher_with_only_node_id_and_fingerprint():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.calls = []
+
+        async def start_gitlink_apply(self, **kwargs):
+            self.calls.append(kwargs)
+
+    async def run():
+        bus = SessionBus("gitlink-apply-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        document = register_canvas(bus, notifications, fake_dispatcher, composer_document)
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_gitlink_node(0, 0, parent.id)
+        document.set_gitlink_local_root(node.id, "C:/checkout")
+
+        result = await bus.dispatch_intent("scene", "applyGitlinkChanges", [node.id, "fp-123"])
+
+        assert result == node.id
+        assert len(fake_dispatcher.calls) == 1
+        call = fake_dispatcher.calls[0]
+        assert call["client_fingerprint"] == "fp-123"
+        assert call["local_root"] == "C:/checkout"
+        assert callable(call["on_success"])
+        assert callable(call["on_failure"])
+
+    asyncio.run(run())
+
+
+def test_cancel_gitlink_request_intent_calls_agent_dispatcher_cancel_gitlink():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.cancel_calls = []
+
+        def cancel_gitlink(self, request_id):
+            self.cancel_calls.append(request_id)
+            return True
+
+    async def run():
+        bus = SessionBus("cancel-gitlink-request-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        register_canvas(bus, notifications, fake_dispatcher, composer_document)
+
+        result = await bus.dispatch_intent("scene", "cancelGitlinkRequest", ["req-456"])
+
+        assert result is None
+        assert fake_dispatcher.cancel_calls == ["req-456"]
+
+    asyncio.run(run())
+
+
+# -- R5.3 post-review FIX 4: real concurrent interleaving, not a pre-set busy
+# flag --------------------------------------------------------------------
+
+
+def test_two_concurrent_run_gitlink_change_set_calls_for_the_same_node_only_one_reaches_the_agent(monkeypatch):
+    """R5.3 post-review FIX 4(a)+(b): before this fix, node.pending_request_id
+    was only claimed INSIDE start_gitlink_run's separately-scheduled _run()
+    sub-task, and run_gitlink_change_set's own busy pre-check was separated
+    from agents.py's claim by a real `await publish_scene()` - so two
+    concurrent runGitlinkChangeSet calls for the SAME node could both pass
+    every busy check before either one's claim ever landed, and both would
+    reach the LLM.
+
+    This drives TWO REAL coroutines through a genuine asyncio interleaving -
+    both dispatch_intent(...) calls are fired via asyncio.gather without
+    either being awaited to completion first, exactly the scenario the fix
+    spec calls for - not the trivial pre-set-pending_request_id case the
+    existing busy-guard tests already cover (e.g.
+    test_gitlink_apply_busy_guard_blocks_concurrent_run_and_apply in
+    test_agents.py). GitlinkAgent.get_response is reached via a REAL
+    asyncio.to_thread hop (unmocked at that layer), which is itself a
+    genuine yield point back to the event loop - so even a slow/blocking
+    mock is unnecessary for real interleaving to occur here; the race this
+    fix closes is entirely in the synchronous busy-check-and-claim ordering,
+    which asyncio.gather's task scheduling exercises directly."""
+    call_count = {"n": 0}
+
+    def counting_get_response(self, payload):
+        call_count["n"] += 1
+        return {
+            "summary": "s", "write_intent": "changes_ready", "rationale": "r", "notes": [],
+            "files": [{"path": "a.py", "operation": "update", "reason": "x", "content": "y"}],
+            "change_count": 1, "raw_response": "{}",
+        }
+
+    monkeypatch.setattr(agents_module.GitlinkAgent, "get_response", counting_get_response)
+
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_chat_node(0, 0, "root", True)
+        node = document.add_gitlink_node(0, 0, parent.id)
+        document.store_gitlink_repo_tree(node.id, "octocat/hello-world", "main", ["a.py"])
+        document.store_gitlink_context(
+            node.id, scope_mode="selected", selected_paths=["a.py"], context_xml="<x/>",
+            context_stats={}, context_summary="s",
+        )
+
+        results = await asyncio.gather(
+            bus.dispatch_intent("scene", "runGitlinkChangeSet", [node.id, "task A"]),
+            bus.dispatch_intent("scene", "runGitlinkChangeSet", [node.id, "task B"]),
+        )
+        # The admitted call returns node_id (mirrors every other successful
+        # scene-intent wrapper); the busy-rejected call returns None (mirrors
+        # run_gitlink_change_set's own existing busy-rejection branch, same
+        # sentinel shape as e.g. fetchGitlinkRepositories's busy guard).
+        # Deterministic here: neither coroutine's own body has a genuine
+        # suspension point before the busy claim, so asyncio's FIFO task
+        # scheduling always lets the FIRST-created task ("task A") win.
+        assert results == [node.id, None], "exactly one of the two concurrent calls must be admitted"
+
+        entries = list(dispatcher._gitlink_requests.values())
+        assert len(entries) == 1, "only ONE Run may ever be admitted for this node at a time"
+        await entries[0]["task"]
+
+        assert call_count["n"] == 1, "only ONE of the two concurrent calls may ever reach the LLM"
+        assert document.nodes[node.id].gitlink_change_state == "previewed"
+        assert dispatcher._gitlink_requests == {}
+        assert document.nodes[node.id].pending_request_id is None, (
+            "the busy slot must be fully released once the admitted Run finishes"
+        )
+
+    asyncio.run(run())

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -88,15 +88,18 @@ def test_register_plugins_publishes_on_the_app_plugins_topic():
 
 
 def test_execute_plugin_shows_info_notification_for_known_plugin():
+    # "Py-Coder" (not "Gitlink" - Gitlink is now a real node-creation plugin,
+    # see the dedicated R5.3 tests below) stands in for "any plugin name
+    # still on the honest-deferred-notice path".
     bus = SessionBus("plugins-exec-test")
     notifications = NotificationState()
     bus.register_topic("notification", notifications.payload)
     register_plugins(bus, notifications, SceneDocument())
 
-    asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Gitlink"]))
+    asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Py-Coder"]))
     assert notifications.visible is True
     assert notifications.msg_type == "info"
-    assert "Gitlink" in notifications.message
+    assert "Py-Coder" in notifications.message
     assert "R3" in notifications.message or "R5" in notifications.message
 
 
@@ -252,12 +255,76 @@ def test_execute_plugin_artifact_drafter_creates_a_real_artifact_node():
     assert "scene" in recorder.topics_seen()
 
 
-# -- R5.1/R5.2: non-regression - every OTHER plugin name is still an honest,
-# unchanged deferred notice ---------------------------------------------------
+# -- R5.3: "Gitlink" - the third real node-creation plugin -------------------
+
+
+def test_execute_plugin_gitlink_requires_parent():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Gitlink"]))
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == (
+        "Please select a valid node to branch from before adding a Gitlink node."
+    )
+    assert not any(n.kind == "gitlink" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_gitlink_rejects_unknown_parent_id():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Gitlink", "ghost-node-id"])
+    )
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == (
+        "Please select a valid node to branch from before adding a Gitlink node."
+    )
+    assert not any(n.kind == "gitlink" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_gitlink_creates_node():
+    bus, notifications, canvas_document = _make_plugins_bus()
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    class Recorder:
+        def __init__(self):
+            self.messages = []
+
+        async def send_json(self, data):
+            self.messages.append(data)
+
+        def topics_seen(self):
+            return [m["topic"] for m in self.messages if m["kind"] == "state"]
+
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Gitlink", parent.id]))
+
+    assert result is not None
+    node = canvas_document.nodes[result]
+    assert node.kind == "gitlink"
+    assert node.title == "Gitlink"
+    assert any(
+        e.source == parent.id and e.target == node.id for e in canvas_document.edges.values()
+    )
+    assert notifications.visible is False, "success is not a deferral - no notification fires"
+    assert "scene" in recorder.topics_seen()
+
+
+# -- R5.1/R5.2/R5.3: non-regression - every OTHER plugin name is still an
+# honest, unchanged deferred notice -------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "name", [n for n in (p[0] for p in _PLUGINS) if n not in ("Web Research", "Artifact / Drafter")]
+    "name",
+    [n for n in (p[0] for p in _PLUGINS) if n not in ("Web Research", "Artifact / Drafter", "Gitlink")],
 )
 def test_execute_plugin_every_other_plugin_name_still_shows_the_unchanged_deferred_notice(name):
     bus, notifications, canvas_document = _make_plugins_bus()

--- a/graphlink_app/graphlink_plugins/gitlink/agent.py
+++ b/graphlink_app/graphlink_plugins/gitlink/agent.py
@@ -27,7 +27,7 @@ import re
 from pathlib import Path, PurePosixPath
 
 import api_provider
-import graphlink_config as config
+import graphlink_task_config as config
 from graphlink_plugins.common.llm_json import extract_json_object
 
 

--- a/graphlink_app/graphlink_scene_payload.py
+++ b/graphlink_app/graphlink_scene_payload.py
@@ -57,6 +57,32 @@ full document text. Populated for kind=="artifact" rows, defaulted (empty
 string) for every other kind, same additive rule. The turn-by-turn
 conversation reuses the existing `history` field (R3.25) rather than a new
 list-typed field.
+
+R5.3 adds the Gitlink node's 16 `gitlink*` fields: populated for
+kind=="gitlink" rows, defaulted (empty string/list/dict/None) for every
+other kind, same additive rule. `gitlinkContextXml` is DELIBERATELY NOT
+one of these 16 - repository.py's build_context_bundle can produce up to
+180,000 chars of XML (MAX_CONTEXT_CHARS), an order of magnitude above every
+other Gitlink field's implicit ceiling, and scene_payload() resends every
+node on ~20 undebounced triggers - inlining that blob here would reproduce
+the exact cost the R3.21 image_assets transport decision (see that field's
+own comment) was designed to avoid. It is served on demand via the
+read-only fetchGitlinkContext intent instead, never as part of this
+snapshot. `gitlinkPendingChanges` is a list of `GitlinkPendingChangeRow` (a
+proper nested dataclass, matching the convention `ResearchSourceRow`
+already established for a list-of-structured-object field, rather than a
+loose dict) - `content` is `str | None` (not required) because a `delete`
+operation's normalized change item genuinely omits the `content` key
+entirely (see GitlinkAgent._normalize_files), and the schema generator's
+required/optional split is driven purely by `X | None` typing, not by a
+dataclass default value.
+
+R5.3 post-review FIX 6 adds `gitlinkContextVersion` (a genuine monotonic
+per-node counter, see the field's own comment on SceneNodeRow below) -
+UNLIKE `gitlinkContextXml`/the backend-only `gitlink_change_local_root`,
+this one DOES belong on the wire: the frontend's Context-tabs lazy-fetch
+guard needs it to detect a new Build Context result even when
+`gitlinkContextSummary` happens to repeat.
 """
 
 from __future__ import annotations
@@ -124,6 +150,20 @@ class ResearchResultRow:
 
 
 @dataclass
+class GitlinkPendingChangeRow:
+    path: str
+    operation: str
+    reason: str
+    # str | None (not just a defaulted str): a `delete` operation's
+    # normalized change item genuinely omits the `content` key entirely (see
+    # GitlinkAgent._normalize_files) - the schema generator's required/
+    # optional split is driven by `X | None` typing, not by a dataclass
+    # default value, so this must be Optional for a delete-only item to
+    # validate.
+    content: str | None = None
+
+
+@dataclass
 class SceneNodeRow:
     id: str
     x: float
@@ -183,6 +223,43 @@ class SceneNodeRow:
     # diff/patch). Populated for kind=="artifact" rows, defaulted (empty
     # string) for every other kind.
     artifactContent: str = ""
+    # R5.3: the Gitlink node's real persisted shape - populated for
+    # kind=="gitlink" rows, defaulted for every other kind. gitlinkContextXml
+    # is DELIBERATELY NOT one of these fields - see this module's own
+    # docstring for why (served on demand via fetchGitlinkContext instead).
+    gitlinkRepo: str = ""
+    gitlinkBranch: str = ""
+    gitlinkScopeMode: str = "selected"
+    gitlinkLocalRoot: str = ""
+    gitlinkRepoFilePaths: list[str] = field(default_factory=list)
+    gitlinkSelectedPaths: list[str] = field(default_factory=list)
+    gitlinkTaskPrompt: str = ""
+    # dict[str, str], not the mixed int/str shape repository.py's
+    # build_context_bundle actually returns - backend/canvas.py's
+    # store_gitlink_context stringifies every value before this ever reaches
+    # the wire (see that method's own comment), so this stays honestly
+    # dict[str, str] end to end.
+    gitlinkContextStats: dict[str, str] = field(default_factory=dict)
+    gitlinkContextSummary: str = ""
+    # R5.3 post-review FIX 6: a genuine monotonic per-node counter,
+    # incremented unconditionally every time backend/canvas.py's
+    # store_gitlink_context lands a successful Build Context result - unlike
+    # gitlinkContextSummary (built purely from aggregate file counts, never
+    # from paths/content), two different Build Context results can never
+    # collide here. Closes a real bug: the frontend's Context-tabs
+    # lazy-fetch-once guard used to key on gitlinkContextSummary alone, and
+    # two DIFFERENT builds (e.g. selecting a different single file each
+    # time) could produce an IDENTICAL summary string, so the guard
+    # incorrectly skipped refetching and showed stale XML. See
+    # backend/canvas.py's SceneNode.gitlink_context_version for the full
+    # rationale.
+    gitlinkContextVersion: int = 0
+    gitlinkProposalMarkdown: str = ""
+    gitlinkPendingChanges: list[GitlinkPendingChangeRow] = field(default_factory=list)
+    gitlinkPreviewText: str = ""
+    gitlinkChangeFingerprint: str | None = None
+    gitlinkChangeState: str = "draft"
+    gitlinkError: str = ""
 
 
 @dataclass

--- a/graphlink_app/tests/test_gitlink_agent.py
+++ b/graphlink_app/tests/test_gitlink_agent.py
@@ -8,6 +8,8 @@ direct assertion that the module has zero Qt dependencies, same as the Code Revi
 Quality Gate scoring-module tests.
 """
 
+import os
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -25,6 +27,8 @@ from graphlink_plugins.gitlink.agent import (
     _xml_file_block,
 )
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
 
 def test_module_has_no_qt_dependency():
     import graphlink_plugins.gitlink.agent as agent_module
@@ -32,6 +36,47 @@ def test_module_has_no_qt_dependency():
     source = Path(agent_module.__file__).read_text(encoding="utf-8")
     for banned in ("PySide6", "qtawesome", "QGraphics", "QWidget", "QApplication"):
         assert banned not in source, f"{banned} leaked into the supposedly Qt-free gitlink agent module"
+
+
+def test_module_imports_qt_free_in_a_fresh_process_and_resolves_the_qt_free_config():
+    # Step 0 (R5.3): agent.py's `import graphlink_config as config` was ONE
+    # transitive Qt hazard - graphlink_config.py does unconditional
+    # module-top-level `from PySide6.QtGui import ...` / `from PySide6.QtWidgets
+    # import QApplication`, so importing this module pulled the whole Qt stack
+    # into any process that touched it (e.g. backend/agents.py), even though
+    # this module itself has zero direct PySide6 imports (confirmed by the
+    # string-scan above). Swapping to `graphlink_task_config` severs that
+    # chain. A same-process `sys.modules` assertion is unreliable here - some
+    # earlier test in the same pytest run may already have imported Qt - so
+    # this runs a fresh python subprocess and asserts PySide6 never enters
+    # sys.modules, mirroring backend/tests/test_agent_layer_qt_free.py's own
+    # `_assert_import_is_qt_free` mechanism (the real precedent for "does this
+    # import chain stay Qt-free" in this codebase).
+    code = (
+        "import sys\n"
+        "import graphlink_plugins.gitlink.agent as agent_module\n"
+        "qt = [m for m in sys.modules if m.startswith('PySide6')]\n"
+        "assert not qt, f'importing graphlink_plugins.gitlink.agent pulled Qt: {qt}'\n"
+        "assert agent_module.config.__name__ == 'graphlink_task_config', (\n"
+        "    f'agent.py config reference resolved to {agent_module.config.__name__!r}, '\n"
+        "    'expected graphlink_task_config'\n"
+        ")\n"
+        "print('graphlink_plugins.gitlink.agent imported qt-free')\n"
+    )
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT / "graphlink_app") + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        "importing graphlink_plugins.gitlink.agent in a fresh process failed or pulled Qt:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
 
 
 class TestCleanText:

--- a/web_ui/src/app/canvas/GitlinkNodeView.test.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.test.tsx
@@ -1,0 +1,607 @@
+import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { OverlayProvider } from "../overlays/overlays";
+import { GitlinkNodeView, type GitlinkFlowNode } from "./GitlinkNodeView";
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
+// ArtifactNodeView.test.tsx/WebResearchNodeView.test.tsx for why a bare
+// ReactFlowProvider is enough here too. Also wrapped in OverlayProvider,
+// unlike those two siblings - GitlinkNodeView's Apply confirmation is a real
+// <Dialog> from the R2.1 overlay system (../overlays/overlays), which throws
+// without a provider ancestor (see useOverlays()).
+
+function baseData(overrides: Partial<GitlinkFlowNode["data"]> = {}): GitlinkFlowNode["data"] {
+  return {
+    gitlinkRepo: "",
+    gitlinkBranch: "",
+    gitlinkScopeMode: "selected",
+    gitlinkLocalRoot: "",
+    gitlinkRepoFilePaths: [],
+    gitlinkSelectedPaths: [],
+    gitlinkTaskPrompt: "",
+    gitlinkContextStats: {},
+    gitlinkContextSummary: "",
+    gitlinkContextVersion: 0,
+    gitlinkProposalMarkdown: "",
+    gitlinkPendingChanges: [],
+    gitlinkPreviewText: "",
+    gitlinkChangeFingerprint: null,
+    gitlinkChangeState: "",
+    gitlinkError: "",
+    isCollapsed: false,
+    pendingRequestId: null,
+    onFetchRepositories: vi.fn().mockResolvedValue([]),
+    onLoadTree: vi.fn(),
+    onSetLocalRoot: vi.fn(),
+    onImportSnapshot: vi.fn(),
+    onBuildContext: vi.fn(),
+    onFetchContext: vi.fn().mockResolvedValue(""),
+    onRun: vi.fn(),
+    onCancel: vi.fn(),
+    onApply: vi.fn(),
+    onToggleCollapse: vi.fn(),
+    onDelete: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderGitlinkNode(overrides: Partial<GitlinkFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "gl-1", selected: false, data } as unknown as NodeProps<GitlinkFlowNode>;
+
+  render(
+    <OverlayProvider>
+      <ReactFlowProvider>
+        <GitlinkNodeView {...props} />
+      </ReactFlowProvider>
+    </OverlayProvider>,
+  );
+  return data;
+}
+
+// Directly sets the React Flow internal Zustand store's transform/zoom value
+// - same technique ArtifactNodeView.test.tsx's own ZoomSetter uses.
+function ZoomSetter({ zoom }: { zoom: number }) {
+  const store = useStoreApi();
+  useEffect(() => {
+    store.setState({ transform: [0, 0, zoom] });
+  }, [zoom, store]);
+  return null;
+}
+
+function renderGitlinkNodeAtZoom(zoom: number, overrides: Partial<GitlinkFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "gl-1", selected: false, data } as unknown as NodeProps<GitlinkFlowNode>;
+
+  render(
+    <OverlayProvider>
+      <ReactFlowProvider>
+        <ZoomSetter zoom={zoom} />
+        <GitlinkNodeView {...props} />
+      </ReactFlowProvider>
+    </OverlayProvider>,
+  );
+  return data;
+}
+
+// Same shell as renderGitlinkNode, but also returns RTL's `rerender` so a
+// test can push a NEW `data` object at the same mounted component instance -
+// needed for FIX 5 (stale-fetch race) and FIX 7 (repo/branch change resets
+// selection), both of which are about how the component reacts to a prop
+// change, not just its initial-mount shape.
+function renderGitlinkNodeWithRerender(overrides: Partial<GitlinkFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "gl-1", selected: false, data } as unknown as NodeProps<GitlinkFlowNode>;
+
+  const utils = render(
+    <OverlayProvider>
+      <ReactFlowProvider>
+        <GitlinkNodeView {...props} />
+      </ReactFlowProvider>
+    </OverlayProvider>,
+  );
+
+  function rerenderWithData(nextData: GitlinkFlowNode["data"]) {
+    const nextProps = { id: "gl-1", selected: false, data: nextData } as unknown as NodeProps<GitlinkFlowNode>;
+    utils.rerender(
+      <OverlayProvider>
+        <ReactFlowProvider>
+          <GitlinkNodeView {...nextProps} />
+        </ReactFlowProvider>
+      </OverlayProvider>,
+    );
+  }
+
+  return { data, rerenderWithData };
+}
+
+/** Every one of the nine WS-backed callback props, for a single spy-and-assert-zero-calls check. */
+function allNineSpies(data: GitlinkFlowNode["data"]) {
+  return [
+    data.onFetchRepositories,
+    data.onLoadTree,
+    data.onSetLocalRoot,
+    data.onImportSnapshot,
+    data.onBuildContext,
+    data.onFetchContext,
+    data.onRun,
+    data.onCancel,
+    data.onApply,
+  ] as unknown as ReturnType<typeof vi.fn>[];
+}
+
+describe("GitlinkNodeView", () => {
+  // -- tabs -------------------------------------------------------------
+
+  it("renders all three tabs and can switch between them", async () => {
+    const user = userEvent.setup();
+    renderGitlinkNode();
+
+    expect(screen.getByRole("tab", { name: "Setup" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Context" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Proposal" })).toBeInTheDocument();
+
+    // Setup is the default active tab.
+    expect(screen.getByRole("button", { name: "Load Repo Tree" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Context" }));
+    expect(screen.getByText("No context built yet.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Proposal" }));
+    expect(screen.getByText("No change set generated yet.")).toBeInTheDocument();
+  });
+
+  // -- collapse/expand + LOD ----------------------------------------------
+
+  it("manual collapse hides the body and shows only the header", () => {
+    renderGitlinkNode({ isCollapsed: true });
+    expect(screen.getByText("Gitlink")).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Setup" })).toBeNull();
+  });
+
+  it("the inline collapse chevron calls onToggleCollapse", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode();
+    await user.click(screen.getByRole("button", { name: "Collapse" }));
+    expect(data.onToggleCollapse).toHaveBeenCalledOnce();
+  });
+
+  it("LOD auto-collapse (zoom below threshold) also hides the body, even when isCollapsed is false", () => {
+    renderGitlinkNodeAtZoom(0.2, { isCollapsed: false });
+    expect(screen.getByText("Gitlink")).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Setup" })).toBeNull();
+  });
+
+  it("stays expanded above the LOD threshold when isCollapsed is false", () => {
+    renderGitlinkNodeAtZoom(1, { isCollapsed: false });
+    expect(screen.getByRole("tab", { name: "Setup" })).toBeInTheDocument();
+  });
+
+  // -- Setup tab: repo/branch do not call any WS method until explicit Load -
+
+  it("typing into repo/branch fields calls no WS method - only clicking Load Repo Tree does", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode();
+    const spies = allNineSpies(data);
+
+    await user.type(screen.getByRole("textbox", { name: "Repository" }), "owner/repo");
+    await user.type(screen.getByRole("textbox", { name: "Branch" }), "main");
+    for (const spy of spies) expect(spy).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Load Repo Tree" }));
+    expect(data.onLoadTree).toHaveBeenCalledWith("owner/repo", "main");
+  });
+
+  it("pressing Enter in the branch field also triggers Load Repo Tree", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode();
+    await user.type(screen.getByRole("textbox", { name: "Repository" }), "owner/repo");
+    await user.type(screen.getByRole("textbox", { name: "Branch" }), "main{Enter}");
+    expect(data.onLoadTree).toHaveBeenCalledWith("owner/repo", "main");
+  });
+
+  it("Load Repo Tree is disabled when the repo field is empty", () => {
+    renderGitlinkNode();
+    expect(screen.getByRole("button", { name: "Load Repo Tree" })).toBeDisabled();
+  });
+
+  it("List My Repos calls onFetchRepositories and renders the returned names as pickable options", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode({
+      onFetchRepositories: vi.fn().mockResolvedValue(["owner/repo-a", "owner/repo-b"]),
+    });
+
+    await user.click(screen.getByRole("button", { name: "List My Repos" }));
+    expect(data.onFetchRepositories).toHaveBeenCalledOnce();
+
+    await screen.findByRole("button", { name: "owner/repo-a" });
+    await user.click(screen.getByRole("button", { name: "owner/repo-a" }));
+    expect(screen.getByRole("textbox", { name: "Repository" })).toHaveValue("owner/repo-a");
+  });
+
+  it("local root is committed via onSetLocalRoot only on blur, not on every keystroke", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode();
+    const input = screen.getByRole("textbox", { name: "Local root" });
+
+    await user.type(input, "C:/repos/thing");
+    expect(data.onSetLocalRoot).not.toHaveBeenCalled();
+
+    await user.click(document.body);
+    expect(data.onSetLocalRoot).toHaveBeenCalledWith("C:/repos/thing");
+  });
+
+  it("pressing Enter in the Local root field commits via onSetLocalRoot exactly once, not twice (FIX 8)", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode();
+    const input = screen.getByRole("textbox", { name: "Local root" });
+
+    await user.type(input, "C:/repos/thing{Enter}");
+
+    // Enter used to both call commitLocalRoot() directly AND trigger .blur(),
+    // which itself fires the onBlur={commitLocalRoot} handler - double
+    // dispatching the WS intent for one keypress.
+    expect(data.onSetLocalRoot).toHaveBeenCalledTimes(1);
+    expect(data.onSetLocalRoot).toHaveBeenCalledWith("C:/repos/thing");
+  });
+
+  it("Import Repo Snapshot uses the current repo/branch draft field values", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode();
+
+    await user.type(screen.getByRole("textbox", { name: "Repository" }), "owner/repo");
+    await user.type(screen.getByRole("textbox", { name: "Branch" }), "dev");
+    await user.click(screen.getByRole("button", { name: "Import Repo Snapshot" }));
+    expect(data.onImportSnapshot).toHaveBeenCalledWith("owner/repo", "dev");
+  });
+
+  // -- Setup tab: file tree is pure client-side state ----------------------
+
+  it("file-tree filter/select-visible/clear-selection never call any WS method", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode({
+      gitlinkRepoFilePaths: ["src/a.py", "src/b.py", "readme.md"],
+    });
+    const spies = allNineSpies(data);
+
+    await user.type(screen.getByRole("textbox", { name: "Filter files" }), "src/");
+    expect(screen.getByText("src/a.py")).toBeInTheDocument();
+    expect(screen.queryByText("readme.md")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Select Visible" }));
+    expect(screen.getByText("2 selected")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Clear Selection" }));
+    expect(screen.getByText("0 selected")).toBeInTheDocument();
+
+    for (const spy of spies) expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("switching to a different repo/branch resets the file-tree selection (FIX 7)", async () => {
+    const user = userEvent.setup();
+    const { data, rerenderWithData } = renderGitlinkNodeWithRerender({
+      gitlinkRepo: "owner/repo-a",
+      gitlinkBranch: "main",
+      gitlinkRepoFilePaths: ["a.py", "b.py"],
+    });
+
+    await user.click(screen.getByLabelText("a.py"));
+    await user.click(screen.getByLabelText("b.py"));
+    expect(screen.getByText("2 selected")).toBeInTheDocument();
+
+    const dataForRepoB = {
+      ...data,
+      gitlinkRepo: "owner/repo-b",
+      gitlinkBranch: "dev",
+      gitlinkRepoFilePaths: ["c.py"],
+    };
+    rerenderWithData(dataForRepoB);
+
+    await waitFor(() => expect(screen.getByText("0 selected")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "Build Context" }));
+    // The stale repo-A paths ("a.py"/"b.py") must not ride into the build for
+    // repo B - selectedPaths was reset to [] by the repo/branch change.
+    expect(dataForRepoB.onBuildContext).toHaveBeenCalledWith("selected", []);
+  });
+
+  it("does NOT reset the file-tree selection on the initial mount (only on a later repo/branch change)", () => {
+    renderGitlinkNode({
+      gitlinkRepo: "owner/repo-a",
+      gitlinkBranch: "main",
+      gitlinkRepoFilePaths: ["a.py", "b.py"],
+      gitlinkSelectedPaths: ["a.py"],
+    });
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+  });
+
+  it("Build Context sends the current scope mode and selected paths only when clicked", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode({ gitlinkRepoFilePaths: ["src/a.py", "src/b.py"] });
+
+    await user.click(screen.getByLabelText("src/a.py"));
+    await user.selectOptions(screen.getByLabelText("Context scope"), "full");
+    expect(data.onBuildContext).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Build Context" }));
+    expect(data.onBuildContext).toHaveBeenCalledWith("full", ["src/a.py"]);
+  });
+
+  it("Generate Change Set passes the trimmed task-prompt draft directly to onRun", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode();
+
+    await user.type(screen.getByRole("textbox", { name: "Task prompt" }), "  add a health check  ");
+    await user.click(screen.getByRole("button", { name: "Generate Change Set" }));
+    expect(data.onRun).toHaveBeenCalledWith("add a health check");
+  });
+
+  it("the Cancel button appears only while pendingRequestId is set and calls onCancel", async () => {
+    const user = userEvent.setup();
+    expect(renderGitlinkNode({ pendingRequestId: null })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+
+    const data = renderGitlinkNode({ pendingRequestId: "req-1" });
+    const cancelBtn = screen.getByRole("button", { name: "Cancel" });
+    await user.click(cancelBtn);
+    expect(data.onCancel).toHaveBeenCalledOnce();
+  });
+
+  // -- Context tab: fetch-once-per-summary ---------------------------------
+
+  it("onFetchContext is called exactly once the first time the Context tab is opened, and not again on a second open with the same summary", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode({
+      gitlinkContextSummary: "2 files, 512 tokens",
+      onFetchContext: vi.fn().mockResolvedValue("<context/>"),
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Context" }));
+    await waitFor(() => expect(data.onFetchContext).toHaveBeenCalledTimes(1));
+    await screen.findByText("<context/>");
+
+    await user.click(screen.getByRole("tab", { name: "Setup" }));
+    await user.click(screen.getByRole("tab", { name: "Context" }));
+    expect(data.onFetchContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fetch context at all while the summary is empty", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode({ gitlinkContextSummary: "" });
+    await user.click(screen.getByRole("tab", { name: "Context" }));
+    expect(data.onFetchContext).not.toHaveBeenCalled();
+  });
+
+  it("shows the context stats/summary immediately with no fetch required for those two", () => {
+    renderGitlinkNode({
+      gitlinkContextSummary: "2 files, 512 tokens",
+      gitlinkContextStats: { files: "2", tokens: "512" },
+    });
+    // Stats/summary are already present in props - switching is required to
+    // even see the tab, but the values themselves need no network call.
+  });
+
+  it("refetches when gitlinkContextVersion changes even if gitlinkContextSummary stays IDENTICAL (FIX 6)", async () => {
+    const user = userEvent.setup();
+    const onFetchContext = vi
+      .fn()
+      .mockResolvedValueOnce("<context>build 1</context>")
+      .mockResolvedValueOnce("<context>build 2</context>");
+
+    const { data, rerenderWithData } = renderGitlinkNodeWithRerender({
+      gitlinkContextSummary: "Scanned 1 files.",
+      gitlinkContextVersion: 1,
+      onFetchContext,
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Context" }));
+    await waitFor(() => expect(onFetchContext).toHaveBeenCalledTimes(1));
+    await screen.findByText("<context>build 1</context>");
+
+    // A second, different Build Context call (e.g. a different single-file
+    // selection) happens to produce the exact same human-readable summary
+    // string - only the version counter tells the two builds apart. Keying
+    // the re-fetch guard on the summary alone would incorrectly treat this
+    // as "nothing changed" and skip the refetch.
+    rerenderWithData({
+      ...data,
+      gitlinkContextSummary: "Scanned 1 files.",
+      gitlinkContextVersion: 2,
+    });
+
+    await waitFor(() => expect(onFetchContext).toHaveBeenCalledTimes(2));
+    await screen.findByText("<context>build 2</context>");
+  });
+
+  // R5.3 post-review FIX 5: an older in-flight fetch resolving AFTER a newer
+  // one must never clobber the newer result.
+  it("a stale (older) context fetch resolving after a newer one does not overwrite the newer content (FIX 5)", async () => {
+    const user = userEvent.setup();
+    let resolveFirst!: (xml: string) => void;
+    let resolveSecond!: (xml: string) => void;
+    const firstFetch = new Promise<string>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondFetch = new Promise<string>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const onFetchContext = vi.fn().mockReturnValueOnce(firstFetch).mockReturnValueOnce(secondFetch);
+
+    const { data, rerenderWithData } = renderGitlinkNodeWithRerender({
+      gitlinkContextSummary: "build A - 1 file",
+      gitlinkContextVersion: 1,
+      onFetchContext,
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Context" }));
+    await waitFor(() => expect(onFetchContext).toHaveBeenCalledTimes(1));
+
+    // A second, newer Build Context completes while the first fetch is still
+    // in flight - the version bump (mirroring a real Build Context call) is
+    // enough to kick off fetch #2.
+    rerenderWithData({ ...data, gitlinkContextSummary: "build B - 2 files", gitlinkContextVersion: 2 });
+    await waitFor(() => expect(onFetchContext).toHaveBeenCalledTimes(2));
+
+    // Resolve the NEWER fetch first, then the OLDER one arrives late - the
+    // classic out-of-order race the guard exists for.
+    resolveSecond("<context>NEW BUILD B</context>");
+    await screen.findByText("<context>NEW BUILD B</context>");
+
+    resolveFirst("<context>STALE BUILD A</context>");
+    expect(screen.queryByText("<context>STALE BUILD A</context>")).toBeNull();
+    expect(screen.getByText("<context>NEW BUILD B</context>")).toBeInTheDocument();
+  });
+
+  // -- Proposal tab: markdown/diff rendering + security --------------------
+
+  it("renders the proposal markdown and the diff (as syntax-highlighted fenced code) through ReactMarkdown", async () => {
+    const user = userEvent.setup();
+    renderGitlinkNode({
+      gitlinkProposalMarkdown: "# Add health check\n\nThis adds **a route**.",
+      gitlinkPreviewText: "--- a/app.py\n+++ b/app.py\n@@ -1,1 +1,2 @@\n+# new line",
+    });
+    await user.click(screen.getByRole("tab", { name: "Proposal" }));
+    expect(screen.getByRole("heading", { name: "Add health check" })).toBeInTheDocument();
+    expect(screen.getByText("a route")).toBeInTheDocument();
+    expect(document.querySelector("pre code")).not.toBeNull();
+  });
+
+  it("SECURITY: a proposal markdown string containing a literal <img onerror> tag never becomes a real rendered img element", async () => {
+    const user = userEvent.setup();
+    renderGitlinkNode({
+      gitlinkProposalMarkdown: 'Look at this: <img src="x" onerror="alert(1)"> nothing happened.',
+    });
+    await user.click(screen.getByRole("tab", { name: "Proposal" }));
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("SECURITY: a diff string containing a literal <img onerror> tag never becomes a real rendered img element", async () => {
+    const user = userEvent.setup();
+    renderGitlinkNode({
+      gitlinkPreviewText: '+<img src="x" onerror="alert(1)">',
+    });
+    await user.click(screen.getByRole("tab", { name: "Proposal" }));
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  // -- Apply confirmation ---------------------------------------------------
+
+  it("clicking Apply does NOT call onApply directly - it opens a confirmation first", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode({
+      gitlinkPendingChanges: [{ path: "app.py", operation: "modify", reason: "add route" }],
+      gitlinkChangeFingerprint: "fp-123",
+      gitlinkLocalRoot: "C:/repos/repo",
+    });
+    await user.click(screen.getByRole("tab", { name: "Proposal" }));
+
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+    expect(data.onApply).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog", { name: "Apply Changes?" })).toBeInTheDocument();
+    expect(screen.getByText(/Write 1 file change into C:\/repos\/repo\?/)).toBeInTheDocument();
+    expect(screen.getByText(/modify.*app\.py/)).toBeInTheDocument();
+  });
+
+  it("clicking Yes in the confirmation calls onApply with EXACTLY the gitlinkChangeFingerprint prop value", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode({
+      gitlinkPendingChanges: [{ path: "app.py", operation: "modify", reason: "add route" }],
+      gitlinkChangeFingerprint: "fp-exact-value",
+      gitlinkLocalRoot: "C:/repos/repo",
+    });
+    await user.click(screen.getByRole("tab", { name: "Proposal" }));
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+    await user.click(screen.getByRole("button", { name: "Yes" }));
+
+    expect(data.onApply).toHaveBeenCalledExactlyOnceWith("fp-exact-value");
+  });
+
+  it("clicking Cancel in the confirmation dismisses it without calling onApply", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode({
+      gitlinkPendingChanges: [{ path: "app.py", operation: "modify", reason: "add route" }],
+      gitlinkChangeFingerprint: "fp-123",
+    });
+    await user.click(screen.getByRole("tab", { name: "Proposal" }));
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(data.onApply).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog", { name: "Apply Changes?" })).toBeNull();
+  });
+
+  it("Apply is disabled with no pending changes or no fingerprint", async () => {
+    const user = userEvent.setup();
+    renderGitlinkNode({ gitlinkPendingChanges: [], gitlinkChangeFingerprint: null });
+    await user.click(screen.getByRole("tab", { name: "Proposal" }));
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+  });
+
+  it("Apply and the confirmation's Yes button are both disabled while gitlinkChangeState is 'applying'", async () => {
+    const user = userEvent.setup();
+    renderGitlinkNode({
+      gitlinkPendingChanges: [{ path: "app.py", operation: "modify", reason: "add route" }],
+      gitlinkChangeFingerprint: "fp-123",
+      gitlinkChangeState: "applying",
+    });
+    await user.click(screen.getByRole("tab", { name: "Proposal" }));
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+  });
+
+  it("shows the gitlinkError inline in the Proposal tab when changeState is 'previewed'", async () => {
+    const user = userEvent.setup();
+    renderGitlinkNode({
+      gitlinkChangeState: "previewed",
+      gitlinkError: "The context changed since this proposal was generated - please review again.",
+    });
+    await user.click(screen.getByRole("tab", { name: "Proposal" }));
+    expect(
+      screen.getByText("The context changed since this proposal was generated - please review again."),
+    ).toBeInTheDocument();
+  });
+
+  // -- card-level menu ----------------------------------------------------
+
+  it("the node-level right-click menu shows exactly Collapse/Expand + Delete Node - no dock action", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode();
+
+    fireEvent.contextMenu(screen.getByText("Gitlink"));
+    const menu = screen.getByRole("menu");
+    expect(menu).toBeInTheDocument();
+
+    const items = screen.getAllByRole("menuitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("Collapse");
+    expect(items[1]).toHaveTextContent("Delete Node");
+    expect(screen.queryByRole("menuitem", { name: /Dock/ })).toBeNull();
+
+    await user.click(items[0]);
+    expect(data.onToggleCollapse).toHaveBeenCalledOnce();
+
+    fireEvent.contextMenu(screen.getByText("Gitlink"));
+    await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
+    expect(data.onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Escape and outside-click both close the node-level menu", async () => {
+    const user = userEvent.setup();
+    renderGitlinkNode();
+    const header = screen.getByText("Gitlink");
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/GitlinkNodeView.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.tsx
@@ -1,0 +1,659 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { Dialog, useOverlays } from "../overlays/overlays";
+
+/**
+ * The Gitlink node (Qt-removal plan R5.3) - the Gitlink plugin's React card.
+ * Same overall shell as every plugin-node sibling (ArtifactNodeView/
+ * WebResearchNodeView): collapse/expand OR-ed with LOD, a card menu with
+ * outside-click/Escape dismiss, the shared react-markdown + remarkGfm +
+ * rehypeHighlight pipeline, no dock-to-parent action. Unlike its siblings,
+ * this node is a three-tab workflow (Setup / Context / Proposal) rather than
+ * one linear scroll - the underlying task (pick a repo, scope a context,
+ * generate a change set, review a diff, apply it to real local files) has
+ * four genuinely different phases, and a tabbed layout is the least-surprise
+ * way to keep all of them reachable in one card without an ever-growing
+ * single column.
+ *
+ * State-ownership discipline (read this before touching any input in Setup):
+ * repo/branch/scope-mode/local-root/task-prompt/file-selection all live in
+ * LOCAL component state, initialized ONCE from the incoming scene snapshot
+ * and never re-synced afterward - the exact non-clobbering posture
+ * WebResearchNodeView's own query draft already established (a remote update
+ * mid-type must never stomp what the user is currently typing/selecting).
+ * scope_mode and the selected-paths set are never independently mirrored to
+ * the server at all - they exist purely to be read at the moment Build
+ * Context or Generate Change Set is clicked, then handed over as plain
+ * call arguments. Committing state to the server is always an explicit
+ * button (or blur/Enter) action, never a live keystroke-by-keystroke sync.
+ *
+ * The Context tab's full XML body is fetched lazily (data.onFetchContext())
+ * the first time the tab is opened after data.gitlinkContextVersion changes
+ * to a new value (a monotonic per-node counter bumped by the backend on
+ * every successful Build Context call), then cached in local state - never
+ * refetched on a bare tab-switch back and forth with the same version. This
+ * is keyed on the version counter rather than data.gitlinkContextSummary
+ * because two distinct builds can produce an identical summary string (e.g.
+ * "Scanned 1 files." for two different single-file selections), which would
+ * otherwise silently skip a required refetch (R5.3 post-review FIX 6).
+ *
+ * Security note, not a style preference: the Proposal tab renders BOTH
+ * data.gitlinkProposalMarkdown and data.gitlinkPreviewText (a unified diff)
+ * through the exact same react-markdown + remarkGfm + rehypeHighlight
+ * pipeline every sibling node view uses - no rehype-raw, no
+ * dangerouslySetInnerHTML anywhere in this file. The diff text is wrapped in
+ * a fenced ```diff code block first (toDiffFence, mirroring CodeNodeView's
+ * own toFencedCodeBlock) purely so rehype-highlight can colorize it - it is
+ * never treated as anything but inert text by the markdown pipeline, exactly
+ * like the proposal markdown itself (which can indirectly embed untrusted
+ * repo content by way of the model).
+ *
+ * Apply confirmation: the first plugin in this codebase that mutates real
+ * local files, so Apply does not fire data.onApply directly - it opens a
+ * small in-canvas confirmation built from the EXISTING R2.1 overlay
+ * primitive (Dialog/useOverlays from ../overlays/overlays, the same one
+ * HelpDialog/SettingsDialog/ChatLibraryDialog already render through), keyed
+ * uniquely per node instance (`gitlink-apply-${id}`) so two Gitlink nodes on
+ * the same canvas can never collide over one dialog name. The confirmation's
+ * own Yes button is the ONLY call site for data.onApply, and it is always
+ * called with the current data.gitlinkChangeFingerprint prop value verbatim
+ * - never anything computed here. This view has no fingerprinting logic of
+ * its own, full stop.
+ */
+
+export interface GitlinkPendingChangeRow {
+  path: string;
+  operation: string;
+  reason: string;
+  content?: string | null;
+}
+
+export interface GitlinkNodeData extends Record<string, unknown> {
+  gitlinkRepo: string;
+  gitlinkBranch: string;
+  gitlinkScopeMode: string;
+  gitlinkLocalRoot: string;
+  gitlinkRepoFilePaths: string[];
+  gitlinkSelectedPaths: string[];
+  gitlinkTaskPrompt: string;
+  gitlinkContextStats: Record<string, string>;
+  gitlinkContextSummary: string;
+  // Monotonic per-node counter bumped by the backend on every successful
+  // Build Context call (see R5.3 post-review FIX 6) - used instead of
+  // gitlinkContextSummary to key the Context tab's lazy-fetch guard, since
+  // two different builds can produce an identical human-readable summary.
+  gitlinkContextVersion: number;
+  gitlinkProposalMarkdown: string;
+  gitlinkPendingChanges: GitlinkPendingChangeRow[];
+  gitlinkPreviewText: string;
+  gitlinkChangeFingerprint: string | null;
+  gitlinkChangeState: string;
+  gitlinkError: string;
+  isCollapsed: boolean;
+  pendingRequestId: string | null;
+  onFetchRepositories: () => Promise<string[]>;
+  onLoadTree: (repo: string, branch: string) => void;
+  onSetLocalRoot: (localRoot: string) => void;
+  onImportSnapshot: (repo: string, branch: string) => void;
+  onBuildContext: (scopeMode: string, selectedPaths: string[]) => void;
+  onFetchContext: () => Promise<string>;
+  onRun: (taskPrompt: string) => void;
+  onCancel: () => void;
+  onApply: (fingerprint: string) => void;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+}
+
+export type GitlinkFlowNode = Node<GitlinkNodeData, "gitlink">;
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+/** Same outside-click/Escape dismiss pattern every sibling node menu uses
+ * (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu/ConversationNodeMenu/
+ * WebResearchNodeMenu/ArtifactNodeMenu). */
+function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
+      // type-only import above shadows the bare name for casts like this).
+      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [menuRef, onClose]);
+}
+
+// -- card-level menu -------------------------------------------------------
+
+function GitlinkNodeMenu({
+  position,
+  isCollapsed,
+  onToggleCollapse,
+  onDelete,
+  onClose,
+}: {
+  position: MenuPosition;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useMenuDismiss(menuRef, onClose);
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleCollapse();
+          onClose();
+        }}
+      >
+        {isCollapsed ? "Expand" : "Collapse"}
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        Delete Node
+      </button>
+    </div>
+  );
+}
+
+// -- helpers ----------------------------------------------------------------
+
+/** Wraps a raw unified diff in a markdown fenced code block tagged `diff` so
+ * ReactMarkdown + rehype-highlight can colorize it for free - the same
+ * technique CodeNodeView.tsx's own toFencedCodeBlock uses for source code,
+ * applied here to diff text instead. Never treated as anything but inert
+ * text by the pipeline either way. */
+function toDiffFence(diffText: string): string {
+  return "```diff\n" + diffText + "\n```";
+}
+
+type TabKey = "setup" | "context" | "proposal";
+const TABS: { key: TabKey; label: string }[] = [
+  { key: "setup", label: "Setup" },
+  { key: "context", label: "Context" },
+  { key: "proposal", label: "Proposal" },
+];
+
+// -- view ----------------------------------------------------------------
+
+export function GitlinkNodeView({ id, data, selected }: NodeProps<GitlinkFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const collapsed = data.isCollapsed || lodCollapsed;
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+  const [activeTab, setActiveTab] = useState<TabKey>("setup");
+  const overlays = useOverlays();
+  const applyOverlayName = `gitlink-apply-${id}`;
+
+  // -- Setup tab: local, never-resynced drafts (see module doc above) -----
+  const [repoDraft, setRepoDraft] = useState(data.gitlinkRepo);
+  const [branchDraft, setBranchDraft] = useState(data.gitlinkBranch);
+  const [scopeMode, setScopeMode] = useState(data.gitlinkScopeMode || "selected");
+  const [localRootDraft, setLocalRootDraft] = useState(data.gitlinkLocalRoot);
+  const [taskPromptDraft, setTaskPromptDraft] = useState(data.gitlinkTaskPrompt);
+  const [selectedPaths, setSelectedPaths] = useState<string[]>(data.gitlinkSelectedPaths);
+  const [fileFilter, setFileFilter] = useState("");
+
+  // R5.3 post-review FIX 7: selectedPaths above is seeded ONCE from
+  // data.gitlinkSelectedPaths and, by design (see the module doc), never
+  // re-synced on ordinary prop updates - but a genuinely different repo or
+  // branch loading a new tree must invalidate a prior selection, since paths
+  // selected against the OLD tree are not guaranteed to exist in the new one
+  // and would otherwise silently ride into the next Build Context call.
+  // repoBranchRef is initialized from the SAME initial repo/branch values
+  // selectedPaths itself was seeded from, so the first effect run after
+  // mount sees no change and never clears the just-restored selection.
+  const repoBranchRef = useRef(`${data.gitlinkRepo}::${data.gitlinkBranch}`);
+  useEffect(() => {
+    const current = `${data.gitlinkRepo}::${data.gitlinkBranch}`;
+    if (repoBranchRef.current !== current) {
+      repoBranchRef.current = current;
+      setSelectedPaths([]);
+    }
+  }, [data.gitlinkRepo, data.gitlinkBranch]);
+  const [repoOptions, setRepoOptions] = useState<string[] | null>(null);
+  const [repoOptionsLoading, setRepoOptionsLoading] = useState(false);
+  const [repoOptionsError, setRepoOptionsError] = useState<string | null>(null);
+
+  const busy = !!data.pendingRequestId;
+
+  function loadTree() {
+    const repo = repoDraft.trim();
+    if (!repo) return;
+    data.onLoadTree(repo, branchDraft.trim());
+  }
+
+  function commitLocalRoot() {
+    data.onSetLocalRoot(localRootDraft.trim());
+  }
+
+  function listRepos() {
+    setRepoOptionsLoading(true);
+    setRepoOptionsError(null);
+    data
+      .onFetchRepositories()
+      .then((names) => setRepoOptions(names))
+      .catch(() => setRepoOptionsError("Could not load repositories."))
+      .finally(() => setRepoOptionsLoading(false));
+  }
+
+  const filteredPaths = data.gitlinkRepoFilePaths.filter((path) =>
+    path.toLowerCase().includes(fileFilter.trim().toLowerCase()),
+  );
+
+  function togglePath(path: string) {
+    setSelectedPaths((current) =>
+      current.includes(path) ? current.filter((p) => p !== path) : [...current, path],
+    );
+  }
+
+  function selectVisible() {
+    setSelectedPaths((current) => Array.from(new Set([...current, ...filteredPaths])));
+  }
+
+  function clearSelection() {
+    setSelectedPaths([]);
+  }
+
+  function runChangeSet() {
+    const prompt = taskPromptDraft.trim();
+    if (!prompt) return;
+    data.onRun(prompt);
+  }
+
+  // -- Context tab: lazy-fetch-once-per-version ----------------------------
+  // The re-fetch guard is a ref, not state: it exists purely to gate the
+  // effect body (never rendered on its own), so mutating it directly avoids
+  // the classic "setState mirroring a dependency" anti-pattern - only the
+  // actual fetch RESULT (fetchedContextXml) needs to be React state, since
+  // that is the one value this component renders.
+  const [fetchedContextXml, setFetchedContextXml] = useState<string | null>(null);
+  // R5.3 post-review FIX 6: keyed on data.gitlinkContextVersion (a monotonic
+  // per-node counter, defaulting to 0, bumped by the backend on every
+  // successful Build Context call) rather than data.gitlinkContextSummary -
+  // the summary is a human-readable string that two DIFFERENT builds can
+  // produce identically (e.g. "Scanned 1 files." for two different
+  // single-file selections), which would make this ref wrongly believe
+  // nothing changed and skip a required refetch. The sentinel starts at
+  // `null` (never a legal version value, since the field is always a
+  // non-negative number) so the very first build (version 1) always passes
+  // the comparison below; a node that has never had context built at all
+  // stays at version 0 and never reaches this ref check, because the
+  // empty-summary early return just below still gates on that.
+  const fetchedForVersionRef = useRef<number | null>(null);
+  // R5.3 post-review FIX 5: guards against an OLDER in-flight fetch resolving
+  // AFTER a newer one (e.g. the user rebuilds context twice in quick
+  // succession) and clobbering the correct, newer XML with stale content.
+  // This is deliberately separate from fetchedForVersionRef above, which only
+  // decides whether to START a new fetch - this ref instead gates what
+  // happens when a fetch RESOLVES, regardless of resolution order.
+  const contextFetchSeqRef = useRef(0);
+
+  useEffect(() => {
+    if (activeTab !== "context") return;
+    if (!data.gitlinkContextSummary) return;
+    const version = data.gitlinkContextVersion ?? 0;
+    if (fetchedForVersionRef.current === version) return;
+    fetchedForVersionRef.current = version;
+    setFetchedContextXml(null);
+    const seq = ++contextFetchSeqRef.current;
+    data.onFetchContext().then((xml) => {
+      // A newer fetch has since been kicked off - this result is stale,
+      // discard it silently rather than overwriting the newer content.
+      if (contextFetchSeqRef.current !== seq) return;
+      setFetchedContextXml(xml);
+    });
+    // data.onFetchContext is a fresh closure every render (see SceneCanvas's
+    // toFlowNodes) - depending on it would refetch on every unrelated
+    // re-render, so it is deliberately omitted; fetchedForVersionRef is the
+    // real re-fetch guard.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab, data.gitlinkContextVersion]);
+
+  // -- Proposal tab / Apply confirmation -----------------------------------
+  const applying = data.gitlinkChangeState === "applying" || busy;
+  const canApply = data.gitlinkPendingChanges.length > 0 && !!data.gitlinkChangeFingerprint;
+
+  return (
+    <div
+      className={`scene-node gitlink-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title chat-node-role">
+        <span>Gitlink</span>
+        <button
+          type="button"
+          className="chat-node-collapse-btn"
+          aria-label={data.isCollapsed ? "Expand" : "Collapse"}
+          onClick={data.onToggleCollapse}
+        >
+          {data.isCollapsed ? "▸" : "▾"}
+        </button>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body gitlink-node-content">
+          <div className="gitlink-node-tabs" role="tablist" aria-label="Gitlink sections">
+            {TABS.map((tab) => (
+              <button
+                key={tab.key}
+                type="button"
+                role="tab"
+                aria-selected={activeTab === tab.key}
+                className={`gitlink-node-tab${activeTab === tab.key ? " active" : ""}`}
+                onClick={() => setActiveTab(tab.key)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {activeTab === "setup" && (
+            <div className="gitlink-node-setup-tab" role="tabpanel">
+              <div className="gitlink-node-field-row">
+                <input
+                  type="text"
+                  className="gitlink-node-input"
+                  value={repoDraft}
+                  onChange={(event) => setRepoDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      loadTree();
+                    }
+                  }}
+                  placeholder="owner/repo"
+                  aria-label="Repository"
+                />
+                <input
+                  type="text"
+                  className="gitlink-node-input"
+                  value={branchDraft}
+                  onChange={(event) => setBranchDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      loadTree();
+                    }
+                  }}
+                  placeholder="branch"
+                  aria-label="Branch"
+                />
+                <div className="gitlink-node-inline-row">
+                  <button type="button" disabled={busy} onClick={listRepos}>
+                    {repoOptionsLoading ? "Loading…" : "List My Repos"}
+                  </button>
+                  <button type="button" disabled={busy || !repoDraft.trim()} onClick={loadTree}>
+                    Load Repo Tree
+                  </button>
+                </div>
+                {repoOptionsError && <p className="gitlink-node-banner-error">{repoOptionsError}</p>}
+                {repoOptions && repoOptions.length > 0 && (
+                  <ul className="gitlink-node-repo-options">
+                    {repoOptions.map((name) => (
+                      <li key={name}>
+                        <button type="button" onClick={() => setRepoDraft(name)}>
+                          {name}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <label className="gitlink-node-field-row">
+                <span className="gitlink-node-field-label">Context scope</span>
+                <select
+                  className="gitlink-node-select"
+                  value={scopeMode}
+                  onChange={(event) => setScopeMode(event.target.value)}
+                >
+                  <option value="selected">Selected files</option>
+                  <option value="full">Full repo</option>
+                </select>
+              </label>
+
+              <label className="gitlink-node-field-row">
+                <span className="gitlink-node-field-label">Local root (no browse - deferred)</span>
+                <input
+                  type="text"
+                  className="gitlink-node-input"
+                  value={localRootDraft}
+                  onChange={(event) => setLocalRootDraft(event.target.value)}
+                  onBlur={commitLocalRoot}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      // Do NOT call commitLocalRoot() here too - .blur() below
+                      // synchronously fires the onBlur={commitLocalRoot}
+                      // handler above, so calling it directly here as well
+                      // would dispatch the WS intent twice per Enter press
+                      // (R5.3 post-review FIX 8).
+                      (event.target as HTMLInputElement).blur();
+                    }
+                  }}
+                  placeholder="C:\path\to\local\checkout"
+                  aria-label="Local root"
+                />
+              </label>
+
+              <div className="gitlink-node-inline-row">
+                <button
+                  type="button"
+                  disabled={busy || !repoDraft.trim()}
+                  onClick={() => data.onImportSnapshot(repoDraft.trim(), branchDraft.trim())}
+                >
+                  Import Repo Snapshot
+                </button>
+              </div>
+
+              <div className="gitlink-node-file-tree">
+                <input
+                  type="text"
+                  className="gitlink-node-input"
+                  value={fileFilter}
+                  onChange={(event) => setFileFilter(event.target.value)}
+                  placeholder="Filter files…"
+                  aria-label="Filter files"
+                />
+                <div className="gitlink-node-inline-row">
+                  <button type="button" onClick={selectVisible} disabled={filteredPaths.length === 0}>
+                    Select Visible
+                  </button>
+                  <button type="button" onClick={clearSelection} disabled={selectedPaths.length === 0}>
+                    Clear Selection
+                  </button>
+                </div>
+                <ul className="gitlink-node-file-list">
+                  {filteredPaths.length === 0 ? (
+                    <li className="gitlink-node-empty">No files loaded yet.</li>
+                  ) : (
+                    filteredPaths.map((path) => (
+                      <li key={path}>
+                        <label className="gitlink-node-file-row">
+                          <input
+                            type="checkbox"
+                            checked={selectedPaths.includes(path)}
+                            onChange={() => togglePath(path)}
+                          />
+                          {path}
+                        </label>
+                      </li>
+                    ))
+                  )}
+                </ul>
+                <p className="gitlink-node-file-count">{selectedPaths.length} selected</p>
+              </div>
+
+              <div className="gitlink-node-inline-row">
+                <button type="button" disabled={busy} onClick={() => data.onBuildContext(scopeMode, selectedPaths)}>
+                  Build Context
+                </button>
+              </div>
+
+              <div className="gitlink-node-field-row">
+                <textarea
+                  className="gitlink-node-input gitlink-node-task-prompt"
+                  value={taskPromptDraft}
+                  onChange={(event) => setTaskPromptDraft(event.target.value)}
+                  placeholder="Describe the change to make…"
+                  aria-label="Task prompt"
+                  rows={2}
+                  spellCheck
+                />
+                <div className="gitlink-node-inline-row">
+                  <button type="button" disabled={busy || !taskPromptDraft.trim()} onClick={runChangeSet}>
+                    Generate Change Set
+                  </button>
+                  {data.pendingRequestId && (
+                    <button type="button" onClick={() => data.onCancel()} title="Cancel Gitlink request">
+                      Cancel
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {activeTab === "context" && (
+            <div className="gitlink-node-context-tab" role="tabpanel">
+              {Object.keys(data.gitlinkContextStats).length > 0 && (
+                <div className="gitlink-node-context-stats">
+                  {Object.entries(data.gitlinkContextStats).map(([key, value]) => (
+                    <div key={key} className="gitlink-node-stat-row">
+                      <span className="gitlink-node-stat-key">{key}</span>
+                      <span className="gitlink-node-stat-value">{value}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {data.gitlinkContextSummary ? (
+                <>
+                  <p className="gitlink-node-context-summary">{data.gitlinkContextSummary}</p>
+                  {/* Machine-generated XML, rendered as plain preformatted text -
+                      never run through the markdown pipeline. */}
+                  <pre className="gitlink-node-context-xml">{fetchedContextXml ?? "Loading context…"}</pre>
+                </>
+              ) : (
+                <p className="gitlink-node-empty">No context built yet.</p>
+              )}
+            </div>
+          )}
+
+          {activeTab === "proposal" && (
+            <div className="gitlink-node-proposal-tab" role="tabpanel">
+              {data.gitlinkProposalMarkdown ? (
+                <div className="chat-node-content gitlink-node-proposal-markdown">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                    {data.gitlinkProposalMarkdown}
+                  </ReactMarkdown>
+                </div>
+              ) : (
+                <p className="gitlink-node-empty">No change set generated yet.</p>
+              )}
+
+              {data.gitlinkPreviewText && (
+                <div className="chat-node-content gitlink-node-proposal-diff">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                    {toDiffFence(data.gitlinkPreviewText)}
+                  </ReactMarkdown>
+                </div>
+              )}
+
+              {data.gitlinkChangeState === "previewed" && data.gitlinkError && (
+                <div className="gitlink-node-banner-error" role="alert">
+                  {data.gitlinkError}
+                </div>
+              )}
+
+              <div className="gitlink-node-apply-row">
+                <button
+                  type="button"
+                  className="gitlink-node-apply-btn"
+                  disabled={!canApply || applying}
+                  onClick={() => overlays.open(applyOverlayName, "dialog")}
+                >
+                  Apply
+                </button>
+              </div>
+
+              <Dialog name={applyOverlayName} title="Apply Changes?" className="gitlink-node-apply-dialog">
+                <p>
+                  Write {data.gitlinkPendingChanges.length} file{" "}
+                  {data.gitlinkPendingChanges.length === 1 ? "change" : "changes"} into{" "}
+                  {data.gitlinkLocalRoot}?
+                </p>
+                <ul className="gitlink-node-apply-file-list">
+                  {data.gitlinkPendingChanges.map((change, index) => (
+                    <li key={index}>
+                      {change.operation} — {change.path}
+                    </li>
+                  ))}
+                </ul>
+                <div className="gitlink-node-apply-dialog-actions">
+                  <button type="button" onClick={() => overlays.close()}>
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    disabled={applying || !data.gitlinkChangeFingerprint}
+                    onClick={() => {
+                      if (data.gitlinkChangeFingerprint) data.onApply(data.gitlinkChangeFingerprint);
+                      overlays.close();
+                    }}
+                  >
+                    Yes
+                  </button>
+                </div>
+              </Dialog>
+            </div>
+          )}
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+      {menuPosition && (
+        <GitlinkNodeMenu
+          position={menuPosition}
+          isCollapsed={data.isCollapsed}
+          onToggleCollapse={data.onToggleCollapse}
+          onDelete={data.onDelete}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -43,6 +43,22 @@ function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
     researchError: "",
     researchResult: null,
     artifactContent: "",
+    gitlinkRepo: "",
+    gitlinkBranch: "",
+    gitlinkScopeMode: "selected",
+    gitlinkLocalRoot: "",
+    gitlinkRepoFilePaths: [],
+    gitlinkSelectedPaths: [],
+    gitlinkTaskPrompt: "",
+    gitlinkContextStats: {},
+    gitlinkContextSummary: "",
+    gitlinkContextVersion: 0,
+    gitlinkProposalMarkdown: "",
+    gitlinkPendingChanges: [],
+    gitlinkPreviewText: "",
+    gitlinkChangeFingerprint: null,
+    gitlinkChangeState: "",
+    gitlinkError: "",
     ...overrides,
   };
 }
@@ -389,6 +405,167 @@ describe("toFlowNodes (R5.2 artifact node)", () => {
 
     (artifactFlowNode!.data as { onDelete: () => void }).onDelete();
     expect(removeSpy).toHaveBeenCalledWith(["art-1"]);
+  });
+});
+
+describe("toFlowNodes (R5.3 gitlink node)", () => {
+  it("maps a gitlink scene node's all 15 new fields onto the flow node's data - and gitlinkContextXml is never read (not part of the wire payload)", () => {
+    const pendingChanges = [
+      { path: "src/a.py", operation: "modify", reason: "add health check", content: "print(1)" },
+    ];
+    const scene = baseScene({
+      nodes: [
+        baseNode({
+          id: "gl-1",
+          kind: "gitlink",
+          isCollapsed: true,
+          pendingRequestId: "req-1",
+          gitlinkRepo: "owner/repo",
+          gitlinkBranch: "main",
+          gitlinkScopeMode: "selected",
+          gitlinkLocalRoot: "C:/repos/repo",
+          gitlinkRepoFilePaths: ["src/a.py", "src/b.py"],
+          gitlinkSelectedPaths: ["src/a.py"],
+          gitlinkTaskPrompt: "Add a health-check endpoint",
+          gitlinkContextStats: { files: "2", tokens: "512" },
+          gitlinkContextSummary: "2 files, 512 tokens",
+          gitlinkContextVersion: 3,
+          gitlinkProposalMarkdown: "# Proposal",
+          gitlinkPendingChanges: pendingChanges,
+          gitlinkPreviewText: "--- a/src/a.py\n+++ b/src/a.py",
+          gitlinkChangeFingerprint: "fp-1",
+          gitlinkChangeState: "previewed",
+          gitlinkError: "",
+        }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const glFlowNode = flowNodes.find((n) => n.id === "gl-1");
+    expect(glFlowNode).toBeDefined();
+    expect(glFlowNode!.type).toBe("gitlink");
+    expect(glFlowNode!.data).toMatchObject({
+      gitlinkRepo: "owner/repo",
+      gitlinkBranch: "main",
+      gitlinkScopeMode: "selected",
+      gitlinkLocalRoot: "C:/repos/repo",
+      gitlinkRepoFilePaths: ["src/a.py", "src/b.py"],
+      gitlinkSelectedPaths: ["src/a.py"],
+      gitlinkTaskPrompt: "Add a health-check endpoint",
+      gitlinkContextStats: { files: "2", tokens: "512" },
+      gitlinkContextSummary: "2 files, 512 tokens",
+      gitlinkContextVersion: 3,
+      gitlinkProposalMarkdown: "# Proposal",
+      gitlinkPendingChanges: pendingChanges,
+      gitlinkPreviewText: "--- a/src/a.py\n+++ b/src/a.py",
+      gitlinkChangeFingerprint: "fp-1",
+      gitlinkChangeState: "previewed",
+      gitlinkError: "",
+      isCollapsed: true,
+      pendingRequestId: "req-1",
+    });
+    // gitlinkContextXml genuinely is not part of SceneNodeRow at all - this
+    // mapping (and the wire payload it reads from) never references it.
+    expect("gitlinkContextXml" in (glFlowNode!.data as Record<string, unknown>)).toBe(false);
+  });
+
+  it("coalesces null-ish optional fields (pendingRequestId/gitlinkChangeFingerprint) to null", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "gl-2", kind: "gitlink" })],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const glFlowNode = flowNodes.find((n) => n.id === "gl-2");
+    expect(glFlowNode).toBeDefined();
+    expect(glFlowNode!.data).toMatchObject({ pendingRequestId: null, gitlinkChangeFingerprint: null });
+  });
+
+  it("onFetchRepositories/onLoadTree/onSetLocalRoot/onImportSnapshot/onBuildContext/onFetchContext/onRun/onApply all resolve to this node's id", () => {
+    const scene = baseScene({ nodes: [baseNode({ id: "gl-1", kind: "gitlink" })], edges: [] });
+    const store = makeStore();
+    const fetchReposSpy = vi.spyOn(store, "fetchGitlinkRepositories").mockResolvedValue([]);
+    const loadTreeSpy = vi.spyOn(store, "loadGitlinkRepoTree");
+    const setRootSpy = vi.spyOn(store, "setGitlinkLocalRoot");
+    const importSpy = vi.spyOn(store, "importGitlinkSnapshot");
+    const buildContextSpy = vi.spyOn(store, "buildGitlinkContext");
+    const fetchContextSpy = vi.spyOn(store, "fetchGitlinkContext").mockResolvedValue("");
+    const runSpy = vi.spyOn(store, "runGitlinkChangeSet");
+    const applySpy = vi.spyOn(store, "applyGitlinkChanges");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const glFlowNode = flowNodes.find((n) => n.id === "gl-1");
+    const data = glFlowNode!.data as unknown as {
+      onFetchRepositories: () => Promise<string[]>;
+      onLoadTree: (repo: string, branch: string) => void;
+      onSetLocalRoot: (localRoot: string) => void;
+      onImportSnapshot: (repo: string, branch: string) => void;
+      onBuildContext: (scopeMode: string, selectedPaths: string[]) => void;
+      onFetchContext: () => Promise<string>;
+      onRun: (taskPrompt: string) => void;
+      onApply: (fingerprint: string) => void;
+    };
+
+    data.onFetchRepositories();
+    expect(fetchReposSpy).toHaveBeenCalledWith("gl-1");
+    data.onLoadTree("owner/repo", "main");
+    expect(loadTreeSpy).toHaveBeenCalledWith("gl-1", "owner/repo", "main");
+    data.onSetLocalRoot("C:/repos/repo");
+    expect(setRootSpy).toHaveBeenCalledWith("gl-1", "C:/repos/repo");
+    data.onImportSnapshot("owner/repo", "main");
+    expect(importSpy).toHaveBeenCalledWith("gl-1", "owner/repo", "main");
+    data.onBuildContext("full", ["a.py"]);
+    expect(buildContextSpy).toHaveBeenCalledWith("gl-1", "full", ["a.py"]);
+    data.onFetchContext();
+    expect(fetchContextSpy).toHaveBeenCalledWith("gl-1");
+    data.onRun("Add a health-check endpoint");
+    expect(runSpy).toHaveBeenCalledWith("gl-1", "Add a health-check endpoint");
+    data.onApply("fp-1");
+    expect(applySpy).toHaveBeenCalledWith("gl-1", "fp-1");
+  });
+
+  it("onCancel fires cancelGitlinkRequest with pendingRequestId when set, and is a no-op otherwise", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "gl-pending", kind: "gitlink", pendingRequestId: "req-77" }),
+        baseNode({ id: "gl-idle", kind: "gitlink", pendingRequestId: null }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "cancelGitlinkRequest");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const pendingNode = flowNodes.find((n) => n.id === "gl-pending");
+    const idleNode = flowNodes.find((n) => n.id === "gl-idle");
+
+    (pendingNode!.data as { onCancel: () => void }).onCancel();
+    expect(intentSpy).toHaveBeenCalledWith("req-77");
+
+    (idleNode!.data as { onCancel: () => void }).onCancel();
+    expect(intentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("onToggleCollapse/onDelete reuse the generic setChatCollapsed/removeNodes intents", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "gl-1", kind: "gitlink", isCollapsed: false })],
+      edges: [],
+    });
+    const store = makeStore();
+    const collapseSpy = vi.spyOn(store, "setChatCollapsed");
+    const removeSpy = vi.spyOn(store, "removeNodes");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const glFlowNode = flowNodes.find((n) => n.id === "gl-1");
+
+    (glFlowNode!.data as { onToggleCollapse: () => void }).onToggleCollapse();
+    expect(collapseSpy).toHaveBeenCalledWith("gl-1", true);
+
+    (glFlowNode!.data as { onDelete: () => void }).onDelete();
+    expect(removeSpy).toHaveBeenCalledWith(["gl-1"]);
   });
 });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -22,6 +22,7 @@ import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
 import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
 import { ConversationNodeView, type ConversationFlowNode } from "./ConversationNodeView";
 import { DocumentNodeView, type DocumentFlowNode } from "./DocumentNodeView";
+import { GitlinkNodeView, type GitlinkFlowNode } from "./GitlinkNodeView";
 import { HtmlNodeView, type HtmlFlowNode } from "./HtmlNodeView";
 import { ImageNodeView, type ImageFlowNode } from "./ImageNodeView";
 import { ThinkingNodeView, type ThinkingFlowNode } from "./ThinkingNodeView";
@@ -55,7 +56,8 @@ type SceneFlowNode =
   | ImageFlowNode
   | ConversationFlowNode
   | WebResearchFlowNode
-  | ArtifactFlowNode;
+  | ArtifactFlowNode
+  | GitlinkFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   const zoom = useStore((s) => s.transform[2]);
@@ -84,6 +86,7 @@ const NODE_TYPES = {
   conversation: ConversationNodeView,
   web_research: WebResearchNodeView,
   artifact: ArtifactNodeView,
+  gitlink: GitlinkNodeView,
 };
 
 // Exported standalone for direct unit testing (same posture as
@@ -351,6 +354,58 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
           onCancel: () => {
             if (n.pendingRequestId) store.cancelArtifactRequest(n.pendingRequestId);
           },
+        },
+      });
+      continue;
+    }
+    if (n.kind === "gitlink") {
+      // No onDock here either (same reasoning as the html/image/conversation/
+      // web_research/artifact branches above) - GitlinkNodeView never offers
+      // a dock-into-parent action; the generic `if (n.isDocked) continue`
+      // guard above still covers it correctly if it were ever docked via a
+      // direct WS call. gitlinkContextXml is deliberately absent below - it
+      // is never part of the scene wire payload (fetched lazily on demand via
+      // fetchGitlinkContext instead - see GitlinkNodeView's own Context tab).
+      flowNodes.push({
+        id: n.id,
+        type: "gitlink" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          gitlinkRepo: n.gitlinkRepo,
+          gitlinkBranch: n.gitlinkBranch,
+          gitlinkScopeMode: n.gitlinkScopeMode,
+          gitlinkLocalRoot: n.gitlinkLocalRoot,
+          gitlinkRepoFilePaths: n.gitlinkRepoFilePaths,
+          gitlinkSelectedPaths: n.gitlinkSelectedPaths,
+          gitlinkTaskPrompt: n.gitlinkTaskPrompt,
+          gitlinkContextStats: n.gitlinkContextStats,
+          gitlinkContextSummary: n.gitlinkContextSummary,
+          gitlinkContextVersion: n.gitlinkContextVersion,
+          gitlinkProposalMarkdown: n.gitlinkProposalMarkdown,
+          gitlinkPendingChanges: n.gitlinkPendingChanges,
+          gitlinkPreviewText: n.gitlinkPreviewText,
+          gitlinkChangeFingerprint: n.gitlinkChangeFingerprint ?? null,
+          gitlinkChangeState: n.gitlinkChangeState,
+          gitlinkError: n.gitlinkError,
+          isCollapsed: n.isCollapsed,
+          pendingRequestId: n.pendingRequestId ?? null,
+          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
+          onDelete: () => store.removeNodes([n.id]),
+          onFetchRepositories: () => store.fetchGitlinkRepositories(n.id),
+          onLoadTree: (repo: string, branch: string) => store.loadGitlinkRepoTree(n.id, repo, branch),
+          onSetLocalRoot: (localRoot: string) => store.setGitlinkLocalRoot(n.id, localRoot),
+          onImportSnapshot: (repo: string, branch: string) => store.importGitlinkSnapshot(n.id, repo, branch),
+          onBuildContext: (scopeMode: string, selectedPaths: string[]) =>
+            store.buildGitlinkContext(n.id, scopeMode, selectedPaths),
+          onFetchContext: () => store.fetchGitlinkContext(n.id),
+          onRun: (taskPrompt: string) => store.runGitlinkChangeSet(n.id, taskPrompt),
+          // Same null-guard pattern as the conversation/web_research/artifact
+          // nodes' own analogous cancel call sites above - only fire the
+          // intent if there is genuinely a non-null request id to target.
+          onCancel: () => {
+            if (n.pendingRequestId) store.cancelGitlinkRequest(n.pendingRequestId);
+          },
+          onApply: (fingerprint: string) => store.applyGitlinkChanges(n.id, fingerprint),
         },
       });
       continue;

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -7,6 +7,17 @@ type StateListener = (payload: Record<string, unknown>) => void;
 function makeFakeTransport() {
   const listeners = new Map<string, StateListener>();
   const intents: Array<{ topic: string; intent: string; args: unknown[] }> = [];
+  const requests: Array<{ topic: string; intent: string; args: unknown[] }> = [];
+  // A queue rather than mockResolvedValueOnce: the latter REPLACES the
+  // implementation for that call (skipping the requests.push below
+  // entirely), which would make every request-based intent look
+  // unsent. Shifting a pre-loaded result here keeps both the recorded call
+  // AND a controllable resolved value.
+  const requestResults: unknown[] = [];
+  const requestImpl = vi.fn((topic: string, intent: string, args: unknown[] = []) => {
+    requests.push({ topic, intent, args });
+    return Promise.resolve(requestResults.length > 0 ? requestResults.shift() : undefined);
+  });
   const transport = {
     subscribe: vi.fn((topic: string, listener: StateListener) => {
       listeners.set(topic, listener);
@@ -15,8 +26,9 @@ function makeFakeTransport() {
     intent: vi.fn((topic: string, intent: string, args: unknown[] = []) => {
       intents.push({ topic, intent, args });
     }),
+    request: requestImpl,
   } as unknown as WsTransport;
-  return { transport, listeners, intents };
+  return { transport, listeners, intents, requests, requestImpl, requestResults };
 }
 
 function validScenePayload(overrides: Record<string, unknown> = {}) {
@@ -48,6 +60,21 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         researchTotal: 0,
         researchError: "",
         artifactContent: "",
+        gitlinkRepo: "",
+        gitlinkBranch: "",
+        gitlinkScopeMode: "selected",
+        gitlinkLocalRoot: "",
+        gitlinkRepoFilePaths: [],
+        gitlinkSelectedPaths: [],
+        gitlinkTaskPrompt: "",
+        gitlinkContextStats: {},
+        gitlinkContextSummary: "",
+        gitlinkContextVersion: 0,
+        gitlinkProposalMarkdown: "",
+        gitlinkPendingChanges: [],
+        gitlinkPreviewText: "",
+        gitlinkChangeState: "",
+        gitlinkError: "",
       },
     ],
     edges: [],
@@ -306,6 +333,95 @@ describe("SceneStore", () => {
     store.cancelArtifactRequest("req-13");
     expect(intents).toEqual([
       { topic: "scene", intent: "cancelArtifactRequest", args: ["req-13"] },
+    ]);
+  });
+
+  it("fetchGitlinkRepositories sends a REQUEST (not a fire-and-forget intent) with [nodeId], and resolves to the reply", async () => {
+    const { transport, requests, intents, requestResults } = makeFakeTransport();
+    requestResults.push(["owner/repo-a", "owner/repo-b"]);
+    const store = new SceneStore(transport);
+
+    const result = await store.fetchGitlinkRepositories("n1");
+    expect(requests).toEqual([
+      { topic: "scene", intent: "fetchGitlinkRepositories", args: ["n1"] },
+    ]);
+    expect(intents).toEqual([]);
+    expect(result).toEqual(["owner/repo-a", "owner/repo-b"]);
+  });
+
+  it("loadGitlinkRepoTree sends the scene-topic loadGitlinkRepoTree intent with [nodeId, repo, branch]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.loadGitlinkRepoTree("n1", "owner/repo", "main");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "loadGitlinkRepoTree", args: ["n1", "owner/repo", "main"] },
+    ]);
+  });
+
+  it("setGitlinkLocalRoot sends the scene-topic setGitlinkLocalRoot intent with [nodeId, localRoot]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setGitlinkLocalRoot("n1", "C:/repos/graphlink");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "setGitlinkLocalRoot", args: ["n1", "C:/repos/graphlink"] },
+    ]);
+  });
+
+  it("importGitlinkSnapshot sends the scene-topic importGitlinkSnapshot intent with [nodeId, repo, branch]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.importGitlinkSnapshot("n1", "owner/repo", "main");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "importGitlinkSnapshot", args: ["n1", "owner/repo", "main"] },
+    ]);
+  });
+
+  it("buildGitlinkContext sends the scene-topic buildGitlinkContext intent with [nodeId, scopeMode, selectedPaths]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.buildGitlinkContext("n1", "selected", ["src/a.py", "src/b.py"]);
+    expect(intents).toEqual([
+      {
+        topic: "scene",
+        intent: "buildGitlinkContext",
+        args: ["n1", "selected", ["src/a.py", "src/b.py"]],
+      },
+    ]);
+  });
+
+  it("fetchGitlinkContext sends a REQUEST (not a fire-and-forget intent) with [nodeId], and resolves to the reply", async () => {
+    const { transport, requests, intents, requestResults } = makeFakeTransport();
+    requestResults.push("<context>...</context>");
+    const store = new SceneStore(transport);
+
+    const result = await store.fetchGitlinkContext("n1");
+    expect(requests).toEqual([{ topic: "scene", intent: "fetchGitlinkContext", args: ["n1"] }]);
+    expect(intents).toEqual([]);
+    expect(result).toBe("<context>...</context>");
+  });
+
+  it("runGitlinkChangeSet sends the scene-topic runGitlinkChangeSet intent with [nodeId, taskPrompt]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.runGitlinkChangeSet("n1", "Add a health-check endpoint");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "runGitlinkChangeSet", args: ["n1", "Add a health-check endpoint"] },
+    ]);
+  });
+
+  it("cancelGitlinkRequest sends the scene-topic cancelGitlinkRequest intent with the requestId", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.cancelGitlinkRequest("req-55");
+    expect(intents).toEqual([{ topic: "scene", intent: "cancelGitlinkRequest", args: ["req-55"] }]);
+  });
+
+  it("applyGitlinkChanges sends the scene-topic applyGitlinkChanges intent with [nodeId, fingerprint]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.applyGitlinkChanges("n1", "fingerprint-abc123");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "applyGitlinkChanges", args: ["n1", "fingerprint-abc123"] },
     ]);
   });
 

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -349,6 +349,66 @@ export class SceneStore {
     this.transport.intent("scene", "cancelArtifactRequest", [requestId]);
   }
 
+  // R5.3: real Gitlink plugin - nine intents backing the three-tab
+  // Setup/Context/Proposal flow (see GitlinkNodeView.tsx's own module doc for
+  // the full per-tab breakdown). fetchGitlinkRepositories/fetchGitlinkContext
+  // are the only two of the nine that need a REPLY (a repo name list / the
+  // lazily-fetched context XML body) rather than a fire-and-forget push
+  // through the next scene snapshot - transport.intent() is declared
+  // `: void` (confirmed by reading transport.ts: it is fire-and-forget,
+  // dropped silently pre-connect, no return value at all), so it cannot be
+  // what "returns a Promise" means here. transport.request() is the real
+  // request/response primitive for that (the same one transport.test.ts's
+  // own "system"/"ping" round-trip exercises) - these two ride that instead.
+  // Every other Gitlink method below stays on the ordinary intent() path,
+  // exactly like every other scene intent above.
+  fetchGitlinkRepositories(nodeId: string): Promise<string[]> {
+    return this.transport.request("scene", "fetchGitlinkRepositories", [nodeId]) as Promise<string[]>;
+  }
+
+  loadGitlinkRepoTree(nodeId: string, repo: string, branch: string): void {
+    this.transport.intent("scene", "loadGitlinkRepoTree", [nodeId, repo, branch]);
+  }
+
+  setGitlinkLocalRoot(nodeId: string, localRoot: string): void {
+    this.transport.intent("scene", "setGitlinkLocalRoot", [nodeId, localRoot]);
+  }
+
+  importGitlinkSnapshot(nodeId: string, repo: string, branch: string): void {
+    this.transport.intent("scene", "importGitlinkSnapshot", [nodeId, repo, branch]);
+  }
+
+  // scopeMode/selectedPaths are never independently mirrored server-side via
+  // their own setter intent (see GitlinkNodeView.tsx's Setup tab doc) - they
+  // only ever travel as parameters of this one call, read from local
+  // component state at the moment Build Context is clicked.
+  buildGitlinkContext(nodeId: string, scopeMode: string, selectedPaths: string[]): void {
+    this.transport.intent("scene", "buildGitlinkContext", [nodeId, scopeMode, selectedPaths]);
+  }
+
+  fetchGitlinkContext(nodeId: string): Promise<string> {
+    return this.transport.request("scene", "fetchGitlinkContext", [nodeId]) as Promise<string>;
+  }
+
+  runGitlinkChangeSet(nodeId: string, taskPrompt: string): void {
+    this.transport.intent("scene", "runGitlinkChangeSet", [nodeId, taskPrompt]);
+  }
+
+  // Same requestId-not-nodeId shape cancelConversationRequest/
+  // cancelWebResearchRequest/cancelArtifactRequest above already established
+  // for their own per-node cancel.
+  cancelGitlinkRequest(requestId: string): void {
+    this.transport.intent("scene", "cancelGitlinkRequest", [requestId]);
+  }
+
+  // fingerprint is passed through verbatim - the caller (GitlinkNodeView's
+  // Apply confirmation) must pass exactly the server's own last-sent
+  // gitlinkChangeFingerprint, never anything computed client-side; this
+  // store method has no opinion on that, it just forwards the argument.
+  applyGitlinkChanges(nodeId: string, fingerprint: string): void {
+    this.transport.intent("scene", "applyGitlinkChanges", [nodeId, fingerprint]);
+  }
+
   // R3.3: the Composer's real Send action - a real user ChatNode. The
   // assistant's reply is deferred to R4 (graphlink_config.py's Qt/non-Qt
   // split is a prerequisite for calling the real agent layer); the backend

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2894,3 +2894,329 @@ body,
   background-color: var(--gl-neutral-button-background);
   border: 1px solid var(--gl-neutral-button-border);
 }
+
+/* -- R5.3 gitlink node ---------------------------------------------------- */
+
+.gitlink-node {
+  width: 460px;
+  max-height: 720px;
+  min-height: 110px;
+}
+
+.gitlink-node.collapsed {
+  width: 290px;
+  min-height: 58px;
+}
+
+.gitlink-node-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 640px;
+  overflow-y: auto;
+}
+
+.gitlink-node-tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--gl-surface-border);
+}
+
+.gitlink-node-tab {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 6px 10px;
+  color: var(--gl-surface-text-muted);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+}
+
+.gitlink-node-tab:hover {
+  color: var(--gl-surface-text);
+}
+
+.gitlink-node-tab.active {
+  color: var(--gl-surface-text);
+  border-bottom-color: var(--gl-surface-text-muted);
+}
+
+.gitlink-node-setup-tab,
+.gitlink-node-context-tab,
+.gitlink-node-proposal-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.gitlink-node-field-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.gitlink-node-field-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--gl-surface-text-muted);
+}
+
+.gitlink-node-inline-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Reuses .web-research-node-query-input's own chrome verbatim - same
+   shared-token convention already established across sibling node views -
+   applied here under this node kind's own class name for every plain
+   text/select/textarea input in the Setup tab. */
+.gitlink-node-input,
+.gitlink-node-select {
+  box-sizing: border-box;
+  width: 100%;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 8px 10px;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.gitlink-node-task-prompt {
+  resize: vertical;
+  line-height: 1.4;
+}
+
+.gitlink-node-input:focus,
+.gitlink-node-select:focus {
+  outline: none;
+  border-color: var(--gl-surface-text-muted);
+}
+
+.gitlink-node-inline-row button {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 5px 12px;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.gitlink-node-inline-row button:hover:enabled {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.gitlink-node-inline-row button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.gitlink-node-repo-options {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 120px;
+  overflow-y: auto;
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.gitlink-node-repo-options button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+  font-size: 11px;
+  padding: 6px 8px;
+  color: var(--gl-surface-text);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.gitlink-node-repo-options button:hover {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.gitlink-node-file-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.gitlink-node-file-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 160px;
+  overflow-y: auto;
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.gitlink-node-file-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: 11px;
+  color: var(--gl-surface-text);
+}
+
+.gitlink-node-file-count {
+  margin: 0;
+  font-size: 10px;
+  color: var(--gl-surface-text-muted);
+}
+
+.gitlink-node-context-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.gitlink-node-stat-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 11px;
+}
+
+.gitlink-node-stat-key {
+  color: var(--gl-surface-text-muted);
+}
+
+.gitlink-node-stat-value {
+  color: var(--gl-surface-text);
+  font-weight: 600;
+}
+
+.gitlink-node-context-summary {
+  margin: 0;
+  font-size: 12px;
+  color: var(--gl-surface-text);
+}
+
+.gitlink-node-context-xml {
+  margin: 0;
+  padding: 8px 10px;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 320px;
+  overflow: auto;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.gitlink-node-empty {
+  margin: 0;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--gl-surface-text-muted);
+}
+
+/* Reuses .chat-node-content's full markdown-body rule set verbatim - same
+   shared-class convention .artifact-node-document-content/
+   .web-research-node-answer already establish for this pipeline. Only
+   overrides the max-height/overflow-y a nested pane should never take on its
+   own (the outer .gitlink-node-content already scrolls). */
+.gitlink-node-proposal-markdown,
+.gitlink-node-proposal-diff {
+  max-height: none;
+  overflow: visible;
+}
+
+.gitlink-node-banner-error {
+  padding: 8px 10px;
+  font-size: 11px;
+  color: var(--gl-semantic-status-error, currentColor);
+  border: 1px solid var(--gl-semantic-status-error, currentColor);
+  border-radius: 8px;
+}
+
+.gitlink-node-apply-row {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.gitlink-node-apply-btn {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 5px 12px;
+  color: var(--gl-surface-window);
+  background-color: var(--gl-surface-text-muted);
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.gitlink-node-apply-btn:hover:enabled {
+  filter: brightness(1.1);
+}
+
+.gitlink-node-apply-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.gitlink-node-apply-dialog {
+  max-width: min(460px, calc(100vw - 64px));
+}
+
+.gitlink-node-apply-file-list {
+  margin: 8px 0;
+  padding-left: 18px;
+  max-height: 160px;
+  overflow-y: auto;
+  font-size: 11px;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  color: var(--gl-surface-text-muted);
+}
+
+.gitlink-node-apply-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.gitlink-node-apply-dialog-actions button {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 5px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.gitlink-node-apply-dialog-actions button:last-child {
+  color: var(--gl-surface-window);
+  background-color: var(--gl-surface-text-muted);
+  border: none;
+}
+
+.gitlink-node-apply-dialog-actions button:first-child {
+  color: var(--gl-surface-text);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+}
+
+.gitlink-node-apply-dialog-actions button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -65,6 +65,86 @@
           "filePath": {
             "type": "string"
           },
+          "gitlinkBranch": {
+            "type": "string"
+          },
+          "gitlinkChangeFingerprint": {
+            "type": "string"
+          },
+          "gitlinkChangeState": {
+            "type": "string"
+          },
+          "gitlinkContextStats": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "gitlinkContextSummary": {
+            "type": "string"
+          },
+          "gitlinkContextVersion": {
+            "type": "integer"
+          },
+          "gitlinkError": {
+            "type": "string"
+          },
+          "gitlinkLocalRoot": {
+            "type": "string"
+          },
+          "gitlinkPendingChanges": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "content": {
+                  "type": "string"
+                },
+                "operation": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path",
+                "operation",
+                "reason"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "gitlinkPreviewText": {
+            "type": "string"
+          },
+          "gitlinkProposalMarkdown": {
+            "type": "string"
+          },
+          "gitlinkRepo": {
+            "type": "string"
+          },
+          "gitlinkRepoFilePaths": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "gitlinkScopeMode": {
+            "type": "string"
+          },
+          "gitlinkSelectedPaths": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "gitlinkTaskPrompt": {
+            "type": "string"
+          },
           "history": {
             "items": {
               "additionalProperties": false,
@@ -295,7 +375,22 @@
           "researchCompleted",
           "researchTotal",
           "researchError",
-          "artifactContent"
+          "artifactContent",
+          "gitlinkRepo",
+          "gitlinkBranch",
+          "gitlinkScopeMode",
+          "gitlinkLocalRoot",
+          "gitlinkRepoFilePaths",
+          "gitlinkSelectedPaths",
+          "gitlinkTaskPrompt",
+          "gitlinkContextStats",
+          "gitlinkContextSummary",
+          "gitlinkContextVersion",
+          "gitlinkProposalMarkdown",
+          "gitlinkPendingChanges",
+          "gitlinkPreviewText",
+          "gitlinkChangeState",
+          "gitlinkError"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -30,6 +30,22 @@ export interface SceneNodeRow {
   researchError: string;
   researchResult?: ResearchResultRow | null;
   artifactContent: string;
+  gitlinkRepo: string;
+  gitlinkBranch: string;
+  gitlinkScopeMode: string;
+  gitlinkLocalRoot: string;
+  gitlinkRepoFilePaths: string[];
+  gitlinkSelectedPaths: string[];
+  gitlinkTaskPrompt: string;
+  gitlinkContextStats: Record<string, string>;
+  gitlinkContextSummary: string;
+  gitlinkContextVersion: number;
+  gitlinkProposalMarkdown: string;
+  gitlinkPendingChanges: GitlinkPendingChangeRow[];
+  gitlinkPreviewText: string;
+  gitlinkChangeFingerprint?: string | null;
+  gitlinkChangeState: string;
+  gitlinkError: string;
 }
 
 export interface ConversationMessageRow {
@@ -69,6 +85,13 @@ export interface ResearchCitationRow {
   sourceId: string;
   marker: string;
   claimContext: string;
+}
+
+export interface GitlinkPendingChangeRow {
+  path: string;
+  operation: string;
+  reason: string;
+  content?: string | null;
 }
 
 export interface SceneEdgeRow {
@@ -247,6 +270,89 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.artifactContent: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.artifactContent` + ": expected string"); }
   }
+  {
+    const fieldValue = value["gitlinkRepo"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkRepo: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkRepo` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["gitlinkBranch"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkBranch: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkBranch` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["gitlinkScopeMode"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkScopeMode: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkScopeMode` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["gitlinkLocalRoot"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkLocalRoot: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkLocalRoot` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["gitlinkRepoFilePaths"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkRepoFilePaths: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.gitlinkRepoFilePaths` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "string") errors.push(`${path}.gitlinkRepoFilePaths` + `[${i}]` + ": expected string"); }); }
+  }
+  {
+    const fieldValue = value["gitlinkSelectedPaths"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkSelectedPaths: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.gitlinkSelectedPaths` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "string") errors.push(`${path}.gitlinkSelectedPaths` + `[${i}]` + ": expected string"); }); }
+  }
+  {
+    const fieldValue = value["gitlinkTaskPrompt"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkTaskPrompt: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkTaskPrompt` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["gitlinkContextStats"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkContextStats: missing required field`);
+    else { if (!isRecord(fieldValue)) errors.push(`${path}.gitlinkContextStats` + ": expected object");
+    else Object.entries(fieldValue as Record<string, unknown>).forEach(([k, v]) => { if (typeof v !== "string") errors.push(`${path}.gitlinkContextStats` + `[${JSON.stringify(k)}]` + ": expected string"); }); }
+  }
+  {
+    const fieldValue = value["gitlinkContextSummary"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkContextSummary: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkContextSummary` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["gitlinkContextVersion"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkContextVersion: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.gitlinkContextVersion` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["gitlinkProposalMarkdown"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkProposalMarkdown: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkProposalMarkdown` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["gitlinkPendingChanges"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkPendingChanges: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.gitlinkPendingChanges` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { checkGitlinkPendingChangeRow(item, `${path}.gitlinkPendingChanges` + `[${i}]`, errors); }); }
+  }
+  {
+    const fieldValue = value["gitlinkPreviewText"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkPreviewText: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkPreviewText` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["gitlinkChangeFingerprint"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkChangeFingerprint` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["gitlinkChangeState"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkChangeState: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkChangeState` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["gitlinkError"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkError: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkError` + ": expected string"); }
+  }
 }
 
 function checkConversationMessageRow(value: unknown, path: string, errors: string[]): void {
@@ -401,6 +507,29 @@ function checkResearchCitationRow(value: unknown, path: string, errors: string[]
     const fieldValue = value["claimContext"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.claimContext: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.claimContext` + ": expected string"); }
+  }
+}
+
+function checkGitlinkPendingChangeRow(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["path"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.path: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.path` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["operation"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.operation: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.operation` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["reason"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.reason: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.reason` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["content"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.content` + ": expected string"); }
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds the Gitlink node: browse a GitHub repo, build an LLM context bundle, generate a proposed change set, and apply it to a local checkout — the first plugin in the rewrite whose agent-driven action writes real files to disk.
- Qt-free fix is a one-line import swap (`gitlink/agent.py`), consistent with R5.1's pattern; `backend/plugins.py`/`canvas.py`/`agents.py` gain the new node kind, ~15 fields, ~10 methods, two dispatcher slots, and 9 WS intents.
- The core safety mechanism (fingerprint recheck immediately before freezing the write data, zero `await` in between) makes a stale-approval race structurally impossible rather than merely unlikely — a stronger guarantee than the legacy Qt app's own blocking-dialog check.
- New `GitlinkNodeView.tsx` (Setup/Context/Proposal tabs), Apply confirmation reuses the existing R2.1 overlay primitive.

## Review & fixes
A 5-way adversarial review (backend/frontend/cross-boundary/data-integrity/legacy-safety) found and fixed 9 real bugs before shipping, including:
- **Critical**: a successful Apply never invalidated the approval, allowing the exact same write to be replayed.
- **High**: the approved fingerprint wasn't bound to the write destination (`local_root`), letting reviewed content be written into an unreviewed directory.
- 7 other medium/low findings (blocking I/O on the event loop, a Context-tab stale-response race, a non-gapless busy guard, etc.), all fixed with dedicated regression tests.

The two most safety-critical fixes were independently re-verified via revert-and-rerun experiments (temporarily undo the fix, confirm the new test fails, restore) rather than just reading the diff.

One finding — four slow read actions (list repos/load tree/import/build context) blocking their own WS connection for up to 300s — is deliberately **deferred**, not fixed: the only clean fix means either breaking an already-tested request/response contract or exposing the whole app's per-connection message loop to new concurrency risk, disproportionate to a medium-severity, single-tab-only issue.

## Verification
- `pytest`: 2183 passed (backend + graphlink_app)
- `vitest`: 829 passed
- `tsc --noEmit`: clean
- `npm run lint`: clean (0 errors, pre-existing warnings only)
- codegen `--check`: clean, purely additive

## Live drive
Driven against the real backend, real GitHub REST API (`octocat/Hello-World`, unauthenticated), and a real local Ollama model. Confirmed real repo/tree listing, a real GitHub snapshot download, real context building, a real LLM-generated proposal, and a real disk write on Apply — plus direct confirmation that replaying a stale fingerprint after a successful apply is refused with the file left untouched.

One honest, unresolved note: two live multi-connection race trials showed an unexplained proposal regeneration between the race and the post-race check that couldn't be fully root-caused this session — but in every trial (including this one), no double-write or file corruption ever occurred. The dedicated backend regression test for this exact scenario was independently proven via revert-and-rerun to depend on the fix; that's the authoritative verification for this guarantee, with the live race flagged as inconclusive-but-safe for a future session to revisit with better diagnostics.