### PR TITLE
Qt-removal R6.5: Backend session SAVE - SceneDocument -> legacy-compatible chats.db write

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -664,6 +664,17 @@ class SceneDocument:
     # it by add_session_tokens for both the user's own message and the
     # assistant's completed reply, every time either lands.
     total_session_tokens: int = 0
+    # R6.5: the ~/.graphlink/chats.db row this session's scene currently
+    # corresponds to, or None for a brand-new/never-saved session - the
+    # backend analog of ChatSessionManager.current_chat_id. Determines
+    # save_current_chat's own INSERT-vs-UPDATE branch: set on a successful
+    # loadChat (backend/chat_library.py), left None for a fresh session, and
+    # reset to None by clear_for_load/new_chat below (a freshly loaded OR
+    # freshly cleared scene has no id of its own yet until the next load/
+    # save assigns one). Deliberately NOT part of scene_payload() - purely
+    # server-side bookkeeping the frontend never needs to read directly,
+    # same posture as gitlink_imported_root/code_sandbox_sandbox_id.
+    current_chat_id: int | None = None
     _counter: itertools.count = field(default_factory=itertools.count, repr=False)
 
     # -- nodes -------------------------------------------------------------
@@ -714,6 +725,7 @@ class SceneDocument:
         self.scroll_x = 0.0
         self.scroll_y = 0.0
         self.total_session_tokens = 0
+        self.current_chat_id = None
 
     def add_chat_node(
         self,

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -1,29 +1,39 @@
-"""Chat library dialog: list/rename/delete/load (Qt-removal plan R2.5e + R6.4).
+"""Chat library dialog: list/rename/delete/load/save/new (Qt-removal plan
+R2.5e + R6.4 + R6.5).
 
 An INDEPENDENT Qt-free reimplementation of ChatDatabase.get_all_chats()/
-rename_chat()/delete_chat()/load_chat()/load_notes()/load_pins() - not an
-import - because graphlink_session/__init__.py eagerly imports
-ChatSessionManager and SaveWorkerThread (workers.py imports
-PySide6.QtCore.QThread/Signal) before graphlink_session.database can ever be
-imported cleanly: Python always runs a package's __init__.py first, even for
-`from graphlink_session.database import ChatDatabase`. ChatDatabase itself
-(graphlink_session/database.py) is Qt-free; only the package wrapper around
-it is hazardous. Same reimplement-not-import precedent as backend/composer.py
-and backend/plugins.py.
+rename_chat()/delete_chat()/load_chat()/load_notes()/load_pins()/
+save_chat_atomically() - not an import - because graphlink_session/
+__init__.py eagerly imports ChatSessionManager and SaveWorkerThread
+(workers.py imports PySide6.QtCore.QThread/Signal) before graphlink_session.
+database can ever be imported cleanly: Python always runs a package's
+__init__.py first, even for `from graphlink_session.database import
+ChatDatabase`. ChatDatabase itself (graphlink_session/database.py) is
+Qt-free; only the package wrapper around it is hazardous. Same
+reimplement-not-import precedent as backend/composer.py and
+backend/plugins.py.
 
 Reads/writes the SAME real ~/.graphlink/chats.db file the legacy app uses
 (same "chats"/"notes"/"pins" table schemas, same queries, same migration
 ALTER TABLEs for older databases, same _format_timestamp display format moved
-verbatim from graphlink_chat_library_bridge.py) - list, rename, delete, and
-(R6.4) load are all genuinely real here. newChat has no backend counterpart
-at all yet: creating a brand-new empty session is just "clear the canvas",
-which will land alongside R6.5's save primitive, not this file.
+verbatim from graphlink_chat_library_bridge.py) - list, rename, delete,
+load, save, and new are ALL genuinely real here as of R6.5.
+
+R6.5's save_chat_atomically_row mirrors ChatDatabase.save_chat_atomically
+exactly: ONE shared connection for the chats-row write (UPDATE if a
+current_chat_id is set, else INSERT) plus a full delete-then-reinsert-all of
+notes and pins, all committed together - see that method's own docstring
+(database.py:271-289) for why a single transaction matters (three separate
+connections, as the now-dead save_chat/update_chat/save_notes/save_pins
+methods used, left chat/notes/pins inconsistent on a mid-sequence crash).
 """
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
+import re
 import sqlite3
 from datetime import datetime
 from pathlib import Path
@@ -33,6 +43,7 @@ from backend.canvas import SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.session_load import restore_chat_into_document
+from backend.session_save import build_chat_data
 
 DEFAULT_DB_PATH = Path.home() / ".graphlink" / "chats.db"
 
@@ -170,8 +181,6 @@ def load_chat_row(db_path: Path, chat_id: int) -> dict[str, Any] | None:
     already json.loads()'d, or None if the id doesn't exist (a chat deleted
     from another window/process between the library listing and this call -
     the caller shows a real notice, not a crash)."""
-    import json
-
     with contextlib.closing(_connect(db_path)) as conn, conn:
         _ensure_chats_table(conn)
         row = conn.execute("SELECT title, data FROM chats WHERE id = ?", (chat_id,)).fetchone()
@@ -236,6 +245,128 @@ def load_pins_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
     ]
 
 
+def save_chat_atomically_row(
+    db_path: Path,
+    chat_id: int | None,
+    title: str,
+    chat_data: dict[str, Any],
+    notes_data: list[dict[str, Any]],
+    pins_data: list[dict[str, Any]],
+) -> int:
+    """Mirrors ChatDatabase.save_chat_atomically exactly (database.py:271-
+    315): ONE shared connection - UPDATE if `chat_id` is truthy, else INSERT
+    (the SQLite AUTOINCREMENT rowid becomes the new chat's id) - then an
+    unconditional full delete-then-reinsert of notes and pins for the
+    resolved id, all inside the SAME transaction (Python's sqlite3 `with
+    conn:` commits everything together, or rolls all of it back on any
+    exception - never a partial chat/notes/pins write). `chat_data` here is
+    the dict AFTER notes_data/pins_data have already been popped out by the
+    caller (mirrors _prepare_chat_payload's own pop, done once at the
+    boundary rather than inside this function)."""
+    chat_data_json = json.dumps(chat_data)
+    with contextlib.closing(_connect(db_path)) as conn:
+        _ensure_chats_table(conn)
+        _ensure_notes_table(conn)
+        _ensure_pins_table(conn)
+        with conn:
+            if chat_id:
+                conn.execute(
+                    "UPDATE chats SET title = ?, data = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    (title, chat_data_json, chat_id),
+                )
+                resolved_chat_id = chat_id
+            else:
+                cursor = conn.execute(
+                    "INSERT INTO chats (title, data, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
+                    (title, chat_data_json),
+                )
+                resolved_chat_id = cursor.lastrowid
+
+            conn.execute("DELETE FROM notes WHERE chat_id = ?", (resolved_chat_id,))
+            for note in notes_data:
+                position = note.get("position") if isinstance(note.get("position"), dict) else {}
+                size = note.get("size") if isinstance(note.get("size"), dict) else {}
+                conn.execute(
+                    """
+                    INSERT INTO notes (
+                        chat_id, content, position_x, position_y,
+                        width, height, color, header_color, is_system_prompt, is_summary_note
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        resolved_chat_id,
+                        str(note.get("content", "")),
+                        float(position.get("x", 0.0)),
+                        float(position.get("y", 0.0)),
+                        float(size.get("width", 0.0)),
+                        float(size.get("height", 0.0)),
+                        str(note.get("color") or "#4a7c59"),
+                        note.get("header_color"),
+                        1 if note.get("is_system_prompt") else 0,
+                        1 if note.get("is_summary_note") else 0,
+                    ),
+                )
+
+            conn.execute("DELETE FROM pins WHERE chat_id = ?", (resolved_chat_id,))
+            for index, pin in enumerate(pins_data):
+                position = pin.get("position") if isinstance(pin.get("position"), dict) else {}
+                conn.execute(
+                    """
+                    INSERT INTO pins (
+                        chat_id, title, note, position_x, position_y,
+                        pin_id, sort_order, anchor_item_id, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        resolved_chat_id,
+                        str(pin.get("title", "")),
+                        pin.get("note"),
+                        float(position.get("x", 0.0)),
+                        float(position.get("y", 0.0)),
+                        pin.get("pin_id"),
+                        pin.get("sort_order", index),
+                        pin.get("anchor_item_id"),
+                        pin.get("created_at"),
+                    ),
+                )
+
+        return resolved_chat_id
+
+
+_FALLBACK_TITLE_WORD_RE = re.compile(r"[\w']+", re.UNICODE)
+
+
+def _fallback_title(seed_message: str) -> str:
+    """Byte-for-byte port of SaveWorkerThread._fallback_title (workers.py:
+    28-37): first 5 regex-matched words of the seed message, space-joined,
+    truncated to 80 chars; a literal "Chat {timestamp}" if the seed message
+    yields no usable words at all (e.g. empty, or punctuation-only)."""
+    words = _FALLBACK_TITLE_WORD_RE.findall(str(seed_message or ""))
+    if words:
+        title = " ".join(words[:5]).strip()
+        if title:
+            return title[:80]
+    return f"Chat {datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+
+def _resolve_seed_message(document: SceneDocument) -> str:
+    """Deliberate simplification of ChatSessionManager.save_current_chat's
+    own `next((node for node in reversed(scene.nodes) if node.text), None)`
+    (manager.py:108) - legacy's `.text` is a generic attribute several
+    different live Qt widget classes each define with their own meaning;
+    this backend has no single equivalent across all 12 node kinds. Since
+    this text only ever seeds a cosmetic fallback title (see this module's
+    own docstring on skipping the LLM title-generation call entirely), the
+    dominant "has real conversational text" kind - chat - is a reasonable,
+    bounded stand-in: the last chat-kind node's content, in creation order,
+    or "New Chat" if the canvas has no chat node at all yet."""
+    last_chat_content = None
+    for node in document.nodes.values():
+        if node.kind == "chat" and node.content:
+            last_chat_content = node.content
+    return last_chat_content if last_chat_content is not None else "New Chat"
+
+
 def chat_library_payload(db_path: Path) -> dict[str, Any]:
     try:
         rows = get_all_chats(db_path)
