### PR TITLE
Qt-removal R7.4b: Ollama settings page (backend+frontend)

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,24 +1,32 @@
-"""Settings dialog: General + Integrations + API-provider pages
-(Qt-removal plan R2.5d, extended R7.4a).
+"""Settings dialog: General + Integrations + API-provider + Ollama pages
+(Qt-removal plan R2.5d, extended R7.4a, extended R7.4b).
 
 Unlike composer.py/plugins.py this is a genuine REUSE, not a
 reimplementation: SettingsManager (graphlink_licensing.py) and its own
 imports (graphlink_secrets, graphlink_model_catalog) carry zero PySide6
 coupling, confirmed via a runtime sys.modules check in
-test_settings_never_imports_qt below. api_provider.py and
-graphlink_task_config.py (this file's two new R7.4a imports) are
-confirmed Qt-free repo-root survivor modules (Qt-removal plan R7.2).
+test_settings_never_imports_qt below. api_provider.py,
+graphlink_task_config.py, and graphlink_model_catalog.py are confirmed
+Qt-free repo-root survivor modules (Qt-removal plan R7.2); ollama is a
+hard, always-installed dependency (pyproject.toml), not the optional
+llama-cpp-python extra.
 
-Scope (doc/QT_REMOVAL_PLAN.md R2.5d, R7.4a): the General/Appearance page
-(theme, token-counter visibility, system-prompt toggle, notification
-preferences), the Integrations page (GitHub token, write-only), and now
-the API-provider page (OpenAI-Compatible/Anthropic/Gemini endpoint
-config, per-task model assignment, live catalog refresh) are real here.
-Ollama/Llama.cpp pages remain deferred - R7.4b/R7.4c - and the
-update-check pair (checkForUpdates/openRepository) needs a native
-browser-open capability that doesn't exist yet in graphlink_desktop.py.
-The SPA renders those sections disabled with an explicit "lands in R7.4b/
-R7.4c" label rather than faking them.
+Scope (doc/QT_REMOVAL_PLAN.md R2.5d, R7.4a, R7.4b): the General/Appearance
+page, the Integrations page (GitHub token, write-only), the API-provider
+page (OpenAI-Compatible/Anthropic/Gemini), and now the Ollama page
+(reasoning mode, system model scan, per-task model assignment, model pull)
+are real here. Llama.cpp remains deferred - R7.4c - and the update-check
+pair (checkForUpdates/openRepository) needs a native browser-open
+capability that doesn't exist yet in graphlink_desktop.py. The SPA renders
+those sections disabled with an explicit "lands in R7.4c" label rather
+than faking them.
+
+The Ollama page's "Scan Folder..." button is ALSO deferred, narrower than
+the whole page: it needs the same native folder-picker capability R7.4c
+builds for Llama.cpp's GGUF file browse (both are pywebview's
+create_file_dialog, just OPEN_DIALOG vs FOLDER_DIALOG) - deliberately not
+duplicated here ahead of that build. "System Scan" needs no picker and is
+fully real.
 
 The API-provider page deliberately does NOT replicate one piece of legacy
 behavior: the old QWidget pre-filled its API-key field with the saved
@@ -46,9 +54,12 @@ import asyncio
 import threading
 from typing import Any, Callable
 
+import ollama
+
 import api_provider
 import graphlink_task_config as config
 from graphlink_licensing import SettingsManager
+from graphlink_model_catalog import AUTO_MODEL, INHERIT_MODEL
 
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -74,6 +85,18 @@ _KNOWN_API_PROVIDERS = (
     config.API_PROVIDER_ANTHROPIC,
     config.API_PROVIDER_GEMINI,
 )
+
+# Ollama's five per-task model-assignment slots - task_image_gen is
+# deliberately absent (Ollama has no image-generation path, matching
+# legacy: OLLAMA_TASKS in graphlink_settings_bridge.py has the same 5).
+_OLLAMA_TASK_KEYS = (
+    config.TASK_CHAT,
+    config.TASK_TITLE,
+    config.TASK_CHART,
+    config.TASK_WEB_VALIDATE,
+    config.TASK_WEB_SUMMARIZE,
+)
+_OLLAMA_REASONING_MODES = ("Thinking", "Quick")
 
 # Every persistence-touching mutation runs in a worker thread
 # (asyncio.to_thread) so SettingsManager._save_state's json-dump + fsync +
@@ -133,6 +156,46 @@ def _api_model_catalog_for_wire(manager: SettingsManager, provider: str) -> list
     ]
 
 
