### PR TITLE
Autosave must yield to the user: make the shared mutation guard ownership-aware

### DIFF
--- a/backend/autosave.py
+++ b/backend/autosave.py
@@ -71,6 +71,7 @@ from typing import Any
 
 from backend.canvas import SceneDocument
 from backend.chat_library import (
+    AUTOSAVE_OWNER,
     _content_digest,
     _fallback_title,
     _resolve_seed_message,
@@ -196,11 +197,22 @@ def register_autosave(
             # interval entirely rather than racing it; the next tick will
             # try again in `interval_seconds`.
             return
+        # Audit fix: claim the guard as AUTOSAVE, not anonymously. A user
+        # intent arriving mid-tick used to be discarded outright, warned about
+        # an operation they never started; knowing an unattended tick is the
+        # holder is what lets chat_library.py's _serialize_mutating_intent
+        # wait the tick out and honor the click instead. Releasing must also
+        # SIGNAL, or a waiting intent would sit out its whole timeout for a
+        # tick that already finished.
         mutation_guard["active"] = True
+        mutation_guard["owner"] = AUTOSAVE_OWNER
+        mutation_guard["released"].clear()
         try:
             await autosave_tick(bus, db_path, canvas_document, notifications, last_saved)
         finally:
             mutation_guard["active"] = False
+            mutation_guard["owner"] = None
+            mutation_guard["released"].set()
 
     async def _loop() -> None:
         while True:

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -389,6 +389,37 @@ def _content_digest(chat_data: dict[str, Any], notes_data: list, pins_data: list
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+USER_OWNER = "user"
+AUTOSAVE_OWNER = "autosave"
+
+# How long a user-initiated intent will wait out an in-flight autosave tick
+# before giving up and warning instead. A tick measures ~10-50ms even on a
+# large canvas, so this is ~40x headroom; the only way to exceed it is a tick
+# genuinely stuck on sqlite's own lock timeout, where a truthful "try again"
+# beats a UI that appears to have frozen.
+AUTOSAVE_YIELD_TIMEOUT_SECONDS = 2.0
+
+
+def _busy_message(owner: str | None) -> str:
+    """Audit finding: the single generic message named "another chat
+    operation" even when the holder was a background autosave the user never
+    started, which reads as a bug rather than as the app protecting itself."""
+    if owner == AUTOSAVE_OWNER:
+        return "Autosave is still finishing. Please try again in a moment."
+    return "Another chat operation is already in progress. Please wait."
+
+
+def _new_mutation_guard() -> dict[str, Any]:
+    """The one definition of the guard's shape, so register_chat_library,
+    backend/autosave.py and the tests can never drift apart on it.
+
+    `released` is constructed with no running event loop on purpose - safe
+    since 3.10 (Event binds its loop at wait() time, not construction), and
+    register_chat_library is genuinely called outside a loop, which is the
+    exact hazard that broke R6.6's own asyncio.create_task call."""
+    return {"active": False, "owner": None, "released": asyncio.Event()}
+
+
 def _new_save_state() -> dict[str, Any]:
     """The one cell tracking "what is currently on disk for this session",
     shared by every path that writes or reads a chat row: autosave's tick,
@@ -451,7 +482,39 @@ def register_chat_library(
     # entry, cleared in a finally - serializes all three against each
     # other, the generalized (load/new included, not just save)
     # counterpart of ChatSessionManager's own _is_saving reentrancy guard.
-    _mutation_in_progress = {"active": False}
+    #
+    # OWNERSHIP (audit fix). The flag above was written when only a
+    # user-initiated intent could ever hold it, which is what makes "drop the
+    # second one and warn" an honest contract: the user really did start two
+    # operations. R6.6 then had a BACKGROUND task claim the same flag, and the
+    # asymmetry went unnoticed - an autosave tick that happened to be mid-write
+    # made the user's own Save/Load/New Chat vanish, with a warning naming an
+    # operation they never started. A background convenience feature must never
+    # be able to beat the user to their own data.
+    #
+    # So the guard now records WHO holds it, and the two directions differ:
+    #   user arrives, autosave holds  -> wait briefly for the tick to finish,
+    #                                    then proceed (ticks are ~10-50ms)
+    #   user arrives, another user holds -> drop + warn, exactly as before
+    #   autosave arrives, anyone holds   -> skip this interval, as before
+    # The wait is bounded: if a tick is genuinely stuck (sqlite's own 30s lock
+    # timeout), the user gets a truthful message instead of a frozen UI. Every
+    # outcome is at least as good as the pre-fix behavior, and the common one
+    # is strictly better - the Save just works.
+    # `released` is set on every release and cleared on every claim.
+    _mutation_in_progress = _new_mutation_guard()
+
+    def _claim_guard(owner: str) -> None:
+        _mutation_in_progress["active"] = True
+        _mutation_in_progress["owner"] = owner
+        _mutation_in_progress["released"].clear()
+
+    def _release_guard() -> None:
+        _mutation_in_progress["active"] = False
+        _mutation_in_progress["owner"] = None
+        _mutation_in_progress["released"].set()
+
+    bus.chat_mutation_guard = _mutation_in_progress
 
     # R6.6 + audit fix: see _new_save_state's own docstring for what this
     # tracks and the two bugs that came from autosave owning it privately.
@@ -471,16 +534,30 @@ def register_chat_library(
 
     def _serialize_mutating_intent(handler):
         async def wrapped(*args, **kwargs):
+            if _mutation_in_progress["active"] and _mutation_in_progress["owner"] == AUTOSAVE_OWNER:
+                # Yield to the user: wait the tick out rather than discarding
+                # their click. On timeout we fall through to the same
+                # drop-and-warn below, so a stuck tick degrades to exactly the
+                # pre-fix behavior instead of hanging.
+                with contextlib.suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(
+                        _mutation_in_progress["released"].wait(),
+                        timeout=AUTOSAVE_YIELD_TIMEOUT_SECONDS,
+                    )
+
             if _mutation_in_progress["active"]:
+                # Re-checked, not assumed: several intents can be released
+                # from the wait above at once, and only the first may claim.
                 if notifications is not None:
-                    notifications.show("Another chat operation is already in progress. Please wait.", "warning")
+                    notifications.show(_busy_message(_mutation_in_progress["owner"]), "warning")
                     await bus.publish("notification")
                 return
-            _mutation_in_progress["active"] = True
+
+            _claim_guard(USER_OWNER)
             try:
                 await handler(*args, **kwargs)
             finally:
-                _mutation_in_progress["active"] = False
+                _release_guard()
 
         return wrapped
 

--- a/backend/tests/test_autosave.py
+++ b/backend/tests/test_autosave.py
@@ -15,6 +15,7 @@ import pytest
 from backend.autosave import autosave_tick, register_autosave
 from backend.canvas import SceneDocument
 from backend.chat_library import (
+    _new_mutation_guard,
     _new_save_state,
     chat_library_payload,
     delete_chat,
@@ -217,7 +218,7 @@ def test_register_autosave_ticks_on_a_real_timer_and_writes_a_row(tmp_path):
     db_path = tmp_path / "chats.db"
     bus, document, notifications = _bus(db_path)
     document.add_chat_node(0, 0, "hello autosave", is_user=True)
-    mutation_guard = {"active": False}
+    mutation_guard = _new_mutation_guard()
 
     async def _run():
         register_autosave(
@@ -240,7 +241,11 @@ def test_register_autosave_skips_a_tick_while_mutation_guard_is_active(tmp_path)
     db_path = tmp_path / "chats.db"
     bus, document, notifications = _bus(db_path)
     document.add_chat_node(0, 0, "hello autosave", is_user=True)
-    mutation_guard = {"active": True}  # simulates a manual load/save/new-chat in flight
+    # Simulates a manual load/save/new-chat already in flight. Built from the
+    # real factory so this can never drift from the production guard's shape.
+    mutation_guard = _new_mutation_guard()
+    mutation_guard["active"] = True
+    mutation_guard["owner"] = "user"
 
     async def _run():
         register_autosave(

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -2,15 +2,20 @@
 saveChat/newChat)."""
 
 import asyncio
+import contextlib
 import json
 import sqlite3
+import time
 
 import pytest
 
 import backend.autosave as autosave_module
-from backend.autosave import autosave_tick
+import backend.chat_library as chat_library_module
+from backend.autosave import autosave_tick, register_autosave
 from backend.canvas import SceneDocument
 from backend.chat_library import (
+    AUTOSAVE_OWNER,
+    USER_OWNER,
     _fallback_title,
     _format_timestamp,
     _resolve_seed_message,
@@ -616,3 +621,175 @@ def test_deleting_a_different_chat_leaves_the_open_session_pointer_alone(db_path
 
     assert document.current_chat_id == saved_id
     assert bus.chat_save_state["chat_id"] == saved_id
+
+
+# -- audit fix: a background autosave tick must never beat the user to their
+# -- own data. The guard is shared, so it has to be ownership-aware.
+
+
+def test_a_user_save_waits_out_a_real_in_flight_autosave_tick_instead_of_being_dropped(db_path, monkeypatch):
+    # Audit finding (the fix this test exists for): _serialize_mutating_intent
+    # DROPS a blocked intent and warns. That contract was written when only a
+    # user-initiated intent could hold the flag. R6.6 then had a BACKGROUND
+    # task claim the same flag, so an autosave tick that happened to be
+    # mid-write made the user's own Save vanish - with a warning naming an
+    # operation they never started.
+    #
+    # Drives the REAL register_autosave loop, deliberately: an earlier version
+    # of this test used a hand-written double that reimplemented the
+    # claim/release itself, which meant mutating the actual _guarded_tick
+    # (dropping its owner tag, or its release signal) left the test green -
+    # the production wiring was never under test at all.
+    bus, document, notifications = _library_session(db_path)
+    document.add_chat_node(0, 0, "hello", is_user=True)
+
+    real_save = autosave_module.save_chat_atomically_row
+
+    def slow_save(*args, **kwargs):
+        # Runs inside autosave's own asyncio.to_thread, so this holds the
+        # guard across a real await point exactly like a slow disk would.
+        time.sleep(0.1)
+        return real_save(*args, **kwargs)
+
+    monkeypatch.setattr(autosave_module, "save_chat_atomically_row", slow_save)
+
+    async def _run():
+        register_autosave(
+            bus, db_path, document, notifications,
+            bus.chat_mutation_guard, bus.chat_save_state, interval_seconds=0.02,
+        )
+        try:
+            for _ in range(200):  # wait for a real tick to claim the guard
+                if bus.chat_mutation_guard["owner"] == AUTOSAVE_OWNER:
+                    break
+                await asyncio.sleep(0.01)
+            assert bus.chat_mutation_guard["owner"] == AUTOSAVE_OWNER, "no real tick ever started"
+
+            # Bounded well under AUTOSAVE_YIELD_TIMEOUT_SECONDS (2.0s): the
+            # save must proceed as soon as the tick RELEASES, not after
+            # sitting out the whole timeout. Without _guarded_tick's release
+            # signal this hangs past 1s and fails here.
+            await asyncio.wait_for(
+                bus.dispatch_intent("app-chat-library", "saveChat", []), timeout=1.0
+            )
+        finally:
+            bus.autosave_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await bus.autosave_task
+
+    asyncio.run(_run())
+
+    assert notifications.visible and notifications.msg_type == "success", notifications.message
+    assert notifications.message.startswith("Saved "), "the user's Save must not be discarded"
+    assert document.current_chat_id is not None
+
+
+def test_a_user_save_still_loses_to_another_user_operation(db_path):
+    # The other direction is deliberate and must NOT change: two real user
+    # operations racing is an honest "you started two things" conflict.
+    bus, document, notifications = _library_session(db_path)
+    document.add_chat_node(0, 0, "hello", is_user=True)
+    bus.chat_mutation_guard["active"] = True
+    bus.chat_mutation_guard["owner"] = USER_OWNER
+
+    async def _run():
+        # Must be rejected IMMEDIATELY, not after sitting out the 2.0s
+        # autosave-yield timeout. Asserting the outcome alone would pass even
+        # if the wait were (wrongly) applied to user-vs-user conflicts too -
+        # the test would just get slower, which no assertion would notice.
+        await asyncio.wait_for(
+            bus.dispatch_intent("app-chat-library", "saveChat", []), timeout=0.5
+        )
+
+    asyncio.run(_run())
+
+    assert get_all_chats(db_path) == []
+    assert notifications.visible and notifications.msg_type == "warning"
+    assert "Another chat operation" in notifications.message
+
+
+def test_a_user_save_gives_up_with_an_honest_message_if_autosave_is_genuinely_stuck(db_path, monkeypatch):
+    # The wait is bounded: a tick stuck on sqlite's own 30s lock timeout must
+    # not freeze the UI. It degrades to the pre-fix drop - but with a message
+    # that names autosave rather than "another chat operation", which is what
+    # made the original warning read as a bug.
+    monkeypatch.setattr(chat_library_module, "AUTOSAVE_YIELD_TIMEOUT_SECONDS", 0.05)
+    bus, document, notifications = _library_session(db_path)
+    document.add_chat_node(0, 0, "hello", is_user=True)
+    bus.chat_mutation_guard["active"] = True
+    bus.chat_mutation_guard["owner"] = AUTOSAVE_OWNER
+    bus.chat_mutation_guard["released"].clear()
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+
+    assert get_all_chats(db_path) == []
+    assert notifications.visible and notifications.msg_type == "warning"
+    assert "Autosave is still finishing" in notifications.message
+
+
+def test_the_guard_is_released_with_its_owner_cleared_after_a_normal_save(db_path):
+    bus, document, notifications = _library_session(db_path)
+    document.add_chat_node(0, 0, "hello", is_user=True)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+
+    guard = bus.chat_mutation_guard
+    assert guard["active"] is False
+    assert guard["owner"] is None
+    assert guard["released"].is_set()
+
+
+def test_the_yield_still_works_on_a_LATER_autosave_tick_not_just_the_first(db_path, monkeypatch):
+    # Mutation testing caught this gap: the test above only ever observes the
+    # FIRST tick to claim the guard, when `released` has never been set. Drop
+    # _guarded_tick's `released.clear()` and that test stays green - but from
+    # the second tick onward a waiting user intent would be woken instantly by
+    # the STALE signal from the previous tick, re-check, find the guard still
+    # held, and be dropped exactly as before the fix. A fix that works once and
+    # then quietly stops working is worse than no fix, so this pins the
+    # steady-state behavior rather than the first-run behavior.
+    bus, document, notifications = _library_session(db_path)
+    document.add_chat_node(0, 0, "hello", is_user=True)
+
+    real_save = autosave_module.save_chat_atomically_row
+
+    def slow_save(*args, **kwargs):
+        time.sleep(0.1)
+        return real_save(*args, **kwargs)
+
+    monkeypatch.setattr(autosave_module, "save_chat_atomically_row", slow_save)
+
+    async def _await_owner(expected):
+        for _ in range(300):
+            if bus.chat_mutation_guard["owner"] == expected:
+                return True
+            await asyncio.sleep(0.01)
+        return False
+
+    async def _run():
+        register_autosave(
+            bus, db_path, document, notifications,
+            bus.chat_mutation_guard, bus.chat_save_state, interval_seconds=0.02,
+        )
+        try:
+            assert await _await_owner(AUTOSAVE_OWNER), "no first tick"
+            assert await _await_owner(None), "first tick never released"
+            assert bus.chat_mutation_guard["released"].is_set()
+
+            # A real change, so the NEXT tick actually writes (and so holds the
+            # guard) instead of short-circuiting on the unchanged-content guard.
+            document.add_chat_node(300, 0, "a second message", is_user=True)
+            assert await _await_owner(AUTOSAVE_OWNER), "no second tick"
+
+            await asyncio.wait_for(
+                bus.dispatch_intent("app-chat-library", "saveChat", []), timeout=1.0
+            )
+        finally:
+            bus.autosave_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await bus.autosave_task
+
+    asyncio.run(_run())
+
+    assert notifications.visible and notifications.msg_type == "success", notifications.message
+    assert notifications.message.startswith("Saved ")


### PR DESCRIPTION
The last remaining confirmed finding from the R6.6/R6.7/R6.8 audit — deliberately deferred out of #137 rather than bolted onto it.

## The bug

`chat_library.py`'s `_mutation_in_progress` flag serializes `loadChat`/`saveChat`/`newChat` by **dropping** a blocked intent and warning *"Another chat operation is already in progress."*

That contract is honest when only user-initiated intents can hold the flag — the user really did start two things. R6.6 then had a **background** autosave task claim the same flag, and the asymmetry went unnoticed: a tick that happened to be mid-write made the user's own Save/Load/New Chat vanish, with a warning naming an operation they never started.

A background convenience feature must never beat the user to their own data.

## The fix

The guard now records **who** holds it, and the two directions differ:

| arriving | holder | behavior |
|---|---|---|
| user | autosave | **wait the tick out, then proceed** (new) |
| user | another user | drop + warn, exactly as before |
| autosave | anyone | skip this interval, exactly as before |

The wait is bounded — `AUTOSAVE_YIELD_TIMEOUT_SECONDS = 2.0`, roughly 40× the measured 10–50ms tick. A tick genuinely stuck on sqlite's own 30s lock timeout degrades to the pre-fix drop rather than freezing the UI, but with a message that names autosave instead of "another chat operation" — which is what made the original warning read as a bug. Every outcome is at least as good as before; the common one is strictly better, in that the Save just works.

The guard's shape now lives in one factory, `_new_mutation_guard()`, so `chat_library`, `autosave` and the tests can't drift apart on it. Its release `Event` is constructed with no running loop on purpose — safe since 3.10, and `register_chat_library` really is called outside a loop, which is the exact hazard that broke R6.6's own `create_task` call.

## Mutation testing caught two bad tests before this shipped

The first attempt failed its own bar, twice:

1. **The test used a hand-written double** that reimplemented the claim/release itself. Mutating the *real* `_guarded_tick` — dropping its owner tag, or its release signal — left the test green. The production wiring was never under test at all. Rewritten to drive the real `register_autosave` loop with a deliberately slow save, bounded by `asyncio.wait_for` so a lost wakeup **fails** rather than merely running slow.

2. That exposed a second gap: the rewritten test only ever observed the **first** tick to claim the guard, so removing `_guarded_tick`'s `released.clear()` still survived. But without it, every tick after the first wakes a waiter on a **stale** signal, which re-checks, finds the guard still held, and drops the user's intent exactly as before. A fix that works once and then quietly stops working is worse than no fix — so there's now a test pinning the steady state, not just the first run.

**All 5 mutants killed**, including both that initially survived.

## Verification

2375 pytest (+5), 1053 vitest unchanged (no frontend touched), tsc/eslint/build clean, Qt burn-down gate unchanged at 152.

Also re-driven against a scratch copy of a real `~/.graphlink/chats.db`: 5 real legacy chats still load and tick without a spurious rewrite through the rewritten guard. Real `chats.db` verified untouched.

With this, every confirmed finding from the audit is closed except one documented as knowingly unfixable safely: the crash sentinel reporting a phantom crash when a second instance is live, which needs a pid-liveness check with no safe portable form (`os.kill` signal-0 is POSIX-only; on Windows it would terminate the other process).