### PR TITLE
Fix persisted Ollama reasoning level being silently dropped on startup

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -229,7 +229,7 @@ def _apply_mode(mode_text: str, settings_manager: SettingsManager) -> None:
     if mode_text == config.MODE_OLLAMA_LOCAL:
         api_provider.initialize_local_provider(
             config.LOCAL_PROVIDER_OLLAMA,
-            {"reasoning_mode": settings_manager.get_ollama_reasoning_mode()},
+            {"reasoning_level": settings_manager.get_ollama_reasoning_level()},
         )
     elif mode_text == config.MODE_LLAMACPP_LOCAL:
         api_provider.initialize_local_provider(

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -563,6 +563,37 @@ def test_bootstrap_api_endpoint_mode_calls_initialize_api_with_provider_key_and_
     assert settings_manager.get_current_mode() == config.MODE_API_ENDPOINT
 
 
+def test_bootstrap_ollama_local_mode_seeds_initialize_local_provider_with_persisted_reasoning_level(
+    tmp_path, monkeypatch, caplog
+):
+    # Regression test: _apply_mode's Ollama-local branch used to call the
+    # removed get_ollama_reasoning_mode() under the wrong dict key
+    # ("reasoning_mode" instead of "reasoning_level", the key
+    # initialize_local_provider actually reads) - bootstrap_provider_state's
+    # own broad except Exception silently swallowed the resulting
+    # AttributeError every time, so the persisted reasoning level was never
+    # actually applied on startup. Asserting BOTH the real call args AND that
+    # no warning was logged catches a regression that "must not raise" alone
+    # (see the fixture above) cannot.
+    settings_manager = SettingsManager(tmp_path / "session.dat")
+    settings_manager.set_current_mode(config.MODE_OLLAMA_LOCAL)
+    settings_manager.set_ollama_reasoning_level("low")
+
+    calls = []
+
+    def fake_initialize_local_provider(provider, settings=None, *, preload_model=False):
+        calls.append((provider, settings))
+
+    monkeypatch.setattr(api_provider, "initialize_local_provider", fake_initialize_local_provider)
+
+    with caplog.at_level("WARNING"):
+        agents_module.bootstrap_provider_state(settings_manager)
+
+    assert calls == [(config.LOCAL_PROVIDER_OLLAMA, {"reasoning_level": "low"})]
+    assert settings_manager.get_current_mode() == config.MODE_OLLAMA_LOCAL
+    assert not any(record.levelname == "WARNING" for record in caplog.records)
+
+
 def test_bootstrap_falls_back_to_ollama_when_apply_mode_raises(tmp_path, monkeypatch, caplog):
     settings_manager = SettingsManager(tmp_path / "session.dat")
     settings_manager.set_current_mode(config.MODE_API_ENDPOINT)


### PR DESCRIPTION
## Problem

Every backend startup logged:

```
failed to apply persisted provider mode 'Ollama (Local)'; falling back to Ollama (Local)
AttributeError: 'SettingsManager' object has no attribute 'get_ollama_reasoning_mode'. Did you mean: 'get_ollama_reasoning_level'?
```

`backend/agents.py`'s `_apply_mode` (called from `bootstrap_provider_state`
on every process start) still called `settings_manager.get_ollama_reasoning_mode()`,
a method that no longer exists - it was replaced by
`get_ollama_reasoning_level()` when the old 2-value Quick/Thinking mode
became the current 4-value Off/Low/Medium/High reasoning level. The
call also passed the result under the wrong dict key (`"reasoning_mode"`
instead of `"reasoning_level"`, which is what `initialize_local_provider`
actually reads).

`bootstrap_provider_state`'s own broad exception handler caught the
resulting `AttributeError` on every single startup and silently fell
back to defaults, so the app never crashed - but the user's persisted
Ollama reasoning level was never actually applied.

## Change

`backend/agents.py`: `_apply_mode`'s Ollama-local branch now calls
`get_ollama_reasoning_level()` and passes it under the `"reasoning_level"`
key, matching every other already-correct call site (`backend/settings.py`,
`backend/composer.py`).

## Test plan

- Added a regression test asserting the real `initialize_local_provider`
  call args and that no warning is logged - confirmed it fails against
  the old code (reproducing the exact `AttributeError` from the bug
  report) and passes against the fix.
- `python -m pytest -q` from repo root: 1050 passed, no regressions.