### PR TITLE
Add "Branch from here": reply from an earlier message, not just the tip

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -189,6 +189,15 @@ ORGANIZE_SPACING_Y = 180
 # find_branch_position packing algorithm (a later refinement).
 MESSAGE_VERTICAL_SPACING = 160
 
+# ADR-002 Workstream 1: how far apart real branch siblings (2+ chat-kind
+# children of the same parent, from "Branch from here") fan out
+# horizontally, so a genuine divergence doesn't render as two nodes stacked
+# exactly on top of each other. 460px clears a chat node's own current CSS
+# width (420px, styles.css's .chat-node) with room to spare, same "clears
+# the node's width, not just MESSAGE_VERTICAL_SPACING" reasoning the Key
+# Takeaway/Explainer Note offset just below already uses.
+BRANCH_HORIZONTAL_SPACING = 460
+
 # R8a: where a generated Key Takeaway / Explainer Note lands relative to its
 # source chat node, and how it is tinted. 400px clears a chat node's own
 # width (~292px) with room to spare, matching the legacy offset. The colours
@@ -2417,7 +2426,12 @@ class SceneDocument:
         del self.nodes[node_id]
         self._detach_node_from_membership(node_id)
 
-    def send_message(self, text: str, content_parts: list[dict[str, Any]] | None = None) -> SceneNode:
+    def send_message(
+        self,
+        text: str,
+        content_parts: list[dict[str, Any]] | None = None,
+        branch_from_node_id: str | None = None,
+    ) -> SceneNode:
         """The Composer's real Send action (R3.3): create a real user
         ChatNode continuing the current branch (last_chat_node_id), or
         start a fresh root if none exists yet. Positioning is a simple
@@ -2427,15 +2441,48 @@ class SceneDocument:
 
         R8a: content_parts carries real attachments (image/audio) staged in
         the composer - optional, additive, threaded straight to
-        add_chat_node."""
-        parent_id = self.last_chat_node_id
-        if parent_id is not None and parent_id in self.nodes:
+        add_chat_node.
+
+        ADR-002 Workstream 1 ("Branch from here"): branch_from_node_id, when
+        given and still a real node, OVERRIDES last_chat_node_id for this
+        one send - the actual fork primitive. Before this, last_chat_node_id
+        was the ONLY way to pick a parent, so a second real branch (two
+        children of one parent) was reachable only by manual edge
+        manipulation, never through the UI - see that field's own comment
+        ("until real node selection exists"). A bad/stale id (deleted node,
+        typo) falls through to the ordinary last_chat_node_id path rather
+        than raising, same defensive posture chat_branch_history's walk
+        already uses for an unknown id.
+
+        When branching onto a parent that already has one or more chat-kind
+        children (a genuine divergence, not a fresh continuation), the new
+        sibling fans out horizontally by BRANCH_HORIZONTAL_SPACING per
+        existing child instead of landing on the exact same (x, y) as an
+        existing branch - which would render as one node silently hiding
+        another.
+
+        last_chat_node_id is updated to the new node afterward exactly as
+        an ordinary send would be, override or not - so the branch just
+        created becomes the active one for the NEXT (non-overridden) send,
+        the same continue-from-here behavior as always."""
+        if branch_from_node_id is not None and branch_from_node_id in self.nodes:
+            parent_id: str | None = branch_from_node_id
             parent = self.nodes[parent_id]
-            x, y = parent.x, parent.y + MESSAGE_VERTICAL_SPACING
+            sibling_count = sum(
+                1
+                for e in self.edges.values()
+                if e.source == parent_id and (target := self.nodes.get(e.target)) is not None and target.kind == "chat"
+            )
+            x, y = parent.x + sibling_count * BRANCH_HORIZONTAL_SPACING, parent.y + MESSAGE_VERTICAL_SPACING
         else:
-            parent_id = None
-            chat_node_count = sum(1 for n in self.nodes.values() if n.kind == "chat")
-            x, y = 0.0, chat_node_count * MESSAGE_VERTICAL_SPACING
+            parent_id = self.last_chat_node_id
+            if parent_id is not None and parent_id in self.nodes:
+                parent = self.nodes[parent_id]
+                x, y = parent.x, parent.y + MESSAGE_VERTICAL_SPACING
+            else:
+                parent_id = None
+                chat_node_count = sum(1 for n in self.nodes.values() if n.kind == "chat")
+                x, y = 0.0, chat_node_count * MESSAGE_VERTICAL_SPACING
         node = self.add_chat_node(x, y, text, True, parent_id=parent_id, content_parts=content_parts)
         self.last_chat_node_id = node.id
         return node
@@ -3409,11 +3456,16 @@ def register_canvas(
         document.set_chat_scroll_value(node_id, value)
         await publish_scene()
 
-    async def send_message(text):
+    async def send_message(text, branch_from_node_id=None):
         # R3.3: the real Send action - a real user ChatNode, continuing the
         # active branch. R4: the assistant's reply is now a real agent
         # dispatch call, not a deferred notice - see backend/agents.py.
         #
+        # ADR-002 Workstream 1: branch_from_node_id is optional (older
+        # frontend builds calling with just [text] still work unchanged -
+        # dispatch_intent unpacks positionally, so a missing trailing arg
+        # just uses this parameter's own default) - see
+        # SceneDocument.send_message's own docstring for the fork mechanics.
         # R8a: consult whatever is staged in the composer right now. This is
         # WHY composer_document is threaded into register_canvas at all (see
         # this function's own docstring) - take_staged_attachments() pops
@@ -3430,7 +3482,7 @@ def register_canvas(
         media_parts = [item.content_part for item in staged if item.content_part is not None]
         content_parts = [{"type": "text", "text": full_text}, *media_parts] if media_parts else None
 
-        node = document.send_message(full_text, content_parts=content_parts)
+        node = document.send_message(full_text, content_parts=content_parts, branch_from_node_id=branch_from_node_id)
         if staged:
             # The staged list is now empty (popped above) - republish so the
             # composer's attachment chips clear the instant Send fires,

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -16,8 +16,10 @@ import pytest
 import backend.agents as agents_module
 from backend.agents import AgentDispatcher
 from backend.canvas import (
+    BRANCH_HORIZONTAL_SPACING,
     DRAG_FACTOR_MAX,
     DRAG_FACTOR_MIN,
+    MESSAGE_VERTICAL_SPACING,
     NOTE_AGENT_BODY_COLOR,
     NOTE_AGENT_HEADER_COLOR,
     NOTE_AGENT_X_OFFSET,
@@ -1086,6 +1088,93 @@ def test_send_message_after_deleting_the_active_node_continues_from_its_parent()
     assert any(e.source == first.id and e.target == third.id for e in doc.edges.values())
 
 
+# -- ADR-002 Workstream 1: "Branch from here" (send_message's branch_from_node_id) --
+
+
+def test_send_message_branch_from_node_id_overrides_last_chat_node_id():
+    """The actual fork primitive: replying from an EARLIER node than the
+    current branch tip, producing a real second child (genuine divergence)
+    instead of only ever continuing from last_chat_node_id."""
+    doc = SceneDocument()
+    root = doc.send_message("root message")
+    tip = doc.send_message("continues from root")  # last_chat_node_id is now `tip`
+    assert doc.last_chat_node_id == tip.id
+
+    branch = doc.send_message("a different reply to root", branch_from_node_id=root.id)
+
+    assert any(e.source == root.id and e.target == branch.id for e in doc.edges.values())
+    assert not any(e.source == tip.id and e.target == branch.id for e in doc.edges.values())
+    # root now genuinely has two children - a real divergence.
+    children_of_root = [e.target for e in doc.edges.values() if e.source == root.id]
+    assert set(children_of_root) == {tip.id, branch.id}
+
+
+def test_send_message_branch_from_node_id_becomes_the_new_active_branch():
+    """last_chat_node_id updates to the branch just created, exactly like an
+    ordinary send - so the NEXT plain send (no override) continues the new
+    branch, not the one that was active before "Branch from here" was used."""
+    doc = SceneDocument()
+    root = doc.send_message("root message")
+    doc.send_message("continues from root")
+
+    branch = doc.send_message("branching off root", branch_from_node_id=root.id)
+    assert doc.last_chat_node_id == branch.id
+
+    continuation = doc.send_message("continuing the new branch")
+    assert any(e.source == branch.id and e.target == continuation.id for e in doc.edges.values())
+
+
+def test_send_message_branch_from_node_id_fans_out_siblings_so_they_do_not_overlap():
+    doc = SceneDocument()
+    root = doc.send_message("root message")
+    first_reply = doc.send_message("first reply", branch_from_node_id=root.id)
+    second_reply = doc.send_message("second reply", branch_from_node_id=root.id)
+
+    assert first_reply.y == second_reply.y == root.y + MESSAGE_VERTICAL_SPACING
+    assert first_reply.x == root.x
+    assert second_reply.x == root.x + BRANCH_HORIZONTAL_SPACING
+    assert first_reply.x != second_reply.x, "two real siblings must never render at the exact same position"
+
+
+def test_send_message_branch_from_node_id_fan_out_ignores_non_chat_children():
+    """A docked/generated non-chat child (thinking, code, a generated note)
+    under the same parent must never count toward the fan-out index - only
+    real conversational branches are genuine "siblings" for this purpose."""
+    doc = SceneDocument()
+    root = doc.send_message("root message")
+    doc.add_thinking_node(root.x, root.y, "some reasoning", parent_id=root.id)
+    doc.add_code_node(root.x, root.y, "print(1)", "python", parent_id=root.id)
+
+    first_reply = doc.send_message("first real branch", branch_from_node_id=root.id)
+    assert first_reply.x == root.x, "non-chat children must not shift the first real branch's fan-out index"
+
+    second_reply = doc.send_message("second real branch", branch_from_node_id=root.id)
+    assert second_reply.x == root.x + BRANCH_HORIZONTAL_SPACING
+
+
+def test_send_message_branch_from_node_id_unknown_id_falls_back_to_last_chat_node_id():
+    """A stale/bad id (a deleted node, a typo) must never raise or silently
+    create a dangling reference - same defensive posture chat_branch_
+    history's own walk already uses for an unknown node id."""
+    doc = SceneDocument()
+    tip = doc.send_message("hello")
+
+    node = doc.send_message("still works", branch_from_node_id="nonexistent-node-id")
+
+    assert any(e.source == tip.id and e.target == node.id for e in doc.edges.values())
+    assert doc.last_chat_node_id == node.id
+
+
+def test_send_message_branch_from_node_id_none_is_the_ordinary_unmodified_path():
+    """Backward compatibility: omitting branch_from_node_id (its default)
+    must behave byte-identical to before this feature existed."""
+    doc = SceneDocument()
+    first = doc.send_message("first")
+    second = doc.send_message("second")
+    assert any(e.source == first.id and e.target == second.id for e in doc.edges.values())
+    assert doc.last_chat_node_id == second.id
+
+
 # -- R4: chat_branch_history --------------------------------------------------
 
 
