### PR TITLE
Qt-removal R5.4 prereq: WS Origin validation (go/no-go security gate)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -23,6 +23,7 @@ intent - the acceptance round-trip. Real domain topics arrive per-phase
 from __future__ import annotations
 
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -49,6 +50,75 @@ logger = logging.getLogger(__name__)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SPA_DIST_DIR = REPO_ROOT / "web_ui" / "dist" / "app"
+
+# Loopback host Graphlink always binds to (graphlink_desktop.py hardcodes
+# host="127.0.0.1"). Required, not just preferred, for the same-origin check
+# below: comparing Origin's host against the request's own Host header alone
+# is a self-consistency check on two client-supplied values, not a check
+# against anything the server independently knows to be correct - a DNS-
+# rebinding attacker's page has both its Origin AND the Host header it sends
+# echo the SAME attacker-controlled hostname, so an Origin==Host comparison
+# alone would accept it. Requiring the host part to literally be 127.0.0.1
+# closes that: no attacker-controlled hostname is ever literally this string.
+_LOOPBACK_HOST = "127.0.0.1"
+
+
+def _is_allowed_ws_origin(origin: str | None, host_header: str | None, dev_proxy_origin: str | None = None) -> bool:
+    """Handshake-time allowlist for the /ws WebSocket Origin header.
+
+    Defends against cross-site WebSocket hijacking ("localhost service
+    takeover"): browsers do not enforce same-origin policy on WebSocket
+    connects the way they do fetch/XHR, so any page open in the user's
+    regular browser - malicious or compromised, or a bad ad iframe - can
+    already open a socket to ws://127.0.0.1:<port>/ws. The Origin header is
+    the standard mitigation because page JS cannot set or suppress it (it is
+    a forbidden header name); this function is the exact accept/reject
+    decision made from it, once, at handshake time.
+
+    Policy (exact string equality only - never substring/startswith, which
+    would reopen bypasses like "http://127.0.0.1:5173.evil.com"):
+
+    - origin is None or "" -> True. A real browser always sends Origin for a
+      page-script-initiated connect, so an absent Origin cannot be that
+      attack; it can only be a non-browser caller (tests, curl, local
+      tooling) - a different threat model, since anything already able to
+      speak raw WebSocket to this loopback-only port could set Origin to
+      any string it likes anyway (only browsers are forbidden from spoofing
+      it). Rejecting "absent" would stop zero real attacks.
+    - origin == "null" -> False. Only produced by opaque-origin contexts
+      (sandboxed iframe without allow-same-origin, data:/file: pages) - all
+      attacker-constructed, never a legitimate caller of this app.
+    - origin == f"http://{host_header}" AND host_header's host part is
+      literally "127.0.0.1" -> True. The normal packaged-app case (pywebview
+      window and its backend are same-origin), computed per-request (never
+      hardcoded - the port is a dynamically OS-assigned free port; see
+      graphlink_desktop.py's _free_port()) - the added 127.0.0.1 requirement
+      is what actually defeats DNS rebinding, see _LOOPBACK_HOST's comment.
+    - dev_proxy_origin is not None AND origin == dev_proxy_origin -> True.
+      Deliberately NOT a hardcoded constant this function trusts on its own:
+      the real desktop app (graphlink_desktop.py) never passes one, so this
+      branch is dead in the shipped product by construction, not just by
+      convention - only ws_endpoint's own caller, reading an opt-in env var
+      that is unset in normal operation, can ever supply a non-None value
+      here (see GRAPHLINK_DEV_WS_ORIGIN at the call site). Without this, the
+      previous version of this function hardcoded Vite's default dev port
+      (5173) as an always-trusted origin - correct for the real vite-proxy
+      dev workflow, but wrong to trust unconditionally in the shipped app,
+      since 5173 is an extremely common default port for unrelated Vite
+      projects a user could have running in the same browser.
+    - anything else present -> False.
+    """
+    if origin is None or origin == "":
+        return True
+    if origin == "null":
+        return False
+    if host_header:
+        host_only = host_header.rsplit(":", 1)[0]
+        if host_only == _LOOPBACK_HOST and origin == f"http://{host_header}":
+            return True
+    if dev_proxy_origin and origin == dev_proxy_origin:
+        return True
+    return False
 
 
 def _configure_session(bus: SessionBus, settings_manager: SettingsManager, chat_db_path: Path | None) -> None:
