### PR TITLE
Harden AI code execution: credential isolation, per-repair approval, accurate naming

### DIFF
--- a/GRAPHLINK_REPO_NAVIGATION.md
+++ b/GRAPHLINK_REPO_NAVIGATION.md
@@ -168,7 +168,7 @@ Several `backend/` modules (`composer.py`, `chat_library.py`, `plugins.py`, `ses
 | `artifact` | Artifact / Drafter | `ArtifactNodeView.tsx` |
 | `gitlink` | Gitlink | `GitlinkNodeView.tsx` |
 | `pycoder` | Py-Coder | `PyCoderNodeView.tsx` |
-| `code_sandbox` | Execution Sandbox | `CodeSandboxNodeView.tsx` |
+| `code_sandbox` | Virtual Environment Runner | `CodeSandboxNodeView.tsx` |
 | `note` | (System Prompt picker entry creates one) | `NoteNodeView.tsx` |
 | `frame` | (Create Frame command) | `GroupNodeView.tsx` (shared with `container`, distinguished by `data.groupKind`) |
 | `container` | (Create Container command) | `GroupNodeView.tsx` |
@@ -247,7 +247,7 @@ This is the live registration order in `backend/plugins.py::_PLUGINS` / `_CATEGO
 
 - `Gitlink` - creates a `gitlink` node.
 - `Py-Coder` - creates a `pycoder` node.
-- `Execution Sandbox` - creates a `code_sandbox` node.
+- `Virtual Environment Runner` - creates a `code_sandbox` node.
 - `HTML Renderer` - creates an `html` node (starts with empty content).
 
 ### Workflow & Drafting

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Attach these specialist nodes to a branch from the plugin picker:
 | Web Research | Reasoning and Research | Web retrieval, summarization, and source capture for real-time information. |
 | Gitlink | Build and Execution | Loads a GitHub repo into structured context, previews file-level changes, and writes only after approval. |
 | Py-Coder | Build and Execution | Runs Python with AI-assisted generation, execution, and analysis. |
-| Execution Sandbox | Build and Execution | Runs Python in a per-node virtualenv with declared dependencies (isolates installed packages, not the OS or filesystem/network access). |
+| Virtual Environment Runner | Build and Execution | Runs Python in a per-node virtualenv with declared dependencies (isolates installed packages, not the OS or filesystem/network access). |
 | HTML Renderer | Build and Execution | Renders HTML from a parent branch directly inside the app. |
 | Artifact / Drafter | Workflow and Drafting | A split-pane surface for drafting and refining long-form Markdown. |
 
@@ -152,7 +152,7 @@ The app reads these as fallbacks when no key is saved in Settings, or for model 
 
 - **Start** with a chat node or a starter prompt.
 - **Branch** by selecting a node and adding a plugin from the picker or controls; each new node begins a more specialized path (research, code, drafting, execution).
-- **Deliver** with build-oriented nodes — Gitlink for repo-aware change proposals, Py-Coder and Execution Sandbox for running code, Artifact / Drafter for documents.
+- **Deliver** with build-oriented nodes — Gitlink for repo-aware change proposals, Py-Coder and Virtual Environment Runner for running code, Artifact / Drafter for documents.
 - **Export** the whole canvas as a PNG, or export individual nodes — Chat as `.md`, Code as a source file (extension inferred from language, falling back to `.txt`), Image as `.png`.
 - **Ingest**: file attachments are modeled on the backend (a Document node kind exists) but aren't yet wired to any UI action — there is currently no way to attach or ingest a file from the interface.
 
@@ -164,7 +164,7 @@ Graphlink is a Python (FastAPI) backend paired with a Vite/React/TypeScript sing
 - **`backend/`** holds all real application and domain logic: the FastAPI app factory and a WebSocket pub/sub event bus, the node-graph/canvas model (chat, code, document, image, thinking, and other node kinds; connections; autosave; crash recovery), LLM dispatch, settings, chat-library management, and session load/save.
 - **`web_ui/`** is the React SPA (built with Vite) — the entire UI: the canvas surface, the app bar and composer chrome, and dialogs/overlays. It talks to the backend over the REST API and the WebSocket.
 - **`contracts/`** is build-time-only codegen that generates the TypeScript types and JSON Schemas for WebSocket payloads from the backend's Python dataclasses, keeping the two sides in sync.
-- **`graphlink_plugins/`** holds the domain logic behind the plugin nodes (web research, Gitlink, Py-Coder, Execution Sandbox) — no UI code, no Qt.
+- **`graphlink_plugins/`** holds the domain logic behind the plugin nodes (web research, Gitlink, Py-Coder, Virtual Environment Runner) — no UI code, no Qt.
 
 Your data lives entirely on your machine:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ If you discover a security issue in Graphlink:
 Areas that deserve extra care in this project include:
 
 - local storage of API keys and GitHub tokens
-- execution-oriented plugins such as Execution Sandbox and Py-Coder
+- execution-oriented plugins such as Virtual Environment Runner and Py-Coder
 - GitHub-backed repository access
 - provider configuration and outbound API requests
 - file import and export flows

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -1772,6 +1772,7 @@ class AgentDispatcher:
 
                 # -- human-approval gate --------------------------------------
                 node.pycoder_code = current_code
+                node.pycoder_approved_fingerprint = _fingerprint_changes({"code": current_code})
                 node.pycoder_awaiting_approval = True
                 await bus.publish("scene")
                 approved = await approval_future
@@ -1791,6 +1792,21 @@ class AgentDispatcher:
                     if cancel_event.is_set():
                         notifications_state.show("Py-Coder execution cancelled.", "info")
                         await bus.publish("notification")
+                        return
+
+                    # ADR-002 P0: defense-in-depth, not the primary fix (the
+                    # repair re-gate below is) - the code about to execute
+                    # must be EXACTLY what the most recently resolved
+                    # approval gate covered. Always true today (nothing
+                    # mutates current_code between a gate and its matching
+                    # execute call); this exists to fail loudly rather than
+                    # silently execute unapproved content if a future change
+                    # ever breaks that invariant.
+                    if _fingerprint_changes({"code": current_code}) != node.pycoder_approved_fingerprint:
+                        on_failure(
+                            "Py-Coder execution blocked: the approved code no longer matches what is about to run."
+                        )
+                        await bus.publish("scene")
                         return
 
                     try:
@@ -1829,6 +1845,41 @@ class AgentDispatcher:
                         current_code = await asyncio.to_thread(
                             _call_pycoder_repair_agent, current_code, last_error, is_final
                         )
+                        if cancel_event.is_set():
+                            notifications_state.show("Py-Coder execution cancelled.", "info")
+                            await bus.publish("notification")
+                            return
+
+                        # ADR-002 P0: the repair agent just produced code the
+                        # user has never seen. The prior design let this run
+                        # automatically under the FIRST Approve click - the
+                        # confirmed gap the ADR-002 security review named
+                        # explicitly ("approval is not bound to what was
+                        # shown"; the old warning copy even disclosed this:
+                        # "automatically repaired versions of this code may
+                        # run under this same approval"). Every repaired
+                        # variant now goes through its own fresh gate, with a
+                        # NEW Future replacing the resolved one in this same
+                        # dict slot so cancel_pycoder/approve_code_execution/
+                        # deny_code_execution keep targeting whichever gate
+                        # is actually still open (see _resolve_approval's own
+                        # docstring - it always re-reads this slot, never
+                        # caches the future).
+                        request_entry = self._pycoder_requests.get(request_id)
+                        if request_entry is None:
+                            return
+                        repair_future: asyncio.Future = asyncio.get_running_loop().create_future()
+                        request_entry["approval_future"] = repair_future
+                        node.pycoder_code = current_code
+                        node.pycoder_approved_fingerprint = _fingerprint_changes({"code": current_code})
+                        node.pycoder_awaiting_approval = True
+                        await bus.publish("scene")
+                        approved = await repair_future
+                        node.pycoder_awaiting_approval = False
+                        if not approved:
+                            on_failure("Py-Coder run cancelled: repaired code was not approved.")
+                            await bus.publish("scene")
+                            return
 
                 # Every retry exhausted - still a real completed run (never
                 # on_failure), matching legacy's own `finished.emit(result)`
@@ -1938,7 +1989,7 @@ class AgentDispatcher:
         Composer-specific topic): CodeSandboxNode state is scene state, same
         as every other plugin node kind's own dispatch surface."""
         if node.pending_request_id and node.pending_request_id != _CODE_EXEC_RUN_CLAIM_PLACEHOLDER:
