### PR TITLE
Fix Document View overlapping the composer/token counter; make it a real drawer

### DIFF
--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -1,5 +1,5 @@
 import { ReactFlowProvider, useReactFlow } from "@xyflow/react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { TOPIC_VALIDATORS } from "../lib/api-contract/topics";
 import type { AppSettingsState } from "../lib/bridge-core/generated/app-settings-state";
 import { isTextEditable } from "../lib/bridge-core/textFocus";
@@ -9,6 +9,7 @@ import { SceneStore } from "./canvas/sceneStore";
 import { resolveTreeNavigationTarget, type TreeNavigationDirection } from "./canvas/treeNavigation";
 import { requestNewChat } from "./chrome/commands";
 import { isGatedWhileTyping, resolveShortcut, type ShortcutId } from "./chrome/shortcuts";
+import { DocumentViewPanel } from "./canvas/DocumentViewPanel";
 import { AboutDialog } from "./chrome/AboutDialog";
 import { AppBar } from "./chrome/AppBar";
 import { ChatLibraryDialog } from "./chrome/ChatLibraryDialog";
@@ -164,6 +165,21 @@ function App() {
   // has it off.
   const [settingsVisibility, setSettingsVisibility] = useState<SettingsVisibilityState>({ showTokenCounter: false });
 
+  // R8a follow-up: Open Document View's state lives here, not inside
+  // SceneCanvas, because the panel is now a real docked layout sibling of
+  // EVERYTHING in .app-canvas-region (composer/token-counter/search/etc
+  // included, not just the canvas) - see .app-canvas-layout-row below and
+  // DocumentViewPanel.tsx's own doc comment.
+  const [documentViewContent, setDocumentViewContent] = useState<string | null>(null);
+  const [documentViewSourceLabel, setDocumentViewSourceLabel] = useState<string | null>(null);
+  const [isDocumentViewOpen, setIsDocumentViewOpen] = useState(false);
+  const onOpenDocumentView = useCallback((markdown: string, sourceLabel: string) => {
+    setDocumentViewContent(markdown);
+    setDocumentViewSourceLabel(sourceLabel);
+    setIsDocumentViewOpen(true);
+  }, []);
+  const onCloseDocumentView = useCallback(() => setIsDocumentViewOpen(false), []);
+
   const transport = useMemo(() => new WsTransport(defaultWsUrl()), []);
   const sceneStore = useMemo(() => new SceneStore(transport), [transport]);
   const composerStore = useMemo(() => new ComposerStore(transport), [transport]);
@@ -211,29 +227,39 @@ function App() {
           </header>
 
           <main className="app-canvas-region">
-            <SceneCanvas store={sceneStore} />
-            <div className="app-search-layer">
-              <SearchOverlay store={sceneStore} />
-            </div>
-            <PinOverlay store={sceneStore} />
-            <ViewPopover store={sceneStore} />
-            <PluginPicker transport={transport} store={sceneStore} />
-            {settingsVisibility.showTokenCounter !== false && (
-              <div className="app-token-counter-layer">
-                <TokenCounter store={composerStore} />
+            <div className="app-canvas-layout-row">
+              <DocumentViewPanel
+                isOpen={isDocumentViewOpen}
+                content={documentViewContent}
+                sourceLabel={documentViewSourceLabel}
+                onClose={onCloseDocumentView}
+              />
+              <div className="app-canvas-content">
+                <SceneCanvas store={sceneStore} onOpenDocumentView={onOpenDocumentView} />
+                <div className="app-search-layer">
+                  <SearchOverlay store={sceneStore} />
+                </div>
+                <PinOverlay store={sceneStore} />
+                <ViewPopover store={sceneStore} />
+                <PluginPicker transport={transport} store={sceneStore} />
+                {settingsVisibility.showTokenCounter !== false && (
+                  <div className="app-token-counter-layer">
+                    <TokenCounter store={composerStore} />
+                  </div>
+                )}
+                <div className="app-notification-layer">
+                  <NotificationBanner store={composerStore} />
+                </div>
+                <div className="app-composer-layer">
+                  <Composer store={composerStore} sceneStore={sceneStore} />
+                </div>
+                <CommandPalette store={sceneStore} />
+                <AboutDialog transport={transport} />
+                <HelpDialog />
+                <SettingsDialog transport={transport} />
+                <ChatLibraryDialog transport={transport} />
               </div>
-            )}
-            <div className="app-notification-layer">
-              <NotificationBanner store={composerStore} />
             </div>
-            <div className="app-composer-layer">
-              <Composer store={composerStore} sceneStore={sceneStore} />
-            </div>
-            <CommandPalette store={sceneStore} />
-            <AboutDialog transport={transport} />
-            <HelpDialog />
-            <SettingsDialog transport={transport} />
-            <ChatLibraryDialog transport={transport} />
           </main>
         </div>
       </ReactFlowProvider>

--- a/web_ui/src/app/canvas/DocumentViewPanel.test.tsx
+++ b/web_ui/src/app/canvas/DocumentViewPanel.test.tsx
@@ -1,11 +1,22 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { DocumentViewPanel } from "./DocumentViewPanel";
 
+function renderPanel(overrides: Partial<React.ComponentProps<typeof DocumentViewPanel>> = {}) {
+  const props = {
+    isOpen: true,
+    content: "some content",
+    sourceLabel: null as string | null,
+    onClose: vi.fn(),
+    ...overrides,
+  };
+  return render(<DocumentViewPanel {...props} />);
+}
+
 describe("DocumentViewPanel", () => {
   it("renders the fixed title and the passed markdown content", () => {
-    render(<DocumentViewPanel content={"# Heading\n\nA paragraph of body text."} onClose={vi.fn()} />);
+    renderPanel({ content: "# Heading\n\nA paragraph of body text." });
 
     expect(screen.getByText("Document View")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Heading" })).toBeInTheDocument();
@@ -13,24 +24,124 @@ describe("DocumentViewPanel", () => {
   });
 
   it("does not crash and renders an empty body when content is null", () => {
-    render(<DocumentViewPanel content={null} onClose={vi.fn()} />);
-
+    renderPanel({ content: null });
     expect(screen.getByText("Document View")).toBeInTheDocument();
+  });
+
+  it("renders the source label as a subtitle when provided", () => {
+    renderPanel({ sourceLabel: "Conversation transcript" });
+    expect(screen.getByText("Conversation transcript")).toBeInTheDocument();
+  });
+
+  it("renders no subtitle when sourceLabel is null", () => {
+    renderPanel({ sourceLabel: null });
+    expect(screen.queryByText("Conversation transcript")).toBeNull();
   });
 
   it("clicking Close calls onClose - the only way this panel closes, unlike a Dialog", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    render(<DocumentViewPanel content="some content" onClose={onClose} />);
+    renderPanel({ onClose });
 
     await user.click(screen.getByRole("button", { name: "Close" }));
     expect(onClose).toHaveBeenCalledOnce();
   });
 
   it("renders as a plain landmark region, not a modal dialog (no role='dialog', no scrim)", () => {
-    render(<DocumentViewPanel content="some content" onClose={vi.fn()} />);
-
+    renderPanel();
     expect(screen.queryByRole("dialog")).toBeNull();
     expect(screen.getByLabelText("Document View")).toBeInTheDocument();
+  });
+
+  it("collapses to zero width and is aria-hidden when closed, without unmounting", () => {
+    const { container } = renderPanel({ isOpen: false, content: "still here" });
+
+    const panel = container.querySelector(".document-view-panel") as HTMLElement;
+    expect(panel).toHaveAttribute("aria-hidden", "true");
+    expect(panel.style.width).toBe("0px");
+    // Content stays mounted (no unmount/remount flicker on next open) -
+    // just clipped by the closed panel's own overflow:hidden.
+    expect(screen.getByText("still here")).toBeInTheDocument();
+  });
+
+  it("is not aria-hidden and has a real width when open", () => {
+    const { container } = renderPanel({ isOpen: true });
+
+    const panel = container.querySelector(".document-view-panel") as HTMLElement;
+    expect(panel).toHaveAttribute("aria-hidden", "false");
+    expect(panel.style.width).toBe("500px");
+  });
+
+  it("renders a resize handle", () => {
+    renderPanel();
+    expect(screen.getByRole("separator", { name: "Resize Document View panel" })).toBeInTheDocument();
+  });
+
+  it("dragging the resize handle changes the panel's width, and releasing ends the drag cleanly", () => {
+    const { container } = renderPanel();
+    const handle = screen.getByRole("separator", { name: "Resize Document View panel" });
+    const panel = container.querySelector(".document-view-panel") as HTMLElement;
+
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+    expect(panel.className).toContain("document-view-panel-resizing");
+
+    fireEvent.pointerMove(handle, { clientX: 600, pointerId: 1 });
+    expect(panel.style.width).toBe("600px");
+
+    fireEvent.pointerUp(handle, { clientX: 600, pointerId: 1 });
+    expect(panel.className).not.toContain("document-view-panel-resizing");
+
+    // The drag has genuinely ended, not just visually - a stray pointermove
+    // anywhere afterward (this is exactly the class of bug a dangling
+    // window-level listener would have let slip through) must not keep
+    // resizing the panel.
+    fireEvent.pointerMove(handle, { clientX: 900, pointerId: 1 });
+    expect(panel.style.width).toBe("600px");
+  });
+
+  it("clamps the resize width to the configured min/max range", () => {
+    const { container } = renderPanel();
+    const handle = screen.getByRole("separator", { name: "Resize Document View panel" });
+    const panel = container.querySelector(".document-view-panel") as HTMLElement;
+
+    fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: -5000, pointerId: 1 });
+    expect(panel.style.width).toBe("320px");
+
+    fireEvent.pointerMove(handle, { clientX: 5000, pointerId: 1 });
+    expect(panel.style.width).toBe("900px");
+  });
+
+  describe("Copy button", () => {
+    // userEvent.setup() installs its OWN navigator.clipboard stub internally
+    // (so .copy()/.paste() are testable) - defining a mock clipboard BEFORE
+    // calling setup() gets silently clobbered the moment setup() runs. The
+    // fix is ordering: define the mock AFTER setup(), so it's the last
+    // writer, not a beforeEach that necessarily runs first.
+    function mockClipboard(): ReturnType<typeof vi.fn> {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        configurable: true,
+        writable: true,
+      });
+      return writeText;
+    }
+
+    it("is disabled when there is no content", () => {
+      renderPanel({ content: null });
+      expect(screen.getByRole("button", { name: "Copy content" })).toBeDisabled();
+    });
+
+    it("copies the content and flashes 'Copied' on click", async () => {
+      const user = userEvent.setup();
+      const writeText = mockClipboard();
+      renderPanel({ content: "copy me" });
+
+      await user.click(screen.getByRole("button", { name: "Copy content" }));
+
+      expect(writeText).toHaveBeenCalledWith("copy me");
+      expect(await screen.findByText("Copied")).toBeInTheDocument();
+    });
   });
 });

