### PR TITLE
R8a: restore Open Document View for chat and conversation nodes

### DIFF
--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -33,6 +33,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   const onGenerateChart = vi.fn();
   const onGenerateKeyTakeaway = vi.fn();
   const onGenerateExplainerNote = vi.fn();
+  const onOpenDocumentView = vi.fn();
   const onScrollChange = vi.fn();
   const props = {
     id: "n0",
@@ -51,6 +52,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
       onGenerateChart,
       onGenerateKeyTakeaway,
       onGenerateExplainerNote,
+      onOpenDocumentView,
       onScrollChange,
       ...overrides,
     },
@@ -64,7 +66,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   return {
     onToggleCollapse, onDelete, onUndockChild, onRegenerate, onGenerateImage,
     onGenerateChart, onGenerateKeyTakeaway, onGenerateExplainerNote,
-    onScrollChange, container,
+    onOpenDocumentView, onScrollChange, container,
   };
 }
 
@@ -103,12 +105,15 @@ describe("ChatNodeView", () => {
     const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
     expect(hideBranches).toBeDisabled();
     expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
+    // R8a: these three were disabled stubs until their agents/dialog were
+    // wired up (Open Document View: the shared DocumentViewDialog; Key
+    // Takeaway/Explainer Note: ported back from the deleted Qt app). This
+    // assertion is deliberately inverted rather than removed - it was the
+    // guard that encoded the stub as correct, so it has to now encode the
+    // opposite.
     const docView = screen.getByRole("menuitem", { name: "Open Document View" });
-    expect(docView).toBeDisabled();
-    // R8a: these two were disabled stubs until their agents were ported
-    // back from the deleted Qt app. This assertion is deliberately inverted
-    // rather than removed - it was the guard that encoded the stub as
-    // correct, so it has to now encode the opposite.
+    expect(docView).not.toBeDisabled();
+    expect(docView).not.toHaveAttribute("title");
     for (const name of ["Generate Key Takeaway", "Generate Explainer Note"]) {
       const item = screen.getByRole("menuitem", { name });
       expect(item).not.toBeDisabled();
@@ -179,6 +184,17 @@ describe("ChatNodeView", () => {
     await user.click(generateImage);
     expect(onGenerateImage).toHaveBeenCalledOnce();
     expect(screen.queryByRole("menu")).toBeNull(); // onClose fires after onGenerateImage
+  });
+
+  it("Open Document View calls onOpenDocumentView then closes the menu", async () => {
+    const user = userEvent.setup();
+    const { onOpenDocumentView } = renderChatNode({ isUser: false });
+
+    fireEvent.contextMenu(screen.getByText("Assistant"));
+    await user.click(screen.getByRole("menuitem", { name: "Open Document View" }));
+
+    expect(onOpenDocumentView).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 
   it("Generate Key Takeaway calls onGenerateKeyTakeaway then closes the menu", async () => {

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -15,10 +15,8 @@ import { NodeMenu } from "./NodeMenu";
  * honest disabled+title label rather than a fake action or a silent drop
  * (an R3.4 live-drive audit found several legacy ChatNode menu items had
  * been dropped with zero acknowledgment - fixed here): Regenerate (assistant
- * nodes only, needs the R4 agent layer), Open Document View (the
- * document-viewer island isn't wired into the SPA overlay system yet), and
- * Hide Other Branches (the legacy scene's
- * branch-visibility toggle has no backend/frontend equivalent at all yet -
+ * nodes only, needs the R4 agent layer), and Hide Other Branches (the
+ * legacy scene's branch-visibility toggle has no backend/frontend equivalent at all yet -
  * unscoped, not owned by any R-phase). One legacy item is still deliberately
  * NOT listed even as disabled: "Generate Group Summary" is itself
  * conditionally hidden in the legacy menu (only when a multi-selection
@@ -46,6 +44,9 @@ import { NodeMenu } from "./NodeMenu";
  * agent layer had been stale since R4 - the very layer Regenerate/Image/
  * Chart already use. Both now dispatch real intents that drop the agent's
  * output into a new note beside this node (graphlink_note_agent.py).
+ * "Open Document View" is likewise no longer deferred as of this change: it
+ * now opens DocumentViewDialog.tsx with this node's own content
+ * (frontend-only, no backend intent - the content is already client-side).
  * "Export" is
  * likewise no longer deferred as of R7.5a: it downloads the node's raw
  * content (not the rendered markdown) as a .md file via downloadTextFile -
@@ -76,6 +77,7 @@ export interface ChatNodeData extends Record<string, unknown> {
   onGenerateChart: (chartType: string) => void;
   onGenerateKeyTakeaway: () => void;
   onGenerateExplainerNote: () => void;
+  onOpenDocumentView: () => void;
   onScrollChange: (value: number) => void;
 }
 
@@ -114,6 +116,7 @@ function ChatNodeMenu({
   onGenerateChart,
   onGenerateKeyTakeaway,
   onGenerateExplainerNote,
+  onOpenDocumentView,
   onClose,
 }: {
   position: MenuPosition;
@@ -130,6 +133,7 @@ function ChatNodeMenu({
   onGenerateChart: (chartType: string) => void;
   onGenerateKeyTakeaway: () => void;
   onGenerateExplainerNote: () => void;
+  onOpenDocumentView: () => void;
   onClose: () => void;
 }) {
   const [chartMenuOpen, setChartMenuOpen] = useState(false);
@@ -192,7 +196,16 @@ function ChatNodeMenu({
           ))}
         </>
       )}
-      <button type="button" role="menuitem" disabled title="Document view integration isn't wired into the SPA yet">
+      {/* R8a: real. Opens the shared DocumentViewDialog (frontend-only, no
+          backend intent) with this node's own content - already client-side. */}
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onOpenDocumentView();
+          onClose();
+        }}
+      >
         Open Document View
       </button>
       {/* R8a: real. Each runs its agent over THIS node's text and drops the
@@ -388,6 +401,7 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
           onGenerateChart={data.onGenerateChart}
           onGenerateKeyTakeaway={data.onGenerateKeyTakeaway}
           onGenerateExplainerNote={data.onGenerateExplainerNote}
+          onOpenDocumentView={data.onOpenDocumentView}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/ConversationNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.test.tsx
@@ -13,6 +13,7 @@ function renderConversationNode(overrides: Partial<ConversationFlowNode["data"]>
   const onSend = vi.fn();
   const onDeleteMessage = vi.fn();
   const onCancel = vi.fn();
+  const onOpenDocumentView = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -28,6 +29,7 @@ function renderConversationNode(overrides: Partial<ConversationFlowNode["data"]>
       onSend,
       onDeleteMessage,
       onCancel,
+      onOpenDocumentView,
       ...overrides,
     },
   } as unknown as NodeProps<ConversationFlowNode>;
@@ -37,7 +39,7 @@ function renderConversationNode(overrides: Partial<ConversationFlowNode["data"]>
       <ConversationNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onToggleCollapse, onDelete, onSend, onDeleteMessage, onCancel };
+  return { onToggleCollapse, onDelete, onSend, onDeleteMessage, onCancel, onOpenDocumentView };
 }
 
 // Directly sets the React Flow internal Zustand store's transform/zoom
@@ -61,6 +63,7 @@ function renderConversationNodeAtZoom(zoom: number, overrides: Partial<Conversat
   const onSend = vi.fn();
   const onDeleteMessage = vi.fn();
   const onCancel = vi.fn();
+  const onOpenDocumentView = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -73,6 +76,7 @@ function renderConversationNodeAtZoom(zoom: number, overrides: Partial<Conversat
       onSend,
       onDeleteMessage,
       onCancel,
+      onOpenDocumentView,
       ...overrides,
     },
   } as unknown as NodeProps<ConversationFlowNode>;
@@ -182,7 +186,7 @@ describe("ConversationNodeView", () => {
     expect(screen.queryByRole("menuitem", { name: "Delete Node" })).toBeNull();
   });
 
-  it("the node-level right-click menu shows exactly 3 items: Open Document View (disabled, exact title), Collapse/Expand (real), Delete Node (real)", async () => {
+  it("the node-level right-click menu shows exactly 3 items: Open Document View (real), Collapse/Expand (real), Delete Node (real)", async () => {
     const user = userEvent.setup();
     const { onDelete, onToggleCollapse } = renderConversationNode();
 
@@ -195,10 +199,7 @@ describe("ConversationNodeView", () => {
     expect(items).toHaveLength(3);
 
     const docView = screen.getByRole("menuitem", { name: "Open Document View" });
-    expect(docView).toBeDisabled();
-    // Copied verbatim from ChatNodeView.tsx's own disabled "Open Document
-    // View" menu item title string.
-    expect(docView).toHaveAttribute("title", "Document view integration isn't wired into the SPA yet");
+    expect(docView).toBeEnabled();
 
     const collapseItem = screen.getByRole("menuitem", { name: "Collapse" });
     expect(collapseItem).toBeEnabled();
@@ -218,6 +219,18 @@ describe("ConversationNodeView", () => {
     fireEvent.contextMenu(header);
     await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
     expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Open Document View calls onOpenDocumentView then closes the menu", async () => {
+    const user = userEvent.setup();
+    const { onOpenDocumentView } = renderConversationNode();
+
+    const header = screen.getByText("Conversation");
+    fireEvent.contextMenu(header);
+    await user.click(screen.getByRole("menuitem", { name: "Open Document View" }));
+
+    expect(onOpenDocumentView).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 
   it("the node-level menu's Collapse/Expand label flips when isCollapsed is true", () => {

--- a/web_ui/src/app/canvas/ConversationNodeView.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.tsx
@@ -21,18 +21,18 @@ import { NodeMenu } from "./NodeMenu";
  * node is never a branch point/reparented, same as code/thinking/html/image),
  * per-bubble copy + delete-from-history, Send (appends a real user message
  * and triggers the real agent reply via the backend agent layer - see
- * sendConversationMessage's own backend docstring), and (R4.3) Cancel: a
+ * sendConversationMessage's own backend docstring), (R4.3) Cancel: a
  * real per-node cancel affordance, the exact same conditional-render pattern
  * as the Composer's own Cancel button (Composer.tsx) applied one level down
  * - per-node instead of per-session. Cancel is rendered only while this
  * node's own data.pendingRequestId is non-null (this node has an in-flight
  * reply of its own), and Send is additionally disabled while that same
  * field is set, so a second send can't be issued mid-flight for this node.
- * Still deferred, with an honest disabled+title label rather than a silent
- * drop (same audit convention every prior node kind in this plan has
- * followed): Open Document View (the document-viewer island isn't wired
- * into the SPA overlay system yet - same reason ChatNodeView's own menu
- * defers it).
+ * (R8a) Open Document View is real too: it opens the shared
+ * DocumentViewDialog (frontend-only, no backend intent) with this node's
+ * entire history formatted as a numbered markdown transcript - see
+ * DocumentViewDialog.tsx / SceneCanvas.tsx's toFlowNodes for the transcript
+ * formatter.
  *
  * Card menu deliberately does NOT include "Hide Other Branches" or "Include
  * Previous Branch Context": the legacy PluginNodeContextMenu for this node
@@ -56,6 +56,7 @@ export interface ConversationNodeData extends Record<string, unknown> {
   onSend: (text: string) => void;
   onDeleteMessage: (index: number) => void;
   onCancel: () => void;
+  onOpenDocumentView: () => void;
 }
 
 export type ConversationFlowNode = Node<ConversationNodeData, "conversation">;
@@ -74,12 +75,14 @@ function ConversationNodeMenu({
   isCollapsed,
   onToggleCollapse,
   onDelete,
+  onOpenDocumentView,
   onClose,
 }: {
   position: MenuPosition;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
   onDelete: () => void;
+  onOpenDocumentView: () => void;
   onClose: () => void;
 }) {
 
@@ -88,7 +91,17 @@ function ConversationNodeMenu({
       {/* Order verified against the legacy PluginNodeContextMenu's own
           construction order for this node kind: Open Document View,
           Collapse/Expand, Delete Node - nothing else. */}
-      <button type="button" role="menuitem" disabled title="Document view integration isn't wired into the SPA yet">
+      {/* R8a: real. Opens the shared DocumentViewDialog (frontend-only, no
+          backend intent) with this node's entire history formatted as a
+          numbered markdown transcript. */}
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onOpenDocumentView();
+          onClose();
+        }}
+      >
         Open Document View
       </button>
       <button
@@ -304,6 +317,7 @@ export function ConversationNodeView({ data, selected }: NodeProps<ConversationF
           isCollapsed={data.isCollapsed}
           onToggleCollapse={data.onToggleCollapse}
           onDelete={data.onDelete}
+          onOpenDocumentView={data.onOpenDocumentView}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/DocumentViewDialog.test.tsx
+++ b/web_ui/src/app/canvas/DocumentViewDialog.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { DocumentViewDialog } from "./DocumentViewDialog";
+import { OverlayProvider, useOverlays } from "../overlays/overlays";
+
+// R8a: Document View dialog tests - mirrors the OverlayProvider + trigger
+// pattern from SettingsDialog.test.tsx (see that file's OpenDocumentView
+// helper's sibling, OpenSettingsButton), since Dialog only mounts its
+// content while its named surface is the open one.
+
+function OpenDocumentViewButton() {
+  const overlays = useOverlays();
+  return (
+    <button type="button" onClick={() => overlays.open("document-view", "dialog")}>
+      open document view
+    </button>
+  );
+}
+
+function setup(content: string | null) {
+  const user = userEvent.setup();
+  render(
+    <OverlayProvider>
+      <OpenDocumentViewButton />
+      <DocumentViewDialog content={content} />
+    </OverlayProvider>,
+  );
+  return { user };
+}
+
+describe("DocumentViewDialog", () => {
+  it("renders nothing when closed", () => {
+    setup("# Hello");
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByText("Hello")).toBeNull();
+  });
+
+  it("shows the dialog with the fixed title after opening via the trigger", async () => {
+    const { user } = setup("some content");
+    await user.click(screen.getByText("open document view"));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText("Document View")).toBeInTheDocument();
+  });
+
+  it("renders markdown content passed via the content prop", async () => {
+    const { user } = setup("# Heading\n\nA paragraph of body text.");
+    await user.click(screen.getByText("open document view"));
+
+    expect(screen.getByRole("heading", { name: "Heading" })).toBeInTheDocument();
+    expect(screen.getByText("A paragraph of body text.")).toBeInTheDocument();
+  });
+
+  it("does not crash and renders an empty body when content is null", async () => {
+    const { user } = setup(null);
+    await user.click(screen.getByText("open document view"));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText("Document View")).toBeInTheDocument();
+  });
+});

--- a/web_ui/src/app/canvas/DocumentViewDialog.tsx
+++ b/web_ui/src/app/canvas/DocumentViewDialog.tsx
@@ -1,0 +1,41 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { Dialog } from "../overlays/overlays";
+
+/**
+ * Document View dialog (finishes a legacy stub carried over from the Qt
+ * cutover, R7.6b) - the SPA successor to graphlink_document_viewer_web.py,
+ * which the Qt app deleted rather than ported. That panel showed a node's
+ * full text as a read-only, scrollable document; the SPA rebuild left
+ * "Open Document View" wired as a disabled menu stub with an honest tooltip
+ * until this content had somewhere to render.
+ *
+ * Frontend-only: the content a node has to show (a chat node's own message,
+ * or a conversation node's assembled transcript) already lives in this
+ * browser's own scene state - there is nothing to fetch, no backend
+ * involvement, no new WS intent. SceneCanvas.tsx builds the markdown string
+ * and hands it down as `content`; this component only renders it.
+ *
+ * Reuses the shared, centered `Dialog` surface (the same category as
+ * About/Help/Settings - one app-wide, single-open surface) rather than the
+ * raw-createPortal pattern NodeMenu.tsx / CodeExecutionApprovalPanel.tsx
+ * use, since those are anchored popups tied to a click point and this is
+ * not anchored to anything on the canvas.
+ *
+ * The title is a fixed "Document View" rather than something per-node
+ * (e.g. including the node's title) because legacy's own panel never had a
+ * dynamic per-open title either - this restores the original behavior
+ * rather than inventing new behavior.
+ */
+export function DocumentViewDialog({ content }: { content: string | null }) {
+  return (
+    <Dialog name="document-view" title="Document View" className="document-view-dialog">
+      <div className="chat-node-content">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+          {content ?? ""}
+        </ReactMarkdown>
+      </div>
+    </Dialog>
+  );
+}

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   applyGroupDragDelta,
+  conversationHistoryToDocumentMarkdown,
   groupDragKindOf,
   handleSelectionChange,
   isOrthogonalEligible,
@@ -10,6 +11,7 @@ import {
   withPreservedSelection,
   type SceneFlowNode,
 } from "./SceneCanvas";
+import type { ConversationMessage } from "./ConversationNodeView";
 import { SceneStore, initialSceneState } from "./sceneStore";
 import type { WsTransport } from "../../lib/ws/transport";
 import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
@@ -201,6 +203,127 @@ describe("toFlowNodes (R4.4a Generate/Regenerate Image wiring)", () => {
 
     (imageFlowNode!.data as { onRegenerate: () => void }).onRegenerate();
     expect(intentSpy).toHaveBeenCalledWith("image-1");
+  });
+});
+
+describe("conversationHistoryToDocumentMarkdown (R8a Open Document View transcript formatter)", () => {
+  it("formats two messages with 1-based numbered headings, joined by a blank line", () => {
+    const history: ConversationMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello there" },
+    ];
+    expect(conversationHistoryToDocumentMarkdown(history)).toBe(
+      "## Conversation Transcript\n\n### 1. User\n\nhi\n\n### 2. Assistant\n\nhello there",
+    );
+  });
+
+  it("skips a blank message but its number still counts (legacy enumerate-before-filter behavior)", () => {
+    const history: ConversationMessage[] = [
+      { role: "user", content: "first" },
+      { role: "assistant", content: "   " },
+      { role: "user", content: "third" },
+    ];
+    const result = conversationHistoryToDocumentMarkdown(history);
+    expect(result).toBe("## Conversation Transcript\n\n### 1. User\n\nfirst\n\n### 3. User\n\nthird");
+    expect(result).not.toContain("### 2.");
+  });
+
+  it("returns an empty string for an empty history", () => {
+    expect(conversationHistoryToDocumentMarkdown([])).toBe("");
+  });
+
+  it("returns an empty string when every message is blank", () => {
+    const history: ConversationMessage[] = [
+      { role: "user", content: "" },
+      { role: "assistant", content: "   " },
+    ];
+    expect(conversationHistoryToDocumentMarkdown(history)).toBe("");
+  });
+});
+
+describe("toFlowNodes (R8a Open Document View wiring)", () => {
+  it("a chat node's onOpenDocumentView invokes the third-argument callback with its own content", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hello world" })],
+      edges: [],
+    });
+    const store = makeStore();
+    const onOpenDocumentView = vi.fn();
+
+    const flowNodes = toFlowNodes(scene, store, onOpenDocumentView);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    expect(chatFlowNode).toBeDefined();
+
+    (chatFlowNode!.data as { onOpenDocumentView: () => void }).onOpenDocumentView();
+    expect(onOpenDocumentView).toHaveBeenCalledWith("Hello world");
+  });
+
+  it("a chat node with blank/whitespace-only content does NOT invoke the callback", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat", content: "   " })],
+      edges: [],
+    });
+    const store = makeStore();
+    const onOpenDocumentView = vi.fn();
+
+    const flowNodes = toFlowNodes(scene, store, onOpenDocumentView);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    expect(chatFlowNode).toBeDefined();
+
+    (chatFlowNode!.data as { onOpenDocumentView: () => void }).onOpenDocumentView();
+    expect(onOpenDocumentView).not.toHaveBeenCalled();
+  });
+
+  it("a conversation node's onOpenDocumentView invokes the callback with the properly formatted transcript", () => {
+    const history: ConversationMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello there" },
+    ];
+    const scene = baseScene({
+      nodes: [baseNode({ id: "conv-1", kind: "conversation", history })],
+      edges: [],
+    });
+    const store = makeStore();
+    const onOpenDocumentView = vi.fn();
+
+    const flowNodes = toFlowNodes(scene, store, onOpenDocumentView);
+    const conversationFlowNode = flowNodes.find((n) => n.id === "conv-1");
+    expect(conversationFlowNode).toBeDefined();
+
+    (conversationFlowNode!.data as { onOpenDocumentView: () => void }).onOpenDocumentView();
+    expect(onOpenDocumentView).toHaveBeenCalledWith(
+      "## Conversation Transcript\n\n### 1. User\n\nhi\n\n### 2. Assistant\n\nhello there",
+    );
+  });
+
+  it("a conversation node with an empty history does NOT invoke the callback", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "conv-1", kind: "conversation", history: [] })],
+      edges: [],
+    });
+    const store = makeStore();
+    const onOpenDocumentView = vi.fn();
+
+    const flowNodes = toFlowNodes(scene, store, onOpenDocumentView);
+    const conversationFlowNode = flowNodes.find((n) => n.id === "conv-1");
+    expect(conversationFlowNode).toBeDefined();
+
+    (conversationFlowNode!.data as { onOpenDocumentView: () => void }).onOpenDocumentView();
+    expect(onOpenDocumentView).not.toHaveBeenCalled();
+  });
+
+  it("toFlowNodes called with only two arguments (the existing ~50 call sites in this file) still compiles and does not throw when onOpenDocumentView would otherwise fire", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hello world" })],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    expect(chatFlowNode).toBeDefined();
+
+    expect(() => (chatFlowNode!.data as { onOpenDocumentView: () => void }).onOpenDocumentView()).not.toThrow();
   });
 });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -20,13 +20,15 @@ import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
 import type { StreamListener } from "../../lib/ws/transport";