-            notifications_state.show("Execution Sandbox is already busy for this node.", "info")
+            notifications_state.show("Virtual Environment Runner is already busy for this node.", "info")
             await bus.publish("notification")
             return
 
@@ -2024,6 +2075,15 @@ class AgentDispatcher:
                 # point. See SceneNode.code_sandbox_approval_requirements's
                 # own comment for the full race this closes.
                 node.code_sandbox_approval_requirements = manifest
+                # ADR-002 P0: fingerprints exactly what this gate is asking
+                # about - see SceneNode.code_sandbox_approved_fingerprint's
+                # own comment. Frozen from the same already-correct local
+                # `manifest`/`current_code`, at the same moment, for the
+                # same staleness-avoidance reason as the requirements
+                # snapshot right above.
+                node.code_sandbox_approved_fingerprint = _fingerprint_changes(
+                    {"code": current_code, "manifest": manifest}
+                )
                 await bus.publish("scene")
                 approved = await approval_future
                 node.code_sandbox_awaiting_approval = False
@@ -2058,6 +2118,18 @@ class AgentDispatcher:
                 last_error = ""
                 try:
                     for attempt_index in range(max_attempts):
+                        # ADR-002 P0: defense-in-depth, not the primary fix
+                        # (the repair re-gate below is) - see
+                        # start_pycoder_run's identical check for the full
+                        # reasoning.
+                        if _fingerprint_changes(
+                            {"code": current_code, "manifest": manifest}
+                        ) != node.code_sandbox_approved_fingerprint:
+                            on_failure(
+                                "Sandbox execution blocked: the approved code no longer matches what is about to run."
+                            )
+                            await bus.publish("scene")
+                            return
                         final_output, final_return_code = await asyncio.to_thread(
                             sandbox.execute_code, current_code, _should_continue, _thread_emit_line
                         )
@@ -2069,6 +2141,38 @@ class AgentDispatcher:
                         current_code = await asyncio.to_thread(
                             _call_sandbox_repair_agent, current_code, last_error, manifest, prompt_text or None
                         )
+                        if not _should_continue():
+                            notifications_state.show("Sandbox execution cancelled.", "info")
+                            await bus.publish("notification")
+                            return
+
+                        # ADR-002 P0: same reasoning as start_pycoder_run's
+                        # identical repair re-gate - the repair agent just
+                        # produced code the user has never seen, so it must
+                        # not run under the approval that only ever covered
+                        # the FIRST version. Re-disclose the (unchanged)
+                        # manifest alongside it, since code_sandbox_approval_
+                        # requirements was already cleared once the initial
+                        # gate resolved above.
+                        request_entry = self._code_sandbox_requests.get(request_id)
+                        if request_entry is None:
+                            return
+                        repair_future: asyncio.Future = asyncio.get_running_loop().create_future()
+                        request_entry["approval_future"] = repair_future
+                        node.code_sandbox_code = current_code
+                        node.code_sandbox_approval_requirements = manifest
+                        node.code_sandbox_approved_fingerprint = _fingerprint_changes(
+                            {"code": current_code, "manifest": manifest}
+                        )
+                        node.code_sandbox_awaiting_approval = True
+                        await bus.publish("scene")
+                        repair_approved = await repair_future
+                        node.code_sandbox_awaiting_approval = False
+                        node.code_sandbox_approval_requirements = ""
+                        if not repair_approved:
+                            on_failure("Sandbox run cancelled: repaired code was not approved.")
+                            await bus.publish("scene")
+                            return
                     else:
                         # Structurally unreachable (mirrors legacy's own
                         # identical dead `else` branch - every loop path

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -505,6 +505,17 @@ class SceneNode:
     pycoder_analysis: str = ""  # AI's analysis of the last output
     pycoder_last_run_failed: bool = False
     pycoder_awaiting_approval: bool = False
+    # ADR-002 P0: a fingerprint (see graphlink_plugins.gitlink.agent's
+    # _fingerprint_changes, reused here rather than reinvented) of exactly
+    # what the CURRENT pycoder_awaiting_approval gate is asking about -
+    # {"code": pycoder_code}. Set the instant the gate opens (mirrors
+    # gitlink_change_fingerprint's own timing), checked immediately before
+    # the code it covers actually executes (AgentDispatcher.start_pycoder_
+    # run), and cleared everywhere pycoder_awaiting_approval itself is
+    # cleared, so a resolved/denied/superseded approval can never be
+    # replayed. Internal bookkeeping only - EXCLUDED from scene_payload(),
+    # same posture as code_sandbox_sandbox_id.
+    pycoder_approved_fingerprint: str | None = None
     pycoder_error: str = ""
     # R5.4: the Execution Sandbox node's real persisted shape - runs Python
     # inside an isolated per-node virtualenv (VirtualEnvSandbox, keyed by
@@ -554,6 +565,12 @@ class SceneNode:
     # and in complete_code_sandbox_run/fail_code_sandbox_run below. Unused
     # (default) for every other kind.
     code_sandbox_approval_requirements: str = ""
+    # ADR-002 P0: same mechanism as pycoder_approved_fingerprint above,
+    # fingerprinting {"code": code_sandbox_code, "manifest":
+    # code_sandbox_approval_requirements} instead - see that field's own
+    # comment for the full reasoning. Internal bookkeeping only, EXCLUDED
+    # from scene_payload().
+    code_sandbox_approved_fingerprint: str | None = None
     code_sandbox_error: str = ""
     # R6.1: Notes/Frames/Containers - shared color override for note/frame/
     # container kinds. Hex string like "#4a7c59"; None means "use the kind's
@@ -1707,6 +1724,7 @@ class SceneDocument:
         node.pycoder_analysis = str(analysis)
         node.pycoder_last_run_failed = bool(last_run_failed)
         node.pycoder_awaiting_approval = False
+        node.pycoder_approved_fingerprint = None
         node.pycoder_error = ""
         return node
 
@@ -1722,6 +1740,7 @@ class SceneDocument:
         if node is None:
             return None
         node.pycoder_awaiting_approval = False
+        node.pycoder_approved_fingerprint = None
         node.pycoder_error = str(message)
         return node
 
@@ -1731,11 +1750,16 @@ class SceneDocument:
     # NOTHING from graphlink_plugins.code_sandbox.
 
     def add_code_sandbox_node(self, x: float, y: float, parent_id: str) -> SceneNode:
-        """The Execution Sandbox node's creation primitive - same
+        """The Virtual Environment Runner node's creation primitive - same
         required-parent posture as every R5 sibling. Title is always the
