### PR TITLE
Qt-removal R7.5a: 4 bundled mechanical parity fixes

### DIFF
--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -271,6 +271,43 @@ def register_plugins(
             await bus.publish("scene")
             return note.id
 
+        if name == "Conversation Node":
+            # R7.5a: ConversationNode has existed since R3.25 with zero
+            # creation path - add_conversation_node was only ever reachable
+            # from backend tests, never from a real UI action. Same
+            # "branch-point child, real valid parent required" posture as
+            # every real node-creation plugin above.
+            if not parent_node_id or parent_node_id not in canvas_document.nodes:
+                notifications.show(
+                    "Please select a valid node to branch from before adding a Conversation Node.",
+                    "warning",
+                )
+                await bus.publish("notification")
+                return None
+            parent = canvas_document.nodes[parent_node_id]
+            node = canvas_document.add_conversation_node(parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id)
+            await bus.publish("scene")
+            return node.id
+
+        if name == "HTML Renderer":
+            # R7.5a: HtmlViewNode has existed since R3.17 with zero creation
+            # path, same gap class as Conversation Node above. Starts with
+            # empty html_content - the same "create blank, then edit in
+            # place" posture add_note's System Prompt branch above and the
+            # plain "Add Note" command already use, since the plugin picker
+            # has no field to source initial HTML from.
+            if not parent_node_id or parent_node_id not in canvas_document.nodes:
+                notifications.show(
+                    "Please select a valid node to branch from before adding an HTML Renderer node.",
+                    "warning",
+                )
+                await bus.publish("notification")
+                return None
+            parent = canvas_document.nodes[parent_node_id]
+            node = canvas_document.add_html_node(parent.x, parent.y + MESSAGE_VERTICAL_SPACING, "", parent_node_id)
+            await bus.publish("scene")
+            return node.id
+
         notifications.show(f'"{name}" node creation lands in R3/R5.', "info")
         await bus.publish("notification")
         return None

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -2,8 +2,6 @@
 
 import asyncio
 
-import pytest
-
 from backend.canvas import SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -87,21 +85,32 @@ def test_register_plugins_publishes_on_the_app_plugins_topic():
     assert recorder.messages[0]["payload"]["categories"]
 
 
-def test_execute_plugin_shows_info_notification_for_known_plugin():
-    # "HTML Renderer" (not "Gitlink"/"Py-Coder"/"Execution Sandbox" - all
-    # three are now real node-creation plugins, see their own dedicated
-    # tests below) stands in for "any plugin name still on the
-    # honest-deferred-notice path".
+def test_execute_plugin_falls_through_to_the_generic_deferred_notice_for_an_unhandled_registered_name(monkeypatch):
+    # R7.5a closed the last 2 gaps (Conversation Node, HTML Renderer) - every
+    # _PLUGINS entry today has its own real branch, so the generic fallback
+    # at the bottom of execute_plugin has no live entry left to exercise
+    # through the real registry. It stays in place as the established growth
+    # path for the NEXT plugin added to _PLUGINS before its own branch lands
+    # (same state every plugin above was once in) - proven still-correct
+    # here by monkeypatching _PLUGINS into exactly that state for one call.
+    import backend.plugins as plugins_module
+
+    monkeypatch.setattr(
+        plugins_module,
+        "_PLUGINS",
+        plugins_module._PLUGINS + [("Future Plugin", "Not yet wired.", "Build & Execution")],
+    )
     bus = SessionBus("plugins-exec-test")
     notifications = NotificationState()
     bus.register_topic("notification", notifications.payload)
     register_plugins(bus, notifications, SceneDocument())
 
-    asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["HTML Renderer"]))
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Future Plugin"]))
+
+    assert result is None
     assert notifications.visible is True
     assert notifications.msg_type == "info"
-    assert "HTML Renderer" in notifications.message
-    assert "R3" in notifications.message or "R5" in notifications.message
+    assert notifications.message == '"Future Plugin" node creation lands in R3/R5.'
 
 
 def test_execute_plugin_shows_warning_notification_for_unknown_plugin():
@@ -555,27 +564,147 @@ def test_execute_plugin_system_prompt_reuses_an_existing_note_instead_of_creatin
     assert sum(1 for n in canvas_document.nodes.values() if n.kind == "note") == 1
 
 