@@ -2040,6 +2129,44 @@ def test_send_message_intent_dispatches_a_real_agent_reply():
         assert any(e.source == node_id and e.target == reply_node.id for e in document.edges.values())
         assert document.last_chat_node_id == reply_node.id
         assert recorder.topics_seen().count("scene") >= 2, "user node + reply node both publish scene"
+
+    asyncio.run(run())
+
+
+def test_send_message_intent_with_branch_from_node_id_overrides_the_parent():
+    """ADR-002 Workstream 1, WS-intent level: confirms the optional third
+    positional arg (dispatch_intent unpacks the args list positionally)
+    threads through register_canvas's own send_message wrapper into
+    SceneDocument.send_message's branch_from_node_id - not just the bare
+    method call already covered above."""
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+
+        def fake_chat(task, messages, **kwargs):
+            return {"message": {"content": "reply"}}
+
+        async def send(text, *extra_args):
+            pending_before = set(dispatcher._requests.keys())
+            node_id = await bus.dispatch_intent("scene", "sendMessage", [text, *extra_args])
+            new_request_id = next(iter(set(dispatcher._requests.keys()) - pending_before))
+            await dispatcher._requests[new_request_id]["task"]
+            return node_id
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", fake_chat):
+            root_id = await send("root message")
+            await send("continues from root, becomes the tip")
+            branch_id = await send("a different reply to root", root_id)
+
+        assert any(e.source == root_id and e.target == branch_id for e in document.edges.values())
+        # The full pipeline also lands an assistant reply as branch_id's own
+        # child, and last_chat_node_id follows THAT (see send_message
+        # intent's own _on_reply) - so the active branch now descends from
+        # branch_id, not from the original tip's own reply chain.
+        active_parent_edge = document._branch_parent_edge(document.last_chat_node_id)
+        assert active_parent_edge is not None and active_parent_edge.source == branch_id
 
     asyncio.run(run())
 

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -36,6 +36,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   const onOpenDocumentView = vi.fn();
   const onScrollChange = vi.fn();
   const onToggleBranchFocus = vi.fn();
