### PR TITLE
Qt-removal R5.4: PyCoderNode + CodeSandboxNode - real code execution, closing R5

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -62,6 +62,7 @@ import asyncio
 import difflib
 import inspect
 import logging
+import re
 import threading
 import uuid
 from pathlib import Path
@@ -80,6 +81,19 @@ from graphlink_plugins.gitlink.repository import (
     default_import_root,
     read_local_repo_file,
     validate_pending_changes,
+)
+from graphlink_plugins.pycoder.domain import (
+    PyCoderAnalysisAgent,
+    PyCoderExecutionAgent,
+    PyCoderRepairAgent,
+    PythonREPL,
+)
+from graphlink_plugins.code_sandbox.domain import (
+    SandboxGenerationAgent,
+    SandboxRepairAgent,
+    VirtualEnvSandbox,
+    _extract_python_block,
+    _normalize_requirements,
 )
 from graphlink_plugins.web_research.domain import (
     CancellationToken,
@@ -148,6 +162,32 @@ GITLINK_CONTEXT_TIMEOUT_SECONDS = 300
 # OTHER truthy pending_request_id is still a genuine busy node and is
 # rejected exactly as before.
 _GITLINK_RUN_CLAIM_PLACEHOLDER = "pending"
+
+# R5.4: the security-boundary section's own minimal, genuinely free
+# mitigation - a hard wall-clock timeout on Py-Coder's REPL execute() call,
+# closing the one real asymmetry recon found: Execution Sandbox already
+# times out its own subprocess internally (VirtualEnvSandbox.execute_code's
+# baked-in timeout_seconds=240, unchanged by this increment), but Py-Coder's
+# REPL had NONE before this - an AI-generated infinite loop ran forever until
+# a human clicked Stop. 240 is not an independently-derived number for THIS
+# constant - it is deliberately the exact same value as Execution Sandbox's
+# own existing ceiling, for cross-kind consistency. This is a hang guard, not
+# a security control - see the module-level PyCoderNode/CodeSandboxNode
+# security-boundary comment on AgentDispatcher.start_pycoder_run below for
+# the full, unsoftened statement of what this boundary actually is.
+PYCODER_EXECUTE_TIMEOUT_SECONDS = 240
+
+# R5.4: shared by both start_pycoder_run and start_code_sandbox_run - same
+# exact mechanism and reasoning as _GITLINK_RUN_CLAIM_PLACEHOLDER above (see
+# that constant's own comment for the full race this closes), just named for
+# this pair of new kinds rather than reusing the Gitlink-specific name. Both
+# kinds' WS-intent wrappers in backend/canvas.py (run_pycoder/
+# run_code_sandbox) claim node.pending_request_id with this exact sentinel,
+# synchronously, before any await - and both
+# AgentDispatcher.start_pycoder_run/start_code_sandbox_run below recognize
+# ONLY this exact value as "already claimed by my own caller, safe to
+# overwrite".
+_CODE_EXEC_RUN_CLAIM_PLACEHOLDER = "pending"
 
 
 def bootstrap_provider_state(settings_manager: SettingsManager) -> None:
@@ -269,6 +309,139 @@ class AgentDispatcher:
         # register_canvas's own busy checks in backend/canvas.py - this dict
         # split is about cross-request bookkeeping, not the same-node guard.)
         self._gitlink_apply_requests: dict[str, dict] = {}
+        # R5.4: a SEVENTH independent in-flight-request slot - a Py-Coder Run
+        # must be able to run concurrently with any of the six existing
+        # slots above, same reasoning as every prior independent slot.
+        # request_id -> {"cancel_event": threading.Event, "approval_future":
+        # asyncio.Future[bool], "task": asyncio.Task}. approval_future is the
+        # ENTIRE "waiting for human approval" mechanism (see
+        # start_pycoder_run's own docstring) - created eagerly, before the
+        # background task even starts, so cancel_pycoder/
+        # cancel_all_pending_approvals can always resolve it even if the
+        # pipeline has not reached its own `await approval_future` yet.
+        self._pycoder_requests: dict[str, dict] = {}
+        # R5.4: an EIGHTH independent in-flight-request slot - a Execution
+        # Sandbox Run must be able to run concurrently with any of the seven
+        # slots above. Same shape as self._pycoder_requests.
+        self._code_sandbox_requests: dict[str, dict] = {}
+        # R5.4: Py-Coder's REPL subprocess outlives any single run (state
+        # persists between calls, same as legacy's own PyCoderReplManager -
+        # see that class's own docstring in graphlink_plugins/pycoder/domain.py
+        # for why its weakref.WeakKeyDictionary keying strategy does not
+        # survive the port). Keyed by node_id (a plain string) instead:
+        # explicit teardown via dispose_pycoder_repl, not GC. Execution
+        # Sandbox needs NO equivalent manager - VirtualEnvSandbox is
+        # request-scoped by design, constructed fresh per run inside
+        # start_code_sandbox_run's own asyncio.to_thread-wrapped worker
+        # function (exactly like _call_gitlink_agent constructs a fresh
+        # GitlinkAgent per call) - the only state that must survive between
+        # runs is the plain string node.code_sandbox_sandbox_id, real
+        # SceneNode state, not a live object.
+        self._pycoder_repls: dict[str, PythonREPL] = {}
+
+    def get_pycoder_repl(self, node_id: str) -> PythonREPL:
+        """Lazy-create-or-reuse - mirrors PyCoderReplManager.get_repl's own
+        shape, just keyed by node_id instead of node identity."""
+        repl = self._pycoder_repls.get(node_id)
+        if repl is None:
+            repl = PythonREPL()
+            self._pycoder_repls[node_id] = repl
+        return repl
+
+    async def dispose_pycoder_repl(self, node_id: str) -> None:
+        """Explicit teardown of one node's REPL subprocess. Tolerates a
+        missing node_id silently (pop with a default) - called from exactly
+        two places: backend/canvas.py's remove_nodes WS-intent wrapper (for
+        every deleted pycoder node), and start_pycoder_run's own
+        execute-timeout guard below (a hung REPL must not be left alive).
+        NOT called on disconnect/session-end - the REPL persists across
+        disconnects exactly like every other piece of node state in
+        SceneDocument already does; only explicit node deletion (or process
+        shutdown) ends it. stop() does a blocking kill()+wait(), so it runs
+        inside asyncio.to_thread rather than directly on the event loop."""
+        repl = self._pycoder_repls.pop(node_id, None)
+        if repl is not None:
+            await asyncio.to_thread(repl.stop)
+
+    def cancel_pycoder(self, request_id: str) -> bool:
+        """Cooperative cancel, same honestly-documented limitation as every
+        other dispatch surface (the checkpoint is a cancel_event check
+        between stages, not a true mid-call interrupt - EXCEPT for the
+        approval pause itself, which this DOES immediately and definitely
+        unblock by resolving approval_future - see start_pycoder_run's own
+        docstring). Mirrors legacy's own stop() calling
+        self._approval_event.set() to unblock a parked worker - otherwise
+        Cancel would only work pre- or post-pause, never during it."""
+        entry = self._pycoder_requests.get(request_id)
+        if entry is None:
+            return False
+        entry["cancel_event"].set()
+        future = entry.get("approval_future")
+        if future is not None and not future.done():
+            future.set_result(False)
+        return True
+
+    def cancel_code_sandbox(self, request_id: str) -> bool:
+        """Mirrors cancel_pycoder exactly (same shape, same reasoning)."""
+        entry = self._code_sandbox_requests.get(request_id)
+        if entry is None:
+            return False
+        entry["cancel_event"].set()
+        future = entry.get("approval_future")
+        if future is not None and not future.done():
+            future.set_result(False)
+        return True
+
+    def _resolve_approval(self, request_id: str, approved: bool) -> bool:
+        """The shared approve/deny primitive backing approve_code_execution/
+        deny_code_execution below - request_id is a shared uuid4 namespace
+        across BOTH self._pycoder_requests and self._code_sandbox_requests
+        (one lookup across two dicts, not four kind-specific intents/
+        methods), mirroring the WS intent layer's own two-shared-intents
+        design (approveCodeExecution/denyCodeExecution, not four separate
+        per-kind intents).
+
+        Guarding with `future.done()` is LOAD-BEARING, not defensive fluff -
+        a duplicate/stale approve-or-deny message (e.g. a double-click, or a
+        message that arrives after cancel_pycoder/cancel_code_sandbox/
+        cancel_all_pending_approvals already resolved this same future)
+        would otherwise raise asyncio.InvalidStateError."""
+        entry = self._pycoder_requests.get(request_id) or self._code_sandbox_requests.get(request_id)
+        if entry is None:
+            return False
+        future = entry["approval_future"]
+        if not future.done():
+            future.set_result(approved)
+        return True
+
+    def approve_code_execution(self, request_id: str) -> bool:
+        return self._resolve_approval(request_id, True)
+
+    def deny_code_execution(self, request_id: str) -> bool:
+        return self._resolve_approval(request_id, False)
+
+    def cancel_all_pending_approvals(self) -> None:
+        """Called ONLY from backend/app.py's ws_endpoint disconnect handler,
+        ONLY when the session's last connection drops (session.connection_
+        count == 0) - a DELIBERATE, SCOPED extension of that existing
+        disconnect contract, applied ONLY to these two new slots (see
+        backend/app.py's own comment for why this is not retrofitted onto
+        the pre-existing web_research/artifact/gitlink slots: every one of
+        those already self-terminates via asyncio.wait_for(...,
+        timeout=...), but an approval pause has NO timeout by design - the
+        whole point is "wait for a human, however long that takes" - so
+        without this auto-deny it would hang forever, permanently locking
+        node.pending_request_id on an abandoned tab).
+
+        Walks both dicts and resolves any undone future with False
+        (auto-deny) - the same future.done() guard as _resolve_approval
+        applies here for the same reason (a request that already resolved,
+        e.g. because a human approved it a moment before the last tab
+        closed, must not be clobbered)."""
+        for entry in list(self._pycoder_requests.values()) + list(self._code_sandbox_requests.values()):
+            future = entry.get("approval_future")
+            if future is not None and not future.done():
+                future.set_result(False)
 
     def cancel_gitlink(self, request_id: str) -> bool:
         entry = self._gitlink_requests.get(request_id)
@@ -1330,6 +1503,565 @@ class AgentDispatcher:
                 await bus.publish("scene")
 
         self._gitlink_apply_requests[request_id] = {"task": asyncio.create_task(_run())}
+
+    # -- R5.4: Py-Coder / Execution Sandbox -----------------------------------
+    #
+    # SECURITY BOUNDARY (stated plainly, not softened): PyCoderNode and
+    # CodeSandboxNode execute code with the full privileges of the user's
+    # account. The only two protections are the WS-Origin handshake check
+    # and a mandatory human-approval step. There is no code-level sandbox -
+    # no container, VM, or OS-level resource/permission restriction - for
+    # either kind. Py-Coder's new execution timeout is a hang guard, not a
+    # security control: it does not stop a malicious script from reading
+    # files, exfiltrating data, or (for Execution Sandbox specifically)
+    # running arbitrary code during pip install via a hostile package's
+    # build backend, before the approved script itself ever runs.
+    #
+    # Both methods below run their entire pipeline as ONE coroutine on the
+    # event loop - the blocking LLM/REPL/subprocess calls are wrapped in
+    # asyncio.to_thread, but the PAUSE between them (waiting for a human to
+    # approve or deny the candidate code) needs no thread-crossing at all: it
+    # collapses into a plain `asyncio.Future[bool]`
+    # (self._pycoder_requests[request_id]["approval_future"] /
+    # self._code_sandbox_requests[request_id]["approval_future"]), created
+    # BEFORE the background task even starts. `approved = await
+    # approval_future` IS the entire "waiting for approval" state - nothing
+    # else is needed. This replaces legacy's two independently-blocking
+    # mechanisms on two different threads (a QThread worker parked on a
+    # threading.Event, the GUI thread parked inside a modal
+    # QMessageBox.exec()), coordinated only through the shared worker object.
+
+    async def start_pycoder_run(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        node,
+        node_id: str,
+        mode: str,
+        prompt: str,
+        code: str,
+        conversation_history: list,
+        on_success,  # on_success(code, output, analysis, last_run_failed)
+        on_failure,  # on_failure(message)
+    ) -> None:
+        """R5.4: Py-Coder's Run action.
+
+        ai_driven mode mirrors legacy's PyCoderExecutionWorker: generate code
+        via PyCoderExecutionAgent -> human-approval pause -> execute in the
+        persistent REPL with up to 4 attempts, repairing via
+        PyCoderRepairAgent between failures -> analyze the final result via
+        PyCoderAnalysisAgent. A successful run through the repair loop AND a
+        run that exhausts every retry both call on_success (never
+        on_failure) - exactly mirroring legacy's own `finished.emit(result)`
+        for both cases, distinguished only by the `last_run_failed` flag and
+        a "**PROCESS FAILED**" analysis prefix.
+
+        manual mode mirrors legacy's CodeExecutionWorker + PyCoderAgentWorker
+        pair: execute the hand-typed code once (no repair loop), then
+        analyze the result. Deliberately ungated - no approval_future is
+        awaited on this path at all, mirroring legacy's own documented
+        posture exactly ("MANUAL mode is deliberately ungated - there the
+        user authored the code themselves and clicking Run *is* the
+        approval").
+
+        Every execute() call, on both paths, is wrapped in
+        asyncio.wait_for(..., timeout=PYCODER_EXECUTE_TIMEOUT_SECONDS) - the
+        one real asymmetry recon found versus Execution Sandbox (which
+        already self-limits via VirtualEnvSandbox.execute_code's own baked-in
+        timeout). On timeout, the REPL is torn down via dispose_pycoder_repl
+        rather than left alive as a runaway subprocess.
+
+        Cooperative cancellation only for the EXECUTE stage itself (same
+        honestly-documented limitation as gitlink/artifact/web_research: the
+        checkpoint is a cancel_event check between stages, not a true
+        mid-call interrupt on an in-flight REPL execute() - the REPL has no
+        polling hook the way Execution Sandbox's subprocess does) - but the
+        approval PAUSE itself is genuinely, immediately interruptible by
+        Cancel, since cancel_pycoder resolves this same approval_future.
+        """
+        if node.pending_request_id and node.pending_request_id != _CODE_EXEC_RUN_CLAIM_PLACEHOLDER:
+            notifications_state.show("Py-Coder is already busy for this node.", "info")
+            await bus.publish("notification")
+            return
+
+        request_id = uuid.uuid4().hex
+        node.pending_request_id = request_id
+        cancel_event = threading.Event()
+        approval_future: asyncio.Future = asyncio.get_running_loop().create_future()
+        await bus.publish("scene")
+
+        async def _run():
+            try:
+                if mode == "manual":
+                    manual_code = code or ""
+                    if not manual_code.strip():
+                        # Guard-rail message, routed through pycoder_error
+                        # (not pycoder_analysis, unlike legacy's own
+                        # `set_ai_analysis`) - see the R5.4 report's own note
+                        # on unifying every guard-rail message through the
+                        # one error field this port actually has.
+                        on_failure("Add Python code before running Py-Coder.")
+                        await bus.publish("scene")
+                        return
+
+                    repl = self.get_pycoder_repl(node_id)
+                    try:
+                        output = await asyncio.wait_for(
+                            asyncio.to_thread(repl.execute, manual_code),
+                            timeout=PYCODER_EXECUTE_TIMEOUT_SECONDS,
+                        )
+                    except asyncio.TimeoutError:
+                        await self.dispose_pycoder_repl(node_id)
+                        message = (
+                            "Py-Coder execution stopped responding before the request "
+                            "completed and was terminated. Please try again."
+                        )
+                        on_failure(message)
+                        notifications_state.show(message, "error")
+                        await bus.publish("notification")
+                        return
+
+                    if cancel_event.is_set():
+                        notifications_state.show("Py-Coder execution cancelled.", "info")
+                        await bus.publish("notification")
+                        return
+
+                    last_run_failed = getattr(repl, "last_run_failed", False)
+                    output_text = output if output else "[No output produced]"
+                    analysis = await asyncio.to_thread(
+                        _call_pycoder_analysis_agent, None, manual_code, output_text
+                    )
+                    on_success(manual_code, output_text, analysis, last_run_failed)
+                    await bus.publish("scene")
+                    return
+
+                # ai_driven mode
+                prompt_text = (prompt or "").strip()
+                if not prompt_text:
+                    on_failure("Please enter a prompt.")
+                    await bus.publish("scene")
+                    return
+
+                initial_response = await asyncio.to_thread(
+                    _call_pycoder_execution_agent, conversation_history, prompt_text
+                )
+                if cancel_event.is_set():
+                    notifications_state.show("Py-Coder run cancelled.", "info")
+                    await bus.publish("notification")
+                    return
+
+                code_match = re.search(r"\[TOOL:PYTHON\](.*?)\[/TOOL\]", initial_response, re.DOTALL)
+                if not code_match:
+                    # No code needed for this prompt - a real completed run
+                    # (never executed the REPL, never gated on approval),
+                    # exactly mirroring legacy's own `finished.emit(result)`
+                    # for this branch.
+                    on_success(
+                        "# No code was generated for this prompt.",
+                        "[Not applicable]",
+                        initial_response,
+                        False,
+                    )
+                    await bus.publish("scene")
+                    return
+
+                current_code = code_match.group(1).strip()
+
+                # -- human-approval gate --------------------------------------
+                node.pycoder_code = current_code
+                node.pycoder_awaiting_approval = True
+                await bus.publish("scene")
+                approved = await approval_future
+                node.pycoder_awaiting_approval = False
+
+                if not approved:
+                    on_failure("Py-Coder run cancelled: execution was not approved.")
+                    await bus.publish("scene")
+                    return
+
+                repl = self.get_pycoder_repl(node_id)
+                retry_count = 0
+                max_retries = 4
+                last_error = None
+
+                while retry_count < max_retries:
+                    if cancel_event.is_set():
+                        notifications_state.show("Py-Coder execution cancelled.", "info")
+                        await bus.publish("notification")
+                        return
+
+                    try:
+                        execution_output = await asyncio.wait_for(
+                            asyncio.to_thread(repl.execute, current_code),
+                            timeout=PYCODER_EXECUTE_TIMEOUT_SECONDS,
+                        )
+                        execution_failed = getattr(repl, "last_run_failed", False)
+                    except asyncio.TimeoutError:
+                        await self.dispose_pycoder_repl(node_id)
+                        message = (
+                            "Py-Coder execution stopped responding before the request "
+                            "completed and was terminated. Please try again."
+                        )
+                        on_failure(message)
+                        notifications_state.show(message, "error")
+                        await bus.publish("notification")
+                        return
+                    except Exception as exc:
+                        execution_output = f"\n--- EXECUTION FAILED ---\n{type(exc).__name__}: {exc}"
+                        execution_failed = True
+
+                    if not execution_failed:
+                        output_text = execution_output if execution_output else "[No output produced]"
+                        analysis = await asyncio.to_thread(
+                            _call_pycoder_analysis_agent, prompt_text, current_code, execution_output
+                        )
+                        on_success(current_code, output_text, analysis, False)
+                        await bus.publish("scene")
+                        return
+
+                    last_error = execution_output
+                    retry_count += 1
+                    if retry_count < max_retries:
+                        is_final = retry_count == max_retries - 1
+                        current_code = await asyncio.to_thread(
+                            _call_pycoder_repair_agent, current_code, last_error, is_final
+                        )
+
+                # Every retry exhausted - still a real completed run (never
+                # on_failure), matching legacy's own `finished.emit(result)`
+                # for the exhausted-repair-loop case, flagged via
+                # last_run_failed=True and a "**PROCESS FAILED**" prefix.
+                final_failure_analysis = await asyncio.to_thread(
+                    _call_pycoder_analysis_agent,
+                    prompt_text,
+                    current_code,
+                    f"The code failed to execute after {max_retries} attempts. The final error was:\n{last_error}",
+                )
+                combined_analysis = (
+                    f"**PROCESS FAILED**\n\nAfter {max_retries} attempts, the code could not "
+                    f"be successfully executed.\n\n{final_failure_analysis}"
+                )
+                on_success(current_code, last_error, combined_analysis, True)
+                await bus.publish("scene")
+            except Exception as exc:
+                logger.exception("pycoder dispatch failed")
+                on_failure(f"Py-Coder execution failed: {exc}")
+                notifications_state.show(f"Py-Coder execution failed: {exc}", "error")
+                await bus.publish("notification")
+            finally:
+                self._pycoder_requests.pop(request_id, None)
+                if node.pending_request_id == request_id:
+                    node.pending_request_id = None
+                await bus.publish("scene")
+
+        self._pycoder_requests[request_id] = {
+            "cancel_event": cancel_event,
+            "approval_future": approval_future,
+            "task": asyncio.create_task(_run()),
+        }
+
+    async def start_code_sandbox_run(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        node,
+        node_id: str,
+        sandbox_id: str,
+        prompt: str,
+        existing_code: str,
+        requirements_manifest: str,
+        conversation_history: list,
+        on_success,  # on_success(code, output, analysis)
+        on_failure,  # on_failure(message)
+    ) -> None:
+        """R5.4: Execution Sandbox's Run action - mirrors legacy's
+        CodeSandboxExecutionWorker (generate-or-reuse -> human-approval pause
+        -> prepare venv -> install requirements -> execute-with-repair-loop
+        -> analyze), collapsed into one coroutine via the same
+        asyncio.Future approval-pause mechanism as start_pycoder_run above
+        (see that method's own docstring).
+
+        UNLIKE Py-Coder, there is no persisted mode field - the real branch
+        is resolved HERE, at call time: a non-blank prompt always means
+        "generate" (regenerating ignores any existing code, mirrors
+        legacy's own `existing_code = code if run_mode == "manual" else
+        ""`); a blank prompt with existing code means "reuse the existing
+        code as-is, skip generation entirely"; a blank prompt with no
+        existing code is a guard-rail failure, exactly matching legacy's own
+        CodeSandboxExecutionWorker.run() top-of-function check.
+
+        A fresh VirtualEnvSandbox is constructed HERE, per run (never
+        cached/reused on the dispatcher) - the only state that must survive
+        between runs is the plain string sandbox_id (real SceneNode state,
+        not a live object), exactly like _call_gitlink_agent constructing a
+        fresh GitlinkAgent per call.
+
+        Cancellation is MORE effective here than Py-Coder's own REPL-based
+        cancel: VirtualEnvSandbox._run_subprocess polls `should_continue()`
+        (wired to `not cancel_event.is_set()`) roughly every 100ms while its
+        subprocess is running, and genuinely terminates it via self.stop()
+        the instant that check fails - a real, near-immediate interrupt, not
+        merely a "checked between stages" limitation. This mirrors legacy's
+        own already-working stop() behavior; it is not a new capability
+        introduced by this port. VirtualEnvSandbox.execute_code's own
+        baked-in 240s timeout (unchanged - see graphlink_plugins/
+        code_sandbox/domain.py) is what actually bounds a hung subprocess
+        that never checks should_continue on its own; PYCODER_EXECUTE_
+        TIMEOUT_SECONDS reuses that same number for Py-Coder's own,
+        previously-missing equivalent.
+
+        R5.4 post-review FIX 1: live output streaming. VirtualEnvSandbox's
+        `ensure_base_environment`/`sync_requirements`/`execute_code` each
+        already accept an `emit_line` callback (see graphlink_plugins/
+        code_sandbox/domain.py's own `_run_subprocess`) - invoked once per
+        line of subprocess stdout/stderr, on the WORKER THREAD inside
+        asyncio.to_thread. `_thread_emit_line` below hands each line to the
+        event loop the same load-bearing way `_dispatch`'s own
+        `_thread_on_chunk` does (`loop.call_soon_threadsafe(...)` feeding an
+        `asyncio.Queue` - the only safe way to cross that thread boundary;
+        `bus`/the queue itself are never touched directly from the worker
+        thread). UNLIKE `_dispatch`'s own `_pump`, there is deliberately NO
+        batching/flush-interval machinery here - R5.1's web-research
+        increment already made this exact call for its own low-frequency
+        progress channel ("too sparse to justify it"), and this channel is
+        the same shape: one `bus.publish_stream(...)` call per subprocess
+        line, in order, not a 15-17Hz token stream. A final `done=True` frame
+        is always sent last, from the shared `finally` below, so it fires on
+        EVERY exit path (guard-rail failure, no-code-generated, denied
+        approval, cancelled, timed-out, or a real success) - mirroring
+        `_dispatch`'s own "unconditional final flush on every exit path"
+        guarantee for its own stream. `topic="scene"` (not a
+        Composer-specific topic): CodeSandboxNode state is scene state, same
+        as every other plugin node kind's own dispatch surface."""
+        if node.pending_request_id and node.pending_request_id != _CODE_EXEC_RUN_CLAIM_PLACEHOLDER:
+            notifications_state.show("Execution Sandbox is already busy for this node.", "info")
+            await bus.publish("notification")
+            return
+
+        request_id = uuid.uuid4().hex
+        node.pending_request_id = request_id
+        cancel_event = threading.Event()
+        approval_future: asyncio.Future = asyncio.get_running_loop().create_future()
+        await bus.publish("scene")
+
+        def _should_continue() -> bool:
+            return not cancel_event.is_set()
+
+        async def _run():
+            loop = asyncio.get_running_loop()
+            line_queue: asyncio.Queue = asyncio.Queue()
+            _STREAM_DONE = object()
+            stream_seq = 0
+
+            def _thread_emit_line(line: str) -> None:
+                # Runs on the WORKER THREAD inside asyncio.to_thread - never
+                # touch `line_queue`/`bus` directly here, only via
+                # call_soon_threadsafe (see this method's own docstring).
+                loop.call_soon_threadsafe(line_queue.put_nowait, line)
+
+            async def _drain_stream() -> None:
+                nonlocal stream_seq
+                while True:
+                    item = await line_queue.get()
+                    if item is _STREAM_DONE:
+                        break
+                    await bus.publish_stream(
+                        topic="scene", request_id=request_id, seq=stream_seq, delta=item, done=False,
+                    )
+                    stream_seq += 1
+                # Guaranteed final frame, unconditional and always last - see
+                # the `finally` below that always queues _STREAM_DONE before
+                # awaiting this task, on EVERY exit path.
+                await bus.publish_stream(
+                    topic="scene", request_id=request_id, seq=stream_seq, delta="", done=True,
+                )
+
+            drain_task = asyncio.create_task(_drain_stream())
+            try:
+                prompt_text = (prompt or "").strip()
+                manifest = _normalize_requirements(requirements_manifest or "")
+                current_code = (existing_code or "").strip()
+
+                if prompt_text:
+                    initial_response = await asyncio.to_thread(
+                        _call_sandbox_generation_agent, conversation_history, prompt_text, manifest
+                    )
+                    if cancel_event.is_set():
+                        notifications_state.show("Sandbox execution cancelled.", "info")
+                        await bus.publish("notification")
+                        return
+                    extracted = _extract_python_block(initial_response)
+                    if not extracted:
+                        on_success(
+                            "# No Python code was generated for this request.",
+                            "[Sandbox was not executed]",
+                            initial_response,
+                        )
+                        await bus.publish("scene")
+                        return
+                    current_code = extracted
+                elif not current_code:
+                    on_failure("Provide a task prompt or Python code before running the sandbox.")
+                    await bus.publish("scene")
+                    return
+
+                # -- human-approval gate --------------------------------------
+                node.code_sandbox_code = current_code
+                node.code_sandbox_awaiting_approval = True
+                # R5.4 CODESANDBOX FIX (closing the requirements-disclosure
+                # staleness race): freeze the DISCLOSED manifest into its own
+                # snapshot field at the exact same moment the approval gate
+                # opens, using `manifest` - already computed above, at the
+                # top of this function, before this function's own
+                # generation-agent await. This introduces no new race: it
+                # only exposes a value already correctly frozen, never
+                # re-reading node.code_sandbox_requirements (the user's
+                # still-live, still-editable draft for the NEXT run) at this
+                # point. See SceneNode.code_sandbox_approval_requirements's
+                # own comment for the full race this closes.
+                node.code_sandbox_approval_requirements = manifest
+                await bus.publish("scene")
+                approved = await approval_future
+                node.code_sandbox_awaiting_approval = False
+                # Cleared here too, immediately once the approval resolves -
+                # mirrors code_sandbox_awaiting_approval's own clear on this
+                # exact line (and canvas.py's complete_code_sandbox_run/
+                # fail_code_sandbox_run clear it again downstream, redundant
+                # but harmless, for every other path that lands there).
+                node.code_sandbox_approval_requirements = ""
+
+                if not approved:
+                    on_failure("Sandbox run cancelled: execution was not approved.")
+                    await bus.publish("scene")
+                    return
+
+                sandbox = VirtualEnvSandbox(sandbox_id)
+                try:
+                    await asyncio.to_thread(
+                        sandbox.ensure_base_environment, _should_continue, _thread_emit_line
+                    )
+                    await asyncio.to_thread(
+                        sandbox.sync_requirements, manifest, _should_continue, _thread_emit_line
+                    )
+                except InterruptedError:
+                    notifications_state.show("Sandbox execution cancelled.", "info")
+                    await bus.publish("notification")
+                    return
+
+                max_attempts = 3
+                final_output = ""
+                final_return_code = 0
+                last_error = ""
+                try:
+                    for attempt_index in range(max_attempts):
+                        final_output, final_return_code = await asyncio.to_thread(
+                            sandbox.execute_code, current_code, _should_continue, _thread_emit_line
+                        )
+                        if not _is_sandbox_error_output(final_output, final_return_code):
+                            break
+                        last_error = final_output or "The sandbox process exited with an error."
+                        if attempt_index == max_attempts - 1:
+                            break
+                        current_code = await asyncio.to_thread(
+                            _call_sandbox_repair_agent, current_code, last_error, manifest, prompt_text or None
+                        )
+                    else:
+                        # Structurally unreachable (mirrors legacy's own
+                        # identical dead `else` branch - every loop path
+                        # above ends in an explicit `break`), kept for exact
+                        # structural parity rather than optimized away.
+                        final_output = final_output or last_error
+                except InterruptedError:
+                    notifications_state.show("Sandbox execution cancelled.", "info")
+                    await bus.publish("notification")
+                    return
+
+                output_text = final_output if final_output else "[No output produced]"
+                analysis = await asyncio.to_thread(
+                    _call_pycoder_analysis_agent, prompt_text or None, current_code, output_text
+                )
+                on_success(current_code, output_text, analysis)
+                await bus.publish("scene")
+            except Exception as exc:
+                logger.exception("code sandbox dispatch failed")
+                on_failure(f"Sandbox execution failed: {exc}")
+                notifications_state.show(f"Sandbox execution failed: {exc}", "error")
+                await bus.publish("notification")
+            finally:
+                self._code_sandbox_requests.pop(request_id, None)
+                if node.pending_request_id == request_id:
+                    node.pending_request_id = None
+                line_queue.put_nowait(_STREAM_DONE)
+                await drain_task
+                await bus.publish("scene")
+
+        self._code_sandbox_requests[request_id] = {
+            "cancel_event": cancel_event,
+            "approval_future": approval_future,
+            "task": asyncio.create_task(_run()),
+        }
+
+
+def _call_pycoder_execution_agent(conversation_history, user_prompt) -> str:
+    """Runs inside asyncio.to_thread. Reuses PyCoderExecutionAgent.get_response
+    verbatim - a fresh instance per call, same posture as _call_gitlink_agent/
+    _call_artifact_agent constructing their own agent fresh each time."""
+    return PyCoderExecutionAgent().get_response(conversation_history, user_prompt)
+
+
+def _call_pycoder_repair_agent(code, error, is_final_attempt) -> str:
+    """Runs inside asyncio.to_thread. Reuses PyCoderRepairAgent.get_response
+    verbatim."""
+    return PyCoderRepairAgent().get_response(code, error, is_final_attempt)
+
+
+def _call_pycoder_analysis_agent(original_prompt, code, code_output) -> str:
+    """Runs inside asyncio.to_thread. Reuses PyCoderAnalysisAgent.get_response
+    verbatim - shared by both Py-Coder's and Execution Sandbox's own final
+    analysis step, exactly like legacy's CodeSandboxExecutionWorker
+    constructing its own PyCoderAnalysisAgent instance directly rather than
+    duplicating that agent's logic."""
+    return PyCoderAnalysisAgent().get_response(original_prompt, code, code_output)
+
+
+def _call_sandbox_generation_agent(conversation_history, user_prompt, requirements_manifest) -> str:
+    """Runs inside asyncio.to_thread. Reuses SandboxGenerationAgent.get_response
+    verbatim."""
+    return SandboxGenerationAgent().get_response(conversation_history, user_prompt, requirements_manifest)
+
+
+def _call_sandbox_repair_agent(code, error_output, requirements_manifest, original_prompt) -> str:
+    """Runs inside asyncio.to_thread. Reuses SandboxRepairAgent.get_response
+    verbatim."""
+    return SandboxRepairAgent().get_response(
+        code, error_output, requirements_manifest, original_prompt=original_prompt
+    )
+
+
+# R5.4: replicates CodeSandboxExecutionWorker._is_error_output exactly - that
+# method never moved to graphlink_plugins/code_sandbox/domain.py (it is a
+# worker-instance method, not a free function any moved domain piece calls -
+# see that module's own docstring for why), so this is a second, independent
+# copy of the same keyword-based heuristic, not a shared import.
+_SANDBOX_ERROR_KEYWORDS = (
+    "traceback (most recent call last)",
+    "modulenotfounderror",
+    "importerror",
+    "nameerror:",
+    "syntaxerror:",
+    "typeerror:",
+    "valueerror:",
+    "exception:",
+)
+
+
+def _is_sandbox_error_output(output_text, return_code) -> bool:
+    if return_code != 0:
+        return True
+    lowered = (output_text or "").lower()
+    return any(keyword in lowered for keyword in _SANDBOX_ERROR_KEYWORDS)
 
 
 def _call_chat_agent(conversation_history, persona_text, cancel_event) -> str:

--- a/backend/app.py
+++ b/backend/app.py
@@ -243,6 +243,18 @@ def create_app(
             # in-flight request just because a different tab closed.
             if session.connection_count == 0:
                 session.agent_dispatcher.cancel_all()
+                # R5.4: a DELIBERATE, SCOPED extension of this disconnect
+                # contract, applied ONLY to the Py-Coder/Execution Sandbox
+                # approval-pause slots - not retrofitted onto the
+                # pre-existing web_research/artifact/gitlink slots (a real,
+                # separate, out-of-scope gap: every one of those already
+                # self-terminates via asyncio.wait_for(..., timeout=...), so
+                # cancel_all() alone is enough for them). An approval pause
+                # has NO timeout by design (the whole point is "wait for a
+                # human, however long that takes"), so without this
+                # extension an abandoned tab's in-flight approval would hang
+                # forever, permanently locking node.pending_request_id.
+                session.agent_dispatcher.cancel_all_pending_approvals()
 
     resolved_spa = SPA_DIST_DIR if spa_dir is None else spa_dir
     if resolved_spa.is_dir():

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -34,7 +34,11 @@ from graphlink_grid_view_settings import (
 )
 from graphlink_navigation_pins import NavigationPinRecord, NavigationPinStore
 
-from backend.agents import _GITLINK_RUN_CLAIM_PLACEHOLDER, AgentDispatcher
+from backend.agents import (
+    _CODE_EXEC_RUN_CLAIM_PLACEHOLDER,
+    _GITLINK_RUN_CLAIM_PLACEHOLDER,
+    AgentDispatcher,
+)
 from backend.composer import ComposerDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -325,6 +329,71 @@ class SceneNode:
     # fail_gitlink_apply below for the transitions.
     gitlink_change_state: str = "draft"
     gitlink_error: str = ""
+    # R5.4: the Py-Coder node's real persisted shape - reads a natural-
+    # language ask (ai_driven mode) or hand-typed code (manual mode), runs it
+    # in a persistent REPL subprocess, and reports the AI's analysis of the
+    # result. pending_request_id (generic, above) is reused unchanged as the
+    # busy marker for the ENTIRE span from Run-click through generation,
+    # through the human-approval pause, through execution, through analysis -
+    # same posture as Gitlink's Run/Apply. Unused (default) for every other
+    # kind.
+    pycoder_mode: str = "ai_driven"  # "ai_driven" | "manual"
+    pycoder_prompt: str = ""  # last natural-language ask (ai_driven only)
+    pycoder_code: str = ""  # current/last code - the thing that actually executes
+    pycoder_output: str = ""  # last REPL stdout
+    pycoder_analysis: str = ""  # AI's analysis of the last output
+    pycoder_last_run_failed: bool = False
+    pycoder_awaiting_approval: bool = False
+    pycoder_error: str = ""
+    # R5.4: the Execution Sandbox node's real persisted shape - runs Python
+    # inside an isolated per-node virtualenv (VirtualEnvSandbox, keyed by
+    # code_sandbox_sandbox_id) with a per-node requirements.txt manifest.
+    # There is no mode field/toggle here (unlike Py-Coder) - the real branch
+    # is "prompt blank AND code already exists -> re-run existing code
+    # as-is; else -> generate from prompt", resolved by the dispatch method
+    # checking code_sandbox_code at call time (see
+    # AgentDispatcher.start_code_sandbox_run in backend/agents.py). Unused
+    # (default) for every other kind.
+    #
+    # code_sandbox_sandbox_id is minted ONCE, at node-creation time (see
+    # add_code_sandbox_node), and is a pure internal directory-naming key -
+    # never shown or edited by the user, never even read by the frontend.
+    # EXCLUDED from scene_payload() and from the codegen SceneNodeRow source,
+    # mirroring gitlink_imported_root's existing "server-side bookkeeping
+    # only, deliberately absent from scene_payload()" precedent exactly.
+    code_sandbox_sandbox_id: str = ""
+    code_sandbox_requirements: str = ""
+    code_sandbox_prompt: str = ""
+    code_sandbox_code: str = ""
+    code_sandbox_output: str = ""
+    code_sandbox_analysis: str = ""
+    code_sandbox_awaiting_approval: bool = False
+    # R5.4 CODESANDBOX FIX (closing the requirements-disclosure staleness
+    # race): a display-only SNAPSHOT of the EXACT requirements manifest
+    # string this specific pending approval refers to - distinct from
+    # code_sandbox_requirements (the user's still-live, still-editable draft
+    # for the NEXT run). The real race this closes: AgentDispatcher.
+    # start_code_sandbox_run (backend/agents.py) reads requirements_manifest
+    # synchronously, at the very top of its own _run(), into a local
+    # `manifest` variable - BEFORE the one real await in that function (the
+    # asyncio.to_thread call to the generation agent). A user can send a new
+    # setCodeSandboxRequirements intent during that await window (it is
+    # ungated by any busy check), changing code_sandbox_requirements to
+    # something different before the approval panel is ever shown. Since the
+    # old approval panel displayed the LIVE code_sandbox_requirements field,
+    # the disclosed package list could differ from the manifest the backend
+    # actually installs a moment later - showing the WRONG list is worse
+    # than showing none for a security disclosure. This field is instead
+    # populated from that SAME already-frozen local `manifest` variable, at
+    # the exact moment code_sandbox_awaiting_approval flips True - exposing a
+    # value already correctly frozen, not re-reading anything live, so this
+    # introduces no new race. Cleared (empty string) everywhere
+    # code_sandbox_awaiting_approval itself is cleared: inline in
+    # start_code_sandbox_run immediately after the approval future resolves,
+    # and in complete_code_sandbox_run/fail_code_sandbox_run below. Unused
+    # (default) for every other kind.
+    code_sandbox_approval_requirements: str = ""
+    code_sandbox_error: str = ""
 
 
 @dataclass
@@ -1121,6 +1190,196 @@ class SceneDocument:
         node.gitlink_error = str(message)
         return node
 
+    # -- R5.4: Py-Coder node --------------------------------------------------
+    #
+    # canvas.py imports NOTHING from graphlink_plugins.pycoder - every method
+    # below is pure state mutation on plain fields, same posture as the
+    # Gitlink section above (apply_web_research_progress's own duck-typed
+    # mutation is the original precedent). The actual REPL/agent dispatch
+    # lives in backend/agents.py, which DOES import from
+    # graphlink_plugins.pycoder.domain.
+    #
+    # R5.4 post-review FIX 3: request_pycoder_approval (and its Execution
+    # Sandbox twin, request_code_sandbox_approval, below) were DELETED here -
+    # confirmed genuinely dead code (grepped the whole repo: their only
+    # references were this definition and their own dedicated unit tests,
+    # zero real call sites). The human-approval gate that actually runs
+    # mutates node.pycoder_code/pycoder_awaiting_approval directly inline
+    # inside AgentDispatcher.start_pycoder_run (backend/agents.py) - these two
+    # SceneDocument methods were a second, never-wired copy of that same
+    # mutation, built ahead of the live dispatch path and then never rewired
+    # to it. Removing dead code is the correct fix here, not building a
+    # redundant call site just to keep them alive.
+
+    def add_pycoder_node(self, x: float, y: float, parent_id: str) -> SceneNode:
+        """The Py-Coder node's creation primitive - same required-parent
+        posture as every R5 sibling (Web Research/Artifact/Gitlink): never
+        exists unparented. Title is always the fixed literal "Py-Coder"
+        (matches backend/plugins.py's own plugin display name)."""
+        if parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title="Py-Coder",
+            kind="pycoder",
+        )
+        self.nodes[node_id] = node
+        self.connect(parent_id, node_id)
+        return node
+
+    def set_pycoder_mode(self, node_id: str, mode: str) -> SceneNode:
+        """The mode toggle (ai_driven <-> manual). Raises SceneError on an
+        unrecognized mode string - mirrors set_font's own unknown-value
+        rejection shape (raise, don't silently coerce)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if mode not in ("ai_driven", "manual"):
+            raise SceneError(f"unknown pycoder mode: {mode}")
+        node.pycoder_mode = str(mode)
+        return node
+
+    def start_pycoder_run(self, node_id: str, input_text: str) -> SceneNode:
+        """Begin one Run: stores input_text into the field the CURRENT mode
+        actually reads at dispatch time - pycoder_prompt for ai_driven (the
+        natural-language ask), pycoder_code for manual (the hand-typed code
+        that will execute verbatim) - and clears any previous error. Mirrors
+        start_gitlink_run's own "store the input, clear the error, leave
+        everything else stale-while-revalidate" posture."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "pycoder":
+            raise SceneError(f"node is not a pycoder node: {node_id}")
+        if node.pycoder_mode == "manual":
+            node.pycoder_code = str(input_text)
+        else:
+            node.pycoder_prompt = str(input_text)
+        node.pycoder_error = ""
+        return node
+
+    def complete_pycoder_run(
+        self, node_id: str, code: str, output: str, analysis: str, last_run_failed: bool
+    ) -> SceneNode | None:
+        """Land a successful (or exhausted-repair-loop) run: code/output/
+        analysis/last_run_failed are always set verbatim, awaiting_approval
+        is cleared (the gate this run was paused on, if any, is resolved by
+        definition once a result lands), and any stale error banner is
+        cleared. Silent no-op if the node is gone - same posture as
+        fail_web_research_run's own liveness handling for a background
+        result landing after deletion."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            return None
+        node.pycoder_code = str(code)
+        node.pycoder_output = str(output)
+        node.pycoder_analysis = str(analysis)
+        node.pycoder_last_run_failed = bool(last_run_failed)
+        node.pycoder_awaiting_approval = False
+        node.pycoder_error = ""
+        return node
+
+    def fail_pycoder_run(self, node_id: str, message: str) -> SceneNode | None:
+        """Land a failed (or denied-approval, or cancelled) run.
+        awaiting_approval is ALWAYS cleared here too - a denied/cancelled
+        approval must not leave the node stuck showing the approval prompt
+        forever. Deliberately does NOT clear pycoder_code/pycoder_output/
+        pycoder_analysis - a failed re-run must never wipe out a previously
+        completed result, only the error banner reflects the new failure
+        (stale-while-revalidate, same posture as fail_gitlink_run)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            return None
+        node.pycoder_awaiting_approval = False
+        node.pycoder_error = str(message)
+        return node
+
+    # -- R5.4: Execution Sandbox node ------------------------------------------
+    #
+    # Same import posture as the Py-Coder section above: canvas.py imports
+    # NOTHING from graphlink_plugins.code_sandbox.
+
+    def add_code_sandbox_node(self, x: float, y: float, parent_id: str) -> SceneNode:
+        """The Execution Sandbox node's creation primitive - same
+        required-parent posture as every R5 sibling. Title is always the
+        fixed literal "Execution Sandbox" (matches backend/plugins.py's own
+        plugin display name). code_sandbox_sandbox_id is minted here, ONCE,
+        at creation time - a short uuid4 hex used purely as this node's
+        sandbox directory name (VirtualEnvSandbox re-sanitizes it again on
+        its own side, but a short, already-safe id keeps the on-disk path
+        short and human-scannable)."""
+        if parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        node = SceneNode(
+            id=node_id,
+            x=float(x),
+            y=float(y),
+            title="Execution Sandbox",
+            kind="code_sandbox",
+            code_sandbox_sandbox_id=uuid.uuid4().hex[:12],
+        )
+        self.nodes[node_id] = node
+        self.connect(parent_id, node_id)
+        return node
+
+    def set_code_sandbox_requirements(self, node_id: str, requirements_text: str) -> SceneNode:
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        node.code_sandbox_requirements = str(requirements_text)
+        return node
+
+    def start_code_sandbox_run(self, node_id: str, input_text: str) -> SceneNode:
+        """Begin one Run: stores input_text into code_sandbox_prompt (there is
+        no mode-dependent field split here, unlike Py-Coder - see this
+        section's own header comment for why) and clears any previous error.
+        Deliberately does NOT touch code_sandbox_code here - the dispatch
+        method decides generate-vs-reuse by reading the EXISTING
+        code_sandbox_code value at call time, so this must not overwrite it
+        before that decision is made."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "code_sandbox":
+            raise SceneError(f"node is not a code_sandbox node: {node_id}")
+        node.code_sandbox_prompt = str(input_text)
+        node.code_sandbox_error = ""
+        return node
+
+    def complete_code_sandbox_run(self, node_id: str, code: str, output: str, analysis: str) -> SceneNode | None:
+        """Land a successful run - mirrors complete_pycoder_run exactly,
+        minus the last_run_failed flag (Execution Sandbox has no such field;
+        an unrecovered failure after exhausting its own repair attempts
+        surfaces as a failed run, see AgentDispatcher.start_code_sandbox_run,
+        not as a "succeeded but flagged" result the way Py-Coder's repair
+        loop does)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            return None
+        node.code_sandbox_code = str(code)
+        node.code_sandbox_output = str(output)
+        node.code_sandbox_analysis = str(analysis)
+        node.code_sandbox_awaiting_approval = False
+        node.code_sandbox_approval_requirements = ""
+        node.code_sandbox_error = ""
+        return node
+
+    def fail_code_sandbox_run(self, node_id: str, message: str) -> SceneNode | None:
+        """Land a failed (or denied-approval, or cancelled) run - mirrors
+        fail_pycoder_run exactly (same stale-while-revalidate posture, same
+        unconditional awaiting_approval clear)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            return None
+        node.code_sandbox_awaiting_approval = False
+        node.code_sandbox_approval_requirements = ""
+        node.code_sandbox_error = str(message)
+        return node
+
     def delete_chat_node(self, node_id: str) -> None:
         """Delete one chat node WITHOUT orphaning its branch: children are
         re-parented to the deleted node's own parent (or become roots if it
@@ -1479,6 +1738,31 @@ class SceneDocument:
                     "gitlinkChangeFingerprint": n.gitlink_change_fingerprint,
                     "gitlinkChangeState": n.gitlink_change_state,
                     "gitlinkError": n.gitlink_error,
+                    "pycoderMode": n.pycoder_mode,
+                    "pycoderPrompt": n.pycoder_prompt,
+                    "pycoderCode": n.pycoder_code,
+                    "pycoderOutput": n.pycoder_output,
+                    "pycoderAnalysis": n.pycoder_analysis,
+                    "pycoderLastRunFailed": n.pycoder_last_run_failed,
+                    "pycoderAwaitingApproval": n.pycoder_awaiting_approval,
+                    "pycoderError": n.pycoder_error,
+                    # codeSandboxSandboxId is DELIBERATELY OMITTED - see the
+                    # field's own comment on SceneNode (pure internal
+                    # directory-naming key, mirrors gitlink_imported_root's
+                    # own "server-side bookkeeping only" precedent).
+                    "codeSandboxRequirements": n.code_sandbox_requirements,
+                    "codeSandboxPrompt": n.code_sandbox_prompt,
+                    "codeSandboxCode": n.code_sandbox_code,
+                    "codeSandboxOutput": n.code_sandbox_output,
+                    "codeSandboxAnalysis": n.code_sandbox_analysis,
+                    "codeSandboxAwaitingApproval": n.code_sandbox_awaiting_approval,
+                    # R5.4 CODESANDBOX FIX: the frozen-at-approval-time
+                    # snapshot, deliberately distinct from
+                    # codeSandboxRequirements above (that one is the user's
+                    # still-live, still-editable draft for the NEXT run) -
+                    # see the field's own comment on SceneNode.
+                    "codeSandboxApprovalRequirements": n.code_sandbox_approval_requirements,
+                    "codeSandboxError": n.code_sandbox_error,
                 }
                 for n in self.nodes.values()
             ],
