### PR TITLE
Correct three stale Help panel entries

### DIFF
--- a/web_ui/src/app/chrome/help-data/sections.ts
+++ b/web_ui/src/app/chrome/help-data/sections.ts
@@ -274,10 +274,6 @@ export const HELP_SECTIONS: HelpSection[] = [
             "description": "Pins mark important places on the canvas and are saved with the chat. Use the Pins toolbar button to reveal the overlay and jump back to major milestones or hotspots."
           },
           {
-            "action": "Connection Pins",
-            "description": "Ctrl + left-click a connection to add a routing pin and shape the line, then Ctrl + right-click a pin to remove it. This is especially helpful when several branches overlap visually."
-          },
-          {
             "action": "Grid and Guide Controls",
             "description": "The controls overlay can enable snap-to-grid, smart guides, orthogonal routing, font controls, and faded connections. These tools are useful when a canvas needs visual cleanup rather than new AI output."
           },
@@ -351,10 +347,6 @@ export const HELP_SECTIONS: HelpSection[] = [
           {
             "action": "Per-Task Model Selection",
             "description": "Graphlink can store different models for title generation, main chat, chart generation, image generation, web validation, and web summarization. This lets you optimize cost and quality across different tools."
-          },
-          {
-            "action": "Live Provider Reconfiguration",
-            "description": "Switching modes reinitializes the active provider for the current session. If a provider is missing credentials or cannot initialize, the app warns you before you keep working."
           }
         ]
       },
@@ -363,7 +355,7 @@ export const HELP_SECTIONS: HelpSection[] = [
         "items": [
           {
             "action": "Token Counter",
-            "description": "When enabled, the token counter shows prompt, context, output, and running session totals. It is useful when you want a sense of branch size or model budget."
+            "description": "When enabled, the token counter estimates how many tokens your current draft will use before you send it. It is useful for keeping an eye on how large a request is getting."
           },
           {
             "action": "Provider-Specific Guidance",


### PR DESCRIPTION
## Problem

Three Help panel entries described capability that no longer matches the shipped app:

- "Connection Pins" described Ctrl+left-click on a connection to add a routing pin — no such handler exists anywhere in the current canvas implementation.
- "Live Provider Reconfiguration" described switching provider modes live within a session — that control was removed outright (not fixed) in an earlier change, so there is no in-session mode switch left for this entry to describe.
- The Token Counter entry claimed it shows "prompt, context, output, and running session totals." Only the input estimate is real today; output and context are still permanently zero pending backend wiring.

## Change

- Removed the "Connection Pins" entry. "Navigation Pins" (the real, working pins feature) is unaffected.
- Removed the "Live Provider Reconfiguration" entry.
- Reworded the Token Counter entry to describe only what currently works: an estimate of the current draft's token count.

## Test plan

| Layer | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` (full suite) | 880/880 passed |
| `python -m pytest -q` (full suite, unaffected) | 1040/1040 passed |
| `npm run lint` / `npm run build` | clean |

Live-verified against a running instance: "Connection Pins" and "Live Provider Reconfiguration" no longer appear anywhere in the Help panel, the corrected Token Counter description does, and "Navigation Pins" is still present and unchanged.