### PR TITLE
Anchor View/Plugins/Pins popovers to the button that opened them

### DIFF
--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -215,15 +215,9 @@ function App() {
             <div className="app-search-layer">
               <SearchOverlay store={sceneStore} />
             </div>
-            <div className="app-pins-layer">
-              <PinOverlay store={sceneStore} />
-            </div>
-            <div className="app-popover-layer">
-              <ViewPopover store={sceneStore} />
-            </div>
-            <div className="app-plugins-layer">
-              <PluginPicker transport={transport} store={sceneStore} />
-            </div>
+            <PinOverlay store={sceneStore} />
+            <ViewPopover store={sceneStore} />
+            <PluginPicker transport={transport} store={sceneStore} />
             {settingsVisibility.showTokenCounter !== false && (
               <div className="app-token-counter-layer">
                 <TokenCounter store={composerStore} />

--- a/web_ui/src/app/chrome/PinOverlay.tsx
+++ b/web_ui/src/app/chrome/PinOverlay.tsx
@@ -94,7 +94,7 @@ export function PinOverlay({ store }: { store: SceneStore }) {
   }
 
   return (
-    <Popover name="pins" label="Navigation pins" className="pins-popover">
+    <Popover name="pins" label="Navigation pins" className="pins-popover" anchored>
       <div className="pins-header">
         <span className="pins-title">PINS</span>
         <button type="button" className="pins-add" onClick={addPinHere}>

--- a/web_ui/src/app/chrome/PluginPicker.tsx
+++ b/web_ui/src/app/chrome/PluginPicker.tsx
@@ -52,7 +52,7 @@ export function PluginPicker({ transport, store }: { transport: WsTransport; sto
     state.categories.find((c) => c.name === activeCategoryName) ?? state.categories[0] ?? null;
 
   return (
-    <Popover name="plugins" label="Plugins" className="plugin-picker-shell">
+    <Popover name="plugins" label="Plugins" className="plugin-picker-shell" anchored>
       <div className="plugin-picker-rail">
         <p className="plugin-picker-rail-label">Categories</p>
         <div className="plugin-picker-rail-buttons">

--- a/web_ui/src/app/chrome/ViewPopover.tsx
+++ b/web_ui/src/app/chrome/ViewPopover.tsx
@@ -18,7 +18,7 @@ export function ViewPopover({ store }: { store: SceneStore }) {
   const dragPercent = Math.round(scene.dragFactor * 100);
 
   return (
-    <Popover name="view" label="View settings" className="view-popover">
+    <Popover name="view" label="View settings" className="view-popover" anchored>
       <section className="view-section" aria-label="Drag speed">
         <p className="view-section-title">DRAG</p>
         <input

--- a/web_ui/src/app/overlays/overlays.test.tsx
+++ b/web_ui/src/app/overlays/overlays.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Dialog, OverlayProvider, Popover, useOverlays } from "./overlays";
 
 function Chrome() {
@@ -242,5 +242,120 @@ describe("overlay system (the OverlayManager contract)", () => {
     await user.click(opener);
     await user.keyboard("{Escape}");
     expect(document.activeElement).toBe(opener);
+  });
+});
+
+describe("anchored popover placement (R8a finding #27)", () => {
+  function AnchoredChrome() {
+    const overlays = useOverlays();
+    return (
+      <div>
+        <button
+          type="button"
+          data-overlay-trigger="anchored-demo"
+          onClick={() => overlays.toggle("anchored-demo", "popover")}
+        >
+          trigger
+        </button>
+        <Popover name="anchored-demo" label="Anchored demo" anchored>
+          <p>anchored body</p>
+        </Popover>
+      </div>
+    );
+  }
+
+  function setupAnchored() {
+    const user = userEvent.setup();
+    render(
+      <OverlayProvider>
+        <AnchoredChrome />
+      </OverlayProvider>,
+    );
+    return user;
+  }
+
+  // jsdom returns an all-zero rect for anything not explicitly mocked (no
+  // real layout engine) - only the TRIGGER needs mocking for these cases;
+  // the panel's own (real, zero) height/width don't change which branch
+  // the placement math takes for the specific numbers chosen below, so
+  // there's no need for the more elaborate dual-mock this would otherwise
+  // require (NodeMenu.tsx's own identical flip/clamp logic has no
+  // dedicated unit test at all for the same reason - this is deliberately
+  // lighter than a full pixel-accuracy suite, backed by live-browser
+  // verification for the real thing). Call AFTER render - the trigger
+  // must already exist in the DOM to spy on its own instance method.
+  function mockTriggerRect(trigger: HTMLElement, rect: Partial<DOMRect>) {
+    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+      ...rect,
+    } as DOMRect);
+    return trigger;
+  }
+
+  function setViewport(width: number, height: number) {
+    Object.defineProperty(window, "innerWidth", { value: width, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: height, configurable: true });
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("portals to document.body rather than rendering in place", async () => {
+    const user = setupAnchored();
+    await user.click(screen.getByRole("button", { name: "trigger" }));
+    const popover = screen.getByRole("dialog", { name: "Anchored demo" });
+    expect(popover.parentElement).toBe(document.body);
+  });
+
+  it("opens directly below the trigger when there is room", async () => {
+    setViewport(1024, 768);
+    const user = setupAnchored();
+    const trigger = mockTriggerRect(screen.getByRole("button", { name: "trigger" }), {
+      top: 100,
+      bottom: 130,
+      left: 200,
+      right: 260,
+    });
+    await user.click(trigger);
+    const popover = screen.getByRole("dialog", { name: "Anchored demo" });
+    expect(popover.style.top).toBe("136px"); // trigger.bottom (130) + ANCHOR_GAP (6)
+    expect(popover.style.left).toBe("200px"); // trigger.left, unclamped
+  });
+
+  it("flips above the trigger when there is no room below", async () => {
+    setViewport(1024, 768);
+    const user = setupAnchored();
+    const trigger = mockTriggerRect(screen.getByRole("button", { name: "trigger" }), {
+      top: 750,
+      bottom: 780,
+      left: 100,
+      right: 160,
+    });
+    await user.click(trigger);
+    const popover = screen.getByRole("dialog", { name: "Anchored demo" });
+    expect(popover.style.top).toBe("744px"); // trigger.top (750) - panel height (0) - ANCHOR_GAP (6)
+  });
+
+  it("clamps horizontally so it cannot run off the right edge", async () => {
+    setViewport(1024, 768);
+    const user = setupAnchored();
+    const trigger = mockTriggerRect(screen.getByRole("button", { name: "trigger" }), {
+      top: 100,
+      bottom: 130,
+      left: 1020,
+      right: 1024,
+    });
+    await user.click(trigger);
+    const popover = screen.getByRole("dialog", { name: "Anchored demo" });
+    expect(popover.style.left).toBe("1016px"); // innerWidth (1024) - panel width (0) - ANCHOR_MARGIN (8)
   });
 });

--- a/web_ui/src/app/overlays/overlays.tsx
+++ b/web_ui/src/app/overlays/overlays.tsx
@@ -3,12 +3,14 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
   type ReactNode,
   type RefObject,
 } from "react";
+import { createPortal } from "react-dom";
 
 /**
  * The SPA overlay system (Qt-removal plan R2) - the OverlayManager contract
@@ -151,22 +153,97 @@ export function OverlayProvider({ children }: { children: ReactNode }) {
   return <OverlayContext.Provider value={value}>{children}</OverlayContext.Provider>;
 }
 
+const ANCHOR_MARGIN = 8;
+const ANCHOR_GAP = 6;
+
+/**
+ * R8a (UI/UX issue list finding #27): the anchored variant's placement
+ * logic. View/Plugins/Pins used to render inside a wrapper div hard-
+ * positioned at a fixed corner of the canvas (independent of which button
+ * was actually clicked) - View and Plugins sat at byte-identical
+ * coordinates despite being two different, adjacent toolbar buttons.
+ *
+ * Portaled to document.body (so `position: fixed` resolves against the
+ * real viewport, the same reason NodeMenu.tsx does it) and positioned from
+ * the trigger's own getBoundingClientRect(), the same anchoring contract
+ * the Qt OverlayManager had. Opens below-left of the trigger by default,
+ * flips above it if there isn't room below, and clamps horizontally so it
+ * never runs off either edge - mirroring NodeMenu's own flip-and-clamp
+ * effect (same problem, a click point there vs. a trigger rect here).
+ *
+ * Reasoning/Model (Composer.tsx) deliberately do NOT use this - they
+ * already render next to their own trigger via ordinary CSS (anchored to
+ * the composer dock, not a shared top-right/top-left corner div), so
+ * anchoring them here would be solving a problem they don't have.
+ */
+function useAnchoredPlacement(
+  panelRef: RefObject<HTMLElement | null>,
+  triggerName: string,
+  isOpen: boolean,
+) {
+  const [placement, setPlacement] = useState<{ top: number; left: number } | null>(null);
+
+  // One pass, not a render-then-correct two-step: .overlay-popover's width/
+  // height come from its CSS (padding, min/max-width, content) and don't
+  // depend on `position` being fixed vs. the browser's static default, so
+  // the panel's OWN rect is already meaningful on the very first layout
+  // pass after it mounts - there is nothing to flip/clamp against on a
+  // later pass that isn't already available on this one.
+  //
+  // No explicit "reset to null while closed" branch: Popover's own
+  // `if (!isOpen) return null` already unmounts the panel entirely, so a
+  // stale placement value sitting in state while closed is never rendered
+  // - the next open recomputes it before anything reads it again.
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    const trigger = document.querySelector<HTMLElement>(`[data-overlay-trigger="${triggerName}"]`);
+    const panel = panelRef.current;
+    if (!trigger || !panel) return;
+    const triggerRect = trigger.getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+
+    const top =
+      triggerRect.bottom + panelRect.height + ANCHOR_GAP > window.innerHeight
+        ? Math.max(ANCHOR_MARGIN, triggerRect.top - panelRect.height - ANCHOR_GAP)
+        : triggerRect.bottom + ANCHOR_GAP;
+    const left = Math.min(
+      Math.max(ANCHOR_MARGIN, triggerRect.left),
+      window.innerWidth - panelRect.width - ANCHOR_MARGIN,
+    );
+
+    if (!placement || placement.top !== top || placement.left !== left) {
+      setPlacement({ top, left });
+    }
+    // Deliberately excludes `placement` - it is read only to bail out once
+    // the computed value stops changing, so depending on it would loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, triggerName, panelRef]);
+
+  return placement;
+}
+
 /** Anchored light surface. Render it where it should appear (CSS positions
- * it); it mounts only while open. The opener button stays outside. */
+ * it, unless `anchored` is set - see useAnchoredPlacement above); it mounts
+ * only while open. The opener button stays outside. */
 export function Popover({
   name,
   label,
   className,
+  anchored,
   children,
 }: {
   name: string;
   label: string;
   className?: string;
+  /** Portal to document.body and position from the trigger's own rect
+   * rather than relying on CSS to place a wrapper div at a fixed corner. */
+  anchored?: boolean;
   children: ReactNode;
 }) {
   const overlays = useOverlays();
   const ref = useRef<HTMLDivElement | null>(null);
   const isOpen = overlays.isOpen(name);
+  const anchorPlacement = useAnchoredPlacement(ref, name, isOpen && !!anchored);
 
   useEffect(() => {
     overlays.registerSurfaceElement(name, ref.current);
@@ -190,18 +267,20 @@ export function Popover({
   }, [isOpen]);
 
   if (!isOpen) return null;
-  return (
+  const panel = (
     <div
       ref={ref}
       role="dialog"
       aria-modal="false"
       aria-label={label}
       tabIndex={-1}
-      className={`overlay-popover ${className ?? ""}`}
+      className={`overlay-popover ${anchored ? "overlay-popover-anchored" : ""} ${className ?? ""}`}
+      style={anchored && anchorPlacement ? { top: anchorPlacement.top, left: anchorPlacement.left } : undefined}
     >
       {children}
     </div>
   );
+  return anchored ? createPortal(panel, document.body) : panel;
 }
 
 // R8a (UI/UX issue list finding #17): the original selector didn't exclude

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1125,20 +1125,6 @@ body,
   }
 }
 
-.app-popover-layer {
-  position: absolute;
-  top: var(--gl-chrome-inset);
-  right: var(--gl-chrome-inset);
-  z-index: var(--gl-z-app-layer);
-}
-
-.app-plugins-layer {
-  position: absolute;
-  top: var(--gl-chrome-inset);
-  right: var(--gl-chrome-inset);
-  z-index: var(--gl-z-app-layer);
-}
-
 .overlay-popover {
   background-color: var(--gl-surface-node-body);
   border: 1px solid var(--gl-surface-border);
@@ -1159,6 +1145,18 @@ body,
      tuned distance that happens to work for one consumer. */
   max-height: calc(100vh - 96px);
   overflow-y: auto;
+}
+
+/* R8a (UI/UX issue list finding #27): View/Plugins/Pins used to render
+   inside a wrapper div hard-positioned at a fixed corner of the canvas
+   (.app-popover-layer/.app-plugins-layer/.app-pins-layer, since removed) -
+   position: fixed here is computed and set by useAnchoredPlacement in
+   overlays.tsx (top/left as inline style), portaled to document.body so it
+   resolves against the real viewport rather than whatever ancestor it
+   would otherwise have rendered under. */
+.overlay-popover-anchored {
+  position: fixed;
+  z-index: var(--gl-z-app-layer);
 }
 
 .overlay-scrim {
@@ -1796,13 +1794,6 @@ body,
 }
 
 /* -- R2.4 pin overlay ------------------------------------------------------ */
-
-.app-pins-layer {
-  position: absolute;
-  top: var(--gl-chrome-inset);
-  left: var(--gl-chrome-inset);
-  z-index: var(--gl-z-app-layer);
-}
 
 .pins-popover {
   width: 240px;


### PR DESCRIPTION
## Problem

The View, Plugins, and Pins popovers rendered inside a wrapper div hard-positioned at a fixed corner of the canvas, independent of which button was actually clicked. View and Plugins — two different, adjacent toolbar buttons — opened at byte-identical coordinates; Pins opened pinned to the left edge regardless of where its own button sat. Clicking a control and having an unrelated panel appear somewhere else on screen reads as broken, not just imprecise.

## Change

`Popover` now takes an `anchored` prop: when set, it portals to `document.body` (so `position: fixed` resolves against the real viewport) and positions itself from the trigger's own `getBoundingClientRect()` — opening directly below-left of the button, flipping above it if there isn't room below, and clamping horizontally so it can never run off either edge.

The three fixed-corner wrapper divs in `App.tsx` (`.app-popover-layer`, `.app-plugins-layer`, `.app-pins-layer`) are removed along with their now-dead CSS, since the popover positions itself.

Reasoning and Model (`Composer.tsx`) are unchanged — they already anchor correctly via ordinary CSS relative to the composer dock and never had this problem.

## Test plan

| Layer | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` (full suite) | 884/884 passed (4 new) |
| `python -m pytest -q` (full suite, unaffected) | 1040/1040 passed |
| `npm run lint` / `npm run build` | clean |

New coverage in `overlays.test.tsx`: portals to `document.body`, opens below the trigger when there's room, flips above when there isn't, clamps horizontally at the right edge.

Live-verified against a running instance: View's trigger sits at x=698 and its popover now opens at x=698; Plugins' trigger sits at x=748 and its popover opens at x=748 (previously both would have opened at the same fixed corner); Pins opens at its own trigger's x=205. All three confirmed portaled to `document.body`.