### PR TITLE
R8a: portal node context menus so they land where you click

### DIFF
--- a/web_ui/src/app/canvas/ArtifactNodeView.tsx
+++ b/web_ui/src/app/canvas/ArtifactNodeView.tsx
@@ -1,9 +1,10 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The artifact node (Qt-removal plan R5.2) - the Artifact/Drafter plugin's
@@ -65,25 +66,6 @@ interface MenuPosition {
 /** Same outside-click/Escape dismiss pattern every sibling node menu uses
  * (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu/ConversationNodeMenu/
  * WebResearchNodeMenu). */
-function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
-  useEffect(() => {
-    function onPointerDown(event: PointerEvent) {
-      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
-      // type-only import above shadows the bare name for casts like this).
-      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
-    }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [menuRef, onClose]);
-}
-
 // -- card-level menu -------------------------------------------------------
 
 function ArtifactNodeMenu({
@@ -99,16 +81,9 @@ function ArtifactNodeMenu({
   onDelete: () => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
-  useMenuDismiss(menuRef, onClose);
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       <button
         type="button"
         role="menuitem"
@@ -130,7 +105,7 @@ function ArtifactNodeMenu({
       >
         Delete Node
       </button>
-    </div>
+    </NodeMenu>
   );
 }
 

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { CHAT_SCROLL_REPORT_DEBOUNCE_MS, LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { downloadTextFile } from "./downloadTextFile";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The chat node (Qt-removal plan R3.1/R3.2) - ChatNode's React successor:
@@ -122,33 +123,11 @@ function ChatNodeMenu({
   onGenerateChart: (chartType: string) => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
   const [chartMenuOpen, setChartMenuOpen] = useState(false);
 
-  useEffect(() => {
-    function onPointerDown(event: PointerEvent) {
-      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
-      // type-only import above shadows the bare name for casts like this).
-      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
-    }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [onClose]);
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       <button
         type="button"
         role="menuitem"
@@ -277,7 +256,7 @@ function ChatNodeMenu({
           Regenerate Response
         </button>
       )}
-    </div>
+    </NodeMenu>
   );
 }
 

--- a/web_ui/src/app/canvas/CodeNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.tsx
@@ -1,10 +1,11 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { downloadTextFile } from "./downloadTextFile";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The code node (Qt-removal plan R3.5/R3.6) - a card holding a single code
@@ -111,32 +112,10 @@ function CodeNodeMenu({
   onDelete: () => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    function onPointerDown(event: PointerEvent) {
-      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
-      // type-only import above shadows the bare name for casts like this).
-      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
-    }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [onClose]);
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       <button
         type="button"
         role="menuitem"
@@ -183,7 +162,7 @@ function CodeNodeMenu({
       >
         Delete Code Block
       </button>
-    </div>
+    </NodeMenu>
   );
 }
 

--- a/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
@@ -1,11 +1,12 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import type { StreamListener } from "../../lib/ws/transport";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { CodeExecutionApprovalPanel } from "./CodeExecutionApprovalPanel";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The Execution Sandbox node (Qt-removal plan R5.4) - the Code-Sandbox
@@ -81,25 +82,6 @@ interface MenuPosition {
 
 /** Same outside-click/Escape dismiss pattern every sibling node menu uses
  * (ChatNodeMenu/ArtifactNodeMenu/GitlinkNodeMenu/PyCoderNodeMenu/...). */
-function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
-  useEffect(() => {
-    function onPointerDown(event: PointerEvent) {
-      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
-      // type-only import above shadows the bare name for casts like this).
-      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
-    }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [menuRef, onClose]);
-}
-
 // -- card-level menu -------------------------------------------------------
 
 function CodeSandboxNodeMenu({
@@ -115,16 +97,9 @@ function CodeSandboxNodeMenu({
   onDelete: () => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
-  useMenuDismiss(menuRef, onClose);
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       <button
         type="button"
         role="menuitem"
@@ -146,7 +121,7 @@ function CodeSandboxNodeMenu({
       >
         Delete Node
       </button>
-    </div>
+    </NodeMenu>
   );
 }
 

--- a/web_ui/src/app/canvas/ConversationNodeView.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.tsx
@@ -1,9 +1,10 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The conversation node (Qt-removal plan R3.25/R3.26) - ConversationNode's
@@ -66,25 +67,6 @@ interface MenuPosition {
 
 /** Shared outside-click/Escape dismiss behavior - identical pattern to every
  * sibling menu component (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu). */
-function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
-  useEffect(() => {
-    function onPointerDown(event: PointerEvent) {
-      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
-      // type-only import above shadows the bare name for casts like this).
-      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
-    }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [menuRef, onClose]);
-}
-
 // -- card-level menu -------------------------------------------------------
 
 function ConversationNodeMenu({
@@ -100,16 +82,9 @@ function ConversationNodeMenu({
   onDelete: () => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
-  useMenuDismiss(menuRef, onClose);
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       {/* Order verified against the legacy PluginNodeContextMenu's own
           construction order for this node kind: Open Document View,
           Collapse/Expand, Delete Node - nothing else. */}
@@ -137,7 +112,7 @@ function ConversationNodeMenu({
       >
         Delete Node
       </button>
-    </div>
+    </NodeMenu>
   );
 }
 
@@ -154,16 +129,9 @@ function ConversationBubbleMenu({
   onDeleteMessage: () => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
-  useMenuDismiss(menuRef, onClose);
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       <button
         type="button"
         role="menuitem"
@@ -186,7 +154,7 @@ function ConversationBubbleMenu({
       >
         Delete from History
       </button>
-    </div>
+    </NodeMenu>
   );
 }
 

--- a/web_ui/src/app/canvas/DocumentNodeView.tsx
+++ b/web_ui/src/app/canvas/DocumentNodeView.tsx
@@ -1,6 +1,7 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The document node (Qt-removal plan R3.9/R3.10) - graphlink_node_document.py's
@@ -183,24 +184,7 @@ function DocumentNodeMenu({
   onDelete: () => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    function onPointerDown(event: PointerEvent) {
-      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
-      // type-only import above shadows the bare name for casts like this).
-      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
-    }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [onClose]);
 
   const isAudio = attachmentKind === "audio";
   // Legacy gate is `attachment_kind == "document"` (a strict allow-list), not
@@ -211,12 +195,7 @@ function DocumentNodeMenu({
   const isDocumentKind = attachmentKind === "document";
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       {/* Order verified against graphlink_node_document_menu.py's own
           construction order: Copy Details, Collapse/Expand, Dock, Open File
           (conditional), separator, Export (conditional), Hide Other
@@ -281,7 +260,7 @@ function DocumentNodeMenu({
       >
         {isAudio ? "Delete Audio Attachment" : "Delete Attachment"}
       </button>
-    </div>
+    </NodeMenu>
   );
 }
 

--- a/web_ui/src/app/canvas/GitlinkNodeView.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { Dialog, useOverlays } from "../overlays/overlays";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The Gitlink node (Qt-removal plan R5.3) - the Gitlink plugin's React card.
@@ -118,25 +119,6 @@ interface MenuPosition {
 /** Same outside-click/Escape dismiss pattern every sibling node menu uses
  * (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu/ConversationNodeMenu/
  * WebResearchNodeMenu/ArtifactNodeMenu). */
-function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
-  useEffect(() => {
-    function onPointerDown(event: PointerEvent) {
-      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
-      // type-only import above shadows the bare name for casts like this).
-      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
-    }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [menuRef, onClose]);
-}
-
 // -- card-level menu -------------------------------------------------------
 
 function GitlinkNodeMenu({
@@ -152,16 +134,9 @@ function GitlinkNodeMenu({
   onDelete: () => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
-  useMenuDismiss(menuRef, onClose);
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       <button
         type="button"
         role="menuitem"
@@ -183,7 +158,7 @@ function GitlinkNodeMenu({
       >
         Delete Node
       </button>
-    </div>
+    </NodeMenu>
   );
 }
 

--- a/web_ui/src/app/canvas/ImageNodeView.tsx
+++ b/web_ui/src/app/canvas/ImageNodeView.tsx
@@ -1,6 +1,7 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The image node (Qt-removal plan R3.21/R3.22) - graphlink_node_image.py's
@@ -128,32 +129,10 @@ function ImageNodeMenu({
   onRegenerate: () => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    function onPointerDown(event: PointerEvent) {
-      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
-      // type-only import above shadows the bare name for casts like this).
-      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
-    }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [onClose]);
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       {/* Legacy order: Copy Image, Export Image, separator, Hide Other
           Branches, Regenerate Image, Delete Image. */}
       <button
@@ -203,7 +182,7 @@ function ImageNodeMenu({
       >
         Delete Image
       </button>
-    </div>
+    </NodeMenu>
   );
 }
 

--- a/web_ui/src/app/canvas/NodeMenu.tsx
+++ b/web_ui/src/app/canvas/NodeMenu.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { ReactNode } from "react";
+
+/**
+ * The shell every node context menu renders through (R8a).
+ *
+ * WHY THIS EXISTS. All 12 node menus used to render as a plain child of their
+ * own NodeView with `style={{ position: "fixed", left: clientX, top: clientY }}`.
+ * That looks correct and is completely wrong here: React Flow puts an inline
+ * `transform: translate(...)` on EVERY node wrapper and a `translate(...)
+ * scale(zoom)` on `.react-flow__viewport`. A transformed ancestor becomes the
+ * containing block for `position: fixed` descendants, so `left: clientX` stopped
+ * being measured from the viewport and started being measured from the node's
+ * own box in flow space - then translated by the node's canvas position and
+ * multiplied by the zoom. The menu landed at roughly (node.x + clientX) * zoom:
+ * far away for any node not at the origin, usually off-screen entirely, and
+ * visually scaled by the canvas zoom. Right-click read as "does nothing".
+ *
+ * Portaling to document.body removes every transformed ancestor from the chain,
+ * which restores BOTH the coordinate space (clientX/clientY mean what they say
+ * again) and the stacking context (the menu competes at root, so it can finally
+ * paint over canvas chrome instead of under it).
+ *
+ * It also fixes two things the old inline menus never handled: the menu is
+ * clamped so it cannot open off the edge of the window, and it is capped in
+ * height so a long menu scrolls instead of running its last items off-screen.
+ */
+
+const VIEWPORT_MARGIN = 8;
+
+export function NodeMenu({
+  position,
+  onClose,
+  className,
+  children,
+}: {
+  position: { x: number; y: number };
+  onClose: () => void;
+  className?: string;
+  children: ReactNode;
+}) {
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  // Start at the raw pointer position, then correct after measuring. Rendering
+  // at the requested spot first (rather than hiding until measured) keeps the
+  // menu from visibly jumping in the common case where no clamping is needed.
+  const [placement, setPlacement] = useState(position);
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const rect = menu.getBoundingClientRect();
+    // Prefer flipping to the other side of the pointer over merely nudging: a
+    // menu that overlaps the thing you right-clicked is worse than one that
+    // opens up/left of it, which is what every native context menu does.
+    const x =
+      position.x + rect.width + VIEWPORT_MARGIN > window.innerWidth
+        ? Math.max(VIEWPORT_MARGIN, position.x - rect.width)
+        : position.x;
+    const y =
+      position.y + rect.height + VIEWPORT_MARGIN > window.innerHeight
+        ? Math.max(VIEWPORT_MARGIN, position.y - rect.height)
+        : position.y;
+    if (x !== placement.x || y !== placement.y) setPlacement({ x, y });
+    // `placement` is deliberately not a dependency: this runs to CORRECT the
+    // placement it just set, so depending on it would loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [position.x, position.y]);
+
+  useEffect(() => {
+    const onPointerDown = (event: PointerEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) onClose();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        // Stop it here: without this the same Escape also reaches whatever
+        // dialog or overlay is open behind the canvas and closes that too.
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      className={className}
+      style={{ position: "fixed", left: placement.x, top: placement.y }}
+      role="menu"
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}

--- a/web_ui/src/app/canvas/PyCoderNodeView.tsx
+++ b/web_ui/src/app/canvas/PyCoderNodeView.tsx
@@ -1,10 +1,11 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { CodeExecutionApprovalPanel } from "./CodeExecutionApprovalPanel";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The Py-Coder node (Qt-removal plan R5.4) - the Py-Coder plugin's React
@@ -74,25 +75,6 @@ interface MenuPosition {
 
 /** Same outside-click/Escape dismiss pattern every sibling node menu uses
  * (ChatNodeMenu/ArtifactNodeMenu/GitlinkNodeMenu/...). */
-function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
-  useEffect(() => {
-    function onPointerDown(event: PointerEvent) {
-      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
-      // type-only import above shadows the bare name for casts like this).
-      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
-    }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [menuRef, onClose]);
-}
-
 // -- card-level menu -------------------------------------------------------
 
 function PyCoderNodeMenu({
@@ -108,16 +90,9 @@ function PyCoderNodeMenu({
   onDelete: () => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
-  useMenuDismiss(menuRef, onClose);
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       <button
         type="button"
         role="menuitem"
@@ -139,7 +114,7 @@ function PyCoderNodeMenu({
       >
         Delete Node
       </button>
-    </div>
+    </NodeMenu>
   );
 }
 

--- a/web_ui/src/app/canvas/ThinkingNodeView.tsx
+++ b/web_ui/src/app/canvas/ThinkingNodeView.tsx
@@ -1,9 +1,10 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The thinking node (Qt-removal plan R3.13/R3.14) - graphlink_node_thinking.py's
@@ -60,32 +61,10 @@ function ThinkingNodeMenu({
   onDelete: () => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    function onPointerDown(event: PointerEvent) {
-      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
-      // type-only import above shadows the bare name for casts like this).
-      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
-    }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [onClose]);
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       {/* Order verified against graphlink_node_thinking_menu.py's own
           construction order: Copy Content, Dock to Parent Node, Hide Other
           Branches, Delete Node. */}
@@ -123,7 +102,7 @@ function ThinkingNodeMenu({
       >
         Delete Node
       </button>
-    </div>
+    </NodeMenu>
   );
 }
 

--- a/web_ui/src/app/canvas/WebResearchNodeView.tsx
+++ b/web_ui/src/app/canvas/WebResearchNodeView.tsx
@@ -1,9 +1,10 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The web-research node (Qt-removal plan R5.1) - the Web Research plugin's
@@ -96,25 +97,6 @@ interface MenuPosition {
 
 /** Same outside-click/Escape dismiss pattern every sibling node menu uses
  * (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu/ConversationNodeMenu). */
-function useMenuDismiss(menuRef: React.RefObject<HTMLDivElement | null>, onClose: () => void) {
-  useEffect(() => {
-    function onPointerDown(event: PointerEvent) {
-      // globalThis.Node - the DOM interface, not @xyflow/react's Node (the
-      // type-only import above shadows the bare name for casts like this).
-      if (!menuRef.current?.contains(event.target as globalThis.Node)) onClose();
-    }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [menuRef, onClose]);
-}
-
 // -- card-level menu -------------------------------------------------------
 
 function WebResearchNodeMenu({
@@ -130,16 +112,9 @@ function WebResearchNodeMenu({
   onDelete: () => void;
   onClose: () => void;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
-  useMenuDismiss(menuRef, onClose);
 
   return (
-    <div
-      ref={menuRef}
-      className="chat-node-menu"
-      style={{ position: "fixed", left: position.x, top: position.y }}
-      role="menu"
-    >
+    <NodeMenu position={position} onClose={onClose} className="chat-node-menu">
       <button
         type="button"
         role="menuitem"
@@ -161,7 +136,7 @@ function WebResearchNodeMenu({
       >
         Delete Node
       </button>
-    </div>
+    </NodeMenu>
   );
 }
 

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1,6 +1,29 @@
 /* Single-app shell styles (Qt-removal plan R0). Token-driven only - the
  * no-raw-colors gate applies here exactly as it does to island CSS. */
 
+/* R8a: ONE documented z-index scale.
+ *
+ * Before this, the SPA had 10 ad-hoc z-index values (5, 20, 22, 30, 40, 50)
+ * with no stated relationship, and the highest of them - .chat-node-menu's 50 -
+ * was the LEAST visible thing on screen. That is not a numbering mistake: node
+ * menus render inside React Flow's viewport, which is itself a transformed,
+ * z-indexed stacking context, so their 50 only ever competed with their
+ * siblings INSIDE the canvas, never with app chrome at root. No value would
+ * have fixed it; escaping the stacking context (see NodeMenu.tsx's portal) is
+ * what fixes it, and only then does a scale mean anything.
+ *
+ * Everything that floats above the canvas must take a value from here. Numbers
+ * are spaced so a tier can be inserted without renumbering its neighbours. */
+:root {
+  --gl-z-canvas-chrome: 5; /* pins/token counter drawn over the canvas */
+  --gl-z-app-layer: 20; /* app-bar popovers, plugin picker, pin overlay */
+  --gl-z-search: 22; /* search overlay, above the other app layers */
+  --gl-z-notification: 30; /* banner must beat app layers, not dialogs */
+  --gl-z-scrim: 40; /* modal scrim + the dialog it dims for */
+  --gl-z-node-menu: 60; /* PORTALED node context menus (NodeMenu.tsx) */
+  --gl-z-approval: 80; /* blocking code-execution prompt - outranks all */
+}
+
 html,
 body,
 #root {
@@ -512,7 +535,13 @@ body,
 }
 
 .chat-node-menu {
-  z-index: 50;
+  /* R8a: portaled to <body> by NodeMenu.tsx, so this finally competes at root
+     instead of only against its siblings inside React Flow's viewport. The
+     height cap matters for the same reason - a menu that used to run off the
+     bottom of the screen now scrolls inside itself. */
+  z-index: var(--gl-z-node-menu);
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   min-width: 170px;
@@ -2141,9 +2170,13 @@ body,
 
 /* -- Settings dialog (R2.5d) ----------------------------------------------- */
 
+/* R8a: width is PINNED, not a range. It was `min-width: 700px` +
+   `max-width: min(820px, ...)`, which let the dialog shrink-wrap to whatever
+   each tab's content happened to measure - so switching tabs visibly resized
+   the whole Settings window. Height was already pinned; width now matches, so
+   the frame is stable and only the page area inside it changes. */
 .settings-dialog {
-  min-width: 700px;
-  max-width: min(820px, calc(100vw - 64px));
+  width: min(820px, calc(100vw - 64px));
   height: min(560px, calc(100vh - 96px));
 }
 


### PR DESCRIPTION
First repair from the R8a UI/UX scan. Addresses the user's #1 report — *"most if not all UI elements are not correctly Z render order… many of the popout selection lists appear UNDER other elements."*

## The z-order symptom was real, but it wasn't a z-index problem

All 12 node context menus rendered as a plain child of their own NodeView with `style={{ position: "fixed", left: clientX, top: clientY }}`.

React Flow puts an inline `transform: translate(...)` on **every** node wrapper, and `translate(...) scale(zoom)` on `.react-flow__viewport`. A transformed ancestor becomes the containing block for `position: fixed` descendants — so `left: clientX` stopped being measured from the viewport and started being measured from **the node's own box in flow space**, then translated by the node's canvas position and multiplied by zoom.

Net result: the menu landed near `(node.x + clientX) * zoom` — far away for any node not at the origin, usually off-screen, and visually scaled by the canvas zoom. **Right-click read as doing nothing.** It only worked for a node at the origin, at zoom 1, with zero pan.

That same transformed ancestor is a stacking context, which is why `.chat-node-menu`'s `z-index: 50` — the *highest* value in the stylesheet — still painted under app chrome at 20–40. It only ever competed with its siblings inside the canvas. **No z-index value could have fixed it.**

## The fix

New `canvas/NodeMenu.tsx` portals the menu to `document.body`, removing every transformed ancestor from the chain. That restores both the coordinate space and the stacking context. It also adds what the inline menus never had:

- **Edge flipping** — opens up/left rather than off-screen, like a native context menu.
- **Height cap + scroll** — long menus no longer run their last items off the bottom.
- **Scoped Escape** — dismissing a node menu no longer *also* closes whatever dialog is open behind it.

All 13 menus across 12 files route through it, collapsing 12 duplicated dismiss implementations into one — hence **309 deletions against 181 insertions**.

## Plus the z-index scale this exposed

The SPA had 10 ad-hoc z-index values with no stated relationship. They're now named custom properties in one documented block, with tiers reserved for portaled menus and for the code-execution approval prompt.

## Test plan

- [x] `tsc --noEmit` clean — this is what proves the scripted JSX transform stayed balanced across 12 files
- [x] 780 frontend tests pass, 0 lint errors, build clean
- [x] `npm run check` green end to end

## Known-remaining, from the same scan (not in this PR)

- The **code-execution approval modal** has the identical inline-render bug: its "full viewport" scrim is only the size of the node card, so a blocking security prompt doesn't actually block — you can pan away and start a second run. Reserved tier already added to the scale.
- The **note colour picker** is clipped away entirely by `.scene-node { overflow: hidden }`.
- Model selection and attachments are being built out for real, per user decision.