--- a/web_ui/src/app/canvas/DocumentViewPanel.tsx
+++ b/web_ui/src/app/canvas/DocumentViewPanel.tsx
@@ -1,44 +1,151 @@
+import { useCallback, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 
+const DEFAULT_WIDTH = 500;
+const MIN_WIDTH = 320;
+const MAX_WIDTH = 900;
+
 /**
  * Document View panel (Qt-removal plan R7.6b's stub, redone as a real
- * docked panel). Legacy's DocumentViewerPanel/DocumentViewerWebHost
- * (graphlink_window.py/graphlink_document_viewer_web.py, deleted in R7.6b)
- * was a permanent embedded QWidget - a fixed-500px, flush-left panel that
- * was a QHBoxLayout SIBLING of the graph view (content_layout.addWidget
- * ordering: doc_viewer_panel, then chat_view), toggled via setVisible(),
- * never a floating/modal window. The SPA's first cut of this (R7.6b) wired
- * the content into the shared centered Dialog surface instead, since that
- * was the only overlay primitive built at the time - this replaces that
- * with a real docked flex sibling of the canvas (see CanvasInner's own
- * render in SceneCanvas.tsx, which shrinks the graph view exactly like
- * legacy's QHBoxLayout did) rather than a shared Dialog/Popover tier.
+ * docked panel, then refined further). Legacy's DocumentViewerPanel/
+ * DocumentViewerWebHost (graphlink_window.py/graphlink_document_viewer_web.py,
+ * deleted in R7.6b) was a permanent embedded QWidget - a fixed-500px,
+ * flush-left panel that was a QHBoxLayout SIBLING of the graph view, toggled
+ * via setVisible(). This restores that shape (a real docked flex sibling -
+ * see App.tsx, which owns open/close state and mounts this alongside every
+ * other piece of chrome, not just the canvas) and goes further: a real
+ * slide transition (so opening/closing reads as a drawer, not a jump-cut),
+ * a drag-to-resize handle, a Copy button, and a source subtitle so a
+ * complex graph with many nodes doesn't leave "Document View" as the only
+ * clue about which node's content is on screen.
+ *
+ * The slide animation only ever transitions the OUTER element's width
+ * (0 <-> the user's chosen width) while the INNER content is held at a
+ * fixed width the whole time - if the inner content's own width tracked the
+ * animating outer width, ReactMarkdown's rendered text would reflow line by
+ * line for the entire 220ms transition (visibly janky); clipping a
+ * constant-width inner block via the outer's overflow:hidden instead reads
+ * as a real slide, the same technique most CSS-only drawer components use.
+ *
  * Closing it only ever happens via its own Close button, matching legacy
  * exactly - it was never part of Qt's OverlayManager, so no scrim, no
  * Escape-to-close, no focus trap here either.
  */
 export function DocumentViewPanel({
+  isOpen,
   content,
+  sourceLabel,
   onClose,
 }: {
+  isOpen: boolean;
   content: string | null;
+  sourceLabel: string | null;
   onClose: () => void;
 }) {
+  const [width, setWidth] = useState(DEFAULT_WIDTH);
+  const [isResizing, setIsResizing] = useState(false);
+  const dragStartRef = useRef<{ pointerX: number; startWidth: number } | null>(null);
+
+  // Real Pointer Capture, not a window-level pointermove/pointerup pair:
+  // capturing the pointer on the handle ITSELF guarantees the browser keeps
+  // routing every subsequent event for that pointer ID here (even once the
+  // cursor leaves the handle's own thin hit-box, or the window entirely)
+  // and - critically - guarantees a pointerup/pointercancel eventually
+  // fires and auto-releases capture. A manual window listener has no such
+  // guarantee: if pointerup is ever missed (an interrupted drag, a
+  // synthetic click that never dispatches a real mouseup), isResizing gets
+  // stuck true forever with a dangling global listener, and the panel then
+  // silently resizes itself in response to ANY future mouse movement
+  // anywhere on the page, from any other interaction - a real bug found
+  // exactly this way while live-verifying the drawer transition.
+  const onResizeStart = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      dragStartRef.current = { pointerX: event.clientX, startWidth: width };
+      setIsResizing(true);
+      // Feature-detected, not assumed: real browsers have supported Pointer
+      // Capture for years, but the DOM environment this runs in (an older
+      // WebView2/browser, or a test environment like jsdom) may not.
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+    },
+    [width],
+  );
+
+  const onResizeMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const start = dragStartRef.current;
+    if (!start) return;
+    const next = start.startWidth + (event.clientX - start.pointerX);
+    setWidth(Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, next)));
+  }, []);
+
+  const onResizeEnd = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    dragStartRef.current = null;
+    setIsResizing(false);
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  }, []);
+
+  const [copied, setCopied] = useState(false);
+  const onCopy = useCallback(() => {
+    if (!content) return;
+    navigator.clipboard?.writeText(content).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }, [content]);
+
   return (
-    <aside className="document-view-panel" aria-label="Document View">
-      <header className="document-view-panel-header">
-        <span className="document-view-panel-title">Document View</span>
-        <button type="button" className="document-view-panel-close" onClick={onClose}>
-          Close
-        </button>
-      </header>
-      <div className="document-view-panel-scroll chat-node-content">
-        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-          {content ?? ""}
-        </ReactMarkdown>
+    <aside
+      className={[
+        "document-view-panel",
+        isOpen ? "document-view-panel-open" : "",
+        isResizing ? "document-view-panel-resizing" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      aria-label="Document View"
+      aria-hidden={!isOpen}
+      style={{ width: isOpen ? width : 0 }}
+    >
+      <div className="document-view-panel-inner" style={{ width }}>
+        <header className="document-view-panel-header">
+          <div className="document-view-panel-heading">
+            <span className="document-view-panel-title">Document View</span>
+            {sourceLabel && <span className="document-view-panel-subtitle">{sourceLabel}</span>}
+          </div>
+          <button
+            type="button"
+            className="document-view-panel-copy"
+            onClick={onCopy}
+            disabled={!content}
+            title="Copy content"
+            aria-label="Copy content"
+          >
+            {copied ? "Copied" : "Copy"}
+          </button>
+          <button type="button" className="document-view-panel-close" onClick={onClose}>
+            Close
+          </button>
+        </header>
+        <div className="document-view-panel-scroll chat-node-content">
+          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+            {content ?? ""}
+          </ReactMarkdown>
+        </div>
       </div>
+      <div
+        className="document-view-panel-resize-handle"
+        onPointerDown={onResizeStart}
+        onPointerMove={onResizeMove}
+        onPointerUp={onResizeEnd}
+        onPointerCancel={onResizeEnd}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize Document View panel"
+      />
     </aside>
   );
 }

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -256,7 +256,22 @@ describe("toFlowNodes (R8a Open Document View wiring)", () => {
     expect(chatFlowNode).toBeDefined();
 
     (chatFlowNode!.data as { onOpenDocumentView: () => void }).onOpenDocumentView();
-    expect(onOpenDocumentView).toHaveBeenCalledWith("Hello world");
+    expect(onOpenDocumentView).toHaveBeenCalledWith("Hello world", "Assistant message");
+  });
+
+  it("a chat node's onOpenDocumentView labels the source as the user's own message when isUser is true", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hello world", isUser: true })],
+      edges: [],
+    });
+    const store = makeStore();
+    const onOpenDocumentView = vi.fn();
+
+    const flowNodes = toFlowNodes(scene, store, onOpenDocumentView);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+
+    (chatFlowNode!.data as { onOpenDocumentView: () => void }).onOpenDocumentView();
+    expect(onOpenDocumentView).toHaveBeenCalledWith("Hello world", "Your message");
   });
 
   it("a chat node with blank/whitespace-only content does NOT invoke the callback, and shows a notification instead", () => {
@@ -296,6 +311,7 @@ describe("toFlowNodes (R8a Open Document View wiring)", () => {
     (conversationFlowNode!.data as { onOpenDocumentView: () => void }).onOpenDocumentView();
     expect(onOpenDocumentView).toHaveBeenCalledWith(
       "## Conversation Transcript\n\n### 1. User\n\nhi\n\n### 2. Assistant\n\nhello there",
+      "Conversation transcript",
     );
   });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -27,7 +27,6 @@ import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
 import { CodeSandboxNodeView, type CodeSandboxFlowNode } from "./CodeSandboxNodeView";
 import { ConversationNodeView, type ConversationFlowNode, type ConversationMessage } from "./ConversationNodeView";
 import { DocumentNodeView, type DocumentFlowNode } from "./DocumentNodeView";
-import { DocumentViewPanel } from "./DocumentViewPanel";
 import { GitlinkNodeView, type GitlinkFlowNode } from "./GitlinkNodeView";
 import { GroupNodeView, type GroupFlowNode } from "./GroupNodeView";
 import { HtmlNodeView, type HtmlFlowNode } from "./HtmlNodeView";
@@ -343,7 +342,7 @@ export function computeDimmedNodeIds(scene: SceneState, originId: string | null)
 export function toFlowNodes(
   scene: SceneState,
   store: SceneStore,
-  onOpenDocumentView: (markdown: string) => void = () => {},
+  onOpenDocumentView: (markdown: string, sourceLabel: string) => void = () => {},
   branchFocusOriginId: string | null = null,
   onToggleBranchFocus: (nodeId: string) => void = () => {},
 ): SceneFlowNode[] {
@@ -416,7 +415,7 @@ export function toFlowNodes(
           // conversationHistoryToDocumentMarkdown's own doc above for the
           // sibling conversation-node guard).
           onOpenDocumentView: () => {
-            if (n.content.trim()) onOpenDocumentView(n.content);
+            if (n.content.trim()) onOpenDocumentView(n.content, n.isUser ? "Your message" : "Assistant message");
             else store.showInfoNotification(NO_DOCUMENT_VIEW_CONTENT_MESSAGE);
           },
           // R8a: "Hide Other Branches" - isBranchFocusActive is scene-wide
@@ -620,7 +619,7 @@ export function toFlowNodes(
           // above guards on non-blank content.
           onOpenDocumentView: () => {
             const markdown = conversationHistoryToDocumentMarkdown(n.history);
-            if (markdown) onOpenDocumentView(markdown);
+            if (markdown) onOpenDocumentView(markdown, "Conversation transcript");
             else store.showInfoNotification(NO_DOCUMENT_VIEW_CONTENT_MESSAGE);
           },
         },
@@ -1163,7 +1162,13 @@ function useCssVar(name: string, fallback: string): string {
   return value;
 }
 
-function CanvasInner({ store }: { store: SceneStore }) {
+function CanvasInner({
+  store,
+  onOpenDocumentView,
+}: {
+  store: SceneStore;
+  onOpenDocumentView: (markdown: string, sourceLabel: string) => void;
+}) {
   const scene = useSyncExternalStore(store.subscribe, store.getScene);
   const grid = useSyncExternalStore(store.subscribe, store.getGrid);
   // Hoisted above onNodesChange: smart guides (R7.5b-3) need node
@@ -1225,24 +1230,12 @@ function CanvasInner({ store }: { store: SceneStore }) {
 
   // R8a: Open Document View - the read-only markdown panel a chat/
   // conversation node's card menu opens (see toFlowNodes' own
-  // onOpenDocumentView field on each of those two branches). The displayed
-  // markdown is local-only state (never scene state, same posture as
-  // hoveredEdgeId/smartGuideLines above) - SceneCanvas is the only place
-  // that knows how to open this panel. Deliberately its OWN open/closed
-  // boolean, not a name in the shared OverlayProvider registry: legacy's
-  // DocumentViewerPanel was a permanent embedded QWidget outside Qt's
-  // OverlayManager entirely (see DocumentViewPanel.tsx's own doc comment),
-  // so this restores that same independence rather than reusing the
-  // Dialog/Popover single-open-surface system a docked panel was never
-  // part of.
-  const [documentViewContent, setDocumentViewContent] = useState<string | null>(null);
-  const [isDocumentViewOpen, setIsDocumentViewOpen] = useState(false);
-  const onOpenDocumentView = useCallback((markdown: string) => {
-    setDocumentViewContent(markdown);
-    setIsDocumentViewOpen(true);
-  }, []);
-  const onCloseDocumentView = useCallback(() => setIsDocumentViewOpen(false), []);
-
+  // onOpenDocumentView field on each of those two branches). Lives in App
+  // now, not here: the panel is a real docked layout sibling of this WHOLE
+  // canvas region (composer/token-counter/search/etc included), not just
+  // this component's own canvas div, so its open/closed state has to live
+  // above all of them (see App.tsx).
+  //
   // R8a: "Hide Other Branches" - which node id branch focus is currently
   // anchored to, or null when off. Also local-only state (never scene
   // state), same posture as documentViewContent above - it is a pure
@@ -1502,18 +1495,7 @@ function CanvasInner({ store }: { store: SceneStore }) {
   );
 
   return (
-    <>
-      {/* R8a follow-up: a real docked flex sibling of the canvas, restoring
-          legacy's QHBoxLayout(doc_viewer_panel, chat_view) shape - opening
-          it visibly shrinks .scene-canvas-flex-area instead of overlaying
-          on top of the graph (see DocumentViewPanel.tsx's own doc comment
-          for why this is no longer one of the shared Dialog/Popover tiers). */}
-      <div className="scene-canvas-row">
-      {isDocumentViewOpen && (
-        <DocumentViewPanel content={documentViewContent} onClose={onCloseDocumentView} />
-      )}
-      <div className="scene-canvas-flex-area">
-      <div className="scene-canvas" ref={canvasWrapperRef} onDoubleClick={onDoubleClick}>
+    <div className="scene-canvas" ref={canvasWrapperRef} onDoubleClick={onDoubleClick}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -1594,10 +1576,7 @@ function CanvasInner({ store }: { store: SceneStore }) {
           </ViewportPortal>
         )}
       </ReactFlow>
-      </div>
-      </div>
-      </div>
-    </>
+    </div>
   );
 }
 
@@ -1605,6 +1584,12 @@ function CanvasInner({ store }: { store: SceneStore }) {
 // the R2.4 PinOverlay (jump-to-pin via setCenter) need the same React Flow
 // instance the canvas renders into - pins moved out to their own overlay,
 // ported with real search + rename/note editing (R2.4).
-export function SceneCanvas({ store }: { store: SceneStore }) {
-  return <CanvasInner store={store} />;
+export function SceneCanvas({
+  store,
+  onOpenDocumentView,
+}: {
+  store: SceneStore;
+  onOpenDocumentView: (markdown: string, sourceLabel: string) => void;
+}) {
+  return <CanvasInner store={store} onOpenDocumentView={onOpenDocumentView} />;
 }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -91,6 +91,31 @@ body,
   overflow: hidden;
 }
 
+/* R8a follow-up: a real docked flex sibling of EVERYTHING else in this
+   region (the canvas, composer, token counter, search bar, notification
+   banner, pins/view/plugin popovers - all of it), not just the React Flow
+   canvas - restoring legacy's QHBoxLayout(doc_viewer_panel, chat_view)
+   shape at the level it actually needs to apply. Opening Document View
+   shrinks .app-canvas-content, so every piece of floating chrome inside it
+   (most of which is positioned via fixed pixel insets relative to this
+   region's own width) reflows around the panel instead of rendering
+   underneath/through it. Absolutely positioned so it escapes
+   .app-canvas-region's own align-items/justify-content (vestigial from an
+   early placeholder-only layout) exactly like .scene-canvas already did
+   before this existed - the same proven shape, just one level up. */
+.app-canvas-layout-row {
+  position: absolute;
+  inset: 0;
+  display: flex;
+}
+
+.app-canvas-content {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+}
+
 .app-canvas-placeholder {
   text-align: center;
 }
@@ -182,19 +207,6 @@ body,
 }
 
 /* -- R1 canvas (React Flow) ---------------------------------------------- */
-
-.scene-canvas-row {
-  position: absolute;
-  inset: 0;
-  display: flex;
-}
-
-.scene-canvas-flex-area {
-  position: relative;
-  flex: 1;
-  min-width: 0;
-  height: 100%;
-}
 
 .scene-canvas {
   position: absolute;
@@ -2161,24 +2173,42 @@ body,
 }
 
 /* -- Document view panel (R8a follow-up) ------------------------------------
-   Docked flush-left, border-right only, fixed width - restores legacy's
+   Docked flush-left, border-right only - restores legacy's
    DocumentViewerPanel chrome (a permanent embedded QWidget, corner_radius=0,
    .setFixedWidth(500)) instead of the floating-card look every centered
-   Dialog uses. See DocumentViewPanel.tsx's own doc comment. */
+   Dialog uses, PLUS a real slide transition and a drag-to-resize handle
+   legacy never had. See DocumentViewPanel.tsx's own doc comment for why the
+   outer element's width animates while the inner content stays fixed-width. */
 
 .document-view-panel {
+  position: relative;
   flex-shrink: 0;
-  width: 500px;
-  max-width: 45vw;
+  width: 0;
+  height: 100%;
+  box-sizing: border-box;
+  background-color: var(--gl-surface-node-body);
+  border-right: 1px solid transparent;
+  overflow: hidden;
+  transition:
+    width 220ms ease,
+    border-color 220ms ease;
+}
+
+.document-view-panel-open {
+  border-right-color: var(--gl-surface-border);
+}
+
+.document-view-panel-resizing {
+  transition: none;
+}
+
+.document-view-panel-inner {
   height: 100%;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 10px;
   padding: 10px;
-  background-color: var(--gl-surface-node-body);
-  border-right: 1px solid var(--gl-surface-border);
-  overflow: hidden;
 }
 
 .document-view-panel-header {
@@ -2188,13 +2218,28 @@ body,
   gap: 8px;
 }
 
-.document-view-panel-title {
+.document-view-panel-heading {
   flex: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.document-view-panel-title {
   font-size: 14px;
   font-weight: 700;
 }
 
+.document-view-panel-subtitle {
+  font-size: 11px;
+  color: var(--gl-surface-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.document-view-panel-copy,
 .document-view-panel-close {
   flex-shrink: 0;
   padding: 6px 14px;
@@ -2207,8 +2252,14 @@ body,
   cursor: pointer;
 }
 
+.document-view-panel-copy:hover:enabled,
 .document-view-panel-close:hover {
   background-color: var(--gl-neutral-button-hover);
+}
+
+.document-view-panel-copy:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 
 .document-view-panel-scroll {
@@ -2219,6 +2270,22 @@ body,
   padding: 8px 12px;
   border: 1px solid var(--gl-surface-border);
   border-radius: 6px;
+}
+
+.document-view-panel-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -3px;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.document-view-panel-resize-handle:hover,
+.document-view-panel-resizing .document-view-panel-resize-handle {
+  background-color: var(--gl-palette-selection);
+  opacity: 0.5;
 }
 
 .help-rail {


### PR DESCRIPTION
## Problem

The Document View panel was made a flex sibling of only the React Flow
canvas. Every other piece of floating chrome in `.app-canvas-region`
(composer, token counter, search bar, notification banner,
pins/view/plugin popovers) is positioned via fixed pixel insets
relative to that region's full width, and none of it accounted for the
panel's presence - opening it shrank the canvas correctly but left
everything else rendering as if the panel weren't there, overlapping
its column.

The panel itself was also minimal: a plain box with a title and a
Close button, no indication of which node's content it was showing, no
resize, and an instant open/close with no transition.

## Change

- `web_ui/src/app/App.tsx`: the panel now sits alongside ALL the
  floating chrome (a new `.app-canvas-layout-row` / `.app-canvas-content`
  split), not just the canvas. App now owns Document View's open/close
  state (moved out of `SceneCanvas`), since the panel is a layout
  sibling of things `SceneCanvas` doesn't render.
- `web_ui/src/app/canvas/DocumentViewPanel.tsx`:
  - A real slide transition (the outer element's width animates 0 <->
    target while the inner content stays a fixed width, so text never
    reflows mid-transition - the standard CSS-only drawer technique).
  - A drag-to-resize handle using real Pointer Capture (not a
    window-level pointermove/pointerup pair, which can get stuck
    resizing forever if pointerup is ever missed).
  - A Copy button and a source subtitle ("Your message" / "Assistant
    message" / "Conversation transcript") so a graph with many nodes
    doesn't leave "Document View" as the only clue about what's on
    screen.
- `web_ui/src/app/canvas/SceneCanvas.tsx`: `onOpenDocumentView` now
  takes a second `sourceLabel` argument; the panel-hosting JSX moved
  out to App.tsx.
- `web_ui/src/app/styles.css`: the new layout-row/content split, and
  the panel's drawer/resize/copy chrome.

## Test plan

- `npx tsc --noEmit`, `npx vitest run` (898 passed, 15 new/updated
  tests), `npx eslint .` (0 errors), `npx vite build` all clean from
  `web_ui/`.
- Verified in the running dev server at 1440x900 with realistic
  multi-paragraph content: panel height/positioning render correctly,
  and the composer and token counter reflow clear of the panel
  (composer's left edge moved from x=231 to x=730). The resize handle
  drags and terminates cleanly on release. No console errors.
- The open/close slide transition was verified structurally (correct
  class toggling, correct target width applied) rather than by
  observing the animation play in real time in this environment.
