### PR TITLE
R8a: give popovers a scroll fallback instead of silent clipping (findings #4, #13)

### DIFF
--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1147,6 +1147,18 @@ body,
   min-width: 230px;
   max-width: 320px;
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+  /* R8a (UI/UX issue list findings #4/#13 - a literal duplicate entry, one
+     bug): every popover through this shared base class - View, Plugins,
+     Pins, Reasoning, Model - is hosted inside .app-canvas-region, which is
+     overflow:hidden (see that rule's own comment). Before this, content
+     taller than the available space (e.g. ViewPopover's FONT section on a
+     short window) was silently clipped away with no scrollbar and no
+     indication anything was missing. 96px reserves room for the chrome
+     above/below the canvas region on a typical window without needing to
+     know any specific popover's anchor point - a real backstop, not a
+     tuned distance that happens to work for one consumer. */
+  max-height: calc(100vh - 96px);
+  overflow-y: auto;
 }
 
 .overlay-scrim {


### PR DESCRIPTION
## Problem

The audit listed this bug twice — findings #4 and #13 are the same defect, confirmed identical by an independent re-read of the current code. Every popover through the shared `.overlay-popover` base class (View, Plugins, Pins, Reasoning, Model) is hosted inside `.app-canvas-region`, which is `overflow: hidden`. `.overlay-popover` itself declared no `max-height` and no `overflow-y`, so content taller than the available space — most visibly the View popover's FONT section on a short window — was silently clipped away with no scrollbar and no indication anything was missing.

## Change

Added `max-height: calc(100vh - 96px); overflow-y: auto;` to the shared base class. Popovers that already set their own `max-height` (Reasoning, which opens upward from the composer and caps at `min(60vh, 320px)`) are unaffected — their own rule simply wins the cascade, since this is only a default for consumers that don't set one.

## Test plan

| Layer | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` (full suite) | 868/868 passed |
| `npm run lint` / `npm run build` | clean |

Live-verified against a running instance at two window sizes:
- At the app's documented 960x600 floor: the View popover's FONT section now renders in full with no scrolling needed (computed `max-height` 504px vs 485px of real content).
- At a shorter 960x450 window, where content genuinely exceeds the available space: the last color swatch is confirmed off-screen before scrolling and fully reachable after — a real scrollbar, not a resize-and-hope fix.