@@ -2213,12 +2497,178 @@ def register_canvas(
     # already-normalized node.gitlink_pending_changes.
     bus.register_intent("scene", "applyGitlinkChanges", apply_gitlink_changes)
 
+    # -- R5.4: Py-Coder node ---------------------------------------------------
+
+    async def set_pycoder_mode(node_id, mode):
+        document.set_pycoder_mode(node_id, mode)
+        await publish_scene()
+
+    async def run_pycoder(node_id, input_text):
+        # R5.3 post-review FIX 4(b)'s own Run-vs-Run race fix, reused
+        # verbatim for this new kind: claim the busy slot with a shared
+        # placeholder SYNCHRONOUSLY, in the same stretch as the busy
+        # pre-check just above - before document.start_pycoder_run or any
+        # await - so a second concurrent runPyCoder for this SAME node_id
+        # can never pass the same pre-check during the `await
+        # publish_scene()` gap below. Critically, this placeholder stays
+        # claimed for the ENTIRE span from here through generation, through
+        # the human-approval pause, through execution, through analysis - so
+        # a second runPyCoder DURING the pause is refused by this SAME
+        # check, no new logic needed for that case specifically (see the
+        # R5.4 design spec's own section on this).
+        node_for_check = document.nodes.get(node_id)
+        if node_for_check is not None and node_for_check.pending_request_id:
+            notifications.show("Py-Coder is already busy for this node.", "info")
+            await bus.publish("notification")
+            return None
+        if node_for_check is not None:
+            node_for_check.pending_request_id = _CODE_EXEC_RUN_CLAIM_PLACEHOLDER
+        try:
+            node = document.start_pycoder_run(node_id, input_text)
+        except SceneError:
+            if node_for_check is not None:
+                node_for_check.pending_request_id = None
+            notifications.show("This node no longer exists.", "warning")
+            await bus.publish("notification")
+            return None
+        await publish_scene()
+
+        parent_edge = next((e for e in document.edges.values() if e.target == node_id), None)
+        branch_history = document.chat_branch_history(parent_edge.source) if parent_edge else []
+
+        def _on_success(code, output, analysis, last_run_failed):
+            document.complete_pycoder_run(node_id, code, output, analysis, last_run_failed)
+
+        def _on_failure(message):
+            document.fail_pycoder_run(node_id, message)
+
+        await agent_dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id=node_id,
+            mode=node.pycoder_mode, prompt=node.pycoder_prompt, code=node.pycoder_code,
+            conversation_history=branch_history,
+            on_success=_on_success, on_failure=_on_failure,
+        )
+        return node_id
+
+    async def cancel_pycoder_request(request_id):
+        agent_dispatcher.cancel_pycoder(request_id)
+
+    bus.register_intent("scene", "setPyCoderMode", set_pycoder_mode)
+    bus.register_intent("scene", "runPyCoder", run_pycoder)
+    bus.register_intent("scene", "cancelPyCoderRequest", cancel_pycoder_request)
+
+    # -- R5.4: Execution Sandbox node -------------------------------------------
+
+    async def set_code_sandbox_requirements(node_id, requirements_text):
+        document.set_code_sandbox_requirements(node_id, requirements_text)
+        await publish_scene()
+
+    async def run_code_sandbox(node_id, input_text):
+        # Same busy-claim-placeholder pattern as run_pycoder above (and
+        # run_gitlink_change_set before it) - see that function's own
+        # comment for the exact race this closes.
+        node_for_check = document.nodes.get(node_id)
+        if node_for_check is not None and node_for_check.pending_request_id:
+            notifications.show("Execution Sandbox is already busy for this node.", "info")
+            await bus.publish("notification")
+            return None
+        if node_for_check is not None:
+            node_for_check.pending_request_id = _CODE_EXEC_RUN_CLAIM_PLACEHOLDER
+        try:
+            node = document.start_code_sandbox_run(node_id, input_text)
+        except SceneError:
+            if node_for_check is not None:
+                node_for_check.pending_request_id = None
+            notifications.show("This node no longer exists.", "warning")
+            await bus.publish("notification")
+            return None
+        await publish_scene()
+
+        parent_edge = next((e for e in document.edges.values() if e.target == node_id), None)
+        branch_history = document.chat_branch_history(parent_edge.source) if parent_edge else []
+
+        def _on_success(code, output, analysis):
+            document.complete_code_sandbox_run(node_id, code, output, analysis)
+
+        def _on_failure(message):
+            document.fail_code_sandbox_run(node_id, message)
+
+        await agent_dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id=node_id,
+            sandbox_id=node.code_sandbox_sandbox_id,
+            prompt=node.code_sandbox_prompt, existing_code=node.code_sandbox_code,
+            requirements_manifest=node.code_sandbox_requirements,
+            conversation_history=branch_history,
+            on_success=_on_success, on_failure=_on_failure,
+        )
+        return node_id
+
+    async def cancel_code_sandbox_request(request_id):
+        agent_dispatcher.cancel_code_sandbox(request_id)
+
+    bus.register_intent("scene", "setCodeSandboxRequirements", set_code_sandbox_requirements)
+    bus.register_intent("scene", "runCodeSandbox", run_code_sandbox)
+    bus.register_intent("scene", "cancelCodeSandboxRequest", cancel_code_sandbox_request)
+
+    # -- R5.4: shared approve/deny - one request_id namespace across both kinds
+
+    async def approve_code_execution(request_id):
+        agent_dispatcher.approve_code_execution(request_id)
+
+    async def deny_code_execution(request_id):
+        agent_dispatcher.deny_code_execution(request_id)
+
+    bus.register_intent("scene", "approveCodeExecution", approve_code_execution)
+    bus.register_intent("scene", "denyCodeExecution", deny_code_execution)
+
     async def move_node(node_id, x, y):
         document.move_node(node_id, x, y)
         await publish_scene()
 
     async def remove_nodes(node_ids):
-        document.remove_nodes(list(node_ids))
+        ids = list(node_ids)
+        # R5.4: a deleted Py-Coder node's REPL subprocess must not outlive
+        # it - kind is captured BEFORE document.remove_nodes pops the node,
+        # since afterward there is nothing left to read it from.
+        pycoder_ids = [
+            node_id for node_id in ids
+            if document.nodes.get(node_id) is not None and document.nodes[node_id].kind == "pycoder"
+        ]
+        # R5.4 post-review FIX 2: a deleted pycoder/code_sandbox node's
+        # DISPATCHER-SIDE in-flight request must not outlive it either - captured
+        # here, BEFORE document.remove_nodes pops the node, for the same reason
+        # pycoder_ids above is. dispose_pycoder_repl alone only tears down the
+        # REPL subprocess; it does nothing about a request parked on `await
+        # approval_future` in AgentDispatcher._pycoder_requests/
+        # _code_sandbox_requests, which has NO timeout by design (the whole
+        # point is "wait for a human, however long that takes"). Without this,
+        # deleting a node mid-approval-pause would leave that future - and the
+        # asyncio.Task awaiting it - alive forever, and a stale/duplicate
+        # approve-or-deny message arriving later could still resolve it, lazily
+        # recreating a REPL or spinning up a fresh sandbox subprocess for a
+        # node_id no longer present anywhere in the scene.
+        code_exec_cancels = [
+            (document.nodes[node_id].kind, document.nodes[node_id].pending_request_id)
+            for node_id in ids
+            if document.nodes.get(node_id) is not None
+            and document.nodes[node_id].kind in ("pycoder", "code_sandbox")
+            and document.nodes[node_id].pending_request_id
+        ]
+        document.remove_nodes(ids)
+        for node_id in pycoder_ids:
+            await agent_dispatcher.dispose_pycoder_repl(node_id)
+        for kind, request_id in code_exec_cancels:
+            # cancel_pycoder/cancel_code_sandbox resolve any pending
+            # approval_future with False (exactly like a manual Cancel/Deny)
+            # and pop the request out of the dispatcher's own dict - a safe
+            # no-op if request_id does not name a live entry (e.g. it was only
+            # ever the synchronous busy-claim placeholder, never a real
+            # dispatcher request_id, or the request already finished on its
+            # own between the capture above and here).
+            if kind == "pycoder":
+                agent_dispatcher.cancel_pycoder(request_id)
+            else:
+                agent_dispatcher.cancel_code_sandbox(request_id)
         await publish_scene()
 
     async def connect_nodes(source, target):

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -168,6 +168,44 @@ def register_plugins(
             await bus.publish("scene")
             return node.id
 
+        if name == "Py-Coder":
+            # R5.4: the fourth real node-creation plugin, same posture as
+            # Web Research/Artifact/Gitlink above - Py-Coder is a
+            # branch-point child (same as thinking/html/image/conversation/
+            # web_research/artifact/gitlink nodes), so it always requires a
+            # real, valid parent to branch from - there is no unparented/
+            # root form.
+            if not parent_node_id or parent_node_id not in canvas_document.nodes:
+                notifications.show(
+                    "Please select a valid node to branch from before adding a Py-Coder node.",
+                    "warning",
+                )
+                await bus.publish("notification")
+                return None
+            parent = canvas_document.nodes[parent_node_id]
+            node = canvas_document.add_pycoder_node(
+                parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            )
+            await bus.publish("scene")
+            return node.id
+
+        if name == "Execution Sandbox":
+            # R5.4: the fifth real node-creation plugin, same posture as
+            # every prior real node-creation plugin above.
+            if not parent_node_id or parent_node_id not in canvas_document.nodes:
+                notifications.show(
+                    "Please select a valid node to branch from before adding an Execution Sandbox node.",
+                    "warning",
+                )
+                await bus.publish("notification")
+                return None
+            parent = canvas_document.nodes[parent_node_id]
+            node = canvas_document.add_code_sandbox_node(
+                parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            )
+            await bus.publish("scene")
+            return node.id
+
         if name == "Artifact / Drafter":
             # R5.2: the second real node-creation plugin, same posture as
             # Web Research above - an Artifact node is a branch-point child

--- a/backend/tests/test_agent_layer_qt_free.py
+++ b/backend/tests/test_agent_layer_qt_free.py
@@ -74,3 +74,28 @@ def test_artifact_agent_imports_qt_free():
     # machine-checked fact that the real artifact-agent path backend/ needs
     # no longer does.
     _assert_import_is_qt_free("graphlink_artifact_agent")
+
+
+def test_pycoder_domain_imports_qt_free():
+    # R5.4 prerequisite: graphlink_agents_pycoder.py (home of PythonREPL/
+    # PyCoderReplManager/PyCoderExecutionAgent/PyCoderRepairAgent/
+    # PyCoderAnalysisAgent before this split) has its own unconditional
+    # `from PySide6.QtCore import QThread, Signal` at module level, needed
+    # only by its CodeExecutionWorker/PyCoderExecutionWorker/
+    # PyCoderAgentWorker classes - importing anything from it, including
+    # these Qt-free symbols, pulled Qt in regardless. This is the
+    # machine-checked fact that the real Py-Coder dispatch path backend/
+    # needs (backend/agents.py's start_pycoder_run) no longer does.
+    _assert_import_is_qt_free("graphlink_plugins.pycoder.domain")
+
+
+def test_code_sandbox_domain_imports_qt_free():
+    # R5.4 prerequisite: graphlink_agents_code_sandbox.py (home of
+    # SandboxGenerationAgent/SandboxRepairAgent/VirtualEnvSandbox before this
+    # split) has its own unconditional `from PySide6.QtCore import QThread,
+    # Signal` at module level, needed only by its CodeSandboxExecutionWorker
+    # class - importing anything from it, including these Qt-free symbols,
+    # pulled Qt in regardless. This is the machine-checked fact that the
+    # real Execution Sandbox dispatch path backend/ needs (backend/agents.py's
+    # start_code_sandbox_run) no longer does.
+    _assert_import_is_qt_free("graphlink_plugins.code_sandbox.domain")

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -3222,3 +3222,850 @@ def test_agents_never_imports_qt():
         text=True,
     )
     assert result.returncode == 0, result.stderr
+
+
+# -- R5.4: Py-Coder / Execution Sandbox ---------------------------------------
+#
+# The approve/deny asyncio.Future mechanism is the novel piece this section
+# exercises hardest: the future is created EAGERLY, before the background
+# task is even scheduled (see AgentDispatcher.start_pycoder_run/
+# start_code_sandbox_run's own docstrings) - so approve_code_execution/
+# deny_code_execution/cancel_pycoder/cancel_code_sandbox/
+# cancel_all_pending_approvals can all resolve it at ANY point in the
+# request's lifetime, even before the pipeline itself ever reaches its own
+# `await approval_future` line. Tests below rely on this: resolving the
+# future immediately after start_*_run returns (before awaiting the task to
+# completion) is equivalent to resolving it while genuinely parked on the
+# gate, since asyncio.Future carries its resolved value regardless of when
+# `await` is issued on it.
+
+
+def _make_pycoder_node(**overrides):
+    defaults = dict(
+        pending_request_id=None,
+        pycoder_mode="ai_driven",
+        pycoder_prompt="",
+        pycoder_code="",
+        pycoder_output="",
+        pycoder_analysis="",
+        pycoder_last_run_failed=False,
+        pycoder_awaiting_approval=False,
+        pycoder_error="",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_code_sandbox_node(**overrides):
+    defaults = dict(
+        pending_request_id=None,
+        code_sandbox_sandbox_id="sandbox-test-1",
+        code_sandbox_requirements="",
+        code_sandbox_prompt="",
+        code_sandbox_code="",
+        code_sandbox_output="",
+        code_sandbox_analysis="",
+        code_sandbox_awaiting_approval=False,
+        code_sandbox_error="",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_code_exec_env():
+    bus = SessionBus("agents-code-exec-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    bus.register_topic("scene", lambda: {})
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    return bus, notifications, dispatcher
+
+
+class _FakeRepl:
+    """A duck-typed stand-in for PythonREPL - avoids spawning a real
+    subprocess for tests that only care about the dispatch pipeline's own
+    control flow."""
+
+    def __init__(self, script=None):
+        # script: list of (output, failed) tuples, one per execute() call;
+        # the last entry repeats if execute() is called more times than the
+        # script has entries.
+        self.script = list(script or [("", False)])
+        self.last_run_failed = False
+        self.calls = []
+        self.stopped = False
+
+    def execute(self, code):
+        self.calls.append(code)
+        output, failed = self.script.pop(0) if len(self.script) > 1 else self.script[0]
+        self.last_run_failed = failed
+        return output
+
+    def stop(self):
+        self.stopped = True
+
+
+# -- Py-Coder: manual mode -----------------------------------------------------
+
+
+def test_pycoder_manual_mode_blank_code_calls_on_failure_without_creating_a_repl(monkeypatch):
+    repl_created = []
+    monkeypatch.setattr(
+        AgentDispatcher, "get_pycoder_repl", lambda self, node_id: repl_created.append(node_id) or _FakeRepl()
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pycoder_mode="manual")
+        failures = []
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="manual", prompt="", code="   ", conversation_history=[],
+            on_success=lambda *a: None, on_failure=failures.append,
+        )
+        entry = next(iter(dispatcher._pycoder_requests.values()))
+        await entry["task"]
+
+        assert failures == ["Add Python code before running Py-Coder."]
+        assert repl_created == [], "a blank-code guard must never touch the REPL"
+        assert dispatcher._pycoder_requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_pycoder_manual_mode_success_executes_once_and_analyzes(monkeypatch):
+    fake_repl = _FakeRepl(script=[("42", False)])
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: f"analysis of {code_output}",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pycoder_mode="manual")
+        successes = []
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="manual", prompt="", code="print(42)", conversation_history=[],
+            on_success=lambda *a: successes.append(a), on_failure=lambda m: None,
+        )
+        entry = next(iter(dispatcher._pycoder_requests.values()))
+        await entry["task"]
+
+        assert successes == [("print(42)", "42", "analysis of 42", False)]
+        assert fake_repl.calls == ["print(42)"]
+        assert dispatcher._pycoder_requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_pycoder_manual_mode_reports_last_run_failed_from_the_repl(monkeypatch):
+    fake_repl = _FakeRepl(script=[("Traceback...", True)])
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "explains the error",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pycoder_mode="manual")
+        successes = []
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="manual", prompt="", code="raise ValueError()", conversation_history=[],
+            on_success=lambda *a: successes.append(a), on_failure=lambda m: None,
+        )
+        entry = next(iter(dispatcher._pycoder_requests.values()))
+        await entry["task"]
+
+        assert len(successes) == 1
+        code, output, analysis, last_run_failed = successes[0]
+        assert last_run_failed is True
+        assert output == "Traceback..."
+
+    asyncio.run(run())
+
+
+def test_pycoder_manual_mode_execute_timeout_disposes_the_repl_and_calls_on_failure(monkeypatch):
+    monkeypatch.setattr(agents_module, "PYCODER_EXECUTE_TIMEOUT_SECONDS", 0.05)
+
+    class _SlowRepl:
+        def __init__(self):
+            self.last_run_failed = False
+            self.stopped = False
+
+        def execute(self, code):
+            time.sleep(0.3)
+            return "too late"
+
+        def stop(self):
+            self.stopped = True
+
+    fake_repl = _SlowRepl()
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        # Populate the REAL dict directly (not via a monkeypatched
+        # get_pycoder_repl) so dispose_pycoder_repl's own real pop-and-stop
+        # logic has something genuine to tear down.
+        dispatcher._pycoder_repls["n1"] = fake_repl
+        node = _make_pycoder_node(pycoder_mode="manual")
+        failures = []
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="manual", prompt="", code="while True: pass", conversation_history=[],
+            on_success=lambda *a: None, on_failure=failures.append,
+        )
+        entry = next(iter(dispatcher._pycoder_requests.values()))
+        await entry["task"]
+
+        assert len(failures) == 1
+        assert "timed out" in failures[0] or "stopped responding" in failures[0]
+        assert fake_repl.stopped is True, "the hung REPL must be torn down on timeout"
+        assert "n1" not in dispatcher._pycoder_repls
+        assert dispatcher._pycoder_requests == {}
+        assert node.pending_request_id is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+
+    asyncio.run(run())
+
+
+# -- Py-Coder: ai_driven mode ---------------------------------------------------
+
+
+def test_pycoder_ai_driven_empty_prompt_calls_on_failure():
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pycoder_mode="ai_driven")
+        failures = []
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="ai_driven", prompt="   ", code="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=failures.append,
+        )
+        entry = next(iter(dispatcher._pycoder_requests.values()))
+        await entry["task"]
+
+        assert failures == ["Please enter a prompt."]
+        assert dispatcher._pycoder_requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_pycoder_ai_driven_no_code_generated_calls_on_success_with_placeholder_and_skips_approval(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.PyCoderExecutionAgent, "get_response",
+        lambda self, history, prompt: "Here is a direct answer, no code needed.",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pycoder_mode="ai_driven")
+        successes = []
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="ai_driven", prompt="what is 1+1", code="", conversation_history=[],
+            on_success=lambda *a: successes.append(a), on_failure=lambda m: None,
+        )
+        entry = next(iter(dispatcher._pycoder_requests.values()))
+        await entry["task"]
+
+        assert successes == [(
+            "# No code was generated for this prompt.",
+            "[Not applicable]",
+            "Here is a direct answer, no code needed.",
+            False,
+        )]
+        assert node.pycoder_awaiting_approval is False, "no code ever means no approval gate"
+
+    asyncio.run(run())
+
+
+def test_pycoder_ai_driven_denied_approval_calls_on_failure_with_the_exact_legacy_message(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.PyCoderExecutionAgent, "get_response",
+        lambda self, history, prompt: "[TOOL:PYTHON]\nprint(1)\n[/TOOL]",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pycoder_mode="ai_driven")
+        failures = []
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="ai_driven", prompt="add 1+1", code="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=failures.append,
+        )
+        request_id, entry = next(iter(dispatcher._pycoder_requests.items()))
+
+        # Resolve BEFORE awaiting the task to completion - proves the future
+        # carries its value regardless of when the pipeline's own `await
+        # approval_future` actually executes (see this section's own
+        # docstring).
+        assert dispatcher.deny_code_execution(request_id) is True
+        await entry["task"]
+
+        assert failures == ["Py-Coder run cancelled: execution was not approved."]
+        assert node.pycoder_awaiting_approval is False
+        assert dispatcher._pycoder_requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_pycoder_ai_driven_approved_executes_successfully(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.PyCoderExecutionAgent, "get_response",
+        lambda self, history, prompt: "[TOOL:PYTHON]\nprint(2)\n[/TOOL]",
+    )
+    fake_repl = _FakeRepl(script=[("2", False)])
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "the answer is 2",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pycoder_mode="ai_driven")
+        successes = []
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="ai_driven", prompt="add 1+1", code="", conversation_history=[],
+            on_success=lambda *a: successes.append(a), on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(dispatcher._pycoder_requests.items()))
+        assert dispatcher.approve_code_execution(request_id) is True
+        await entry["task"]
+
+        assert successes == [("print(2)", "2", "the answer is 2", False)]
+        assert node.pycoder_awaiting_approval is False
+        assert fake_repl.calls == ["print(2)"]
+        assert dispatcher._pycoder_requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_pycoder_ai_driven_repair_loop_exhausts_retries_calls_on_success_with_last_run_failed_true(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.PyCoderExecutionAgent, "get_response",
+        lambda self, history, prompt: "[TOOL:PYTHON]\nbroken\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderRepairAgent, "get_response",
+        lambda self, code, error, is_final_attempt: "still broken",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "explains the persistent failure",
+    )
+    fake_repl = _FakeRepl(script=[("err", True)])  # every execute() call fails
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pycoder_mode="ai_driven")
+        successes = []
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="ai_driven", prompt="do something impossible", code="", conversation_history=[],
+            on_success=lambda *a: successes.append(a), on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(dispatcher._pycoder_requests.items()))
+        dispatcher.approve_code_execution(request_id)
+        await entry["task"]
+
+        assert len(successes) == 1, "an exhausted repair loop is still a completed run, never on_failure"
+        code, output, analysis, last_run_failed = successes[0]
+        assert last_run_failed is True
+        assert analysis.startswith("**PROCESS FAILED**")
+        assert len(fake_repl.calls) == 4, "max_retries=4, matching legacy exactly"
+
+    asyncio.run(run())
+
+
+def test_pycoder_busy_node_refuses_immediately_without_creating_a_request_entry():
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pending_request_id="already-busy")
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="ai_driven", prompt="x", code="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+
+        assert dispatcher._pycoder_requests == {}
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+
+    asyncio.run(run())
+
+
+# -- Execution Sandbox ----------------------------------------------------------
+
+
+def test_code_sandbox_both_blank_calls_on_failure():
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+        failures = []
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-1", prompt="   ", existing_code="   ",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=failures.append,
+        )
+        entry = next(iter(dispatcher._code_sandbox_requests.values()))
+        await entry["task"]
+
+        assert failures == ["Provide a task prompt or Python code before running the sandbox."]
+        assert dispatcher._code_sandbox_requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_blank_prompt_with_existing_code_reuses_it_without_calling_generation_agent(monkeypatch):
+    generation_calls = []
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: generation_calls.append(prompt) or "unused",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-1", prompt="  ", existing_code="print('reuse me')",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(dispatcher._code_sandbox_requests.items()))
+
+        # Give the pipeline a moment to reach the approval gate, then deny -
+        # this test only cares that generation was skipped, not about a full
+        # execute cycle.
+        for _ in range(200):
+            if node.code_sandbox_awaiting_approval or entry["task"].done():
+                break
+            await asyncio.sleep(0.005)
+        assert node.code_sandbox_code == "print('reuse me')", (
+            "the EXISTING code must be what is shown for approval, unmodified"
+        )
+        dispatcher.deny_code_execution(request_id)
+        await entry["task"]
+
+        assert generation_calls == [], "a blank prompt with existing code must never call the generation agent"
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_nonblank_prompt_always_regenerates_even_with_existing_code(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint('regenerated')\n[/TOOL]",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-1", prompt="write something new", existing_code="print('stale code')",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(dispatcher._code_sandbox_requests.items()))
+        dispatcher.deny_code_execution(request_id)
+        await entry["task"]
+
+        assert node.code_sandbox_code == "print('regenerated')", (
+            "a non-blank prompt must always regenerate, ignoring any existing code"
+        )
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_no_code_extracted_calls_on_success_with_placeholder_and_skips_approval(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "A direct answer, no code tool used.",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+        successes = []
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-1", prompt="what is 1+1", existing_code="",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: successes.append(a), on_failure=lambda m: None,
+        )
+        entry = next(iter(dispatcher._code_sandbox_requests.values()))
+        await entry["task"]
+
+        assert successes == [(
+            "# No Python code was generated for this request.",
+            "[Sandbox was not executed]",
+            "A direct answer, no code tool used.",
+        )]
+        assert node.code_sandbox_awaiting_approval is False
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_denied_approval_calls_on_failure_with_the_exact_legacy_message(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint(1)\n[/TOOL]",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+        failures = []
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-1", prompt="do x", existing_code="",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=failures.append,
+        )
+        request_id, entry = next(iter(dispatcher._code_sandbox_requests.items()))
+        assert dispatcher.deny_code_execution(request_id) is True
+        await entry["task"]
+
+        assert failures == ["Sandbox run cancelled: execution was not approved."]
+        assert node.code_sandbox_awaiting_approval is False
+        assert dispatcher._code_sandbox_requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_approved_full_success_flow_runs_venv_and_analyzes(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint('ok')\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "sandbox ran fine",
+    )
+
+    class _FakeSandbox:
+        def __init__(self, sandbox_id):
+            self.sandbox_id = sandbox_id
+            self.prep_calls = []
+
+        def ensure_base_environment(self, should_continue, emit_line=None):
+            self.prep_calls.append("ensure_base_environment")
+
+        def sync_requirements(self, manifest, should_continue, emit_line=None):
+            self.prep_calls.append(("sync_requirements", manifest))
+
+        def execute_code(self, code, should_continue, emit_line=None):
+            return f"ran: {code}", 0
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _FakeSandbox)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+        successes = []
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="print ok", existing_code="",
+            requirements_manifest="numpy", conversation_history=[],
+            on_success=lambda *a: successes.append(a), on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(dispatcher._code_sandbox_requests.items()))
+        dispatcher.approve_code_execution(request_id)
+        await entry["task"]
+
+        assert len(successes) == 1
+        code, output, analysis = successes[0]
+        assert code == "print('ok')"
+        assert output == "ran: print('ok')"
+        assert analysis == "sandbox ran fine"
+        assert node.code_sandbox_awaiting_approval is False
+        assert dispatcher._code_sandbox_requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_run_streams_live_output_lines_in_order_with_a_final_done_frame(monkeypatch):
+    """R5.4 post-review FIX 1: execute_code's emit_line callback must reach
+    the WS layer via bus.publish_stream, in order, addressed to this run's
+    own request_id, ending with an unconditional final done=True frame -
+    same recorder/assertion shape test_streaming_happy_path_... uses for the
+    chat token-streaming pump above (_StreamRecorderConnection is a plain,
+    reusable Connection double, not chat-specific)."""
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint('ok')\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "sandbox ran fine",
+    )
+
+    class _FakeSandbox:
+        def __init__(self, sandbox_id):
+            self.sandbox_id = sandbox_id
+
+        def ensure_base_environment(self, should_continue, emit_line=None):
+            if emit_line:
+                emit_line("[Sandbox] Creating virtual environment...\n")
+
+        def sync_requirements(self, manifest, should_continue, emit_line=None):
+            if emit_line:
+                emit_line("[Sandbox] No extra dependencies requested.\n")
+
+        def execute_code(self, code, should_continue, emit_line=None):
+            if emit_line:
+                emit_line("line one\n")
+                emit_line("line two\n")
+            return "line one\nline two", 0
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _FakeSandbox)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        recorder = _StreamRecorderConnection()
+        bus.attach(recorder)
+        node = _make_code_sandbox_node()
+        successes = []
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="print ok", existing_code="",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: successes.append(a), on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(dispatcher._code_sandbox_requests.items()))
+        dispatcher.approve_code_execution(request_id)
+        await entry["task"]
+
+        assert len(successes) == 1, "the run must still complete normally alongside the new streaming side-channel"
+
+        assert recorder.frames, "must have received at least one stream frame"
+        assert recorder.frames[-1]["done"] is True
+        assert recorder.frames[-1]["delta"] == ""
+        non_final = [f for f in recorder.frames if not f["done"]]
+        assert [f["delta"] for f in non_final] == [
+            "[Sandbox] Creating virtual environment...\n",
+            "[Sandbox] No extra dependencies requested.\n",
+            "line one\n",
+            "line two\n",
+        ], "one publish_stream call per emit_line call, in order - no batching"
+        assert all(f["topic"] == "scene" for f in recorder.frames)
+        assert all(f["requestId"] == request_id for f in recorder.frames), (
+            "every frame must be addressed to THIS run's own request_id"
+        )
+        seqs = [f["seq"] for f in recorder.frames]
+        assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs), "seq must be strictly increasing"
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_busy_node_refuses_immediately_without_creating_a_request_entry():
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node(pending_request_id="already-busy")
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-1", prompt="x", existing_code="",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+
+        assert dispatcher._code_sandbox_requests == {}
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+
+    asyncio.run(run())
+
+
+def test_is_sandbox_error_output_detects_nonzero_return_code_and_keywords():
+    assert agents_module._is_sandbox_error_output("all good", 1) is True
+    assert agents_module._is_sandbox_error_output("Traceback (most recent call last):", 0) is True
+    assert agents_module._is_sandbox_error_output("ModuleNotFoundError: no module", 0) is True
+    assert agents_module._is_sandbox_error_output("all good, no errors here", 0) is False
+
+
+# -- shared approve/deny + cancel + disconnect auto-deny mechanics ------------
+
+
+def test_cancel_pycoder_sets_cancel_event_and_resolves_the_approval_future_false():
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pending_request_id="req-1")
+        cancel_event = threading.Event()
+        future = asyncio.get_running_loop().create_future()
+        dispatcher._pycoder_requests["req-1"] = {
+            "cancel_event": cancel_event, "approval_future": future, "task": None,
+        }
+
+        assert dispatcher.cancel_pycoder("req-1") is True
+        assert cancel_event.is_set() is True
+        assert future.done() is True
+        assert future.result() is False
+
+    asyncio.run(run())
+
+
+def test_cancel_pycoder_returns_false_for_an_unknown_request_id():
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    assert dispatcher.cancel_pycoder("no-such-request") is False
+
+
+def test_cancel_code_sandbox_returns_false_for_an_unknown_request_id():
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    assert dispatcher.cancel_code_sandbox("no-such-request") is False
+
+
+def test_approve_code_execution_resolves_a_pending_pycoder_future():
+    async def run():
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+        future = asyncio.get_running_loop().create_future()
+        dispatcher._pycoder_requests["req-x"] = {
+            "cancel_event": threading.Event(), "approval_future": future, "task": None,
+        }
+
+        assert dispatcher.approve_code_execution("req-x") is True
+        assert future.result() is True
+
+    asyncio.run(run())
+
+
+def test_deny_code_execution_resolves_a_pending_code_sandbox_future():
+    async def run():
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+        future = asyncio.get_running_loop().create_future()
+        dispatcher._code_sandbox_requests["req-y"] = {
+            "cancel_event": threading.Event(), "approval_future": future, "task": None,
+        }
+
+        assert dispatcher.deny_code_execution("req-y") is True
+        assert future.result() is False
+
+    asyncio.run(run())
+
+
+def test_approve_code_execution_returns_false_for_an_unknown_request_id():
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    assert dispatcher.approve_code_execution("no-such-request") is False
+
+
+def test_resolve_approval_is_idempotent_and_never_raises_on_a_stale_duplicate_call():
+    """LOAD-BEARING guard: a duplicate/stale approve-or-deny (e.g. a
+    double-click, or a message arriving after cancel already resolved this
+    same future) must never raise asyncio.InvalidStateError."""
+    async def run():
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+        future = asyncio.get_running_loop().create_future()
+        dispatcher._pycoder_requests["req-dup"] = {
+            "cancel_event": threading.Event(), "approval_future": future, "task": None,
+        }
+
+        assert dispatcher.approve_code_execution("req-dup") is True
+        assert future.result() is True
+        # A second, stale call for the SAME request must not raise, and must
+        # not flip the already-resolved value.
+        assert dispatcher.deny_code_execution("req-dup") is True
+        assert future.result() is True, "the first resolution wins - a stale deny must not clobber it"
+
+    asyncio.run(run())
+
+
+def test_cancel_all_pending_approvals_auto_denies_every_undone_future_in_both_dicts():
+    async def run():
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+        pycoder_future = asyncio.get_running_loop().create_future()
+        sandbox_future = asyncio.get_running_loop().create_future()
+        already_resolved_future = asyncio.get_running_loop().create_future()
+        already_resolved_future.set_result(True)
+
+        dispatcher._pycoder_requests["p1"] = {
+            "cancel_event": threading.Event(), "approval_future": pycoder_future, "task": None,
+        }
+        dispatcher._code_sandbox_requests["s1"] = {
+            "cancel_event": threading.Event(), "approval_future": sandbox_future, "task": None,
+        }
+        dispatcher._code_sandbox_requests["s2"] = {
+            "cancel_event": threading.Event(), "approval_future": already_resolved_future, "task": None,
+        }
+
+        dispatcher.cancel_all_pending_approvals()
+
+        assert pycoder_future.result() is False
+        assert sandbox_future.result() is False
+        assert already_resolved_future.result() is True, (
+            "an already-resolved future must never be clobbered by the auto-deny sweep"
+        )
+
+    asyncio.run(run())
+
+
+def test_get_pycoder_repl_returns_the_same_instance_for_the_same_node_id():
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    first = dispatcher.get_pycoder_repl("n1")
+    second = dispatcher.get_pycoder_repl("n1")
+    assert first is second
+    assert dispatcher.get_pycoder_repl("n2") is not first
+
+
+def test_dispose_pycoder_repl_tolerates_a_missing_node_id_silently():
+    async def run():
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+        await dispatcher.dispose_pycoder_repl("never-created")  # must not raise
+
+    asyncio.run(run())
+
+
+def test_dispose_pycoder_repl_stops_and_removes_the_repl():
+    class _StoppableRepl:
+        def __init__(self):
+            self.stopped = False
+
+        def stop(self):
+            self.stopped = True
+
+    async def run():
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+        fake_repl = _StoppableRepl()
+        dispatcher._pycoder_repls["n1"] = fake_repl
+
+        await dispatcher.dispose_pycoder_repl("n1")
+
+        assert fake_repl.stopped is True
+        assert "n1" not in dispatcher._pycoder_repls
+
+    asyncio.run(run())

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -189,3 +189,69 @@ def test_disconnect_cancels_any_in_flight_chat_request(monkeypatch):
     while not cancel_event.is_set() and time.monotonic() < deadline:
         time.sleep(0.01)
     assert cancel_event.is_set()
