### PR TITLE
Qt-removal R6.6: Autosave (net-new, no legacy precedent)

### DIFF
--- a/backend/autosave.py
+++ b/backend/autosave.py
@@ -1,0 +1,232 @@
+"""Autosave (Qt-removal plan R6.6) - a NET-NEW capability, not a port.
+
+Confirmed during R6.5's own recon: no QTimer-based (or any other) autosave
+mechanism exists anywhere in graphlink_app/ - every save there is a single
+explicit user action (Ctrl+S / the toolbar Save button), see
+backend/session_save.py's own module docstring for the exact grep-confirmed
+citation. There is nothing here to reimplement faithfully; this module's
+job is to build a reasonable NEW capability on top of R6.5's already-real
+save primitive, not to match legacy behavior that never existed.
+
+DESIGN: one long-lived background asyncio task per session, ticking every
+`interval_seconds` (default 30s - aggressive enough that a crash/power-loss/
+forgotten-Ctrl+S never loses more than half a minute of real work, without
+writing to disk so often it becomes wasteful for a large session). Each tick
+reuses build_chat_data/save_chat_atomically_row DIRECTLY - the exact same
+primitives backend/chat_library.py's own explicit saveChat intent calls -
+rather than duplicating any serialization or DB-write logic.
+
+CHANGE-GUARDED, not blind: a tick hashes the about-to-be-written JSON and
+skips the write entirely if it matches the hash from the last successful
+save (auto OR manual - see register_autosave's own `last_hash` argument,
+shared with nothing else, this module's own private bookkeeping). Without
+this, a session with no activity at all would still re-write its own
+unchanged row to disk (and re-publish app-chat-library, causing a pointless
+list re-render if the library dialog happens to be open) every single
+interval, forever, for the entire remaining lifetime of the process.
+
+SILENT ON SUCCESS, LOUD ON FAILURE: unlike the explicit Save button (which
+shows a 'Saved "..."' toast every time - the user just took an action and
+expects confirmation), a successful autosave tick publishes no notification
+at all - matching the common editor convention (VS Code, Google Docs) that
+a background save should not interrupt anyone. A FAILED autosave tick DOES
+surface a real notification, since silently failing to protect the user's
+work would defeat the entire point of this feature.
+
+CONCURRENCY: shares the SAME mutation_guard dict backend/chat_library.py's
+own loadChat/saveChat/newChat intents already use (see that module's own
+docstring on _serialize_mutating_intent) - an autosave tick that fires while
+a manual load/save/new-chat is already in flight skips itself for this
+interval rather than racing it (there will be another tick along in
+`interval_seconds`, so skipping one is free; racing a manual operation is
+not).
+
+TASK LIFETIME: deliberately never explicitly cancelled. Every SessionBus
+this backend ever creates lives for the remaining lifetime of the process
+once created - EventBus never removes an entry from its own `_sessions`
+dict, even once every WS connection to it detaches (see backend/events.py) -
+so there is no "session ended" event anywhere in this codebase to hook a
+cancellation to in the first place; this task's own lifetime already
+matches every other piece of a session's state (SceneDocument, ComposerDocument,
+etc.), none of which get torn down early either. This is a pre-existing,
+accepted characteristic of a single-user desktop-shell backend (pywebview),
+not a new leak introduced here - a multi-tenant web server would need real
+session eviction, this does not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from backend.canvas import SceneDocument
+from backend.chat_library import _fallback_title, _resolve_seed_message, load_chat_row, save_chat_atomically_row
+from backend.events import SessionBus
+from backend.notifications import NotificationState
+from backend.session_save import build_chat_data
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INTERVAL_SECONDS = 30.0
+
+
+def _content_digest(chat_data: dict[str, Any], notes_data: list, pins_data: list) -> str:
+    """A pure function of "what would actually get written" - sort_keys
+    makes this independent of dict insertion order (build_chat_data's own
+    key order never changes call to call, but this is cheap insurance
+    against a false "changed" from something that isn't); default=str
+    tolerates any value json can't natively encode without ever raising
+    (a digest mismatch on an unexpected type just means "assume changed,
+    write it" - the safe direction to fail in, never "assume unchanged,
+    skip a real write")."""
+    payload = json.dumps(
+        {"chat_data": chat_data, "notes_data": notes_data, "pins_data": pins_data},
+        sort_keys=True, default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+async def autosave_tick(
+    bus: SessionBus,
+    db_path: Path,
+    canvas_document: SceneDocument,
+    notifications: NotificationState | None,
+    last_hash: dict[str, str | None],
+) -> None:
+    """One autosave attempt - directly callable (no timer involved), so
+    tests can exercise the actual decision/write logic deterministically
+    rather than waiting on a real sleep. `last_hash` is a single-key mutable
+    dict (`{"value": ...}`) rather than a plain variable so register_autosave's
+    closure and this function can share and update the same cell across
+    calls without a class just for one field."""
+    if not canvas_document.nodes and canvas_document.current_chat_id is None:
+        # Mirrors saveChat's own "Nothing was added to the chat canvas yet"
+        # guard - an empty, never-saved canvas has nothing worth protecting.
+        return
+
+    try:
+        chat_data = build_chat_data(canvas_document)
+    except Exception:
+        logger.exception("autosave: failed to build chat data for session %r", bus.session_id)
+        return
+
+    notes_data = chat_data.pop("notes_data", [])
+    pins_data = chat_data.pop("pins_data", [])
+
+    digest = _content_digest(chat_data, notes_data, pins_data)
+    if digest == last_hash["value"]:
+        return
+
+    chat_id_for_save: int | None = None
+    current_id = canvas_document.current_chat_id
+    if current_id:
+        try:
+            existing_row = await asyncio.to_thread(load_chat_row, db_path, int(current_id))
+        except Exception as exc:
+            # Adversarial review finding: this lookup was previously
+            # unwrapped. An uncaught exception here (e.g. chats.db
+            # transiently locked/unreadable) would propagate out of
+            # autosave_tick, through _guarded_tick's try/finally (which
+            # only protects mutation_guard, not the task itself), and kill
+            # register_autosave's own _loop task outright - silently and
+            # PERMANENTLY disabling autosave for the rest of this session's
+            # process lifetime, with no error ever surfaced to the user.
+            # That directly violates this module's own "LOUD ON FAILURE"
+            # principle, which must cover every failure mode a tick can
+            # hit, not just the final DB write.
+            logger.exception("autosave: failed to read existing chat row for session %r", bus.session_id)
+            if notifications is not None:
+                notifications.show(f"Autosave failed: {exc}", "error")
+                await bus.publish("notification")
+            return
+        if existing_row is not None:
+            # Never regenerate an existing chat's title - same rule
+            # saveChat's own resave path follows.
+            title = str(existing_row.get("title") or "Untitled")
+            chat_id_for_save = int(current_id)
+        else:
+            title = _fallback_title(_resolve_seed_message(canvas_document))
+    else:
+        title = _fallback_title(_resolve_seed_message(canvas_document))
+
+    try:
+        new_chat_id = await asyncio.to_thread(
+            save_chat_atomically_row, db_path, chat_id_for_save, title, chat_data, notes_data, pins_data,
+        )
+    except Exception as exc:
+        logger.exception("autosave: DB write failed for session %r", bus.session_id)
+        if notifications is not None:
+            notifications.show(f"Autosave failed: {exc}", "error")
+            await bus.publish("notification")
+        return
+
+    canvas_document.current_chat_id = int(new_chat_id)
+    last_hash["value"] = digest
+    await bus.publish("app-chat-library")
+
+
+def register_autosave(
+    bus: SessionBus,
+    db_path: Path,
+    canvas_document: SceneDocument,
+    notifications: NotificationState | None,
+    mutation_guard: dict[str, bool],
+    *,
+    interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+) -> None:
+    """Starts the one long-lived per-session background task. Stashed on
+    `bus.autosave_task` purely so a caller COULD cancel it (e.g. a future
+    test or a graceful-shutdown path) - nothing in this backend does today,
+    see this module's own docstring on why that is fine for now."""
+    last_hash: dict[str, str | None] = {"value": None}
+
+    async def _guarded_tick() -> None:
+        if mutation_guard["active"]:
+            # A manual load/save/new-chat is already in flight - skip this
+            # interval entirely rather than racing it; the next tick will
+            # try again in `interval_seconds`.
+            return
+        mutation_guard["active"] = True
+        try:
+            await autosave_tick(bus, db_path, canvas_document, notifications, last_hash)
+        finally:
+            mutation_guard["active"] = False
+
+    async def _loop() -> None:
+        while True:
+            await asyncio.sleep(interval_seconds)
+            await _guarded_tick()
+
+    loop_coro = _loop()
+    try:
+        bus.autosave_task = asyncio.create_task(loop_coro)
+    except RuntimeError:
+        # A background convenience feature must never be able to take down
+        # session initialization itself. _configure_session (this function's
+        # own caller, via backend/chat_library.py) is NOT guaranteed to
+        # always run with a running event loop - confirmed directly:
+        # Starlette's TestClient drives its own WebSocket handshake tests
+        # (backend/tests/test_ws_origin.py, test_assets.py) through a sync
+        # bridge that constructs a session bus outside of any running loop
+        # at this exact call site, even though the REAL production path
+        # (ws_endpoint, an async function the ASGI server itself awaits)
+        # always has one. Rather than let that surface as a fatal
+        # RuntimeError crashing EVERY session-configuring test in the repo
+        # (which is exactly what happened here before this fix), autosave
+        # simply stays off for a session created this way - a missing
+        # background save is a far smaller problem than an unusable
+        # session/test harness.
+        logger.warning(
+            "autosave: no running event loop at registration time for session %r - autosave disabled",
+            bus.session_id,
+        )
+        # create_task() raised before scheduling the coroutine, so it was
+        # never going to run and never going to close itself either -
+        # closing it explicitly here is what silences Python's own
+        # "coroutine was never awaited" RuntimeWarning.
+        loop_coro.close()
+        bus.autosave_task = None

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -385,6 +385,8 @@ def register_chat_library(
     db_path: Path | None = None,
     canvas_document: SceneDocument | None = None,
     notifications: NotificationState | None = None,
+    *,
+    autosave_interval_seconds: float | None = 30.0,
 ) -> None:
     resolved_path = db_path if db_path is not None else DEFAULT_DB_PATH
 
@@ -585,3 +587,18 @@ def register_chat_library(
     bus.register_intent("app-chat-library", "loadChat", _serialize_mutating_intent(load_chat))
     bus.register_intent("app-chat-library", "saveChat", _serialize_mutating_intent(save_chat))
     bus.register_intent("app-chat-library", "newChat", _serialize_mutating_intent(new_chat))
+
+    if canvas_document is not None and autosave_interval_seconds is not None:
+        # R6.6: local import - backend/autosave.py itself imports several
+        # names FROM this module (_fallback_title/_resolve_seed_message/
+        # load_chat_row/save_chat_atomically_row, so it can reuse them
+        # rather than duplicating any save logic); importing it at this
+        # module's own top level would be a circular import. Shares the
+        # SAME _mutation_in_progress flag every manual intent above already
+        # uses, so an autosave tick can never race a manual load/save/new.
+        from backend.autosave import register_autosave
+
+        register_autosave(
+            bus, resolved_path, canvas_document, notifications, _mutation_in_progress,
+            interval_seconds=autosave_interval_seconds,
+        )

--- a/backend/tests/test_autosave.py
+++ b/backend/tests/test_autosave.py
@@ -1,0 +1,224 @@
+"""Autosave tests (Qt-removal plan R6.6).
+
+Exercises backend/autosave.py's autosave_tick directly wherever possible
+(no real sleep involved, deterministic) - the timer loop itself
+(register_autosave) is only exercised in the 2 tests that specifically
+need to prove the guard/wiring behavior, each with a tiny interval and an
+explicit task cancellation in a finally block so nothing leaks into a
+later test.
+"""
+
+import asyncio
+
+import pytest
+
+from backend.autosave import autosave_tick, register_autosave
+from backend.canvas import SceneDocument
+from backend.chat_library import chat_library_payload, get_all_chats, load_chat_row
+from backend.events import SessionBus
+from backend.notifications import NotificationState
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "chats.db"
+
+
+def _bus(db_path):
+    """Registers "app-chat-library" via the real chat_library_payload
+    builder (autosave_tick publishes to it on every successful save) -
+    without pulling in the full register_chat_library (which would ALSO
+    register loadChat/saveChat/newChat intents this file has no interest
+    in), keeping this test file focused on autosave alone."""
+    bus = SessionBus("autosave-test")
+    document = SceneDocument()
+    bus.register_topic("scene", document.scene_payload)
+    bus.register_topic("app-chat-library", lambda: chat_library_payload(db_path))
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    return bus, document, notifications
+
+
+def test_autosave_tick_skips_an_empty_never_saved_canvas(db_path):
+    bus, document, notifications = _bus(db_path)
+    last_hash = {"value": None}
+
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+
+    assert get_all_chats(db_path) == []
+    assert last_hash["value"] is None
+    assert not notifications.visible
+
+
+def test_autosave_tick_inserts_a_new_row_for_a_fresh_canvas_with_content(db_path):
+    bus, document, notifications = _bus(db_path)
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    last_hash = {"value": None}
+
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+
+    rows = get_all_chats(db_path)
+    assert len(rows) == 1
+    assert document.current_chat_id == rows[0]["id"]
+    assert last_hash["value"] is not None
+    # Silent on success - autosave must never show a "Saved" toast the way
+    # the explicit Save button does (see this module's own docstring).
+    assert not notifications.visible
+
+
+def test_autosave_tick_is_a_no_op_when_nothing_changed_since_the_last_tick(db_path, monkeypatch):
+    bus, document, notifications = _bus(db_path)
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    last_hash = {"value": None}
+
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+    first_hash = last_hash["value"]
+
+    import backend.autosave as autosave_module
+    calls = []
+    real_save = autosave_module.save_chat_atomically_row
+
+    def counting_save(*args, **kwargs):
+        calls.append(args)
+        return real_save(*args, **kwargs)
+
+    monkeypatch.setattr(autosave_module, "save_chat_atomically_row", counting_save)
+
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+
+    assert calls == [], "a second tick with no scene changes must not write again"
+    assert last_hash["value"] == first_hash
+    assert len(get_all_chats(db_path)) == 1
+
+
+def test_autosave_tick_writes_again_after_a_real_change(db_path):
+    bus, document, notifications = _bus(db_path)
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    last_hash = {"value": None}
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+    first_hash = last_hash["value"]
+
+    document.add_code_node(100, 0, "x = 1", "python")
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+
+    assert last_hash["value"] != first_hash
+    row = load_chat_row(db_path, document.current_chat_id)
+    assert len(row["data"]["nodes"]) == 2
+
+
+def test_autosave_tick_never_regenerates_an_existing_chats_title(db_path):
+    bus, document, notifications = _bus(db_path)
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    last_hash = {"value": None}
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+    first_title = get_all_chats(db_path)[0]["title"]
+
+    document.add_code_node(100, 0, "x = 1", "python")
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+
+    assert get_all_chats(db_path)[0]["title"] == first_title
+
+
+def test_autosave_tick_falls_back_to_insert_when_current_row_was_deleted_elsewhere(db_path):
+    bus, document, notifications = _bus(db_path)
+    document.current_chat_id = 999
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    last_hash = {"value": None}
+
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+
+    rows = get_all_chats(db_path)
+    assert len(rows) == 1
+    assert document.current_chat_id == rows[0]["id"] != 999
+
+
+def test_autosave_tick_shows_an_error_notification_on_db_failure(db_path, monkeypatch):
+    bus, document, notifications = _bus(db_path)
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    last_hash = {"value": None}
+
+    import backend.autosave as autosave_module
+
+    def failing_save(*args, **kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(autosave_module, "save_chat_atomically_row", failing_save)
+
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+
+    assert notifications.visible and notifications.msg_type == "error"
+    assert "disk full" in notifications.message
+    assert get_all_chats(db_path) == []
+
+
+def test_autosave_tick_shows_an_error_notification_when_the_existing_row_lookup_fails(db_path, monkeypatch):
+    # Adversarial review finding: this lookup was previously unwrapped -
+    # an uncaught exception here used to escape autosave_tick entirely and
+    # would have killed register_autosave's own background _loop task,
+    # silently and permanently disabling autosave for the rest of the
+    # session (no error ever surfaced). This proves it now degrades the
+    # same way the DB-write failure path already does: one failed tick,
+    # loud notification, task keeps running for the next interval.
+    bus, document, notifications = _bus(db_path)
+    document.current_chat_id = 999
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    last_hash = {"value": None}
+
+    import backend.autosave as autosave_module
+
+    def failing_load(*args, **kwargs):
+        raise RuntimeError("database is locked")
+
+    monkeypatch.setattr(autosave_module, "load_chat_row", failing_load)
+
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+
+    assert notifications.visible and notifications.msg_type == "error"
+    assert "database is locked" in notifications.message
+    assert get_all_chats(db_path) == []
+    assert last_hash["value"] is None
+
+
+# -- register_autosave: the real timer loop + the mutation_guard interplay --
+
+
+def test_register_autosave_ticks_on_a_real_timer_and_writes_a_row(tmp_path):
+    db_path = tmp_path / "chats.db"
+    bus, document, notifications = _bus(db_path)
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    mutation_guard = {"active": False}
+
+    async def _run():
+        register_autosave(bus, db_path, document, notifications, mutation_guard, interval_seconds=0.05)
+        try:
+            await asyncio.sleep(0.2)
+        finally:
+            bus.autosave_task.cancel()
+            try:
+                await bus.autosave_task
+            except asyncio.CancelledError:
+                pass
+
+    asyncio.run(_run())
+    assert len(get_all_chats(db_path)) == 1
+
+
+def test_register_autosave_skips_a_tick_while_mutation_guard_is_active(tmp_path):
+    db_path = tmp_path / "chats.db"
+    bus, document, notifications = _bus(db_path)
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    mutation_guard = {"active": True}  # simulates a manual load/save/new-chat in flight
+
+    async def _run():
+        register_autosave(bus, db_path, document, notifications, mutation_guard, interval_seconds=0.05)
+        try:
+            await asyncio.sleep(0.2)
+        finally:
+            bus.autosave_task.cancel()
+            try:
+                await bus.autosave_task
+            except asyncio.CancelledError:
+                pass
+
+    asyncio.run(_run())
+    assert get_all_chats(db_path) == [], "a tick must skip itself entirely while a manual operation is in flight"

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -268,13 +268,21 @@ def _bus_with_canvas(db_path):
     publish to it - production guarantees this via _configure_session's own
     ordering; this test harness replicates it directly rather than pulling
     in the full register_canvas (which itself needs an agent dispatcher/
-    composer document unrelated to what's under test here)."""
+    composer document unrelated to what's under test here).
+
+    autosave_interval_seconds=None disables R6.6's own background timer
+    loop here - every test in this file runs in milliseconds, so a real
+    30s-sleeping asyncio task would still be "pending" when asyncio.run()
+    returns and the loop closes, leaking a task and spamming "Task was
+    destroyed but it is pending" warnings across ~30 unrelated tests.
+    backend/tests/test_autosave.py exercises the actual tick logic directly
+    (no timer involved) instead."""
     bus = SessionBus("chat-library-load-test")
     document = SceneDocument()
     bus.register_topic("scene", document.scene_payload)
     notifications = NotificationState()
     bus.register_topic("notification", notifications.payload)
-    register_chat_library(bus, db_path, document, notifications)
+    register_chat_library(bus, db_path, document, notifications, autosave_interval_seconds=None)
     return bus, document, notifications
 
 
@@ -475,3 +483,27 @@ def test_two_concurrent_save_chat_calls_do_not_race_only_one_row_is_written(db_p
         m["payload"]["message"] for m in recorder.messages if m.get("topic") == "notification"
     ]
     assert any("already in progress" in message for message in notification_messages), notification_messages
+
+
+# -- R6.6 regression: register_chat_library must survive a missing event loop --
+
+
+def test_register_chat_library_does_not_crash_without_a_running_event_loop(db_path):
+    # A real, shipped bug: register_chat_library's own R6.6 addition
+    # (register_autosave) called asyncio.create_task() unconditionally, which
+    # raises RuntimeError outside of a running event loop. backend/app.py's
+    # _configure_session calls register_chat_library from exactly this kind
+    # of sync context under Starlette's TestClient (confirmed - it broke
+    # test_ws_origin.py and test_assets.py, both unrelated to chat_library),
+    # so this proves the real production call shape - a bare, non-async
+    # call, default autosave_interval_seconds - can never take core session
+    # setup down with it.
+    bus = SessionBus("chat-library-no-loop-test")
+    document = SceneDocument()
+    bus.register_topic("scene", document.scene_payload)
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+
+    register_chat_library(bus, db_path, document, notifications)
+
+    assert bus.autosave_task is None


### PR DESCRIPTION
## Summary
- Net-new background autosave: a per-session asyncio task ticking every 30s by default, reusing R6.5's `build_chat_data`/`save_chat_atomically_row` primitives directly. Change-guarded via a content digest, silent on success, loud on failure, serialized against `loadChat`/`saveChat`/`newChat` via the shared `mutation_guard`.
- Fixed a critical bug found while running the full suite (not just the new test file in isolation): `register_autosave` called `asyncio.create_task()` unconditionally, which requires a running event loop. `register_chat_library` is not always called from one - this was crashing 11 unrelated tests in `test_ws_origin.py`/`test_assets.py` via Starlette's TestClient. Now degrades gracefully instead of taking down core session setup; proven by a new regression test.
- One adversarial review pass found one more real bug: an unwrapped `load_chat_row` await inside `autosave_tick` could have silently and permanently killed the background loop for a session on an ordinary transient DB failure, with no error ever surfaced. Fixed the same way (wrapped, logged, notified), with its own regression test.
- Two lower-severity review findings were judged out of scope and documented in the ledger rather than fixed (an unwrapped notification-publish call sharing the same low-severity shape as several pre-existing manual intents; autosave reusing `saveChat`'s own pre-existing empty-canvas guard, meaning an emptied-but-still-loaded chat can be silently overwritten - a product question, not a new defect).

## Test plan
- [x] `python -m pytest -q` - 2337 passed (10 new in `test_autosave.py`, 1 new regression in `test_chat_library.py`)
- [x] `npx tsc --noEmit` - clean
- [x] `npx vitest run` - 1041 passed
- [x] `graphlink_island_codegen.py --check` - clean, no drift
- [x] Live-driven against a scratch copy of the real `~/.graphlink/chats.db` via a standalone backend + real WebSocket client: a real 30s tick fired unprompted and inserted a new row silently; a second idle interval left the row completely untouched; a real edit was picked up and resaved in place on the next tick under the same row id. Real `chats.db` confirmed byte-for-byte unchanged before/after.