-# -- R5.1/R5.2/R5.3/R5.4/R6.1: non-regression - every OTHER plugin name is
-# still an honest, unchanged deferred notice ----------------------------------
+# -- R7.5a: "Conversation Node" - the seventh real node-creation plugin ------
+#
+# Existed as a real, working node kind since R3.25 (add_conversation_node)
+# with zero UI-reachable creation path - execute_plugin had no branch for
+# it at all, silently falling through to the generic deferred notice despite
+# the node itself being fully functional.
 
 
-@pytest.mark.parametrize(
-    "name",
-    [
-        n for n in (p[0] for p in _PLUGINS)
-        if n not in (
-            "Web Research", "Artifact / Drafter", "Gitlink", "Py-Coder", "Execution Sandbox",
-            "System Prompt",
-        )
-    ],
-)
-def test_execute_plugin_every_other_plugin_name_still_shows_the_unchanged_deferred_notice(name):
+def test_execute_plugin_conversation_node_requires_parent():
     bus, notifications, canvas_document = _make_plugins_bus()
 
-    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", [name]))
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Conversation Node"]))
 
     assert result is None
     assert notifications.visible is True
-    assert notifications.msg_type == "info"
-    assert notifications.message == f'"{name}" node creation lands in R3/R5.'
-    assert not any(n.kind == "web_research" for n in canvas_document.nodes.values())
+    assert notifications.msg_type == "warning"
+    assert notifications.message == (
+        "Please select a valid node to branch from before adding a Conversation Node."
+    )
+    assert not any(n.kind == "conversation" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_conversation_node_rejects_unknown_parent_id():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Conversation Node", "ghost-node-id"])
+    )
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert not any(n.kind == "conversation" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_conversation_node_creates_a_real_conversation_node():
+    bus, notifications, canvas_document = _make_plugins_bus()
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    class Recorder:
+        def __init__(self):
+            self.messages = []
+
+        async def send_json(self, data):
+            self.messages.append(data)
+
+        def topics_seen(self):
+            return [m["topic"] for m in self.messages if m["kind"] == "state"]
+
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Conversation Node", parent.id])
+    )
+
+    assert result is not None
+    node = canvas_document.nodes[result]
+    assert node.kind == "conversation"
+    assert node.title == "Conversation"
+    assert any(
+        e.source == parent.id and e.target == node.id for e in canvas_document.edges.values()
+    )
+    assert notifications.visible is False, "success is not a deferral - no notification fires"
+    assert "scene" in recorder.topics_seen()
+
+
+# -- R7.5a: "HTML Renderer" - the eighth real node-creation plugin -----------
+#
+# Same gap class as Conversation Node above: add_html_node has existed since
+# R3.17 with zero creation path. Starts with empty html_content since the
+# plugin picker has no field to source initial HTML from - same "create
+# blank, then edit in place" posture as "Add Note".
+
+
+def test_execute_plugin_html_renderer_requires_parent():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["HTML Renderer"]))
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == (
+        "Please select a valid node to branch from before adding an HTML Renderer node."
+    )
+    assert not any(n.kind == "html" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_html_renderer_rejects_unknown_parent_id():
+    bus, notifications, canvas_document = _make_plugins_bus()
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["HTML Renderer", "ghost-node-id"])
+    )
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert not any(n.kind == "html" for n in canvas_document.nodes.values())
+
+
+def test_execute_plugin_html_renderer_creates_a_real_html_node_with_empty_content():
+    bus, notifications, canvas_document = _make_plugins_bus()
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    class Recorder:
+        def __init__(self):
+            self.messages = []
+
+        async def send_json(self, data):
+            self.messages.append(data)
+
+        def topics_seen(self):
+            return [m["topic"] for m in self.messages if m["kind"] == "state"]
+
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["HTML Renderer", parent.id])
+    )
+
+    assert result is not None
+    node = canvas_document.nodes[result]
+    assert node.kind == "html"
+    assert node.content == ""
+    assert any(
+        e.source == parent.id and e.target == node.id for e in canvas_document.edges.values()
+    )
+    assert notifications.visible is False, "success is not a deferral - no notification fires"
+    assert "scene" in recorder.topics_seen()
+
+
+def test_every_plugin_now_has_a_real_creation_branch():
+    # R7.5a closes the last 2 gaps - confirms explicitly (rather than
+    # letting the old parametrized non-regression test below silently
+    # collect zero cases) that every _PLUGINS entry has moved off the
+    # generic deferred notice.
+    handled = {
+        "Web Research", "Artifact / Drafter", "Gitlink", "Py-Coder", "Execution Sandbox",
+        "System Prompt", "Conversation Node", "HTML Renderer",
+    }
+    assert handled == {name for name, _description, _category in _PLUGINS}

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -1,8 +1,20 @@
 import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatNodeView, makeDebouncedScrollReport, type ChatFlowNode } from "./ChatNodeView";