+import { useOverlays } from "../overlays/overlays";
 import { ArtifactNodeView, type ArtifactFlowNode } from "./ArtifactNodeView";
 import { ChartNodeView, type ChartFlowNode } from "./ChartNodeView";
 import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
 import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
 import { CodeSandboxNodeView, type CodeSandboxFlowNode } from "./CodeSandboxNodeView";
-import { ConversationNodeView, type ConversationFlowNode } from "./ConversationNodeView";
+import { ConversationNodeView, type ConversationFlowNode, type ConversationMessage } from "./ConversationNodeView";
 import { DocumentNodeView, type DocumentFlowNode } from "./DocumentNodeView";
+import { DocumentViewDialog } from "./DocumentViewDialog";
 import { GitlinkNodeView, type GitlinkFlowNode } from "./GitlinkNodeView";
 import { GroupNodeView, type GroupFlowNode } from "./GroupNodeView";
 import { HtmlNodeView, type HtmlFlowNode } from "./HtmlNodeView";
@@ -186,10 +188,35 @@ const EDGE_TYPES = {
   orthogonal: OrthogonalEdge,
 };
 
+// R8a: ports the deleted Qt app's own `_history_to_markdown` +
+// `_build_document_section("Conversation Transcript", ...)`
+// (graphlink_window.py) byte-for-byte - the exact markdown a conversation
+// node's "Open Document View" menu item renders. Numbering is 1-based over
+// ALL messages (including blank ones that get skipped), since legacy's own
+// `enumerate(history, start=1)` numbers BEFORE filtering - a skipped message
+// still consumes its number. Returns "" when no message survives (empty
+// history, or every message blank) - this is what toFlowNodes' own
+// "don't open on nothing" guard below keys off of.
+export function conversationHistoryToDocumentMarkdown(history: ConversationMessage[]): string {
+  const blocks: string[] = [];
+  history.forEach((message, index) => {
+    const trimmed = message.content.trim();
+    if (!trimmed) return;
+    const role = message.role === "user" ? "User" : "Assistant";
+    blocks.push(`### ${index + 1}. ${role}\n\n${trimmed}`);
+  });
+  if (blocks.length === 0) return "";
+  return `## Conversation Transcript\n\n${blocks.join("\n\n")}`;
+}
+
 // Exported standalone for direct unit testing (same posture as
 // scaleDragPosition in sceneStore.ts) - covers the parentChatNodeId
 // derivation below without needing a full <ReactFlow> mount.
