### PR TITLE
R8a: restore Hide Other Branches across five node kinds

### DIFF
--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -35,6 +35,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   const onGenerateExplainerNote = vi.fn();
   const onOpenDocumentView = vi.fn();
   const onScrollChange = vi.fn();
+  const onToggleBranchFocus = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -54,6 +55,8 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
       onGenerateExplainerNote,
       onOpenDocumentView,
       onScrollChange,
+      isBranchFocusActive: false,
+      onToggleBranchFocus,
       ...overrides,
     },
   } as unknown as NodeProps<ChatFlowNode>;
@@ -66,7 +69,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   return {
     onToggleCollapse, onDelete, onUndockChild, onRegenerate, onGenerateImage,
     onGenerateChart, onGenerateKeyTakeaway, onGenerateExplainerNote,
-    onOpenDocumentView, onScrollChange, container,
+    onOpenDocumentView, onScrollChange, onToggleBranchFocus, container,
   };
 }
 
@@ -102,9 +105,11 @@ describe("ChatNodeView", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
 
     expect(screen.getByRole("menuitem", { name: "Export" })).not.toBeDisabled();
+    // R8a: no longer a disabled stub - see the dedicated Hide Other Branches
+    // describe block below for its data-driven-label behavior.
     const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
-    expect(hideBranches).toBeDisabled();
-    expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
+    expect(hideBranches).not.toBeDisabled();
+    expect(hideBranches).not.toHaveAttribute("title");
     // R8a: these three were disabled stubs until their agents/dialog were
     // wired up (Open Document View: the shared DocumentViewDialog; Key
     // Takeaway/Explainer Note: ported back from the deleted Qt app). This
@@ -325,6 +330,39 @@ describe("ChatNodeView", () => {
     expect(onUndockChild).toHaveBeenCalledOnce();
     expect(onUndockChild).toHaveBeenCalledWith("t1");
     expect(screen.queryByRole("menu")).toBeNull(); // the menu closes after any item fires
+  });
+});
+
+// R8a: Hide Other Branches / Show All Branches - the one menu item in this
+// file whose visible text is data-driven (isBranchFocusActive) rather than
+// fixed. onToggleBranchFocus is the same callback either way - SceneCanvas.tsx
+// (not this file) interprets what "toggle" means given current state.
+describe("ChatNodeView Hide Other Branches / Show All Branches (R8a)", () => {
+  it("labels the item 'Hide Other Branches' and calls onToggleBranchFocus then closes the menu when isBranchFocusActive is false", async () => {
+    const user = userEvent.setup();
+    const { onToggleBranchFocus } = renderChatNode({ isBranchFocusActive: false });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    const item = screen.getByRole("menuitem", { name: "Hide Other Branches" });
+    expect(item).not.toBeDisabled();
+
+    await user.click(item);
+    expect(onToggleBranchFocus).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("labels the item 'Show All Branches' and still calls the same onToggleBranchFocus when isBranchFocusActive is true", async () => {
+    const user = userEvent.setup();
+    const { onToggleBranchFocus } = renderChatNode({ isBranchFocusActive: true });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    expect(screen.queryByRole("menuitem", { name: "Hide Other Branches" })).toBeNull();
+    const item = screen.getByRole("menuitem", { name: "Show All Branches" });
+    expect(item).not.toBeDisabled();
+
+    await user.click(item);
+    expect(onToggleBranchFocus).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 });
 

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -15,9 +15,7 @@ import { NodeMenu } from "./NodeMenu";
  * honest disabled+title label rather than a fake action or a silent drop
  * (an R3.4 live-drive audit found several legacy ChatNode menu items had
  * been dropped with zero acknowledgment - fixed here): Regenerate (assistant
- * nodes only, needs the R4 agent layer), and Hide Other Branches (the
- * legacy scene's branch-visibility toggle has no backend/frontend equivalent at all yet -
- * unscoped, not owned by any R-phase). One legacy item is still deliberately
+ * nodes only, needs the R4 agent layer). One legacy item is still deliberately
  * NOT listed even as disabled: "Generate Group Summary" is itself
  * conditionally hidden in the legacy menu (only when a multi-selection
  * exists), and that precondition can't occur yet in the new stack (no
@@ -51,7 +49,13 @@ import { NodeMenu } from "./NodeMenu";
  * likewise no longer deferred as of R7.5a: it downloads the node's raw
  * content (not the rendered markdown) as a .md file via downloadTextFile -
  * frontend-only, no backend involved, since the content is already in
- * memory client-side.
+ * memory client-side. "Hide Other Branches" is likewise no longer deferred
+ * as of R8a: it now calls the real onToggleBranchFocus callback, already
+ * closed over this node's own id by SceneCanvas.tsx, which owns the actual
+ * branch-isolation graph walk and per-node dimming style entirely - this
+ * file's only job is flipping the button's own label between "Hide Other
+ * Branches" and "Show All Branches" to match the scene-wide
+ * isBranchFocusActive flag SceneCanvas.tsx also hands down.
  *
  * R6.3: the node's own scroll position within .chat-node-content (its
  * scrollable markdown body) is now restored on mount and reported
@@ -79,6 +83,8 @@ export interface ChatNodeData extends Record<string, unknown> {
   onGenerateExplainerNote: () => void;
   onOpenDocumentView: () => void;
   onScrollChange: (value: number) => void;
+  isBranchFocusActive: boolean;
+  onToggleBranchFocus: () => void;
 }
 
 export type ChatFlowNode = Node<ChatNodeData, "chat">;
@@ -117,6 +123,8 @@ function ChatNodeMenu({
   onGenerateKeyTakeaway,
   onGenerateExplainerNote,
   onOpenDocumentView,
+  isBranchFocusActive,
+  onToggleBranchFocus,
   onClose,
 }: {
   position: MenuPosition;
@@ -134,6 +142,8 @@ function ChatNodeMenu({
   onGenerateKeyTakeaway: () => void;
   onGenerateExplainerNote: () => void;
   onOpenDocumentView: () => void;
+  isBranchFocusActive: boolean;
+  onToggleBranchFocus: () => void;
   onClose: () => void;
 }) {
   const [chartMenuOpen, setChartMenuOpen] = useState(false);
@@ -171,8 +181,15 @@ function ChatNodeMenu({
       >
         Export
       </button>
-      <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
-        Hide Other Branches
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleBranchFocus();
+          onClose();
+        }}
+      >
+        {isBranchFocusActive ? "Show All Branches" : "Hide Other Branches"}
       </button>
       {/* Real (not disabled) - matches the legacy's own `if docked_children:`
           guard exactly. One button per docked child, each undocking that
@@ -402,6 +419,8 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
           onGenerateKeyTakeaway={data.onGenerateKeyTakeaway}
           onGenerateExplainerNote={data.onGenerateExplainerNote}
           onOpenDocumentView={data.onOpenDocumentView}
+          isBranchFocusActive={data.isBranchFocusActive}
+          onToggleBranchFocus={data.onToggleBranchFocus}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/CodeNodeView.test.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.test.tsx
@@ -21,6 +21,7 @@ afterEach(() => {
 function renderCodeNode(overrides: Partial<CodeFlowNode["data"]> = {}) {
   const onDelete = vi.fn();
   const onRegenerate = vi.fn();
+  const onToggleBranchFocus = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -30,6 +31,8 @@ function renderCodeNode(overrides: Partial<CodeFlowNode["data"]> = {}) {
       parentChatNodeId: "chat-1",
       onRegenerate,
       onDelete,
+      isBranchFocusActive: false,
+      onToggleBranchFocus,
       ...overrides,
     },
   } as unknown as NodeProps<CodeFlowNode>;
@@ -39,7 +42,7 @@ function renderCodeNode(overrides: Partial<CodeFlowNode["data"]> = {}) {
       <CodeNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onDelete, onRegenerate, container };
+  return { onDelete, onRegenerate, onToggleBranchFocus, container };
 }
 
 describe("CodeNodeView", () => {
@@ -57,7 +60,7 @@ describe("CodeNodeView", () => {
     expect(screen.getByText("code")).toBeInTheDocument();
   });
 
-  it("right-click opens a menu with real Copy Code/Delete Code Block/Export and deferred Hide Other Branches", async () => {
+  it("right-click opens a menu with real Copy Code/Delete Code Block/Export/Hide Other Branches", async () => {
     const user = userEvent.setup();
     const { onDelete } = renderCodeNode();
 
@@ -69,9 +72,7 @@ describe("CodeNodeView", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
 
     expect(screen.getByRole("menuitem", { name: "Export" })).not.toBeDisabled();
-    const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
-    expect(hideBranches).toBeDisabled();
-    expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
+    expect(screen.getByRole("menuitem", { name: "Hide Other Branches" })).not.toBeDisabled();
 
     await user.click(screen.getByRole("menuitem", { name: "Copy Code" }));
     expect(writeText).toHaveBeenCalledWith("def add(a, b):\n    return a + b");
@@ -137,6 +138,32 @@ describe("CodeNodeView", () => {
     renderCodeNode({ parentChatNodeId: null });
     fireEvent.contextMenu(screen.getByText("python"));
     expect(screen.queryByRole("menuitem", { name: "Regenerate Response" })).toBeNull();
+  });
+
+  it("Hide Other Branches reads 'Hide Other Branches' and calls onToggleBranchFocus then closes the menu when branch focus is inactive (R8a)", async () => {
+    const user = userEvent.setup();
+    const { onToggleBranchFocus } = renderCodeNode({ isBranchFocusActive: false });
+
+    fireEvent.contextMenu(screen.getByText("python"));
+    const toggle = screen.getByRole("menuitem", { name: "Hide Other Branches" });
+    expect(toggle).not.toBeDisabled();
+
+    await user.click(toggle);
+    expect(onToggleBranchFocus).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("Hide Other Branches reads 'Show All Branches' and still calls onToggleBranchFocus when branch focus is active (R8a)", async () => {
+    const user = userEvent.setup();
+    const { onToggleBranchFocus } = renderCodeNode({ isBranchFocusActive: true });
+
+    fireEvent.contextMenu(screen.getByText("python"));
+    expect(screen.queryByRole("menuitem", { name: "Hide Other Branches" })).toBeNull();
+    const toggle = screen.getByRole("menuitem", { name: "Show All Branches" });
+
+    await user.click(toggle);
+    expect(onToggleBranchFocus).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 
   it("Escape and outside-click both close the menu", async () => {

--- a/web_ui/src/app/canvas/CodeNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.tsx
@@ -19,17 +19,22 @@ import { NodeMenu } from "./NodeMenu";
  * copy, and (as of R4.3c) Regenerate Response - conditionally rendered
  * (not merely disabled) on parentChatNodeId being non-null, matching
  * legacy's own menu-build-time `if self.node.parent_content_node:` gate.
- * Deferred, with an honest disabled+title label rather than a silent
- * drop (an R3.4 live-drive audit found the legacy CodeNode menu's branch-
- * visibility item had been dropped with zero acknowledgment - fixed here):
- * Hide Other Branches (the legacy scene's
- * branch-visibility toggle has no backend/frontend equivalent at all yet -
- * unscoped, not owned by any R-phase). "Export" is likewise no longer
- * deferred as of R7.5a: it downloads the raw code (not the fenced/
- * highlighted markdown) as a file via downloadTextFile, guessing a
- * reasonable extension from the language field (LANGUAGE_EXTENSIONS below)
- * and falling back to .txt for anything unrecognized - frontend-only, no
- * backend involved, since the code is already in memory client-side.
+ * "Export" is likewise no longer deferred as of R7.5a: it downloads the raw
+ * code (not the fenced/highlighted markdown) as a file via downloadTextFile,
+ * guessing a reasonable extension from the language field
+ * (LANGUAGE_EXTENSIONS below) and falling back to .txt for anything
+ * unrecognized - frontend-only, no backend involved, since the code is
+ * already in memory client-side. Hide Other Branches is real as of R8a too
+ * (an R3.4 live-drive audit had found the legacy CodeNode menu's branch-
+ * visibility item dropped with zero acknowledgment; it stood as an honest
+ * disabled+title stub until now): it calls data.onToggleBranchFocus
+ * (already bound to this node's id by SceneCanvas) to toggle branch-focus
+ * isolation, and its own label mirrors data.isBranchFocusActive - a
+ * scene-wide flag, not a per-node one - reading "Show All Branches" when
+ * active and "Hide Other Branches" otherwise, matching legacy's own
+ * `"Show All Branches" if is_branch_hidden else "Hide Other Branches"`
+ * swap. The actual graph algorithm and all state management live in
+ * SceneCanvas.tsx, not here. Nothing left deferred in this menu.
  */
 
 export interface CodeNodeData extends Record<string, unknown> {
@@ -43,6 +48,13 @@ export interface CodeNodeData extends Record<string, unknown> {
   parentChatNodeId: string | null;
   onRegenerate: () => void;
   onDelete: () => void;
+  // R8a: isBranchFocusActive is scene-wide (true if branch focus is active
+  // ANYWHERE in the scene, not just on this node) - it exists purely to
+  // drive the Hide/Show Branches menu item's own label. onToggleBranchFocus
+  // is already closed over this node's id by SceneCanvas; called with no
+  // arguments here.
+  isBranchFocusActive: boolean;
+  onToggleBranchFocus: () => void;
 }
 
 export type CodeFlowNode = Node<CodeNodeData, "code">;
@@ -101,6 +113,8 @@ function CodeNodeMenu({
   parentChatNodeId,
   onRegenerate,
   onDelete,
+  isBranchFocusActive,
+  onToggleBranchFocus,
   onClose,
 }: {
   position: MenuPosition;
@@ -110,6 +124,8 @@ function CodeNodeMenu({
   parentChatNodeId: string | null;
   onRegenerate: () => void;
   onDelete: () => void;
+  isBranchFocusActive: boolean;
+  onToggleBranchFocus: () => void;
   onClose: () => void;
 }) {
 
@@ -136,8 +152,15 @@ function CodeNodeMenu({
       >
         Export
       </button>
-      <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
-        Hide Other Branches
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleBranchFocus();
+          onClose();
+        }}
+      >
+        {isBranchFocusActive ? "Show All Branches" : "Hide Other Branches"}
       </button>
       {parentChatNodeId && (
         <button
@@ -200,6 +223,8 @@ export function CodeNodeView({ id, data, selected }: NodeProps<CodeFlowNode>) {
           parentChatNodeId={data.parentChatNodeId}
           onRegenerate={data.onRegenerate}
           onDelete={data.onDelete}
+          isBranchFocusActive={data.isBranchFocusActive}
+          onToggleBranchFocus={data.onToggleBranchFocus}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/DocumentNodeView.test.tsx
+++ b/web_ui/src/app/canvas/DocumentNodeView.test.tsx
@@ -16,6 +16,7 @@ function renderDocumentNode(overrides: Partial<DocumentFlowNode["data"]> = {}) {
   const onToggleCollapse = vi.fn();
   const onDock = vi.fn();
   const onDelete = vi.fn();
+  const onToggleBranchFocus = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -32,6 +33,8 @@ function renderDocumentNode(overrides: Partial<DocumentFlowNode["data"]> = {}) {
       onToggleCollapse,
       onDock,
       onDelete,
+      isBranchFocusActive: false,
+      onToggleBranchFocus,
       ...overrides,
     },
   } as unknown as NodeProps<DocumentFlowNode>;
@@ -41,7 +44,7 @@ function renderDocumentNode(overrides: Partial<DocumentFlowNode["data"]> = {}) {
       <DocumentNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onToggleCollapse, onDock, onDelete };
+  return { onToggleCollapse, onDock, onDelete, onToggleBranchFocus };
 }
 
 describe("formatByteSize (ported DocumentNode._format_byte_size)", () => {
@@ -190,8 +193,7 @@ describe("DocumentNodeView", () => {
 
     fireEvent.contextMenu(title);
     const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
-    expect(hideBranches).toBeDisabled();
-    expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
+    expect(hideBranches).toBeEnabled();
 
     const exportItem = screen.getByRole("menuitem", { name: "Export" });
     expect(exportItem).toBeDisabled();
@@ -245,6 +247,29 @@ describe("DocumentNodeView", () => {
     const title = screen.getByText("notes.pdf");
     fireEvent.contextMenu(title);
     expect(screen.queryByRole("menuitem", { name: "Export" })).toBeNull();
+  });
+
+  it("Hide Other Branches calls onToggleBranchFocus and closes the menu when branch focus is inactive", async () => {
+    const user = userEvent.setup();
+    const { onToggleBranchFocus } = renderDocumentNode({ isBranchFocusActive: false });
+    const title = screen.getByText("notes.pdf");
+
+    fireEvent.contextMenu(title);
+    await user.click(screen.getByRole("menuitem", { name: "Hide Other Branches" }));
+    expect(onToggleBranchFocus).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("reads 'Show All Branches' when branch focus is active, and still calls the same onToggleBranchFocus", async () => {
+    const user = userEvent.setup();
+    const { onToggleBranchFocus } = renderDocumentNode({ isBranchFocusActive: true });
+    const title = screen.getByText("notes.pdf");
+
+    fireEvent.contextMenu(title);
+    expect(screen.queryByRole("menuitem", { name: "Hide Other Branches" })).toBeNull();
+    await user.click(screen.getByRole("menuitem", { name: "Show All Branches" }));
+    expect(onToggleBranchFocus).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 
   it("Escape and outside-click both close the menu", async () => {

--- a/web_ui/src/app/canvas/DocumentNodeView.tsx
+++ b/web_ui/src/app/canvas/DocumentNodeView.tsx
@@ -17,12 +17,16 @@ import { NodeMenu } from "./NodeMenu";
  * intent ThinkingNodeView uses; SceneCanvas.tsx's node/edge filtering and
  * ChatNodeView's badge/"Reveal Docked Items" are already kind-agnostic, so
  * no further wiring was needed beyond this file and SceneCanvas's document
- * branch. Deferred, with an honest disabled+title label rather than a
- * silently-dropped action (see the R3.7-era audit this increment is
+ * branch. Also real as of this increment: Hide Other Branches / Show All
+ * Branches - this view only proxies data.onToggleBranchFocus (already bound
+ * to this node's id by SceneCanvas.tsx) and flips its own label off
+ * data.isBranchFocusActive, a scene-wide flag rather than a per-node one;
+ * the branch-scoping algorithm and the actual dimming style live entirely in
+ * SceneCanvas.tsx. Deferred, with an honest disabled+title label rather than
+ * a silently-dropped action (see the R3.7-era audit this increment is
  * following up on): Open File (needs a new backend endpoint; browsers
  * cannot open arbitrary local paths), Export (R6, document-kind only -
- * matches the legacy menu's own conditional), Hide Other Branches (branch
- * visibility isn't built yet).
+ * matches the legacy menu's own conditional).
  */
 
 export interface DocumentNodeData extends Record<string, unknown> {
@@ -47,6 +51,8 @@ export interface DocumentNodeData extends Record<string, unknown> {
   onToggleCollapse: () => void;
   onDock: () => void;
   onDelete: () => void;
+  isBranchFocusActive: boolean;
+  onToggleBranchFocus: () => void;
 }
 
 export type DocumentFlowNode = Node<DocumentNodeData, "document">;
@@ -172,6 +178,8 @@ function DocumentNodeMenu({
   onToggleCollapse,
   onDock,
   onDelete,
+  isBranchFocusActive,
+  onToggleBranchFocus,
   onClose,
 }: {
   position: MenuPosition;
@@ -182,6 +190,8 @@ function DocumentNodeMenu({
   onToggleCollapse: () => void;
   onDock: () => void;
   onDelete: () => void;
+  isBranchFocusActive: boolean;
+  onToggleBranchFocus: () => void;
   onClose: () => void;
 }) {
 
@@ -246,8 +256,15 @@ function DocumentNodeMenu({
           Export
         </button>
       )}
-      <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
-        Hide Other Branches
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleBranchFocus();
+          onClose();
+        }}
+      >
+        {isBranchFocusActive ? "Show All Branches" : "Hide Other Branches"}
       </button>
       <button
         type="button"
@@ -338,6 +355,8 @@ export function DocumentNodeView({ data, selected }: NodeProps<DocumentFlowNode>
           onToggleCollapse={data.onToggleCollapse}
           onDock={data.onDock}
           onDelete={data.onDelete}
+          isBranchFocusActive={data.isBranchFocusActive}
+          onToggleBranchFocus={data.onToggleBranchFocus}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/ImageNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ImageNodeView.test.tsx
@@ -9,6 +9,7 @@ import { ImageNodeView, type ImageFlowNode } from "./ImageNodeView";
 function renderImageNode(overrides: Partial<ImageFlowNode["data"]> = {}, id = "n0") {
   const onDelete = vi.fn();
   const onRegenerate = vi.fn();
+  const onToggleBranchFocus = vi.fn();
   const props = {
     id,
     selected: false,
@@ -17,6 +18,8 @@ function renderImageNode(overrides: Partial<ImageFlowNode["data"]> = {}, id = "n
       prompt: "a red fox in the snow",
       onDelete,
       onRegenerate,
+      isBranchFocusActive: false,
+      onToggleBranchFocus,
       ...overrides,
     },
   } as unknown as NodeProps<ImageFlowNode>;
@@ -26,7 +29,7 @@ function renderImageNode(overrides: Partial<ImageFlowNode["data"]> = {}, id = "n
       <ImageNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onDelete, onRegenerate, container };
+  return { onDelete, onRegenerate, onToggleBranchFocus, container };
 }
 
 // jsdom implements neither URL.createObjectURL/revokeObjectURL nor
@@ -89,7 +92,7 @@ describe("ImageNodeView", () => {
     expect(container.querySelector("img")).toBeNull();
   });
 
-  it("right-click opens a menu with real Copy Image/Export Image/Regenerate Image/Delete Image and disabled Hide Other Branches", async () => {
+  it("right-click opens a menu with real Copy Image/Export Image/Hide Other Branches/Regenerate Image/Delete Image", async () => {
     const user = userEvent.setup();
     const { onDelete } = renderImageNode({ prompt: "a red fox in the snow" });
 
@@ -99,15 +102,42 @@ describe("ImageNodeView", () => {
 
     expect(screen.getByRole("menuitem", { name: "Copy Image" })).toBeEnabled();
     expect(screen.getByRole("menuitem", { name: "Export Image" })).toBeEnabled();
-
-    const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
-    expect(hideBranches).toBeDisabled();
-    expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
-
+    expect(screen.getByRole("menuitem", { name: "Hide Other Branches" })).toBeEnabled();
     expect(screen.getByRole("menuitem", { name: "Regenerate Image" })).toBeEnabled();
 
     await user.click(screen.getByRole("menuitem", { name: "Delete Image" }));
     expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Hide Other Branches calls onToggleBranchFocus and closes the menu when branch focus is inactive", async () => {
+    const user = userEvent.setup();
+    const { onToggleBranchFocus } = renderImageNode({
+      prompt: "a red fox in the snow",
+      isBranchFocusActive: false,
+    });
+
+    fireEvent.contextMenu(screen.getByText("a red fox in the snow"));
+    const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
+
+    await user.click(hideBranches);
+    expect(onToggleBranchFocus).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("labels the item 'Show All Branches' and still calls onToggleBranchFocus when branch focus is active", async () => {
+    const user = userEvent.setup();
+    const { onToggleBranchFocus } = renderImageNode({
+      prompt: "a red fox in the snow",
+      isBranchFocusActive: true,
+    });
+
+    fireEvent.contextMenu(screen.getByText("a red fox in the snow"));
+    expect(screen.queryByRole("menuitem", { name: "Hide Other Branches" })).toBeNull();
+    const showAll = screen.getByRole("menuitem", { name: "Show All Branches" });
+
+    await user.click(showAll);
+    expect(onToggleBranchFocus).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 
   it("Regenerate Image is a real, enabled item that calls onRegenerate then closes the menu", async () => {

--- a/web_ui/src/app/canvas/ImageNodeView.tsx
+++ b/web_ui/src/app/canvas/ImageNodeView.tsx
@@ -35,9 +35,12 @@ import { NodeMenu } from "./NodeMenu";
  * deferred as of R4.4a: it now calls the real regenerateImage intent -
  * unlike CodeNodeView's own onRegenerate, no client-side parent-lookup/
  * null-guard is needed here, since the backend resolves the ImageNode's
- * parent chat node internally (see sceneStore.ts's regenerateImage). Still
- * deferred, with an honest disabled+title label: Hide Other Branches (branch
- * visibility isn't built yet - unscoped, not owned by any R-phase).
+ * parent chat node internally (see sceneStore.ts's regenerateImage). Hide
+ * Other Branches is likewise no longer deferred as of R8a: it now calls the
+ * real onToggleBranchFocus intent, closed over this node's own id by
+ * SceneCanvas, and its label flips to "Show All Branches" once
+ * isBranchFocusActive is true - both fields (and the dimming itself) are
+ * SceneCanvas's concern, this file just renders whatever it's handed.
  */
 
 export interface ImageNodeData extends Record<string, unknown> {
@@ -45,6 +48,8 @@ export interface ImageNodeData extends Record<string, unknown> {
   prompt: string;
   onDelete: () => void;
   onRegenerate: () => void;
+  isBranchFocusActive: boolean;
+  onToggleBranchFocus: () => void;
 }
 
 export type ImageFlowNode = Node<ImageNodeData, "image">;
@@ -119,6 +124,8 @@ function ImageNodeMenu({
   prompt,
   onDelete,
   onRegenerate,
+  isBranchFocusActive,
+  onToggleBranchFocus,
   onClose,
 }: {
   position: MenuPosition;
@@ -127,6 +134,8 @@ function ImageNodeMenu({
   prompt: string;
   onDelete: () => void;
   onRegenerate: () => void;
+  isBranchFocusActive: boolean;
+  onToggleBranchFocus: () => void;
   onClose: () => void;
 }) {
 
@@ -156,8 +165,15 @@ function ImageNodeMenu({
         Export Image
       </button>
       <div className="chat-node-menu-separator" role="separator" />
-      <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
-        Hide Other Branches
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleBranchFocus();
+          onClose();
+        }}
+      >
+        {isBranchFocusActive ? "Show All Branches" : "Hide Other Branches"}
       </button>
       {prompt.trim() && (
         <button
@@ -229,6 +245,8 @@ export function ImageNodeView({ id, data, selected }: NodeProps<ImageFlowNode>) 
           prompt={data.prompt}
           onDelete={data.onDelete}
           onRegenerate={data.onRegenerate}
+          isBranchFocusActive={data.isBranchFocusActive}
+          onToggleBranchFocus={data.onToggleBranchFocus}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   applyGroupDragDelta,
+  computeDimmedNodeIds,
   conversationHistoryToDocumentMarkdown,
   groupDragKindOf,
   handleSelectionChange,
@@ -1776,5 +1777,296 @@ describe("withPreservedSelection (R7.5c snapshot-rebuild selection wipe)", () =>
     const rebuilt = [node("a")];
     withPreservedSelection(rebuilt, current);
     expect(rebuilt[0].selected).toBeUndefined();
+  });
+});
+
+// -- R8a: "Hide Other Branches" (computeDimmedNodeIds + its toFlowNodes wiring) --
+//
+// This is the one genuinely algorithmic piece of R8a's four-item deferred-
+// menu-item cleanup - real ancestor/descendant graph traversal, not just
+// callback threading - so it gets deliberately heavier coverage than a
+// typical wiring test: every scenario below was hand-traced against the
+// implementation before being written down here as an assertion, not
+// reverse-engineered from whatever the code happened to produce.
+
+describe("computeDimmedNodeIds (R8a Hide Other Branches)", () => {
+  it("returns an empty set when focus is off (originId is null)", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat" })],
+      edges: [],
+    });
+    expect(computeDimmedNodeIds(scene, null)).toEqual(new Set());
+  });
+
+  it("returns an empty set when the origin node no longer exists (deleted while focus was active)", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat" })],
+      edges: [],
+    });
+    expect(computeDimmedNodeIds(scene, "chat-gone")).toEqual(new Set());
+  });
+
+  it("dims nothing for a lone chat node with no siblings", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat" })],
+      edges: [],
+    });
+    expect(computeDimmedNodeIds(scene, "chat-1")).toEqual(new Set());
+  });
+
+  it("isolates a sibling branch: two chats sharing one parent, focused from one, dims only the other", () => {
+    // A -> B, A -> B2 (a real fork - B and B2 are independent children of A).
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "A", kind: "chat" }),
+        baseNode({ id: "B", kind: "chat" }),
+        baseNode({ id: "B2", kind: "chat" }),
+      ],
+      edges: [
+        { id: "e1", source: "A", target: "B" },
+        { id: "e2", source: "A", target: "B2" },
+      ],
+    });
+    expect(computeDimmedNodeIds(scene, "B")).toEqual(new Set(["B2"]));
+  });
+
+  it("a linear chain (A -> B -> C) focused from B keeps both the ancestor and the descendant visible", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "A", kind: "chat" }),
+        baseNode({ id: "B", kind: "chat" }),
+        baseNode({ id: "C", kind: "chat" }),
+      ],
+      edges: [
+        { id: "e1", source: "A", target: "B" },
+        { id: "e2", source: "B", target: "C" },
+      ],
+    });
+    expect(computeDimmedNodeIds(scene, "B")).toEqual(new Set());
+  });
+
+  it("a content node (code) attached to an active chat node is not dimmed", () => {
+    // A -> B, B -> X (code, attached to B). Focused from B: B's own content
+    // node must stay visible, matching legacy's parent_content_node anchor.
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "A", kind: "chat" }),
+        baseNode({ id: "B", kind: "chat" }),
+        baseNode({ id: "X", kind: "code" }),
+      ],
+      edges: [
+        { id: "e1", source: "A", target: "B" },
+        { id: "e2", source: "B", target: "X" },
+      ],
+    });
+    expect(computeDimmedNodeIds(scene, "B")).toEqual(new Set());
+  });
+
+  it("a content node attached to a DIMMED sibling branch is itself dimmed", () => {
+    // A -> B, A -> B2, B2 -> X (code, attached to the sibling branch B2).
+    // Focused from B: X must be dimmed along with its owner B2.
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "A", kind: "chat" }),
+        baseNode({ id: "B", kind: "chat" }),
+        baseNode({ id: "B2", kind: "chat" }),
+        baseNode({ id: "X", kind: "code" }),
+      ],
+      edges: [
+        { id: "e1", source: "A", target: "B" },
+        { id: "e2", source: "A", target: "B2" },
+        { id: "e3", source: "B2", target: "X" },
+      ],
+    });
+    expect(computeDimmedNodeIds(scene, "B")).toEqual(new Set(["B2", "X"]));
+  });
+
+  it("descends through the FULL downstream chain, including a content node several hops down", () => {
+    // A -> B -> C, C -> D (document, attached to C). Focused from the root A.
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "A", kind: "chat" }),
+        baseNode({ id: "B", kind: "chat" }),
+        baseNode({ id: "C", kind: "chat" }),
+        baseNode({ id: "D", kind: "document" }),
+      ],
+      edges: [
+        { id: "e1", source: "A", target: "B" },
+        { id: "e2", source: "B", target: "C" },
+        { id: "e3", source: "C", target: "D" },
+      ],
+    });
+    expect(computeDimmedNodeIds(scene, "A")).toEqual(new Set());
+  });
+
+  it("focusing FROM a content node resolves to its parent chat node's branch, not just itself", () => {
+    // A -> B, A -> B2, B -> X (code). Right-clicking X's own menu must
+    // isolate B's branch (X's owner), dimming B2 exactly as focusing from B
+    // directly would - matches legacy's _branch_anchor_nodes mapping a
+    // content node to its parent_content_node.
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "A", kind: "chat" }),
+        baseNode({ id: "B", kind: "chat" }),
+        baseNode({ id: "B2", kind: "chat" }),
+        baseNode({ id: "X", kind: "code" }),
+      ],
+      edges: [
+        { id: "e1", source: "A", target: "B" },
+        { id: "e2", source: "A", target: "B2" },
+        { id: "e3", source: "B", target: "X" },
+      ],
+    });
+    expect(computeDimmedNodeIds(scene, "X")).toEqual(new Set(["B2"]));
+  });
+
+  it("an orphaned content node with no chat parent isolates only itself, without crashing", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "A", kind: "chat" }),
+        baseNode({ id: "orphan", kind: "code" }),
+      ],
+      edges: [],
+    });
+    expect(computeDimmedNodeIds(scene, "orphan")).toEqual(new Set(["A"]));
+  });
+
+  it("never dims a node kind outside the five that carry this menu item, regardless of branch membership", () => {
+    // A -> B, A -> B2 (dimmed sibling), plus a conversation node and a note
+    // with no edges at all - both must be left alone by this feature
+    // entirely (ConversationNodeView.tsx's own docstring documents the
+    // conversation exclusion as deliberate).
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "A", kind: "chat" }),
+        baseNode({ id: "B", kind: "chat" }),
+        baseNode({ id: "B2", kind: "chat" }),
+        baseNode({ id: "conv-1", kind: "conversation" }),
+        baseNode({ id: "note-1", kind: "note" }),
+      ],
+      edges: [
+        { id: "e1", source: "A", target: "B" },
+        { id: "e2", source: "A", target: "B2" },
+      ],
+    });
+    expect(computeDimmedNodeIds(scene, "B")).toEqual(new Set(["B2"]));
+  });
+
+  it("terminates and produces a sane result on a manually-created cycle (A -> B -> A), rather than hanging", () => {
+    // SceneDocument.connect() has no cycle prevention (backend/canvas.py),
+    // unlike legacy's QGraphicsScene-constrained edges - this is a
+    // deliberate hardening test, not a scenario legacy itself could reach.
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "A", kind: "chat" }),
+        baseNode({ id: "B", kind: "chat" }),
+      ],
+      edges: [
+        { id: "e1", source: "A", target: "B" },
+        { id: "e2", source: "B", target: "A" },
+      ],
+    });
+    expect(computeDimmedNodeIds(scene, "A")).toEqual(new Set());
+  });
+
+  it("a docked node can still be dimmed by the algorithm itself (toFlowNodes filters docked nodes out separately)", () => {
+    // computeDimmedNodeIds has no isDocked awareness of its own - docked-node
+    // exclusion from the rendered canvas is toFlowNodes' own concern (the
+    // top-of-loop `if (n.isDocked) continue` guard), same separation of
+    // concerns as every other per-kind field in that function. This test
+    // exists to pin that computeDimmedNodeIds does not silently duplicate
+    // that filtering itself.
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "A", kind: "chat" }),
+        baseNode({ id: "B", kind: "chat" }),
+        baseNode({ id: "B2", kind: "chat", isDocked: true }),
+      ],
+      edges: [
+        { id: "e1", source: "A", target: "B" },
+        { id: "e2", source: "A", target: "B2" },
+      ],
+    });
+    expect(computeDimmedNodeIds(scene, "B")).toEqual(new Set(["B2"]));
+  });
+});
+
+describe("toFlowNodes (R8a Hide Other Branches wiring)", () => {
+  function sceneWithFork() {
+    return baseScene({
+      nodes: [
+        baseNode({ id: "A", kind: "chat", x: 0, y: 0 }),
+        baseNode({ id: "B", kind: "chat", x: 0, y: 0 }),
+        baseNode({ id: "B2", kind: "chat", x: 0, y: 0 }),
+        baseNode({ id: "X", kind: "code", x: 0, y: 0 }),
+        baseNode({ id: "Y", kind: "document", x: 0, y: 0 }),
+        baseNode({ id: "Z", kind: "thinking", x: 0, y: 0 }),
+        baseNode({ id: "W", kind: "image", x: 0, y: 0 }),
+      ],
+      edges: [
+        { id: "e1", source: "A", target: "B" },
+        { id: "e2", source: "A", target: "B2" },
+        { id: "e3", source: "B", target: "X" },
+        { id: "e4", source: "B", target: "Y" },
+        { id: "e5", source: "B", target: "Z" },
+        { id: "e6", source: "B", target: "W" },
+      ],
+    });
+  }
+
+  it("applies the dim opacity style to a dimmed node of each of the five participating kinds, and no style to active ones", () => {
+    const scene = sceneWithFork();
+    const store = makeStore();
+    const flowNodes = toFlowNodes(scene, store, () => {}, "B", () => {});
+
+    // B2 is the dimmed sibling - the only dimmed node in this fixture.
+    expect(flowNodes.find((n) => n.id === "B2")?.style).toEqual({ opacity: 0.18 });
+    // Every kind attached to the active branch (B) stays undimmed - no
+    // style override at all, not an explicit opacity: 1.
+    for (const id of ["A", "B", "X", "Y", "Z", "W"]) {
+      expect(flowNodes.find((n) => n.id === id)?.style).toBeUndefined();
+    }
+  });
+
+  it("applies no style to anyone when branch focus is off (default/omitted argument)", () => {
+    const scene = sceneWithFork();
+    const store = makeStore();
+    // Two-argument call - the pre-R8a call shape - must still work and dim
+    // nothing, matching every other backward-compat check in this file.
+    const flowNodes = toFlowNodes(scene, store);
+    for (const n of flowNodes) expect(n.style).toBeUndefined();
+  });
+
+  it("isBranchFocusActive is true scene-wide for all five kinds once focus is active anywhere, regardless of which node is dimmed", () => {
+    const scene = sceneWithFork();
+    const store = makeStore();
+    const flowNodes = toFlowNodes(scene, store, () => {}, "B", () => {});
+    for (const id of ["A", "B", "B2", "X", "Y", "Z", "W"]) {
+      const data = flowNodes.find((n) => n.id === id)?.data as { isBranchFocusActive: boolean };
+      expect(data.isBranchFocusActive).toBe(true);
+    }
+  });
+
+  it("isBranchFocusActive is false for all five kinds when focus is off", () => {
+    const scene = sceneWithFork();
+    const store = makeStore();
+    const flowNodes = toFlowNodes(scene, store, () => {}, null, () => {});
+    for (const id of ["A", "B", "B2", "X", "Y", "Z", "W"]) {
+      const data = flowNodes.find((n) => n.id === id)?.data as { isBranchFocusActive: boolean };
+      expect(data.isBranchFocusActive).toBe(false);
+    }
+  });
+
+  it("each of the five kinds' onToggleBranchFocus calls the outer callback with its OWN node id, not some other node's", () => {
+    const scene = sceneWithFork();
+    const store = makeStore();
+    const calls: string[] = [];
+    const flowNodes = toFlowNodes(scene, store, () => {}, null, (nodeId) => calls.push(nodeId));
+
+    for (const id of ["A", "B", "X", "Y", "Z", "W"]) {
+      const data = flowNodes.find((n) => n.id === id)?.data as { onToggleBranchFocus: () => void };
+      data.onToggleBranchFocus();
+    }
+    expect(calls).toEqual(["A", "B", "X", "Y", "Z", "W"]);
   });
 });

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -209,6 +209,126 @@ export function conversationHistoryToDocumentMarkdown(history: ConversationMessa
   return `## Conversation Transcript\n\n${blocks.join("\n\n")}`;
 }
 
