### PR TITLE
Fix focus-restore clobbering across overlay replacement; drop the About dialog's stray blue links

### DIFF
--- a/web_ui/src/app/overlays/overlays.test.tsx
+++ b/web_ui/src/app/overlays/overlays.test.tsx
@@ -243,6 +243,29 @@ describe("overlay system (the OverlayManager contract)", () => {
     await user.keyboard("{Escape}");
     expect(document.activeElement).toBe(opener);
   });
+
+  it("opening a second surface without closing the first does not clobber the original opener", async () => {
+    // Regression: open() used to unconditionally overwrite the restore
+    // target on every call. The system is single-open - opening View while
+    // Settings is already showing replaces it without ever calling
+    // close() - so this used to capture View's own trigger as the restore
+    // target instead of keeping Settings' original opener. Closing View
+    // afterward then tried to restore focus onto an element already
+    // inside Settings' unmounted subtree, silently failed the
+    // document.contains() check, and left focus on document.body.
+    const user = setup();
+    const settingsOpener = screen.getByRole("button", { name: /^Settings/ });
+    await user.click(settingsOpener);
+    expect(screen.getByRole("dialog", { name: "Settings" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^View/ }));
+    expect(screen.getByText("view popover body")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Settings" })).toBeNull();
+
+    await user.keyboard("{Escape}");
+
+    expect(document.activeElement).toBe(settingsOpener);
+  });
 });
 
 describe("anchored popover placement (R8a finding #27)", () => {

--- a/web_ui/src/app/overlays/overlays.tsx
+++ b/web_ui/src/app/overlays/overlays.tsx
@@ -61,11 +61,25 @@ export function OverlayProvider({ children }: { children: ReactNode }) {
   const surfaceElements = useRef(new Map<string, HTMLElement>());
   const restoreFocusRef = useRef<HTMLElement | null>(null);
 
-  const open = useCallback((name: string, tier: OverlayTier) => {
-    restoreFocusRef.current = document.activeElement as HTMLElement | null;
-    setOpenSurface(name);
-    setOpenTier(tier);
-  }, []);
+  const open = useCallback(
+    (name: string, tier: OverlayTier) => {
+      // Only capture a new restore target when nothing is currently open.
+      // The system is single-open: opening surface B while A is already
+      // showing replaces A without ever calling close() - unconditionally
+      // overwriting restoreFocusRef here used to clobber A's own opener
+      // with document.activeElement (an element inside A, about to
+      // unmount), so closing B later tried to restore focus onto a
+      // detached node, silently failed the document.contains() check in
+      // close() below, and left focus on document.body instead of back on
+      // A's original trigger.
+      if (openSurface === null) {
+        restoreFocusRef.current = document.activeElement as HTMLElement | null;
+      }
+      setOpenSurface(name);
+      setOpenTier(tier);
+    },
+    [openSurface],
+  );
 
   const close = useCallback(() => {
     setOpenSurface(null);

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2109,7 +2109,11 @@ body,
 
 .about-links a {
   font-size: 12px;
-  color: var(--gl-accent, #6ea8fe);
+  /* --gl-accent was never defined anywhere in the token files, so this
+     always took its hardcoded fallback - a saturated blue, the only
+     non-grey color in an otherwise entirely greyscale palette. Matches
+     .chat-node-content a's own link convention instead. */
+  color: var(--gl-palette-selection, var(--gl-surface-text-primary));
   text-decoration: none;
 }
 

--- a/web_ui/src/lib/no-raw-colors.test.ts
+++ b/web_ui/src/lib/no-raw-colors.test.ts
@@ -101,9 +101,13 @@ function findColorLiteralsInInlineStyles(source: string): string[] {
 //     existing token: --gl-shadow-3 is `0 8px 28px rgba(0,0,0,0.55)`, so it
 //     shares geometry with one and alpha with the other but equals neither.
 //   - `rgba(0,0,0,0.43)` is a scrim with no token of any kind.
-//   - `var(--gl-accent, #6ea8fe)`'s fallback is load-bearing: --gl-accent is
-//     not defined in the generated token files, so the literal is what
-//     actually renders. Dropping it would remove the color entirely.
+//
+// R8a (UI/UX audit POLISH finding #3): `#6ea8fe` - the load-bearing
+// fallback var(--gl-accent, #6ea8fe) described above used to rely on - is
+// gone from this list. .about-links a now uses --gl-palette-selection
+// (the same greyscale link token .chat-node-content a already uses)
+// instead of an undefined token whose hex fallback was the only
+// saturated color in the app's otherwise entirely greyscale palette.
 const PINNED_APP_CSS_LITERALS: Record<string, string[]> = {
   "app\\styles.css": [
     "rgba(0, 0, 0, 0.45)",
@@ -118,7 +122,6 @@ const PINNED_APP_CSS_LITERALS: Record<string, string[]> = {
     "rgba(0, 0, 0, 0.45)",
     "rgba(0, 0, 0, 0.55)",
     "rgba(0, 0, 0, 0.45)",
-    "#6ea8fe",
     "rgba(0, 0, 0, 0.45)",
   ],
 };


### PR DESCRIPTION
## Problem

Two small, unrelated issues:

- The overlay system is single-open: opening surface B while A is already showing replaces A directly, without ever calling `close()`. `open()` unconditionally overwrote the restore-focus target on every call, so opening B clobbered A's own opener with `document.activeElement` (an element already inside A, about to unmount). Closing B later tried to restore focus onto that now-detached node, silently failed the `document.contains()` check, and left focus on `document.body` instead of back on A's original trigger.
- The About dialog's links used `var(--gl-accent, #6ea8fe)` — a token defined nowhere in the generated token files, so the hardcoded fallback always rendered: a saturated blue, the only non-grey color in an otherwise entirely greyscale app.

## Change

- `open()` now only captures a new restore target when nothing is currently open, keeping the ORIGINAL opener intact across any number of surface replacements.
- About dialog links switched to `--gl-palette-selection`, the same greyscale link color `.chat-node-content a` already uses. `no-raw-colors.test.ts`'s pinned literal ratchet updated to match (one fewer `#6ea8fe` entry).

## Test plan

| Layer | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` (full suite) | 885/885 passed (1 new) |
| `npm run lint` / `npm run build` | clean |

Live-verified against a running instance: opening Settings, then View (replacing it without closing), then Escape now correctly returns focus to the Settings button rather than `document.body`. About dialog links now compute to `rgb(133, 133, 133)`, not blue.