### PR TITLE
Qt-removal R7.5f: remove stale phase promises from user-visible text

### DIFF
--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -308,7 +308,7 @@ def register_plugins(
             await bus.publish("scene")
             return node.id
 
-        notifications.show(f'"{name}" node creation lands in R3/R5.', "info")
+        notifications.show(f'"{name}" node creation isn\'t available yet.', "info")
         await bus.publish("notification")
         return None
 

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -110,7 +110,7 @@ def test_execute_plugin_falls_through_to_the_generic_deferred_notice_for_an_unha
     assert result is None
     assert notifications.visible is True
     assert notifications.msg_type == "info"
-    assert notifications.message == '"Future Plugin" node creation lands in R3/R5.'
+    assert notifications.message == '"Future Plugin" node creation isn\'t available yet.'
 
 
 def test_execute_plugin_shows_warning_notification_for_unknown_plugin():

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -100,7 +100,7 @@ describe("ChatNodeView", () => {
     for (const name of ["Generate Key Takeaway", "Generate Explainer Note"]) {
       const item = screen.getByRole("menuitem", { name });
       expect(item).toBeDisabled();
-      expect(item).toHaveAttribute("title", "AI generation lands in R4");
+      expect(item).toHaveAttribute("title", "AI note generation isn't available yet");
     }
     expect(screen.getByRole("menuitem", { name: "Generate Image" })).not.toBeDisabled();
     expect(screen.getByRole("menuitem", { name: "Generate Chart" })).not.toBeDisabled();

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -207,10 +207,10 @@ function ChatNodeMenu({
       <button type="button" role="menuitem" disabled title="Document view integration isn't wired into the SPA yet">
         Open Document View
       </button>
-      <button type="button" role="menuitem" disabled title="AI generation lands in R4">
+      <button type="button" role="menuitem" disabled title="AI note generation isn't available yet">
         Generate Key Takeaway
       </button>
-      <button type="button" role="menuitem" disabled title="AI generation lands in R4">
+      <button type="button" role="menuitem" disabled title="AI note generation isn't available yet">
         Generate Explainer Note
       </button>
       {/* R6.2: a real click-to-expand submenu (not disabled) - same

--- a/web_ui/src/app/canvas/DocumentNodeView.test.tsx
+++ b/web_ui/src/app/canvas/DocumentNodeView.test.tsx
@@ -195,7 +195,7 @@ describe("DocumentNodeView", () => {
 
     const exportItem = screen.getByRole("menuitem", { name: "Export" });
     expect(exportItem).toBeDisabled();
-    expect(exportItem).toHaveAttribute("title", "Export lands in R6");
+    expect(exportItem).toHaveAttribute("title", "Document export isn't available yet");
 
     // filePath is empty -> Open File must be entirely absent, matching the
     // legacy menu's own conditional (only added when file_path is set).

--- a/web_ui/src/app/canvas/DocumentNodeView.tsx
+++ b/web_ui/src/app/canvas/DocumentNodeView.tsx
@@ -263,7 +263,7 @@ function DocumentNodeMenu({
       )}
       <div className="chat-node-menu-separator" role="separator" />
       {isDocumentKind && (
-        <button type="button" role="menuitem" disabled title="Export lands in R6">
+        <button type="button" role="menuitem" disabled title="Document export isn't available yet">
           Export
         </button>
       )}

--- a/web_ui/src/app/canvas/HtmlNodeView.test.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.test.tsx
@@ -178,7 +178,7 @@ describe("HtmlNodeView", () => {
     expect(popout).toBeDisabled();
     expect(popout).toHaveAttribute(
       "title",
-      "Popout view isn't built yet - see the R3 plan doc for why a naive window.open() would be unsafe for untrusted HTML",
+      "Popout view isn't built yet - opening untrusted HTML in a separate window needs a security review first",
     );
 
     await user.click(popout); // disabled - fires nothing

--- a/web_ui/src/app/canvas/HtmlNodeView.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.tsx
@@ -202,7 +202,7 @@ export function HtmlNodeView({ data, selected }: NodeProps<HtmlFlowNode>) {
             type="button"
             className="html-node-header-btn"
             disabled
-            title="Popout view isn't built yet - see the R3 plan doc for why a naive window.open() would be unsafe for untrusted HTML"
+            title="Popout view isn't built yet - opening untrusted HTML in a separate window needs a security review first"
           >
             Popout
           </button>

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -146,7 +146,7 @@ function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
           on bottom. */}
       <Handle type="target" position={Position.Top} className="scene-node-handle" />
       <div className="scene-node-title">{data.title}</div>
-      {!collapsed && <div className="scene-node-body">placeholder — real nodes land in R3</div>}
+      {!collapsed && <div className="scene-node-body">Placeholder node</div>}
       <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
     </div>
   );

--- a/web_ui/src/app/chrome/AppBar.tsx
+++ b/web_ui/src/app/chrome/AppBar.tsx
@@ -116,7 +116,7 @@ export function AppBar({ store }: { store: SceneStore }) {
         value="Ollama (Local)"
         aria-label="Provider mode"
         disabled
-        title="Provider modes land in R4"
+        title="Switching provider modes isn't available yet"
         onChange={() => {}}
       >
         <option>Ollama (Local)</option>

--- a/web_ui/src/app/chrome/Composer.test.tsx
+++ b/web_ui/src/app/chrome/Composer.test.tsx
@@ -69,7 +69,9 @@ describe("Composer", () => {
     );
     expect(screen.getByLabelText("Send message")).toBeDisabled();
     expect(screen.getByLabelText("Attach context")).toBeDisabled();
-    expect(screen.getByTitle("Model/provider selection lands in R4")).toBeDisabled();
+    expect(
+      screen.getByTitle("Model selection isn't available here yet - configure models in Settings"),
+    ).toBeDisabled();
   });
 
   it("Send is enabled once there's text, calls sceneStore.sendMessage, and clears the draft", async () => {

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -95,7 +95,7 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
           type="button"
           className="composer-icon-button"
           disabled
-          title="Attachments land in R4 (file-staging pipeline)"
+          title="Attachments aren't available yet"
           aria-label="Attach context"
         >
           <Icon name="attach" />
@@ -119,7 +119,7 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
           type="button"
           className="composer-control"
           disabled
-          title="Model/provider selection lands in R4"
+          title="Model selection isn't available here yet - configure models in Settings"
         >
           <span className="control-copy">
             <span className="control-kicker">{composer.route.provider}</span>


### PR DESCRIPTION
Final R7.5 parity sub-increment, closing the phase (a–g). Previous: #147, #148/#149/#150, #151, #152/#153, #154.

## Problem

Several disabled controls and one backend notification told users a capability would arrive in an internal project phase (R3/R4/R5/R6) that had **already shipped and closed** — the app promised "coming in R4" when R4 was long done and the feature still wasn't there.

Scope was derived by grepping the codebase rather than from the plan's "4 R4 placeholders" shorthand, which undercounted it. Eight strings across six files, including a stale **R6** promise on `DocumentNodeView`'s Export item and a **backend notification** in `plugins.py`'s `executePlugin` fallthrough — neither of which an "R4" search would have found.

## Change

Phase-free replacements:

| Location | New text |
|---|---|
| `ChatNodeView` — Key Takeaway, Explainer Note | "AI note generation isn't available yet" |
| `DocumentNodeView` — Export | "Document export isn't available yet" |
| `AppBar` — provider mode select | "Switching provider modes isn't available yet" |
| `Composer` — attach | "Attachments aren't available yet" |
| `Composer` — model/provider | "Model selection isn't available here yet - configure models in Settings" |
| `plugins.py` — executePlugin fallthrough | node creation "isn't available yet" |
| `HtmlNodeView` — popout | keeps the real security reason, drops the internal plan-doc citation |
| `SceneCanvas` — placeholder node body | "Placeholder node" |

Every new claim was checked against the code before being written, to avoid replacing one false statement with another. Model selection **is** genuinely reachable in Settings for all three providers (`setOllamaModelAssignment`, `saveApiConfiguration`/`loadApiModels`, `setLlamaCppChatModelPath`), so the one string that points somewhere is accurate. Provider-**mode** switching exists nowhere — `set_current_mode` is only called by `bootstrap_provider_state` at startup — so that string deliberately offers no workaround.

Five coupled test assertions updated to match.

## Test plan

- [x] 885 backend / 1208 frontend tests pass, 0 lint errors, typecheck/build clean
- [x] Burn-down gate unchanged at 152/84/68 (text-only, no Qt files touched)
- [x] Adversarial review verified each new string against the code — confirmed all five remaining deferrals are genuinely unimplemented (no takeaway/explainer backend symbols; `capabilities.attachments` still `False`; `downloadTextFile` imported only by ChatNodeView/CodeNodeView) and that the HtmlNodeView rewording matches the actual sandbox posture (`sandbox="allow-scripts"`, no `allow-same-origin`)
- [x] Review caught one miss, now fixed: `SceneCanvas`'s `PlaceholderNodeView` rendered "placeholder — real nodes land in R3" as body text — the most visible instance, reachable by double-clicking empty canvas and as the fallback for any unrecognized node kind. The initial sweep covered `title` attributes and quoted strings but not JSX text content.
- [x] Final sweep confirms zero user-visible phase references remain in `web_ui/src/app/` or `backend/`; remaining hits are code comments, docstrings, and test-failure messages (internal history, out of scope)
