### PR TITLE
R8a: build real composer attachments end to end

### DIFF
--- a/backend/attachments.py
+++ b/backend/attachments.py
@@ -1,0 +1,327 @@
+"""Real file-attachment classification and text extraction (R8a).
+
+Ported faithfully from the deleted graphlink_app/graphlink_file_handler.py
+and graphlink_window.py's _stage_attachment_file (git show 6c919f6~1:...) -
+this is not a redesign, it is the same three-way dispatch, the same
+extension sets, the same byte-sniff heuristic, and the same graceful
+missing-optional-dependency messages, made Qt-free.
+
+Classification (extension-based, exactly as legacy decided it):
+  - image  (.png/.jpg/.jpeg/.webp)      -> multimodal image_bytes content-part
+  - audio  (graphlink_audio.py's set)   -> multimodal audio_file content-part,
+                                            duration-validated via inspect_audio_file
+  - document (everything else FileHandler could read: ~44 text/code
+    extensions, named files like Dockerfile/Makefile, .pdf via pypdf,
+    .docx via python-docx, or a byte-sniff heuristic for anything else) ->
+    extracted TEXT, never sent as raw bytes
+
+Anything outside all three is rejected with "Unsupported file type." - the
+exact legacy message, kept unchanged since it is user-facing copy, not an
+implementation detail.
+
+Unlike legacy, there is no PDF_AVAILABLE/DOCX_AVAILABLE class-level cache
+computed once at FileHandler() construction time: pypdf/python-docx are
+imported lazily, per call, inside a try/except - simpler for a stateless
+module-level API, and the cost of re-attempting a failed import is one
+dict lookup in sys.modules, not a real re-scan.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from graphlink_audio import (
+    AudioValidationError,
+    format_duration,
+    inspect_audio_file,
+)
+from graphlink_token_estimator import TokenEstimator
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp"}
+
+# Verbatim from FileHandler.PLAIN_TEXT_EXTENSIONS.
+PLAIN_TEXT_EXTENSIONS = {
+    ".bat", ".c", ".cc", ".cfg", ".conf", ".cpp", ".cs", ".css", ".csv",
+    ".env", ".go", ".h", ".hpp", ".html", ".ini", ".java", ".js", ".json",
+    ".jsx", ".kt", ".kts", ".log", ".lua", ".md", ".mdx", ".php", ".ps1",
+    ".py", ".rb", ".rs", ".rst", ".sh", ".sql", ".svg", ".swift", ".tex",
+    ".toml", ".ts", ".tsx", ".txt", ".xml", ".yaml", ".yml",
+}
+# Verbatim from FileHandler.SUPPORTED_FILENAMES.
+SUPPORTED_FILENAMES = {
+    ".editorconfig", ".env", ".gitignore", "Dockerfile", "Gemfile",
+    "Makefile", "Procfile", "README", "README.md", "requirements.txt",
+}
+# Verbatim from _looks_like_code_text's own extension set (used only for the
+# cosmetic "Code" vs "Text" context label, not for the read/reject decision).
+_CODE_EXTENSIONS = {
+    ".py", ".js", ".ts", ".tsx", ".jsx", ".java", ".cs", ".cpp", ".c",
+    ".h", ".hpp", ".go", ".rs", ".php", ".rb", ".swift", ".kt",
+    ".sql", ".sh", ".ps1", ".json", ".yaml", ".yml", ".xml", ".html", ".css",
+}
+
+PDF_INSTALL_MESSAGE = "PDF support is not installed. Please run: pip install pypdf"
+DOCX_INSTALL_MESSAGE = "Word document support is not installed. Please run: pip install python-docx"
+
+
+class AttachmentError(Exception):
+    """A file could not be attached. The message is user-facing (surfaced
+    verbatim via NotificationBanner), matching every rejection string
+    _stage_attachment_file/FileHandler.read_file returned."""
+
+
+@dataclass
+class StagedAttachment:
+    """One attachment sitting in the composer, waiting for Send. Lives only
+    in backend memory (ComposerDocument.staged_attachments) - the raw bytes/
+    extracted text never round-trip to the frontend; only metadata does
+    (see to_wire())."""
+
+    id: str = field(default_factory=lambda: uuid4().hex)
+    kind: str = ""  # "image" | "audio" | "document"
+    name: str = ""
+    path: str = ""
+    byte_size: int = 0
+    context_label: str = ""
+    mime_type: str = ""
+    duration_seconds: float | None = None
+    # Populated for kind == "image"/"audio" only: the exact content-part
+    # shape api_provider.py's _prepare_ollama_messages/
+    # _anthropic_content_block_from_part/_gemini_part_from_content already
+    # know how to convert (image_bytes.data as raw bytes; audio_file.path as
+    # a plain path string, read lazily downstream via _read_attachment_bytes -
+    # matches how audio already worked, no eager read needed here).
+    content_part: dict[str, Any] | None = None
+    # Populated for kind == "document" only: the extracted text, merged into
+    # the sent message's plain text rather than becoming a content-part -
+    # every existing consumer of SceneNode.content already expects a plain
+    # string, so a document attachment never touches the multimodal path.
+    extracted_text: str | None = None
+    token_count: int = 0
+
+    def to_wire(self) -> dict[str, Any]:
+        """The ONLY shape the frontend ever sees for a staged attachment -
+        display metadata, never path/bytes/extracted content."""
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "name": self.name,
+            "byteSize": self.byte_size,
+            "contextLabel": self.context_label,
+            "tokenCount": self.token_count,
+        }
+
+
+def _looks_like_text_file(sample: bytes) -> bool:
+    """Verbatim port of FileHandler._looks_like_text_file."""
+    if not sample:
+        return True
+    if b"\x00" in sample:
+        return False
+    text_bytes = bytes(range(32, 127)) + b"\n\r\t\f\b"
+    non_text_count = sum(byte not in text_bytes for byte in sample)
+    return (non_text_count / len(sample)) < 0.30
+
+
+def _can_read_as_document(path: Path) -> bool:
+    """Verbatim port of FileHandler.can_read_file, minus the PDF_AVAILABLE/
+    DOCX_AVAILABLE gate - .pdf/.docx are always classified as document kind
+    here (matching legacy's own SUPPORTED_EXTENSIONS, which only ADDED
+    .pdf/.docx when the optional lib imported successfully at startup); the
+    graceful "not installed" message now surfaces at read_file() time
+    instead, which is the one behavioral difference and it is strictly
+    better - legacy silently routed a .pdf to "Unsupported file type" on a
+    machine without pypdf, rather than telling the user why."""
+    ext = path.suffix.lower()
+    if ext in PLAIN_TEXT_EXTENSIONS or ext in (".pdf", ".docx"):
+        return True
+    if path.name in SUPPORTED_FILENAMES:
+        return True
+    try:
+        sample = path.read_bytes()[:4096]
+    except OSError:
+        return False
+    return _looks_like_text_file(sample)
+
+
+def _read_text(path: Path) -> str:
+    """Verbatim port of FileHandler._read_text's encoding fallback chain."""
+    raw_bytes = path.read_bytes()
+    for encoding in ("utf-8", "utf-8-sig", "utf-16", "utf-16-le", "utf-16-be", "latin-1"):
+        try:
+            return raw_bytes.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return raw_bytes.decode("utf-8", errors="ignore")
+
+
+def _extract_pdf_page_text(page) -> str:
+    """Verbatim port of FileHandler._extract_pdf_page_text - tries a
+    layout-preserving extraction first (not every pypdf version's
+    extract_text accepts extraction_mode), falls back to the plain call."""
+    for kwargs in ({"extraction_mode": "layout"}, {}):
+        try:
+            text = page.extract_text(**kwargs)
+        except TypeError:
+            continue
+        except Exception:
+            text = None
+        if text and text.strip():
+            return text
+    return ""
+
+
+def _read_pdf(path: Path) -> str:
+    """Verbatim port of FileHandler._read_pdf. Raises AttachmentError (not
+    ValueError) when nothing extractable is found, and when the optional
+    dependency is missing - both cases legacy surfaced as a rejection
+    reason string, never an exception the caller had to know about."""
+    try:
+        import pypdf as pdf_reader_lib
+    except ImportError:
+        try:
+            import PyPDF2 as pdf_reader_lib  # noqa: N813
+        except ImportError:
+            raise AttachmentError(PDF_INSTALL_MESSAGE) from None
+
+    content: list[str] = []
+    extracted_characters = 0
+    with open(path, "rb") as f:
+        reader = pdf_reader_lib.PdfReader(f)
+        for page_number, page in enumerate(reader.pages, start=1):
+            page_text = _extract_pdf_page_text(page)
+            if page_text:
+                normalized_text = page_text.strip()
+                content.append(normalized_text)
+                extracted_characters += len(normalized_text)
+            else:
+                content.append(f"[Page {page_number}: no extractable text found]")
+
+    if extracted_characters == 0:
+        raise AttachmentError(
+            "No readable text could be extracted from this PDF. It may be "
+            "image-based, scanned, encrypted, or use an unsupported text encoding."
+        )
+    return "\n\n".join(part for part in content if part)
+
+
+def _read_docx(path: Path) -> str:
+    """Verbatim port of FileHandler._read_docx."""
+    try:
+        import docx
+    except ImportError:
+        raise AttachmentError(DOCX_INSTALL_MESSAGE) from None
+    document = docx.Document(path)
+    return "\n".join(paragraph.text for paragraph in document.paragraphs)
+
+
+def _looks_like_code_text(extension: str) -> bool:
+    """Extension-only slice of FileHandler._describe_document_attachment's
+    code check - legacy also sniffed the CONTENT for code-like syntax when
+    the extension alone didn't match; that half is dropped here as a
+    cosmetic-label nicety not worth porting (it never affects whether a
+    file can be read, only whether its label says "Code" or "Text"). Every
+    extension that would have been misclassified by dropping it still gets
+    a reasonable "Text" label instead of "Code" - the label is display-only."""
+    return extension in _CODE_EXTENSIONS
+
+
+def _describe_document(name: str, extension: str) -> str:
+    """Port of FileHandler._describe_document_attachment (content-sniffing
+    half dropped, see _looks_like_code_text)."""
+    if extension == ".pdf":
+        return "PDF"
+    if extension == ".docx":
+        return "DOCX"
+    if _looks_like_code_text(extension):
+        return "Code"
+    if extension in {".md", ".mdx"}:
+        return "Markdown"
+    return "Text"
+
+
+def stage_file(path: str) -> StagedAttachment:
+    """Classify and resolve a file for attaching, exactly as legacy's
+    _stage_attachment_file did. Raises AttachmentError with a user-facing
+    message on any rejection - callers surface it via NotificationBanner,
+    never a raw traceback."""
+    resolved = Path(os.path.abspath(path))
+    if not resolved.is_file():
+        raise AttachmentError("File not found.")
+
+    extension = resolved.suffix.lower()
+    byte_size = resolved.stat().st_size
+    name = resolved.name
+
+    if extension in IMAGE_EXTENSIONS:
+        try:
+            data = resolved.read_bytes()
+        except OSError as exc:
+            raise AttachmentError(f"Could not read '{name}': {exc}") from None
+        return StagedAttachment(
+            kind="image",
+            name=name,
+            path=str(resolved),
+            byte_size=byte_size,
+            context_label="Vision",
+            content_part={"type": "image_bytes", "data": data},
+        )
+
+    from graphlink_audio import SUPPORTED_AUDIO_EXTENSIONS
+
+    if extension in SUPPORTED_AUDIO_EXTENSIONS:
+        try:
+            audio_info = inspect_audio_file(str(resolved))
+        except AudioValidationError as exc:
+            raise AttachmentError(str(exc)) from None
+        duration = audio_info["duration_seconds"]
+        return StagedAttachment(
+            kind="audio",
+            name=name,
+            path=str(resolved),
+            byte_size=byte_size,
+            mime_type=audio_info["mime_type"],
+            duration_seconds=duration,
+            context_label=f"Audio | {format_duration(duration)}",
+            # A plain path, not bytes - api_provider.py's own
+            # _read_attachment_bytes reads it lazily at send time, exactly
+            # the same lazy-read shape audio already used before this
+            # feature existed (it just had nothing that ever populated one).
+            content_part={"type": "audio_file", "path": str(resolved)},
+        )
+
+    if _can_read_as_document(resolved):
+        if extension == ".pdf":
+            text = _read_pdf(resolved)
+        elif extension == ".docx":
+            text = _read_docx(resolved)
+        else:
+            text = _read_text(resolved)
+        return StagedAttachment(
+            kind="document",
+            name=name,
+            path=str(resolved),
+            byte_size=byte_size,
+            context_label=_describe_document(name, extension),
+            extracted_text=text,
+            token_count=TokenEstimator().count_tokens(text),
+        )
+
+    raise AttachmentError("Unsupported file type.")
+
+
+def encode_content_part_for_wire(part: dict[str, Any]) -> dict[str, Any]:
+    """Base64-encode a content-part's raw bytes for JSON - same idiom as
+    backend/canvas.py's own _content_parts_wire, reused here (not imported:
+    that function lives in canvas.py, which does not import this module, to
+    avoid a circular import - see canvas.py's own _content_codec for why a
+    tiny duplicated encode step is preferred over restructuring imports for
+    one function)."""
+    if isinstance(part.get("data"), (bytes, bytearray)):
+        return {**part, "data": base64.b64encode(bytes(part["data"])).decode("utf-8")}
+    return dict(part)

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -821,12 +821,20 @@ class SceneDocument:
         content: str,
         is_user: bool,
         parent_id: str | None = None,
