### PR TITLE
Fold Token usage into the composer as a hover popout, not a floating island

### DIFF
--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -22,7 +22,6 @@ import { PinOverlay } from "./chrome/PinOverlay";
 import { PluginPicker } from "./chrome/PluginPicker";
 import { SearchOverlay } from "./chrome/SearchOverlay";
 import { SettingsDialog } from "./chrome/SettingsDialog";
-import { TokenCounter } from "./chrome/TokenCounter";
 import { ViewPopover } from "./chrome/ViewPopover";
 import { OverlayProvider, useOverlays } from "./overlays/overlays";
 
@@ -242,16 +241,15 @@ function App() {
                 <PinOverlay store={sceneStore} />
                 <ViewPopover store={sceneStore} />
                 <PluginPicker transport={transport} store={sceneStore} />
-                {settingsVisibility.showTokenCounter !== false && (
-                  <div className="app-token-counter-layer">
-                    <TokenCounter store={composerStore} />
-                  </div>
-                )}
                 <div className="app-notification-layer">
                   <NotificationBanner store={composerStore} />
                 </div>
                 <div className="app-composer-layer">
-                  <Composer store={composerStore} sceneStore={sceneStore} />
+                  <Composer
+                    store={composerStore}
+                    sceneStore={sceneStore}
+                    showTokenCounter={settingsVisibility.showTokenCounter !== false}
+                  />
                 </div>
                 <CommandPalette store={sceneStore} />
                 <AboutDialog transport={transport} />

--- a/web_ui/src/app/chrome/Composer.test.tsx
+++ b/web_ui/src/app/chrome/Composer.test.tsx
@@ -491,14 +491,37 @@ describe("Composer", () => {
 });
 
 describe("TokenCounter", () => {
-  it("renders all four counts", () => {
+  it("shows only the compact total until hovered", () => {
     const { store } = makeStore({
       tokenCounter: { inputTokens: 3, outputTokens: 2, contextTokens: 1, totalTokens: 6 },
     });
     // @ts-expect-error - test double
     render(<TokenCounter store={store} />);
-    expect(screen.getByText("3")).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: "Token usage: 6 total" })).toBeInTheDocument();
     expect(screen.getByText("6")).toBeInTheDocument();
+    // Input/Output/Context only exist inside the hover popout - not shown yet.
+    expect(screen.queryByText("3")).toBeNull();
+    expect(screen.queryByRole("status", { name: "Token usage breakdown" })).toBeNull();
+  });
+
+  it("reveals all four counts in a popout on hover, and hides them again on unhover", async () => {
+    const user = userEvent.setup();
+    const { store } = makeStore({
+      tokenCounter: { inputTokens: 3, outputTokens: 2, contextTokens: 1, totalTokens: 6 },
+    });
+    // @ts-expect-error - test double
+    render(<TokenCounter store={store} />);
+
+    await user.hover(screen.getByRole("button", { name: "Token usage: 6 total" }));
+    const popout = screen.getByRole("status", { name: "Token usage breakdown" });
+    expect(popout).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+
+    await user.unhover(screen.getByRole("button", { name: "Token usage: 6 total" }));
+    expect(screen.queryByRole("status", { name: "Token usage breakdown" })).toBeNull();
   });
 });
 

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import type { SceneStore } from "../canvas/sceneStore";
 import { Popover, useOverlays } from "../overlays/overlays";
 import type { ComposerStore } from "./composerStore";