+
+
+def test_disconnect_auto_denies_any_pending_pycoder_approval(monkeypatch):
+    # R5.4: an approval pause has NO timeout by design (the whole point is
+    # "wait for a human, however long that takes") - so a client that starts
+    # a Py-Coder run, sees the approval gate, then closes its tab WITHOUT
+    # ever approving or denying must not leave that request parked forever,
+    # permanently locking node.pending_request_id. ws_endpoint's disconnect
+    # handler must resolve the pending approval_future to False (auto-deny)
+    # once the session's last connection drops - this exercises that through
+    # the real ASGI app end to end, not just AgentDispatcher.
+    # cancel_all_pending_approvals in isolation (test_agents.py already
+    # covers that unit-level).
+    import graphlink_plugins.pycoder.domain as pycoder_domain
+
+    monkeypatch.setattr(
+        pycoder_domain.PyCoderExecutionAgent, "get_response",
+        lambda self, history, prompt: "[TOOL:PYTHON]\nprint(1)\n[/TOOL]",
+    )
+
+    client = make_client()
+    with client.websocket_connect("/ws?session=pycoder-disconnect-test") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["scene"]})
+        ws.receive_json()  # initial scene snapshot
+
+        # No "id" on either intent below - deliberately, to keep message
+        # ordering simple: each add_*/execute_plugin wrapper broadcasts its
+        # own scene state DURING the call (before dispatch_intent returns),
+        # so with no id there is exactly one message per intent to drain,
+        # and the new node's id is read back from that broadcast's own
+        # payload rather than from a "result" envelope.
+        ws.send_json({"kind": "intent", "topic": "scene", "intent": "addNode", "args": [0, 0, "root"]})
+        scene_after_add = ws.receive_json()["payload"]
+        parent_id = scene_after_add["nodes"][0]["id"]
+
+        ws.send_json(
+            {"kind": "intent", "topic": "app-plugins", "intent": "executePlugin", "args": ["Py-Coder", parent_id]}
+        )
+        scene_after_plugin = ws.receive_json()["payload"]
+        node_id = next(n["id"] for n in scene_after_plugin["nodes"] if n["kind"] == "pycoder")
+
+        ws.send_json(
+            {"kind": "intent", "topic": "scene", "intent": "runPyCoder", "args": [node_id, "add 1"]}
+        )
+        # Exactly two scene republishes land before the pipeline genuinely
+        # pauses: (1) run_pycoder's own synchronous busy-claim publish, (2)
+        # the background task's publish right after it sets
+        # pycoder_awaiting_approval=True and parks on `await
+        # approval_future` - nothing more arrives until approve/deny or
+        # disconnect.
+        ws.receive_json()  # (1) busy-claim publish
+        ws.receive_json()  # (2) awaiting-approval publish
+
+        session = client.app.state.bus.session("pycoder-disconnect-test")
+        assert session.agent_dispatcher._pycoder_requests, "runPyCoder never created a request entry"
+        entry = next(iter(session.agent_dispatcher._pycoder_requests.values()))
+        approval_future = entry["approval_future"]
+        assert not approval_future.done(), "the pipeline must genuinely be parked on the gate here"
+    # Exiting the `with` block closes the websocket, running ws_endpoint's
+    # finally - the disconnect this test exists to exercise.
+
+    deadline = time.monotonic() + 5
+    while not approval_future.done() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert approval_future.done(), "the pending approval must be auto-denied on disconnect"
+    assert approval_future.result() is False

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -3713,3 +3713,775 @@ def test_two_concurrent_run_gitlink_change_set_calls_for_the_same_node_only_one_
         )
 
     asyncio.run(run())
