### PR TITLE
Qt-removal R6.4: Backend session LOAD - legacy chats.db -> full SceneDocument

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -176,7 +176,11 @@ def _configure_session(bus: SessionBus, settings_manager: SettingsManager, chat_
     # (canvas_document exists before register_plugins runs) is load-bearing.
     register_plugins(bus, notifications_state, bus.canvas_document)
     register_settings(bus, settings_manager)
-    register_chat_library(bus, chat_db_path)
+    # R6.4: register_chat_library needs the same session's canvas_document
+    # (built above) so loadChat can actually restore a session into it, and
+    # notifications_state so a failed/empty load can surface a real banner -
+    # same load-bearing ordering precedent as register_plugins above.
+    register_chat_library(bus, chat_db_path, bus.canvas_document, notifications_state)
 
 
 def create_app(

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -674,6 +674,47 @@ class SceneDocument:
         self.nodes[node_id] = node
         return node
 
+    def register_restored_node(self, node: SceneNode) -> SceneNode:
+        """R6.4: used ONLY by the session loader (backend/session_load.py),
+        which builds every node's full field set directly from a legacy
+        payload dict before any parent/child edge exists - unlike every
+        add_X_node method above, which creates a node AND its parent edge as
+        one atomic action, the loader cannot do that: legacy's own restore
+        order creates ALL nodes first (in whatever order the saved array
+        happens to hold them, parent or child first, no guarantee) and only
+        resolves edges afterward in a separate phase (children_indices/
+        children_ids, then the 7 connection lists). Assigns a fresh id (the
+        node's own `id` field, if the caller set one from the legacy
+        payload's `id`/persistent_id, is overwritten here - backend ids are
+        a different namespace/format than legacy's uuid-based persistent
+        ids, and the loader tracks its OWN payload-id -> new-id mapping
+        separately, exactly mirroring legacy's `_nodes_by_id`) and inserts
+        the node with no edges - the caller creates those separately once
+        every node it might reference has been registered."""
+        node.id = f"n{next(self._counter)}"
+        self.nodes[node.id] = node
+        return node
+
+    def clear_for_load(self) -> None:
+        """R6.4: resets every mutable piece of scene state to a fresh-
+        session default, immediately before a session load replaces it all -
+        mirrors legacy ChatScene.clear() (called first thing in
+        restore_chat, deserializers.py:476) plus this backend's own R6.3
+        view-state/token additions, which legacy's clear() has no equivalent
+        for (they get overwritten by _restore_view_state/the token-counter
+        reset a few lines later in restore_chat instead - reset here too so
+        a load that fails partway through never leaves a stale value from
+        the PREVIOUS session)."""
+        self.nodes.clear()
+        self.edges.clear()
+        self.image_assets.clear()
+        self.pins.clear()
+        self.last_chat_node_id = None
+        self.zoom_factor = 1.0
+        self.scroll_x = 0.0
+        self.scroll_y = 0.0
+        self.total_session_tokens = 0
+
     def add_chat_node(
         self,
         x: float,
@@ -1935,7 +1976,7 @@ class SceneDocument:
         self,
         x: float,
         y: float,
-        parent_id: str,
+        parent_id: str | None,
         chart_type: str,
         chart_data: dict[str, Any],
         *,
@@ -1943,12 +1984,21 @@ class SceneDocument:
     ) -> SceneNode:
         """The Chart node's creation primitive - same required-parent
         posture as every other branch-point-child kind (web_research/
-        artifact/gitlink/pycoder/code_sandbox above): a chart never exists
-        unparented, it is always generated FROM some other node's content.
-        chart_type MUST be one of SUPPORTED_CHART_TYPES (SceneError
-        otherwise, same "validate up front, never construct a half-invalid
-        node" posture create_frame/create_container use for their own
-        item_ids checks).
+        artifact/gitlink/pycoder/code_sandbox above) for every NEW chart:
+        the UI-driven generateChart intent always passes a real parent_id,
+        since a chart is always generated FROM some other node's content in
+        that flow. chart_type MUST be one of SUPPORTED_CHART_TYPES
+        (SceneError otherwise, same "validate up front, never construct a
+        half-invalid node" posture create_frame/create_container use for
+        their own item_ids checks).
+
+        R6.4: parent_id is None-able for the session LOADER only - legacy
+        genuinely allows a chart with no parent at all (both
+        parent_node_index/parent_node_id absent in the persisted payload is
+        a real, valid legacy state, confirmed by recon), which the original
+        required-parent signature could not represent. When parent_id is
+        None, no parent-existence check runs and no edge is created -
+        chart_source_node_id stays "" rather than getting a real node id.
 
         chart_data is assumed ALREADY canonicalized by the CALLER - this
         method deliberately does NOT call canonicalize_chart_data itself
@@ -1969,7 +2019,7 @@ class SceneDocument:
         SAME image_assets dict R3.21's image nodes already use (reused, not
         a parallel store), and sets chart_asset_version = 1 for this first
         render."""
-        if parent_id not in self.nodes:
+        if parent_id is not None and parent_id not in self.nodes:
             raise SceneError(f"unknown parent node: {parent_id}")
         normalized_type = str(chart_type or "").strip().lower()
         if normalized_type not in SUPPORTED_CHART_TYPES:
@@ -1987,7 +2037,7 @@ class SceneDocument:
             chart_type=normalized_type,
             chart_data=safe_chart_data,
             chart_error=str(chart_error),
-            chart_source_node_id=parent_id,
+            chart_source_node_id=parent_id or "",
         )
 
         png_bytes = render_chart_png(
@@ -1999,7 +2049,8 @@ class SceneDocument:
         node.chart_asset_version = 1
 
         self.nodes[node_id] = node
-        self.connect(parent_id, node_id)
+        if parent_id is not None:
+            self.connect(parent_id, node_id)
         return node
 
     def resize_chart(self, node_id: str, width: float, height: float) -> None:

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -1,23 +1,23 @@
-"""Chat library dialog: list/rename/delete (Qt-removal plan R2.5e).
+"""Chat library dialog: list/rename/delete/load (Qt-removal plan R2.5e + R6.4).
 
 An INDEPENDENT Qt-free reimplementation of ChatDatabase.get_all_chats()/
-rename_chat()/delete_chat() - not an import - because
-graphlink_session/__init__.py eagerly imports ChatSessionManager and
-SaveWorkerThread (workers.py imports PySide6.QtCore.QThread/Signal) before
-graphlink_session.database can ever be imported cleanly: Python always runs
-a package's __init__.py first, even for `from graphlink_session.database
-import ChatDatabase`. ChatDatabase itself (graphlink_session/database.py)
-is Qt-free; only the package wrapper around it is hazardous. Same
-reimplement-not-import precedent as backend/composer.py and
-backend/plugins.py.
+rename_chat()/delete_chat()/load_chat()/load_notes()/load_pins() - not an
+import - because graphlink_session/__init__.py eagerly imports
+ChatSessionManager and SaveWorkerThread (workers.py imports
+PySide6.QtCore.QThread/Signal) before graphlink_session.database can ever be
+imported cleanly: Python always runs a package's __init__.py first, even for
+`from graphlink_session.database import ChatDatabase`. ChatDatabase itself
+(graphlink_session/database.py) is Qt-free; only the package wrapper around
+it is hazardous. Same reimplement-not-import precedent as backend/composer.py
+and backend/plugins.py.
 
 Reads/writes the SAME real ~/.graphlink/chats.db file the legacy app uses
-(same "chats" table schema, same queries, same _format_timestamp display
-format moved verbatim from graphlink_chat_library_bridge.py) - list, rename,
-and delete are genuinely real here. loadChat/newChat are deferred to R6:
-session load rebuilds the whole scene through backend/canvas.py's
-SceneDocument and session save doesn't exist yet, so the SPA renders those
-as disabled controls with an explicit R6 label rather than faking them.
+(same "chats"/"notes"/"pins" table schemas, same queries, same migration
+ALTER TABLEs for older databases, same _format_timestamp display format moved
+verbatim from graphlink_chat_library_bridge.py) - list, rename, delete, and
+(R6.4) load are all genuinely real here. newChat has no backend counterpart
+at all yet: creating a brand-new empty session is just "clear the canvas",
+which will land alongside R6.5's save primitive, not this file.
 """
 
 from __future__ import annotations
@@ -29,7 +29,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from backend.canvas import SceneDocument
 from backend.events import SessionBus
+from backend.notifications import NotificationState
+from backend.session_load import restore_chat_into_document
 
 DEFAULT_DB_PATH = Path.home() / ".graphlink" / "chats.db"
 
@@ -72,6 +75,61 @@ def _ensure_chats_table(conn: sqlite3.Connection) -> None:
     )
 
 
+def _ensure_notes_table(conn: sqlite3.Connection) -> None:
+    # R6.4: mirrors ChatDatabase.init_database()'s notes table + its own
+    # is_system_prompt/is_summary_note migration ALTER TABLEs exactly - a
+    # chats.db written by an OLDER legacy build may still be missing these
+    # two columns, and load_notes_rows below unconditionally SELECTs them.
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS notes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id INTEGER NOT NULL,
+            content TEXT NOT NULL,
+            position_x REAL NOT NULL,
+            position_y REAL NOT NULL,
+            width REAL NOT NULL,
+            height REAL NOT NULL,
+            color TEXT NOT NULL,
+            header_color TEXT,
+            FOREIGN KEY (chat_id) REFERENCES chats (id) ON DELETE CASCADE
+        )
+        """
+    )
+    columns = [info[1] for info in conn.execute("PRAGMA table_info(notes)").fetchall()]
+    if "is_system_prompt" not in columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN is_system_prompt INTEGER DEFAULT 0")
+    if "is_summary_note" not in columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN is_summary_note INTEGER DEFAULT 0")
+
+
+def _ensure_pins_table(conn: sqlite3.Connection) -> None:
+    # R6.4: mirrors ChatDatabase.init_database()'s pins table + its own
+    # pin_id/sort_order/anchor_item_id/created_at migration ALTER TABLEs.
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS pins (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            note TEXT,
+            position_x REAL NOT NULL,
+            position_y REAL NOT NULL,
+            FOREIGN KEY (chat_id) REFERENCES chats (id) ON DELETE CASCADE
+        )
+        """
+    )
+    columns = [info[1] for info in conn.execute("PRAGMA table_info(pins)").fetchall()]
+    if "pin_id" not in columns:
+        conn.execute("ALTER TABLE pins ADD COLUMN pin_id TEXT")
+    if "sort_order" not in columns:
+        conn.execute("ALTER TABLE pins ADD COLUMN sort_order INTEGER DEFAULT 0")
+    if "anchor_item_id" not in columns:
+        conn.execute("ALTER TABLE pins ADD COLUMN anchor_item_id TEXT")
+    if "created_at" not in columns:
+        conn.execute("ALTER TABLE pins ADD COLUMN created_at TEXT")
+
+
 def get_all_chats(db_path: Path) -> list[dict[str, Any]]:
     # closing() + the connection's own transaction context: sqlite3's
     # `with conn:` commits/rolls back but does NOT close the connection -
@@ -107,6 +165,77 @@ def delete_chat(db_path: Path, chat_id: int) -> None:
         conn.execute("DELETE FROM chats WHERE id = ?", (chat_id,))
 
 
+def load_chat_row(db_path: Path, chat_id: int) -> dict[str, Any] | None:
+    """Mirrors ChatDatabase.load_chat exactly: {"title", "data"} with `data`
+    already json.loads()'d, or None if the id doesn't exist (a chat deleted
+    from another window/process between the library listing and this call -
+    the caller shows a real notice, not a crash)."""
+    import json
+
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        _ensure_chats_table(conn)
+        row = conn.execute("SELECT title, data FROM chats WHERE id = ?", (chat_id,)).fetchone()
+    if row is None:
+        return None
+    return {"title": row[0], "data": json.loads(row[1])}
+
+
+def load_notes_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
+    """Mirrors ChatDatabase.load_notes exactly - see that method's own
+    SELECT column list; shape matches what backend/session_load.py's
+    _restore_notes expects (nested "position"/"size" dicts)."""
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        _ensure_notes_table(conn)
+        rows = conn.execute(
+            """
+            SELECT content, position_x, position_y, width, height,
+                   color, header_color, is_system_prompt, is_summary_note
+            FROM notes WHERE chat_id = ?
+            """,
+            (chat_id,),
+        ).fetchall()
+    return [
+        {
+            "content": row[0],
+            "position": {"x": row[1], "y": row[2]},
+            "size": {"width": row[3], "height": row[4]},
+            "color": row[5],
+            "header_color": row[6],
+            "is_system_prompt": bool(row[7]),
+            "is_summary_note": bool(row[8]),
+        }
+        for row in rows
+    ]
+
+
+def load_pins_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
+    """Mirrors ChatDatabase.load_pins exactly, including its own
+    sort_order-defaults-to-enumerate-index fallback for pre-migration rows."""
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        _ensure_pins_table(conn)
+        rows = conn.execute(
+            """
+            SELECT pin_id, title, note, position_x, position_y,
+                   anchor_item_id, sort_order, created_at
+            FROM pins WHERE chat_id = ?
+            ORDER BY sort_order, id
+            """,
+            (chat_id,),
+        ).fetchall()
+    return [
+        {
+            "pin_id": row[0],
+            "title": row[1],
+            "note": row[2],
+            "position": {"x": row[3], "y": row[4]},
+            "anchor_item_id": row[5],
+            "sort_order": row[6] if row[6] is not None else index,
+            "created_at": row[7],
+        }
+        for index, row in enumerate(rows)
+    ]
+
+
 def chat_library_payload(db_path: Path) -> dict[str, Any]:
     try:
         rows = get_all_chats(db_path)
@@ -120,7 +249,12 @@ def chat_library_payload(db_path: Path) -> dict[str, Any]:
     return {"rows": rows, "notice": notice}
 
 
-def register_chat_library(bus: SessionBus, db_path: Path | None = None) -> None:
+def register_chat_library(
+    bus: SessionBus,
+    db_path: Path | None = None,
+    canvas_document: SceneDocument | None = None,
+    notifications: NotificationState | None = None,
+) -> None:
     resolved_path = db_path if db_path is not None else DEFAULT_DB_PATH
 
     bus.register_topic("app-chat-library", lambda: chat_library_payload(resolved_path))
@@ -148,5 +282,54 @@ def register_chat_library(bus: SessionBus, db_path: Path | None = None) -> None:
         await asyncio.to_thread(delete_chat, resolved_path, int(chat_id))
         await bus.publish("app-chat-library")
 
+    async def load_chat(chat_id: int):
+        # R6.4: replicates ChatSessionManager.load_chat's own orchestration
+        # order (load row -> load notes/pins -> restore) and
+        # SceneDeserializer._handle_load_error's "notification, not a
+        # crash" posture for anything that goes wrong - canvas_document/
+        # notifications are only None in a test harness that didn't wire
+        # them; a real running session always has both (see backend/app.py's
+        # _configure_session ordering).
+        try:
+            row = await asyncio.to_thread(load_chat_row, resolved_path, int(chat_id))
+            if row is None:
+                if notifications is not None:
+                    notifications.show("This chat could not be found. It may have already been deleted.", "error")
+                    await bus.publish("notification")
+                return
+
+            notes_rows = await asyncio.to_thread(load_notes_rows, resolved_path, int(chat_id))
+            pins_rows = await asyncio.to_thread(load_pins_rows, resolved_path, int(chat_id))
+
+            if canvas_document is None:
+                return
+
+            restore_chat_into_document(canvas_document, row, notes_rows, pins_rows)
+        except Exception as exc:
+            # Adversarial review finding: load_notes_rows/load_pins_rows (a
+            # real sqlite3.Error, e.g. a locked/corrupted db file) previously
+            # had no safety net here, unlike load_chat_row's None-check and
+            # restore_chat_into_document's own try/except - it would
+            # propagate uncaught out of dispatch_intent. Since the frontend's
+            # loadChat call is fire-and-forget (no msg_id), the generic WS-
+            # level error reply that DOES still get sent lands nowhere the
+            # user can see (console.error only) - the dialog just closes and
+            # goes silent. Wrapping the whole load sequence, not just the
+            # restore step, guarantees a real, visible notification for
+            # every failure mode here, matching legacy's own
+            # _handle_load_error posture (one catch-all around the entire
+            # load, not per-step).
+            if notifications is not None:
+                notifications.show(f"Failed to load the chat session. It may be corrupted.\nError: {exc}", "error")
+                await bus.publish("notification")
+            return
+
+        await bus.publish("scene")
+        if notifications is not None:
+            title = str(row.get("title") or "chat")
+            notifications.show(f'Loaded "{title}".', "success")
+            await bus.publish("notification")
+
     bus.register_intent("app-chat-library", "renameChat", rename)
     bus.register_intent("app-chat-library", "deleteChat", delete)
+    bus.register_intent("app-chat-library", "loadChat", load_chat)

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -1,0 +1,1016 @@
+"""Qt-free session LOAD (Qt-removal plan R6.4).
+
+Reimplements graphlink_session/deserializers.py's SceneDeserializer.
+restore_chat() algorithm against backend/canvas.py's SceneDocument - NOT an
+import, matching this project's established "reimplement, don't import"
+precedent (backend/chat_library.py, backend/composer.py, backend/plugins.py):
+deserializers.py itself does `from PySide6.QtCore import QPointF, QRectF` at
+module scope, and every `deserialize_*` method body constructs real
+QGraphicsItem-family objects (scene.addItem, node.setPos,
+node.prompt_input.setPlainText, ...) with no backend analog at all - unlike
+graphlink_session/content_codec.py (already 100% Qt-free, loaded directly via
+importlib in backend/canvas.py), there is no leaf module here worth loading
+as-is. The file's actual VALUE is its ID/index-resolution ALGORITHM, ported
+faithfully below; none of its executable Qt-widget code is reused.
+
+Ground truth for every field/key name below was pulled directly from the
+CURRENT (still on disk, still Qt-tainted, never imported) deserializers.py/
+serializers.py for the 7 surviving node kinds, and from
+`git show af72ffd~1:graphlink_app/graphlink_session/{de,}serializers.py` +
+`graphlink_app/graphlink_web.py` (the commit immediately before R5-closeout
+deleted the Web/Artifact/Gitlink/PyCoder/CodeSandbox branches) for the 5
+plugin kinds - never from paraphrase or memory.
+
+THE ALGORITHM (ported from deserializers.py's restore_chat):
+1. Every node in the payload's node list is restored in a SINGLE pass, in
+   payload order - NOT nodes-then-edges in two separate phases. This matters:
+   every kind except "chat" REQUIRES an already-resolved parent to be
+   restored at all.
+     - chat: no parent, always restored, never connected to anything by this
+       step (legacy passes parent_node=None unconditionally).
+     - code/document/image/thinking: `parent_content_node_index` (a payload
+       LIST POSITION, not persistent_id - no id-fallback exists for this
+       specific reference), resolved against all_nodes_map AS BUILT SO FAR
+       (i.e. only positions strictly earlier in the list can resolve, since
+       later ones haven't been added yet - this exactly matches legacy's own
+       single forward pass). If it doesn't resolve, legacy's own
+       `if parent_node:` guard means the node is not created at all - ported
+       verbatim: no id/edge is registered for that payload index.
+     - conversation/html/pycoder/code_sandbox/web/artifact/gitlink:
+       `parent_node_index`, same resolution/skip-if-missing rule, different
+       key name (this split was verified directly against both the current
+       file and the pre-deletion recovery, not assumed).
+   Whenever a parent DOES resolve, the freshly-restored node is connected to
+   it immediately (document.connect(parent_id, node_id)) - this is the exact
+   structural edge legacy's own `scene.add_code_node(..., parent_node)`-style
+   constructors create as a side effect of construction; there is no separate
+   "basic connection" payload entry for it (those 7+5 connection lists below
+   are visual/branch connections between UNRELATED nodes, never the
+   node<->its own required parent link).
+   Two lookup maps are built as this happens: `all_nodes_map` (payload list
+   POSITION -> new backend node id) and `nodes_by_id` (payload persistent
+   "id" -> new backend node id, for every kind, used later by connections/
+   frames/containers that DO support id-preferred resolution). A third,
+   `chat_nodes_map`, is keyed by an ordinal counted ONLY across "chat"-type
+   payload entries (not their position in the full node list) - bug #47's own
+   fix: system-prompt/group-summary connections reference chat nodes by this
+   save-side ordinal specifically, so a skipped node elsewhere can never
+   shift it.
+2. _restore_children: children_indices/children_ids (id-preferred + index-
+   fallback per position) are restored next, but only for kinds the CURRENT
+   (post-R5-closeout) CHILD_LINK_NODE_TYPES actually still covers - see
+   _CHILD_LINK_KINDS below. Some now-deleted kinds (pycoder/web/artifact/
+   gitlink/code_sandbox) also once wrote children_indices, but there is no
+   live concept left to restore it into, so they're correctly excluded.
+3. Notes, then charts (each in its own try/except - one bad chart must never
+   abort the whole load, matching deserializers.py's own per-chart catch),
+   are restored next, each building a position -> new-id map of their own.
+4. Frames are restored against a "frame source map" = all_nodes_map PLUS
+   charts placed at offset node_slot_count+chart_index (frames may reference
+   charts as members, never notes). Frame membership is PURE POSITIONAL
+   (payload key "items", legacy fallback "nodes") - despite frames also
+   carrying an "item_ids" list in the payload, deserialize_frame never reads
+   it; only the index list is ever consulted.
+5. Containers are restored against a "full item map" = all_nodes_map PLUS
+   notes at node_slot_count+note_index, PLUS charts at
+   node_slot_count+note_slot_count+chart_index, PLUS frames at
+   node_slot_count+note_slot_count+chart_slot_count+frame_index. Also PURE
+   POSITIONAL (payload key "items" - required in legacy, tolerated-missing
+   here).
+   CRITICAL: every one of these offsets is computed from the ORIGINAL
+   PAYLOAD COUNTS (node_slot_count = len(node_payloads), etc.), never from
+   how many nodes/notes/charts actually survived restoration - using
+   survivor counts would shift every later slot whenever anything was
+   skipped, silently misattributing frame/container membership. This is
+   deserializers.py's own bug #47 fix, re-confirmed by direct reading - the
+   single most important invariant in this file.
+6. The basic connection lists (the 7 shared by every era:
+   connections/content_connections/document_connections/image_connections/
+   thinking_connections/conversation_connections/html_connections, PLUS 5
+   that existed only before R5-closeout deleted their node kinds:
+   pycoder_connections/code_sandbox_connections/web_connections/
+   artifact_connections/gitlink_connections - restoring these 5 from an OLD
+   save is still meaningful even though the node kinds they usually joined
+   are gone, since a connection can link any two nodes) share IDENTICAL
+   shape (start/end_node_index + start/end_node_id) and are all resolved the
+   same way, against all_nodes_map/nodes_by_id only (never notes/charts/
+   frames/containers) - one generic helper handles all 12.
+7. system_prompt_connections (note -> chat node) and group_summary_connections
+   (chat node -> note) resolve their NODE side id-preferred against the
+   GENERAL nodes_by_id map (a node's payload id is unique across every kind)
+   and index-fallback against chat_nodes_map specifically (verified directly
+   against the call sites in restore_chat: both pass chat_nodes_map, not
+   all_nodes_map, as the "nodes_map" positional argument) - the note side is
+   always plain positional against notes_map.
+8. Pins, view state, and total_session_tokens are restored last.
+
+CONFIRMED, DOCUMENTED GAPS (fields with no backend/canvas.py destination at
+all - silently dropped on load, never a crash):
+- Note: size (width/height - Notes have no manual-size concept in this
+  backend, sized purely from content like legacy itself),
+  role/source_ids/operation_id/source_revisions/provider_snapshot (summary-
+  note provenance - dead weight even in legacy's own persisted format, since
+  no SQL column for these ever existed, so real saved chats never actually
+  carry them).
+- Web: include_branch_context, warnings, the free-text `status` string (no
+  destination distinct from the enum-like `research_stage`).
+- Artifact: `local_history` (a second, separate history list from
+  conversation_history), `chat_html_cache` (a rendered-HTML cache, not
+  source data).
+- Code sandbox: the free-text `status` string (backend only has an
+  awaiting_approval bool + an error string, a coarser model).
+- Chart: `source_node_id` when it legitimately differs from parent_node_id -
+  add_chart_node has no parameter for a distinct source id at all (always
+  derives it from parent_id); already documented as an accepted
+  simplification on chart_source_node_id's own field comment in canvas.py.
+- Connections: per-connection waypoint/bend-point pins (legacy's
+  serialize_connection alone, of the 12, carries a `pins` list - SceneEdge
+  has no field for this at all). A chart's rarer chart-as-parent-of-another-
+  chart id-reference (_resolve_chart_ref's own _charts_by_id fallback) - only
+  index-based chart-parent resolution is ported here, matching every other
+  reference's own "index is the common case, id is the safety net" posture,
+  but for this one narrow id-shaped edge case falling back to charts_by_id
+  was judged not worth a second parameter on the shared _resolve_ref helper.
+- Pycoder/code_sandbox/web/artifact live in-flight-request markers: never
+  restored - a loaded node always starts settled (not awaiting approval, not
+  mid-run), matching that these are in-memory-only concepts even in legacy.
+
+DELIBERATE RESILIENCE IMPROVEMENT OVER LEGACY (not a gap - a fix): legacy's
+own restore_chat has exactly ONE outer try/except around the ENTIRE method
+(bar the per-chart loop) - a single malformed node payload (a missing
+required key, e.g. `data["code"]`) raises all the way out and aborts the
+WHOLE chat load via _handle_load_error, discarding every other node that
+would otherwise have restored fine. Every per-node/per-frame/per-container
+restore step here is wrapped in its own try/except instead, so one corrupted
+entry is skipped rather than sinking the entire session - matches this
+increment's already-established "never let one bad item abort everything"
+posture (charts already had this in legacy itself; this extends the same
+posture everywhere else).
+
+TRANSLATIONS APPLIED (not gaps - legacy and backend just use different
+literal values for the same concept):
+- node_type "web" -> kind "web_research".
+- pycoder `mode` is the persisted enum MEMBER NAME (`node.mode.name`, e.g.
+  "AI_DRIVEN"/"MANUAL", uppercase) -> backend `pycoder_mode` wants
+  "ai_driven"/"manual" (lowercase).
+- gitlink's flat `repo_state` dict (repo/branch/scope_mode/local_root/
+  imported_root) -> the 5 discrete gitlink_repo/branch/scope_mode/
+  local_root/imported_root fields, a direct 1:1 unpack.
+- gitlink's `proposal_data["files"]` -> gitlink_pending_changes, direct copy.
+  gitlink_proposal_markdown is DERIVED in legacy (a method on the deleted
+  GitlinkNode class, not recoverable as a pure display string with no
+  functional role - Apply/regenerate act on gitlink_pending_changes, never on
+  the markdown) - synthesized here as a simple, honest list of changed file
+  paths instead. Documented simplification, not a silent gap.
+- gitlink's `_approved_fingerprint`/change_state are never persisted in
+  legacy either (always reset to None / recomputed as
+  previewed-if-pending-else-draft on restore there too) - matches backend's
+  own complete_gitlink_run contract exactly, so this recomputes the same way
+  rather than reading any (nonexistent) payload key.
+- research_result: legacy persists `WebNode.research_result_payload`, a
+  snake_case dict produced by `ResearchResult.to_dict()`-equivalent
+  construction (confirmed directly:
+  `graphlink_web.py`'s own `restore_research_result` reads
+  request_id/original_query/effective_query/answer_markdown/sources/
+  citations/warnings/provider_snapshot - all snake_case), while backend's own
+  `research_result` field is CAMEL-CASE (`_research_result_wire`'s own output
+  shape, canvas.py - requestId/originalQuery/sources[...]/etc). A generic,
+  reversible snake_case -> camelCase key transform (_snake_to_camel_deep
+  below) is applied on load.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from backend.canvas import SceneDocument, SceneNode, SUPPORTED_CHART_TYPES, _content_codec, _placeholder_chart_data
+from graphlink_chart_data import ChartDataError, canonicalize_chart_data
+from graphlink_navigation_pins import NavigationPinRecord
+
+
+# -- small, generic helpers --------------------------------------------------
+
+_SNAKE_RE = re.compile(r"_([a-z0-9])")
+
+
+def _snake_to_camel(key: str) -> str:
+    return _SNAKE_RE.sub(lambda m: m.group(1).upper(), key)
+
+
+def _snake_to_camel_deep(value: Any) -> Any:
+    """Recursively re-keys dicts from snake_case to camelCase. Used only for
+    `research_result` - see this module's own docstring for why. A pure,
+    side-effect-free mapping function, not a SceneDocument method (same
+    posture as canvas.py's own _research_result_wire/_content_parts_wire
+    helpers)."""
+    if isinstance(value, dict):
+        return {_snake_to_camel(str(k)): _snake_to_camel_deep(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_snake_to_camel_deep(item) for item in value]
+    return value
+
+
+def _flatten_multimodal_text(parts: list[dict[str, Any]]) -> str:
+    """Derives the plain-text mirror every existing piece of code expects in
+    SceneNode.content, from a decoded multimodal parts list - joins text-type
+    parts, and stands in a plain placeholder for any non-text part, matching
+    content_parts's own field comment on SceneNode ("a placeholder like
+    '[Image]' for non-text parts")."""
+    pieces: list[str] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") == "text" and isinstance(part.get("text"), str):
+            pieces.append(part["text"])
+        elif part.get("type") == "image_bytes":
+            pieces.append("[Image]")
+    return "\n".join(pieces)
+
+
+def _restore_history(raw_history: Any) -> list[dict[str, Any]]:
+    """SceneNode.history is typed list[dict[str, str]] - a PLAIN-TEXT mirror,
+    unlike content_parts (which has its own dedicated wire-side base64 re-
+    encoder, _content_parts_wire in canvas.py). A legacy conversation_history
+    entry's "content" can legitimately be a multimodal parts list too (an
+    old pasted-image turn) - calling content_codec.deserialize_history on it
+    would decode that into raw Python bytes, which then has nowhere safe to
+    go: history has no equivalent wire re-encoder, so those bytes would hit
+    json.dumps() directly and crash the ENTIRE scene publish (found via a
+    live drive against a real ~/.graphlink/chats.db entry - "TypeError:
+    Object of type bytes is not JSON serializable", not a hypothetical).
+    Flattening multimodal entries to the same "[Image]"-placeholder text
+    mirror _flatten_multimodal_text already uses for the node's own content
+    field keeps this field's own str contract intact instead."""
+    if not isinstance(raw_history, list):
+        return []
+    restored: list[dict[str, Any]] = []
+    for message in raw_history:
+        if not isinstance(message, dict):
+            continue
+        new_message = dict(message)
+        content = new_message.get("content")
+        if isinstance(content, list):
+            # _flatten_multimodal_text only ever reads a part's "type"/"text"
+            # keys, never "data" - flattening straight from the still-
+            # base64-encoded parts (no need to decode_image_bytes first just
+            # to immediately discard the bytes).
+            new_message["content"] = _flatten_multimodal_text(content)
+        restored.append(new_message)
+    return restored
+
+
+def _resolve_node_payload_list(chat_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Ports restore_chat's own 3-level fallback: current shape
+    (`chat_data["nodes"]`), legacy shape (`chat_data["items"]`), or a
+    double-nested legacy shape (`chat_data["data"]["nodes"/"items"]`) -
+    tolerating every shape a real saved chat could actually be in, not just
+    the current one. Always returns a list (empty if nothing resolves)."""
+    for key in ("nodes", "items"):
+        candidate = chat_data.get(key)
+        if isinstance(candidate, list):
+            return candidate
+    nested = chat_data.get("data")
+    if isinstance(nested, dict):
+        for key in ("nodes", "items"):
+            candidate = nested.get(key)
+            if isinstance(candidate, list):
+                return candidate
+    return []
+
+
+def _resolve_ref(
+    payload: dict[str, Any],
+    id_key: str,
+    index_key: str,
+    nodes_by_id: dict[str, str],
+    position_map: dict[int, str],
+) -> str | None:
+    """Ports _resolve_node_ref: ID-preferred, index-fallback. Both a missing
+    id AND a missing/unresolved index legitimately return None (caller drops
+    the reference silently, matching legacy's own tolerance for a
+    partially-resolvable payload)."""
+    ref_id = payload.get(id_key)
+    if ref_id and ref_id in nodes_by_id:
+        return nodes_by_id[ref_id]
+    ref_index = payload.get(index_key)
+    if isinstance(ref_index, int) and ref_index in position_map:
+        return position_map[ref_index]
+    return None
+
+
+def _position(payload: dict[str, Any]) -> tuple[float, float]:
+    position = payload.get("position")
+    if isinstance(position, dict):
+        return float(position.get("x", 0.0)), float(position.get("y", 0.0))
+    return 0.0, 0.0
+
+
+# -- per-kind node restoration ------------------------------------------------
+# Each function takes ONE payload dict (already known to be `node_type`-
+# appropriate) and returns a plain SceneNode with every field this backend
+# can represent set - NO id (register_restored_node assigns a fresh one).
+# Parent resolution/skip-if-missing/connect is handled uniformly by
+# _restore_node below, NOT by these functions - clean separation between
+# "build this node's own fields" and "does it have a valid parent".
+
+def _restore_chat_payload(payload: dict[str, Any]) -> SceneNode:
+    x, y = _position(payload)
+    raw_content = payload.get("raw_content", payload.get("text", ""))
+    content_parts: list[dict[str, Any]] | None = None
+    content_text = ""
+    if isinstance(raw_content, list):
+        content_parts = _content_codec.process_content_for_deserialization(raw_content)
+        content_text = _flatten_multimodal_text(content_parts)
+    else:
+        content_text = str(raw_content or "")
+    return SceneNode(
+        id="", x=x, y=y, title="Chat", kind="chat",
+        content=content_text,
+        content_parts=content_parts,
+        # Legacy's own restore-time default is True (data.get("is_user",
+        # True)) - deliberately NOT False, unlike every other bool field on
+        # this dataclass. Getting this backwards would silently relabel
+        # every AI response in an old save as if the user had typed it.
+        is_user=bool(payload.get("is_user", True)),
+        is_collapsed=bool(payload.get("is_collapsed", False)),
+        history=_restore_history(payload.get("conversation_history")),
+        chat_scroll_value=float(payload.get("scroll_value", 0.0) or 0.0),
+    )
+
+
+def _restore_code_payload(payload: dict[str, Any]) -> SceneNode:
+    x, y = _position(payload)
+    return SceneNode(
+        id="", x=x, y=y, title="Code", kind="code",
+        code=str(payload.get("code", "")),
+        language=str(payload.get("language", "")),
+    )
+
+
+def _restore_document_payload(payload: dict[str, Any]) -> SceneNode:
+    x, y = _position(payload)
+    return SceneNode(
+        id="", x=x, y=y, title=str(payload.get("title", "") or "Document"), kind="document",
+        content=str(payload.get("content", "")),
+        attachment_kind=str(payload.get("attachment_kind", "document")),
+        file_path=str(payload.get("file_path", "")),
+        mime_type=str(payload.get("mime_type", "")),
+        duration_seconds=payload.get("duration_seconds"),
+        byte_size=payload.get("byte_size"),
+        preview_label=str(payload.get("preview_label", "") or ""),
+        is_collapsed=bool(payload.get("is_collapsed", False)),
+        is_docked=bool(payload.get("is_docked", False)),
+    )
+
+
+def _restore_image_payload(payload: dict[str, Any], document: SceneDocument) -> SceneNode:
+    """Unlike every other kind, an image node's bytes live in
+    document.image_assets (R3.21's existing pattern), addressed by an opaque
+    image_asset_id - not a field the payload has a 1:1 name for (legacy
+    stores raw base64 `image_bytes` directly on the node payload). Decode
+    once here and mint a fresh asset id, mirroring add_image_node's own
+    asset-registration shape."""
+    import uuid as _uuid
+
+    x, y = _position(payload)
+    node = SceneNode(id="", x=x, y=y, title="Image", kind="image")
+    raw_b64 = payload.get("image_bytes")
+    if isinstance(raw_b64, str) and raw_b64:
+        try:
+            image_bytes = _content_codec.decode_image_bytes(raw_b64)
+        except Exception:
+            image_bytes = b""
+        if image_bytes:
+            asset_id = f"img{_uuid.uuid4().hex}"
+            document.image_assets[asset_id] = (image_bytes, "image/png")
+            node.image_asset_id = asset_id
+    node.content = str(payload.get("prompt", ""))
+    return node
+
+
+def _restore_thinking_payload(payload: dict[str, Any]) -> SceneNode:
+    x, y = _position(payload)
+    return SceneNode(
+        id="", x=x, y=y, title="Thinking", kind="thinking",
+        content=str(payload.get("thinking_text", "")),
+        is_docked=bool(payload.get("is_docked", False)),
+    )
+
+
+def _restore_conversation_payload(payload: dict[str, Any]) -> SceneNode:
+    x, y = _position(payload)
+    return SceneNode(
+        id="", x=x, y=y, title="Conversation", kind="conversation",
+        history=_restore_history(payload.get("conversation_history")),
+        is_collapsed=bool(payload.get("is_collapsed", False)),
+    )
+
+
+def _restore_html_payload(payload: dict[str, Any]) -> SceneNode:
+    x, y = _position(payload)
+    return SceneNode(
+        id="", x=x, y=y, title="HTML", kind="html",
+        content=str(payload.get("html_content", "")),
+        html_splitter_state=payload.get("splitter_state"),
+        history=_restore_history(payload.get("conversation_history")),
+        is_collapsed=bool(payload.get("is_collapsed", False)),
+    )
+
+
+def _restore_web_payload(payload: dict[str, Any]) -> SceneNode:
+    # R6.4 translation: legacy node_type "web" -> backend kind
+    # "web_research" (confirmed distinct strings, not a typo).
+    x, y = _position(payload)
+    node = SceneNode(
+        id="", x=x, y=y, title="Web Research", kind="web_research",
+        content=str(payload.get("query", "")),
+        history=_restore_history(payload.get("conversation_history")),
+        is_collapsed=bool(payload.get("is_collapsed", False)),
+    )
+    research_result = payload.get("research_result")
+    if isinstance(research_result, dict) and research_result:
+        node.research_result = _snake_to_camel_deep(research_result)
+    else:
+        summary = payload.get("summary")
+        sources = payload.get("sources")
+        if isinstance(summary, str) and summary:
+            # Mirrors WebNode.restore_research_result's own else-branch
+            # (`elif summary: node.set_result(summary, sources)`) - an
+            # older-shape session predating the research_result field
+            # entirely. Synthesized as a minimal, best-effort
+            # ResearchResult-shaped dict from the flat summary/sources pair
+            # that IS present.
+            node.research_result = _snake_to_camel_deep({
+                "request_id": "legacy",
+                "original_query": payload.get("query", ""),
+                "effective_query": payload.get("query", ""),
+                "answer_markdown": summary,
+                "sources": sources if isinstance(sources, list) else [],
+                "citations": [],
+                "warnings": payload.get("warnings") if isinstance(payload.get("warnings"), list) else [],
+                "provider_snapshot": {},
+            })
+    return node
+
+
+def _restore_artifact_payload(payload: dict[str, Any]) -> SceneNode:
+    x, y = _position(payload)
+    return SceneNode(
+        id="", x=x, y=y, title="Artifact", kind="artifact",
+        # R6.4 judgment call: legacy's "instruction" field has no dedicated
+        # backend destination distinct from the generic `content` field,
+        # which every other kind already reuses for "the node's primary
+        # editable text" - reused the same way here, not left to drop.
+        content=str(payload.get("instruction", "")),
+        artifact_content=str(payload.get("content", "")),
+        history=_restore_history(payload.get("conversation_history")),
+        is_collapsed=bool(payload.get("is_collapsed", False)),
+    )
+
+
+def _build_simple_proposal_markdown(pending_changes: list) -> str:
+    if not pending_changes:
+        return ""
+    lines = ["**Proposed changes:**", ""]
+    for change in pending_changes:
+        if isinstance(change, dict):
+            path = change.get("path") or change.get("file_path") or "unknown file"
+        else:
+            path = str(change)
+        lines.append(f"- `{path}`")
+    return "\n".join(lines)
+
+
+def _restore_gitlink_payload(payload: dict[str, Any]) -> SceneNode:
+    x, y = _position(payload)
+    repo_state = payload.get("repo_state")
+    repo_state = repo_state if isinstance(repo_state, dict) else {}
+    proposal_data = payload.get("proposal_data")
+    proposal_data = proposal_data if isinstance(proposal_data, dict) else {}
+    pending_changes = proposal_data.get("files")
+    pending_changes = pending_changes if isinstance(pending_changes, list) else []
+    context_stats = payload.get("context_stats")
+    context_stats = context_stats if isinstance(context_stats, dict) else {}
+
+    return SceneNode(
+        id="", x=x, y=y, title="Gitlink", kind="gitlink",
+        gitlink_task_prompt=str(payload.get("task_prompt", "")),
+        gitlink_repo=str(repo_state.get("repo", "")),
+        gitlink_branch=str(repo_state.get("branch", "")),
+        gitlink_scope_mode=str(repo_state.get("scope_mode", "selected")),
+        gitlink_local_root=str(repo_state.get("local_root", "")),
+        gitlink_imported_root=str(repo_state.get("imported_root", "")),
+        gitlink_repo_file_paths=list(payload.get("repo_file_paths") or []),
+        gitlink_selected_paths=list(payload.get("selected_paths") or []),
+        gitlink_context_xml=str(payload.get("context_xml", "")),
+        gitlink_context_stats={str(k): str(v) for k, v in context_stats.items()},
+        gitlink_pending_changes=pending_changes,
+        # Derived, not persisted - see this module's own docstring for why
+        # the exact legacy rendering can't be recovered, and why a simple
+        # honest summary is the documented substitute.
+        gitlink_proposal_markdown=_build_simple_proposal_markdown(pending_changes),
+        gitlink_preview_text=str(payload.get("preview_text", "")),
+        # Never persisted in legacy either - always reset on restore there
+        # too, matching backend's own complete_gitlink_run contract.
+        gitlink_change_fingerprint=None,
+        gitlink_change_local_root=None,
+        gitlink_change_state="previewed" if pending_changes else "draft",
+        history=_restore_history(payload.get("conversation_history")),
+        is_collapsed=bool(payload.get("is_collapsed", False)),
+    )
+
+
+def _restore_pycoder_payload(payload: dict[str, Any]) -> SceneNode:
+    x, y = _position(payload)
+    raw_mode = str(payload.get("mode", "AI_DRIVEN") or "AI_DRIVEN")
+    return SceneNode(
+        id="", x=x, y=y, title="Py-Coder", kind="pycoder",
+        # R6.4 translation: legacy persists the enum MEMBER NAME
+        # ("AI_DRIVEN"/"MANUAL", uppercase, via node.mode.name); backend
+        # wants "ai_driven"/"manual" (lowercase).
+        pycoder_mode=raw_mode.lower(),
+        pycoder_prompt=str(payload.get("prompt", "")),
+        pycoder_code=str(payload.get("code", "")),
+        pycoder_output=str(payload.get("output", "")),
+        pycoder_analysis=str(payload.get("analysis", "")),
+        history=_restore_history(payload.get("conversation_history")),
+        is_collapsed=bool(payload.get("is_collapsed", False)),
+    )
+
+
+def _restore_code_sandbox_payload(payload: dict[str, Any]) -> SceneNode:
+    x, y = _position(payload)
+    return SceneNode(
+        id="", x=x, y=y, title="Execution Sandbox", kind="code_sandbox",
+        code_sandbox_requirements=str(payload.get("requirements", "")),
+        code_sandbox_prompt=str(payload.get("prompt", "")),
+        code_sandbox_code=str(payload.get("code", "")),
+        code_sandbox_output=str(payload.get("output", "")),
+        code_sandbox_analysis=str(payload.get("analysis", "")),
+        code_sandbox_sandbox_id=str(payload.get("sandbox_id", "")),
+        history=_restore_history(payload.get("conversation_history")),
+        is_collapsed=bool(payload.get("is_collapsed", False)),
+    )
+
+
+_NODE_RESTORERS = {
+    "chat": lambda payload, document: _restore_chat_payload(payload),
+    "code": lambda payload, document: _restore_code_payload(payload),
+    "document": lambda payload, document: _restore_document_payload(payload),
+    "image": lambda payload, document: _restore_image_payload(payload, document),
+    "thinking": lambda payload, document: _restore_thinking_payload(payload),
+    "conversation": lambda payload, document: _restore_conversation_payload(payload),
+    "html": lambda payload, document: _restore_html_payload(payload),
+    "web": lambda payload, document: _restore_web_payload(payload),
+    "artifact": lambda payload, document: _restore_artifact_payload(payload),
+    "gitlink": lambda payload, document: _restore_gitlink_payload(payload),
+    "pycoder": lambda payload, document: _restore_pycoder_payload(payload),
+    "code_sandbox": lambda payload, document: _restore_code_sandbox_payload(payload),
+}
+
+# Verified directly against both serializers.py (which field each isinstance
+# branch writes) and deserializers.py (which field each elif branch reads):
+# "chat" needs no parent at all (absent from this map); every other kind
+# requires ONE of these two positional (index-only, no id-fallback) parent
+# references, and is skipped entirely - no node created - when it fails to
+# resolve, exactly matching legacy's own `if parent_node:` guard.
+_PARENT_CONTENT_INDEX_KINDS = {"code", "document", "image", "thinking"}
+_PARENT_NODE_INDEX_KINDS = {
+    "conversation", "html", "pycoder", "code_sandbox", "web", "artifact", "gitlink",
+}
+
+# Kinds whose live children_indices/children_ids relationship the CURRENT
+# backend model actually tracks anything for - mirrors
+# graphlink_session/scene_index.py's own CHILD_LINK_NODE_TYPES (currently
+# (ChatNode, ConversationNode, HtmlViewNode) post-R5-closeout, confirmed by
+# direct reading). Some now-deleted kinds (pycoder/web/artifact/gitlink/
+# code_sandbox) once wrote children_indices too, but there is no live class
+# left to restore that relationship into, so they are correctly excluded
+# here rather than silently mishandled.
+_CHILD_LINK_KINDS = {"chat", "conversation", "html"}
+
+
+def _restore_node(
+    document: SceneDocument, node_type: str, payload: dict[str, Any], all_nodes_map: dict[int, str],
+) -> tuple[SceneNode | None, str | None]:
+    """Ports deserialize_node's own dispatch: default to "chat" for an
+    untagged payload (old-old sessions predating the node_type tag), and
+    silently skip - never raise - for anything unrecognized OR whose
+    required parent doesn't resolve, exactly matching legacy's own graceful
+    fall-through / `if parent_node:` guard. Returns (node_or_None,
+    resolved_parent_new_id_or_None) - the caller connects the edge itself
+    once the node is registered, since register_restored_node needs to run
+    first to mint the child's own id."""
+    restorer = _NODE_RESTORERS.get(node_type or "chat")
+    if restorer is None:
+        return None, None
+
+    parent_new_id: str | None = None
+    if node_type in _PARENT_CONTENT_INDEX_KINDS or node_type in _PARENT_NODE_INDEX_KINDS:
+        parent_key = "parent_content_node_index" if node_type in _PARENT_CONTENT_INDEX_KINDS else "parent_node_index"
+        parent_index = payload.get(parent_key)
+        parent_new_id = all_nodes_map.get(parent_index) if isinstance(parent_index, int) else None
+        if parent_new_id is None:
+            return None, None
+
+    try:
+        node = restorer(payload, document)
+    except Exception:
+        return None, None
+    return document.register_restored_node(node), parent_new_id
+
+
+def _restore_children(
+    node_payloads: list[dict[str, Any]],
+    all_nodes_map: dict[int, str],
+    nodes_by_id: dict[str, str],
+    kind_by_new_id: dict[str, str],
+    document: SceneDocument,
+) -> None:
+    """Ports deserializers.py's _restore_children: only meaningful for kinds
+    in _CHILD_LINK_KINDS. children_indices/children_ids are parallel lists
+    (same position in both = the same original child) - id-preferred,
+    index-fallback per position. The CURRENT backend model has no explicit
+    "children" field on SceneNode at all (branch structure lives entirely in
+    edges) - so a restored child relationship here becomes a real
+    document.connect(parent, child) edge, the same structural relationship
+    the "connections" lists also establish elsewhere; this is deliberately
+    idempotent (document.connect is itself idempotent for a duplicate pair),
+    so restoring the same edge from two different legacy sources is
+    harmless, not a double-edge bug."""
+    for index, payload in enumerate(node_payloads):
+        new_id = all_nodes_map.get(index)
+        if new_id is None or kind_by_new_id.get(new_id) not in _CHILD_LINK_KINDS:
+            continue
+        child_ids = payload.get("children_ids")
+        child_ids = child_ids if isinstance(child_ids, list) else []
+        child_indices = payload.get("children_indices")
+        child_indices = child_indices if isinstance(child_indices, list) else []
+        if not child_ids and not child_indices:
+            continue
+        for position in range(max(len(child_ids), len(child_indices))):
+            child_new_id = None
+            if position < len(child_ids) and child_ids[position] in nodes_by_id:
+                child_new_id = nodes_by_id[child_ids[position]]
+            elif position < len(child_indices):
+                child_new_id = all_nodes_map.get(child_indices[position])
+            if child_new_id is not None:
+                try:
+                    document.connect(new_id, child_new_id)
+                except Exception:
+                    continue
+
+
+def _restore_notes(document: SceneDocument, notes_data: list) -> dict[int, str]:
+    notes_map: dict[int, str] = {}
+    if not isinstance(notes_data, list):
+        return notes_map
+    for index, note_payload in enumerate(notes_data):
+        if not isinstance(note_payload, dict):
+            continue
+        try:
+            x, y = _position(note_payload)
+            note = document.add_note(
+                x, y,
+                is_system_prompt=bool(note_payload.get("is_system_prompt", False)),
+                is_summary_note=bool(note_payload.get("is_summary_note", False)),
+            )
+            document.set_note_content(note.id, str(note_payload.get("content", "")))
+            document.set_group_color(note.id, note_payload.get("color"), note_payload.get("header_color"))
+        except Exception:
+            continue
+        notes_map[index] = note.id
+    return notes_map
+
+
+def _restore_charts(
+    document: SceneDocument, charts_data: list, all_nodes_map: dict[int, str], nodes_by_id: dict[str, str],
+) -> tuple[dict[int, str], dict[str, str]]:
+    """Each chart restored in its own try/except - one bad chart must never
+    abort the whole load (deserializers.py's own posture, ported exactly)."""
+    charts_map: dict[int, str] = {}
+    charts_by_id: dict[str, str] = {}
+    if not isinstance(charts_data, list):
+        return charts_map, charts_by_id
+    for index, chart_payload in enumerate(charts_data):
+        if not isinstance(chart_payload, dict):
+            continue
+        try:
+            raw_data = chart_payload.get("data")
+            raw_data = raw_data if isinstance(raw_data, dict) else {}
+            chart_type = str(raw_data.get("type", "") or "").strip().lower()
+            if chart_type not in SUPPORTED_CHART_TYPES:
+                continue
+            try:
+                # Mirrors generate_chart's own _on_success contract exactly:
+                # persisted chart data is NOT trusted to already be
+                # canonical (an old save could predate a
+                # canonicalize_chart_data shape change), so this runs it
+                # through the same canonicalizer a live generation would,
+                # falling back to the same placeholder-with-chart_error
+                # shape on failure rather than dropping the chart.
+                chart_data = canonicalize_chart_data(raw_data, chart_type)
+                chart_error = ""
+            except ChartDataError as exc:
+                chart_data = _placeholder_chart_data(chart_type)
+                chart_error = f"This chart's saved data could not be validated: {exc}"
+            parent_id = _resolve_ref(
+                chart_payload, "parent_node_id", "parent_node_index", nodes_by_id, all_nodes_map,
+            )
+            x, y = _position(chart_payload)
+            chart = document.add_chart_node(x, y, parent_id, chart_type, chart_data, chart_error=chart_error)
+            # Aspect-lock MUST be applied before any resize: resize_chart's
+            # own aspect-preserving re-derivation reads chart_aspect_locked
+            # at call time, and a freshly-created chart always starts locked
+            # (the dataclass default) - toggling it afterward would be too
+            # late, since the requested (width, height) would already have
+            # been silently overridden to preserve the default 680x500 ratio.
+            aspect_locked = bool(chart_payload.get("aspect_ratio_locked", True))
+            if aspect_locked != chart.chart_aspect_locked:
+                document.toggle_chart_aspect_lock(chart.id)
+            size = chart_payload.get("size")
+            if isinstance(size, dict) and "width" in size and "height" in size:
+                document.resize_chart(chart.id, float(size["width"]), float(size["height"]))
+        except Exception:
+            continue
+        charts_map[index] = chart.id
+        chart_payload_id = chart_payload.get("id")
+        if chart_payload_id:
+            charts_by_id[str(chart_payload_id)] = chart.id
+    return charts_map, charts_by_id
+
+
+def _restore_frames(
+    document: SceneDocument, frames_data: list, frame_source_map: dict[int, str],
+) -> dict[int, str]:
+    frames_map: dict[int, str] = {}
+    if not isinstance(frames_data, list):
+        return frames_map
+    for index, frame_payload in enumerate(frames_data):
+        if not isinstance(frame_payload, dict):
+            continue
+        try:
+            # Pure positional membership - despite frames also carrying an
+            # "item_ids" list, deserialize_frame never reads it; "nodes" is
+            # an older fallback key name for the same list.
+            item_indices = frame_payload.get("items", frame_payload.get("nodes", []))
+            item_indices = item_indices if isinstance(item_indices, list) else []
+            member_ids = [frame_source_map[i] for i in item_indices if i in frame_source_map]
+            if not member_ids:
+                continue
+            frame = document.create_frame(member_ids)
+            document.set_group_label(frame.id, str(frame_payload.get("note", "") or ""))
+            document.set_group_color(frame.id, frame_payload.get("color"), frame_payload.get("header_color"))
+            if bool(frame_payload.get("is_locked", True)) != frame.is_locked:
+                document.toggle_frame_lock(frame.id)
+            # R6.4 translation, NOT a gap: deserialize_frame sets
+            # frame._user_resized = True whenever the payload's "rect" key
+            # is truthy, and serialize_frame ALWAYS writes a fully-populated
+            # "rect" dict - so every legacy load marks every frame as
+            # manually-sized, regardless of whether the user ever actually
+            # dragged a resize handle. The backend's analogous mechanism is
+            # group_manual_width/height being non-None. Getting this wrong
+            # (leaving them None "because it wasn't manually resized") would
+            # make a freshly-loaded frame silently auto-resnap to its
+            # content bbox the moment any member moves - so this ALWAYS
+            # populates them from the saved size when present, matching
+            # legacy's own unconditional behavior. "size" (width/height
+            # only, no x/y) is the older fallback shape.
+            rect = frame_payload.get("rect")
+            size = frame_payload.get("size")
+            width_height = None
+            if isinstance(rect, dict) and "width" in rect and "height" in rect:
+                width_height = (float(rect["width"]), float(rect["height"]))
+            elif isinstance(size, dict) and "width" in size and "height" in size:
+                width_height = (float(size["width"]), float(size["height"]))
+            if width_height is not None:
+                document.resize_frame(frame.id, width_height[0], width_height[1])
+            if bool(frame_payload.get("is_collapsed", False)):
+                document.toggle_group_collapsed(frame.id)
+        except Exception:
+            continue
+        frames_map[index] = frame.id
+    return frames_map
+
+
+def _restore_containers(document: SceneDocument, containers_data: list, all_items_map: dict[int, str]) -> None:
+    if not isinstance(containers_data, list):
+        return
+    for container_payload in containers_data:
+        if not isinstance(container_payload, dict):
+            continue
+        try:
+            # Pure positional membership, same posture as frames - "items"
+            # is required in legacy (KeyError if absent); tolerated-missing
+            # here instead of aborting the whole load.
+            item_indices = container_payload.get("items", [])
+            item_indices = item_indices if isinstance(item_indices, list) else []
+            member_ids = [all_items_map[i] for i in item_indices if i in all_items_map]
+            if not member_ids:
+                continue
+            container = document.create_container(member_ids)
+            # "Container" matches deserialize_container's own restore-time
+            # default (data.get("title", "Container")) - NOT
+            # create_container's own fresh-creation default ("New
+            # Container"), a different code path with a different default.
+            document.set_group_label(container.id, str(container_payload.get("title", "") or "Container"))
+            document.set_group_color(container.id, container_payload.get("color"), container_payload.get("header_color"))
+            if bool(container_payload.get("is_collapsed", False)):
+                document.toggle_group_collapsed(container.id)
+        except Exception:
+            continue
+
+
+# The 7 kinds every era has always had, plus 5 that only existed before
+# R5-closeout deleted their node kinds - restoring THESE 5 from an old save
+# is still meaningful even though the node kinds they usually joined are
+# gone, since a connection can link any two still-restorable nodes.
+_BASIC_CONNECTION_KEYS = (
+    "connections", "content_connections", "document_connections",
+    "image_connections", "thinking_connections", "conversation_connections", "html_connections",
+    "pycoder_connections", "code_sandbox_connections", "web_connections",
+    "artifact_connections", "gitlink_connections",
+)
+
+
+def _restore_basic_connections(
+    document: SceneDocument, chat_data: dict[str, Any],
+    all_nodes_map: dict[int, str], nodes_by_id: dict[str, str],
+) -> None:
+    """All 12 lists share IDENTICAL shape (_serialize_basic_connection:
+    start/end_node_index + start/end_node_id) - one generic pass handles all
+    of them; the specific node KIND at either end is irrelevant to edge
+    creation."""
+    for key in _BASIC_CONNECTION_KEYS:
+        entries = chat_data.get(key)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            source_id = _resolve_ref(entry, "start_node_id", "start_node_index", nodes_by_id, all_nodes_map)
+            target_id = _resolve_ref(entry, "end_node_id", "end_node_index", nodes_by_id, all_nodes_map)
+            if source_id is None or target_id is None or source_id == target_id:
+                continue
+            try:
+                document.connect(source_id, target_id)
+            except Exception:
+                continue
+
+
+def _restore_system_prompt_and_summary_connections(
+    document: SceneDocument, chat_data: dict[str, Any],
+    notes_map: dict[int, str], chat_nodes_map: dict[int, str], nodes_by_id: dict[str, str],
+) -> None:
+    """The chat-node-side reference resolves id-preferred against the
+    GENERAL nodes_by_id map (a node's payload id is unique across every
+    kind) and index-fallback against chat_nodes_map specifically (verified
+    directly against restore_chat's own call sites: both
+    deserialize_system_prompt_connection and deserialize_group_summary_
+    connection are called with chat_nodes_map bound to the "nodes_map"
+    parameter, not all_nodes_map) - the save-side ordinal counted only
+    across chat-type payload entries (bug #47's own fix)."""
+    sp_entries = chat_data.get("system_prompt_connections")
+    if isinstance(sp_entries, list):
+        for entry in sp_entries:
+            if not isinstance(entry, dict):
+                continue
+            note_id = notes_map.get(entry.get("start_note_index"))
+            target_id = _resolve_ref(entry, "end_node_id", "end_node_index", nodes_by_id, chat_nodes_map)
+            if note_id is not None and target_id is not None:
+                try:
+                    document.connect(note_id, target_id)
+                except Exception:
+                    continue
+
+    gs_entries = chat_data.get("group_summary_connections")
+    if isinstance(gs_entries, list):
+        for entry in gs_entries:
+            if not isinstance(entry, dict):
+                continue
+            source_id = _resolve_ref(entry, "start_node_id", "start_node_index", nodes_by_id, chat_nodes_map)
+            note_id = notes_map.get(entry.get("end_note_index"))
+            if source_id is not None and note_id is not None:
+                try:
+                    document.connect(source_id, note_id)
+                except Exception:
+                    continue
+
+
+def _restore_pins(document: SceneDocument, pins_data: list) -> None:
+    if not isinstance(pins_data, list) or not pins_data:
+        return
+    records = []
+    for pin_payload in pins_data:
+        if not isinstance(pin_payload, dict):
+            continue
+        try:
+            records.append(NavigationPinRecord.from_mapping(pin_payload, fallback_order=len(records)))
+        except Exception:
+            continue
+    if records:
+        try:
+            document.pins.reset(records)
+        except Exception:
+            pass
+
+
+def _restore_view_state(document: SceneDocument, chat_data: dict[str, Any]) -> None:
+    view_state = chat_data.get("view_state")
+    if not isinstance(view_state, dict):
+        return
+    zoom = view_state.get("zoom_factor", document.zoom_factor)
+    scroll = view_state.get("scroll_position")
+    scroll_x = document.scroll_x
+    scroll_y = document.scroll_y
+    if isinstance(scroll, dict):
+        scroll_x = scroll.get("x", scroll_x)
+        scroll_y = scroll.get("y", scroll_y)
+    try:
+        document.set_view_state(float(zoom), float(scroll_x), float(scroll_y))
+    except Exception:
+        pass
+
+
+def restore_chat_into_document(
+    document: SceneDocument, chat: dict[str, Any], notes_data: list, pins_data: list,
+) -> None:
+    """The top-level orchestrator - ports SceneDeserializer.restore_chat()'s
+    own exact ordering, reimplemented against SceneDocument. See this
+    module's own docstring for the full algorithm and every confirmed gap/
+    translation. Raises only for a genuinely unusable `chat` argument (not a
+    mapping at all) - every per-item failure inside is already swallowed
+    locally; the caller (backend/chat_library.py's loadChat intent) is
+    responsible for the OUTER safety net matching legacy's own
+    _handle_load_error (a notification, not a crash) for anything that still
+    escapes."""
+    if not isinstance(chat, dict):
+        raise ValueError("chat payload must be a mapping")
+
+    document.clear_for_load()
+
+    chat_data = chat.get("data")
+    chat_data = chat_data if isinstance(chat_data, dict) else {}
+
+    node_payloads = _resolve_node_payload_list(chat_data)
+
+    all_nodes_map: dict[int, str] = {}
+    nodes_by_id: dict[str, str] = {}
+    kind_by_new_id: dict[str, str] = {}
+    chat_nodes_map: dict[int, str] = {}
+    chat_payload_position = 0
+
+    for index, node_payload in enumerate(node_payloads):
+        if not isinstance(node_payload, dict):
+            continue
+        node_type = node_payload.get("node_type", "chat")
+        node, parent_new_id = _restore_node(document, node_type, node_payload, all_nodes_map)
+        if node is not None:
+            all_nodes_map[index] = node.id
+            kind_by_new_id[node.id] = node.kind
+            payload_id = node_payload.get("id")
+            if payload_id:
+                nodes_by_id[str(payload_id)] = node.id
+            if parent_new_id is not None:
+                document.connect(parent_new_id, node.id)
+        if node_type == "chat":
+            if node is not None:
+                chat_nodes_map[chat_payload_position] = node.id
+            chat_payload_position += 1
+
+    _restore_children(node_payloads, all_nodes_map, nodes_by_id, kind_by_new_id, document)
+
+    notes_map = _restore_notes(document, notes_data)
+
+    charts_map, charts_by_id = _restore_charts(document, chat_data.get("charts", []), all_nodes_map, nodes_by_id)
+
+    node_slot_count = len(node_payloads)
+    note_slot_count = len(notes_data) if isinstance(notes_data, list) else 0
+    chart_slot_count = len(chat_data.get("charts", [])) if isinstance(chat_data.get("charts"), list) else 0
+
+    frame_source_map = dict(all_nodes_map)
+    for chart_index, chart_new_id in charts_map.items():
+        frame_source_map[node_slot_count + chart_index] = chart_new_id
+    frames_map = _restore_frames(document, chat_data.get("frames", []), frame_source_map)
+
+    all_items_map = dict(all_nodes_map)
+    for note_index, note_new_id in notes_map.items():
+        all_items_map[node_slot_count + note_index] = note_new_id
+    for chart_index, chart_new_id in charts_map.items():
+        all_items_map[node_slot_count + note_slot_count + chart_index] = chart_new_id
+    for frame_index, frame_new_id in frames_map.items():
+        all_items_map[node_slot_count + note_slot_count + chart_slot_count + frame_index] = frame_new_id
+    _restore_containers(document, chat_data.get("containers", []), all_items_map)
+
+    _restore_basic_connections(document, chat_data, all_nodes_map, nodes_by_id)
+    _restore_system_prompt_and_summary_connections(document, chat_data, notes_map, chat_nodes_map, nodes_by_id)
+
+    _restore_pins(document, pins_data)
+    _restore_view_state(document, chat_data)
+
+    total_tokens = chat_data.get("total_session_tokens", 0)
+    try:
+        document.total_session_tokens = int(total_tokens)
+    except (TypeError, ValueError):
+        document.total_session_tokens = 0

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -1,19 +1,25 @@
-"""Chat library topic tests (Qt-removal plan R2.5e)."""
+"""Chat library topic tests (Qt-removal plan R2.5e + R6.4 loadChat)."""
 
 import asyncio
+import json
 import sqlite3
 
 import pytest
 
+from backend.canvas import SceneDocument
 from backend.chat_library import (
     _format_timestamp,
     chat_library_payload,
     delete_chat,
     get_all_chats,
+    load_chat_row,
+    load_notes_rows,
+    load_pins_rows,
     register_chat_library,
     rename_chat,
 )
 from backend.events import SessionBus
+from backend.notifications import NotificationState
 
 
 @pytest.fixture
@@ -161,3 +167,152 @@ def test_delete_chat_intent_removes_and_republishes(db_path):
 
     asyncio.run(bus.dispatch_intent("app-chat-library", "deleteChat", [chat_id]))
     assert recorder.messages[-1]["payload"]["rows"] == []
+
+
+# -- R6.4: load_chat_row / load_notes_rows / load_pins_rows -----------------
+
+
+def _insert_note(db_path, chat_id: int, **overrides) -> None:
+    conn = sqlite3.connect(db_path, timeout=30)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id INTEGER NOT NULL, "
+            "content TEXT NOT NULL, position_x REAL NOT NULL, position_y REAL NOT NULL, width REAL NOT NULL, "
+            "height REAL NOT NULL, color TEXT NOT NULL, header_color TEXT, "
+            "is_system_prompt INTEGER DEFAULT 0, is_summary_note INTEGER DEFAULT 0)"
+        )
+        row = {
+            "content": "hello note", "position_x": 1.0, "position_y": 2.0,
+            "width": 100.0, "height": 50.0, "color": "#111111", "header_color": None,
+            "is_system_prompt": 0, "is_summary_note": 0,
+        }
+        row.update(overrides)
+        conn.execute(
+            "INSERT INTO notes (chat_id, content, position_x, position_y, width, height, color, "
+            "header_color, is_system_prompt, is_summary_note) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (chat_id, row["content"], row["position_x"], row["position_y"], row["width"], row["height"],
+             row["color"], row["header_color"], row["is_system_prompt"], row["is_summary_note"]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_pin(db_path, chat_id: int, **overrides) -> None:
+    conn = sqlite3.connect(db_path, timeout=30)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS pins (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id INTEGER NOT NULL, "
+            "title TEXT NOT NULL, note TEXT, position_x REAL NOT NULL, position_y REAL NOT NULL, "
+            "pin_id TEXT, sort_order INTEGER DEFAULT 0, anchor_item_id TEXT, created_at TEXT)"
+        )
+        row = {
+            "title": "My Pin", "note": "", "position_x": 5.0, "position_y": 6.0,
+            "pin_id": "pin-1", "sort_order": 0, "anchor_item_id": None, "created_at": "2026-01-01 00:00:00",
+        }
+        row.update(overrides)
+        conn.execute(
+            "INSERT INTO pins (chat_id, title, note, position_x, position_y, pin_id, sort_order, "
+            "anchor_item_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (chat_id, row["title"], row["note"], row["position_x"], row["position_y"],
+             row["pin_id"], row["sort_order"], row["anchor_item_id"], row["created_at"]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_load_chat_row_returns_title_and_parsed_data(db_path):
+    chat_id = _insert_chat(db_path, "Loadable", data=json.dumps({"nodes": [{"node_type": "chat"}]}))
+    row = load_chat_row(db_path, chat_id)
+    assert row == {"title": "Loadable", "data": {"nodes": [{"node_type": "chat"}]}}
+
+
+def test_load_chat_row_returns_none_for_missing_id(db_path):
+    assert load_chat_row(db_path, 999) is None
+
+
+def test_load_notes_rows_shape_matches_session_load_expectations(db_path):
+    chat_id = _insert_chat(db_path, "WithNotes")
+    _insert_note(db_path, chat_id, content="A note", is_system_prompt=1)
+
+    rows = load_notes_rows(db_path, chat_id)
+    assert len(rows) == 1
+    assert rows[0] == {
+        "content": "A note", "position": {"x": 1.0, "y": 2.0}, "size": {"width": 100.0, "height": 50.0},
+        "color": "#111111", "header_color": None, "is_system_prompt": True, "is_summary_note": False,
+    }
+
+
+def test_load_pins_rows_orders_by_sort_order_and_shape(db_path):
+    chat_id = _insert_chat(db_path, "WithPins")
+    _insert_pin(db_path, chat_id, title="Second", sort_order=1, pin_id="pin-b")
+    _insert_pin(db_path, chat_id, title="First", sort_order=0, pin_id="pin-a")
+
+    rows = load_pins_rows(db_path, chat_id)
+    assert [row["title"] for row in rows] == ["First", "Second"]
+    assert rows[0]["position"] == {"x": 5.0, "y": 6.0}
+    assert rows[0]["pin_id"] == "pin-a"
+
+
+# -- R6.4: the loadChat intent -----------------------------------------------
+
+
+def _bus_with_canvas(db_path):
+    """Mirrors backend/app.py's own registration order: canvas's "scene"
+    topic must exist before register_chat_library's loadChat intent can
+    publish to it - production guarantees this via _configure_session's own
+    ordering; this test harness replicates it directly rather than pulling
+    in the full register_canvas (which itself needs an agent dispatcher/
+    composer document unrelated to what's under test here)."""
+    bus = SessionBus("chat-library-load-test")
+    document = SceneDocument()
+    bus.register_topic("scene", document.scene_payload)
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    register_chat_library(bus, db_path, document, notifications)
+    return bus, document, notifications
+
+
+def test_load_chat_intent_restores_a_real_node_into_the_canvas_document(db_path):
+    chat_data = {
+        "nodes": [
+            {"node_type": "chat", "id": "n1", "raw_content": "Hi", "is_user": True, "position": {"x": 0, "y": 0}},
+        ],
+    }
+    chat_id = _insert_chat(db_path, "Real Session", data=json.dumps(chat_data))
+    bus, document, notifications = _bus_with_canvas(db_path)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "loadChat", [chat_id]))
+
+    assert len(document.nodes) == 1
+    node = next(iter(document.nodes.values()))
+    assert node.kind == "chat" and node.content == "Hi" and node.is_user is True
+    assert notifications.visible and notifications.msg_type == "success"
+    scene_messages = [m for m in recorder.messages if m["topic"] == "scene"]
+    assert scene_messages, "loadChat must publish a fresh scene snapshot"
+
+
+def test_load_chat_intent_shows_an_error_notification_for_a_missing_chat(db_path):
+    bus, document, notifications = _bus_with_canvas(db_path)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "loadChat", [999]))
+
+    assert document.nodes == {}
+    assert notifications.visible and notifications.msg_type == "error"
+
+
+def test_load_chat_intent_restores_notes_and_pins_too(db_path):
+    chat_data = {"nodes": []}
+    chat_id = _insert_chat(db_path, "Notes And Pins", data=json.dumps(chat_data))
+    _insert_note(db_path, chat_id, content="A restored note")
+    _insert_pin(db_path, chat_id, title="A restored pin")
+    bus, document, _ = _bus_with_canvas(db_path)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "loadChat", [chat_id]))
+
+    notes = [n for n in document.nodes.values() if n.kind == "note"]
+    assert len(notes) == 1 and notes[0].content == "A restored note"
+    assert len(document.pins.records) == 1

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -1,0 +1,563 @@
+"""Backend session LOAD tests (Qt-removal plan R6.4).
+
+Exercises backend/session_load.py's restore_chat_into_document against
+backend/canvas.py's real SceneDocument - no mocking of the document itself,
+since the whole point of this module is that it drives the SAME public
+SceneDocument API a live session already uses (add_note/create_frame/
+connect/etc). Payload shapes below are copied from the ACTUAL serialize
+side (graphlink_session/serializers.py, plus the pre-R5-closeout recovery
+via `git show af72ffd~1:...` for the 5 deleted plugin kinds) - not
+approximated.
+"""
+
+import backend.agents as agents_module  # noqa: F401 - see test_canvas.py's own import-order note
+from backend.canvas import SceneDocument
+from backend.session_load import restore_chat_into_document
+
+
+def _chat(index_id, *, is_user=True, raw_content="hi", **extra):
+    payload = {"node_type": "chat", "id": index_id, "raw_content": raw_content, "is_user": is_user,
+               "position": {"x": 0.0, "y": 0.0}}
+    payload.update(extra)
+    return payload
+
+
+def _restore(nodes=None, notes=None, pins=None, **chat_data_extra):
+    document = SceneDocument()
+    chat_data = {"nodes": nodes or []}
+    chat_data.update(chat_data_extra)
+    restore_chat_into_document(document, {"data": chat_data}, notes or [], pins or [])
+    return document
+
+
+# -- chat node -----------------------------------------------------------
+
+
+def test_chat_node_is_user_defaults_true_when_key_missing():
+    document = _restore(nodes=[{"node_type": "chat", "raw_content": "hey", "position": {"x": 0, "y": 0}}])
+    node = next(iter(document.nodes.values()))
+    assert node.is_user is True
+
+
+def test_chat_node_raw_content_falls_back_to_legacy_text_key():
+    document = _restore(nodes=[{"node_type": "chat", "text": "old shape", "position": {"x": 0, "y": 0}}])
+    node = next(iter(document.nodes.values()))
+    assert node.content == "old shape"
+
+
+def test_untagged_node_type_defaults_to_chat():
+    document = _restore(nodes=[{"raw_content": "no tag", "position": {"x": 0, "y": 0}}])
+    assert len(document.nodes) == 1
+    assert next(iter(document.nodes.values())).kind == "chat"
+
+
+def test_unrecognized_node_type_is_skipped_not_raised():
+    document = _restore(nodes=[
+        {"node_type": "some_future_kind", "position": {"x": 0, "y": 0}},
+        _chat("a"),
+    ])
+    assert len(document.nodes) == 1
+
+
+# -- parent-required kinds: parent_content_node_index ------------------------
+
+
+def test_code_node_restores_and_connects_when_parent_resolves():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "code", "code": "print(1)", "language": "python",
+         "position": {"x": 10, "y": 10}, "parent_content_node_index": 0},
+    ])
+    assert len(document.nodes) == 2
+    code_node = next(n for n in document.nodes.values() if n.kind == "code")
+    chat_node = next(n for n in document.nodes.values() if n.kind == "chat")
+    assert code_node.code == "print(1)" and code_node.language == "python"
+    assert any(e.source == chat_node.id and e.target == code_node.id for e in document.edges.values())
+
+
+def test_code_node_is_skipped_entirely_when_parent_index_does_not_resolve():
+    document = _restore(nodes=[
+        _chat("only"),
+        {"node_type": "code", "code": "print(1)", "language": "python",
+         "position": {"x": 10, "y": 10}, "parent_content_node_index": 5},
+    ])
+    assert len(document.nodes) == 1
+    assert next(iter(document.nodes.values())).kind == "chat"
+
+
+def test_code_node_cannot_reference_a_later_payload_position_as_parent():
+    # The single-pass restore loop builds all_nodes_map incrementally - a
+    # node at position 0 referencing position 1 (which hasn't been created
+    # yet) must fail to resolve, exactly like legacy's own forward-only pass.
+    document = _restore(nodes=[
+        {"node_type": "code", "code": "x", "language": "python",
+         "position": {"x": 0, "y": 0}, "parent_content_node_index": 1},
+        _chat("later"),
+    ])
+    assert len(document.nodes) == 1
+    assert next(iter(document.nodes.values())).kind == "chat"
+
+
+def test_document_node_field_mapping():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "document", "title": "report.pdf", "content": "body text",
+         "attachment_kind": "document", "file_path": "/tmp/report.pdf", "mime_type": "application/pdf",
+         "duration_seconds": None, "byte_size": 2048, "preview_label": "PDF",
+         "is_collapsed": True, "is_docked": True,
+         "position": {"x": 0, "y": 0}, "parent_content_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "document")
+    assert node.title == "report.pdf" and node.content == "body text"
+    assert node.byte_size == 2048 and node.is_docked is True and node.is_collapsed is True
+
+
+def test_thinking_node_field_mapping():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "thinking", "thinking_text": "reasoning...", "is_docked": True,
+         "position": {"x": 0, "y": 0}, "parent_content_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "thinking")
+    assert node.content == "reasoning..." and node.is_docked is True
+
+
+# -- parent-required kinds: parent_node_index --------------------------------
+
+
+def test_conversation_node_uses_parent_node_index_not_parent_content_node_index():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "conversation", "conversation_history": [{"role": "user", "content": "hi"}],
+         "is_collapsed": False, "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    assert len(document.nodes) == 2
+    conv = next(n for n in document.nodes.values() if n.kind == "conversation")
+    assert conv.history == [{"role": "user", "content": "hi"}]
+
+
+def test_html_node_field_mapping():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "html", "html_content": "<h1>Hi</h1>", "splitter_state": 0.4,
+         "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "html")
+    assert node.content == "<h1>Hi</h1>" and node.html_splitter_state == 0.4
+
+
+def test_pycoder_mode_translates_enum_member_name_to_lowercase():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "pycoder", "mode": "MANUAL", "prompt": "do x", "code": "x=1",
+         "output": "1", "analysis": "ok", "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "pycoder")
+    assert node.pycoder_mode == "manual"
+
+
+def test_code_sandbox_field_mapping():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "code_sandbox", "prompt": "build x", "requirements": "numpy",
+         "code": "import numpy", "output": "ok", "analysis": "good", "sandbox_id": "sbx-1",
+         "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "code_sandbox")
+    assert node.code_sandbox_requirements == "numpy" and node.code_sandbox_sandbox_id == "sbx-1"
+
+
+def test_artifact_node_reuses_instruction_as_content_and_content_as_artifact_content():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "artifact", "instruction": "write a poem", "content": "roses are red",
+         "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "artifact")
+    assert node.content == "write a poem" and node.artifact_content == "roses are red"
+
+
+def test_gitlink_node_unpacks_repo_state_and_synthesizes_proposal_markdown():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {
+            "node_type": "gitlink", "task_prompt": "fix bug",
+            "repo_state": {"repo": "org/repo", "branch": "main", "scope_mode": "all",
+                            "local_root": "/tmp/repo", "imported_root": ""},
+            "proposal_data": {"files": [{"path": "a.py"}, {"path": "b.py"}]},
+            "position": {"x": 0, "y": 0}, "parent_node_index": 0,
+        },
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "gitlink")
+    assert node.gitlink_repo == "org/repo" and node.gitlink_branch == "main"
+    assert node.gitlink_pending_changes == [{"path": "a.py"}, {"path": "b.py"}]
+    assert "a.py" in node.gitlink_proposal_markdown and "b.py" in node.gitlink_proposal_markdown
+    assert node.gitlink_change_state == "previewed"
+    assert node.gitlink_change_fingerprint is None
+
+
+def test_gitlink_node_with_no_pending_changes_is_draft_state():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "gitlink", "task_prompt": "", "repo_state": {}, "proposal_data": {},
+         "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "gitlink")
+    assert node.gitlink_change_state == "draft"
+
+
+# -- web research / research_result translation ------------------------------
+
+
+def test_web_node_research_result_translates_snake_case_to_camel_case():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {
+            "node_type": "web", "query": "best pasta recipe",
+            "research_result": {
+                "request_id": "req-1", "original_query": "pasta", "effective_query": "best pasta recipe",
+                "answer_markdown": "Use fresh tomatoes.",
+                "sources": [{"source_id": "s1", "title": "Recipe Site", "url": "https://example.com"}],
+                "citations": [{"source_id": "s1", "marker": "[1]", "claim_context": "tomatoes"}],
+                "warnings": [], "provider_snapshot": {},
+            },
+            "position": {"x": 0, "y": 0}, "parent_node_index": 0,
+        },
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "web_research")
+    result = node.research_result
+    assert result["requestId"] == "req-1"
+    assert result["answerMarkdown"] == "Use fresh tomatoes."
+    assert result["sources"][0]["sourceId"] == "s1"
+    assert result["citations"][0]["claimContext"] == "tomatoes"
+
+
+def test_web_node_falls_back_to_summary_and_sources_for_older_shape_sessions():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "web", "query": "q", "summary": "the answer", "sources": [{"title": "t"}],
+         "research_result": {}, "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "web_research")
+    assert node.research_result["answerMarkdown"] == "the answer"
+    assert node.research_result["sources"] == [{"title": "t"}]
+
+
+def test_web_node_kind_is_web_research_not_web():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "web", "query": "q", "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind != "chat")
+    assert node.kind == "web_research"
+
+
+# -- children_indices / children_ids ------------------------------------------
+
+
+def test_children_indices_restore_as_real_edges_for_child_link_kinds():
+    document = _restore(nodes=[
+        {"node_type": "chat", "id": "root", "raw_content": "root", "is_user": True,
+         "position": {"x": 0, "y": 0}, "children_indices": [1]},
+        {"node_type": "chat", "id": "child", "raw_content": "child", "is_user": False,
+         "position": {"x": 0, "y": 100}},
+    ])
+    root = next(n for n in document.nodes.values() if n.content == "root")
+    child = next(n for n in document.nodes.values() if n.content == "child")
+    assert any(e.source == root.id and e.target == child.id for e in document.edges.values())
+
+
+def test_children_ids_are_id_preferred_over_children_indices():
+    document = _restore(nodes=[
+        {"node_type": "chat", "id": "root", "raw_content": "root", "is_user": True,
+         "position": {"x": 0, "y": 0}, "children_ids": ["child-b"], "children_indices": [1]},
+        {"node_type": "chat", "id": "child-a", "raw_content": "wrong child", "is_user": False,
+         "position": {"x": 0, "y": 100}},
+        {"node_type": "chat", "id": "child-b", "raw_content": "right child", "is_user": False,
+         "position": {"x": 0, "y": 200}},
+    ])
+    root = next(n for n in document.nodes.values() if n.content == "root")
+    right_child = next(n for n in document.nodes.values() if n.content == "right child")
+    wrong_child = next(n for n in document.nodes.values() if n.content == "wrong child")
+    assert any(e.source == root.id and e.target == right_child.id for e in document.edges.values())
+    assert not any(e.source == root.id and e.target == wrong_child.id for e in document.edges.values())
+
+
+# -- notes --------------------------------------------------------------
+
+
+def test_notes_restore_position_content_and_flags():
+    document = _restore(notes=[
+        {"content": "sys prompt", "position": {"x": 12.0, "y": 34.0}, "size": {"width": 1, "height": 1},
+         "color": "#abcdef", "header_color": None, "is_system_prompt": True, "is_summary_note": False},
+    ])
+    note = next(iter(document.nodes.values()))
+    assert note.kind == "note" and note.content == "sys prompt"
+    assert (note.x, note.y) == (12.0, 34.0)
+    assert note.color == "#abcdef" and note.is_system_prompt is True
+
+
+# -- charts ---------------------------------------------------------------
+
+
+def test_chart_restores_with_size_and_aspect_lock_override():
+    document = _restore(
+        nodes=[_chat("parent")],
+        charts=[{
+            "id": "chart-1", "data": {"type": "bar", "title": "T", "labels": ["a"], "values": [1.0]},
+            "position": {"x": 5, "y": 5}, "size": {"width": 600, "height": 400},
+            "aspect_ratio_locked": False, "parent_node_index": 0,
+        }],
+    )
+    chart = next(n for n in document.nodes.values() if n.kind == "chart")
+    assert chart.chart_width == 600.0 and chart.chart_height == 400.0
+    assert chart.chart_aspect_locked is False
+
+
+def test_chart_aspect_lock_is_applied_before_resize_not_after():
+    # Adversarial-review finding: 600x400 (both already above CHART_MIN_
+    # WIDTH/HEIGHT) never actually exercises resize_chart's aspect-preserving
+    # branch, since nothing needs clamping - the ordering bug (toggling
+    # aspect_locked AFTER resize_chart runs, instead of before) would pass
+    # that test even reverted. A requested size BELOW both minimums (100x100,
+    # vs CHART_MIN_WIDTH=440/CHART_MIN_HEIGHT=320) genuinely diverges:
+    # confirmed empirically that resizing while still locked (the bug) yields
+    # a square 440x440 (the aspect-preserving re-derivation kicks in off the
+    # clamped width), while unlocking first (the fix) yields 440x320 (each
+    # dimension clamped independently, no re-derivation) - this test would
+    # fail if the two calls in _restore_charts were reordered.
+    document = _restore(
+        nodes=[_chat("parent")],
+        charts=[{
+            "id": "chart-1", "data": {"type": "bar", "title": "T", "labels": ["a"], "values": [1.0]},
+            "position": {"x": 0, "y": 0}, "size": {"width": 100, "height": 100},
+            "aspect_ratio_locked": False, "parent_node_index": 0,
+        }],
+    )
+    chart = next(n for n in document.nodes.values() if n.kind == "chart")
+    assert (chart.chart_width, chart.chart_height) == (440.0, 320.0)
+
+
+def test_malformed_chart_is_skipped_without_aborting_the_rest_of_the_load():
+    document = _restore(
+        nodes=[_chat("a")],
+        charts=[
+            {"id": "bad", "data": "not-a-dict", "position": {"x": 0, "y": 0}},
+            {"id": "good", "data": {"type": "bar", "title": "T", "labels": ["a"], "values": [1.0]},
+             "position": {"x": 0, "y": 0}},
+        ],
+    )
+    charts = [n for n in document.nodes.values() if n.kind == "chart"]
+    assert len(charts) == 1
+
+
+def test_chart_with_unsupported_type_is_skipped():
+    document = _restore(
+        nodes=[],
+        charts=[{"id": "x", "data": {"type": "not-a-real-type"}, "position": {"x": 0, "y": 0}}],
+    )
+    assert not any(n.kind == "chart" for n in document.nodes.values())
+
+
+# -- frames -----------------------------------------------------------------
+
+
+def test_frame_membership_uses_items_key_not_item_indices():
+    document = _restore(
+        nodes=[_chat("a"), _chat("b")],
+        frames=[{"items": [0, 1], "note": "Group", "position": {"x": 0, "y": 0},
+                 "rect": {"x": 0, "y": 0, "width": 500, "height": 500}, "is_locked": True, "is_collapsed": False}],
+    )
+    frame = next(n for n in document.nodes.values() if n.kind == "frame")
+    member_kinds = {document.nodes[i].kind for i in frame.item_ids}
+    assert member_kinds == {"chat"}
+    assert frame.group_manual_width is not None and frame.group_manual_height is not None
+
+
+def test_frame_falls_back_to_legacy_nodes_key():
+    document = _restore(
+        nodes=[_chat("a")],
+        frames=[{"nodes": [0], "note": "Old shape", "position": {"x": 0, "y": 0}}],
+    )
+    frame = next(n for n in document.nodes.values() if n.kind == "frame")
+    assert len(frame.item_ids) == 1
+
+
+def test_frame_with_no_resolvable_members_is_skipped():
+    document = _restore(
+        nodes=[_chat("a")],
+        frames=[{"items": [99], "note": "Ghost", "position": {"x": 0, "y": 0}}],
+    )
+    assert not any(n.kind == "frame" for n in document.nodes.values())
+
+
+def test_frame_unlocked_flag_is_applied():
+    document = _restore(
+        nodes=[_chat("a")],
+        frames=[{"items": [0], "note": "Unlocked", "position": {"x": 0, "y": 0}, "is_locked": False}],
+    )
+    frame = next(n for n in document.nodes.values() if n.kind == "frame")
+    assert frame.is_locked is False
+
+
+# -- containers (nest frames/notes/charts, offset math) ----------------------
+
+
+def test_container_default_title_matches_legacy_restore_time_default():
+    document = _restore(
+        nodes=[_chat("a")],
+        containers=[{"items": [0]}],
+    )
+    container = next(n for n in document.nodes.values() if n.kind == "container")
+    assert container.content == "Container"
+
+
+def test_container_offsets_survive_a_skipped_node_bug_47_regression():
+    # 3 node payloads; position 1 has a bad parent and gets skipped entirely.
+    # notes/charts/frames offsets must be computed from the ORIGINAL 3-slot
+    # node count, not from the 2 nodes that actually survived - otherwise the
+    # note (originally at combined-space position node_slot_count+0 = 3)
+    # would be misread as combined-space position 2, silently attaching the
+    # container to the wrong item.
+    document = _restore(
+        nodes=[
+            _chat("a"),
+            {"node_type": "code", "code": "x", "language": "python",
+             "position": {"x": 0, "y": 0}, "parent_content_node_index": 99},  # skipped
+            _chat("c"),
+        ],
+        notes=[{"content": "the note", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
+                "color": "#fff", "header_color": None}],
+        containers=[{"items": [3]}],  # node_slot_count(3) + note_index(0) = 3
+    )
+    assert len(document.nodes) == 4  # 2 chats + 1 note + 1 container
+    container = next(n for n in document.nodes.values() if n.kind == "container")
+    note = next(n for n in document.nodes.values() if n.kind == "note")
+    assert container.item_ids == [note.id]
+
+
+def test_container_can_reference_a_frame_via_the_full_offset_chain():
+    document = _restore(
+        nodes=[_chat("a"), _chat("b")],
+        frames=[{"items": [0, 1], "note": "F", "position": {"x": 0, "y": 0}}],
+        # node_slot_count(2) + note_slot_count(0) + chart_slot_count(0) + frame_index(0) = 2
+        containers=[{"items": [2]}],
+    )
+    container = next(n for n in document.nodes.values() if n.kind == "container")
+    frame = next(n for n in document.nodes.values() if n.kind == "frame")
+    assert container.item_ids == [frame.id]
+
+
+# -- basic connections (12 keys), system-prompt / group-summary -------------
+
+
+def test_basic_connection_resolves_by_index():
+    document = _restore(
+        nodes=[_chat("a"), _chat("b")],
+        connections=[{"start_node_index": 0, "end_node_index": 1}],
+    )
+    a, b = list(document.nodes.values())
+    assert any(e.source == a.id and e.target == b.id for e in document.edges.values())
+
+
+def test_basic_connection_resolves_by_id_when_index_is_wrong():
+    document = _restore(
+        nodes=[_chat("a"), _chat("b")],
+        content_connections=[{"start_node_index": 99, "start_node_id": "a", "end_node_index": 99, "end_node_id": "b"}],
+    )
+    a = next(n for n in document.nodes.values() if n.content == "hi")
+    assert len(document.edges) == 1
+
+
+def test_plugin_era_connection_keys_still_resolve():
+    # pycoder_connections/web_connections/etc only existed before R5-closeout
+    # deleted those node kinds, but the connection can still legitimately
+    # link two SURVIVING node kinds from an old save.
+    document = _restore(
+        nodes=[_chat("a"), _chat("b")],
+        pycoder_connections=[{"start_node_index": 0, "end_node_index": 1}],
+        gitlink_connections=[{"start_node_index": 1, "end_node_index": 0}],
+    )
+    assert len(document.edges) == 2
+
+
+def test_system_prompt_connection_resolves_chat_node_via_chat_payload_ordinal():
+    document = _restore(
+        nodes=[
+            {"node_type": "document", "title": "t", "content": "c", "position": {"x": 0, "y": 0},
+             "parent_content_node_index": 99},  # skipped - shifts chat ordinal test
+            _chat("only-chat"),
+        ],
+        notes=[{"content": "sp", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
+                "color": "#fff", "header_color": None, "is_system_prompt": True}],
+        system_prompt_connections=[{"start_note_index": 0, "end_node_index": 0}],
+    )
+    note = next(n for n in document.nodes.values() if n.kind == "note")
+    chat = next(n for n in document.nodes.values() if n.kind == "chat")
+    assert any(e.source == note.id and e.target == chat.id for e in document.edges.values())
+
+
+def test_group_summary_connection_chat_to_note():
+    document = _restore(
+        nodes=[_chat("only-chat")],
+        notes=[{"content": "summary", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
+                "color": "#fff", "header_color": None, "is_summary_note": True}],
+        group_summary_connections=[{"start_node_index": 0, "end_note_index": 0}],
+    )
+    note = next(n for n in document.nodes.values() if n.kind == "note")
+    chat = next(n for n in document.nodes.values() if n.kind == "chat")
+    assert any(e.source == chat.id and e.target == note.id for e in document.edges.values())
+
+
+# -- pins / view state / tokens ------------------------------------------
+
+
+def test_pins_restore_via_navigation_pin_record():
+    document = _restore(pins=[
+        {"pin_id": "pin-1", "title": "My Pin", "note": "n", "position": {"x": 1.0, "y": 2.0},
+         "anchor_item_id": None, "sort_order": 0, "created_at": "2026-01-01 00:00:00"},
+    ])
+    assert len(document.pins.records) == 1
+    assert document.pins.records[0].title == "My Pin"
+
+
+def test_view_state_and_total_session_tokens_restore():
+    document = _restore(
+        view_state={"zoom_factor": 2.0, "scroll_position": {"x": 100, "y": 200}},
+        total_session_tokens=555,
+    )
+    assert document.zoom_factor == 2.0
+    assert (document.scroll_x, document.scroll_y) == (100.0, 200.0)
+    assert document.total_session_tokens == 555
+
+
+# -- top-level orchestrator contract -----------------------------------------
+
+
+def test_restore_chat_into_document_raises_for_non_mapping_chat():
+    document = SceneDocument()
+    try:
+        restore_chat_into_document(document, "not-a-dict", [], [])
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_restore_clears_prior_document_state_first():
+    document = SceneDocument()
+    document.add_node(0, 0, "stale")
+    restore_chat_into_document(document, {"data": {"nodes": [_chat("fresh")]}}, [], [])
+    assert len(document.nodes) == 1
+    assert next(iter(document.nodes.values())).content == "hi"
+
+
+def test_resolve_node_payload_list_tolerates_legacy_items_key():
+    document = SceneDocument()
+    restore_chat_into_document(document, {"data": {"items": [_chat("legacy-shape")]}}, [], [])
+    assert len(document.nodes) == 1
+
+
+def test_resolve_node_payload_list_tolerates_double_nested_legacy_shape():
+    document = SceneDocument()
+    restore_chat_into_document(document, {"data": {"data": {"nodes": [_chat("nested")]}}}, [], [])
+    assert len(document.nodes) == 1

--- a/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
@@ -1,0 +1,100 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { ChatLibraryDialog } from "./ChatLibraryDialog";
+import { OverlayProvider, useOverlays } from "../overlays/overlays";
+import type { WsTransport } from "../../lib/ws/transport";
+
+const snapshot = {
+  schemaVersion: 1,
+  minCompatibleSchemaVersion: 1,
+  revision: 1,
+  rows: [
+    { id: 1, title: "First Chat", createdLabel: "Jan 01, 2026", updatedLabel: "Jan 02, 2026" },
+    { id: 2, title: "Second Chat", createdLabel: "Jan 03, 2026", updatedLabel: "Jan 04, 2026" },
+  ],
+  notice: null,
+};
+
+function makeTransport() {
+  const intents: unknown[][] = [];
+  let listener: ((payload: Record<string, unknown>) => void) | null = null;
+  const transport = {
+    subscribe: (_topic: string, l: (payload: Record<string, unknown>) => void) => {
+      listener = l;
+      return () => {
+        listener = null;
+      };
+    },
+    intent: (topic: string, intent: string, args: unknown[]) => {
+      intents.push([topic, intent, args]);
+    },
+  } as unknown as WsTransport;
+  return {
+    transport,
+    intents,
+    push: (payload: Record<string, unknown>) => listener?.(payload),
+  };
+}
+
+function OpenLibraryButton() {
+  const overlays = useOverlays();
+  return (
+    <button type="button" onClick={() => overlays.open("library", "dialog")}>
+      open library
+    </button>
+  );
+}
+
+function setup() {
+  const user = userEvent.setup();
+  const fake = makeTransport();
+  render(
+    <OverlayProvider>
+      <OpenLibraryButton />
+      <ChatLibraryDialog transport={fake.transport} />
+    </OverlayProvider>,
+  );
+  act(() => fake.push(snapshot));
+  return { user, ...fake };
+}
+
+describe("ChatLibraryDialog", () => {
+  it("disables Load Chat when there are no saved chats at all", async () => {
+    const { user, push } = setup();
+    act(() => push({ ...snapshot, rows: [] }));
+    await user.click(screen.getByText("open library"));
+
+    expect(screen.getByText("Load Chat")).toBeDisabled();
+  });
+
+  it("Load Chat is enabled once a row is selectable, dispatches loadChat with the right id, and closes the dialog", async () => {
+    const { user, intents } = setup();
+    await user.click(screen.getByText("open library"));
+
+    // The first row is the default effective selection.
+    const loadButton = screen.getByText("Load Chat");
+    expect(loadButton).not.toBeDisabled();
+
+    await user.click(loadButton);
+    expect(intents).toContainEqual(["app-chat-library", "loadChat", [1]]);
+    // Dialog closes immediately on Load Chat, matching legacy's own behavior.
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("loadChat targets whichever row is explicitly selected, not always the first", async () => {
+    const { user, intents } = setup();
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByText("Second Chat"));
+    await user.click(screen.getByText("Load Chat"));
+    expect(intents).toContainEqual(["app-chat-library", "loadChat", [2]]);
+  });
+
+  it("New Chat stays disabled - no session SAVE primitive exists until R6.5", async () => {
+    const { user } = setup();
+    await user.click(screen.getByText("open library"));
+
+    expect(screen.getByText("New Chat")).toBeDisabled();
+  });
+});

--- a/web_ui/src/app/chrome/ChatLibraryDialog.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.tsx
@@ -2,16 +2,17 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { WsTransport } from "../../lib/ws/transport";
 import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
 import type { AppChatLibraryState } from "../../lib/bridge-core/generated/app-chat-library-state";
-import { Dialog } from "../overlays/overlays";
+import { Dialog, useOverlays } from "../overlays/overlays";
 
 /**
- * The chat library dialog (Qt-removal plan R2.5e) - chat-library island's
- * SPA successor. List/search/rename/delete are real (backend/chat_library.py
- * reads/writes the same ~/.graphlink/chats.db the legacy app uses). Load
- * Chat and New Chat are deferred to R6 - session load rebuilds the whole
- * scene through backend/canvas.py's SceneDocument and session save doesn't
- * exist yet - rendered disabled with an explicit R6 label rather than
- * silently no-op'ing a double-click/button press.
+ * The chat library dialog (Qt-removal plan R2.5e + R6.4) - chat-library
+ * island's SPA successor. List/search/rename/delete/load are all real
+ * (backend/chat_library.py reads/writes the same ~/.graphlink/chats.db the
+ * legacy app uses; R6.4 wired Load Chat to a real backend/session_load.py
+ * restore). New Chat has no backend counterpart yet - there is no session
+ * SAVE primitive until R6.5, so "start a new session" would have nothing to
+ * offer the user beyond clearing the canvas - rendered disabled with an
+ * explicit label rather than silently no-op'ing a click.
  */
 
 const initialState: AppChatLibraryState = {
@@ -23,6 +24,7 @@ const initialState: AppChatLibraryState = {
 };
 
 export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
+  const overlays = useOverlays();
   const [state, setState] = useState<AppChatLibraryState>(initialState);
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<number | null>(null);
@@ -99,6 +101,18 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
     setConfirmingDeleteId(null);
   }
 
+  function loadChat() {
+    if (!effectiveSelected) return;
+    // Fire-and-forget, same posture as rename/delete above - the backend's
+    // own loadChat intent (backend/chat_library.py) reports success/failure
+    // via a real "notification" publish, not a return value here. Closing
+    // the dialog immediately (rather than waiting on that notification)
+    // matches legacy's own ChatLibraryDialog, which closed itself the
+    // moment Load Chat was clicked.
+    transport.intent("app-chat-library", "loadChat", [effectiveSelected.id]);
+    overlays.close();
+  }
+
   function onRenameKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
     if (event.key === "Enter") {
       event.preventDefault();
@@ -171,14 +185,14 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
             </>
           ) : (
             <>
-              <button type="button" className="library-button" disabled title="Session load/save lands in R6">
+              <button type="button" className="library-button" disabled title="Session save lands in R6.5">
                 New Chat
               </button>
               <button
                 type="button"
-                className="library-button"
-                disabled
-                title="Session load/save lands in R6"
+                className="library-button library-button-primary"
+                onClick={loadChat}
+                disabled={!effectiveSelected}
               >
                 Load Chat
               </button>


### PR DESCRIPTION
## Summary

- New `backend/session_load.py` reimplements `SceneDeserializer.restore_chat()`'s full ID/index-resolution algorithm (bug #47's ID-preferred/index-fallback rule, per-kind parent-required-and-skip-if-missing restoration, frame/container offset math derived from original payload counts) against `SceneDocument` - ported directly from the legacy source (current `deserializers.py`/`serializers.py` plus `git show af72ffd~1:...` for the 5 plugin node kinds R5-closeout deleted), not from summary.
- `backend/chat_library.py` gets `load_chat_row`/`load_notes_rows`/`load_pins_rows` (Qt-free reimplementations of `ChatDatabase`'s equivalents, including table migrations) and a real `loadChat` WS intent replicating `ChatSessionManager.load_chat`'s orchestration order.
- The SPA's previously-disabled "Load Chat" button in `ChatLibraryDialog.tsx` is now real.

## Notable findings along the way

- A first draft written from an earlier recon summary had several wrong assumptions once checked against the real legacy source directly (chat's `is_user` default is `True` not `False`; every non-chat kind requires an already-resolved parent and is skipped entirely if it doesn't resolve, using different key names by kind; frame/container membership key is `"items"` not `"item_indices"`; chart aspect-lock must be toggled before `resize_chart` runs or the requested size gets silently overridden).
- Live-driving against the user's real `~/.graphlink/chats.db` (19 real saved chats) caught a genuine crash: multimodal `conversation_history` entries decode to raw Python bytes with no wire-safe re-encoder, unlike `content_parts` - fixed by flattening to a text mirror instead.
- One adversarial review pass found and fixed two more issues: a missing error-notification path in `loadChat` for a notes/pins DB read failure, and a chart-resize test that didn't actually exercise the ordering bug it claimed to guard against.

## Test plan

- [x] `pytest` - 2287 passed (51 new: 43 in `backend/tests/test_session_load.py`, 8 extending `backend/tests/test_chat_library.py`)
- [x] `tsc --noEmit` clean
- [x] `vitest` - 1041/1041 passed (4 new in `ChatLibraryDialog.test.tsx`)
- [x] codegen check clean
- [x] Live drive: all 19 real chats in the user's actual `~/.graphlink/chats.db` load successfully (chat/thinking/image/chart node kinds, real edges, real token counts, real view state, real success notifications)