### PR TITLE
Redesign frame/container visual chrome

### DIFF
--- a/web_ui/src/app/canvas/GroupNodeView.tsx
+++ b/web_ui/src/app/canvas/GroupNodeView.tsx
@@ -1,5 +1,5 @@
 import { NodeResizer, type Node, type NodeProps } from "@xyflow/react";
-import { useRef, useState } from "react";
+import { useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { GroupColorPicker } from "./GroupColorPicker";
 import { GROUP_RESIZE_MIN_HEIGHT, GROUP_RESIZE_MIN_WIDTH } from "./canvasConstants";
 
@@ -29,7 +29,12 @@ import { GROUP_RESIZE_MIN_HEIGHT, GROUP_RESIZE_MIN_WIDTH } from "./canvasConstan
  * inside `data`) in SceneCanvas.tsx's toFlowNodes - the documented xyflow
  * mechanism for letting <NodeResizer/> drive the node WRAPPER element's own
  * size directly. This component's own root div therefore fills that wrapper
- * (100%/100%) rather than carrying its own pixel width/height.
+ * (100%/100%) rather than carrying its own pixel width/height. A collapsed
+ * group is NOT a CSS-only illusion - backend/canvas.py's
+ * _recompute_group_bounds pins group_width/group_height to the fixed
+ * GROUP_COLLAPSED_WIDTH/HEIGHT (260x50) while collapsed, so the wrapper
+ * really does shrink to that footprint; the pill treatment below relies on
+ * that being a small, fixed, wide-and-short box.
  *
  * Drag: a locked frame's (or any container's) own body is the intentional
  * group-drag handle - see SceneCanvas.tsx's onNodesChange for the delta
@@ -40,6 +45,20 @@ import { GROUP_RESIZE_MIN_HEIGHT, GROUP_RESIZE_MIN_WIDTH } from "./canvasConstan
  * its members" behavior) - it just doesn't carry members along; see
  * groupDragKindOf in SceneCanvas.tsx, which gates the member cascade on
  * lock state, not draggability itself.