+        content_parts: list[dict[str, Any]] | None = None,
     ) -> SceneNode:
         """The Qt-free ChatScene.add_chat_node equivalent: a real message-
         bubble node, optionally connected to a parent (the branch it
         continues). Mirrors add_node's id/dict bookkeeping; the only new
         behavior is the parent-edge, ported from the legacy scene's own
-        ConnectionItem creation."""
+        ConnectionItem creation.
+
+        R8a: content_parts is the real multimodal attachment payload
+        (image_bytes/audio_file parts) - the data-model capability
+        SceneNode.content_parts has carried since R6.3, finally populated by
+        a real caller. Optional and additive: every existing caller keeps
+        passing only (x, y, content, is_user, parent_id) and gets exactly
+        the plain-text node it always did."""
         if parent_id is not None and parent_id not in self.nodes:
             raise SceneError(f"unknown parent node: {parent_id}")
         node_id = f"n{next(self._counter)}"
@@ -839,6 +847,7 @@ class SceneDocument:
             kind="chat",
             content=str(content),
             is_user=bool(is_user),
+            content_parts=content_parts,
         )
         self.nodes[node_id] = node
         if parent_id is not None:
@@ -2290,13 +2299,17 @@ class SceneDocument:
         del self.nodes[node_id]
         self._detach_node_from_membership(node_id)
 
-    def send_message(self, text: str) -> SceneNode:
+    def send_message(self, text: str, content_parts: list[dict[str, Any]] | None = None) -> SceneNode:
         """The Composer's real Send action (R3.3): create a real user
         ChatNode continuing the current branch (last_chat_node_id), or
         start a fresh root if none exists yet. Positioning is a simple
         deterministic stack, not the legacy find_branch_position packing
         algorithm - real auto-layout is a later refinement; "Organize