+
+
+# -- R5.4: Py-Coder node ------------------------------------------------------
+
+
+def test_add_pycoder_node_requires_valid_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_pycoder_node(0, 0, "ghost")
+
+
+def test_add_pycoder_node_creates_child_with_defaults():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "wire up pycoder", True)
+    node = doc.add_pycoder_node(10, 20, parent.id)
+    assert node.kind == "pycoder"
+    assert node.title == "Py-Coder"
+    assert node.pycoder_mode == "ai_driven"
+    assert node.pycoder_prompt == ""
+    assert node.pycoder_code == ""
+    assert node.pycoder_output == ""
+    assert node.pycoder_analysis == ""
+    assert node.pycoder_last_run_failed is False
+    assert node.pycoder_awaiting_approval is False
+    assert node.pycoder_error == ""
+    assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
+
+
+def test_add_pycoder_node_requires_a_parent_id():
+    doc = SceneDocument()
+    with pytest.raises(TypeError):
+        doc.add_pycoder_node(0, 0)
+
+
+def test_pycoder_node_deletion_goes_through_the_generic_remove_nodes_path():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_pycoder_node(10, 10, parent.id)
+    assert not hasattr(doc, "delete_pycoder_node"), (
+        "pycoder nodes are not branch points - no special delete method"
+    )
+    doc.remove_nodes([node.id])
+    assert node.id not in doc.nodes
+
+
+def test_set_pycoder_mode_sets_the_field():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_pycoder_node(0, 0, parent.id)
+    returned = doc.set_pycoder_mode(node.id, "manual")
+    assert returned is node
+    assert node.pycoder_mode == "manual"
+
+
+def test_set_pycoder_mode_rejects_unknown_mode():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_pycoder_node(0, 0, parent.id)
+    with pytest.raises(SceneError):
+        doc.set_pycoder_mode(node.id, "turbo")
+
+
+def test_set_pycoder_mode_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().set_pycoder_mode("ghost", "manual")
+
+
+def test_start_pycoder_run_ai_driven_stores_prompt_and_clears_error():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_pycoder_node(0, 0, parent.id)
+    node.pycoder_error = "a previous error"
+
+    returned = doc.start_pycoder_run(node.id, "sort this list")
+
+    assert returned is node
+    assert node.pycoder_prompt == "sort this list"
+    assert node.pycoder_error == ""
+
+
+def test_start_pycoder_run_manual_stores_code_not_prompt():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_pycoder_node(0, 0, parent.id)
+    doc.set_pycoder_mode(node.id, "manual")
+
+    doc.start_pycoder_run(node.id, "print('hi')")
+
+    assert node.pycoder_code == "print('hi')"
+    assert node.pycoder_prompt == ""
+
+
+def test_start_pycoder_run_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().start_pycoder_run("ghost", "x")
+
+
+def test_start_pycoder_run_wrong_kind_raises_scene_error():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_gitlink_node(0, 0, parent.id)
+    with pytest.raises(SceneError):
+        doc.start_pycoder_run(node.id, "x")
+
+
+def test_complete_pycoder_run_sets_all_fields_and_clears_approval_and_error():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_pycoder_node(0, 0, parent.id)
+    node.pycoder_awaiting_approval = True
+    node.pycoder_error = "stale error"
+
+    returned = doc.complete_pycoder_run(node.id, "print(1)", "1", "analysis text", False)
+
+    assert returned is node
+    assert node.pycoder_code == "print(1)"
+    assert node.pycoder_output == "1"
+    assert node.pycoder_analysis == "analysis text"
+    assert node.pycoder_last_run_failed is False
+    assert node.pycoder_awaiting_approval is False
+    assert node.pycoder_error == ""
+
+
+def test_complete_pycoder_run_is_a_silent_noop_for_a_deleted_node():
+    assert SceneDocument().complete_pycoder_run("ghost", "c", "o", "a", False) is None
+
+
+def test_fail_pycoder_run_sets_error_clears_approval_but_preserves_output():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_pycoder_node(0, 0, parent.id)
+    node.pycoder_code = "print(1)"
+    node.pycoder_output = "1"
+    node.pycoder_analysis = "old analysis"
+    node.pycoder_awaiting_approval = True
+
+    returned = doc.fail_pycoder_run(node.id, "execution timed out")
+
+    assert returned is node
+    assert node.pycoder_error == "execution timed out"
+    assert node.pycoder_awaiting_approval is False
+    # stale-while-revalidate: a failed run must not wipe out a previously
+    # completed result.
+    assert node.pycoder_code == "print(1)"
+    assert node.pycoder_output == "1"
+    assert node.pycoder_analysis == "old analysis"
+
+
+def test_fail_pycoder_run_is_a_silent_noop_for_a_deleted_node():
+    assert SceneDocument().fail_pycoder_run("ghost", "x") is None
+
+
+def test_scene_payload_pycoder_fields_default_correctly_for_a_fresh_node():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_pycoder_node(0, 0, parent.id)
+    row = {n["id"]: n for n in doc.scene_payload()["nodes"]}[node.id]
+    assert row["pycoderMode"] == "ai_driven"
+    assert row["pycoderPrompt"] == ""
+    assert row["pycoderCode"] == ""
+    assert row["pycoderOutput"] == ""
+    assert row["pycoderAnalysis"] == ""
+    assert row["pycoderLastRunFailed"] is False
+    assert row["pycoderAwaitingApproval"] is False
+    assert row["pycoderError"] == ""
+
+
+# -- R5.4: Execution Sandbox node ---------------------------------------------
+
+
+def test_add_code_sandbox_node_requires_valid_parent():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.add_code_sandbox_node(0, 0, "ghost")
+
+
+def test_add_code_sandbox_node_creates_child_with_defaults_and_mints_sandbox_id():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "wire up sandbox", True)
+    node = doc.add_code_sandbox_node(10, 20, parent.id)
+    assert node.kind == "code_sandbox"
+    assert node.title == "Execution Sandbox"
+    assert node.code_sandbox_sandbox_id, "a sandbox id must be minted at creation time"
+    assert node.code_sandbox_requirements == ""
+    assert node.code_sandbox_prompt == ""
+    assert node.code_sandbox_code == ""
+    assert node.code_sandbox_output == ""
+    assert node.code_sandbox_analysis == ""
+    assert node.code_sandbox_awaiting_approval is False
+    assert node.code_sandbox_error == ""
+    assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
+
+
+def test_add_code_sandbox_node_mints_a_different_id_per_node():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    a = doc.add_code_sandbox_node(0, 0, parent.id)
+    b = doc.add_code_sandbox_node(0, 0, parent.id)
+    assert a.code_sandbox_sandbox_id != b.code_sandbox_sandbox_id
+
+
+def test_add_code_sandbox_node_requires_a_parent_id():
+    doc = SceneDocument()
+    with pytest.raises(TypeError):
+        doc.add_code_sandbox_node(0, 0)
+
+
+def test_code_sandbox_node_deletion_goes_through_the_generic_remove_nodes_path():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_code_sandbox_node(10, 10, parent.id)
+    assert not hasattr(doc, "delete_code_sandbox_node")
+    doc.remove_nodes([node.id])
+    assert node.id not in doc.nodes
+
+
+def test_set_code_sandbox_requirements_sets_the_field():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_code_sandbox_node(0, 0, parent.id)
+    returned = doc.set_code_sandbox_requirements(node.id, "numpy\nrequests")
+    assert returned is node
+    assert node.code_sandbox_requirements == "numpy\nrequests"
+
+
+def test_set_code_sandbox_requirements_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().set_code_sandbox_requirements("ghost", "numpy")
+
+
+def test_start_code_sandbox_run_stores_prompt_and_clears_error_without_touching_code():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_code_sandbox_node(0, 0, parent.id)
+    node.code_sandbox_code = "print('previous run')"
+    node.code_sandbox_error = "a previous error"
+
+    returned = doc.start_code_sandbox_run(node.id, "add a health check")
+
+    assert returned is node
+    assert node.code_sandbox_prompt == "add a health check"
+    assert node.code_sandbox_error == ""
+    assert node.code_sandbox_code == "print('previous run')", (
+        "start_code_sandbox_run must not overwrite the existing code - the "
+        "dispatch method decides generate-vs-reuse by reading it at call time"
+    )
+
+
+def test_start_code_sandbox_run_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().start_code_sandbox_run("ghost", "x")
+
+
+def test_start_code_sandbox_run_wrong_kind_raises_scene_error():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_pycoder_node(0, 0, parent.id)
+    with pytest.raises(SceneError):
+        doc.start_code_sandbox_run(node.id, "x")
+
+
+def test_complete_code_sandbox_run_sets_all_fields_and_clears_approval_and_error():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_code_sandbox_node(0, 0, parent.id)
+    node.code_sandbox_awaiting_approval = True
+    node.code_sandbox_approval_requirements = "numpy"
+    node.code_sandbox_error = "stale error"
+
+    returned = doc.complete_code_sandbox_run(node.id, "print(1)", "1", "analysis text")
+
+    assert returned is node
+    assert node.code_sandbox_code == "print(1)"
+    assert node.code_sandbox_output == "1"
+    assert node.code_sandbox_analysis == "analysis text"
+    assert node.code_sandbox_awaiting_approval is False
+    assert node.code_sandbox_approval_requirements == "", (
+        "the frozen approval snapshot must be cleared alongside awaiting_approval"
+    )
+    assert node.code_sandbox_error == ""
+
+
+def test_complete_code_sandbox_run_is_a_silent_noop_for_a_deleted_node():
+    assert SceneDocument().complete_code_sandbox_run("ghost", "c", "o", "a") is None
+
+
+def test_fail_code_sandbox_run_sets_error_clears_approval_but_preserves_output():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_code_sandbox_node(0, 0, parent.id)
+    node.code_sandbox_code = "print(1)"
+    node.code_sandbox_output = "1"
+    node.code_sandbox_analysis = "old analysis"
+    node.code_sandbox_awaiting_approval = True
+    node.code_sandbox_approval_requirements = "numpy"
+
+    returned = doc.fail_code_sandbox_run(node.id, "sandbox timed out")
+
+    assert returned is node
+    assert node.code_sandbox_error == "sandbox timed out"
+    assert node.code_sandbox_awaiting_approval is False
+    assert node.code_sandbox_approval_requirements == "", (
+        "the frozen approval snapshot must be cleared alongside awaiting_approval"
+    )
+    assert node.code_sandbox_code == "print(1)"
+    assert node.code_sandbox_output == "1"
+    assert node.code_sandbox_analysis == "old analysis"
+
+
+def test_fail_code_sandbox_run_is_a_silent_noop_for_a_deleted_node():
+    assert SceneDocument().fail_code_sandbox_run("ghost", "x") is None
+
+
+def test_scene_payload_code_sandbox_fields_default_correctly_and_excludes_sandbox_id():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_code_sandbox_node(0, 0, parent.id)
+    row = {n["id"]: n for n in doc.scene_payload()["nodes"]}[node.id]
+    assert "codeSandboxSandboxId" not in row, (
+        "the internal sandbox directory-naming key must never reach the wire"
+    )
+    assert row["codeSandboxRequirements"] == ""
+    assert row["codeSandboxPrompt"] == ""
+    assert row["codeSandboxCode"] == ""
+    assert row["codeSandboxOutput"] == ""
+    assert row["codeSandboxAnalysis"] == ""
+    assert row["codeSandboxAwaitingApproval"] is False
+    assert row["codeSandboxApprovalRequirements"] == ""
+    assert row["codeSandboxError"] == ""
+
+
+# -- R5.4: Py-Coder / Execution Sandbox - WS-intent level ---------------------
+
+
+def test_set_pycoder_mode_intent_publishes_scene():
+    async def run():
+        bus, document, recorder, _dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_pycoder_node(0, 0, parent.id)
+
+        await bus.dispatch_intent("scene", "setPyCoderMode", [node.id, "manual"])
+
+        assert document.nodes[node.id].pycoder_mode == "manual"
+
+    asyncio.run(run())
+
+
+def test_run_pycoder_intent_busy_node_refuses_without_calling_dispatcher():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.called = False
+
+        async def start_pycoder_run(self, **kwargs):
+            self.called = True
+
+    async def run():
+        bus = SessionBus("pycoder-busy-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        document = register_canvas(bus, notifications, fake_dispatcher, composer_document)
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_pycoder_node(0, 0, parent.id)
+        node.pending_request_id = "already-busy"
+
+        result = await bus.dispatch_intent("scene", "runPyCoder", [node.id, "sort this"])
+
+        assert result is None
+        assert fake_dispatcher.called is False
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+
+    asyncio.run(run())
+
+
+def test_run_pycoder_intent_dispatches_with_correct_node_fields():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.calls = []
+
+        async def start_pycoder_run(self, **kwargs):
+            self.calls.append(kwargs)
+
+    async def run():
+        bus = SessionBus("pycoder-run-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        document = register_canvas(bus, notifications, fake_dispatcher, composer_document)
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_pycoder_node(0, 0, parent.id)
+
+        result = await bus.dispatch_intent("scene", "runPyCoder", [node.id, "sort this list"])
+
+        assert result == node.id
+        assert document.nodes[node.id].pycoder_prompt == "sort this list"
+        assert len(fake_dispatcher.calls) == 1
+        call = fake_dispatcher.calls[0]
+        assert call["mode"] == "ai_driven"
+        assert call["prompt"] == "sort this list"
+        assert callable(call["on_success"])
+        assert callable(call["on_failure"])
+
+    asyncio.run(run())
+
+
+def test_cancel_pycoder_request_intent_calls_agent_dispatcher_cancel_pycoder():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.cancel_calls = []
+
+        def cancel_pycoder(self, request_id):
+            self.cancel_calls.append(request_id)
+            return True
+
+    async def run():
+        bus = SessionBus("cancel-pycoder-request-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        register_canvas(bus, notifications, fake_dispatcher, composer_document)
+
+        result = await bus.dispatch_intent("scene", "cancelPyCoderRequest", ["req-789"])
+
+        assert result is None
+        assert fake_dispatcher.cancel_calls == ["req-789"]
+
+    asyncio.run(run())
+
+
+def test_run_code_sandbox_intent_dispatches_with_correct_node_fields():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.calls = []
+
+        async def start_code_sandbox_run(self, **kwargs):
+            self.calls.append(kwargs)
+
+    async def run():
+        bus = SessionBus("sandbox-run-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        document = register_canvas(bus, notifications, fake_dispatcher, composer_document)
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_code_sandbox_node(0, 0, parent.id)
+
+        result = await bus.dispatch_intent("scene", "runCodeSandbox", [node.id, "generate a health check"])
+
+        assert result == node.id
+        assert document.nodes[node.id].code_sandbox_prompt == "generate a health check"
+        assert len(fake_dispatcher.calls) == 1
+        call = fake_dispatcher.calls[0]
+        assert call["sandbox_id"] == document.nodes[node.id].code_sandbox_sandbox_id
+        assert call["prompt"] == "generate a health check"
+        assert call["existing_code"] == ""
+        assert callable(call["on_success"])
+        assert callable(call["on_failure"])
+
+    asyncio.run(run())
+
+
+def test_run_code_sandbox_intent_busy_node_refuses_without_calling_dispatcher():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.called = False
+
+        async def start_code_sandbox_run(self, **kwargs):
+            self.called = True
+
+    async def run():
+        bus = SessionBus("sandbox-busy-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        document = register_canvas(bus, notifications, fake_dispatcher, composer_document)
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_code_sandbox_node(0, 0, parent.id)
+        node.pending_request_id = "already-busy"
+
+        result = await bus.dispatch_intent("scene", "runCodeSandbox", [node.id, "x"])
+
+        assert result is None
+        assert fake_dispatcher.called is False
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+
+    asyncio.run(run())
+
+
+def test_cancel_code_sandbox_request_intent_calls_agent_dispatcher_cancel_code_sandbox():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.cancel_calls = []
+
+        def cancel_code_sandbox(self, request_id):
+            self.cancel_calls.append(request_id)
+            return True
+
+    async def run():
+        bus = SessionBus("cancel-sandbox-request-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        register_canvas(bus, notifications, fake_dispatcher, composer_document)
+
+        result = await bus.dispatch_intent("scene", "cancelCodeSandboxRequest", ["req-321"])
+
+        assert result is None
+        assert fake_dispatcher.cancel_calls == ["req-321"]
+
+    asyncio.run(run())
+
+
+def test_approve_code_execution_intent_calls_agent_dispatcher_approve():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.calls = []
+
+        def approve_code_execution(self, request_id):
+            self.calls.append(request_id)
+            return True
+
+    async def run():
+        bus = SessionBus("approve-code-execution-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        register_canvas(bus, notifications, fake_dispatcher, composer_document)
+
+        result = await bus.dispatch_intent("scene", "approveCodeExecution", ["req-abc"])
+
+        assert result is None
+        assert fake_dispatcher.calls == ["req-abc"]
+
+    asyncio.run(run())
+
+
+def test_deny_code_execution_intent_calls_agent_dispatcher_deny():
+    class _FakeDispatcher:
+        def __init__(self):
+            self.calls = []
+
+        def deny_code_execution(self, request_id):
+            self.calls.append(request_id)
+            return True
+
+    async def run():
+        bus = SessionBus("deny-code-execution-intent-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        register_canvas(bus, notifications, fake_dispatcher, composer_document)
+
+        result = await bus.dispatch_intent("scene", "denyCodeExecution", ["req-def"])
+
+        assert result is None
+        assert fake_dispatcher.calls == ["req-def"]
+
+    asyncio.run(run())
+
+
+def test_remove_nodes_disposes_the_repl_for_every_deleted_pycoder_node():
+    """R5.4: a deleted Py-Coder node's REPL subprocess must not outlive it -
+    uses the REAL AgentDispatcher (make_bus_with_dispatcher) so this proves
+    the actual dispose_pycoder_repl wiring, not a mocked stand-in."""
+    async def run():
+        bus, document, _recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        pycoder_node = document.add_pycoder_node(0, 0, parent.id)
+        other_node = document.add_gitlink_node(0, 0, parent.id)
+        # Populate a REPL for this node id, so there is something real to
+        # tear down.
+        repl = dispatcher.get_pycoder_repl(pycoder_node.id)
+        assert pycoder_node.id in dispatcher._pycoder_repls
+
+        await bus.dispatch_intent("scene", "removeNodes", [[pycoder_node.id, other_node.id]])
+
+        assert pycoder_node.id not in document.nodes
+        assert other_node.id not in document.nodes
+        assert pycoder_node.id not in dispatcher._pycoder_repls, (
+            "the REPL must be disposed once its owning pycoder node is deleted"
+        )
+
+    asyncio.run(run())
+
+
+def test_remove_nodes_does_not_touch_the_repl_dict_when_no_pycoder_node_is_deleted():
+    async def run():
+        bus, document, _recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        pycoder_node = document.add_pycoder_node(0, 0, parent.id)
+        other_node = document.add_gitlink_node(0, 0, parent.id)
+        dispatcher.get_pycoder_repl(pycoder_node.id)
+
+        await bus.dispatch_intent("scene", "removeNodes", [[other_node.id]])
+
+        assert other_node.id not in document.nodes
+        assert pycoder_node.id in document.nodes
+        assert pycoder_node.id in dispatcher._pycoder_repls, (
+            "a still-live pycoder node's REPL must not be disposed just "
+            "because a DIFFERENT node was deleted"
+        )
+
+    asyncio.run(run())
+
+
+def test_remove_nodes_cancels_the_dispatchers_pycoder_request_when_deleted_mid_approval_pause(monkeypatch):
+    """R5.4 post-review FIX 2: dispose_pycoder_repl (proven above) only tears
+    down the REPL subprocess - it does nothing about a request genuinely
+    parked on `await approval_future` in AgentDispatcher._pycoder_requests,
+    which has NO timeout by design (the whole point is "wait for a human,
+    however long that takes"). Deleting the node mid-pause must ALSO
+    resolve/cancel that dispatcher-side request (mirrors a manual Cancel
+    exactly - see AgentDispatcher.cancel_pycoder), closing the orphan window
+    completely rather than leaving the future - and the asyncio.Task awaiting
+    it - alive forever."""
+    monkeypatch.setattr(
+        agents_module.PyCoderExecutionAgent, "get_response",
+        lambda self, history, prompt: "[TOOL:PYTHON]\nprint(1)\n[/TOOL]",
+    )
+
+    async def run():
+        bus, document, _recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        pycoder_node = document.add_pycoder_node(0, 0, parent.id)
+
+        await bus.dispatch_intent("scene", "runPyCoder", [pycoder_node.id, "do something"])
+        request_id, entry = next(iter(dispatcher._pycoder_requests.items()))
+
+        # Let the pipeline genuinely reach the approval gate (a real
+        # asyncio.to_thread hop for PyCoderExecutionAgent.get_response, then a
+        # real `await approval_future` with nothing else ever resolving it) -
+        # same polling idiom test_agents.py's own
+        # test_code_sandbox_blank_prompt_with_existing_code_reuses_it_...
+        # uses for the equivalent code_sandbox gate.
+        for _ in range(200):
+            if pycoder_node.pycoder_awaiting_approval or entry["task"].done():
+                break
+            await asyncio.sleep(0.005)
+        assert pycoder_node.pycoder_awaiting_approval is True, "must genuinely be parked on the approval gate"
+        assert request_id in dispatcher._pycoder_requests
+
+        await bus.dispatch_intent("scene", "removeNodes", [[pycoder_node.id]])
+        await entry["task"]
+
+        assert pycoder_node.id not in document.nodes
+        assert dispatcher._pycoder_requests == {}, (
+            "the orphaned dispatcher-side request must be resolved and popped - "
+            "not left parked on approval_future forever"
+        )
+        assert entry["task"].done(), "the background task must actually complete, not hang"
+
+    asyncio.run(run())
+
+
+def test_remove_nodes_cancels_the_dispatchers_code_sandbox_request_when_deleted_mid_approval_pause(monkeypatch):
+    """R5.4 post-review FIX 2's Execution Sandbox twin - mirrors the pycoder
+    test above exactly (same race, same fix, same asserted outcome)."""
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint(1)\n[/TOOL]",
+    )
+
+    async def run():
+        bus, document, _recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        sandbox_node = document.add_code_sandbox_node(0, 0, parent.id)
+
+        await bus.dispatch_intent("scene", "runCodeSandbox", [sandbox_node.id, "do something"])
+        request_id, entry = next(iter(dispatcher._code_sandbox_requests.items()))
+
+        for _ in range(200):
+            if sandbox_node.code_sandbox_awaiting_approval or entry["task"].done():
+                break
+            await asyncio.sleep(0.005)
+        assert sandbox_node.code_sandbox_awaiting_approval is True, "must genuinely be parked on the approval gate"
+        assert request_id in dispatcher._code_sandbox_requests
+
+        await bus.dispatch_intent("scene", "removeNodes", [[sandbox_node.id]])
+        await entry["task"]
+
+        assert sandbox_node.id not in document.nodes
+        assert dispatcher._code_sandbox_requests == {}, (
+            "the orphaned dispatcher-side request must be resolved and popped - "
+            "not left parked on approval_future forever"
+        )
+        assert entry["task"].done(), "the background task must actually complete, not hang"
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_approval_requirements_snapshot_is_decoupled_from_the_live_draft_field(monkeypatch):
+    """R5.4 CODESANDBOX FIX: closes the requirements-disclosure staleness
+    race. AgentDispatcher.start_code_sandbox_run (backend/agents.py) reads
+    requirements_manifest synchronously into a local `manifest` variable at
+    the very top of its own _run(), BEFORE its one real await (the
+    asyncio.to_thread call to SandboxGenerationAgent). A setCodeSandboxRequirements
+    intent - ungated by any busy check - can land during that await window
+    and change the LIVE node.code_sandbox_requirements field before the
+    approval panel is ever shown. Uses the REAL AgentDispatcher
+    (make_bus_with_dispatcher) driven through the real runCodeSandbox/
+    setCodeSandboxRequirements WS intents, and genuinely parks on the
+    approval gate (same polling idiom as
+    test_remove_nodes_cancels_the_dispatchers_code_sandbox_request_when_deleted_mid_approval_pause
+    above), proving node.code_sandbox_approval_requirements - the frozen
+    snapshot this pending approval genuinely refers to - stays "numpy" even
+    after a fresh setCodeSandboxRequirements changes the live draft field to
+    "requests"."""
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint(1)\n[/TOOL]",
+    )
+
+    async def run():
+        bus, document, _recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        sandbox_node = document.add_code_sandbox_node(0, 0, parent.id)
+
+        await bus.dispatch_intent("scene", "setCodeSandboxRequirements", [sandbox_node.id, "numpy"])
+
+        await bus.dispatch_intent("scene", "runCodeSandbox", [sandbox_node.id, "do something"])
+        request_id, entry = next(iter(dispatcher._code_sandbox_requests.items()))
+
+        for _ in range(200):
+            if sandbox_node.code_sandbox_awaiting_approval or entry["task"].done():
+                break
+            await asyncio.sleep(0.005)
+        assert sandbox_node.code_sandbox_awaiting_approval is True, "must genuinely be parked on the approval gate"
+        assert sandbox_node.code_sandbox_approval_requirements == "numpy", (
+            "the frozen snapshot must be populated the instant the approval gate opens"
+        )
+
+        # A fresh live-draft edit arrives WHILE this approval is still
+        # pending - exactly the real race this fix closes.
+        await bus.dispatch_intent("scene", "setCodeSandboxRequirements", [sandbox_node.id, "requests"])
+
+        assert sandbox_node.code_sandbox_approval_requirements == "numpy", (
+            "the disclosed approval snapshot must stay the frozen manifest this "
+            "pending approval genuinely refers to, unaffected by a later live edit"
+        )
+        assert sandbox_node.code_sandbox_requirements == "requests", (
+            "the live draft field must still reflect the user's newest edit, "
+            "proving the two fields are genuinely decoupled"
+        )
+
+        # Deny, so the background task completes cleanly without touching a
+        # real virtualenv.
+        assert dispatcher.deny_code_execution(request_id) is True
+        await entry["task"]
+        assert sandbox_node.code_sandbox_approval_requirements == "", (
+            "must be cleared once the approval resolves, mirroring "
+            "code_sandbox_awaiting_approval's own clear"
+        )
+
+    asyncio.run(run())

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -88,18 +88,19 @@ def test_register_plugins_publishes_on_the_app_plugins_topic():
 
 
 def test_execute_plugin_shows_info_notification_for_known_plugin():
-    # "Py-Coder" (not "Gitlink" - Gitlink is now a real node-creation plugin,
-    # see the dedicated R5.3 tests below) stands in for "any plugin name
-    # still on the honest-deferred-notice path".
+    # "HTML Renderer" (not "Gitlink"/"Py-Coder"/"Execution Sandbox" - all
+    # three are now real node-creation plugins, see their own dedicated
+    # tests below) stands in for "any plugin name still on the
+    # honest-deferred-notice path".
     bus = SessionBus("plugins-exec-test")
     notifications = NotificationState()
     bus.register_topic("notification", notifications.payload)
     register_plugins(bus, notifications, SceneDocument())
 
-    asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Py-Coder"]))
+    asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["HTML Renderer"]))
     assert notifications.visible is True
     assert notifications.msg_type == "info"
-    assert "Py-Coder" in notifications.message
+    assert "HTML Renderer" in notifications.message
     assert "R3" in notifications.message or "R5" in notifications.message
 
 
@@ -318,13 +319,139 @@ def test_execute_plugin_gitlink_creates_node():
     assert "scene" in recorder.topics_seen()
 
 
-# -- R5.1/R5.2/R5.3: non-regression - every OTHER plugin name is still an
+# -- R5.4: "Py-Coder" - the fourth real node-creation plugin ------------------
+
+
+def test_execute_plugin_pycoder_requires_parent():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Py-Coder"]))
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == (
+        "Please select a valid node to branch from before adding a Py-Coder node."
+    )
+    assert not any(n.kind == "pycoder" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_pycoder_rejects_unknown_parent_id():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Py-Coder", "ghost-node-id"])
+    )
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert not any(n.kind == "pycoder" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_pycoder_creates_a_real_pycoder_node():
+    bus, notifications, canvas_document = _make_plugins_bus()
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    class Recorder:
+        def __init__(self):
+            self.messages = []
+
+        async def send_json(self, data):
+            self.messages.append(data)
+
+        def topics_seen(self):
+            return [m["topic"] for m in self.messages if m["kind"] == "state"]
+
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Py-Coder", parent.id]))
+
+    assert result is not None
+    node = canvas_document.nodes[result]
+    assert node.kind == "pycoder"
+    assert node.title == "Py-Coder"
+    assert any(
+        e.source == parent.id and e.target == node.id for e in canvas_document.edges.values()
+    )
+    assert notifications.visible is False, "success is not a deferral - no notification fires"
+    assert "scene" in recorder.topics_seen()
+
+
+# -- R5.4: "Execution Sandbox" - the fifth real node-creation plugin ----------
+
+
+def test_execute_plugin_execution_sandbox_requires_parent():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Execution Sandbox"]))
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == (
+        "Please select a valid node to branch from before adding an Execution Sandbox node."
+    )
+    assert not any(n.kind == "code_sandbox" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_execution_sandbox_rejects_unknown_parent_id():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Execution Sandbox", "ghost-node-id"])
+    )
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert not any(n.kind == "code_sandbox" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_execution_sandbox_creates_a_real_code_sandbox_node():
+    bus, notifications, canvas_document = _make_plugins_bus()
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    class Recorder:
+        def __init__(self):
+            self.messages = []
+
+        async def send_json(self, data):
+            self.messages.append(data)
+
+        def topics_seen(self):
+            return [m["topic"] for m in self.messages if m["kind"] == "state"]
+
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Execution Sandbox", parent.id])
+    )
+
+    assert result is not None
+    node = canvas_document.nodes[result]
+    assert node.kind == "code_sandbox"
+    assert node.title == "Execution Sandbox"
+    assert node.code_sandbox_sandbox_id, "a sandbox id must be minted at creation time"
+    assert any(
+        e.source == parent.id and e.target == node.id for e in canvas_document.edges.values()
+    )
+    assert notifications.visible is False, "success is not a deferral - no notification fires"
+    assert "scene" in recorder.topics_seen()
+
+
+# -- R5.1/R5.2/R5.3/R5.4: non-regression - every OTHER plugin name is still an
 # honest, unchanged deferred notice -------------------------------------------
 
 
 @pytest.mark.parametrize(
     "name",
-    [n for n in (p[0] for p in _PLUGINS) if n not in ("Web Research", "Artifact / Drafter", "Gitlink")],
+    [
+        n for n in (p[0] for p in _PLUGINS)
+        if n not in ("Web Research", "Artifact / Drafter", "Gitlink", "Py-Coder", "Execution Sandbox")
+    ],
 )
 def test_execute_plugin_every_other_plugin_name_still_shows_the_unchanged_deferred_notice(name):
     bus, notifications, canvas_document = _make_plugins_bus()

--- a/graphlink_app/graphlink_agents_code_sandbox.py
+++ b/graphlink_app/graphlink_agents_code_sandbox.py
@@ -1,311 +1,54 @@
-import hashlib
-import json
-import os
-import queue
-import re
-import subprocess
-import sys
-import tempfile
-import threading
-import time
-from enum import Enum
-from pathlib import Path
+"""Execution Sandbox's QThread worker class - the Qt-coupled half of the
+legacy Code Sandbox plugin.
+
+Qt-removal plan R5.4: the Qt-free domain pieces this module used to define
+inline (SandboxStage, _subprocess_kwargs, _normalize_requirements,
+_extract_python_block, SandboxGenerationAgent, SandboxRepairAgent,
+VirtualEnvSandbox) moved VERBATIM to graphlink_plugins/code_sandbox/domain.py,
+so backend/agents.py can import them without ever pulling PySide6 into the
+FastAPI process (this module's own `from PySide6.QtCore import QThread,
+Signal` is unconditional and module-top-level, so importing anything from
+here at all used to pull the whole Qt stack in regardless of whether the
+imported symbol itself touched Qt).
+
+Only CodeSandboxExecutionWorker (the QThread subclass) stays here, now a thin
+wrapper around the imported domain classes, plus its own _is_error_output
+helper (never moved - it is a worker-instance method, not a free function any
+domain piece calls). Its public class name, constructor, signals, and
+behavior are unchanged; the legacy Qt app's own call sites
+(graphlink_window_actions.py) keep working unmodified.
+
+The cross-module dependency on Py-Coder's own analysis agent moves with this
+extraction: `from graphlink_agents_pycoder import PyCoderAnalysisAgent,
+PyCoderStatus` becomes `from graphlink_plugins.pycoder.domain import
+PyCoderAnalysisAgent, PyCoderStatus` - the real Qt-free home of those two
+names as of R5.4.
+"""
 
 from PySide6.QtCore import QThread, Signal
 
-import api_provider
-import graphlink_config as config
-from graphlink_agents_pycoder import PyCoderAnalysisAgent, PyCoderStatus
+import threading
 
+from graphlink_plugins.code_sandbox.domain import (
+    SandboxGenerationAgent,
+    SandboxRepairAgent,
+    SandboxStage,
+    VirtualEnvSandbox,
+    _extract_python_block,
+    _normalize_requirements,
+    _subprocess_kwargs,
+)
+from graphlink_plugins.pycoder.domain import PyCoderAnalysisAgent, PyCoderStatus
 
-class SandboxStage(Enum):
-    GENERATE = 1
-    PREPARE = 2
-    INSTALL = 3
-    EXECUTE = 4
-    ANALYZE = 5
-
-
-def _subprocess_kwargs():
-    kwargs = {}
-    if sys.platform == "win32":
-        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
-    return kwargs
-
-
-def _normalize_requirements(requirements_text):
-    normalized = requirements_text.replace("\r\n", "\n").replace("\r", "\n")
-    lines = [line.rstrip() for line in normalized.split("\n")]
-    return "\n".join(lines).strip()
-
-
-def _extract_python_block(response_text):
-    tool_match = re.search(r"\[TOOL:PYTHON\](.*?)\[/TOOL\]", response_text, re.DOTALL)
-    if tool_match:
-        return tool_match.group(1).strip()
-
-    fenced_match = re.search(r"```python\s*(.*?)```", response_text, re.DOTALL | re.IGNORECASE)
-    if fenced_match:
-        return fenced_match.group(1).strip()
-
-    return None
-
-
-class SandboxGenerationAgent:
-    def __init__(self):
-        self.system_prompt = """
-You are Graphlink's Execution Sandbox coding agent.
-You will receive prior branch history, the user's prompt, and a requirements manifest.
-
-Rules:
-1. If code execution is needed, return ONLY Python code wrapped in [TOOL:PYTHON] and [/TOOL].
-2. The code may use Python standard library plus the libraries explicitly listed in Available Dependencies.
-3. Do not import or reference packages that are not in Available Dependencies.
-4. The code must be runnable as a standalone script and should print meaningful output.
-5. If code execution is not actually needed, provide a concise direct answer with no tool tags.
-6. Never output markdown fences when you use the tool tags.
-"""
-
-    def get_response(self, conversation_history, user_prompt, requirements_manifest):
-        history_str = json.dumps(conversation_history, indent=2)
-        user_message = f"""
-Conversation History:
-{history_str}
-
-Available Dependencies:
-{requirements_manifest if requirements_manifest else "[none specified]"}
-
-Final User Prompt:
-{user_prompt}
-"""
-        messages = [
-            {"role": "system", "content": self.system_prompt},
-            {"role": "user", "content": user_message},
-        ]
-        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
-        return response["message"]["content"]
-
-
-class SandboxRepairAgent:
-    def __init__(self):
-        self.system_prompt = """
-You are Graphlink's sandbox repair agent.
-You will be given Python code, the runtime error, and the sandbox requirements manifest.
-
-Rules:
-1. Return ONLY the complete corrected Python code.
-2. The code may use only Python standard library plus dependencies explicitly listed in the requirements manifest.
-3. Do not include explanations, markdown fences, or extra commentary.
-4. Prefer small repairs before rewriting the whole solution.
-"""
-
-    def get_response(self, code, error_output, requirements_manifest, original_prompt=None):
-        user_message = f"""
-Original Prompt:
-{original_prompt or "[manual execution]"}
-
-Available Dependencies:
-{requirements_manifest if requirements_manifest else "[none specified]"}
-
-Broken Code:
-{code}
-
-Error Output:
-{error_output}
-"""
-        messages = [
-            {"role": "system", "content": self.system_prompt},
-            {"role": "user", "content": user_message},
-        ]
-        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
-        repaired = response["message"]["content"].strip()
-        fenced_match = re.search(r"```python\s*(.*?)```", repaired, re.DOTALL | re.IGNORECASE)
-        if fenced_match:
-            return fenced_match.group(1).strip()
-        return repaired
-
-
-class VirtualEnvSandbox:
-    def __init__(self, sandbox_id):
-        safe_id = re.sub(r"[^A-Za-z0-9_-]", "_", sandbox_id or "default")
-        self.base_dir = Path(tempfile.gettempdir()) / "graphlink_execution_sandboxes" / safe_id
-        self.venv_dir = self.base_dir / "venv"
-        self.requirements_file = self.base_dir / "requirements.txt"
-        self.requirements_hash_file = self.base_dir / ".requirements.sha256"
-        self.script_path = self.base_dir / "sandbox_entry.py"
-        self.current_process = None
-
-    @property
-    def python_executable(self):
-        if os.name == "nt":
-            return self.venv_dir / "Scripts" / "python.exe"
-        return self.venv_dir / "bin" / "python"
-
-    def stop(self):
-        if self.current_process and self.current_process.poll() is None:
-            try:
-                self.current_process.terminate()
-                self.current_process.wait(timeout=3)
-            except Exception:
-                try:
-                    self.current_process.kill()
-                except Exception:
-                    pass
-        self.current_process = None
-
-    def _run_subprocess(self, args, should_continue, emit_line=None, cwd=None, timeout_seconds=None):
-        output_chunks = []
-        start_time = time.monotonic()
-        process = subprocess.Popen(
-            args,
-            cwd=str(cwd) if cwd else None,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-            **_subprocess_kwargs(),
-        )
-        self.current_process = process
-        output_queue = queue.Queue()
-        done_signal = object()
-
-        def _reader():
-            if not process.stdout:
-                output_queue.put(done_signal)
-                return
-            try:
-                for line in iter(process.stdout.readline, ""):
-                    output_queue.put(line)
-            finally:
-                output_queue.put(done_signal)
-
-        reader_thread = threading.Thread(target=_reader, daemon=True)
-        reader_thread.start()
-
-        try:
-            while True:
-                if not should_continue():
-                    self.stop()
-                    raise InterruptedError("Sandbox execution was stopped.")
-
-                if timeout_seconds and (time.monotonic() - start_time) > timeout_seconds:
-                    self.stop()
-                    raise RuntimeError(f"Sandbox process timed out after {timeout_seconds} seconds.")
-
-                try:
-                    line = output_queue.get(timeout=0.1)
-                except queue.Empty:
-                    if process.poll() is None:
-                        continue
-                    # The process has exited. The reader thread owns
-                    # process.stdout exclusively (audit finding B3: a direct
-                    # stdout.read() here used to race the reader's readline on
-                    # the same pipe, garbling/duplicating captured output) -
-                    # let it drain to EOF and post done_signal instead.
-                    reader_thread.join(timeout=5)
-                    if not reader_thread.is_alive() and output_queue.empty():
-                        break
-                    continue
-
-                if line is done_signal:
-                    break
-
-                output_chunks.append(line)
-                if emit_line:
-                    emit_line(line)
-
-            # done_signal received (or the reader finished with an empty
-            # queue): stdout has been consumed to EOF by the reader, so no
-            # direct read is needed - or safe - here. Reap the process so
-            # returncode is real rather than a still-None poll() snapshot.
-            try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                # Pathological: the child closed stdout but kept running.
-                process.kill()
-                process.wait()
-
-            return "".join(output_chunks), process.returncode
-        except Exception:
-            if process.poll() is None:
-                self.stop()
-            raise
-        finally:
-            if reader_thread.is_alive():
-                reader_thread.join(timeout=0.5)
-            self.current_process = None
-
-    def ensure_base_environment(self, should_continue, emit_line=None):
-        self.base_dir.mkdir(parents=True, exist_ok=True)
-        if self.python_executable.exists():
-            return
-
-        if emit_line:
-            emit_line("[Sandbox] Creating virtual environment...\n")
-        output, return_code = self._run_subprocess(
-            [sys.executable, "-m", "venv", str(self.venv_dir)],
-            should_continue=should_continue,
-            emit_line=emit_line,
-            cwd=self.base_dir,
-            timeout_seconds=180,
-        )
-        if return_code != 0:
-            raise RuntimeError(f"Failed to create sandbox environment.\n{output.strip()}")
-
-    def sync_requirements(self, requirements_manifest, should_continue, emit_line=None):
-        normalized = _normalize_requirements(requirements_manifest)
-        manifest_hash = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-        previous_hash = self.requirements_hash_file.read_text(encoding="utf-8").strip() if self.requirements_hash_file.exists() else ""
-
-        self.requirements_file.write_text(normalized + ("\n" if normalized else ""), encoding="utf-8")
-
-        if manifest_hash == previous_hash:
-            if emit_line:
-                emit_line("[Sandbox] Requirements unchanged. Reusing cached environment.\n")
-            return
-
-        if not normalized:
-            if emit_line:
-                emit_line("[Sandbox] No extra dependencies requested.\n")
-            self.requirements_hash_file.write_text(manifest_hash, encoding="utf-8")
-            return
-
-        if emit_line:
-            emit_line("[Sandbox] Installing sandbox dependencies...\n")
-        output, return_code = self._run_subprocess(
-            [
-                str(self.python_executable),
-                "-m",
-                "pip",
-                "install",
-                "--disable-pip-version-check",
-                "-r",
-                str(self.requirements_file),
-            ],
-            should_continue=should_continue,
-            emit_line=emit_line,
-            cwd=self.base_dir,
-            timeout_seconds=600,
-        )
-        if return_code != 0:
-            raise RuntimeError(f"Dependency installation failed.\n{output.strip()}")
-
-        self.requirements_hash_file.write_text(manifest_hash, encoding="utf-8")
-
-    def execute_code(self, code, should_continue, emit_line=None):
-        self.base_dir.mkdir(parents=True, exist_ok=True)
-        self.script_path.write_text(code, encoding="utf-8")
-        if emit_line:
-            emit_line(f"[Sandbox] Running {self.script_path.name} in the virtualenv...\n")
-
-        output, return_code = self._run_subprocess(
-            [str(self.python_executable), str(self.script_path)],
-            should_continue=should_continue,
-            emit_line=emit_line,
-            cwd=self.base_dir,
-            timeout_seconds=240,
-        )
-        return output.strip(), return_code
+# Re-exported for backward compatibility with any existing call site that
+# imports these names from this module.
+__all__ = [
+    "SandboxStage",
+    "SandboxGenerationAgent",
+    "SandboxRepairAgent",
+    "VirtualEnvSandbox",
+    "CodeSandboxExecutionWorker",
+]
 
 
 class CodeSandboxExecutionWorker(QThread):

--- a/graphlink_app/graphlink_agents_pycoder.py
+++ b/graphlink_app/graphlink_agents_pycoder.py
@@ -1,170 +1,55 @@
-import subprocess
-import tempfile
-import sys
-import os
-import re
-import json
-import base64
-import threading
-import uuid
-import weakref
-from enum import Enum
-from PySide6.QtCore import QThread, Signal
-import graphlink_config as config
-import api_provider
+"""Py-Coder's QThread worker classes - the Qt-coupled half of the legacy
+Py-Coder plugin.
 
+Qt-removal plan R5.4: the Qt-free domain pieces this module used to define
+inline (PyCoderStage, PyCoderStatus, PythonREPL, PyCoderReplManager,
+PyCoderExecutionAgent, PyCoderRepairAgent, PyCoderAnalysisAgent) moved
+VERBATIM to graphlink_plugins/pycoder/domain.py, so backend/agents.py can
+import them without ever pulling PySide6 into the FastAPI process (this
+module's own `from PySide6.QtCore import QThread, Signal` is unconditional
+and module-top-level, so importing anything from here at all used to pull
+the whole Qt stack in regardless of whether the imported symbol itself
+touched Qt).
 
-class PyCoderStage(Enum):
-    ANALYZE = 1
-    GENERATE = 2
-    EXECUTE = 3
-    REPAIR = 4
-    ANALYZE_RESULT = 5
-
-
-class PyCoderStatus(Enum):
-    PENDING = 1
-    RUNNING = 2
-    SUCCESS = 3
-    FAILURE = 4
-
-
-class PythonREPL:
-    """
-    A persistent Python subprocess that acts as a stateful REPL.
-    Variables and imports survive between executions.
-    Communicates via base64-encoded strings over stdin/stdout (encoding for safe IPC
-    framing, not a security mechanism).
-
-    After every execute() call, last_run_failed reports whether the executed
-    code raised - the wrapper reports it structurally on the boundary line, so
-    callers no longer scan stdout for English error keywords (which
-    misclassified correct programs that merely printed words like "failed";
-    audit finding B2). The boundary line carries a per-session nonce and is
-    matched as an exact full line, so program output that happens to contain
-    the marker text can no longer truncate the result or desync every
-    subsequent call (audit finding B4).
-    """
-    def __init__(self):
-        self.process = None
-        self.last_run_failed = False
-        self._boundary_prefix = ""
-
-    def start(self):
-        nonce = uuid.uuid4().hex
-        self._boundary_prefix = f"---GRAPHLINK_EXEC_BOUNDARY:{nonce}:"
-        script = f"""
-import sys, traceback, base64
-env = {{}}
-while True:
-    line = sys.stdin.readline()
-    if not line: break
-    failed = False
-    try:
-        code = base64.b64decode(line.strip()).decode('utf-8')
-        exec(code, env)
-    except Exception:
-        failed = True
-        traceback.print_exc()
-    status = "ERROR" if failed else "OK"
-    print("\\n---GRAPHLINK_EXEC_BOUNDARY:{nonce}:" + status + "---", flush=True)
+Only the three QThread subclasses stay here - CodeExecutionWorker,
+PyCoderExecutionWorker, PyCoderAgentWorker - now thin wrappers around the
+imported domain classes. Their public class names, constructors, signals, and
+behavior are unchanged; the legacy Qt app's own call sites
+(graphlink_window_actions.py) keep working unmodified.
 """
-        kwargs = {}
-        # Hide the console window on Windows
-        if sys.platform == 'win32':
-            kwargs['creationflags'] = subprocess.CREATE_NO_WINDOW
 
-        self.process = subprocess.Popen(
-            [sys.executable, '-c', script],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-            **kwargs
-        )
+from PySide6.QtCore import QThread, Signal
 
-    def execute(self, code):
-        if not self.process or self.process.poll() is not None:
-            self.start()
+import re
+import threading
 
-        encoded_code = base64.b64encode(code.encode('utf-8')).decode('utf-8')
-        try:
-            self.process.stdin.write(encoded_code + "\n")
-            self.process.stdin.flush()
-        except Exception as e:
-            self.last_run_failed = True
-            return f"Failed to send code to REPL: {e}"
+from graphlink_plugins.pycoder.domain import (
+    PyCoderAnalysisAgent,
+    PyCoderExecutionAgent,
+    PyCoderRepairAgent,
+    PyCoderReplManager,
+    PyCoderStage,
+    PyCoderStatus,
+    PythonREPL,
+)
 
-        output = []
-        while True:
-            line = self.process.stdout.readline()
-            if not line:
-                # EOF with no boundary line: the REPL process died mid-run
-                # (e.g. the executed code called sys.exit() or hard-crashed
-                # the interpreter). Reap it now - stdout EOF can arrive
-                # before poll() reports the exit, and without this the next
-                # execute() could write into the dying process's stdin
-                # (EINVAL) instead of restarting.
-                self.last_run_failed = True
-                self.stop()
-                break
-            stripped = line.strip()
-            if stripped == self._boundary_prefix + "OK---":
-                self.last_run_failed = False
-                break
-            if stripped == self._boundary_prefix + "ERROR---":
-                self.last_run_failed = True
-                break
-            output.append(line)
-
-        return "".join(output).strip()
-
-    def stop(self):
-        if self.process:
-            self.process.kill()
-            self.process.wait()
-            self.process = None
-
-
-class PyCoderReplManager:
-    """Owns the PythonREPL subprocess for each PyCoderNode, keyed by node
-    identity. PyCoderNode used to construct and stop its own REPL directly;
-    ownership moves here so the node no longer manages a live subprocess.
-
-    A weakref.finalize callback registered at REPL-creation time stops the
-    subprocess once the owning node is garbage collected, regardless of
-    whether stop()/dispose() was ever called first. This is load-bearing,
-    not just a safety net: ChatScene.clear() (the "New Chat"/chat-switch
-    path) never calls PyCoderNode.dispose() at all - only Python's own GC,
-    via this finalizer, stops the REPL on that path. dispose() (the
-    individual right-click-delete path) still calls stop() directly for
-    immediate, deterministic cleanup rather than waiting on GC.
-
-    A plain dict keyed by node would keep every node alive forever (the
-    dict entry itself would be a strong reference), which would prevent the
-    very GC this manager relies on - hence WeakKeyDictionary.
-    """
-
-    def __init__(self):
-        self._repls = weakref.WeakKeyDictionary()
-        self._finalizers = weakref.WeakKeyDictionary()
-
-    def get_repl(self, node):
-        repl = self._repls.get(node)
-        if repl is None:
-            repl = PythonREPL()
-            self._repls[node] = repl
-            self._finalizers[node] = weakref.finalize(node, repl.stop)
-        return repl
-
-    def stop(self, node):
-        finalizer = self._finalizers.pop(node, None)
-        if finalizer is not None:
-            finalizer.detach()
-        repl = self._repls.pop(node, None)
-        if repl is not None:
-            repl.stop()
+# Re-exported for backward compatibility with any existing call site that
+# imports these names from this module (e.g.
+# `from graphlink_agents_pycoder import PyCoderAnalysisAgent, PyCoderStatus`
+# in the legacy graphlink_agents_code_sandbox.py, updated below to import
+# from the new domain module directly, and any other lingering import).
+__all__ = [
+    "PyCoderStage",
+    "PyCoderStatus",
+    "PythonREPL",
+    "PyCoderReplManager",
+    "PyCoderExecutionAgent",
+    "PyCoderRepairAgent",
+    "PyCoderAnalysisAgent",
+    "CodeExecutionWorker",
+    "PyCoderExecutionWorker",
+    "PyCoderAgentWorker",
+]
 
 
 class CodeExecutionWorker(QThread):
@@ -191,147 +76,6 @@ class CodeExecutionWorker(QThread):
         except Exception as e:
             if self._is_running:
                 self.error.emit(f"Execution Error: {str(e)}")
-
-
-class PyCoderExecutionAgent:
-    def __init__(self):
-        self.system_prompt = """
-You are an expert programmer and a helpful assistant. Your goal is to answer user prompts, using a Python code tool when necessary.
-You will be given the previous conversation history for context, followed by the user's final prompt.
-
-1.  First, analyze the user's final prompt in the context of the conversation history.
-2.  If the prompt can be answered without computation, provide a direct, helpful answer.
-3.  If the prompt requires computation or information from the history, you MUST generate Python code to solve it.
-4.  When you generate code, you MUST wrap it in [TOOL:PYTHON] and [/TOOL] tags.
-5.  The code should be self-contained and print its result. Do not assume any external libraries unless they are standard.
-6.  Do not include any other text or explanation outside the tool tags if you decide to use the tool.
-
-Example (with context):
-Conversation History:
-[
-  {"role": "user", "content": "I have a list of numbers: 15, 8, 22, 5, 19."},
-  {"role": "assistant", "content": "Okay, I see that list of numbers."}
-]
-Final User Prompt: "Please sort them in descending order."
-Your response:
-[TOOL:PYTHON]
-numbers = [15, 8, 22, 5, 19]
-numbers.sort(reverse=True)
-print(numbers)
-[/TOOL]
-"""
-    def get_response(self, conversation_history, user_prompt):
-        history_str = json.dumps(conversation_history, indent=2)
-        
-        full_prompt = f"""
-Conversation History:
-{history_str}
-
-Final User Prompt: "{user_prompt}"
-"""
-        messages = [
-            {'role': 'system', 'content': self.system_prompt},
-            {'role': 'user', 'content': full_prompt}
-        ]
-        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
-        return response['message']['content']
-
-
-class PyCoderRepairAgent:
-    def __init__(self):
-        self.system_prompt = """You are an expert Python code debugging assistant. You will be given a block of Python code and the error that occurred when it was executed.
-Your task is to analyze the error and fix the code.
-You MUST return ONLY the complete, corrected, and runnable Python code block.
-Do not add explanations, apologies, or any text outside the code.
-"""
-        self.retry_prompt = """The previous attempts to fix the code have failed. The fundamental approach might be wrong.
-Re-evaluate the original problem and the previous error. Provide a new, different block of Python code to solve it.
-Return ONLY the complete, runnable Python code. Do not include any other text.
-"""
-    
-    def get_response(self, code, error, is_final_attempt=False):
-        if is_final_attempt:
-            user_message = f"""
-Original Problem: Find a new way to solve the task that previously resulted in an error.
-Previous Code:
-```python
-{code}
-```
-Resulting Error:
-```
-{error}
-```
-{self.retry_prompt}
-"""
-        else:
-            user_message = f"""
-The following Python code produced an error. Please fix it.
-
---- Code with Bug ---
-```python
-{code}
-```
-
---- Error Message ---
-```
-{error}
-```
-
-Return only the corrected code.
-"""
-        messages = [
-            {'role': 'system', 'content': self.system_prompt},
-            {'role': 'user', 'content': user_message}
-        ]
-        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
-        cleaned_response = response['message']['content']
-        code_match = re.search(r'```python\n(.*?)\n```', cleaned_response, re.DOTALL)
-        if code_match:
-            return code_match.group(1).strip()
-        return cleaned_response.strip()
-
-
-class PyCoderAnalysisAgent:
-    def __init__(self):
-        self.system_prompt = """
-You are a code analysis AI. Your task is to provide a final, user-facing answer based on the available information.
-
-- If an "Original Prompt" is provided, synthesize all information to answer it directly.
-- If no "Original Prompt" is provided, simply analyze the given code and its output.
-- Explain what the code does and how the output relates to it.
-- If the output contains an error, explain the error and suggest a fix.
-- Format your response clearly using markdown.
-"""
-
-    def get_response(self, original_prompt, code, code_output):
-        if original_prompt:
-            user_message = f"""
-Original Prompt: "{original_prompt}"
-
---- Generated Python Code ---
-{code}
-
---- Code Execution Output ---
-{code_output}
-
-Based on all the above, please provide a comprehensive and helpful final answer to my original prompt.
-"""
-        else:
-            user_message = f"""
-Please analyze the following Python code and its execution output.
-
---- Python Code ---
-{code}
-
---- Execution Output ---
-{code_output}
-"""
-        messages = [
-            {'role': 'system', 'content': self.system_prompt},
-            {'role': 'user', 'content': user_message}
-        ]
-        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
-        return response['message']['content']
 
 
 class PyCoderExecutionWorker(QThread):
@@ -399,7 +143,7 @@ class PyCoderExecutionWorker(QThread):
                     self.finished.emit(result)
                     self.log_update.emit(PyCoderStage.ANALYZE_RESULT, PyCoderStatus.SUCCESS)
                 return
-            
+
             current_code = code_match.group(1).strip()
             self.log_update.emit(PyCoderStage.GENERATE, PyCoderStatus.SUCCESS)
 
@@ -421,7 +165,7 @@ class PyCoderExecutionWorker(QThread):
             while retry_count < max_retries:
                 if not self._is_running: return
                 self.log_update.emit(PyCoderStage.EXECUTE, PyCoderStatus.RUNNING)
-                
+
                 # Failure is reported structurally by the REPL wrapper
                 # (repl.last_run_failed) instead of keyword-scanning stdout,
                 # which used to mark correct programs that merely printed
@@ -456,11 +200,11 @@ class PyCoderExecutionWorker(QThread):
                 last_error = execution_output
                 self.log_update.emit(PyCoderStage.EXECUTE, PyCoderStatus.FAILURE)
                 retry_count += 1
-                
+
                 if retry_count < max_retries:
                     is_final = (retry_count == max_retries - 1)
                     current_code = self.repair_agent.get_response(current_code, last_error, is_final)
-            
+
             if not self._is_running: return
             self.log_update.emit(PyCoderStage.ANALYZE_RESULT, PyCoderStatus.RUNNING)
             final_failure_analysis = self.analysis_agent.get_response(

--- a/graphlink_app/graphlink_plugins/code_sandbox/__init__.py
+++ b/graphlink_app/graphlink_plugins/code_sandbox/__init__.py
@@ -1,0 +1,3 @@
+"""Qt-free Execution Sandbox domain package, split out so the virtualenv/agent
+logic is testable (and importable by backend/agents.py) without ever pulling
+in PySide6."""

--- a/graphlink_app/graphlink_plugins/code_sandbox/domain.py
+++ b/graphlink_app/graphlink_plugins/code_sandbox/domain.py
@@ -1,0 +1,341 @@
+"""Execution Sandbox's Qt-free domain pieces, split out of
+graphlink_agents_code_sandbox.py (Qt-removal plan R5.4) so backend/agents.py
+can import the virtualenv sandbox and its two LLM-calling agents without ever
+pulling the Qt stack into the FastAPI process.
+
+Moved here VERBATIM (same code, same behavior) from
+graphlink_agents_code_sandbox.py: SandboxStage, _subprocess_kwargs,
+_normalize_requirements, _extract_python_block, SandboxGenerationAgent,
+SandboxRepairAgent, VirtualEnvSandbox - all of these were already pure/Qt-free
+in the legacy file (confirmed by reading it directly before this split: zero
+Qt references anywhere in this block). The venv-creation/pip-install/
+script-execution timeout numbers inside VirtualEnvSandbox (180s / 600s / 240s)
+are carried forward completely unchanged - see backend/agents.py's own
+PYCODER_EXECUTE_TIMEOUT_SECONDS comment for why 240 is reused there rather
+than reinvented.
+
+The ONLY change from the legacy source is the config import:
+`graphlink_config` (which transitively imports Qt's GUI/widget modules at
+module scope) becomes `graphlink_task_config`, mirroring the exact same swap
+graphlink_plugins/gitlink/agent.py and graphlink_plugins/pycoder/domain.py
+already made for the same reason.
+
+What did NOT move here (stays in graphlink_agents_code_sandbox.py, unchanged):
+CodeSandboxExecutionWorker (the Qt worker-thread subclass) and its own
+_is_error_output helper (a worker instance method, never called by anything
+that moved here) - backend/agents.py carries its own equivalent copy of that
+same keyword-based heuristic (see _is_sandbox_error_output there) rather than
+reaching back into the legacy Qt-coupled file for it.
+
+backend/agents.py's own new AgentDispatcher pipeline (R5.4) constructs a
+fresh VirtualEnvSandbox per run, exactly like _call_gitlink_agent constructs a
+fresh GitlinkAgent per call - the only state that must survive between runs is
+the plain string code_sandbox_sandbox_id (real SceneNode state), not a live
+VirtualEnvSandbox object.
+"""
+
+import hashlib
+import json
+import os
+import queue
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from enum import Enum
+from pathlib import Path
+
+import api_provider
+import graphlink_task_config as config
+
+
+class SandboxStage(Enum):
+    GENERATE = 1
+    PREPARE = 2
+    INSTALL = 3
+    EXECUTE = 4
+    ANALYZE = 5
+
+
+def _subprocess_kwargs():
+    kwargs = {}
+    if sys.platform == "win32":
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+    return kwargs
+
+
+def _normalize_requirements(requirements_text):
+    normalized = requirements_text.replace("\r\n", "\n").replace("\r", "\n")
+    lines = [line.rstrip() for line in normalized.split("\n")]
+    return "\n".join(lines).strip()
+
+
+def _extract_python_block(response_text):
+    tool_match = re.search(r"\[TOOL:PYTHON\](.*?)\[/TOOL\]", response_text, re.DOTALL)
+    if tool_match:
+        return tool_match.group(1).strip()
+
+    fenced_match = re.search(r"```python\s*(.*?)```", response_text, re.DOTALL | re.IGNORECASE)
+    if fenced_match:
+        return fenced_match.group(1).strip()
+
+    return None
+
+
+class SandboxGenerationAgent:
+    def __init__(self):
+        self.system_prompt = """
+You are Graphlink's Execution Sandbox coding agent.
+You will receive prior branch history, the user's prompt, and a requirements manifest.
+
+Rules:
+1. If code execution is needed, return ONLY Python code wrapped in [TOOL:PYTHON] and [/TOOL].
+2. The code may use Python standard library plus the libraries explicitly listed in Available Dependencies.
+3. Do not import or reference packages that are not in Available Dependencies.
+4. The code must be runnable as a standalone script and should print meaningful output.
+5. If code execution is not actually needed, provide a concise direct answer with no tool tags.
+6. Never output markdown fences when you use the tool tags.
+"""
+
+    def get_response(self, conversation_history, user_prompt, requirements_manifest):
+        history_str = json.dumps(conversation_history, indent=2)
+        user_message = f"""
+Conversation History:
+{history_str}
+
+Available Dependencies:
+{requirements_manifest if requirements_manifest else "[none specified]"}
+
+Final User Prompt:
+{user_prompt}
+"""
+        messages = [
+            {"role": "system", "content": self.system_prompt},
+            {"role": "user", "content": user_message},
+        ]
+        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
+        return response["message"]["content"]
+
+
+class SandboxRepairAgent:
+    def __init__(self):
+        self.system_prompt = """
+You are Graphlink's sandbox repair agent.
+You will be given Python code, the runtime error, and the sandbox requirements manifest.
+
+Rules:
+1. Return ONLY the complete corrected Python code.
+2. The code may use only Python standard library plus dependencies explicitly listed in the requirements manifest.
+3. Do not include explanations, markdown fences, or extra commentary.
+4. Prefer small repairs before rewriting the whole solution.
+"""
+
+    def get_response(self, code, error_output, requirements_manifest, original_prompt=None):
+        user_message = f"""
+Original Prompt:
+{original_prompt or "[manual execution]"}
+
+Available Dependencies:
+{requirements_manifest if requirements_manifest else "[none specified]"}
+
+Broken Code:
+{code}
+
+Error Output:
+{error_output}
+"""
+        messages = [
+            {"role": "system", "content": self.system_prompt},
+            {"role": "user", "content": user_message},
+        ]
+        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
+        repaired = response["message"]["content"].strip()
+        fenced_match = re.search(r"```python\s*(.*?)```", repaired, re.DOTALL | re.IGNORECASE)
+        if fenced_match:
+            return fenced_match.group(1).strip()
+        return repaired
+
+
+class VirtualEnvSandbox:
+    def __init__(self, sandbox_id):
+        safe_id = re.sub(r"[^A-Za-z0-9_-]", "_", sandbox_id or "default")
+        self.base_dir = Path(tempfile.gettempdir()) / "graphlink_execution_sandboxes" / safe_id
+        self.venv_dir = self.base_dir / "venv"
+        self.requirements_file = self.base_dir / "requirements.txt"
+        self.requirements_hash_file = self.base_dir / ".requirements.sha256"
+        self.script_path = self.base_dir / "sandbox_entry.py"
+        self.current_process = None
+
+    @property
+    def python_executable(self):
+        if os.name == "nt":
+            return self.venv_dir / "Scripts" / "python.exe"
+        return self.venv_dir / "bin" / "python"
+
+    def stop(self):
+        if self.current_process and self.current_process.poll() is None:
+            try:
+                self.current_process.terminate()
+                self.current_process.wait(timeout=3)
+            except Exception:
+                try:
+                    self.current_process.kill()
+                except Exception:
+                    pass
+        self.current_process = None
+
+    def _run_subprocess(self, args, should_continue, emit_line=None, cwd=None, timeout_seconds=None):
+        output_chunks = []
+        start_time = time.monotonic()
+        process = subprocess.Popen(
+            args,
+            cwd=str(cwd) if cwd else None,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            **_subprocess_kwargs(),
+        )
+        self.current_process = process
+        output_queue = queue.Queue()
+        done_signal = object()
+
+        def _reader():
+            if not process.stdout:
+                output_queue.put(done_signal)
+                return
+            try:
+                for line in iter(process.stdout.readline, ""):
+                    output_queue.put(line)
+            finally:
+                output_queue.put(done_signal)
+
+        reader_thread = threading.Thread(target=_reader, daemon=True)
+        reader_thread.start()
+
+        try:
+            while True:
+                if not should_continue():
+                    self.stop()
+                    raise InterruptedError("Sandbox execution was stopped.")
+
+                if timeout_seconds and (time.monotonic() - start_time) > timeout_seconds:
+                    self.stop()
+                    raise RuntimeError(f"Sandbox process timed out after {timeout_seconds} seconds.")
+
+                try:
+                    line = output_queue.get(timeout=0.1)
+                except queue.Empty:
+                    if process.poll() is None:
+                        continue
+                    # The process has exited. The reader thread owns
+                    # process.stdout exclusively (audit finding B3: a direct
+                    # stdout.read() here used to race the reader's readline on
+                    # the same pipe, garbling/duplicating captured output) -
+                    # let it drain to EOF and post done_signal instead.
+                    reader_thread.join(timeout=5)
+                    if not reader_thread.is_alive() and output_queue.empty():
+                        break
+                    continue
+
+                if line is done_signal:
+                    break
+
+                output_chunks.append(line)
+                if emit_line:
+                    emit_line(line)
+
+            # done_signal received (or the reader finished with an empty
+            # queue): stdout has been consumed to EOF by the reader, so no
+            # direct read is needed - or safe - here. Reap the process so
+            # returncode is real rather than a still-None poll() snapshot.
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                # Pathological: the child closed stdout but kept running.
+                process.kill()
+                process.wait()
+
+            return "".join(output_chunks), process.returncode
+        except Exception:
+            if process.poll() is None:
+                self.stop()
+            raise
+        finally:
+            if reader_thread.is_alive():
+                reader_thread.join(timeout=0.5)
+            self.current_process = None
+
+    def ensure_base_environment(self, should_continue, emit_line=None):
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        if self.python_executable.exists():
+            return
+
+        if emit_line:
+            emit_line("[Sandbox] Creating virtual environment...\n")
+        output, return_code = self._run_subprocess(
+            [sys.executable, "-m", "venv", str(self.venv_dir)],
+            should_continue=should_continue,
+            emit_line=emit_line,
+            cwd=self.base_dir,
+            timeout_seconds=180,
+        )
+        if return_code != 0:
+            raise RuntimeError(f"Failed to create sandbox environment.\n{output.strip()}")
+
+    def sync_requirements(self, requirements_manifest, should_continue, emit_line=None):
+        normalized = _normalize_requirements(requirements_manifest)
+        manifest_hash = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+        previous_hash = self.requirements_hash_file.read_text(encoding="utf-8").strip() if self.requirements_hash_file.exists() else ""
+
+        self.requirements_file.write_text(normalized + ("\n" if normalized else ""), encoding="utf-8")
+
+        if manifest_hash == previous_hash:
+            if emit_line:
+                emit_line("[Sandbox] Requirements unchanged. Reusing cached environment.\n")
+            return
+
+        if not normalized:
+            if emit_line:
+                emit_line("[Sandbox] No extra dependencies requested.\n")
+            self.requirements_hash_file.write_text(manifest_hash, encoding="utf-8")
+            return
+
+        if emit_line:
+            emit_line("[Sandbox] Installing sandbox dependencies...\n")
+        output, return_code = self._run_subprocess(
+            [
+                str(self.python_executable),
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "-r",
+                str(self.requirements_file),
+            ],
+            should_continue=should_continue,
+            emit_line=emit_line,
+            cwd=self.base_dir,
+            timeout_seconds=600,
+        )
+        if return_code != 0:
+            raise RuntimeError(f"Dependency installation failed.\n{output.strip()}")
+
+        self.requirements_hash_file.write_text(manifest_hash, encoding="utf-8")
+
+    def execute_code(self, code, should_continue, emit_line=None):
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.script_path.write_text(code, encoding="utf-8")
+        if emit_line:
+            emit_line(f"[Sandbox] Running {self.script_path.name} in the virtualenv...\n")
+
+        output, return_code = self._run_subprocess(
+            [str(self.python_executable), str(self.script_path)],
+            should_continue=should_continue,
+            emit_line=emit_line,
+            cwd=self.base_dir,
+            timeout_seconds=240,
+        )
+        return output.strip(), return_code

--- a/graphlink_app/graphlink_plugins/pycoder/__init__.py
+++ b/graphlink_app/graphlink_plugins/pycoder/__init__.py
@@ -1,0 +1,2 @@
+"""Qt-free Py-Coder domain package, split out so the REPL/agent logic is testable
+(and importable by backend/agents.py) without ever pulling in PySide6."""

--- a/graphlink_app/graphlink_plugins/pycoder/domain.py
+++ b/graphlink_app/graphlink_plugins/pycoder/domain.py
@@ -1,0 +1,341 @@
+"""Py-Coder's Qt-free domain pieces, split out of graphlink_agents_pycoder.py
+(Qt-removal plan R5.4) so backend/agents.py can import a persistent Python
+REPL and the three LLM-calling agents without ever pulling the Qt stack into
+the FastAPI process.
+
+Moved here VERBATIM (same code, same behavior) from graphlink_agents_pycoder.py:
+PyCoderStage, PyCoderStatus, PythonREPL, PyCoderReplManager,
+PyCoderExecutionAgent, PyCoderRepairAgent, PyCoderAnalysisAgent - all of these
+were already pure/Qt-free in the legacy file (confirmed by reading it directly
+before this split: zero Qt references anywhere in this block). The ONLY
+change from the legacy source is the config import: `graphlink_config` (which
+transitively imports Qt's GUI/widget modules at module scope) becomes
+`graphlink_task_config` (the R4.1 Qt-free split), mirroring the exact same
+swap graphlink_plugins/gitlink/agent.py already made for the same reason.
+
+What did NOT move here (stays in graphlink_agents_pycoder.py, unchanged):
+CodeExecutionWorker, PyCoderExecutionWorker, PyCoderAgentWorker - the three
+Qt worker-thread subclasses. They still import these classes below (via this
+module) directly rather than defining them inline.
+
+backend/agents.py's own new AgentDispatcher pipeline (R5.4) does NOT use
+PyCoderReplManager - that class's weakref.WeakKeyDictionary keying strategy
+is bound to a live scene-graph node object's own identity, which does not
+survive the port (a backend SceneNode's node_id is a plain string, never
+weakly referenceable, and no GC signal reaches the session layer when a
+SceneNode dataclass instance is dropped). PyCoderReplManager is kept here, unmodified,
+purely so the legacy Qt app's own graphlink_window_actions.py can keep using
+it exactly as before. The new backend instead does explicit, string-keyed
+REPL lifecycle management on AgentDispatcher itself (see that module's
+_pycoder_repls/get_pycoder_repl/dispose_pycoder_repl).
+"""
+
+import base64
+import json
+import re
+import subprocess
+import sys
+import uuid
+import weakref
+from enum import Enum
+
+import api_provider
+import graphlink_task_config as config
+
+
+class PyCoderStage(Enum):
+    ANALYZE = 1
+    GENERATE = 2
+    EXECUTE = 3
+    REPAIR = 4
+    ANALYZE_RESULT = 5
+
+
+class PyCoderStatus(Enum):
+    PENDING = 1
+    RUNNING = 2
+    SUCCESS = 3
+    FAILURE = 4
+
+
+class PythonREPL:
+    """
+    A persistent Python subprocess that acts as a stateful REPL.
+    Variables and imports survive between executions.
+    Communicates via base64-encoded strings over stdin/stdout (encoding for safe IPC
+    framing, not a security mechanism).
+
+    After every execute() call, last_run_failed reports whether the executed
+    code raised - the wrapper reports it structurally on the boundary line, so
+    callers no longer scan stdout for English error keywords (which
+    misclassified correct programs that merely printed words like "failed";
+    audit finding B2). The boundary line carries a per-session nonce and is
+    matched as an exact full line, so program output that happens to contain
+    the marker text can no longer truncate the result or desync every
+    subsequent call (audit finding B4).
+    """
+    def __init__(self):
+        self.process = None
+        self.last_run_failed = False
+        self._boundary_prefix = ""
+
+    def start(self):
+        nonce = uuid.uuid4().hex
+        self._boundary_prefix = f"---GRAPHLINK_EXEC_BOUNDARY:{nonce}:"
+        script = f"""
+import sys, traceback, base64
+env = {{}}
+while True:
+    line = sys.stdin.readline()
+    if not line: break
+    failed = False
+    try:
+        code = base64.b64decode(line.strip()).decode('utf-8')
+        exec(code, env)
+    except Exception:
+        failed = True
+        traceback.print_exc()
+    status = "ERROR" if failed else "OK"
+    print("\\n---GRAPHLINK_EXEC_BOUNDARY:{nonce}:" + status + "---", flush=True)
+"""
+        kwargs = {}
+        # Hide the console window on Windows
+        if sys.platform == 'win32':
+            kwargs['creationflags'] = subprocess.CREATE_NO_WINDOW
+
+        self.process = subprocess.Popen(
+            [sys.executable, '-c', script],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            **kwargs
+        )
+
+    def execute(self, code):
+        if not self.process or self.process.poll() is not None:
+            self.start()
+
+        encoded_code = base64.b64encode(code.encode('utf-8')).decode('utf-8')
+        try:
+            self.process.stdin.write(encoded_code + "\n")
+            self.process.stdin.flush()
+        except Exception as e:
+            self.last_run_failed = True
+            return f"Failed to send code to REPL: {e}"
+
+        output = []
+        while True:
+            line = self.process.stdout.readline()
+            if not line:
+                # EOF with no boundary line: the REPL process died mid-run
+                # (e.g. the executed code called sys.exit() or hard-crashed
+                # the interpreter). Reap it now - stdout EOF can arrive
+                # before poll() reports the exit, and without this the next
+                # execute() could write into the dying process's stdin
+                # (EINVAL) instead of restarting.
+                self.last_run_failed = True
+                self.stop()
+                break
+            stripped = line.strip()
+            if stripped == self._boundary_prefix + "OK---":
+                self.last_run_failed = False
+                break
+            if stripped == self._boundary_prefix + "ERROR---":
+                self.last_run_failed = True
+                break
+            output.append(line)
+
+        return "".join(output).strip()
+
+    def stop(self):
+        if self.process:
+            self.process.kill()
+            self.process.wait()
+            self.process = None
+
+
+class PyCoderReplManager:
+    """Owns the PythonREPL subprocess for each PyCoderNode, keyed by node
+    identity. PyCoderNode used to construct and stop its own REPL directly;
+    ownership moves here so the node no longer manages a live subprocess.
+
+    A weakref.finalize callback registered at REPL-creation time stops the
+    subprocess once the owning node is garbage collected, regardless of
+    whether stop()/dispose() was ever called first. This is load-bearing,
+    not just a safety net: ChatScene.clear() (the "New Chat"/chat-switch
+    path) never calls PyCoderNode.dispose() at all - only Python's own GC,
+    via this finalizer, stops the REPL on that path. dispose() (the
+    individual right-click-delete path) still calls stop() directly for
+    immediate, deterministic cleanup rather than waiting on GC.
+
+    A plain dict keyed by node would keep every node alive forever (the
+    dict entry itself would be a strong reference), which would prevent the
+    very GC this manager relies on - hence WeakKeyDictionary.
+
+    R5.4: this class stays legacy-only (the Qt app's graphlink_window_actions.py
+    is its only remaining caller) - see this module's own docstring for why
+    the new backend's AgentDispatcher does not use it.
+    """
+
+    def __init__(self):
+        self._repls = weakref.WeakKeyDictionary()
+        self._finalizers = weakref.WeakKeyDictionary()
+
+    def get_repl(self, node):
+        repl = self._repls.get(node)
+        if repl is None:
+            repl = PythonREPL()
+            self._repls[node] = repl
+            self._finalizers[node] = weakref.finalize(node, repl.stop)
+        return repl
+
+    def stop(self, node):
+        finalizer = self._finalizers.pop(node, None)
+        if finalizer is not None:
+            finalizer.detach()
+        repl = self._repls.pop(node, None)
+        if repl is not None:
+            repl.stop()
+
+
+class PyCoderExecutionAgent:
+    def __init__(self):
+        self.system_prompt = """
+You are an expert programmer and a helpful assistant. Your goal is to answer user prompts, using a Python code tool when necessary.
+You will be given the previous conversation history for context, followed by the user's final prompt.
+
+1.  First, analyze the user's final prompt in the context of the conversation history.
+2.  If the prompt can be answered without computation, provide a direct, helpful answer.
+3.  If the prompt requires computation or information from the history, you MUST generate Python code to solve it.
+4.  When you generate code, you MUST wrap it in [TOOL:PYTHON] and [/TOOL] tags.
+5.  The code should be self-contained and print its result. Do not assume any external libraries unless they are standard.
+6.  Do not include any other text or explanation outside the tool tags if you decide to use the tool.
+
+Example (with context):
+Conversation History:
+[
+  {"role": "user", "content": "I have a list of numbers: 15, 8, 22, 5, 19."},
+  {"role": "assistant", "content": "Okay, I see that list of numbers."}
+]
+Final User Prompt: "Please sort them in descending order."
+Your response:
+[TOOL:PYTHON]
+numbers = [15, 8, 22, 5, 19]
+numbers.sort(reverse=True)
+print(numbers)
+[/TOOL]
+"""
+    def get_response(self, conversation_history, user_prompt):
+        history_str = json.dumps(conversation_history, indent=2)
+
+        full_prompt = f"""
+Conversation History:
+{history_str}
+
+Final User Prompt: "{user_prompt}"
+"""
+        messages = [
+            {'role': 'system', 'content': self.system_prompt},
+            {'role': 'user', 'content': full_prompt}
+        ]
+        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
+        return response['message']['content']
+
+
+class PyCoderRepairAgent:
+    def __init__(self):
+        self.system_prompt = """You are an expert Python code debugging assistant. You will be given a block of Python code and the error that occurred when it was executed.
+Your task is to analyze the error and fix the code.
+You MUST return ONLY the complete, corrected, and runnable Python code block.
+Do not add explanations, apologies, or any text outside the code.
+"""
+        self.retry_prompt = """The previous attempts to fix the code have failed. The fundamental approach might be wrong.
+Re-evaluate the original problem and the previous error. Provide a new, different block of Python code to solve it.
+Return ONLY the complete, runnable Python code. Do not include any other text.
+"""
+
+    def get_response(self, code, error, is_final_attempt=False):
+        if is_final_attempt:
+            user_message = f"""
+Original Problem: Find a new way to solve the task that previously resulted in an error.
+Previous Code:
+```python
+{code}
+```
+Resulting Error:
+```
+{error}
+```
+{self.retry_prompt}
+"""
+        else:
+            user_message = f"""
+The following Python code produced an error. Please fix it.
+
+--- Code with Bug ---
+```python
+{code}
+```
+
+--- Error Message ---
+```
+{error}
+```
+
+Return only the corrected code.
+"""
+        messages = [
+            {'role': 'system', 'content': self.system_prompt},
+            {'role': 'user', 'content': user_message}
+        ]
+        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
+        cleaned_response = response['message']['content']
+        code_match = re.search(r'```python\n(.*?)\n```', cleaned_response, re.DOTALL)
+        if code_match:
+            return code_match.group(1).strip()
+        return cleaned_response.strip()
+
+
+class PyCoderAnalysisAgent:
+    def __init__(self):
+        self.system_prompt = """
+You are a code analysis AI. Your task is to provide a final, user-facing answer based on the available information.
+
+- If an "Original Prompt" is provided, synthesize all information to answer it directly.
+- If no "Original Prompt" is provided, simply analyze the given code and its output.
+- Explain what the code does and how the output relates to it.
+- If the output contains an error, explain the error and suggest a fix.
+- Format your response clearly using markdown.
+"""
+
+    def get_response(self, original_prompt, code, code_output):
+        if original_prompt:
+            user_message = f"""
+Original Prompt: "{original_prompt}"
+
+--- Generated Python Code ---
+{code}
+
+--- Code Execution Output ---
+{code_output}
+
+Based on all the above, please provide a comprehensive and helpful final answer to my original prompt.
+"""
+        else:
+            user_message = f"""
+Please analyze the following Python code and its execution output.
+
+--- Python Code ---
+{code}
+
+--- Execution Output ---
+{code_output}
+"""
+        messages = [
+            {'role': 'system', 'content': self.system_prompt},
+            {'role': 'user', 'content': user_message}
+        ]
+        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
+        return response['message']['content']

--- a/graphlink_app/graphlink_scene_payload.py
+++ b/graphlink_app/graphlink_scene_payload.py
@@ -260,6 +260,38 @@ class SceneNodeRow:
     gitlinkChangeFingerprint: str | None = None
     gitlinkChangeState: str = "draft"
     gitlinkError: str = ""
+    # R5.4: the Py-Coder node's real persisted shape - populated for
+    # kind=="pycoder" rows, defaulted for every other kind.
+    pycoderMode: str = "ai_driven"
+    pycoderPrompt: str = ""
+    pycoderCode: str = ""
+    pycoderOutput: str = ""
+    pycoderAnalysis: str = ""
+    pycoderLastRunFailed: bool = False
+    pycoderAwaitingApproval: bool = False
+    pycoderError: str = ""
+    # R5.4: the Execution Sandbox node's real persisted shape - populated for
+    # kind=="code_sandbox" rows, defaulted for every other kind.
+    # codeSandboxSandboxId is DELIBERATELY NOT one of these fields - see
+    # backend/canvas.py's own comment on SceneNode.code_sandbox_sandbox_id
+    # (pure internal directory-naming key, mirrors gitlink_imported_root's
+    # own "server-side bookkeeping only" precedent).
+    codeSandboxRequirements: str = ""
+    codeSandboxPrompt: str = ""
+    codeSandboxCode: str = ""
+    codeSandboxOutput: str = ""
+    codeSandboxAnalysis: str = ""
+    codeSandboxAwaitingApproval: bool = False
+    # R5.4 CODESANDBOX FIX (closing the requirements-disclosure staleness
+    # race): a display-only snapshot of the EXACT requirements manifest this
+    # specific pending approval refers to, frozen the instant
+    # codeSandboxAwaitingApproval flips True - deliberately distinct from
+    # codeSandboxRequirements above (the user's still-live, still-editable
+    # draft for the NEXT run). See backend/canvas.py's own comment on
+    # SceneNode.code_sandbox_approval_requirements for the full race this
+    # closes.
+    codeSandboxApprovalRequirements: str = ""
+    codeSandboxError: str = ""
 
 
 @dataclass

--- a/graphlink_app/tests/test_code_sandbox_domain.py
+++ b/graphlink_app/tests/test_code_sandbox_domain.py
@@ -1,0 +1,151 @@
+"""Tests for graphlink_plugins/code_sandbox/domain.py, the Qt-free half of
+the Execution Sandbox plugin split out of graphlink_agents_code_sandbox.py
+(Qt-removal plan R5.4).
+
+Mirrors graphlink_app/tests/test_gitlink_agent.py's own shape: a direct
+source-scan assertion that the module has zero Qt dependencies, plus a fresh-
+subprocess import check.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from graphlink_plugins.code_sandbox.domain import (
+    SandboxGenerationAgent,
+    SandboxRepairAgent,
+    SandboxStage,
+    VirtualEnvSandbox,
+    _extract_python_block,
+    _normalize_requirements,
+    _subprocess_kwargs,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_module_has_no_qt_dependency():
+    import graphlink_plugins.code_sandbox.domain as domain_module
+
+    source = Path(domain_module.__file__).read_text(encoding="utf-8")
+    for banned in ("PySide6", "qtawesome", "QGraphics", "QWidget", "QApplication"):
+        assert banned not in source, f"{banned} leaked into the supposedly Qt-free code_sandbox domain module"
+
+
+def test_module_imports_qt_free_in_a_fresh_process_and_resolves_the_qt_free_config():
+    code = (
+        "import sys\n"
+        "import graphlink_plugins.code_sandbox.domain as domain_module\n"
+        "qt = [m for m in sys.modules if m.startswith('PySide6')]\n"
+        "assert not qt, f'importing graphlink_plugins.code_sandbox.domain pulled Qt: {qt}'\n"
+        "assert domain_module.config.__name__ == 'graphlink_task_config', (\n"
+        "    f'domain.py config reference resolved to {domain_module.config.__name__!r}, '\n"
+        "    'expected graphlink_task_config'\n"
+        ")\n"
+        "print('graphlink_plugins.code_sandbox.domain imported qt-free')\n"
+    )
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT / "graphlink_app") + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        "importing graphlink_plugins.code_sandbox.domain in a fresh process failed or pulled Qt:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+class TestNormalizeRequirements:
+    def test_normalizes_crlf_and_strips_trailing_whitespace(self):
+        assert _normalize_requirements("numpy \r\nrequests \r\n") == "numpy\nrequests"
+
+    def test_empty_input_stays_empty(self):
+        assert _normalize_requirements("") == ""
+
+
+class TestExtractPythonBlock:
+    def test_extracts_tool_tagged_block(self):
+        assert _extract_python_block("[TOOL:PYTHON]\nprint(1)\n[/TOOL]") == "print(1)"
+
+    def test_extracts_fenced_block_when_no_tool_tags(self):
+        assert _extract_python_block("```python\nprint(1)\n```") == "print(1)"
+
+    def test_returns_none_when_neither_shape_present(self):
+        assert _extract_python_block("just a direct answer, no code") is None
+
+
+class TestSubprocessKwargs:
+    def test_returns_a_dict(self):
+        assert isinstance(_subprocess_kwargs(), dict)
+
+
+class TestSandboxGenerationAgent:
+    def test_get_response_calls_api_provider_chat(self):
+        fake_response = {"message": {"content": "[TOOL:PYTHON]\nprint(1)\n[/TOOL]"}}
+        with patch("graphlink_plugins.code_sandbox.domain.api_provider.chat", return_value=fake_response) as mock_chat:
+            result = SandboxGenerationAgent().get_response([], "print 1", "")
+        assert result == fake_response["message"]["content"]
+        assert mock_chat.called
+
+
+class TestSandboxRepairAgent:
+    def test_get_response_extracts_fenced_python_block(self):
+        fake_response = {"message": {"content": "```python\nprint('fixed')\n```"}}
+        with patch("graphlink_plugins.code_sandbox.domain.api_provider.chat", return_value=fake_response):
+            result = SandboxRepairAgent().get_response("print(", "SyntaxError", "", original_prompt="do x")
+        assert result == "print('fixed')"
+
+    def test_get_response_falls_back_to_raw_text_when_unfenced(self):
+        fake_response = {"message": {"content": "print('fixed')"}}
+        with patch("graphlink_plugins.code_sandbox.domain.api_provider.chat", return_value=fake_response):
+            result = SandboxRepairAgent().get_response("print(", "SyntaxError", "")
+        assert result == "print('fixed')"
+
+
+class TestVirtualEnvSandbox:
+    def test_sandbox_id_is_sanitized_into_the_base_dir_name(self, tmp_path, monkeypatch):
+        import tempfile
+
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+        sandbox = VirtualEnvSandbox("weird id/with*chars")
+        assert sandbox.base_dir.name == "weird_id_with_chars"
+
+    def test_blank_sandbox_id_falls_back_to_default(self, tmp_path, monkeypatch):
+        import tempfile
+
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+        sandbox = VirtualEnvSandbox("")
+        assert sandbox.base_dir.name == "default"
+
+    def test_execute_code_runs_the_given_script_in_the_venv_python(self, tmp_path, monkeypatch):
+        # Uses the REAL host Python as a stand-in "venv" python (avoids the
+        # slow real venv-creation path) - proves execute_code writes the
+        # script and runs it end to end.
+        sandbox = VirtualEnvSandbox("test-sandbox")
+        sandbox.base_dir = tmp_path
+        sandbox.script_path = tmp_path / "sandbox_entry.py"
+        monkeypatch.setattr(
+            type(sandbox), "python_executable", property(lambda self: Path(sys.executable))
+        )
+        output, return_code = sandbox.execute_code("print('sandboxed output')", lambda: True)
+        assert return_code == 0
+        assert "sandboxed output" in output
+
+    def test_stop_is_safe_when_no_process_is_running(self):
+        sandbox = VirtualEnvSandbox("idle-sandbox")
+        sandbox.stop()  # must not raise
+
+
+def test_sandbox_stage_enum_has_the_expected_members():
+    assert {member.name for member in SandboxStage} == {
+        "GENERATE", "PREPARE", "INSTALL", "EXECUTE", "ANALYZE",
+    }

--- a/graphlink_app/tests/test_pycoder_domain.py
+++ b/graphlink_app/tests/test_pycoder_domain.py
@@ -1,0 +1,190 @@
+"""Tests for graphlink_plugins/pycoder/domain.py, the Qt-free half of the
+Py-Coder plugin split out of graphlink_agents_pycoder.py (Qt-removal plan
+R5.4).
+
+Mirrors graphlink_app/tests/test_gitlink_agent.py's own shape: a direct
+source-scan assertion that the module has zero Qt dependencies, plus a fresh-
+subprocess import check (a same-process check is unreliable once anything
+else in the same pytest run has already imported Qt).
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from graphlink_plugins.pycoder.domain import (
+    PyCoderAnalysisAgent,
+    PyCoderExecutionAgent,
+    PyCoderRepairAgent,
+    PyCoderReplManager,
+    PyCoderStage,
+    PyCoderStatus,
+    PythonREPL,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_module_has_no_qt_dependency():
+    import graphlink_plugins.pycoder.domain as domain_module
+
+    source = Path(domain_module.__file__).read_text(encoding="utf-8")
+    for banned in ("PySide6", "qtawesome", "QGraphics", "QWidget", "QApplication"):
+        assert banned not in source, f"{banned} leaked into the supposedly Qt-free pycoder domain module"
+
+
+def test_module_imports_qt_free_in_a_fresh_process_and_resolves_the_qt_free_config():
+    # Mirrors backend/tests/test_agent_layer_qt_free.py's own
+    # _assert_import_is_qt_free mechanism - the real precedent for "does this
+    # import chain stay Qt-free" in this codebase - plus confirms the
+    # `graphlink_config` -> `graphlink_task_config` swap this split made.
+    code = (
+        "import sys\n"
+        "import graphlink_plugins.pycoder.domain as domain_module\n"
+        "qt = [m for m in sys.modules if m.startswith('PySide6')]\n"
+        "assert not qt, f'importing graphlink_plugins.pycoder.domain pulled Qt: {qt}'\n"
+        "assert domain_module.config.__name__ == 'graphlink_task_config', (\n"
+        "    f'domain.py config reference resolved to {domain_module.config.__name__!r}, '\n"
+        "    'expected graphlink_task_config'\n"
+        ")\n"
+        "print('graphlink_plugins.pycoder.domain imported qt-free')\n"
+    )
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT / "graphlink_app") + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        "importing graphlink_plugins.pycoder.domain in a fresh process failed or pulled Qt:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+class TestPythonREPL:
+    def test_execute_runs_code_and_reports_success(self):
+        repl = PythonREPL()
+        try:
+            output = repl.execute("print('hello from repl')")
+            assert "hello from repl" in output
+            assert repl.last_run_failed is False
+        finally:
+            repl.stop()
+
+    def test_execute_reports_failure_on_a_raised_exception(self):
+        repl = PythonREPL()
+        try:
+            output = repl.execute("raise ValueError('boom')")
+            assert repl.last_run_failed is True
+            assert "ValueError" in output
+        finally:
+            repl.stop()
+
+    def test_state_persists_between_execute_calls(self):
+        repl = PythonREPL()
+        try:
+            repl.execute("x = 41")
+            output = repl.execute("print(x + 1)")
+            assert "42" in output
+            assert repl.last_run_failed is False
+        finally:
+            repl.stop()
+
+    def test_stop_is_idempotent_and_safe_before_start(self):
+        repl = PythonREPL()
+        repl.stop()  # never started - must not raise
+        repl.stop()  # already stopped - must not raise
+
+
+class _FakeNode:
+    """A minimal weakly-referenceable stand-in for a live QGraphicsObject
+    node - plain `object()` instances cannot be weakly referenced, but
+    PyCoderReplManager's WeakKeyDictionary keying requires it, same as a
+    real node would support."""
+
+
+class TestPyCoderReplManager:
+    def test_get_repl_returns_the_same_instance_for_the_same_node(self):
+        manager = PyCoderReplManager()
+        node = _FakeNode()
+        try:
+            first = manager.get_repl(node)
+            second = manager.get_repl(node)
+            assert first is second
+        finally:
+            manager.stop(node)
+
+    def test_get_repl_returns_different_instances_for_different_nodes(self):
+        manager = PyCoderReplManager()
+        node_a, node_b = _FakeNode(), _FakeNode()
+        try:
+            assert manager.get_repl(node_a) is not manager.get_repl(node_b)
+        finally:
+            manager.stop(node_a)
+            manager.stop(node_b)
+
+    def test_stop_removes_the_repl_so_a_later_get_repl_creates_a_fresh_one(self):
+        manager = PyCoderReplManager()
+        node = _FakeNode()
+        first = manager.get_repl(node)
+        manager.stop(node)
+        second = manager.get_repl(node)
+        try:
+            assert first is not second
+        finally:
+            manager.stop(node)
+
+
+class TestPyCoderExecutionAgent:
+    def test_get_response_calls_api_provider_chat_and_returns_content(self):
+        fake_response = {"message": {"content": "[TOOL:PYTHON]\nprint(1)\n[/TOOL]"}}
+        with patch("graphlink_plugins.pycoder.domain.api_provider.chat", return_value=fake_response) as mock_chat:
+            result = PyCoderExecutionAgent().get_response([], "add 1")
+        assert result == fake_response["message"]["content"]
+        assert mock_chat.called
+
+
+class TestPyCoderRepairAgent:
+    def test_get_response_extracts_fenced_python_block(self):
+        fake_response = {"message": {"content": "```python\nprint('fixed')\n```"}}
+        with patch("graphlink_plugins.pycoder.domain.api_provider.chat", return_value=fake_response):
+            result = PyCoderRepairAgent().get_response("print(", "SyntaxError")
+        assert result == "print('fixed')"
+
+    def test_get_response_falls_back_to_raw_text_when_unfenced(self):
+        fake_response = {"message": {"content": "print('fixed')"}}
+        with patch("graphlink_plugins.pycoder.domain.api_provider.chat", return_value=fake_response):
+            result = PyCoderRepairAgent().get_response("print(", "SyntaxError")
+        assert result == "print('fixed')"
+
+
+class TestPyCoderAnalysisAgent:
+    def test_get_response_with_original_prompt_calls_api_provider_chat(self):
+        fake_response = {"message": {"content": "Analysis text"}}
+        with patch("graphlink_plugins.pycoder.domain.api_provider.chat", return_value=fake_response) as mock_chat:
+            result = PyCoderAnalysisAgent().get_response("what is 1+1", "print(2)", "2")
+        assert result == "Analysis text"
+        assert mock_chat.called
+
+    def test_get_response_without_original_prompt_still_calls_api_provider_chat(self):
+        fake_response = {"message": {"content": "Analysis text"}}
+        with patch("graphlink_plugins.pycoder.domain.api_provider.chat", return_value=fake_response):
+            result = PyCoderAnalysisAgent().get_response(None, "print(2)", "2")
+        assert result == "Analysis text"
+
+
+def test_pycoder_stage_and_status_enums_have_the_expected_members():
+    assert {member.name for member in PyCoderStage} == {
+        "ANALYZE", "GENERATE", "EXECUTE", "REPAIR", "ANALYZE_RESULT",
+    }
+    assert {member.name for member in PyCoderStatus} == {
+        "PENDING", "RUNNING", "SUCCESS", "FAILURE",
+    }

--- a/web_ui/src/app/canvas/CodeExecutionApprovalPanel.test.tsx
+++ b/web_ui/src/app/canvas/CodeExecutionApprovalPanel.test.tsx
@@ -1,0 +1,237 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { CodeExecutionApprovalPanel, type CodeExecutionKind } from "./CodeExecutionApprovalPanel";
+
+// Rendered standalone, with NO <OverlayProvider> ancestor (post-review
+// architecture correction - see this component's own module doc for FIX A/
+// FIX B): unlike GitlinkNodeView's own Apply confirmation, this is no longer
+// a <Dialog> from the R2.1 overlay system at all, so there is nothing here
+// that would throw without a provider.
+
+function renderPanel(overrides: Partial<Parameters<typeof CodeExecutionApprovalPanel>[0]> = {}) {
+  const onApprove = vi.fn();
+  const onDeny = vi.fn();
+  const props = {
+    nodeId: "n0",
+    kind: "pycoder" as CodeExecutionKind,
+    code: "print('hello')",
+    awaitingApproval: true,
+    busy: false,
+    onApprove,
+    onDeny,
+    ...overrides,
+  };
+  render(<CodeExecutionApprovalPanel {...props} />);
+  return { onApprove, onDeny };
+}
+
+describe("CodeExecutionApprovalPanel", () => {
+  // -- visibility -----------------------------------------------------------
+
+  it("renders nothing at all when awaitingApproval is false", () => {
+    renderPanel({ awaitingApproval: false });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("auto-opens (no button click needed) the instant awaitingApproval is true", () => {
+    renderPanel({ awaitingApproval: true });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  // -- FIX A regression guard: zero passive-dismissal affordances -----------
+
+  it("FIX A: there is no close/X button anywhere - Approve and Deny are the only two buttons rendered", () => {
+    renderPanel();
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+    expect(buttons.map((b) => b.textContent)).toEqual(["Deny", "Approve"]);
+    expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
+    expect(screen.queryByLabelText(/close/i)).toBeNull();
+  });
+
+  it("FIX A: pressing Escape does NOT dismiss the panel and does NOT call onApprove/onDeny", () => {
+    const { onApprove, onDeny } = renderPanel();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onApprove).not.toHaveBeenCalled();
+    expect(onDeny).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("FIX A: clicking the backdrop/scrim does NOT dismiss the panel and does NOT call onApprove/onDeny", () => {
+    const { onApprove, onDeny } = renderPanel();
+    const dialog = screen.getByRole("dialog");
+    const scrim = dialog.parentElement!;
+    expect(scrim).not.toBe(document.body);
+    fireEvent.pointerDown(scrim);
+    fireEvent.click(scrim);
+    expect(onApprove).not.toHaveBeenCalled();
+    expect(onDeny).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("FIX A: focuses the Deny button on mount (the safe default for a stray Enter keypress)", () => {
+    renderPanel();
+    expect(screen.getByRole("button", { name: "Deny" })).toHaveFocus();
+  });
+
+  // -- FIX B regression guard: independent instances, no shared slot --------
+
+  it("FIX B: two simultaneously-open panels for different nodes are both rendered, and each one's Approve/Deny fires only its own callback", async () => {
+    const user = userEvent.setup();
+    const nodeA = { onApprove: vi.fn(), onDeny: vi.fn() };
+    const nodeB = { onApprove: vi.fn(), onDeny: vi.fn() };
+
+    render(
+      <>
+        <CodeExecutionApprovalPanel
+          nodeId="node-a"
+          kind="pycoder"
+          code="print('a')"
+          awaitingApproval
+          busy={false}
+          onApprove={nodeA.onApprove}
+          onDeny={nodeA.onDeny}
+        />
+        <CodeExecutionApprovalPanel
+          nodeId="node-b"
+          kind="code_sandbox"
+          code="print('b')"
+          awaitingApproval
+          busy={false}
+          onApprove={nodeB.onApprove}
+          onDeny={nodeB.onDeny}
+        />
+      </>,
+    );
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(2);
+
+    const approveButtons = screen.getAllByRole("button", { name: "Approve" });
+    expect(approveButtons).toHaveLength(2);
+    await user.click(approveButtons[0]);
+    expect(nodeA.onApprove).toHaveBeenCalledOnce();
+    expect(nodeB.onApprove).not.toHaveBeenCalled();
+
+    // Both panels remain mounted (nothing "stole" the other's slot) - the
+    // second one's Deny is independently clickable and only fires its own
+    // callback.
+    const denyButtons = screen.getAllByRole("button", { name: "Deny" });
+    expect(denyButtons).toHaveLength(2);
+    await user.click(denyButtons[1]);
+    expect(nodeB.onDeny).toHaveBeenCalledOnce();
+    expect(nodeA.onDeny).not.toHaveBeenCalled();
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(2);
+  });
+
+  // -- kind-specific warning copy (regression guard against softening it) ---
+
+  it("SECURITY-COPY: PyCoder shows the exact legacy phrase 'there is no sandboxing'", () => {
+    renderPanel({ kind: "pycoder" });
+    expect(screen.getByText(/there is no sandboxing/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /This will run AI-generated Python code in a persistent local session with the full privileges of your user account \(there is no sandboxing\)\. If execution fails, automatically repaired versions of this code may run under this same approval\./,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("SECURITY-COPY: Code-Sandbox shows the exact legacy phrase 'isolates installed packages, not the operating system'", () => {
+    renderPanel({ kind: "code_sandbox" });
+    expect(
+      screen.getByText(/isolates installed packages, not the operating system/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /This will run Python code inside an isolated virtual environment with the full privileges of your user account \(the environment isolates installed packages, not the operating system\)\./,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the other kind's warning sentence", () => {
+    renderPanel({ kind: "pycoder" });
+    expect(screen.queryByText(/isolates installed packages/)).toBeNull();
+  });
+
+  // -- FIX C regression guard: code_sandbox requirements/repair disclosure --
+
+  it("FIX C: Code-Sandbox warning also discloses the repair-loop re-execution risk", () => {
+    renderPanel({ kind: "code_sandbox" });
+    expect(
+      screen.getByText(/automatically repaired versions of this code may run under this same approval/),
+    ).toBeInTheDocument();
+  });
+
+  it("FIX C: renders a labeled 'Packages to be installed' block for code_sandbox when requirements is supplied", () => {
+    renderPanel({ kind: "code_sandbox", requirements: "numpy\npandas==2.2.0" });
+    expect(screen.getByText("Packages to be installed")).toBeInTheDocument();
+    expect(screen.getByText(/numpy/)).toBeInTheDocument();
+    expect(screen.getByText(/pandas==2\.2\.0/)).toBeInTheDocument();
+  });
+
+  it("FIX C: does not render the Packages block when requirements is blank or omitted", () => {
+    renderPanel({ kind: "code_sandbox", requirements: "" });
+    expect(screen.queryByText("Packages to be installed")).toBeNull();
+    renderPanel({ kind: "code_sandbox", requirements: undefined });
+    expect(screen.queryByText("Packages to be installed")).toBeNull();
+  });
+
+  it("FIX C: never renders the Packages block for pycoder, even if a requirements value were somehow supplied", () => {
+    renderPanel({
+      kind: "pycoder",
+      ...({ requirements: "numpy" } as Partial<Parameters<typeof CodeExecutionApprovalPanel>[0]>),
+    });
+    expect(screen.queryByText("Packages to be installed")).toBeNull();
+  });
+
+  // -- code rendering + security ---------------------------------------------
+
+  it("renders the pending code verbatim through the markdown pipeline as a syntax-highlighted fenced block", () => {
+    renderPanel({ code: "def add(a, b):\n    return a + b" });
+    // rehype-highlight splits the line across several <span> tokens, so the
+    // full phrase is never one text node - assert against the code block's
+    // combined textContent instead (same approach GitlinkNodeView's own
+    // diff-rendering test uses via document.querySelector("pre code")).
+    const codeBlock = document.querySelector("pre code");
+    expect(codeBlock).not.toBeNull();
+    expect(codeBlock!.textContent).toContain("def add(a, b):");
+    expect(codeBlock!.textContent).toContain("return a + b");
+  });
+
+  it("SECURITY: pending code containing a literal <img onerror> tag never becomes a real rendered img element", () => {
+    renderPanel({ code: '<img src="x" onerror="alert(1)">\nprint("hi")' });
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  // -- Approve/Deny: zero-argument callbacks only ----------------------------
+
+  it("Approve calls onApprove with NO arguments", async () => {
+    const user = userEvent.setup();
+    const { onApprove } = renderPanel();
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    expect(onApprove).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it("Deny calls onDeny with NO arguments", async () => {
+    const user = userEvent.setup();
+    const { onDeny } = renderPanel();
+    await user.click(screen.getByRole("button", { name: "Deny" }));
+    expect(onDeny).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  // -- busy gate --------------------------------------------------------------
+
+  it("both Approve and Deny are disabled while busy is true", () => {
+    renderPanel({ busy: true });
+    expect(screen.getByRole("button", { name: "Approve" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Deny" })).toBeDisabled();
+  });
+
+  it("both buttons are enabled when busy is false", () => {
+    renderPanel({ busy: false });
+    expect(screen.getByRole("button", { name: "Approve" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Deny" })).toBeEnabled();
+  });
+});

--- a/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
+++ b/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useRef } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+
+/**
+ * The mandatory human-approval gate (Qt-removal plan R5.4, corrected in the
+ * R5.4 post-review fix pass) - rendered by BOTH PyCoderNodeView and
+ * CodeSandboxNodeView whenever their own node-kind-specific
+ * `*AwaitingApproval` flag is true. One component, not two copies, because
+ * the gate itself (show the pending code, get an explicit yes/no, forward
+ * ONLY a requestId never anything content-bearing) is identical across both
+ * plugins - only the warning sentence (and, for code_sandbox, a requirements
+ * disclosure) differs, and legacy's own sentences must survive VERBATIM (see
+ * WARNING_TEXT below) rather than be paraphrased into something friendlier
+ * than what is actually true.
+ *
+ * ARCHITECTURE (post-review correction - do not revert this): this is
+ * DELIBERATELY NOT built on the shared Dialog/useOverlays() primitive from
+ * ../overlays/overlays, even though every other modal in this app is. Two
+ * independent reasons, both fatal for THIS specific dialog:
+ *
+ * 1. Dialog gives every surface a working Escape key, scrim-click, and a
+ *    close (X) button - all three call overlays.close() directly, NONE of
+ *    which resolve onApprove/onDeny. For a chrome dialog (Settings, Search)
+ *    that is exactly correct: dismissing it does nothing because there was
+ *    nothing pending. For THIS dialog it is a real bug: dismissing it left
+ *    the node genuinely stuck - *_awaiting_approval stays true server-side,
+ *    the approval_future stays pending forever (no timeout by design), and
+ *    the busy marker stays claimed - with nothing that ever reopens the
+ *    dialog (the old reopening effect only fired on the false-to-true
+ *    transition, which had already happened). Legacy's own QMessageBox (the
+ *    thing this replaces) never had this problem: a QMessageBox with a
+ *    defined default button resolves Escape/Alt+F4 to that default button's
+ *    action, so it is never left unresolved by a dismissal gesture. THE FIX:
+ *    this component has ZERO passive-dismissal affordances. No Escape
+ *    handler, no scrim-click-to-close, no X/close button. The ONLY two ways
+ *    to make this panel disappear are clicking Approve or clicking Deny -
+ *    the correct, literal reading of "mandatory approval".
+ *
+ * 2. overlays.open()/isOpen() is a single global "one surface open at a
+ *    time" registry - correct for app-chrome overlays like Settings/Search,
+ *    which really are mutually exclusive, but WRONG for per-node approval
+ *    dialogs: two different nodes can legitimately need review at the same
+ *    time (a user starting Py-Coder runs on two different nodes a few
+ *    seconds apart is a completely ordinary sequence, not a hypothetical).
+ *    Under the old design, the second node's overlays.open() call would
+ *    silently steal the visible slot from the first, and the losing node's
+ *    dialog would never come back (same "reopening effect only fires once"
+ *    gap as above). THE FIX: because this is now a small, self-contained
+ *    modal - its own fixed-position overlay + scrim, rendered directly by
+ *    whichever NodeView needs it, conditionally, whenever ITS OWN
+ *    awaitingApproval flag is true - there is no shared global slot to
+ *    collide over in the first place. Each node's instance is naturally
+ *    independent; React mounts one per node that needs it. See
+ *    CodeExecutionApprovalPanel.test.tsx's two-simultaneous-instances test
+ *    and PyCoderNodeView.test.tsx/CodeSandboxNodeView.test.tsx for the
+ *    regression guard.
+ *
+ * Server-initiated, not user-initiated: unlike GitlinkNodeView's own Apply
+ * confirmation (which the user opens by clicking a button), this pause is
+ * something the BACKEND decided to interrupt the user with - a code
+ * execution is sitting there waiting on a human yes/no with the full
+ * privileges of the user's own account. There is no auto-open effect to
+ * write here at all (unlike the old Dialog-backed version) - this component
+ * simply renders its modal markup whenever awaitingApproval is true and
+ * renders nothing otherwise; that IS "auto-open", with no separate act of
+ * registering itself anywhere.
+ *
+ * CRITICAL security property, enforced structurally, not just by convention:
+ * onApprove/onDeny are BOTH zero-argument callbacks. This component has no
+ * prop, no state, no code path capable of naming a DIFFERENT requestId than
+ * whatever the caller (SceneCanvas's toFlowNodes) already closed over from
+ * the CURRENT scene snapshot's own pendingRequestId for this node - see
+ * SceneCanvas.tsx's own onApprove/onDeny closures for where that id is
+ * actually read and forwarded to sceneStore's approveCodeExecution/
+ * denyCodeExecution. The UI layer is structurally unable to approve or deny
+ * a request other than the one the server is actually holding.
+ *
+ * Security note, not a style preference: the pending code is rendered
+ * through the exact same react-markdown + remarkGfm + rehypeHighlight
+ * pipeline every sibling node view uses (see GitlinkNodeView's own
+ * toDiffFence/CodeNodeView's own toFencedCodeBlock for the same technique
+ * applied to different content) - no rehype-raw, no
+ * dangerouslySetInnerHTML anywhere in this file. Fencing it as ```python
+ * only affects syntax-colorization; the pipeline never interprets any of it
+ * as live markup either way.
+ *
+ * Requirements disclosure (post-review FIX C): CodeSandboxNode's one
+ * mandatory approval step must show the requirements.txt-style manifest that
+ * will be pip-installed (from PyPI, potentially running arbitrary
+ * build-backend code) immediately after Approve, before the reviewed code
+ * itself ever runs - legacy's own approval dialog
+ * (graphlink_window_actions.py) built and displayed a package-summary string
+ * enumerating every declared package before asking Yes/No, and this omission
+ * was a real security-relevant regression, not a cosmetic gap. `requirements`
+ * is optional and is only ever rendered for kind="code_sandbox" (pycoder has
+ * no such concept) - CodeSandboxNodeView passes data.codeSandboxRequirements
+ * straight through, since that field already reflects the exact manifest
+ * run_code_sandbox reads synchronously at the moment Run is dispatched (no
+ * new backend wiring was needed for this).
+ */
+
+export type CodeExecutionKind = "pycoder" | "code_sandbox";
+
+// Verbatim legacy sentences (graphlink_window_actions.py, confirmed during
+// the R5.4 design/recon pass and reused unchanged in backend/agents.py's own
+// module comment) - do NOT soften or paraphrase either of these. The
+// "there is no sandboxing" / "isolates installed packages, not the operating
+// system" substrings are the load-bearing honesty this copy exists for, and
+// are directly regression-tested in CodeExecutionApprovalPanel.test.tsx. The
+// repair-loop-reexecution sentence is appended to BOTH kinds (post-review
+// FIX C) since backend/agents.py's start_code_sandbox_run has the exact same
+// "approve once, repair-and-retry under that one approval" behavior as
+// start_pycoder_run's ai_driven path - omitting it for code_sandbox would be
+// disclosing only half of what one Approve click actually authorizes.
+const WARNING_TEXT: Record<CodeExecutionKind, string> = {
+  pycoder:
+    "This will run AI-generated Python code in a persistent local session with the full privileges of your user account (there is no sandboxing). If execution fails, automatically repaired versions of this code may run under this same approval.",
+  code_sandbox:
+    "This will run Python code inside an isolated virtual environment with the full privileges of your user account (the environment isolates installed packages, not the operating system). If execution fails, automatically repaired versions of this code may run under this same approval.",
+};
+
+const DIALOG_TITLE: Record<CodeExecutionKind, string> = {
+  pycoder: "Approve Py-Coder Execution?",
+  code_sandbox: "Approve Sandbox Execution?",
+};
+
+/** Wraps the pending code in a markdown fenced ```python code block so
+ * ReactMarkdown + rehype-highlight can syntax-highlight it for free - same
+ * technique CodeNodeView's own toFencedCodeBlock / GitlinkNodeView's own
+ * toDiffFence use for their own content. */
+function toPythonFence(code: string): string {
+  return "```python\n" + code + "\n```";
+}
+
+// Scoped to THIS panel's own three intended focus stops (the code display,
+// Deny, Approve) - deliberately narrower than overlays.tsx's own shared
+// FOCUSABLE selector (which also matches inputs/selects/links/textareas),
+// since nothing else in this panel's markup is ever meant to receive focus.
+const FOCUSABLE = 'button, [tabindex]:not([tabindex="-1"])';
+
+export interface CodeExecutionApprovalPanelProps {
+  /** No longer used to register with any shared overlay registry (there is
+   * none here anymore - see module doc). Kept as a per-node identifier for
+   * the rendered DOM (data-node-id) so two simultaneously-open instances for
+   * different nodes are independently addressable in tests/devtools. Never
+   * sent anywhere over the wire. */
+  nodeId: string;
+  kind: CodeExecutionKind;
+  code: string;
+  awaitingApproval: boolean;
+  /** code_sandbox ONLY (post-review FIX C) - the pending requirements.txt-
+   * style manifest that will be pip-installed immediately after Approve,
+   * before the reviewed code itself ever runs. Ignored entirely for
+   * kind="pycoder" (no such concept there). Rendered only when non-blank. */
+  requirements?: string;
+  /** Disables both buttons while the caller's own click handler is waiting
+   * out the brief window between a click and the next scene snapshot
+   * reflecting it - prevents a double-fire (e.g. Approve clicked twice
+   * before awaitingApproval flips back to false). Owned and reset by the
+   * caller (PyCoderNodeView/CodeSandboxNodeView), not by this component -
+   * it has no way to know when "the next scene snapshot" has arrived on its
+   * own. */
+  busy: boolean;
+  onApprove: () => void;
+  onDeny: () => void;
+}
+
+export function CodeExecutionApprovalPanel({
+  nodeId,
+  kind,
+  code,
+  awaitingApproval,
+  requirements,
+  busy,
+  onApprove,
+  onDeny,
+}: CodeExecutionApprovalPanelProps) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const denyButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  // Focus the Deny button the instant the panel appears - the safe default a
+  // stray Enter/Space keypress lands on. There is no dismiss path here (see
+  // module doc), so unlike overlays.tsx's own Dialog (which focuses whatever
+  // the FIRST focusable descendant happens to be, close button included),
+  // this panel focuses a SPECIFIC button deliberately rather than generically
+  // walking the DOM for one.
+  useEffect(() => {
+    if (awaitingApproval) denyButtonRef.current?.focus();
+  }, [awaitingApproval]);
+
+  // Tab focus trap scoped to this panel's own three focusable stops (the
+  // scrollable code display, Deny, Approve) - Tab/Shift+Tab must never let
+  // focus escape to the rest of the page while a mandatory approval is
+  // pending. Deliberately has NO Escape branch at all (unlike overlays.tsx's
+  // own Dialog focus trap, which lives alongside that component's Escape-
+  // closes-everything effect) - see module doc's FIX A.
+  useEffect(() => {
+    if (!awaitingApproval) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Tab") return;
+      const focusables = [...panel!.querySelectorAll<HTMLElement>(FOCUSABLE)];
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+    panel.addEventListener("keydown", onKeyDown);
+    return () => panel.removeEventListener("keydown", onKeyDown);
+  }, [awaitingApproval]);
+
+  if (!awaitingApproval) return null;
+
+  const showRequirements = kind === "code_sandbox" && !!requirements?.trim();
+
+  return (
+    // Deliberately NO onClick/onPointerDown handler on this scrim - clicking
+    // it does nothing at all (no light-dismiss), unlike overlays.tsx's own
+    // .overlay-scrim, whose onPointerDown closes on a direct hit. Reusing the
+    // .overlay-scrim/.overlay-dialog class names purely for visual
+    // consistency (fixed full-viewport centering, matching colors/shadows) -
+    // this div is NOT registered with, and shares no state with, the
+    // useOverlays() registry those classes were originally styled for.
+    <div className="overlay-scrim code-exec-approval-scrim" data-node-id={nodeId}>
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={DIALOG_TITLE[kind]}
+        tabIndex={-1}
+        className="overlay-dialog code-exec-approval-dialog"
+      >
+        <header className="overlay-dialog-header">
+          <span className="overlay-dialog-title">{DIALOG_TITLE[kind]}</span>
+        </header>
+        <div className="overlay-dialog-body">
+          <p className="code-exec-approval-warning">{WARNING_TEXT[kind]}</p>
+          {showRequirements && (
+            <div className="code-exec-approval-requirements">
+              <span className="code-exec-approval-requirements-label">Packages to be installed</span>
+              <pre className="code-exec-approval-requirements-list">{requirements}</pre>
+            </div>
+          )}
+          <div
+            className="chat-node-content code-exec-approval-code"
+            tabIndex={0}
+            role="region"
+            aria-label="Pending code"
+          >
+            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+              {toPythonFence(code)}
+            </ReactMarkdown>
+          </div>
+          <div className="code-exec-approval-actions">
+            <button
+              ref={denyButtonRef}
+              type="button"
+              className="code-exec-approval-deny-btn"
+              disabled={busy}
+              onClick={() => onDeny()}
+            >
+              Deny
+            </button>
+            <button
+              type="button"
+              className="code-exec-approval-approve-btn"
+              disabled={busy}
+              onClick={() => onApprove()}
+            >
+              Approve
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/CodeSandboxNodeView.test.tsx
+++ b/web_ui/src/app/canvas/CodeSandboxNodeView.test.tsx
@@ -1,0 +1,483 @@
+import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { CodeSandboxNodeView, type CodeSandboxFlowNode } from "./CodeSandboxNodeView";
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
+// ArtifactNodeView.test.tsx for why a bare ReactFlowProvider is enough here
+// too. NOT wrapped in OverlayProvider (unlike GitlinkNodeView.test.tsx) -
+// this view's <CodeExecutionApprovalPanel> is a small, self-contained modal
+// post-R5.4-fix-pass (see that component's own module doc for FIX A/FIX B),
+// not a <Dialog> from the R2.1 overlay system, so there is no provider
+// ancestor requirement here at all.
+
+type StreamListener = (delta: string, done: boolean, reset: boolean, seq: number) => void;
+
+function makeSubscribeStreamMock() {
+  const listeners = new Map<string, StreamListener>();
+  const unsubscribe = vi.fn();
+  const subscribeStream = vi.fn((requestId: string, listener: StreamListener) => {
+    listeners.set(requestId, listener);
+    return unsubscribe;
+  });
+  return { subscribeStream, listeners, unsubscribe };
+}
+
+function baseData(overrides: Partial<CodeSandboxFlowNode["data"]> = {}): CodeSandboxFlowNode["data"] {
+  return {
+    codeSandboxRequirements: "",
+    codeSandboxApprovalRequirements: "",
+    codeSandboxPrompt: "",
+    codeSandboxCode: "",
+    codeSandboxOutput: "",
+    codeSandboxAnalysis: "",
+    codeSandboxAwaitingApproval: false,
+    codeSandboxError: "",
+    isCollapsed: false,
+    pendingRequestId: null,
+    onSetRequirements: vi.fn(),
+    onRun: vi.fn(),
+    onCancel: vi.fn(),
+    onApprove: vi.fn(),
+    onDeny: vi.fn(),
+    onToggleCollapse: vi.fn(),
+    onDelete: vi.fn(),
+    subscribeStream: vi.fn().mockReturnValue(vi.fn()),
+    ...overrides,
+  };
+}
+
+function renderCodeSandboxNode(overrides: Partial<CodeSandboxFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "cs-1", selected: false, data } as unknown as NodeProps<CodeSandboxFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <CodeSandboxNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return data;
+}
+
+function renderCodeSandboxNodeWithRerender(overrides: Partial<CodeSandboxFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "cs-1", selected: false, data } as unknown as NodeProps<CodeSandboxFlowNode>;
+
+  const utils = render(
+    <ReactFlowProvider>
+      <CodeSandboxNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+
+  function rerenderWithData(nextData: CodeSandboxFlowNode["data"]) {
+    const nextProps = { id: "cs-1", selected: false, data: nextData } as unknown as NodeProps<CodeSandboxFlowNode>;
+    utils.rerender(
+      <ReactFlowProvider>
+        <CodeSandboxNodeView {...nextProps} />
+      </ReactFlowProvider>,
+    );
+  }
+
+  return { data, rerenderWithData };
+}
+
+// Directly sets the React Flow internal Zustand store's transform/zoom value
+// - same technique GitlinkNodeView.test.tsx/ArtifactNodeView.test.tsx's own
+// ZoomSetter uses.
+function ZoomSetter({ zoom }: { zoom: number }) {
+  const store = useStoreApi();
+  useEffect(() => {
+    store.setState({ transform: [0, 0, zoom] });
+  }, [zoom, store]);
+  return null;
+}
+
+function renderCodeSandboxNodeAtZoom(zoom: number, overrides: Partial<CodeSandboxFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "cs-1", selected: false, data } as unknown as NodeProps<CodeSandboxFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <ZoomSetter zoom={zoom} />
+      <CodeSandboxNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return data;
+}
+
+describe("CodeSandboxNodeView", () => {
+  // -- requirements: local draft, committed only on blur/Enter -------------
+
+  it("typing into Requirements calls no WS method - only blur commits it", async () => {
+    const user = userEvent.setup();
+    const data = renderCodeSandboxNode();
+    const input = screen.getByRole("textbox", { name: "Requirements" });
+
+    await user.type(input, "numpy");
+    expect(data.onSetRequirements).not.toHaveBeenCalled();
+
+    await user.click(document.body);
+    expect(data.onSetRequirements).toHaveBeenCalledWith("numpy");
+  });
+
+  it("pressing Enter (no shift) in Requirements commits exactly once via blur, not twice", async () => {
+    const user = userEvent.setup();
+    const data = renderCodeSandboxNode();
+    const input = screen.getByRole("textbox", { name: "Requirements" });
+
+    await user.type(input, "numpy{Enter}");
+    expect(data.onSetRequirements).toHaveBeenCalledTimes(1);
+    expect(data.onSetRequirements).toHaveBeenCalledWith("numpy");
+  });
+
+  it("Shift+Enter inserts a newline in Requirements instead of committing", async () => {
+    const user = userEvent.setup();
+    const data = renderCodeSandboxNode();
+    const input = screen.getByRole("textbox", { name: "Requirements" });
+
+    await user.type(input, "numpy{Shift>}{Enter}{/Shift}pandas");
+    expect(data.onSetRequirements).not.toHaveBeenCalled();
+    expect(input).toHaveValue("numpy\npandas");
+  });
+
+  // -- prompt / Run enablement -----------------------------------------------
+
+  it("Run is disabled when both the prompt and any existing code are empty", () => {
+    renderCodeSandboxNode({ codeSandboxPrompt: "", codeSandboxCode: "" });
+    expect(screen.getByRole("button", { name: "Run" })).toBeDisabled();
+  });
+
+  it("Run is enabled once a prompt is typed, even with no existing code", async () => {
+    const user = userEvent.setup();
+    renderCodeSandboxNode({ codeSandboxCode: "" });
+    await user.type(screen.getByRole("textbox", { name: "Prompt" }), "plot a sine wave");
+    expect(screen.getByRole("button", { name: "Run" })).toBeEnabled();
+  });
+
+  it("Run is enabled with an empty prompt as long as code already exists (re-run), matching the backend's own guard", () => {
+    renderCodeSandboxNode({ codeSandboxPrompt: "", codeSandboxCode: "print(1)" });
+    expect(screen.getByRole("button", { name: "Run" })).toBeEnabled();
+  });
+
+  it("clicking Run passes the trimmed prompt draft to onRun and never fires on typing alone", async () => {
+    const user = userEvent.setup();
+    const data = renderCodeSandboxNode();
+    await user.type(screen.getByRole("textbox", { name: "Prompt" }), "  plot a sine wave  ");
+    expect(data.onRun).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Run" }));
+    expect(data.onRun).toHaveBeenCalledExactlyOnceWith("plot a sine wave");
+  });
+
+  it("Run is disabled while pendingRequestId is set", () => {
+    renderCodeSandboxNode({ pendingRequestId: "req-1", codeSandboxCode: "print(1)" });
+    expect(screen.getByRole("button", { name: "Run" })).toBeDisabled();
+  });
+
+  // -- Cancel ---------------------------------------------------------------
+
+  it("Cancel is absent when pendingRequestId is null, and present+wired when set", async () => {
+    const user = userEvent.setup();
+    expect(renderCodeSandboxNode({ pendingRequestId: null })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+
+    const data = renderCodeSandboxNode({ pendingRequestId: "req-1" });
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(data.onCancel).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  // -- live terminal streaming ------------------------------------------------
+
+  it("subscribes to the stream for pendingRequestId the instant a run starts", () => {
+    const { subscribeStream } = makeSubscribeStreamMock();
+    renderCodeSandboxNode({ pendingRequestId: "req-1", subscribeStream });
+    expect(subscribeStream).toHaveBeenCalledWith("req-1", expect.any(Function));
+  });
+
+  it("accumulates ordered stream deltas into the live terminal pane while a run is in flight", () => {
+    const { subscribeStream, listeners } = makeSubscribeStreamMock();
+    renderCodeSandboxNode({ pendingRequestId: "req-1", subscribeStream });
+    const listener = listeners.get("req-1")!;
+
+    act(() => listener("Hello ", false, false, 1));
+    act(() => listener("World", false, false, 2));
+
+    expect(screen.getByText("Hello World")).toBeInTheDocument();
+  });
+
+  it("a reset delta clears prior accumulated output before appending", () => {
+    const { subscribeStream, listeners } = makeSubscribeStreamMock();
+    renderCodeSandboxNode({ pendingRequestId: "req-1", subscribeStream });
+    const listener = listeners.get("req-1")!;
+
+    act(() => listener("stale first attempt", false, false, 1));
+    act(() => listener("fresh start", false, true, 2));
+
+    expect(screen.queryByText(/stale first attempt/)).toBeNull();
+    expect(screen.getByText("fresh start")).toBeInTheDocument();
+  });
+
+  it("shows a waiting placeholder before any delta has arrived for an in-flight run", () => {
+    const { subscribeStream } = makeSubscribeStreamMock();
+    renderCodeSandboxNode({ pendingRequestId: "req-1", subscribeStream });
+    expect(screen.getByText("Waiting for output…")).toBeInTheDocument();
+  });
+
+  it("reconciles with the static codeSandboxOutput field once the run completes (pendingRequestId back to null)", () => {
+    const { subscribeStream, listeners } = makeSubscribeStreamMock();
+    const { data, rerenderWithData } = renderCodeSandboxNodeWithRerender({
+      pendingRequestId: "req-1",
+      subscribeStream,
+    });
+    const listener = listeners.get("req-1")!;
+    act(() => listener("partial output", false, false, 1));
+    expect(screen.getByText("partial output")).toBeInTheDocument();
+
+    rerenderWithData({
+      ...data,
+      pendingRequestId: null,
+      codeSandboxOutput: "final complete output",
+    });
+
+    expect(screen.queryByText("partial output")).toBeNull();
+    expect(screen.getByText("final complete output")).toBeInTheDocument();
+  });
+
+  it("unsubscribes the prior stream when pendingRequestId changes to a new run", () => {
+    const { subscribeStream, unsubscribe } = makeSubscribeStreamMock();
+    const { data, rerenderWithData } = renderCodeSandboxNodeWithRerender({
+      pendingRequestId: "req-1",
+      subscribeStream,
+    });
+    rerenderWithData({ ...data, pendingRequestId: "req-2" });
+    expect(unsubscribe).toHaveBeenCalled();
+    expect(subscribeStream).toHaveBeenCalledWith("req-2", expect.any(Function));
+  });
+
+  it("shows the static codeSandboxOutput with no subscription at all when no run is in flight", () => {
+    const { subscribeStream } = makeSubscribeStreamMock();
+    renderCodeSandboxNode({ pendingRequestId: null, codeSandboxOutput: "previous run's output", subscribeStream });
+    expect(subscribeStream).not.toHaveBeenCalled();
+    expect(screen.getByText("previous run's output")).toBeInTheDocument();
+  });
+
+  // -- error / code / analysis panes ------------------------------------------
+
+  it("shows the codeSandboxError banner when set", () => {
+    renderCodeSandboxNode({ codeSandboxError: "Provide a task prompt or Python code before running the sandbox." });
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Provide a task prompt or Python code before running the sandbox.",
+    );
+  });
+
+  it("renders code as a syntax-highlighted fenced block and analysis as markdown", () => {
+    renderCodeSandboxNode({
+      codeSandboxCode: "import numpy as np\nprint(np.pi)",
+      codeSandboxAnalysis: "This **prints pi**.",
+    });
+    expect(screen.getByText("Code")).toBeInTheDocument();
+    expect(document.querySelector("pre code")).not.toBeNull();
+    expect(screen.getByText("Analysis")).toBeInTheDocument();
+    expect(screen.getByText("prints pi")).toBeInTheDocument();
+  });
+
+  it("SECURITY: analysis text containing a literal <img onerror> tag never becomes a real rendered img element", () => {
+    renderCodeSandboxNode({ codeSandboxAnalysis: '<img src="x" onerror="alert(1)"> as requested.' });
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("SECURITY: terminal output containing literal HTML never becomes real markup (plain <pre> text, not markdown)", () => {
+    renderCodeSandboxNode({ codeSandboxOutput: '<img src="x" onerror="alert(1)">' });
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.getByText('<img src="x" onerror="alert(1)">')).toBeInTheDocument();
+  });
+
+  // -- approval panel ---------------------------------------------------------
+
+  it("renders the approval panel only when codeSandboxAwaitingApproval is true", () => {
+    renderCodeSandboxNode({ codeSandboxAwaitingApproval: false });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders the approval panel (with the code_sandbox-specific warning) when codeSandboxAwaitingApproval is true", () => {
+    renderCodeSandboxNode({ codeSandboxAwaitingApproval: true, codeSandboxCode: "print(1)" });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/isolates installed packages, not the operating system/)).toBeInTheDocument();
+  });
+
+  it("Approve calls onApprove with no arguments", async () => {
+    const user = userEvent.setup();
+    const data = renderCodeSandboxNode({ codeSandboxAwaitingApproval: true, codeSandboxCode: "print(1)" });
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    expect(data.onApprove).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it("Deny calls onDeny with no arguments", () => {
+    // Separate render from Approve's own test above - both buttons share one
+    // busy flag that locks BOTH the instant either is clicked (see
+    // CodeExecutionApprovalPanel's own busy-gate doc), so exercising Approve
+    // and then Deny on the SAME mounted instance would find Deny disabled.
+    const data = renderCodeSandboxNode({ codeSandboxAwaitingApproval: true, codeSandboxCode: "print(1)" });
+    fireEvent.click(screen.getByRole("button", { name: "Deny" }));
+    expect(data.onDeny).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  // FIX C regression guard: the approval panel must show the pending
+  // requirements manifest for this kind - CodeSandboxNodeView passes the
+  // frozen codeSandboxApprovalRequirements snapshot straight through as the
+  // panel's requirements prop, no new backend wiring involved.
+  it("FIX C: the approval panel shows the Packages to be installed block, sourced from codeSandboxApprovalRequirements", () => {
+    renderCodeSandboxNode({
+      codeSandboxAwaitingApproval: true,
+      codeSandboxCode: "print(1)",
+      codeSandboxApprovalRequirements: "numpy\npandas==2.2.0",
+    });
+    expect(screen.getByText("Packages to be installed")).toBeInTheDocument();
+    // Query the panel's own requirements-list element specifically - the
+    // Requirements textarea elsewhere on this same node could ALSO contain
+    // overlapping text depending on the live draft, so an unscoped
+    // screen.getByText(/numpy/) would ambiguously match both.
+    const packagesList = document.querySelector(".code-exec-approval-requirements-list");
+    expect(packagesList).not.toBeNull();
+    expect(packagesList!.textContent).toContain("numpy");
+    expect(packagesList!.textContent).toContain("pandas==2.2.0");
+  });
+
+  it("FIX C: the approval panel omits the Packages block when codeSandboxApprovalRequirements is blank", () => {
+    renderCodeSandboxNode({
+      codeSandboxAwaitingApproval: true,
+      codeSandboxCode: "print(1)",
+      codeSandboxApprovalRequirements: "",
+    });
+    expect(screen.queryByText("Packages to be installed")).toBeNull();
+  });
+
+  // R5.4 CODESANDBOX regression guard: codeSandboxApprovalRequirements is a
+  // frozen snapshot of the manifest a pending approval refers to, distinct
+  // from codeSandboxRequirements - the user's still-live, editable draft for
+  // the NEXT run. The two can genuinely differ at once (the user keeps
+  // typing a new manifest while a previous run's approval is still parked
+  // awaiting a decision), so the approval panel must read ONLY the frozen
+  // field and never fall back to - or leak - the live draft.
+  it("shows the frozen codeSandboxApprovalRequirements snapshot, never the live codeSandboxRequirements draft, while awaiting approval", () => {
+    renderCodeSandboxNode({
+      codeSandboxAwaitingApproval: true,
+      codeSandboxCode: "print(1)",
+      codeSandboxRequirements: "requests",
+      codeSandboxApprovalRequirements: "numpy",
+    });
+    const packagesList = document.querySelector(".code-exec-approval-requirements-list");
+    expect(packagesList).not.toBeNull();
+    expect(packagesList!.textContent).toBe("numpy");
+    expect(packagesList!.textContent).not.toContain("requests");
+  });
+
+  it("FIX C: the approval panel also discloses the repair-loop re-execution risk for code_sandbox", () => {
+    renderCodeSandboxNode({ codeSandboxAwaitingApproval: true, codeSandboxCode: "print(1)" });
+    expect(
+      screen.getByText(/automatically repaired versions of this code may run under this same approval/),
+    ).toBeInTheDocument();
+  });
+
+  // FIX B regression guard, at the real NodeView-integration level (not just
+  // the panel-unit level covered in CodeExecutionApprovalPanel.test.tsx):
+  // two different nodes awaiting approval simultaneously must both render
+  // and stay independently interactable.
+  it("FIX B: two CodeSandboxNodeView instances both awaiting approval are independently visible and interactable", async () => {
+    const user = userEvent.setup();
+    const dataA = baseData({ codeSandboxAwaitingApproval: true, codeSandboxCode: "print('a')" });
+    const dataB = baseData({ codeSandboxAwaitingApproval: true, codeSandboxCode: "print('b')" });
+    const propsA = { id: "cs-a", selected: false, data: dataA } as unknown as NodeProps<CodeSandboxFlowNode>;
+    const propsB = { id: "cs-b", selected: false, data: dataB } as unknown as NodeProps<CodeSandboxFlowNode>;
+
+    render(
+      <ReactFlowProvider>
+        <CodeSandboxNodeView {...propsA} />
+        <CodeSandboxNodeView {...propsB} />
+      </ReactFlowProvider>,
+    );
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(2);
+
+    const approveButtons = screen.getAllByRole("button", { name: "Approve" });
+    expect(approveButtons).toHaveLength(2);
+    await user.click(approveButtons[0]);
+    expect(dataA.onApprove).toHaveBeenCalledExactlyOnceWith();
+    expect(dataB.onApprove).not.toHaveBeenCalled();
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(2);
+    const denyButtons = screen.getAllByRole("button", { name: "Deny" });
+    await user.click(denyButtons[1]);
+    expect(dataB.onDeny).toHaveBeenCalledExactlyOnceWith();
+    expect(dataA.onDeny).not.toHaveBeenCalled();
+  });
+
+  // -- collapse/expand + LOD -------------------------------------------------
+
+  it("manual collapse hides the body and shows only the header", () => {
+    renderCodeSandboxNode({ isCollapsed: true });
+    expect(screen.getByText("Execution Sandbox")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Run" })).toBeNull();
+  });
+
+  it("the inline collapse chevron calls onToggleCollapse", async () => {
+    const user = userEvent.setup();
+    const data = renderCodeSandboxNode();
+    await user.click(screen.getByRole("button", { name: "Collapse" }));
+    expect(data.onToggleCollapse).toHaveBeenCalledOnce();
+  });
+
+  it("LOD auto-collapse (zoom below threshold) also hides the body, even when isCollapsed is false", () => {
+    renderCodeSandboxNodeAtZoom(0.2, { isCollapsed: false });
+    expect(screen.getByText("Execution Sandbox")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Run" })).toBeNull();
+  });
+
+  it("stays expanded above the LOD threshold when isCollapsed is false", () => {
+    renderCodeSandboxNodeAtZoom(1, { isCollapsed: false });
+    expect(screen.getByRole("button", { name: "Run" })).toBeInTheDocument();
+  });
+
+  // -- card-level menu ----------------------------------------------------
+
+  it("the node-level right-click menu shows exactly Collapse/Expand + Delete Node - no dock action", async () => {
+    const user = userEvent.setup();
+    const data = renderCodeSandboxNode();
+
+    fireEvent.contextMenu(screen.getByText("Execution Sandbox"));
+    const menu = screen.getByRole("menu");
+    expect(menu).toBeInTheDocument();
+
+    const items = screen.getAllByRole("menuitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("Collapse");
+    expect(items[1]).toHaveTextContent("Delete Node");
+    expect(screen.queryByRole("menuitem", { name: /Dock/ })).toBeNull();
+
+    await user.click(items[0]);
+    expect(data.onToggleCollapse).toHaveBeenCalledOnce();
+
+    fireEvent.contextMenu(screen.getByText("Execution Sandbox"));
+    await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
+    expect(data.onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Escape and outside-click both close the node-level menu", async () => {
+    const user = userEvent.setup();
+    renderCodeSandboxNode();
+    const header = screen.getByText("Execution Sandbox");
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
@@ -1,0 +1,381 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import type { StreamListener } from "../../lib/ws/transport";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { CodeExecutionApprovalPanel } from "./CodeExecutionApprovalPanel";
+
+/**
+ * The Execution Sandbox node (Qt-removal plan R5.4) - the Code-Sandbox
+ * plugin's React card. Same overall shell as every plugin-node sibling
+ * (PyCoderNodeView/GitlinkNodeView): collapse/expand OR-ed with LOD, a card
+ * menu with outside-click/Escape dismiss, the shared react-markdown +
+ * remarkGfm + rehypeHighlight pipeline, no dock-to-parent action.
+ *
+ * Unlike Py-Coder, there is no mode toggle here - backend/canvas.py's own
+ * start_code_sandbox_run docstring is explicit that there is "no
+ * mode-dependent field split here" for this kind: a Run's input_text always
+ * lands in code_sandbox_prompt, and code_sandbox_code is only ever populated
+ * as the OUTPUT of a prior generation (there is no manual-code entry point
+ * for this kind at all, unlike Py-Coder). So Run is enabled whenever there is
+ * EITHER a non-empty prompt draft OR already-generated code to re-run -
+ * mirroring the backend's own guard ("if prompt_text: regenerate ... elif
+ * not current_code: refuse") rather than requiring the prompt box to be
+ * non-empty unconditionally.
+ *
+ * Requirements field: local draft committed via data.onSetRequirements only
+ * on blur or Enter (never every keystroke) - the same local-field-commit
+ * discipline GitlinkNodeView's own Local Root field established, including
+ * its FIX 8 (Enter triggers `.blur()` only, never calls the commit function
+ * directly in the same handler - otherwise the onBlur handler that .blur()
+ * itself triggers would double-dispatch the WS intent for one keypress).
+ * Shift+Enter is additionally treated as a literal newline rather than a
+ * commit, since - unlike Local Root's single path string - a requirements
+ * manifest is naturally multi-line (one package per line).
+ *
+ * Live terminal: this is the one genuine capability asymmetry against
+ * Py-Coder, matching the backends' own real difference (not a frontend
+ * embellishment) - VirtualEnvSandbox's subprocess-based execution has a real
+ * line-emission hook (`emit_line`) its Py-Coder REPL-based counterpart has
+ * no equivalent for, so ONLY this node subscribes to transport's existing
+ * subscribeStream(requestId, listener) mechanism (already exercised by
+ * R4.4's own chat token streaming) for its own pendingRequestId while a run
+ * is in flight, falling back to the static data.codeSandboxOutput field once
+ * a run completes (pendingRequestId returns to null) or on initial mount
+ * with no run in flight. Rendered as plain preformatted text, NOT through
+ * the markdown pipeline - raw subprocess stdout/stderr is machine output,
+ * not prose or code-to-be-colorized, the same posture GitlinkNodeView's own
+ * Context tab takes for its machine-generated XML body ("rendered as plain
+ * preformatted text - never run through the markdown pipeline").
+ */
+
+export interface CodeSandboxNodeData extends Record<string, unknown> {
+  codeSandboxRequirements: string;
+  codeSandboxApprovalRequirements: string;
+  codeSandboxPrompt: string;
+  codeSandboxCode: string;
+  codeSandboxOutput: string;
+  codeSandboxAnalysis: string;
+  codeSandboxAwaitingApproval: boolean;
+  codeSandboxError: string;
+  isCollapsed: boolean;
+  pendingRequestId: string | null;
+  onSetRequirements: (requirementsText: string) => void;
+  onRun: (inputText: string) => void;
+  onCancel: () => void;
+  onApprove: () => void;
+  onDeny: () => void;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  subscribeStream: (requestId: string, listener: StreamListener) => () => void;
+}
+
+export type CodeSandboxFlowNode = Node<CodeSandboxNodeData, "code_sandbox">;
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+/** Same outside-click/Escape dismiss pattern every sibling node menu uses
+ * (ChatNodeMenu/ArtifactNodeMenu/GitlinkNodeMenu/PyCoderNodeMenu/...). */
+function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
+      // type-only import above shadows the bare name for casts like this).
+      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [menuRef, onClose]);
+}
+
+// -- card-level menu -------------------------------------------------------
+
+function CodeSandboxNodeMenu({
+  position,
+  isCollapsed,
+  onToggleCollapse,
+  onDelete,
+  onClose,
+}: {
+  position: MenuPosition;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useMenuDismiss(menuRef, onClose);
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleCollapse();
+          onClose();
+        }}
+      >
+        {isCollapsed ? "Expand" : "Collapse"}
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        Delete Node
+      </button>
+    </div>
+  );
+}
+
+// -- helpers ----------------------------------------------------------------
+
+function toPythonFence(code: string): string {
+  return "```python\n" + code + "\n```";
+}
+
+// -- view ----------------------------------------------------------------
+
+export function CodeSandboxNodeView({ id, data, selected }: NodeProps<CodeSandboxFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const collapsed = data.isCollapsed || lodCollapsed;
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+
+  // -- requirements: local draft, committed only on blur/Enter -------------
+  const [requirementsDraft, setRequirementsDraft] = useState(data.codeSandboxRequirements);
+
+  function commitRequirements() {
+    data.onSetRequirements(requirementsDraft.trim());
+  }
+
+  // -- prompt: single local draft, same one-shot-until-Run economy as ------
+  // PyCoderNodeView's own input (see module doc re: Run-enablement).
+  const [promptDraft, setPromptDraft] = useState(data.codeSandboxPrompt);
+
+  const busy = !!data.pendingRequestId;
+  const canRun = !!promptDraft.trim() || !!data.codeSandboxCode.trim();
+
+  function runNow() {
+    if (!canRun) return;
+    data.onRun(promptDraft.trim());
+  }
+
+  // -- live terminal: subscribes only while a run is genuinely in flight ---
+  // The buffer reset is adjusted directly during render (React's own
+  // documented "adjusting state when a prop changes" pattern) rather than as
+  // a synchronous setState call inside the effect below - it needs to happen
+  // the INSTANT pendingRequestId changes (so a brand-new run never shows the
+  // previous run's stale content even before its first delta arrives), which
+  // is a derived-state reset, not a reaction to the external stream itself.
+  // The effect below is left to do only what effects are for: synchronizing
+  // with the external transport (subscribing/unsubscribing), calling
+  // setState solely from within the async listener callback.
+  const [streamedOutput, setStreamedOutput] = useState("");
+  const [subscribedRequestId, setSubscribedRequestId] = useState(data.pendingRequestId);
+  if (data.pendingRequestId !== subscribedRequestId) {
+    setSubscribedRequestId(data.pendingRequestId);
+    setStreamedOutput("");
+  }
+
+  useEffect(() => {
+    const requestId = data.pendingRequestId;
+    if (!requestId) return;
+    const unsubscribe = data.subscribeStream(requestId, (delta, _done, reset) => {
+      setStreamedOutput((current) => (reset ? delta : current + delta));
+    });
+    return () => unsubscribe();
+    // data.subscribeStream is a fresh closure every render (see SceneCanvas's
+    // toFlowNodes) - depending on it would resubscribe on every unrelated
+    // re-render; data.pendingRequestId itself is the real re-subscribe key.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data.pendingRequestId]);
+
+  // -- approval --------------------------------------------------------------
+  // Same render-time-adjustment posture as the streamedOutput reset above -
+  // see PyCoderNodeView's own identical pattern for the full rationale.
+  const [approvalBusy, setApprovalBusy] = useState(false);
+  const [awaitingApprovalSeen, setAwaitingApprovalSeen] = useState(data.codeSandboxAwaitingApproval);
+  if (data.codeSandboxAwaitingApproval !== awaitingApprovalSeen) {
+    setAwaitingApprovalSeen(data.codeSandboxAwaitingApproval);
+    if (data.codeSandboxAwaitingApproval) setApprovalBusy(false);
+  }
+
+  function handleApprove() {
+    setApprovalBusy(true);
+    data.onApprove();
+  }
+
+  function handleDeny() {
+    setApprovalBusy(true);
+    data.onDeny();
+  }
+
+  return (
+    <div
+      className={`scene-node code-sandbox-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title chat-node-role">
+        <span>Execution Sandbox</span>
+        <button
+          type="button"
+          className="chat-node-collapse-btn"
+          aria-label={data.isCollapsed ? "Expand" : "Collapse"}
+          onClick={data.onToggleCollapse}
+        >
+          {data.isCollapsed ? "▸" : "▾"}
+        </button>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body code-sandbox-node-content">
+          <label className="code-sandbox-node-field-row">
+            <span className="code-sandbox-node-field-label">Requirements</span>
+            <textarea
+              className="code-sandbox-node-requirements"
+              value={requirementsDraft}
+              onChange={(event) => setRequirementsDraft(event.target.value)}
+              onBlur={commitRequirements}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  // Do NOT call commitRequirements() here too - .blur()
+                  // below synchronously fires the onBlur={commitRequirements}
+                  // handler above, so calling it directly here as well would
+                  // dispatch the WS intent twice per Enter press (mirrors
+                  // GitlinkNodeView's own FIX 8).
+                  (event.target as HTMLTextAreaElement).blur();
+                }
+              }}
+              placeholder={"numpy\npandas==2.2.0"}
+              aria-label="Requirements"
+              rows={2}
+              spellCheck={false}
+            />
+          </label>
+
+          <textarea
+            className="code-sandbox-node-input"
+            value={promptDraft}
+            onChange={(event) => setPromptDraft(event.target.value)}
+            placeholder="Describe what the code should do…"
+            aria-label="Prompt"
+            rows={3}
+            spellCheck
+          />
+
+          <div className="code-sandbox-node-run-row">
+            <button type="button" disabled={!canRun || busy} onClick={runNow}>
+              Run
+            </button>
+            {data.pendingRequestId && (
+              <button type="button" onClick={() => data.onCancel()} title="Cancel Execution Sandbox request">
+                Cancel
+              </button>
+            )}
+          </div>
+
+          {data.codeSandboxError && (
+            <div className="code-sandbox-node-banner-error" role="alert">
+              {data.codeSandboxError}
+            </div>
+          )}
+
+          {data.codeSandboxCode && (
+            <div className="code-sandbox-node-section">
+              <span className="code-sandbox-node-section-label">Code</span>
+              <div className="chat-node-content code-sandbox-node-code">
+                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                  {toPythonFence(data.codeSandboxCode)}
+                </ReactMarkdown>
+              </div>
+            </div>
+          )}
+
+          <div className="code-sandbox-node-section">
+            <span className="code-sandbox-node-section-label">Terminal</span>
+            {/* Plain preformatted text, never the markdown pipeline - see
+                module doc. While a run is in flight, shows live streamed
+                deltas; once it completes (pendingRequestId back to null),
+                falls back to the static, already-persisted
+                codeSandboxOutput field. */}
+            <pre className="code-sandbox-node-terminal">
+              {data.pendingRequestId
+                ? streamedOutput || "Waiting for output…"
+                : data.codeSandboxOutput || "No output yet."}
+            </pre>
+          </div>
+
+          {data.codeSandboxAnalysis && (
+            <div className="code-sandbox-node-section">
+              <span className="code-sandbox-node-section-label">Analysis</span>
+              <div className="chat-node-content code-sandbox-node-analysis">
+                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                  {data.codeSandboxAnalysis}
+                </ReactMarkdown>
+              </div>
+            </div>
+          )}
+
+          <CodeExecutionApprovalPanel
+            nodeId={id}
+            kind="code_sandbox"
+            code={data.codeSandboxCode}
+            awaitingApproval={data.codeSandboxAwaitingApproval}
+            // R5.4 CODESANDBOX fix: the approval panel must show the FROZEN
+            // manifest snapshot the pending approval actually refers to
+            // (codeSandboxApprovalRequirements), NOT the live, still-editable
+            // codeSandboxRequirements draft. The Requirements textarea above
+            // is never disabled during a run, so the user can keep typing a
+            // manifest for their NEXT run while this approval is still
+            // pending - reading the live field here would show that
+            // in-progress edit instead of what the paused run actually asked
+            // to install (backend/canvas.py freezes this at the moment
+            // code_sandbox_awaiting_approval flips true; see
+            // AgentDispatcher.start_code_sandbox_run).
+            requirements={data.codeSandboxApprovalRequirements}
+            busy={approvalBusy}
+            onApprove={handleApprove}
+            onDeny={handleDeny}
+          />
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+      {menuPosition && (
+        <CodeSandboxNodeMenu
+          position={menuPosition}
+          isCollapsed={data.isCollapsed}
+          onToggleCollapse={data.onToggleCollapse}
+          onDelete={data.onDelete}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/PyCoderNodeView.test.tsx
+++ b/web_ui/src/app/canvas/PyCoderNodeView.test.tsx
@@ -1,0 +1,341 @@
+import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { PyCoderNodeView, type PyCoderFlowNode } from "./PyCoderNodeView";
+
+// Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
+// ArtifactNodeView.test.tsx for why a bare ReactFlowProvider is enough here
+// too. NOT wrapped in OverlayProvider (unlike GitlinkNodeView.test.tsx) -
+// this view's <CodeExecutionApprovalPanel> is a small, self-contained modal
+// post-R5.4-fix-pass (see that component's own module doc for FIX A/FIX B),
+// not a <Dialog> from the R2.1 overlay system, so there is no provider
+// ancestor requirement here at all.
+
+function baseData(overrides: Partial<PyCoderFlowNode["data"]> = {}): PyCoderFlowNode["data"] {
+  return {
+    pycoderMode: "ai_driven",
+    pycoderPrompt: "",
+    pycoderCode: "",
+    pycoderOutput: "",
+    pycoderAnalysis: "",
+    pycoderLastRunFailed: false,
+    pycoderAwaitingApproval: false,
+    pycoderError: "",
+    isCollapsed: false,
+    pendingRequestId: null,
+    onSetMode: vi.fn(),
+    onRun: vi.fn(),
+    onCancel: vi.fn(),
+    onApprove: vi.fn(),
+    onDeny: vi.fn(),
+    onToggleCollapse: vi.fn(),
+    onDelete: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderPyCoderNode(overrides: Partial<PyCoderFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "pc-1", selected: false, data } as unknown as NodeProps<PyCoderFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <PyCoderNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return data;
+}
+
+// Directly sets the React Flow internal Zustand store's transform/zoom value
+// - same technique GitlinkNodeView.test.tsx/ArtifactNodeView.test.tsx's own
+// ZoomSetter uses.
+function ZoomSetter({ zoom }: { zoom: number }) {
+  const store = useStoreApi();
+  useEffect(() => {
+    store.setState({ transform: [0, 0, zoom] });
+  }, [zoom, store]);
+  return null;
+}
+
+function renderPyCoderNodeAtZoom(zoom: number, overrides: Partial<PyCoderFlowNode["data"]> = {}) {
+  const data = baseData(overrides);
+  const props = { id: "pc-1", selected: false, data } as unknown as NodeProps<PyCoderFlowNode>;
+
+  render(
+    <ReactFlowProvider>
+      <ZoomSetter zoom={zoom} />
+      <PyCoderNodeView {...props} />
+    </ReactFlowProvider>,
+  );
+  return data;
+}
+
+describe("PyCoderNodeView", () => {
+  // -- mode toggle --------------------------------------------------------
+
+  it("defaults to the Prompt textarea (ai_driven) and clicking Manual calls onSetMode", async () => {
+    const user = userEvent.setup();
+    const data = renderPyCoderNode();
+    expect(screen.getByRole("textbox", { name: "Prompt" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Manual" }));
+    expect(data.onSetMode).toHaveBeenCalledExactlyOnceWith("manual");
+  });
+
+  it("clicking AI-Driven calls onSetMode with ai_driven", async () => {
+    const user = userEvent.setup();
+    const data = renderPyCoderNode({ pycoderMode: "manual" });
+    await user.click(screen.getByRole("button", { name: "AI-Driven" }));
+    expect(data.onSetMode).toHaveBeenCalledExactlyOnceWith("ai_driven");
+  });
+
+  it("in manual mode, the input area is labeled Code instead of Prompt, and the Manual button shows active", () => {
+    renderPyCoderNode({ pycoderMode: "manual" });
+    expect(screen.getByRole("textbox", { name: "Code" })).toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "Prompt" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Manual" })).toHaveClass("active");
+    expect(screen.getByRole("button", { name: "AI-Driven" })).not.toHaveClass("active");
+  });
+
+  // -- single input economy: local until Run -------------------------------
+
+  it("typing does not call onRun; only clicking Run does, with the trimmed text", async () => {
+    const user = userEvent.setup();
+    const data = renderPyCoderNode();
+    const input = screen.getByRole("textbox", { name: "Prompt" });
+
+    await user.type(input, "  write a fibonacci function  ");
+    expect(data.onRun).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Run" }));
+    expect(data.onRun).toHaveBeenCalledExactlyOnceWith("write a fibonacci function");
+  });
+
+  it("Run is disabled while the input is empty or whitespace-only", async () => {
+    const user = userEvent.setup();
+    renderPyCoderNode();
+    const runButton = screen.getByRole("button", { name: "Run" });
+    expect(runButton).toBeDisabled();
+
+    await user.type(screen.getByRole("textbox", { name: "Prompt" }), "   ");
+    expect(runButton).toBeDisabled();
+  });
+
+  it("Run is disabled while pendingRequestId is set, even with non-empty input", async () => {
+    const user = userEvent.setup();
+    renderPyCoderNode({ pendingRequestId: "req-1" });
+    await user.type(screen.getByRole("textbox", { name: "Prompt" }), "hello");
+    expect(screen.getByRole("button", { name: "Run" })).toBeDisabled();
+  });
+
+  // -- Cancel ---------------------------------------------------------------
+
+  it("Cancel is absent when pendingRequestId is null, and present+wired when set", async () => {
+    const user = userEvent.setup();
+    expect(renderPyCoderNode({ pendingRequestId: null })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+
+    const data = renderPyCoderNode({ pendingRequestId: "req-1" });
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(data.onCancel).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  // -- error / failed-run indicators ----------------------------------------
+
+  it("shows the pycoderError banner when set", () => {
+    renderPyCoderNode({ pycoderError: "Please enter a prompt." });
+    expect(screen.getByRole("alert")).toHaveTextContent("Please enter a prompt.");
+  });
+
+  it("shows the last-run-failed badge only when pycoderLastRunFailed is true", () => {
+    renderPyCoderNode({ pycoderLastRunFailed: true });
+    expect(screen.getByText(/Last run failed/)).toBeInTheDocument();
+  });
+
+  it("does not show the failed badge when pycoderLastRunFailed is false", () => {
+    renderPyCoderNode({ pycoderLastRunFailed: false });
+    expect(screen.queryByText(/Last run failed/)).toBeNull();
+  });
+
+  // -- code/output/analysis panes + security -------------------------------
+
+  it("renders the code/output/analysis panes only when their fields are non-empty", () => {
+    renderPyCoderNode({ pycoderCode: "", pycoderOutput: "", pycoderAnalysis: "" });
+    expect(screen.queryByText("Code")).toBeNull();
+    expect(screen.queryByText("Output")).toBeNull();
+    expect(screen.queryByText("Analysis")).toBeNull();
+  });
+
+  it("renders code as a syntax-highlighted fenced block and output/analysis as markdown", () => {
+    renderPyCoderNode({
+      pycoderCode: "def add(a, b):\n    return a + b",
+      pycoderOutput: "3",
+      pycoderAnalysis: "This **adds** two numbers.",
+    });
+    expect(screen.getByText("Code")).toBeInTheDocument();
+    expect(document.querySelector("pre code")).not.toBeNull();
+    expect(screen.getByText("Output")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("Analysis")).toBeInTheDocument();
+    expect(screen.getByText("adds")).toBeInTheDocument();
+  });
+
+  it("SECURITY: analysis text containing a literal <img onerror> tag never becomes a real rendered img element", () => {
+    renderPyCoderNode({ pycoderAnalysis: '<img src="x" onerror="alert(1)"> as requested.' });
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  // -- approval panel ---------------------------------------------------------
+
+  it("renders the approval panel only when pycoderAwaitingApproval is true", () => {
+    renderPyCoderNode({ pycoderAwaitingApproval: false });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders the approval panel (with the pycoder-specific warning) when pycoderAwaitingApproval is true", () => {
+    renderPyCoderNode({ pycoderAwaitingApproval: true, pycoderCode: "print(1)" });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/there is no sandboxing/)).toBeInTheDocument();
+  });
+
+  it("Approve calls onApprove with no arguments", async () => {
+    const user = userEvent.setup();
+    const data = renderPyCoderNode({ pycoderAwaitingApproval: true, pycoderCode: "print(1)" });
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    expect(data.onApprove).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it("Deny calls onDeny with no arguments", () => {
+    // Separate render from Approve's own test above - both buttons share one
+    // busy flag that locks BOTH the instant either is clicked (see
+    // CodeExecutionApprovalPanel's own busy-gate doc), so exercising Approve
+    // and then Deny on the SAME mounted instance would find Deny disabled.
+    const data = renderPyCoderNode({ pycoderAwaitingApproval: true, pycoderCode: "print(1)" });
+    fireEvent.click(screen.getByRole("button", { name: "Deny" }));
+    expect(data.onDeny).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  // FIX B regression guard, at the real NodeView-integration level (not just
+  // the panel-unit level covered in CodeExecutionApprovalPanel.test.tsx):
+  // two different nodes awaiting approval simultaneously must both render
+  // and stay independently interactable - there is no shared overlays.open()
+  // slot left for a second node's mount to steal from the first anymore.
+  it("FIX B: two PyCoderNodeView instances both awaiting approval are independently visible and interactable", async () => {
+    const user = userEvent.setup();
+    const dataA = baseData({ pycoderAwaitingApproval: true, pycoderCode: "print('a')" });
+    const dataB = baseData({ pycoderAwaitingApproval: true, pycoderCode: "print('b')" });
+    const propsA = { id: "pc-a", selected: false, data: dataA } as unknown as NodeProps<PyCoderFlowNode>;
+    const propsB = { id: "pc-b", selected: false, data: dataB } as unknown as NodeProps<PyCoderFlowNode>;
+
+    render(
+      <ReactFlowProvider>
+        <PyCoderNodeView {...propsA} />
+        <PyCoderNodeView {...propsB} />
+      </ReactFlowProvider>,
+    );
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(2);
+
+    const approveButtons = screen.getAllByRole("button", { name: "Approve" });
+    expect(approveButtons).toHaveLength(2);
+    await user.click(approveButtons[0]);
+    expect(dataA.onApprove).toHaveBeenCalledExactlyOnceWith();
+    expect(dataB.onApprove).not.toHaveBeenCalled();
+
+    // Both panels remain mounted - node B's own dialog was never stolen or
+    // hidden by node A's mount/interaction.
+    expect(screen.getAllByRole("dialog")).toHaveLength(2);
+    const denyButtons = screen.getAllByRole("button", { name: "Deny" });
+    await user.click(denyButtons[1]);
+    expect(dataB.onDeny).toHaveBeenCalledExactlyOnceWith();
+    expect(dataA.onDeny).not.toHaveBeenCalled();
+  });
+
+  // -- no streaming here (unlike CodeSandboxNodeView) -----------------------
+  // PyCoderNodeData has no subscribeStream field at all in its type, so there
+  // is no plumbing FOR this component to call in the first place - but as a
+  // defense-in-depth runtime check, a spy attached under the same property
+  // name (bypassing the type) is asserted never called across a full mount +
+  // mode-toggle + type + Run + Cancel interaction sequence.
+  it("never calls a subscribeStream-shaped prop, even if one were present on the data object", async () => {
+    const user = userEvent.setup();
+    const subscribeStreamSpy = vi.fn();
+    const data = renderPyCoderNode({
+      pendingRequestId: "req-1",
+      ...( { subscribeStream: subscribeStreamSpy } as unknown as Partial<PyCoderFlowNode["data"]> ),
+    });
+    await user.click(screen.getByRole("button", { name: "Manual" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(subscribeStreamSpy).not.toHaveBeenCalled();
+    expect(data.onCancel).toHaveBeenCalled();
+  });
+
+  // -- collapse/expand + LOD -------------------------------------------------
+
+  it("manual collapse hides the body and shows only the header", () => {
+    renderPyCoderNode({ isCollapsed: true });
+    expect(screen.getByText("Py-Coder")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Run" })).toBeNull();
+  });
+
+  it("the inline collapse chevron calls onToggleCollapse", async () => {
+    const user = userEvent.setup();
+    const data = renderPyCoderNode();
+    await user.click(screen.getByRole("button", { name: "Collapse" }));
+    expect(data.onToggleCollapse).toHaveBeenCalledOnce();
+  });
+
+  it("LOD auto-collapse (zoom below threshold) also hides the body, even when isCollapsed is false", () => {
+    renderPyCoderNodeAtZoom(0.2, { isCollapsed: false });
+    expect(screen.getByText("Py-Coder")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Run" })).toBeNull();
+  });
+
+  it("stays expanded above the LOD threshold when isCollapsed is false", () => {
+    renderPyCoderNodeAtZoom(1, { isCollapsed: false });
+    expect(screen.getByRole("button", { name: "Run" })).toBeInTheDocument();
+  });
+
+  // -- card-level menu ----------------------------------------------------
+
+  it("the node-level right-click menu shows exactly Collapse/Expand + Delete Node - no dock action", async () => {
+    const user = userEvent.setup();
+    const data = renderPyCoderNode();
+
+    fireEvent.contextMenu(screen.getByText("Py-Coder"));
+    const menu = screen.getByRole("menu");
+    expect(menu).toBeInTheDocument();
+
+    const items = screen.getAllByRole("menuitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("Collapse");
+    expect(items[1]).toHaveTextContent("Delete Node");
+    expect(screen.queryByRole("menuitem", { name: /Dock/ })).toBeNull();
+
+    await user.click(items[0]);
+    expect(data.onToggleCollapse).toHaveBeenCalledOnce();
+
+    fireEvent.contextMenu(screen.getByText("Py-Coder"));
+    await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
+    expect(data.onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Escape and outside-click both close the node-level menu", async () => {
+    const user = userEvent.setup();
+    renderPyCoderNode();
+    const header = screen.getByText("Py-Coder");
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(header);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/web_ui/src/app/canvas/PyCoderNodeView.tsx
+++ b/web_ui/src/app/canvas/PyCoderNodeView.tsx
@@ -1,0 +1,338 @@
+import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { CodeExecutionApprovalPanel } from "./CodeExecutionApprovalPanel";
+
+/**
+ * The Py-Coder node (Qt-removal plan R5.4) - the Py-Coder plugin's React
+ * card. Same overall shell as every plugin-node sibling (ArtifactNodeView/
+ * GitlinkNodeView): collapse/expand OR-ed with LOD, a card menu with
+ * outside-click/Escape dismiss, the shared react-markdown + remarkGfm +
+ * rehypeHighlight pipeline, no dock-to-parent action.
+ *
+ * Mode + single input economy: the AI-driven/Manual toggle commits
+ * IMMEDIATELY on click via data.onSetMode (backend/canvas.py registers a
+ * dedicated setPyCoderMode intent for it, unlike scope_mode on the Gitlink
+ * node, which has no such intent and only ever rides along a later call) -
+ * but the actual prompt-or-code text lives in ONE local textarea, held in
+ * component state until Run is clicked, then passed directly as
+ * data.onRun(inputText)'s argument. This mirrors Artifact's/Gitlink's own
+ * "instruction input is a local draft, never separately mirrored via its own
+ * setter intent" economy - backend/canvas.py's start_pycoder_run docstring
+ * confirms the SAME input_text lands in pycoder_prompt or pycoder_code
+ * purely depending on the CURRENT server-side mode at dispatch time, so this
+ * view does not need two separate draft fields for the two modes. The draft
+ * is seeded ONCE from whichever field the initial mode reads (never
+ * re-synced afterward - same non-clobbering posture GitlinkNodeView's own
+ * Setup-tab fields document) and is NOT cleared after Run, since (unlike
+ * Artifact's one-shot chat instruction) a Py-Coder prompt/code is something
+ * you commonly re-run with small tweaks - the same posture Gitlink's own
+ * task-prompt field takes for Generate Change Set.
+ *
+ * Approval: manual mode is deliberately ungated server-side (per backend/
+ * agents.py's own docstring: "clicking Run *is* the approval" when the user
+ * authored the code themselves) - so pycoderAwaitingApproval simply never
+ * becomes true in manual mode. This view has no mode-specific conditional
+ * for that; it just renders <CodeExecutionApprovalPanel> whenever the flag
+ * is true, exactly like every other data-driven condition here.
+ *
+ * No live-streaming pane here, unlike CodeSandboxNodeView's terminal - the
+ * Py-Coder REPL has no equivalent server-side emit mechanism (see
+ * CodeSandboxNodeView's own module doc for the real asymmetry this reflects,
+ * not an oversight in this file).
+ */
+
+export interface PyCoderNodeData extends Record<string, unknown> {
+  pycoderMode: string; // "ai_driven" | "manual"
+  pycoderPrompt: string;
+  pycoderCode: string;
+  pycoderOutput: string;
+  pycoderAnalysis: string;
+  pycoderLastRunFailed: boolean;
+  pycoderAwaitingApproval: boolean;
+  pycoderError: string;
+  isCollapsed: boolean;
+  pendingRequestId: string | null;
+  onSetMode: (mode: string) => void;
+  onRun: (inputText: string) => void;
+  onCancel: () => void;
+  onApprove: () => void;
+  onDeny: () => void;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+}
+
+export type PyCoderFlowNode = Node<PyCoderNodeData, "pycoder">;
+
+interface MenuPosition {
+  x: number;
+  y: number;
+}
+
+/** Same outside-click/Escape dismiss pattern every sibling node menu uses
+ * (ChatNodeMenu/ArtifactNodeMenu/GitlinkNodeMenu/...). */
+function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent) {
+      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
+      // type-only import above shadows the bare name for casts like this).
+      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [menuRef, onClose]);
+}
+
+// -- card-level menu -------------------------------------------------------
+
+function PyCoderNodeMenu({
+  position,
+  isCollapsed,
+  onToggleCollapse,
+  onDelete,
+  onClose,
+}: {
+  position: MenuPosition;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  useMenuDismiss(menuRef, onClose);
+
+  return (
+    <div
+      ref={menuRef}
+      className="chat-node-menu"
+      style={{ position: "fixed", left: position.x, top: position.y }}
+      role="menu"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleCollapse();
+          onClose();
+        }}
+      >
+        {isCollapsed ? "Expand" : "Collapse"}
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="chat-node-menu-danger"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        Delete Node
+      </button>
+    </div>
+  );
+}
+
+// -- helpers ----------------------------------------------------------------
+
+/** Wraps raw text in an untagged markdown fenced code block so ReactMarkdown
+ * can render it as inert, monospaced text with zero syntax-highlighting
+ * guesswork - used for the Output pane (arbitrary program stdout/stderr is
+ * not Python source, so it is deliberately NOT tagged ```python the way the
+ * Code pane below is). */
+function toPlainFence(text: string): string {
+  return "```\n" + text + "\n```";
+}
+
+function toPythonFence(code: string): string {
+  return "```python\n" + code + "\n```";
+}
+
+// -- view ----------------------------------------------------------------
+
+export function PyCoderNodeView({ id, data, selected }: NodeProps<PyCoderFlowNode>) {
+  const zoom = useStore((s) => s.transform[2]);
+  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+  const collapsed = data.isCollapsed || lodCollapsed;
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+  const isManual = data.pycoderMode === "manual";
+
+  // Single local draft, seeded ONCE from whichever field the initial mode
+  // reads and never re-synced afterward (see module doc) - meaning switching
+  // modes mid-type does not swap or clear whatever is currently in the box,
+  // by design (there is exactly one input area here, not two).
+  const [inputDraft, setInputDraft] = useState(isManual ? data.pycoderCode : data.pycoderPrompt);
+
+  const busy = !!data.pendingRequestId;
+
+  function runNow() {
+    const text = inputDraft.trim();
+    if (!text) return;
+    data.onRun(text);
+  }
+
+  // Disables Approve/Deny for the brief window between a click and the next
+  // scene snapshot reflecting it (preventing a double-fire) - reset the
+  // instant a FRESH approval request starts (awaitingApproval flipping to
+  // true again means a new, unrelated approval cycle). Adjusted directly
+  // during render rather than via a useEffect + setState (React's own
+  // documented "adjusting state when a prop changes" pattern) - this is a
+  // derived reset keyed on a prop transition, not a subscription to an
+  // external system, so doing it here avoids an extra
+  // render-then-effect-then-render round trip.
+  const [approvalBusy, setApprovalBusy] = useState(false);
+  const [awaitingApprovalSeen, setAwaitingApprovalSeen] = useState(data.pycoderAwaitingApproval);
+  if (data.pycoderAwaitingApproval !== awaitingApprovalSeen) {
+    setAwaitingApprovalSeen(data.pycoderAwaitingApproval);
+    if (data.pycoderAwaitingApproval) setApprovalBusy(false);
+  }
+
+  function handleApprove() {
+    setApprovalBusy(true);
+    data.onApprove();
+  }
+
+  function handleDeny() {
+    setApprovalBusy(true);
+    data.onDeny();
+  }
+
+  return (
+    <div
+      className={`scene-node pycoder-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        setMenuPosition({ x: event.clientX, y: event.clientY });
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="scene-node-handle" />
+      <div className="scene-node-title chat-node-role">
+        <span>Py-Coder</span>
+        <button
+          type="button"
+          className="chat-node-collapse-btn"
+          aria-label={data.isCollapsed ? "Expand" : "Collapse"}
+          onClick={data.onToggleCollapse}
+        >
+          {data.isCollapsed ? "▸" : "▾"}
+        </button>
+      </div>
+      {!collapsed && (
+        <div className="scene-node-body pycoder-node-content">
+          <div className="pycoder-node-mode-toggle" role="group" aria-label="Mode">
+            <button
+              type="button"
+              aria-pressed={!isManual}
+              className={`pycoder-node-mode-btn${!isManual ? " active" : ""}`}
+              onClick={() => data.onSetMode("ai_driven")}
+            >
+              AI-Driven
+            </button>
+            <button
+              type="button"
+              aria-pressed={isManual}
+              className={`pycoder-node-mode-btn${isManual ? " active" : ""}`}
+              onClick={() => data.onSetMode("manual")}
+            >
+              Manual
+            </button>
+          </div>
+
+          <textarea
+            className="pycoder-node-input"
+            value={inputDraft}
+            onChange={(event) => setInputDraft(event.target.value)}
+            placeholder={isManual ? "Write Python code…" : "Describe what the code should do…"}
+            aria-label={isManual ? "Code" : "Prompt"}
+            rows={4}
+            spellCheck={!isManual}
+          />
+
+          <div className="pycoder-node-run-row">
+            <button type="button" disabled={!inputDraft.trim() || busy} onClick={runNow}>
+              Run
+            </button>
+            {data.pendingRequestId && (
+              <button type="button" onClick={() => data.onCancel()} title="Cancel Py-Coder request">
+                Cancel
+              </button>
+            )}
+          </div>
+
+          {data.pycoderError && (
+            <div className="pycoder-node-banner-error" role="alert">
+              {data.pycoderError}
+            </div>
+          )}
+
+          {data.pycoderLastRunFailed && (
+            <p className="pycoder-node-failed-badge">Last run failed - result may still be repaired code.</p>
+          )}
+
+          {data.pycoderCode && (
+            <div className="pycoder-node-section">
+              <span className="pycoder-node-section-label">Code</span>
+              <div className="chat-node-content pycoder-node-code">
+                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                  {toPythonFence(data.pycoderCode)}
+                </ReactMarkdown>
+              </div>
+            </div>
+          )}
+
+          {data.pycoderOutput && (
+            <div className="pycoder-node-section">
+              <span className="pycoder-node-section-label">Output</span>
+              <div className="chat-node-content pycoder-node-output">
+                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                  {toPlainFence(data.pycoderOutput)}
+                </ReactMarkdown>
+              </div>
+            </div>
+          )}
+
+          {data.pycoderAnalysis && (
+            <div className="pycoder-node-section">
+              <span className="pycoder-node-section-label">Analysis</span>
+              <div className="chat-node-content pycoder-node-analysis">
+                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                  {data.pycoderAnalysis}
+                </ReactMarkdown>
+              </div>
+            </div>
+          )}
+
+          <CodeExecutionApprovalPanel
+            nodeId={id}
+            kind="pycoder"
+            code={data.pycoderCode}
+            awaitingApproval={data.pycoderAwaitingApproval}
+            busy={approvalBusy}
+            onApprove={handleApprove}
+            onDeny={handleDeny}
+          />
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
+      {menuPosition && (
+        <PyCoderNodeMenu
+          position={menuPosition}
+          isCollapsed={data.isCollapsed}
+          onToggleCollapse={data.onToggleCollapse}
+          onDelete={data.onDelete}
+          onClose={() => setMenuPosition(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -59,6 +59,22 @@ function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
     gitlinkChangeFingerprint: null,
     gitlinkChangeState: "",
     gitlinkError: "",
+    pycoderMode: "ai_driven",
+    pycoderPrompt: "",
+    pycoderCode: "",
+    pycoderOutput: "",
+    pycoderAnalysis: "",
+    pycoderLastRunFailed: false,
+    pycoderAwaitingApproval: false,
+    pycoderError: "",
+    codeSandboxRequirements: "",
+    codeSandboxApprovalRequirements: "",
+    codeSandboxPrompt: "",
+    codeSandboxCode: "",
+    codeSandboxOutput: "",
+    codeSandboxAnalysis: "",
+    codeSandboxAwaitingApproval: false,
+    codeSandboxError: "",
     ...overrides,
   };
 }
@@ -566,6 +582,313 @@ describe("toFlowNodes (R5.3 gitlink node)", () => {
 
     (glFlowNode!.data as { onDelete: () => void }).onDelete();
     expect(removeSpy).toHaveBeenCalledWith(["gl-1"]);
+  });
+});
+
+describe("toFlowNodes (R5.4 pycoder node)", () => {
+  it("maps a pycoder scene node's all 8 new fields onto the flow node's data", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({
+          id: "pc-1",
+          kind: "pycoder",
+          isCollapsed: true,
+          pendingRequestId: "req-1",
+          pycoderMode: "manual",
+          pycoderPrompt: "write a fibonacci function",
+          pycoderCode: "def fib(n): ...",
+          pycoderOutput: "[1, 1, 2, 3]",
+          pycoderAnalysis: "Computes Fibonacci numbers.",
+          pycoderLastRunFailed: true,
+          pycoderAwaitingApproval: true,
+          pycoderError: "previous run timed out",
+        }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const pcFlowNode = flowNodes.find((n) => n.id === "pc-1");
+    expect(pcFlowNode).toBeDefined();
+    expect(pcFlowNode!.type).toBe("pycoder");
+    expect(pcFlowNode!.data).toMatchObject({
+      pycoderMode: "manual",
+      pycoderPrompt: "write a fibonacci function",
+      pycoderCode: "def fib(n): ...",
+      pycoderOutput: "[1, 1, 2, 3]",
+      pycoderAnalysis: "Computes Fibonacci numbers.",
+      pycoderLastRunFailed: true,
+      pycoderAwaitingApproval: true,
+      pycoderError: "previous run timed out",
+      isCollapsed: true,
+      pendingRequestId: "req-1",
+    });
+  });
+
+  it("coalesces a null-ish pendingRequestId to null", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "pc-2", kind: "pycoder" })],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const pcFlowNode = flowNodes.find((n) => n.id === "pc-2");
+    expect(pcFlowNode).toBeDefined();
+    expect(pcFlowNode!.data).toMatchObject({ pendingRequestId: null });
+  });
+
+  it("onSetMode/onRun resolve to this node's id", () => {
+    const scene = baseScene({ nodes: [baseNode({ id: "pc-1", kind: "pycoder" })], edges: [] });
+    const store = makeStore();
+    const setModeSpy = vi.spyOn(store, "setPyCoderMode");
+    const runSpy = vi.spyOn(store, "runPyCoder");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const pcFlowNode = flowNodes.find((n) => n.id === "pc-1");
+    const data = pcFlowNode!.data as unknown as {
+      onSetMode: (mode: string) => void;
+      onRun: (inputText: string) => void;
+    };
+
+    data.onSetMode("manual");
+    expect(setModeSpy).toHaveBeenCalledWith("pc-1", "manual");
+    data.onRun("print('hi')");
+    expect(runSpy).toHaveBeenCalledWith("pc-1", "print('hi')");
+  });
+
+  it("onCancel fires cancelPyCoderRequest with pendingRequestId when set, and is a no-op otherwise", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "pc-pending", kind: "pycoder", pendingRequestId: "req-77" }),
+        baseNode({ id: "pc-idle", kind: "pycoder", pendingRequestId: null }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "cancelPyCoderRequest");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const pendingNode = flowNodes.find((n) => n.id === "pc-pending");
+    const idleNode = flowNodes.find((n) => n.id === "pc-idle");
+
+    (pendingNode!.data as { onCancel: () => void }).onCancel();
+    expect(intentSpy).toHaveBeenCalledWith("req-77");
+
+    (idleNode!.data as { onCancel: () => void }).onCancel();
+    expect(intentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("onApprove/onDeny always resolve to the CURRENT scene snapshot's own pendingRequestId, never a UI-supplied id, and are no-ops when it is null", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "pc-pending", kind: "pycoder", pendingRequestId: "req-approve-1" }),
+        baseNode({ id: "pc-idle", kind: "pycoder", pendingRequestId: null }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+    const approveSpy = vi.spyOn(store, "approveCodeExecution");
+    const denySpy = vi.spyOn(store, "denyCodeExecution");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const pendingNode = flowNodes.find((n) => n.id === "pc-pending");
+    const idleNode = flowNodes.find((n) => n.id === "pc-idle");
+    const pendingData = pendingNode!.data as unknown as { onApprove: () => void; onDeny: () => void };
+    const idleData = idleNode!.data as unknown as { onApprove: () => void; onDeny: () => void };
+
+    pendingData.onApprove();
+    expect(approveSpy).toHaveBeenCalledWith("req-approve-1");
+    pendingData.onDeny();
+    expect(denySpy).toHaveBeenCalledWith("req-approve-1");
+
+    idleData.onApprove();
+    idleData.onDeny();
+    expect(approveSpy).toHaveBeenCalledTimes(1);
+    expect(denySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("onToggleCollapse/onDelete reuse the generic setChatCollapsed/removeNodes intents", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "pc-1", kind: "pycoder", isCollapsed: false })],
+      edges: [],
+    });
+    const store = makeStore();
+    const collapseSpy = vi.spyOn(store, "setChatCollapsed");
+    const removeSpy = vi.spyOn(store, "removeNodes");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const pcFlowNode = flowNodes.find((n) => n.id === "pc-1");
+
+    (pcFlowNode!.data as { onToggleCollapse: () => void }).onToggleCollapse();
+    expect(collapseSpy).toHaveBeenCalledWith("pc-1", true);
+
+    (pcFlowNode!.data as { onDelete: () => void }).onDelete();
+    expect(removeSpy).toHaveBeenCalledWith(["pc-1"]);
+  });
+});
+
+describe("toFlowNodes (R5.4 code_sandbox node)", () => {
+  it("maps a code_sandbox scene node's all 7 new fields onto the flow node's data", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({
+          id: "cs-1",
+          kind: "code_sandbox",
+          isCollapsed: true,
+          pendingRequestId: "req-1",
+          codeSandboxRequirements: "numpy\npandas",
+          codeSandboxPrompt: "plot a sine wave",
+          codeSandboxCode: "import numpy as np\n...",
+          codeSandboxOutput: "[plot saved]",
+          codeSandboxAnalysis: "Generates and saves a sine wave plot.",
+          codeSandboxAwaitingApproval: true,
+          codeSandboxError: "previous run timed out",
+        }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const csFlowNode = flowNodes.find((n) => n.id === "cs-1");
+    expect(csFlowNode).toBeDefined();
+    expect(csFlowNode!.type).toBe("code_sandbox");
+    expect(csFlowNode!.data).toMatchObject({
+      codeSandboxRequirements: "numpy\npandas",
+      codeSandboxPrompt: "plot a sine wave",
+      codeSandboxCode: "import numpy as np\n...",
+      codeSandboxOutput: "[plot saved]",
+      codeSandboxAnalysis: "Generates and saves a sine wave plot.",
+      codeSandboxAwaitingApproval: true,
+      codeSandboxError: "previous run timed out",
+      isCollapsed: true,
+      pendingRequestId: "req-1",
+    });
+    // code_sandbox_sandbox_id is pure internal server bookkeeping - it is not
+    // part of SceneNodeRow at all, so this mapping never references it.
+    expect("codeSandboxSandboxId" in (csFlowNode!.data as Record<string, unknown>)).toBe(false);
+  });
+
+  it("coalesces a null-ish pendingRequestId to null", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "cs-2", kind: "code_sandbox" })],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const csFlowNode = flowNodes.find((n) => n.id === "cs-2");
+    expect(csFlowNode).toBeDefined();
+    expect(csFlowNode!.data).toMatchObject({ pendingRequestId: null });
+  });
+
+  it("onSetRequirements/onRun resolve to this node's id", () => {
+    const scene = baseScene({ nodes: [baseNode({ id: "cs-1", kind: "code_sandbox" })], edges: [] });
+    const store = makeStore();
+    const setReqSpy = vi.spyOn(store, "setCodeSandboxRequirements");
+    const runSpy = vi.spyOn(store, "runCodeSandbox");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const csFlowNode = flowNodes.find((n) => n.id === "cs-1");
+    const data = csFlowNode!.data as unknown as {
+      onSetRequirements: (requirementsText: string) => void;
+      onRun: (inputText: string) => void;
+    };
+
+    data.onSetRequirements("numpy==1.24");
+    expect(setReqSpy).toHaveBeenCalledWith("cs-1", "numpy==1.24");
+    data.onRun("plot a sine wave");
+    expect(runSpy).toHaveBeenCalledWith("cs-1", "plot a sine wave");
+  });
+
+  it("onCancel fires cancelCodeSandboxRequest with pendingRequestId when set, and is a no-op otherwise", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "cs-pending", kind: "code_sandbox", pendingRequestId: "req-77" }),
+        baseNode({ id: "cs-idle", kind: "code_sandbox", pendingRequestId: null }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+    const intentSpy = vi.spyOn(store, "cancelCodeSandboxRequest");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const pendingNode = flowNodes.find((n) => n.id === "cs-pending");
+    const idleNode = flowNodes.find((n) => n.id === "cs-idle");
+
+    (pendingNode!.data as { onCancel: () => void }).onCancel();
+    expect(intentSpy).toHaveBeenCalledWith("req-77");
+
+    (idleNode!.data as { onCancel: () => void }).onCancel();
+    expect(intentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("onApprove/onDeny always resolve to the CURRENT scene snapshot's own pendingRequestId, never a UI-supplied id, and are no-ops when it is null", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "cs-pending", kind: "code_sandbox", pendingRequestId: "req-approve-2" }),
+        baseNode({ id: "cs-idle", kind: "code_sandbox", pendingRequestId: null }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+    const approveSpy = vi.spyOn(store, "approveCodeExecution");
+    const denySpy = vi.spyOn(store, "denyCodeExecution");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const pendingNode = flowNodes.find((n) => n.id === "cs-pending");
+    const idleNode = flowNodes.find((n) => n.id === "cs-idle");
+    const pendingData = pendingNode!.data as unknown as { onApprove: () => void; onDeny: () => void };
+    const idleData = idleNode!.data as unknown as { onApprove: () => void; onDeny: () => void };
+
+    pendingData.onApprove();
+    expect(approveSpy).toHaveBeenCalledWith("req-approve-2");
+    pendingData.onDeny();
+    expect(denySpy).toHaveBeenCalledWith("req-approve-2");
+
+    idleData.onApprove();
+    idleData.onDeny();
+    expect(approveSpy).toHaveBeenCalledTimes(1);
+    expect(denySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("subscribeStream forwards directly to store.subscribeStream (generic transport passthrough, no scene-specific plumbing)", () => {
+    const scene = baseScene({ nodes: [baseNode({ id: "cs-1", kind: "code_sandbox" })], edges: [] });
+    const store = makeStore();
+    const unsubscribe = vi.fn();
+    const subscribeSpy = vi.spyOn(store, "subscribeStream").mockReturnValue(unsubscribe);
+
+    const flowNodes = toFlowNodes(scene, store);
+    const csFlowNode = flowNodes.find((n) => n.id === "cs-1");
+    const data = csFlowNode!.data as unknown as {
+      subscribeStream: (requestId: string, listener: (...args: unknown[]) => void) => () => void;
+    };
+    const listener = vi.fn();
+
+    const result = data.subscribeStream("req-1", listener);
+    expect(subscribeSpy).toHaveBeenCalledWith("req-1", listener);
+    expect(result).toBe(unsubscribe);
+  });
+
+  it("onToggleCollapse/onDelete reuse the generic setChatCollapsed/removeNodes intents", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "cs-1", kind: "code_sandbox", isCollapsed: false })],
+      edges: [],
+    });
+    const store = makeStore();
+    const collapseSpy = vi.spyOn(store, "setChatCollapsed");
+    const removeSpy = vi.spyOn(store, "removeNodes");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const csFlowNode = flowNodes.find((n) => n.id === "cs-1");
+
+    (csFlowNode!.data as { onToggleCollapse: () => void }).onToggleCollapse();
+    expect(collapseSpy).toHaveBeenCalledWith("cs-1", true);
+
+    (csFlowNode!.data as { onDelete: () => void }).onDelete();
+    expect(removeSpy).toHaveBeenCalledWith(["cs-1"]);
   });
 });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -17,14 +17,17 @@ import {
 import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
+import type { StreamListener } from "../../lib/ws/transport";
 import { ArtifactNodeView, type ArtifactFlowNode } from "./ArtifactNodeView";
 import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
 import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
+import { CodeSandboxNodeView, type CodeSandboxFlowNode } from "./CodeSandboxNodeView";
 import { ConversationNodeView, type ConversationFlowNode } from "./ConversationNodeView";
 import { DocumentNodeView, type DocumentFlowNode } from "./DocumentNodeView";
 import { GitlinkNodeView, type GitlinkFlowNode } from "./GitlinkNodeView";
 import { HtmlNodeView, type HtmlFlowNode } from "./HtmlNodeView";
 import { ImageNodeView, type ImageFlowNode } from "./ImageNodeView";
+import { PyCoderNodeView, type PyCoderFlowNode } from "./PyCoderNodeView";
 import { ThinkingNodeView, type ThinkingFlowNode } from "./ThinkingNodeView";
 import { WebResearchNodeView, type WebResearchFlowNode } from "./WebResearchNodeView";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
@@ -57,7 +60,9 @@ type SceneFlowNode =
   | ConversationFlowNode
   | WebResearchFlowNode
   | ArtifactFlowNode
-  | GitlinkFlowNode;
+  | GitlinkFlowNode
+  | PyCoderFlowNode
+  | CodeSandboxFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
   const zoom = useStore((s) => s.transform[2]);
@@ -87,6 +92,8 @@ const NODE_TYPES = {
   web_research: WebResearchNodeView,
   artifact: ArtifactNodeView,
   gitlink: GitlinkNodeView,
+  pycoder: PyCoderNodeView,
+  code_sandbox: CodeSandboxNodeView,
 };
 
 // Exported standalone for direct unit testing (same posture as
@@ -406,6 +413,105 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
             if (n.pendingRequestId) store.cancelGitlinkRequest(n.pendingRequestId);
           },
           onApply: (fingerprint: string) => store.applyGitlinkChanges(n.id, fingerprint),
+        },
+      });
+      continue;
+    }
+    if (n.kind === "pycoder") {
+      // No onDock here either (same reasoning as every non-dockable R5
+      // plugin-node branch above) - PyCoderNodeView never offers a
+      // dock-into-parent action; the generic `if (n.isDocked) continue`
+      // guard above still covers it correctly if it were ever docked via a
+      // direct WS call.
+      flowNodes.push({
+        id: n.id,
+        type: "pycoder" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          pycoderMode: n.pycoderMode,
+          pycoderPrompt: n.pycoderPrompt,
+          pycoderCode: n.pycoderCode,
+          pycoderOutput: n.pycoderOutput,
+          pycoderAnalysis: n.pycoderAnalysis,
+          pycoderLastRunFailed: n.pycoderLastRunFailed,
+          pycoderAwaitingApproval: n.pycoderAwaitingApproval,
+          pycoderError: n.pycoderError,
+          isCollapsed: n.isCollapsed,
+          pendingRequestId: n.pendingRequestId ?? null,
+          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
+          onDelete: () => store.removeNodes([n.id]),
+          onSetMode: (mode: string) => store.setPyCoderMode(n.id, mode),
+          onRun: (inputText: string) => store.runPyCoder(n.id, inputText),
+          // Same null-guard pattern as every other plugin node's own
+          // analogous cancel call site above - only fire the intent if there
+          // is genuinely a non-null request id to target.
+          onCancel: () => {
+            if (n.pendingRequestId) store.cancelPyCoderRequest(n.pendingRequestId);
+          },
+          // CRITICAL (see CodeExecutionApprovalPanel.tsx's own module doc):
+          // these read n.pendingRequestId - the CURRENT scene snapshot's own
+          // value for THIS node - never anything the UI layer could supply
+          // as a distinct argument. Same null-guard posture as onCancel
+          // above; approveCodeExecution/denyCodeExecution both require a
+          // non-null string.
+          onApprove: () => {
+            if (n.pendingRequestId) store.approveCodeExecution(n.pendingRequestId);
+          },
+          onDeny: () => {
+            if (n.pendingRequestId) store.denyCodeExecution(n.pendingRequestId);
+          },
+        },
+      });
+      continue;
+    }
+    if (n.kind === "code_sandbox") {
+      // No onDock here either (same reasoning as every non-dockable R5
+      // plugin-node branch above) - CodeSandboxNodeView never offers a
+      // dock-into-parent action; the generic `if (n.isDocked) continue`
+      // guard above still covers it correctly if it were ever docked via a
+      // direct WS call. code_sandbox_sandbox_id is deliberately absent below
+      // - it is pure internal server bookkeeping (a sandbox directory name),
+      // never part of the scene wire payload at all (see scene-state.ts) and
+      // never read/forwarded anywhere in this mapping.
+      flowNodes.push({
+        id: n.id,
+        type: "code_sandbox" as const,
+        position: { x: n.x, y: n.y },
+        data: {
+          codeSandboxRequirements: n.codeSandboxRequirements,
+          codeSandboxApprovalRequirements: n.codeSandboxApprovalRequirements,
+          codeSandboxPrompt: n.codeSandboxPrompt,
+          codeSandboxCode: n.codeSandboxCode,
+          codeSandboxOutput: n.codeSandboxOutput,
+          codeSandboxAnalysis: n.codeSandboxAnalysis,
+          codeSandboxAwaitingApproval: n.codeSandboxAwaitingApproval,
+          codeSandboxError: n.codeSandboxError,
+          isCollapsed: n.isCollapsed,
+          pendingRequestId: n.pendingRequestId ?? null,
+          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
+          onDelete: () => store.removeNodes([n.id]),
+          onSetRequirements: (requirementsText: string) =>
+            store.setCodeSandboxRequirements(n.id, requirementsText),
+          onRun: (inputText: string) => store.runCodeSandbox(n.id, inputText),
+          onCancel: () => {
+            if (n.pendingRequestId) store.cancelCodeSandboxRequest(n.pendingRequestId);
+          },
+          // CRITICAL - same posture as the pycoder branch's own
+          // onApprove/onDeny above: always n.pendingRequestId, never a
+          // UI-supplied argument.
+          onApprove: () => {
+            if (n.pendingRequestId) store.approveCodeExecution(n.pendingRequestId);
+          },
+          onDeny: () => {
+            if (n.pendingRequestId) store.denyCodeExecution(n.pendingRequestId);
+          },
+          // Generic passthrough to the transport's own stream fan-out (see
+          // sceneStore.ts's own subscribeStream doc) - the live terminal
+          // pane keys its subscription off data.pendingRequestId itself,
+          // this closure only needs to exist so the component never touches
+          // the store/transport directly.
+          subscribeStream: (requestId: string, listener: StreamListener) =>
+            store.subscribeStream(requestId, listener),
         },
       });
       continue;

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -75,6 +75,22 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         gitlinkPreviewText: "",
         gitlinkChangeState: "",
         gitlinkError: "",
+        pycoderMode: "ai_driven",
+        pycoderPrompt: "",
+        pycoderCode: "",
+        pycoderOutput: "",
+        pycoderAnalysis: "",
+        pycoderLastRunFailed: false,
+        pycoderAwaitingApproval: false,
+        pycoderError: "",
+        codeSandboxRequirements: "",
+        codeSandboxApprovalRequirements: "",
+        codeSandboxPrompt: "",
+        codeSandboxCode: "",
+        codeSandboxOutput: "",
+        codeSandboxAnalysis: "",
+        codeSandboxAwaitingApproval: false,
+        codeSandboxError: "",
       },
     ],
     edges: [],
@@ -423,6 +439,88 @@ describe("SceneStore", () => {
     expect(intents).toEqual([
       { topic: "scene", intent: "applyGitlinkChanges", args: ["n1", "fingerprint-abc123"] },
     ]);
+  });
+
+  it("setPyCoderMode sends the scene-topic setPyCoderMode intent with [nodeId, mode]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setPyCoderMode("n1", "manual");
+    expect(intents).toEqual([{ topic: "scene", intent: "setPyCoderMode", args: ["n1", "manual"] }]);
+  });
+
+  it("runPyCoder sends the scene-topic runPyCoder intent with [nodeId, inputText]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.runPyCoder("n1", "write a fibonacci function");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "runPyCoder", args: ["n1", "write a fibonacci function"] },
+    ]);
+  });
+
+  it("cancelPyCoderRequest sends the scene-topic cancelPyCoderRequest intent with the requestId", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.cancelPyCoderRequest("req-1");
+    expect(intents).toEqual([{ topic: "scene", intent: "cancelPyCoderRequest", args: ["req-1"] }]);
+  });
+
+  it("setCodeSandboxRequirements sends the scene-topic setCodeSandboxRequirements intent with [nodeId, requirementsText]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setCodeSandboxRequirements("n1", "numpy\npandas==2.2.0");
+    expect(intents).toEqual([
+      {
+        topic: "scene",
+        intent: "setCodeSandboxRequirements",
+        args: ["n1", "numpy\npandas==2.2.0"],
+      },
+    ]);
+  });
+
+  it("runCodeSandbox sends the scene-topic runCodeSandbox intent with [nodeId, inputText]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.runCodeSandbox("n1", "plot a sine wave");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "runCodeSandbox", args: ["n1", "plot a sine wave"] },
+    ]);
+  });
+
+  it("cancelCodeSandboxRequest sends the scene-topic cancelCodeSandboxRequest intent with the requestId", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.cancelCodeSandboxRequest("req-2");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "cancelCodeSandboxRequest", args: ["req-2"] },
+    ]);
+  });
+
+  it("approveCodeExecution sends the scene-topic approveCodeExecution intent with ONLY the requestId", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.approveCodeExecution("req-3");
+    expect(intents).toEqual([{ topic: "scene", intent: "approveCodeExecution", args: ["req-3"] }]);
+  });
+
+  it("denyCodeExecution sends the scene-topic denyCodeExecution intent with ONLY the requestId", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.denyCodeExecution("req-4");
+    expect(intents).toEqual([{ topic: "scene", intent: "denyCodeExecution", args: ["req-4"] }]);
+  });
+
+  it("subscribeStream forwards directly to transport.subscribeStream and returns its unsubscribe function", () => {
+    const { transport } = makeFakeTransport();
+    const unsubscribe = vi.fn();
+    const subscribeStreamMock = vi.fn().mockReturnValue(unsubscribe);
+    (transport as unknown as { subscribeStream: typeof subscribeStreamMock }).subscribeStream =
+      subscribeStreamMock;
+    const store = new SceneStore(transport);
+    const listener = vi.fn();
+
+    const result = store.subscribeStream("req-5", listener);
+    expect(subscribeStreamMock).toHaveBeenCalledWith("req-5", listener);
+    expect(result).toBe(unsubscribe);
   });
 
   it("suppresses empty removal intents", () => {

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -13,7 +13,7 @@ import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
 import type { GridControlState } from "../../lib/bridge-core/generated/grid-control-state";
 import type { DragSpeedState } from "../../lib/bridge-core/generated/drag-speed-state";
 import type { FontControlState } from "../../lib/bridge-core/generated/font-control-state";
-import type { WsTransport } from "../../lib/ws/transport";
+import type { StreamListener, WsTransport } from "../../lib/ws/transport";
 
 export const initialSceneState: SceneState = {
   schemaVersion: 1,
@@ -407,6 +407,84 @@ export class SceneStore {
   // store method has no opinion on that, it just forwards the argument.
   applyGitlinkChanges(nodeId: string, fingerprint: string): void {
     this.transport.intent("scene", "applyGitlinkChanges", [nodeId, fingerprint]);
+  }
+
+  // R5.4: Py-Coder node - setPyCoderMode/runPyCoder/cancelPyCoderRequest
+  // mirror backend/canvas.py's registered intent names 1:1, same convention
+  // as every scene intent above. mode is a plain string ("ai_driven" |
+  // "manual") - the backend (SceneDocument.set_pycoder_mode) is the one and
+  // only validator of that value; this store has no opinion on it, same
+  // posture as applyGitlinkChanges's fingerprint passthrough above.
+  setPyCoderMode(nodeId: string, mode: string): void {
+    this.transport.intent("scene", "setPyCoderMode", [nodeId, mode]);
+  }
+
+  // inputText's meaning (a natural-language prompt vs hand-typed code) is
+  // entirely a function of the node's CURRENT server-side pycoder_mode -
+  // this store (and the WS intent itself) is mode-agnostic, matching
+  // backend/canvas.py's own start_pycoder_run docstring ("stores input_text
+  // into the field the CURRENT mode actually reads at dispatch time").
+  runPyCoder(nodeId: string, inputText: string): void {
+    this.transport.intent("scene", "runPyCoder", [nodeId, inputText]);
+  }
+
+  // Same requestId-not-nodeId shape cancelConversationRequest/
+  // cancelWebResearchRequest/cancelArtifactRequest/cancelGitlinkRequest above
+  // already established for their own per-node cancel.
+  cancelPyCoderRequest(requestId: string): void {
+    this.transport.intent("scene", "cancelPyCoderRequest", [requestId]);
+  }
+
+  // R5.4: Execution Sandbox node - same three-intent shape as Py-Coder above
+  // (setCodeSandboxRequirements/runCodeSandbox/cancelCodeSandboxRequest),
+  // minus a mode toggle - backend/canvas.py's start_code_sandbox_run has no
+  // mode-dependent field split (see its own docstring); a run's input_text
+  // always lands in code_sandbox_prompt, and an empty prompt is a legitimate
+  // "re-run the existing code_sandbox_code" request, not an error, at the
+  // WS-intent layer - CodeSandboxNodeView is the one that decides whether
+  // that's currently sensible to allow (see its own Run-enablement comment).
+  setCodeSandboxRequirements(nodeId: string, requirementsText: string): void {
+    this.transport.intent("scene", "setCodeSandboxRequirements", [nodeId, requirementsText]);
+  }
+
+  runCodeSandbox(nodeId: string, inputText: string): void {
+    this.transport.intent("scene", "runCodeSandbox", [nodeId, inputText]);
+  }
+
+  cancelCodeSandboxRequest(requestId: string): void {
+    this.transport.intent("scene", "cancelCodeSandboxRequest", [requestId]);
+  }
+
+  // R5.4: the shared human-approval gate - ONE request_id namespace across
+  // both Py-Coder and Execution Sandbox (backend/agents.py's
+  // AgentDispatcher._resolve_approval looks the id up across both request
+  // dicts), so these two intents are not duplicated per-kind. Both take
+  // ONLY a requestId - never a node id, never the code itself - mirroring
+  // applyGitlinkChanges's own "this store method has no opinion on the
+  // content, it just forwards the caller's requestId" posture; the caller
+  // (CodeExecutionApprovalPanel via SceneCanvas's toFlowNodes closures) is
+  // responsible for that requestId always being the CURRENT
+  // pendingRequestId the scene snapshot says is in flight for that node,
+  // never anything UI-supplied.
+  approveCodeExecution(requestId: string): void {
+    this.transport.intent("scene", "approveCodeExecution", [requestId]);
+  }
+
+  denyCodeExecution(requestId: string): void {
+    this.transport.intent("scene", "denyCodeExecution", [requestId]);
+  }
+
+  // R5.4: NOT one of the 8 registered WS intents above - a thin passthrough
+  // to the transport's own subscribeStream() (already exercised by R4.4's
+  // token streaming through composerStore.ts's own syncStream), exposed here
+  // so CodeSandboxNodeView's live terminal pane can subscribe to a run's
+  // stream frames (keyed by its own pendingRequestId) without needing direct
+  // access to the private `transport` field. No backend registration is
+  // needed for this - subscribeStream is a pure client-side fan-out over
+  // `kind:"stream"` frames the server already broadcasts unconditionally
+  // (see transport.ts's own doc comment on it).
+  subscribeStream(requestId: string, listener: StreamListener): () => void {
+    return this.transport.subscribeStream(requestId, listener);
   }
 
   // R3.3: the Composer's real Send action - a real user ChatNode. The

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -3220,3 +3220,291 @@ body,
   opacity: 0.45;
   cursor: default;
 }
+
+/* -- R5.4 pycoder + code_sandbox nodes ------------------------------------ */
+
+.pycoder-node,
+.code-sandbox-node {
+  width: 420px;
+  max-height: 720px;
+  min-height: 110px;
+}
+
+.pycoder-node.collapsed,
+.code-sandbox-node.collapsed {
+  width: 290px;
+  min-height: 58px;
+}
+
+.pycoder-node-content,
+.code-sandbox-node-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 640px;
+  overflow-y: auto;
+}
+
+.pycoder-node-mode-toggle {
+  display: flex;
+  gap: 4px;
+}
+
+.pycoder-node-mode-btn {
+  flex: 1;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 6px 10px;
+  color: var(--gl-surface-text-muted);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.pycoder-node-mode-btn:hover {
+  color: var(--gl-surface-text);
+}
+
+.pycoder-node-mode-btn.active {
+  color: var(--gl-surface-window);
+  background-color: var(--gl-surface-text-muted);
+  border-color: transparent;
+}
+
+/* Reuses .web-research-node-query-input's/.gitlink-node-input's own chrome
+   verbatim - same shared-token convention already established across sibling
+   node views - applied here under this node kind's own class name. */
+.pycoder-node-input,
+.code-sandbox-node-requirements,
+.code-sandbox-node-input {
+  box-sizing: border-box;
+  width: 100%;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 8px 10px;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.code-sandbox-node-requirements {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 11px;
+}
+
+.pycoder-node-input:focus,
+.code-sandbox-node-requirements:focus,
+.code-sandbox-node-input:focus {
+  outline: none;
+  border-color: var(--gl-surface-text-muted);
+}
+
+.code-sandbox-node-field-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.code-sandbox-node-field-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--gl-surface-text-muted);
+}
+
+.pycoder-node-run-row,
+.code-sandbox-node-run-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.pycoder-node-run-row button,
+.code-sandbox-node-run-row button {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 5px 12px;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.pycoder-node-run-row button:hover:enabled,
+.code-sandbox-node-run-row button:hover:enabled {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.pycoder-node-run-row button:disabled,
+.code-sandbox-node-run-row button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.pycoder-node-banner-error,
+.code-sandbox-node-banner-error {
+  padding: 8px 10px;
+  font-size: 11px;
+  color: var(--gl-semantic-status-error, currentColor);
+  border: 1px solid var(--gl-semantic-status-error, currentColor);
+  border-radius: 8px;
+}
+
+.pycoder-node-failed-badge {
+  margin: 0;
+  font-size: 11px;
+  font-style: italic;
+  color: var(--gl-semantic-status-error, currentColor);
+}
+
+.pycoder-node-section,
+.code-sandbox-node-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pycoder-node-section-label,
+.code-sandbox-node-section-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--gl-surface-text-muted);
+}
+
+/* Reuses .chat-node-content's full markdown-body rule set verbatim - same
+   shared-class convention .artifact-node-document-content/
+   .gitlink-node-proposal-markdown already establish for this pipeline. Only
+   overrides the max-height/overflow-y a nested pane should never take on its
+   own (the outer .pycoder-node-content/.code-sandbox-node-content already
+   scrolls). */
+.pycoder-node-code,
+.pycoder-node-output,
+.pycoder-node-analysis,
+.code-sandbox-node-code,
+.code-sandbox-node-analysis {
+  max-height: none;
+  overflow: visible;
+}
+
+/* The live terminal / static output fallback - plain preformatted text, NOT
+   the markdown pipeline (see CodeSandboxNodeView's own module doc for why:
+   raw subprocess stdout/stderr is machine output, not prose or code-to-be-
+   colorized - same posture .gitlink-node-context-xml already takes for its
+   own machine-generated XML body). */
+.code-sandbox-node-terminal {
+  margin: 0;
+  padding: 8px 10px;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+  overflow: auto;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+/* -- R5.4 shared code-execution approval panel ---------------------------- */
+/* Post-review fix pass: CodeExecutionApprovalPanel is now a small,
+   self-contained modal (its own .overlay-scrim + .overlay-dialog markup,
+   rendered directly by PyCoderNodeView/CodeSandboxNodeView) rather than a
+   <Dialog> registered with the shared useOverlays() singleton - see that
+   component's own module doc for why. It reuses .overlay-scrim/
+   .overlay-dialog purely for visual consistency (colors/shadows/centering),
+   not because it participates in that registry. */
+
+.code-exec-approval-dialog {
+  max-width: min(520px, calc(100vw - 64px));
+}
+
+.code-exec-approval-warning {
+  margin: 0 0 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--gl-semantic-status-error, currentColor);
+}
+
+/* R5.4 post-review FIX C: the pending pip-install manifest, shown for
+   code_sandbox only, positioned BEFORE the code display so it is seen prior
+   to clicking Approve (never buried below the fold). Reuses the same
+   monospace/inset-surface treatment as .code-sandbox-node-terminal, since
+   both are raw machine-formatted text, not prose. */
+.code-exec-approval-requirements {
+  margin: 0 0 12px;
+}
+
+.code-exec-approval-requirements-label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--gl-surface-text-muted);
+}
+
+.code-exec-approval-requirements-list {
+  margin: 0;
+  padding: 8px 10px;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 120px;
+  overflow: auto;
+  color: var(--gl-surface-text);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.code-exec-approval-code {
+  max-height: 320px;
+  overflow: auto;
+}
+
+.code-exec-approval-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.code-exec-approval-actions button {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 5px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.code-exec-approval-approve-btn {
+  color: var(--gl-surface-window);
+  background-color: var(--gl-surface-text-muted);
+  border: none;
+}
+
+.code-exec-approval-deny-btn {
+  color: var(--gl-surface-text);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+}
+
+.code-exec-approval-actions button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -56,6 +56,30 @@
           "code": {
             "type": "string"
           },
+          "codeSandboxAnalysis": {
+            "type": "string"
+          },
+          "codeSandboxApprovalRequirements": {
+            "type": "string"
+          },
+          "codeSandboxAwaitingApproval": {
+            "type": "boolean"
+          },
+          "codeSandboxCode": {
+            "type": "string"
+          },
+          "codeSandboxError": {
+            "type": "string"
+          },
+          "codeSandboxOutput": {
+            "type": "string"
+          },
+          "codeSandboxPrompt": {
+            "type": "string"
+          },
+          "codeSandboxRequirements": {
+            "type": "string"
+          },
           "content": {
             "type": "string"
           },
@@ -196,6 +220,30 @@
             "type": "string"
           },
           "previewLabel": {
+            "type": "string"
+          },
+          "pycoderAnalysis": {
+            "type": "string"
+          },
+          "pycoderAwaitingApproval": {
+            "type": "boolean"
+          },
+          "pycoderCode": {
+            "type": "string"
+          },
+          "pycoderError": {
+            "type": "string"
+          },
+          "pycoderLastRunFailed": {
+            "type": "boolean"
+          },
+          "pycoderMode": {
+            "type": "string"
+          },
+          "pycoderOutput": {
+            "type": "string"
+          },
+          "pycoderPrompt": {
             "type": "string"
           },
           "researchActiveSourceId": {
@@ -390,7 +438,23 @@
           "gitlinkPendingChanges",
           "gitlinkPreviewText",
           "gitlinkChangeState",
-          "gitlinkError"
+          "gitlinkError",
+          "pycoderMode",
+          "pycoderPrompt",
+          "pycoderCode",
+          "pycoderOutput",
+          "pycoderAnalysis",
+          "pycoderLastRunFailed",
+          "pycoderAwaitingApproval",
+          "pycoderError",
+          "codeSandboxRequirements",
+          "codeSandboxPrompt",
+          "codeSandboxCode",
+          "codeSandboxOutput",
+          "codeSandboxAnalysis",
+          "codeSandboxAwaitingApproval",
+          "codeSandboxApprovalRequirements",
+          "codeSandboxError"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -46,6 +46,22 @@ export interface SceneNodeRow {
   gitlinkChangeFingerprint?: string | null;
   gitlinkChangeState: string;
   gitlinkError: string;
+  pycoderMode: string;
+  pycoderPrompt: string;
+  pycoderCode: string;
+  pycoderOutput: string;
+  pycoderAnalysis: string;
+  pycoderLastRunFailed: boolean;
+  pycoderAwaitingApproval: boolean;
+  pycoderError: string;
+  codeSandboxRequirements: string;
+  codeSandboxPrompt: string;
+  codeSandboxCode: string;
+  codeSandboxOutput: string;
+  codeSandboxAnalysis: string;
+  codeSandboxAwaitingApproval: boolean;
+  codeSandboxApprovalRequirements: string;
+  codeSandboxError: string;
 }
 
 export interface ConversationMessageRow {
@@ -352,6 +368,86 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["gitlinkError"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.gitlinkError: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.gitlinkError` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["pycoderMode"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.pycoderMode: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.pycoderMode` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["pycoderPrompt"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.pycoderPrompt: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.pycoderPrompt` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["pycoderCode"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.pycoderCode: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.pycoderCode` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["pycoderOutput"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.pycoderOutput: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.pycoderOutput` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["pycoderAnalysis"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.pycoderAnalysis: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.pycoderAnalysis` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["pycoderLastRunFailed"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.pycoderLastRunFailed: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.pycoderLastRunFailed` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["pycoderAwaitingApproval"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.pycoderAwaitingApproval: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.pycoderAwaitingApproval` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["pycoderError"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.pycoderError: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.pycoderError` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["codeSandboxRequirements"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxRequirements: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.codeSandboxRequirements` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["codeSandboxPrompt"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxPrompt: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.codeSandboxPrompt` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["codeSandboxCode"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxCode: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.codeSandboxCode` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["codeSandboxOutput"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxOutput: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.codeSandboxOutput` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["codeSandboxAnalysis"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxAnalysis: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.codeSandboxAnalysis` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["codeSandboxAwaitingApproval"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxAwaitingApproval: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.codeSandboxAwaitingApproval` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["codeSandboxApprovalRequirements"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxApprovalRequirements: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.codeSandboxApprovalRequirements` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["codeSandboxError"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxError: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.codeSandboxError` + ": expected string"); }
   }
 }
 


### PR DESCRIPTION
## Summary
Adds the final two R5 plugin node kinds: **PyCoderNode** (a persistent Python REPL, AI-driven or Manual) and **CodeSandboxNode** (ephemeral-per-run script execution in a reused-per-node venv) — the highest-risk increment in the rewrite, since both execute real code with the full privileges of the user account.

- Qt-free fix is a real file split for both (`graphlink_plugins/pycoder/domain.py`, `graphlink_plugins/code_sandbox/domain.py`), since the legacy files had direct PySide6 `QThread`/`Signal` imports.
- The human-approval pause collapses legacy's two-thread coordination (a `QThread` parked on a `threading.Event`, the GUI thread blocked in a modal `QMessageBox`) into a single `asyncio.Future` awaited directly inside the dispatch coroutine. The busy marker is held for the entire generate→pause→execute span, not just pre-generation.
- Ships with exactly two protection layers, stated plainly: the WS-Origin handshake check (a separate prerequisite, already merged in #125) and a mandatory human-approval step. There is deliberately **no code-level sandbox** for either kind — a decision, not an oversight, stated verbatim in both code comments and the approval dialog's UI copy.

## Review & fixes
A 5-way adversarial review (backend/frontend/cross-boundary/security/legacy-safety) found 13 confirmed issues. The most serious:
- The approval modal's Escape/scrim/close-button dismissal left a "mandatory" approval unresolved instead of denying it.
- Two nodes needing approval simultaneously collided in a shared single-open overlay slot, making one unreachable.

Both fixed by rebuilding the approval panel as a self-contained, per-node modal with zero passive-dismissal affordances — Approve or Deny are the only ways out.

Also fixed: CodeSandbox's live-terminal output was never wired to actually stream, deleting a node mid-approval-pause orphaned the paused dispatcher request, and the approval dialog's package-installation disclosure could show a stale requirements list rather than the manifest actually being installed.

## Verification
- `pytest`: 2312 passed (backend + graphlink_app)
- `vitest`: 931 passed
- `tsc --noEmit`: clean
- `npm run lint`: clean (0 errors, pre-existing warnings only)

This closes out R5 (plugins): Web-Research, Artifact, Gitlink, and now PyCoder/CodeSandbox are all shipped.