+
+// R7.5a: jsdom implements neither URL.createObjectURL nor
+// URL.revokeObjectURL - same hand-installed-fakes pattern
+// ImageNodeView.test.tsx's own Export Image tests already established.
+beforeEach(() => {
+  URL.createObjectURL = vi.fn().mockReturnValue("blob:fake-object-url");
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount): RF's
 // own node wrapper stays `visibility: hidden` in jsdom until its
@@ -79,9 +91,7 @@ describe("ChatNodeView", () => {
     fireEvent.contextMenu(role);
     expect(screen.getByRole("menu")).toBeInTheDocument();
 
-    const exportItem = screen.getByRole("menuitem", { name: "Export" });
-    expect(exportItem).toBeDisabled();
-    expect(exportItem).toHaveAttribute("title", "Export lands in R6");
+    expect(screen.getByRole("menuitem", { name: "Export" })).not.toBeDisabled();
     const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
     expect(hideBranches).toBeDisabled();
     expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
@@ -101,6 +111,30 @@ describe("ChatNodeView", () => {
     fireEvent.contextMenu(role);
     await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
     expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("clicking Export downloads the raw content (not rendered markdown) as a .md file, then closes the menu (R7.5a)", async () => {
+    const user = userEvent.setup();
+    renderChatNode({ content: "Hello **world**" });
+
+    const captured: { anchor?: HTMLAnchorElement } = {};
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        captured.anchor = this;
+      });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    await user.click(screen.getByRole("menuitem", { name: "Export" }));
+
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled());
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    const blobArg = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock.calls[0][0] as Blob;
+    expect(await blobArg.text()).toBe("Hello **world**");
+    expect(captured.anchor?.getAttribute("href")).toBe("blob:fake-object-url");
+    expect(captured.anchor?.getAttribute("download")).toBe("chat-n0.md");
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:fake-object-url");
+    expect(screen.queryByRole("menu")).toBeNull(); // onClose fires after Export
   });
 
   it("Regenerate Response only appears for assistant messages, matching the legacy is_user guard", () => {

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { CHAT_SCROLL_REPORT_DEBOUNCE_MS, LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { downloadTextFile } from "./downloadTextFile";
 
 /**
  * The chat node (Qt-removal plan R3.1/R3.2) - ChatNode's React successor:
@@ -14,9 +15,9 @@ import { CHAT_SCROLL_REPORT_DEBOUNCE_MS, LOD_ZOOM_THRESHOLD } from "./canvasCons
  * (an R3.4 live-drive audit found several legacy ChatNode menu items had
  * been dropped with zero acknowledgment - fixed here): Regenerate (assistant
  * nodes only, needs the R4 agent layer), Key Takeaway/Explainer Note
- * generation (R4, same agent-layer blocker), Export (R6 session/export
- * work), Open Document View (the document-viewer island isn't wired into the
- * SPA overlay system yet), and Hide Other Branches (the legacy scene's
+ * generation (R4, same agent-layer blocker), Open Document View (the
+ * document-viewer island isn't wired into the SPA overlay system yet), and
+ * Hide Other Branches (the legacy scene's
  * branch-visibility toggle has no backend/frontend equivalent at all yet -
  * unscoped, not owned by any R-phase). One legacy item is still deliberately
  * NOT listed even as disabled: "Generate Group Summary" is itself
@@ -41,7 +42,11 @@ import { CHAT_SCROLL_REPORT_DEBOUNCE_MS, LOD_ZOOM_THRESHOLD } from "./canvasCons
  * each dispatching the real generateChart intent with this node as the
  * parent. Key Takeaway/Explainer Note remain honestly deferred (still no
  * agent-layer support of their own) - the stale "Chart" mention in their old
- * shared R4-blocker note above has been removed accordingly.
+ * shared R4-blocker note above has been removed accordingly. "Export" is
+ * likewise no longer deferred as of R7.5a: it downloads the node's raw
+ * content (not the rendered markdown) as a .md file via downloadTextFile -
+ * frontend-only, no backend involved, since the content is already in
+ * memory client-side.
  *
  * R6.3: the node's own scroll position within .chat-node-content (its
  * scrollable markdown body) is now restored on mount and reported
@@ -90,6 +95,7 @@ const CHART_TYPE_OPTIONS: { value: string; label: string }[] = [
 
 function ChatNodeMenu({
   position,
+  nodeId,
   content,
   isUser,
   isCollapsed,
@@ -103,6 +109,7 @@ function ChatNodeMenu({
   onClose,
 }: {
   position: MenuPosition;
+  nodeId: string;
   content: string;
   isUser: boolean;
   isCollapsed: boolean;
@@ -162,7 +169,14 @@ function ChatNodeMenu({
       >
         {isCollapsed ? "Expand" : "Collapse"}
       </button>
-      <button type="button" role="menuitem" disabled title="Export lands in R6">
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          downloadTextFile(content, `chat-${nodeId}.md`);
+          onClose();
+        }}
+      >
         Export
       </button>
       <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
@@ -286,7 +300,7 @@ export function makeDebouncedScrollReport(
   };
 }
 
-export function ChatNodeView({ data, selected }: NodeProps<ChatFlowNode>) {
+export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
   const zoom = useStore((s) => s.transform[2]);
   const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
   const collapsed = data.isCollapsed || lodCollapsed;
@@ -355,6 +369,7 @@ export function ChatNodeView({ data, selected }: NodeProps<ChatFlowNode>) {
       {menuPosition && (
         <ChatNodeMenu
           position={menuPosition}
+          nodeId={id}
           content={data.content}
           isUser={data.isUser}
           isCollapsed={data.isCollapsed}

--- a/web_ui/src/app/canvas/CodeNodeView.test.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.test.tsx
@@ -1,8 +1,20 @@
 import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
+
+// R7.5a: jsdom implements neither URL.createObjectURL nor
+// URL.revokeObjectURL - same hand-installed-fakes pattern
+// ImageNodeView.test.tsx's own Export Image tests already established.
+beforeEach(() => {
+  URL.createObjectURL = vi.fn().mockReturnValue("blob:fake-object-url");
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
 // ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too.
@@ -45,7 +57,7 @@ describe("CodeNodeView", () => {
     expect(screen.getByText("code")).toBeInTheDocument();
   });
 
-  it("right-click opens a menu with real Copy Code/Delete Code Block and deferred Export", async () => {
+  it("right-click opens a menu with real Copy Code/Delete Code Block/Export and deferred Hide Other Branches", async () => {
     const user = userEvent.setup();
     const { onDelete } = renderCodeNode();
 
@@ -56,9 +68,7 @@ describe("CodeNodeView", () => {
     fireEvent.contextMenu(label);
     expect(screen.getByRole("menu")).toBeInTheDocument();
 
-    const exportItem = screen.getByRole("menuitem", { name: "Export" });
-    expect(exportItem).toBeDisabled();
-    expect(exportItem).toHaveAttribute("title", "Export lands in R6");
+    expect(screen.getByRole("menuitem", { name: "Export" })).not.toBeDisabled();
     const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
     expect(hideBranches).toBeDisabled();
     expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
@@ -69,6 +79,45 @@ describe("CodeNodeView", () => {
     fireEvent.contextMenu(label);
     await user.click(screen.getByRole("menuitem", { name: "Delete Code Block" }));
     expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("clicking Export downloads the raw code as a language-appropriate file, then closes the menu (R7.5a)", async () => {
+    const user = userEvent.setup();
+    renderCodeNode({ code: "print('hi')", language: "python" });
+
+    const captured: { anchor?: HTMLAnchorElement } = {};
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        captured.anchor = this;
+      });
+
+    fireEvent.contextMenu(screen.getByText("python"));
+    await user.click(screen.getByRole("menuitem", { name: "Export" }));
+
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled());
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    const blobArg = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock.calls[0][0] as Blob;
+    expect(await blobArg.text()).toBe("print('hi')");
+    expect(captured.anchor?.getAttribute("download")).toBe("code-n0.py");
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:fake-object-url");
+    expect(screen.queryByRole("menu")).toBeNull(); // onClose fires after Export
+  });
+
+  it("falls back to a .txt extension for an unrecognized language (R7.5a)", async () => {
+    const user = userEvent.setup();
+    renderCodeNode({ language: "brainfuck" });
+
+    const captured: { anchor?: HTMLAnchorElement } = {};
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (this: HTMLAnchorElement) {
+      captured.anchor = this;
+    });
+
+    fireEvent.contextMenu(screen.getByText("brainfuck"));
+    await user.click(screen.getByRole("menuitem", { name: "Export" }));
+
+    await waitFor(() => expect(captured.anchor).toBeDefined());
+    expect(captured.anchor?.getAttribute("download")).toBe("code-n0.txt");
   });
 
   it("Regenerate Response renders enabled and fires onRegenerate then closes the menu when parentChatNodeId is non-null", async () => {

--- a/web_ui/src/app/canvas/CodeNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { downloadTextFile } from "./downloadTextFile";
 
 /**
  * The code node (Qt-removal plan R3.5/R3.6) - a card holding a single code
@@ -20,9 +21,14 @@ import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
  * Deferred, with an honest disabled+title label rather than a silent
  * drop (an R3.4 live-drive audit found the legacy CodeNode menu's branch-
  * visibility item had been dropped with zero acknowledgment - fixed here):
- * Export (R6) and Hide Other Branches (the legacy scene's
+ * Hide Other Branches (the legacy scene's
  * branch-visibility toggle has no backend/frontend equivalent at all yet -
- * unscoped, not owned by any R-phase).
+ * unscoped, not owned by any R-phase). "Export" is likewise no longer
+ * deferred as of R7.5a: it downloads the raw code (not the fenced/
+ * highlighted markdown) as a file via downloadTextFile, guessing a
+ * reasonable extension from the language field (LANGUAGE_EXTENSIONS below)
+ * and falling back to .txt for anything unrecognized - frontend-only, no
+ * backend involved, since the code is already in memory client-side.
  */
 
 export interface CodeNodeData extends Record<string, unknown> {
@@ -52,16 +58,54 @@ function toFencedCodeBlock(code: string, language: string): string {
   return "```" + language + "\n" + code + "\n```";
 }
 
+/** R7.5a: a best-effort language -> file extension guess for Export's
+ * download filename - browsers don't require a "correct" extension to
+ * accept a download (same reasoning ImageNodeView.tsx's own filename helper
+ * already documents), so an unrecognized language just falls back to .txt
+ * rather than growing this list to be exhaustive. */
+const LANGUAGE_EXTENSIONS: Record<string, string> = {
+  python: "py",
+  javascript: "js",
+  typescript: "ts",
+  jsx: "jsx",
+  tsx: "tsx",
+  json: "json",
+  bash: "sh",
+  shell: "sh",
+  sh: "sh",
+  html: "html",
+  css: "css",
+  markdown: "md",
+  sql: "sql",
+  java: "java",
+  c: "c",
+  cpp: "cpp",
+  "c++": "cpp",
+  csharp: "cs",
+  go: "go",
+  rust: "rs",
+  yaml: "yaml",
+  xml: "xml",
+};
+
+function codeFileExtension(language: string): string {
+  return LANGUAGE_EXTENSIONS[language.trim().toLowerCase()] ?? "txt";
+}
+
 function CodeNodeMenu({
   position,
+  nodeId,
   code,
+  language,
   parentChatNodeId,
   onRegenerate,
   onDelete,
   onClose,
 }: {
   position: MenuPosition;
+  nodeId: string;
   code: string;
+  language: string;
   parentChatNodeId: string | null;
   onRegenerate: () => void;
   onDelete: () => void;
@@ -103,7 +147,14 @@ function CodeNodeMenu({
       >
         Copy Code
       </button>
-      <button type="button" role="menuitem" disabled title="Export lands in R6">
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          downloadTextFile(code, `code-${nodeId}.${codeFileExtension(language)}`);
+          onClose();
+        }}
+      >
         Export
       </button>
       <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
@@ -136,7 +187,7 @@ function CodeNodeMenu({
   );
 }
 
-export function CodeNodeView({ data, selected }: NodeProps<CodeFlowNode>) {
+export function CodeNodeView({ id, data, selected }: NodeProps<CodeFlowNode>) {
   const zoom = useStore((s) => s.transform[2]);
   const collapsed = zoom < LOD_ZOOM_THRESHOLD;
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
@@ -164,7 +215,9 @@ export function CodeNodeView({ data, selected }: NodeProps<CodeFlowNode>) {
       {menuPosition && (
         <CodeNodeMenu
           position={menuPosition}
+          nodeId={id}
           code={data.code}
+          language={data.language}
           parentChatNodeId={data.parentChatNodeId}
           onRegenerate={data.onRegenerate}
           onDelete={data.onDelete}

--- a/web_ui/src/app/canvas/downloadTextFile.ts
+++ b/web_ui/src/app/canvas/downloadTextFile.ts
@@ -1,0 +1,16 @@
+/** R7.5a: the one place Chat/Code node Export turns raw text into a
+ * downloaded file - a Blob -> object URL -> temporary anchor click, the same
+ * "save this blob as a file" pattern ImageNodeView.tsx's handleExportImage
+ * already established for images (object URL revoked immediately after the
+ * synchronous click, since the browser has already captured what it needs by
+ * then). Shared here rather than duplicated per node view since both Export
+ * actions are otherwise byte-identical. */
+export function downloadTextFile(content: string, filename: string): void {
+  const blob = new Blob([content], { type: "text/plain" });
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(objectUrl);
+}

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -548,6 +548,14 @@ export class SceneStore {
     this.transport.intent("app-chat-library", "saveChat", []);
   }
 
+  // R7.5a: command-palette's "New Chat" - same "app-chat-library", not
+  // "scene", topic-ownership reasoning as saveChat above; newChat already
+  // exists and is wired from the chat-library dialog, this just gives the
+  // command palette a second entry point to the same real intent.
+  newChat(): void {
+    this.transport.intent("app-chat-library", "newChat", []);
+  }
+
   // -- R6.1: Notes/Frames/Containers ----------------------------------------
   //
   // Mirrors backend/canvas.py's register_canvas() intent names/argument

--- a/web_ui/src/app/chrome/commands.test.ts
+++ b/web_ui/src/app/chrome/commands.test.ts
@@ -24,6 +24,7 @@ function makeStore(nodes: Array<{ id: string; x: number; y: number; title: strin
     addNote: vi.fn(),
     createFrame: vi.fn(),
     createContainer: vi.fn(),
+    newChat: vi.fn(),
   };
 }
 
@@ -149,6 +150,38 @@ describe("buildCommands", () => {
     expect(createContainer.enabled()).toBe(true);
     createContainer.run();
     expect(store.createContainer).toHaveBeenCalledWith(["n0", "n1"]);
+  });
+
+  it("new-chat is always enabled and calls store.newChat (R7.5a)", () => {
+    const store = makeStore();
+    // @ts-expect-error - test double
+    const commands = buildCommands(store, makeRf(), makeOverlays());
+    const newChat = commands.find((c) => c.id === "new-chat")!;
+    expect(newChat.enabled()).toBe(true);
+    newChat.run();
+    expect(store.newChat).toHaveBeenCalledTimes(1);
+  });
+
+  it("focus-selection is disabled with no selection and calls fitView scoped to the selected ids when run (R7.5a)", () => {
+    const store = makeStore([
+      { id: "n0", x: 0, y: 0, title: "A", kind: "placeholder" },
+      { id: "n1", x: 0, y: 0, title: "B", kind: "placeholder" },
+    ]);
+    const noneSelected = makeRf([{ id: "n0" }, { id: "n1" }]);
+    // @ts-expect-error - test double
+    const disabled = buildCommands(store, noneSelected, makeOverlays());
+    expect(disabled.find((c) => c.id === "focus-selection")!.enabled()).toBe(false);
+
+    const rf = makeRf([
+      { id: "n0", selected: true },
+      { id: "n1", selected: false },
+    ]);
+    // @ts-expect-error - test double
+    const commands = buildCommands(store, rf, makeOverlays());
+    const focusSelection = commands.find((c) => c.id === "focus-selection")!;
+    expect(focusSelection.enabled()).toBe(true);
+    focusSelection.run();
+    expect(rf.fitView).toHaveBeenCalledWith({ nodes: [{ id: "n0" }], duration: 200 });
   });
 
   it("export-canvas-png is disabled with an empty scene and enabled once nodes exist (R6.8)", () => {

--- a/web_ui/src/app/chrome/commands.ts
+++ b/web_ui/src/app/chrome/commands.ts
@@ -179,6 +179,26 @@ export function buildCommands(
       enabled: () => true,
     },
     {
+      // R7.5a: real, ungated - store.newChat() already exists (wired from
+      // the chat-library dialog); this just gives the palette its own entry
+      // point to the same intent, same posture as "add-note" above.
+      id: "new-chat",
+      name: "New Chat",
+      aliases: ["new session", "clear canvas", "start over"],
+      run: () => store.newChat(),
+      enabled: () => true,
+    },
+    {
+      // R7.5a: zero new capability - rf.fitView with a nodes filter is the
+      // same primitive "fit-all" above already uses, just scoped to the
+      // current selection instead of every node.
+      id: "focus-selection",
+      name: "Focus on Selection",
+      aliases: ["zoom to selection", "frame selection view"],
+      run: () => rf.fitView({ nodes: selectedNodeIds().map((id) => ({ id })), duration: 200 }),
+      enabled: hasSelection,
+    },
+    {
       id: "create-frame",
       name: "Create Frame",
       aliases: ["group into frame", "frame selection"],

--- a/web_ui/src/app/chrome/help-data/sections.ts
+++ b/web_ui/src/app/chrome/help-data/sections.ts
@@ -279,7 +279,7 @@ export const HELP_SECTIONS: HelpSection[] = [
           },
           {
             "action": "Grid and Guide Controls",
-            "description": "The controls overlay can enable snap-to-grid, smart guides, orthogonal routing, font controls, and faded connections. These tools are useful when a canvas needs visual cleanup rather than new AI output."
+            "description": "The controls overlay can enable snap-to-grid and font controls. Smart guides, orthogonal routing, and faded connections are not available yet in this build. These tools are useful when a canvas needs visual cleanup rather than new AI output."
           },
           {
             "action": "Reduce Visual Noise",


### PR DESCRIPTION
## Summary
- Wires "Conversation Node" and "HTML Renderer" into `execute_plugin` — both node kinds have existed since R3.17/R3.25 with zero UI-reachable creation path; reuses the already-shipped `add_conversation_node`/`add_html_node` canvas methods with the same branch-point-child pattern as the other 6 real node-creation plugins.
- Adds "New Chat" and "Focus on Selection" to the command palette (both reuse existing capability — `newChat`'s backend intent already existed, `fitView`/selection reads are already used elsewhere).
- Makes Export real on Chat and Code canvas nodes (previously a disabled "Export lands in R6" stub) — frontend-only download via a new shared `downloadTextFile` helper, matching `ImageNodeView`'s existing Export pattern. Code node guesses a file extension from its language field, falling back to `.txt`.
- Corrects the Help panel's "Grid and Guide Controls" text, which falsely claimed smart guides, orthogonal routing, and faded connections are all available today — none of the three exist yet in this rewritten stack.

This is R7.5a of the Qt-removal plan's R7.5 phase (closing confirmed parity gaps ahead of the Qt cutover) — the smallest, most mechanical bundle of the 7 scoped sub-increments, chosen first since it reuses 100% existing, already-tested backend primitives.

## Test plan
- [x] `backend/tests/test_plugins.py`: new tests for both `execute_plugin` branches (no-parent, unknown-parent, real-creation), a monkeypatch-based test proving the generic fallback notice still works for a future unhandled plugin name, and an explicit check that every `_PLUGINS` entry now has a real branch
- [x] `commands.test.ts`, `ChatNodeView.test.tsx`, `CodeNodeView.test.tsx`: new tests for the 2 commands and both Export actions
- [x] Full verification: 864 backend / 1105 frontend tests passing, typecheck/lint/build clean, Qt-free burn-down gate unchanged
- [x] One adversarial review pass (backend/frontend/integration) — zero confirmed defects, no fix pass needed
- [x] Live-driven against a real `create_app()` instance over the real WS protocol (isolated scratch settings/chat-db files; real `~/.graphlink/session.dat` SHA-256 confirmed unchanged before/after)