### PR TITLE
Fix stale Quick/Thinking mode text in Help panel

### DIFF
--- a/web_ui/src/app/chrome/help-data/sections.ts
+++ b/web_ui/src/app/chrome/help-data/sections.ts
@@ -338,7 +338,7 @@ export const HELP_SECTIONS: HelpSection[] = [
         "items": [
           {
             "action": "Ollama (Local)",
-            "description": "Use local Ollama when you want on-device chat and reasoning. You can choose a default chat model and switch between Quick mode and Thinking mode for different response styles."
+            "description": "Use local Ollama when you want on-device chat and reasoning. You can choose a default chat model and set a reasoning level - Off, Low, Medium, or High - to control how much the model thinks before responding."
           },
           {
             "action": "API Endpoint Mode",


### PR DESCRIPTION
## Problem

The "Ollama (Local)" Help entry described the old 2-value reasoning mode (Quick/Thinking), which was replaced by a graded 4-level scale (Off/Low/Medium/High).

## Change

Updated the description to name the current levels instead of the retired terminology. Checked the rest of the file for the same staleness — no other entry referenced "Quick mode" or "Thinking mode".

## Test plan

| Layer | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` (full suite) | 880/880 passed |
| `npm run lint` | clean |