+def _flatten_ollama_assignment(assignment: Any) -> str:
+    # Wire representation collapses {"mode": ..., "model_id": ...} to a
+    # single string ("inherit"/"auto"/an explicit model id) - matches the
+    # legacy bridge's own _flatten_ollama_assignment exactly, including
+    # preserving an explicit model id verbatim even if it is no longer in
+    # the scanned-models list (the field always shows whatever is actually
+    # persisted, never silently drops it).
+    mode = assignment.get("mode", AUTO_MODEL) if isinstance(assignment, dict) else AUTO_MODEL
+    if mode == "explicit":
+        return assignment.get("model_id") or AUTO_MODEL
+    return mode
+
+
+def _ollama_model_assignments_for_wire(manager: SettingsManager) -> dict[str, str]:
+    raw = manager.get_ollama_model_assignments()
+    return {task: _flatten_ollama_assignment(raw.get(task, {})) for task in _OLLAMA_TASK_KEYS}
+
+
+def _ollama_scan_summary(manager: SettingsManager) -> str:
+    scan_mode = manager.get_ollama_model_scan_mode()
+    scan_path = manager.get_ollama_model_scan_path()
+    cached_models = manager.get_ollama_scanned_models()
+    has_saved_scan = bool(scan_mode or scan_path or manager.get_ollama_model_scan_locations())
+    if not has_saved_scan:
+        return "No saved scan yet. Run a system scan to build the local model list."
+    if not cached_models:
+        return "The last scan is saved, but it did not find any Ollama models."
+    if scan_mode == "folder" and scan_path:
+        # Folder scanning isn't wired in THIS page yet - it needs the same
+        # native-picker capability R7.4c builds for Llama.cpp's GGUF file
+        # browse, deliberately deferred out of this increment's scope (see
+        # doc/QT_REMOVAL_PLAN.md's R7.4 scoping). This branch only DISPLAYS
+        # a scan a user already saved via the legacy Qt app sharing the
+        # same session.dat - it doesn't let this page create one.
+        return f"Using saved scan from folder: {scan_path}"
+    if scan_mode == "system":
+        return "Using saved system scan results from local Ollama locations."
+    return "Using saved scanned model list."
+
+
 def settings_payload(manager: SettingsManager) -> dict[str, Any]:
     return {
         "theme": manager.get_theme(),
@@ -182,6 +245,16 @@ def register_settings(
     def _catalog_state_for(provider: str) -> dict[str, str]:
         return api_catalog_state.get(provider, _default_catalog_state)
 
+    # Ollama has exactly one page (unlike API-provider's 3), so a flat pair
+    # of cells - not one keyed by anything client-supplied - carries no
+    # analog of the per-provider bug the API-provider page's catalog state
+    # had to be fixed for. scan and pull deliberately share one notice
+    # field, matching the legacy bridge's own single self._notice exactly
+    # (not a new gap: legacy never isolated scan-vs-pull messages either).
+    ollama_scan_status = {"value": "idle"}
+    ollama_pull_status = {"value": "idle"}
+    ollama_notice = {"value": ""}
+
     def build_payload() -> dict[str, Any]:
         payload = settings_payload(manager)
         payload["activeSection"] = active_section["value"]
@@ -206,6 +279,15 @@ def register_settings(
         # update when the list changes.
         payload["geminiStaticModels"] = list(api_provider.GEMINI_MODELS_STATIC)
         payload["geminiStaticImageModels"] = list(api_provider.GEMINI_IMAGE_MODELS_STATIC)
+
+        payload["ollamaReasoningMode"] = manager.get_ollama_reasoning_mode()
+        payload["ollamaCurrentModel"] = config.OLLAMA_MODELS.get(config.TASK_CHAT, "")
+        payload["ollamaModelAssignments"] = _ollama_model_assignments_for_wire(manager)
+        payload["ollamaScannedModels"] = manager.get_ollama_scanned_models()
+        payload["ollamaScanSummary"] = _ollama_scan_summary(manager)
+        payload["ollamaScanStatus"] = ollama_scan_status["value"]
+        payload["ollamaPullStatus"] = ollama_pull_status["value"]
+        payload["ollamaNotice"] = ollama_notice["value"]
         return payload
 
     bus.register_topic("app-settings", build_payload)
@@ -492,6 +574,190 @@ def register_settings(
             await bus.publish("notification")
         await bus.publish("app-settings")
 
+    async def set_ollama_reasoning_mode(mode: str):
+        mode = str(mode)
+        if mode not in _OLLAMA_REASONING_MODES:
+            return
+        await asyncio.to_thread(_apply, manager.set_ollama_reasoning_mode, mode)
+
+        def _reapply_if_ollama_is_still_the_live_provider() -> None:
+            # Checked and applied inside the SAME to_thread hop, not split
+            # across an await boundary: a concurrent mode switch (the
+            # toolbar's provider selector) landing in a gap between a
+            # separate check and a later apply could otherwise force the
+            # live provider back to Ollama after the user had already
+            # switched away - the same class of stale-check-then-await
+            # race the R7.4a audit found and fixed elsewhere in this file.
+            # Legacy-parity note (corrected after adversarial review): this
+            # live re-apply is NOT what legacy's own settings dialog did.
+            # graphlink_settings_bridge.py's setOllamaReasoningMode called
+            # _reinitialize_main_window_agent() unconditionally, which just
+            # rebuilds ChatAgent - it never touched the live
+            # OLLAMA_REASONING_MODE global api_provider.py's chat dispatch
+            # actually reads. Legacy's ONLY path that ever updated that
+            # global was a completely separate control - the composer
+            # toolbar's setReasoningLevel - which the Settings dialog was
+            # never wired to. So in real legacy usage, changing reasoning
+            # mode via Settings persisted the value but left the live
+            # think= kwarg stale until the next provider-mode switch or
+            # restart. This re-apply is a genuine fix for that gap, not a
+            # port of existing legacy behavior - gated on
+            # is_local_ollama_mode() so it can't be the mechanism that
+            # forces a user who already switched to a different provider
+            # back onto Ollama.
+            if api_provider.is_local_ollama_mode():
+                api_provider.initialize_local_provider(config.LOCAL_PROVIDER_OLLAMA, {"reasoning_mode": mode})
+
+        await asyncio.to_thread(_reapply_if_ollama_is_still_the_live_provider)
+        await bus.publish("app-settings")
+
+    async def set_ollama_model_assignment(task: str, value: str):
+        # Coerced before use, matching every intent in this file post the
+        # R7.4a audit: task ends up as a dict key below, and a client can
+        # send any JSON type over the wire with zero validation anywhere
+        # in the dispatch path.
+        task = str(task)
+        value = str(value).strip()
+        if task not in _OLLAMA_TASK_KEYS:
+            return
+        if task == config.TASK_CHAT and value == INHERIT_MODEL:
+            # Adversarial-review finding: task_chat has no "inherit"
+            # concept - it IS the base chat model, and its <select> in
+            # SettingsDialog.tsx never renders an "inherit" option (task !==
+            # "task_chat" guards it there). Without this normalization, a
+            # stray or hand-edited "inherit" for this one task would persist
+            # fine but leave the frontend's <select> showing a value with no
+            # matching <option> - falling back here to auto instead, which
+            # the UI CAN represent.
+            value = AUTO_MODEL
+        if not value or value in (INHERIT_MODEL, AUTO_MODEL):
+            assignment = {"mode": value or AUTO_MODEL, "model_id": ""}
+        else:
+            assignment = {"mode": "explicit", "model_id": value}
+
+        def _persist() -> None:
+            # Read-modify-write, all inside this one _apply-locked closure -
+            # not read-before-await-then-write-after. Splitting those across
+            # an await boundary is exactly the R7.4a save_api_configuration
+            # race: a concurrent assignment change for a DIFFERENT task
+            # (two browser tabs on the same session) landing in the gap
+            # would get its own freshly-persisted change silently reverted
+            # by this call's stale pre-read of the whole assignments dict.
+            assignments = manager.get_ollama_model_assignments()
+            assignments[task] = assignment
+            manager.set_ollama_model_assignments(assignments)
+            config.sync_ollama_task_models(manager)
+            if task == config.TASK_CHAT and assignment["mode"] == "explicit":
+                config.set_current_model(assignment["model_id"])
+
+        await asyncio.to_thread(_apply, _persist)
+        await bus.publish("app-settings")
+
+    async def scan_ollama_system():
+        # Check-then-set with no await between them - safe under asyncio's
+        # single-threaded event loop (unlike the two genuinely async-gapped
+        # races above), matching legacy's own isRunning()-guarded no-op.
+        if ollama_scan_status["value"] == "running":
+            return
+        ollama_scan_status["value"] = "running"
+        ollama_notice["value"] = ""
+        await bus.publish("app-settings")
+
+        try:
+            # scan_local_ollama_models never raises for "Ollama not
+            # running" - that's reported via the returned server_reachable/
+            # server_error fields (which legacy's own worker/bridge never
+            # surfaced either; matched here, not newly dropped). Only a
+            # genuine, unexpected exception (e.g. a filesystem error
+            # walking a manifest folder) reaches this except.
+            results = await asyncio.to_thread(api_provider.scan_local_ollama_models, None)
+        except Exception as exc:  # noqa: BLE001 - no secret in this path to redact
+            ollama_scan_status["value"] = "error"
+            ollama_notice["value"] = f"Scan failed: {exc}"
+            await bus.publish("app-settings")
+            return
+
+        def _persist() -> None:
+            manager.set_ollama_model_scan_cache(
+                results.get("models", []),
+                results.get("scan_mode", ""),
+                results.get("scan_path", ""),
+                results.get("locations", []),
+            )
+            config.sync_ollama_task_models(manager)
+
+        try:
+            # Adversarial-review finding: set_ollama_model_scan_cache does a
+            # real disk write (SettingsManager._save_state - json dump +
+            # fsync + atomic replace), which CAN fail (locked file,
+            # permission denied, disk full). Before this fix, a failure here
+            # propagated uncaught out of the intent handler - the WS layer
+            # logs and survives it, but ollama_scan_status["value"] was left
+            # at "running" forever, so the "already running" reentrancy
+            # guard at the top of this function would silently no-op every
+            # future scan for the rest of the session. Legacy never had this
+            # failure mode: its reentrancy check was tied to the QThread
+            # object, nulled at the start of its finished-handler regardless
+            # of whether persistence succeeded.
+            await asyncio.to_thread(_apply, _persist)
+        except Exception as exc:  # noqa: BLE001 - no secret in this path to redact
+            ollama_scan_status["value"] = "error"
+            ollama_notice["value"] = f"Scan failed: {exc}"
+            await bus.publish("app-settings")
+            return
+        ollama_scan_status["value"] = "done"
+        await bus.publish("app-settings")
+
+    async def pull_ollama_model(model_name: str):
+        model_name = str(model_name).strip()
+        if not model_name:
+            ollama_notice["value"] = "Model name cannot be empty."
+            await bus.publish("app-settings")
+            return
+        if ollama_pull_status["value"] == "running":
+            return
+        ollama_pull_status["value"] = "running"
+        ollama_notice["value"] = ""
+        await bus.publish("app-settings")
+
+        try:
+            await asyncio.to_thread(ollama.pull, model_name)
+        except Exception as exc:  # noqa: BLE001 - mapped to a friendly message, matching ModelPullWorkerThread's own 3-way mapping; no secret here to redact (a model name is not a credential)
+            text = str(exc).lower()
+            if "not found" in text:
+                message = f"Model '{model_name}' was not found on the Ollama hub."
+            elif "connection refused" in text:
+                message = "Could not connect to Ollama. Is Ollama running?"
+            else:
+                message = f"An unexpected error occurred: {exc}"
+            ollama_pull_status["value"] = "error"
+            ollama_notice["value"] = message
+            await bus.publish("app-settings")
+            return
+
+        def _persist() -> None:
+            api_provider.invalidate_ollama_capability_cache(model_name)
+            config.set_current_model(model_name)
+
+        try:
+            # Belt-and-suspenders for the same reentrancy-gate hazard fixed
+            # in scan_ollama_system's own _persist call above - unlike that
+            # one, neither invalidate_ollama_capability_cache nor
+            # set_current_model do disk I/O today (both are in-memory-only
+            # global mutations), so this has no realistic failure mode right
+            # now, but a stranded "running" gate is bad enough - and cheap
+            # enough to guard against - that this doesn't wait for one of
+            # them to grow a fallible path first.
+            await asyncio.to_thread(_apply, _persist)
+        except Exception as exc:  # noqa: BLE001 - no secret here to redact (a model name is not a credential)
+            ollama_pull_status["value"] = "error"
+            ollama_notice["value"] = f"An unexpected error occurred: {exc}"
+            await bus.publish("app-settings")
+            return
+        ollama_pull_status["value"] = "done"
+        ollama_notice["value"] = ""
+        await bus.publish("app-settings")
+
     bus.register_intent("app-settings", "setActiveSection", set_active_section)
     bus.register_intent("app-settings", "setTheme", set_theme)
     bus.register_intent("app-settings", "setShowTokenCounter", set_show_token_counter)
@@ -503,3 +769,7 @@ def register_settings(
     bus.register_intent("app-settings", "loadApiModels", load_api_models)
     bus.register_intent("app-settings", "saveApiConfiguration", save_api_configuration)
     bus.register_intent("app-settings", "resetApiSettings", reset_api_settings)
+    bus.register_intent("app-settings", "setOllamaReasoningMode", set_ollama_reasoning_mode)
+    bus.register_intent("app-settings", "setOllamaModelAssignment", set_ollama_model_assignment)
+    bus.register_intent("app-settings", "scanOllamaSystem", scan_ollama_system)
+    bus.register_intent("app-settings", "pullOllamaModel", pull_ollama_model)

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -2,6 +2,7 @@
 
 import asyncio
 
+import ollama
 import pytest
 from graphlink_licensing import SettingsManager
 
@@ -796,3 +797,329 @@ def test_reset_api_settings_intent_clears_everything(manager, monkeypatch):
     assert manager.get_openai_key() == ""
     assert manager.get_api_provider() == "OpenAI-Compatible"
     assert manager.get_api_models("OpenAI-Compatible") == {}
+
+
+# -- R7.4b: Ollama settings page - reasoning mode, per-task model
+# -- assignment, system model scan, model pull. "Scan Folder..." is
+# -- deliberately NOT covered here (deferred alongside R7.4c's native
+# -- folder-picker capability - see backend/settings.py's module
+# -- docstring).
+#
+# graphlink_task_config.OLLAMA_MODELS is a module-level dict mutated
+# IN PLACE by the real sync_ollama_task_models/set_current_model this
+# file's intents call - a plain monkeypatch.setattr on an attribute a
+# function later does `dict[key] = value` on would NOT be restored by
+# monkeypatch's teardown (only whole-object reassignment is). Every test
+# below that can trigger either function replaces the dict with a fresh
+# copy first, so mutations are contained and reverted like any other
+# monkeypatched value.
+
+
+def _isolate_ollama_task_config(monkeypatch):
+    monkeypatch.setattr(config, "OLLAMA_MODELS", dict(config.OLLAMA_MODELS))
+
+
+def test_set_ollama_reasoning_mode_persists_and_rejects_unknown_modes(manager):
+    bus = SessionBus("settings-ollama-reasoning-mode-test")
+    register_settings(bus, manager)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setOllamaReasoningMode", ["Quick"]))
+    assert manager.get_ollama_reasoning_mode() == "Quick"
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setOllamaReasoningMode", ["not-a-real-mode"]))
+    assert manager.get_ollama_reasoning_mode() == "Quick"  # unchanged, not overwritten with garbage
+
+
+def test_set_ollama_reasoning_mode_reapplies_live_only_when_ollama_is_the_active_provider(manager, monkeypatch):
+    # Regression-shaped test for a race preempted at design time (the same
+    # class the R7.4a audit found after the fact): re-applying the live
+    # provider state unconditionally would forcibly switch an active
+    # Anthropic/OpenAI session back to Ollama just because its reasoning
+    # mode changed in the background.
+    calls = []
+    monkeypatch.setattr(api_provider, "initialize_local_provider", lambda *a, **k: calls.append(a))
+
+    monkeypatch.setattr(api_provider, "is_local_ollama_mode", lambda: False)
+    bus = SessionBus("settings-ollama-reasoning-not-active-test")
+    register_settings(bus, manager)
+    asyncio.run(bus.dispatch_intent("app-settings", "setOllamaReasoningMode", ["Quick"]))
+    assert calls == []  # Ollama isn't live - must not touch the live provider at all
+
+    monkeypatch.setattr(api_provider, "is_local_ollama_mode", lambda: True)
+    asyncio.run(bus.dispatch_intent("app-settings", "setOllamaReasoningMode", ["Thinking"]))
+    assert calls == [(config.LOCAL_PROVIDER_OLLAMA, {"reasoning_mode": "Thinking"})]
+
+
+def test_set_ollama_model_assignment_rejects_unknown_task(manager, monkeypatch):
+    _isolate_ollama_task_config(monkeypatch)
+    bus = SessionBus("settings-ollama-assignment-unknown-task-test")
+    register_settings(bus, manager)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setOllamaModelAssignment", ["task_image_gen", "llava"]))
+
+    assert manager.get_ollama_model_assignments().get("task_image_gen") is None
+
+
+def test_set_ollama_model_assignment_explicit_auto_and_inherit(manager, monkeypatch):
+    _isolate_ollama_task_config(monkeypatch)
+    bus = SessionBus("settings-ollama-assignment-modes-test")
+    register_settings(bus, manager)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setOllamaModelAssignment", [config.TASK_TITLE, "llama3.2:3b"]))
+    assert manager.get_ollama_model_assignments()[config.TASK_TITLE] == {"mode": "explicit", "model_id": "llama3.2:3b"}
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setOllamaModelAssignment", [config.TASK_TITLE, "inherit"]))
+    assert manager.get_ollama_model_assignments()[config.TASK_TITLE]["mode"] == "inherit"
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setOllamaModelAssignment", [config.TASK_TITLE, ""]))
+    assert manager.get_ollama_model_assignments()[config.TASK_TITLE]["mode"] == "auto"
+
+
+def test_set_ollama_model_assignment_normalizes_inherit_to_auto_for_task_chat(manager, monkeypatch):
+    # Adversarial-review finding: task_chat has no "inherit" concept (it IS
+    # the base chat model) and its <select> in SettingsDialog.tsx never
+    # renders that option for this one task - a stray/hand-edited "inherit"
+    # for task_chat must not persist as-is, since the frontend would then
+    # show a value its own <select> has no matching <option> for.
+    _isolate_ollama_task_config(monkeypatch)
+    bus = SessionBus("settings-ollama-assignment-chat-inherit-test")
+    register_settings(bus, manager)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setOllamaModelAssignment", [config.TASK_CHAT, "inherit"]))
+
+    assert manager.get_ollama_model_assignments()[config.TASK_CHAT] == {"mode": "auto", "model_id": ""}
+
+
+def test_set_ollama_model_assignment_sets_current_model_for_an_explicit_chat_task(manager, monkeypatch):
+    _isolate_ollama_task_config(monkeypatch)
+    bus = SessionBus("settings-ollama-assignment-current-model-test")
+    register_settings(bus, manager)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setOllamaModelAssignment", [config.TASK_CHAT, "qwen3:8b"]))
+
+    assert config.OLLAMA_MODELS[config.TASK_CHAT] == "qwen3:8b"
+
+
+def test_set_ollama_model_assignment_reads_and_writes_atomically_across_concurrent_calls(manager, monkeypatch):
+    # Mirrors the R7.4a save_api_configuration regression test: the
+    # read-modify-write of the whole assignments dict must happen inside
+    # ONE locked critical section, or a concurrent assignment change for a
+    # DIFFERENT task landing between this call's read and its write gets
+    # silently reverted by this call's stale copy of the dict.
+    _isolate_ollama_task_config(monkeypatch)
+
+    real_apply = settings_module._apply
+    injected = {"done": False}
+
+    def _apply_with_a_concurrent_assignment_in_the_window(mutation, *args):
+        if not injected["done"]:
+            injected["done"] = True
+            assignments = manager.get_ollama_model_assignments()
+            assignments[config.TASK_CHART] = {"mode": "explicit", "model_id": "concurrent-chart-model"}
+            manager.set_ollama_model_assignments(assignments)
+        return real_apply(mutation, *args)
+
+    monkeypatch.setattr(settings_module, "_apply", _apply_with_a_concurrent_assignment_in_the_window)
+    bus = SessionBus("settings-ollama-assignment-race-test")
+    register_settings(bus, manager)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setOllamaModelAssignment", [config.TASK_TITLE, "llama3.2:3b"]))
+
+    assert injected["done"], "the concurrent write never ran - the test no longer exercises the window"
+    assert manager.get_ollama_model_assignments()[config.TASK_TITLE] == {"mode": "explicit", "model_id": "llama3.2:3b"}
+    # Must NOT be reverted - the concurrently-assigned chart model must
+    # survive this call's own read-modify-write.
+    assert manager.get_ollama_model_assignments()[config.TASK_CHART]["model_id"] == "concurrent-chart-model"
+
+
+def test_scan_ollama_system_persists_results_and_reports_done(manager, monkeypatch):
+    _isolate_ollama_task_config(monkeypatch)
+    monkeypatch.setattr(
+        api_provider,
+        "scan_local_ollama_models",
+        lambda scan_path: {"models": ["llama3.2:3b"], "scan_mode": "system", "scan_path": "", "locations": ["~/.ollama"]},
+    )
+    bus = SessionBus("settings-ollama-scan-test")
+    register_settings(bus, manager)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "scanOllamaSystem", []))
+
+    assert manager.get_ollama_scanned_models() == ["llama3.2:3b"]
+    payload = recorder.messages[-1]["payload"]
+    assert payload["ollamaScanStatus"] == "done"
+    assert "llama3.2:3b" in payload["ollamaScannedModels"]
+
+
+def test_scan_ollama_system_reports_error_on_a_genuine_exception(manager, monkeypatch):
+    def _boom(scan_path):
+        raise OSError("permission denied walking manifest folder")
+
+    monkeypatch.setattr(api_provider, "scan_local_ollama_models", _boom)
+    bus = SessionBus("settings-ollama-scan-error-test")
+    register_settings(bus, manager)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "scanOllamaSystem", []))
+
+    payload = recorder.messages[-1]["payload"]
+    assert payload["ollamaScanStatus"] == "error"
+    assert "permission denied" in payload["ollamaNotice"]
+    assert manager.get_ollama_scanned_models() == []  # a failed scan does not persist a partial result
+
+
+def test_scan_ollama_system_is_a_no_op_while_already_running(manager, monkeypatch):
+    calls = []
+    monkeypatch.setattr(api_provider, "scan_local_ollama_models", lambda scan_path: calls.append(1) or {"models": []})
+    bus = SessionBus("settings-ollama-scan-no-op-test")
+    register_settings(bus, manager)
+
+    async def _run():
+        first = asyncio.create_task(bus.dispatch_intent("app-settings", "scanOllamaSystem", []))
+        await asyncio.sleep(0)  # let the first call claim "running" before the second is dispatched
+        await bus.dispatch_intent("app-settings", "scanOllamaSystem", [])
+        await first
+
+    asyncio.run(_run())
+    assert len(calls) == 1
+
+
+def test_scan_ollama_system_persist_failure_reports_error_and_does_not_strand_the_running_gate(manager, monkeypatch):
+    # Adversarial-review finding: set_ollama_model_scan_cache does a real
+    # disk write (json dump + fsync + atomic replace) that CAN fail (locked
+    # file, permission denied, disk full). Before this fix, that exception
+    # propagated uncaught out of the intent handler, leaving
+    # ollama_scan_status["value"] stuck at "running" forever - every future
+    # scanOllamaSystem call would then silently no-op via the "already
+    # running" guard, with no way to recover short of restarting the app.
+    _isolate_ollama_task_config(monkeypatch)
+    monkeypatch.setattr(
+        api_provider, "scan_local_ollama_models", lambda scan_path: {"models": ["llama3.2:3b"], "scan_mode": "system"}
+    )
+
+    def _boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(SettingsManager, "set_ollama_model_scan_cache", _boom)
+    bus = SessionBus("settings-ollama-scan-persist-failure-test")
+    register_settings(bus, manager)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "scanOllamaSystem", []))
+
+    payload = recorder.messages[-1]["payload"]
+    assert payload["ollamaScanStatus"] == "error"
+    assert "disk full" in payload["ollamaNotice"]
+
+    # The gate must not be stranded - a second scan must actually run, not
+    # silently no-op against a status that never left "running".
+    calls = []
+    monkeypatch.setattr(SettingsManager, "set_ollama_model_scan_cache", lambda *a, **k: calls.append(1))
+    asyncio.run(bus.dispatch_intent("app-settings", "scanOllamaSystem", []))
+    assert calls == [1]
+
+
+def test_pull_ollama_model_rejects_an_empty_model_name(manager, monkeypatch):
+    calls = []
+    monkeypatch.setattr(ollama, "pull", lambda name: calls.append(name))
+    bus = SessionBus("settings-ollama-pull-empty-test")
+    register_settings(bus, manager)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "pullOllamaModel", ["   "]))
+
+    assert calls == []
+    assert recorder.messages[-1]["payload"]["ollamaNotice"] == "Model name cannot be empty."
+
+
+def test_pull_ollama_model_success_invalidates_cache_and_sets_current_model(manager, monkeypatch):
+    _isolate_ollama_task_config(monkeypatch)
+    monkeypatch.setattr(ollama, "pull", lambda name: None)
+    invalidated = []
+    monkeypatch.setattr(api_provider, "invalidate_ollama_capability_cache", lambda name: invalidated.append(name))
+    bus = SessionBus("settings-ollama-pull-success-test")
+    register_settings(bus, manager)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "pullOllamaModel", ["qwen3:8b"]))
+
+    assert invalidated == ["qwen3:8b"]
+    assert config.OLLAMA_MODELS[config.TASK_CHAT] == "qwen3:8b"
+    payload = recorder.messages[-1]["payload"]
+    assert payload["ollamaPullStatus"] == "done"
+    assert payload["ollamaNotice"] == ""
+
+
+@pytest.mark.parametrize(
+    "raw_error,expected_fragment",
+    [
+        ("model 'bogus' not found", "was not found on the Ollama hub"),
+        ("connection refused", "Is Ollama running?"),
+        ("some other disk i/o failure", "unexpected error occurred"),
+    ],
+)
+def test_pull_ollama_model_maps_errors_to_friendly_messages(manager, monkeypatch, raw_error, expected_fragment):
+    def _boom(name):
+        raise RuntimeError(raw_error)
+
+    monkeypatch.setattr(ollama, "pull", _boom)
+    bus = SessionBus("settings-ollama-pull-error-test")
+    register_settings(bus, manager)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "pullOllamaModel", ["some-model"]))
+
+    payload = recorder.messages[-1]["payload"]
+    assert payload["ollamaPullStatus"] == "error"
+    assert expected_fragment in payload["ollamaNotice"]
+
+
+def test_pull_ollama_model_is_a_no_op_while_already_running(manager, monkeypatch):
+    calls = []
+    monkeypatch.setattr(ollama, "pull", lambda name: calls.append(name))
+    bus = SessionBus("settings-ollama-pull-no-op-test")
+    register_settings(bus, manager)
+
+    async def _run():
+        first = asyncio.create_task(bus.dispatch_intent("app-settings", "pullOllamaModel", ["model-a"]))
+        await asyncio.sleep(0)
+        await bus.dispatch_intent("app-settings", "pullOllamaModel", ["model-b"])
+        await first
+
+    asyncio.run(_run())
+    assert calls == ["model-a"]
+
+
+def test_pull_ollama_model_persist_failure_reports_error_and_does_not_strand_the_running_gate(manager, monkeypatch):
+    # Same reentrancy-gate hazard as scan_ollama_system's own persist step -
+    # guarded here even though neither invalidate_ollama_capability_cache
+    # nor set_current_model do disk I/O today, so a stuck "running" gate
+    # can't reappear if one of them grows a fallible path later.
+    _isolate_ollama_task_config(monkeypatch)
+    monkeypatch.setattr(ollama, "pull", lambda name: None)
+
+    def _boom(name):
+        raise RuntimeError("cache invalidation blew up")
+
+    monkeypatch.setattr(api_provider, "invalidate_ollama_capability_cache", _boom)
+    bus = SessionBus("settings-ollama-pull-persist-failure-test")
+    register_settings(bus, manager)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "pullOllamaModel", ["qwen3:8b"]))
+
+    payload = recorder.messages[-1]["payload"]
+    assert payload["ollamaPullStatus"] == "error"
+    assert "cache invalidation blew up" in payload["ollamaNotice"]
+
+    calls = []
+    monkeypatch.setattr(api_provider, "invalidate_ollama_capability_cache", lambda name: calls.append(name))
+    asyncio.run(bus.dispatch_intent("app-settings", "pullOllamaModel", ["qwen3:8b"]))
+    assert calls == ["qwen3:8b"]

