### PR TITLE
Audit fixes for R6.6/R6.7/R6.8: 4 real bugs + 3 tests that could not fail

### DIFF
--- a/backend/autosave.py
+++ b/backend/autosave.py
@@ -17,13 +17,21 @@ primitives backend/chat_library.py's own explicit saveChat intent calls -
 rather than duplicating any serialization or DB-write logic.
 
 CHANGE-GUARDED, not blind: a tick hashes the about-to-be-written JSON and
-skips the write entirely if it matches the hash from the last successful
-save (auto OR manual - see register_autosave's own `last_hash` argument,
-shared with nothing else, this module's own private bookkeeping). Without
-this, a session with no activity at all would still re-write its own
-unchanged row to disk (and re-publish app-chat-library, causing a pointless
-list re-render if the library dialog happens to be open) every single
-interval, forever, for the entire remaining lifetime of the process.
+skips the write when BOTH that hash and the current chat_id still match what
+was last put on disk. Without this, a session with no activity at all would
+still re-write its own unchanged row to disk (and re-publish
+app-chat-library, causing a pointless list re-render if the library dialog
+happens to be open) every single interval, forever, for the entire remaining
+lifetime of the process.
+
+That "what was last put on disk" cell is `last_saved`, a real argument passed
+in by backend/chat_library.py's register_chat_library and genuinely shared
+with the manual saveChat/loadChat/deleteChat paths - see _new_save_state's
+own docstring there for its shape, and for the two bugs an audit found in
+the original version of this guard, which owned the cell privately (nothing
+else could seed it) and compared content only (so a row deleted underneath
+the session still read as "already saved", silently ending all autosave
+protection for that session).
 
 SILENT ON SUCCESS, LOUD ON FAILURE: unlike the explicit Save button (which
 shows a 'Saved "..."' toast every time - the user just took an action and
@@ -57,14 +65,18 @@ session eviction, this does not.
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import json
 import logging
 from pathlib import Path
 from typing import Any
 
 from backend.canvas import SceneDocument
-from backend.chat_library import _fallback_title, _resolve_seed_message, load_chat_row, save_chat_atomically_row
+from backend.chat_library import (
+    _content_digest,
+    _fallback_title,
+    _resolve_seed_message,
+    load_chat_row,
+    save_chat_atomically_row,
+)
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.session_save import build_chat_data
@@ -74,35 +86,18 @@ logger = logging.getLogger(__name__)
 DEFAULT_INTERVAL_SECONDS = 30.0
 
 
-def _content_digest(chat_data: dict[str, Any], notes_data: list, pins_data: list) -> str:
-    """A pure function of "what would actually get written" - sort_keys
-    makes this independent of dict insertion order (build_chat_data's own
-    key order never changes call to call, but this is cheap insurance
-    against a false "changed" from something that isn't); default=str
-    tolerates any value json can't natively encode without ever raising
-    (a digest mismatch on an unexpected type just means "assume changed,
-    write it" - the safe direction to fail in, never "assume unchanged,
-    skip a real write")."""
-    payload = json.dumps(
-        {"chat_data": chat_data, "notes_data": notes_data, "pins_data": pins_data},
-        sort_keys=True, default=str,
-    )
-    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
-
-
 async def autosave_tick(
     bus: SessionBus,
     db_path: Path,
     canvas_document: SceneDocument,
     notifications: NotificationState | None,
-    last_hash: dict[str, str | None],
+    last_saved: dict[str, Any],
 ) -> None:
     """One autosave attempt - directly callable (no timer involved), so
     tests can exercise the actual decision/write logic deterministically
-    rather than waiting on a real sleep. `last_hash` is a single-key mutable
-    dict (`{"value": ...}`) rather than a plain variable so register_autosave's
-    closure and this function can share and update the same cell across
-    calls without a class just for one field."""
+    rather than waiting on a real sleep. `last_saved` is the mutable cell
+    backend/chat_library.py's _new_save_state() creates and every write path
+    shares (see this module's own docstring, and that function's)."""
     if not canvas_document.nodes and canvas_document.current_chat_id is None:
         # Mirrors saveChat's own "Nothing was added to the chat canvas yet"
         # guard - an empty, never-saved canvas has nothing worth protecting.
@@ -118,7 +113,12 @@ async def autosave_tick(
     pins_data = chat_data.pop("pins_data", [])
 
     digest = _content_digest(chat_data, notes_data, pins_data)
-    if digest == last_hash["value"]:
+    if digest == last_saved["digest"] and canvas_document.current_chat_id == last_saved["chat_id"]:
+        # Both halves matter. Content alone is not enough: chats.db is shared
+        # mutable state, and a row that vanished underneath this session (the
+        # user deleting their own open chat from the library) leaves the
+        # document's content digest completely unchanged - comparing chat_id
+        # too is what stops that from reading as "already saved" forever.
         return
 
     chat_id_for_save: int | None = None
@@ -165,7 +165,8 @@ async def autosave_tick(
         return
 
     canvas_document.current_chat_id = int(new_chat_id)
-    last_hash["value"] = digest
+    last_saved["digest"] = digest
+    last_saved["chat_id"] = int(new_chat_id)
     await bus.publish("app-chat-library")
 
 
@@ -175,14 +176,19 @@ def register_autosave(
     canvas_document: SceneDocument,
     notifications: NotificationState | None,
     mutation_guard: dict[str, bool],
+    last_saved: dict[str, Any],
     *,
     interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
 ) -> None:
     """Starts the one long-lived per-session background task. Stashed on
     `bus.autosave_task` purely so a caller COULD cancel it (e.g. a future
     test or a graceful-shutdown path) - nothing in this backend does today,
-    see this module's own docstring on why that is fine for now."""
-    last_hash: dict[str, str | None] = {"value": None}
+    see this module's own docstring on why that is fine for now.
+
+    `last_saved` is owned by the caller (register_chat_library), not created
+    here, precisely so the manual save/load/delete paths can seed and
+    invalidate the same cell - see this module's own CHANGE-GUARDED
+    paragraph."""
 
     async def _guarded_tick() -> None:
         if mutation_guard["active"]:
@@ -192,14 +198,26 @@ def register_autosave(
             return
         mutation_guard["active"] = True
         try:
-            await autosave_tick(bus, db_path, canvas_document, notifications, last_hash)
+            await autosave_tick(bus, db_path, canvas_document, notifications, last_saved)
         finally:
             mutation_guard["active"] = False
 
     async def _loop() -> None:
         while True:
             await asyncio.sleep(interval_seconds)
-            await _guarded_tick()
+            try:
+                await _guarded_tick()
+            except Exception:
+                # Defence in depth, not a fix for a known escape: an audit
+                # walked every unguarded line in autosave_tick and found no
+                # reachable one that can raise today. But this task is never
+                # awaited by anyone and holds a strong reference for the
+                # process's whole life, so if one ever did escape, the task
+                # would die and Python's own "Task exception was never
+                # retrieved" warning would never fire either - autosave would
+                # be off for the rest of the session with literally no signal
+                # anywhere. One bad tick must never be able to end the loop.
+                logger.exception("autosave: tick failed for session %r", bus.session_id)
 
     loop_coro = _loop()
     try:

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import re
 import sqlite3
@@ -367,6 +368,51 @@ def _resolve_seed_message(document: SceneDocument) -> str:
     return last_chat_content if last_chat_content is not None else "New Chat"
 
 
+def _content_digest(chat_data: dict[str, Any], notes_data: list, pins_data: list) -> str:
+    """A pure function of "what would actually get written" - the change-guard
+    autosave skips redundant writes with. Lives here, next to the save
+    primitives it digests the output of, rather than in backend/autosave.py:
+    saveChat and loadChat both need to record a digest too (see
+    _new_save_state below), and autosave.py already imports FROM this module,
+    never the reverse.
+
+    sort_keys makes this independent of dict insertion order (build_chat_data's
+    own key order never changes call to call, but this is cheap insurance
+    against a false "changed" from something that isn't); default=str tolerates
+    any value json can't natively encode without ever raising (a digest
+    mismatch on an unexpected type just means "assume changed, write it" - the
+    safe direction to fail in, never "assume unchanged, skip a real write")."""
+    payload = json.dumps(
+        {"chat_data": chat_data, "notes_data": notes_data, "pins_data": pins_data},
+        sort_keys=True, default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _new_save_state() -> dict[str, Any]:
+    """The one cell tracking "what is currently on disk for this session",
+    shared by every path that writes or reads a chat row: autosave's tick,
+    the manual saveChat, and loadChat.
+
+    Audit finding (this used to be a closure-local in register_autosave that
+    NOTHING else could reach, while autosave.py's own docstring claimed it
+    covered manual saves too). Two real consequences of that, both fixed by
+    making it shared and by tracking chat_id alongside the digest:
+
+    1. A manual Save or a loadChat left the cell stale, so the very next tick
+       rewrote a byte-identical row - bumping updated_at and re-sorting the
+       Chat Library (get_all_chats orders by updated_at DESC) under the user
+       for no reason.
+    2. The guard compared CONTENT only, but chats.db is shared mutable state.
+       Delete the currently-open chat from the library and keep working
+       without touching the canvas: the document's digest never changes, so
+       every subsequent tick short-circuited and autosave silently stopped
+       protecting the session entirely. Comparing chat_id too means a row
+       that vanished underneath the session can no longer be mistaken for
+       "already saved"."""
+    return {"digest": None, "chat_id": None}
+
+
 def chat_library_payload(db_path: Path) -> dict[str, Any]:
     try:
         rows = get_all_chats(db_path)
@@ -407,6 +453,22 @@ def register_chat_library(
     # counterpart of ChatSessionManager's own _is_saving reentrancy guard.
     _mutation_in_progress = {"active": False}
 
+    # R6.6 + audit fix: see _new_save_state's own docstring for what this
+    # tracks and the two bugs that came from autosave owning it privately.
+    _last_saved = _new_save_state()
+    # Stashed on the bus for the same reason register_autosave stashes
+    # bus.autosave_task: it is per-session state a caller may legitimately
+    # need to observe, and a closure-local is unreachable to anything -
+    # including the tests that have to prove the sharing actually works,
+    # which is the whole point of the fix.
+    bus.chat_save_state = _last_saved
+
+    def _record_saved(
+        chat_data: dict[str, Any], notes_data: list, pins_data: list, chat_id: int | None
+    ) -> None:
+        _last_saved["digest"] = _content_digest(chat_data, notes_data, pins_data)
+        _last_saved["chat_id"] = int(chat_id) if chat_id is not None else None
+
     def _serialize_mutating_intent(handler):
         async def wrapped(*args, **kwargs):
             if _mutation_in_progress["active"]:
@@ -443,6 +505,18 @@ def register_chat_library(
         # The SPA only calls this after its own two-step confirm, so no
         # confirmation happens here - same contract as the legacy bridge.
         await asyncio.to_thread(delete_chat, resolved_path, int(chat_id))
+        if canvas_document is not None and canvas_document.current_chat_id == int(chat_id):
+            # Audit fix: deleting the row this session is currently pointed at
+            # used to leave current_chat_id dangling AND leave the autosave
+            # digest looking "already saved", so a user who deleted their open
+            # chat and kept working silently had no autosave protection at all
+            # until they happened to edit the canvas. Dropping both makes the
+            # next tick treat this as an unsaved session and INSERT a fresh
+            # row - the same thing a manual Save already does here (save_chat's
+            # own existing_row-is-None fallback).
+            canvas_document.current_chat_id = None
+            _last_saved["digest"] = None
+            _last_saved["chat_id"] = None
         await bus.publish("app-chat-library")
 
     async def load_chat(chat_id: int):
@@ -473,6 +547,21 @@ def register_chat_library(
             # one - the backend analog of ChatSessionManager.current_chat_id
             # being set from the load path, not just the save path.
             canvas_document.current_chat_id = int(chat_id)
+            # Audit fix: the document now matches this row exactly, so record
+            # that. Without it the first tick after a load rewrote a
+            # byte-identical row and bumped updated_at, re-sorting the Chat
+            # Library under the user for a session they had only just opened.
+            try:
+                fresh = build_chat_data(canvas_document)
+                fresh_notes = fresh.pop("notes_data", [])
+                fresh_pins = fresh.pop("pins_data", [])
+                _record_saved(fresh, fresh_notes, fresh_pins, chat_id)
+            except Exception:
+                # Never fail a successful load over bookkeeping - leaving the
+                # digest unset just means one redundant tick, the pre-fix
+                # behavior.
+                _last_saved["digest"] = None
+                _last_saved["chat_id"] = int(chat_id)
         except Exception as exc:
             # Adversarial review finding: load_notes_rows/load_pins_rows (a
             # real sqlite3.Error, e.g. a locked/corrupted db file) previously
@@ -565,6 +654,10 @@ def register_chat_library(
             return
 
         canvas_document.current_chat_id = int(new_chat_id)
+        # Audit fix: record what this manual Save just put on disk, so the
+        # next autosave tick recognizes it as already-saved instead of
+        # rewriting a byte-identical row 30 seconds later.
+        _record_saved(chat_data, notes_data, pins_data, new_chat_id)
         await bus.publish("app-chat-library")
         if notifications is not None:
             notifications.show(f'Saved "{title}".', "success")
@@ -580,6 +673,10 @@ def register_chat_library(
         if canvas_document is None:
             return
         canvas_document.clear_for_load()
+        # clear_for_load drops current_chat_id, so the save state that
+        # described the old document no longer describes anything.
+        _last_saved["digest"] = None
+        _last_saved["chat_id"] = None
         await bus.publish("scene")
 
     bus.register_intent("app-chat-library", "renameChat", rename)
@@ -599,6 +696,6 @@ def register_chat_library(
         from backend.autosave import register_autosave
 
         register_autosave(
-            bus, resolved_path, canvas_document, notifications, _mutation_in_progress,
+            bus, resolved_path, canvas_document, notifications, _mutation_in_progress, _last_saved,
             interval_seconds=autosave_interval_seconds,
         )

--- a/backend/crash_recovery.py
+++ b/backend/crash_recovery.py
@@ -113,13 +113,30 @@ def configure_logging(base_dir: Path | str | None = None, level: int = logging.I
     resolved = log_path(base_dir)
     resolved.parent.mkdir(parents=True, exist_ok=True)
 
+    formatter = logging.Formatter(_LOG_FORMAT)
+
     handler = logging.handlers.RotatingFileHandler(
         resolved, maxBytes=_LOG_MAX_BYTES, backupCount=_LOG_BACKUP_COUNT, encoding="utf-8",
     )
-    handler.setFormatter(logging.Formatter(_LOG_FORMAT))
+    handler.setFormatter(formatter)
 
     root_logger = logging.getLogger()
     root_logger.addHandler(handler)
+
+    # Audit fix: this function replaced graphlink_desktop.py's own
+    # logging.basicConfig() call, which had given the root logger a stderr
+    # StreamHandler. Attaching only the file handler silently took the console
+    # away - and because logging.lastResort only fires when root has NO
+    # handler, `python graphlink_desktop.py` with a missing SPA build printed
+    # absolutely nothing and exited 1, despite that path logging a perfectly
+    # good error. Running from a terminal is the documented launch story for
+    # this entry point, so the console stays. The windowed-app argument was
+    # always a reason to ADD the file, never to remove stderr.
+    if sys.stderr is not None:
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(formatter)
+        root_logger.addHandler(stream_handler)
+
     root_logger.setLevel(level)
 
     _logging_configured = True
@@ -134,7 +151,6 @@ def install_exception_handlers(base_dir: Path | str | None = None) -> None:
     global _handlers_installed, _faulthandler_file
     if _handlers_installed:
         return
-    _handlers_installed = True
 
     directory = crash_dir(base_dir)
     directory.mkdir(parents=True, exist_ok=True)
@@ -159,6 +175,13 @@ def install_exception_handlers(base_dir: Path | str | None = None) -> None:
     sys.excepthook = _excepthook
     threading.excepthook = _threading_excepthook
 
+    # Set LAST, matching configure_logging above. Audit finding: this used to
+    # be set first, so if mkdir or open() raised (an unwritable ~/.graphlink/
+    # crash, a full disk) the flag was already latched and every later retry
+    # became a silent no-op - leaving the hooks this function exists to
+    # install permanently absent, with no second chance.
+    _handlers_installed = True
+
 
 def mark_running(base_dir: Path | str | None = None) -> None:
     path = sentinel_path(base_dir)
@@ -170,7 +193,32 @@ def mark_running(base_dir: Path | str | None = None) -> None:
 
 
 def mark_clean_exit(base_dir: Path | str | None = None) -> None:
+    """Removes this process's own sentinel. Audit fix: this used to unlink
+    unconditionally, which made two concurrent instances corrupt each other -
+    B starts while A is running and overwrites the lock with B's pid, then A
+    exits cleanly and deletes it, so a later crash of B left no evidence and
+    went unreported on the next launch. Only the pid that wrote the sentinel
+    may remove it.
+
+    KNOWN, UNFIXED: the other half of that scenario - B seeing A's live lock
+    at startup and reporting a crash that never happened - needs a real
+    is-that-pid-alive check, which has no safe portable form here (os.kill's
+    signal-0 liveness probe is POSIX-only; on Windows os.kill calls
+    TerminateProcess and would kill the other instance). Left alone
+    deliberately rather than fixed with something dangerous."""
     path = sentinel_path(base_dir)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        owner = payload.get("pid")
+    except (FileNotFoundError, ValueError, OSError):
+        # Unreadable or malformed: fall back to the old unconditional
+        # behavior rather than leaving a stale lock that would report a
+        # phantom crash forever.
+        owner = os.getpid()
+
+    if owner != os.getpid():
+        return
+
     try:
         path.unlink()
     except FileNotFoundError:

--- a/backend/tests/test_autosave.py
+++ b/backend/tests/test_autosave.py
@@ -14,9 +14,27 @@ import pytest
 
 from backend.autosave import autosave_tick, register_autosave
 from backend.canvas import SceneDocument
-from backend.chat_library import chat_library_payload, get_all_chats, load_chat_row
+from backend.chat_library import (
+    _new_save_state,
+    chat_library_payload,
+    delete_chat,
+    get_all_chats,
+    load_chat_row,
+    rename_chat,
+)
 from backend.events import SessionBus
 from backend.notifications import NotificationState
+
+
+class Recorder:
+    """Same shape backend/tests/test_chat_library.py already uses - the bus's
+    Connection protocol is just an async send_json(dict)."""
+
+    def __init__(self):
+        self.messages = []
+
+    async def send_json(self, data):
+        self.messages.append(data)
 
 
 @pytest.fixture
@@ -41,26 +59,26 @@ def _bus(db_path):
 
 def test_autosave_tick_skips_an_empty_never_saved_canvas(db_path):
     bus, document, notifications = _bus(db_path)
-    last_hash = {"value": None}
+    last_saved = _new_save_state()
 
-    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
 
     assert get_all_chats(db_path) == []
-    assert last_hash["value"] is None
+    assert last_saved["digest"] is None
     assert not notifications.visible
 
 
 def test_autosave_tick_inserts_a_new_row_for_a_fresh_canvas_with_content(db_path):
     bus, document, notifications = _bus(db_path)
     document.add_chat_node(0, 0, "hello autosave", is_user=True)
-    last_hash = {"value": None}
+    last_saved = _new_save_state()
 
-    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
 
     rows = get_all_chats(db_path)
     assert len(rows) == 1
     assert document.current_chat_id == rows[0]["id"]
-    assert last_hash["value"] is not None
+    assert last_saved["digest"] is not None
     # Silent on success - autosave must never show a "Saved" toast the way
     # the explicit Save button does (see this module's own docstring).
     assert not notifications.visible
@@ -69,10 +87,10 @@ def test_autosave_tick_inserts_a_new_row_for_a_fresh_canvas_with_content(db_path
 def test_autosave_tick_is_a_no_op_when_nothing_changed_since_the_last_tick(db_path, monkeypatch):
     bus, document, notifications = _bus(db_path)
     document.add_chat_node(0, 0, "hello autosave", is_user=True)
-    last_hash = {"value": None}
+    last_saved = _new_save_state()
 
-    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
-    first_hash = last_hash["value"]
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
+    first_digest = last_saved["digest"]
 
     import backend.autosave as autosave_module
     calls = []
@@ -84,48 +102,61 @@ def test_autosave_tick_is_a_no_op_when_nothing_changed_since_the_last_tick(db_pa
 
     monkeypatch.setattr(autosave_module, "save_chat_atomically_row", counting_save)
 
-    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
 
     assert calls == [], "a second tick with no scene changes must not write again"
-    assert last_hash["value"] == first_hash
+    assert last_saved["digest"] == first_digest
     assert len(get_all_chats(db_path)) == 1
 
 
 def test_autosave_tick_writes_again_after_a_real_change(db_path):
     bus, document, notifications = _bus(db_path)
     document.add_chat_node(0, 0, "hello autosave", is_user=True)
-    last_hash = {"value": None}
-    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
-    first_hash = last_hash["value"]
+    last_saved = _new_save_state()
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
+    first_digest = last_saved["digest"]
 
     document.add_code_node(100, 0, "x = 1", "python")
-    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
 
-    assert last_hash["value"] != first_hash
+    assert last_saved["digest"] != first_digest
     row = load_chat_row(db_path, document.current_chat_id)
     assert len(row["data"]["nodes"]) == 2
 
 
 def test_autosave_tick_never_regenerates_an_existing_chats_title(db_path):
+    # Audit fix - this test used to be unable to fail. Its only inter-tick
+    # change was add_code_node, but _resolve_seed_message reads chat-kind
+    # nodes ONLY, so the regenerated title would have been byte-identical to
+    # the original and the assertion held whether or not the implementation
+    # preserved the row's title (verified by mutation: swapping the
+    # preserve-title line for the regeneration it exists to prevent still
+    # passed). Renaming the row out of band - what the library's own Rename
+    # action really does - plus a seed-changing chat node makes regeneration
+    # observably wrong, which is the only version of this that can fail.
     bus, document, notifications = _bus(db_path)
     document.add_chat_node(0, 0, "hello autosave", is_user=True)
-    last_hash = {"value": None}
-    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
-    first_title = get_all_chats(db_path)[0]["title"]
+    last_saved = _new_save_state()
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
+    chat_id = document.current_chat_id
 
-    document.add_code_node(100, 0, "x = 1", "python")
-    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+    rename_chat(db_path, chat_id, "Q3 planning")
+    document.add_chat_node(200, 0, "an entirely different seed message", is_user=True)
 
-    assert get_all_chats(db_path)[0]["title"] == first_title
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
+
+    rows = get_all_chats(db_path)
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Q3 planning"
 
 
 def test_autosave_tick_falls_back_to_insert_when_current_row_was_deleted_elsewhere(db_path):
     bus, document, notifications = _bus(db_path)
     document.current_chat_id = 999
     document.add_chat_node(0, 0, "hello autosave", is_user=True)
-    last_hash = {"value": None}
+    last_saved = _new_save_state()
 
-    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
 
     rows = get_all_chats(db_path)
     assert len(rows) == 1
@@ -135,7 +166,7 @@ def test_autosave_tick_falls_back_to_insert_when_current_row_was_deleted_elsewhe
 def test_autosave_tick_shows_an_error_notification_on_db_failure(db_path, monkeypatch):
     bus, document, notifications = _bus(db_path)
     document.add_chat_node(0, 0, "hello autosave", is_user=True)
-    last_hash = {"value": None}
+    last_saved = _new_save_state()
 
     import backend.autosave as autosave_module
 
@@ -144,7 +175,7 @@ def test_autosave_tick_shows_an_error_notification_on_db_failure(db_path, monkey
 
     monkeypatch.setattr(autosave_module, "save_chat_atomically_row", failing_save)
 
-    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
 
     assert notifications.visible and notifications.msg_type == "error"
     assert "disk full" in notifications.message
@@ -162,7 +193,7 @@ def test_autosave_tick_shows_an_error_notification_when_the_existing_row_lookup_
     bus, document, notifications = _bus(db_path)
     document.current_chat_id = 999
     document.add_chat_node(0, 0, "hello autosave", is_user=True)
-    last_hash = {"value": None}
+    last_saved = _new_save_state()
 
     import backend.autosave as autosave_module
 
@@ -171,12 +202,12 @@ def test_autosave_tick_shows_an_error_notification_when_the_existing_row_lookup_
 
     monkeypatch.setattr(autosave_module, "load_chat_row", failing_load)
 
-    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_hash))
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
 
     assert notifications.visible and notifications.msg_type == "error"
     assert "database is locked" in notifications.message
     assert get_all_chats(db_path) == []
-    assert last_hash["value"] is None
+    assert last_saved["digest"] is None
 
 
 # -- register_autosave: the real timer loop + the mutation_guard interplay --
@@ -189,7 +220,9 @@ def test_register_autosave_ticks_on_a_real_timer_and_writes_a_row(tmp_path):
     mutation_guard = {"active": False}
 
     async def _run():
-        register_autosave(bus, db_path, document, notifications, mutation_guard, interval_seconds=0.05)
+        register_autosave(
+            bus, db_path, document, notifications, mutation_guard, _new_save_state(), interval_seconds=0.05
+        )
         try:
             await asyncio.sleep(0.2)
         finally:
@@ -210,7 +243,9 @@ def test_register_autosave_skips_a_tick_while_mutation_guard_is_active(tmp_path)
     mutation_guard = {"active": True}  # simulates a manual load/save/new-chat in flight
 
     async def _run():
-        register_autosave(bus, db_path, document, notifications, mutation_guard, interval_seconds=0.05)
+        register_autosave(
+            bus, db_path, document, notifications, mutation_guard, _new_save_state(), interval_seconds=0.05
+        )
         try:
             await asyncio.sleep(0.2)
         finally:
@@ -222,3 +257,78 @@ def test_register_autosave_skips_a_tick_while_mutation_guard_is_active(tmp_path)
 
     asyncio.run(_run())
     assert get_all_chats(db_path) == [], "a tick must skip itself entirely while a manual operation is in flight"
+
+
+# -- audit fixes: the change-guard must not mask a row that vanished, and the
+# -- error paths must actually reach a connected client, not just local state --
+
+
+def test_autosave_tick_writes_again_when_its_row_was_deleted_despite_unchanged_content(db_path):
+    # Audit finding (real bug): the guard compared CONTENT only. Deleting the
+    # currently-open chat leaves the document's digest completely unchanged,
+    # so every subsequent tick short-circuited and autosave silently stopped
+    # protecting the session - the recovery path below (existing_row is None
+    # -> fresh INSERT) was unreachable. Comparing chat_id too fixes it.
+    bus, document, notifications = _bus(db_path)
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    last_saved = _new_save_state()
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
+    first_id = document.current_chat_id
+    assert last_saved["chat_id"] == first_id
+
+    # The row goes away and the canvas is NOT touched - exactly the state the
+    # content-only guard could not distinguish from "already saved".
+    delete_chat(db_path, first_id)
+    document.current_chat_id = None  # what deleteChat's intent now does
+
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
+
+    rows = get_all_chats(db_path)
+    assert len(rows) == 1, "the work must be re-protected under a fresh row"
+    assert rows[0]["id"] != first_id
+    assert document.current_chat_id == rows[0]["id"]
+
+
+def test_a_failed_autosave_actually_broadcasts_its_error_to_a_connected_client(db_path, monkeypatch):
+    # Audit finding: both error-path tests asserted on the NotificationState
+    # object the test itself constructed, never on what was broadcast -
+    # verified by mutation that all three `await bus.publish(...)` calls in
+    # backend/autosave.py could be replaced with `pass` and the whole file
+    # stayed green. NotificationState.show() only mutates in-memory state; a
+    # connected SPA learns about it solely through the publish.
+    bus, document, notifications = _bus(db_path)
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    last_saved = _new_save_state()
+
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    import backend.autosave as autosave_module
+
+    def failing_save(*args, **kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(autosave_module, "save_chat_atomically_row", failing_save)
+
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
+
+    broadcast = [
+        m["payload"]["message"] for m in recorder.messages if m.get("topic") == "notification"
+    ]
+    assert any("disk full" in message for message in broadcast), recorder.messages
+
+
+def test_a_successful_autosave_broadcasts_the_library_refresh(db_path):
+    # Same gap, success side: without the app-chat-library publish an open
+    # Chat Library dialog never learns the new row exists.
+    bus, document, notifications = _bus(db_path)
+    document.add_chat_node(0, 0, "hello autosave", is_user=True)
+    last_saved = _new_save_state()
+
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
+
+    topics = [m.get("topic") for m in recorder.messages]
+    assert "app-chat-library" in topics, recorder.messages

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -7,6 +7,8 @@ import sqlite3
 
 import pytest
 
+import backend.autosave as autosave_module
+from backend.autosave import autosave_tick
 from backend.canvas import SceneDocument
 from backend.chat_library import (
     _fallback_title,
@@ -507,3 +509,110 @@ def test_register_chat_library_does_not_crash_without_a_running_event_loop(db_pa
     register_chat_library(bus, db_path, document, notifications)
 
     assert bus.autosave_task is None
+
+
+# -- audit fixes: the save-state cell is genuinely shared across every path --
+
+
+def _library_session(db_path):
+    bus = SessionBus("chat-library-save-state-test")
+    document = SceneDocument()
+    bus.register_topic("scene", document.scene_payload)
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    # autosave_interval_seconds=None: no background timer, so these tests
+    # drive autosave_tick explicitly and deterministically instead.
+    register_chat_library(bus, db_path, document, notifications, autosave_interval_seconds=None)
+    return bus, document, notifications
+
+
+def test_a_manual_save_seeds_the_save_state_so_the_next_tick_is_a_no_op(db_path, monkeypatch):
+    # Audit finding: backend/autosave.py's docstring claimed its change-guard
+    # covered "auto OR manual", but the cell was a closure-local nothing else
+    # could reach, so every manual Save was followed 30s later by a
+    # byte-identical rewrite that bumped updated_at and re-sorted the Chat
+    # Library out from under the user.
+    bus, document, notifications = _library_session(db_path)
+    document.add_chat_node(0, 0, "hello", is_user=True)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+    assert len(get_all_chats(db_path)) == 1
+    saved_id = document.current_chat_id
+
+    state = bus.chat_save_state
+    assert state["digest"] is not None and state["chat_id"] == saved_id
+
+    # A tick with nothing changed since that manual save must not write.
+    writes = []
+    real_save = autosave_module.save_chat_atomically_row
+    monkeypatch.setattr(
+        autosave_module, "save_chat_atomically_row",
+        lambda *a, **k: (writes.append(a), real_save(*a, **k))[1],
+    )
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, state))
+    assert writes == [], "a tick right after a manual Save must not rewrite the row"
+
+
+def test_loading_a_chat_seeds_the_save_state_so_the_next_tick_is_a_no_op(db_path, monkeypatch):
+    # Same gap on the load side: opening a chat and touching nothing still
+    # rewrote its row on the first tick, re-sorting the library.
+    seed_bus, seed_document, seed_notifications = _library_session(db_path)
+    seed_document.add_chat_node(0, 0, "hello", is_user=True)
+    asyncio.run(seed_bus.dispatch_intent("app-chat-library", "saveChat", []))
+    chat_id = seed_document.current_chat_id
+
+    bus, document, notifications = _library_session(db_path)
+    asyncio.run(bus.dispatch_intent("app-chat-library", "loadChat", [chat_id]))
+    assert document.current_chat_id == chat_id
+
+    state = bus.chat_save_state
+    assert state["chat_id"] == chat_id
+    assert state["digest"] is not None
+
+    writes = []
+    real_save = autosave_module.save_chat_atomically_row
+    monkeypatch.setattr(
+        autosave_module, "save_chat_atomically_row",
+        lambda *a, **k: (writes.append(a), real_save(*a, **k))[1],
+    )
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, state))
+    assert writes == [], "a tick right after loadChat must not rewrite the row"
+
+
+def test_deleting_the_open_chat_clears_the_pointer_and_reenables_autosave(db_path):
+    # Audit finding (real bug): deleteChat left current_chat_id dangling and
+    # left the content-only digest looking "already saved", so a user who
+    # deleted their open chat and kept working had NO autosave protection
+    # until they happened to edit the canvas.
+    bus, document, notifications = _library_session(db_path)
+    document.add_chat_node(0, 0, "hello", is_user=True)
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+    saved_id = document.current_chat_id
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "deleteChat", [saved_id]))
+
+    assert get_all_chats(db_path) == []
+    assert document.current_chat_id is None, "the pointer to a deleted row must not dangle"
+
+    state = bus.chat_save_state
+    # The canvas is deliberately NOT touched - the pre-fix content-only guard
+    # could not tell this apart from "already saved" and skipped forever.
+    asyncio.run(autosave_tick(bus, db_path, document, notifications, state))
+
+    rows = get_all_chats(db_path)
+    assert len(rows) == 1, "the still-open work must be re-protected under a fresh row"
+    assert rows[0]["id"] != saved_id
+
+
+def test_deleting_a_different_chat_leaves_the_open_session_pointer_alone(db_path):
+    # The guard must be scoped to the row the session actually points at.
+    bus, document, notifications = _library_session(db_path)
+    other_id = _insert_chat(db_path, "Someone else's chat")
+    document.add_chat_node(0, 0, "hello", is_user=True)
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+    saved_id = document.current_chat_id
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "deleteChat", [other_id]))
+
+    assert document.current_chat_id == saved_id
+    assert bus.chat_save_state["chat_id"] == saved_id

--- a/backend/tests/test_crash_recovery.py
+++ b/backend/tests/test_crash_recovery.py
@@ -11,6 +11,7 @@ into unrelated tests elsewhere in the suite.
 import json
 import logging
 import logging.handlers
+import os
 import sys
 import threading
 from pathlib import Path
@@ -227,3 +228,81 @@ def test_excepthook_logs_the_unhandled_exception_and_still_calls_the_default_hoo
     assert "boom" in log_content
     assert "ValueError" in log_content
     assert len(default_hook_calls) == 1
+
+
+# -- audit fixes --
+
+
+def test_mark_clean_exit_leaves_another_instances_sentinel_alone(tmp_path):
+    # Audit finding: mark_clean_exit unlinked unconditionally, so two
+    # concurrent instances corrupted each other - B overwrites the lock with
+    # its own pid, A then exits cleanly and deletes B's lock, and a later
+    # crash of B goes completely unreported on the next launch.
+    mark_running(tmp_path)
+    payload = json.loads(sentinel_path(tmp_path).read_text(encoding="utf-8"))
+    payload["pid"] = os.getpid() + 1  # as if a second instance had marked it
+    sentinel_path(tmp_path).write_text(json.dumps(payload), encoding="utf-8")
+
+    mark_clean_exit(tmp_path)
+
+    assert previous_run_crashed(tmp_path), "a sibling instance's lock must survive"
+
+
+def test_mark_clean_exit_still_removes_our_own_sentinel(tmp_path):
+    mark_running(tmp_path)
+
+    mark_clean_exit(tmp_path)
+
+    assert not previous_run_crashed(tmp_path)
+
+
+def test_mark_clean_exit_clears_a_malformed_sentinel_rather_than_stranding_it(tmp_path):
+    # A lock we can't parse must not become permanent - that would report a
+    # phantom crash on every launch, forever.
+    sentinel_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+    sentinel_path(tmp_path).write_text("not json", encoding="utf-8")
+
+    mark_clean_exit(tmp_path)
+
+    assert not previous_run_crashed(tmp_path)
+
+
+def test_configure_logging_keeps_a_stderr_handler_so_terminal_runs_still_print(tmp_path, isolated_logging_state):
+    # Audit finding: this replaced graphlink_desktop.py's logging.basicConfig,
+    # which had provided the only stderr handler. Without one, root HAS a
+    # handler (so logging.lastResort never fires) but nothing reaches the
+    # console - `python graphlink_desktop.py` with a missing SPA build printed
+    # nothing at all and exited 1, despite logging a perfectly good error.
+    configure_logging(tmp_path)
+
+    stream_handlers = [
+        h for h in logging.getLogger().handlers
+        if type(h) is logging.StreamHandler
+    ]
+    assert stream_handlers, "terminal runs must still see log output"
+
+
+def test_install_exception_handlers_can_be_retried_after_a_failure(
+    tmp_path, monkeypatch, isolated_exception_handler_state
+):
+    # Audit finding: the installed flag was set BEFORE the work, so a single
+    # failure (unwritable ~/.graphlink/crash, full disk) latched it forever
+    # and every retry became a silent no-op - leaving sys.excepthook
+    # permanently uninstalled with no second chance.
+    import builtins
+
+    original_hook = sys.excepthook
+    real_open = builtins.open
+
+    def failing_open(*args, **kwargs):
+        raise PermissionError("crash dir is not writable")
+
+    monkeypatch.setattr(builtins, "open", failing_open)
+    with pytest.raises(PermissionError):
+        install_exception_handlers(tmp_path)
+    assert sys.excepthook is original_hook
+
+    monkeypatch.setattr(builtins, "open", real_open)
+    install_exception_handlers(tmp_path)
+
+    assert sys.excepthook is not original_hook, "a retry after a failure must actually install"

--- a/web_ui/src/app/canvas/exportCanvasPng.test.ts
+++ b/web_ui/src/app/canvas/exportCanvasPng.test.ts
@@ -1,4 +1,4 @@
-import { getNodesBounds, getViewportForBounds } from "@xyflow/react";
+import { getNodesBounds, getViewportForBounds, type Viewport } from "@xyflow/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // html-to-image performs real DOM-to-canvas rasterization that jsdom can't
@@ -25,6 +25,24 @@ function fakeNode(id: string, x: number, y: number) {
   };
 }
 
+const USER_VIEWPORT: Viewport = { x: -50, y: -25, zoom: 0.4 };
+
+/** A stand-in for the bits of ReactFlowInstance this module actually uses,
+ * recording every setViewport call so the set-then-restore contract can be
+ * asserted on rather than assumed. */
+function fakeRf(nodes: ReturnType<typeof fakeNode>[]) {
+  const setViewportCalls: Viewport[] = [];
+  return {
+    getNodes: () => nodes,
+    getViewport: () => USER_VIEWPORT,
+    setViewport: (viewport: Viewport) => {
+      setViewportCalls.push(viewport);
+      return Promise.resolve(true);
+    },
+    setViewportCalls,
+  };
+}
+
 describe("exportCanvasAsPng", () => {
   let viewportEl: HTMLDivElement;
 
@@ -44,19 +62,24 @@ describe("exportCanvasAsPng", () => {
 
   it("does nothing when the canvas has no nodes - no rasterization, no download", async () => {
     const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    const rf = fakeRf([]);
 
-    await exportCanvasAsPng({ getNodes: () => [] }, "--gl-surface-window");
+    await exportCanvasAsPng(rf, "--gl-surface-window");
 
     expect(toPngMock).not.toHaveBeenCalled();
     expect(clickSpy).not.toHaveBeenCalled();
+    // Nothing to export must also mean nothing moved on screen.
+    expect(rf.setViewportCalls).toEqual([]);
   });
 
   it("does nothing when .react-flow__viewport isn't in the DOM", async () => {
     document.body.removeChild(viewportEl); // remove it before calling
+    const rf = fakeRf([fakeNode("n1", 0, 0)]);
 
-    await exportCanvasAsPng({ getNodes: () => [fakeNode("n1", 0, 0)] }, "--gl-surface-window");
+    await exportCanvasAsPng(rf, "--gl-surface-window");
 
     expect(toPngMock).not.toHaveBeenCalled();
+    expect(rf.setViewportCalls).toEqual([]);
 
     document.body.appendChild(viewportEl); // restore for afterEach's own removal
   });
@@ -71,7 +94,7 @@ describe("exportCanvasAsPng", () => {
     document.documentElement.style.setProperty("--gl-surface-window", "#1E1E1E");
     vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
 
-    await exportCanvasAsPng({ getNodes: () => [fakeNode("n1", 0, 0)] }, "--gl-surface-window");
+    await exportCanvasAsPng(fakeRf([fakeNode("n1", 0, 0)]), "--gl-surface-window");
 
     const [, options] = toPngMock.mock.calls[0];
     expect(options.backgroundColor).toBe("#1E1E1E");
@@ -80,7 +103,7 @@ describe("exportCanvasAsPng", () => {
   it("falls back to a concrete dark color when the CSS custom property isn't defined", async () => {
     vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
 
-    await exportCanvasAsPng({ getNodes: () => [fakeNode("n1", 0, 0)] }, "--gl-surface-window-does-not-exist");
+    await exportCanvasAsPng(fakeRf([fakeNode("n1", 0, 0)]), "--gl-surface-window-does-not-exist");
 
     const [, options] = toPngMock.mock.calls[0];
     expect(options.backgroundColor).toBe("#1a1a1a");
@@ -102,7 +125,7 @@ describe("exportCanvasAsPng", () => {
     const expectedBounds = getNodesBounds(nodes);
     const expectedViewport = getViewportForBounds(expectedBounds, 1920, 1080, 0.1, 2.5, 0.1);
 
-    await exportCanvasAsPng({ getNodes: () => nodes }, "--gl-surface-window");
+    await exportCanvasAsPng(fakeRf(nodes), "--gl-surface-window");
 
     expect(toPngMock).toHaveBeenCalledOnce();
     const [target, options] = toPngMock.mock.calls[0];
@@ -116,14 +139,27 @@ describe("exportCanvasAsPng", () => {
     );
   });
 
+  it("pins pixelRatio to 1 so the output really is 1920x1080 on a high-DPI display", async () => {
+    // Audit finding: without this, html-to-image multiplies the canvas by
+    // window.devicePixelRatio - the same graph exported from a 150%-scaled
+    // Windows display came out 2880x1620, contradicting the fixed size this
+    // module documents and giving two users different files for one graph.
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    await exportCanvasAsPng(fakeRf([fakeNode("n1", 0, 0)]), "--gl-surface-window");
+
+    const [, options] = toPngMock.mock.calls[0];
+    expect(options.pixelRatio).toBe(1);
+  });
+
   it("a single node produces a different transform than two spread-out nodes", async () => {
     vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
 
-    await exportCanvasAsPng({ getNodes: () => [fakeNode("n1", 0, 0)] }, "--gl-surface-window");
+    await exportCanvasAsPng(fakeRf([fakeNode("n1", 0, 0)]), "--gl-surface-window");
     const singleNodeTransform = toPngMock.mock.calls[0][1].style.transform;
 
     toPngMock.mockClear();
-    await exportCanvasAsPng({ getNodes: () => [fakeNode("n1", 0, 0), fakeNode("n2", 900, 700)] }, "--gl-surface-window");
+    await exportCanvasAsPng(fakeRf([fakeNode("n1", 0, 0), fakeNode("n2", 900, 700)]), "--gl-surface-window");
     const twoNodeTransform = toPngMock.mock.calls[0][1].style.transform;
 
     expect(twoNodeTransform).not.toBe(singleNodeTransform);
@@ -135,9 +171,59 @@ describe("exportCanvasAsPng", () => {
       captured.anchor = this;
     });
 
-    await exportCanvasAsPng({ getNodes: () => [fakeNode("n1", 0, 0)] }, "--gl-surface-window");
+    await exportCanvasAsPng(fakeRf([fakeNode("n1", 0, 0)]), "--gl-surface-window");
 
     expect(captured.anchor?.getAttribute("href")).toBe("data:image/png;base64,fake");
     expect(captured.anchor?.getAttribute("download")).toMatch(/^graphlink-canvas-.+\.png$/);
+  });
+
+  // -- audit fix: the live viewport must be at the export zoom during capture --
+
+  it("puts the LIVE viewport at the export framing before rasterizing, then restores the user's own", async () => {
+    // Audit finding (real bug): node views read React Flow's live store zoom
+    // to decide whether to render collapsed (lodCollapsed = zoom < 0.5). With
+    // the export transform applied only to html-to-image's clone, a user
+    // zoomed out below that threshold exported title bars with no content -
+    // the clone is taken from DOM React already rendered collapsed, so no
+    // CSS override on the clone can bring the bodies back. Only moving the
+    // live store makes React re-render at the export zoom.
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    const nodes = [fakeNode("n1", 0, 0), fakeNode("n2", 900, 700)];
+    const expectedViewport = getViewportForBounds(getNodesBounds(nodes), 1920, 1080, 0.1, 2.5, 0.1);
+
+    const rf = fakeRf(nodes);
+    let viewportDuringCapture: Viewport | undefined;
+    toPngMock.mockImplementation(() => {
+      viewportDuringCapture = rf.setViewportCalls[rf.setViewportCalls.length - 1];
+      return Promise.resolve("data:image/png;base64,fake");
+    });
+
+    await exportCanvasAsPng(rf, "--gl-surface-window");
+
+    // The zoom in force AT capture time is the computed export zoom, not the
+    // user's 0.4 - this is the assertion the old implementation would fail.
+    expect(viewportDuringCapture).toEqual(expectedViewport);
+    expect(expectedViewport.zoom).not.toBe(USER_VIEWPORT.zoom);
+    // ...and the user is put back exactly where they were.
+    expect(rf.setViewportCalls).toEqual([expectedViewport, USER_VIEWPORT]);
+  });
+
+  it("restores the user's viewport and logs, without rejecting, when rasterization fails", async () => {
+    // Audit finding: toPng genuinely rejects when a node's image asset is
+    // unreachable (a state ImageNodeView already renders a placeholder for).
+    // Both call sites `void` this promise, so an unhandled rejection meant a
+    // dead button and a user stranded at the export zoom.
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    toPngMock.mockRejectedValue(new Error("Failed to embed image"));
+
+    const rf = fakeRf([fakeNode("n1", 0, 0)]);
+
+    await expect(exportCanvasAsPng(rf, "--gl-surface-window")).resolves.toBeUndefined();
+
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith("[export-png] Export failed:", expect.any(Error));
+    // The user must not be left stranded at the export zoom.
+    expect(rf.setViewportCalls[rf.setViewportCalls.length - 1]).toEqual(USER_VIEWPORT);
   });
 });

--- a/web_ui/src/app/canvas/exportCanvasPng.ts
+++ b/web_ui/src/app/canvas/exportCanvasPng.ts
@@ -26,10 +26,35 @@ import { toPng } from "html-to-image";
  * of what's currently visible" - the point of a canvas export is a complete,
  * shareable picture of the conversation, not a viewport crop.
  *
+ * WHY THE LIVE VIEWPORT IS SET AND RESTORED (audit finding, was a real bug):
+ * an earlier version applied the export transform ONLY to html-to-image's own
+ * clone and never touched the live canvas - which sounds strictly better
+ * (no flicker, nothing to restore) but silently made the exported IMAGE
+ * CONTENT depend on the viewer's current zoom, the exact thing the FRAMING
+ * paragraph above promises it doesn't. Every node view derives its collapsed
+ * state from React Flow's LIVE store zoom (ChatNodeView.tsx's
+ * `lodCollapsed = zoom < LOD_ZOOM_THRESHOLD`, threshold 0.5 in
+ * canvasConstants.ts), and a node's body is behind `{!collapsed && ...}` -
+ * so a user zoomed out to 0.4 to see their whole graph (the natural thing to
+ * do right before exporting it) got a PNG of title bars with no content.
+ * Overriding the clone's CSS transform cannot fix that: the clone is taken
+ * from DOM React has already rendered collapsed. The only fix is to put the
+ * live store at the export zoom, let React re-render, and capture that -
+ * hence setViewport + a double-rAF wait for the resulting paint, with the
+ * user's own viewport restored in a `finally` so a failed export can never
+ * strand them somewhere they didn't navigate to. The cost is one frame of
+ * visible movement during an export; the benefit is that the exported image
+ * no longer depends on where the user happened to be looking.
+ *
  * OUTPUT SIZE: a fixed 1920x1080 (a first, simple v1 default rather than
  * dynamically sizing to the content's own aspect ratio - avoids a much
  * larger, more speculative "what's the right image size for an arbitrarily
- * shaped graph" design problem for a first cut of this feature).
+ * shaped graph" design problem for a first cut of this feature). `pixelRatio:
+ * 1` is passed explicitly to make that literally true: html-to-image
+ * otherwise multiplies the canvas by window.devicePixelRatio, so the same
+ * graph exported from a 150%-scaled Windows display came out 2880x1620 and
+ * from a 200% display 3840x2160 - three users, three different files, none of
+ * them the documented size.
  *
  * MIN/MAX ZOOM: reuses the SAME 0.1-2.5 bounds SceneCanvas.tsx's own
  * <ReactFlow minZoom={0.1} maxZoom={2.5}> already enforces on the live
@@ -54,10 +79,15 @@ import { toPng } from "html-to-image";
  * defined - before ever handing anything to toPng is what actually avoids
  * that trap.
  *
- * html-to-image's toPng() clones the target node into an off-screen SVG
- * foreignObject, applies the `style` overrides ONLY to that clone, rasterizes
- * it, then discards the clone - the live page's actual pan/zoom is never
- * touched, so there is no visible flicker and nothing to restore afterward.
+ * FAILURE HANDLING: toPng genuinely rejects in states this app already
+ * anticipates - one unreachable /api/assets/{id} (ImageNodeView renders an
+ * "Image unavailable" placeholder for exactly that case) makes html-to-image's
+ * own embedImageNode reject the whole capture. Both call sites `void` this
+ * function's promise, so an unhandled rejection would mean the button does
+ * nothing, silently, with no way for the user to tell a failed export from a
+ * slow one. Caught and logged here instead, matching ImageNodeView.tsx's own
+ * handleExportImage - the directly analogous "rasterize/fetch, then download
+ * via a temporary anchor" helper in this codebase.
  */
 
 const IMAGE_WIDTH = 1920;
@@ -77,8 +107,18 @@ function resolveBackgroundColor(cssCustomPropertyName: string): string {
   return resolved || FALLBACK_BACKGROUND_COLOR;
 }
 
+/** Two frames, not one: the first rAF fires after React has committed the
+ * setViewport state update, the second after the browser has actually laid
+ * out and painted it. Capturing on the first would race the very re-render
+ * this wait exists to observe. */
+function nextPaint(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  });
+}
+
 export async function exportCanvasAsPng(
-  rf: Pick<ReactFlowInstance, "getNodes">,
+  rf: Pick<ReactFlowInstance, "getNodes" | "getViewport" | "setViewport">,
   backgroundColorVar: string,
 ): Promise<void> {
   const nodes = rf.getNodes();
@@ -98,19 +138,34 @@ export async function exportCanvasAsPng(
   const bounds = getNodesBounds(nodes);
   const viewport = getViewportForBounds(bounds, IMAGE_WIDTH, IMAGE_HEIGHT, MIN_ZOOM, MAX_ZOOM, PADDING);
 
-  const dataUrl = await toPng(viewportEl, {
-    backgroundColor: resolveBackgroundColor(backgroundColorVar),
-    width: IMAGE_WIDTH,
-    height: IMAGE_HEIGHT,
-    style: {
-      width: `${IMAGE_WIDTH}px`,
-      height: `${IMAGE_HEIGHT}px`,
-      transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
-    },
-  });
+  const userViewport = rf.getViewport();
+  try {
+    await rf.setViewport(viewport);
+    await nextPaint();
 
-  const anchor = document.createElement("a");
-  anchor.href = dataUrl;
-  anchor.download = timestampedFilename();
-  anchor.click();
+    const dataUrl = await toPng(viewportEl, {
+      backgroundColor: resolveBackgroundColor(backgroundColorVar),
+      width: IMAGE_WIDTH,
+      height: IMAGE_HEIGHT,
+      pixelRatio: 1,
+      style: {
+        // Redundant with the live viewport we just set, deliberately: it
+        // pins the clone's framing to the exact numbers computed above even
+        // if React Flow's own transform hasn't settled, and it is what React
+        // Flow's documented export recipe does.
+        width: `${IMAGE_WIDTH}px`,
+        height: `${IMAGE_HEIGHT}px`,
+        transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+      },
+    });
+
+    const anchor = document.createElement("a");
+    anchor.href = dataUrl;
+    anchor.download = timestampedFilename();
+    anchor.click();
+  } catch (error) {
+    console.error("[export-png] Export failed:", error);
+  } finally {
+    await rf.setViewport(userViewport);
+  }
 }

--- a/web_ui/src/app/chrome/AppBar.tsx
+++ b/web_ui/src/app/chrome/AppBar.tsx
@@ -83,7 +83,7 @@ export function AppBar({ store }: { store: SceneStore }) {
         type="button"
         className="appbar-btn"
         title="Export the whole canvas as a PNG image"
-        onClick={() => void exportCanvasAsPng({ getNodes }, "--gl-surface-window")}
+        onClick={() => void exportCanvasAsPng({ getNodes, getViewport, setViewport }, "--gl-surface-window")}
       >
         Export PNG
       </button>

--- a/web_ui/src/app/chrome/commands.test.ts
+++ b/web_ui/src/app/chrome/commands.test.ts
@@ -1,4 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
+
+// Mocked so the export-canvas-png test can assert on the WIRING (that run()
+// actually invokes it, with the right instance and token) rather than on
+// "run() didn't throw" - which, since run() `void`s a call to an async
+// function, held for every possible implementation including a no-op.
+const exportCanvasAsPngMock = vi.fn();
+vi.mock("../canvas/exportCanvasPng", () => ({
+  exportCanvasAsPng: (...args: unknown[]) => exportCanvasAsPngMock(...args),
+}));
+
 import { buildCommands } from "./commands";
 import { initialSceneState } from "../canvas/sceneStore";
 import type { OverlayContextValue } from "../overlays/overlays";
@@ -143,10 +153,8 @@ describe("buildCommands", () => {
 
   it("export-canvas-png is disabled with an empty scene and enabled once nodes exist (R6.8)", () => {
     // exportCanvasAsPng itself is fully unit-tested in exportCanvasPng.test.ts
-    // (including the html-to-image mock) - this just confirms the command is
-    // wired to the same hasNodes gate fit-all/organize-nodes already use, and
-    // that run() doesn't throw when there's no real .react-flow__viewport in
-    // the DOM (exportCanvasAsPng's own defensive no-op covers that case).
+    // (including the html-to-image mock) - this confirms the command is wired
+    // to the same hasNodes gate fit-all/organize-nodes already use.
     // @ts-expect-error - test double
     const empty = buildCommands(makeStore([]), makeRf(), makeOverlays());
     const exportEmpty = empty.find((c) => c.id === "export-canvas-png")!;
@@ -154,14 +162,27 @@ describe("buildCommands", () => {
     expect(exportEmpty.enabled()).toBe(false);
 
     const nodeList = [{ id: "n0", x: 0, y: 0, title: "A", kind: "placeholder" }];
-    // rf.getNodes() must ALSO return a real node here (not the default []) -
-    // otherwise run() would hit exportCanvasAsPng's empty-nodes no-op path
-    // instead of the "no real .react-flow__viewport in the DOM" path this
-    // test's own comment claims to exercise.
     // @ts-expect-error - test double
     const withNodes = buildCommands(makeStore(nodeList), makeRf([{ id: "n0" }]), makeOverlays());
     const exportWithNodes = withNodes.find((c) => c.id === "export-canvas-png")!;
     expect(exportWithNodes.enabled()).toBe(true);
-    expect(() => exportWithNodes.run()).not.toThrow();
+  });
+
+  it("export-canvas-png's run() actually invokes exportCanvasAsPng with the instance and background token", () => {
+    // Audit finding: this used to assert `expect(() => run()).not.toThrow()`,
+    // which is vacuous - run() `void`s a call to an async function, and an
+    // async function never throws synchronously, so it held for EVERY
+    // implementation including `run: () => {}` (verified by mutation: the
+    // command could be wired to nothing at all and the suite stayed green).
+    exportCanvasAsPngMock.mockClear();
+    const rf = makeRf([{ id: "n0" }]);
+    const nodeList = [{ id: "n0", x: 0, y: 0, title: "A", kind: "placeholder" }];
+    // @ts-expect-error - test double
+    const commands = buildCommands(makeStore(nodeList), rf, makeOverlays());
+
+    commands.find((c) => c.id === "export-canvas-png")!.run();
+
+    expect(exportCanvasAsPngMock).toHaveBeenCalledOnce();
+    expect(exportCanvasAsPngMock).toHaveBeenCalledWith(rf, "--gl-surface-window");
   });
 });


### PR DESCRIPTION
A 6-dimension adversarial audit of the last four shipped commits (autosave, crash recovery, PNG export, npm audit fix) produced 24 findings. Each was handed to an independent skeptic told to refute it; **14 survived**. This fixes every survivor that was a real defect.

Every fix is **mutation-tested**: a harness reverts each one and confirms the test claiming to cover it actually fails. **14/14 mutants killed.**

## Export PNG (R6.8)

**The exported image silently depended on the viewer's live zoom.** Node views derive collapse from React Flow's live store zoom (`lodCollapsed = zoom < 0.5`), so a user zoomed out to see their whole graph — the natural thing to do right before exporting it — got a PNG of title bars with no content. Overriding the clone's CSS transform can't fix that: the clone comes from DOM React already rendered collapsed. Now sets the live viewport to the export framing, waits a double-rAF for the repaint, captures, and restores the user's viewport in a `finally`. Cost is one frame of visible movement.

**No error handling at all.** `toPng` genuinely rejects when a node's image asset is unreachable (a state `ImageNodeView` already renders a placeholder for), and both call sites `void` the promise — so the button silently did nothing, with no way to tell a failed export from a slow one. Now caught and logged, matching `ImageNodeView`'s own `handleExportImage`.

**Output wasn't the documented size** — 1920×`devicePixelRatio` (2880×1620 on a 150%-scaled Windows display). `pixelRatio` pinned to 1.

## Autosave (R6.6)

**Deleting the currently-open chat silently ended autosave protection.** The change-guard compared content only, and deleting a row leaves the document's digest unchanged — so every later tick short-circuited and the recovery path was unreachable. The guard now compares `chat_id` too, and `deleteChat` clears the dangling `current_chat_id`.

**The docstring described a mechanism that didn't exist.** It claimed the guard covered "auto OR manual" via "register_autosave's own `last_hash` argument" — there was no such argument, and no manual path could reach the cell. Consequence: every manual Save and every `loadChat` was followed by a byte-identical rewrite that bumped `updated_at` and re-sorted the Chat Library. The cell is now genuinely shared — owned by `register_chat_library`, seeded by `saveChat`/`loadChat`, invalidated by `deleteChat`/`newChat`, and passed to `register_autosave` as a real argument.

**Tick loop had no exception guard.** Defence in depth, not a known bug — the audit walked every unguarded line and found no reachable escape today. But the task is never awaited and holds a strong reference for the process's life, so an escape would kill autosave with no signal anywhere.

## Crash recovery (R6.7)

- `configure_logging` replaced `basicConfig` without a StreamHandler, so `python graphlink_desktop.py` with a missing SPA build printed **nothing** and exited 1. stderr is back alongside the file handler.
- `mark_clean_exit` unlinked unconditionally, so two concurrent instances corrupted each other's sentinel and a later crash went unreported. Only the pid that wrote it may remove it. The other half — a false crash notice while a sibling is live — is documented as knowingly unfixed: it needs a pid-liveness check with no safe portable form (`os.kill` signal-0 is POSIX-only; on Windows it would terminate the other process).
- `install_exception_handlers` latched its idempotency flag *before* doing the work, so one failure disabled the hooks permanently with no retry. Set last now, matching `configure_logging`.

## Three tests that looked like coverage but weren't

All verified by mutation:

- `test_autosave_tick_never_regenerates_an_existing_chats_title` changed only a **code** node between ticks, which `_resolve_seed_message` ignores — so the regenerated title was byte-identical and the test passed whether or not the implementation preserved it.
- No autosave test observed the bus: all three `await bus.publish(...)` calls could be replaced with `pass` and the file stayed green.
- `commands.test.ts` asserted `expect(() => run()).not.toThrow()` on a `void`ed async call — which holds for every implementation, including `run: () => {}`.

## Verification

2370 pytest (+12), 1053 vitest (+4), tsc/eslint/build/codegen clean, Qt burn-down gate unchanged at 152.

Also live-driven against a scratch copy of a real `~/.graphlink/chats.db`: 5 real legacy chats (up to 15 nodes) load and then tick **without a rewrite**, confirming the seeded digest survives a real load/save round trip — the one thing the unit tests couldn't prove. Real `chats.db` verified untouched.

## Knowingly not fixed

An autosave tick holds the same `mutation_guard` user intents use, so a manual Save landing in that window is dropped with an "already in progress" warning. Verified real but measured at ~10-50ms once per 30s, with no data loss (the tick writes the same document). Fixing it properly means an awaited handoff rather than a reject — out of scope here.