+ *
+ * Visual system ("Quiet Frame", R8a visual-quality pass): the box itself is
+ * a near-invisible tint at rest - no permanent header bar, no full-opacity
+ * border - so it reads as a boundary around its members rather than a card
+ * competing with them. Identity (label + the 5 actions) lives in small
+ * floating chips anchored above the top-left corner, which only fully
+ * assert themselves on hover/selection. The one deliberate exception is the
+ * Collapse/Expand toggle, which stays dimly visible even at rest (see
+ * .group-node-collapse-btn) since it is the single action a user needs to
+ * discover without first knowing to hover a near-invisible box.
+ * <NodeResizer/>'s handles follow the same rule: `isVisible` is gated on
+ * `hovered || selected`, never rendered unconditionally - this was the
+ * literal, named complaint that triggered this pass (resize scaffolding
+ * permanently exposed on every expanded frame).
  *
  * Collapsed container hover preview: a simplified equivalent of legacy's
  * timer-based "ghost frame" (a rendered miniature preview of expanded
@@ -68,6 +87,22 @@ export interface GroupNodeData extends Record<string, unknown> {
 
 export type GroupFlowNode = Node<GroupNodeData, "frame" | "container">;
 
+// Kills the resizer's connecting outline entirely (dots only, no wireframe
+// rectangle) - a cross-judge borrow from the design-panel review: a full
+// connecting line reintroduces the "exposed scaffolding" look this pass
+// exists to remove. Inline style (not a CSS class) so it wins outright over
+// @xyflow/react's own resize-control stylesheet regardless of import order.
+const RESIZE_HANDLE_STYLE: CSSProperties = {
+  width: 6,
+  height: 6,
+  borderRadius: 0,
+  backgroundColor: "var(--gl-palette-selection)",
+  border: "1px solid var(--gl-surface-window)",
+};
+const RESIZE_LINE_STYLE: CSSProperties = {
+  borderColor: "transparent",
+};
+
 export function GroupNodeView({ id, data, selected }: NodeProps<GroupFlowNode>) {
   const isFrame = data.groupKind === "frame";
   const [editing, setEditing] = useState(false);
@@ -77,6 +112,17 @@ export function GroupNodeView({ id, data, selected }: NodeProps<GroupFlowNode>) 
   const skipBlurRef = useRef(false);
   const [hovered, setHovered] = useState(false);
   const showGhostPreview = !isFrame && data.isCollapsed && hovered && data.memberKinds.length > 0;
+  const hasBodyColor = data.color !== null;
+  const hasHeaderColor = data.headerColor !== null;
+  // Expanded chips reflect ONLY an explicit header color, leaving the body
+  // tint visible around them - the collapsed pill IS the whole visible
+  // object, so it falls back to the body color too (same headerColor-first
+  // fallback GroupColorPicker's own swatch trigger already uses).
+  const chipStyle: CSSProperties | undefined = hasHeaderColor
+    ? { backgroundColor: data.headerColor ?? undefined }
+    : undefined;
+  const pillStyle: CSSProperties | undefined =
+    hasHeaderColor || hasBodyColor ? { backgroundColor: data.headerColor ?? data.color ?? undefined } : undefined;
 
   function beginEdit() {
     setDraft(data.label);
@@ -113,13 +159,71 @@ export function GroupNodeView({ id, data, selected }: NodeProps<GroupFlowNode>) 
     commit(draft);
   }
 
+  const labelNode = editing ? (
+    <input
+      type="text"
+      className="group-node-label-input nodrag"
+      value={draft}
+      onChange={(event) => setDraft(event.target.value)}
+      onKeyDown={onKeyDown}
+      onBlur={onBlur}
+      autoFocus
+    />
+  ) : (
+    <span className="group-node-label">{data.label}</span>
+  );
+
+  // Lock/Fit cluster, then a divider, then Color/Ungroup - shared by both
+  // the floating controls chip (expanded) and the pill's control row
+  // (collapsed). The divider only renders for frames, since containers have
+  // no left cluster (no Lock, no Fit) to separate from the right one.
+  const controlsCluster = (
+    <>
+      {isFrame && (
+        <button
+          type="button"
+          className="group-node-btn"
+          title={data.isLocked ? "Unlock" : "Lock"}
+          aria-label={data.isLocked ? "Unlock" : "Lock"}
+          onClick={data.onToggleLock}
+        >
+          <GroupIcon name={data.isLocked ? "unlock" : "lock"} />
+        </button>
+      )}
+      {isFrame && !data.isCollapsed && (
+        <button
+          type="button"
+          className="group-node-btn"
+          title="Fit to Content"
+          aria-label="Fit to Content"
+          onClick={data.onFitToContent}
+        >
+          <GroupIcon name="fit" />
+        </button>
+      )}
+      {isFrame && <span className="group-node-controls-divider" aria-hidden="true" />}
+      <GroupColorPicker color={data.color} headerColor={data.headerColor} onSelect={data.onSetColor} />
+      <button
+        type="button"
+        className="group-node-btn group-node-ungroup-btn"
+        title="Ungroup"
+        aria-label="Ungroup"
+        onClick={data.onUngroup}
+      >
+        <GroupIcon name="ungroup" />
+      </button>
+    </>
+  );
+
   return (
     <div
       className={
         "group-node" +
         ` ${data.groupKind}-group-node` +
         (selected ? " selected" : "") +
-        (data.isCollapsed ? " collapsed" : "")
+        (data.isCollapsed ? " collapsed" : "") +
+        (hasBodyColor ? " has-body-color" : "") +
+        (hasHeaderColor ? " has-header-color" : "")
       }
       style={{ width: "100%", height: "100%", backgroundColor: data.color ?? undefined }}
       onMouseEnter={() => setHovered(true)}
@@ -128,49 +232,58 @@ export function GroupNodeView({ id, data, selected }: NodeProps<GroupFlowNode>) 
       {showGhostPreview && <GhostPreview memberKinds={data.memberKinds} />}
       <NodeResizer
         nodeId={id}
-        isVisible={isFrame && !data.isCollapsed}
+        isVisible={isFrame && !data.isCollapsed && (hovered || selected)}
         minWidth={GROUP_RESIZE_MIN_WIDTH}
         minHeight={GROUP_RESIZE_MIN_HEIGHT}
         onResizeEnd={(_event, params) => data.onResize(params.width, params.height)}
+        handleStyle={RESIZE_HANDLE_STYLE}
+        lineStyle={RESIZE_LINE_STYLE}
       />
-      <div
-        className="group-node-header"
-        style={{ backgroundColor: data.headerColor ?? undefined }}
-        onDoubleClick={beginEdit}
-      >
-        {editing ? (
-          <input
-            type="text"
-            className="group-node-label-input nodrag"
-            value={draft}
-            onChange={(event) => setDraft(event.target.value)}
-            onKeyDown={onKeyDown}
-            onBlur={onBlur}
-            autoFocus
-          />
-        ) : (
-          <span className="group-node-label">{data.label}</span>
-        )}
-        <div className="group-node-controls nodrag">
-          <button type="button" className="group-node-btn" onClick={data.onToggleCollapsed}>
-            {data.isCollapsed ? "Expand" : "Collapse"}
-          </button>
-          {isFrame && (
-            <button type="button" className="group-node-btn" onClick={data.onToggleLock}>
-              {data.isLocked ? "Unlock" : "Lock"}
+      {data.isCollapsed ? (
+        <div
+          className="group-node-header group-node-pill-header"
+          style={pillStyle}
+          onDoubleClick={beginEdit}
+        >
+          {labelNode}
+          <div className="group-node-controls nodrag">
+            <button
+              type="button"
+              className="group-node-btn"
+              title="Expand"
+              aria-label="Expand"
+              onClick={data.onToggleCollapsed}
+            >
+              <GroupIcon name="expand" />
             </button>
-          )}
-          {isFrame && !data.isCollapsed && (
-            <button type="button" className="group-node-btn" onClick={data.onFitToContent}>
-              Fit to Content
-            </button>
-          )}
-          <GroupColorPicker color={data.color} headerColor={data.headerColor} onSelect={data.onSetColor} />
-          <button type="button" className="group-node-btn group-node-ungroup-btn" onClick={data.onUngroup}>
-            Ungroup
-          </button>
+            {controlsCluster}
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="group-node-topbar">
+          <div
+            className="group-node-header group-node-label-chip nodrag"
+            style={chipStyle}
+            onDoubleClick={beginEdit}
+          >
+            {labelNode}
+          </div>
+          <div className="group-node-controls-row nodrag">
+            <button
+              type="button"
+              className="group-node-btn group-node-collapse-btn"
+              title="Collapse"
+              aria-label="Collapse"
+              onClick={data.onToggleCollapsed}
+            >
+              <GroupIcon name="collapse" />
+            </button>
+            <div className="group-node-controls-chip" style={chipStyle}>
+              {controlsCluster}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -193,5 +306,45 @@ function GhostPreview({ memberKinds }: { memberKinds: string[] }) {
       </span>
       <span className="group-node-ghost-preview-breakdown">{breakdown.join(", ")}</span>
     </div>
+  );
+}
+
+// R8a visual-quality pass: small hand-authored stroke icons (fill:none,
+// stroke:currentColor, matching the same convention Composer.tsx's own
+// Icon() already established) replacing the previous text-label buttons -
+// every control is now an icon-only 22x22px hit target with the action name
+// carried as aria-label/title instead of visible text, per the design-panel
+// review's unanimous "icon-only, hover-reveal" recommendation.
+type GroupIconName = "collapse" | "expand" | "lock" | "unlock" | "fit" | "ungroup";
+
+const GROUP_ICON_PATHS: Record<GroupIconName, ReactNode> = {
+  collapse: <path d="M4 6l4 4 4-4" />,
+  expand: <path d="M4 10l4-4 4 4" />,
+  lock: (
+    <>
+      <rect x="4" y="7" width="8" height="6" rx="1.2" />
+      <path d="M6 7V5a2 2 0 0 1 4 0v2" />
+    </>
+  ),
+  unlock: (
+    <>
+      <rect x="4" y="7" width="8" height="6" rx="1.2" />
+      <path d="M6 7V5a2 2 0 0 1 4 0v1" />
+    </>
+  ),
+  fit: <path d="M3 6V3h3M13 6V3h-3M3 10v3h3M13 10v3h-3" />,
+  ungroup: (
+    <>
+      <rect x="2" y="5" width="5.5" height="5.5" rx="1" />
+      <rect x="8.5" y="5" width="5.5" height="5.5" rx="1" />
+    </>
+  ),
+};
+
+function GroupIcon({ name }: { name: GroupIconName }) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 16 16" className="group-node-icon">
+      {GROUP_ICON_PATHS[name]}
+    </svg>
   );
 }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -4378,17 +4378,17 @@ body,
 }
 
 .group-color-swatch-trigger {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   padding: 0;
   border-radius: 50%;
   background-color: var(--gl-neutral-button-background);
-  border: 1px solid var(--gl-neutral-button-border);
+  border: 1px solid var(--gl-surface-border);
   cursor: pointer;
 }
 
 .group-color-swatch-trigger:hover {
-  border-color: var(--gl-surface-text-muted);
+  border-color: var(--gl-surface-border-strong);
 }
 
 /* R8a: the code-execution approval prompt is a BLOCKING security decision, so
@@ -4483,10 +4483,56 @@ body,
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  background-color: var(--gl-surface-node-body);
-  border: 1px solid var(--gl-surface-border);
-  border-radius: 10px;
-  opacity: 0.92;
+  background-color: color-mix(in srgb, var(--gl-surface-node-body) 55%, transparent);
+  border: 1px solid color-mix(in srgb, var(--gl-surface-border) 45%, transparent);
+  border-radius: var(--gl-radius-lg);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--gl-surface-text-bright) 3%, transparent);
+  opacity: 1;
+  transition:
+    background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    border-color var(--gl-motion-fast) var(--gl-motion-ease),
+    box-shadow var(--gl-motion-base) var(--gl-motion-ease);
+}
+
+.group-node:hover {
+  background-color: color-mix(in srgb, var(--gl-surface-node-body) 75%, transparent);
+  border-color: var(--gl-surface-border);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--gl-surface-text-bright) 3%, transparent),
+    var(--gl-shadow-1);
+}
+
+.group-node.selected {
+  background-color: color-mix(in srgb, var(--gl-surface-node-body) 75%, transparent);
+  border-color: var(--gl-surface-border);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--gl-surface-text-bright) 3%, transparent),
+    0 0 0 1px var(--gl-surface-border-strong),
+    var(--gl-shadow-2);
+}
+
+/* Custom body color (GroupColorPicker) is applied inline on the root and
+   always wins over the background-color rules above; only the border needs
+   its own dark-hairline treatment here so it stays legible against every
+   swatch, including the light ones (Yellow/Orange). */
+.group-node.has-body-color {
+  border-color: color-mix(in srgb, var(--gl-surface-inset-deep) 55%, transparent);
+}
+
+.group-node.has-body-color:hover,
+.group-node.has-body-color.selected {
+  border-color: color-mix(in srgb, var(--gl-surface-inset-deep) 75%, transparent);
+}
+
+/* Collapsed: .group-node-pill-header below carries ALL visible chrome
+   (fill, border, radius); the root becomes a plain invisible sizing box so
+   its own radius-lg rectangle never peeks out from behind the pill's
+   fully-rounded corners. Placed after :hover/.selected so it wins
+   regardless of which of those also match. */
+.group-node.collapsed {
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
 }
 
 /* R6.1 follow-up: the collapsed-container hover preview - a simplified
@@ -4525,31 +4571,151 @@ body,
   color: var(--gl-surface-text-muted);
 }
 
-.group-node.selected {
-  border-color: var(--gl-surface-border-strong, var(--gl-surface-text-muted));
+/* -- Expanded chrome: a floating label chip + a hover-revealed controls
+   chip, anchored above the box's top-left corner, replacing the old
+   full-width header bar (R8a: that permanent bar plus a full-opacity
+   border was the "ugly hard edge box" complaint). ---------------------- */
+
+.group-node-topbar {
+  position: absolute;
+  top: -26px;
+  left: 6px;
+  right: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  pointer-events: none;
 }
 
-.group-node-header {
+.group-node-topbar > * {
+  pointer-events: auto;
+}
+
+.group-node-label-chip {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--gl-surface-text-muted);
+  background-color: var(--gl-surface-node-body);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: var(--gl-radius-sm);
+  cursor: default;
+  transition:
+    color var(--gl-motion-fast) var(--gl-motion-ease),
+    border-color var(--gl-motion-fast) var(--gl-motion-ease);
+}
+
+.group-node:hover .group-node-label-chip {
+  color: var(--gl-surface-text-secondary);
+  border-color: var(--gl-surface-border-strong);
+}
+
+.group-node.selected .group-node-label-chip {
+  color: var(--gl-surface-text-primary);
+  border-color: var(--gl-surface-border-strong);
+}
+
+.group-node-controls-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.group-node-controls-chip {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  background-color: var(--gl-surface-node-body);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: var(--gl-radius-sm);
+  opacity: 0;
+  transform: translateX(-4px);
+  pointer-events: none;
+  transition:
+    opacity var(--gl-motion-fast) var(--gl-motion-ease),
+    transform var(--gl-motion-fast) var(--gl-motion-ease);
+}
+
+.group-node:hover .group-node-controls-chip,
+.group-node.selected .group-node-controls-chip {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.group-node-controls-divider {
+  width: 1px;
+  height: 14px;
+  flex-shrink: 0;
+  background-color: var(--gl-surface-border);
+}
+
+.group-node.has-header-color .group-node-label-chip,
+.group-node.has-header-color .group-node-controls-chip {
+  color: var(--gl-surface-text-bright);
+  border-color: color-mix(in srgb, var(--gl-surface-inset-deep) 65%, transparent);
+}
+
+/* The one control that stays discoverable without hovering first - see
+   GroupNodeView.tsx's doc comment for why Collapse/Expand is exempted from
+   the hover-reveal rule every other control follows. */
+.group-node-collapse-btn {
+  opacity: 0.6;
+}
+
+.group-node-collapse-btn:hover,
+.group-node:hover .group-node-collapse-btn,
+.group-node.selected .group-node-collapse-btn {
+  opacity: 1;
+}
+
+/* -- Collapsed chrome: a fixed-size pill. backend/canvas.py pins
+   group_width/group_height to GROUP_COLLAPSED_WIDTH/HEIGHT (260x50) while
+   collapsed, so this is a real fixed footprint, not just a CSS trick. --- */
+
+.group-node-pill-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 6px 8px;
+  width: 100%;
+  height: 100%;
+  padding: 0 10px;
   font-size: 11px;
   font-weight: 600;
-  color: var(--gl-surface-text-primary);
-  background-color: var(--gl-surface-inset, var(--gl-surface-node-body));
-  border-bottom: 1px solid var(--gl-surface-border);
-  border-radius: 9px 9px 0 0;
+  color: var(--gl-surface-text-secondary);
+  background-color: var(--gl-surface-node-body);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 9999px;
   cursor: default;
+  transition:
+    border-color var(--gl-motion-fast) var(--gl-motion-ease),
+    box-shadow var(--gl-motion-base) var(--gl-motion-ease);
 }
 
-.group-node.collapsed .group-node-header {
-  border-bottom: none;
-  border-radius: 9px;
+.group-node.collapsed:hover .group-node-pill-header {
+  border-color: var(--gl-surface-border-strong);
+  box-shadow: var(--gl-shadow-1);
+}
+
+.group-node.collapsed.selected .group-node-pill-header {
+  border-color: var(--gl-surface-border-strong);
+  box-shadow: 0 0 0 1px var(--gl-surface-border-strong), var(--gl-shadow-2);
+}
+
+.group-node.has-body-color .group-node-pill-header,
+.group-node.has-header-color .group-node-pill-header {
+  color: var(--gl-surface-text-bright);
+  border-color: color-mix(in srgb, var(--gl-surface-inset-deep) 65%, transparent);
 }
 
 .group-node-label {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -4580,21 +4746,35 @@ body,
 }
 
 .group-node-btn {
-  font-size: 10px;
-  font-weight: 600;
-  font-family: inherit;
-  padding: 3px 7px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
   color: var(--gl-surface-text-muted);
   background: transparent;
   border: none;
-  border-radius: 5px;
+  border-radius: var(--gl-radius-sm);
   cursor: pointer;
-  white-space: nowrap;
+  transition:
+    background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    color var(--gl-motion-fast) var(--gl-motion-ease);
 }
 
 .group-node-btn:hover {
   color: var(--gl-surface-text-primary);
   background-color: var(--gl-neutral-button-hover);
+}
+
+.group-node-icon {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .group-node-ungroup-btn {


### PR DESCRIPTION
## Problem

`GroupNodeView.tsx` (the shared frame/container canvas node) rendered as a flat, single-weight-bordered box with a permanent full-width header bar, and its resize handles (`NodeResizer`) were unconditionally visible on every expanded frame regardless of hover or selection state.

## Change

- Root box is now a near-invisible tint at rest (`color-mix()` on the existing `--gl-surface-*` tokens, no new hues introduced), escalating through hover (soft border + `--gl-shadow-1`) to selected (opaque border + ring + `--gl-shadow-2`).
- The permanent header bar is replaced by a floating label chip anchored above the top-left corner; the 5 actions (Collapse/Expand, Lock/Unlock, Fit to Content, color swatch, Ungroup) live in a second chip that only fully reveals on hover/selection, with a hairline divider separating the two action clusters. Collapse/Expand stays dimly visible at rest as the one action a user needs to discover without hovering first.
- Actions are now icon-only (hand-authored stroke SVGs matching the existing `Composer.tsx` icon convention) instead of text-label buttons, with `aria-label`/`title` carrying the accessible name.
- `NodeResizer`'s `isVisible` is now gated on `hovered || selected` instead of rendering unconditionally, and its connecting outline is hidden so only the corner/edge grab points show.
- A collapsed frame/container has a real fixed footprint (backend pins `group_width`/`group_height` to 260x50 while collapsed), so it now renders as a true pill: the root becomes an invisible sizing box and the pill child carries all visible chrome, avoiding a mismatched rectangle showing behind the pill's rounded corners.
- Custom colors (`GroupColorPicker`) still fully work: a body color switches the border to a dark, hue-agnostic hairline instead of the neutral gray one; a header color tints the label/controls chips (or the whole pill when collapsed) with forced bright text, legible against every swatch including the light ones (Yellow, Orange).

## Test plan

- [x] `npx tsc --noEmit` - clean
- [x] `npx vitest run` - 908/908 frontend tests passing (43/43 files)
- [x] `npx eslint .` - zero errors, no new warnings
- [x] `npx vite build` - production build succeeds
- [x] Live-verified in a real Chromium engine: `color-mix()` resolves correctly, and every state (default/hover/selected/collapsed/custom-body-color) computes the intended colors, shadows, radii, and chip opacity
- [ ] Full interactive verification (drag, resize handle, live hover) not performed - React Flow doesn't measure/paint nodes in a backgrounded browser pane in this environment