-export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode[] {
+export function toFlowNodes(
+  scene: SceneState,
+  store: SceneStore,
+  onOpenDocumentView: (markdown: string) => void = () => {},
+): SceneFlowNode[] {
   // Looked up per-chat-node below to build dockedChildren - a docked node is
   // omitted from the returned array entirely (see the "thinking" branch), so
   // this is the only remaining way a chat node's dock badge/menu can find it.
@@ -244,6 +271,14 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
           // arrives through the next scene snapshot.
           onGenerateKeyTakeaway: () => store.generateKeyTakeaway(n.id),
           onGenerateExplainerNote: () => store.generateExplainerNote(n.id),
+          // R8a: Open Document View - shows this node's own message text
+          // verbatim in the read-only document modal. Guards on non-blank
+          // content the same way legacy's own document-view action silently
+          // no-op'd on nothing (see conversationHistoryToDocumentMarkdown's
+          // own doc above for the sibling conversation-node guard).
+          onOpenDocumentView: () => {
+            if (n.content.trim()) onOpenDocumentView(n.content);
+          },
           // R6.3: the node's own scroll position within its content area -
           // read on mount by ChatNodeView (restore) and reported (debounced)
           // via the new setChatScrollValue intent on every scroll. Defaults
@@ -412,6 +447,16 @@ export function toFlowNodes(scene: SceneState, store: SceneStore): SceneFlowNode
           // non-null request id to target.
           onCancel: () => {
             if (n.pendingRequestId) store.cancelConversationRequest(n.pendingRequestId);
+          },
+          // R8a: Open Document View - the node's ENTIRE message history,
+          // formatted as a numbered transcript (see
+          // conversationHistoryToDocumentMarkdown's own doc above). Guards
+          // on a non-empty formatted result (empty history, or every
+          // message blank, both format to "") the same way the chat branch
+          // above guards on non-blank content.
+          onOpenDocumentView: () => {
+            const markdown = conversationHistoryToDocumentMarkdown(n.history);
+            if (markdown) onOpenDocumentView(markdown);
           },
         },
       });
