### PR TITLE
R8a: gate notifications on type preference, wire up node font styling (findings #10, #11)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -146,7 +146,7 @@ def _configure_session(
 
     # R2: notifications, moved ahead of canvas - R3.3's sendMessage intent
     # needs a real NotificationState to give an honest agent-dispatch notice.
-    notifications_state = register_notifications(bus)
+    notifications_state = register_notifications(bus, settings_manager)
     # R6.7: a no-op unless graphlink_desktop.py's own running.lock sentinel
     # found the prior run didn't reach a clean shutdown - see
     # backend/crash_recovery.py's module docstring for the full mechanism.

--- a/backend/notifications.py
+++ b/backend/notifications.py
@@ -9,10 +9,13 @@ save/load) call `show()` from their own handlers as those land.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Literal
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
 
 from backend.events import SessionBus
+
+if TYPE_CHECKING:
+    from graphlink_licensing import SettingsManager
 
 MessageType = Literal["info", "success", "warning", "error"]
 
@@ -22,8 +25,19 @@ class NotificationState:
     visible: bool = False
     message: str = ""
     msg_type: MessageType = "info"
+    # R8a (UI/UX issue list finding #10): Settings' own "Notification types"
+    # checkboxes wrote real preferences (SettingsManager.get_notification_
+    # type_enabled already existed) that nothing ever read - show() set
+    # visible=True unconditionally no matter what the user had unchecked.
+    # Optional so the many call sites/tests that only ever had `bus` still
+    # work unchanged; None means "no preference to check", i.e. always show.
+    settings_manager: "SettingsManager | None" = field(default=None, repr=False, compare=False)
 
     def show(self, message: str, msg_type: MessageType = "info") -> None:
+        if self.settings_manager is not None and not self.settings_manager.get_notification_type_enabled(
+            msg_type
+        ):
+            return
         self.message = str(message)
         self.msg_type = msg_type
         self.visible = True
@@ -35,8 +49,8 @@ class NotificationState:
         return {"visible": self.visible, "message": self.message, "msgType": self.msg_type}
 
 