+// R8a: "Hide Other Branches" - restores graphlink_scene.py's
+// toggle_branch_visibility (line 1097). The legacy name is misleading: it
+// never removes anything, it DIMS every node outside the clicked node's
+// branch down to a low opacity, and restores full opacity on toggle-off.
+// 0.18 is legacy's own BRANCH_DIM_OPACITY constant (graphlink_scene.py:23),
+// ported unchanged. This file already established the "restore a legacy dim
+// effect via React Flow's own style.opacity, not a new CSS class or DOM
+// removal" convention for FADED_CONNECTION_OPACITY below - this reuses it.
+const BRANCH_DIM_OPACITY = 0.18;
+
+// Only these five node kinds ever carried this menu item in the legacy app
+// (one dedicated *_menu.py file each - graphlink_node_chat_menu.py,
+// _code_menu.py, _document_menu.py, _image_menu.py, _thinking_menu.py).
+// Every other kind - including Conversation, which ConversationNodeView.tsx's
+// own docstring already documents as a deliberate exclusion from this
+// feature - is left untouched by computeDimmedNodeIds below, exactly as if
+// the feature did not exist for it.
+const BRANCH_FOCUS_KINDS = new Set(["chat", "code", "document", "thinking", "image"]);
+
+/**
+ * Computes which node ids should be dimmed while branch focus is active,
+ * given the node id the user invoked "Hide Other Branches" from
+ * (`originId`). Returns an empty set when focus is off (`originId === null`)
+ * or the origin node no longer exists (deleted while focus was active - this
+ * is how focus self-heals to "show everyone" rather than pointing at
+ * nothing; SceneCanvas below derives its own effectiveBranchFocusOriginId
+ * with the identical existence check, so the menu label un-flips in the
+ * same render rather than one render behind).
+ *
+ * Ported from graphlink_scene.py's toggle_branch_visibility/
+ * _branch_anchor_nodes, adapted to this app's uniform (source, target) edge
+ * model. Legacy modeled "chat A replied by chat B" and "chat A owns code
+ * block B" as different attribute pairs (parent_node/children vs.
+ * parent_content_node); the modern backend models both identically as one
+ * edge (backend/canvas.py's SceneDocument.connect), so this tells them apart
+ * by KIND instead: a node's "chat anchor" is itself if it is chat-kind, else
+ * its nearest parent if THAT is chat-kind, else - an orphaned content node
+ * with no chat parent at all, not reachable through today's UI since every
+ * creation path supplies one, but not impossible after a manual edge edit -
+ * itself, isolating just that one node rather than crashing or silently
+ * dimming nothing.
+ *
+ * The active branch is the set of CHAT nodes reachable from the anchor by
+ * walking chat-to-chat edges only, in both directions (ancestors up,
+ * descendants down) - a content node attached to any branch member is
+ * counted as active via its anchor, not by the walk expanding through it
+ * (content nodes are leaves: they never have children of their own in
+ * current usage, and are never treated as branch-tree interior nodes even
+ * if they somehow did).
+ *
+ * Both the ancestor walk and the descendant BFS are visited-set-guarded, a
+ * deliberate hardening legacy's own equivalent walks do NOT have:
+ * SceneDocument.connect() allows creating a cycle or a second incoming edge
+ * to the same node with no validation at all (there is no such thing as a
+ * malformed QGraphicsScene the same way), so an unguarded walk here could
+ * infinite-loop where legacy's structurally never could.
+ */
+export function computeDimmedNodeIds(scene: SceneState, originId: string | null): Set<string> {
+  if (originId === null) return new Set();
+
+  const nodesById = new Map(scene.nodes.map((n) => [n.id, n]));
+  if (!nodesById.has(originId)) return new Set();
+
+  // parentOf/childrenOf are built fresh here rather than reusing toFlowNodes'
+  // own nodesById map below - this function is exported standalone for
+  // direct unit testing (same posture as toFlowEdges/
+  // conversationHistoryToDocumentMarkdown above), and threading maps between
+  // functions to save one more Map construction over a scene of at most a
+  // few hundred nodes is not worth the coupling.
+  const parentOf = new Map<string, string>();
+  const childrenOf = new Map<string, string[]>();
+  for (const e of scene.edges) {
+    // First edge whose target is this node wins - a deliberate tie-break for
+    // the (currently UI-unreachable, but structurally possible via
+    // connectNodes) case of a node with more than one incoming edge. Legacy
+    // has no multi-parent concept to fall back on for comparison: parent_node
+    // is a single pointer set once at creation, so this is this port's own
+    // reasonable interpretation, not a legacy behavior being matched.
+    if (!parentOf.has(e.target)) parentOf.set(e.target, e.source);
+    const siblings = childrenOf.get(e.source);
+    if (siblings) siblings.push(e.target);
+    else childrenOf.set(e.source, [e.target]);
+  }
+
+  const isChat = (id: string) => nodesById.get(id)?.kind === "chat";
+
+  function chatAnchorOf(id: string): string {
+    if (isChat(id)) return id;
+    const parentId = parentOf.get(id);
+    return parentId && isChat(parentId) ? parentId : id;
+  }
+
+  const anchorId = chatAnchorOf(originId);
+  const activeChatIds = new Set<string>([anchorId]);
+
+  if (isChat(anchorId)) {
+    let cursor = parentOf.get(anchorId);
+    while (cursor !== undefined && isChat(cursor) && !activeChatIds.has(cursor)) {
+      activeChatIds.add(cursor);
+      cursor = parentOf.get(cursor);
+    }
+    const queue = [anchorId];
+    while (queue.length > 0) {
+      const current = queue.shift() as string;
+      for (const childId of childrenOf.get(current) ?? []) {
+        if (activeChatIds.has(childId) || !isChat(childId)) continue;
+        activeChatIds.add(childId);
+        queue.push(childId);
+      }
+    }
+  }
+
+  const dimmed = new Set<string>();
+  for (const node of scene.nodes) {
+    if (!BRANCH_FOCUS_KINDS.has(node.kind)) continue;
+    if (!activeChatIds.has(chatAnchorOf(node.id))) dimmed.add(node.id);
+  }
+  return dimmed;
+}
+
 // Exported standalone for direct unit testing (same posture as
 // scaleDragPosition in sceneStore.ts) - covers the parentChatNodeId
 // derivation below without needing a full <ReactFlow> mount.