@@ -138,6 +208,19 @@ def create_app(
 
     @app.websocket("/ws")
     async def ws_endpoint(websocket: WebSocket) -> None:
+        origin = websocket.headers.get("origin")
+        host_header = websocket.headers.get("host")
+        # Unset in every real launch (graphlink_desktop.py never sets this) -
+        # a developer running `npm run dev` (web_ui/vite.config.ts's
+        # GRAPHLINK_ISLAND=app target) against a separately-run backend must
+        # opt in explicitly by setting this to their vite dev server's real
+        # origin (e.g. "http://127.0.0.1:5173"), rather than that origin
+        # being trusted unconditionally in the shipped app.
+        dev_proxy_origin = os.environ.get("GRAPHLINK_DEV_WS_ORIGIN")
+        if not _is_allowed_ws_origin(origin, host_header, dev_proxy_origin):
+            logger.warning("rejected WS handshake: origin=%r host=%r", origin, host_header)
+            await websocket.close(code=1008)
+            return
         session_id = websocket.query_params.get("session", "default")
         session = bus.session(session_id)
         await websocket.accept()

--- a/backend/tests/test_ws_origin.py
+++ b/backend/tests/test_ws_origin.py
@@ -1,0 +1,154 @@
+"""WebSocket Origin allowlist tests (R5.4 security fix): guards /ws against
+cross-site WebSocket hijacking ("localhost service takeover"), since browsers
+do not enforce same-origin policy on WebSocket connects the way they do on
+fetch/XHR. See backend/app.py's _is_allowed_ws_origin docstring for the full
+policy rationale.
+
+Split into two groups:
+- Pure unit tests of _is_allowed_ws_origin (no ASGI needed).
+- Integration tests through the real ASGI app (reuses make_client from
+  test_app_ws.py rather than duplicating it).
+"""
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+from backend.app import _is_allowed_ws_origin
+from backend.tests.test_app_ws import make_client
+
+
+# --- Pure unit tests of _is_allowed_ws_origin -------------------------------
+
+
+def test_absent_origin_allowed():
+    assert _is_allowed_ws_origin(None, "127.0.0.1:9999") is True
+    assert _is_allowed_ws_origin("", "127.0.0.1:9999") is True
+
+
+def test_same_origin_allowed():
+    assert _is_allowed_ws_origin("http://127.0.0.1:9999", "127.0.0.1:9999") is True
+
+
+def test_dev_proxy_origin_allowed_only_when_explicitly_opted_in():
+    # host_header deliberately a *different* port, to prove this branch
+    # doesn't depend on same-origin matching. Requires the caller to pass a
+    # non-None dev_proxy_origin explicitly - the real ws_endpoint only does
+    # this when GRAPHLINK_DEV_WS_ORIGIN is set, which is never true in the
+    # shipped app (graphlink_desktop.py never sets it).
+    assert _is_allowed_ws_origin(
+        "http://127.0.0.1:5173", "127.0.0.1:9999", dev_proxy_origin="http://127.0.0.1:5173"
+    ) is True
+
+
+def test_dev_proxy_origin_rejected_by_default_when_not_opted_in():
+    # Post-review fix: this exact port string used to be an unconditional,
+    # hardcoded allow - live in the real shipped desktop app forever, not
+    # just during the vite dev workflow. 5173 is Vite's own default dev port,
+    # extremely common across unrelated projects - trusting it unconditionally
+    # let any other local `npm run dev` tab talk to this backend. Now the
+    # caller must explicitly opt in via dev_proxy_origin (omitted here, so it
+    # defaults to None) before this origin is trusted at all.
+    assert _is_allowed_ws_origin("http://127.0.0.1:5173", "127.0.0.1:9999") is False
+
+
+def test_mismatched_origin_rejected():
+    assert _is_allowed_ws_origin("http://evil.example.com", "127.0.0.1:9999") is False
+
+
+def test_null_origin_rejected():
+    assert _is_allowed_ws_origin("null", "127.0.0.1:9999") is False
+
+
+def test_scheme_mismatch_rejected():
+    # This app is http-only; proves the scheme is checked, not just the host.
+    assert _is_allowed_ws_origin("https://127.0.0.1:9999", "127.0.0.1:9999") is False
+
+
+def test_no_substring_bypass():
+    assert _is_allowed_ws_origin("http://127.0.0.1:5173.evil.com", "127.0.0.1:9999") is False
+
+
+def test_no_port_prefix_bypass():
+    assert _is_allowed_ws_origin("http://127.0.0.1:51730", "127.0.0.1:5173") is False
+
+
+def test_dns_rebinding_style_host_origin_self_match_rejected():
+    # Post-review fix: comparing Origin to the request's own Host header is a
+    # self-consistency check on two client-supplied values, not a check
+    # against anything the server independently knows. A DNS-rebinding
+    # attacker's page has Origin and Host both echo the SAME
+    # attacker-controlled hostname (not 127.0.0.1) - requiring the host part
+    # to literally be 127.0.0.1 closes this even though Origin == Host here.
+    assert _is_allowed_ws_origin("http://evil.example.com:9999", "evil.example.com:9999") is False
+
+
+# --- Integration tests through the real ASGI app ----------------------------
+
+
+def test_ws_connect_missing_origin_succeeds():
+    # No Origin header override - names the security decision explicitly
+    # even though test_app_ws.py already covers this implicitly.
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json({"kind": "intent", "topic": "system", "intent": "ping", "args": [], "id": 1})
+        message = ws.receive_json()
+        assert message["kind"] == "result"
+
+
+def test_ws_connect_same_origin_succeeds():
+    # Post-review fix: the same-origin branch now also requires the Host's
+    # own hostname to literally be 127.0.0.1 (see _LOOPBACK_HOST), so this
+    # must override TestClient's default "testserver" Host to exercise the
+    # real production case (pywebview window + backend, always 127.0.0.1).
+    client = make_client()
+    headers = {"origin": "http://127.0.0.1:8000", "host": "127.0.0.1:8000"}
+    with client.websocket_connect("/ws", headers=headers) as ws:
+        ws.send_json({"kind": "intent", "topic": "system", "intent": "ping", "args": [], "id": 1})
+        message = ws.receive_json()
+        assert message["kind"] == "result"
+
+
+def test_ws_connect_dev_proxy_origin_rejected_without_env_opt_in():
+    # Post-review fix regression test: without GRAPHLINK_DEV_WS_ORIGIN set,
+    # even Vite's own default dev port is just another untrusted origin - the
+    # real gap the review found (this string was previously always trusted,
+    # live in the shipped app, not just during the vite dev workflow).
+    client = make_client()
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/ws", headers={"origin": "http://127.0.0.1:5173"}):
+            pass
+    assert exc_info.value.code == 1008
+    assert client.app.state.bus.session("default").connection_count == 0
+
+
+def test_ws_connect_dev_proxy_origin_succeeds_with_env_opt_in(monkeypatch):
+    # Succeeds only once a developer explicitly opts in via
+    # GRAPHLINK_DEV_WS_ORIGIN, and despite the client's own Host being
+    # testserver (proving this branch doesn't depend on same-origin match).
+    monkeypatch.setenv("GRAPHLINK_DEV_WS_ORIGIN", "http://127.0.0.1:5173")
+    client = make_client()
+    with client.websocket_connect("/ws", headers={"origin": "http://127.0.0.1:5173"}) as ws:
+        ws.send_json({"kind": "intent", "topic": "system", "intent": "ping", "args": [], "id": 1})
+        message = ws.receive_json()
+        assert message["kind"] == "result"
+
+
+def test_ws_connect_mismatched_origin_rejected():
+    client = make_client()
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/ws", headers={"origin": "http://evil.example.com"}):
+            pass
+    assert exc_info.value.code == 1008
+    # session.attach() was never reached, so no connection was ever
+    # registered - confirms rejection happened before any intent could
+    # possibly dispatch.
+    assert client.app.state.bus.session("default").connection_count == 0
+
+
+def test_ws_connect_null_origin_rejected():
+    client = make_client()
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/ws", headers={"origin": "null"}):
+            pass
+    assert exc_info.value.code == 1008
+    assert client.app.state.bus.session("default").connection_count == 0


### PR DESCRIPTION
## Summary

R5 scoping required an explicit go/no-go gate before any Code-Sandbox/PyCoder work starts: does `backend/app.py` bind loopback-only, and does it validate the WebSocket `Origin` header? Checked directly:

- **Bind**: confirmed safe — `graphlink_desktop.py` hardcodes `host="127.0.0.1"`.
- **Origin validation**: confirmed **NO-GO** — `ws_endpoint` accepted every WebSocket handshake unconditionally, with zero Origin check anywhere in `backend/`.

This is a real, live gap today, not just a future risk: browsers do not apply same-origin policy to WebSocket connects the way they do to `fetch`/`XHR`, so any webpage open in the user's regular browser — malicious, compromised, or a bad ad iframe — can already open a socket to `ws://127.0.0.1:<port>/ws` and issue arbitrary intents. Once the next increment adds real code-execution intents (PyCoderNode/CodeSandboxNode), this same gap becomes remote code execution triggered by nothing more than a malicious tab being open.

## Fix

Adds `_is_allowed_ws_origin(origin, host_header, dev_proxy_origin=None)`, checked before `websocket.accept()` (rejecting via `websocket.close(code=1008)`):
- Allows an absent `Origin` header — real browsers always send one for a page-initiated connect (it's a forbidden header name, unspoofable by page JS), so a missing one can only be non-browser tooling (this project's own test suite included) — a different threat model this fix isn't targeting.
- Allows same-origin, but **only when the host is literally `127.0.0.1`** — not just self-consistent with the request's own `Host` header, which a DNS-rebinding attacker's page can also satisfy (both its `Origin` and `Host` echo the same attacker-controlled hostname).
- Allows the Vite dev-proxy origin (`web_ui/vite.config.ts`'s `npm run dev` workflow, a real cross-port scenario for this SPA target) **only when explicitly opted into** via `GRAPHLINK_DEV_WS_ORIGIN` — unset in every real launch, so this branch is dead in the shipped desktop app by construction, not convention.

A dedicated adversarial security review of the first-pass implementation found and this session fixed two real gaps before shipping (see the plan doc ledger for full detail): the dev-proxy allowance was originally hardcoded and unconditionally trusted even in production (Vite's default port 5173 is extremely common, so any unrelated local dev server could talk to Graphlink), and the same-origin check didn't independently verify the host was actually `127.0.0.1` rather than just self-consistent.

## Verification
- `pytest`: 2199 passed (backend + graphlink_app), including a new `backend/tests/test_ws_origin.py` with 16 tests covering the allow/reject matrix and regression tests proving both post-review fixes actually close their gaps.
- No existing test needed weakening to pass.

R5.4's go/no-go gate is now genuinely satisfied — PyCoder/CodeSandbox implementation can proceed.