### PR TITLE
Wire real Output/Context values into the token counter

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -177,7 +177,9 @@ def _configure_session(
     # canvas document outside this closure. SessionBus has no fixed attribute
     # set (no __slots__), so this is a plain, minimal bolt-on attribute, not
     # a SessionBus API change.
-    bus.canvas_document = register_canvas(bus, notifications_state, agent_dispatcher, composer_document)
+    bus.canvas_document = register_canvas(
+        bus, notifications_state, agent_dispatcher, composer_document, token_counter
+    )
 
     # R2.5: about, plugins, settings, chat library.
     register_about(bus)

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -53,7 +53,7 @@ from backend.response_parsing import (
     PLACEHOLDER_ASSISTANT_REASONING,
     PLACEHOLDER_EMPTY_RESPONSE,
 )
-from backend.token_counter import estimate_tokens
+from backend.token_counter import TokenCounterState, estimate_tokens
 
 
 # R7.2: ported from graphlink_app/graphlink_session/content_codec.py, not
@@ -2956,6 +2956,31 @@ def _research_result_wire(result) -> dict[str, Any]:
     }
 
 
+def _history_turn_text(turn: dict) -> str:
+    """Flattens one chat_branch_history entry's "content" into plain text,
+    for callers whose interface is a flat string (token estimation here;
+    _chart_source_text below has its own, separate flattening for
+    ChartDataAgent). A turn's content is a plain str for an ordinary
+    message, or (R8a attachments) a content_parts list of {"type", ...}
+    dicts - only the "text" part has a token-count analog, so image/audio
+    parts are skipped rather than stringified."""
+    content = turn.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            part.get("text", "") for part in content if isinstance(part, dict) and part.get("type") == "text"
+        )
+    return ""
+
+
+def _history_token_text(history: list[dict]) -> str:
+    """Joins an entire chat_branch_history's turns into one string for
+    token_counter.py's set_context_text (which, like set_input_text, takes
+    a single flat string and estimates it via whitespace-split)."""
+    return "\n\n".join(text for text in (_history_turn_text(turn) for turn in history) if text)
+
+
 def _chart_source_text(branch_history: list[dict]) -> str:
     """R6.2: flattens chat_branch_history's own {"role","content"} list (the
     SAME branch walk web_research/pycoder/gitlink already reuse via
@@ -3011,6 +3036,7 @@ def register_canvas(
     notifications: NotificationState,
     agent_dispatcher: AgentDispatcher,
     composer_document: ComposerDocument,
+    token_counter: TokenCounterState | None = None,
 ) -> SceneDocument:
     """Give a session its canvas document + the scene/grid topics and every
     R1 intent. Intent names for grid mirror GridControlBridge's @Slot names