--- a/graphlink_app/graphlink_app_settings_payload.py
+++ b/graphlink_app/graphlink_app_settings_payload.py
@@ -1,14 +1,15 @@
-"""The SPA settings topic's wire contract (Qt-removal plan R2.5d, extended R7.4a).
+"""The SPA settings topic's wire contract (Qt-removal plan R2.5d, extended R7.4a, R7.4b).
 
 Was deliberately a SUBSET of graphlink_settings_payload.py::SettingsStatePayload
 (General + Integrations fields only) - Ollama/Llama.cpp/API-provider pages
 weren't implemented yet (see backend/settings.py's module docstring for
-why). R7.4a adds the API-provider fields for real; Ollama/Llama.cpp remain
-deferred (R7.4b/R7.4c) so their fields would still be dead weight here -
-the same "only what the SPA actually needs" rationale as every other
-R2.3-R2.5 app-* payload. Registered as its own codegen artifact (topic
-"app-settings") so the generated validator doesn't collide with the legacy
-island's own settings-state.ts.
+why). R7.4a added the API-provider fields for real; R7.4b now adds the
+Ollama fields for real too. Llama.cpp remains deferred (R7.4c) so its
+fields would still be dead weight here - the same "only what the SPA
+actually needs" rationale as every other R2.3-R2.5 app-* payload.
+Registered as its own codegen artifact (topic "app-settings") so the
+generated validator doesn't collide with the legacy island's own
+settings-state.ts.
 """
 
 from __future__ import annotations
@@ -52,4 +53,13 @@ class AppSettingsStatePayload:
     apiCatalogMessage: str
     geminiStaticModels: list[str]
     geminiStaticImageModels: list[str]
+    # R7.4b: Ollama page.
+    ollamaReasoningMode: str
+    ollamaCurrentModel: str
+    ollamaModelAssignments: dict[str, str]
+    ollamaScannedModels: list[str]
+    ollamaScanSummary: str
+    ollamaScanStatus: str
+    ollamaPullStatus: str
+    ollamaNotice: str
     minCompatibleSchemaVersion: int | None = None

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -32,6 +32,14 @@ const snapshot = {
   apiCatalogMessage: "Model catalog has not been refreshed yet.",
   geminiStaticModels: ["gemini-2.5-flash", "gemini-2.5-pro"],
   geminiStaticImageModels: ["gemini-2.5-flash-image"],
+  ollamaReasoningMode: "Thinking",
+  ollamaCurrentModel: "",
+  ollamaModelAssignments: {},
+  ollamaScannedModels: [],
+  ollamaScanSummary: "No saved scan yet. Run a system scan to build the local model list.",
+  ollamaScanStatus: "idle",
+  ollamaPullStatus: "idle",
+  ollamaNotice: "",
 };
 
 function makeTransport() {
@@ -92,6 +100,16 @@ async function goToApiEndpoint(
   act(() => push({ ...snapshot, ...overrides, activeSection: "api endpoint" }));
 }
 
+async function goToOllama(
+  user: ReturnType<typeof userEvent.setup>,
+  push: (payload: Record<string, unknown>) => void,
+  overrides: Record<string, unknown> = {},
+) {
+  await user.click(screen.getByText("open settings"));
+  await user.click(screen.getByRole("button", { name: "Ollama (Local)" }));
+  act(() => push({ ...snapshot, ...overrides, activeSection: "ollama (local)" }));
+}
+
 describe("SettingsDialog", () => {
   it("navigating sections fires setActiveSection with the clicked section's key", async () => {
     const { user, intents } = setup();
@@ -110,13 +128,143 @@ describe("SettingsDialog", () => {
     expect(screen.getByText("API Provider")).toBeInTheDocument();
   });
 
-  it("Ollama and Llama.cpp still render the deferred placeholder", async () => {
+  it("Llama.cpp still renders the deferred placeholder", async () => {
     const { user, push } = setup();
     await user.click(screen.getByText("open settings"));
     await user.click(screen.getByRole("button", { name: "Llama.cpp (Local)" }));
     act(() => push({ ...snapshot, activeSection: "llama.cpp (local)" }));
 
-    expect(screen.getByText("Llama.cpp (Local) configuration lands in R7.4b/R7.4c.")).toBeInTheDocument();
+    expect(screen.getByText("Llama.cpp (Local) configuration lands in R7.4c.")).toBeInTheDocument();
+  });
+
+  it("Ollama page renders for the real (not deferred-placeholder) section", async () => {
+    const { user, push } = setup();
+    await goToOllama(user, push);
+
+    expect(screen.queryByText(/lands in R7\.4c/)).toBeNull();
+    expect(screen.getByText("Reasoning Mode")).toBeInTheDocument();
+  });
+
+  it("clicking a reasoning mode radio fires setOllamaReasoningMode", async () => {
+    const { user, push, intents } = setup();
+    await goToOllama(user, push);
+
+    await user.click(screen.getByLabelText("Quick Mode (No CoT)"));
+
+    expect(intents).toContainEqual(["app-settings", "setOllamaReasoningMode", ["Quick"]]);
+  });
+
+  it("shows the current active model when one is set", async () => {
+    const { user, push } = setup();
+    await goToOllama(user, push, { ollamaCurrentModel: "llama3.2:3b" });
+
+    expect(screen.getByText("llama3.2:3b")).toBeInTheDocument();
+  });
+
+  it("falls back to an Auto message when no current model is set", async () => {
+    const { user, push } = setup();
+    await goToOllama(user, push, { ollamaCurrentModel: "" });
+
+    expect(screen.getByText("Auto - no compatible installed model found")).toBeInTheDocument();
+  });
+
+  it("System Scan fires scanOllamaSystem and disables while running", async () => {
+    const { user, push, intents } = setup();
+    await goToOllama(user, push, { ollamaScanStatus: "running" });
+
+    expect(screen.getByText("Scanning...")).toBeDisabled();
+
+    act(() => push({ ...snapshot, activeSection: "ollama (local)", ollamaScanStatus: "idle" }));
+    await user.click(screen.getByText("System Scan"));
+
+    expect(intents).toContainEqual(["app-settings", "scanOllamaSystem", []]);
+  });
+
+  it("Scan Folder... is disabled - deferred to R7.4c's native picker", async () => {
+    const { user, push } = setup();
+    await goToOllama(user, push);
+
+    expect(screen.getByText("Scan Folder...")).toBeDisabled();
+  });
+
+  it("a per-task select defaults to auto and switching to inherit fires setOllamaModelAssignment immediately", async () => {
+    const { user, push, intents } = setup();
+    await goToOllama(user, push);
+
+    await user.selectOptions(screen.getByLabelText("Chat Naming Model"), "Use chat model");
+
+    expect(intents).toContainEqual(["app-settings", "setOllamaModelAssignment", ["task_title", "inherit"]]);
+  });
+
+  it("task_chat has no 'Use chat model' inherit option (it IS the chat model)", async () => {
+    const { user, push } = setup();
+    await goToOllama(user, push);
+
+    const chatSelect = screen.getByLabelText("Chat Model") as HTMLSelectElement;
+    const optionLabels = Array.from(chatSelect.options).map((o) => o.textContent);
+    expect(optionLabels).not.toContain("Use chat model");
+  });
+
+  it("switching a task to explicit reveals a text field; typing fires setOllamaModelAssignment", async () => {
+    const { user, push, intents } = setup();
+    await goToOllama(user, push);
+
+    await user.selectOptions(screen.getByLabelText("Chart Generation Model"), "Custom model ID...");
+    await user.type(screen.getByLabelText("Chart Generation Model (custom model ID)"), "x");
+
+    expect(intents).toContainEqual(["app-settings", "setOllamaModelAssignment", ["task_chart", "x"]]);
+  });
+
+  it("an existing explicit assignment shows the custom-ID field pre-populated, not the special modes", async () => {
+    const { user, push } = setup();
+    await goToOllama(user, push, { ollamaModelAssignments: { task_chart: "qwen3:8b" } });
+
+    expect(screen.getByLabelText("Chart Generation Model (custom model ID)")).toHaveValue("qwen3:8b");
+  });
+
+  it("scanned models populate the shared datalist used by task fields and the pull input", async () => {
+    const { user, push } = setup();
+    await goToOllama(user, push, { ollamaScannedModels: ["llama3.2:3b", "qwen3:8b"] });
+
+    const datalist = document.getElementById("settings-ollama-scanned-models");
+    expect(datalist?.querySelectorAll("option")).toHaveLength(2);
+  });
+
+  it("Validate and Pull Model stays disabled until a model name is typed", async () => {
+    const { user, push } = setup();
+    await goToOllama(user, push);
+
+    const pullButton = screen.getByRole("button", { name: "Validate and Pull Model" });
+    expect(pullButton).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText("Advanced model ID entry"), "llama3.2:3b");
+    expect(pullButton).toBeEnabled();
+  });
+
+  it("Validate and Pull Model fires pullOllamaModel with the typed name", async () => {
+    const { user, push, intents } = setup();
+    await goToOllama(user, push);
+
+    await user.type(screen.getByPlaceholderText("Advanced model ID entry"), "llama3.2:3b");
+    await user.click(screen.getByRole("button", { name: "Validate and Pull Model" }));
+
+    expect(intents).toContainEqual(["app-settings", "pullOllamaModel", ["llama3.2:3b"]]);
+  });
+
+  it("Validate and Pull Model is disabled and relabeled while a pull is running", async () => {
+    const { user, push } = setup();
+    await goToOllama(user, push, { ollamaPullStatus: "running" });
+
+    await user.type(screen.getByPlaceholderText("Advanced model ID entry"), "llama3.2:3b");
+
+    expect(screen.getByRole("button", { name: "Validating..." })).toBeDisabled();
+  });
+
+  it("an ollamaNotice renders as an inline error", async () => {
+    const { user, push } = setup();
+    await goToOllama(user, push, { ollamaNotice: "Model 'bogus' was not found on the Ollama hub." });
+
+    expect(screen.getByText("Model 'bogus' was not found on the Ollama hub.")).toBeInTheDocument();
   });
 
   it("the API key field always starts blank, even when a key is already configured", async () => {

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -5,19 +5,34 @@ import type { AppSettingsState } from "../../lib/bridge-core/generated/app-setti
 import { Dialog } from "../overlays/overlays";
 
 /**
- * The settings dialog (Qt-removal plan R2.5d, extended R7.4a) - settings
- * island's SPA successor. General + Integrations + API-provider pages are
- * real. Ollama/Llama.cpp remain deferred (R7.4b/R7.4c) - both need a native
- * file-picker capability that doesn't exist yet in graphlink_desktop.py -
- * rendered here as disabled placeholders with an explicit label rather than
- * faking them, the same explicit-defer discipline as the app bar's disabled
- * Save/provider-select.
+ * The settings dialog (Qt-removal plan R2.5d, extended R7.4a, R7.4b) -
+ * settings island's SPA successor. General + Integrations + API-provider +
+ * Ollama pages are real. Llama.cpp remains deferred (R7.4c) - it needs a
+ * native GGUF file-picker capability that doesn't exist yet in
+ * graphlink_desktop.py - rendered here as a disabled placeholder with an
+ * explicit label rather than faking it, the same explicit-defer discipline
+ * as the app bar's disabled Save/provider-select. The Ollama page's own
+ * "Scan Folder..." button is ALSO deferred for the same reason, narrower
+ * than the whole page - see backend/settings.py's module docstring.
  */
 
 const SECTIONS = ["General", "Ollama (Local)", "Llama.cpp (Local)", "API Endpoint", "Integrations"] as const;
 type Section = (typeof SECTIONS)[number];
 
-const DEFERRED_SECTIONS = new Set<Section>(["Ollama (Local)", "Llama.cpp (Local)"]);
+const DEFERRED_SECTIONS = new Set<Section>(["Llama.cpp (Local)"]);
+
+// Mirrors graphlink_task_config.py's TASK_* constants - the same 5-slot set
+// backend/settings.py's _OLLAMA_TASK_KEYS uses (task_image_gen is absent:
+// Ollama has no image-generation path).
+const OLLAMA_TASKS = ["task_chat", "task_title", "task_chart", "task_web_validate", "task_web_summarize"] as const;
+const OLLAMA_TASK_LABELS: Record<(typeof OLLAMA_TASKS)[number], string> = {
+  task_chat: "Chat Model",
+  task_title: "Chat Naming Model",
+  task_chart: "Chart Generation Model",
+  task_web_validate: "Web Content Validation Model",
+  task_web_summarize: "Web Content Summarization Model",
+};
+const OLLAMA_MODELS_DATALIST_ID = "settings-ollama-scanned-models";
 
 const THEME_OPTIONS = [
   { value: "dark", label: "Dark" },
@@ -80,6 +95,14 @@ const initialState: AppSettingsState = {
   apiCatalogMessage: "Model catalog has not been refreshed yet.",
   geminiStaticModels: [],
   geminiStaticImageModels: [],
+  ollamaReasoningMode: "Thinking",
+  ollamaCurrentModel: "",
+  ollamaModelAssignments: {},
+  ollamaScannedModels: [],
+  ollamaScanSummary: "",
+  ollamaScanStatus: "idle",
+  ollamaPullStatus: "idle",
+  ollamaNotice: "",
 };
 
 function sectionKey(section: Section): string {
@@ -416,14 +439,170 @@ function ApiProviderPage({
   );
 }
 
+// The flat wire value ("inherit"|"auto"|"<explicit model id>") maps onto two
+// UI controls: a mode select (mirrors the legacy island's 3 special combo
+// entries) and a conditionally-shown text input for the explicit case. This
+// is a deliberate 2-control simplification of the legacy single editable
+// combo, ported verbatim from web_ui/src/islands/settings/App.tsx's own
+// OllamaTaskField.
+function OllamaTaskField({
+  task,
+  value,
+  transport,
+}: {
+  task: (typeof OLLAMA_TASKS)[number];
+  value: string;
+  transport: WsTransport;
+}) {
+  const isSpecial = value === "inherit" || value === "auto";
+  const [uiMode, setUiMode] = useState(isSpecial ? value : "explicit");
+  const [prevValue, setPrevValue] = useState(value);
+
+  if (value !== prevValue) {
+    setPrevValue(value);
+    setUiMode(isSpecial ? value : "explicit");
+  }
+
+  return (
+    <>
+      <label className="settings-field">
+        <span className="settings-field-label">{OLLAMA_TASK_LABELS[task]}</span>
+        <select
+          className="settings-select"
+          value={uiMode}
+          onChange={(event) => {
+            const nextMode = event.target.value;
+            setUiMode(nextMode);
+            if (nextMode !== "explicit") {
+              transport.intent("app-settings", "setOllamaModelAssignment", [task, nextMode]);
+            }
+          }}
+        >
+          {task !== "task_chat" && <option value="inherit">Use chat model</option>}
+          <option value="auto">Auto - choose a compatible installed model</option>
+          <option value="explicit">Custom model ID...</option>
+        </select>
+      </label>
+      {uiMode === "explicit" && (
+        <label className="settings-field">
+          <span className="settings-field-label">{OLLAMA_TASK_LABELS[task]} (custom model ID)</span>
+          <input
+            type="text"
+            className="settings-select"
+            list={OLLAMA_MODELS_DATALIST_ID}
+            value={isSpecial ? "" : value}
+            onChange={(event) => transport.intent("app-settings", "setOllamaModelAssignment", [task, event.target.value])}
+          />
+        </label>
+      )}
+    </>
+  );
+}
+
+function OllamaPage({ state, transport }: { state: AppSettingsState; transport: WsTransport }) {
+  const [draftPullModel, setDraftPullModel] = useState("");
+
+  return (
+    <div className="settings-general-page">
+      <fieldset className="settings-fieldset">
+        <legend>Reasoning Mode</legend>
+        <label className="settings-checkbox-row">
+          <input
+            type="radio"
+            name="ollama-reasoning-mode"
+            checked={state.ollamaReasoningMode === "Thinking"}
+            onChange={() => transport.intent("app-settings", "setOllamaReasoningMode", ["Thinking"])}
+          />
+          Thinking Mode (Enable CoT)
+        </label>
+        <label className="settings-checkbox-row">
+          <input
+            type="radio"
+            name="ollama-reasoning-mode"
+            checked={state.ollamaReasoningMode === "Quick"}
+            onChange={() => transport.intent("app-settings", "setOllamaReasoningMode", ["Quick"])}
+          />
+          Quick Mode (No CoT)
+        </label>
+      </fieldset>
+
+      <p className="settings-update-status">
+        Current Active Model: <strong>{state.ollamaCurrentModel || "Auto - no compatible installed model found"}</strong>
+      </p>
+
+      <div className="settings-button-row">
+        <button
+          type="button"
+          className="settings-button"
+          disabled={state.ollamaScanStatus === "running"}
+          onClick={() => transport.intent("app-settings", "scanOllamaSystem", [])}
+        >
+          {state.ollamaScanStatus === "running" ? "Scanning..." : "System Scan"}
+        </button>
+        {/* "Scan Folder..." is deliberately deferred - see this file's module
+            docstring - it needs the same native folder-picker capability
+            R7.4c builds for Llama.cpp's GGUF file browse. */}
+        <button type="button" className="settings-button" disabled title="Lands with R7.4c's native file-picker capability">
+          Scan Folder...
+        </button>
+      </div>
+      <p className="settings-update-status">{state.ollamaScanSummary}</p>
+
+      <datalist id={OLLAMA_MODELS_DATALIST_ID}>
+        {state.ollamaScannedModels.map((model) => (
+          <option key={model} value={model} />
+        ))}
+      </datalist>
+
+      <fieldset className="settings-fieldset">
+        <legend>Model Selection (per task)</legend>
+        {OLLAMA_TASKS.map((task) => (
+          <OllamaTaskField
+            key={task}
+            task={task}
+            value={state.ollamaModelAssignments[task] ?? "auto"}
+            transport={transport}
+          />
+        ))}
+      </fieldset>
+
+      <label className="settings-field">
+        <span className="settings-field-label">Validate and Pull Model</span>
+        <input
+          type="text"
+          className="settings-select"
+          list={OLLAMA_MODELS_DATALIST_ID}
+          placeholder="Advanced model ID entry"
+          value={draftPullModel}
+          onChange={(event) => setDraftPullModel(event.target.value)}
+        />
+      </label>
+      <div className="settings-button-row">
+        <button
+          type="button"
+          className="settings-button settings-button-primary"
+          disabled={draftPullModel.trim().length === 0 || state.ollamaPullStatus === "running"}
+          onClick={() => transport.intent("app-settings", "pullOllamaModel", [draftPullModel])}
+        >
+          {state.ollamaPullStatus === "running" ? "Validating..." : "Validate and Pull Model"}
+        </button>
+      </div>
+
+      {state.ollamaNotice && (
+        <p className="settings-update-status" data-level="error">
+          {state.ollamaNotice}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function DeferredPage({ section }: { section: Section }) {
   return (
     <div className="settings-deferred-page">
-      <p>{section} configuration lands in R7.4b/R7.4c.</p>
+      <p>{section} configuration lands in R7.4c.</p>
       <p className="settings-deferred-detail">
-        {section === "Llama.cpp (Local)"
-          ? "Needs a native GGUF file picker that doesn't exist yet in graphlink_desktop.py."
-          : "Backend model scan/pull wiring for this provider hasn't landed yet."}
+        Needs a native GGUF file picker that doesn't exist yet in graphlink_desktop.py.
       </p>
     </div>
   );
@@ -465,6 +644,8 @@ export function SettingsDialog({ transport }: { transport: WsTransport }) {
             <IntegrationsPage state={state} transport={transport} />
           ) : activeSection === "API Endpoint" ? (
             <ApiProviderPage state={state} transport={transport} />
+          ) : activeSection === "Ollama (Local)" ? (
+            <OllamaPage state={state} transport={transport} />
           ) : DEFERRED_SECTIONS.has(activeSection) ? (
             <DeferredPage section={activeSection} />
           ) : (

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
@@ -90,6 +90,36 @@
       },
       "type": "object"
     },
+    "ollamaCurrentModel": {
+      "type": "string"
+    },
+    "ollamaModelAssignments": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "ollamaNotice": {
+      "type": "string"
+    },
+    "ollamaPullStatus": {
+      "type": "string"
+    },
+    "ollamaReasoningMode": {
+      "type": "string"
+    },
+    "ollamaScanStatus": {
+      "type": "string"
+    },
+    "ollamaScanSummary": {
+      "type": "string"
+    },
+    "ollamaScannedModels": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "revision": {
       "type": "integer"
     },
@@ -124,7 +154,15 @@
     "apiCatalogStatus",
     "apiCatalogMessage",
     "geminiStaticModels",
-    "geminiStaticImageModels"
+    "geminiStaticImageModels",
+    "ollamaReasoningMode",
+    "ollamaCurrentModel",
+    "ollamaModelAssignments",
+    "ollamaScannedModels",
+    "ollamaScanSummary",
+    "ollamaScanStatus",
+    "ollamaPullStatus",
+    "ollamaNotice"
   ],
   "title": "AppSettingsState",
   "type": "object"

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
@@ -29,6 +29,14 @@ export interface AppSettingsState {
   apiCatalogMessage: string;
   geminiStaticModels: string[];
   geminiStaticImageModels: string[];
+  ollamaReasoningMode: string;
+  ollamaCurrentModel: string;
+  ollamaModelAssignments: Record<string, string>;
+  ollamaScannedModels: string[];
+  ollamaScanSummary: string;
+  ollamaScanStatus: string;
+  ollamaPullStatus: string;
+  ollamaNotice: string;
   minCompatibleSchemaVersion?: number | null;
 }
 
@@ -174,6 +182,48 @@ function checkAppSettingsState(value: unknown, path: string, errors: string[]): 
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.geminiStaticImageModels: missing required field`);
     else { if (!Array.isArray(fieldValue)) errors.push(`${path}.geminiStaticImageModels` + ": expected array");
     else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "string") errors.push(`${path}.geminiStaticImageModels` + `[${i}]` + ": expected string"); }); }
+  }
+  {
+    const fieldValue = value["ollamaReasoningMode"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.ollamaReasoningMode: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.ollamaReasoningMode` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["ollamaCurrentModel"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.ollamaCurrentModel: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.ollamaCurrentModel` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["ollamaModelAssignments"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.ollamaModelAssignments: missing required field`);
+    else { if (!isRecord(fieldValue)) errors.push(`${path}.ollamaModelAssignments` + ": expected object");
+    else Object.entries(fieldValue as Record<string, unknown>).forEach(([k, v]) => { if (typeof v !== "string") errors.push(`${path}.ollamaModelAssignments` + `[${JSON.stringify(k)}]` + ": expected string"); }); }
+  }
+  {
+    const fieldValue = value["ollamaScannedModels"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.ollamaScannedModels: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.ollamaScannedModels` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "string") errors.push(`${path}.ollamaScannedModels` + `[${i}]` + ": expected string"); }); }
+  }
+  {
+    const fieldValue = value["ollamaScanSummary"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.ollamaScanSummary: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.ollamaScanSummary` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["ollamaScanStatus"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.ollamaScanStatus: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.ollamaScanStatus` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["ollamaPullStatus"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.ollamaPullStatus: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.ollamaPullStatus` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["ollamaNotice"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.ollamaNotice: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.ollamaNotice` + ": expected string"); }
   }
   {
     const fieldValue = value["minCompatibleSchemaVersion"];


### PR DESCRIPTION
## Summary
- Closes the second of R2.5d's 3 deferred settings pages: reasoning mode, per-task model assignment (auto/inherit/explicit), real system model scan, and real model pull - 4 new `backend/settings.py` intents + a new `OllamaPage`/`OllamaTaskField` pair in `SettingsDialog.tsx`.
- Proactively applies the R7.4a "fix classes not instances" lesson at design time: every intent argument is coerced before use, every read-modify-write happens inside one locked closure, and the reasoning-mode live-reapply collapses its check-then-act into a single hop so a concurrent provider switch can't be clobbered back to Ollama.
- A 4-way adversarial review (backend/frontend/integration/legacy-parity) found and fixed 3 real issues: a stranded reentrancy gate on a scan/pull persistence failure, a missing `task_chat` + `"inherit"` normalization gap, and a misleading legacy-parity comment (the reasoning-mode live-reapply is actually a fix for a real legacy staleness bug, not a port of existing behavior). All fixes mutation-tested against reverted code.
- Deliberately deferred, unchanged from the R7.4 scoping call: the Ollama page's "Scan Folder..." button stays disabled (visible tooltip, not silently broken) pending R7.4c's native folder-picker capability. "System Scan" is fully real.

## Test plan
- [x] `python -m compileall -q .` clean
- [x] Burn-down gate (`tests/test_no_qt_anywhere.py`) unchanged: 152/84/68
- [x] Full backend pytest: 2456 passed (2453 + 3 net new)
- [x] Full frontend `npm run check` (schema-check/tsc/eslint/vitest/build): 1081 vitest passed, 0 lint errors, build clean
- [x] All 3 fix-pass regression tests mutation-verified (revert the fix → test fails)
- [x] Live WS drive against a real running backend with a real Ollama server (10 real models scanned, a real pull succeeded), using an isolated scratch settings file - the real `~/.graphlink/session.dat` confirmed byte-identical before and after