-def register_notifications(bus: SessionBus) -> NotificationState:
-    state = NotificationState()
+def register_notifications(bus: SessionBus, settings_manager: "SettingsManager | None" = None) -> NotificationState:
+    state = NotificationState(settings_manager=settings_manager)
     bus.register_topic("notification", state.payload)
 
     async def dismiss():

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,106 @@
+"""NotificationState preference-gating tests (R8a UI/UX issue list finding #10).
+
+Settings' "Notification types" checkboxes wrote real preferences via
+SettingsManager.set_notification_preferences - the getter existed and had
+zero callers. NotificationState.show() set visible=True unconditionally, so
+unchecking a type had no effect on whether its banner appeared.
+"""
+
+import pytest
+from graphlink_licensing import SettingsManager
+
+from backend.events import SessionBus
+from backend.notifications import NotificationState, register_notifications
+
+
+@pytest.fixture
+def manager(tmp_path):
+    return SettingsManager(tmp_path / "session.dat")
+
+
+def test_show_with_no_settings_manager_always_shows():
+    # The many existing call sites/tests construct NotificationState/
+    # register_notifications with no settings manager at all - that must
+    # keep behaving exactly as before (always show).
+    state = NotificationState()
+    state.show("hello", "warning")
+    assert state.visible is True
+    assert state.message == "hello"
+    assert state.msg_type == "warning"
+
+
+def test_show_is_suppressed_when_the_type_is_disabled(manager):
+    manager.set_notification_preferences({"warning": False})
+    state = NotificationState(settings_manager=manager)
+
+    state.show("a warning", "warning")
+
+    assert state.visible is False
+    assert state.message == ""
+
+
+def test_show_still_works_for_a_type_left_enabled(manager):
+    manager.set_notification_preferences({"warning": False})
+    state = NotificationState(settings_manager=manager)
+
+    state.show("all good", "success")
+
+    assert state.visible is True
+    assert state.message == "all good"
+    assert state.msg_type == "success"
+
+
+def test_disabling_and_then_reenabling_a_type_restores_show(manager):
+    manager.set_notification_preferences({"error": False})
+    state = NotificationState(settings_manager=manager)
+    state.show("boom", "error")
+    assert state.visible is False
+
+    manager.set_notification_preferences({"error": True})
+    state.show("boom again", "error")
+    assert state.visible is True
+
+
+def test_a_suppressed_show_does_not_clobber_a_currently_visible_banner(manager):
+    # show() bails out before touching message/msg_type/visible when the
+    # type is disabled - a currently-showing banner of a DIFFERENT type must
+    # survive a suppressed call, not get silently wiped to blank.
+    manager.set_notification_preferences({"warning": False})
+    state = NotificationState(settings_manager=manager)
+    state.show("still here", "info")
+    assert state.visible is True
+
+    state.show("suppressed", "warning")
+
+    assert state.visible is True
+    assert state.message == "still here"
+    assert state.msg_type == "info"
+
+
+def test_dismiss_is_unaffected_by_preferences(manager):
+    manager.set_notification_preferences({"info": False})
+    state = NotificationState(settings_manager=manager)
+    state.visible = True
+
+    state.dismiss()
+
+    assert state.visible is False
+
+
+def test_register_notifications_wires_the_settings_manager_through(manager):
+    manager.set_notification_preferences({"success": False})
+    bus = SessionBus("notifications-gating-test")
+    state = register_notifications(bus, manager)
+
+    state.show("saved", "success")
+
+    assert state.visible is False
+
+
+def test_register_notifications_without_a_settings_manager_still_shows_everything():
+    bus = SessionBus("notifications-no-manager-test")
+    state = register_notifications(bus)
+
+    state.show("hello", "error")
+
+    assert state.visible is True

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -1189,6 +1189,28 @@ function CanvasInner({ store }: { store: SceneStore }) {
   const [smartGuideLines, setSmartGuideLines] = useState<GuideLine[]>([]);
   const visibleGuideLines = scene.smartGuides ? smartGuideLines : [];
 
+  // R8a (UI/UX issue list finding #11): the View popover's FONT section
+  // (family/size/color) already round-trips real intents into scene state -
+  // nothing ever consumed them. Written as CSS custom properties on the
+  // canvas wrapper (not per-node inline styles) so every current AND future
+  // node inherits them for free through .scene-node's own rules in
+  // styles.css, the same way .scene-canvas already carries grid state down
+  // via React Flow's own Background props.
+  const canvasWrapperRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = canvasWrapperRef.current;
+    if (!el) return;
+    el.style.setProperty("--gl-node-font-family", scene.fontFamily);
+    // fontSizePt is POINTS (backend field: font_size_pt, default 9 -> the
+    // FONT_SIZE_MIN/MAX range of 8-16 only makes sense as points, not
+    // pixels: 16px node text would be barely a size change from the 12px/
+    // 11px base, while 16pt is a real, visible jump). `pt` is a real CSS
+    // unit (1pt = 1/72in = 4/3px), not print-only, so this needs no
+    // conversion - just the right unit suffix.
+    el.style.setProperty("--gl-node-font-size", `${scene.fontSizePt}pt`);
+    el.style.setProperty("--gl-node-font-color", scene.fontColor);
+  }, [scene.fontFamily, scene.fontSizePt, scene.fontColor]);
+
   // R8a: Open Document View - the read-only markdown modal a chat/
   // conversation node's card menu opens (see toFlowNodes' own
   // onOpenDocumentView field on each of those two branches). The displayed