@@ -258,6 +389,36 @@ def register_chat_library(
     resolved_path = db_path if db_path is not None else DEFAULT_DB_PATH
 
     bus.register_topic("app-chat-library", lambda: chat_library_payload(resolved_path))
+
+    # Adversarial review finding: loadChat/saveChat/newChat all mutate the
+    # SAME canvas_document and each awaits at least one asyncio.to_thread DB
+    # call - an await point that yields control back to the event loop. A
+    # session can have MULTIPLE attached WS connections at once (every tab/
+    # window that doesn't pass its own ?session= query param shares
+    # session="default" - see backend/app.py's ws_endpoint), so two tabs
+    # racing Save/Load/New Chat could genuinely interleave mid-await and
+    # silently overwrite or corrupt one another's work - there is no
+    # per-window isolation here the way Qt's single-threaded-per-window
+    # model gave legacy for free. This mutable flag - checked and set at
+    # entry, cleared in a finally - serializes all three against each
+    # other, the generalized (load/new included, not just save)
+    # counterpart of ChatSessionManager's own _is_saving reentrancy guard.
+    _mutation_in_progress = {"active": False}
+
+    def _serialize_mutating_intent(handler):
+        async def wrapped(*args, **kwargs):
+            if _mutation_in_progress["active"]:
+                if notifications is not None:
+                    notifications.show("Another chat operation is already in progress. Please wait.", "warning")
+                    await bus.publish("notification")
+                return
+            _mutation_in_progress["active"] = True
+            try:
+                await handler(*args, **kwargs)
+            finally:
+                _mutation_in_progress["active"] = False
+
+        return wrapped
 
     # Writes run in worker threads (asyncio.to_thread) so a slow disk/WAL
     # commit never stalls the event loop. No Python-side lock is needed:
@@ -305,6 +466,11 @@ def register_chat_library(
                 return
 
             restore_chat_into_document(canvas_document, row, notes_rows, pins_rows)
+            # R6.5: remember which row this scene now corresponds to, so a
+            # later Save updates THIS row instead of always inserting a new
+            # one - the backend analog of ChatSessionManager.current_chat_id
+            # being set from the load path, not just the save path.
+            canvas_document.current_chat_id = int(chat_id)
         except Exception as exc:
             # Adversarial review finding: load_notes_rows/load_pins_rows (a
             # real sqlite3.Error, e.g. a locked/corrupted db file) previously
@@ -330,6 +496,92 @@ def register_chat_library(
             notifications.show(f'Loaded "{title}".', "success")
             await bus.publish("notification")
 
+    async def save_chat():
+        # R6.5: replicates ChatSessionManager.save_current_chat's own
+        # orchestration (manager.py:83-133) - serialize -> resolve title/
+        # chat_id -> one atomic DB write -> adopt the resolved chat_id.
+        # Unlike legacy, this runs synchronously start-to-finish on the
+        # event loop rather than handing off to a background QThread; the
+        # _serialize_mutating_intent wrapper this is registered through
+        # (see register_chat_library's own docstring above it) is this
+        # function's actual reentrancy guard - see that comment for why one
+        # is needed at all (a naive "nothing else runs during an await" -
+        # this file's own ORIGINAL, WRONG assumption - does not hold once a
+        # session can have more than one attached WS connection).
+        if canvas_document is None:
+            return
+
+        has_any_nodes = bool(canvas_document.nodes)
+        if not has_any_nodes and canvas_document.current_chat_id is None:
+            # Mirrors save_current_chat's own "Nothing was added to the chat
+            # canvas yet." guard (manager.py:94-96) - an empty, never-saved
+            # canvas has nothing worth writing a row for.
+            if notifications is not None:
+                notifications.show("Nothing was added to the chat canvas yet.", "warning")
+                await bus.publish("notification")
+            return
+
+        try:
+            chat_data = build_chat_data(canvas_document)
+        except Exception as exc:
+            if notifications is not None:
+                notifications.show(f"Failed to prepare chat save payload: {exc}", "error")
+                await bus.publish("notification")
+            return
+
+        notes_data = chat_data.pop("notes_data", [])
+        pins_data = chat_data.pop("pins_data", [])
+
+        chat_id_for_save: int | None = None
+        title: str
+        current_id = canvas_document.current_chat_id
+        if not current_id:
+            title = _fallback_title(_resolve_seed_message(canvas_document))
+        else:
+            existing_row = await asyncio.to_thread(load_chat_row, resolved_path, int(current_id))
+            if existing_row is not None:
+                # Resaving an existing chat NEVER regenerates its title,
+                # matching SaveWorkerThread.run()'s own `title = chat["title"]`
+                # (workers.py:69) exactly.
+                title = str(existing_row.get("title") or "Untitled")
+                chat_id_for_save = int(current_id)
+            else:
+                # The row was deleted elsewhere between load and this save -
+                # falls back to a fresh INSERT, matching legacy's own
+                # tolerance for this race (workers.py:71-72) rather than
+                # erroring.
+                title = _fallback_title(_resolve_seed_message(canvas_document))
+
+        try:
+            new_chat_id = await asyncio.to_thread(
+                save_chat_atomically_row, resolved_path, chat_id_for_save, title, chat_data, notes_data, pins_data,
+            )
+        except Exception as exc:
+            if notifications is not None:
+                notifications.show(f"Failed to save the chat session.\nError: {exc}", "error")
+                await bus.publish("notification")
+            return
+
+        canvas_document.current_chat_id = int(new_chat_id)
+        await bus.publish("app-chat-library")
+        if notifications is not None:
+            notifications.show(f'Saved "{title}".', "success")
+            await bus.publish("notification")
+
+    async def new_chat():
+        # R6.5: the backend counterpart of legacy's "start with an empty
+        # scene" - there is no legacy method this ports 1:1 (Qt's
+        # ChatSessionManager has no "new chat" concept at all; a fresh scene
+        # is just whatever exists before the first load/save of a session),
+        # so this simply clears the live document and drops current_chat_id,
+        # exactly like clear_for_load already does for a session LOAD.
+        if canvas_document is None:
+            return
+        canvas_document.clear_for_load()
+        await bus.publish("scene")
+
     bus.register_intent("app-chat-library", "renameChat", rename)
     bus.register_intent("app-chat-library", "deleteChat", delete)
-    bus.register_intent("app-chat-library", "loadChat", load_chat)
+    bus.register_intent("app-chat-library", "loadChat", _serialize_mutating_intent(load_chat))
+    bus.register_intent("app-chat-library", "saveChat", _serialize_mutating_intent(save_chat))
+    bus.register_intent("app-chat-library", "newChat", _serialize_mutating_intent(new_chat))

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -1,0 +1,691 @@
+"""Qt-free session SAVE (Qt-removal plan R6.5) - the mirror path of R6.4's
+backend/session_load.py.
+
+Reimplements graphlink_session/serializers.py's SceneSerializer.
+serialize_chat_data() against backend/canvas.py's SceneDocument - NOT an
+import, same "reimplement, don't import" precedent as session_load.py:
+serializers.py has no Qt imports of its own, but it is a module INSIDE the
+Qt-tainted graphlink_session package (whose __init__.py eagerly imports
+ChatSessionManager/SaveWorkerThread, which import PySide6.QtCore), and every
+one of its methods reads live QGraphicsItem attributes (node.pos(),
+node.text, chart.rect.width(), ...) that have no meaning on a SceneNode.
+
+THE CORE DESIGN PROBLEM this file exists to solve: legacy's data model has
+TWO SEPARATE relationship concepts that this backend's SceneEdge model
+merged into one flat `document.edges` dict back in R3-R5:
+  1. A node's own `children` list (a live Qt object-tree relationship,
+     restored via children_indices/children_ids - see session_load.py's own
+     _restore_children) - conceptually distinct from...
+  2. Seven (now twelve, after R5's own plugin-connection additions)
+     parallel `ConnectionItem`-family visual line objects, each its own
+     scene-level list (scene.connections/content_connections/etc.).
+...PLUS a THIRD concept, a node's own required structural parent
+(parent_content_node_index/parent_node_index), which is never a
+"connection" or a "child" at all in legacy - it is baked directly into the
+child's OWN payload at construction time.
+Since document.edges has no such distinction (an edge is just an edge -
+document.connect() is the single primitive every one of these legacy
+concepts long ago collapsed onto, R3.1 through R6.1), this serializer must
+CLASSIFY every edge back into exactly one of these four buckets before it
+can write a legacy-shaped payload. See _classify_edges below for the exact,
+total (every edge accounted for exactly once), deterministic algorithm -
+this is the single most important piece of logic in this file, the save-
+side mirror of session_load.py's own bug #47 offset math.
+
+GROUND TRUTH for every field name/shape below came from the same direct
+reads used to build session_load.py: the current serializers.py (the 7
+surviving node kinds, the 7 "always existed" connection lists, frame/note/
+container/chart/pin serialization, and scene_index.py's own get_all_nodes/
+get_all_serializable_items/CHILD_LINK_NODE_TYPES/NODE_LIST_NAMES), plus
+`git show af72ffd~1:graphlink_app/graphlink_session/serializers.py` for the
+5 plugin kinds (pycoder/code_sandbox/web/artifact/gitlink) R5-closeout later
+deleted the branches for.
+
+KNOWN, ALREADY-EXISTING GAP THIS FILE DELIBERATELY DOES NOT "FIX" (present
+in legacy itself, not introduced here): scene_index.py's own
+get_all_serializable_items positions containers LAST in the combined item-
+index space (nodes+notes+charts+frames+containers), and create_container's
+own docstring confirms a container CAN legitimately hold another container
+as a member - but legacy's OWN restore_chat builds all_items_map from only
+nodes+notes+charts+frames BEFORE its containers-deserialization loop runs,
+and never adds containers to that map afterward either. A session containing
+a container nested inside another container would therefore fail to
+resolve that one reference on load in BOTH the legacy Qt app AND this
+project's own backend/session_load.py (which faithfully ported this exact
+restore_chat behavior in R6.4, offsets included). This file's own
+_serialize_container mirrors get_all_serializable_items's item-index
+scheme exactly (containers ARE included, at the tail) for save-side
+fidelity with legacy's OWN serializer - the corresponding load-side gap is
+a pre-existing, shared limitation, not a regression this increment
+introduces, and is out of scope to fix here (it would be a session_load.py
+change, not a session_save.py one).
+
+DELIBERATE SIMPLIFICATION (documented, not silent): legacy's own title
+generation for a brand-new chat tries an LLM call first (title_generator.
+generate_title, a 2-3-word-title prompt to Ollama/the API provider) before
+falling back to a plain heuristic (first 5 words of the seed message,
+regex-matched, truncated to 80 chars; else a timestamp). This module ports
+ONLY the heuristic fallback (byte-for-byte identical to
+SaveWorkerThread._fallback_title's own regex/truncation), never the LLM
+call - titles are cosmetic, not correctness-critical, and skipping the LLM
+call keeps Save synchronous and free of a new agent-dispatch surface for a
+purely cosmetic quality difference.
+
+TWO FURTHER ACCEPTED GAPS surfaced by an adversarial review of this
+increment, both judged out of scope to fix here (each is a pre-existing
+ambiguity/looseness in this backend's OWN live domain model, dating to
+R3.1/R6.1 respectively - a genuine fix belongs in canvas.py, with its own
+dedicated recon/design/test cycle, not bolted onto a serializer):
+
+1. children_indices vs. an ordinary connection, for chat/conversation/html
+   pairs specifically: _classify_edges' Step C cannot distinguish "this
+   edge represents a genuine branch-continuation relationship" from "the
+   user manually drew an ordinary connectNodes line between two pre-
+   existing chat-family nodes" - this backend's own document.edges model
+   has represented both identically, with zero distinguishing metadata,
+   since R3.1 first unified them; nothing about R6.5 introduces the
+   ambiguity, it just has to serialize whatever state already exists. The
+   practical consequence: a manually-drawn link between two chat/
+   conversation/html nodes, saved and then reloaded in the CURRENT legacy
+   Qt app specifically, would be interpreted as a real children_indices
+   branch relationship there (affecting that app's own delete_chat_node
+   reparenting logic) - reloading through this project's own
+   session_load.py is unaffected either way, since both readings resolve
+   to the identical document.connect() call.
+2. A note included in a frame's own members (create_frame has no kind
+   restriction, unlike create_container, which explicitly documents the
+   contrast) has no representable position in _serialize_frame's own
+   frame_source_index (which spans only regular nodes + charts, matching
+   deserialize_frame's own frame_source_map) - such a note is silently
+   excluded from that frame's serialized item list on save (the note
+   itself still serializes fine as its own independent notes_data entry;
+   it just stops being grouped in that frame). Legacy's own frame concept
+   never included notes as members in the first place (see
+   session_load.py's own docstring: "frames may reference charts as
+   members, never notes"), so this is closer to a self-correcting no-op
+   than a data-loss bug - but it is not literally a no-op.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from backend.canvas import SceneDocument, SceneNode, _content_codec
+
+# The 12 "regular" node kinds - everything that is NOT note/frame/container/
+# chart. Mirrors scene_index.py's own NODE_LIST_NAMES (7 kinds, the current,
+# post-R5-closeout surviving set) PLUS the 5 kinds R5-closeout deleted from
+# the legacy app's own lists but which this backend still fully supports
+# (see this module's own docstring: a NEW-app save containing one of these
+# 5 will simply have that one node silently skipped if ever loaded back into
+# the CURRENT legacy app, matching legacy's own tolerant unrecognized-
+# node_type behavior - not a regression, since the legacy app's own load
+# path already lost the ability to restore these 5 kinds when R5-closeout
+# deleted their deserializer branches).
+_REGULAR_KINDS = (
+    "chat", "code", "document", "image", "thinking", "conversation", "html",
+    "web_research", "artifact", "gitlink", "pycoder", "code_sandbox",
+)
+
+# Mirrors backend/session_load.py's own _PARENT_CONTENT_INDEX_KINDS /
+# _PARENT_NODE_INDEX_KINDS split exactly - every regular kind except "chat"
+# requires exactly one incoming edge (its structural parent), keyed to one
+# of two legacy field names depending on kind.
+_PARENT_CONTENT_INDEX_KINDS = {"code", "document", "image", "thinking"}
+_PARENT_NODE_INDEX_KINDS = {
+    "conversation", "html", "pycoder", "code_sandbox", "web_research", "artifact", "gitlink",
+}
+
+# Mirrors scene_index.py's CHILD_LINK_NODE_TYPES = (ChatNode, ConversationNode,
+# HtmlViewNode) exactly - see session_load.py's own _CHILD_LINK_KINDS.
+_CHILD_LINK_KINDS = {"chat", "conversation", "html"}
+
+_SNAKE_RE = re.compile(r"_([a-z0-9])")
+_CAMEL_RE = re.compile(r"([A-Z])")
+
+
+def _camel_to_snake(key: str) -> str:
+    return _CAMEL_RE.sub(lambda m: "_" + m.group(1).lower(), key)
+
+
+def _camel_to_snake_deep(value: Any) -> Any:
+    """Inverse of session_load.py's _snake_to_camel_deep - reverses the
+    research_result translation back into the snake_case shape
+    ResearchResult.to_dict()-equivalent construction produces, which is what
+    legacy's own WebNode.research_result_payload (and therefore a legacy
+    reload) expects."""
+    if isinstance(value, dict):
+        return {_camel_to_snake(str(k)): _camel_to_snake_deep(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_camel_to_snake_deep(item) for item in value]
+    return value
+
+
+def _position(node: SceneNode) -> dict[str, float]:
+    return {"x": float(node.x), "y": float(node.y)}
+
+
+def _serialize_history(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return _content_codec.serialize_history(history or [])
+
+
+# -- per-kind node serialization ----------------------------------------
+# Each function takes a SceneNode already known to be of the matching kind
+# and returns its OWN payload dict - node_type/position/id are added by the
+# caller uniformly (build_chat_data below), matching
+# _serialize_node_with_identity's own "stamp id/children_ids outside the
+# isinstance chain" posture. Parent-index fields are filled in later, once
+# every node's own id has a resolved combined-space position (see
+# _classify_edges) - these functions never reference `document` or other
+# nodes at all, mirroring session_load.py's equivalent restorers.
+
+def _serialize_chat_node(node: SceneNode) -> dict[str, Any]:
+    if node.content_parts is not None:
+        raw_content = _content_codec.process_content_for_serialization(node.content_parts)
+    else:
+        raw_content = node.content
+    return {
+        "node_type": "chat",
+        "raw_content": raw_content,
+        "is_user": bool(node.is_user),
+        "conversation_history": _serialize_history(node.history),
+        "scroll_value": node.chat_scroll_value,
+        "is_collapsed": bool(node.is_collapsed),
+    }
+
+
+def _serialize_code_node(node: SceneNode) -> dict[str, Any]:
+    return {"node_type": "code", "code": node.code, "language": node.language}
+
+
+def _serialize_document_node(node: SceneNode) -> dict[str, Any]:
+    return {
+        "node_type": "document",
+        "title": node.title,
+        "content": node.content,
+        "attachment_kind": node.attachment_kind,
+        "file_path": node.file_path,
+        "mime_type": node.mime_type,
+        "duration_seconds": node.duration_seconds,
+        "byte_size": node.byte_size,
+        "preview_label": node.preview_label,
+        "is_collapsed": bool(node.is_collapsed),
+        "is_docked": bool(node.is_docked),
+    }
+
+
+def _serialize_image_node(node: SceneNode, document: SceneDocument) -> dict[str, Any]:
+    asset = document.image_assets.get(node.image_asset_id)
+    image_bytes = asset[0] if asset is not None else b""
+    return {
+        "node_type": "image",
+        "image_bytes": _content_codec.encode_image_bytes(image_bytes),
+        "prompt": node.content,
+    }
+
+
+def _serialize_thinking_node(node: SceneNode) -> dict[str, Any]:
+    return {"node_type": "thinking", "thinking_text": node.content, "is_docked": bool(node.is_docked)}
+
+
+def _serialize_conversation_node(node: SceneNode) -> dict[str, Any]:
+    return {
+        "node_type": "conversation",
+        "conversation_history": _serialize_history(node.history),
+        "is_collapsed": bool(node.is_collapsed),
+    }
+
+
+def _serialize_html_node(node: SceneNode) -> dict[str, Any]:
+    return {
+        "node_type": "html",
+        "html_content": node.content,
+        "splitter_state": node.html_splitter_state,
+        "conversation_history": _serialize_history(node.history),
+        "is_collapsed": bool(node.is_collapsed),
+    }
+
+
+def _serialize_web_node(node: SceneNode) -> dict[str, Any]:
+    research_result = _camel_to_snake_deep(node.research_result) if node.research_result else {}
+    return {
+        # R6.5 translation (inverse of R6.4's own): backend kind
+        # "web_research" -> legacy node_type "web".
+        "node_type": "web",
+        "query": node.content,
+        "research_result": research_result,
+        "conversation_history": _serialize_history(node.history),
+        "is_collapsed": bool(node.is_collapsed),
+    }
+
+
+def _serialize_artifact_node(node: SceneNode) -> dict[str, Any]:
+    return {
+        "node_type": "artifact",
+        "instruction": node.content,
+        "content": node.artifact_content,
+        "conversation_history": _serialize_history(node.history),
+        "is_collapsed": bool(node.is_collapsed),
+    }
+
+
+def _serialize_gitlink_node(node: SceneNode) -> dict[str, Any]:
+    return {
+        "node_type": "gitlink",
+        "task_prompt": node.gitlink_task_prompt,
+        "repo_state": {
+            "repo": node.gitlink_repo,
+            "branch": node.gitlink_branch,
+            "scope_mode": node.gitlink_scope_mode,
+            "local_root": node.gitlink_local_root,
+            "imported_root": node.gitlink_imported_root,
+        },
+        "repo_file_paths": list(node.gitlink_repo_file_paths),
+        "selected_paths": list(node.gitlink_selected_paths),
+        "context_xml": node.gitlink_context_xml,
+        "context_stats": dict(node.gitlink_context_stats),
+        # Inverse of R6.4's own proposal_data["files"] -> gitlink_pending_changes
+        # unpack.
+        "proposal_data": {"files": list(node.gitlink_pending_changes)},
+        "preview_text": node.gitlink_preview_text,
+        "conversation_history": _serialize_history(node.history),
+        "is_collapsed": bool(node.is_collapsed),
+    }
+
+
+def _serialize_pycoder_node(node: SceneNode) -> dict[str, Any]:
+    return {
+        "node_type": "pycoder",
+        # Inverse of R6.4's own lowercase translation: legacy persists the
+        # enum MEMBER NAME, uppercase.
+        "mode": node.pycoder_mode.upper(),
+        "prompt": node.pycoder_prompt,
+        "code": node.pycoder_code,
+        "output": node.pycoder_output,
+        "analysis": node.pycoder_analysis,
+        "conversation_history": _serialize_history(node.history),
+        "is_collapsed": bool(node.is_collapsed),
+    }
+
+
+def _serialize_code_sandbox_node(node: SceneNode) -> dict[str, Any]:
+    return {
+        "node_type": "code_sandbox",
+        "prompt": node.code_sandbox_prompt,
+        "requirements": node.code_sandbox_requirements,
+        "code": node.code_sandbox_code,
+        "output": node.code_sandbox_output,
+        "analysis": node.code_sandbox_analysis,
+        "sandbox_id": node.code_sandbox_sandbox_id,
+        "conversation_history": _serialize_history(node.history),
+        "is_collapsed": bool(node.is_collapsed),
+    }
+
+
+_NODE_SERIALIZERS = {
+    "chat": lambda node, document: _serialize_chat_node(node),
+    "code": lambda node, document: _serialize_code_node(node),
+    "document": lambda node, document: _serialize_document_node(node),
+    "image": lambda node, document: _serialize_image_node(node, document),
+    "thinking": lambda node, document: _serialize_thinking_node(node),
+    "conversation": lambda node, document: _serialize_conversation_node(node),
+    "html": lambda node, document: _serialize_html_node(node),
+    "web_research": lambda node, document: _serialize_web_node(node),
+    "artifact": lambda node, document: _serialize_artifact_node(node),
+    "gitlink": lambda node, document: _serialize_gitlink_node(node),
+    "pycoder": lambda node, document: _serialize_pycoder_node(node),
+    "code_sandbox": lambda node, document: _serialize_code_sandbox_node(node),
+}
+
+
+def _serialize_note(node: SceneNode) -> dict[str, Any]:
+    return {
+        "id": node.id,
+        "content": node.content,
+        "position": _position(node),
+        # Notes have no manual-size concept in this backend at all (sized
+        # purely from content, like legacy itself) - a fixed placeholder
+        # size, matching the field's own already-documented gap in
+        # session_load.py's own _restore_notes (width/height are read back
+        # by NOTHING on load; this exists only because legacy's own SQL
+        # schema declares the columns NOT NULL).
+        "size": {"width": 220.0, "height": 140.0},
+        "color": node.color,
+        "header_color": node.header_color,
+        "is_system_prompt": bool(node.is_system_prompt),
+        "is_summary_note": bool(node.is_summary_note),
+        # Note provenance fields (role/source_ids/operation_id/
+        # source_revisions/provider_snapshot) - dead even in legacy's own
+        # persisted format (no SQL column for them ever existed; see
+        # session_load.py's own docstring), so there is nothing to write
+        # back regardless of whether this backend tracked them.
+    }
+
+
+def _serialize_pin(record) -> dict[str, Any]:
+    return {
+        "pin_id": record.pin_id,
+        "title": record.title,
+        "note": record.note,
+        "position": {"x": float(record.position[0]), "y": float(record.position[1])},
+        "anchor_item_id": record.anchor_item_id,
+        "sort_order": record.sort_order,
+        "created_at": record.created_at,
+    }
+
+
+def _serialize_frame(node: SceneNode, frame_source_index: dict[str, int]) -> dict[str, Any]:
+    item_indices = [frame_source_index[i] for i in node.item_ids if i in frame_source_index]
+    width = node.group_width if node.group_width is not None else 0.0
+    height = node.group_height if node.group_height is not None else 0.0
+    return {
+        "id": node.id,
+        "items": item_indices,
+        "item_ids": list(node.item_ids),
+        "position": _position(node),
+        "note": node.content,
+        "size": {"width": width, "height": height},
+        # R6.5 mirrors deserialize_frame's own reading exactly: "rect"
+        # (x/y/width/height) is what actually drives frame._user_resized on
+        # load, and session_load.py's own _restore_frames reads it (falling
+        # back to "size" only for an older shape) - x/y here match the
+        # frame's own live position since this backend has no separate
+        # "local rect origin" concept distinct from the node's own x/y
+        # (unlike legacy's QGraphicsItem coordinate model).
+        "rect": {"x": node.x, "y": node.y, "width": width, "height": height},
+        "expanded_rect": {"x": node.x, "y": node.y, "width": width, "height": height},
+        "is_locked": bool(node.is_locked),
+        "is_collapsed": bool(node.is_collapsed),
+        "color": node.color,
+        "header_color": node.header_color,
+    }
+
+
+def _serialize_container(node: SceneNode, all_items_index: dict[str, int]) -> dict[str, Any]:
+    item_indices = [all_items_index[i] for i in node.item_ids if i in all_items_index]
+    width = node.group_width if node.group_width is not None else 0.0
+    height = node.group_height if node.group_height is not None else 0.0
+    return {
+        "id": node.id,
+        "items": item_indices,
+        "item_ids": list(node.item_ids),
+        "position": _position(node),
+        "title": node.content,
+        "is_collapsed": bool(node.is_collapsed),
+        "color": node.color,
+        "header_color": node.header_color,
+        "expanded_rect": {"x": node.x, "y": node.y, "width": width, "height": height},
+        "rect": {"x": node.x, "y": node.y, "width": width, "height": height},
+    }
+
+
+def _serialize_chart(
+    node: SceneNode, nodes_index: dict[str, int], parent_id: str | None,
+) -> dict[str, Any]:
+    parent_index = nodes_index.get(parent_id) if parent_id is not None else None
+    return {
+        "id": node.id,
+        "data": dict(node.chart_data),
+        "position": _position(node),
+        "size": {"width": node.chart_width, "height": node.chart_height},
+        "aspect_ratio_locked": bool(node.chart_aspect_locked),
+        "parent_node_index": parent_index,
+        "parent_node_id": parent_id,
+        # chart_source_node_id is always derived from parent_id in this
+        # backend (add_chart_node's own contract - see that field's comment
+        # on SceneNode) - legacy's rarer differs-from-parent case was
+        # already documented there as an accepted simplification, so
+        # source_node_id is simply the same id, never a genuinely distinct
+        # value.
+        "source_node_id": parent_id,
+        "data_error": node.chart_error or None,
+    }
+
+
+# -- edge classification -------------------------------------------------
+
+def _basic_connection_entry(source_id: str, target_id: str, nodes_index: dict[str, int]) -> dict[str, Any]:
+    return {
+        "start_node_index": nodes_index.get(source_id),
+        "end_node_index": nodes_index.get(target_id),
+        "start_node_id": source_id,
+        "end_node_id": target_id,
+    }
+
+
+def _classify_edges(
+    document: SceneDocument,
+    nodes_index: dict[str, int],
+    kind_by_id: dict[str, str],
+) -> dict[str, Any]:
+    """The save-side mirror of session_load.py's own multi-step restore
+    algorithm - see this module's own docstring for why a flat edges dict
+    needs this at all. Returns a dict with keys: parent_by_child (node id ->
+    parent node id, for every non-chat regular kind, chart parents handled
+    SEPARATELY by the caller since charts aren't in `kind_by_id`),
+    children_by_parent (node id -> ordered list of child node ids, for
+    chat/conversation/html sources only), system_prompt_connections,
+    group_summary_connections (each a list of (source_id, target_id) pairs),
+    and connections (the catch-all list of (source_id, target_id) pairs for
+    every edge not claimed by an earlier rule)."""
+    parent_by_child: dict[str, str] = {}
+    children_by_parent: dict[str, list[str]] = {}
+    system_prompt_pairs: list[tuple[str, str]] = []
+    group_summary_pairs: list[tuple[str, str]] = []
+    connections: list[tuple[str, str]] = []
+
+    consumed: set[str] = set()
+
+    # Step A: note<->regular-node edges (system-prompt / group-summary),
+    # resolved purely by direction + endpoint kind - this backend has no
+    # separate "connection subtype" to consult, unlike legacy's own parallel
+    # scene.system_prompt_connections/scene.group_summary_connections lists.
+    for edge_id, edge in document.edges.items():
+        source_kind = kind_by_id.get(edge.source)
+        target_kind = kind_by_id.get(edge.target)
+        if source_kind == "note" and target_kind in _REGULAR_KINDS:
+            system_prompt_pairs.append((edge.source, edge.target))
+            consumed.add(edge_id)
+        elif source_kind in _REGULAR_KINDS and target_kind == "note":
+            group_summary_pairs.append((edge.source, edge.target))
+            consumed.add(edge_id)
+
+    # Step B: each non-chat regular kind's ONE required structural parent,
+    # PLUS a chart's own (optional) parent - the first (in document.edges
+    # insertion/creation order) not-yet-consumed incoming edge. Charts are
+    # included here (not just the 11 "regular" parent-requiring kinds)
+    # because _serialize_chart reads its own parent from this SAME
+    # parent_by_child map - a chart's parent edge is structurally identical
+    # to any other kind's (add_chart_node's own self.connect(parent_id,
+    # node_id) call), it just gets written to a dedicated
+    # parent_node_index/parent_node_id pair on the chart's OWN payload
+    # (chart is not part of the "nodes" list at all) rather than onto a
+    # sibling "nodes" list entry. Any FURTHER incoming edge to the same
+    # target (a user manually drew a second connection into an already-
+    # parented node via the live connectNodes intent) falls through to the
+    # catch-all below instead of overwriting the first - documented,
+    # bounded simplification; this backend never creates more than one
+    # incoming edge to these kinds through its own add_X_node methods, so
+    # this only matters for a manually-drawn extra connection, an edge case
+    # with no legacy analog to be faithful to in the first place.
+    for edge_id, edge in document.edges.items():
+        if edge_id in consumed:
+            continue
+        target_kind = kind_by_id.get(edge.target)
+        if target_kind in _PARENT_CONTENT_INDEX_KINDS or target_kind in _PARENT_NODE_INDEX_KINDS or target_kind == "chart":
+            if edge.target not in parent_by_child:
+                parent_by_child[edge.target] = edge.source
+                consumed.add(edge_id)
+
+    # Step C: children_indices/ids - chat/conversation/html source AND
+    # target (legacy's own children concept is scoped to the branch-tree of
+    # chat-family nodes specifically, never "every node this one spawned" -
+    # a chat's generated code/image/document node is ALREADY fully captured
+    # via that child's own parent_content_node_index from Step B, and was
+    # never additionally listed in the parent's children_indices in legacy
+    # either).
+    for edge_id, edge in document.edges.items():
+        if edge_id in consumed:
+            continue
+        if kind_by_id.get(edge.source) in _CHILD_LINK_KINDS and kind_by_id.get(edge.target) in _CHILD_LINK_KINDS:
+            children_by_parent.setdefault(edge.source, []).append(edge.target)
+            consumed.add(edge_id)
+
+    # Step D: everything else - the generic/basic "connections" catch-all,
+    # covering user-drawn connectNodes edges between any two nodes that
+    # steps A-C didn't already claim. Total coverage: no edge is ever
+    # silently dropped.
+    for edge_id, edge in document.edges.items():
+        if edge_id in consumed:
+            continue
+        connections.append((edge.source, edge.target))
+
+    return {
+        "parent_by_child": parent_by_child,
+        "children_by_parent": children_by_parent,
+        "system_prompt_pairs": system_prompt_pairs,
+        "group_summary_pairs": group_summary_pairs,
+        "connections": connections,
+    }
+
+
+def build_chat_data(document: SceneDocument) -> dict[str, Any]:
+    """The top-level orchestrator - ports SceneSerializer.serialize_chat_
+    data()'s own exact top-level shape. notes_data/pins_data are nested
+    INSIDE this single returned dict (matching legacy's own
+    serialize_chat_data exactly) - the caller (backend/chat_library.py's
+    saveChat intent) pops them back out before writing, mirroring
+    SaveWorkerThread.run()'s own `self.chat_data.get("notes_data", [])`
+    pattern precisely."""
+    all_nodes = [n for n in document.nodes.values() if n.kind in _REGULAR_KINDS]
+    notes = [n for n in document.nodes.values() if n.kind == "note"]
+    charts = [n for n in document.nodes.values() if n.kind == "chart"]
+    frames = [n for n in document.nodes.values() if n.kind == "frame"]
+    containers = [n for n in document.nodes.values() if n.kind == "container"]
+
+    nodes_index = {n.id: i for i, n in enumerate(all_nodes)}
+    notes_index = {n.id: i for i, n in enumerate(notes)}
+    charts_index = {n.id: i for i, n in enumerate(charts)}
+    frames_index = {n.id: i for i, n in enumerate(frames)}
+    kind_by_id = {n.id: n.kind for n in document.nodes.values()}
+
+    node_slot_count = len(all_nodes)
+    note_slot_count = len(notes)
+    chart_slot_count = len(charts)
+    frame_slot_count = len(frames)
+
+    # "frame source index" = all_nodes + charts, at offset node_slot_count -
+    # mirrors deserialize_frame's own frame_source_map exactly (frames may
+    # reference charts as members, never notes).
+    frame_source_index = dict(nodes_index)
+    for i, n in enumerate(charts):
+        frame_source_index[n.id] = node_slot_count + i
+
+    # "all items index" = nodes + notes + charts + frames (+ containers,
+    # tail - see this module's own docstring on the known, shared,
+    # already-existing nested-container load-side gap) - mirrors
+    # get_all_serializable_items exactly.
+    all_items_index = dict(nodes_index)
+    for i, n in enumerate(notes):
+        all_items_index[n.id] = node_slot_count + i
+    for i, n in enumerate(charts):
+        all_items_index[n.id] = node_slot_count + note_slot_count + i
+    for i, n in enumerate(frames):
+        all_items_index[n.id] = node_slot_count + note_slot_count + chart_slot_count + i
+    for i, n in enumerate(containers):
+        all_items_index[n.id] = node_slot_count + note_slot_count + chart_slot_count + frame_slot_count + i
+
+    edges = _classify_edges(document, nodes_index, kind_by_id)
+    parent_by_child = edges["parent_by_child"]
+    children_by_parent = edges["children_by_parent"]
+
+    node_payloads: list[dict[str, Any]] = []
+    for node in all_nodes:
+        serializer = _NODE_SERIALIZERS.get(node.kind)
+        if serializer is None:
+            continue
+        payload = serializer(node, document)
+        payload["position"] = _position(node)
+        payload["id"] = node.id
+
+        parent_id = parent_by_child.get(node.id)
+        if node.kind in _PARENT_CONTENT_INDEX_KINDS and parent_id is not None:
+            payload["parent_content_node_index"] = nodes_index.get(parent_id)
+        elif node.kind in _PARENT_NODE_INDEX_KINDS and parent_id is not None:
+            payload["parent_node_index"] = nodes_index.get(parent_id)
+
+        children = children_by_parent.get(node.id)
+        if children:
+            payload["children_indices"] = [nodes_index[c] for c in children if c in nodes_index]
+            payload["children_ids"] = list(children)
+
+        node_payloads.append(payload)
+
+    chart_payloads = []
+    for chart_node in charts:
+        chart_parent_id = parent_by_child.get(chart_node.id)
+        chart_payloads.append(_serialize_chart(chart_node, nodes_index, chart_parent_id))
+
+    frame_payloads = [_serialize_frame(f, frame_source_index) for f in frames]
+    container_payloads = [_serialize_container(c, all_items_index) for c in containers]
+
+    basic_connections = [_basic_connection_entry(s, t, nodes_index) for s, t in edges["connections"]]
+
+    system_prompt_connections = []
+    for note_id, chat_id in edges["system_prompt_pairs"]:
+        system_prompt_connections.append({
+            "start_note_index": notes_index.get(note_id),
+            "end_node_index": nodes_index.get(chat_id),
+            "end_node_id": chat_id,
+        })
+
+    group_summary_connections = []
+    for chat_id, note_id in edges["group_summary_pairs"]:
+        group_summary_connections.append({
+            "start_node_index": nodes_index.get(chat_id),
+            "end_note_index": notes_index.get(note_id),
+            "start_node_id": chat_id,
+        })
+
+    return {
+        # Matches scene_index.py's own CURRENT_CHAT_SCHEMA_VERSION exactly
+        # (confirmed directly, not assumed) - this format has not changed
+        # shape in a way that would warrant bumping it.
+        "schema_version": 1,
+        "nodes": node_payloads,
+        "system_prompt_connections": system_prompt_connections,
+        "group_summary_connections": group_summary_connections,
+        "frames": frame_payloads,
+        "containers": container_payloads,
+        "charts": chart_payloads,
+        "total_session_tokens": document.total_session_tokens,
+        "view_state": {
+            "zoom_factor": document.zoom_factor,
+            "scroll_position": {"x": document.scroll_x, "y": document.scroll_y},
+        },
+        "notes_data": [_serialize_note(n) for n in notes],
+        "pins_data": [_serialize_pin(r) for r in document.pins.records],
+        # The 12 basic connection lists all draw from the SAME classified
+        # "connections" bucket - this backend has no way to tell which of
+        # the 12 legacy visual-line CLASSES a user-drawn connection would
+        # have been, since they all collapsed onto one document.connect()
+        # primitive years before this increment. Writing every catch-all
+        # edge into the single original "connections" list (rather than
+        # guessing a subtype, or fanning the same edge out into all 12)
+        # is the only defensible choice: it's the one list every era of
+        # both apps has always read unconditionally, and it round-trips
+        # perfectly through this project's own session_load.py regardless.
+        "connections": basic_connections,
+        "content_connections": [],
+        "document_connections": [],
+        "image_connections": [],
+        "thinking_connections": [],
+        "conversation_connections": [],
+        "html_connections": [],
+        "pycoder_connections": [],
+        "code_sandbox_connections": [],
+        "web_connections": [],
+        "artifact_connections": [],
+        "gitlink_connections": [],
+    }

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -1,4 +1,5 @@
-"""Chat library topic tests (Qt-removal plan R2.5e + R6.4 loadChat)."""
+"""Chat library topic tests (Qt-removal plan R2.5e + R6.4 loadChat + R6.5
+saveChat/newChat)."""
 
 import asyncio
 import json
@@ -8,7 +9,9 @@ import pytest
 
 from backend.canvas import SceneDocument
 from backend.chat_library import (
+    _fallback_title,
     _format_timestamp,
+    _resolve_seed_message,
     chat_library_payload,
     delete_chat,
     get_all_chats,
@@ -17,6 +20,7 @@ from backend.chat_library import (
     load_pins_rows,
     register_chat_library,
     rename_chat,
+    save_chat_atomically_row,
 )
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -316,3 +320,158 @@ def test_load_chat_intent_restores_notes_and_pins_too(db_path):
     notes = [n for n in document.nodes.values() if n.kind == "note"]
     assert len(notes) == 1 and notes[0].content == "A restored note"
     assert len(document.pins.records) == 1
+
+
+# -- R6.5: save_chat_atomically_row / title helpers --------------------------
+
+
+def test_save_chat_atomically_row_inserts_when_chat_id_is_none(db_path):
+    new_id = save_chat_atomically_row(db_path, None, "New Title", {"nodes": []}, [], [])
+    row = load_chat_row(db_path, new_id)
+    assert row == {"title": "New Title", "data": {"nodes": []}}
+
+
+def test_save_chat_atomically_row_updates_the_same_row_when_chat_id_given(db_path):
+    first_id = save_chat_atomically_row(db_path, None, "First", {"nodes": [1]}, [], [])
+    second_id = save_chat_atomically_row(db_path, first_id, "First", {"nodes": [1, 2]}, [], [])
+    assert second_id == first_id
+    assert len(get_all_chats(db_path)) == 1
+    row = load_chat_row(db_path, first_id)
+    assert row["data"] == {"nodes": [1, 2]}
+
+
+def test_save_chat_atomically_row_replaces_notes_and_pins_wholesale(db_path):
+    chat_id = save_chat_atomically_row(
+        db_path, None, "T", {"nodes": []},
+        [{"content": "note A", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
+          "color": "#fff", "header_color": None, "is_system_prompt": False, "is_summary_note": False}],
+        [{"title": "pin A", "note": "", "position": {"x": 0, "y": 0}, "pin_id": "p1",
+          "sort_order": 0, "anchor_item_id": None, "created_at": None}],
+    )
+    assert len(load_notes_rows(db_path, chat_id)) == 1
+    assert len(load_pins_rows(db_path, chat_id)) == 1
+
+    # Resaving with EMPTY notes/pins must wholesale-replace, not append to,
+    # the previous set - mirrors ChatDatabase._write_notes/_write_pins's own
+    # DELETE-then-reinsert-all contract exactly.
+    save_chat_atomically_row(db_path, chat_id, "T", {"nodes": []}, [], [])
+    assert load_notes_rows(db_path, chat_id) == []
+    assert load_pins_rows(db_path, chat_id) == []
+
+
+def test_fallback_title_matches_legacy_regex_and_truncation():
+    assert _fallback_title("Hello, world! This is a test message.") == "Hello world This is a"
+    assert _fallback_title("") .startswith("Chat 20")
+    assert _fallback_title("...") .startswith("Chat 20")
+    long_word_title = _fallback_title("a" * 200)
+    assert len(long_word_title) == 80
+
+
+def test_resolve_seed_message_uses_last_chat_node_content():
+    document = SceneDocument()
+    document.add_chat_node(0, 0, "first message", is_user=True)
+    ai = document.add_chat_node(0, 100, "second message", is_user=False)
+    assert _resolve_seed_message(document) == "second message"
+
+
+def test_resolve_seed_message_falls_back_to_new_chat_when_no_chat_nodes():
+    document = SceneDocument()
+    document.add_note(0, 0)
+    assert _resolve_seed_message(document) == "New Chat"
+
+
+# -- R6.5: the saveChat / newChat intents ------------------------------------
+
+
+def test_save_chat_intent_warns_and_skips_write_for_a_never_saved_empty_canvas(db_path):
+    bus, document, notifications = _bus_with_canvas(db_path)
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+    assert get_all_chats(db_path) == []
+    assert notifications.visible and notifications.msg_type == "warning"
+
+
+def test_save_chat_intent_inserts_a_new_row_and_adopts_the_id(db_path):
+    bus, document, notifications = _bus_with_canvas(db_path)
+    document.add_chat_node(0, 0, "hello world", is_user=True)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+
+    rows = get_all_chats(db_path)
+    assert len(rows) == 1
+    assert document.current_chat_id == rows[0]["id"]
+    assert notifications.visible and notifications.msg_type == "success"
+
+
+def test_save_chat_intent_resave_updates_same_row_and_keeps_existing_title(db_path):
+    bus, document, notifications = _bus_with_canvas(db_path)
+    document.add_chat_node(0, 0, "hello world", is_user=True)
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+    first_id = document.current_chat_id
+    first_title = get_all_chats(db_path)[0]["title"]
+
+    document.add_code_node(100, 0, "x = 1", "python")
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+
+    rows = get_all_chats(db_path)
+    assert len(rows) == 1
+    assert rows[0]["id"] == first_id
+    assert rows[0]["title"] == first_title
+    row = load_chat_row(db_path, first_id)
+    assert len(row["data"]["nodes"]) == 2
+
+
+def test_save_chat_intent_falls_back_to_insert_when_current_row_was_deleted_elsewhere(db_path):
+    bus, document, notifications = _bus_with_canvas(db_path)
+    document.current_chat_id = 999  # a row that never existed / was deleted
+    document.add_chat_node(0, 0, "hello world", is_user=True)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+
+    assert notifications.visible and notifications.msg_type == "success"
+    rows = get_all_chats(db_path)
+    assert len(rows) == 1
+    assert document.current_chat_id == rows[0]["id"] != 999
+
+
+def test_new_chat_intent_clears_canvas_and_resets_current_chat_id(db_path):
+    bus, document, _ = _bus_with_canvas(db_path)
+    document.add_chat_node(0, 0, "hello", is_user=True)
+    document.current_chat_id = 5
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "newChat", []))
+
+    assert document.nodes == {}
+    assert document.current_chat_id is None
+
+
+def test_two_concurrent_save_chat_calls_do_not_race_only_one_row_is_written(db_path):
+    # Adversarial review finding: loadChat/saveChat/newChat share ONE
+    # canvas_document, and a session can have MULTIPLE attached WS
+    # connections (every tab that doesn't pass its own ?session= shares
+    # session="default") - without a reentrancy guard, two tabs racing Save
+    # could interleave mid-await (asyncio.to_thread yields control back to
+    # the loop) and silently corrupt or double-write. asyncio.gather here
+    # genuinely interleaves both coroutines on the same event loop, exactly
+    # the scenario two real WS connections would create.
+    bus, document, notifications = _bus_with_canvas(db_path)
+    document.add_chat_node(0, 0, "hello world", is_user=True)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    async def _race():
+        await asyncio.gather(
+            bus.dispatch_intent("app-chat-library", "saveChat", []),
+            bus.dispatch_intent("app-chat-library", "saveChat", []),
+        )
+
+    asyncio.run(_race())
+
+    # Exactly one row, regardless of which of the two calls "won" - the
+    # loser must have been rejected by the guard, not raced to a second
+    # INSERT.
+    assert len(get_all_chats(db_path)) == 1
+
+    notification_messages = [
+        m["payload"]["message"] for m in recorder.messages if m.get("topic") == "notification"
+    ]
+    assert any("already in progress" in message for message in notification_messages), notification_messages

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -1,0 +1,375 @@
+"""Backend session SAVE tests (Qt-removal plan R6.5).
+
+Exercises backend/session_save.py's build_chat_data against a real
+SceneDocument, built via the SAME public API a live session already uses
+(add_chat_node/create_frame/connect/etc - no mocking). Where a shape
+matters for legacy compatibility, the expected keys/values are the ones
+confirmed directly against graphlink_session/serializers.py (see
+session_save.py's own module docstring for the exact citations) - not
+approximated. Several tests round-trip the output straight back through
+backend/session_load.py (already independently tested in
+test_session_load.py) as the strongest possible correctness signal: if a
+payload this module produces can't be read back by the project's own
+loader, nothing else about its shape matters.
+"""
+
+import backend.agents as agents_module  # noqa: F401 - see test_canvas.py's own import-order note
+from backend.canvas import SceneDocument
+from backend.session_load import restore_chat_into_document
+from backend.session_save import build_chat_data, _camel_to_snake_deep
+
+
+def _round_trip(doc: SceneDocument) -> SceneDocument:
+    chat_data = build_chat_data(doc)
+    notes_data = chat_data.pop("notes_data")
+    pins_data = chat_data.pop("pins_data")
+    doc2 = SceneDocument()
+    restore_chat_into_document(doc2, {"data": chat_data}, notes_data, pins_data)
+    return doc2
+
+
+def _has_edge(document, source_id, target_id) -> bool:
+    return any(e.source == source_id and e.target == target_id for e in document.edges.values())
+
+
+# -- per-kind node serialization ------------------------------------------
+
+
+def test_chat_node_serializes_is_user_and_content():
+    doc = SceneDocument()
+    doc.add_chat_node(0, 0, "hello", is_user=True)
+    chat_data = build_chat_data(doc)
+    payload = chat_data["nodes"][0]
+    assert payload["node_type"] == "chat"
+    assert payload["raw_content"] == "hello"
+    assert payload["is_user"] is True
+
+
+def test_code_node_gets_parent_content_node_index_not_parent_node_index():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    doc.add_code_node(10, 10, "x=1", "python", parent.id)
+    chat_data = build_chat_data(doc)
+    code_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "code")
+    assert code_payload["parent_content_node_index"] == 0
+    assert "parent_node_index" not in code_payload
+
+
+def test_conversation_node_gets_parent_node_index_not_parent_content_node_index():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    doc.add_conversation_node(10, 10, parent.id)
+    chat_data = build_chat_data(doc)
+    conv_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "conversation")
+    assert conv_payload["parent_node_index"] == 0
+    assert "parent_content_node_index" not in conv_payload
+
+
+def test_web_node_kind_translates_to_legacy_web_node_type():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    doc.add_web_research_node(10, 10, parent.id)
+    chat_data = build_chat_data(doc)
+    web_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "web")
+    assert web_payload is not None
+
+
+def test_pycoder_mode_translates_back_to_uppercase_enum_member_name():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    node = doc.add_pycoder_node(10, 10, parent.id)
+    node.pycoder_mode = "manual"
+    chat_data = build_chat_data(doc)
+    payload = next(n for n in chat_data["nodes"] if n["node_type"] == "pycoder")
+    assert payload["mode"] == "MANUAL"
+
+
+def test_gitlink_node_packs_repo_state_and_proposal_data():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    node = doc.add_gitlink_node(10, 10, parent.id)
+    node.gitlink_repo = "org/repo"
+    node.gitlink_branch = "main"
+    node.gitlink_scope_mode = "all"
+    node.gitlink_local_root = "/tmp/x"
+    node.gitlink_pending_changes = [{"path": "a.py"}]
+    chat_data = build_chat_data(doc)
+    payload = next(n for n in chat_data["nodes"] if n["node_type"] == "gitlink")
+    assert payload["repo_state"] == {
+        "repo": "org/repo", "branch": "main", "scope_mode": "all",
+        "local_root": "/tmp/x", "imported_root": "",
+    }
+    assert payload["proposal_data"] == {"files": [{"path": "a.py"}]}
+
+
+def test_image_node_encodes_bytes_from_image_assets_store():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    node = doc.add_image_node(10, 10, b"fake-png-bytes", "a prompt", parent.id)
+    chat_data = build_chat_data(doc)
+    payload = next(n for n in chat_data["nodes"] if n["node_type"] == "image")
+    import base64
+    assert base64.b64decode(payload["image_bytes"]) == b"fake-png-bytes"
+    assert payload["prompt"] == "a prompt"
+
+
+def test_research_result_translates_camel_case_back_to_snake_case():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    node = doc.add_web_research_node(10, 10, parent.id)
+    node.research_result = {
+        "requestId": "r1", "originalQuery": "q", "effectiveQuery": "q2",
+        "answerMarkdown": "answer", "sources": [{"sourceId": "s1", "canonicalUrl": "u"}],
+        "citations": [{"sourceId": "s1", "claimContext": "c"}], "warnings": [], "providerSnapshot": {},
+    }
+    chat_data = build_chat_data(doc)
+    payload = next(n for n in chat_data["nodes"] if n["node_type"] == "web")
+    result = payload["research_result"]
+    assert result["request_id"] == "r1"
+    assert result["answer_markdown"] == "answer"
+    assert result["sources"][0]["source_id"] == "s1"
+    assert result["sources"][0]["canonical_url"] == "u"
+    assert result["citations"][0]["claim_context"] == "c"
+
+
+def test_camel_to_snake_deep_is_a_true_inverse_of_snake_to_camel():
+    from backend.session_load import _snake_to_camel_deep
+    original = {"request_id": "x", "nested_list": [{"source_id": "y", "canonical_url": "z"}]}
+    camel = _snake_to_camel_deep(original)
+    back = _camel_to_snake_deep(camel)
+    assert back == original
+
+
+# -- edge classification --------------------------------------------------
+
+
+def test_child_node_kinds_do_not_get_a_generic_connections_entry():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    doc.add_code_node(10, 10, "x", "python", parent.id)
+    chat_data = build_chat_data(doc)
+    assert chat_data["connections"] == []
+
+
+def test_two_incoming_edges_to_one_target_only_the_first_becomes_parent_the_rest_is_catchall():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p1", is_user=False)
+    other = doc.add_chat_node(0, 200, "p2", is_user=False)
+    code = doc.add_code_node(10, 10, "x", "python", parent.id)
+    # A second, manually-drawn incoming edge into the same code node.
+    doc.connect(other.id, code.id)
+    chat_data = build_chat_data(doc)
+    code_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "code")
+    assert code_payload["parent_content_node_index"] == chat_data["nodes"].index(
+        next(n for n in chat_data["nodes"] if n["id"] == parent.id)
+    )
+    assert len(chat_data["connections"]) == 1
+    other_index = chat_data["nodes"].index(next(n for n in chat_data["nodes"] if n["id"] == other.id))
+    assert chat_data["connections"][0]["start_node_index"] == other_index
+
+
+def test_chat_to_code_edge_is_not_double_counted_as_a_child_relationship():
+    # A chat's own code-node child is fully captured via the code node's own
+    # parent_content_node_index - it must NOT also appear in the chat's
+    # children_indices (legacy never did this either - children is scoped
+    # to the chat-family branch tree only).
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    doc.add_code_node(10, 10, "x", "python", parent.id)
+    chat_data = build_chat_data(doc)
+    parent_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "chat")
+    assert "children_indices" not in parent_payload
+
+
+def test_manual_connection_between_two_chat_nodes_becomes_children_not_catchall():
+    doc = SceneDocument()
+    a = doc.add_chat_node(0, 0, "a", is_user=True)
+    b = doc.add_chat_node(0, 100, "b", is_user=False)
+    doc.connect(a.id, b.id)
+    chat_data = build_chat_data(doc)
+    a_payload = next(n for n in chat_data["nodes"] if n["id"] == a.id)
+    assert a_payload["children_indices"] == [chat_data["nodes"].index(next(n for n in chat_data["nodes"] if n["id"] == b.id))]
+    assert chat_data["connections"] == []
+
+
+def test_note_to_chat_edge_becomes_system_prompt_connection():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "hi", is_user=True)
+    note = doc.add_note(-100, 0, is_system_prompt=True)
+    doc.connect(note.id, chat.id)
+    chat_data = build_chat_data(doc)
+    assert len(chat_data["system_prompt_connections"]) == 1
+    assert chat_data["system_prompt_connections"][0]["end_node_id"] == chat.id
+    assert chat_data["connections"] == []
+
+
+def test_chat_to_note_edge_becomes_group_summary_connection():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "hi", is_user=True)
+    note = doc.add_note(-100, 0, is_summary_note=True)
+    doc.connect(chat.id, note.id)
+    chat_data = build_chat_data(doc)
+    assert len(chat_data["group_summary_connections"]) == 1
+    assert chat_data["group_summary_connections"][0]["start_node_id"] == chat.id
+    assert chat_data["connections"] == []
+
+
+def test_chart_parent_edge_is_captured_on_the_charts_own_payload():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    chart = doc.add_chart_node(10, 10, parent.id, "bar", {"type": "bar", "title": "t", "labels": ["a"], "values": [1.0]})
+    chat_data = build_chat_data(doc)
+    assert len(chat_data["charts"]) == 1
+    assert chat_data["charts"][0]["parent_node_id"] == parent.id
+    # The chart's parent edge must NOT also leak into the generic catch-all.
+    assert chat_data["connections"] == []
+
+
+def test_parentless_chart_serializes_null_parent_fields():
+    doc = SceneDocument()
+    doc.add_chart_node(10, 10, None, "bar", {"type": "bar", "title": "t", "labels": ["a"], "values": [1.0]})
+    chat_data = build_chat_data(doc)
+    chart_payload = chat_data["charts"][0]
+    assert chart_payload["parent_node_id"] is None
+    assert chart_payload["parent_node_index"] is None
+
+
+# -- frames / containers / offset math -------------------------------------
+
+
+def test_frame_item_indices_reference_the_regular_nodes_list_positions():
+    doc = SceneDocument()
+    a = doc.add_chat_node(0, 0, "a", is_user=True)
+    b = doc.add_chat_node(0, 100, "b", is_user=False)
+    doc.create_frame([a.id, b.id])
+    chat_data = build_chat_data(doc)
+    frame_payload = chat_data["frames"][0]
+    a_index = chat_data["nodes"].index(next(n for n in chat_data["nodes"] if n["id"] == a.id))
+    b_index = chat_data["nodes"].index(next(n for n in chat_data["nodes"] if n["id"] == b.id))
+    assert frame_payload["items"] == [a_index, b_index]
+
+
+def test_frame_can_reference_a_chart_member_at_the_node_slot_count_offset():
+    doc = SceneDocument()
+    a = doc.add_chat_node(0, 0, "a", is_user=True)
+    chart = doc.add_chart_node(10, 10, a.id, "bar", {"type": "bar", "title": "t", "labels": ["x"], "values": [1.0]})
+    doc.create_frame([a.id, chart.id])
+    chat_data = build_chat_data(doc)
+    node_slot_count = len(chat_data["nodes"])
+    frame_payload = chat_data["frames"][0]
+    assert frame_payload["items"] == [0, node_slot_count]
+
+
+def test_container_item_indices_reference_the_full_combined_offset_space():
+    doc = SceneDocument()
+    a = doc.add_chat_node(0, 0, "a", is_user=True)
+    b = doc.add_chat_node(0, 100, "b", is_user=False)
+    frame = doc.create_frame([a.id, b.id])
+    doc.create_container([frame.id])
+    chat_data = build_chat_data(doc)
+    node_slot_count = len(chat_data["nodes"])
+    note_slot_count = len(chat_data["notes_data"])
+    chart_slot_count = len(chat_data["charts"])
+    container_payload = chat_data["containers"][0]
+    assert container_payload["items"] == [node_slot_count + note_slot_count + chart_slot_count]
+
+
+def test_container_default_title_round_trips_through_content_field():
+    doc = SceneDocument()
+    a = doc.add_chat_node(0, 0, "a", is_user=True)
+    container = doc.create_container([a.id])
+    doc.set_group_label(container.id, "My Container")
+    chat_data = build_chat_data(doc)
+    assert chat_data["containers"][0]["title"] == "My Container"
+
+
+# -- notes / pins / view state / tokens ------------------------------------
+
+
+def test_note_serializes_content_position_and_flags():
+    doc = SceneDocument()
+    note = doc.add_note(12.0, 34.0, is_system_prompt=True)
+    doc.set_note_content(note.id, "sys prompt text")
+    chat_data = build_chat_data(doc)
+    note_payload = chat_data["notes_data"][0]
+    assert note_payload["content"] == "sys prompt text"
+    assert note_payload["position"] == {"x": 12.0, "y": 34.0}
+    assert note_payload["is_system_prompt"] is True
+
+
+def test_pins_serialize_via_navigation_pin_record():
+    doc = SceneDocument()
+    doc.pins.add(title="My Pin", note="n", x=1.0, y=2.0)
+    chat_data = build_chat_data(doc)
+    assert len(chat_data["pins_data"]) == 1
+    assert chat_data["pins_data"][0]["title"] == "My Pin"
+
+
+def test_view_state_and_total_session_tokens_serialize():
+    doc = SceneDocument()
+    doc.set_view_state(1.5, 10.0, 20.0)
+    doc.total_session_tokens = 42
+    chat_data = build_chat_data(doc)
+    assert chat_data["view_state"] == {"zoom_factor": 1.5, "scroll_position": {"x": 10.0, "y": 20.0}}
+    assert chat_data["total_session_tokens"] == 42
+
+
+# -- round trip (the strongest possible signal) ----------------------------
+
+
+def test_round_trip_preserves_node_count_and_kinds_for_a_rich_scene():
+    doc = SceneDocument()
+    user = doc.add_chat_node(0, 0, "hello", is_user=True)
+    ai = doc.add_chat_node(0, 100, "hi there", is_user=False, parent_id=user.id)
+    doc.add_code_node(200, 100, "print(1)", "python", ai.id)
+    doc.add_conversation_node(400, 100, ai.id)
+    note = doc.add_note(-200, 0, is_system_prompt=True)
+    doc.connect(note.id, user.id)
+    doc.add_chart_node(300, 300, ai.id, "bar", {"type": "bar", "title": "T", "labels": ["a"], "values": [1.0]})
+    frame = doc.create_frame([user.id, ai.id])
+    doc.create_container([frame.id])
+    doc.pins.add(title="P", note="", x=0.0, y=0.0)
+    doc.set_view_state(2.0, 5.0, 6.0)
+    doc.total_session_tokens = 77
+
+    doc2 = _round_trip(doc)
+
+    assert len(doc2.nodes) == len(doc.nodes)
+    assert sorted(n.kind for n in doc2.nodes.values()) == sorted(n.kind for n in doc.nodes.values())
+    assert doc2.zoom_factor == 2.0 and doc2.scroll_x == 5.0 and doc2.scroll_y == 6.0
+    assert doc2.total_session_tokens == 77
+    assert len(doc2.pins.records) == 1
+
+
+def test_round_trip_preserves_every_edge_topologically():
+    doc = SceneDocument()
+    user = doc.add_chat_node(0, 0, "hello", is_user=True)
+    ai = doc.add_chat_node(0, 100, "hi", is_user=False, parent_id=user.id)
+    code = doc.add_code_node(200, 0, "x", "python", ai.id)
+    doc.connect(user.id, code.id)  # extra manual connection
+
+    doc2 = _round_trip(doc)
+    user2 = next(n for n in doc2.nodes.values() if n.kind == "chat" and n.is_user)
+    ai2 = next(n for n in doc2.nodes.values() if n.kind == "chat" and not n.is_user)
+    code2 = next(n for n in doc2.nodes.values() if n.kind == "code")
+
+    assert len(doc2.edges) == len(doc.edges) == 3
+    assert _has_edge(doc2, user2.id, ai2.id)
+    assert _has_edge(doc2, ai2.id, code2.id)
+    assert _has_edge(doc2, user2.id, code2.id)
+
+
+def test_round_trip_preserves_gitlink_field_values():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    node = doc.add_gitlink_node(10, 10, parent.id)
+    node.gitlink_repo = "org/repo"
+    node.gitlink_branch = "dev"
+    node.gitlink_pending_changes = [{"path": "a.py"}, {"path": "b.py"}]
+
+    doc2 = _round_trip(doc)
+    node2 = next(n for n in doc2.nodes.values() if n.kind == "gitlink")
+    assert node2.gitlink_repo == "org/repo"
+    assert node2.gitlink_branch == "dev"
+    assert node2.gitlink_pending_changes == [{"path": "a.py"}, {"path": "b.py"}]
+    assert node2.gitlink_change_state == "previewed"

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -536,6 +536,18 @@ export class SceneStore {
     this.transport.intent("scene", "organizeNodes", []);
   }
 
+  // R6.5: session save - targets "app-chat-library", not "scene", since
+  // Save is a chat-library concern (it needs chat_id/title bookkeeping the
+  // scene topic has no notion of), matching loadChat's own home despite
+  // being triggered from a different UI surface (the app bar's Save
+  // button, not the library dialog) - an intent's topic is about which
+  // backend module owns it, not which component happens to dispatch it
+  // (see this file's own "grid-control" calls just below for the same
+  // precedent: not every method here targets "scene").
+  saveChat(): void {
+    this.transport.intent("app-chat-library", "saveChat", []);
+  }
+
   // -- R6.1: Notes/Frames/Containers ----------------------------------------
   //
   // Mirrors backend/canvas.py's register_canvas() intent names/argument

--- a/web_ui/src/app/chrome/AppBar.tsx
+++ b/web_ui/src/app/chrome/AppBar.tsx
@@ -14,9 +14,10 @@ import { useOverlays } from "../overlays/overlays";
  *   drag/grid/font instead of three stacked cards)
  * - library/settings/about/help/plugins -> overlay dialogs; chips read REAL
  *   open state from the overlay context (audit B6), never latched clicks
- * - saveChat -> R6 (sessions); provider mode select -> R4 (providers).
- *   Both rendered disabled with the phase called out - explicitly deferred,
- *   never silently dropped.
+ * - saveChat -> real as of R6.5 (store.saveChat(), targets the
+ *   app-chat-library topic - see SceneStore's own comment on why); provider
+ *   mode select -> still deferred to R4's own remaining work, rendered
+ *   disabled with the phase called out.
  */
 
 export function AppBar({ store }: { store: SceneStore }) {
@@ -42,7 +43,7 @@ export function AppBar({ store }: { store: SceneStore }) {
       >
         Library
       </button>
-      <button type="button" className="appbar-btn" disabled title="Session save lands in R6">
+      <button type="button" className="appbar-btn" onClick={() => store.saveChat()}>
         Save
       </button>
       <button

--- a/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
@@ -91,10 +91,12 @@ describe("ChatLibraryDialog", () => {
     expect(intents).toContainEqual(["app-chat-library", "loadChat", [2]]);
   });
 
-  it("New Chat stays disabled - no session SAVE primitive exists until R6.5", async () => {
-    const { user } = setup();
+  it("New Chat dispatches the newChat intent and closes the dialog", async () => {
+    const { user, intents } = setup();
     await user.click(screen.getByText("open library"));
 
-    expect(screen.getByText("New Chat")).toBeDisabled();
+    await user.click(screen.getByText("New Chat"));
+    expect(intents).toContainEqual(["app-chat-library", "newChat", []]);
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 });

--- a/web_ui/src/app/chrome/ChatLibraryDialog.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.tsx
@@ -5,14 +5,13 @@ import type { AppChatLibraryState } from "../../lib/bridge-core/generated/app-ch
 import { Dialog, useOverlays } from "../overlays/overlays";
 
 /**
- * The chat library dialog (Qt-removal plan R2.5e + R6.4) - chat-library
- * island's SPA successor. List/search/rename/delete/load are all real
- * (backend/chat_library.py reads/writes the same ~/.graphlink/chats.db the
- * legacy app uses; R6.4 wired Load Chat to a real backend/session_load.py
- * restore). New Chat has no backend counterpart yet - there is no session
- * SAVE primitive until R6.5, so "start a new session" would have nothing to
- * offer the user beyond clearing the canvas - rendered disabled with an
- * explicit label rather than silently no-op'ing a click.
+ * The chat library dialog (Qt-removal plan R2.5e + R6.4 + R6.5) - chat-
+ * library island's SPA successor. List/search/rename/delete/load/new are
+ * all real (backend/chat_library.py reads/writes the same
+ * ~/.graphlink/chats.db the legacy app uses; R6.4 wired Load Chat to a real
+ * backend/session_load.py restore, R6.5 wired New Chat to a real
+ * clear_for_load + current_chat_id reset - Save itself lives on the app
+ * bar, not this dialog, see AppBar.tsx's own comment).
  */
 
 const initialState: AppChatLibraryState = {
@@ -113,6 +112,13 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
     overlays.close();
   }
 
+  function newChat() {
+    // R6.5: clears the live canvas and drops current_chat_id server-side -
+    // same fire-and-forget, close-immediately posture as loadChat above.
+    transport.intent("app-chat-library", "newChat", []);
+    overlays.close();
+  }
+
   function onRenameKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
     if (event.key === "Enter") {
       event.preventDefault();
@@ -185,7 +191,7 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
             </>
           ) : (
             <>
-              <button type="button" className="library-button" disabled title="Session save lands in R6.5">
+              <button type="button" className="library-button" onClick={newChat}>
                 New Chat
               </button>
               <button


### PR DESCRIPTION
## Summary

- New `backend/session_save.py` is the mirror path of R6.4: it serializes the live `SceneDocument` back into the exact legacy `chats.db` JSON shape, so a session saved by the new backend still loads in the old Qt app - the actual acceptance criterion for the whole R6 phase.
- The core problem it solves: legacy's data model has three separate relationship concepts (a node's own `children` list, twelve parallel `ConnectionItem`-family visual-line lists, and a node's own required structural parent) that this backend's `SceneEdge` model collapsed into one flat `document.edges` dict back in R3-R5. `_classify_edges` reverse-engineers which bucket each live edge belongs to using only the two endpoints' kinds and the edge's direction - total and deterministic, every edge accounted for exactly once.
- `backend/chat_library.py` gets `save_chat_atomically_row` (one-transaction chat+notes+pins write, mirroring `ChatDatabase.save_chat_atomically`), a byte-for-byte port of legacy's fallback-title heuristic, and real `saveChat`/`newChat` WS intents.
- The previously-disabled Save button (`AppBar.tsx`) and New Chat button (`ChatLibraryDialog.tsx`) are now wired to real backend behavior.

## Notable findings along the way

- One adversarial review pass found and fixed 2 issues: a hardcoded `schema_version` that didn't match the real legacy value (confirmed against `scene_index.py`), and a missing reentrancy guard - `loadChat`/`saveChat`/`newChat` all mutate the same `SceneDocument` and each awaits a DB call, so two WS connections sharing one session (the default) could race each other. Fixed with a shared in-flight flag, proven with a genuine `asyncio.gather` race test that fails without the fix.
- Two further findings were judged out of scope to fix here - both are pre-existing looseness in this backend's own domain model predating R6.5 (a manually-drawn connection between two chat-family nodes is indistinguishable from a real branch relationship at save time; a note dragged into a frame's members gets silently excluded from that frame's item list) - documented prominently in `session_save.py`'s own docstring rather than fixed under review pressure.

## Test plan

- [x] `pytest` - 2326 passed (39 new: 27 in `backend/tests/test_session_save.py`, 11 extending `backend/tests/test_chat_library.py`, 1 updating `ChatLibraryDialog.test.tsx`)
- [x] `tsc --noEmit` clean
- [x] `vitest` - 1041/1041 passed
- [x] codegen check clean
- [x] Live drive against a **scratch copy** of the user's real `~/.graphlink/chats.db` (never the actual file, since this increment writes): all 19 real saved chats round-tripped (load -> save -> reload) with stable node counts; a resave correctly updated the same row instead of duplicating it; New Chat + Save correctly created a fresh row; the richest real chat (15 nodes) was verified for exact content equality, not just counts; the real `chats.db` file's own modification timestamp was confirmed unchanged before and after this session