@@ -990,6 +1035,22 @@ function CanvasInner({ store }: { store: SceneStore }) {
   const [smartGuideLines, setSmartGuideLines] = useState<GuideLine[]>([]);
   const visibleGuideLines = scene.smartGuides ? smartGuideLines : [];
 
+  // R8a: Open Document View - the read-only markdown modal a chat/
+  // conversation node's card menu opens (see toFlowNodes' own
+  // onOpenDocumentView field on each of those two branches). The displayed
+  // markdown is local-only state (never scene state, same posture as
+  // hoveredEdgeId/smartGuideLines above) - SceneCanvas is the only place
+  // that knows how to open this dialog.
+  const overlays = useOverlays();
+  const [documentViewContent, setDocumentViewContent] = useState<string | null>(null);
+  const onOpenDocumentView = useCallback(
+    (markdown: string) => {
+      setDocumentViewContent(markdown);
+      overlays.open("document-view", "dialog");
+    },
+    [overlays],
+  );
+
   // R6.3: viewport (pan/zoom) reporting - see makeDebouncedViewportReport's
   // own doc above. onMove fires on every frame of a pan/zoom gesture (never
   // just once at the end, unlike NodeResizer's onResizeEnd), so the debounce
@@ -1013,8 +1074,8 @@ function CanvasInner({ store }: { store: SceneStore }) {
 
   useEffect(() => {
     if (draggingRef.current) return;
-    setNodes((current) => withPreservedSelection(toFlowNodes(scene, store), current));
-  }, [scene, store]);
+    setNodes((current) => withPreservedSelection(toFlowNodes(scene, store, onOpenDocumentView), current));
+  }, [scene, store, onOpenDocumentView]);
 
   const edges = useMemo(() => toFlowEdges(scene, hoveredEdgeId), [scene, hoveredEdgeId]);
 