@@ -1465,7 +1487,7 @@ function CanvasInner({ store }: { store: SceneStore }) {
 
   return (
     <>
-      <div className="scene-canvas" onDoubleClick={onDoubleClick}>
+      <div className="scene-canvas" ref={canvasWrapperRef} onDoubleClick={onDoubleClick}>
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -199,6 +199,16 @@ body,
   border-radius: 8px;
   overflow: hidden;
   font-size: 12px;
+  /* R8a (UI/UX issue list finding #11): the View popover's FONT section -
+     family/size/color, --gl-node-font-* set on .scene-canvas by
+     SceneCanvas.tsx - used to round-trip into scene state with nothing
+     consuming it. Applied here, the shared base every node kind renders
+     through, rather than per-kind content rules (markdown headers, code
+     blocks) so headings/monospace keep their own intentional typography;
+     this is the node's title bar and any plain body text that doesn't set
+     its own font-size. Falls back to the pre-existing literal when unset
+     (e.g. in tests that render a node outside SceneCanvas). */
+  font-family: var(--gl-node-font-family, inherit);
 }
 
 .scene-node.selected {
@@ -208,7 +218,8 @@ body,
 .scene-node-title {
   padding: 6px 10px;
   font-weight: 600;
-  color: var(--gl-surface-text);
+  font-size: var(--gl-node-font-size, inherit);
+  color: var(--gl-node-font-color, var(--gl-surface-text));
   background-color: var(--gl-surface-inset, var(--gl-surface-node-body));
   border-bottom: 1px solid var(--gl-surface-border);
 }
@@ -219,8 +230,8 @@ body,
 
 .scene-node-body {
   padding: 8px 10px;
-  color: var(--gl-surface-text-muted);
-  font-size: 11px;
+  color: var(--gl-node-font-color, var(--gl-surface-text-muted));
+  font-size: var(--gl-node-font-size, 11px);
 }
 
 .scene-canvas .react-flow__edge-path {


### PR DESCRIPTION
## Problem

Two settings from the R8a audit persisted real state that nothing consumed:

- **Finding #10:** Settings' Info/Success/Warning/Error notification-type checkboxes wrote real preferences via `SettingsManager.set_notification_preferences`, and `get_notification_type_enabled` already existed to read them back, but `NotificationState.show()` set `visible = True` unconditionally. Unchecking a type had no effect on whether its banner appeared.
- **Finding #11:** The View popover's FONT section (family select, size slider, color swatches) already round-tripped real `setFontFamily`/`setFontSize`/`setFontColor` intents into scene state, but nothing on the frontend ever consumed `scene.fontFamily`/`fontSizePt`/`fontColor` as CSS. Changing any of the three controls visibly changed nothing on the canvas.

## Change

- `backend/notifications.py`: `register_notifications` now takes an optional `SettingsManager`. `NotificationState.show()` early-returns (leaving any currently-visible banner untouched) when the message's type is disabled in preferences. The gate lives in the one method every existing `notifications.show(...)` call site already goes through (canvas.py, agents.py, chat_library.py, settings.py, plugins.py, autosave.py, crash_recovery.py), so all of them are covered without individual changes. `backend/app.py` now passes the session's real settings manager through.
- `web_ui/src/app/canvas/SceneCanvas.tsx`: writes `scene.fontFamily`/`fontSizePt`/`fontColor` onto the canvas wrapper as `--gl-node-font-family`/`-size`/`-color` custom properties. `fontSizePt` is points (backend field `font_size_pt`, range 8-16, default 9) — `pt` is a real CSS unit, so no conversion needed beyond the correct suffix.
- `web_ui/src/app/styles.css`: `.scene-node`, `.scene-node-title`, and `.scene-node-body` reference the new tokens with their prior literal values as fallbacks. Scoped to the shared base rules (title bar, generic body text) rather than each node kind's own content styling, so markdown heading hierarchy and monospace code blocks keep their own intentional typography.

## Test plan

| Layer | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` (full suite) | 868/868 passed |
| `python -m pytest -q` (full suite) | 1041/1041 passed (8 new) |
| `npm run lint` | clean (0 errors) |

New coverage: `backend/tests/test_notifications.py` (gating on/off per type, a suppressed `show()` doesn't clobber a currently-visible banner of a different type, `dismiss()` unaffected by preferences, `register_notifications` wiring, and the pre-existing no-settings-manager call sites still always show).

Live-verified end to end against a running instance (real WS round-trip, not a mock): dragging the font-size slider, picking a font family, and picking a font color each immediately restyled a real canvas node's title and body text to the new values; the initial page load already reflected the backend's default font settings correctly.