### PR TITLE
Fix group/frame drag visibly stretching and resettling on release

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -2696,6 +2696,47 @@ class SceneDocument:
                 self._recompute_group_bounds(group.id)
         return node
 
+    def move_nodes(self, positions: list[tuple[str, float, float]]) -> None:
+        """Atomically commit a BATCH of node positions - the group-drag
+        counterpart to move_node above. A group drag's commit touches the
+        group's own node AND every one of its (possibly nested-transitive)
+        members; calling move_node once per node in that set publishes a
+        scene snapshot after EACH individual position lands, so the
+        frontend briefly renders N genuinely inconsistent intermediate
+        states (some members caught up, some not) before the last one
+        commits - and since _recompute_group_bounds now correctly grows a
+        frame/container's box to enclose whatever the CURRENT bbox-of-
+        members is (see that method's own comment), those intermediate
+        states aren't just "slightly stale", they visibly stretch and
+        resettle each time - a real, user-visible glitch on every group
+        drag release, not a cosmetic footnote.
+
+        This updates every position in ONE pass first, THEN recomputes
+        bounds exactly once per affected group (deduplicated - both "this
+        IS a group that moved" and "this owns a node that moved" collapse
+        to the same set), using the fully-settled positions throughout.
+        Callers still using move_node for a single, non-group node stay
+        unaffected - this is purely additive."""
+        moved_ids: set[str] = set()
+        for node_id, x, y in positions:
+            node = self.nodes.get(node_id)
+            if node is None:
+                continue
+            node.x, node.y = float(x), float(y)
+            moved_ids.add(node_id)
+            if node.kind == "frame":
+                node.group_manual_x, node.group_manual_y = node.x, node.y
+        affected_groups: set[str] = set()
+        for moved_id in moved_ids:
+            moved_node = self.nodes.get(moved_id)
+            if moved_node is not None and moved_node.kind in ("frame", "container"):
+                affected_groups.add(moved_id)
+        for group in self.nodes.values():
+            if group.kind in ("frame", "container") and moved_ids.intersection(group.item_ids):
+                affected_groups.add(group.id)
+        for group_id in affected_groups:
+            self._recompute_group_bounds(group_id)
+
     def remove_nodes(self, node_ids: list[str]) -> None:
         for node_id in node_ids:
             node = self.nodes.pop(node_id, None)