@@ -1208,7 +1269,8 @@ function CanvasInner({ store }: { store: SceneStore }) {
   );
 
   return (
-    <div className="scene-canvas" onDoubleClick={onDoubleClick}>
+    <>
+      <div className="scene-canvas" onDoubleClick={onDoubleClick}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -1289,7 +1351,9 @@ function CanvasInner({ store }: { store: SceneStore }) {
           </ViewportPortal>
         )}
       </ReactFlow>
-    </div>
+      </div>
+      <DocumentViewDialog content={documentViewContent} />
+    </>
   );
 }
 

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1950,6 +1950,18 @@ body,
   height: 100%;
 }
 
+/* -- Document view dialog (R8a) -------------------------------------------- */
+
+.document-view-dialog {
+  min-width: 480px;
+  width: min(760px, calc(100vw - 64px));
+}
+
+.document-view-dialog .chat-node-content {
+  max-height: none;
+  overflow: visible;
+}
+
 .help-rail {
   width: 220px;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

Restores the "Open Document View" menu action on chat nodes and conversation nodes, replacing a disabled placeholder with a working read-only overlay.

## Problem

Both node kinds' right-click menus carried the item disabled, with the tooltip *"Document view integration isn't wired into the SPA yet"*. The R7.6b Qt cutover deleted the legacy embedded document-viewer panel (`graphlink_document_viewer_web.py`) without porting a successor.

## Changes

**`DocumentViewDialog.tsx`** is a new read-only, scrollable modal showing a node's full content as markdown. The feature is frontend-only: the content is already client-side (a chat node's own text, or a conversation node's message history), so no backend change or new WS intent was needed — only formatting and display.

It reuses the app's existing shared `Dialog` surface, the same centered, single-open-across-the-app modal `About`/`Help`/`Settings`/`Chat Library` already use, rather than the raw-`createPortal` anchored-popup pattern `NodeMenu`/`CodeExecutionApprovalPanel` use — this surface isn't anchored to a click point.

**Conversation transcript formatting** is ported from the deleted application's own `_history_to_markdown` + `_build_document_section("Conversation Transcript", ...)`: each non-blank message becomes `### N. Role`, numbered 1-indexed over the full history including skipped blanks (a blank message consumes its number rather than compressing the sequence), joined under one `## Conversation Transcript` heading.

**`SceneCanvas.tsx`** owns the one piece of state this needs — which markdown is currently displayed — and threads an `onOpenDocumentView` callback through `toFlowNodes` as a new optional third parameter, so the ~50 existing two-argument call sites in `SceneCanvas.test.tsx` are unaffected. Both node kinds guard against opening on empty content.

## Verification

| Check | Result |
| --- | --- |
| Backend suite | 1033 passed (unaffected — no backend changes) |
| Frontend `tsc --noEmit` / ESLint / tests / build | clean / 0 errors / 813 passed (16 new) / succeeds |
| Live: menu item enabled, no tooltip | confirmed against the running app |
| Live: real chat node's content renders inside the dialog | confirmed |
| Live: Escape closes the dialog | confirmed |
| Live: no console errors | confirmed |

Live verification covered the chat-node path end to end. The conversation-transcript formatter — including the blank-message numbering edge case — was hand-verified against the exact ported algorithm and covered by dedicated unit tests, but not observed live, as the available test data contained no conversation nodes.

## Related

`Hide Other Branches` remains disabled — a distinct legacy feature (branch-visibility toggling) with no backend or frontend equivalent yet, tracked as separate work.