### PR TITLE
Fix layout jump in Settings/Help, search matching, IME send, palette scroll

### DIFF
--- a/web_ui/src/app/canvas/ConversationNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.test.tsx
@@ -262,6 +262,17 @@ describe("ConversationNodeView", () => {
     expect(input).toHaveValue("line one\nline two");
   });
 
+  it("Enter fired while an IME is still composing does not send", async () => {
+    const { onSend } = renderConversationNode();
+    const input = screen.getByRole("textbox", { name: "Message" });
+
+    fireEvent.change(input, { target: { value: "半角" } });
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(input).toHaveValue("半角");
+  });
+
   it("the Send button is disabled when the input is empty or whitespace-only", async () => {
     const user = userEvent.setup();
     renderConversationNode();

--- a/web_ui/src/app/canvas/ConversationNodeView.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.tsx
@@ -276,7 +276,11 @@ export function ConversationNodeView({ data, selected }: NodeProps<ConversationF
               onKeyDown={(event) => {
                 // Enter-to-send / Shift+Enter-for-newline - same convention
                 // the existing Composer already uses (Composer.tsx's own
-                // onKeyDown handler).
+                // onKeyDown handler), including the IME-composing guard: an
+                // IME's Enter-to-commit keystroke also reports
+                // key==="Enter", so without it, confirming a composed
+                // character sent the half-typed buffer.
+                if (event.nativeEvent.isComposing) return;
                 if (event.key === "Enter" && !event.shiftKey) {
                   event.preventDefault();
                   send();

--- a/web_ui/src/app/chrome/CommandPalette.test.tsx
+++ b/web_ui/src/app/chrome/CommandPalette.test.tsx
@@ -1,7 +1,7 @@
 import { ReactFlowProvider } from "@xyflow/react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { CommandPalette } from "./CommandPalette";
 import { initialSceneState } from "../canvas/sceneStore";
 import { OverlayProvider, useOverlays } from "../overlays/overlays";
@@ -72,6 +72,23 @@ describe("CommandPalette", () => {
     // "Zoom In" then "Zoom Out" per the registry order.
     await user.keyboard("{ArrowDown}{Enter}");
     expect(screen.queryByLabelText("Search commands")).toBeNull();
+  });
+
+  it("scrolls the highlighted row into view as the selection moves", async () => {
+    // jsdom doesn't implement scrollIntoView - stub it so the effect that
+    // calls it doesn't throw, then assert it actually ran for the newly
+    // selected row rather than just that navigation still works.
+    const scrollIntoView = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    const user = setup();
+    await user.click(screen.getByText("open palette"));
+    scrollIntoView.mockClear(); // opening itself selects index 0 - not the interaction under test
+
+    await user.keyboard("{ArrowDown}");
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    const selected = document.querySelector('[aria-selected="true"]');
+    expect(scrollIntoView.mock.instances[scrollIntoView.mock.instances.length - 1]).toBe(selected);
   });
 
   it("executing an 'open X' command leaves that surface open, not just closed", async () => {

--- a/web_ui/src/app/chrome/CommandPalette.tsx
+++ b/web_ui/src/app/chrome/CommandPalette.tsx
@@ -16,6 +16,7 @@ export function CommandPalette({ store }: { store: SceneStore }) {
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const resultsRef = useRef<HTMLUListElement>(null);
   const isOpen = overlays.isOpen("palette");
 
   // Reset local state during render on the false->true transition (not in
@@ -47,6 +48,15 @@ export function CommandPalette({ store }: { store: SceneStore }) {
   }, [commands, query]);
 
   const clampedIndex = Math.min(selectedIndex, Math.max(filtered.length - 1, 0));
+
+  // Arrow-key selection only moved a data index - past roughly a dozen
+  // results the highlighted row scrolled out of the visible list with
+  // nothing to bring it back, so Enter could run a command the user could
+  // no longer see. "nearest" scrolls only when the row is actually outside
+  // the viewport, so real reordering doesn't also cause a viewport jump.
+  useEffect(() => {
+    resultsRef.current?.querySelector('[aria-selected="true"]')?.scrollIntoView({ block: "nearest" });
+  }, [clampedIndex]);
 
   if (!isOpen) return null;
 
@@ -95,7 +105,7 @@ export function CommandPalette({ store }: { store: SceneStore }) {
           autoComplete="off"
           spellCheck={false}
         />
-        <ul className="palette-results" role="listbox" aria-label="Commands">
+        <ul className="palette-results" role="listbox" aria-label="Commands" ref={resultsRef}>
           {filtered.length === 0 && <li className="palette-empty">No matching commands</li>}
           {filtered.map((command, index) => (
             <li

--- a/web_ui/src/app/chrome/Composer.test.tsx
+++ b/web_ui/src/app/chrome/Composer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { Composer } from "./Composer";
@@ -164,6 +164,27 @@ describe("Composer", () => {
     await user.type(input, "{Enter}");
     expect(sendMessage).toHaveBeenCalledWith("hi");
     expect(updateDraft).toHaveBeenCalledWith("");
+  });
+
+  it("Enter fired while an IME is still composing does not send", () => {
+    const { store } = makeStore({
+      composer: {
+        draft: { ...initialComposerState.draft, text: "半角" },
+        request: { ...initialComposerState.request, canSend: true },
+      },
+    });
+    const { sceneStore, sendMessage } = makeSceneStore();
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={sceneStore} />
+      </OverlayProvider>,
+    );
+    const input = screen.getByLabelText("Message composer");
+
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("whitespace-only text does not enable Send", () => {

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -103,6 +103,10 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
           value={composer.draft.text}
           onChange={(e) => store.updateDraft(e.target.value)}
           onKeyDown={(e) => {
+            // An IME's Enter-to-commit keystroke also reports key==="Enter",
+            // so without this guard, confirming a composed character (e.g.
+            // Japanese/Chinese/Korean input) sent the half-typed buffer.
+            if (e.nativeEvent.isComposing) return;
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
               send();

--- a/web_ui/src/app/chrome/SearchOverlay.test.tsx
+++ b/web_ui/src/app/chrome/SearchOverlay.test.tsx
@@ -10,9 +10,17 @@ function makeStore() {
   const scene = {
     ...initialSceneState,
     nodes: [
-      { id: "n0", x: 0, y: 0, title: "Alpha node", kind: "placeholder" },
-      { id: "n1", x: 100, y: 100, title: "Beta node", kind: "placeholder" },
-      { id: "n2", x: 200, y: 200, title: "Another alpha", kind: "placeholder" },
+      { id: "n0", x: 0, y: 0, title: "Alpha node", content: "", kind: "placeholder" },
+      { id: "n1", x: 100, y: 100, title: "Beta node", content: "", kind: "placeholder" },
+      { id: "n2", x: 200, y: 200, title: "Another alpha", content: "", kind: "placeholder" },
+      {
+        id: "n3",
+        x: 300,
+        y: 300,
+        title: "Gamma node",
+        content: "the quick brown zebra jumps",
+        kind: "placeholder",
+      },
     ],
   };
   return { subscribe: () => () => {}, getScene: () => scene };
@@ -60,6 +68,13 @@ describe("SearchOverlay", () => {
     expect(screen.getByText("2 / 2")).toBeInTheDocument();
     await user.keyboard("{Shift>}{Enter}{/Shift}");
     expect(screen.getByText("1 / 2")).toBeInTheDocument();
+  });
+
+  it("matches against a node's full content, not just its title", async () => {
+    const user = setup();
+    await user.click(screen.getByText("open search"));
+    await user.type(screen.getByLabelText("Search the canvas"), "zebra");
+    expect(screen.getByText("0 / 1")).toBeInTheDocument();
   });
 
   it("shows 0/0 for a query with no matches", async () => {

--- a/web_ui/src/app/chrome/SearchOverlay.tsx
+++ b/web_ui/src/app/chrome/SearchOverlay.tsx
@@ -5,10 +5,8 @@ import { useOverlays } from "../overlays/overlays";
 
 /**
  * The search overlay (Qt-removal plan R2.4) - search-overlay island's
- * successor. Searches live node titles (real, today); once R3 nodes carry
- * real text content, matching extends to it the same way the legacy
- * SearchOverlay matched conversation text - no interface change needed,
- * just a richer haystack per node.
+ * successor. Searches both a node's title and its full text content, the
+ * same haystack the legacy SearchOverlay matched conversation text against.
  */
 export function SearchOverlay({ store }: { store: SceneStore }) {
   const scene = useSyncExternalStore(store.subscribe, store.getScene);
@@ -37,7 +35,9 @@ export function SearchOverlay({ store }: { store: SceneStore }) {
   const matches = useMemo(() => {
     const term = query.toLowerCase().trim();
     if (!term) return [];
-    return scene.nodes.filter((n) => n.title.toLowerCase().includes(term));
+    return scene.nodes.filter(
+      (n) => n.title.toLowerCase().includes(term) || n.content.toLowerCase().includes(term),
+    );
   }, [query, scene.nodes]);
 
   function jumpTo(index: number) {

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2221,6 +2221,10 @@ body,
   flex-direction: column;
   padding: 16px 20px;
   overflow-y: auto;
+  /* Some Help sections overflow and get a scrollbar, others don't - without
+     reserving the gutter unconditionally, every click between them shifted
+     all the content sideways by the scrollbar's own width. */
+  scrollbar-gutter: stable;
 }
 
 .help-content-title {
@@ -2508,6 +2512,11 @@ body,
   overflow-y: auto;
   color: var(--gl-surface-text-primary);
   font-size: 13px;
+  /* Some tabs (Ollama, Llama.cpp, API Endpoint) overflow and get a
+     scrollbar, others (General, Integrations) don't - without reserving
+     the gutter unconditionally, switching tabs shifted every field/label/
+     button sideways by the scrollbar's own width. */
+  scrollbar-gutter: stable;
 }
 
 .settings-general-page {

--- a/web_ui/vitest.setup.ts
+++ b/web_ui/vitest.setup.ts
@@ -20,3 +20,12 @@ class ResizeObserverStub {
   disconnect() {}
 }
 (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub;
+
+// jsdom implements no scrollIntoView at all (not even a no-op stub) - calling
+// it throws "is not a function" in any component that does. A no-op default
+// is enough for tests that don't care about scrolling; a test that DOES care
+// (CommandPalette.test.tsx's scroll-into-view case) overrides it locally
+// with its own vi.fn() to make assertions.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}


### PR DESCRIPTION
## Problem

Four small, independent issues:

- Settings and Help both switch between tabs/sections with different content heights. Whichever one currently overflows reserves a scrollbar, shifting every field/label/button sideways by its width when the tab changes.
- Ctrl+F search matched only a node's title (a 60-character preview), never its full message content, even though the full text is already on the wire.
- Enter fired while an IME is still composing a character (Japanese/Chinese/Korean input, among others) also triggered Send, dispatching a half-typed buffer — the IME's own commit keystroke reports `key === "Enter"` too.
- The command palette's arrow-key selection had no scroll-into-view logic, so past a dozen or so results the highlighted row could move off-screen with nothing bringing it back.

## Change

- Added `scrollbar-gutter: stable` to both the Settings content panel and the Help panel.
- Extended the search predicate to match against a node's full content, not just its title.
- Added an `isComposing` guard to both the composer dock's and the per-node conversation input's Enter-to-send handlers.
- Added a `scrollIntoView` effect to the command palette, keyed on the selected index.

`vitest.setup.ts` now stubs `Element.prototype.scrollIntoView` globally (jsdom implements no version at all, not even a no-op), matching the existing `ResizeObserver` stub already there for the same reason.

## Test plan

| Layer | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` (full suite) | 875/875 passed (4 new) |
| `python -m pytest -q` (full suite, unaffected) | 1040/1040 passed |
| `npm run lint` / `npm run build` | clean |

Live-verified against a running instance: switching Settings tabs between one with no scrollbar and one with a real scrollbar keeps every field at the identical position (left/width unchanged).