@@ -4282,6 +4323,13 @@ def register_canvas(
         document.move_node(node_id, x, y)
         await publish_scene()
 
+    async def move_nodes(positions):
+        # positions: a JSON array of [node_id, x, y] triples - see
+        # SceneDocument.move_nodes's own docstring for why a group drag's
+        # commit uses this batched intent instead of N calls to moveNode.
+        document.move_nodes([(p[0], p[1], p[2]) for p in positions])
+        await publish_scene()
+
     async def remove_nodes(node_ids):
         ids = list(node_ids)
         # R5.4: a deleted Py-Coder node's REPL subprocess must not outlive
@@ -4434,6 +4482,7 @@ def register_canvas(
     bus.register_intent("scene", "resizeChart", resize_chart)
     bus.register_intent("scene", "toggleChartAspectLock", toggle_chart_aspect_lock)
     bus.register_intent("scene", "moveNode", move_node)
+    bus.register_intent("scene", "moveNodes", move_nodes)
     bus.register_intent("scene", "removeNodes", remove_nodes)
     bus.register_intent("scene", "connectNodes", connect_nodes)
     bus.register_intent("scene", "removeEdges", remove_edges)

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -5493,6 +5493,94 @@ def test_moving_a_container_does_not_pin_a_manual_position_anchor():
     assert node.group_manual_y is None
 
 
+def test_move_nodes_updates_every_position_in_one_batch():
+    doc = SceneDocument()
+    m1, m2 = doc.add_node(0, 0), doc.add_node(10, 10)
+
+    doc.move_nodes([(m1.id, 100, 200), (m2.id, 300, 400)])
+
+    assert (doc.nodes[m1.id].x, doc.nodes[m1.id].y) == (100.0, 200.0)
+    assert (doc.nodes[m2.id].x, doc.nodes[m2.id].y) == (300.0, 400.0)
+
+
+def test_move_nodes_skips_an_unknown_id_without_raising():
+    doc = SceneDocument()
+    m1 = doc.add_node(0, 0)
+    doc.move_nodes([(m1.id, 5, 5), ("ghost", 1, 1)])  # must not raise
+    assert (doc.nodes[m1.id].x, doc.nodes[m1.id].y) == (5.0, 5.0)
+
+
+def test_move_nodes_recomputes_a_group_exactly_once_using_the_fully_settled_positions():
+    # The whole point of the batch primitive: a locked-frame drag commits
+    # the frame's own new position AND both members' new positions in ONE
+    # call, so _recompute_group_bounds only ever sees the fully-settled
+    # bbox - never a transient state where only some members have caught
+    # up (which move_node called N times, once per node, would produce -
+    # and which, combined with the union-growth geometry, rendered as a
+    # visible stretch-then-resettle glitch on every group drag release).
+    doc = SceneDocument()
+    m1, m2 = doc.add_node(0, 0), doc.add_node(300, 300)
+    frame = doc.create_frame([m1.id, m2.id])
+
+    # Drag the whole group by delta (+50, +50): the frame's own commit
+    # plus both members', exactly what SceneCanvas.tsx's onNodesChange now
+    # sends as one batch instead of three sequential moveNode calls.
+    doc.move_nodes(
+        [
+            (frame.id, frame.x + 50, frame.y + 50),
+            (m1.id, 50, 50),
+            (m2.id, 350, 350),
+        ]
+    )
+
+    node = doc.nodes[frame.id]
+    # Members moved by the identical delta, so the auto-fit bbox shifted
+    # by the same (+50, +50) - the frame's manual position anchor (from
+    # its own direct move) and the live bbox agree exactly, same as a
+    # correct locked-group drag always should.
+    assert node.x == pytest.approx(-40.0 + 50.0)
+    assert node.y == pytest.approx(-50.0 + 50.0)
+    assert node.group_width == pytest.approx(600.0)
+    assert node.group_height == pytest.approx(510.0)
+
+
+def test_move_nodes_recomputes_a_container_holding_a_moved_member():
+    doc = SceneDocument()
+    m1 = doc.add_node(0, 0)
+    container = doc.create_container([m1.id])
+
+    doc.move_nodes([(m1.id, 1000, 1000)])
+
+    node = doc.nodes[container.id]
+    # Containers have no manual anchor - pure auto-fit, same as move_node.
+    assert node.x == pytest.approx(1000.0 - 40.0)
+    assert node.y == pytest.approx(1000.0 - 50.0)
+
+
+def test_move_nodes_intent_publishes_the_scene_exactly_once_for_a_whole_group_drag():
+    async def run():
+        bus, document, recorder = make_bus()
+        m1_id = await bus.dispatch_intent("scene", "addNode", [0, 0])
+        m2_id = await bus.dispatch_intent("scene", "addNode", [300, 300])
+        frame_id = await bus.dispatch_intent("scene", "createFrame", [[m1_id, m2_id]])
+        frame = document.nodes[frame_id]
+
+        publishes_before = recorder.topics_seen().count("scene")
+        await bus.dispatch_intent(
+            "scene",
+            "moveNodes",
+            [[[frame_id, frame.x + 20, frame.y + 20], [m1_id, 20, 20], [m2_id, 320, 320]]],
+        )
+
+        assert recorder.topics_seen().count("scene") - publishes_before == 1, (
+            "a whole group drag's commit must publish exactly once, not once per node moved"
+        )
+        assert (document.nodes[m1_id].x, document.nodes[m1_id].y) == (20.0, 20.0)
+        assert (document.nodes[m2_id].x, document.nodes[m2_id].y) == (320.0, 320.0)
+
+    asyncio.run(run())
+
+
 def test_fit_frame_to_content_clears_manual_override():
     doc = SceneDocument()
     m1, m2 = doc.add_node(0, 0), doc.add_node(300, 300)

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -1404,7 +1404,12 @@ function CanvasInner({
       // member's local position updates in lockstep with its group, every
       // drag frame.
       const memberChanges: NodeChange<SceneFlowNode>[] = [];
-      const memberMoveIntents: Array<{ id: string; x: number; y: number }> = [];
+      // Every drag-end position this change batch produces - the dragged
+      // node(s) own settled position AND every cascaded group member -
+      // collected here and committed as ONE atomic store.moveNodes call
+      // below, never as individual moveNode calls (see that call site's
+      // own comment for why).
+      const settledMoveIntents: Array<{ id: string; x: number; y: number }> = [];
       // R7.5b-3: guides produced by this frame's drag changes - applied via
       // one setSmartGuideLines call after the map, cleared on drag end.
       // DELIBERATE deviation for multi-select drags (review-confirmed):
@@ -1478,11 +1483,16 @@ function CanvasInner({
         const settled = nodes.find((n) => n.id === change.id);
         dragStartRef.current.delete(change.id);
         if (settled) {
-          store.moveNode(change.id, settled.position.x, settled.position.y);
+          // R6.1 follow-up: collected, not committed here directly - see
+          // the single store.moveNodes call below for why a group drag's
+          // whole commit (the group's own node plus every cascaded member)
+          // must land as ONE atomic batch, not N individual moveNode
+          // calls.
+          settledMoveIntents.push({ id: change.id, x: settled.position.x, y: settled.position.y });
           if (groupDragKindOf(settled)) {
             for (const memberId of collectTransitiveMemberIds(nodes, settled)) {
               const member = nodes.find((n) => n.id === memberId);
-              if (member) memberMoveIntents.push({ id: memberId, x: member.position.x, y: member.position.y });
+              if (member) settledMoveIntents.push({ id: memberId, x: member.position.x, y: member.position.y });
             }
           }
           // R7.5b-3 review fix: RF's drag-stop change carries its own
@@ -1492,16 +1502,26 @@ function CanvasInner({
           // node visibly bounce off its corrected position on release, then
           // reconcile after the backend echo. Return the settled (last
           // corrected frame's) position instead, which is also exactly what
-          // moveNode just committed - local state and the wire now agree at
+          // the batch below commits - local state and the wire now agree at
           // the instant of release.
           return { ...change, position: { ...settled.position } };
         }
         return change;
       });
-      // Persist each carried-along member's settled position too - the same
-      // moveNode call site the group's own commit above uses, fired after
-      // the map so every real change's own drag-end has already run.
-      for (const move of memberMoveIntents) store.moveNode(move.id, move.x, move.y);
+      // R6.1 follow-up: ONE atomic batch for the WHOLE drag-end (the
+      // dragged node's own settled position plus every cascaded member),
+      // not the group's own moveNode call followed by N separate member
+      // moveNode calls. Each individual moveNode intent publishes its own
+      // scene snapshot the instant it lands - calling it once per node in
+      // a group drag meant the frontend rendered N genuinely inconsistent
+      // intermediate states (some members caught up, some not) in rapid
+      // succession right after release, and since a frame/container's
+      // bounds correctly grow to enclose whatever the CURRENT member bbox
+      // is, those intermediate states visibly stretched and resettled
+      // instead of just being briefly stale - a real glitch on every group
+      // drag, not a cosmetic footnote. moveNodes commits every position in
+      // one pass server-side and publishes exactly once.
+      if (settledMoveIntents.length > 0) store.moveNodes(settledMoveIntents);
       // Guides re-derive every drag frame (legacy cleared + re-added its
       // QGraphicsLineItems per recompute); drag end always clears.
       if (sawDragging) setSmartGuideLines(frameGuides);

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -173,6 +173,29 @@ describe("SceneStore", () => {
     ]);
   });
 
+  it("moveNodes sends the scene-topic moveNodes intent with one [id, x, y] triple per position", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.moveNodes([
+      { id: "frame-1", x: 120, y: 220 },
+      { id: "m1", x: 20, y: 20 },
+      { id: "m2", x: 320, y: 320 },
+    ]);
+    expect(intents).toEqual([
+      {
+        topic: "scene",
+        intent: "moveNodes",
+        args: [
+          [
+            ["frame-1", 120, 220],
+            ["m1", 20, 20],
+            ["m2", 320, 320],
+          ],
+        ],
+      },
+    ]);
+  });
+
   it("sends chat-node intents with the backend's registered names and shapes", () => {
     const { transport, intents } = makeFakeTransport();
     const store = new SceneStore(transport);

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -527,6 +527,22 @@ export class SceneStore {
     this.transport.intent("scene", "moveNode", [id, x, y]);
   }
 
+  // R6.1 follow-up: a group drag's commit (the group's own node PLUS every
+  // transitive member) uses this instead of N individual moveNode calls -
+  // see backend/canvas.py's SceneDocument.move_nodes for why calling
+  // moveNode once per node published a scene snapshot after EACH one
+  // landed, rendering as a visible stretch-then-resettle glitch on every
+  // group drag release once the group-bounds recompute could genuinely
+  // grow a box (rather than staying frozen, the bug the growth logic
+  // itself was fixing).
+  moveNodes(positions: Array<{ id: string; x: number; y: number }>): void {
+    this.transport.intent(
+      "scene",
+      "moveNodes",
+      [positions.map((p) => [p.id, p.x, p.y])],
+    );
+  }
+
   removeNodes(ids: string[]): void {
     if (ids.length > 0) this.transport.intent("scene", "removeNodes", [ids]);
   }


### PR DESCRIPTION
## Problem

Committing a group drag's final position sent one `moveNode` intent per
node moved - the group itself, then every member, in sequence. Each
intent publishes its own scene snapshot the instant it lands, so the
frontend rendered N genuinely inconsistent intermediate states in rapid
succession right after release (some members caught up to the drag,
some not yet). Since a frame/container's bounds correctly grow to
enclose whatever the current member bounding box actually is, each of
those transient states rendered the group's box at a different, wrong
size before settling on the final one - a visible stretch-and-resettle
glitch on every group drag.

## Change

- `backend/canvas.py`: added `SceneDocument.move_nodes` - a batch
  primitive that updates every position in one pass, then recomputes
  each affected group's bounds exactly once (deduplicated), using the
  fully-settled positions throughout. Registered as a new `moveNodes`
  intent alongside the existing single-node `moveNode` (left
  unchanged - this is purely additive).
- `web_ui/src/app/canvas/sceneStore.ts`: added `moveNodes`, sending the
  batched intent.
- `web_ui/src/app/canvas/SceneCanvas.tsx`: the drag-end commit in
  `onNodesChange` now collects the dragged node's settled position plus
  every cascaded member into one array and sends a single `moveNodes`
  call, instead of one `moveNode` call for the group followed by N more
  for its members.

## Test plan

- `python -m pytest -q` from repo root: 1069 passed (5 new tests,
  including one asserting a whole group-drag commit publishes the
  scene exactly once, not once per node moved).
- `npx tsc --noEmit`, `npx vitest run` (908 passed), `npx eslint .`
  (0 errors), `npx vite build` all clean from `web_ui/`.
- Live-verified against the running backend: created two nodes and a
  frame over a raw WebSocket, cleared the message log, sent the exact
  batched `moveNodes` payload a group drag now produces (the frame's
  own new position plus both members'), and confirmed exactly one
  scene snapshot was published with every position correctly settled -
  no intermediate states possible. No console errors.