+  const onBranchFromHere = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -57,6 +58,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
       onScrollChange,
       isBranchFocusActive: false,
       onToggleBranchFocus,
+      onBranchFromHere,
       ...overrides,
     },
   } as unknown as NodeProps<ChatFlowNode>;
@@ -69,7 +71,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   return {
     onToggleCollapse, onDelete, onUndockChild, onRegenerate, onGenerateImage,
     onGenerateChart, onGenerateKeyTakeaway, onGenerateExplainerNote,
-    onOpenDocumentView, onScrollChange, onToggleBranchFocus, container,
+    onOpenDocumentView, onScrollChange, onToggleBranchFocus, onBranchFromHere, container,
   };
 }
 
@@ -363,6 +365,35 @@ describe("ChatNodeView Hide Other Branches / Show All Branches (R8a)", () => {
     await user.click(item);
     expect(onToggleBranchFocus).toHaveBeenCalledOnce();
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+// ADR-002 Workstream 1: "Branch from Here" - stages this node as the
+// composer's next reply target instead of creating anything itself; the
+// actual fork happens server-side once the user sends a message.
+describe("ChatNodeView Branch from Here (ADR-002 Workstream 1)", () => {
+  it("calls onBranchFromHere and closes the menu when clicked, for a user node", async () => {
+    const user = userEvent.setup();
+    const { onBranchFromHere } = renderChatNode({ isUser: true });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    const item = screen.getByRole("menuitem", { name: "Branch from Here" });
+    expect(item).not.toBeDisabled();
+
+    await user.click(item);
+    expect(onBranchFromHere).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("is also available (not gated on isUser) for an assistant node", async () => {
+    const user = userEvent.setup();
+    const { onBranchFromHere } = renderChatNode({ isUser: false });
+
+    fireEvent.contextMenu(screen.getByText("Assistant"));
+    const item = screen.getByRole("menuitem", { name: "Branch from Here" });
+
+    await user.click(item);
+    expect(onBranchFromHere).toHaveBeenCalledOnce();
   });
 });
 

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -85,6 +85,13 @@ export interface ChatNodeData extends Record<string, unknown> {
   onScrollChange: (value: number) => void;
   isBranchFocusActive: boolean;
   onToggleBranchFocus: () => void;
+  // ADR-002 Workstream 1 ("Branch from here"): marks this node as the reply
+  // target for the composer's NEXT send, instead of only ever continuing
+  // from the current branch tip (sceneStore's replyTargetNodeId - see that
+  // field's own comment). The actual fork happens server-side
+  // (SceneDocument.send_message's branch_from_node_id) once the user
+  // types a message and sends it; this callback only stages the pick.
+  onBranchFromHere: () => void;
 }
 
 export type ChatFlowNode = Node<ChatNodeData, "chat">;
@@ -125,6 +132,7 @@ function ChatNodeMenu({
   onOpenDocumentView,
   isBranchFocusActive,
   onToggleBranchFocus,
+  onBranchFromHere,
   onClose,
 }: {
   position: MenuPosition;
@@ -144,6 +152,7 @@ function ChatNodeMenu({
   onOpenDocumentView: () => void;
   isBranchFocusActive: boolean;
   onToggleBranchFocus: () => void;
+  onBranchFromHere: () => void;
   onClose: () => void;
 }) {
   const [chartMenuOpen, setChartMenuOpen] = useState(false);
@@ -190,6 +199,22 @@ function ChatNodeMenu({
         }}
       >
         {isBranchFocusActive ? "Show All Branches" : "Hide Other Branches"}
+      </button>
+      {/* ADR-002 Workstream 1: stages this node as the composer's next reply
+          target (sceneStore's replyTargetNodeId) - available regardless of
+          isUser, since either a user message or an assistant reply is a
+          valid point to fork a new branch from. The composer shows a
+          "Replying to" indicator once set; the actual second-child branch
+          is created server-side the moment the user sends. */}
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onBranchFromHere();
+          onClose();
+        }}
+      >
+        Branch from Here
       </button>
       {/* Real (not disabled) - matches the legacy's own `if docked_children:`
           guard exactly. One button per docked child, each undocking that
@@ -421,6 +446,7 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
           onOpenDocumentView={data.onOpenDocumentView}
           isBranchFocusActive={data.isBranchFocusActive}
           onToggleBranchFocus={data.onToggleBranchFocus}
+          onBranchFromHere={data.onBranchFromHere}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -259,6 +259,23 @@ describe("toFlowNodes (R8a Open Document View wiring)", () => {
     expect(onOpenDocumentView).toHaveBeenCalledWith("Hello world", "Assistant message");
   });
 
+  it("a chat node's onBranchFromHere calls store.setReplyTargetNodeId with its own id (ADR-002 Workstream 1)", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hello world" })],
+      edges: [],
+    });
+    const store = makeStore();
+    const setReplyTargetSpy = vi.spyOn(store, "setReplyTargetNodeId");
+    const onOpenDocumentView = vi.fn();
+
+    const flowNodes = toFlowNodes(scene, store, onOpenDocumentView);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    expect(chatFlowNode).toBeDefined();
+
+    (chatFlowNode!.data as { onBranchFromHere: () => void }).onBranchFromHere();
+    expect(setReplyTargetSpy).toHaveBeenCalledWith("chat-1");
+  });
+
   it("a chat node's onOpenDocumentView labels the source as the user's own message when isUser is true", () => {
     const scene = baseScene({
       nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hello world", isUser: true })],

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -425,6 +425,13 @@ export function toFlowNodes(
           // "Hide Other Branches"` regardless of which node's menu is open.
           isBranchFocusActive: branchFocusOriginId !== null,
           onToggleBranchFocus: () => onToggleBranchFocus(n.id),
+          // ADR-002 Workstream 1: stages this node as sceneStore's
+          // replyTargetNodeId - the composer's next Send then reads and
+          // consumes it (see sceneStore.ts's sendMessage). `store` is
+          // already threaded into toFlowNodes, so no new parameter is
+          // needed here (unlike onToggleBranchFocus, which lives as local
+          // state on SceneCanvas itself, not on the store).
+          onBranchFromHere: () => store.setReplyTargetNodeId(n.id),
           // R6.3: the node's own scroll position within its content area -
           // read on mount by ChatNodeView (restore) and reported (debounced)
           // via the new setChatScrollValue intent on every scroll. Defaults

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -748,6 +748,63 @@ describe("SceneStore", () => {
     expect(store.getSelectedNodeId()).toBe("n1");
   });
 
+  // -- ADR-002 Workstream 1: "Branch from here" ------------------------------
+
+  it("setReplyTargetNodeId/getReplyTargetNodeId update state and notify listeners", () => {
+    const { transport } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    const seen = vi.fn();
+    store.subscribe(seen);
+
+    expect(store.getReplyTargetNodeId()).toBeNull();
+    store.setReplyTargetNodeId("n1");
+    expect(store.getReplyTargetNodeId()).toBe("n1");
+    expect(seen).toHaveBeenCalledTimes(1);
+
+    store.setReplyTargetNodeId(null);
+    expect(store.getReplyTargetNodeId()).toBeNull();
+    expect(seen).toHaveBeenCalledTimes(2);
+  });
+
+  it("setReplyTargetNodeId is a no-op (no re-emit) when the id is unchanged", () => {
+    const { transport } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    const seen = vi.fn();
+    store.subscribe(seen);
+
+    store.setReplyTargetNodeId("n1");
+    expect(seen).toHaveBeenCalledTimes(1);
+    store.setReplyTargetNodeId("n1");
+    expect(seen).toHaveBeenCalledTimes(1);
+  });
+
+  it("sendMessage with no pending reply target sends just [text] - unmodified default behavior", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.sendMessage("hello");
+    expect(intents).toEqual([{ topic: "scene", intent: "sendMessage", args: ["hello"] }]);
+  });
+
+  it("sendMessage consumes a pending reply target as the branch_from_node_id arg, then clears it", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setReplyTargetNodeId("n-root");
+
+    store.sendMessage("branching off root");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "sendMessage", args: ["branching off root", "n-root"] },
+    ]);
+    expect(store.getReplyTargetNodeId()).toBeNull();
+
+    // A SECOND send, with no reply target pending anymore, must NOT replay
+    // the stale target - proving it was genuinely consumed, not just read.
+    store.sendMessage("a normal follow-up");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "sendMessage", args: ["branching off root", "n-root"] },
+      { topic: "scene", intent: "sendMessage", args: ["a normal follow-up"] },
+    ]);
+  });
+
   it("showInfoNotification sends the notification-topic showInfo intent, not scene", () => {
     const { transport, intents } = makeFakeTransport();
     const store = new SceneStore(transport);

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -80,6 +80,14 @@ export class SceneStore {
   // node was selected when a plugin was launched" to executePlugin without
   // either component reaching into the other's internals.
   private selectedNodeId: string | null = null;
+  // ADR-002 Workstream 1 ("Branch from here"): which chat node the NEXT
+  // sendMessage should reply to instead of the current branch tip - local
+  // UI state only, same posture as selectedNodeId above. Set by a chat
+  // node's own context-menu action (ChatNodeView.tsx, wired in
+  // toFlowNodes below), read by Composer.tsx to show a "Replying to"
+  // indicator, and consumed-then-cleared by sendMessage itself so it never
+  // silently applies to a later, unrelated send.
+  private replyTargetNodeId: string | null = null;
 
   constructor(private readonly transport: WsTransport) {}
 
@@ -119,12 +127,19 @@ export class SceneStore {
   getDragConfig = (): DragSpeedState => this.dragConfig;
   getFontConfig = (): FontControlState => this.fontConfig;
   getSelectedNodeId = (): string | null => this.selectedNodeId;
+  getReplyTargetNodeId = (): string | null => this.replyTargetNodeId;
 
   // R5.1: no-op-if-unchanged, same discipline as every other setter here that
   // guards a redundant assignment before paying for an emit() fan-out.
   setSelectedNodeId(id: string | null): void {
     if (id === this.selectedNodeId) return;
     this.selectedNodeId = id;
+    this.emit();
+  }
+
+  setReplyTargetNodeId(id: string | null): void {
+    if (id === this.replyTargetNodeId) return;
+    this.replyTargetNodeId = id;
     this.emit();
   }
 
@@ -519,8 +534,18 @@ export class SceneStore {
   // split is a prerequisite for calling the real agent layer); the backend
   // surfaces that honestly via the existing notification topic, no fake
   // response synthesized here.
+  //
+  // ADR-002 Workstream 1: consumes replyTargetNodeId (if a "Branch from
+  // here" pick is pending) as this one send's branch_from_node_id override,
+  // then clears it - so it applies to exactly one send, never lingers onto
+  // a later, unrelated one. Callers never pass a branch target directly;
+  // they call setReplyTargetNodeId first (see that setter's own comment).
   sendMessage(text: string): void {
-    this.transport.intent("scene", "sendMessage", [text]);
+    const branchFromNodeId = this.replyTargetNodeId;
+    const args: unknown[] = [text];
+    if (branchFromNodeId !== null) args.push(branchFromNodeId);
+    this.transport.intent("scene", "sendMessage", args);
+    if (branchFromNodeId !== null) this.setReplyTargetNodeId(null);
   }
 
   moveNode(id: string, x: number, y: number): void {

--- a/web_ui/src/app/chrome/Composer.test.tsx
+++ b/web_ui/src/app/chrome/Composer.test.tsx
@@ -5,6 +5,7 @@ import { Composer } from "./Composer";
 import { TokenCounter } from "./TokenCounter";
 import { NotificationBanner } from "./NotificationBanner";
 import { initialComposerState, initialNotificationState, initialTokenCounterState } from "./composerStore";
+import { initialSceneState } from "../canvas/sceneStore";
 import { OverlayProvider } from "../overlays/overlays";
 
 function makeStore(
@@ -47,9 +48,19 @@ function makeStore(
   };
 }
 
-function makeSceneStore() {
+function makeSceneStore(overrides: { replyTargetNodeId?: string | null; scene?: object } = {}) {
   const sendMessage = vi.fn();
-  return { sceneStore: { sendMessage }, sendMessage };
+  const setReplyTargetNodeId = vi.fn();
+  const scene = { ...initialSceneState, ...overrides.scene };
+  const replyTargetNodeId = overrides.replyTargetNodeId ?? null;
+  const sceneStore = {
+    sendMessage,
+    setReplyTargetNodeId,
+    subscribe: () => () => {},
+    getScene: () => scene,
+    getReplyTargetNodeId: () => replyTargetNodeId,
+  };
+  return { sceneStore, sendMessage, setReplyTargetNodeId };
 }
 
 describe("Composer", () => {
@@ -316,7 +327,7 @@ describe("Composer", () => {
     render(
       <OverlayProvider>
         {/* @ts-expect-error - test double */}
-        <Composer store={store} />
+        <Composer store={store} sceneStore={makeSceneStore().sceneStore} />
       </OverlayProvider>,
     );
     await user.click(screen.getByText("Off"));
@@ -522,6 +533,67 @@ describe("TokenCounter", () => {
 
     await user.unhover(screen.getByRole("button", { name: "Token usage: 6 total" }));
     expect(screen.queryByRole("status", { name: "Token usage breakdown" })).toBeNull();
+  });
+});
+
+// ADR-002 Workstream 1: the "Branch from here" reply-target indicator.
+describe("Composer reply target (ADR-002 Workstream 1)", () => {
+  it("renders nothing when no reply target is pending", () => {
+    const { store } = makeStore();
+    const { sceneStore } = makeSceneStore({ replyTargetNodeId: null });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(screen.queryByLabelText("Branching from")).toBeNull();
+  });
+
+  it("shows a preview of the target node's content when a reply target is pending", () => {
+    const { store } = makeStore();
+    const { sceneStore } = makeSceneStore({
+      replyTargetNodeId: "n-root",
+      scene: { nodes: [{ id: "n-root", content: "the original root message" }] },
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={sceneStore} />
+      </OverlayProvider>,
+    );
+    const indicator = screen.getByLabelText("Branching from");
+    expect(indicator).toBeInTheDocument();
+    expect(screen.getByText("the original root message")).toBeInTheDocument();
+  });
+
+  it("does not render an indicator for a stale target whose node no longer exists", () => {
+    const { store } = makeStore();
+    const { sceneStore } = makeSceneStore({ replyTargetNodeId: "deleted-node", scene: { nodes: [] } });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(screen.queryByLabelText("Branching from")).toBeNull();
+  });
+
+  it("the clear button calls sceneStore.setReplyTargetNodeId(null)", async () => {
+    const user = userEvent.setup();
+    const { store } = makeStore();
+    const { sceneStore, setReplyTargetNodeId } = makeSceneStore({
+      replyTargetNodeId: "n-root",
+      scene: { nodes: [{ id: "n-root", content: "root" }] },
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={sceneStore} />
+      </OverlayProvider>,
+    );
+    await user.click(screen.getByLabelText("Cancel branching from this message"));
+    expect(setReplyTargetNodeId).toHaveBeenCalledWith(null);
   });
 });
 

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -64,6 +64,19 @@ export function Composer({
   const overlays = useOverlays();
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
+  // ADR-002 Workstream 1 ("Branch from here"): sceneStore's own
+  // replyTargetNodeId/scene, subscribed here (not just in SceneCanvas) so
+  // this indicator re-renders both when a node is picked and when the
+  // target's own content changes or the node itself is deleted. A stale
+  // target (deleted mid-pick) is treated as no target - same "derive an
+  // effective value, don't force-clear the store" posture SceneCanvas.tsx's
+  // own isBranchFocusOriginValid already uses for the sibling "Hide Other
+  // Branches" feature - so a dangling id can never render a fork indicator
+  // for a node that no longer exists.
+  const scene = useSyncExternalStore(sceneStore.subscribe, sceneStore.getScene);
+  const replyTargetNodeId = useSyncExternalStore(sceneStore.subscribe, sceneStore.getReplyTargetNodeId);
+  const replyTargetNode = replyTargetNodeId ? scene.nodes.find((n) => n.id === replyTargetNodeId) : undefined;
+
   useLayoutEffect(() => {
     const input = inputRef.current;
     if (!input) return;
@@ -82,6 +95,26 @@ export function Composer({
 
   return (
     <div className="composer-dock">
+      {replyTargetNode && (
+        // ADR-002 Workstream 1: the "Branch from here" pick, staged via a
+        // chat node's own context menu (ChatNodeView.tsx) and cleared
+        // either by this button or automatically once consumed by the next
+        // Send (sceneStore.ts's sendMessage).
+        <div className="composer-reply-target" aria-label="Branching from">
+          <span className="composer-reply-target-label">Branching from</span>
+          <span className="composer-reply-target-preview">
+            {replyTargetNode.content.trim().slice(0, 80) || "(empty message)"}
+          </span>
+          <button
+            type="button"
+            className="composer-reply-target-clear"
+            aria-label="Cancel branching from this message"
+            onClick={() => sceneStore.setReplyTargetNodeId(null)}
+          >
+            ×
+          </button>
+        </div>
+      )}
       {composer.context.items.length > 0 && (
         // R8a: real staged attachments. Metadata only - the composer never
         // receives raw bytes/extracted text, just what StagedAttachment.

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1450,6 +1450,60 @@ body,
   color: var(--gl-surface-text-primary);
 }
 
+/* ADR-002 Workstream 1 ("Branch from here"): the pending fork indicator,
+   same chrome vocabulary as .composer-attachment-chip above but a single
+   full-width bar rather than a wrapped row of chips - there is only ever
+   one reply target at a time. */
+.composer-reply-target {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px 5px 10px;
+  border-radius: 8px;
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  font-size: 11px;
+  color: var(--gl-surface-text-primary);
+}
+
+.composer-reply-target-label {
+  flex-shrink: 0;
+  color: var(--gl-surface-text-muted);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.03em;
+}
+
+.composer-reply-target-preview {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer-reply-target-clear {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background-color: transparent;
+  color: var(--gl-surface-text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.composer-reply-target-clear:hover {
+  background-color: var(--gl-surface-border);
+  color: var(--gl-surface-text-primary);
+}
+
 .composer-input-wrap {
   display: flex;
 }


### PR DESCRIPTION
## Problem

Every Send attached only to `last_chat_node_id` (the single current "active branch" pointer) - there was no way to reply to an earlier message in a conversation instead of only the most recent one. A genuine second branch (two children under one parent) was reachable only by manual edge manipulation, never through the UI.

## Change

- `SceneDocument.send_message` (`backend/canvas.py`) gained an optional `branch_from_node_id` parameter that overrides `last_chat_node_id` as the parent for one send. A bad/stale id (deleted node, typo) falls through to the ordinary continuation path rather than raising. When branching onto a parent that already has one or more chat-kind children, the new sibling fans out horizontally by a new `BRANCH_HORIZONTAL_SPACING` constant, so a genuine divergence never renders as one node silently hiding another. `last_chat_node_id` still updates to the newly created node afterward, so that branch becomes active for the next ordinary send.
- The WS `sendMessage` intent takes this as an optional second positional argument; an older caller passing just `[text]` is unaffected (`dispatch_intent` unpacks positionally, so the missing argument uses the parameter's own default).
- A chat node's context menu (`ChatNodeView.tsx`, available for both user and assistant nodes) gained a "Branch from Here" action, staging that node as the composer's next reply target (`sceneStore`'s new `replyTargetNodeId`, local UI state mirroring the existing `selectedNodeId` field).
- The composer (`Composer.tsx`) shows a "Branching from" indicator with a preview of the target's content and a clear button whenever a target is pending. The target is consumed and cleared automatically the moment a message is sent, so it can never silently apply to a later, unrelated send.

## Test plan

- [x] `python -m pytest -q` (full suite, repo root) - 1087/1087 passing, including 8 new backend tests covering the override, the sibling fan-out (asserting concrete coordinates, not just edge existence), non-chat siblings being excluded from the fan-out count, the stale-id fallback, and the WS-intent-level passthrough
- [x] `npx tsc --noEmit`, `npx vitest run` (919/919), `npx eslint .`, `npx vite build` - all clean; 11 new frontend tests across `sceneStore`, `ChatNodeView`, `SceneCanvas`, and `Composer`
- [x] **Independent adversarial review** of the diff before commit (a separate agent instance, briefed only on the change description, told to try to break it - not shown my own reasoning): checked (A) backend fork-logic correctness (sibling-count filtering, fallback behavior, WS-wrapper backward compatibility, interaction with attachments/token-counting/the assistant-reply path), (B) frontend state-consumption correctness (the consume-then-clear semantics, stale-target handling, no parallel send path), (C) test coverage honesty (ran the new tests independently rather than trusting they pass), and (D) regression risk on the ordinary no-override send path. It found and I fixed three real issues: a stale doc comment (said "420px" where the constant is 460), one true test gap (no coverage for non-chat siblings being excluded from the fan-out count - added), and an aria-label/visible-text naming inconsistency ("Replying to" vs "Branching from" - aligned to "Branching from" throughout, including the corresponding test assertions)
- [ ] Live interactive UI verification (right-click a node, pick "Branch from Here", send) was not possible - the browser preview pane is backgrounded in this environment, which stops React Flow from measuring/hit-testing nodes at all (a known constraint, not specific to this change); relying on the component/unit test suite above as the verification of record for the UI layer