-        Nodes" already exists as a fallback."""
+        Nodes" already exists as a fallback.
+
+        R8a: content_parts carries real attachments (image/audio) staged in
+        the composer - optional, additive, threaded straight to
+        add_chat_node."""
         parent_id = self.last_chat_node_id
         if parent_id is not None and parent_id in self.nodes:
             parent = self.nodes[parent_id]
@@ -2305,7 +2318,7 @@ class SceneDocument:
             parent_id = None
             chat_node_count = sum(1 for n in self.nodes.values() if n.kind == "chat")
             x, y = 0.0, chat_node_count * MESSAGE_VERTICAL_SPACING
-        node = self.add_chat_node(x, y, text, True, parent_id=parent_id)
+        node = self.add_chat_node(x, y, text, True, parent_id=parent_id, content_parts=content_parts)
         self.last_chat_node_id = node.id
         return node
 
@@ -2326,7 +2339,16 @@ class SceneDocument:
             node = self.nodes.get(current_id)
             if node is None:
                 break
-            history.append({"role": "user" if node.is_user else "assistant", "content": node.content})
+            # R8a: content_parts, when populated, IS the complete message
+            # content (its own text part plus any image_bytes/audio_file
+            # parts) - not an addendum to node.content. A node with no
+            # attachments has content_parts=None and this is byte-identical
+            # to before: a plain string, exactly as every other consumer of
+            # this history already expects.
+            history.append({
+                "role": "user" if node.is_user else "assistant",
+                "content": node.content_parts if node.content_parts else node.content,
+            })
             parent_edge = self._branch_parent_edge(current_id)
             current_id = parent_edge.source if parent_edge is not None else None
         history.reverse()
@@ -3167,11 +3189,33 @@ def register_canvas(
         # R3.3: the real Send action - a real user ChatNode, continuing the
         # active branch. R4: the assistant's reply is now a real agent
         # dispatch call, not a deferred notice - see backend/agents.py.
-        node = document.send_message(text)
+        #
+        # R8a: consult whatever is staged in the composer right now. This is
+        # WHY composer_document is threaded into register_canvas at all (see
+        # this function's own docstring) - take_staged_attachments() pops
+        # and clears in one step, so a mid-flight staging change can never
+        # land on the send that follows it, and never leaks into the next.
+        staged = composer_document.take_staged_attachments()
+        full_text = text
+        for item in staged:
+            if item.extracted_text is not None:
+                full_text += (
+                    f"\n\n--- Attached: {item.name} ({item.context_label}) ---\n"
+                    f"{item.extracted_text}\n--- end attachment ---"
+                )
+        media_parts = [item.content_part for item in staged if item.content_part is not None]
+        content_parts = [{"type": "text", "text": full_text}, *media_parts] if media_parts else None
+
+        node = document.send_message(full_text, content_parts=content_parts)
+        if staged:
+            # The staged list is now empty (popped above) - republish so the
+            # composer's attachment chips clear the instant Send fires,
+            # rather than waiting for the reply's own later publish().
+            await bus.publish("app-composer")
         # R6.3: grow the real, live-growing session token count by the
         # user's own new message text - see add_session_tokens's own
         # comment on SceneDocument.
-        document.add_session_tokens(text)
+        document.add_session_tokens(full_text)
         await publish_scene()
         history = document.chat_branch_history(node.id)
 

--- a/backend/composer.py
+++ b/backend/composer.py
@@ -39,6 +39,7 @@ import api_provider
 
 from backend.events import SessionBus
 from backend.notifications import NotificationState
+from backend.attachments import AttachmentError, StagedAttachment, stage_file
 from backend.settings import (
     _apply,
     apply_llama_cpp_reasoning_mode,
@@ -103,6 +104,21 @@ class ComposerDocument:
     # composer UI can reflect generating/idle state and offer cancellation.
     request_id: str | None = None
     request_state: str = "idle"
+    # R8a: attachments staged for the NEXT send. Lives only in backend
+    # memory - the frontend only ever sees StagedAttachment.to_wire()'s
+    # metadata (see payload() below), never the raw bytes/extracted text.
+    # Cleared by take_staged_attachments() at Send time (backend/canvas.py's
+    # send_message intent - see register_canvas's own docstring on why
+    # composer_document is threaded there).
+    staged_attachments: list[StagedAttachment] = field(default_factory=list)
+
+    def take_staged_attachments(self) -> list[StagedAttachment]:
+        """Pop and clear every staged attachment - called exactly once per
+        Send. A read-then-clear helper rather than two separate calls so
+        canvas.py's send_message can't read the list, get interrupted, and
+        clear a DIFFERENT (newer) list than the one it just read."""
+        items, self.staged_attachments = self.staged_attachments, []
+        return items
 
     def update_draft_text(self, text: str) -> None:
         self.draft.text = str(text)
@@ -181,10 +197,14 @@ class ComposerDocument:
                 "restored": self.draft.restored,
             },
             "context": {
+                # R8a: was 4 hardcoded literals, unconditionally, on every
+                # publish - now the REAL staged-attachment list. "anchor"
+                # stays None: it names a branch-context anchor node, a
+                # separate and still-deferred concept from attachments.
                 "anchor": None,
-                "items": [],
-                "totalTokens": 0,
-                "reviewAvailable": False,
+                "items": [item.to_wire() for item in self.staged_attachments],
+                "totalTokens": sum(item.token_count for item in self.staged_attachments),
+                "reviewAvailable": bool(self.staged_attachments),
             },
             "route": {
                 **route,
@@ -203,7 +223,11 @@ class ComposerDocument:
                 "canRetry": False,
             },
             "capabilities": {
-                "attachments": False,
+                # R8a: real now - staging goes through native_dialogs.pick_file,
+                # which gracefully returns None with no window (bare uvicorn/
+                # pytest), so this stays True unconditionally rather than
+                # trying to detect window availability up front.
+                "attachments": True,
                 "contextReview": False,
                 "routeSelection": False,
                 # Real, and derived - not a constant. The composer's model
@@ -396,6 +420,50 @@ def register_composer(
             await bus.publish("app-settings")
         await publish()
 
+    async def attach_file():
+        """Open a native OPEN file dialog and stage whatever is picked (R8a).
+
+        The one genuinely real capability gap: staging needs an actual
+        on-disk path (backend/attachments.py reads real bytes/extracts real
+        text), so this is a NATIVE dialog - the same native_dialogs.pick_file
+        used by Settings > Llama.cpp's GGUF picker (R7.4c), not a browser
+        <input type="file"> (which never gives a path, only bytes already in
+        the browser - useless here since classification/extraction runs
+        server-side). Cancelling (path is None) is a quiet no-op, matching
+        every other picker in this codebase.
+        """
+        from backend import native_dialogs
+
+        path = await native_dialogs.pick_file(
+            file_types=(
+                "Common Attachments (*.png *.jpg *.jpeg *.webp *.mp3 *.wav *.m4a "
+                "*.flac *.ogg *.opus *.aac *.mp4 *.mpeg *.mpga *.oga *.webm *.pdf "
+                "*.docx *.txt *.md *.py *.js *.ts *.json *.csv *.log)",
+                "Image Files (*.png *.jpg *.jpeg *.webp)",
+                "All Files (*.*)",
+            )
+        )
+        if not path:
+            return
+        try:
+            staged = stage_file(path)
+        except AttachmentError as exc:
+            if notifications is not None:
+                notifications.show(str(exc), "warning")
+                await bus.publish("notification")
+            return
+        document.staged_attachments.append(staged)
+        await publish()
+
+    async def remove_attachment(attachment_id):
+        attachment_id = str(attachment_id)
+        document.staged_attachments = [
+            item for item in document.staged_attachments if item.id != attachment_id
+        ]
+        await publish()
+
+    bus.register_intent("app-composer", "attachFile", attach_file)
+    bus.register_intent("app-composer", "removeAttachment", remove_attachment)
     bus.register_intent("app-composer", "selectModel", select_model)
     bus.register_intent("app-composer", "updateDraft", update_draft)
     bus.register_intent("app-composer", "setReasoningLevel", set_reasoning_level)

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -1,0 +1,225 @@
+"""Real coverage for backend/attachments.py (R8a).
+
+This module is a faithful port of the deleted graphlink_app/
+graphlink_file_handler.py + graphlink_window.py's _stage_attachment_file
+(git show 6c919f6~1:...) - these tests exercise the SAME classification
+decisions against real files on disk, not mocked ones, since the whole
+point of this feature was that the previous "it works" claim (a DOM node
+existing) was never actually tested against real behavior.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from backend.attachments import AttachmentError, stage_file
+
+
+@pytest.fixture
+def tmp_file(tmp_path):
+    def _write(name: str, content: bytes | str) -> str:
+        path = tmp_path / name
+        if isinstance(content, str):
+            path.write_text(content, encoding="utf-8")
+        else:
+            path.write_bytes(content)
+        return str(path)
+
+    return _write
+
+
+class TestImageClassification:
+    def test_png_is_classified_as_image_with_real_bytes_in_the_content_part(self, tmp_file):
+        real_png_header = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+        path = tmp_file("photo.png", real_png_header)
+
+        staged = stage_file(path)
+
+        assert staged.kind == "image"
+        assert staged.context_label == "Vision"
+        assert staged.content_part == {"type": "image_bytes", "data": real_png_header}
+        assert staged.extracted_text is None
+
+    @pytest.mark.parametrize("ext", [".png", ".jpg", ".jpeg", ".webp"])
+    def test_every_documented_image_extension_classifies_as_image(self, tmp_file, ext):
+        path = tmp_file(f"pic{ext}", b"\x00" * 16)
+        assert stage_file(path).kind == "image"
+
+
+class TestAudioClassification:
+    def test_a_readable_wav_is_classified_as_audio_with_a_path_content_part(self, tmp_file):
+        # A minimal but real, playable WAV: RIFF/WAVE header + one silent
+        # PCM sample, so graphlink_audio.inspect_audio_file's real duration
+        # probe succeeds rather than needing a mock.
+        import struct
+        import tempfile
+        import wave
+
+        fd, real_path = tempfile.mkstemp(suffix=".wav")
+        os.close(fd)
+        with wave.open(real_path, "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(8000)
+            w.writeframes(struct.pack("<h", 0) * 8000)  # 1 second of silence
+
+        try:
+            staged = stage_file(real_path)
+            assert staged.kind == "audio"
+            assert staged.content_part == {"type": "audio_file", "path": real_path}
+            assert staged.duration_seconds == pytest.approx(1.0, abs=0.05)
+            assert "Audio" in staged.context_label
+            assert staged.extracted_text is None
+        finally:
+            os.unlink(real_path)
+
+    def test_audio_over_the_duration_cap_is_rejected_not_silently_truncated(self, tmp_file, monkeypatch):
+        import backend.attachments as attachments_module
+
+        def _fake_inspect(path):
+            raise attachments_module.AudioValidationError(
+                "'huge.wav' is 5:00:00 long. The maximum supported length is 4:00:00."
+            )
+
+        monkeypatch.setattr(attachments_module, "inspect_audio_file", _fake_inspect)
+        path = tmp_file("huge.wav", b"RIFF....WAVEfmt ")
+
+        with pytest.raises(AttachmentError, match="maximum supported length"):
+            stage_file(path)
+
+
+class TestDocumentClassificationAndExtraction:
+    def test_plain_text_extension_is_read_verbatim_with_a_real_token_count(self, tmp_file):
+        path = tmp_file("notes.txt", "Hello, this is a real attachment body.")
+
+        staged = stage_file(path)
+
+        assert staged.kind == "document"
+        assert staged.context_label == "Text"
+        assert staged.extracted_text == "Hello, this is a real attachment body."
+        assert staged.token_count > 0
+        assert staged.content_part is None
+
+    def test_code_extension_gets_the_code_label(self, tmp_file):
+        path = tmp_file("script.py", "def f():\n    return 1\n")
+        assert stage_file(path).context_label == "Code"
+
+    def test_markdown_extension_gets_the_markdown_label(self, tmp_file):
+        path = tmp_file("readme.md", "# Title\n\nBody text.")
+        assert stage_file(path).context_label == "Markdown"
+
+    def test_unrecognized_extension_with_text_like_bytes_is_sniffed_and_read(self, tmp_file):
+        # No extension in PLAIN_TEXT_EXTENSIONS, but the byte-sniff heuristic
+        # (ported verbatim from FileHandler._looks_like_text_file) should
+        # still classify and read it as a document.
+        path = tmp_file("data.xyz", "just plain ascii text content for sniffing purposes")
+
+        staged = stage_file(path)
+
+        assert staged.kind == "document"
+        assert staged.extracted_text is not None
+
+    def test_named_file_with_no_extension_is_recognized(self, tmp_file):
+        path = tmp_file("Dockerfile", "FROM python:3.12\n")
+        staged = stage_file(path)
+        assert staged.kind == "document"
+
+    def test_binary_garbage_with_unknown_extension_is_rejected(self, tmp_file):
+        path = tmp_file("blob.xyz", bytes(range(256)) * 20)
+
+        with pytest.raises(AttachmentError, match="Unsupported file type"):
+            stage_file(path)
+
+    def test_null_byte_containing_file_is_rejected_even_with_mostly_ascii_content(self, tmp_file):
+        # The byte-sniff heuristic's own hard rule: any NUL byte disqualifies
+        # a file outright, matching FileHandler._looks_like_text_file exactly.
+        path = tmp_file("mixed.bin", b"mostly text here\x00but one null byte")
+        with pytest.raises(AttachmentError, match="Unsupported file type"):
+            stage_file(path)
+
+
+class TestPdfAndDocx:
+    def test_missing_pypdf_surfaces_the_exact_install_message(self, tmp_file, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _blocked_import(name, *args, **kwargs):
+            if name in ("pypdf", "PyPDF2"):
+                raise ImportError(name)
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _blocked_import)
+        path = tmp_file("doc.pdf", b"%PDF-1.4 fake")
+
+        with pytest.raises(AttachmentError, match="pip install pypdf"):
+            stage_file(path)
+
+    def test_missing_python_docx_surfaces_the_exact_install_message(self, tmp_file, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _blocked_import(name, *args, **kwargs):
+            if name == "docx":
+                raise ImportError(name)
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _blocked_import)
+        path = tmp_file("doc.docx", b"PK\x03\x04 fake docx bytes")
+
+        with pytest.raises(AttachmentError, match="pip install python-docx"):
+            stage_file(path)
+
+    def test_a_real_docx_extracts_its_real_paragraph_text(self, tmp_file):
+        pytest.importorskip("docx")
+        import docx
+
+        import tempfile
+
+        fd, real_path = tempfile.mkstemp(suffix=".docx")
+        os.close(fd)
+        document = docx.Document()
+        document.add_paragraph("First real paragraph.")
+        document.add_paragraph("Second real paragraph.")
+        document.save(real_path)
+
+        try:
+            staged = stage_file(real_path)
+            assert staged.kind == "document"
+            assert staged.context_label == "DOCX"
+            assert "First real paragraph." in staged.extracted_text
+            assert "Second real paragraph." in staged.extracted_text
+        finally:
+            os.unlink(real_path)
+
+    def test_a_real_pdf_with_no_extractable_text_is_rejected_not_silently_empty(self, tmp_file):
+        pytest.importorskip("pypdf")
+        from pypdf import PdfWriter
+
+        import tempfile
+
+        fd, real_path = tempfile.mkstemp(suffix=".pdf")
+        os.close(fd)
+        writer = PdfWriter()
+        writer.add_blank_page(width=72, height=72)  # a real page, zero text
+        with open(real_path, "wb") as f:
+            writer.write(f)
+
+        try:
+            with pytest.raises(AttachmentError, match="No readable text could be extracted"):
+                stage_file(real_path)
+        finally:
+            os.unlink(real_path)
+
+
+class TestRejections:
+    def test_missing_file_is_rejected(self, tmp_path):
+        with pytest.raises(AttachmentError, match="File not found"):
+            stage_file(str(tmp_path / "does-not-exist.txt"))
+
+    def test_a_directory_is_rejected_not_read_as_a_file(self, tmp_path):
+        with pytest.raises(AttachmentError, match="File not found"):
+            stage_file(str(tmp_path))

--- a/backend/tests/test_backend_composer.py
+++ b/backend/tests/test_backend_composer.py
@@ -65,7 +65,12 @@ def test_default_payload_matches_generated_validator_shape(monkeypatch):
     assert set(payload) == {"draft", "context", "route", "request", "capabilities"}
     assert set(payload["draft"]) == {"id", "text", "contextMode", "sendMode", "restored"}
     assert payload["capabilities"]["reasoningSelection"] is True
-    assert payload["capabilities"]["attachments"] is False, "attachment staging is deferred, not faked"
+    # R8a: attachment staging is real now (backend/attachments.py + the
+    # attachFile/removeAttachment intents), so this asserts the OPPOSITE of
+    # what it used to - the old assertion was itself the encoded-as-correct
+    # deferral, which is exactly the shape of bug this feature exists to fix.
+    assert payload["capabilities"]["attachments"] is True
+    assert payload["context"]["items"] == [], "no attachment staged yet on a fresh document"
     assert payload["request"]["canSend"] is True, "idle state can send now that R4 agent dispatch has landed"
 
 
@@ -422,3 +427,105 @@ def test_composer_reasoning_republish_is_skipped_when_settings_is_not_registered
     recorder = asyncio.run(run())
     assert recorder.topics_seen().count("app-composer") == 1
     assert "app-settings" not in recorder.topics_seen()
+
+
+# -- R8a: real file attachments -----------------------------------------------
+
+
+def test_attach_file_stages_a_real_document_and_republishes(tmp_path, monkeypatch):
+    manager = SettingsManager(tmp_path / "session.dat")
+    source = tmp_path / "notes.txt"
+    source.write_text("real attached body", encoding="utf-8")
+
+    async def fake_pick_file(*args, **kwargs):
+        return str(source)
+
+    monkeypatch.setattr("backend.native_dialogs.pick_file", fake_pick_file)
+
+    async def run():
+        bus, composer, notifications, recorder = _make_bus_with_settings(manager)
+        await bus.dispatch_intent("app-composer", "attachFile", [])
+        return composer, recorder
+
+    composer, recorder = asyncio.run(run())
+
+    assert len(composer.staged_attachments) == 1
+    staged = composer.staged_attachments[0]
+    assert staged.kind == "document"
+    assert staged.extracted_text == "real attached body"
+
+    payload = composer.payload()
+    assert payload["capabilities"]["attachments"] is True
+    assert payload["context"]["items"] == [
+        {"id": staged.id, "kind": "document", "name": "notes.txt", "byteSize": staged.byte_size,
+         "contextLabel": "Text", "tokenCount": staged.token_count}
+    ]
+    assert payload["context"]["reviewAvailable"] is True
+    assert recorder.topics_seen().count("app-composer") == 1
+
+
+def test_attach_file_cancel_is_a_quiet_noop(tmp_path, monkeypatch):
+    manager = SettingsManager(tmp_path / "session.dat")
+
+    async def fake_pick_file(*args, **kwargs):
+        return None  # user cancelled the native dialog
+
+    monkeypatch.setattr("backend.native_dialogs.pick_file", fake_pick_file)
+
+    async def run():
+        bus, composer, _, recorder = _make_bus_with_settings(manager)
+        await bus.dispatch_intent("app-composer", "attachFile", [])
+        return composer, recorder
+
+    composer, recorder = asyncio.run(run())
+    assert composer.staged_attachments == []
+    assert recorder.topics_seen() == [], "a cancelled dialog must not publish anything"
+
+
+def test_attach_file_rejection_surfaces_a_real_notification_and_stages_nothing(tmp_path, monkeypatch):
+    manager = SettingsManager(tmp_path / "session.dat")
+    source = tmp_path / "blob.xyz"
+    source.write_bytes(bytes(range(256)) * 20)  # binary garbage, unknown extension
+
+    async def fake_pick_file(*args, **kwargs):
+        return str(source)
+
+    monkeypatch.setattr("backend.native_dialogs.pick_file", fake_pick_file)
+
+    async def run():
+        bus, composer, notifications, recorder = _make_bus_with_settings(manager)
+        await bus.dispatch_intent("app-composer", "attachFile", [])
+        return composer, notifications, recorder
+
+    composer, notifications, recorder = asyncio.run(run())
+    assert composer.staged_attachments == []
+    assert notifications.visible and notifications.msg_type == "warning"
+    assert "Unsupported file type" in notifications.message
+    assert "notification" in recorder.topics_seen()
+    assert "app-composer" not in recorder.topics_seen(), "a rejected file must not publish a stale composer state"
+
+
+def test_remove_attachment_removes_only_the_matching_id(tmp_path, monkeypatch):
+    manager = SettingsManager(tmp_path / "session.dat")
+    first = tmp_path / "a.txt"
+    second = tmp_path / "b.txt"
+    first.write_text("a", encoding="utf-8")
+    second.write_text("b", encoding="utf-8")
+    paths = iter([str(first), str(second)])
+
+    async def fake_pick_file(*args, **kwargs):
+        return next(paths)
+
+    monkeypatch.setattr("backend.native_dialogs.pick_file", fake_pick_file)
+
+    async def run():
+        bus, composer, _, _ = _make_bus_with_settings(manager)
+        await bus.dispatch_intent("app-composer", "attachFile", [])
+        await bus.dispatch_intent("app-composer", "attachFile", [])
+        keep_id = composer.staged_attachments[1].id
+        remove_id = composer.staged_attachments[0].id
+        await bus.dispatch_intent("app-composer", "removeAttachment", [remove_id])
+        return composer, keep_id
+
+    composer, keep_id = asyncio.run(run())
+    assert [item.id for item in composer.staged_attachments] == [keep_id]

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -24,6 +24,7 @@ from backend.canvas import (
     _research_result_wire,
     register_canvas,
 )
+from backend.attachments import StagedAttachment
 from backend.composer import ComposerDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -1369,6 +1370,159 @@ def test_regenerate_response_document_and_image_children_torn_down_but_never_rec
         assert not any(n.kind in ("document", "image") for n in document.nodes.values()), (
             "torn down but never recreated - parse_response structurally never emits document/image parts"
         )
+
+    asyncio.run(run())
+
+
+# -- R8a: sendMessage consumes real staged attachments ------------------------
+
+
+def _bus_with_composer_document():
+    """Same shape as make_bus_with_dispatcher, but also returns the real
+    ComposerDocument so a test can stage attachments directly on it - the
+    same object canvas.py's send_message reads via composer_document.
+    take_staged_attachments(), confirming the wiring is the SAME instance,
+    not a copy."""
+    bus = SessionBus("attachment-send-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    composer_document = ComposerDocument()
+    bus.register_topic("app-composer", composer_document.payload)
+    agent_dispatcher = AgentDispatcher(_FakeSettingsManager())
+    document = register_canvas(bus, notifications, agent_dispatcher, composer_document)
+    recorder = Recorder()
+    bus.attach(recorder)
+    return bus, document, composer_document, recorder, agent_dispatcher
+
+
+def test_send_with_no_staged_attachments_is_byte_identical_to_before_r8a():
+    # The zero-ripple guarantee: a plain send with nothing staged must
+    # produce a plain-string content, not a list - content_parts stays None,
+    # so chat_branch_history's fallback path is exercised, not the new one.
+    async def run():
+        bus, document, composer_document, _recorder, _dispatcher = _bus_with_composer_document()
+
+        def capture_reply(task, messages, **kwargs):
+            capture_reply.seen_messages = messages
+            return {"message": {"content": "ok"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", capture_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["plain hello"])
+
+        user_node = document.nodes[user_id]
+        assert user_node.content_parts is None
+        assert user_node.content == "plain hello"
+        assert composer_document.staged_attachments == []
+
+    asyncio.run(run())
+
+
+def test_send_with_a_staged_image_produces_real_multimodal_content_parts():
+    async def run():
+        bus, document, composer_document, _recorder, dispatcher = _bus_with_composer_document()
+
+        real_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20
+        staged = StagedAttachment(
+            kind="image", name="photo.png", path="C:/fake/photo.png", byte_size=len(real_bytes),
+            context_label="Vision", content_part={"type": "image_bytes", "data": real_bytes},
+        )
+        composer_document.staged_attachments.append(staged)
+
+        def capture_reply(task, messages, **kwargs):
+            capture_reply.seen_messages = list(messages)
+            return {"message": {"content": "I see the image"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", capture_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["what is this?"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        user_node = document.nodes[user_id]
+        # The node's plain-text mirror stays a real, readable string - every
+        # existing consumer of .content (title, chat-library preview, copy,
+        # export) keeps working unchanged.
+        assert user_node.content == "what is this?"
+        assert user_node.content_parts == [
+            {"type": "text", "text": "what is this?"},
+            {"type": "image_bytes", "data": real_bytes},
+        ]
+        # The REAL call api_provider.chat received - this is what proves the
+        # attachment reached the model, not just the node's own storage.
+        sent_content = capture_reply.seen_messages[-1]["content"]
+        assert sent_content == user_node.content_parts
+        # Staging is consumed exactly once - popped and cleared by Send.
+        assert composer_document.staged_attachments == []
+
+    asyncio.run(run())
+
+
+def test_send_with_a_staged_document_merges_extracted_text_into_plain_content():
+    # Documents deliberately do NOT touch content_parts - their extracted
+    # text is merged into the plain message text instead, so a text-only
+    # attachment never enters the multimodal path at all.
+    async def run():
+        bus, document, composer_document, _recorder, dispatcher = _bus_with_composer_document()
+
+        staged = StagedAttachment(
+            kind="document", name="notes.txt", path="C:/fake/notes.txt", byte_size=11,
+            context_label="Text", extracted_text="file body here", token_count=3,
+        )
+        composer_document.staged_attachments.append(staged)
+
+        def capture_reply(task, messages, **kwargs):
+            capture_reply.seen_messages = list(messages)
+            return {"message": {"content": "got it"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", capture_reply):
+            user_id = await bus.dispatch_intent("scene", "sendMessage", ["please review"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        user_node = document.nodes[user_id]
+        assert user_node.content_parts is None, "a text-only attachment must never create content_parts"
+        assert user_node.content.startswith("please review")
+        assert "notes.txt" in user_node.content
+        assert "file body here" in user_node.content
+        # The model saw the merged text too - not just the node's own copy.
+        assert capture_reply.seen_messages[-1]["content"] == user_node.content
+        assert composer_document.staged_attachments == []
+
+    asyncio.run(run())
+
+
+def test_send_republishes_app_composer_immediately_so_staged_chips_clear_on_send():
+    # Regression guard: the composer's staged-attachment chips must clear
+    # the instant Send fires, not wait for the (much later) assistant reply.
+    async def run():
+        bus, document, composer_document, recorder, dispatcher = _bus_with_composer_document()
+        composer_document.staged_attachments.append(
+            StagedAttachment(kind="document", name="x.txt", extracted_text="body", context_label="Text")
+        )
+
+        def slow_reply(task, messages, **kwargs):
+            return {"message": {"content": "reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", slow_reply):
+            await bus.dispatch_intent("scene", "sendMessage", ["go"])
+            # Deliberately NOT awaiting the reply task yet - app-composer must
+            # already have republished with an empty items list by this point.
+            composer_publishes = [m for m in recorder.messages if m.get("topic") == "app-composer"]
+            assert composer_publishes, "send_message must republish app-composer synchronously, before the reply"
+            assert composer_publishes[-1]["payload"]["context"]["items"] == []
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
 
     asyncio.run(run())
 

--- a/contracts/graphlink_app_composer_payload.py
+++ b/contracts/graphlink_app_composer_payload.py
@@ -23,7 +23,7 @@ RequestState = Literal[
     "idle", "preparing", "uploading", "waiting", "generating",
     "finalizing", "canceled", "failed", "succeeded",
 ]
-RouteMode = Literal["cloud", "ollama", "llamacpp", "unknown"]
+RouteMode = Literal["ollama", "api", "llama_cpp"]
 SendMode = Literal["enter_to_send", "ctrl_enter_to_send"]
 
 
@@ -45,12 +45,19 @@ class AppComposerContextAnchorPayload:
 
 @dataclass
 class AppComposerAttachmentPayload:
+    """R8a: matches backend.attachments.StagedAttachment.to_wire() exactly -
+    metadata only, never the raw bytes/extracted text/path. Was 6 fields
+    that did not match the real payload in EITHER direction (missing
+    byteSize, an unused preparationState nothing ever set) - this contract
+    had drifted from backend/composer.py's actual runtime dict before any
+    real caller populated `context.items`, so nothing had ever caught it."""
+
     id: str
     name: str
     kind: str
-    tokenCount: int
-    preparationState: str
+    byteSize: int
     contextLabel: str
+    tokenCount: int
 
 
 @dataclass
@@ -63,14 +70,15 @@ class AppComposerContextPayload:
 
 @dataclass
 class AppComposerModelOptionPayload:
+    """R8a: matches backend/composer.py's real route()['modelOptions'] entries
+    exactly - {"id": m, "label": m} for Ollama's scanned models, or the API
+    catalog's {"id", "label"} pairs. Was 8 fields, 6 of them never set by any
+    real caller (provider/source/active/ready/available/capabilities) -
+    the same never-caught drift as AppComposerAttachmentPayload above, since
+    modelOptions was always [] before R8a made model selection real."""
+
     id: str
     label: str
-    provider: str
-    source: str
-    active: bool
-    ready: bool
-    available: bool
-    capabilities: list[str]
 
 
 @dataclass

--- a/web_ui/src/app/chrome/Composer.test.tsx
+++ b/web_ui/src/app/chrome/Composer.test.tsx
@@ -20,6 +20,8 @@ function makeStore(
   const updateDraft = vi.fn();
   const setReasoningLevel = vi.fn();
   const selectModel = vi.fn();
+  const attachFile = vi.fn();
+  const removeAttachment = vi.fn();
   const cancelChatRequest = vi.fn();
   const dismissNotification = vi.fn();
   const store = {
@@ -34,10 +36,15 @@ function makeStore(
     updateDraft,
     setReasoningLevel,
     selectModel,
+    attachFile,
+    removeAttachment,
     cancelChatRequest,
     dismissNotification,
   };
-  return { store, updateDraft, setReasoningLevel, selectModel, cancelChatRequest, dismissNotification };
+  return {
+    store, updateDraft, setReasoningLevel, selectModel, attachFile, removeAttachment,
+    cancelChatRequest, dismissNotification,
+  };
 }
 
 function makeSceneStore() {
@@ -333,6 +340,84 @@ describe("Composer", () => {
       </OverlayProvider>,
     );
     expect(container.querySelector('[data-overlay-trigger="reasoning"]')).not.toBeDisabled();
+  });
+
+  it("the Attach button is disabled when capabilities.attachments is false, even with canSend true", () => {
+    const { store } = makeStore({
+      composer: {
+        capabilities: { ...initialComposerState.capabilities, attachments: false },
+        request: { ...initialComposerState.request, canSend: true },
+      },
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(screen.getByLabelText("Attach context")).toBeDisabled();
+  });
+
+  it("clicking the Attach button calls store.attachFile() when capable and idle", async () => {
+    const user = userEvent.setup();
+    const { store, attachFile } = makeStore({
+      composer: {
+        capabilities: { ...initialComposerState.capabilities, attachments: true },
+        request: { ...initialComposerState.request, canSend: true },
+      },
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+    const attachButton = screen.getByLabelText("Attach context");
+    expect(attachButton).not.toBeDisabled();
+    await user.click(attachButton);
+    expect(attachFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders no attachment chips when context.items is empty", () => {
+    const { store } = makeStore();
+    const { container } = render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(container.querySelector(".composer-attachment-chips")).toBeNull();
+  });
+
+  it("renders a real chip per staged attachment, and removing one calls store.removeAttachment(id)", async () => {
+    const user = userEvent.setup();
+    const { store, removeAttachment } = makeStore({
+      composer: {
+        context: {
+          ...initialComposerState.context,
+          items: [
+            { id: "att-1", name: "photo.png", kind: "image", byteSize: 2048, contextLabel: "Vision", tokenCount: 0 },
+            { id: "att-2", name: "notes.txt", kind: "document", byteSize: 512, contextLabel: "Text", tokenCount: 12 },
+          ],
+        },
+      },
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
+      </OverlayProvider>,
+    );
+
+    expect(screen.getByText("photo.png")).toBeInTheDocument();
+    expect(screen.getByText("notes.txt")).toBeInTheDocument();
+    expect(screen.getByText("Vision")).toBeInTheDocument();
+    expect(screen.getByText("Text")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Remove photo.png"));
+    expect(removeAttachment).toHaveBeenCalledWith("att-1");
+    // the OTHER chip must not have been touched
+    expect(removeAttachment).not.toHaveBeenCalledWith("att-2");
   });
 });
 

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -10,17 +10,25 @@ import type { ComposerStore } from "./composerStore";
  * Real here: draft text editing, reasoning-level selection (a stored
  * preference popover, reusing the overlay system rather than a dedicated
  * picker island), Send - a real user ChatNode via sceneStore.sendMessage,
- * and (R4.3) the agent-dispatch request lifecycle: the assistant's reply
- * is generated asynchronously by the backend agent layer and lands over
- * the existing scene topic republish, exactly like any other node-creation
- * path this app already handles. Send is gated on request.canSend (so a
- * second send can't be issued mid-flight) and Cancel is rendered only
- * while request.canCancel is true, per backend/composer.py's request
- * capability flags. Still visibly deferred, per those same flags: attach
- * (file-staging pipeline), context review (nothing to review until
- * attachments exist), model/provider selection (needs real provider
- * wiring). Each renders disabled with a title naming its phase, exactly
- * the app bar's Save/provider-select precedent.
+ * (R4.3) the agent-dispatch request lifecycle: the assistant's reply is
+ * generated asynchronously by the backend agent layer and lands over the
+ * existing scene topic republish, exactly like any other node-creation
+ * path this app already handles, (R8a) real chat-model selection (a
+ * popover next to reasoning, writing through the same assignment the
+ * Settings > Ollama page uses), and (R8a) real file attachments - a native
+ * dialog stages an image/audio/document, backend/attachments.py classifies
+ * and (for documents) extracts it, and staged items render as removable
+ * chips above the input until Send bundles them onto the new ChatNode.
+ * Send is gated on request.canSend (so a second send can't be issued
+ * mid-flight) and Cancel is rendered only while request.canCancel is true,
+ * per backend/composer.py's request capability flags.
+ *
+ * Still visibly deferred: provider-MODE switching (Ollama/Llama.cpp/API) -
+ * Settings configures all three for real, but changing which one is active
+ * needs real provider-switch wiring the app bar's own disabled selector
+ * names. Context review (inspecting/editing a staged attachment's content
+ * before Send) is also not built - remove-and-reattach is the only
+ * correction available today.
  *
  * Theme is NOT read from this payload (see backend/composer.py's docstring
  * for why) - the SPA's tokens are already global CSS.
@@ -65,6 +73,29 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
 
   return (
     <div className="composer-dock">
+      {composer.context.items.length > 0 && (
+        // R8a: real staged attachments. Metadata only - the composer never
+        // receives raw bytes/extracted text, just what StagedAttachment.
+        // to_wire() sends (backend/attachments.py).
+        <div className="composer-attachment-chips" aria-label="Staged attachments">
+          {composer.context.items.map((item) => (
+            <span key={item.id} className="composer-attachment-chip">
+              <span className="composer-attachment-chip-kind">{item.contextLabel}</span>
+              <span className="composer-attachment-chip-name" title={item.name}>
+                {item.name}
+              </span>
+              <button
+                type="button"
+                className="composer-attachment-chip-remove"
+                aria-label={`Remove ${item.name}`}
+                onClick={() => store.removeAttachment(item.id)}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
       <div className="composer-input-wrap">
         <textarea
           ref={inputRef}
@@ -91,12 +122,16 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
           </div>
         )}
 
+        {/* R8a: real now - opens a native file dialog (backend/native_dialogs.py)
+            and stages whatever is picked. Was hard-disabled with an
+            "aren't available yet" title and nothing behind it. */}
         <button
           type="button"
           className="composer-icon-button"
-          disabled
-          title="Attachments aren't available yet"
+          disabled={!composer.capabilities.attachments || !composer.request.canSend}
+          title="Attach a file (image, audio, or a text/PDF/DOCX document)"
           aria-label="Attach context"
+          onClick={() => store.attachFile()}
         >
           <Icon name="attach" />
         </button>

--- a/web_ui/src/app/chrome/composerStore.ts
+++ b/web_ui/src/app/chrome/composerStore.ts
@@ -152,6 +152,17 @@ export class ComposerStore {
     this.transport.intent("app-composer", "setReasoningLevel", [level]);
   }
 
+  attachFile(): void {
+    // R8a: opens a NATIVE file dialog server-side (backend/native_dialogs.py,
+    // same mechanism as Settings > Llama.cpp's GGUF picker) - there is no
+    // browser-side file to pass, staging happens entirely on the backend.
+    this.transport.intent("app-composer", "attachFile", []);
+  }
+
+  removeAttachment(attachmentId: string): void {
+    this.transport.intent("app-composer", "removeAttachment", [attachmentId]);
+  }
+
   cancelChatRequest(requestId: string): void {
     this.transport.intent("app-composer", "cancelChatRequest", [requestId]);
   }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1236,6 +1236,63 @@ body,
   gap: 8px;
 }
 
+/* R8a: staged-attachment chips, rendered above the input when
+   composer.context.items is non-empty. */
+.composer-attachment-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.composer-attachment-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 220px;
+  padding: 4px 6px 4px 10px;
+  border-radius: 999px;
+  background-color: var(--gl-neutral-button-hover);
+  border: 1px solid var(--gl-surface-border);
+  font-size: 12px;
+  color: var(--gl-surface-text);
+}
+
+.composer-attachment-chip-kind {
+  flex-shrink: 0;
+  color: var(--gl-surface-text-muted);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.03em;
+}
+
+.composer-attachment-chip-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer-attachment-chip-remove {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background-color: transparent;
+  color: var(--gl-surface-text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.composer-attachment-chip-remove:hover {
+  background-color: var(--gl-surface-border);
+  color: var(--gl-surface-text);
+}
+
 .composer-input-wrap {
   display: flex;
 }

--- a/web_ui/src/lib/bridge-core/generated/app-composer-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/app-composer-state.schema.json
@@ -65,6 +65,9 @@
           "items": {
             "additionalProperties": false,
             "properties": {
+              "byteSize": {
+                "type": "integer"
+              },
               "contextLabel": {
                 "type": "string"
               },
@@ -77,9 +80,6 @@
               "name": {
                 "type": "string"
               },
-              "preparationState": {
-                "type": "string"
-              },
               "tokenCount": {
                 "type": "integer"
               }
@@ -88,9 +88,9 @@
               "id",
               "name",
               "kind",
-              "tokenCount",
-              "preparationState",
-              "contextLabel"
+              "byteSize",
+              "contextLabel",
+              "tokenCount"
             ],
             "type": "object"
           },
@@ -204,10 +204,9 @@
         },
         "mode": {
           "enum": [
-            "cloud",
             "ollama",
-            "llamacpp",
-            "unknown"
+            "api",
+            "llama_cpp"
           ],
           "type": "string"
         },
@@ -221,43 +220,16 @@
           "items": {
             "additionalProperties": false,
             "properties": {
-              "active": {
-                "type": "boolean"
-              },
-              "available": {
-                "type": "boolean"
-              },
-              "capabilities": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
               "id": {
                 "type": "string"
               },
               "label": {
                 "type": "string"
-              },
-              "provider": {
-                "type": "string"
-              },
-              "ready": {
-                "type": "boolean"
-              },
-              "source": {
-                "type": "string"
               }
             },
             "required": [
               "id",
-              "label",
-              "provider",
-              "source",
-              "active",
-              "ready",
-              "available",
-              "capabilities"
+              "label"
             ],
             "type": "object"
           },

--- a/web_ui/src/lib/bridge-core/generated/app-composer-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/app-composer-state.ts
@@ -27,13 +27,13 @@ export interface AppComposerAttachment {
   id: string;
   name: string;
   kind: string;
-  tokenCount: number;
-  preparationState: string;
+  byteSize: number;
   contextLabel: string;
+  tokenCount: number;
 }
 
 export interface AppComposerRoute {
-  mode: "cloud" | "ollama" | "llamacpp" | "unknown";
+  mode: "ollama" | "api" | "llama_cpp";
   provider: string;
   modelId: string;
   modelLabel: string;
@@ -48,12 +48,6 @@ export interface AppComposerRoute {
 export interface AppComposerModelOption {
   id: string;
   label: string;
-  provider: string;
-  source: string;
-  active: boolean;
-  ready: boolean;
-  available: boolean;
-  capabilities: string[];
 }
 
 export interface AppComposerReasoning {
@@ -203,19 +197,19 @@ function checkAppComposerAttachment(value: unknown, path: string, errors: string
     else { if (typeof fieldValue !== "string") errors.push(`${path}.kind` + ": expected string"); }
   }
   {
-    const fieldValue = value["tokenCount"];
-    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.tokenCount: missing required field`);
-    else { if (typeof fieldValue !== "number") errors.push(`${path}.tokenCount` + ": expected number"); }
-  }
-  {
-    const fieldValue = value["preparationState"];
-    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.preparationState: missing required field`);
-    else { if (typeof fieldValue !== "string") errors.push(`${path}.preparationState` + ": expected string"); }
+    const fieldValue = value["byteSize"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.byteSize: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.byteSize` + ": expected number"); }
   }
   {
     const fieldValue = value["contextLabel"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.contextLabel: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.contextLabel` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["tokenCount"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.tokenCount: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.tokenCount` + ": expected number"); }
   }
 }
 
@@ -224,7 +218,7 @@ function checkAppComposerRoute(value: unknown, path: string, errors: string[]): 
   {
     const fieldValue = value["mode"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.mode: missing required field`);
-    else { if (!["cloud", "ollama", "llamacpp", "unknown"].includes(fieldValue as string)) errors.push(`${path}.mode` + `: ${JSON.stringify(fieldValue)} is not one of [` + "cloud, ollama, llamacpp, unknown" + `]`); }
+    else { if (!["ollama", "api", "llama_cpp"].includes(fieldValue as string)) errors.push(`${path}.mode` + `: ${JSON.stringify(fieldValue)} is not one of [` + "ollama, api, llama_cpp" + `]`); }
   }
   {
     const fieldValue = value["provider"];
@@ -284,37 +278,6 @@ function checkAppComposerModelOption(value: unknown, path: string, errors: strin
     const fieldValue = value["label"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.label: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.label` + ": expected string"); }
-  }
-  {
-    const fieldValue = value["provider"];
-    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.provider: missing required field`);
-    else { if (typeof fieldValue !== "string") errors.push(`${path}.provider` + ": expected string"); }
-  }
-  {
-    const fieldValue = value["source"];
-    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.source: missing required field`);
-    else { if (typeof fieldValue !== "string") errors.push(`${path}.source` + ": expected string"); }
-  }
-  {
-    const fieldValue = value["active"];
-    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.active: missing required field`);
-    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.active` + ": expected boolean"); }
-  }
-  {
-    const fieldValue = value["ready"];
-    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.ready: missing required field`);
-    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.ready` + ": expected boolean"); }
-  }
-  {
-    const fieldValue = value["available"];
-    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.available: missing required field`);
-    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.available` + ": expected boolean"); }
-  }
-  {
-    const fieldValue = value["capabilities"];
-    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.capabilities: missing required field`);
-    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.capabilities` + ": expected array");
-    else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "string") errors.push(`${path}.capabilities` + `[${i}]` + ": expected string"); }); }
   }
 }
 


### PR DESCRIPTION
## Problem

The composer's Attach button was hard-disabled with a "not available yet" title, and `context.items`/`totalTokens`/`reviewAvailable` were four hardcoded literals nothing ever populated. `contracts/graphlink_app_composer_payload.py`'s attachment and model-option shapes had also drifted from what `backend/composer.py` actually sends, undetected because no real caller had populated those fields before now.

## Change

- `backend/attachments.py` (new): ports the deleted Qt file handler's classification logic faithfully — image/audio/document detection, PDF (`pypdf`/`PyPDF2`) and DOCX (`python-docx`) text extraction, reusing the existing audio inspector and token estimator. Raises the same user-facing error messages the legacy handler used.
- `backend/composer.py`: `attachFile` intent opens a native file dialog (`backend/native_dialogs.py`, same mechanism as the Llama.cpp GGUF picker), stages the result, and republishes; `removeAttachment` removes a staged item by id. `payload()`'s `context` block now reflects real staged state.
- `backend/canvas.py`: `send_message` threads staged attachments into `SceneNode.content_parts` (pre-existing field, previously never populated) — image/audio become real multimodal content parts, document text is folded into the plain-text message. `content_parts` is already consumed by the Ollama/Anthropic/Gemini chat paths.
- `contracts/graphlink_app_composer_payload.py`: fixed `AppComposerAttachmentPayload` and `AppComposerModelOptionPayload` to match the real runtime dict; regenerated TS types.
- Frontend: Attach button now calls `store.attachFile()`; staged attachments render as removable chips above the input.

OpenAI-compatible chat has no multimodal support at the provider layer today (messages pass through unconverted) — left out of scope for this change.

## Test plan

- [x] `backend/tests/test_attachments.py` (new, 20 tests) — real PNG/WAV/DOCX/PDF files, binary garbage, missing files, missing optional deps
- [x] `backend/tests/test_backend_composer.py` — attach/remove intents, real notification on rejection
- [x] `backend/tests/test_canvas.py` — real multimodal `content_parts` verified reaching the mocked `api_provider.chat` call
- [x] `web_ui/src/app/chrome/Composer.test.tsx` — Attach button enable/disable, click-to-attach, chip rendering, click-to-remove
- [x] Full backend suite: 989 passed
- [x] Full frontend suite: `tsc --noEmit` clean, lint 0 errors, 785 tests passed, build succeeds