### PR TITLE
Fix group/frame/container geometry, membership validation, and drag mechanics

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -221,6 +221,15 @@ GROUP_MEMBER_DEFAULT_WIDTH = 220.0
 GROUP_MEMBER_DEFAULT_HEIGHT = 120.0
 GROUP_COLLAPSED_WIDTH = 260.0
 GROUP_COLLAPSED_HEIGHT = 50.0
+# create_frame's member-kind allowlist gate, as an EXCLUDE-list rather than
+# an allowlist of the ~12 leaf content kinds: legacy's own createFrame only
+# ever accepted leaf content nodes (never a Note, never another Frame or
+# Container - see graphlink_scene.py's own selection filter), which this
+# reproduces the semantics of without needing to enumerate (and keep in
+# sync with) every current or future leaf kind. create_container has no
+# equivalent restriction - container membership can legitimately nest
+# (a container may hold another container or a frame).
+GROUP_INELIGIBLE_FRAME_MEMBER_KINDS = frozenset({"note", "frame", "container"})
 
 # R6.2: Chart node - legacy ChartItem's own MIN_WIDTH/MIN_HEIGHT/MAX_WIDTH/
 # MAX_HEIGHT bounds, enforced server-side by resize_chart below (the
@@ -589,6 +598,22 @@ class SceneNode:
     # no manual-resize capability (no resize_container method exists).
     group_manual_width: float | None = None
     group_manual_height: float | None = None
+    # frame kind only - the position counterpart to group_manual_width/
+    # height above: set by move_node whenever a frame is dragged directly
+    # (locked whole-group drag OR an independently-dragged unlocked frame),
+    # cleared back to None by fit_frame_to_content. Exists so an unlocked
+    # frame's own drag actually sticks - without an explicit anchor, the
+    # very next member move would recompute the frame straight back to
+    # bbox-of-members-centered, silently undoing the drag (legacy let an
+    # unlocked frame's outline be repositioned independently of its
+    # members; this is that same capability, ported). See
+    # _recompute_group_bounds for how this anchor is unioned with the live
+    # bbox so it still can never clip a member, matching legacy's own
+    # rect.united() guarantee. Same wire/kind-scoping posture as
+    # group_manual_width/height above (server-side only, unused for
+    # container).
+    group_manual_x: float | None = None
+    group_manual_y: float | None = None
     # frame/container's current effective on-canvas size, kept live by
     # _recompute_group_bounds: the fixed GROUP_COLLAPSED_WIDTH/HEIGHT pill
     # while is_collapsed, else group_manual_width/height verbatim while a
@@ -1858,6 +1883,24 @@ class SceneDocument:
         height = (bottom - top) + GROUP_PADDING_TOP + GROUP_PADDING
         return x, y, width, height
 
+    @staticmethod
+    def _union_rect(
+        a: tuple[float, float, float, float], b: tuple[float, float, float, float]
+    ) -> tuple[float, float, float, float]:
+        """The smallest (x, y, width, height) rect that fully contains both
+        inputs - legacy's own QRectF.united(), ported. The single primitive
+        _recompute_group_bounds uses to guarantee a frame's manual size
+        and/or manually-dragged position never clips a member: whichever
+        direction the live content has drifted, the result grows to cover
+        it, never shrinks below either input."""
+        ax, ay, aw, ah = a
+        bx, by, bw, bh = b
+        left = min(ax, bx)
+        top = min(ay, by)
+        right = max(ax + aw, bx + bw)
+        bottom = max(ay + ah, by + bh)
+        return left, top, right - left, bottom - top
+
     def _recompute_group_bounds(self, node_id: str) -> None:
         """The core "legacy never clips, always auto-grows to enclose
         members" recompute - plain server-side math, NOT a React Flow
@@ -1866,17 +1909,25 @@ class SceneDocument:
         only ever calls this with a live frame/container id, but a caller
         that races a delete must never crash here).
 
-        Three cases, in priority order:
+        Priority order:
         1. Collapsed: skip the bbox computation entirely, snap to the fixed
            GROUP_COLLAPSED_WIDTH/HEIGHT pill size. x/y are left untouched -
            a collapsed pill stays wherever it was expanded from.
-        2. Frame with a manual size override (group_manual_width/height both
-           set): the override's WIDTH/HEIGHT stay exactly as manually set,
-           but x/y still re-centers so the manually-sized rect stays
-           centered on the live bbox-of-members center point.
-        3. Otherwise (auto-fit - every container, and every frame with no
-           override): x/y/width/height all come straight from the padded
-           bbox-of-members.
+        2. Frame with a manual size override and/or a manually-dragged
+           position (group_manual_width/height and/or group_manual_x/y
+           set): build a rect from whichever of those four are set (falling
+           back to the frame's current group_width/height for an unset
+           size, or the live bbox-of-members' own center for an unset
+           position), then UNION that rect with the live bbox-of-members -
+           never just substitute it. This is what makes both a manual
+           resize AND an independent drag stick (survive the very next
+           member move) without ever letting a member visually escape the
+           frame: if the live content has grown past the manual rect on any
+           edge, the union grows to re-enclose it instead of clipping or
+           silently reverting to bbox-centering.
+        3. Otherwise (auto-fit - every container, and every frame with
+           nothing manual set): x/y/width/height come straight from the
+           padded bbox-of-members.
         """
         node = self.nodes.get(node_id)
         if node is None or node.kind not in ("frame", "container"):
@@ -1885,16 +1936,26 @@ class SceneDocument:
             node.group_width = GROUP_COLLAPSED_WIDTH
             node.group_height = GROUP_COLLAPSED_HEIGHT
             return
