### PR TITLE
Wire a real folder picker to the Gitlink node's local root field

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -25,6 +25,7 @@ import binascii
 import itertools
 import logging
 import math
+import os
 import uuid
 from dataclasses import dataclass, field
 from types import SimpleNamespace
@@ -39,6 +40,7 @@ from graphlink_grid_view_settings import (
 )
 from graphlink_navigation_pins import NavigationPinRecord, NavigationPinStore
 
+from backend import native_dialogs
 from backend.agents import (
     _CODE_EXEC_RUN_CLAIM_PLACEHOLDER,
     _GITLINK_RUN_CLAIM_PLACEHOLDER,
@@ -3851,6 +3853,29 @@ def register_canvas(
         document.set_gitlink_local_root(node_id, local_root)
         await publish_scene()
 
+    async def pick_gitlink_local_root(node_id):
+        # R8a (UI/UX audit POLISH finding #1): the field's own label used to
+        # say "no browse - deferred", dating from before native_dialogs.py
+        # existed. pick_folder is already generic and already used by
+        # Settings' Ollama/Llama.cpp Scan Folder buttons - this just wires
+        # the same primitive to Gitlink's own local-root field instead of
+        # requiring the user to type a path by hand. A cancelled dialog is
+        # a quiet no-op, matching every other pick_folder call site.
+        node = document.nodes.get(node_id)
+        if node is None:
+            return
+        directory = node.gitlink_local_root or os.path.expanduser("~")
+        try:
+            folder = await native_dialogs.pick_folder(directory=directory)
+        except Exception as exc:  # noqa: BLE001 - a local folder path, not a credential
+            notifications.show(f"Could not open the folder picker: {exc}", "error")
+            await bus.publish("notification")
+            return
+        if not folder:
+            return
+        document.set_gitlink_local_root(node_id, folder)
+        await publish_scene()
+
     async def import_gitlink_snapshot(node_id, repo, branch):
         node = document.nodes.get(node_id)
         if node is None or node.pending_request_id:
@@ -3958,6 +3983,7 @@ def register_canvas(
     bus.register_intent("scene", "fetchGitlinkRepositories", fetch_gitlink_repositories)
     bus.register_intent("scene", "loadGitlinkRepoTree", load_gitlink_repo_tree)
     bus.register_intent("scene", "setGitlinkLocalRoot", set_gitlink_local_root)
+    bus.register_intent("scene", "pickGitlinkLocalRoot", pick_gitlink_local_root)
     bus.register_intent("scene", "importGitlinkSnapshot", import_gitlink_snapshot)
     bus.register_intent("scene", "buildGitlinkContext", build_gitlink_context)
     bus.register_intent("scene", "fetchGitlinkContext", fetch_gitlink_context)

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -29,6 +29,7 @@ from backend.canvas import (
     _research_result_wire,
     register_canvas,
 )
+from backend import native_dialogs
 from backend.attachments import StagedAttachment
 from backend.composer import ComposerDocument
 from backend.events import SessionBus
@@ -3978,6 +3979,91 @@ def test_set_gitlink_local_root_intent_publishes_scene():
         await bus.dispatch_intent("scene", "setGitlinkLocalRoot", [node.id, "C:/checkout"])
 
         assert document.nodes[node.id].gitlink_local_root == "C:/checkout"
+
+    asyncio.run(run())
+
+
+def test_pick_gitlink_local_root_sets_the_field_from_the_picked_folder(monkeypatch):
+    # R8a (UI/UX audit POLISH finding #1): the "no browse - deferred" label
+    # is gone - this is the real un-defer, wiring the same native_dialogs.
+    # pick_folder primitive Settings' Ollama/Llama.cpp pages already use.
+    async def _fake_pick_folder(directory=""):
+        return "C:/repos/checkout"
+
+    monkeypatch.setattr(native_dialogs, "pick_folder", _fake_pick_folder)
+
+    async def run():
+        bus, notifications, document, _dispatcher = _make_gitlink_plugins_bus()
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_gitlink_node(0, 0, parent.id)
+
+        await bus.dispatch_intent("scene", "pickGitlinkLocalRoot", [node.id])
+
+        assert document.nodes[node.id].gitlink_local_root == "C:/repos/checkout"
+
+    asyncio.run(run())
+
+
+def test_pick_gitlink_local_root_is_a_no_op_when_cancelled(monkeypatch):
+    async def _fake_pick_folder(directory=""):
+        return None
+
+    monkeypatch.setattr(native_dialogs, "pick_folder", _fake_pick_folder)
+
+    async def run():
+        bus, notifications, document, _dispatcher = _make_gitlink_plugins_bus()
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_gitlink_node(0, 0, parent.id)
+        document.set_gitlink_local_root(node.id, "C:/original")
+
+        await bus.dispatch_intent("scene", "pickGitlinkLocalRoot", [node.id])
+
+        assert document.nodes[node.id].gitlink_local_root == "C:/original"
+
+    asyncio.run(run())
+
+
+def test_pick_gitlink_local_root_seeds_the_dialog_with_the_current_value(monkeypatch):
+    seen_directories = []
+
+    async def _fake_pick_folder(directory=""):
+        seen_directories.append(directory)
+        return None
+
+    monkeypatch.setattr(native_dialogs, "pick_folder", _fake_pick_folder)
+
+    async def run():
+        bus, notifications, document, _dispatcher = _make_gitlink_plugins_bus()
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_gitlink_node(0, 0, parent.id)
+        document.set_gitlink_local_root(node.id, "C:/existing/checkout")
+
+        await bus.dispatch_intent("scene", "pickGitlinkLocalRoot", [node.id])
+
+        assert seen_directories == ["C:/existing/checkout"]
+
+    asyncio.run(run())
+
+
+def test_pick_gitlink_local_root_shows_a_notification_when_the_dialog_itself_raises(monkeypatch):
+    async def _boom(directory=""):
+        raise OSError("no folder dialog available")
+
+    monkeypatch.setattr(native_dialogs, "pick_folder", _boom)
+
+    async def run():
+        bus, notifications, document, _dispatcher = _make_gitlink_plugins_bus()
+        recorder = Recorder()
+        bus.attach(recorder)
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_gitlink_node(0, 0, parent.id)
+
+        await bus.dispatch_intent("scene", "pickGitlinkLocalRoot", [node.id])
+
+        assert document.nodes[node.id].gitlink_local_root == ""
+        assert notifications.visible is True
+        assert notifications.msg_type == "error"
+        assert recorder.topics_seen().count("notification") >= 1
 
     asyncio.run(run())
 

--- a/web_ui/src/app/canvas/GitlinkNodeView.test.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.test.tsx
@@ -36,6 +36,7 @@ function baseData(overrides: Partial<GitlinkFlowNode["data"]> = {}): GitlinkFlow
     onFetchRepositories: vi.fn().mockResolvedValue([]),
     onLoadTree: vi.fn(),
     onSetLocalRoot: vi.fn(),
+    onBrowseLocalRoot: vi.fn(),
     onImportSnapshot: vi.fn(),
     onBuildContext: vi.fn(),
     onFetchContext: vi.fn().mockResolvedValue(""),
@@ -118,12 +119,13 @@ function renderGitlinkNodeWithRerender(overrides: Partial<GitlinkFlowNode["data"
   return { data, rerenderWithData };
 }
 
-/** Every one of the nine WS-backed callback props, for a single spy-and-assert-zero-calls check. */
-function allNineSpies(data: GitlinkFlowNode["data"]) {
+/** Every one of the ten WS-backed callback props, for a single spy-and-assert-zero-calls check. */
+function allTenSpies(data: GitlinkFlowNode["data"]) {
   return [
     data.onFetchRepositories,
     data.onLoadTree,
     data.onSetLocalRoot,
+    data.onBrowseLocalRoot,
     data.onImportSnapshot,
     data.onBuildContext,
     data.onFetchContext,
@@ -185,7 +187,7 @@ describe("GitlinkNodeView", () => {
   it("typing into repo/branch fields calls no WS method - only clicking Load Repo Tree does", async () => {
     const user = userEvent.setup();
     const data = renderGitlinkNode();
-    const spies = allNineSpies(data);
+    const spies = allTenSpies(data);
 
     await user.type(screen.getByRole("textbox", { name: "Repository" }), "owner/repo");
     await user.type(screen.getByRole("textbox", { name: "Branch" }), "main");
@@ -248,6 +250,14 @@ describe("GitlinkNodeView", () => {
     expect(data.onSetLocalRoot).toHaveBeenCalledWith("C:/repos/thing");
   });
 
+  it("clicking Browse… next to Local root calls onBrowseLocalRoot", async () => {
+    const user = userEvent.setup();
+    const data = renderGitlinkNode();
+
+    await user.click(screen.getByRole("button", { name: "Browse…" }));
+    expect(data.onBrowseLocalRoot).toHaveBeenCalledOnce();
+  });
+
   it("Import Repo Snapshot uses the current repo/branch draft field values", async () => {
     const user = userEvent.setup();
     const data = renderGitlinkNode();
@@ -265,7 +275,7 @@ describe("GitlinkNodeView", () => {
     const data = renderGitlinkNode({
       gitlinkRepoFilePaths: ["src/a.py", "src/b.py", "readme.md"],
     });
-    const spies = allNineSpies(data);
+    const spies = allTenSpies(data);
 
     await user.type(screen.getByRole("textbox", { name: "Filter files" }), "src/");
     expect(screen.getByText("src/a.py")).toBeInTheDocument();

--- a/web_ui/src/app/canvas/GitlinkNodeView.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.tsx
@@ -99,6 +99,7 @@ export interface GitlinkNodeData extends Record<string, unknown> {
   onFetchRepositories: () => Promise<string[]>;
   onLoadTree: (repo: string, branch: string) => void;
   onSetLocalRoot: (localRoot: string) => void;
+  onBrowseLocalRoot: () => void;
   onImportSnapshot: (repo: string, branch: string) => void;
   onBuildContext: (scopeMode: string, selectedPaths: string[]) => void;
   onFetchContext: () => Promise<string>;
@@ -422,29 +423,36 @@ export function GitlinkNodeView({ id, data, selected }: NodeProps<GitlinkFlowNod
                 </select>
               </label>
 
-              <label className="gitlink-node-field-row">
-                <span className="gitlink-node-field-label">Local root (no browse - deferred)</span>
-                <input
-                  type="text"
-                  className="gitlink-node-input"
-                  value={localRootDraft}
-                  onChange={(event) => setLocalRootDraft(event.target.value)}
-                  onBlur={commitLocalRoot}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      event.preventDefault();
-                      // Do NOT call commitLocalRoot() here too - .blur() below
-                      // synchronously fires the onBlur={commitLocalRoot}
-                      // handler above, so calling it directly here as well
-                      // would dispatch the WS intent twice per Enter press
-                      // (R5.3 post-review FIX 8).
-                      (event.target as HTMLInputElement).blur();
-                    }
-                  }}
-                  placeholder="C:\path\to\local\checkout"
-                  aria-label="Local root"
-                />
-              </label>
+              <div className="gitlink-node-field-row">
+                <label className="gitlink-node-field-row">
+                  <span className="gitlink-node-field-label">Local root</span>
+                  <input
+                    type="text"
+                    className="gitlink-node-input"
+                    value={localRootDraft}
+                    onChange={(event) => setLocalRootDraft(event.target.value)}
+                    onBlur={commitLocalRoot}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        // Do NOT call commitLocalRoot() here too - .blur() below
+                        // synchronously fires the onBlur={commitLocalRoot}
+                        // handler above, so calling it directly here as well
+                        // would dispatch the WS intent twice per Enter press
+                        // (R5.3 post-review FIX 8).
+                        (event.target as HTMLInputElement).blur();
+                      }
+                    }}
+                    placeholder="C:\path\to\local\checkout"
+                    aria-label="Local root"
+                  />
+                </label>
+                <div className="gitlink-node-inline-row">
+                  <button type="button" disabled={busy} onClick={data.onBrowseLocalRoot}>
+                    Browse…
+                  </button>
+                </div>
+              </div>
 
               <div className="gitlink-node-inline-row">
                 <button

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -650,12 +650,13 @@ describe("toFlowNodes (R5.3 gitlink node)", () => {
     expect(glFlowNode!.data).toMatchObject({ pendingRequestId: null, gitlinkChangeFingerprint: null });
   });
 
-  it("onFetchRepositories/onLoadTree/onSetLocalRoot/onImportSnapshot/onBuildContext/onFetchContext/onRun/onApply all resolve to this node's id", () => {
+  it("onFetchRepositories/onLoadTree/onSetLocalRoot/onBrowseLocalRoot/onImportSnapshot/onBuildContext/onFetchContext/onRun/onApply all resolve to this node's id", () => {
     const scene = baseScene({ nodes: [baseNode({ id: "gl-1", kind: "gitlink" })], edges: [] });
     const store = makeStore();
     const fetchReposSpy = vi.spyOn(store, "fetchGitlinkRepositories").mockResolvedValue([]);
     const loadTreeSpy = vi.spyOn(store, "loadGitlinkRepoTree");
     const setRootSpy = vi.spyOn(store, "setGitlinkLocalRoot");
+    const browseRootSpy = vi.spyOn(store, "pickGitlinkLocalRoot");
     const importSpy = vi.spyOn(store, "importGitlinkSnapshot");
     const buildContextSpy = vi.spyOn(store, "buildGitlinkContext");
     const fetchContextSpy = vi.spyOn(store, "fetchGitlinkContext").mockResolvedValue("");
@@ -668,6 +669,7 @@ describe("toFlowNodes (R5.3 gitlink node)", () => {
       onFetchRepositories: () => Promise<string[]>;
       onLoadTree: (repo: string, branch: string) => void;
       onSetLocalRoot: (localRoot: string) => void;
+      onBrowseLocalRoot: () => void;
       onImportSnapshot: (repo: string, branch: string) => void;
       onBuildContext: (scopeMode: string, selectedPaths: string[]) => void;
       onFetchContext: () => Promise<string>;
@@ -681,6 +683,8 @@ describe("toFlowNodes (R5.3 gitlink node)", () => {
     expect(loadTreeSpy).toHaveBeenCalledWith("gl-1", "owner/repo", "main");
     data.onSetLocalRoot("C:/repos/repo");
     expect(setRootSpy).toHaveBeenCalledWith("gl-1", "C:/repos/repo");
+    data.onBrowseLocalRoot();
+    expect(browseRootSpy).toHaveBeenCalledWith("gl-1");
     data.onImportSnapshot("owner/repo", "main");
     expect(importSpy).toHaveBeenCalledWith("gl-1", "owner/repo", "main");
     data.onBuildContext("full", ["a.py"]);

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -718,6 +718,7 @@ export function toFlowNodes(
           onFetchRepositories: () => store.fetchGitlinkRepositories(n.id),
           onLoadTree: (repo: string, branch: string) => store.loadGitlinkRepoTree(n.id, repo, branch),
           onSetLocalRoot: (localRoot: string) => store.setGitlinkLocalRoot(n.id, localRoot),
+          onBrowseLocalRoot: () => store.pickGitlinkLocalRoot(n.id),
           onImportSnapshot: (repo: string, branch: string) => store.importGitlinkSnapshot(n.id, repo, branch),
           onBuildContext: (scopeMode: string, selectedPaths: string[]) =>
             store.buildGitlinkContext(n.id, scopeMode, selectedPaths),

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -401,6 +401,13 @@ describe("SceneStore", () => {
     ]);
   });
 
+  it("pickGitlinkLocalRoot sends the scene-topic pickGitlinkLocalRoot intent with [nodeId]", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.pickGitlinkLocalRoot("n1");
+    expect(intents).toEqual([{ topic: "scene", intent: "pickGitlinkLocalRoot", args: ["n1"] }]);
+  });
+
   it("importGitlinkSnapshot sends the scene-topic importGitlinkSnapshot intent with [nodeId, repo, branch]", () => {
     const { transport, intents } = makeFakeTransport();
     const store = new SceneStore(transport);

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -392,6 +392,15 @@ export class SceneStore {
     this.transport.intent("scene", "setGitlinkLocalRoot", [nodeId, localRoot]);
   }
 
+  // Opens the real native OS folder picker (backend/native_dialogs.py, the
+  // same primitive Settings' Ollama/Llama.cpp Scan Folder buttons already
+  // use) and, on a folder being picked, sets it server-side exactly like
+  // setGitlinkLocalRoot above - fire-and-forget, the new value arrives back
+  // through the next scene snapshot rather than a direct reply.
+  pickGitlinkLocalRoot(nodeId: string): void {
+    this.transport.intent("scene", "pickGitlinkLocalRoot", [nodeId]);
+  }
+
   importGitlinkSnapshot(nodeId: string, repo: string, branch: string): void {
     this.transport.intent("scene", "importGitlinkSnapshot", [nodeId, repo, branch]);
   }


### PR DESCRIPTION
## Problem

The Gitlink node's "Local root" field required typing an absolute local
checkout path by hand, with no way to browse for it.

## Change

- `backend/canvas.py`: new `pickGitlinkLocalRoot` intent opens the same
  native OS folder picker (`native_dialogs.pick_folder`) that Settings'
  Ollama and Llama.cpp Scan Folder buttons already use, seeded with the
  field's current value (falling back to the user's home directory).
  On success it sets `gitlink_local_root` and republishes the scene. A
  cancelled dialog is a quiet no-op; an exception from the picker itself
  shows an error notification instead of crashing the request.
- `web_ui/src/app/canvas/sceneStore.ts`: new `pickGitlinkLocalRoot(nodeId)`
  method sending the intent.
- `web_ui/src/app/canvas/GitlinkNodeView.tsx`: added a "Browse…" button
  next to the Local root input, wired to the new store method.

## Test plan

- `python -m pytest -q` from repo root: 1053 passed (4 new tests covering
  the success, cancelled, seeded-directory, and picker-exception cases).
- `npx tsc --noEmit`, `npx vitest run` (887 passed), `npx eslint .`, and
  `npx vite build` all clean from `web_ui/`.
- Did not get a live end-to-end browser check of the button itself: the
  dev environment's browser pane isn't currently displayed, and React
  Flow leaves every node at `visibility: hidden` until it's measured,
  which never happens while hidden - so a Gitlink node can't be selected
  or clicked in this session at all right now. Coverage for this change
  rests on the backend integration tests (real intent dispatch, mocking
  only `native_dialogs.pick_folder` itself) and the frontend unit test
  (real `userEvent.click()` on the rendered button) above.