### PR TITLE
Qt-removal R6.3: scene-level serialization gaps

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -21,10 +21,12 @@ document IS the source of truth the window can reload against.
 from __future__ import annotations
 
 import base64
+import importlib.util
 import itertools
 import math
 import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from graphlink_chart_data import ChartDataError, canonicalize_chart_data, SUPPORTED_CHART_TYPES
@@ -50,6 +52,36 @@ from backend.response_parsing import (
     PLACEHOLDER_ASSISTANT_REASONING,
     PLACEHOLDER_EMPTY_RESPONSE,
 )
+from backend.token_counter import estimate_tokens
+
+
+def _load_graphlink_content_codec():
+    """R6.3: graphlink_app/graphlink_session/content_codec.py is 100%
+    Qt-free (it imports only base64/binascii/logging - confirmed by direct
+    read), but the graphlink_session PACKAGE it lives in is not:
+    graphlink_session/__init__.py eagerly imports ChatSessionManager and
+    SaveWorkerThread, and workers.py in turn imports PySide6.QtCore - so a
+    plain `from graphlink_session.content_codec import ...` would run that
+    __init__.py first (Python always runs a package's __init__.py, even for
+    a submodule import) and pull Qt into backend/'s import graph. Same
+    "package wrapper is hazardous, the leaf module itself is not" situation
+    backend/chat_library.py's own docstring already documents for
+    graphlink_session.database - but UNLIKE chat_library.py (which
+    reimplements ChatDatabase's small SQL surface rather than import it),
+    content_codec.py is loaded here directly via importlib, bypassing the
+    package's __init__.py entirely, rather than ported/copied - there is
+    nothing about it worth forking into a second maintained copy."""
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "graphlink_app" / "graphlink_session" / "content_codec.py"
+    )
+    spec = importlib.util.spec_from_file_location("_graphlink_session_content_codec", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_content_codec = _load_graphlink_content_codec()
 
 # Dark-theme grid swatches. The Qt bridge derived 3 of 5 from the live
 # QPalette; the backend is Qt-free by law (test_no_qt_anywhere.py), so until
@@ -541,6 +573,38 @@ class SceneNode:
     # simplification, not replicated). Unused (default "") for every other
     # kind.
     chart_source_node_id: str = ""
+    # R6.3: HtmlViewNode's persisted draggable code/preview splitter
+    # position - legacy's own splitter_state field, not currently modeled at
+    # all before this increment. None means "use the frontend's own
+    # default", not "0" - a real 0.0 position (fully collapsed to one side)
+    # must round-trip distinctly from "never set". html kind only; unused
+    # (default None) for every other kind.
+    html_splitter_state: float | None = None
+    # R6.3: ChatNode's persisted scroll position within its own content
+    # area (legacy's own scroll_value field). Unlike html_splitter_state
+    # above, 0.0 (scrolled to the top) IS the genuine default for a node
+    # that has never been scrolled, so this is a plain float, not an
+    # Optional - there is no "unset" state worth distinguishing here. chat
+    # kind only; unused (default 0.0) for every other kind.
+    chat_scroll_value: float = 0.0
+    # R6.3: the RAW (already-decoded - "data" holds real Python bytes, never
+    # base64 text) multimodal parts list for a chat node whose legacy
+    # raw_content was a list of typed parts (e.g. an inline pasted image)
+    # rather than a plain string - see content_codec.py's own
+    # process_content_for_serialization/_for_deserialization, which this
+    # increment does not call directly (see scene_payload()'s own comment
+    # for the wire-side base64 encoding step this field feeds). None for the
+    # overwhelmingly common plain-text case, where `content` above is the
+    # only source of truth. ADDITIVE, not a replacement for `content`: even
+    # when this is populated, `content` continues to hold a flattened-text
+    # mirror (join of the text-type parts, or a placeholder like "[Image]"
+    # for non-text parts) so every existing piece of code that already reads
+    # `content` as a plain string keeps working unchanged. chat kind only;
+    # unused (default None) for every other kind. Nothing in this increment
+    # creates multimodal content yet (no image-paste-into-composer feature
+    # exists) - this is purely the data-model capability so R6.4's session
+    # loader has somewhere to put it when an OLD saved session has it.
+    content_parts: list[dict[str, Any]] | None = None
 
 
 @dataclass
@@ -582,6 +646,24 @@ class SceneDocument:
     # increment, same posture as every prior node-type increment before its
     # real trigger landed.
     image_assets: dict[str, tuple[bytes, str]] = field(default_factory=dict)
+    # R6.3: the canvas viewport's persisted zoom/scroll (legacy's own
+    # zoom_factor/scroll_position(x, y)) - document-wide, not per-node, since
+    # there is exactly one viewport per session regardless of node count.
+    # No min/max clamping here (unlike drag_factor/font_size_pt above): the
+    # frontend's own viewport constraints already bound these, so there is
+    # nothing meaningful for the server to enforce independently.
+    zoom_factor: float = 1.0
+    scroll_x: float = 0.0
+    scroll_y: float = 0.0
+    # R6.3: legacy's running cumulative token count for the whole session,
+    # restored into the window's token counter on load - DISTINCT from
+    # backend/token_counter.py's TokenCounterState (a transient, in-memory,
+    # per-process ESTIMATE that resets every restart and is never
+    # persisted). This field is the real, live-growing, save/restore-able
+    # counterpart: send_message's WS wrapper (register_canvas, below) grows
+    # it by add_session_tokens for both the user's own message and the
+    # assistant's completed reply, every time either lands.
+    total_session_tokens: int = 0
     _counter: itertools.count = field(default_factory=itertools.count, repr=False)
 
     # -- nodes -------------------------------------------------------------
@@ -804,6 +886,18 @@ class SceneDocument:
         self.nodes[node_id] = node
         self.connect(parent_id, node_id)
         return node
+
+    def set_html_splitter_state(self, node_id: str, value: float) -> None:
+        """R6.3: persists an HtmlViewNode's draggable code/preview splitter
+        position. html kind only (SceneError otherwise), matching every
+        other kind-specific setter's guard pattern in this file (e.g.
+        resize_chart/toggle_frame_lock)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "html":
+            raise SceneError(f"node is not an html node: {node_id}")
+        node.html_splitter_state = float(value)
 
     def add_image_node(
         self,
@@ -2270,6 +2364,18 @@ class SceneDocument:
         if node.kind in ("frame", "container"):
             self._recompute_group_bounds(node_id)
 
+    def set_chat_scroll_value(self, node_id: str, value: float) -> None:
+        """R6.3: persists a chat node's own scroll position within its
+        content area. chat kind only (SceneError otherwise), matching every
+        other kind-specific setter's guard pattern in this file (e.g.
+        resize_chart/toggle_frame_lock)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "chat":
+            raise SceneError(f"node is not a chat node: {node_id}")
+        node.chat_scroll_value = float(value)
+
     def set_node_docked(self, node_id: str, docked: bool) -> None:
         """R3.13: a single generic setter handling both dock (docked=True)
         and undock (docked=False) - mirrors set_chat_collapsed's generic-
@@ -2379,6 +2485,24 @@ class SceneDocument:
             self.font_size_pt = max(FONT_SIZE_MIN, min(FONT_SIZE_MAX, int(size_pt)))
         if color is not None:
             self.font_color = str(color)
+
+    def set_view_state(self, zoom_factor: float, scroll_x: float, scroll_y: float) -> None:
+        """R6.3: plain setter for the canvas viewport's persisted zoom/
+        scroll, no validation beyond basic float coercion - see
+        zoom_factor's own field comment for why there is nothing meaningful
+        to clamp server-side."""
+        self.zoom_factor = float(zoom_factor)
+        self.scroll_x = float(scroll_x)
+        self.scroll_y = float(scroll_y)
+
+    def add_session_tokens(self, text: str) -> None:
+        """R6.3: grow total_session_tokens by `text`'s estimate_tokens count
+        - the one piece of real accumulation logic behind that field. Called
+        from register_canvas's sendMessage wrapper below, once for the
+        user's own new message text and once for the assistant's completed
+        reply text, so the counter genuinely grows as the conversation
+        continues rather than sitting fixed at 0."""
+        self.total_session_tokens += estimate_tokens(str(text))
 
     def organize(self) -> None:
         """Tidy layout: nodes into a near-square grid, stable id order."""
@@ -2496,6 +2620,20 @@ class SceneDocument:
                     "chartHeight": n.chart_height,
                     "chartAspectLocked": n.chart_aspect_locked,
                     "chartSourceNodeId": n.chart_source_node_id,
+                    # R6.3: HTML splitter + chat scroll gaps.
+                    "htmlSplitterState": n.html_splitter_state,
+                    "chatScrollValue": n.chat_scroll_value,
+                    # R6.3: null (not []) when content_parts is None - "no
+                    # multimodal content" must stay distinguishable from
+                    # "multimodal content that happens to be empty". Any
+                    # part carrying raw bytes under "data" gets that key
+                    # base64-encoded for the wire via content_codec's own
+                    # encode_image_bytes - the WIRE shape this produces
+                    # matches content_codec.process_content_for_serialization's
+                    # own output shape exactly, while n.content_parts itself
+                    # (in memory) keeps holding real bytes, per the field's
+                    # own contract.
+                    "contentParts": _content_parts_wire(n.content_parts),
                 }
                 for n in self.nodes.values()
             ],
@@ -2510,6 +2648,11 @@ class SceneDocument:
                     "note": p.note,
                     "x": p.position[0],
                     "y": p.position[1],
+                    # R6.3: NavigationPinRecord already carries these three -
+                    # they just weren't exposed on the wire until now.
+                    "anchorItemId": p.anchor_item_id,
+                    "sortOrder": p.sort_order,
+                    "createdAt": p.created_at,
                 }
                 for p in self.pins.records
             ],
@@ -2518,6 +2661,12 @@ class SceneDocument:
             "fontFamily": self.font_family,
             "fontSizePt": self.font_size_pt,
             "fontColor": self.font_color,
+            # R6.3: canvas view state + the real, live-growing session token
+            # count - see these fields' own comments on SceneDocument.
+            "zoomFactor": self.zoom_factor,
+            "scrollX": self.scroll_x,
+            "scrollY": self.scroll_y,
+            "totalSessionTokens": self.total_session_tokens,
         }
 
     def grid_payload(self) -> dict[str, Any]:
@@ -2533,6 +2682,33 @@ class SceneDocument:
             "stylePresets": list(GRID_STYLE_PRESETS),
             "colorPresets": list(GRID_COLOR_PRESETS),
         }
+
+
+def _content_parts_wire(parts: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:
+    """R6.3: scene_payload()'s wire-side transform for SceneNode.content_parts
+    - a pure mapping function, NOT a SceneDocument method (same posture as
+    _research_result_wire below). None stays None (never []), so "no
+    multimodal content" and "multimodal content that happens to be empty"
+    remain distinguishable on the wire. Any part that is a dict carrying raw
+    bytes under its "data" key gets that key base64-encoded as a string via
+    content_codec.encode_image_bytes - matching content_codec.
+    process_content_for_serialization's own output shape exactly - while
+    leaving every other key/part untouched. Builds fresh dicts throughout;
+    never mutates the SceneNode's own in-memory parts (which must keep
+    holding real bytes, per content_parts's own field contract)."""
+    if parts is None:
+        return None
+    wire_parts: list[dict[str, Any]] = []
+    for part in parts:
+        if isinstance(part, dict) and isinstance(part.get("data"), (bytes, bytearray)):
+            wire_part = dict(part)
+            wire_part["data"] = _content_codec.encode_image_bytes(bytes(part["data"]))
+            wire_parts.append(wire_part)
+        elif isinstance(part, dict):
+            wire_parts.append(dict(part))
+        else:
+            wire_parts.append(part)
+    return wire_parts
 
 
 def _research_result_wire(result) -> dict[str, Any]:
@@ -2725,6 +2901,10 @@ def register_canvas(
         await publish_scene()
         return node.id
 
+    async def set_html_splitter_state(node_id, value):
+        document.set_html_splitter_state(node_id, value)
+        await publish_scene()
+
     async def add_image_node(x, y, image_bytes_base64, prompt, parent_id, mime_type="image/png"):
         # Unlike every prior wrapper, the WS intent transport is JSON, which
         # cannot carry raw bytes - the caller sends base64 text, decoded here
@@ -2798,15 +2978,28 @@ def register_canvas(
         document.set_chat_collapsed(node_id, collapsed)
         await publish_scene()
 
+    async def set_chat_scroll_value(node_id, value):
+        document.set_chat_scroll_value(node_id, value)
+        await publish_scene()
+
     async def send_message(text):
         # R3.3: the real Send action - a real user ChatNode, continuing the
         # active branch. R4: the assistant's reply is now a real agent
         # dispatch call, not a deferred notice - see backend/agents.py.
         node = document.send_message(text)
+        # R6.3: grow the real, live-growing session token count by the
+        # user's own new message text - see add_session_tokens's own
+        # comment on SceneDocument.
+        document.add_session_tokens(text)
         await publish_scene()
         history = document.chat_branch_history(node.id)
 
         def _on_reply(reply_text):
+            # R6.3: the assistant's reply has completed (regardless of
+            # whether parse_response below finds anything node-worthy in
+            # it) - grow total_session_tokens by its estimated count too,
+            # same as the user's own message text just above.
+            document.add_session_tokens(reply_text)
             # R4.3b: port legacy handle_response's _parse_response retrofit -
             # split the flat reply into thinking/text/code parts and create
             # separate thinking-kind/code-kind CHILD nodes instead of
@@ -3661,12 +3854,17 @@ def register_canvas(
         document.set_drag_factor(factor)
         await publish_scene()
 
+    async def set_view_state(zoom_factor, scroll_x, scroll_y):
+        document.set_view_state(zoom_factor, scroll_x, scroll_y)
+        await publish_scene()
+
     bus.register_intent("scene", "addNode", add_node)
     bus.register_intent("scene", "addChatNode", add_chat_node)
     bus.register_intent("scene", "addCodeNode", add_code_node)
     bus.register_intent("scene", "addDocumentNode", add_document_node)
     bus.register_intent("scene", "addThinkingNode", add_thinking_node)
     bus.register_intent("scene", "addHtmlNode", add_html_node)
+    bus.register_intent("scene", "setHtmlSplitterState", set_html_splitter_state)
     bus.register_intent("scene", "addImageNode", add_image_node)
     bus.register_intent("scene", "addConversationNode", add_conversation_node)
     bus.register_intent("scene", "sendConversationMessage", send_conversation_message)
@@ -3677,6 +3875,7 @@ def register_canvas(
     bus.register_intent("scene", "setNodeDocked", set_node_docked)
     bus.register_intent("scene", "deleteChatNode", delete_chat_node)
     bus.register_intent("scene", "setChatCollapsed", set_chat_collapsed)
+    bus.register_intent("scene", "setChatScrollValue", set_chat_scroll_value)
     bus.register_intent("scene", "sendMessage", send_message)
     bus.register_intent("scene", "regenerateResponse", regenerate_response)
     # R4.4a: "Generate Image from Text" (ChatNode) and "Regenerate Image"
@@ -3712,6 +3911,7 @@ def register_canvas(
     bus.register_intent("scene", "updatePin", update_pin)
     bus.register_intent("scene", "setSnapToGrid", set_snap_to_grid)
     bus.register_intent("scene", "setDragFactor", set_drag_factor)
+    bus.register_intent("scene", "setViewState", set_view_state)
     # R4.3: per-node cancel for a ConversationNode's in-flight reply. Reuses
     # the exact intent NAME "cancelChatRequest" already registered on the
     # "app-composer" topic by R4.2 - SessionBus keys handlers by the

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -32,7 +32,9 @@ from backend.notifications import NotificationState
 
 import api_provider
 import graphlink_task_config as task_config
+from graphlink_navigation_pins import NavigationPinRecord
 from graphlink_plugins.web_research.domain import ResearchCitation, ResearchResult, ResearchSource
+from backend.token_counter import estimate_tokens
 
 
 # -- document invariants ----------------------------------------------------
@@ -2012,15 +2014,48 @@ def test_pin_intents_round_trip_through_the_store():
         bus, document, _ = make_bus()
         pin_id = await bus.dispatch_intent("scene", "addPin", ["Start here", 5, 9, "note!"])
         payload = document.scene_payload()
-        assert payload["pins"] == [
-            {"id": pin_id, "title": "Start here", "note": "note!", "x": 5.0, "y": 9.0}
-        ]
+        pin = payload["pins"][0]
+        # R6.3: anchorItemId/sortOrder/createdAt asserted separately below
+        # (not baked into one exact-dict-equality assert) since createdAt is
+        # a real timestamp, not a fixed value.
+        assert pin["id"] == pin_id
+        assert pin["title"] == "Start here"
+        assert pin["note"] == "note!"
+        assert pin["x"] == 5.0
+        assert pin["y"] == 9.0
+        assert pin["anchorItemId"] is None
+        assert pin["sortOrder"] == 0
+        assert isinstance(pin["createdAt"], str) and pin["createdAt"]
         await bus.dispatch_intent("scene", "movePin", [pin_id, 50, 90])
         assert document.scene_payload()["pins"][0]["x"] == 50.0
         await bus.dispatch_intent("scene", "removePin", [pin_id])
         assert document.scene_payload()["pins"] == []
 
     asyncio.run(run())
+
+
+def test_pin_payload_exposes_anchor_item_id_sort_order_and_created_at():
+    # R6.3: NavigationPinRecord already carried anchor_item_id/sort_order/
+    # created_at (graphlink_navigation_pins.py) - this is purely a wire-
+    # exposure gap, closed by adding 3 keys to scene_payload()'s existing
+    # pin dict. Uses non-default values throughout so a field being silently
+    # dropped or swapped with another would be caught.
+    doc = SceneDocument()
+    doc.pins.add(
+        NavigationPinRecord.create(
+            title="Anchored",
+            note="pinned to a node",
+            x=1.0,
+            y=2.0,
+            anchor_item_id="n42",
+            sort_order=7,
+            created_at="2020-01-02T03:04:05+00:00",
+        )
+    )
+    pin = doc.scene_payload()["pins"][0]
+    assert pin["anchorItemId"] == "n42"
+    assert pin["sortOrder"] == 7
+    assert pin["createdAt"] == "2020-01-02T03:04:05+00:00"
 
 
 def test_update_pin_intent_renames_and_validates():
@@ -5499,3 +5534,176 @@ def test_generate_chart_intent_dispatcher_level_failure_shows_notification_witho
         assert add_chart_node_calls == []
 
     asyncio.run(run())
+
+
+# -- R6.3: view state, session tokens, splitter/scroll gaps, multimodal content ----
+
+
+def test_set_view_state_persists_and_appears_on_scene_payload():
+    doc = SceneDocument()
+    default_payload = doc.scene_payload()
+    assert default_payload["zoomFactor"] == 1.0
+    assert default_payload["scrollX"] == 0.0
+    assert default_payload["scrollY"] == 0.0
+
+    doc.set_view_state(1.5, 120.0, -40.0)
+    payload = doc.scene_payload()
+    assert payload["zoomFactor"] == 1.5
+    assert payload["scrollX"] == 120.0
+    assert payload["scrollY"] == -40.0
+
+
+def test_set_view_state_intent_mutates_and_publishes_scene():
+    async def run():
+        bus, document, recorder = make_bus()
+        await bus.dispatch_intent("scene", "setViewState", [2.0, 10, 20])
+        payload = document.scene_payload()
+        assert payload["zoomFactor"] == 2.0
+        assert payload["scrollX"] == 10.0
+        assert payload["scrollY"] == 20.0
+        assert recorder.topics_seen().count("scene") == 1
+
+    asyncio.run(run())
+
+
+def test_total_session_tokens_starts_at_zero_and_grows_after_send_message_and_reply():
+    # R6.3: total_session_tokens must be a REAL, live-growing counter, not a
+    # static field stuck at 0 - grows once for the user's own message text
+    # (send_message's own domain mutation) and once for the assistant's
+    # completed reply text (the _on_reply callback), both via
+    # estimate_tokens. Same fake-dispatcher/monkeypatch seam as
+    # test_send_message_intent_dispatches_a_real_agent_reply above.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        assert document.total_session_tokens == 0
+
+        user_text = "what is this graph about?"
+        reply_text = "a real agent reply with several distinct words"
+
+        def fake_chat(task, messages, **kwargs):
+            return {"message": {"content": reply_text}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", fake_chat):
+            await bus.dispatch_intent("scene", "sendMessage", [user_text])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        expected = estimate_tokens(user_text) + estimate_tokens(reply_text)
+        assert expected > 0, "the test fixture itself must exercise a non-zero token count"
+        assert document.total_session_tokens == expected
+        assert document.scene_payload()["totalSessionTokens"] == expected
+
+    asyncio.run(run())
+
+
+def test_set_html_splitter_state_accepts_html_kind_and_rejects_others():
+    doc = SceneDocument()
+    chat_node = doc.add_chat_node(0, 0, "hi", True)
+    html_node = doc.add_html_node(0, 0, "<p>hi</p>", chat_node.id)
+    assert html_node.html_splitter_state is None
+
+    doc.set_html_splitter_state(html_node.id, 0.35)
+    assert html_node.html_splitter_state == 0.35
+    payload_node = next(n for n in doc.scene_payload()["nodes"] if n["id"] == html_node.id)
+    assert payload_node["htmlSplitterState"] == 0.35
+
+    with pytest.raises(SceneError):
+        doc.set_html_splitter_state(chat_node.id, 0.5)
+
+    with pytest.raises(SceneError):
+        doc.set_html_splitter_state("does-not-exist", 0.5)
+
+
+def test_set_html_splitter_state_intent_mutates_and_publishes_scene():
+    async def run():
+        bus, document, recorder = make_bus()
+        chat_id = await bus.dispatch_intent("scene", "addChatNode", [0, 0, "hi", True])
+        html_id = await bus.dispatch_intent("scene", "addHtmlNode", [0, 0, "<p>hi</p>", chat_id])
+        recorder.messages.clear()
+
+        await bus.dispatch_intent("scene", "setHtmlSplitterState", [html_id, 0.6])
+        assert document.nodes[html_id].html_splitter_state == 0.6
+        assert recorder.topics_seen().count("scene") == 1
+
+        with pytest.raises(Exception):
+            await bus.dispatch_intent("scene", "setHtmlSplitterState", [chat_id, 0.6])
+
+    asyncio.run(run())
+
+
+def test_set_chat_scroll_value_accepts_chat_kind_and_rejects_others():
+    doc = SceneDocument()
+    chat_node = doc.add_chat_node(0, 0, "hi", True)
+    other_node = doc.add_node(0, 0, "placeholder")
+    assert chat_node.chat_scroll_value == 0.0
+
+    doc.set_chat_scroll_value(chat_node.id, 123.0)
+    assert chat_node.chat_scroll_value == 123.0
+    payload_node = next(n for n in doc.scene_payload()["nodes"] if n["id"] == chat_node.id)
+    assert payload_node["chatScrollValue"] == 123.0
+
+    with pytest.raises(SceneError):
+        doc.set_chat_scroll_value(other_node.id, 5.0)
+
+    with pytest.raises(SceneError):
+        doc.set_chat_scroll_value("does-not-exist", 5.0)
+
+
+def test_set_chat_scroll_value_intent_mutates_and_publishes_scene():
+    async def run():
+        bus, document, recorder = make_bus()
+        chat_id = await bus.dispatch_intent("scene", "addChatNode", [0, 0, "hi", True])
+        other_id = await bus.dispatch_intent("scene", "addNode", [0, 0, "placeholder"])
+        recorder.messages.clear()
+
+        await bus.dispatch_intent("scene", "setChatScrollValue", [chat_id, 88.0])
+        assert document.nodes[chat_id].chat_scroll_value == 88.0
+        assert recorder.topics_seen().count("scene") == 1
+
+        with pytest.raises(Exception):
+            await bus.dispatch_intent("scene", "setChatScrollValue", [other_id, 1.0])
+
+    asyncio.run(run())
+
+
+def test_scene_payload_round_trips_content_parts_with_base64_encoded_image_bytes():
+    # R6.3: content_parts is the RAW in-memory form (real bytes under
+    # "data"); scene_payload()'s wire form base64-encodes any part carrying
+    # raw bytes via content_codec.encode_image_bytes, matching content_codec.
+    # process_content_for_serialization's own output shape, while leaving
+    # the SceneNode's own in-memory field untouched.
+    doc = SceneDocument()
+    chat_node = doc.add_chat_node(0, 0, "look at this", True)
+    raw_image_bytes = b"\x89PNG\r\n raw bytes here"
+    chat_node.content_parts = [
+        {"type": "text", "text": "look at this"},
+        {"type": "image_bytes", "data": raw_image_bytes},
+    ]
+
+    payload_node = next(n for n in doc.scene_payload()["nodes"] if n["id"] == chat_node.id)
+    content_parts = payload_node["contentParts"]
+    assert content_parts[0] == {"type": "text", "text": "look at this"}
+    assert content_parts[1]["type"] == "image_bytes"
+    assert isinstance(content_parts[1]["data"], str), "wire form must be base64 text, not raw bytes"
+    assert base64.b64decode(content_parts[1]["data"]) == raw_image_bytes
+
+    # The in-memory field itself must be untouched by building the wire
+    # payload - still real bytes, never mutated into base64 text in place.
+    assert chat_node.content_parts[1]["data"] == raw_image_bytes
+    assert isinstance(chat_node.content_parts[1]["data"], bytes)
+
+
+def test_scene_payload_content_parts_is_none_not_empty_list_when_unset():
+    # R6.3: "no multimodal content" (None) must stay distinguishable on the
+    # wire from "multimodal content that happens to be empty" ([]) - the
+    # overwhelmingly common plain-text chat node must get contentParts:
+    # null, never [].
+    doc = SceneDocument()
+    chat_node = doc.add_chat_node(0, 0, "plain text only", True)
+    assert chat_node.content_parts is None
+
+    payload_node = next(n for n in doc.scene_payload()["nodes"] if n["id"] == chat_node.id)
+    assert payload_node["contentParts"] is None

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -2,7 +2,7 @@ import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
+import { ChatNodeView, makeDebouncedScrollReport, type ChatFlowNode } from "./ChatNodeView";
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount): RF's
 // own node wrapper stays `visibility: hidden` in jsdom until its
@@ -19,6 +19,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   const onRegenerate = vi.fn();
   const onGenerateImage = vi.fn();
   const onGenerateChart = vi.fn();
+  const onScrollChange = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -27,22 +28,24 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
       isUser: true,
       isCollapsed: false,
       dockedChildren: [],
+      chatScrollValue: 0,
       onToggleCollapse,
       onDelete,
       onUndockChild,
       onRegenerate,
       onGenerateImage,
       onGenerateChart,
+      onScrollChange,
       ...overrides,
     },
   } as unknown as NodeProps<ChatFlowNode>;
 
-  render(
+  const { container } = render(
     <ReactFlowProvider>
       <ChatNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onToggleCollapse, onDelete, onUndockChild, onRegenerate, onGenerateImage, onGenerateChart };
+  return { onToggleCollapse, onDelete, onUndockChild, onRegenerate, onGenerateImage, onGenerateChart, onScrollChange, container };
 }
 
 describe("ChatNodeView", () => {
@@ -227,5 +230,85 @@ describe("ChatNodeView", () => {
     expect(onUndockChild).toHaveBeenCalledOnce();
     expect(onUndockChild).toHaveBeenCalledWith("t1");
     expect(screen.queryByRole("menu")).toBeNull(); // the menu closes after any item fires
+  });
+});
+
+// R6.3: the node's own scroll position within .chat-node-content.
+describe("ChatNodeView scroll position (R6.3)", () => {
+  it("restores the saved chatScrollValue into .chat-node-content's scrollTop once on mount", () => {
+    const { container } = renderChatNode({ chatScrollValue: 250 });
+    const content = container.querySelector(".chat-node-content");
+    expect(content).not.toBeNull();
+    expect((content as HTMLDivElement).scrollTop).toBe(250);
+  });
+
+  it("defaults to scrollTop 0 when chatScrollValue is 0 (the default)", () => {
+    const { container } = renderChatNode({ chatScrollValue: 0 });
+    const content = container.querySelector(".chat-node-content") as HTMLDivElement;
+    expect(content.scrollTop).toBe(0);
+  });
+
+  it("scrolling reports the new position (debounced) via onScrollChange", () => {
+    vi.useFakeTimers();
+    try {
+      const { container, onScrollChange } = renderChatNode({ chatScrollValue: 0 });
+      const content = container.querySelector(".chat-node-content") as HTMLDivElement;
+
+      content.scrollTop = 120;
+      fireEvent.scroll(content);
+      expect(onScrollChange).not.toHaveBeenCalled(); // still debouncing
+
+      vi.advanceTimersByTime(200);
+      expect(onScrollChange).toHaveBeenCalledOnce();
+      expect(onScrollChange).toHaveBeenCalledWith(120);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("collapsing hides .chat-node-content, so no scroll container exists to attach onScroll to", () => {
+    const { container } = renderChatNode({ isCollapsed: true });
+    expect(container.querySelector(".chat-node-content")).toBeNull();
+  });
+});
+
+describe("makeDebouncedScrollReport", () => {
+  it("does not call onScrollChange until debounceMs have elapsed with no further calls", () => {
+    vi.useFakeTimers();
+    try {
+      const onScrollChange = vi.fn();
+      const timerRef: { current: ReturnType<typeof setTimeout> | null } = { current: null };
+      const debounced = makeDebouncedScrollReport(timerRef, onScrollChange, 200);
+
+      debounced(75);
+      expect(onScrollChange).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(199);
+      expect(onScrollChange).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(1);
+      expect(onScrollChange).toHaveBeenCalledOnce();
+      expect(onScrollChange).toHaveBeenCalledWith(75);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a call before the debounce window elapses cancels the previous one - only the LAST scroll position fires", () => {
+    vi.useFakeTimers();
+    try {
+      const onScrollChange = vi.fn();
+      const timerRef: { current: ReturnType<typeof setTimeout> | null } = { current: null };
+      const debounced = makeDebouncedScrollReport(timerRef, onScrollChange, 200);
+
+      debounced(50);
+      vi.advanceTimersByTime(150);
+      debounced(90); // simulates continued scrolling before the debounce settled
+      vi.advanceTimersByTime(150);
+      expect(onScrollChange).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(50);
+      expect(onScrollChange).toHaveBeenCalledOnce();
+      expect(onScrollChange).toHaveBeenCalledWith(90);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { CHAT_SCROLL_REPORT_DEBOUNCE_MS, LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 
 /**
  * The chat node (Qt-removal plan R3.1/R3.2) - ChatNode's React successor:
@@ -42,6 +42,12 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * parent. Key Takeaway/Explainer Note remain honestly deferred (still no
  * agent-layer support of their own) - the stale "Chart" mention in their old
  * shared R4-blocker note above has been removed accordingly.
+ *
+ * R6.3: the node's own scroll position within .chat-node-content (its
+ * scrollable markdown body) is now restored on mount and reported
+ * (debounced) on every scroll - the legacy serializer's own scroll_value
+ * field, previously unmodeled here entirely, needed for R6.4/R6.5's session
+ * load/save round trip.
  */
 
 export interface ChatNodeData extends Record<string, unknown> {
@@ -49,12 +55,17 @@ export interface ChatNodeData extends Record<string, unknown> {
   isUser: boolean;
   isCollapsed: boolean;
   dockedChildren: { id: string; label: string }[];
+  // R6.3: the node's own persisted scroll position - restored into
+  // .chat-node-content's scrollTop once on mount, then kept live-updated
+  // (debounced) via onScrollChange as the user scrolls.
+  chatScrollValue: number;
   onToggleCollapse: () => void;
   onDelete: () => void;
   onUndockChild: (childId: string) => void;
   onRegenerate: () => void;
   onGenerateImage: () => void;
   onGenerateChart: (chartType: string) => void;
+  onScrollChange: (value: number) => void;
 }
 
 export type ChatFlowNode = Node<ChatNodeData, "chat">;
@@ -256,11 +267,55 @@ function ChatNodeMenu({
   );
 }
 
+/** R6.3: the debounce wrapper for scroll-position reporting - same plain
+ * clearTimeout/setTimeout-box-keyed-off-the-caller's-own-timerRef shape as
+ * ChartNodeView.tsx's makeDebouncedChartResize / HtmlNodeView.tsx's
+ * makeDebouncedSplitterReport, exported standalone for the same direct-unit-
+ * testability reason. */
+export function makeDebouncedScrollReport(
+  timerRef: { current: ReturnType<typeof setTimeout> | null },
+  onScrollChange: (value: number) => void,
+  debounceMs: number = CHAT_SCROLL_REPORT_DEBOUNCE_MS,
+): (value: number) => void {
+  return (value) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      onScrollChange(value);
+    }, debounceMs);
+  };
+}
+
 export function ChatNodeView({ data, selected }: NodeProps<ChatFlowNode>) {
   const zoom = useStore((s) => s.transform[2]);
   const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
   const collapsed = data.isCollapsed || lodCollapsed;
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+
+  // R6.3: restore the saved scroll position once on mount (an empty dep
+  // array - deliberate, not a lint oversight: re-running this on every scene
+  // snapshot/re-render would fight the user's own live scrolling every time
+  // an unrelated field on this node changes). scrollTimerRef carries the
+  // debounce state across scroll events (see makeDebouncedScrollReport
+  // above).
+  const contentRef = useRef<HTMLDivElement>(null);
+  const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (contentRef.current) contentRef.current.scrollTop = data.chatScrollValue;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
+    },
+    [],
+  );
+
+  function onScroll(event: React.UIEvent<HTMLDivElement>) {
+    makeDebouncedScrollReport(scrollTimerRef, data.onScrollChange)(event.currentTarget.scrollTop);
+  }
 
   return (
     <div
@@ -290,7 +345,7 @@ export function ChatNodeView({ data, selected }: NodeProps<ChatFlowNode>) {
         </button>
       </div>
       {!collapsed && (
-        <div className="scene-node-body chat-node-content">
+        <div className="scene-node-body chat-node-content" ref={contentRef} onScroll={onScroll}>
           <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
             {data.content}
           </ReactMarkdown>

--- a/web_ui/src/app/canvas/HtmlNodeView.test.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.test.tsx
@@ -2,7 +2,14 @@ import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { buildSandboxedHtmlDocument, HtmlNodeView, type HtmlFlowNode } from "./HtmlNodeView";
+import {
+  buildSandboxedHtmlDocument,
+  clampSplitterValue,
+  HtmlNodeView,
+  makeDebouncedSplitterReport,
+  type HtmlFlowNode,
+} from "./HtmlNodeView";
+import { HTML_SPLIT_MAX, HTML_SPLIT_MIN, HTML_SPLIT_TOTAL_PX } from "./canvasConstants";
 
 const EXACT_CSP =
   "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; base-uri 'none'; frame-src 'none'; object-src 'none'; form-action 'none'";
@@ -13,14 +20,17 @@ const EXACT_CSP_META = `<meta http-equiv="Content-Security-Policy" content="${EX
 function renderHtmlNode(overrides: Partial<HtmlFlowNode["data"]> = {}) {
   const onToggleCollapse = vi.fn();
   const onDelete = vi.fn();
+  const onSplitterChange = vi.fn();
   const props = {
     id: "n0",
     selected: false,
     data: {
       htmlContent: "<p>hello</p>",
       isCollapsed: false,
+      htmlSplitterState: null,
       onToggleCollapse,
       onDelete,
+      onSplitterChange,
       ...overrides,
     },
   } as unknown as NodeProps<HtmlFlowNode>;
@@ -30,7 +40,13 @@ function renderHtmlNode(overrides: Partial<HtmlFlowNode["data"]> = {}) {
       <HtmlNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onToggleCollapse, onDelete, container };
+  return { onToggleCollapse, onDelete, onSplitterChange, container };
+}
+
+function getSplitter(container: HTMLElement): HTMLDivElement {
+  const splitter = container.querySelector(".html-node-splitter");
+  expect(splitter).not.toBeNull();
+  return splitter as HTMLDivElement;
 }
 
 function getIframe(container: HTMLElement): HTMLIFrameElement {
@@ -194,5 +210,144 @@ describe("HtmlNodeView", () => {
     expect(container.querySelector("textarea.html-node-source")).toBeNull();
     expect(container.querySelector("iframe.html-node-preview")).toBeNull();
     expect(screen.queryByRole("button", { name: "Render" })).toBeNull();
+  });
+});
+
+// R6.3: HTML node splitter-position scaffolding.
+describe("HtmlNodeView splitter (R6.3)", () => {
+  it("defaults to a 50/50 split (HTML_SPLIT_TOTAL_PX/2 each pane) when htmlSplitterState is null", () => {
+    const { container } = renderHtmlNode({ htmlSplitterState: null });
+    const textarea = getSourceTextarea(container);
+    const iframe = getIframe(container);
+    expect(textarea.style.height).toBe(`${HTML_SPLIT_TOTAL_PX / 2}px`);
+    expect(iframe.style.height).toBe(`${HTML_SPLIT_TOTAL_PX / 2}px`);
+  });
+
+  it("restores a previously saved split position on mount, and the two panes always sum to HTML_SPLIT_TOTAL_PX", () => {
+    const { container } = renderHtmlNode({ htmlSplitterState: 0.3 });
+    const textarea = getSourceTextarea(container);
+    const iframe = getIframe(container);
+    expect(textarea.style.height).toBe(`${Math.round(0.3 * HTML_SPLIT_TOTAL_PX)}px`);
+    expect(iframe.style.height).toBe(`${HTML_SPLIT_TOTAL_PX - Math.round(0.3 * HTML_SPLIT_TOTAL_PX)}px`);
+  });
+
+  it("the splitter is a real separator element wired to a pointerdown handler", () => {
+    const { container } = renderHtmlNode();
+    const splitter = getSplitter(container);
+    expect(splitter).toHaveAttribute("role", "separator");
+    expect(splitter).toHaveAttribute("aria-orientation", "horizontal");
+  });
+
+  it("dragging the splitter updates the pane heights immediately, then reports the settled value once debounceMs elapses", () => {
+    vi.useFakeTimers();
+    try {
+      const { container, onSplitterChange } = renderHtmlNode({ htmlSplitterState: 0.5 });
+      const splitter = getSplitter(container);
+
+      fireEvent.pointerDown(splitter, { clientY: 100 });
+      // Dragging DOWN by 28px (10% of HTML_SPLIT_TOTAL_PX=280) grows the
+      // Source pane's fraction from 0.5 to 0.6 - visible immediately, no
+      // debounce on the live drag itself.
+      fireEvent.pointerMove(window, { clientY: 128 });
+      const textarea = getSourceTextarea(container);
+      expect(textarea.style.height).toBe(`${Math.round(0.6 * HTML_SPLIT_TOTAL_PX)}px`);
+      expect(onSplitterChange).not.toHaveBeenCalled();
+
+      fireEvent.pointerUp(window);
+      expect(onSplitterChange).not.toHaveBeenCalled(); // still debouncing
+      vi.advanceTimersByTime(200);
+      expect(onSplitterChange).toHaveBeenCalledOnce();
+      expect(onSplitterChange).toHaveBeenCalledWith(0.6);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clamps a far drag to HTML_SPLIT_MAX rather than letting the Preview pane collapse to nothing", () => {
+    vi.useFakeTimers();
+    try {
+      const { container, onSplitterChange } = renderHtmlNode({ htmlSplitterState: 0.5 });
+      const splitter = getSplitter(container);
+
+      fireEvent.pointerDown(splitter, { clientY: 0 });
+      fireEvent.pointerMove(window, { clientY: 10000 }); // absurdly far down
+      fireEvent.pointerUp(window);
+      vi.advanceTimersByTime(200);
+
+      expect(onSplitterChange).toHaveBeenCalledWith(HTML_SPLIT_MAX);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a pointerdown/pointerup with no movement in between reports nothing (not even the unchanged value)", () => {
+    vi.useFakeTimers();
+    try {
+      const { container, onSplitterChange } = renderHtmlNode({ htmlSplitterState: 0.5 });
+      const splitter = getSplitter(container);
+
+      fireEvent.pointerDown(splitter, { clientY: 50 });
+      fireEvent.pointerUp(window);
+      vi.advanceTimersByTime(500);
+
+      expect(onSplitterChange).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("clampSplitterValue", () => {
+  it("passes values already inside [HTML_SPLIT_MIN, HTML_SPLIT_MAX] through unchanged", () => {
+    expect(clampSplitterValue(0.5)).toBe(0.5);
+  });
+
+  it("clamps below HTML_SPLIT_MIN up to HTML_SPLIT_MIN", () => {
+    expect(clampSplitterValue(-1)).toBe(HTML_SPLIT_MIN);
+  });
+
+  it("clamps above HTML_SPLIT_MAX down to HTML_SPLIT_MAX", () => {
+    expect(clampSplitterValue(2)).toBe(HTML_SPLIT_MAX);
+  });
+});
+
+describe("makeDebouncedSplitterReport", () => {
+  it("does not call onSplitterChange until debounceMs have elapsed with no further calls", () => {
+    vi.useFakeTimers();
+    try {
+      const onSplitterChange = vi.fn();
+      const timerRef: { current: ReturnType<typeof setTimeout> | null } = { current: null };
+      const debounced = makeDebouncedSplitterReport(timerRef, onSplitterChange, 200);
+
+      debounced(0.4);
+      expect(onSplitterChange).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(199);
+      expect(onSplitterChange).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(1);
+      expect(onSplitterChange).toHaveBeenCalledOnce();
+      expect(onSplitterChange).toHaveBeenCalledWith(0.4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a call before the debounce window elapses cancels the previous one - only the LAST value fires", () => {
+    vi.useFakeTimers();
+    try {
+      const onSplitterChange = vi.fn();
+      const timerRef: { current: ReturnType<typeof setTimeout> | null } = { current: null };
+      const debounced = makeDebouncedSplitterReport(timerRef, onSplitterChange, 200);
+
+      debounced(0.4);
+      vi.advanceTimersByTime(150);
+      debounced(0.6);
+      vi.advanceTimersByTime(150);
+      expect(onSplitterChange).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(50);
+      expect(onSplitterChange).toHaveBeenCalledOnce();
+      expect(onSplitterChange).toHaveBeenCalledWith(0.6);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/web_ui/src/app/canvas/HtmlNodeView.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.tsx
@@ -1,6 +1,13 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useState } from "react";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { useEffect, useRef, useState } from "react";
+import {
+  HTML_SPLIT_DEFAULT,
+  HTML_SPLIT_MAX,
+  HTML_SPLIT_MIN,
+  HTML_SPLIT_TOTAL_PX,
+  HTML_SPLITTER_REPORT_DEBOUNCE_MS,
+  LOD_ZOOM_THRESHOLD,
+} from "./canvasConstants";
 
 /**
  * The HTML view node (Qt-removal plan R3.17/R3.18) - graphlink_node_htmlview.py's
@@ -31,13 +38,32 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * small enough (Collapse/Expand, Popout placeholder, Delete) that it renders
  * as a plain inline button row in the header instead - no menu component,
  * no onContextMenu handler, nothing to dismiss.
+ *
+ * R6.3: the Source/Preview split position (splitterValue, a fraction of
+ * HTML_SPLIT_TOTAL_PX) is now a real draggable divider between the two
+ * panes, not just fixed 140px/140px panes as before. This was a deliberate
+ * scope cut back in R3.17/R3.18 (legacy's own splitter_state had "no domain
+ * meaning" at the time - see styles.css's own now-superseded comment on
+ * .html-node-source) - R6.3 re-scopes it in because R6.4/R6.5's session
+ * load/save pipeline needs every legacy-persisted field to round-trip
+ * losslessly, this one included (see canvasConstants.ts's own HTML_SPLIT_*
+ * doc). Dragging updates the visible split immediately (no debounce on the
+ * live drag itself - only the final settled value gets reported over the
+ * wire, via makeDebouncedSplitterReport below, same "report once settled"
+ * posture as ChartNodeView.tsx's resize debounce).
  */
 
 export interface HtmlNodeData extends Record<string, unknown> {
   htmlContent: string;
   isCollapsed: boolean;
+  // R6.3: null means "no saved split position yet" (a brand-new node, or one
+  // loaded from before this field existed) - HTML_SPLIT_DEFAULT is applied
+  // locally in that case, never sent back over the wire as a fake "0.5" the
+  // backend would think was a real user choice.
+  htmlSplitterState: number | null;
   onToggleCollapse: () => void;
   onDelete: () => void;
+  onSplitterChange: (value: number) => void;
 }
 
 export type HtmlFlowNode = Node<HtmlNodeData, "html">;
@@ -74,6 +100,32 @@ ${raw}
 </body></html>`;
 }
 
+/** R6.3: clamps a raw drag-derived fraction into [HTML_SPLIT_MIN,
+ * HTML_SPLIT_MAX] so a fast/far drag can never collapse either pane to zero
+ * (or negative) height - exported standalone for direct unit testing of the
+ * clamp boundaries without simulating a full pointer-drag sequence. */
+export function clampSplitterValue(value: number): number {
+  return Math.min(HTML_SPLIT_MAX, Math.max(HTML_SPLIT_MIN, value));
+}
+
+/** R6.3: the debounce wrapper for splitter-position reporting - same
+ * plain-clearTimeout/setTimeout-box-keyed-off-the-caller's-own-timerRef
+ * shape as ChartNodeView.tsx's makeDebouncedChartResize, exported standalone
+ * for the same direct-unit-testability reason. */
+export function makeDebouncedSplitterReport(
+  timerRef: { current: ReturnType<typeof setTimeout> | null },
+  onSplitterChange: (value: number) => void,
+  debounceMs: number = HTML_SPLITTER_REPORT_DEBOUNCE_MS,
+): (value: number) => void {
+  return (value) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      onSplitterChange(value);
+    }, debounceMs);
+  };
+}
+
 export function HtmlNodeView({ data, selected }: NodeProps<HtmlFlowNode>) {
   const zoom = useStore((s) => s.transform[2]);
   const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
@@ -87,6 +139,55 @@ export function HtmlNodeView({ data, selected }: NodeProps<HtmlFlowNode>) {
   // literally cannot reach the iframe through any path in this component.
   const [sourceText, setSourceText] = useState(data.htmlContent);
   const [renderedDoc, setRenderedDoc] = useState(() => buildSandboxedHtmlDocument(data.htmlContent));
+
+  // R6.3: the Source/Preview split - restored from data.htmlSplitterState on
+  // mount (see the component-level useState initializer), then dragged
+  // locally via onSplitterPointerDown below. splitterTimerRef carries the
+  // debounce state across drags (see makeDebouncedSplitterReport above).
+  const [splitterValue, setSplitterValue] = useState(data.htmlSplitterState ?? HTML_SPLIT_DEFAULT);
+  const splitterTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (splitterTimerRef.current) clearTimeout(splitterTimerRef.current);
+    },
+    [],
+  );
+
+  // Plain window-level pointermove/pointerup listeners (added on pointerdown,
+  // removed on pointerup) rather than setPointerCapture - jsdom implements no
+  // setPointerCapture/releasePointerCapture at all (confirmed during recon),
+  // so calling either would break every test simulating this drag; window
+  // listeners work identically in a real browser and need no such API.
+  // `latestValue` is a plain mutable box read synchronously by onPointerUp -
+  // NOT the splitterValue React state var, which only updates on the next
+  // render and would risk a stale read if onPointerUp ran before that render
+  // flushed.
+  function onSplitterPointerDown(event: React.PointerEvent<HTMLDivElement>) {
+    const startY = event.clientY;
+    const startValue = splitterValue;
+    const latestValue = { current: startValue };
+
+    function onPointerMove(moveEvent: PointerEvent) {
+      const next = clampSplitterValue(startValue + (moveEvent.clientY - startY) / HTML_SPLIT_TOTAL_PX);
+      latestValue.current = next;
+      setSplitterValue(next);
+    }
+    function onPointerUp() {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      // A plain click with no real movement is a no-op - don't fire a
+      // network round trip for an unchanged value.
+      if (latestValue.current !== startValue) {
+        makeDebouncedSplitterReport(splitterTimerRef, data.onSplitterChange)(latestValue.current);
+      }
+    }
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+  }
+
+  const sourceHeightPx = Math.round(splitterValue * HTML_SPLIT_TOTAL_PX);
+  const previewHeightPx = HTML_SPLIT_TOTAL_PX - sourceHeightPx;
 
   return (
     <div className={`scene-node html-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}>
@@ -120,11 +221,25 @@ export function HtmlNodeView({ data, selected }: NodeProps<HtmlFlowNode>) {
             <p className="html-node-section-label">Source</p>
             <textarea
               className="html-node-source"
+              style={{ height: sourceHeightPx }}
               value={sourceText}
               onChange={(event) => setSourceText(event.target.value)}
               spellCheck={false}
             />
           </div>
+          {/* R6.3: the draggable split handle - `nodrag` keeps React Flow's
+              own node-drag gesture from hijacking this pointer-down (same
+              convention as GroupNodeView's label input / ChartNodeView's
+              toolbar). Purely a resize handle for the Source pane above it;
+              the Preview pane below takes up whatever's left of
+              HTML_SPLIT_TOTAL_PX. */}
+          <div
+            className="html-node-splitter nodrag"
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label="Resize source and preview panes"
+            onPointerDown={onSplitterPointerDown}
+          />
           <button
             type="button"
             className="html-node-render-btn"
@@ -142,6 +257,7 @@ export function HtmlNodeView({ data, selected }: NodeProps<HtmlFlowNode>) {
                 and it only ever holds buildSandboxedHtmlDocument's output. */}
             <iframe
               className="html-node-preview"
+              style={{ height: previewHeightPx }}
               sandbox="allow-scripts"
               srcDoc={renderedDoc}
               title="HTML preview"

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { applyGroupDragDelta, groupDragKindOf, handleSelectionChange, toFlowNodes, type SceneFlowNode } from "./SceneCanvas";
+import {
+  applyGroupDragDelta,
+  groupDragKindOf,
+  handleSelectionChange,
+  makeDebouncedViewportReport,
+  toFlowNodes,
+  type SceneFlowNode,
+} from "./SceneCanvas";
 import { SceneStore, initialSceneState } from "./sceneStore";
 import type { WsTransport } from "../../lib/ws/transport";
 import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
@@ -1230,6 +1237,137 @@ describe("toFlowNodes (R6.2 chart node)", () => {
     const scene = baseScene({ nodes: [chartNode({ id: "chart-1", isDocked: true })], edges: [] });
     const store = makeStore();
     expect(toFlowNodes(scene, store).find((n) => n.id === "chart-1")).toBeUndefined();
+  });
+});
+
+// R6.3: Scene-level serialization gaps. Same situation as ChartTestFields
+// above - htmlSplitterState/chatScrollValue aren't in the generated
+// SceneNodeRow type yet (see SceneCanvas.tsx's own SceneNodeR63Fields
+// comment).
+interface R63TestFields {
+  htmlSplitterState: number | null;
+  chatScrollValue: number;
+}
+
+function withR63Fields(node: SceneNodeRow, overrides: Partial<R63TestFields> = {}): SceneNodeRow & R63TestFields {
+  return {
+    ...node,
+    htmlSplitterState: null,
+    chatScrollValue: 0,
+    ...overrides,
+  } as SceneNodeRow & R63TestFields;
+}
+
+describe("toFlowNodes (R6.3 chat node scroll value)", () => {
+  it("maps a saved chatScrollValue onto the flow node's data", () => {
+    const scene = baseScene({
+      nodes: [withR63Fields(baseNode({ id: "chat-1", kind: "chat", content: "Hi" }), { chatScrollValue: 240 })],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    expect((chatFlowNode!.data as { chatScrollValue: number }).chatScrollValue).toBe(240);
+  });
+
+  it("defaults chatScrollValue to 0 when the field is absent (ahead of codegen regenerating SceneNodeRow)", () => {
+    const scene = baseScene({ nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hi" })], edges: [] });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    expect((chatFlowNode!.data as { chatScrollValue: number }).chatScrollValue).toBe(0);
+  });
+
+  it("onScrollChange calls setChatScrollValue with this node's own id and the given value", () => {
+    const scene = baseScene({ nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hi" })], edges: [] });
+    const store = makeStore();
+    const spy = vi.spyOn(store, "setChatScrollValue");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const data = flowNodes.find((n) => n.id === "chat-1")!.data as { onScrollChange: (value: number) => void };
+    data.onScrollChange(180);
+    expect(spy).toHaveBeenCalledWith("chat-1", 180);
+  });
+});
+
+describe("toFlowNodes (R6.3 html node splitter state)", () => {
+  it("maps a saved htmlSplitterState onto the flow node's data", () => {
+    const scene = baseScene({
+      nodes: [
+        withR63Fields(baseNode({ id: "html-1", kind: "html", content: "<p>hi</p>" }), { htmlSplitterState: 0.35 }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const htmlFlowNode = flowNodes.find((n) => n.id === "html-1");
+    expect((htmlFlowNode!.data as { htmlSplitterState: number | null }).htmlSplitterState).toBe(0.35);
+  });
+
+  it("defaults htmlSplitterState to null when the field is absent (ahead of codegen regenerating SceneNodeRow)", () => {
+    const scene = baseScene({ nodes: [baseNode({ id: "html-1", kind: "html", content: "<p>hi</p>" })], edges: [] });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const htmlFlowNode = flowNodes.find((n) => n.id === "html-1");
+    expect((htmlFlowNode!.data as { htmlSplitterState: number | null }).htmlSplitterState).toBeNull();
+  });
+
+  it("onSplitterChange calls setHtmlSplitterState with this node's own id and the given value", () => {
+    const scene = baseScene({ nodes: [baseNode({ id: "html-1", kind: "html", content: "<p>hi</p>" })], edges: [] });
+    const store = makeStore();
+    const spy = vi.spyOn(store, "setHtmlSplitterState");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const data = flowNodes.find((n) => n.id === "html-1")!.data as { onSplitterChange: (value: number) => void };
+    data.onSplitterChange(0.6);
+    expect(spy).toHaveBeenCalledWith("html-1", 0.6);
+  });
+});
+
+describe("makeDebouncedViewportReport (R6.3 canvas pan/zoom reporting)", () => {
+  it("does not call onReport until debounceMs have elapsed with no further calls", () => {
+    vi.useFakeTimers();
+    try {
+      const onReport = vi.fn();
+      const timerRef: { current: ReturnType<typeof setTimeout> | null } = { current: null };
+      const debounced = makeDebouncedViewportReport(timerRef, onReport, 250);
+
+      debounced(1.5, 100, 200);
+      expect(onReport).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(249);
+      expect(onReport).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(1);
+      expect(onReport).toHaveBeenCalledOnce();
+      expect(onReport).toHaveBeenCalledWith(1.5, 100, 200);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a call before the debounce window elapses cancels the previous one - only the LAST viewport fires, never every intermediate pan/zoom frame", () => {
+    vi.useFakeTimers();
+    try {
+      const onReport = vi.fn();
+      const timerRef: { current: ReturnType<typeof setTimeout> | null } = { current: null };
+      const debounced = makeDebouncedViewportReport(timerRef, onReport, 250);
+
+      debounced(1, 0, 0); // frame 1 of a pan/zoom gesture
+      vi.advanceTimersByTime(100);
+      debounced(1.2, 40, 60); // frame 2, still mid-gesture
+      vi.advanceTimersByTime(100);
+      debounced(1.4, 80, 120); // frame 3 (the settled end position)
+      vi.advanceTimersByTime(200);
+      expect(onReport).not.toHaveBeenCalled(); // only 200ms since the LAST frame
+      vi.advanceTimersByTime(50);
+      expect(onReport).toHaveBeenCalledOnce();
+      expect(onReport).toHaveBeenCalledWith(1.4, 80, 120);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -12,6 +12,7 @@ import {
   type Node,
   type NodeChange,
   type NodeProps,
+  type OnMove,
   applyNodeChanges,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
@@ -33,7 +34,12 @@ import { NoteNodeView, type NoteFlowNode } from "./NoteNodeView";
 import { PyCoderNodeView, type PyCoderFlowNode } from "./PyCoderNodeView";
 import { ThinkingNodeView, type ThinkingFlowNode } from "./ThinkingNodeView";
 import { WebResearchNodeView, type WebResearchFlowNode } from "./WebResearchNodeView";
-import { GROUP_FALLBACK_HEIGHT, GROUP_FALLBACK_WIDTH, LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import {
+  GROUP_FALLBACK_HEIGHT,
+  GROUP_FALLBACK_WIDTH,
+  LOD_ZOOM_THRESHOLD,
+  VIEWPORT_REPORT_DEBOUNCE_MS,
+} from "./canvasConstants";
 import { SceneStore, scaleDragPosition } from "./sceneStore";
 
 // R6.1: Notes/Frames/Containers - the generated SceneNodeRow type (codegen
@@ -78,6 +84,20 @@ interface SceneNodeChartFields {
   chartSourceNodeId: string;
 }
 type SceneNodeRowWithChart = SceneNodeRow & SceneNodeChartFields;
+
+// R6.3: Scene-level serialization gaps. Same situation as
+// SceneNodeGroupFields/SceneNodeChartFields above - the generated
+// SceneNodeRow type hasn't been regenerated yet to carry
+// htmlSplitterState/chatScrollValue (backend/canvas.py's scene_payload()
+// contract for this increment). contentParts is deliberately absent here -
+// nothing in this increment's frontend scope reads it (see this increment's
+// own report for why: it's a backend-only round-trip capability for OLD
+// multimodal sessions R6.4 may load, not a new frontend feature).
+interface SceneNodeR63Fields {
+  htmlSplitterState: number | null;
+  chatScrollValue: number;
+}
+type SceneNodeRowWithR63 = SceneNodeRow & SceneNodeR63Fields;
 
 /**
  * The React Flow canvas (Qt-removal plan R1) - the QGraphicsScene/ChatView
@@ -187,6 +207,7 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
         const target = nodesById.get(e.target);
         if (target?.isDocked) dockedChildren.push({ id: target.id, label: target.title });
       }
+      const chatR63 = n as SceneNodeRowWithR63;
       flowNodes.push({
         id: n.id,
         type: "chat" as const,
@@ -207,6 +228,13 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
           // onGenerateImage above - the new chart node arrives through the
           // next scene snapshot.
           onGenerateChart: (chartType: string) => store.generateChart(n.id, chartType),
+          // R6.3: the node's own scroll position within its content area -
+          // read on mount by ChatNodeView (restore) and reported (debounced)
+          // via the new setChatScrollValue intent on every scroll. Defaults
+          // to 0 the same way every other numeric ?? fallback in this file
+          // does, ahead of codegen regenerating SceneNodeRow to carry it.
+          chatScrollValue: chatR63.chatScrollValue ?? 0,
+          onScrollChange: (value: number) => store.setChatScrollValue(n.id, value),
         },
       });
       continue;
@@ -297,6 +325,7 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
       // entry exists on this node's own header, and ChatNodeView's own
       // dockedChildren/undock badge is kind-agnostic already, so undocking
       // it is still possible from the parent chat node's side).
+      const htmlR63 = n as SceneNodeRowWithR63;
       flowNodes.push({
         id: n.id,
         type: "html" as const,
@@ -306,6 +335,14 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
           isCollapsed: n.isCollapsed,
           onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
           onDelete: () => store.removeNodes([n.id]),
+          // R6.3: the Source/Preview split position - read on mount by
+          // HtmlNodeView (restore; null means "no saved value, use the
+          // component's own 50/50 default") and reported (debounced) via the
+          // new setHtmlSplitterState intent once a drag settles. See
+          // canvasConstants.ts's own HTML_SPLIT_* doc for why this exists
+          // now despite being scoped OUT back in R3.17/R3.18.
+          htmlSplitterState: htmlR63.htmlSplitterState ?? null,
+          onSplitterChange: (value: number) => store.setHtmlSplitterState(n.id, value),
         },
       });
       continue;
@@ -766,6 +803,27 @@ function toFlowEdges(scene: SceneState): Edge[] {
     .map((e) => ({ id: e.id, source: e.source, target: e.target }));
 }
 
+// R6.3: the debounce wrapper for viewport (pan/zoom) reporting - same posture
+// as ChartNodeView.tsx's makeDebouncedChartResize (a plain clearTimeout/
+// setTimeout box keyed off the caller's own timerRef, so debounce state
+// survives across repeated calls without this function owning any React
+// state itself), exported standalone for direct unit testing without
+// mounting a real <ReactFlow> pan/zoom gesture - the same testability
+// posture as scaleDragPosition/toFlowNodes/handleSelectionChange above.
+export function makeDebouncedViewportReport(
+  timerRef: { current: ReturnType<typeof setTimeout> | null },
+  onReport: (zoomFactor: number, scrollX: number, scrollY: number) => void,
+  debounceMs: number = VIEWPORT_REPORT_DEBOUNCE_MS,
+): (zoomFactor: number, scrollX: number, scrollY: number) => void {
+  return (zoomFactor, scrollX, scrollY) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      onReport(zoomFactor, scrollX, scrollY);
+    }, debounceMs);
+  };
+}
+
 function CanvasInner({ store }: { store: SceneStore }) {
   const scene = useSyncExternalStore(store.subscribe, store.getScene);
   const grid = useSyncExternalStore(store.subscribe, store.getGrid);
@@ -776,6 +834,27 @@ function CanvasInner({ store }: { store: SceneStore }) {
   const [nodes, setNodes] = useState<SceneFlowNode[]>([]);
   const dragStartRef = useRef<Map<string, { x: number; y: number }>>(new Map());
   const draggingRef = useRef(false);
+
+  // R6.3: viewport (pan/zoom) reporting - see makeDebouncedViewportReport's
+  // own doc above. onMove fires on every frame of a pan/zoom gesture (never
+  // just once at the end, unlike NodeResizer's onResizeEnd), so the debounce
+  // here is load-bearing, not just a burst guard: without it, setViewState
+  // would fire a WS intent every animation frame of every pan/zoom gesture.
+  const viewportTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (viewportTimerRef.current) clearTimeout(viewportTimerRef.current);
+    },
+    [],
+  );
+  const onMove: OnMove = useCallback(
+    (_event, viewport) => {
+      makeDebouncedViewportReport(viewportTimerRef, (zoomFactor, scrollX, scrollY) =>
+        store.setViewState(zoomFactor, scrollX, scrollY),
+      )(viewport.zoom, viewport.x, viewport.y);
+    },
+    [store],
+  );
 
   useEffect(() => {
     if (!draggingRef.current) setNodes(toFlowNodes(scene, store));
@@ -892,6 +971,7 @@ function CanvasInner({ store }: { store: SceneStore }) {
         onNodesChange={onNodesChange}
         onConnect={onConnect}
         onDelete={onDelete}
+        onMove={onMove}
         // R5.1: mirrors React Flow's own selection state into the store so
         // PluginPicker can attach "which node was selected" to executePlugin
         // without either component reaching into the other's internals.

--- a/web_ui/src/app/canvas/canvasConstants.ts
+++ b/web_ui/src/app/canvas/canvasConstants.ts
@@ -49,3 +49,31 @@ export const CHART_DEFAULT_HEIGHT = 500;
  * 90ms after a same-process Qt repaint; this is intentionally longer since a
  * resize-then-WS-round-trip in this stack has a different cost profile. */
 export const CHART_RESIZE_DEBOUNCE_MS = 200;
+
+/** R6.3: Scene-level serialization gaps. Three independent "report after
+ * settling, not on every intermediate frame" debounces - same guard-against-
+ * a-network-call-burst posture as CHART_RESIZE_DEBOUNCE_MS above, just
+ * applied to three different gestures (canvas pan/zoom, the HTML node's
+ * splitter drag, a chat node's own content scroll) instead of NodeResizer's
+ * onResizeEnd. */
+export const VIEWPORT_REPORT_DEBOUNCE_MS = 250;
+export const HTML_SPLITTER_REPORT_DEBOUNCE_MS = 200;
+export const CHAT_SCROLL_REPORT_DEBOUNCE_MS = 200;
+
+/** R6.3: HTML view node splitter-position scaffolding. Legacy's own
+ * splitter_state (graphlink_html_view.py's QSplitter) was a deliberate scope
+ * cut back in R3.17/R3.18 (see HtmlNodeView.tsx/styles.css's own now-
+ * superseded comments) - it was pure Qt UI state with no domain meaning AT
+ * THE TIME, confirmed by a since-removed test asserting scene_payload needed
+ * no new key for it. R6.3 re-scopes it back in because R6.4/R6.5's session
+ * load/save pipeline needs every legacy-persisted field to round-trip
+ * losslessly, this one included - a value this app itself never wrote before
+ * can still show up in an OLD chats.db row R6.4 loads. HTML_SPLIT_TOTAL_PX is
+ * the combined source+preview pane height the split fraction is measured
+ * against, chosen to equal the pre-R6.3 fixed 140px+140px total exactly, so
+ * the default 0.5 fraction renders pixel-identical to the old fixed layout.
+ * MIN/MAX keep either pane from being dragged down to zero height. */
+export const HTML_SPLIT_TOTAL_PX = 280;
+export const HTML_SPLIT_DEFAULT = 0.5;
+export const HTML_SPLIT_MIN = 0.15;
+export const HTML_SPLIT_MAX = 0.85;

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -622,6 +622,27 @@ describe("SceneStore", () => {
     expect(intents).toEqual([{ topic: "scene", intent: "toggleChartAspectLock", args: ["n1"] }]);
   });
 
+  it("setViewState sends the scene-topic setViewState intent with [zoomFactor, scrollX, scrollY]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setViewState(1.5, 120, -80);
+    expect(intents).toEqual([{ topic: "scene", intent: "setViewState", args: [1.5, 120, -80] }]);
+  });
+
+  it("setHtmlSplitterState sends the scene-topic setHtmlSplitterState intent with [nodeId, value]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setHtmlSplitterState("html-1", 0.4);
+    expect(intents).toEqual([{ topic: "scene", intent: "setHtmlSplitterState", args: ["html-1", 0.4] }]);
+  });
+
+  it("setChatScrollValue sends the scene-topic setChatScrollValue intent with [nodeId, value]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setChatScrollValue("chat-1", 320);
+    expect(intents).toEqual([{ topic: "scene", intent: "setChatScrollValue", args: ["chat-1", 320] }]);
+  });
+
   it("subscribeStream forwards directly to transport.subscribeStream and returns its unsubscribe function", () => {
     const { transport } = makeFakeTransport();
     const unsubscribe = vi.fn();

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -625,6 +625,33 @@ export class SceneStore {
     this.transport.intent("scene", "toggleChartAspectLock", [nodeId]);
   }
 
+  // -- R6.3: Scene-level serialization gaps ---------------------------------
+  //
+  // Mirrors backend/canvas.py's register_canvas() intent names/argument order
+  // 1:1, same convention as every scene intent above. These three back the
+  // legacy session serializer's own view_state/HTML splitter_state/chat
+  // scroll_value fields - not because anything reads them back INTO this
+  // increment's UI yet, but because R6.4 (session LOAD) and R6.5 (session
+  // SAVE) need somewhere real on the document/node model to persist and
+  // restore them; without these, a value present in an old chats.db row (or
+  // one a user sets by panning/zooming/dragging/scrolling in this session)
+  // would have nowhere to land. Fire-and-forget, same posture as every other
+  // plain setter intent above (setChatCollapsed, resizeChart, ...) - no reply
+  // needed, the next scene snapshot is enough if the value round-trips
+  // through it at all.
+
+  setViewState(zoomFactor: number, scrollX: number, scrollY: number): void {
+    this.transport.intent("scene", "setViewState", [zoomFactor, scrollX, scrollY]);
+  }
+
+  setHtmlSplitterState(nodeId: string, value: number): void {
+    this.transport.intent("scene", "setHtmlSplitterState", [nodeId, value]);
+  }
+
+  setChatScrollValue(nodeId: string, value: number): void {
+    this.transport.intent("scene", "setChatScrollValue", [nodeId, value]);
+  }
+
   // Grid intents ride the grid-control topic; font intents ride scene - both
   // keep the legacy bridges' @Slot names 1:1 (backend/canvas.py contract).
   setGridSize(size: number): void {

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -828,13 +828,20 @@ body,
   color: var(--gl-surface-text-muted);
 }
 
-/* Fixed-height source/preview panes, deliberately not resizable by drag in
-   either direction. Legacy graphlink_html_view.py's QSplitter (splitter_state)
-   was pure Qt UI state with no domain meaning - never in scene_payload/the DB
-   row (confirmed by backend/tests/test_canvas.py's
-   test_html_node_scene_payload_needs_no_new_key) - so it's a scope cut here,
-   not an oversight. `resize: none` on the textarea keeps the browser from
-   offering its own native drag handle as an accidental substitute. */
+/* Source/Preview pane heights are set inline by HtmlNodeView.tsx (driven by
+   its own splitterValue state), not fixed here - the 140px below is only the
+   pre-drag/pre-restore fallback (matches HTML_SPLIT_DEFAULT's 0.5 fraction of
+   HTML_SPLIT_TOTAL_PX exactly, so it's never visibly different from the
+   inline value on first paint). This USED to be genuinely fixed, deliberately
+   not resizable: legacy graphlink_html_view.py's QSplitter (splitter_state)
+   was scoped out as "pure Qt UI state with no domain meaning" back in
+   R3.17/R3.18. R6.3 reintroduced a real drag handle (.html-node-splitter
+   below) because R6.4/R6.5's session load/save pipeline needs every
+   legacy-persisted field - splitter_state included - to round-trip
+   losslessly; see canvasConstants.ts's own HTML_SPLIT_* doc. `resize: none`
+   on the textarea still stands: it suppresses the BROWSER's own native
+   textarea resize handle, an unrelated affordance from this custom splitter
+   that would otherwise fight it for the same corner. */
 .html-node-source {
   box-sizing: border-box;
   width: 100%;
@@ -852,6 +859,22 @@ body,
 .html-node-source:focus {
   outline: none;
   border-color: var(--gl-surface-text-muted);
+}
+
+/* R6.3: the draggable Source/Preview split handle - a thin bar, not a full
+   row, so it reads as a resize affordance rather than another content
+   section. row-resize cursor matches the only axis it actually drags on. */
+.html-node-splitter {
+  height: 6px;
+  margin: 0 2px;
+  border-radius: 3px;
+  background-color: var(--gl-surface-border);
+  cursor: row-resize;
+  touch-action: none;
+}
+
+.html-node-splitter:hover {
+  background-color: var(--gl-surface-text-muted);
 }
 
 .html-node-render-btn {


### PR DESCRIPTION
## Summary
Closes the smaller cross-cutting gaps between the legacy session format and `backend/canvas.py` - a prerequisite for R6.4/R6.5's session load/save, since every field here needs to exist and round-trip before a session can be persisted losslessly.

- View state (`zoom_factor`/`scroll_x`/`scroll_y`), reported by the frontend on viewport pan/zoom, debounced.
- `total_session_tokens` - a real, live-growing cumulative count (not a static field), accumulated on every sent message and completed reply via the existing `estimate_tokens()`, distinct from `TokenCounterState`'s transient per-session estimate.
- HTML node `splitter_state` - the HTML view node had no draggable-split mechanism at all before this; built a real one, since a round-trippable value needs something real behind it.
- Chat node `scroll_value` - restore-on-mount + debounced report from the chat card's already-real scrollable content area.
- `content_parts` field for multimodal chat content, reusing `content_codec.py` directly (already Qt-free) for the wire-side base64 encode. Deliberately scoped to data-model capability only - no new "paste an image into chat" UI feature, since nothing today creates such content.
- Exposes 3 pin fields (`anchorItemId`/`sortOrder`/`createdAt`) that already existed in `NavigationPinStore` but were thinned out of the wire payload.

Spot-checked directly rather than a full adversarial review, given this is mechanical field-plumbing across independent small areas rather than novel interaction logic (unlike R6.1/R6.2).

## Test plan
- [x] Full pytest suite: 2236 passed
- [x] `tsc --noEmit`: 0 errors
- [x] `vitest run`: 1037/1037 passed