-        if node.kind == "frame" and node.group_manual_width is not None and node.group_manual_height is not None:
-            bx, by, bw, bh = self._bbox_of_members(node.item_ids)
-            center_x, center_y = bx + bw / 2.0, by + bh / 2.0
-            node.group_width = node.group_manual_width
-            node.group_height = node.group_manual_height
-            node.x = center_x - node.group_width / 2.0
-            node.y = center_y - node.group_height / 2.0
+        bx, by, bw, bh = self._bbox_of_members(node.item_ids)
+        has_manual = node.kind == "frame" and (
+            node.group_manual_width is not None
+            or node.group_manual_height is not None
+            or node.group_manual_x is not None
+            or node.group_manual_y is not None
+        )
+        if has_manual:
+            width = node.group_manual_width if node.group_manual_width is not None else (node.group_width or bw)
+            height = node.group_manual_height if node.group_manual_height is not None else (node.group_height or bh)
+            if node.group_manual_x is not None and node.group_manual_y is not None:
+                anchor_x, anchor_y = node.group_manual_x, node.group_manual_y
+            else:
+                anchor_x = bx + bw / 2.0 - width / 2.0
+                anchor_y = by + bh / 2.0 - height / 2.0
+            node.x, node.y, node.group_width, node.group_height = self._union_rect(
+                (anchor_x, anchor_y, width, height), (bx, by, bw, bh)
+            )
             return
-        x, y, width, height = self._bbox_of_members(node.item_ids)
-        node.x, node.y, node.group_width, node.group_height = x, y, width, height
+        node.x, node.y, node.group_width, node.group_height = bx, by, bw, bh
 
     def _detach_from_existing_group(self, member_id: str, group_kind: str) -> None:
         """Part of create_frame/create_container's shared validation: if
@@ -1920,16 +1981,28 @@ class SceneDocument:
 
     def create_frame(self, item_ids: list[str]) -> SceneNode:
         """Group an existing set of nodes into a new frame. Validates every
