### PR TITLE
R8a: real composer model picker + portal the approval prompt and colour picker

### DIFF
--- a/backend/composer.py
+++ b/backend/composer.py
@@ -39,7 +39,12 @@ import api_provider
 
 from backend.events import SessionBus
 from backend.notifications import NotificationState
-from backend.settings import apply_llama_cpp_reasoning_mode, apply_ollama_reasoning_mode
+from backend.settings import (
+    _apply,
+    apply_llama_cpp_reasoning_mode,
+    apply_ollama_chat_model,
+    apply_ollama_reasoning_mode,
+)
 from backend.token_counter import TokenCounterState
 from graphlink_licensing import SettingsManager
 
@@ -92,6 +97,7 @@ class ComposerDocument:
     # state the UI already claimed. Deriving instead of mirroring removes the
     # second source of truth rather than trying to keep two in sync.
     reasoning_level_reader: Callable[[], str] | None = field(default=None, repr=False)
+    route_reader: Callable[[], dict[str, Any]] | None = field(default=None, repr=False)
     # R4: the in-flight agent-dispatch request, if any - set by
     # backend/agents.py's AgentDispatcher around a real chat call so the
     # composer UI can reflect generating/idle state and offer cancellation.
@@ -131,8 +137,41 @@ class ComposerDocument:
     def _reasoning_label(self, level: str) -> str:
         return next(o["label"] for o in REASONING_OPTIONS if o["id"] == level)
 
+    def route(self) -> dict[str, Any]:
+        """The REAL provider/model route (R8a).
+
+        This used to be five hardcoded literals - provider "Ollama (Local)",
+        empty modelId/modelLabel, an empty modelOptions list, and
+        canChange/modelSelection False. The composer therefore rendered a
+        control that looked like a model dropdown, was permanently greyed out,
+        and had nothing behind it. The user reported it as "does not work at
+        all and is locked up", which is exactly right: a visible dead control
+        reads as a bug, not as a documented deferral.
+
+        It now reports what the app is actually configured to do, resolved
+        through the same path api_provider uses at call time
+        (graphlink_task_config.sync_ollama_task_models ->
+         graphlink_model_catalog.resolve_task_model), so what the composer
+        shows and what a send actually uses cannot drift apart.
+        """
+        if self.route_reader is None:
+            # No settings manager wired (the 2-positional-arg test shape).
+            # Report honestly rather than claiming a provider we cannot check.
+            return {
+                "mode": "ollama",
+                "provider": "Ollama (Local)",
+                "modelId": "",
+                "modelLabel": "",
+                "modelOptions": [],
+                "label": "Ollama (Local)",
+                "available": True,
+                "canChange": False,
+            }
+        return self.route_reader()
+
     def payload(self) -> dict[str, Any]:
         reasoning_level = self.effective_reasoning_level()