@@ -3018,7 +3044,17 @@ def register_canvas(
 
     R4: agent_dispatcher/composer_document are threaded through so
     sendMessage's real Send action (below) can hand off to the real agent
-    dispatch pipeline instead of the R3-era deferred notice."""
+    dispatch pipeline instead of the R3-era deferred notice. token_counter
+    (R8a) lets sendMessage/regenerateResponse set real outputTokens/
+    contextTokens once a reply completes - see those intents' own comments.
+    Optional (default a throwaway, unregistered instance) only so the ~30
+    pre-R8a canvas/agents tests that call register_canvas with 4 positional
+    args keep working unchanged - the real (and only) production call site,
+    backend/app.py's _configure_session, always passes the session's real,
+    bus-registered one."""
+
+    if token_counter is None:
+        token_counter = TokenCounterState()
 
     document = SceneDocument()
 
@@ -3050,6 +3086,21 @@ def register_canvas(
 
     async def publish_grid():
         await bus.publish("grid-control")
+
+    async def publish_token_counter():
+        # R8a: guarded, unlike publish_scene/publish_grid above - "scene"
+        # and "grid-control" are registered a few lines above in THIS same
+        # function, always present by construction. token_counter's own
+        # topic is registered elsewhere (backend/token_counter.py's
+        # register_token_counter, called once per session in
+        # backend/app.py), and the ~30 pre-R8a canvas/agents tests that
+        # construct a bare SessionBus + register_canvas directly (with the
+        # optional token_counter left at its unregistered default above)
+        # never call it - has_topic keeps sendMessage/regenerateResponse
+        # working in exactly those tests instead of raising
+        # UnknownTopicError the first time either intent runs.
+        if bus.has_topic("token-counter"):
+            await bus.publish("token-counter")
 
     # -- scene intents (async: they publish after mutating) ---------------
 
@@ -3230,12 +3281,35 @@ def register_canvas(
         await publish_scene()
         history = document.chat_branch_history(node.id)
 
-        def _on_reply(reply_text):
+        # R8a (token counter wiring): contextTokens is the branch history the
+        # reply will be generated FROM - explicitly NOT `history` above,
+        # which already includes the message just sent (inputTokens, set
+        # live as the draft was typed in Composer.tsx, already owns that
+        # text; counting it again here would inflate payload()'s total).
+        # Rooted at node's own parent, the same "history before this node"
+        # walk every specialized agent flow below (web research/artifact/
+        # gitlink/pycoder/sandbox) already uses via _branch_parent_edge -
+        # applied to the plain-chat path for the first time here.
+        context_parent_edge = document._branch_parent_edge(node.id)
+        context_history = (
+            document.chat_branch_history(context_parent_edge.source) if context_parent_edge else []
+        )
+        token_counter.set_context_text(_history_token_text(context_history))
+        await publish_token_counter()
+
+        async def _on_reply(reply_text):
             # R6.3: the assistant's reply has completed (regardless of
             # whether parse_response below finds anything node-worthy in
             # it) - grow total_session_tokens by its estimated count too,
             # same as the user's own message text just above.
             document.add_session_tokens(reply_text)
+            # R8a: outputTokens reflects what the model actually returned,
+            # regardless of whether parse_response below finds anything
+            # node-worthy in it (the empty-reply early return just below)
+            # - the reply happened and consumed real output tokens either
+            # way.
+            token_counter.set_output_text(reply_text)
+            await publish_token_counter()
             # R4.3b: port legacy handle_response's _parse_response retrofit -
             # split the flat reply into thinking/text/code parts and create
             # separate thinking-kind/code-kind CHILD nodes instead of
@@ -3340,8 +3414,21 @@ def register_canvas(
             return None
 
         history = document.chat_branch_history(parent_id)
+        # R8a (token counter wiring): unlike send_message, `history` here
+        # already excludes the node being regenerated (rooted at parent_id,
+        # not node_id) - there is no fresh draft text to double-count
+        # against, so it's usable directly as contextTokens with no
+        # adjustment.
+        token_counter.set_context_text(_history_token_text(history))
+        await publish_token_counter()
 
         async def _on_reply(reply_text):
+            # R8a: outputTokens reflects what the model actually returned,
+            # ahead of every early-return below - a regenerate that comes
+            # back empty, or lands after the node was deleted mid-flight,
+            # still consumed real output tokens.
+            token_counter.set_output_text(reply_text)
+            await publish_token_counter()
             # (1) Empty/whitespace reply: keep ORIGINAL content, notify, stop.
             # Checked FIRST - exact legacy order (window_actions.py:544-546),
             # even before the liveness check below (see its own comment).

--- a/backend/tests/test_backend_composer.py
+++ b/backend/tests/test_backend_composer.py
@@ -336,6 +336,22 @@ def test_token_counter_payload_totals_all_three():
     assert set(payload) == {"inputTokens", "outputTokens", "contextTokens", "totalTokens"}
 
 
+def test_set_output_text_estimates_the_same_way_as_set_input_text():
+    state = TokenCounterState()
+    state.set_output_text("a four word reply")
+    assert state.output_tokens == 4
+    assert state.input_tokens == 0
+    assert state.context_tokens == 0
+
+
+def test_set_context_text_estimates_the_same_way_as_set_input_text():
+    state = TokenCounterState()
+    state.set_context_text("some prior branch history text")
+    assert state.context_tokens == 5
+    assert state.input_tokens == 0
+    assert state.output_tokens == 0
+
+
 # -- notifications -------------------------------------------------------------
 
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -24,6 +24,8 @@ from backend.canvas import (
     SceneDocument,
     SceneEmptyPromptError,
     SceneError,
+    _history_token_text,
+    _history_turn_text,
     _research_result_wire,
     register_canvas,
 )
@@ -36,7 +38,7 @@ import api_provider
 import graphlink_task_config as task_config
 from graphlink_navigation_pins import NavigationPinRecord
 from graphlink_plugins.web_research.domain import ResearchCitation, ResearchResult, ResearchSource
-from backend.token_counter import estimate_tokens
+from backend.token_counter import estimate_tokens, register_token_counter
 
 
 # -- document invariants ----------------------------------------------------
@@ -1257,6 +1259,45 @@ def test_regenerate_response_intent_mutates_the_existing_node_in_place_not_a_new
     asyncio.run(run())
 
 
+def test_regenerate_response_sets_output_and_context_tokens_and_publishes_token_counter():
+    # R8a: regenerate reuses the SAME chat_branch_history(parent_id) call it
+    # already made for the real LLM request as contextTokens too - unlike
+    # send_message, there is no fresh draft text to exclude, so it needs no
+    # adjustment before counting.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "original reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            await bus.dispatch_intent("scene", "sendMessage", ["hi there"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.is_user is False)
+
+        def regenerated_reply(task, messages, **kwargs):
+            return {"message": {"content": "a fresh regenerated reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", regenerated_reply):
+            await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assert bus.token_counter.output_tokens == estimate_tokens("a fresh regenerated reply")
+        assert bus.token_counter.context_tokens == estimate_tokens("hi there")
+        assert recorder.topics_seen().count("token-counter") >= 1
+
+    asyncio.run(run())
+
+
 def test_regenerate_response_does_not_stream_unlike_an_ordinary_send():
     # R4.4 regression: start_chat_reply's stream=True default is for
     # send_message's Composer-send surface only. regenerate_response passes
@@ -1894,7 +1935,15 @@ def make_bus_with_dispatcher():
     composer_document = ComposerDocument()
     bus.register_topic("app-composer", composer_document.payload)
     agent_dispatcher = AgentDispatcher(_FakeSettingsManager())
-    document = register_canvas(bus, notifications, agent_dispatcher, composer_document)
+    # R8a: a real, bus-registered TokenCounterState - not left at
+    # register_canvas's own throwaway default - so tests can assert on
+    # send_message/regenerateResponse's outputTokens/contextTokens wiring
+    # via bus.token_counter, the same "bolt an extra reference onto the
+    # bus" convention backend/app.py itself uses for canvas_document/
+    # agent_dispatcher (SessionBus has no fixed attribute set).
+    token_counter = register_token_counter(bus)
+    document = register_canvas(bus, notifications, agent_dispatcher, composer_document, token_counter)
+    bus.token_counter = token_counter
     recorder = Recorder()
     bus.attach(recorder)
     return bus, document, recorder, agent_dispatcher
@@ -1990,6 +2039,102 @@ def test_send_message_intent_dispatches_a_real_agent_reply():
         assert any(e.source == node_id and e.target == reply_node.id for e in document.edges.values())
         assert document.last_chat_node_id == reply_node.id
         assert recorder.topics_seen().count("scene") >= 2, "user node + reply node both publish scene"
+
+    asyncio.run(run())
+
+
+# -- history-to-text flattening (R8a token counter wiring) -------------------
+
+
+def test_history_turn_text_returns_a_plain_string_content_as_is():
+    assert _history_turn_text({"role": "user", "content": "hello there"}) == "hello there"
+
+
+def test_history_turn_text_extracts_only_the_text_part_from_content_parts():
+    turn = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "look at this"},
+            {"type": "image", "image_bytes": "base64stuff"},
+        ],
+    }
+    assert _history_turn_text(turn) == "look at this"
+
+
+def test_history_turn_text_returns_empty_string_for_a_content_parts_list_with_no_text_part():
+    turn = {"role": "user", "content": [{"type": "image", "image_bytes": "base64stuff"}]}
+    assert _history_turn_text(turn) == ""
+
+
+def test_history_token_text_joins_turns_and_skips_empty_ones():
+    history = [
+        {"role": "user", "content": "first turn"},
+        {"role": "assistant", "content": ""},
+        {"role": "user", "content": [{"type": "image", "image_bytes": "x"}]},
+        {"role": "assistant", "content": "second turn"},
+    ]
+    assert _history_token_text(history) == "first turn\n\nsecond turn"
+
+
+def test_send_message_sets_output_tokens_from_the_reply_and_publishes_token_counter():
+    # R8a: outputTokens/contextTokens used to sit at 0 forever - nothing in
+    # the backend ever set them. This is the first real assertion that a
+    # plain chat send wires them up.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def fake_chat(task, messages, **kwargs):
+            return {"message": {"content": "four word reply here"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", fake_chat):
+            await bus.dispatch_intent("scene", "sendMessage", ["hello there"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        assert bus.token_counter.output_tokens == estimate_tokens("four word reply here")
+        assert recorder.topics_seen().count("token-counter") >= 1
+
+    asyncio.run(run())
+
+
+def test_send_message_sets_context_tokens_from_prior_history_not_the_new_message():
+    # contextTokens must reflect the branch history the reply was generated
+    # FROM - not the message just typed (inputTokens, set live from the
+    # composer draft, already owns that text - counting it again here would
+    # inflate payload()'s total). Verified by sending a SECOND message and
+    # checking contextTokens matches the FIRST exchange's own text, not the
+    # second message's.
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def first_reply(task, messages, **kwargs):
+            return {"message": {"content": "first reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", first_reply):
+            await bus.dispatch_intent("scene", "sendMessage", ["first message"])
+            entry = next(iter(dispatcher._requests.values()))
+            await entry["task"]
+
+        def second_reply(task, messages, **kwargs):
+            return {"message": {"content": "second reply"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", second_reply):
+            await bus.dispatch_intent("scene", "sendMessage", ["second message, much longer than the first"])
+
+        # contextTokens is set synchronously, before the reply dispatch even
+        # starts (unlike outputTokens, which needs the reply to complete) -
+        # no need to await the dispatcher's background task here.
+        expected = estimate_tokens("first message") + estimate_tokens("first reply")
+        assert bus.token_counter.context_tokens == expected
 
     asyncio.run(run())
 

--- a/backend/token_counter.py
+++ b/backend/token_counter.py
@@ -2,11 +2,13 @@
 
 TokenCounterBridge was always a passive display - window_actions.py pushed
 counts into it via update_counts() after real tokenization elsewhere.
-Nothing populates outputTokens/contextTokens yet (no send flow until R4, no
-conversation history until R3), so this mirrors that: inputTokens tracks the
-live composer draft for real (a whitespace-split estimate - tiktoken is not
-a dependency yet; swap in real tokenization here once R4 wires it), the rest
-sit at 0 rather than showing a fabricated number.
+inputTokens tracks the live composer draft (a whitespace-split estimate -
+tiktoken is not a dependency yet; swap in real tokenization here if it ever
+becomes one). outputTokens/contextTokens are set by backend/canvas.py's
+send_message/regenerate_response intents once a reply completes -
+outputTokens from the reply text itself, contextTokens from the prior
+branch history the reply was generated from (excluding, for a fresh send,
+the message just typed - inputTokens already owns that text).
 """
 
 from __future__ import annotations
@@ -29,6 +31,12 @@ class TokenCounterState:
 
     def set_input_text(self, text: str) -> None:
         self.input_tokens = estimate_tokens(text)
+
+    def set_output_text(self, text: str) -> None:
+        self.output_tokens = estimate_tokens(text)
+
+    def set_context_text(self, text: str) -> None:
+        self.context_tokens = estimate_tokens(text)
 
     def payload(self) -> dict[str, Any]:
         total = self.input_tokens + self.output_tokens + self.context_tokens


### PR DESCRIPTION
## Problem

The token counter overlay's Output and Context rows permanently displayed 0. Nothing in the backend ever set them — only Input (the live composer draft) was ever real.

## Change

- `TokenCounterState` gains `set_output_text`/`set_context_text`, mirroring the existing `set_input_text` (a whitespace-split estimate, consistent with the rest of the counter).
- Plain chat sends (`send_message`) and response regeneration (`regenerate_response`) now set both fields once a reply completes: Output from the reply text itself; Context from the branch history the reply was generated from. For a fresh send, that history deliberately excludes the message just typed — Input already owns that text, and including it again would double-count it in the Total.
- A new `_history_turn_text`/`_history_token_text` pair flattens a branch history entry's content into plain text for estimation, correctly handling both an ordinary string and an attachment's content-parts list (extracting only the text part).
- `register_canvas` takes an optional `token_counter` parameter (a throwaway default keeps the ~30 pre-existing canvas/agents tests working unchanged); the `token-counter` republish is gated on the topic actually being registered.

Scoped to the composer's own primary chat flow (send + regenerate) — image generation, chart generation, web research, gitlink, and code-execution each have their own separate agent-dispatch paths and are not touched here.

## Test plan

| Layer | Result |
|---|---|
| `python -m pytest -q` (full suite) | 1049/1049 passed (9 new) |
| `npx vitest run` / `npx tsc --noEmit` (full suite, unaffected) | 884/884 passed, clean |

New backend coverage: direct unit tests for `set_output_text`/`set_context_text`, the content-flattening helpers (plain string, content-parts with a text part, content-parts with no text part, multi-turn joining), and integration tests dispatching real `sendMessage`/`regenerateResponse` intents against a mocked chat call, asserting the exact estimated counts and that the `token-counter` topic republishes.

## Outstanding

Live-verified against a running instance up to the point a real LLM connection would be needed (no local Ollama server available in this environment): sending a first message correctly left Context at 0 (no prior history); sending a second message correctly set Context to the first message's own word count, not the second message's and not double-counted with Input. A full reply-completing round trip (confirming Output populates against a real model) is recommended before merge.