### PR TITLE
Move keyboard focus into popovers on open; make the find bar dismiss on outside click

### DIFF
--- a/web_ui/src/app/chrome/AppBar.tsx
+++ b/web_ui/src/app/chrome/AppBar.tsx
@@ -204,7 +204,7 @@ export function AppBar({ store }: { store: SceneStore }) {
       >
         <span aria-hidden="true">&#8942;</span>
       </button>
-      <Popover name="toolbar-overflow" className="appbar-overflow-menu">
+      <Popover name="toolbar-overflow" label="More toolbar actions" className="appbar-overflow-menu">
         <button
           type="button"
           className="appbar-overflow-item"

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -237,7 +237,7 @@ function ModelPicker({ store }: { store: ComposerStore }) {
   const options = useMemo(() => composer.route.modelOptions, [composer.route.modelOptions]);
 
   return (
-    <Popover name="model" className="reasoning-popover model-picker-popover">
+    <Popover name="model" label="Choose a model" className="reasoning-popover model-picker-popover">
       {options.length === 0 ? (
         <p className="model-picker-empty">
           No models found for {composer.route.provider}. Run a scan on its Settings page.
@@ -267,7 +267,7 @@ function Reasoning({ store }: { store: ComposerStore }) {
   const options = useMemo(() => composer.route.reasoning.options, [composer.route.reasoning.options]);
 
   return (
-    <Popover name="reasoning" className="reasoning-popover">
+    <Popover name="reasoning" label="Choose a reasoning level" className="reasoning-popover">
       {options.map((option) => (
         <button
           key={option.id}

--- a/web_ui/src/app/chrome/PinOverlay.tsx
+++ b/web_ui/src/app/chrome/PinOverlay.tsx
@@ -94,7 +94,7 @@ export function PinOverlay({ store }: { store: SceneStore }) {
   }
 
   return (
-    <Popover name="pins" className="pins-popover">
+    <Popover name="pins" label="Navigation pins" className="pins-popover">
       <div className="pins-header">
         <span className="pins-title">PINS</span>
         <button type="button" className="pins-add" onClick={addPinHere}>

--- a/web_ui/src/app/chrome/PluginPicker.tsx
+++ b/web_ui/src/app/chrome/PluginPicker.tsx
@@ -52,7 +52,7 @@ export function PluginPicker({ transport, store }: { transport: WsTransport; sto
     state.categories.find((c) => c.name === activeCategoryName) ?? state.categories[0] ?? null;
 
   return (
-    <Popover name="plugins" className="plugin-picker-shell">
+    <Popover name="plugins" label="Plugins" className="plugin-picker-shell">
       <div className="plugin-picker-rail">
         <p className="plugin-picker-rail-label">Categories</p>
         <div className="plugin-picker-rail-buttons">

--- a/web_ui/src/app/chrome/SearchOverlay.test.tsx
+++ b/web_ui/src/app/chrome/SearchOverlay.test.tsx
@@ -42,6 +42,7 @@ function setup() {
     <OverlayProvider>
       <ReactFlowProvider>
         <OpenSearchButton />
+        <button type="button">elsewhere</button>
         {/* @ts-expect-error - test double */}
         <SearchOverlay store={store} />
       </ReactFlowProvider>
@@ -89,5 +90,22 @@ describe("SearchOverlay", () => {
     await user.click(screen.getByText("open search"));
     await user.click(screen.getByLabelText("Close (Esc)"));
     expect(screen.queryByLabelText("Search the canvas")).toBeNull();
+  });
+
+  it("R8a finding #17: clicking outside the search bar dismisses it, like every other popover", async () => {
+    const user = setup();
+    await user.click(screen.getByText("open search"));
+    expect(screen.getByLabelText("Search the canvas")).toBeInTheDocument();
+
+    await user.click(screen.getByText("elsewhere"));
+
+    expect(screen.queryByLabelText("Search the canvas")).toBeNull();
+  });
+
+  it("R8a finding #17: clicking inside the search bar does not dismiss it", async () => {
+    const user = setup();
+    await user.click(screen.getByText("open search"));
+    await user.click(screen.getByLabelText("Search the canvas"));
+    expect(screen.getByLabelText("Search the canvas")).toBeInTheDocument();
   });
 });

--- a/web_ui/src/app/chrome/SearchOverlay.tsx
+++ b/web_ui/src/app/chrome/SearchOverlay.tsx
@@ -15,7 +15,18 @@ export function SearchOverlay({ store }: { store: SceneStore }) {
   const [query, setQuery] = useState("");
   const [currentIndex, setCurrentIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
+  const shellRef = useRef<HTMLDivElement | null>(null);
   const isOpen = overlays.isOpen("search");
+
+  // Unlike every other popover (Pins, View, Plugins, Reasoning, Model),
+  // this shell was never registered as a surface element - it renders a
+  // bare div rather than the shared <Popover>, so the outside-click
+  // light-dismiss effect in overlays.tsx could never find it and clicking
+  // away did nothing at all.
+  useEffect(() => {
+    overlays.registerSurfaceElement("search", shellRef.current);
+    return () => overlays.registerSurfaceElement("search", null);
+  });
 
   // Reset during render on the false->true transition - see
   // CommandPalette's identical fix for the full rationale.
@@ -81,7 +92,7 @@ export function SearchOverlay({ store }: { store: SceneStore }) {
   const tone = matches.length === 0 && query ? "error" : current > 0 ? "active" : "idle";
 
   return (
-    <div className="search-overlay-shell">
+    <div className="search-overlay-shell" ref={shellRef}>
       <input
         ref={inputRef}
         className="search-overlay-input"

--- a/web_ui/src/app/chrome/ViewPopover.tsx
+++ b/web_ui/src/app/chrome/ViewPopover.tsx
@@ -18,7 +18,7 @@ export function ViewPopover({ store }: { store: SceneStore }) {
   const dragPercent = Math.round(scene.dragFactor * 100);
 
   return (
-    <Popover name="view" className="view-popover">
+    <Popover name="view" label="View settings" className="view-popover">
       <section className="view-section" aria-label="Drag speed">
         <p className="view-section-title">DRAG</p>
         <input

--- a/web_ui/src/app/overlays/overlays.test.tsx
+++ b/web_ui/src/app/overlays/overlays.test.tsx
@@ -21,8 +21,9 @@ function Chrome() {
         Settings {overlays.isOpen("settings") ? "(active)" : ""}
       </button>
       <button type="button">elsewhere</button>
-      <Popover name="view">
+      <Popover name="view" label="View">
         <p>view popover body</p>
+        <button type="button">first control</button>
       </Popover>
       <Dialog name="settings" title="Settings">
         {/* R8a finding #16: mirrors ChatLibraryDialog's own rename input -
@@ -100,6 +101,26 @@ describe("overlay system (the OverlayManager contract)", () => {
     expect(screen.getByText("view popover body")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "elsewhere" }));
     expect(screen.queryByText("view popover body")).toBeNull();
+  });
+
+  it("R8a finding #19: opening a popover moves focus onto its first focusable control", async () => {
+    const user = setup();
+    await user.click(screen.getByRole("button", { name: /^View/ }));
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "first control" }));
+  });
+
+  it("R8a finding #19: closing a popover restores focus to its trigger, same as a dialog", async () => {
+    const user = setup();
+    const trigger = screen.getByRole("button", { name: /^View/ });
+    await user.click(trigger);
+    await user.keyboard("{Escape}");
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("R8a finding #19: a popover has a real aria-label, not an unnamed dialog role", async () => {
+    const user = setup();
+    await user.click(screen.getByRole("button", { name: /^View/ }));
+    expect(screen.getByRole("dialog", { name: "View" })).toBeInTheDocument();
   });
 
   it("every dialog has a working close button (audit B5)", async () => {

--- a/web_ui/src/app/overlays/overlays.tsx
+++ b/web_ui/src/app/overlays/overlays.tsx
@@ -155,24 +155,50 @@ export function OverlayProvider({ children }: { children: ReactNode }) {
  * it); it mounts only while open. The opener button stays outside. */
 export function Popover({
   name,
+  label,
   className,
   children,
 }: {
   name: string;
+  label: string;
   className?: string;
   children: ReactNode;
 }) {
   const overlays = useOverlays();
   const ref = useRef<HTMLDivElement | null>(null);
+  const isOpen = overlays.isOpen(name);
 
   useEffect(() => {
     overlays.registerSurfaceElement(name, ref.current);
     return () => overlays.registerSurfaceElement(name, null);
   });
 
-  if (!overlays.isOpen(name)) return null;
+  // R8a (UI/UX issue list finding #19): opening a popover via keyboard
+  // (Enter on its trigger button) left focus sitting on the trigger - the
+  // panel's own controls were reachable only by continuing to Tab through
+  // whatever else sits between the trigger and the panel in DOM order (the
+  // rest of the app bar, for View/Plugins/Pins). Focus RESTORATION on
+  // close is already handled generically by open()/close() above for every
+  // overlay tier; moving focus IN on open is the other half, specific to
+  // this component (Dialog already does it in its own effect).
+  useEffect(() => {
+    if (!isOpen) return;
+    const panel = ref.current;
+    if (!panel) return;
+    const first = panel.querySelector<HTMLElement>(FOCUSABLE);
+    (first ?? panel).focus();
+  }, [isOpen]);
+
+  if (!isOpen) return null;
   return (
-    <div ref={ref} role="dialog" aria-modal="false" className={`overlay-popover ${className ?? ""}`}>
+    <div
+      ref={ref}
+      role="dialog"
+      aria-modal="false"
+      aria-label={label}
+      tabIndex={-1}
+      className={`overlay-popover ${className ?? ""}`}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
## Problem

Two related gaps in the shared popover system:

- Opening a popover (View, Plugins, Pins, Reasoning, Model) via keyboard left focus sitting on the trigger button — reaching the panel's own controls meant continuing to Tab through everything else between the trigger and the panel in DOM order (the rest of the app bar, for View/Plugins/Pins).
- The find bar (Ctrl+F) never dismissed on outside click, unlike every other popover — it rendered a bare div rather than registering itself as a surface element, so the light-dismiss logic could never find it to close it.

## Change

- `Popover` now moves focus onto its first focusable control on open, the same way `Dialog` already does. Focus restoration to the trigger on close was already handled generically for every overlay tier and needed no change.
- `Popover` also now takes a required `label` prop and sets `aria-label`, so it's a real named region instead of an unnamed dialog role. Every call site (View, Plugins, Pins, Reasoning, Model, the toolbar overflow menu) was updated.
- `SearchOverlay` now registers itself as a surface element the same way every other popover already does, so outside-click dismissal works for it too.

## Test plan

| Layer | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` (full suite) | 880/880 passed (5 new) |
| `python -m pytest -q` (full suite, unaffected) | 1040/1040 passed |
| `npm run lint` / `npm run build` | clean |

Live-verified against a running instance: opening the View popover moves focus onto its first control (confirmed via `document.activeElement`, with a real `aria-label` of "View settings"); clicking elsewhere on the toolbar while the find bar is open now closes it.