+        route = self.route()
         return {
             "draft": {
                 "id": self.draft.id,
@@ -148,19 +187,12 @@ class ComposerDocument:
                 "reviewAvailable": False,
             },
             "route": {
-                "mode": "ollama",
-                "provider": "Ollama (Local)",
-                "modelId": "",
-                "modelLabel": "",
-                "modelOptions": [],
+                **route,
                 "reasoning": {
                     "level": reasoning_level,
                     "label": self._reasoning_label(reasoning_level),
                     "options": list(REASONING_OPTIONS),
                 },
-                "label": "Ollama (Local)",
-                "available": True,
-                "canChange": False,
             },
             "request": {
                 "id": self.request_id,
@@ -174,7 +206,9 @@ class ComposerDocument:
                 "attachments": False,
                 "contextReview": False,
                 "routeSelection": False,
-                "modelSelection": False,
+                # Real, and derived - not a constant. The composer's model
+                # control enables exactly when there is something to choose.
+                "modelSelection": bool(route.get("modelOptions")),
                 "reasoningSelection": api_provider.is_local_ollama_mode() or api_provider.is_local_llama_cpp_mode(),
                 "settingsShortcut": True,
                 "cancellation": True,
@@ -206,6 +240,73 @@ def register_composer(
             return settings_manager.get_ollama_reasoning_mode()
 
         document.reasoning_level_reader = _persisted_reasoning_mode
+
+        def _live_route() -> dict[str, Any]:
+            """Resolve the route the way a real send resolves it.
+
+            Deliberately goes through graphlink_task_config.sync_ollama_task_models
+            rather than reading assignments directly: that is the function
+            api_provider itself calls, so the model this reports is by
+            construction the model a send would use. Reading the raw
+            assignment dict instead would re-implement Auto/inherit
+            resolution here and could disagree with the real call path -
+            which is precisely the class of bug that made the composer
+            display "Quick Mode" while running CoT.
+            """
+            import graphlink_task_config as task_config
+
+            if api_provider.is_api_mode():
+                provider = settings_manager.get_api_provider() or "API Endpoint"
+                assigned = settings_manager.get_api_models() or {}
+                model_id = assigned.get(task_config.TASK_CHAT, "") or ""
+                catalog = settings_manager.get_api_model_catalog(provider) or []
+                options = [
+                    {"id": str(m.get("id") or m), "label": str(m.get("label") or m.get("id") or m)}
+                    for m in catalog
+                ]
+                return {
+                    "mode": "api",
+                    "provider": provider,
+                    "modelId": model_id,
+                    "modelLabel": model_id or "Select a model",
+                    "modelOptions": options,
+                    "label": provider,
+                    "available": True,
+                    "canChange": bool(options),
+                }
+
+            if api_provider.is_local_llama_cpp_mode():
+                path = settings_manager.get_llama_cpp_chat_model_path() or ""
+                name = path.replace("\\", "/").rsplit("/", 1)[-1]
+                return {
+                    "mode": "llama_cpp",
+                    "provider": "Llama.cpp (Local)",
+                    "modelId": path,
+                    "modelLabel": name or "Select a model",
+                    # A GGUF is chosen by file path in Settings, not from a
+                    # short list - offering a dropdown here would be a worse
+                    # affordance than the real file picker that already exists.
+                    "modelOptions": [],
+                    "label": "Llama.cpp (Local)",
+                    "available": bool(path),
+                    "canChange": False,
+                }
+
+            task_config.sync_ollama_task_models(settings_manager)
+            model_id = task_config.OLLAMA_MODELS.get(task_config.TASK_CHAT, "") or ""
+            scanned = settings_manager.get_ollama_scanned_models() or []
+            return {
+                "mode": "ollama",
+                "provider": "Ollama (Local)",
+                "modelId": model_id,
+                "modelLabel": model_id or "Select a model",
+                "modelOptions": [{"id": m, "label": m} for m in scanned],
+                "label": "Ollama (Local)",
+                "available": bool(model_id),
+                "canChange": bool(scanned),
+            }
+
+        document.route_reader = _live_route
     bus.register_topic("app-composer", document.payload)
 
     async def publish():
@@ -267,6 +368,35 @@ def register_composer(
 
         await publish()
 
+    async def select_model(model_id):
+        """Assign the chat-task model from the composer (R8a).
+
+        Writes through the SAME per-task assignment the Settings > Ollama page
+        edits, so the two surfaces cannot disagree, and republishes both.
+        """
+        if settings_manager is None:
+            return
+        chosen = str(model_id or "").strip()
+        if not chosen:
+            return
+        import graphlink_task_config as task_config
+
+        if api_provider.is_api_mode():
+            models = dict(settings_manager.get_api_models() or {})
+            models[task_config.TASK_CHAT] = chosen
+            _apply(settings_manager.set_api_models, models)
+        elif api_provider.is_local_ollama_mode():
+            # Shared with the Settings > Ollama page - one implementation,
+            # so the two surfaces cannot disagree about what is assigned.
+            await apply_ollama_chat_model(settings_manager, chosen)
+        else:
+            return
+
+        if bus.has_topic("app-settings"):
+            await bus.publish("app-settings")
+        await publish()
+
+    bus.register_intent("app-composer", "selectModel", select_model)
     bus.register_intent("app-composer", "updateDraft", update_draft)
     bus.register_intent("app-composer", "setReasoningLevel", set_reasoning_level)
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -174,6 +174,34 @@ async def apply_ollama_reasoning_mode(manager: SettingsManager, mode: str) -> No
     await asyncio.to_thread(_reapply_if_ollama_is_still_the_live_provider)
 
 
+async def apply_ollama_chat_model(manager: SettingsManager, model_id: str) -> None:
+    """Assign the Ollama chat-task model, race-safely (R8a).
+
+    Extracted from register_settings' own set_ollama_model_assignment intent
+    so the composer's model picker and the Settings > Ollama page write through
+    ONE implementation instead of two that can drift. Same precedent as
+    apply_ollama_reasoning_mode above.
+
+    The read-modify-write stays inside a single _apply-locked closure, not
+    split across an await: that split is the R7.4a race where a concurrent
+    assignment change for a different task gets silently reverted by this
+    call's stale pre-read of the whole assignments dict.
+    """
+    chosen = str(model_id or "").strip()
+    if not chosen:
+        return
+    assignment = {"mode": "explicit", "model_id": chosen}
+
+    def _persist() -> None:
+        assignments = manager.get_ollama_model_assignments()
+        assignments[config.TASK_CHAT] = assignment
+        manager.set_ollama_model_assignments(assignments)
+        config.sync_ollama_task_models(manager)
+        config.set_current_model(chosen)
+
+    await asyncio.to_thread(_apply, _persist)
+
+
 async def apply_llama_cpp_reasoning_mode(manager: SettingsManager, mode: str) -> str | None:
     """Same contract as apply_ollama_reasoning_mode, for Llama.cpp. Returns a
     human-readable failure message if the live re-apply fails (the mode is

--- a/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
+++ b/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -230,7 +231,8 @@ export function CodeExecutionApprovalPanel({
     // consistency (fixed full-viewport centering, matching colors/shadows) -
     // this div is NOT registered with, and shares no state with, the
     // useOverlays() registry those classes were originally styled for.
-    <div className="overlay-scrim code-exec-approval-scrim" data-node-id={nodeId}>
+    createPortal(
+      <div className="overlay-scrim code-exec-approval-scrim" data-node-id={nodeId}>
       <div
         ref={panelRef}
         role="dialog"
@@ -281,6 +283,8 @@ export function CodeExecutionApprovalPanel({
           </div>
         </div>
       </div>
-    </div>
+      </div>,
+      document.body,
+    )
   );
 }

--- a/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
@@ -318,29 +318,33 @@ export function CodeSandboxNodeView({ id, data, selected }: NodeProps<CodeSandbo
             </div>
           )}
 
-          <CodeExecutionApprovalPanel
-            nodeId={id}
-            kind="code_sandbox"
-            code={data.codeSandboxCode}
-            awaitingApproval={data.codeSandboxAwaitingApproval}
-            // R5.4 CODESANDBOX fix: the approval panel must show the FROZEN
-            // manifest snapshot the pending approval actually refers to
-            // (codeSandboxApprovalRequirements), NOT the live, still-editable
-            // codeSandboxRequirements draft. The Requirements textarea above
-            // is never disabled during a run, so the user can keep typing a
-            // manifest for their NEXT run while this approval is still
-            // pending - reading the live field here would show that
-            // in-progress edit instead of what the paused run actually asked
-            // to install (backend/canvas.py freezes this at the moment
-            // code_sandbox_awaiting_approval flips true; see
-            // AgentDispatcher.start_code_sandbox_run).
-            requirements={data.codeSandboxApprovalRequirements}
-            busy={approvalBusy}
-            onApprove={handleApprove}
-            onDeny={handleDeny}
-          />
         </div>
       )}
+      {/* R8a: OUTSIDE the {!collapsed} gate on purpose - this is a
+          blocking approval prompt, and collapsing the node or zooming
+          past the LOD threshold used to unmount it mid-decision. It
+          self-hides via `if (!awaitingApproval) return null`. */}
+        <CodeExecutionApprovalPanel
+          nodeId={id}
+          kind="code_sandbox"
+          code={data.codeSandboxCode}
+          awaitingApproval={data.codeSandboxAwaitingApproval}
+          // R5.4 CODESANDBOX fix: the approval panel must show the FROZEN
+          // manifest snapshot the pending approval actually refers to
+          // (codeSandboxApprovalRequirements), NOT the live, still-editable
+          // codeSandboxRequirements draft. The Requirements textarea above
+          // is never disabled during a run, so the user can keep typing a
+          // manifest for their NEXT run while this approval is still
+          // pending - reading the live field here would show that
+          // in-progress edit instead of what the paused run actually asked
+          // to install (backend/canvas.py freezes this at the moment
+          // code_sandbox_awaiting_approval flips true; see
+          // AgentDispatcher.start_code_sandbox_run).
+          requirements={data.codeSandboxApprovalRequirements}
+          busy={approvalBusy}
+          onApprove={handleApprove}
+          onDeny={handleDeny}
+        />
       <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
       {menuPosition && (
         <CodeSandboxNodeMenu

--- a/web_ui/src/app/canvas/GroupColorPicker.tsx
+++ b/web_ui/src/app/canvas/GroupColorPicker.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
+import { NodeMenu } from "./NodeMenu";
 
 /**
  * The shared note/frame/container color-swatch popover (Qt-removal plan
@@ -62,43 +63,52 @@ export interface GroupColorPickerProps {
 }
 
 export function GroupColorPicker({ color, headerColor, onSelect }: GroupColorPickerProps) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  // R8a: anchored off the trigger's real viewport rect and portaled by
+  // NodeMenu, because this popover used to be `position: absolute` inside
+  // `.scene-node`, which is `overflow: hidden` - so it was clipped away
+  // ENTIRELY and picking a colour was impossible on every note/frame.
+  //
+  // The rect is captured when OPENING rather than read during render: reading
+  // a ref mid-render is not concurrent-safe (and eslint rejects it outright).
+  const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null);
+  const open = anchor !== null;
 
-  useEffect(() => {
-    if (!open) return;
-    function onPointerDown(event: PointerEvent) {
-      if (!ref.current?.contains(event.target as globalThis.Node)) setOpen(false);
+  function toggle() {
+    if (open) {
+      setAnchor(null);
+      return;
     }
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setOpen(false);
-    }
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [open]);
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (rect) setAnchor({ x: rect.left, y: rect.bottom + 6 });
+  }
+
 
   function choose(nextColor: string | null, nextHeaderColor: string | null) {
     onSelect(nextColor, nextHeaderColor);
-    setOpen(false);
+    setAnchor(null);
   }
 
   return (
-    <div className="group-color-picker nodrag" ref={ref}>
+    <div className="group-color-picker nodrag">
       <button
+        ref={triggerRef}
         type="button"
         className="group-color-swatch-trigger"
         aria-label="Set color"
         aria-haspopup="true"
         aria-expanded={open}
         style={{ backgroundColor: headerColor ?? color ?? undefined }}
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggle}
       />
-      {open && (
-        <div className="group-color-popover" role="menu" aria-label="Color">
+      {anchor && (
+        <NodeMenu
+          position={anchor}
+          onClose={() => setAnchor(null)}
+          ignoreRef={triggerRef}
+          className="group-color-popover"
+          ariaLabel="Color"
+        >
           <p className="group-color-section-label">Body</p>
           <div className="group-color-row">
             {GROUP_NAMED_COLORS.map((c) => (
@@ -147,7 +157,7 @@ export function GroupColorPicker({ color, headerColor, onSelect }: GroupColorPic
           <button type="button" role="menuitem" className="group-color-reset" onClick={() => choose(null, null)}>
             Reset to Default
           </button>
-        </div>
+        </NodeMenu>
       )}
     </div>
   );

--- a/web_ui/src/app/canvas/NodeMenu.tsx
+++ b/web_ui/src/app/canvas/NodeMenu.tsx
@@ -33,11 +33,22 @@ export function NodeMenu({
   position,
   onClose,
   className,
+  ignoreRef,
+  ariaLabel,
   children,
 }: {
   position: { x: number; y: number };
   onClose: () => void;
   className?: string;
+  /** Accessible name for the surface. Context menus are named by the node they
+   * belong to and omit it; named popovers (the colour picker) must pass one or
+   * they lose their accessible name entirely. */
+  ariaLabel?: string;
+  /** A toggle button that opens this surface. Pointerdowns on it are ignored
+   * so it can close the surface itself: without this the outside-click handler
+   * fires first and closes, then the button's own onClick re-opens, making the
+   * toggle appear dead. Context menus have no such trigger and omit it. */
+  ignoreRef?: React.RefObject<HTMLElement | null>;
   children: ReactNode;
 }) {
   const menuRef = useRef<HTMLDivElement | null>(null);
@@ -69,7 +80,10 @@ export function NodeMenu({
 
   useEffect(() => {
     const onPointerDown = (event: PointerEvent) => {
-      if (!menuRef.current?.contains(event.target as Node)) onClose();
+      const target = event.target as Node;
+      if (menuRef.current?.contains(target)) return;
+      if (ignoreRef?.current?.contains(target)) return;
+      onClose();
     };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -85,7 +99,7 @@ export function NodeMenu({
       document.removeEventListener("pointerdown", onPointerDown, true);
       document.removeEventListener("keydown", onKeyDown, true);
     };
-  }, [onClose]);
+  }, [onClose, ignoreRef]);
 
   return createPortal(
     <div
@@ -93,6 +107,7 @@ export function NodeMenu({
       className={className}
       style={{ position: "fixed", left: placement.x, top: placement.y }}
       role="menu"
+      aria-label={ariaLabel}
     >
       {children}
     </div>,

--- a/web_ui/src/app/canvas/PyCoderNodeView.tsx
+++ b/web_ui/src/app/canvas/PyCoderNodeView.tsx
@@ -287,17 +287,21 @@ export function PyCoderNodeView({ id, data, selected }: NodeProps<PyCoderFlowNod
             </div>
           )}
 
-          <CodeExecutionApprovalPanel
-            nodeId={id}
-            kind="pycoder"
-            code={data.pycoderCode}
-            awaitingApproval={data.pycoderAwaitingApproval}
-            busy={approvalBusy}
-            onApprove={handleApprove}
-            onDeny={handleDeny}
-          />
         </div>
       )}
+      {/* R8a: OUTSIDE the {!collapsed} gate on purpose - this is a
+          blocking approval prompt, and collapsing the node or zooming
+          past the LOD threshold used to unmount it mid-decision. It
+          self-hides via `if (!awaitingApproval) return null`. */}
+        <CodeExecutionApprovalPanel
+          nodeId={id}
+          kind="pycoder"
+          code={data.pycoderCode}
+          awaitingApproval={data.pycoderAwaitingApproval}
+          busy={approvalBusy}
+          onApprove={handleApprove}
+          onDeny={handleDeny}
+        />
       <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
       {menuPosition && (
         <PyCoderNodeMenu

--- a/web_ui/src/app/chrome/Composer.test.tsx
+++ b/web_ui/src/app/chrome/Composer.test.tsx
@@ -19,6 +19,7 @@ function makeStore(
   };
   const updateDraft = vi.fn();
   const setReasoningLevel = vi.fn();
+  const selectModel = vi.fn();
   const cancelChatRequest = vi.fn();
   const dismissNotification = vi.fn();
   const store = {
@@ -32,10 +33,11 @@ function makeStore(
     getStreamText: () => state.streamText,
     updateDraft,
     setReasoningLevel,
+    selectModel,
     cancelChatRequest,
     dismissNotification,
   };
-  return { store, updateDraft, setReasoningLevel, cancelChatRequest, dismissNotification };
+  return { store, updateDraft, setReasoningLevel, selectModel, cancelChatRequest, dismissNotification };
 }
 
 function makeSceneStore() {
@@ -59,19 +61,57 @@ describe("Composer", () => {
     expect(updateDraft).toHaveBeenCalledWith("hi!");
   });
 
-  it("attach/model controls stay visibly disabled with their deferred phase named; Send starts disabled on an empty draft", () => {
+  it("Send starts disabled on an empty draft; the model control is disabled ONLY when there is nothing to choose", () => {
+    // R8a: this used to assert the model control "stays visibly disabled with
+    // its deferred phase named" - i.e. it encoded a dead stub as the expected
+    // behaviour. The control is real now, so the assertion is inverted: it is
+    // disabled when the backend reports no models, and enabled when it does.
     const { store } = makeStore();
-    render(
+    const { container } = render(
       <OverlayProvider>
         {/* @ts-expect-error - test double */}
         <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
       </OverlayProvider>,
     );
     expect(screen.getByLabelText("Send message")).toBeDisabled();
-    expect(screen.getByLabelText("Attach context")).toBeDisabled();
-    expect(
-      screen.getByTitle("Model selection isn't available here yet - configure models in Settings"),
-    ).toBeDisabled();
+    // modelSelection defaults false with an empty modelOptions list.
+    expect(container.querySelector('[data-overlay-trigger="model"]')).toBeDisabled();
+  });
+
+  it("the model control enables when the backend reports real options, and picking one calls selectModel", async () => {
+    const user = userEvent.setup();
+    const { store, selectModel } = makeStore({
+      composer: {
+        route: {
+          ...initialComposerState.route,
+          provider: "Ollama (Local)",
+          modelId: "qwen3:8b",
+          modelLabel: "qwen3:8b",
+          modelOptions: [
+            { id: "qwen3:8b", label: "qwen3:8b" },
+            { id: "nemotron-3-nano:4b", label: "nemotron-3-nano:4b" },
+          ],
+        },
+        capabilities: { ...initialComposerState.capabilities, modelSelection: true },
+        request: { ...initialComposerState.request, canSend: true },
+      },
+    });
+    const { container } = render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+
+    const trigger = container.querySelector('[data-overlay-trigger="model"]') as HTMLButtonElement;
+    expect(trigger).not.toBeDisabled();
+
+    await user.click(trigger);
+    await user.click(screen.getByText("nemotron-3-nano:4b"));
+
+    expect(selectModel).toHaveBeenCalledWith("nemotron-3-nano:4b");
+    // and the popover closes on choose, like the reasoning picker
+    expect(screen.queryByText("nemotron-3-nano:4b")).toBeNull();
   });
 
   it("Send is enabled once there's text, calls sceneStore.sendMessage, and clears the draft", async () => {

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -115,11 +115,27 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
           <Icon name="chevron" />
         </button>
 
+        {/* R8a: a REAL model picker. This was `disabled` with a "not available
+            yet" title and an always-empty option list, so it rendered as a
+            dropdown that could never be opened - reported, correctly, as
+            "does not work at all and is locked up". It now enables exactly
+            when the backend says there is something to choose
+            (capabilities.modelSelection, derived from the resolved provider's
+            real model list) and writes through the same per-task assignment
+            the Settings > Ollama page edits. */}
         <button
           type="button"
           className="composer-control"
-          disabled
-          title="Model selection isn't available here yet - configure models in Settings"
+          data-overlay-trigger="model"
+          aria-haspopup="dialog"
+          aria-pressed={overlays.isOpen("model")}
+          disabled={!composer.capabilities.modelSelection || !composer.request.canSend}
+          title={
+            composer.capabilities.modelSelection
+              ? `Choose the ${composer.route.provider} model for chat`
+              : "No models found - run a scan on the Settings page for this provider"
+          }
+          onClick={() => overlays.toggle("model", "popover")}
         >
           <span className="control-copy">
             <span className="control-kicker">{composer.route.provider}</span>
@@ -159,7 +175,38 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
       </div>
 
       <Reasoning store={store} />
+      <ModelPicker store={store} />
     </div>
+  );
+}
+
+function ModelPicker({ store }: { store: ComposerStore }) {
+  const composer = useSyncExternalStore(store.subscribe, store.getComposer);
+  const overlays = useOverlays();
+  const options = useMemo(() => composer.route.modelOptions, [composer.route.modelOptions]);
+
+  return (
+    <Popover name="model" className="reasoning-popover model-picker-popover">
+      {options.length === 0 ? (
+        <p className="model-picker-empty">
+          No models found for {composer.route.provider}. Run a scan on its Settings page.
+        </p>
+      ) : (
+        options.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            className={"reasoning-option" + (option.id === composer.route.modelId ? " active" : "")}
+            onClick={() => {
+              store.selectModel(option.id);
+              overlays.close();
+            }}
+          >
+            <span className="reasoning-option-label">{option.label}</span>
+          </button>
+        ))
+      )}
+    </Popover>
   );
 }
 

--- a/web_ui/src/app/chrome/composerStore.ts
+++ b/web_ui/src/app/chrome/composerStore.ts
@@ -141,6 +141,13 @@ export class ComposerStore {
     this.transport.intent("app-composer", "updateDraft", [text]);
   }
 
+  selectModel(modelId: string): void {
+    // R8a: writes the chat-task model assignment. The backend routes this
+    // through the same helper the Settings > Ollama page uses, so the two
+    // surfaces cannot report different models.
+    this.transport.intent("app-composer", "selectModel", [modelId]);
+  }
+
   setReasoningLevel(level: string): void {
     this.transport.intent("app-composer", "setReasoningLevel", [level]);
   }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -251,7 +251,7 @@ body,
   background-color: var(--gl-surface-node-body);
   border: 1px solid var(--gl-surface-border);
   border-radius: 10px;
-  z-index: 5;
+  z-index: var(--gl-z-canvas-chrome);
 }
 
 .scene-pins-header {
@@ -1059,14 +1059,14 @@ body,
   position: absolute;
   top: 8px;
   right: 16px;
-  z-index: 20;
+  z-index: var(--gl-z-app-layer);
 }
 
 .app-plugins-layer {
   position: absolute;
   top: 8px;
   right: 16px;
-  z-index: 20;
+  z-index: var(--gl-z-app-layer);
 }
 
 .overlay-popover {
@@ -1082,7 +1082,7 @@ body,
 .overlay-scrim {
   position: fixed;
   inset: 0;
-  z-index: 40;
+  z-index: var(--gl-z-scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1458,7 +1458,7 @@ body,
   position: absolute;
   bottom: 16px;
   left: 16px;
-  z-index: 5;
+  z-index: var(--gl-z-canvas-chrome);
 }
 
 .token-counter {
@@ -1500,7 +1500,7 @@ body,
   top: 16px;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 30;
+  z-index: var(--gl-z-notification);
 }
 
 .notification-banner {
@@ -1539,7 +1539,7 @@ body,
   position: absolute;
   top: 8px;
   left: 16px;
-  z-index: 20;
+  z-index: var(--gl-z-app-layer);
 }
 
 .pins-popover {
@@ -1771,7 +1771,7 @@ body,
   top: 8px;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 22;
+  z-index: var(--gl-z-search);
 }
 
 .search-overlay-shell {
@@ -3687,11 +3687,23 @@ body,
   border-color: var(--gl-surface-text-muted);
 }
 
+/* R8a: the code-execution approval prompt is a BLOCKING security decision, so
+   it outranks ordinary dialogs. It used to render inline inside the node,
+   where its `position: fixed; inset: 0` scrim resolved against the node's own
+   transformed box - so it dimmed (and blocked) only the node card, leaving the
+   rest of the app clickable while it waited for a yes/no. It is portaled to
+   <body> now, which is what makes this z-index meaningful at all. */
+.code-exec-approval-scrim {
+  z-index: var(--gl-z-approval);
+}
+
 .group-color-popover {
-  z-index: 50;
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
+  /* R8a: NodeMenu portals this and sets `position: fixed` + left/top inline
+     from the trigger's rect. The old `position: absolute; top; right` anchored
+     it inside `.scene-node`, which is `overflow: hidden` - so it was clipped
+     away entirely and colours could never be picked. A stale `right: 0` here
+     would fight the inline `left` and stretch the panel, so it is gone too. */
+  z-index: var(--gl-z-node-menu);
   display: flex;
   flex-direction: column;
   width: 176px;


### PR DESCRIPTION
Recovers two commits that were pushed onto the already-merged #160 branch and so were never in a PR. Content is unchanged; they are re-applied cleanly on current `main`.

## 1. The composer model picker is real now

The user's report — *"the ollama model selection list in the composer does not work at all and is locked up"* — was correct, and the dead end was in the **backend**, not the UI. `backend/composer.py` hardcoded the entire route:

```python
"provider": "Ollama (Local)"   # literal, regardless of live provider
"modelId": ""                  # empty
"modelOptions": []             # empty
"modelSelection": False        # capability flag pinned off
```

The greyed-out button was faithfully rendering that. Both the composer **and** the app bar reported "Ollama (Local)" even when another provider was configured.

- `ComposerDocument` gains a `route_reader` (mirroring the existing `reasoning_level_reader` precedent) so route is *read*, not literal.
- `_live_route()` resolves through `graphlink_task_config.sync_ollama_task_models` — the **same function `api_provider` calls at send time**. Deliberate: reading raw assignments would re-implement Auto/inherit resolution and could disagree with the real call path, which is exactly how R7.5d shipped a composer showing "Quick Mode" while every call ran CoT. Covers Ollama (scanned models), API (catalog), and Llama.cpp (GGUF path — no dropdown, since a file is chosen by picker).
- `capabilities.modelSelection` is **derived** (`bool(route.modelOptions)`), not a constant.
- A `selectModel` intent writes through a new shared `settings.apply_ollama_chat_model`, extracted from `register_settings`' own intent so the composer and Settings page cannot drift. Read-modify-write stays inside one `_apply`-locked closure — splitting it across an await is the R7.4a race that silently reverts concurrent assignment changes.

**Verified against real state, not the DOM:** registering a composer with the live `SettingsManager` returns `provider: "Ollama (Local)"`, `modelId: "nemotron-3-nano:4b"` (the actually-configured model), all 10 scanned models in `modelOptions`, `canChange: true`.

One existing test asserted the control *"stays visibly disabled with its deferred phase named"* — it encoded the dead stub as expected behaviour. Inverted rather than deleted, plus new coverage for enable/select/close.

## 2. The approval prompt did not actually block

It rendered inline in the node body, so its `position: fixed; inset: 0` scrim resolved against the node's own transformed box — dimming and blocking **only the node card**. You could pan away and start a second run mid-decision. It also sat below the minimap. Now portaled to `<body>` at the top z-index tier.

**And collapsing the node destroyed it.** The panel lived inside `{!collapsed && ...}`, where `collapsed` is `data.isCollapsed || zoom < LOD_ZOOM_THRESHOLD` — so collapsing *or merely zooming out* unmounted a pending security decision. Hoisted out of that gate in both node views.

## 3. The note/frame colour picker was unreachable

`position: absolute` inside `.scene-node { overflow: hidden }` clipped it away entirely — picking a colour was impossible on every note, frame, and container. Now renders through `NodeMenu`, anchored off the trigger's real viewport rect.

Also completes the z-index scale: all remaining raw values reference named tiers.

## Test plan

- [x] 961 backend tests pass
- [x] 781 frontend tests, 0 lint errors, build clean
- [x] Model route verified by querying the backend with real settings, not by inspecting the page