@@ -216,11 +336,17 @@ export function toFlowNodes(
   scene: SceneState,
   store: SceneStore,
   onOpenDocumentView: (markdown: string) => void = () => {},
+  branchFocusOriginId: string | null = null,
+  onToggleBranchFocus: (nodeId: string) => void = () => {},
 ): SceneFlowNode[] {
   // Looked up per-chat-node below to build dockedChildren - a docked node is
   // omitted from the returned array entirely (see the "thinking" branch), so
   // this is the only remaining way a chat node's dock badge/menu can find it.
   const nodesById = new Map(scene.nodes.map((n) => [n.id, n]));
+  // R8a: computed once per call, then just a Set.has() per node below -
+  // see computeDimmedNodeIds' own doc for why it builds its own maps rather
+  // than reusing nodesById above.
+  const dimmedIds = computeDimmedNodeIds(scene, branchFocusOriginId);
   const flowNodes: SceneFlowNode[] = [];
 
   for (const n of scene.nodes) {
@@ -250,6 +376,10 @@ export function toFlowNodes(
         id: n.id,
         type: "chat" as const,
         position: { x: n.x, y: n.y },
+        // R8a: "Hide Other Branches" dimming - see computeDimmedNodeIds' own
+        // doc above. undefined (not an explicit opacity: 1) when not dimmed,
+        // so this never overrides anything else that might set style later.
+        style: dimmedIds.has(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           content: n.content,
           isUser: n.isUser,
@@ -279,6 +409,13 @@ export function toFlowNodes(
           onOpenDocumentView: () => {
             if (n.content.trim()) onOpenDocumentView(n.content);
           },
+          // R8a: "Hide Other Branches" - isBranchFocusActive is scene-wide
+          // (not per-node), purely so the menu button can flip its own label
+          // to "Show All Branches" once ANY branch focus is active, matching
+          // legacy's own `"Show All Branches" if is_branch_hidden else
+          // "Hide Other Branches"` regardless of which node's menu is open.
+          isBranchFocusActive: branchFocusOriginId !== null,
+          onToggleBranchFocus: () => onToggleBranchFocus(n.id),
           // R6.3: the node's own scroll position within its content area -
           // read on mount by ChatNodeView (restore) and reported (debounced)
           // via the new setChatScrollValue intent on every scroll. Defaults
@@ -303,6 +440,7 @@ export function toFlowNodes(
         id: n.id,
         type: "code" as const,
         position: { x: n.x, y: n.y },
+        style: dimmedIds.has(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           code: n.code,
           language: n.language,
@@ -311,6 +449,10 @@ export function toFlowNodes(
             if (parentChatNodeId) store.regenerateResponse(parentChatNodeId);
           },
           onDelete: () => store.removeNodes([n.id]),
+          // R8a: "Hide Other Branches" - see the chat branch above for why
+          // isBranchFocusActive is scene-wide rather than per-node.
+          isBranchFocusActive: branchFocusOriginId !== null,
+          onToggleBranchFocus: () => onToggleBranchFocus(n.id),
         },
       });
       continue;
@@ -320,6 +462,7 @@ export function toFlowNodes(
         id: n.id,
         type: "document" as const,
         position: { x: n.x, y: n.y },
+        style: dimmedIds.has(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           title: n.title,
           content: n.content,
@@ -344,6 +487,9 @@ export function toFlowNodes(
           onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
           onDock: () => store.setNodeDocked(n.id, true),
           onDelete: () => store.removeNodes([n.id]),
+          // R8a: "Hide Other Branches" - see the chat branch above.
+          isBranchFocusActive: branchFocusOriginId !== null,
+          onToggleBranchFocus: () => onToggleBranchFocus(n.id),
         },
       });
       continue;
@@ -356,10 +502,14 @@ export function toFlowNodes(
         id: n.id,
         type: "thinking" as const,
         position: { x: n.x, y: n.y },
+        style: dimmedIds.has(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           thinkingText: n.content,
           onDock: () => store.setNodeDocked(n.id, true),
           onDelete: () => store.removeNodes([n.id]),
+          // R8a: "Hide Other Branches" - see the chat branch above.
+          isBranchFocusActive: branchFocusOriginId !== null,
+          onToggleBranchFocus: () => onToggleBranchFocus(n.id),
         },
       });
       continue;
@@ -408,6 +558,7 @@ export function toFlowNodes(
         id: n.id,
         type: "image" as const,
         position: { x: n.x, y: n.y },
+        style: dimmedIds.has(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           imageAssetId: n.imageAssetId,
           prompt: n.content,
@@ -417,6 +568,9 @@ export function toFlowNodes(
           // image's parent chat node internally (see sceneStore.ts's
           // regenerateImage / backend/canvas.py's resolve_regenerate_image).
           onRegenerate: () => store.regenerateImage(n.id),
+          // R8a: "Hide Other Branches" - see the chat branch above.
+          isBranchFocusActive: branchFocusOriginId !== null,
+          onToggleBranchFocus: () => onToggleBranchFocus(n.id),
         },
       });
       continue;
@@ -1051,6 +1205,42 @@ function CanvasInner({ store }: { store: SceneStore }) {
     [overlays],
   );
 
+  // R8a: "Hide Other Branches" - which node id branch focus is currently
+  // anchored to, or null when off. Also local-only state (never scene
+  // state), same posture as documentViewContent above - it is a pure
+  // display concern, not something that needs to survive a reload or be
+  // shared with a hypothetical second viewer.
+  const [branchFocusOriginId, setBranchFocusOriginId] = useState<string | null>(null);
+  // Derived, not stored: raw state alone can go stale the moment its origin
+  // node is deleted while focus is active, and "is this state still
+  // meaningful" is exactly the kind of derivation React's own guidance says
+  // to compute during render rather than reconcile via a setState-in-effect
+  // (the first version of this self-heal DID use such an effect, and the
+  // react-hooks/set-state-in-effect rule correctly flagged it as the
+  // cascading-render anti-pattern it is - this replaces it, not suppresses
+  // it). Every consumer below reads this derived value, never the raw
+  // state directly, so a deleted origin self-heals within the SAME render
+  // instead of flashing "Show All Branches" for one extra frame first.
+  const isBranchFocusOriginValid =
+    branchFocusOriginId !== null && scene.nodes.some((n) => n.id === branchFocusOriginId);
+  const effectiveBranchFocusOriginId = isBranchFocusOriginValid ? branchFocusOriginId : null;
+  const onToggleBranchFocus = useCallback(
+    (nodeId: string) => {
+      // Mirrors graphlink_scene.py's own toggle_branch_visibility exactly:
+      // if focus is already active (from ANY origin), any click anywhere
+      // clears it - the menu label is "Show All Branches" scene-wide once
+      // active, not "focus a different branch". Only when focus is OFF -
+      // including "was on, but its origin has since been deleted", which
+      // reads as off per isBranchFocusOriginValid above - does the clicked
+      // node become the new origin.
+      setBranchFocusOriginId((current) => {
+        const currentIsValid = current !== null && scene.nodes.some((n) => n.id === current);
+        return currentIsValid ? null : nodeId;
+      });
+    },
+    [scene.nodes],
+  );
+
   // R6.3: viewport (pan/zoom) reporting - see makeDebouncedViewportReport's
   // own doc above. onMove fires on every frame of a pan/zoom gesture (never
   // just once at the end, unlike NodeResizer's onResizeEnd), so the debounce
@@ -1074,8 +1264,13 @@ function CanvasInner({ store }: { store: SceneStore }) {
 
   useEffect(() => {
     if (draggingRef.current) return;
-    setNodes((current) => withPreservedSelection(toFlowNodes(scene, store, onOpenDocumentView), current));
-  }, [scene, store, onOpenDocumentView]);
+    setNodes((current) =>
+      withPreservedSelection(
+        toFlowNodes(scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus),
+        current,
+      ),
+    );
+  }, [scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus]);
 
   const edges = useMemo(() => toFlowEdges(scene, hoveredEdgeId), [scene, hoveredEdgeId]);
 

--- a/web_ui/src/app/canvas/ThinkingNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ThinkingNodeView.test.tsx
@@ -9,6 +9,7 @@ import { ThinkingNodeView, type ThinkingFlowNode } from "./ThinkingNodeView";
 function renderThinkingNode(overrides: Partial<ThinkingFlowNode["data"]> = {}) {
   const onDock = vi.fn();
   const onDelete = vi.fn();
+  const onToggleBranchFocus = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -16,6 +17,8 @@ function renderThinkingNode(overrides: Partial<ThinkingFlowNode["data"]> = {}) {
       thinkingText: "Considering **several** approaches before answering.",
       onDock,
       onDelete,
+      isBranchFocusActive: false,
+      onToggleBranchFocus,
       ...overrides,
     },
   } as unknown as NodeProps<ThinkingFlowNode>;
@@ -25,7 +28,7 @@ function renderThinkingNode(overrides: Partial<ThinkingFlowNode["data"]> = {}) {
       <ThinkingNodeView {...props} />
     </ReactFlowProvider>,
   );
-  return { onDock, onDelete };
+  return { onDock, onDelete, onToggleBranchFocus };
 }
 
 describe("ThinkingNodeView", () => {
@@ -34,7 +37,7 @@ describe("ThinkingNodeView", () => {
     expect(screen.getByText("several")).toBeInTheDocument(); // bold text still renders as text
   });
 
-  it("right-click opens a menu with real Copy Content/Dock to Parent Node/Delete Node and honest disabled Hide Other Branches", async () => {
+  it("right-click opens a menu with real Copy Content/Dock to Parent Node/Hide Other Branches/Delete Node", async () => {
     const user = userEvent.setup();
     const { onDock, onDelete } = renderThinkingNode();
 
@@ -52,8 +55,7 @@ describe("ThinkingNodeView", () => {
     expect(copyItem).toBeEnabled();
     expect(dockItem).toBeEnabled();
     expect(deleteItem).toBeEnabled();
-    expect(hideBranches).toBeDisabled();
-    expect(hideBranches).toHaveAttribute("title", "Branch visibility isn't built yet");
+    expect(hideBranches).toBeEnabled();
 
     await user.click(copyItem);
     expect(writeText).toHaveBeenCalledWith("Considering **several** approaches before answering.");
@@ -65,6 +67,33 @@ describe("ThinkingNodeView", () => {
     fireEvent.contextMenu(label);
     await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
     expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("Hide Other Branches calls onToggleBranchFocus and closes the menu when branch focus is inactive", async () => {
+    const user = userEvent.setup();
+    const { onToggleBranchFocus } = renderThinkingNode({ isBranchFocusActive: false });
+    const label = screen.getByText("Thinking");
+
+    fireEvent.contextMenu(label);
+    const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
+    await user.click(hideBranches);
+
+    expect(onToggleBranchFocus).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("labels the item Show All Branches and still calls onToggleBranchFocus when branch focus is active", async () => {
+    const user = userEvent.setup();
+    const { onToggleBranchFocus } = renderThinkingNode({ isBranchFocusActive: true });
+    const label = screen.getByText("Thinking");
+
+    fireEvent.contextMenu(label);
+    expect(screen.queryByRole("menuitem", { name: "Hide Other Branches" })).toBeNull();
+    const showBranches = screen.getByRole("menuitem", { name: "Show All Branches" });
+    await user.click(showBranches);
+
+    expect(onToggleBranchFocus).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 
   it("Escape and outside-click both close the menu", async () => {

--- a/web_ui/src/app/canvas/ThinkingNodeView.tsx
+++ b/web_ui/src/app/canvas/ThinkingNodeView.tsx
@@ -28,17 +28,18 @@ import { NodeMenu } from "./NodeMenu";
  * Real: render (markdown thinking text, same react-markdown + rehype-
  * highlight pipeline every other node kind pulls in), delete (generic
  * cascade-delete - a thinking node is never a branch point/reparented, same
- * as CodeNode), copy, dock. Deferred, with an honest disabled+title label
- * rather than a silent drop (same audit convention every prior node kind in
- * this plan has followed): Hide Other Branches (the legacy scene's branch-
- * visibility toggle has no backend/frontend equivalent at all yet - unscoped,
- * not owned by any R-phase).
+ * as CodeNode), copy, dock, and now Hide Other Branches / Show All Branches -
+ * a scene-wide toggle (SceneCanvas.tsx owns the graph walk and the dimming
+ * style; this view just calls the closed-over onToggleBranchFocus() and
+ * mirrors isBranchFocusActive back into the menu item's own label).
  */
 
 export interface ThinkingNodeData extends Record<string, unknown> {
   thinkingText: string;
   onDock: () => void;
   onDelete: () => void;
+  isBranchFocusActive: boolean;
+  onToggleBranchFocus: () => void;
 }
 
 export type ThinkingFlowNode = Node<ThinkingNodeData, "thinking">;
@@ -53,12 +54,16 @@ function ThinkingNodeMenu({
   thinkingText,
   onDock,
   onDelete,
+  isBranchFocusActive,
+  onToggleBranchFocus,
   onClose,
 }: {
   position: MenuPosition;
   thinkingText: string;
   onDock: () => void;
   onDelete: () => void;
+  isBranchFocusActive: boolean;
+  onToggleBranchFocus: () => void;
   onClose: () => void;
 }) {
 
@@ -88,8 +93,15 @@ function ThinkingNodeMenu({
       >
         Dock to Parent Node
       </button>
-      <button type="button" role="menuitem" disabled title="Branch visibility isn't built yet">
-        Hide Other Branches
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onToggleBranchFocus();
+          onClose();
+        }}
+      >
+        {isBranchFocusActive ? "Show All Branches" : "Hide Other Branches"}
       </button>
       <button
         type="button"
@@ -137,6 +149,8 @@ export function ThinkingNodeView({ data, selected }: NodeProps<ThinkingFlowNode>
           thinkingText={data.thinkingText}
           onDock={data.onDock}
           onDelete={data.onDelete}
+          isBranchFocusActive={data.isBranchFocusActive}
+          onToggleBranchFocus={data.onToggleBranchFocus}
           onClose={() => setMenuPosition(null)}
         />
       )}


### PR DESCRIPTION
## Summary

Restores the "Hide Other Branches" menu action across chat, code, document, thinking and image nodes, replacing a disabled placeholder with a working branch-isolation toggle.

## Problem

All five node kinds' menus carried the item disabled, with the tooltip *"Branch visibility isn't built yet"*. The Qt cutover deleted the legacy scene's `toggle_branch_visibility` (`graphlink_scene.py`) without porting a successor.

Legacy's own name is misleading: it never removes anything. It dims every node outside the clicked node's branch — its ancestor chain and everything descended from it — down to a low opacity, restoring full opacity on toggle-off. It is a scene-wide toggle: once active, the button reads "Show All Branches" everywhere, and clicking anywhere clears it regardless of which node's menu the second click came from.

## Changes

**`computeDimmedNodeIds`** (`SceneCanvas.tsx`) ports the legacy algorithm to this app's uniform `(source, target)` edge model. Legacy told "chat replied by chat" and "chat owns a code block" apart with different attribute pairs; the modern backend models both as one edge type, so this tells them apart by kind instead — a node's branch anchor is itself if chat-kind, else its nearest parent if that is chat-kind. The active branch is the set of chat nodes reachable by walking chat-to-chat edges only, in both directions; a content node attached to any branch member counts as active via its anchor, not by the walk expanding through it.

Both the ancestor walk and the descendant search are visited-set-guarded — a deliberate hardening legacy's own equivalent walks lack, since `SceneDocument.connect()` permits creating a cycle with no validation. Dimming is applied via React Flow's per-node `style.opacity`, the same mechanism this file already uses for the fade-connections feature, at `0.18` — legacy's own constant, ported unchanged.

Dimming is scoped to exactly the five node kinds that carried this menu item in the legacy app. Every other kind, including Conversation (whose own file already documents excluding this feature deliberately), is left untouched.

## Process

Built in two stages. The algorithm and all `SceneCanvas` state were written and hand-verified against 13 graph scenarios — linear chains, sibling forks, deep descendant chains, content nodes on dimmed branches, focusing from a content node itself, orphaned nodes, manually-created cycles — before any other file was touched. Five agents then wired the mechanical menu-button change into the five node views in parallel from one shared contract.

Three independent reviews followed: one devised its own six adversarial graph scenarios blind to the existing test suite and hand-traced them against the implementation before cross-checking against it; one verified cross-file contract correctness; one checked legacy fidelity and test quality. All three came back clean bar one test-coverage gap — a missing menu-closed assertion in one file's active-state test — fixed directly.

That same direct verification pass caught a real lint error outside the reviewed scope: the original self-heal-on-deleted-origin logic called `setState` synchronously inside a `useEffect`, the cascading-render anti-pattern `react-hooks/set-state-in-effect` exists to catch. Replaced with a value derived during render — simpler, and resolves a stale node reference within the same render instead of one render later.

## Verification

| Check | Result |
| --- | --- |
| Backend suite | 1033 passed (unaffected — no backend changes) |
| Frontend `tsc --noEmit` / ESLint / tests / build | clean / 0 errors / 841 passed (31 new) / succeeds |
| Live: real 13-node scene with an actual branch fork | confirmed |
| Live: toggling dims exactly the sibling branch (5 nodes, multiple kinds incl. a thinking node) to opacity `0.18` | confirmed |
| Live: label flips to "Show All Branches" | confirmed |
| Live: toggling off restores all 13 nodes to opacity `1` | confirmed |
| Live: console | zero errors |

## Related

This closes out the four-item deferred-menu-item cleanup started with Key Takeaway/Explainer Note (#169) and Open Document View (#170).