### PR TITLE
Fix brace-expansion DoS vulnerability (npm audit fix)

### DIFF
--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -2756,16 +2756,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {


### PR DESCRIPTION
## Summary
- \`brace-expansion@5.0.7\` (transitive via \`eslint@10.7.0\` -> \`minimatch@10.2.5\`) had a high-severity DoS vulnerability - GHSA-mh99-v99m-4gvg. Dev-only build-tool dependency, never shipped in the production bundle.
- \`npm audit fix\` resolved it cleanly to \`5.0.8\`, no \`--force\` needed, \`eslint\` itself unchanged at \`10.7.0\`.

## Test plan
- [x] \`npm audit\` - 0 vulnerabilities
- [x] \`npm ls eslint\` - confirmed unchanged at 10.7.0
- [x] \`npm run check\` (schema-check + typecheck + lint + test + build) - all green, 1049 vitest tests pass