-        id exists BEFORE any mutation (fail fast, no partial detach), then
-        detaches each from any frame it was already a member of (see
+        id exists AND is an eligible leaf-content kind BEFORE any mutation
+        (fail fast, no partial detach) - GROUP_INELIGIBLE_FRAME_MEMBER_KINDS
+        rejects a note or another frame/container, matching legacy's own
+        createFrame selection filter (frames never nest, and never absorb a
+        note - a note member would also be silently dropped from this
+        frame's own membership on save/reload, since frame_source_map has
+        no slot for one; see session_save.py). Then detaches each surviving
+        candidate from any frame it was already a member of (see
         _detach_from_existing_group). is_locked defaults True (the legacy
         frame default - locked). Initial x/y/width/height come from the
         padded bbox-of-members, computed immediately via
         _recompute_group_bounds right after construction."""
         ids = list(item_ids)
         for member_id in ids:
-            if member_id not in self.nodes:
+            member = self.nodes.get(member_id)
+            if member is None:
                 raise SceneError(f"unknown member node: {member_id}")
+            if member.kind in GROUP_INELIGIBLE_FRAME_MEMBER_KINDS:
+                raise SceneError(
+                    f"node {member_id} (kind={member.kind!r}) cannot be a frame member - "
+                    f"frames only group leaf content nodes, never a note or another frame/container"
+                )
         for member_id in ids:
             self._detach_from_existing_group(member_id, "frame")
         node_id = f"n{next(self._counter)}"
@@ -2054,9 +2127,13 @@ class SceneDocument:
         self._recompute_group_bounds(node_id)
 
     def fit_frame_to_content(self, node_id: str) -> None:
-        """Frame kind only. Clears the manual size override back to None
-        (auto-fit) and forces an immediate bbox recompute - the exact
-        inverse of resize_frame."""
+        """Frame kind only. Clears BOTH the manual size override (set by
+        resize_frame) AND the manual position anchor (set by move_node
+        whenever this frame was dragged directly - see that method's own
+        comment) back to None, a full reset to pure auto-fit, then forces
+        an immediate bbox recompute. The size half is the exact inverse of
+        resize_frame; the position half is what makes this button also undo
+        an independent unlocked-frame drag, not just a resize."""
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
@@ -2064,6 +2141,8 @@ class SceneDocument:
             raise SceneError(f"node is not a frame node: {node_id}")
         node.group_manual_width = None
         node.group_manual_height = None
+        node.group_manual_x = None
+        node.group_manual_y = None
         self._recompute_group_bounds(node_id)
 
     def ungroup(self, node_id: str) -> None:
@@ -2592,6 +2671,20 @@ class SceneDocument:
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
         node.x, node.y = float(x), float(y)
+        if node.kind == "frame":
+            # R6.1 follow-up: dragging a frame directly - a locked whole-
+            # group drag (the frontend commits the frame's own position
+            # before its members') OR an unlocked frame dragged
+            # independently of its members - pins an explicit position
+            # anchor. Without this, the very next member move would
+            # recompute this frame straight back to bbox-of-members-
+            # centered, silently undoing the drag. Harmless for a locked
+            # drag: members move by the identical delta, so the anchor and
+            # the live bbox stay in agreement. See _recompute_group_bounds
+            # for how this anchor is unioned with live content so it still
+            # can never clip a member.
+            node.group_manual_x, node.group_manual_y = node.x, node.y
+            self._recompute_group_bounds(node_id)
         # R6.1: keep every frame/container this node is a member of enclosing
         # it - a node is a member of at most one frame AND at most one
         # container simultaneously (see item_ids's own field comment), so

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -5122,6 +5122,53 @@ def test_create_container_validates_membership():
         doc.create_container(["ghost"])
 
 
+def test_create_frame_rejects_a_note_member():
+    # Regression test: create_frame used to only check that member ids
+    # existed, no kind restriction at all - legacy's own createFrame only
+    # ever accepted leaf content nodes, never a note. A note member would
+    # also be silently dropped from serialization (frame_source_map has no
+    # slot for one - see session_save.py), so rejecting it at creation
+    # time is the real fix, not a cosmetic parity detail.
+    doc = SceneDocument()
+    note = doc.add_note(0, 0)
+    with pytest.raises(SceneError):
+        doc.create_frame([note.id])
+    assert all(n.kind != "frame" for n in doc.nodes.values())
+
+
+def test_create_frame_rejects_a_frame_member():
+    # Legacy frames never nest (only Container can hold another
+    # Container/Frame) - create_frame used to allow this with nothing
+    # stopping it, and the frontend's drag cascade doesn't recurse into a
+    # frame member either, so a frame-in-frame would visibly desync from
+    # its own contents the moment the outer frame was dragged.
+    doc = SceneDocument()
+    m1 = doc.add_node(0, 0)
+    inner_frame = doc.create_frame([m1.id])
+    m2 = doc.add_node(300, 300)
+    with pytest.raises(SceneError):
+        doc.create_frame([inner_frame.id, m2.id])
+
+
+def test_create_frame_rejects_a_container_member():
+    doc = SceneDocument()
+    m1 = doc.add_node(0, 0)
+    container = doc.create_container([m1.id])
+    m2 = doc.add_node(300, 300)
+    with pytest.raises(SceneError):
+        doc.create_frame([container.id, m2.id])
+
+
+def test_create_container_still_accepts_a_note_member():
+    # Unlike create_frame above, containers were never restricted this way
+    # - confirm the new create_frame validation didn't accidentally leak
+    # into create_container.
+    doc = SceneDocument()
+    note = doc.add_note(0, 0)
+    container = doc.create_container([note.id])
+    assert container.item_ids == [note.id]
+
+
 def test_create_frame_sets_correct_defaults_and_initial_bbox():
     doc = SceneDocument()
     m1 = doc.add_node(0, 0)
@@ -5312,7 +5359,14 @@ def test_resize_frame_clamps_below_bbox_minimum():
     assert node.group_height == pytest.approx(510.0), "must clamp up to the auto-fit bbox height"
 
 
-def test_resize_frame_manual_override_survives_a_member_move():
+def test_resize_frame_grows_to_re_enclose_a_member_that_moves_far_outside_it():
+    # Regression test: _recompute_group_bounds used to keep the manual
+    # size FROZEN regardless of where members currently are, contradicting
+    # its own docstring's claim of "legacy never clips, always auto-grows
+    # to enclose members" - a member could move and visibly escape a
+    # manually-sized frame with nothing correcting for it. It must now
+    # grow (union with the live bbox), never stay smaller than the current
+    # content actually needs.
     doc = SceneDocument()
     m1, m2 = doc.add_node(0, 0), doc.add_node(300, 300)
     frame = doc.create_frame([m1.id, m2.id])
@@ -5321,12 +5375,122 @@ def test_resize_frame_manual_override_survives_a_member_move():
     doc.move_node(m2.id, 1000, 1000)
 
     node = doc.nodes[frame.id]
-    assert node.group_width == 800.0, "manual size must survive a member move"
-    assert node.group_height == 700.0
-    # New bbox-of-members center after the move: bbox is x=-40,y=-50,
-    # w=1300,h=1210 -> center (610, 555).
-    assert node.x == pytest.approx(610.0 - 400.0)
-    assert node.y == pytest.approx(555.0 - 350.0)
+    # The member moved far enough that the live auto-fit bbox (x=-40,
+    # y=-50, w=1300, h=1210) now fully contains the old manual-size rect
+    # (which was centered on the OLD bbox) - the union collapses to
+    # exactly the live bbox, i.e. it grew all the way back to auto-fit
+    # rather than clipping the member outside a frozen 800x700 box.
+    assert node.x == pytest.approx(-40.0)
+    assert node.y == pytest.approx(-50.0)
+    assert node.group_width == pytest.approx(1300.0)
+    assert node.group_height == pytest.approx(1210.0)
+
+
+def test_resize_frame_grows_only_the_axis_that_actually_needs_it():
+    # A subtler case than the "grows all the way back to auto-fit" test
+    # above: a smaller move that only pushes the live bbox past the
+    # manual rect on SOME edges, not all - the union must grow only what's
+    # actually needed per axis, not discard the manual size entirely.
+    doc = SceneDocument()
+    m1, m2 = doc.add_node(0, 0), doc.add_node(300, 300)
+    frame = doc.create_frame([m1.id, m2.id])
+    doc.resize_frame(frame.id, 800, 700)
+
+    doc.move_node(m2.id, 600, 300)  # only x moves further out; y unchanged
+
+    node = doc.nodes[frame.id]
+    # Live bbox after the move: x=-40, y=-50, w=900, h=510 (wider than
+    # before, same height). Manual-size rect re-anchored on this bbox's
+    # own center: x=10, y=-145, w=800, h=700. Union of the two:
+    # left=min(10,-40)=-40, top=min(-145,-50)=-145,
+    # right=max(810,860)=860, bottom=max(555,460)=555.
+    assert node.x == pytest.approx(-40.0)
+    assert node.y == pytest.approx(-145.0)
+    assert node.group_width == pytest.approx(900.0)
+    assert node.group_height == pytest.approx(700.0)
+
+
+def test_moving_a_frame_directly_pins_a_manual_position_anchor():
+    # Restores legacy's "an unlocked frame can be dragged independently of
+    # its members" capability: without this, dragging a frame (locked
+    # whole-group drag, or an unlocked frame moved on its own) was
+    # immediately meaningless - the very next member move recomputed the
+    # frame straight back to bbox-of-members-centered. move_node now pins
+    # group_manual_x/y and recomputes immediately, so the box unions the
+    # drag target with the still-distant members instead of discarding it.
+    doc = SceneDocument()
+    m1, m2 = doc.add_node(0, 0), doc.add_node(300, 300)
+    frame = doc.create_frame([m1.id, m2.id])
+
+    doc.move_node(frame.id, 100, 100)
+
+    node = doc.nodes[frame.id]
+    assert node.group_manual_x == pytest.approx(100.0)
+    assert node.group_manual_y == pytest.approx(100.0)
+    # Anchor rect (100,100,600,510) unioned with the untouched member bbox
+    # (-40,-50,600,510): left=min(100,-40)=-40, top=min(100,-50)=-50,
+    # right=max(700,560)=700, bottom=max(610,460)=610.
+    assert node.x == pytest.approx(-40.0)
+    assert node.y == pytest.approx(-50.0)
+    assert node.group_width == pytest.approx(740.0)
+    assert node.group_height == pytest.approx(660.0)
+
+
+def test_manual_position_anchor_survives_a_member_move_and_still_grows():
+    doc = SceneDocument()
+    m1, m2 = doc.add_node(0, 0), doc.add_node(300, 300)
+    frame = doc.create_frame([m1.id, m2.id])
+    doc.move_node(frame.id, 100, 100)
+
+    doc.move_node(m1.id, 0, 700)
+
+    node = doc.nodes[frame.id]
+    # The anchor (100, 100) must NOT have reverted to bbox-centering just
+    # because a member moved - it's still the position basis, unioned with
+    # the new live bbox: m1(0,700)-(220,820), m2(300,300)-(520,420) ->
+    # bbox x=-40,y=250,w=600,h=610. Anchor rect (100,100,740,660) union
+    # bbox (-40,250,600,610): left=min(100,-40)=-40, top=min(100,250)=100,
+    # right=max(840,560)=840, bottom=max(760,860)=860.
+    assert node.group_manual_x == pytest.approx(100.0)
+    assert node.group_manual_y == pytest.approx(100.0)
+    assert node.x == pytest.approx(-40.0)
+    assert node.y == pytest.approx(100.0)
+    assert node.group_width == pytest.approx(880.0)
+    assert node.group_height == pytest.approx(760.0)
+
+
+def test_fit_frame_to_content_clears_manual_position_anchor_too():
+    doc = SceneDocument()
+    m1, m2 = doc.add_node(0, 0), doc.add_node(300, 300)
+    frame = doc.create_frame([m1.id, m2.id])
+    doc.move_node(frame.id, 100, 100)
+
+    doc.fit_frame_to_content(frame.id)
+
+    node = doc.nodes[frame.id]
+    assert node.group_manual_x is None
+    assert node.group_manual_y is None
+    # Back to a pure auto-fit bbox of the (untouched) members.
+    assert node.x == pytest.approx(-40.0)
+    assert node.y == pytest.approx(-50.0)
+    assert node.group_width == pytest.approx(600.0)
+    assert node.group_height == pytest.approx(510.0)
+
+
+def test_moving_a_container_does_not_pin_a_manual_position_anchor():
+    # Containers have no manual-position concept, matching legacy (no lock,
+    # no independent-drag distinction for Container - it always owns and
+    # moves its children as one unit) and mirroring how group_manual_width/
+    # height are already frame-only.
+    doc = SceneDocument()
+    m1 = doc.add_node(0, 0)
+    container = doc.create_container([m1.id])
+
+    doc.move_node(container.id, 100, 100)
+
+    node = doc.nodes[container.id]
+    assert node.group_manual_x is None
+    assert node.group_manual_y is None
 
 
 def test_fit_frame_to_content_clears_manual_override():

--- a/web_ui/src/app/canvas/GroupNodeView.test.tsx
+++ b/web_ui/src/app/canvas/GroupNodeView.test.tsx
@@ -23,6 +23,7 @@ function renderGroupNode(overrides: Partial<GroupFlowNode["data"]> = {}) {
       isCollapsed: false,
       isLocked: true,
       itemIds: ["n1", "n2"],
+      memberKinds: ["chat", "chat"],
       onSetLabel,
       onToggleCollapsed,
       onToggleLock,
@@ -144,5 +145,58 @@ describe("GroupNodeView (container)", () => {
   it("never renders a Fit to Content button for kind=container (frame-only)", () => {
     renderGroupNode({ groupKind: "container" });
     expect(screen.queryByRole("button", { name: "Fit to Content" })).toBeNull();
+  });
+});
+
+describe("GroupNodeView collapsed-container hover preview (R6.1 follow-up)", () => {
+  it("shows a member-count + kind-breakdown tooltip on hover when collapsed", () => {
+    const { container } = renderGroupNode({
+      groupKind: "container",
+      isCollapsed: true,
+      memberKinds: ["chat", "chat", "code"],
+    });
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    fireEvent.mouseEnter(container.querySelector(".group-node")!);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    expect(screen.getByText("3 items")).toBeInTheDocument();
+    expect(screen.getByText("chat x2, code")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(container.querySelector(".group-node")!);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("does not show the preview for a frame, even when collapsed and hovered (container-only, matching legacy)", () => {
+    const { container } = renderGroupNode({
+      groupKind: "frame",
+      isCollapsed: true,
+      memberKinds: ["chat"],
+    });
+
+    fireEvent.mouseEnter(container.querySelector(".group-node")!);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("does not show the preview for an EXPANDED container, even when hovered", () => {
+    const { container } = renderGroupNode({
+      groupKind: "container",
+      isCollapsed: false,
+      memberKinds: ["chat"],
+    });
+
+    fireEvent.mouseEnter(container.querySelector(".group-node")!);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("does not show the preview for an empty container", () => {
+    const { container } = renderGroupNode({
+      groupKind: "container",
+      isCollapsed: true,
+      memberKinds: [],
+    });
+
+    fireEvent.mouseEnter(container.querySelector(".group-node")!);
+    expect(screen.queryByRole("tooltip")).toBeNull();
   });
 });

--- a/web_ui/src/app/canvas/GroupNodeView.tsx
+++ b/web_ui/src/app/canvas/GroupNodeView.tsx
@@ -21,8 +21,9 @@ import { GROUP_RESIZE_MIN_HEIGHT, GROUP_RESIZE_MIN_WIDTH } from "./canvasConstan
  * children - see that same backend comment for why this is the deliberate,
  * simpler equivalent of legacy's "auto-grow, never clip" behavior) - so
  * paint order alone is what keeps this box visually behind its members:
- * SceneCanvas.tsx's toFlowNodes sets zIndex:-1 on every frame/container flow
- * node for exactly that.
+ * SceneCanvas.tsx's toFlowNodes sets zIndex to -1 for a frame and -2 for a
+ * container (container further back, matching legacy's own relative
+ * ordering) for exactly that.
  *
  * Sizing: `width`/`height` are set on the FLOW NODE OBJECT itself (not just
  * inside `data`) in SceneCanvas.tsx's toFlowNodes - the documented xyflow
@@ -32,11 +33,19 @@ import { GROUP_RESIZE_MIN_HEIGHT, GROUP_RESIZE_MIN_WIDTH } from "./canvasConstan
  *
  * Drag: a locked frame's (or any container's) own body is the intentional
  * group-drag handle - see SceneCanvas.tsx's onNodesChange for the delta
- * application to itemIds members. An UNLOCKED frame has draggable:false set
- * on its flow node (also in toFlowNodes) - a deliberate simplification vs.
- * legacy's own "unlocked frame can still be dragged independently" behavior,
- * confirmed as not worth preserving; its position is entirely server-
- * computed from its members either way.
+ * application to itemIds members, which now cascades recursively into any
+ * member that is itself a group (container-of-container, or a frame nested
+ * inside a container). An UNLOCKED frame is ALSO draggable (restored,
+ * matching legacy's own "an unlocked frame can be dragged independently of
+ * its members" behavior) - it just doesn't carry members along; see
+ * groupDragKindOf in SceneCanvas.tsx, which gates the member cascade on
+ * lock state, not draggability itself.
+ *
+ * Collapsed container hover preview: a simplified equivalent of legacy's
+ * timer-based "ghost frame" (a rendered miniature preview of expanded
+ * contents on hover, without actually expanding). This shows a lightweight
+ * tooltip listing member count and kinds instead of a full content
+ * render - container-only, matching legacy (frames never had this).
  */
 
 export interface GroupNodeData extends Record<string, unknown> {
@@ -47,6 +56,7 @@ export interface GroupNodeData extends Record<string, unknown> {
   isCollapsed: boolean;
   isLocked: boolean;
   itemIds: string[];
+  memberKinds: string[];
   onSetLabel: (text: string) => void;
   onToggleCollapsed: () => void;
   onToggleLock: () => void;
@@ -65,6 +75,8 @@ export function GroupNodeView({ id, data, selected }: NodeProps<GroupFlowNode>) 
   // Same "programmatic unmount fires a redundant blur" guard as
   // NoteNodeView's own editor - see that component's doc comment.
   const skipBlurRef = useRef(false);
+  const [hovered, setHovered] = useState(false);
+  const showGhostPreview = !isFrame && data.isCollapsed && hovered && data.memberKinds.length > 0;
 
   function beginEdit() {
     setDraft(data.label);
@@ -110,7 +122,10 @@ export function GroupNodeView({ id, data, selected }: NodeProps<GroupFlowNode>) 
         (data.isCollapsed ? " collapsed" : "")
       }
       style={{ width: "100%", height: "100%", backgroundColor: data.color ?? undefined }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
+      {showGhostPreview && <GhostPreview memberKinds={data.memberKinds} />}
       <NodeResizer
         nodeId={id}
         isVisible={isFrame && !data.isCollapsed}
@@ -156,6 +171,27 @@ export function GroupNodeView({ id, data, selected }: NodeProps<GroupFlowNode>) 
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+// R6.1 follow-up: the simplified ghost-preview tooltip - member count plus
+// a per-kind breakdown ("3 items: chat x2, code x1"), not a rendered
+// miniature of each member's actual content the way legacy's real
+// ghost-frame preview was. Kinds are counted (not listed one-by-one) since
+// a container can easily hold a dozen+ members - a flat list would be
+// noisier than useful at that size.
+function GhostPreview({ memberKinds }: { memberKinds: string[] }) {
+  const counts = new Map<string, number>();
+  for (const kind of memberKinds) counts.set(kind, (counts.get(kind) ?? 0) + 1);
+  const breakdown = [...counts.entries()].map(([kind, count]) => `${kind}${count > 1 ? ` x${count}` : ""}`);
+
+  return (
+    <div className="group-node-ghost-preview nodrag" role="tooltip">
+      <span className="group-node-ghost-preview-count">
+        {memberKinds.length} item{memberKinds.length === 1 ? "" : "s"}
+      </span>
+      <span className="group-node-ghost-preview-breakdown">{breakdown.join(", ")}</span>
     </div>
   );
 }

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -1207,7 +1207,7 @@ describe("toFlowNodes (R6.1 frame/container nodes)", () => {
     });
   });
 
-  it("an UNLOCKED frame gets draggable:false", () => {
+  it("an UNLOCKED frame is STILL draggable:true (R6.1 follow-up: restores independent-of-members dragging)", () => {
     const scene = baseScene({
       nodes: [groupNode({ id: "frame-1", kind: "frame", isLocked: false, groupWidth: 300, groupHeight: 200 })],
       edges: [],
@@ -1216,7 +1216,10 @@ describe("toFlowNodes (R6.1 frame/container nodes)", () => {
 
     const flowNodes = toFlowNodes(scene, store);
     const frameFlowNode = flowNodes.find((n) => n.id === "frame-1");
-    expect(frameFlowNode!.draggable).toBe(false);
+    // Draggable regardless of lock state now - groupDragKindOf (tested
+    // separately below) is what gates whether a drag carries members
+    // along, not whether the frame can be dragged at all.
+    expect(frameFlowNode!.draggable).toBe(true);
   });
 
   it("a container is ALWAYS draggable regardless of isLocked (containers have no lock concept)", () => {
@@ -1233,6 +1236,37 @@ describe("toFlowNodes (R6.1 frame/container nodes)", () => {
     expect(containerFlowNode!.type).toBe("container");
     expect(containerFlowNode!.draggable).toBe(true);
     expect((containerFlowNode!.data as { groupKind: string }).groupKind).toBe("container");
+  });
+
+  it("a container's zIndex sits BEHIND a frame's (-2 vs -1), so a nested frame-in-container stacks correctly", () => {
+    const scene = baseScene({
+      nodes: [
+        groupNode({ id: "frame-1", kind: "frame", groupWidth: 300, groupHeight: 200 }),
+        groupNode({ id: "container-1", kind: "container", groupWidth: 300, groupHeight: 200 }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    expect(flowNodes.find((n) => n.id === "frame-1")!.zIndex).toBe(-1);
+    expect(flowNodes.find((n) => n.id === "container-1")!.zIndex).toBe(-2);
+  });
+
+  it("computes memberKinds from the current member nodes, skipping a stale/dangling item id", () => {
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "m1", kind: "chat" }),
+        baseNode({ id: "m2", kind: "code" }),
+        groupNode({ id: "container-1", kind: "container", itemIds: ["m1", "m2", "gone"] }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const data = flowNodes.find((n) => n.id === "container-1")!.data as { memberKinds: string[] };
+    expect(data.memberKinds).toEqual(["chat", "code"]);
   });
 
   it("falls back to GROUP_FALLBACK_WIDTH/HEIGHT when groupWidth/groupHeight are null", () => {
@@ -1632,6 +1666,60 @@ describe("applyGroupDragDelta (R6.1 group-drag)", () => {
       } as unknown as SceneFlowNode,
     ];
     expect(applyGroupDragDelta(nodes, "frame-1", { x: 10, y: 10 })).toEqual([]);
+  });
+
+  it("R6.1 follow-up: dragging an outer container cascades into a NESTED group's own members too", () => {
+    // Regression test: applyGroupDragDelta used to only shift a dragged
+    // group's DIRECT itemIds by a flat delta - if a member was itself a
+    // group (container-of-container, or a frame nested inside a
+    // container), that inner group's own members never moved, visibly
+    // desyncing it from its own contents. Nesting is legitimately
+    // possible (create_container has no kind restriction).
+    const nodes: SceneFlowNode[] = [
+      {
+        id: "outer-container",
+        type: "container",
+        position: { x: 0, y: 0 },
+        data: { itemIds: ["inner-frame"] },
+      } as unknown as SceneFlowNode,
+      {
+        id: "inner-frame",
+        type: "frame",
+        position: { x: 50, y: 50 },
+        data: { isLocked: true, itemIds: ["leaf-1"] },
+      } as unknown as SceneFlowNode,
+      { id: "leaf-1", type: "chat", position: { x: 70, y: 90 }, data: {} } as unknown as SceneFlowNode,
+    ];
+
+    // The outer container moved from (0,0) to (10,20): delta (10,20).
+    const changes = applyGroupDragDelta(nodes, "outer-container", { x: 10, y: 20 });
+
+    const byId = new Map(
+      (changes as unknown as Array<{ id: string; position: { x: number; y: number } }>).map((c) => [c.id, c]),
+    );
+    expect(byId.size).toBe(2);
+    expect(byId.get("inner-frame")!.position).toEqual({ x: 60, y: 70 });
+    // The innermost leaf moved by the SAME delta too, not left behind.
+    expect(byId.get("leaf-1")!.position).toEqual({ x: 80, y: 110 });
+  });
+
+  it("R6.1 follow-up: a cycle in group membership never infinite-loops (defensive - creation-time validation should prevent this)", () => {
+    const nodes: SceneFlowNode[] = [
+      {
+        id: "container-a",
+        type: "container",
+        position: { x: 0, y: 0 },
+        data: { itemIds: ["container-b"] },
+      } as unknown as SceneFlowNode,
+      {
+        id: "container-b",
+        type: "container",
+        position: { x: 10, y: 10 },
+        data: { itemIds: ["container-a"] },
+      } as unknown as SceneFlowNode,
+    ];
+
+    expect(() => applyGroupDragDelta(nodes, "container-a", { x: 5, y: 5 })).not.toThrow();
   });
 });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -869,12 +869,18 @@ export function toFlowNodes(
       continue;
     }
     if (n.kind === "frame" || n.kind === "container") {
-      // R6.1: rendered BEHIND every other node (zIndex:-1 - React Flow paints
-      // in ascending zIndex order) since members are ordinary top-level flow
-      // nodes at their own absolute positions, never React Flow
-      // parentId/extent children of this node - see GroupNodeView.tsx's own
-      // module doc for why that is the deliberate, simpler equivalent of
-      // legacy's "auto-grow to enclose, never clip" behavior.
+      // R6.1/R6.1 follow-up: rendered BEHIND every other node (zIndex < 0 -
+      // React Flow paints in ascending zIndex order) since members are
+      // ordinary top-level flow nodes at their own absolute positions,
+      // never React Flow parentId/extent children of this node - see
+      // GroupNodeView.tsx's own module doc for why that is the deliberate,
+      // simpler equivalent of legacy's "auto-grow to enclose, never clip"
+      // behavior. Container sits BEHIND frame (-2 vs -1), matching
+      // legacy's own relative z-ordering (Frame=-2, Container=-3 there) -
+      // container membership can nest a frame inside it (create_container
+      // has no kind restriction, unlike create_frame), so without this
+      // distinction a nested frame would have undefined stacking against
+      // its own parent container's background.
       //
       // width/height are set on the FLOW NODE OBJECT itself (not just inside
       // `data`) - the documented xyflow mechanism that lets <NodeResizer/>
@@ -883,13 +889,12 @@ export function toFlowNodes(
       // GROUP_FALLBACK_WIDTH/HEIGHT covers the (should-be-unreachable, see
       // canvasConstants.ts) case of a null groupWidth/groupHeight.
       //
-      // draggable: an unlocked frame gets draggable:false (a deliberate
-      // simplification vs. legacy's own independently-draggable-when-
-      // unlocked behavior, confirmed as not worth preserving - see
-      // GroupNodeView.tsx's doc) - every locked frame and every container
-      // (which has no lock concept, always drags as a group) stays
-      // draggable, and its own onNodesChange drag carries its itemIds
-      // members along by the identical delta (see onNodesChange below).
+      // draggable: always true now (R6.1 follow-up restores legacy's own
+      // "an unlocked frame can still be dragged independently of its
+      // members" behavior - see groupDragKindOf/applyGroupDragDelta below,
+      // which gate the MEMBER-cascade on lock state, not draggability
+      // itself; backend/canvas.py's move_node pins a manual position
+      // anchor so the drag actually sticks instead of snapping back).
       const group = n as SceneNodeRowWithGroups;
       flowNodes.push({
         id: n.id,
@@ -897,8 +902,8 @@ export function toFlowNodes(
         position: { x: n.x, y: n.y },
         width: group.groupWidth ?? GROUP_FALLBACK_WIDTH,
         height: group.groupHeight ?? GROUP_FALLBACK_HEIGHT,
-        zIndex: -1,
-        draggable: n.kind === "container" || group.isLocked,
+        zIndex: n.kind === "container" ? -2 : -1,
+        draggable: true,
         data: {
           groupKind: n.kind,
           label: n.content,
@@ -907,6 +912,14 @@ export function toFlowNodes(
           isCollapsed: n.isCollapsed,
           isLocked: group.isLocked,
           itemIds: group.itemIds,
+          // R6.1 follow-up: a simplified equivalent of legacy's collapsed-
+          // container hover "ghost frame" preview - just member kinds, not
+          // a rendered miniature of actual content. Looked up from the
+          // SAME nodesById map the dockedChildren computation above
+          // already builds once per call; a stale/dangling item_ids entry
+          // (a member deleted out from under a group) is silently skipped,
+          // matching _bbox_of_members' own posture on the backend.
+          memberKinds: group.itemIds.map((id) => nodesById.get(id)?.kind).filter((kind): kind is string => !!kind),
           onSetLabel: (text: string) => store.setGroupLabel(n.id, text),
           onToggleCollapsed: () => store.toggleGroupCollapsed(n.id),
           onToggleLock: () => store.toggleFrameLock(n.id),
@@ -1005,19 +1018,72 @@ export function applyGroupDragDelta(
   if (!groupDragKindOf(draggedNode) || !draggedNode) return [];
   const deltaX = scaledPosition.x - draggedNode.position.x;
   const deltaY = scaledPosition.y - draggedNode.position.y;
-  const itemIds = (draggedNode.data as { itemIds?: string[] }).itemIds ?? [];
-  const memberChanges: NodeChange<SceneFlowNode>[] = [];
+  return collectGroupMemberDeltaChanges(nodes, draggedNode, deltaX, deltaY, new Set([draggedId]));
+}
+
+// R6.1 follow-up: recurses into any member that is itself a group (a
+// container nesting a frame or another container - create_container has
+// no kind restriction, unlike create_frame - see backend/canvas.py's own
+// docstrings), so dragging the OUTER group carries the FULL nested tree,
+// not just its direct itemIds. Without this, an inner group's own
+// members stayed put while only the inner group's single bounding node
+// moved with the outer drag, visibly desyncing it from its own contents -
+// a real, reachable bug given nesting is legitimately possible today.
+// `visited` is a defensive cycle guard (creation-time validation should
+// make a cycle unreachable, but this must never infinite-loop even if one
+// existed) and also prevents re-visiting the node being dragged itself.
+function collectGroupMemberDeltaChanges(
+  nodes: SceneFlowNode[],
+  groupNode: SceneFlowNode,
+  deltaX: number,
+  deltaY: number,
+  visited: Set<string>,
+): NodeChange<SceneFlowNode>[] {
+  const itemIds = (groupNode.data as { itemIds?: string[] }).itemIds ?? [];
+  const changes: NodeChange<SceneFlowNode>[] = [];
   for (const memberId of itemIds) {
+    if (visited.has(memberId)) continue;
     const member = nodes.find((n) => n.id === memberId);
     if (!member) continue;
-    memberChanges.push({
+    visited.add(memberId);
+    changes.push({
       id: memberId,
       type: "position",
       dragging: true,
       position: { x: member.position.x + deltaX, y: member.position.y + deltaY },
     });
+    if (member.type === "frame" || member.type === "container") {
+      changes.push(...collectGroupMemberDeltaChanges(nodes, member, deltaX, deltaY, visited));
+    }
   }
-  return memberChanges;
+  return changes;
+}
+
+// R6.1 follow-up: the id-only counterpart to collectGroupMemberDeltaChanges
+// above, for the two call sites that need "every node this group drag
+// carries along, transitively" without also computing a position delta -
+// the smart-guide exclusion set (a carried member must never be an
+// alignment candidate for the group dragging it) and the drag-end commit
+// loop (every carried member's SETTLED position must be persisted via
+// moveNode, not just the outer group's directly-listed itemIds - without
+// this, a nested group's own members would visually follow the drag but
+// snap back the moment the scene re-syncs, since their moved position was
+// never actually committed).
+function collectTransitiveMemberIds(
+  nodes: SceneFlowNode[],
+  groupNode: SceneFlowNode,
+  visited: Set<string> = new Set(),
+): Set<string> {
+  const itemIds = (groupNode.data as { itemIds?: string[] }).itemIds ?? [];
+  for (const memberId of itemIds) {
+    if (visited.has(memberId)) continue;
+    visited.add(memberId);
+    const member = nodes.find((n) => n.id === memberId);
+    if (member && (member.type === "frame" || member.type === "container")) {
+      collectTransitiveMemberIds(nodes, member, visited);
+    }
+  }
+  return visited;
 }
 
 // R7.5b-1: legacy's exact faded-connections opacity (graphlink_connections.py's
@@ -1383,7 +1449,7 @@ function CanvasInner({
             const movingSize = measuredNodeSize(reactFlow, change.id);
             if (moving && movingSize) {
               const memberIds = groupDragKindOf(moving)
-                ? new Set((moving.data as { itemIds?: string[] }).itemIds ?? [])
+                ? collectTransitiveMemberIds(nodes, moving)
                 : new Set<string>();
               const candidates: Rect[] = [];
               for (const n of nodes) {
@@ -1414,8 +1480,7 @@ function CanvasInner({
         if (settled) {
           store.moveNode(change.id, settled.position.x, settled.position.y);
           if (groupDragKindOf(settled)) {
-            const itemIds = (settled.data as { itemIds?: string[] }).itemIds ?? [];
-            for (const memberId of itemIds) {
+            for (const memberId of collectTransitiveMemberIds(nodes, settled)) {
               const member = nodes.find((n) => n.id === memberId);
               if (member) memberMoveIntents.push({ id: memberId, x: member.position.x, y: member.position.y });
             }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -4479,6 +4479,7 @@ body,
    comment), this root fills 100%/100% of that wrapper. */
 
 .group-node {
+  position: relative;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -4486,6 +4487,42 @@ body,
   border: 1px solid var(--gl-surface-border);
   border-radius: 10px;
   opacity: 0.92;
+}
+
+/* R6.1 follow-up: the collapsed-container hover preview - a simplified
+   equivalent of legacy's timer-based "ghost frame" (see GroupNodeView.tsx's
+   own GhostPreview comment for why this shows counted kinds rather than a
+   rendered miniature of actual content). Positioned above the pill, same
+   convention as .reasoning-popover; reuses the shared popover chrome
+   (background/border/shadow) so it reads as the same kind of floating
+   surface as every other tooltip/popover in the app. */
+.group-node-ghost-preview {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  min-width: 140px;
+  background-color: var(--gl-surface-node-body);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.group-node-ghost-preview-count {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--gl-surface-text-primary);
+}
+
+.group-node-ghost-preview-breakdown {
+  font-size: 10px;
+  color: var(--gl-surface-text-muted);
 }
 
 .group-node.selected {

--- a/web_ui/src/lib/no-raw-colors.test.ts
+++ b/web_ui/src/lib/no-raw-colors.test.ts
@@ -128,6 +128,10 @@ const PINNED_APP_CSS_LITERALS: Record<string, string[]> = {
     "rgba(0, 0, 0, 0.55)",
     "rgba(0, 0, 0, 0.45)",
     "rgba(0, 0, 0, 0.45)",
+    // R6.1 follow-up: .group-node-ghost-preview's box-shadow (the
+    // collapsed-container hover preview, GroupNodeView.tsx) - same shared
+    // popover shadow reuse as every entry above.
+    "rgba(0, 0, 0, 0.45)",
   ],
 };
 


### PR DESCRIPTION
## Problem

An audit comparing the current groups/frames/containers implementation
against the original desktop implementation found several real defects
in how this subsystem was ported, beyond stylistic differences:

1. `create_frame` only checked that member ids existed - no restriction
   on member kind at all. A note added to a frame is silently dropped
   from that frame's own membership on save/reload (the serialization
   format has no slot for a note inside a frame), and nothing stopped
   nesting a frame or container inside a frame.
2. A manually-resized frame's bounds stayed frozen even after a member
   moved outside them, contradicting the recompute function's own
   docstring ("never clips, always auto-grows to enclose members"). A
   member could visibly escape a manually-sized frame with nothing
   correcting for it.
3. An unlocked frame was fully non-draggable - the original allowed
   repositioning a frame's outline independently of its members while
   unlocked.
4. Dragging a group only shifted its *direct* members by a flat delta -
   a nested group's own members (a container holding another container
   or a frame) never moved, desyncing the inner group from its own
   contents the moment the outer group was dragged.
5. Frame and container rendered at an identical z-index, leaving a
   nested frame-in-container's stacking undefined.

## Change

- `backend/canvas.py`: `create_frame` now validates member kind,
  rejecting note/frame/container (container membership is unaffected -
  nesting there is legitimate). The group-bounds recompute is rewritten
  around a proper rect-union primitive, so a manual size and/or a
  manually-dragged position always grows (never shrinks below either
  the manual value or live content) to keep every member enclosed. A
  new manual position anchor (`group_manual_x/y`, alongside the
  existing manual size anchor) is set whenever a frame is dragged
  directly, which is what makes an independent drag actually stick
  instead of snapping back the next time a member moves;
  `fit_frame_to_content` clears it along with the size override.
- `web_ui/src/app/canvas/SceneCanvas.tsx`: frames are draggable
  regardless of lock state now (locked drags still carry members via
  the existing delta cascade; unlocked drags move the frame alone). The
  drag cascade and its two supporting helpers (smart-guide exclusion,
  drag-end commit) recurse through the full nested-group tree, with a
  cycle guard. Container's flow-node z-index is one layer further back
  than frame's.
- `web_ui/src/app/canvas/GroupNodeView.tsx`: added a lightweight hover
  tooltip on a collapsed container showing member count and a per-kind
  breakdown - a simplified equivalent of the original's content preview
  (a rendered miniature, not attempted here).

## Test plan

- `python -m pytest -q` from repo root: 1064 passed (16 new tests
  covering the validation, the union-growth geometry for both manual
  size and manual position, and that fit-to-content clears both).
- `npx tsc --noEmit`, `npx vitest run` (907 passed, including new tests
  for the z-index split, recursive drag cascade with a cycle-guard
  test, unlocked-frame draggability, and the hover preview), `npx eslint .`
  (0 errors), `npx vite build` all clean from `web_ui/`.
- Could not live-verify the drag/resize interactions themselves in this
  environment: React Flow nodes stay `visibility: hidden` until
  measured, which requires the browser pane to actually be displayed
  and composited - neither is available here, so hit-testing based
  interactions (selecting or dragging a node) aren't reachable. Coverage
  rests on the unit tests above, including hand-derived geometry
  expectations for every new code path (verified against the
  implementation, not just asserted).