+import { TokenCounter } from "./TokenCounter";
 
 /**
  * The composer dock (Qt-removal plan R2.3/R3.3/R4.3) - ComposerApp's SPA
@@ -49,7 +50,15 @@ function Icon({ name }: { name: "attach" | "send" | "chevron" | "stop" }) {
   );
 }
 
-export function Composer({ store, sceneStore }: { store: ComposerStore; sceneStore: SceneStore }) {
+export function Composer({
+  store,
+  sceneStore,
+  showTokenCounter = true,
+}: {
+  store: ComposerStore;
+  sceneStore: SceneStore;
+  showTokenCounter?: boolean;
+}) {
   const composer = useSyncExternalStore(store.subscribe, store.getComposer);
   const streamText = useSyncExternalStore(store.subscribe, store.getStreamText);
   const overlays = useOverlays();
@@ -196,6 +205,8 @@ export function Composer({ store, sceneStore }: { store: ComposerStore; sceneSto
           </span>
           <Icon name="chevron" />
         </button>
+
+        {showTokenCounter && <TokenCounter store={store} />}
 
         <div className="composer-send-group">
           {composer.request.canCancel && (

--- a/web_ui/src/app/chrome/TokenCounter.tsx
+++ b/web_ui/src/app/chrome/TokenCounter.tsx
@@ -1,26 +1,59 @@
+import { useState } from "react";
 import { useSyncExternalStore } from "react";
 import type { ComposerStore } from "./composerStore";
 
+/**
+ * Token usage (R8a follow-up) - a hover-triggered fold-out attached to the
+ * composer's own control row, replacing what used to be a standalone
+ * floating widget pinned to the canvas's bottom-left corner. That widget
+ * had no relationship to anything else on screen - an island, per the
+ * user's own description - and (before the App.tsx layout fix alongside
+ * it) didn't even know to get out of the way when Document View's docked
+ * panel opened. Folding it into the composer removes both problems at
+ * once: it's now part of the SAME control row as Reasoning/Model, so it
+ * reflows with everything else the composer already reflows with, and it
+ * only ever shows a compact total until hovered.
+ */
 export function TokenCounter({ store }: { store: ComposerStore }) {
   const counter = useSyncExternalStore(store.subscribe, store.getTokenCounter);
+  const [hovered, setHovered] = useState(false);
+
   return (
-    <div className="token-counter" aria-label="Token usage">
-      <span className="token-counter-row">
-        <span className="token-counter-label">Input</span>
-        <span className="token-counter-value">{counter.inputTokens}</span>
-      </span>
-      <span className="token-counter-row">
-        <span className="token-counter-label">Output</span>
-        <span className="token-counter-value">{counter.outputTokens}</span>
-      </span>
-      <span className="token-counter-row">
-        <span className="token-counter-label">Context</span>
-        <span className="token-counter-value">{counter.contextTokens}</span>
-      </span>
-      <span className="token-counter-row token-counter-total">
-        <span className="token-counter-label">Total</span>
-        <span className="token-counter-value">{counter.totalTokens}</span>
-      </span>
+    <div
+      className="token-counter-trigger"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <button
+        type="button"
+        className="composer-control token-counter-summary"
+        aria-haspopup="true"
+        aria-expanded={hovered}
+        aria-label={`Token usage: ${counter.totalTokens} total`}
+      >
+        <span className="control-kicker">Tokens</span>
+        <span className="control-value">{counter.totalTokens}</span>
+      </button>
+      {hovered && (
+        <div className="token-counter-popout" role="status" aria-label="Token usage breakdown">
+          <span className="token-counter-row">
+            <span className="token-counter-label">Input</span>
+            <span className="token-counter-value">{counter.inputTokens}</span>
+          </span>
+          <span className="token-counter-row">
+            <span className="token-counter-label">Output</span>
+            <span className="token-counter-value">{counter.outputTokens}</span>
+          </span>
+          <span className="token-counter-row">
+            <span className="token-counter-label">Context</span>
+            <span className="token-counter-value">{counter.contextTokens}</span>
+          </span>
+          <span className="token-counter-row token-counter-total">
+            <span className="token-counter-label">Total</span>
+            <span className="token-counter-value">{counter.totalTokens}</span>
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1341,31 +1341,24 @@ body,
 
 /* R8a: the composer used to be a <footer> spanning the full window width,
    docked flush at the bottom with no visual container of its own. It's now
-   a floating island - a sibling of app-token-counter-layer/
-   app-notification-layer inside app-canvas-region - so the canvas renders
-   full-bleed behind it.
+   a floating island - a sibling of app-notification-layer inside
+   app-canvas-region - so the canvas renders full-bleed behind it.
 
-   It shares the bottom-left and bottom-right corners with two other real
-   pieces of chrome (the token counter, the minimap), so its box reserves
-   REAL space on both sides rather than relying on a thin, easy-to-erode
-   margin: `left: 230px` clears the token counter's measured footprint
-   (16px inset + ~193px content + a real gap, not a bare few px), `right:
-   232px` clears the minimap's footprint (16px margin + 200px + 16px) the
-   same way. The card centers WITHIN that narrowed box via flex, not the
-   full viewport, so centering can never land it in territory either
-   neighbor already owns - a structural guarantee, not a tuned distance
-   that happens to work today. bottom:64px on top of that gives the
-   token-counter side a SECOND, independent vertical guarantee (its ~41px
-   height plus the 16px inset it shares with this layer still leaves real
-   clearance even if the horizontal reservation above were ever wrong).
-   And on both sides, --gl-z-canvas-hud gives the token counter and the
-   minimap themselves a THIRD guarantee: outranking every app-layer
-   surface regardless of position (see .scene-minimap's and
-   .app-token-counter-layer's own comments) - "should never be able to"
-   means no single mechanism carries that promise alone. pointer-
-   events:none on the layer + pointer-events:auto on the card keeps the
-   canvas clickable/draggable everywhere the card doesn't visually cover
-   it. */
+   It shares the bottom-right corner with one other real piece of chrome
+   (the minimap), so its box reserves REAL space rather than relying on a
+   thin, easy-to-erode margin: `right: 232px` clears the minimap's
+   footprint (16px margin + 200px + 16px). The card centers WITHIN that
+   narrowed box via flex, not the full viewport, so centering can never
+   land it on top of the minimap - a structural guarantee, not a tuned
+   distance that happens to work today. `left: 230px` is a symmetric
+   holdover from when the token counter was ALSO a standalone bottom-left
+   neighbor this box had to clear (R8a follow-up folded it into the
+   composer's own control row instead - see TokenCounter.tsx - so nothing
+   occupies that corner anymore); left unchanged since a slightly wider
+   left margin than strictly necessary today isn't a bug, and narrowing it
+   isn't part of this change. pointer-events:none on the layer + pointer-
+   events:auto on the card keeps the canvas clickable/draggable everywhere
+   the card doesn't visually cover it. */
 .app-composer-layer {
   position: absolute;
   left: 230px;
@@ -1714,22 +1707,39 @@ body,
   color: var(--gl-surface-text-muted);
 }
 
-.app-token-counter-layer {
-  position: absolute;
-  bottom: var(--gl-chrome-inset);
-  left: var(--gl-chrome-inset);
-  /* R8a: outranks the composer/app-layer tier, same reasoning as the
-     minimap - see .scene-minimap's own comment. */
-  z-index: var(--gl-z-canvas-hud);
+/* R8a follow-up: Token usage is now a hover fold-out living inside the
+   composer's own control row (TokenCounter.tsx), not a standalone widget
+   floating at the canvas's bottom-left corner - it no longer needs its
+   own positioned layer or z-index tier at all; it reflows with the
+   composer exactly like Reasoning/Model already do. */
+
+.token-counter-trigger {
+  position: relative;
+  display: flex;
 }
 
-.token-counter {
+.token-counter-summary .control-value {
+  min-width: 2ch;
+  text-align: right;
+}
+
+.token-counter-popout {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
   display: flex;
   gap: 12px;
-  padding: 6px 12px;
+  padding: 12px 14px;
   background-color: var(--gl-surface-node-body);
   border: 1px solid var(--gl-surface-border);
-  border-radius: 8px;
+  border-radius: 10px;
+  /* Same box-shadow as .overlay-popover's shared chrome (see that rule's
+     own comment + no-raw-colors.test.ts's pinned-literal ratchet) - this
+     popout intentionally looks like every other floating panel in the
+     app, it just isn't driven by the shared overlay system (a hover
+     fold-out has no "open surface" to register - see TokenCounter.tsx). */
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+  white-space: nowrap;
 }
 
 .token-counter-row {

--- a/web_ui/src/lib/no-raw-colors.test.ts
+++ b/web_ui/src/lib/no-raw-colors.test.ts
@@ -120,6 +120,11 @@ const PINNED_APP_CSS_LITERALS: Record<string, string[]> = {
     // color, so it's added to the ratchet rather than tokenized alone.
     "rgba(0, 0, 0, 0.45)",
     "rgba(0, 0, 0, 0.45)",
+    // R8a follow-up: .token-counter-popout's box-shadow - the Token usage
+    // hover fold-out (TokenCounter.tsx), same reasoning as the composer
+    // entries just above: reuses the SAME shared popover shadow rather
+    // than being tokenized alone.
+    "rgba(0, 0, 0, 0.45)",
     "rgba(0, 0, 0, 0.55)",
     "rgba(0, 0, 0, 0.45)",
     "rgba(0, 0, 0, 0.45)",


### PR DESCRIPTION
## Problem

Token usage was a standalone widget pinned to the canvas's bottom-left
corner, with no visual or structural relationship to anything else on
screen.

## Change

- `web_ui/src/app/chrome/TokenCounter.tsx`: rewritten as a hover
  fold-out. A compact total (`Tokens 0`, styled like the composer's own
  Reasoning/Model controls) is always visible; hovering reveals the
  full Input/Output/Context/Total breakdown in a popout, using the same
  visual chrome (background/border/shadow) every other floating panel
  in the app already uses.
- `web_ui/src/app/chrome/Composer.tsx`: renders `TokenCounter` inline in
  its own control row (between Model and the send group), gated by a
  new `showTokenCounter` prop (defaults `true`, so no other call site
  needed changes).
- `web_ui/src/app/App.tsx`: the standalone `.app-token-counter-layer`
  is gone; `showTokenCounter` now threads straight into `Composer`
  instead.
- `web_ui/src/app/styles.css`: removed the old floating-layer rules,
  added the trigger/popout chrome, reused the existing `.token-counter-row`
  /`-label`/`-value` classes for the breakdown rows unchanged.

## Test plan

- `npx tsc --noEmit`, `npx vitest run` (899 passed - Composer's own
  TokenCounter tests rewritten for the hover behavior instead of an
  always-visible one), `npx eslint .` (0 errors), `npx vite build` all
  clean from `web_ui/`.
- Verified in the running dev server: the standalone bottom-left widget
  is gone; the compact total renders inline in the composer; hovering
  it shows the full breakdown (Input/Output/Context/Total) in a popout
  positioned above the trigger, and it disappears on unhover. No
  console errors.