-        fixed literal "Execution Sandbox" (matches backend/plugins.py's own
-        plugin display name). code_sandbox_sandbox_id is minted here, ONCE,
-        at creation time - a short uuid4 hex used purely as this node's
+        fixed literal "Virtual Environment Runner" (matches
+        backend/plugins.py's own plugin display name - renamed under
+        ADR-002 P0 from "Execution Sandbox", which oversold what is
+        actually a plain OS subprocess running inside a venv, not an
+        OS-level sandbox; the internal kind="code_sandbox" identifier is
+        UNCHANGED, since it's persisted wire/save-format state, not a
+        display string). code_sandbox_sandbox_id is minted here, ONCE, at
+        creation time - a short uuid4 hex used purely as this node's
         sandbox directory name (VirtualEnvSandbox re-sanitizes it again on
         its own side, but a short, already-safe id keeps the on-disk path
         short and human-scannable)."""
@@ -1746,7 +1770,7 @@ class SceneDocument:
             id=node_id,
             x=float(x),
             y=float(y),
-            title="Execution Sandbox",
+            title="Virtual Environment Runner",
             kind="code_sandbox",
             code_sandbox_sandbox_id=uuid.uuid4().hex[:12],
         )
@@ -1793,6 +1817,7 @@ class SceneDocument:
         node.code_sandbox_analysis = str(analysis)
         node.code_sandbox_awaiting_approval = False
         node.code_sandbox_approval_requirements = ""
+        node.code_sandbox_approved_fingerprint = None
         node.code_sandbox_error = ""
         return node
 
@@ -1805,6 +1830,7 @@ class SceneDocument:
             return None
         node.code_sandbox_awaiting_approval = False
         node.code_sandbox_approval_requirements = ""
+        node.code_sandbox_approved_fingerprint = None
         node.code_sandbox_error = str(message)
         return node
 
@@ -4204,7 +4230,7 @@ def register_canvas(
         # comment for the exact race this closes.
         node_for_check = document.nodes.get(node_id)
         if node_for_check is not None and node_for_check.pending_request_id:
-            notifications.show("Execution Sandbox is already busy for this node.", "info")
+            notifications.show("Virtual Environment Runner is already busy for this node.", "info")
             await bus.publish("notification")
             return None
         if node_for_check is not None:

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -64,7 +64,7 @@ _PLUGINS = [
     ("Web Research", "Searches, retrieves, and summarizes cited web sources under a bounded network policy.", "Reasoning & Research"),
     ("Gitlink", "Loads a GitHub repository into structured XML context, prepares file-level changes, and only writes after explicit approval.", "Build & Execution"),
     ("Py-Coder", "Opens a Python execution environment to run code and get AI analysis.", "Build & Execution"),
-    ("Execution Sandbox", "Runs Python inside an isolated virtualenv with your full user-account privileges (isolates installed packages, not the operating system) and lets you declare per-node requirements.txt dependencies.", "Build & Execution"),
+    ("Virtual Environment Runner", "Runs Python inside an isolated virtualenv with your full user-account privileges (isolates installed packages, not the operating system) and lets you declare per-node requirements.txt dependencies.", "Build & Execution"),
     ("HTML Renderer", "Adds a node to render HTML code from a parent node.", "Build & Execution"),
     ("Artifact / Drafter", "A split-pane node for iteratively drafting and refining living documents (Markdown).", "Workflow & Drafting"),
 ]
@@ -189,12 +189,12 @@ def register_plugins(
             await bus.publish("scene")
             return node.id
 
-        if name == "Execution Sandbox":
+        if name == "Virtual Environment Runner":
             # R5.4: the fifth real node-creation plugin, same posture as
             # every prior real node-creation plugin above.
             if not parent_node_id or parent_node_id not in canvas_document.nodes:
                 notifications.show(
-                    "Please select a valid node to branch from before adding an Execution Sandbox node.",
+                    "Please select a valid node to branch from before adding a Virtual Environment Runner node.",
                     "warning",
                 )
                 await bus.publish("notification")

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -542,7 +542,7 @@ def _restore_pycoder_payload(payload: dict[str, Any]) -> SceneNode:
 def _restore_code_sandbox_payload(payload: dict[str, Any]) -> SceneNode:
     x, y = _position(payload)
     return SceneNode(
-        id="", x=x, y=y, title="Execution Sandbox", kind="code_sandbox",
+        id="", x=x, y=y, title="Virtual Environment Runner", kind="code_sandbox",
         code_sandbox_requirements=str(payload.get("requirements", "")),
         code_sandbox_prompt=str(payload.get("prompt", "")),
         code_sandbox_code=str(payload.get("code", "")),

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -3478,6 +3478,7 @@ def _make_pycoder_node(**overrides):
         pycoder_analysis="",
         pycoder_last_run_failed=False,
         pycoder_awaiting_approval=False,
+        pycoder_approved_fingerprint=None,
         pycoder_error="",
     )
     defaults.update(overrides)
@@ -3494,10 +3495,34 @@ def _make_code_sandbox_node(**overrides):
         code_sandbox_output="",
         code_sandbox_analysis="",
         code_sandbox_awaiting_approval=False,
+        code_sandbox_approval_requirements="",
+        code_sandbox_approved_fingerprint=None,
         code_sandbox_error="",
     )
     defaults.update(overrides)
     return SimpleNamespace(**defaults)
+
+
+async def _approve_every_gate_until_done(dispatcher, request_id, task, requests_dict_name, max_iterations=400):
+    """ADR-002 P0 test helper: the repair loop now opens a FRESH approval
+    gate (a new asyncio.Future replacing the resolved one in the same dict
+    slot) before every repaired execution attempt, instead of reusing the
+    original approval. There is no single moment to "resolve the future" the
+    way the old one-gate-per-run tests could (see this section's own
+    docstring for why resolving before the task even starts still works for
+    a SINGLE gate) - so this polls, approving whatever gate is currently
+    open, until the task completes. approve_code_execution/deny_code_
+    execution are idempotent on an already-resolved future (see
+    AgentDispatcher._resolve_approval's own `future.done()` guard), so
+    calling this every tick is safe even when no new gate has opened yet."""
+    requests = getattr(dispatcher, requests_dict_name)
+    for _ in range(max_iterations):
+        if task.done():
+            return
+        if request_id in requests:
+            dispatcher.approve_code_execution(request_id)
+        await asyncio.sleep(0.005)
+    raise AssertionError("task did not complete after repeatedly approving every gate")
 
 
 def _make_code_exec_env():
@@ -3794,9 +3819,10 @@ def test_pycoder_ai_driven_repair_loop_exhausts_retries_calls_on_success_with_la
         agents_module.PyCoderExecutionAgent, "get_response",
         lambda self, history, prompt: "[TOOL:PYTHON]\nbroken\n[/TOOL]",
     )
+    repair_calls = []
     monkeypatch.setattr(
         agents_module.PyCoderRepairAgent, "get_response",
-        lambda self, code, error, is_final_attempt: "still broken",
+        lambda self, code, error, is_final_attempt: repair_calls.append(1) or f"still broken v{len(repair_calls)}",
     )
     monkeypatch.setattr(
         agents_module.PyCoderAnalysisAgent, "get_response",
@@ -3805,9 +3831,21 @@ def test_pycoder_ai_driven_repair_loop_exhausts_retries_calls_on_success_with_la
     fake_repl = _FakeRepl(script=[("err", True)])  # every execute() call fails
     monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
 
+    # ADR-002 P0 regression guard: every repaired variant must open its own
+    # fresh gate - a local SimpleNamespace subclass (NOT a patch on the
+    # shared builtin SimpleNamespace type) counts how many times
+    # pycoder_awaiting_approval transitions to True, since its final value is
+    # always False by the time the run completes and would hide a regression
+    # back to "one gate, reused for every repair".
+    class _CountingNode(SimpleNamespace):
+        def __setattr__(self, name, value):
+            if name == "pycoder_awaiting_approval" and value is True:
+                self.__dict__["gate_open_count"] = self.__dict__.get("gate_open_count", 0) + 1
+            super().__setattr__(name, value)
+
     async def run():
         bus, notifications, dispatcher = _make_code_exec_env()
-        node = _make_pycoder_node(pycoder_mode="ai_driven")
+        node = _CountingNode(**_make_pycoder_node(pycoder_mode="ai_driven").__dict__, gate_open_count=0)
         successes = []
 
         await dispatcher.start_pycoder_run(
@@ -3816,7 +3854,7 @@ def test_pycoder_ai_driven_repair_loop_exhausts_retries_calls_on_success_with_la
             on_success=lambda *a: successes.append(a), on_failure=lambda m: None,
         )
         request_id, entry = next(iter(dispatcher._pycoder_requests.items()))
-        dispatcher.approve_code_execution(request_id)
+        await _approve_every_gate_until_done(dispatcher, request_id, entry["task"], "_pycoder_requests")
         await entry["task"]
 
         assert len(successes) == 1, "an exhausted repair loop is still a completed run, never on_failure"
@@ -3824,6 +3862,104 @@ def test_pycoder_ai_driven_repair_loop_exhausts_retries_calls_on_success_with_la
         assert last_run_failed is True
         assert analysis.startswith("**PROCESS FAILED**")
         assert len(fake_repl.calls) == 4, "max_retries=4, matching legacy exactly"
+        assert repair_calls == [1, 1, 1], "3 repairs between the 4 execute attempts"
+        assert node.gate_open_count == 4, (
+            "ADR-002 P0: one gate for the original code, plus one fresh gate per repaired "
+            "variant (3) - repaired code must never run under the original approval"
+        )
+
+    asyncio.run(run())
+
+
+def test_pycoder_ai_driven_repair_gate_denied_stops_immediately_without_further_repairs(monkeypatch):
+    """ADR-002 P0: denying a LATER gate (a repaired variant, not the
+    original code) must stop the run with its own distinct message, and must
+    not fall through to yet another repair attempt."""
+    monkeypatch.setattr(
+        agents_module.PyCoderExecutionAgent, "get_response",
+        lambda self, history, prompt: "[TOOL:PYTHON]\nbroken\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderRepairAgent, "get_response",
+        lambda self, code, error, is_final_attempt: "still broken",
+    )
+    fake_repl = _FakeRepl(script=[("err", True)])  # every execute() call fails
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pycoder_mode="ai_driven")
+        failures = []
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="ai_driven", prompt="do something impossible", code="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=failures.append,
+        )
+        request_id, entry = next(iter(dispatcher._pycoder_requests.items()))
+
+        # Approve the FIRST gate (the original code) only.
+        for _ in range(200):
+            if node.pycoder_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert dispatcher.approve_code_execution(request_id) is True
+
+        # Wait for the SECOND gate (the repaired code) to open, then deny it.
+        for _ in range(200):
+            if len(fake_repl.calls) >= 1 and node.pycoder_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert node.pycoder_awaiting_approval is True, "the repaired variant must open its own gate"
+        assert dispatcher.deny_code_execution(request_id) is True
+        await entry["task"]
+
+        assert failures == ["Py-Coder run cancelled: repaired code was not approved."]
+        assert len(fake_repl.calls) == 1, "denying the repair gate must prevent the repaired code from ever running"
+        assert node.pycoder_awaiting_approval is False
+        assert dispatcher._pycoder_requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_pycoder_execution_blocked_when_approved_fingerprint_does_not_match(monkeypatch):
+    """ADR-002 P0 defense-in-depth: if node.pycoder_approved_fingerprint
+    ever disagrees with the code about to execute (simulating a future bug
+    that mutates current_code without opening a fresh gate), the run must
+    fail loudly instead of silently executing unapproved content."""
+    monkeypatch.setattr(
+        agents_module.PyCoderExecutionAgent, "get_response",
+        lambda self, history, prompt: "[TOOL:PYTHON]\nprint(1)\n[/TOOL]",
+    )
+    fake_repl = _FakeRepl(script=[("1", False)])
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pycoder_mode="ai_driven")
+        failures = []
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="ai_driven", prompt="add 1", code="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=failures.append,
+        )
+        request_id, entry = next(iter(dispatcher._pycoder_requests.items()))
+        for _ in range(200):
+            if node.pycoder_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        # Tamper with the fingerprint the way a hypothetical future bug that
+        # mutated the code without re-gating would leave it mismatched.
+        node.pycoder_approved_fingerprint = "not-the-real-fingerprint"
+        assert dispatcher.approve_code_execution(request_id) is True
+        await entry["task"]
+
+        assert failures == [
+            "Py-Coder execution blocked: the approved code no longer matches what is about to run."
+        ]
+        assert fake_repl.calls == [], "execution must never happen once the fingerprint check fails"
 
     asyncio.run(run())
 
@@ -4043,6 +4179,215 @@ def test_code_sandbox_approved_full_success_flow_runs_venv_and_analyzes(monkeypa
         assert node.code_sandbox_awaiting_approval is False
         assert dispatcher._code_sandbox_requests == {}
         assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_repair_loop_requires_a_fresh_approval_for_each_repaired_attempt(monkeypatch):
+    """ADR-002 P0: the code_sandbox twin of the pycoder repair-gate test
+    above - same confirmed gap, same fix, same shape."""
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nbroken\n[/TOOL]",
+    )
+    repair_calls = []
+    monkeypatch.setattr(
+        agents_module.SandboxRepairAgent, "get_response",
+        lambda self, code, error, manifest, original_prompt=None: repair_calls.append(1) or "still broken",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "explains the persistent failure",
+    )
+
+    class _FailingSandbox:
+        def __init__(self, sandbox_id):
+            self.sandbox_id = sandbox_id
+            self.execute_calls = []
+
+        def ensure_base_environment(self, should_continue, emit_line=None):
+            pass
+
+        def sync_requirements(self, manifest, should_continue, emit_line=None):
+            pass
+
+        def execute_code(self, code, should_continue, emit_line=None):
+            self.execute_calls.append(code)
+            return "Traceback (most recent call last):\nboom", 1
+
+    fake_sandbox_holder = {}
+
+    def _make_sandbox(sandbox_id):
+        sandbox = _FailingSandbox(sandbox_id)
+        fake_sandbox_holder["sandbox"] = sandbox
+        return sandbox
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _make_sandbox)
+
+    class _CountingNode(SimpleNamespace):
+        def __setattr__(self, name, value):
+            if name == "code_sandbox_awaiting_approval" and value is True:
+                self.__dict__["gate_open_count"] = self.__dict__.get("gate_open_count", 0) + 1
+            super().__setattr__(name, value)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _CountingNode(**_make_code_sandbox_node().__dict__, gate_open_count=0)
+        successes = []
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="do something impossible", existing_code="",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: successes.append(a), on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(dispatcher._code_sandbox_requests.items()))
+        await _approve_every_gate_until_done(dispatcher, request_id, entry["task"], "_code_sandbox_requests")
+        await entry["task"]
+
+        assert len(successes) == 1, "an exhausted repair loop is still a completed run, never on_failure"
+        sandbox = fake_sandbox_holder["sandbox"]
+        assert len(sandbox.execute_calls) == 3, "max_attempts=3, matching the existing sandbox behavior"
+        assert repair_calls == [1, 1], "2 repairs between the 3 execute attempts"
+        assert node.gate_open_count == 3, (
+            "ADR-002 P0: one gate for the original code, plus one fresh gate per repaired "
+            "variant (2) - repaired code must never run under the original approval"
+        )
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_repair_gate_denied_stops_immediately_without_further_repairs(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nbroken\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.SandboxRepairAgent, "get_response",
+        lambda self, code, error, manifest, original_prompt=None: "still broken",
+    )
+
+    class _FailingSandbox:
+        def __init__(self, sandbox_id):
+            self.execute_calls = []
+
+        def ensure_base_environment(self, should_continue, emit_line=None):
+            pass
+
+        def sync_requirements(self, manifest, should_continue, emit_line=None):
+            pass
+
+        def execute_code(self, code, should_continue, emit_line=None):
+            self.execute_calls.append(code)
+            return "Traceback (most recent call last):\nboom", 1
+
+    fake_sandbox_holder = {}
+
+    def _make_sandbox(sandbox_id):
+        sandbox = _FailingSandbox(sandbox_id)
+        fake_sandbox_holder["sandbox"] = sandbox
+        return sandbox
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _make_sandbox)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+        failures = []
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="do something impossible", existing_code="",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=failures.append,
+        )
+        request_id, entry = next(iter(dispatcher._code_sandbox_requests.items()))
+
+        for _ in range(200):
+            if node.code_sandbox_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert dispatcher.approve_code_execution(request_id) is True
+
+        for _ in range(200):
+            if "sandbox" in fake_sandbox_holder:
+                break
+            await asyncio.sleep(0.005)
+        sandbox = fake_sandbox_holder["sandbox"]
+        for _ in range(200):
+            if len(sandbox.execute_calls) >= 1 and node.code_sandbox_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert node.code_sandbox_awaiting_approval is True, "the repaired variant must open its own gate"
+        assert dispatcher.deny_code_execution(request_id) is True
+        await entry["task"]
+
+        assert failures == ["Sandbox run cancelled: repaired code was not approved."]
+        assert len(sandbox.execute_calls) == 1, (
+            "denying the repair gate must prevent the repaired code from ever running"
+        )
+        assert node.code_sandbox_awaiting_approval is False
+        assert dispatcher._code_sandbox_requests == {}
+        assert node.pending_request_id is None
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_execution_blocked_when_approved_fingerprint_does_not_match(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint(1)\n[/TOOL]",
+    )
+
+    class _FakeSandbox:
+        def __init__(self, sandbox_id):
+            self.execute_calls = []
+
+        def ensure_base_environment(self, should_continue, emit_line=None):
+            pass
+
+        def sync_requirements(self, manifest, should_continue, emit_line=None):
+            pass
+
+        def execute_code(self, code, should_continue, emit_line=None):
+            self.execute_calls.append(code)
+            return "1", 0
+
+    fake_sandbox_holder = {}
+
+    def _make_sandbox(sandbox_id):
+        sandbox = _FakeSandbox(sandbox_id)
+        fake_sandbox_holder["sandbox"] = sandbox
+        return sandbox
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _make_sandbox)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+        failures = []
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="print 1", existing_code="",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=failures.append,
+        )
+        request_id, entry = next(iter(dispatcher._code_sandbox_requests.items()))
+        for _ in range(200):
+            if node.code_sandbox_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        node.code_sandbox_approved_fingerprint = "not-the-real-fingerprint"
+        assert dispatcher.approve_code_execution(request_id) is True
+        await entry["task"]
+
+        assert failures == [
+            "Sandbox execution blocked: the approved code no longer matches what is about to run."
+        ]
+        assert fake_sandbox_holder["sandbox"].execute_calls == [], (
+            "execution must never happen once the fingerprint check fails"
+        )
 
     asyncio.run(run())
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -4470,7 +4470,7 @@ def test_add_code_sandbox_node_creates_child_with_defaults_and_mints_sandbox_id(
     parent = doc.add_chat_node(0, 0, "wire up sandbox", True)
     node = doc.add_code_sandbox_node(10, 20, parent.id)
     assert node.kind == "code_sandbox"
-    assert node.title == "Execution Sandbox"
+    assert node.title == "Virtual Environment Runner"
     assert node.code_sandbox_sandbox_id, "a sandbox id must be minted at creation time"
     assert node.code_sandbox_requirements == ""
     assert node.code_sandbox_prompt == ""

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -394,13 +394,13 @@ def test_execute_plugin_pycoder_creates_a_real_pycoder_node():
 def test_execute_plugin_execution_sandbox_requires_parent():
     bus, notifications, canvas_document = _make_plugins_bus()
 
-    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Execution Sandbox"]))
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Virtual Environment Runner"]))
 
     assert result is None
     assert notifications.visible is True
     assert notifications.msg_type == "warning"
     assert notifications.message == (
-        "Please select a valid node to branch from before adding an Execution Sandbox node."
+        "Please select a valid node to branch from before adding a Virtual Environment Runner node."
     )
     assert not any(n.kind == "code_sandbox" for n in canvas_document.nodes.values())
 
@@ -409,7 +409,7 @@ def test_execute_plugin_execution_sandbox_rejects_unknown_parent_id():
     bus, notifications, canvas_document = _make_plugins_bus()
 
     result = asyncio.run(
-        bus.dispatch_intent("app-plugins", "executePlugin", ["Execution Sandbox", "ghost-node-id"])
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Virtual Environment Runner", "ghost-node-id"])
     )
 
     assert result is None
@@ -436,13 +436,13 @@ def test_execute_plugin_execution_sandbox_creates_a_real_code_sandbox_node():
     bus.attach(recorder)
 
     result = asyncio.run(
-        bus.dispatch_intent("app-plugins", "executePlugin", ["Execution Sandbox", parent.id])
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Virtual Environment Runner", parent.id])
     )
 
     assert result is not None
     node = canvas_document.nodes[result]
     assert node.kind == "code_sandbox"
-    assert node.title == "Execution Sandbox"
+    assert node.title == "Virtual Environment Runner"
     assert node.code_sandbox_sandbox_id, "a sandbox id must be minted at creation time"
     assert any(
         e.source == parent.id and e.target == node.id for e in canvas_document.edges.values()
@@ -704,7 +704,7 @@ def test_every_plugin_now_has_a_real_creation_branch():
     # collect zero cases) that every _PLUGINS entry has moved off the
     # generic deferred notice.
     handled = {
-        "Web Research", "Artifact / Drafter", "Gitlink", "Py-Coder", "Execution Sandbox",
+        "Web Research", "Artifact / Drafter", "Gitlink", "Py-Coder", "Virtual Environment Runner",
         "System Prompt", "Conversation Node", "HTML Renderer",
     }
     assert handled == {name for name, _description, _category in _PLUGINS}

--- a/backend/tests/test_process_env_allowlist.py
+++ b/backend/tests/test_process_env_allowlist.py
@@ -1,0 +1,104 @@
+"""Tests for graphlink_process_env's explicit-allowlist subprocess
+environment builder (ADR-002 P0).
+
+Regression coverage for the confirmed gap: Py-Coder's REPL subprocess and
+the Virtual Environment Runner's venv-create/pip-install/script-run trio
+used to call subprocess.Popen(...) with no `env=` argument, silently
+inheriting the backend's FULL environment - including any provider API key
+configured as an environment variable. safe_subprocess_env() replaces that
+with an explicit allowlist; these tests pin down that it (1) actually
+excludes secret-shaped variables, (2) still includes what a real
+python/pip/venv subprocess needs, and (3) is case-insensitive on Windows,
+where os.environ key casing is inconsistent.
+
+Live end-to-end proof that a real `python -m venv` + `pip install` still
+works under this restricted environment was done manually against this
+change (real venv creation, real network pip install, confirmed the
+allowlist doesn't break either) - not re-asserted here as an automated
+test, since spinning up a real venv + network install in the pytest suite
+would be slow and flaky in CI; this file covers the allowlist's own pure
+logic instead.
+"""
+
+import os
+
+from graphlink_process_env import safe_subprocess_env
+
+
+def test_excludes_provider_api_key_style_variables(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-not-leak")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-should-not-leak")
+    monkeypatch.setenv("GEMINI_API_KEY", "should-not-leak")
+    monkeypatch.setenv("GRAPHLINK_ANTHROPIC_API_KEY", "should-not-leak")
+    monkeypatch.setenv("GRAPHITE_OPENAI_API_KEY", "should-not-leak")
+
+    env = safe_subprocess_env()
+
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert "GEMINI_API_KEY" not in env
+    assert "GRAPHLINK_ANTHROPIC_API_KEY" not in env
+    assert "GRAPHITE_OPENAI_API_KEY" not in env
+
+
+def test_excludes_an_arbitrary_unknown_secret_shaped_variable(monkeypatch):
+    """The allowlist protects even secrets this codebase has never heard
+    of - a personal AWS key, a work VPN token, anything - since it copies
+    through only a fixed known-safe set, not everything except a blocklist."""
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "should-not-leak")
+    monkeypatch.setenv("MY_RANDOM_PERSONAL_TOKEN", "should-not-leak")
+
+    env = safe_subprocess_env()
+
+    assert "AWS_SECRET_ACCESS_KEY" not in env
+    assert "MY_RANDOM_PERSONAL_TOKEN" not in env
+
+
+def test_includes_what_a_python_pip_venv_subprocess_actually_needs(monkeypatch):
+    monkeypatch.setenv("PATH", r"C:\Windows\System32;C:\Python")
+    monkeypatch.setenv("SYSTEMROOT", r"C:\Windows")
+    monkeypatch.setenv("TEMP", r"C:\Users\test\AppData\Local\Temp")
+
+    env = safe_subprocess_env()
+
+    assert env["PATH"] == r"C:\Windows\System32;C:\Python"
+    assert env["SYSTEMROOT"] == r"C:\Windows"
+    assert env["TEMP"] == r"C:\Users\test\AppData\Local\Temp"
+
+
+def test_case_insensitive_on_the_allowlist_match(monkeypatch):
+    """Windows env var casing in os.environ is inconsistent (e.g.
+    "SystemRoot" vs "SYSTEMROOT" depending on how the process was launched) -
+    the allowlist match must not silently drop a needed variable just
+    because of casing."""
+    monkeypatch.delenv("SystemRoot", raising=False)
+    monkeypatch.delenv("SYSTEMROOT", raising=False)
+    monkeypatch.setenv("SystemRoot", r"C:\Windows")
+
+    env = safe_subprocess_env()
+
+    assert any(name.upper() == "SYSTEMROOT" for name in env)
+
+
+def test_does_not_mutate_the_real_os_environ(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-not-leak")
+
+    safe_subprocess_env()
+
+    assert os.environ.get("ANTHROPIC_API_KEY") == "sk-should-not-leak", (
+        "building a restricted copy must never touch the real process environment"
+    )
+
+
+def test_excludes_proxy_variables_by_design(monkeypatch):
+    """Deliberately conservative (see graphlink_process_env's own module
+    doc): a proxy URL can itself carry embedded credentials
+    (http://user:pass@host:port), so proxy variables are excluded even
+    though this could break `pip install` behind a corporate proxy."""
+    monkeypatch.setenv("HTTP_PROXY", "http://user:pass@proxy.example:8080")
+    monkeypatch.setenv("HTTPS_PROXY", "http://user:pass@proxy.example:8080")
+
+    env = safe_subprocess_env()
+
+    assert "HTTP_PROXY" not in env
+    assert "HTTPS_PROXY" not in env

--- a/graphlink_plugins/code_sandbox/domain.py
+++ b/graphlink_plugins/code_sandbox/domain.py
@@ -49,6 +49,7 @@ from pathlib import Path
 
 import api_provider
 import graphlink_task_config as config
+from graphlink_process_env import safe_subprocess_env
 
 
 class SandboxStage(Enum):
@@ -60,7 +61,12 @@ class SandboxStage(Enum):
 
 
 def _subprocess_kwargs():
-    kwargs = {}
+    # ADR-002 P0: env= is explicit-allowlist, not inherited - see
+    # graphlink_process_env's own module doc for why. Every venv-create/
+    # pip-install/script-execute call in this file goes through
+    # _run_subprocess below, which passes these kwargs, so this is the one
+    # place that needs to set it.
+    kwargs = {"env": safe_subprocess_env()}
     if sys.platform == "win32":
         kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
     return kwargs

--- a/graphlink_plugins/pycoder/domain.py
+++ b/graphlink_plugins/pycoder/domain.py
@@ -41,6 +41,7 @@ from enum import Enum
 
 import api_provider
 import graphlink_task_config as config
+from graphlink_process_env import safe_subprocess_env
 
 
 class PyCoderStage(Enum):
@@ -98,7 +99,11 @@ while True:
     status = "ERROR" if failed else "OK"
     print("\\n---GRAPHLINK_EXEC_BOUNDARY:{nonce}:" + status + "---", flush=True)
 """
-        kwargs = {}
+        # ADR-002 P0: env= is explicit-allowlist, not inherited - see
+        # graphlink_process_env's own module doc. Without this, the REPL
+        # subprocess would inherit the backend's full os.environ, including
+        # any provider API key configured as an environment variable.
+        kwargs = {'env': safe_subprocess_env()}
         # Hide the console window on Windows
         if sys.platform == 'win32':
             kwargs['creationflags'] = subprocess.CREATE_NO_WINDOW

--- a/graphlink_process_env.py
+++ b/graphlink_process_env.py
@@ -1,0 +1,73 @@
+"""ADR-002 P0: an explicit-allowlist environment builder for subprocesses
+that execute AI-generated code (Py-Coder's persistent REPL,
+graphlink_plugins/pycoder/domain.py; the Virtual Environment Runner's
+venv-create/pip-install/script-run trio, graphlink_plugins/code_sandbox/
+domain.py). Both previously called subprocess.Popen(...) with no `env=`
+argument, which means Python's default applies: the child inherits the
+FULL parent os.environ - including every provider API key this app itself
+reads via os.environ.get(...) fallbacks (see api_provider.py), if the user
+has configured one as an environment variable rather than through Settings.
+
+An ALLOWLIST, not a blocklist: block-listing known secret var names is
+fragile - a user's own OS environment can carry secrets under names this
+codebase has never heard of (a personal AWS_SECRET_ACCESS_KEY, a work VPN
+token, anything). Only the variables a plain `python`/`pip`/`venv`
+subprocess actually needs to function are copied through; every provider
+key this app itself reads from the environment is excluded by
+construction, not by name-matching.
+
+Deliberately conservative: proxy variables (HTTP_PROXY/HTTPS_PROXY/
+NO_PROXY) are NOT included, even though excluding them could break `pip
+install` behind a corporate proxy - a proxy URL can itself carry embedded
+credentials (`http://user:pass@host:port`), and "secure by default" wins
+over that convenience for code the user has not yet reviewed.
+"""
+
+import os
+
+# The minimum a `python`/`pip`/`venv` subprocess needs to run at all on
+# Windows: resolve the interpreter/its DLLs, create a venv, resolve DNS for
+# `pip install`, and read/write temp files. A short list of POSIX
+# equivalents is included too, for parity if this ever runs on macOS/Linux -
+# none of these carry secrets.
+_SAFE_ENV_VAR_NAMES = frozenset(
+    {
+        "PATH",
+        "PATHEXT",
+        "SYSTEMROOT",
+        "SYSTEMDRIVE",
+        "WINDIR",
+        "COMSPEC",
+        "TEMP",
+        "TMP",
+        "USERPROFILE",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "NUMBER_OF_PROCESSORS",
+        "PROCESSOR_ARCHITECTURE",
+        "PROCESSOR_IDENTIFIER",
+        "OS",
+        # POSIX equivalents.
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "SHELL",
+        "USER",
+    }
+)
+
+
+def safe_subprocess_env() -> dict[str, str]:
+    """Build an explicit-allowlist environment dict for a subprocess that
+    will execute AI-generated code. Pass this as
+    `subprocess.Popen(..., env=safe_subprocess_env())` - never omit `env=`
+    at one of these call sites, which would silently fall back to
+    inheriting the full parent environment.
+
+    Case-insensitive on the allowlist match (Windows env var casing in
+    os.environ is inconsistent - e.g. "SystemRoot" vs "SYSTEMROOT" -
+    while POSIX systems are case-sensitive by convention; comparing
+    upper-cased names is correct for both)."""
+    return {name: value for name, value in os.environ.items() if name.upper() in _SAFE_ENV_VAR_NAMES}

--- a/web_ui/src/app/canvas/CodeExecutionApprovalPanel.test.tsx
+++ b/web_ui/src/app/canvas/CodeExecutionApprovalPanel.test.tsx
@@ -132,7 +132,7 @@ describe("CodeExecutionApprovalPanel", () => {
     expect(screen.getByText(/there is no sandboxing/)).toBeInTheDocument();
     expect(
       screen.getByText(
-        /This will run AI-generated Python code in a persistent local session with the full privileges of your user account \(there is no sandboxing\)\. If execution fails, automatically repaired versions of this code may run under this same approval\./,
+        /This will run AI-generated Python code in a persistent local session with the full privileges of your user account \(there is no sandboxing\)\. If execution fails, you will be asked to approve each automatically repaired version before it runs\./,
       ),
     ).toBeInTheDocument();
   });
@@ -156,10 +156,10 @@ describe("CodeExecutionApprovalPanel", () => {
 
   // -- FIX C regression guard: code_sandbox requirements/repair disclosure --
 
-  it("FIX C: Code-Sandbox warning also discloses the repair-loop re-execution risk", () => {
+  it("FIX C: Code-Sandbox warning also discloses that repaired code needs its own approval", () => {
     renderPanel({ kind: "code_sandbox" });
     expect(
-      screen.getByText(/automatically repaired versions of this code may run under this same approval/),
+      screen.getByText(/you will be asked to approve each automatically repaired version before it runs/),
     ).toBeInTheDocument();
   });
 

--- a/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
+++ b/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
@@ -110,22 +110,26 @@ export type CodeExecutionKind = "pycoder" | "code_sandbox";
 // module comment) - do NOT soften or paraphrase either of these. The
 // "there is no sandboxing" / "isolates installed packages, not the operating
 // system" substrings are the load-bearing honesty this copy exists for, and
-// are directly regression-tested in CodeExecutionApprovalPanel.test.tsx. The
-// repair-loop-reexecution sentence is appended to BOTH kinds (post-review
-// FIX C) since backend/agents.py's start_code_sandbox_run has the exact same
-// "approve once, repair-and-retry under that one approval" behavior as
-// start_pycoder_run's ai_driven path - omitting it for code_sandbox would be
-// disclosing only half of what one Approve click actually authorizes.
+// are directly regression-tested in CodeExecutionApprovalPanel.test.tsx.
+//
+// ADR-002 P0 UPDATE: the second sentence used to read "...automatically
+// repaired versions of this code may run under this same approval" - that
+// was true of the old implementation and is NOT true anymore.
+// backend/agents.py's start_pycoder_run/start_code_sandbox_run now open a
+// FRESH approval gate (a new panel, this same component, re-rendered) for
+// every repaired variant before it runs - see either function's own "ADR-002
+// P0" comment at its repair-loop re-gate. The sentence below reflects that
+// corrected behavior; do not revert it to the old wording.
 const WARNING_TEXT: Record<CodeExecutionKind, string> = {
   pycoder:
-    "This will run AI-generated Python code in a persistent local session with the full privileges of your user account (there is no sandboxing). If execution fails, automatically repaired versions of this code may run under this same approval.",
+    "This will run AI-generated Python code in a persistent local session with the full privileges of your user account (there is no sandboxing). If execution fails, you will be asked to approve each automatically repaired version before it runs.",
   code_sandbox:
-    "This will run Python code inside an isolated virtual environment with the full privileges of your user account (the environment isolates installed packages, not the operating system). If execution fails, automatically repaired versions of this code may run under this same approval.",
+    "This will run Python code inside an isolated virtual environment with the full privileges of your user account (the environment isolates installed packages, not the operating system). If execution fails, you will be asked to approve each automatically repaired version before it runs.",
 };
 
 const DIALOG_TITLE: Record<CodeExecutionKind, string> = {
   pycoder: "Approve Py-Coder Execution?",
-  code_sandbox: "Approve Sandbox Execution?",
+  code_sandbox: "Approve Virtual Environment Runner Execution?",
 };
 
 /** Wraps the pending code in a markdown fenced ```python code block so

--- a/web_ui/src/app/canvas/CodeSandboxNodeView.test.tsx
+++ b/web_ui/src/app/canvas/CodeSandboxNodeView.test.tsx
@@ -375,10 +375,10 @@ describe("CodeSandboxNodeView", () => {
     expect(packagesList!.textContent).not.toContain("requests");
   });
 
-  it("FIX C: the approval panel also discloses the repair-loop re-execution risk for code_sandbox", () => {
+  it("FIX C: the approval panel also discloses that repaired code needs its own approval", () => {
     renderCodeSandboxNode({ codeSandboxAwaitingApproval: true, codeSandboxCode: "print(1)" });
     expect(
-      screen.getByText(/automatically repaired versions of this code may run under this same approval/),
+      screen.getByText(/you will be asked to approve each automatically repaired version before it runs/),
     ).toBeInTheDocument();
   });
 
@@ -419,7 +419,7 @@ describe("CodeSandboxNodeView", () => {
 
   it("manual collapse hides the body and shows only the header", () => {
     renderCodeSandboxNode({ isCollapsed: true });
-    expect(screen.getByText("Execution Sandbox")).toBeInTheDocument();
+    expect(screen.getByText("Virtual Environment Runner")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Run" })).toBeNull();
   });
 
@@ -432,7 +432,7 @@ describe("CodeSandboxNodeView", () => {
 
   it("LOD auto-collapse (zoom below threshold) also hides the body, even when isCollapsed is false", () => {
     renderCodeSandboxNodeAtZoom(0.2, { isCollapsed: false });
-    expect(screen.getByText("Execution Sandbox")).toBeInTheDocument();
+    expect(screen.getByText("Virtual Environment Runner")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Run" })).toBeNull();
   });
 
@@ -447,7 +447,7 @@ describe("CodeSandboxNodeView", () => {
     const user = userEvent.setup();
     const data = renderCodeSandboxNode();
 
-    fireEvent.contextMenu(screen.getByText("Execution Sandbox"));
+    fireEvent.contextMenu(screen.getByText("Virtual Environment Runner"));
     const menu = screen.getByRole("menu");
     expect(menu).toBeInTheDocument();
 
@@ -460,7 +460,7 @@ describe("CodeSandboxNodeView", () => {
     await user.click(items[0]);
     expect(data.onToggleCollapse).toHaveBeenCalledOnce();
 
-    fireEvent.contextMenu(screen.getByText("Execution Sandbox"));
+    fireEvent.contextMenu(screen.getByText("Virtual Environment Runner"));
     await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
     expect(data.onDelete).toHaveBeenCalledOnce();
   });
@@ -468,7 +468,7 @@ describe("CodeSandboxNodeView", () => {
   it("Escape and outside-click both close the node-level menu", async () => {
     const user = userEvent.setup();
     renderCodeSandboxNode();
-    const header = screen.getByText("Execution Sandbox");
+    const header = screen.getByText("Virtual Environment Runner");
 
     fireEvent.contextMenu(header);
     expect(screen.getByRole("menu")).toBeInTheDocument();

--- a/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
@@ -9,8 +9,12 @@ import { CodeExecutionApprovalPanel } from "./CodeExecutionApprovalPanel";
 import { NodeMenu } from "./NodeMenu";
 
 /**
- * The Execution Sandbox node (Qt-removal plan R5.4) - the Code-Sandbox
- * plugin's React card. Same overall shell as every plugin-node sibling
+ * The Virtual Environment Runner node (Qt-removal plan R5.4, renamed under
+ * ADR-002 P0 from "Execution Sandbox" - that name oversold what is actually
+ * a plain OS subprocess running inside a venv, not OS-level isolation; the
+ * internal kind="code_sandbox" identifier/CSS classes/WS intents are
+ * UNCHANGED, only the display string moved) - the Code-Sandbox plugin's
+ * React card. Same overall shell as every plugin-node sibling
  * (PyCoderNodeView/GitlinkNodeView): collapse/expand OR-ed with LOD, a card
  * menu with outside-click/Escape dismiss, the shared react-markdown +
  * remarkGfm + rehypeHighlight pipeline, no dock-to-parent action.
@@ -218,7 +222,7 @@ export function CodeSandboxNodeView({ id, data, selected }: NodeProps<CodeSandbo
     >
       <Handle type="target" position={Position.Top} className="scene-node-handle" />
       <div className="scene-node-title chat-node-role">
-        <span>Execution Sandbox</span>
+        <span>Virtual Environment Runner</span>
         <button
           type="button"
           className="chat-node-collapse-btn"
@@ -270,7 +274,7 @@ export function CodeSandboxNodeView({ id, data, selected }: NodeProps<CodeSandbo
               Run
             </button>
             {data.pendingRequestId && (
-              <button type="button" onClick={() => data.onCancel()} title="Cancel Execution Sandbox request">
+              <button type="button" onClick={() => data.onCancel()} title="Cancel Virtual Environment Runner request">
                 Cancel
               </button>
             )}

--- a/web_ui/src/app/chrome/help-data/sections.ts
+++ b/web_ui/src/app/chrome/help-data/sections.ts
@@ -314,7 +314,7 @@ export const HELP_SECTIONS: HelpSection[] = [
             "description": "A coding workspace with AI-driven and manual modes, generated code, terminal output, and final analysis tabs. Use it for fast implementation, debugging, code generation, and lightweight computation."
           },
           {
-            "action": "Execution Sandbox",
+            "action": "Virtual Environment Runner",
             "description": "Runs Python in a per-node virtualenv with declared dependencies - the venv isolates installed packages, not the operating system; code still runs with your full account privileges. Choose this over Py-Coder when you need dependency-aware execution or a cleaner reproducible runtime."
           },
           {
@@ -426,7 +426,7 @@ export const HELP_SECTIONS: HelpSection[] = [
           },
           {
             "action": "Coding and Debugging",
-            "description": "Ask for code on the main canvas, move promising results into Py-Coder for iteration, and switch to Execution Sandbox when dependencies or reproducibility matter. This keeps ideation and execution connected."
+            "description": "Ask for code on the main canvas, move promising results into Py-Coder for iteration, and switch to Virtual Environment Runner when dependencies or reproducibility matter. This keeps ideation and execution connected."
           },
           {
             "action": "Planning and Execution",


### PR DESCRIPTION
## Problem

GraphLink's two AI-code-execution features (Py-Coder's persistent REPL, and the venv-based runner previously named "Execution Sandbox") had three gaps:

1. Both subprocess call sites called `subprocess.Popen(...)` with no `env=` argument, silently inheriting the backend's **full** environment - including any provider API key (Anthropic/OpenAI/Gemini, and their `GRAPHLINK_*`/`GRAPHITE_*` variants) if the user had configured one as an OS environment variable.
2. The repair loop (both node kinds regenerate code via an LLM call after a failed run, up to 4/3 attempts) reused the **same already-resolved approval** for every repaired variant - a script the user never saw could run without asking again.
3. The venv-based runner was named "Execution Sandbox" in the node-creation menu and node title, overselling what it actually provides (a Python venv isolates installed packages, not the OS).

## Change

- **Credential isolation**: new `graphlink_process_env.safe_subprocess_env()` builds an explicit allowlist environment (PATH, SYSTEMROOT, TEMP, etc. - the minimum a `python`/`pip`/`venv` subprocess needs) instead of inheriting the parent process's environment. Wired into both subprocess call sites (`graphlink_plugins/pycoder/domain.py`, `graphlink_plugins/code_sandbox/domain.py`). Live-verified against a real `venv` creation + network `pip install` on Windows; confirmed a canary secret does not leak through.
- **Per-repair approval**: `backend/agents.py`'s `start_pycoder_run`/`start_code_sandbox_run` now open a fresh approval gate (a new `asyncio.Future` replacing the resolved one in the same dispatcher-state slot, so cancel/approve/deny keep targeting whichever gate is actually open) before every repaired execution attempt, instead of running it under the original approval. A code+dependencies fingerprint (new `pycoder_approved_fingerprint`/`code_sandbox_approved_fingerprint` fields on `SceneNode`) is checked immediately before every execute call as defense-in-depth against a future regression reintroducing this gap.
- **Accurate naming**: renamed to "Virtual Environment Runner" everywhere the name is user-facing (node-creation menu, node title, approval dialog, in-app help, README/SECURITY.md). The internal `kind="code_sandbox"` identifier, WS intent names, and CSS classes are unchanged, so saved sessions remain compatible.

## Test plan

- [x] `python -m pytest -q` (full suite, repo root) - 1080/1080 passing, including 6 new tests for the env allowlist and 6 new tests for the fingerprint/per-repair-approval behavior (repair-loop-exhaustion regression test, repair-gate-denial test, and a fingerprint-mismatch defense-in-depth test, for both node kinds)
- [x] `npx tsc --noEmit`, `npx vitest run` (908/908), `npx eslint .`, `npx vite build` - all clean
- [x] Live-verified the env allowlist against a real `python -m venv` + network `pip install` + REPL execution on this machine, confirming a canary secret set via `os.environ` does not reach the child process
- [x] Independent adversarial review pass on the diff (env allowlist completeness, async control-flow correctness around the new approval-gate/fingerprint logic, rename completeness) before commit - found and fixed one leftover stale notification string