### PR TITLE
R8a: remove the dead Theme setting (finding #9)

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -349,7 +349,6 @@ def _llama_cpp_scan_summary(manager: SettingsManager) -> str:
 
 def settings_payload(manager: SettingsManager) -> dict[str, Any]:
     return {
-        "theme": manager.get_theme(),
         "showTokenCounter": manager.get_show_token_counter(),
         "enableSystemPrompt": manager.get_enable_system_prompt(),
         "notificationPreferences": manager.get_notification_preferences(),
@@ -481,10 +480,6 @@ def register_settings(
     # The topic builder (read path) stays on the loop, unlocked: field reads
     # are GIL-atomic, and every mutation republishes on completion, so a
     # snapshot that races a write is immediately superseded by a settled one.
-
-    async def set_theme(theme: str):
-        await asyncio.to_thread(_apply, manager.set_theme, str(theme))
-        await bus.publish("app-settings")
 
     async def set_show_token_counter(enabled: bool):
         await asyncio.to_thread(_apply, manager.set_show_token_counter, bool(enabled))
@@ -1236,7 +1231,6 @@ def register_settings(
         await bus.publish("app-settings")
 
     bus.register_intent("app-settings", "setActiveSection", set_active_section)
-    bus.register_intent("app-settings", "setTheme", set_theme)
     bus.register_intent("app-settings", "setShowTokenCounter", set_show_token_counter)
     bus.register_intent("app-settings", "setEnableSystemPrompt", set_enable_system_prompt)
     bus.register_intent("app-settings", "setNotificationPreference", set_notification_preference)

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -32,7 +32,6 @@ class Recorder:
 def test_settings_payload_shape_matches_generated_validator_shape(manager):
     payload = settings_payload(manager)
     assert set(payload) == {
-        "theme",
         "showTokenCounter",
         "enableSystemPrompt",
         "notificationPreferences",
@@ -42,7 +41,6 @@ def test_settings_payload_shape_matches_generated_validator_shape(manager):
 
 def test_settings_payload_reflects_real_manager_defaults(manager):
     payload = settings_payload(manager)
-    assert payload["theme"] == "dark"
     # R8a: the token counter overlay is off by default - opt-in, not opt-out.
     assert payload["showTokenCounter"] is False
     assert payload["enableSystemPrompt"] is True
@@ -80,7 +78,6 @@ def test_register_settings_publishes_active_section_alongside_manager_state(mana
     asyncio.run(bus.publish("app-settings"))
     payload = recorder.messages[0]["payload"]
     assert payload["activeSection"] == "general"
-    assert payload["theme"] == "dark"
 
 
 def test_set_active_section_intent_updates_only_local_ui_state(manager):
@@ -92,18 +89,6 @@ def test_set_active_section_intent_updates_only_local_ui_state(manager):
     asyncio.run(bus.dispatch_intent("app-settings", "setActiveSection", ["integrations"]))
     payload = recorder.messages[-1]["payload"]
     assert payload["activeSection"] == "integrations"
-
-
-def test_set_theme_intent_persists_to_the_real_settings_manager(manager):
-    bus = SessionBus("settings-theme-test")
-    register_settings(bus, manager)
-
-    asyncio.run(bus.dispatch_intent("app-settings", "setTheme", ["light"]))
-    assert manager.get_theme() == "light"
-    # A fresh manager reading the same file proves it was actually persisted,
-    # not just mutated in memory.
-    reloaded = SettingsManager(manager.state_file)
-    assert reloaded.get_theme() == "light"
 
 
 def test_set_show_token_counter_intent(manager):
@@ -178,17 +163,17 @@ def test_an_old_settings_file_without_schema_version_is_backfilled(tmp_path):
     import json
 
     state_file = tmp_path / "session.dat"
-    state_file.write_text(json.dumps({"theme": "mono"}), encoding="utf-8")
+    state_file.write_text(json.dumps({"show_token_counter": True}), encoding="utf-8")
 
     old_manager = SettingsManager(state_file)
 
     # Backfilled in memory immediately, the same as every other pre-existing
-    # key here (theme, show_token_counter, ...) - none of those write back to
-    # disk until the next explicit set_*() call either, so schema_version
+    # key here (show_token_counter, ...) - none of those write back to disk
+    # until the next explicit set_*() call either, so schema_version
     # matching that existing pattern is correct, not a gap.
     assert old_manager.get_schema_version() == SettingsManager.CURRENT_SCHEMA_VERSION
 
-    old_manager.set_theme("mono")  # any setter call persists the whole (now-backfilled) state
+    old_manager.set_show_token_counter(False)  # any setter call persists the whole (now-backfilled) state
     assert json.loads(state_file.read_text(encoding="utf-8"))["schema_version"] == SettingsManager.CURRENT_SCHEMA_VERSION
 
 

--- a/contracts/graphlink_app_settings_payload.py
+++ b/contracts/graphlink_app_settings_payload.py
@@ -35,7 +35,6 @@ class AppSettingsStatePayload:
     schemaVersion: int
     revision: int
     activeSection: str
-    theme: str
     showTokenCounter: bool
     enableSystemPrompt: bool
     notificationPreferences: dict[str, bool]

--- a/graphlink_licensing.py
+++ b/graphlink_licensing.py
@@ -85,8 +85,6 @@ class SettingsManager:
         try:
             with open(self.state_file, 'r') as f:
                 state = json.load(f)
-                if 'theme' not in state:
-                    state['theme'] = 'dark'
                 if 'show_token_counter' not in state:
                     state['show_token_counter'] = False
                 state_changed = False
@@ -232,7 +230,6 @@ class SettingsManager:
     def _create_initial_state(self):
         state = {
             "schema_version": self.CURRENT_SCHEMA_VERSION,
-            "theme": "dark",
             "show_token_counter": False,
             "ollama_chat_model": "",
             "ollama_title_model": "",
@@ -369,13 +366,6 @@ class SettingsManager:
 
     def get_schema_version(self):
         return self.state.get("schema_version", self.CURRENT_SCHEMA_VERSION)
-
-    def get_theme(self):
-        return self.state.get("theme", "dark")
-
-    def set_theme(self, theme_name):
-        self.state['theme'] = theme_name
-        self._save_state()
 
     def get_show_token_counter(self):
         # R8a: off by default - the overlay is opt-in now, not opt-out.

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -17,7 +17,6 @@ const snapshot = {
   minCompatibleSchemaVersion: 1,
   revision: 1,
   activeSection: "general",
-  theme: "dark",
   showTokenCounter: true,
   enableSystemPrompt: true,
   notificationPreferences: { info: true, success: true, warning: true, error: true },

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -49,12 +49,6 @@ function basename(path: string): string {
   return path.split(/[\\/]/).pop() || path;
 }
 
-const THEME_OPTIONS = [
-  { value: "dark", label: "Dark" },
-  { value: "muted", label: "Muted" },
-  { value: "mono", label: "Monochromatic" },
-];
-
 const NOTIFICATION_TYPE_LABELS: Record<string, string> = {
   info: "Info",
   success: "Success",
@@ -95,7 +89,6 @@ const initialState: AppSettingsState = {
   minCompatibleSchemaVersion: 1,
   revision: 0,
   activeSection: "General",
-  theme: "dark",
   showTokenCounter: true,
   enableSystemPrompt: true,
   notificationPreferences: {},
@@ -146,23 +139,15 @@ function GeneralPage({
   state: AppSettingsState;
   transport: WsTransport;
 }) {
+  // R8a (UI/UX issue list finding #9): a Theme select (Dark/Muted/
+  // Monochromatic) used to live here. It persisted a real setTheme intent,
+  // but nothing in the SPA ever applied the value - no data-theme attribute,
+  // no alternate token set, the app rendered identically no matter what was
+  // selected. Removed rather than wired up: building two real alternate
+  // palettes is a design decision, not a bug fix, and a persisted preference
+  // that provably does nothing is worse than no preference at all.
   return (
     <div className="settings-general-page">
-      <label className="settings-field">
-        <span className="settings-field-label">Theme</span>
-        <select
-          className="settings-select"
-          value={state.theme}
-          onChange={(event) => transport.intent("app-settings", "setTheme", [event.target.value])}
-        >
-          {THEME_OPTIONS.map(({ value, label }) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </select>
-      </label>
-
       <label className="settings-checkbox-row">
         <input
           type="checkbox"

--- a/web_ui/src/app/chrome/help-data/sections.ts
+++ b/web_ui/src/app/chrome/help-data/sections.ts
@@ -362,10 +362,6 @@ export const HELP_SECTIONS: HelpSection[] = [
         "title": "Personalization and Feedback",
         "items": [
           {
-            "action": "Appearance",
-            "description": "Theme and appearance settings restyle the app, including flyouts and node accents, around the current palette. This is mainly cosmetic, but it helps tailor the workspace to your preference."
-          },
-          {
             "action": "Token Counter",
             "description": "When enabled, the token counter shows prompt, context, output, and running session totals. It is useful when you want a sense of branch size or model budget."
           },

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
@@ -165,9 +165,6 @@
     "showTokenCounter": {
       "type": "boolean"
     },
-    "theme": {
-      "type": "string"
-    },
     "viewingApiProvider": {
       "type": "string"
     }
@@ -176,7 +173,6 @@
     "schemaVersion",
     "revision",
     "activeSection",
-    "theme",
     "showTokenCounter",
     "enableSystemPrompt",
     "notificationPreferences",

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
@@ -14,7 +14,6 @@ export interface AppSettingsState {
   schemaVersion: number;
   revision: number;
   activeSection: string;
-  theme: string;
   showTokenCounter: boolean;
   enableSystemPrompt: boolean;
   notificationPreferences: Record<string, boolean>;
@@ -112,11 +111,6 @@ function checkAppSettingsState(value: unknown, path: string, errors: string[]): 
     const fieldValue = value["activeSection"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.activeSection: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.activeSection` + ": expected string"); }
-  }
-  {
-    const fieldValue = value["theme"];
-    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.theme: missing required field`);
-    else { if (typeof fieldValue !== "string") errors.push(`${path}.theme` + ": expected string"); }
   }
   {
     const fieldValue = value["showTokenCounter"];


### PR DESCRIPTION
## Problem

Settings' General page had a Theme select (Dark/Muted/Monochromatic) that persisted a real `setTheme` intent, but nothing in the SPA ever applied the value — no `data-theme` attribute, no alternate token set, the app rendered identically regardless of selection.

## Change

Removed rather than wired up, per product decision: building two real alternate palettes is a design investment (new `--gl-surface-*` token sets need real color choices), not a mechanical fix, and a persisted preference that provably does nothing is worse than no preference.

Removed end to end:
- The frontend Theme select and its options (`SettingsDialog.tsx`).
- The `setTheme` intent and its handler (`backend/settings.py`).
- `get_theme`/`set_theme` on `SettingsManager`, including the now-pointless in-memory backfill for legacy state files missing the key (`graphlink_licensing.py`).
- The `theme` field from the `app-settings` wire contract, with the generated TS/JSON artifacts regenerated (`contracts/graphlink_app_settings_payload.py`).
- The now-stale "Appearance" Help entry that described this exact control (`help-data/sections.ts`).

## Test plan

| Layer | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` (full suite) | 868/868 passed |
| `python -m pytest -q` (full suite) | 1040/1040 passed |
| `npm run check:schema` | 11/11 generated artifact sets up to date |
| `npm run lint` / `npm run build` | clean |

Live-verified against a running instance: Settings > General now opens directly to "Show Token Counter Overlay" with no Theme control, and the Notification-types checkboxes still round-trip correctly.