### PR TITLE
Show a notification when Document View has nothing to display

### DIFF
--- a/backend/notifications.py
+++ b/backend/notifications.py
@@ -57,5 +57,18 @@ def register_notifications(bus: SessionBus, settings_manager: "SettingsManager |
         state.dismiss()
         await bus.publish("notification")
 
+    async def show_info(message: str):
+        # The one frontend-triggerable "show" entry point, deliberately fixed
+        # to "info" rather than accepting an arbitrary msg_type over the wire
+        # (Literal["info", "success", "warning", "error"] isn't enforced at
+        # runtime - a caller-supplied type could otherwise land in the
+        # payload's msgType and mismatch the CSS class the frontend switches
+        # on). Exists for genuinely frontend-only conditions - a Document
+        # View request for a node with no content to show, say - that have no
+        # other reason to round-trip through a backend intent handler.
+        state.show(str(message), "info")
+        await bus.publish("notification")
+
     bus.register_intent("notification", "dismiss", dismiss)
+    bus.register_intent("notification", "showInfo", show_info)
     return state

--- a/backend/tests/test_backend_composer.py
+++ b/backend/tests/test_backend_composer.py
@@ -375,6 +375,24 @@ def test_notification_dismiss_intent_publishes():
     asyncio.run(run())
 
 
+def test_notification_show_info_intent_publishes_a_fixed_info_type():
+    # The one frontend-triggerable "show" entry point (Document View's
+    # empty-content guard is its first real caller) - fixed to msg_type
+    # "info" regardless of what the frontend passes, since only the
+    # message string travels over the wire.
+    async def run():
+        bus, _, _, notifications, recorder = make_bus()
+        await bus.dispatch_intent("notification", "showInfo", ["No document view content is available for this node yet."])
+        assert notifications.payload() == {
+            "visible": True,
+            "message": "No document view content is available for this node yet.",
+            "msgType": "info",
+        }
+        assert recorder.topics_seen().count("notification") == 1
+
+    asyncio.run(run())
+
+
 # -- R7.5d follow-up: the composer must DISPLAY the same persisted reasoning
 # level it writes. The first R7.5d pass wired only the write half, leaving the
 # composer's own private reasoning_level as the display source - and since

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -259,12 +259,13 @@ describe("toFlowNodes (R8a Open Document View wiring)", () => {
     expect(onOpenDocumentView).toHaveBeenCalledWith("Hello world");
   });
 
-  it("a chat node with blank/whitespace-only content does NOT invoke the callback", () => {
+  it("a chat node with blank/whitespace-only content does NOT invoke the callback, and shows a notification instead", () => {
     const scene = baseScene({
       nodes: [baseNode({ id: "chat-1", kind: "chat", content: "   " })],
       edges: [],
     });
     const store = makeStore();
+    const notifySpy = vi.spyOn(store, "showInfoNotification");
     const onOpenDocumentView = vi.fn();
 
     const flowNodes = toFlowNodes(scene, store, onOpenDocumentView);
@@ -273,6 +274,7 @@ describe("toFlowNodes (R8a Open Document View wiring)", () => {
 
     (chatFlowNode!.data as { onOpenDocumentView: () => void }).onOpenDocumentView();
     expect(onOpenDocumentView).not.toHaveBeenCalled();
+    expect(notifySpy).toHaveBeenCalledWith("No document view content is available for this node yet.");
   });
 
   it("a conversation node's onOpenDocumentView invokes the callback with the properly formatted transcript", () => {
@@ -297,12 +299,13 @@ describe("toFlowNodes (R8a Open Document View wiring)", () => {
     );
   });
 
-  it("a conversation node with an empty history does NOT invoke the callback", () => {
+  it("a conversation node with an empty history does NOT invoke the callback, and shows a notification instead", () => {
     const scene = baseScene({
       nodes: [baseNode({ id: "conv-1", kind: "conversation", history: [] })],
       edges: [],
     });
     const store = makeStore();
+    const notifySpy = vi.spyOn(store, "showInfoNotification");
     const onOpenDocumentView = vi.fn();
 
     const flowNodes = toFlowNodes(scene, store, onOpenDocumentView);
@@ -311,6 +314,7 @@ describe("toFlowNodes (R8a Open Document View wiring)", () => {
 
     (conversationFlowNode!.data as { onOpenDocumentView: () => void }).onOpenDocumentView();
     expect(onOpenDocumentView).not.toHaveBeenCalled();
+    expect(notifySpy).toHaveBeenCalledWith("No document view content is available for this node yet.");
   });
 
   it("toFlowNodes called with only two arguments (the existing ~50 call sites in this file) still compiles and does not throw when onOpenDocumentView would otherwise fire", () => {

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -187,6 +187,15 @@ const EDGE_TYPES = {
   orthogonal: OrthogonalEdge,
 };
 
+// R8a follow-up: legacy's graphlink_window.py show_document_view() showed
+// this exact message (via notification_banner.show_message(..., "info"))
+// when a node had nothing to show, rather than silently doing nothing - the
+// SPA's first cut of "don't open on nothing" (both onOpenDocumentView guards
+// below) dropped that half of the behavior. Restored via SceneStore's
+// showInfoNotification, the one frontend-triggerable entry point into the
+// shared notification banner.
+const NO_DOCUMENT_VIEW_CONTENT_MESSAGE = "No document view content is available for this node yet.";
+
 // R8a: ports the deleted Qt app's own `_history_to_markdown` +
 // `_build_document_section("Conversation Transcript", ...)`
 // (graphlink_window.py) byte-for-byte - the exact markdown a conversation
@@ -401,12 +410,14 @@ export function toFlowNodes(
           onGenerateKeyTakeaway: () => store.generateKeyTakeaway(n.id),
           onGenerateExplainerNote: () => store.generateExplainerNote(n.id),
           // R8a: Open Document View - shows this node's own message text
-          // verbatim in the read-only document modal. Guards on non-blank
-          // content the same way legacy's own document-view action silently
-          // no-op'd on nothing (see conversationHistoryToDocumentMarkdown's
-          // own doc above for the sibling conversation-node guard).
+          // verbatim in the read-only document panel. Guards on non-blank
+          // content, matching legacy's own document-view action exactly:
+          // a notification on nothing, not a silent no-op (see
+          // conversationHistoryToDocumentMarkdown's own doc above for the
+          // sibling conversation-node guard).
           onOpenDocumentView: () => {
             if (n.content.trim()) onOpenDocumentView(n.content);
+            else store.showInfoNotification(NO_DOCUMENT_VIEW_CONTENT_MESSAGE);
           },
           // R8a: "Hide Other Branches" - isBranchFocusActive is scene-wide
           // (not per-node), purely so the menu button can flip its own label
@@ -610,6 +621,7 @@ export function toFlowNodes(
           onOpenDocumentView: () => {
             const markdown = conversationHistoryToDocumentMarkdown(n.history);
             if (markdown) onOpenDocumentView(markdown);
+            else store.showInfoNotification(NO_DOCUMENT_VIEW_CONTENT_MESSAGE);
           },
         },
       });

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -725,6 +725,19 @@ describe("SceneStore", () => {
     expect(store.getSelectedNodeId()).toBe("n1");
   });
 
+  it("showInfoNotification sends the notification-topic showInfo intent, not scene", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.showInfoNotification("No document view content is available for this node yet.");
+    expect(intents).toEqual([
+      {
+        topic: "notification",
+        intent: "showInfo",
+        args: ["No document view content is available for this node yet."],
+      },
+    ]);
+  });
+
   it("dispose() unsubscribes every topic", () => {
     const { transport, listeners } = makeFakeTransport();
     const store = new SceneStore(transport);

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -758,6 +758,18 @@ export class SceneStore {
   setFontColor(hex: string): void {
     this.transport.intent("scene", "setFontColor", [hex]);
   }
+
+  // Rides the notification topic, not scene - same "this store already
+  // spans more than one topic" precedent as the grid-control intents above.
+  // Document View's empty-content guard (SceneCanvas.tsx's toFlowNodes) is
+  // the first caller: a genuinely frontend-only condition (the node's own
+  // already-synced content is blank) that still needs the app's one shared
+  // notification banner, which is server-authoritative state - see
+  // backend/notifications.py's showInfo intent for why this exists instead
+  // of a second, parallel client-local notification UI.
+  showInfoNotification(message: string): void {
+    this.transport.intent("notification", "showInfo", [message]);
+  }
 }
 
 /** start + (proposed - start) * factor: the drag-speed contract carried over


### PR DESCRIPTION
## Problem

The original Qt app's Document View action showed an info notification
("No document view content is available for this node yet.") when a
node had nothing to display. The SPA rebuild's guard against opening
on blank content dropped that half of the behavior, leaving the menu
action a silent no-op with no feedback at all.

## Change

- `backend/notifications.py`: added a minimal `showInfo` intent on the
  existing `notification` topic - fixed to the `"info"` message type
  rather than accepting an arbitrary type over the wire (only a message
  string travels over the wire; the type isn't runtime-validated
  otherwise). This is the first genuinely frontend-only notification
  trigger in the app - Document View's content is already synced scene
  state with nothing to fetch, so this exists purely to reach the app's
  one shared notification banner rather than duplicating it client-side.
- `web_ui/src/app/canvas/sceneStore.ts`: added `showInfoNotification(message)`
  sending that intent.
- `web_ui/src/app/canvas/SceneCanvas.tsx`: both Open Document View guards
  (chat node, conversation node) now call it in their empty-content branch
  instead of doing nothing.

## Test plan

- `python -m pytest -q` from repo root: 1055 passed (1 new test covering
  the `showInfo` intent's wire shape and fixed msg type).
- `npx tsc --noEmit`, `npx vitest run` (888 passed, including two updated
  tests asserting the notification call), `npx eslint .` (0 errors), and
  `npx vite build` all clean from `web_ui/`.
- Live-verified against the running dev server: sent the raw
  `notification/showInfo` intent over the WS and confirmed the backend
  published the exact message with `msgType: "info"`, and that the real
  `NotificationBanner` component rendered it. No console errors.