### PR TITLE
Qt-removal R6.7: Crash recovery (backend logging + in-app notice)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -40,6 +40,7 @@ from backend.assets import register_assets
 from backend.canvas import register_canvas
 from backend.chat_library import register_chat_library
 from backend.composer import register_composer
+from backend.crash_recovery import maybe_show_crash_notice
 from backend.events import EventBus, SessionBus, UnknownIntentError, UnknownTopicError
 from backend.notifications import register_notifications
 from backend.plugins import register_plugins
@@ -121,7 +122,12 @@ def _is_allowed_ws_origin(origin: str | None, host_header: str | None, dev_proxy
     return False
 
 
-def _configure_session(bus: SessionBus, settings_manager: SettingsManager, chat_db_path: Path | None) -> None:
+def _configure_session(
+    bus: SessionBus,
+    settings_manager: SettingsManager,
+    chat_db_path: Path | None,
+    previous_run_crashed: bool = False,
+) -> None:
     """Give every session the R0 topic surface. Later phases extend this
     with canvas/chrome/node topics - one registrar, one place to read the
     whole API surface."""
@@ -141,6 +147,10 @@ def _configure_session(bus: SessionBus, settings_manager: SettingsManager, chat_
     # R2: notifications, moved ahead of canvas - R3.3's sendMessage intent
     # needs a real NotificationState to give an honest agent-dispatch notice.
     notifications_state = register_notifications(bus)
+    # R6.7: a no-op unless graphlink_desktop.py's own running.lock sentinel
+    # found the prior run didn't reach a clean shutdown - see
+    # backend/crash_recovery.py's module docstring for the full mechanism.
+    maybe_show_crash_notice(notifications_state, previous_run_crashed)
 
     # R2: composer draft/reasoning, token counter. Moved ahead of canvas (R4):
     # sendMessage's real agent dispatch needs a real ComposerDocument to flip
@@ -187,6 +197,7 @@ def create_app(
     spa_dir: Path | None = None,
     settings_state_file: Path | None = None,
     chat_db_path: Path | None = None,
+    previous_run_crashed: bool = False,
 ) -> FastAPI:
     app = FastAPI(title="Graphlink backend", version=BACKEND_VERSION)
     # ONE SettingsManager for the whole app (it owns a single shared
@@ -198,7 +209,9 @@ def create_app(
     # session state (see backend/agents.py's docstring).
     bootstrap_provider_state(settings_manager)
     bus = EventBus(
-        configure_session=lambda session_bus: _configure_session(session_bus, settings_manager, chat_db_path)
+        configure_session=lambda session_bus: _configure_session(
+            session_bus, settings_manager, chat_db_path, previous_run_crashed
+        )
     )
     app.state.bus = bus
 
@@ -226,7 +239,27 @@ def create_app(
             await websocket.close(code=1008)
             return
         session_id = websocket.query_params.get("session", "default")
-        session = bus.session(session_id)
+        try:
+            session = bus.session(session_id)
+        except Exception:
+            # R6.7 adversarial-review finding: a bug in one of
+            # _configure_session's register_X calls used to be swallowed
+            # entirely - it never reaches here as a Python-level unhandled
+            # exception (uvicorn's own ASGI machinery catches it first and
+            # logs it via "uvicorn.error", a logger that does NOT propagate
+            # to the root logger - see backend/crash_recovery.py's own
+            # RotatingFileHandler, attached to root), so it landed neither
+            # in graphlink.log nor in sys.excepthook, contradicting this
+            # increment's own point. Logging it via THIS module's own
+            # logger (which does propagate to root, exactly like the
+            # existing dispatch_intent failure path just below does) is
+            # what actually gets it into the log file; closing with 1011
+            # (server error) mirrors the origin-rejection branch above -
+            # reject cleanly before accept() rather than leaving the
+            # client to uvicorn's own default handling.
+            logger.exception("session setup failed for session_id=%r", session_id)
+            await websocket.close(code=1011)
+            return
         await websocket.accept()
         session.attach(websocket)
         try:

--- a/backend/crash_recovery.py
+++ b/backend/crash_recovery.py
@@ -1,0 +1,192 @@
+"""Crash recovery (Qt-removal plan R6.7): a next-launch "did we crash last
+time" notice, plus backend logging so unhandled exceptions land somewhere
+durable instead of vanishing in a windowed app with no console.
+
+REIMPLEMENTED, not imported, from graphlink_app/graphlink_crash.py and
+graphlink_app/graphlink_logging.py - same "port the algorithm, never import
+the Qt-adjacent legacy module" precedent every other backend/ module in this
+migration follows (backend/chat_library.py, session_save.py, autosave.py,
+...), since graphlink_app/ is slated for full deletion at the R7 cutover.
+
+SENTINEL (ported faithfully): a JSON file at ~/.graphlink/running.lock is
+written at startup (mark_running) and removed on a clean shutdown
+(mark_clean_exit). If it's still there at the NEXT startup, the previous run
+didn't reach the clean-exit path - previous_run_crashed() is the whole check.
+Same file path/shape as the legacy app for continuity - it's plain JSON with
+no Qt dependency, nothing here needs to change about it.
+
+LOGGING + UNHANDLED-EXCEPTION CAPTURE (ported): configure_logging() attaches
+a RotatingFileHandler to the root logger, same path/rotation/format as
+graphlink_logging.py's configure_logging() (~/.graphlink/graphlink.log, 2MB
+x3 backups), so the many logger.exception()/logger.error() calls already
+scattered across backend/ (app.py, autosave.py, agents.py, canvas.py, ...)
+land somewhere durable instead of going nowhere (no root handler is
+configured anywhere in backend/ today) or to stderr, invisible in a
+windowed app with no console. install_exception_handlers() installs
+sys.excepthook/threading.excepthook (catches unhandled Python exceptions
+escaping the main thread or a bare threading.Thread - exactly the failure
+mode the R6.7 recon found has zero detection today, e.g. a crash in
+graphlink_desktop.py's daemon backend thread after successful startup) plus
+faulthandler (native/segfault crashes) into the same log, mirroring the
+legacy module's channels 1 and 2 exactly.
+
+Deliberately NOT ported: legacy's channel 3 (qInstallMessageHandler, routing
+Qt's own qCritical/qFatal into the log) - there is no Qt in this stack to
+route messages from. Also NOT ported: the separate per-crash structured JSON
+report + prefilled "Open GitHub issue" URL (build_crash_report/
+write_crash_report/build_github_issue_url in the legacy module). That's a
+genuinely separate diagnostics-artifact-plus-user-action feature beyond this
+increment's scoped "backend logging + in-app notice" - a crash's full
+exception and traceback still lands in graphlink.log via the excepthook
+above, so nothing is silently lost, it's just not additionally packaged into
+its own JSON file with a prefilled issue URL.
+
+BOTH configure_logging() and install_exception_handlers() mutate PROCESS-WIDE
+global state (the root logger's handlers, sys.excepthook, threading.excepthook,
+faulthandler) and are idempotent by design (a module-level flag makes the
+second and later calls no-ops) - matching graphlink_logging.py's own
+_configured guard exactly. Because of that, neither is called from
+backend/app.py's create_app() (which real tests construct many times over
+the life of a pytest run - repeatedly attaching handlers, or attaching one
+pointed at a tmp_path that a later test's teardown deletes out from under a
+"once installed, never reinstalled" handler, would leak across unrelated
+tests). Both are called exactly once, for the whole real process, from
+graphlink_desktop.py's own main() - the actual entry point, never invoked by
+the test suite - the same relationship graphlink_app.py's main() had with
+the legacy configure_logging()/install_crash_handlers() calls.
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import json
+import logging
+import logging.handlers
+import os
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+from backend.notifications import NotificationState
+
+_LOG_MAX_BYTES = 2 * 1024 * 1024
+_LOG_BACKUP_COUNT = 3
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+
+_logging_configured = False
+_handlers_installed = False
+_faulthandler_file = None
+
+CRASH_NOTICE_MESSAGE = (
+    "Graphlink didn't shut down cleanly last time. Your work should be safe - "
+    "autosave protects your session automatically. See graphlink.log for "
+    "details if anything looks wrong."
+)
+
+
+def _data_dir(base_dir: Path | str | None = None) -> Path:
+    return Path(base_dir) if base_dir is not None else Path.home() / ".graphlink"
+
+
+def log_path(base_dir: Path | str | None = None) -> Path:
+    return _data_dir(base_dir) / "graphlink.log"
+
+
+def sentinel_path(base_dir: Path | str | None = None) -> Path:
+    return _data_dir(base_dir) / "running.lock"
+
+
+def crash_dir(base_dir: Path | str | None = None) -> Path:
+    return _data_dir(base_dir) / "crash"
+
+
+def configure_logging(base_dir: Path | str | None = None, level: int = logging.INFO) -> None:
+    """Attach a rotating file handler to the root logger. Idempotent - later
+    calls are no-ops so handlers are never duplicated across a process's
+    lifetime (see this module's own docstring for why that also means this
+    must never be called from create_app())."""
+    global _logging_configured
+    if _logging_configured:
+        return
+
+    resolved = log_path(base_dir)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+
+    handler = logging.handlers.RotatingFileHandler(
+        resolved, maxBytes=_LOG_MAX_BYTES, backupCount=_LOG_BACKUP_COUNT, encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter(_LOG_FORMAT))
+
+    root_logger = logging.getLogger()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(level)
+
+    _logging_configured = True
+
+
+def install_exception_handlers(base_dir: Path | str | None = None) -> None:
+    """Installs faulthandler (native crashes) and sys.excepthook/
+    threading.excepthook (unhandled Python exceptions on the main thread or
+    any bare threading.Thread) so both land in the same log configure_logging
+    sets up, instead of vanishing. Idempotent, same reasoning as
+    configure_logging."""
+    global _handlers_installed, _faulthandler_file
+    if _handlers_installed:
+        return
+    _handlers_installed = True
+
+    directory = crash_dir(base_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    _faulthandler_file = open(directory / "faulthandler.log", "a", encoding="utf-8")
+    faulthandler.enable(file=_faulthandler_file)
+
+    crash_logger = logging.getLogger("graphlink.crash")
+
+    def _excepthook(exc_type, exc_value, exc_tb):
+        crash_logger.error(
+            "Unhandled exception on %s", threading.current_thread().name,
+            exc_info=(exc_type, exc_value, exc_tb),
+        )
+        sys.__excepthook__(exc_type, exc_value, exc_tb)
+
+    def _threading_excepthook(args):
+        crash_logger.error(
+            "Unhandled exception on %s", getattr(args.thread, "name", None) or "?",
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
+
+    sys.excepthook = _excepthook
+    threading.excepthook = _threading_excepthook
+
+
+def mark_running(base_dir: Path | str | None = None) -> None:
+    path = sentinel_path(base_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"pid": os.getpid(), "started_at": datetime.now(timezone.utc).isoformat()}),
+        encoding="utf-8",
+    )
+
+
+def mark_clean_exit(base_dir: Path | str | None = None) -> None:
+    path = sentinel_path(base_dir)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def previous_run_crashed(base_dir: Path | str | None = None) -> bool:
+    return sentinel_path(base_dir).exists()
+
+
+def maybe_show_crash_notice(notifications: NotificationState, crashed: bool) -> None:
+    """Called once per session configuration (backend/app.py's
+    _configure_session), before any WS connection has subscribed - a no-op
+    unless the sentinel above found evidence the prior run didn't reach a
+    clean shutdown. No publish() call needed: a subscribe's send_snapshot
+    reads current state fresh, and no connection can exist yet at the point
+    _configure_session runs."""
+    if crashed:
+        notifications.show(CRASH_NOTICE_MESSAGE, "warning")

--- a/backend/tests/test_crash_recovery.py
+++ b/backend/tests/test_crash_recovery.py
@@ -1,0 +1,229 @@
+"""Crash recovery tests (Qt-removal plan R6.7).
+
+configure_logging/install_exception_handlers mutate PROCESS-WIDE global state
+(the root logger's handlers, sys.excepthook, threading.excepthook,
+faulthandler) by design - see backend/crash_recovery.py's own docstring on
+why they're idempotent and never called from create_app(). Every test that
+exercises them resets that global state in a finally block so nothing leaks
+into unrelated tests elsewhere in the suite.
+"""
+
+import json
+import logging
+import logging.handlers
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from backend.crash_recovery import (
+    CRASH_NOTICE_MESSAGE,
+    configure_logging,
+    crash_dir,
+    install_exception_handlers,
+    log_path,
+    maybe_show_crash_notice,
+    mark_clean_exit,
+    mark_running,
+    previous_run_crashed,
+    sentinel_path,
+)
+import backend.crash_recovery as crash_recovery_module
+from backend.notifications import NotificationState
+
+
+# -- path construction --------------------------------------------------
+
+
+def test_paths_default_to_the_established_graphlink_data_dir():
+    home_graphlink = Path.home() / ".graphlink"
+    assert log_path() == home_graphlink / "graphlink.log"
+    assert sentinel_path() == home_graphlink / "running.lock"
+    assert crash_dir() == home_graphlink / "crash"
+
+
+def test_paths_honor_a_base_dir_override(tmp_path):
+    assert log_path(tmp_path) == tmp_path / "graphlink.log"
+    assert sentinel_path(tmp_path) == tmp_path / "running.lock"
+    assert crash_dir(tmp_path) == tmp_path / "crash"
+
+
+# -- sentinel lifecycle ---------------------------------------------------
+
+
+def test_previous_run_crashed_is_false_with_no_sentinel_present(tmp_path):
+    assert previous_run_crashed(tmp_path) is False
+
+
+def test_mark_running_writes_a_valid_json_sentinel_with_pid(tmp_path):
+    mark_running(tmp_path)
+
+    path = sentinel_path(tmp_path)
+    assert path.is_file()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["pid"] > 0
+    assert "started_at" in payload
+
+
+def test_mark_running_creates_the_parent_directory(tmp_path):
+    nested = tmp_path / "does" / "not" / "exist" / "yet"
+    mark_running(nested)
+    assert sentinel_path(nested).is_file()
+
+
+def test_previous_run_crashed_is_true_once_marked_running(tmp_path):
+    mark_running(tmp_path)
+    assert previous_run_crashed(tmp_path) is True
+
+
+def test_mark_clean_exit_removes_the_sentinel(tmp_path):
+    mark_running(tmp_path)
+    mark_clean_exit(tmp_path)
+    assert previous_run_crashed(tmp_path) is False
+
+
+def test_mark_clean_exit_is_a_no_op_when_no_sentinel_exists(tmp_path):
+    # Must never raise - called on every controlled early-return path in
+    # graphlink_desktop.py's main(), including ones before mark_running
+    # could plausibly have failed to run.
+    mark_clean_exit(tmp_path)
+    assert previous_run_crashed(tmp_path) is False
+
+
+def test_full_lifecycle_clean_shutdown_leaves_no_crash_evidence(tmp_path):
+    assert previous_run_crashed(tmp_path) is False  # first-ever launch
+    mark_running(tmp_path)
+    mark_clean_exit(tmp_path)  # this run shut down cleanly
+    assert previous_run_crashed(tmp_path) is False  # next launch sees no crash
+
+
+def test_full_lifecycle_unclean_shutdown_is_detected_next_launch(tmp_path):
+    mark_running(tmp_path)
+    # ... process dies here without ever reaching mark_clean_exit ...
+    assert previous_run_crashed(tmp_path) is True  # next launch sees the crash
+    mark_clean_exit(tmp_path)
+    assert previous_run_crashed(tmp_path) is False  # and clears it going forward
+
+
+# -- in-app notice ----------------------------------------------------------
+
+
+def test_maybe_show_crash_notice_shows_the_warning_when_crashed():
+    notifications = NotificationState()
+    maybe_show_crash_notice(notifications, True)
+
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == CRASH_NOTICE_MESSAGE
+
+
+def test_maybe_show_crash_notice_is_a_no_op_when_not_crashed():
+    notifications = NotificationState()
+    maybe_show_crash_notice(notifications, False)
+
+    assert notifications.visible is False
+    assert notifications.message == ""
+
+
+# -- logging + exception-handler configuration (idempotent, global state) --
+
+
+@pytest.fixture
+def isolated_logging_state(monkeypatch):
+    """configure_logging's idempotency flag is module-global by design (see
+    the module docstring) - flip it back to unconfigured for this test only,
+    and strip whatever handler(s) got attached to the REAL root logger so
+    they don't outlive the test (which would otherwise leave a handler
+    pointed at this test's about-to-be-deleted tmp_path, breaking any later
+    test in the suite that logs anything)."""
+    root_logger = logging.getLogger()
+    handlers_before = list(root_logger.handlers)
+    level_before = root_logger.level
+    monkeypatch.setattr(crash_recovery_module, "_logging_configured", False)
+    yield
+    for handler in list(root_logger.handlers):
+        if handler not in handlers_before:
+            root_logger.removeHandler(handler)
+            handler.close()
+    root_logger.setLevel(level_before)
+
+
+@pytest.fixture
+def isolated_exception_handler_state(monkeypatch):
+    """Same idempotency concern as configure_logging, for
+    install_exception_handlers - restores sys.excepthook/threading.excepthook
+    to their pre-test values and closes the faulthandler file this test
+    caused to be opened."""
+    excepthook_before = sys.excepthook
+    threading_excepthook_before = threading.excepthook
+    monkeypatch.setattr(crash_recovery_module, "_handlers_installed", False)
+    yield
+    sys.excepthook = excepthook_before
+    threading.excepthook = threading_excepthook_before
+    if crash_recovery_module._faulthandler_file is not None:
+        try:
+            crash_recovery_module._faulthandler_file.close()
+        except (OSError, ValueError):
+            pass
+        crash_recovery_module._faulthandler_file = None
+
+
+def test_configure_logging_attaches_a_rotating_file_handler(tmp_path, isolated_logging_state):
+    configure_logging(tmp_path)
+
+    assert log_path(tmp_path).parent.is_dir()
+    root_logger = logging.getLogger()
+    assert any(
+        isinstance(h, logging.handlers.RotatingFileHandler) and h.baseFilename == str(log_path(tmp_path))
+        for h in root_logger.handlers
+    )
+
+
+def test_configure_logging_is_idempotent(tmp_path, isolated_logging_state):
+    configure_logging(tmp_path)
+    handler_count_after_first = len(logging.getLogger().handlers)
+
+    configure_logging(tmp_path)  # a second call must be a no-op
+    assert len(logging.getLogger().handlers) == handler_count_after_first
+
+
+def test_install_exception_handlers_replaces_both_hooks(tmp_path, isolated_exception_handler_state):
+    original_excepthook = sys.excepthook
+    original_threading_excepthook = threading.excepthook
+
+    install_exception_handlers(tmp_path)
+
+    assert sys.excepthook is not original_excepthook
+    assert threading.excepthook is not original_threading_excepthook
+    assert (crash_dir(tmp_path) / "faulthandler.log").is_file()
+
+
+def test_install_exception_handlers_is_idempotent(tmp_path, isolated_exception_handler_state):
+    install_exception_handlers(tmp_path)
+    hook_after_first = sys.excepthook
+
+    install_exception_handlers(tmp_path)  # a second call must be a no-op
+    assert sys.excepthook is hook_after_first
+
+
+def test_excepthook_logs_the_unhandled_exception_and_still_calls_the_default_hook(
+    tmp_path, isolated_logging_state, isolated_exception_handler_state, monkeypatch,
+):
+    configure_logging(tmp_path)
+    install_exception_handlers(tmp_path)
+
+    default_hook_calls = []
+    monkeypatch.setattr(sys, "__excepthook__", lambda *args: default_hook_calls.append(args))
+
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        exc_type, exc_value, exc_tb = sys.exc_info()
+
+    sys.excepthook(exc_type, exc_value, exc_tb)
+
+    log_content = log_path(tmp_path).read_text(encoding="utf-8")
+    assert "boom" in log_content
+    assert "ValueError" in log_content
+    assert len(default_hook_calls) == 1

--- a/backend/tests/test_crash_recovery_notice.py
+++ b/backend/tests/test_crash_recovery_notice.py
@@ -1,0 +1,103 @@
+"""Integration test (Qt-removal plan R6.7): create_app's previous_run_crashed
+flag actually reaches a real WS session's notification topic. Runs the real
+ASGI app through Starlette's TestClient, mirroring test_app_ws.py's own
+make_client() pattern (fresh temp settings/chat-db paths, never the real
+~/.graphlink) with one addition: previous_run_crashed=True."""
+
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi import WebSocketDisconnect
+from fastapi.testclient import TestClient
+
+import backend.app as app_module
+from backend.app import create_app
+from backend.crash_recovery import CRASH_NOTICE_MESSAGE
+
+# Importing any backend.* submodule (above) runs backend/__init__.py first,
+# which puts graphlink_app/ on sys.path - these bare top-level imports must
+# come after it, same ordering rule backend/tests/test_agents.py documents.
+import api_provider
+import graphlink_task_config as config
+
+
+def _client(previous_run_crashed: bool) -> TestClient:
+    state_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    state_path = Path(state_dir.name)
+    client = TestClient(
+        create_app(
+            spa_dir=Path("__no_such_dir__"),
+            settings_state_file=state_path / "session.dat",
+            chat_db_path=state_path / "chats.db",
+            previous_run_crashed=previous_run_crashed,
+        )
+    )
+    client._state_tmpdir = state_dir  # type: ignore[attr-defined]
+    return client
+
+
+def test_a_crashed_previous_run_surfaces_the_notice_on_first_subscribe():
+    client = _client(previous_run_crashed=True)
+    with client.websocket_connect("/ws?session=test-crash") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["notification"]})
+        message = ws.receive_json()
+
+        assert message["kind"] == "state"
+        assert message["topic"] == "notification"
+        assert message["payload"]["visible"] is True
+        assert message["payload"]["msgType"] == "warning"
+        assert message["payload"]["message"] == CRASH_NOTICE_MESSAGE
+
+
+def test_a_clean_previous_run_shows_no_notice():
+    client = _client(previous_run_crashed=False)
+    with client.websocket_connect("/ws?session=test-no-crash") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["notification"]})
+        message = ws.receive_json()
+
+        assert message["payload"]["visible"] is False
+
+
+def test_the_notice_can_still_be_dismissed_like_any_other_notification():
+    client = _client(previous_run_crashed=True)
+    with client.websocket_connect("/ws?session=test-crash-dismiss") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["notification"]})
+        ws.receive_json()  # the initial crash-notice snapshot
+
+        ws.send_json({"kind": "intent", "topic": "notification", "intent": "dismiss", "args": []})
+        message = ws.receive_json()
+
+        assert message["topic"] == "notification"
+        assert message["payload"]["visible"] is False
+
+
+def test_a_session_setup_bug_is_logged_via_this_apps_own_logger_and_closed_cleanly(monkeypatch, caplog):
+    # Adversarial-review regression test: a bug in any of _configure_session's
+    # register_X calls used to vanish entirely - it never becomes a
+    # Python-level unhandled exception (uvicorn's own ASGI machinery catches
+    # it first and logs it via "uvicorn.error", a logger that does NOT
+    # propagate to the root logger backend/crash_recovery.py's
+    # RotatingFileHandler is attached to), so it landed in neither
+    # graphlink.log nor sys.excepthook - directly contradicting this
+    # increment's own point. This proves the fix: backend/app.py's ws_endpoint
+    # now catches it itself and logs via its OWN logger (which DOES
+    # propagate to root), then closes the connection with code 1011 instead
+    # of leaving it to uvicorn's default handling.
+    def _boom(bus):
+        raise RuntimeError("register_about exploded")
+
+    monkeypatch.setattr(app_module, "register_about", _boom)
+
+    client = _client(previous_run_crashed=False)
+    with caplog.at_level(logging.ERROR, logger="backend.app"):
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with client.websocket_connect("/ws?session=test-broken-session"):
+                pass
+        assert exc_info.value.code == 1011
+
+    assert any(
+        "session setup failed" in record.message and "test-broken-session" in record.message
+        for record in caplog.records
+    )

--- a/graphlink_desktop.py
+++ b/graphlink_desktop.py
@@ -55,13 +55,13 @@ def _wait_for_health(base_url: str, timeout: float) -> bool:
     return False
 
 
-def _start_backend(port: int) -> threading.Thread:
+def _start_backend(port: int, previous_run_crashed: bool = False) -> threading.Thread:
     import uvicorn
 
     from backend.app import create_app
 
     config = uvicorn.Config(
-        create_app(),
+        create_app(previous_run_crashed=previous_run_crashed),
         host="127.0.0.1",
         port=port,
         log_level="warning",
@@ -75,7 +75,23 @@ def _start_backend(port: int) -> threading.Thread:
 
 
 def main() -> int:
-    logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
+    # R6.7 (Qt-removal plan): real rotating-file logging plus unhandled-
+    # exception/native-crash capture, replacing the old bare stderr-only
+    # basicConfig call - see backend/crash_recovery.py's own docstring for
+    # why these two calls (and the sentinel check/mark_running below) live
+    # here, in the real entry point, rather than inside create_app().
+    from backend.crash_recovery import (
+        configure_logging,
+        install_exception_handlers,
+        mark_clean_exit,
+        mark_running,
+        previous_run_crashed,
+    )
+
+    configure_logging()
+    install_exception_handlers()
+    crashed = previous_run_crashed()
+    mark_running()
 
     spa_index = REPO_ROOT / "web_ui" / "dist" / "app" / "index.html"
     if not spa_index.is_file():
@@ -83,14 +99,16 @@ def main() -> int:
             "SPA build missing at %s - run: cd web_ui && GRAPHLINK_ISLAND=app npx vite build",
             spa_index,
         )
+        mark_clean_exit()
         return 1
 
     port = int(os.environ.get("GRAPHLINK_BACKEND_PORT", 0)) or _free_port()
     base_url = f"http://127.0.0.1:{port}"
 
-    _start_backend(port)
+    _start_backend(port, previous_run_crashed=crashed)
     if not _wait_for_health(base_url, STARTUP_TIMEOUT_SECONDS):
         logger.error("backend did not become healthy at %s within %.0fs", base_url, STARTUP_TIMEOUT_SECONDS)
+        mark_clean_exit()
         return 1
     logger.info("backend healthy at %s", base_url)
 
@@ -105,6 +123,11 @@ def main() -> int:
         background_color="#1a1a1a",
     )
     webview.start(debug=bool(os.environ.get("GRAPHLINK_DEBUG_WEBVIEW")))
+    # Reached only on a normal window close - webview.start() blocks until
+    # then. An uncaught exception anywhere above (or a hard kill/power loss)
+    # never reaches this line, leaving running.lock in place - exactly the
+    # signal previous_run_crashed() checks for on the NEXT launch.
+    mark_clean_exit()
     return 0
 
 


### PR DESCRIPTION
## Summary
- New `backend/crash_recovery.py` reimplements two of legacy `graphlink_app/graphlink_crash.py`'s real mechanisms: the `running.lock` sentinel (`mark_running`/`mark_clean_exit`/`previous_run_crashed`) and unhandled-exception/native-crash capture (`sys.excepthook`/`threading.excepthook`/`faulthandler`) into a `RotatingFileHandler`-backed `~/.graphlink/graphlink.log` (same path/rotation as legacy).
- Deliberately not ported: the Qt message-handler channel (nothing to route from) and the separate per-crash JSON-report/GitHub-issue-URL system - out of scope for "backend logging + in-app notice"; a crash's traceback still lands in `graphlink.log` via the excepthook either way.
- `create_app()` gained a `previous_run_crashed` flag threaded into `_configure_session`, which shows a warning notice via the existing `NotificationState` when set. `graphlink_desktop.py`'s `main()` now configures logging/exception handlers and checks+marks the sentinel at startup, calling `mark_clean_exit()` on every return path.
- Adversarial review caught the increment's central risk: an uncaught exception during `_configure_session`'s `register_X` calls (the exact failure mode this feature was scoped to close) was still going nowhere - uvicorn's own ASGI handling catches it via a `"uvicorn.error"` logger with `propagate=False`, so it never reached the root logger or `sys.excepthook`. Fixed by having `ws_endpoint` catch it itself and log via this module's own (propagating) logger before closing the connection with code 1011.

## Test plan
- [x] `python -m pytest -q` - 2358 passed (17 new in `test_crash_recovery.py`, 4 new in `test_crash_recovery_notice.py` including the review-fix regression test)
- [x] `npx tsc --noEmit` - clean (no frontend files touched this increment)
- [x] `graphlink_island_codegen.py --check` - clean, no drift
- [x] Live-driven in two parts, neither touching the real `~/.graphlink`: (1) the real sentinel+logging+exception-handler mechanism against a scratch data dir with real filesystem I/O - a real ERROR log call and a real unhandled exception on a background thread both landed in a real `graphlink.log` with full traceback; (2) a real uvicorn process launched with `previous_run_crashed=True`, connected to over a real network WebSocket from a separate process, confirming the exact notice text/severity arrives end-to-end. Confirmed the real `~/.graphlink/running.lock` was never created and `graphlink.log`'s mtime was unchanged afterward.