### PR TITLE
R8a: give the notification banner its own band, clear of the search bar (findings #3, #25)

### DIFF
--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1714,9 +1714,23 @@ body,
   color: var(--gl-surface-text-primary);
 }
 
+/* R8a (UI/UX issue list findings #3/#25 - a literal duplicate entry, one
+   bug): this layer and .app-search-layer both centre on the same top-
+   centre band. Before this fix both used the same --gl-chrome-inset top,
+   so a banner showing while search was open fully covered it (measured
+   live: .search-overlay-shell renders at top:16/height:42 relative to
+   .app-canvas-region, and a real .notification-banner renders 40px tall -
+   two 40px+ elements at an identical top offset is total overlap, not a
+   near-miss). Search keeps the stable slot (it's the one the user is
+   actively looking at/typing into); the banner gets a second band below
+   it with real clearance - 68px clears search's own measured bottom
+   (16+42=58) by 10px, so the two can never touch regardless of which
+   shows first. The z-index gap (still --gl-z-notification over
+   --gl-z-search) stays as a second guarantee in case a longer banner
+   message ever wraps taller than assumed here. */
 .app-notification-layer {
   position: absolute;
-  top: var(--gl-chrome-inset);
+  top: calc(var(--gl-chrome-inset) + 52px);
   left: 50%;
   transform: translateX(-50%);
   z-index: var(--gl-z-notification);


### PR DESCRIPTION
## Problem

The audit listed this bug twice — findings #3 and #25 are the same defect, confirmed identical by an independent re-read of the current code. The notification banner and the Ctrl+F search bar both centre on the same top-centre band of the canvas region. A recent, unrelated change (the R8a edge-inset unification) had moved both onto the identical `--gl-chrome-inset` top offset, so a notification showing while search was open no longer partially overlapped it — it covered it completely: search's own shell measures 42px tall live, notification's measures 40px, both starting at the same y.

## Change

Search keeps its stable slot — it's the surface the user is actively typing into, and its position shouldn't jump depending on whether a banner happens to be showing. `.app-notification-layer` moves to its own band 68px down (measured search bottom is 58px; 10px of real clearance beyond that), so the two can never touch regardless of which shows first or which closes first. The z-index gap (`--gl-z-notification` still above `--gl-z-search`) stays as a second guarantee in case a longer banner message ever wraps taller than assumed here.

## Test plan

| Layer | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` (full suite) | 868/868 passed |
| `npm run lint` / `npm run build` | clean |

Live-verified against a running instance: with search open (real `.search-overlay-shell` rendered) and a real `.notification-banner` appended into the actual `.app-notification-layer`, the two elements' bounding rects no longer intersect — measured 10px gap between them.