### PR TITLE
Add "Compare Branches": AI-generated comparison across 2+ selected branches

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -74,7 +74,7 @@ import graphlink_task_config as config
 from graphlink_artifact_agent import ArtifactAgent
 from graphlink_chart_agent import ChartDataAgent
 from graphlink_chat_agent import ChatAgent
-from graphlink_note_agent import ExplainerAgent, KeyTakeawayAgent
+from graphlink_note_agent import BranchComparisonAgent, ExplainerAgent, KeyTakeawayAgent
 from graphlink_licensing import SettingsManager  # type hint only
 from graphlink_plugins.common.github_client import GitHubRestClient
 from graphlink_plugins.gitlink.agent import GitlinkAgent, _fingerprint_changes, _is_repo_text_path
@@ -357,6 +357,12 @@ class AgentDispatcher:
         # request_id -> True; no task/cancel_event to store, since the legacy
         # workers these replace had no stop() either.
         self._note_requests: dict[str, bool] = {}
+        # ADR-002 Workstream 1 ("Compare Branches") - a SEPARATE busy-guard
+        # from _note_requests above: comparing branches and generating a Key
+        # Takeaway/Explainer Note are unrelated features, so one running
+        # must never block the other. Same "request_id -> True, no task/
+        # cancel_event" shape - this is directly awaited, not scheduled.
+        self._branch_comparison_requests: dict[str, bool] = {}
         # R5.4: Py-Coder's REPL subprocess outlives any single run (state
         # persists between calls, same as legacy's own PyCoderReplManager -
         # see that class's own docstring in graphlink_plugins/pycoder/domain.py
@@ -2394,6 +2400,68 @@ class AgentDispatcher:
         finally:
             self._note_requests.pop(request_id, None)
 
+    async def start_branch_comparison(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        source_text: str,
+        on_success,
+        on_failure,
+    ) -> None:
+        """ADR-002 Workstream 1 ("Compare Branches"): mirrors start_note_
+        generation's own shape exactly (directly awaited - the result is a
+        brand new note node and there is no pre-existing node to attach a
+        spinner to; single dict-registry busy guard; WATCHDOG_TIMEOUT_
+        SECONDS; on_success/on_failure callbacks) but with its own
+        _branch_comparison_requests guard rather than reusing
+        _note_requests - see that field's own comment for why. source_text
+        is already the fully-formatted multi-branch block
+        (backend/canvas.py's _format_branches_for_comparison) - this method
+        itself is agnostic to how many branches went into it."""
+        if self._branch_comparison_requests:
+            notifications_state.show("A branch comparison is already being generated.", "info")
+            await bus.publish("notification")
+            return
+
+        request_id = uuid.uuid4().hex
+        self._branch_comparison_requests[request_id] = True
+
+        async def _invoke(fn, *a):
+            if inspect.iscoroutinefunction(fn):
+                await fn(*a)
+            else:
+                fn(*a)
+
+        try:
+            text = await asyncio.wait_for(
+                asyncio.to_thread(_call_branch_comparison_agent, source_text),
+                timeout=WATCHDOG_TIMEOUT_SECONDS,
+            )
+            if not str(text or "").strip():
+                message = "Branch comparison returned an empty response. Please try again."
+                await _invoke(on_failure, message)
+                notifications_state.show(message, "error")
+                await bus.publish("notification")
+            else:
+                await _invoke(on_success, text)
+        except asyncio.TimeoutError:
+            message = (
+                "Branch comparison stopped responding before the request completed. "
+                "Please try again."
+            )
+            await _invoke(on_failure, message)
+            notifications_state.show(message, "error")
+            await bus.publish("notification")
+        except Exception as exc:
+            logger.exception("branch comparison dispatch failed")
+            message = f"Branch comparison failed: {exc}"
+            await _invoke(on_failure, message)
+            notifications_state.show(message, "error")
+            await bus.publish("notification")
+        finally:
+            self._branch_comparison_requests.pop(request_id, None)
+
 
 # R8a: the two note agents, keyed by the `note_kind` start_note_generation
 # takes. Kept as data rather than an if/elif so adding a third note agent is
@@ -2411,6 +2479,13 @@ def _call_note_agent(note_kind: str, source_text: str) -> str:
     if agent_cls is None:
         raise ValueError(f"unknown note kind: {note_kind}")
     return agent_cls().get_response(source_text)
+
+
+def _call_branch_comparison_agent(source_text: str) -> str:
+    """Runs inside asyncio.to_thread - the blocking driver for
+    start_branch_comparison above, mirroring _call_note_agent's own shape
+    (fresh agent instance per call)."""
+    return BranchComparisonAgent().get_response(source_text)
 
 
 def _call_pycoder_execution_agent(conversation_history, user_prompt) -> str:

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -597,12 +597,27 @@ class SceneNode:
     # Both default False; unused for every other kind.
     is_system_prompt: bool = False
     is_summary_note: bool = False
+    # ADR-002 Workstream 1 ("Compare Branches") - note kind only, a NEW badge
+    # flag alongside the two above, marking a note as the output of the
+    # Compare Branches agent rather than a plain/system-prompt/summary note.
+    # Deliberately NOT is_summary_note: that flag is legacy's own "Group
+    # Summary" concept (an arbitrary multi-select of any node kinds,
+    # summarized - never ported, since it depended on a multi-select model
+    # the app didn't have yet), which is semantically a different feature
+    # from comparing conversation branches specifically. Reusing it here
+    # would make a future real port of Group Summary collide with this one.
+    is_branch_comparison: bool = False
     # frame/container membership: the ids of the member nodes this group
     # currently encloses. In this implementation a node can be a member of
     # AT MOST ONE frame AND AT MOST ONE container simultaneously (never two
     # frames, never two containers) - create_frame/create_container's own
     # detach-from-existing-same-kind-group rule enforces this (see below).
-    # Unused (default empty list) for every other kind.
+    # ALSO reused (ADR-002 Workstream 1) by an is_branch_comparison note to
+    # record the source chat-node ids it was compared from - a second,
+    # unrelated "list of node ids this node references" use of the same
+    # field rather than a new one, exactly like frame/container's own
+    # membership use above. Unused (default empty list) for every other
+    # case.
     item_ids: list[str] = field(default_factory=list)
     # frame kind only - legacy default is LOCKED (True), unlike every other
     # bool field on this dataclass (which all default False). Containers
@@ -1886,6 +1901,21 @@ class SceneDocument:
             raise SceneError(f"unknown node: {node_id}")
         node.content = str(content)
 
+    def mark_branch_comparison_note(self, node_id: str, source_node_ids: list[str]) -> None:
+        """ADR-002 Workstream 1 ("Compare Branches"): stamps an already-created
+        note as the output of the Compare Branches agent and records which
+        branches it compared - called once, immediately after add_note +
+        set_note_content, mirroring set_group_color's own "extra setter call
+        right after creation" shape (see the WS intent wrapper in
+        register_canvas)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "note":
+            raise SceneError(f"node is not a note node: {node_id}")
+        node.is_branch_comparison = True
+        node.item_ids = list(source_node_ids)
+
     def _bbox_of_members(self, item_ids: list[str]) -> tuple[float, float, float, float]:
         """Compute the padded union rect (x, y, width, height) enclosing
         every member id's ESTIMATED footprint - GROUP_MEMBER_DEFAULT_WIDTH/
@@ -3014,6 +3044,9 @@ class SceneDocument:
                     "headerColor": n.header_color,
                     "isSystemPrompt": n.is_system_prompt,
                     "isSummaryNote": n.is_summary_note,
+                    # ADR-002 Workstream 1 ("Compare Branches") - see
+                    # SceneNode.is_branch_comparison's own comment.
+                    "isBranchComparison": n.is_branch_comparison,
                     "itemIds": list(n.item_ids),
                     "isLocked": n.is_locked,
                     "groupWidth": n.group_width,
@@ -3210,6 +3243,29 @@ def _chart_source_text(branch_history: list[dict]) -> str:
         speaker = "User" if turn.get("role") == "user" else "Assistant"
         lines.append(f"{speaker}: {content}")
     return "\n\n".join(lines)
+
+
+def _format_branches_for_comparison(branches: list[tuple[str, list[dict]]]) -> str:
+    """ADR-002 Workstream 1 ("Compare Branches"): flattens 2+ labeled
+    chat_branch_history results into the single plain-text block
+    BranchComparisonAgent.get_response expects - one labeled section per
+    branch, each turn formatted "Speaker: text" (same convention as
+    _chart_source_text above), but built on _history_turn_text rather than
+    that function's own simpler `str(turn.get("content") or "")` - a turn
+    carrying R8a attachment content_parts (a list, not a plain string)
+    needs _history_turn_text's real flattening or it would stringify the
+    raw list instead of extracting the text part."""
+    sections = []
+    for label, history in branches:
+        lines = []
+        for turn in history:
+            text = _history_turn_text(turn).strip()
+            if not text:
+                continue
+            speaker = "User" if turn.get("role") == "user" else "Assistant"
+            lines.append(f"{speaker}: {text}")
+        sections.append(f"=== {label} ===\n" + "\n\n".join(lines))
+    return "\n\n".join(sections)
 
 
 def _placeholder_chart_data(chart_type: str) -> dict[str, Any]:
@@ -4020,6 +4076,75 @@ def register_canvas(
         # other - the same 100px stagger legacy used.
         return await _generate_note_from_node(source_node_id, "explainer", NOTE_AGENT_X_OFFSET, 100)
 
+    async def compare_branches(node_ids):
+        """ADR-002 Workstream 1 ("Compare Branches") - the second sequenced
+        item after "Branch from here" (that same workstream's fork
+        primitive). Takes 2+ existing chat nodes, walks each one's own
+        chat_branch_history, and drops a single agent-authored comparison
+        into a new note linked back to every source branch (note.item_ids
+        - see mark_branch_comparison_note).
+
+        Deliberately no auto-selection fallback, unlike the single-node
+        note agents above: there is no sensible single "the selected node"
+        default here - the caller (App.tsx's own Compare Branches shortcut)
+        must supply 2+ real ids up front, the same "the frontend already
+        gathered React Flow's own multi-selection" contract create_frame/
+        create_container already use."""
+        ids = list(dict.fromkeys(str(i) for i in (node_ids or [])))  # de-dupe, preserve order
+        if len(ids) < 2:
+            notifications.show("Select at least 2 branches to compare.", "warning")
+            await bus.publish("notification")
+            return None
+
+        sources = []
+        for node_id in ids:
+            node = document.nodes.get(node_id)
+            if node is None or node.kind != "chat":
+                notifications.show("Every selected node must be a real chat message to compare.", "warning")
+                await bus.publish("notification")
+                return None
+            sources.append(node)
+
+        branches = [
+            (f"Branch {index + 1}", document.chat_branch_history(node.id))
+            for index, node in enumerate(sources)
+        ]
+        formatted = _format_branches_for_comparison(branches)
+
+        # Positioned below-and-right of the source branches, the same
+        # "offset to the side" convention _generate_note_from_node uses for
+        # a single source - averaged/maxed across all sources here since
+        # there's more than one.
+        avg_x = sum(node.x for node in sources) / len(sources)
+        max_y = max(node.y for node in sources)
+
+        result_holder: dict[str, str] = {}
+
+        async def _on_success(text):
+            if any(node_id not in document.nodes for node_id in ids):
+                # A source was deleted mid-flight - same liveness posture as
+                # _generate_note_from_node's own on_success guard.
+                return
+            note = document.add_note(avg_x + NOTE_AGENT_X_OFFSET, max_y)
+            document.set_note_content(note.id, text)
+            document.set_group_color(note.id, NOTE_AGENT_BODY_COLOR, NOTE_AGENT_HEADER_COLOR)
+            document.mark_branch_comparison_note(note.id, ids)
+            result_holder["node_id"] = note.id
+            await bus.publish("scene")
+
+        def _on_failure(message):
+            # start_branch_comparison already surfaced the notification.
+            pass
+
+        await agent_dispatcher.start_branch_comparison(
+            bus=bus,
+            notifications_state=notifications,
+            source_text=formatted,
+            on_success=_on_success,
+            on_failure=_on_failure,
+        )
+        return result_holder.get("node_id")
+
     async def resize_chart(node_id, width, height):
         document.resize_chart(node_id, width, height)
         await publish_scene()
@@ -4557,6 +4682,7 @@ def register_canvas(
     # graphlink_note_agent.py's own docstring for why they were dead stubs.
     bus.register_intent("scene", "generateKeyTakeaway", generate_key_takeaway)
     bus.register_intent("scene", "generateExplainerNote", generate_explainer_note)
+    bus.register_intent("scene", "compareBranches", compare_branches)
     bus.register_intent("scene", "resizeChart", resize_chart)
     bus.register_intent("scene", "toggleChartAspectLock", toggle_chart_aspect_lock)
     bus.register_intent("scene", "moveNode", move_node)

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -4963,3 +4963,109 @@ def test_start_note_generation_agent_exception_surfaces_and_clears_the_slot(monk
         assert dispatcher._note_requests == {}, "the slot must not leak after a failure"
 
     asyncio.run(run())
+
+
+# -- ADR-002 Workstream 1: start_branch_comparison ("Compare Branches") ------
+#
+# Mirrors start_note_generation's own test shape exactly - same busy-guard/
+# timeout/empty-response/exception coverage - but against the SEPARATE
+# _branch_comparison_requests slot, proving the two features' busy states
+# are genuinely independent (see that field's own comment for why).
+
+
+def test_start_branch_comparison_calls_on_success_then_clears_the_slot(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.BranchComparisonAgent, "get_response",
+        lambda self, text: f"Branch Comparison\n\nAgreements:\n• from {text}",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_note_env()
+        successes, failures = [], []
+        await dispatcher.start_branch_comparison(
+            bus=bus, notifications_state=notifications,
+            source_text="=== Branch 1 ===\n...",
+            on_success=successes.append, on_failure=failures.append,
+        )
+        assert successes == ["Branch Comparison\n\nAgreements:\n• from === Branch 1 ===\n..."]
+        assert failures == []
+        assert dispatcher._branch_comparison_requests == {}
+        assert notifications.visible is False
+
+    asyncio.run(run())
+
+
+def test_start_branch_comparison_rejects_a_second_concurrent_run(monkeypatch):
+    monkeypatch.setattr(agents_module.BranchComparisonAgent, "get_response", lambda self, text: "ok")
+
+    async def run():
+        bus, notifications, dispatcher = _make_note_env()
+        dispatcher._branch_comparison_requests["already-running"] = True
+        successes = []
+        await dispatcher.start_branch_comparison(
+            bus=bus, notifications_state=notifications, source_text="x",
+            on_success=successes.append, on_failure=lambda m: None,
+        )
+        assert successes == [], "the busy guard must not run a second agent"
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert dispatcher._branch_comparison_requests == {"already-running": True}
+
+    asyncio.run(run())
+
+
+def test_start_branch_comparison_does_not_share_a_busy_slot_with_note_generation(monkeypatch):
+    # The whole reason for a SEPARATE dict: an in-flight Key Takeaway must
+    # never block an unrelated Compare Branches call, and vice versa.
+    monkeypatch.setattr(agents_module.BranchComparisonAgent, "get_response", lambda self, text: "Branch Comparison")
+
+    async def run():
+        bus, notifications, dispatcher = _make_note_env()
+        dispatcher._note_requests["unrelated-takeaway"] = True
+        successes = []
+        await dispatcher.start_branch_comparison(
+            bus=bus, notifications_state=notifications, source_text="x",
+            on_success=successes.append, on_failure=lambda m: None,
+        )
+        assert successes == ["Branch Comparison"], "an in-flight note generation must not block this"
+
+    asyncio.run(run())
+
+
+def test_start_branch_comparison_empty_response_fails_instead_of_creating_a_blank_note(monkeypatch):
+    monkeypatch.setattr(agents_module.BranchComparisonAgent, "get_response", lambda self, text: "   ")
+
+    async def run():
+        bus, notifications, dispatcher = _make_note_env()
+        successes, failures = [], []
+        await dispatcher.start_branch_comparison(
+            bus=bus, notifications_state=notifications, source_text="x",
+            on_success=successes.append, on_failure=failures.append,
+        )
+        assert successes == [], "an empty agent response must not become a note"
+        assert len(failures) == 1
+        assert notifications.msg_type == "error"
+        assert dispatcher._branch_comparison_requests == {}
+
+    asyncio.run(run())
+
+
+def test_start_branch_comparison_agent_exception_surfaces_and_clears_the_slot(monkeypatch):
+    def _boom(self, text):
+        raise RuntimeError("model exploded")
+
+    monkeypatch.setattr(agents_module.BranchComparisonAgent, "get_response", _boom)
+
+    async def run():
+        bus, notifications, dispatcher = _make_note_env()
+        successes, failures = [], []
+        await dispatcher.start_branch_comparison(
+            bus=bus, notifications_state=notifications, source_text="x",
+            on_success=successes.append, on_failure=failures.append,
+        )
+        assert successes == []
+        assert "model exploded" in failures[0]
+        assert notifications.msg_type == "error"
+        assert dispatcher._branch_comparison_requests == {}, "the slot must not leak after a failure"
+
+    asyncio.run(run())

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -26,6 +26,7 @@ from backend.canvas import (
     SceneDocument,
     SceneEmptyPromptError,
     SceneError,
+    _format_branches_for_comparison,
     _history_token_text,
     _history_turn_text,
     _research_result_wire,
@@ -6774,3 +6775,183 @@ def test_generate_key_takeaway_sends_the_nodes_own_text_not_the_branch_history(m
         assert "the parent question" not in seen[0]
 
     asyncio.run(run())
+
+
+# -- ADR-002 Workstream 1: "Compare Branches" ---------------------------------
+#
+# The second sequenced item after "Branch from here" (that workstream's fork
+# primitive) - takes 2+ existing chat nodes and drops a single agent-authored
+# comparison into a new note linked back to every source branch.
+
+
+def test_format_branches_for_comparison_labels_each_section_and_flattens_turns():
+    branches = [
+        ("Branch 1", [{"role": "user", "content": "question one"}, {"role": "assistant", "content": "answer one"}]),
+        ("Branch 2", [{"role": "user", "content": "question two"}]),
+    ]
+    result = _format_branches_for_comparison(branches)
+    assert "=== Branch 1 ===" in result
+    assert "=== Branch 2 ===" in result
+    assert "User: question one" in result
+    assert "Assistant: answer one" in result
+    assert "User: question two" in result
+    # Branch 1's section must come before Branch 2's.
+    assert result.index("Branch 1") < result.index("Branch 2")
+
+
+def test_format_branches_for_comparison_skips_blank_turns():
+    branches = [("Branch 1", [{"role": "user", "content": "   "}, {"role": "assistant", "content": "real answer"}])]
+    result = _format_branches_for_comparison(branches)
+    assert "real answer" in result
+    assert result.count("\n\n") <= 1, "a blank turn must not inject a stray blank line"
+
+
+def test_format_branches_for_comparison_flattens_a_content_parts_multimodal_turn():
+    """A turn whose "content" is an R8a content_parts LIST (not a plain
+    string - e.g. text plus a staged image) must be flattened to its text
+    part via _history_turn_text, never stringified as a raw Python list -
+    that would leak a repr artifact like "[{'type':" into what the agent
+    reads."""
+    branches = [
+        (
+            "Branch 1",
+            [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look at this image"},
+                    {"type": "image", "image_bytes": "base64-ignored-here"},
+                ],
+            }],
+        ),
+    ]
+    result = _format_branches_for_comparison(branches)
+    assert "look at this image" in result
+    assert "[{" not in result, "a content_parts list must never be stringified via repr"
+    assert "'type'" not in result
+
+
+def test_compare_branches_creates_a_note_linked_to_all_sources(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.BranchComparisonAgent, "get_response",
+        lambda self, text: "Branch Comparison\n\nAgreements:\n• both agree",
+    )
+
+    async def run():
+        bus, document, recorder, _ = make_bus_with_dispatcher()
+        root = document.add_chat_node(0, 0, "root question", True)
+        first = document.add_chat_node(0, 160, "first answer", False, parent_id=root.id)
+        second = document.add_chat_node(460, 160, "second answer", False, parent_id=root.id)
+        scene_publishes_before = recorder.topics_seen().count("scene")
+
+        note_id = await bus.dispatch_intent("scene", "compareBranches", [[first.id, second.id]])
+
+        assert note_id is not None
+        note = document.nodes[note_id]
+        assert note.kind == "note"
+        assert note.content == "Branch Comparison\n\nAgreements:\n• both agree"
+        assert note.is_branch_comparison is True
+        assert note.item_ids == [first.id, second.id]
+        assert note.color == NOTE_AGENT_BODY_COLOR
+        assert note.header_color == NOTE_AGENT_HEADER_COLOR
+        # Positioned below-and-between the two sources, offset to the side -
+        # same "clears the source's width" convention as the single-node
+        # note agents.
+        assert note.x == (first.x + second.x) / 2 + NOTE_AGENT_X_OFFSET
+        assert note.y == max(first.y, second.y)
+        assert recorder.topics_seen().count("scene") > scene_publishes_before
+
+    asyncio.run(run())
+
+
+def test_compare_branches_sends_each_branchs_own_full_history_not_just_its_own_content(monkeypatch):
+    # UNLIKE generate_key_takeaway (one node's own text only), comparing
+    # branches needs each branch's FULL conversation, so an agent can
+    # actually judge agreements/differences across turns, not just leaves.
+    seen = []
+    monkeypatch.setattr(
+        agents_module.BranchComparisonAgent, "get_response",
+        lambda self, text: seen.append(text) or "Branch Comparison",
+    )
+
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        root = document.add_chat_node(0, 0, "shared root question", True)
+        first = document.add_chat_node(0, 160, "first branch reply", False, parent_id=root.id)
+        second = document.add_chat_node(460, 160, "second branch reply", False, parent_id=root.id)
+
+        await bus.dispatch_intent("scene", "compareBranches", [[first.id, second.id]])
+
+        assert len(seen) == 1
+        formatted = seen[0]
+        assert "shared root question" in formatted, "each branch's full history must be included, not just its own leaf"
+        assert "first branch reply" in formatted
+        assert "second branch reply" in formatted
+
+    asyncio.run(run())
+
+
+def test_compare_branches_rejects_fewer_than_two_ids():
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        only = document.add_chat_node(0, 0, "solo", True)
+        node_count_before = len(document.nodes)
+
+        assert await bus.dispatch_intent("scene", "compareBranches", [[]]) is None
+        assert await bus.dispatch_intent("scene", "compareBranches", [[only.id]]) is None
+        assert len(document.nodes) == node_count_before, "no note should be created"
+
+    asyncio.run(run())
+
+
+def test_compare_branches_dedupes_repeated_ids_before_the_minimum_check():
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        only = document.add_chat_node(0, 0, "solo", True)
+
+        result = await bus.dispatch_intent("scene", "compareBranches", [[only.id, only.id]])
+        assert result is None, "the same id twice must still fail the real 2-distinct-branches minimum"
+
+    asyncio.run(run())
+
+
+def test_compare_branches_rejects_a_non_chat_node(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        agents_module.BranchComparisonAgent, "get_response",
+        lambda self, text: calls.append(text) or "should not happen",
+    )
+
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        chat = document.add_chat_node(0, 0, "a real chat node", True)
+        note = document.add_note(0, 0)
+
+        result = await bus.dispatch_intent("scene", "compareBranches", [[chat.id, note.id]])
+
+        assert result is None
+        assert calls == [], "a non-chat node in the selection must block the agent call entirely"
+
+    asyncio.run(run())
+
+
+def test_compare_branches_rejects_an_unknown_node_id():
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        chat = document.add_chat_node(0, 0, "a real chat node", True)
+        result = await bus.dispatch_intent("scene", "compareBranches", [[chat.id, "does-not-exist"]])
+        assert result is None
+
+    asyncio.run(run())
+
+
+def test_mark_branch_comparison_note_rejects_a_non_note_node():
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "not a note", True)
+    with pytest.raises(SceneError):
+        doc.mark_branch_comparison_note(chat.id, ["x", "y"])
+
+
+def test_mark_branch_comparison_note_rejects_an_unknown_node_id():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.mark_branch_comparison_note("does-not-exist", ["x", "y"])

--- a/graphlink_note_agent.py
+++ b/graphlink_note_agent.py
@@ -147,6 +147,50 @@ No markdown formatting, no special characters."""
         return self.clean_text(response['message']['content'])
 
 
+class BranchComparisonAgent:
+    """ADR-002 Workstream 1 ("Compare Branches"): compares 2+ independent
+    conversation branches that diverged from the same starting point.
+    Genuinely new (not ported from anywhere) - GraphLink's branching
+    workflow never had a compare feature at all until this one. Same
+    "one chat call, no tools, no history" shape as KeyTakeawayAgent/
+    ExplainerAgent above, and reuses their shared clean_agent_markdown_
+    response post-processor rather than inventing a new formatter."""
+
+    def __init__(self):
+        self.system_prompt = """You are a branch-comparison analyst. You will be given two or more independent conversation branches that were explored from the same starting point. Compare them and format your response exactly like this:
+
+Branch Comparison
+
+Agreements:
+• [a point where the branches agree, or "None found" if there are none]
+
+Differences:
+• [a point where the branches diverge - name which branch says what]
+
+Unique Findings:
+• [something only one branch surfaced - name which branch]
+
+Unresolved Questions:
+• [an open question none of the branches resolved]
+
+Reference specific claims from the branches, not generic observations. Keep it focused and concrete. No markdown formatting, no special characters."""
+
+    def clean_text(self, text):
+        return clean_agent_markdown_response(
+            text,
+            required_title="Branch Comparison",
+            section_markers=["Agreements:", "Differences:", "Unique Findings:", "Unresolved Questions:"],
+        )
+
+    def get_response(self, formatted_branches_text):
+        messages = [
+            {'role': 'system', 'content': self.system_prompt},
+            {'role': 'user', 'content': f"Compare these branches:\n\n{formatted_branches_text}"},
+        ]
+        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
+        return self.clean_text(response['message']['content'])
+
+
 class ExplainerAgent:
     """Simplifies complex topics into plain language."""
 

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -115,6 +115,8 @@ function GlobalShortcuts({ store }: { store: SceneStore }) {
           return applyGrouping("frame");
         case "create-container":
           return applyGrouping("container");
+        case "compare-branches":
+          return applyCompareBranches();
         case "toggle-palette":
           return overlays.toggle("palette", "dialog");
         case "toggle-search":
@@ -135,6 +137,21 @@ function GlobalShortcuts({ store }: { store: SceneStore }) {
       if (ids.length === 0) return; // legacy: bare return, no message
       if (kind === "frame") store.createFrame(ids);
       else store.createContainer(ids);
+    }
+
+    // ADR-002 Workstream 1 ("Compare Branches"): same selection-gathering
+    // shape as applyGrouping above, but forwards even a single selected id
+    // rather than bare-returning on anything short of the real minimum -
+    // compare_branches's own backend validation shows an informative
+    // notification ("Select at least 2 branches to compare") for that near-
+    // miss case, which is more helpful than legacy's silent "nothing
+    // selected" convention when the user very clearly attempted a real
+    // action (bare-returning is still correct for the genuine zero-selected
+    // case - nothing to give feedback about there).
+    function applyCompareBranches() {
+      const ids = reactFlow.getNodes().filter((n) => n.selected).map((n) => n.id);
+      if (ids.length === 0) return;
+      store.compareBranches(ids);
     }
 
     function onKeyDown(event: KeyboardEvent) {

--- a/web_ui/src/app/canvas/NoteNodeView.test.tsx
+++ b/web_ui/src/app/canvas/NoteNodeView.test.tsx
@@ -20,6 +20,8 @@ function renderNoteNode(overrides: Partial<NoteFlowNode["data"]> = {}) {
       headerColor: null,
       isSystemPrompt: false,
       isSummaryNote: false,
+      isBranchComparison: false,
+      compareSourceNodeIds: [],
       onSetContent,
       onSetColor,
       onDelete,
@@ -135,6 +137,19 @@ describe("NoteNodeView", () => {
     );
     expect(container.querySelector(".note-node.system-prompt")).toBeNull();
     expect(screen.getByTitle("Summary Note")).toBeInTheDocument();
+  });
+
+  // ADR-002 Workstream 1 ("Compare Branches") - a third, distinct badge
+  // alongside isSystemPrompt/isSummaryNote above.
+  it("isBranchComparison renders a distinct badge showing the source-branch count, absent otherwise", () => {
+    renderNoteNode({ isBranchComparison: false });
+    expect(screen.queryByTitle(/Branch Comparison/)).toBeNull();
+
+    renderNoteNode({ isBranchComparison: true, compareSourceNodeIds: ["n1", "n2", "n3"] });
+    expect(screen.getByLabelText("Branch Comparison")).toBeInTheDocument();
+    expect(screen.getByTitle("Branch Comparison (3 sources)")).toBeInTheDocument();
+    // Distinct from isSummaryNote's own badge - never conflated.
+    expect(screen.queryByTitle("Summary Note")).toBeNull();
   });
 
   it("Delete button calls onDelete", async () => {

--- a/web_ui/src/app/canvas/NoteNodeView.tsx
+++ b/web_ui/src/app/canvas/NoteNodeView.tsx
@@ -30,7 +30,11 @@ import { GroupColorPicker, NOTE_SYSTEM_PROMPT_BORDER_COLOR } from "./GroupColorP
  * isSummaryNote gets a small "grouped items" badge (no border change) - both
  * badges are purely presentational, neither is user-togglable from this
  * view (they are set once at creation, by the plugin/creation path that made
- * the note).
+ * the note). isBranchComparison (ADR-002 Workstream 1, "Compare Branches")
+ * gets a third badge the same way - a distinct icon/tooltip from
+ * isSummaryNote's, since it is a different feature (see backend/canvas.py's
+ * SceneNode.is_branch_comparison for why they aren't the same flag), showing
+ * how many source branches compareSourceNodeIds records.
  */
 
 export interface NoteNodeData extends Record<string, unknown> {
@@ -39,6 +43,8 @@ export interface NoteNodeData extends Record<string, unknown> {
   headerColor: string | null;
   isSystemPrompt: boolean;
   isSummaryNote: boolean;
+  isBranchComparison: boolean;
+  compareSourceNodeIds: string[];
   onSetContent: (content: string) => void;
   onSetColor: (color: string | null, headerColor: string | null) => void;
   onDelete: () => void;
@@ -116,6 +122,15 @@ export function NoteNodeView({ data, selected }: NodeProps<NoteFlowNode>) {
           {data.isSummaryNote && (
             <span className="note-node-badge" title="Summary Note" aria-label="Summary Note">
               ⧉
+            </span>
+          )}
+          {data.isBranchComparison && (
+            <span
+              className="note-node-badge"
+              title={`Branch Comparison (${data.compareSourceNodeIds.length} sources)`}
+              aria-label="Branch Comparison"
+            >
+              ⇄
             </span>
           )}
         </span>

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -1109,6 +1109,9 @@ interface GroupTestFields {
   headerColor: string | null;
   isSystemPrompt: boolean;
   isSummaryNote: boolean;
+  // ADR-002 Workstream 1 ("Compare Branches") - same "generated type
+  // doesn't carry this yet" situation as every other field here.
+  isBranchComparison: boolean;
   itemIds: string[];
   isLocked: boolean;
   groupWidth: number | null;
@@ -1122,6 +1125,7 @@ function groupNode(overrides: Partial<SceneNodeRow & GroupTestFields> = {}): Sce
     headerColor: null,
     isSystemPrompt: false,
     isSummaryNote: false,
+    isBranchComparison: false,
     itemIds: [],
     isLocked: true,
     groupWidth: null,
@@ -1158,6 +1162,28 @@ describe("toFlowNodes (R6.1 note node)", () => {
       headerColor: "#3f7dc9",
       isSystemPrompt: true,
       isSummaryNote: false,
+    });
+  });
+
+  it("maps a note's isBranchComparison and reuses itemIds as compareSourceNodeIds (ADR-002 Workstream 1)", () => {
+    const scene = baseScene({
+      nodes: [
+        groupNode({
+          id: "note-1",
+          kind: "note",
+          isBranchComparison: true,
+          itemIds: ["chat-1", "chat-2"],
+        }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const noteFlowNode = flowNodes.find((n) => n.id === "note-1");
+    expect(noteFlowNode!.data).toMatchObject({
+      isBranchComparison: true,
+      compareSourceNodeIds: ["chat-1", "chat-2"],
     });
   });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -59,6 +59,12 @@ interface SceneNodeGroupFields {
   headerColor: string | null;
   isSystemPrompt: boolean;
   isSummaryNote: boolean;
+  // ADR-002 Workstream 1 ("Compare Branches") - note kind only, same
+  // "generated type doesn't carry this yet" situation as every other
+  // field on this interface. itemIds (already here, for frame/container
+  // membership) doubles as the source branch node ids for a comparison
+  // note - see backend/canvas.py's SceneNode.item_ids comment.
+  isBranchComparison: boolean;
   itemIds: string[];
   isLocked: boolean;
   groupWidth: number | null;
@@ -867,6 +873,11 @@ export function toFlowNodes(
           headerColor: note.headerColor,
           isSystemPrompt: note.isSystemPrompt,
           isSummaryNote: note.isSummaryNote,
+          // ADR-002 Workstream 1: itemIds doubles as the source branch ids
+          // for a Compare Branches result note - see SceneNodeGroupFields'
+          // own comment.
+          isBranchComparison: note.isBranchComparison,
+          compareSourceNodeIds: note.itemIds,
           onSetContent: (content: string) => store.setNoteContent(n.id, content),
           onSetColor: (color: string | null, headerColor: string | null) =>
             store.setGroupColor(n.id, color, headerColor),

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -596,6 +596,13 @@ describe("SceneStore", () => {
     expect(intents).toEqual([{ topic: "scene", intent: "createContainer", args: [["n1", "n2"]] }]);
   });
 
+  it("compareBranches sends the scene-topic compareBranches intent with [nodeIds] (ADR-002 Workstream 1)", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.compareBranches(["n1", "n2", "n3"]);
+    expect(intents).toEqual([{ topic: "scene", intent: "compareBranches", args: [["n1", "n2", "n3"]] }]);
+  });
+
   it("setGroupLabel sends the scene-topic setGroupLabel intent with [nodeId, text]", () => {
     const { transport, intents } = makeFakeTransport();
     const store = new SceneStore(transport);

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -670,6 +670,15 @@ export class SceneStore {
     this.transport.intent("scene", "createContainer", [itemIds]);
   }
 
+  // ADR-002 Workstream 1 ("Compare Branches") - same fire-and-forget shape
+  // as createFrame/createContainer above: the frontend already gathered
+  // React Flow's own multi-selection (App.tsx's GlobalShortcuts), the
+  // backend validates/does the work, and the resulting note arrives
+  // through the next scene snapshot like any other mutation.
+  compareBranches(nodeIds: string[]): void {
+    this.transport.intent("scene", "compareBranches", [nodeIds]);
+  }
+
   // Shared setter for frame/container header-note/title text (backend/
   // canvas.py's set_group_label) - reused verbatim for both kinds, same
   // posture as setGroupColor below.

--- a/web_ui/src/app/chrome/shortcuts.test.ts
+++ b/web_ui/src/app/chrome/shortcuts.test.ts
@@ -30,6 +30,17 @@ describe("resolveShortcut", () => {
     expect(resolveShortcut(key("G", { shift: true }))).toBe("create-container");
   });
 
+  // ADR-002 Workstream 1 ("Compare Branches") - a genuinely new binding, not
+  // a legacy port.
+  it("treats Ctrl+Shift+C as Compare Branches", () => {
+    expect(resolveShortcut(key("c", { shift: true }))).toBe("compare-branches");
+    expect(resolveShortcut(key("C", { shift: true }))).toBe("compare-branches");
+  });
+
+  it("does NOT bind bare Ctrl+C - it must stay the browser's native copy shortcut", () => {
+    expect(resolveShortcut(key("c"))).toBeNull();
+  });
+
   it("is case-insensitive, since Shift/CapsLock change event.key's case", () => {
     expect(resolveShortcut(key("T"))).toBe("new-chat");
   });
@@ -63,7 +74,10 @@ describe("resolveShortcut", () => {
 describe("isGatedWhileTyping", () => {
   // The exact membership of legacy's GATED_SHORTCUTS
   // (graphlink_web_island_host.py:735-745), which legacy itself
-  // contract-tests. Mirrored here so a future edit to the set has to be
+  // contract-tests, PLUS "compare-branches" (ADR-002 Workstream 1 - a new
+  // shortcut, not a legacy port, gated for the same reason as its closest
+  // sibling create-frame/create-container - see shortcuts.ts's own
+  // comment). Mirrored here so a future edit to the set has to be
   // deliberate rather than incidental.
   const GATED: ShortcutId[] = [
     "new-chat",
@@ -71,6 +85,7 @@ describe("isGatedWhileTyping", () => {
     "toggle-search",
     "create-frame",
     "create-container",
+    "compare-branches",
     "navigate-up",
     "navigate-down",
     "navigate-left",
@@ -86,8 +101,8 @@ describe("isGatedWhileTyping", () => {
     expect(isGatedWhileTyping(id)).toBe(false);
   });
 
-  it("gates exactly the 9 legacy combinations, no more and no fewer", () => {
+  it("gates exactly the 9 legacy combinations plus compare-branches (10 total), no more and no fewer", () => {
     const all: ShortcutId[] = [...GATED, ...EXEMPT];
-    expect(all.filter(isGatedWhileTyping)).toHaveLength(9);
+    expect(all.filter(isGatedWhileTyping)).toHaveLength(10);
   });
 });

--- a/web_ui/src/app/chrome/shortcuts.ts
+++ b/web_ui/src/app/chrome/shortcuts.ts
@@ -23,6 +23,7 @@ export type ShortcutId =
   | "save-chat"
   | "create-frame"
   | "create-container"
+  | "compare-branches"
   | "toggle-palette"
   | "toggle-search"
   | "navigate-up"
@@ -40,6 +41,12 @@ export type ShortcutId =
  * as intentional exemptions - Ctrl+S is non-destructive and reflexively
  * expected mid-sentence, and Ctrl+K is the palette's own summon key (its
  * handler was made idempotent specifically so the exemption is safe).
+ *
+ * "compare-branches" is a genuinely NEW shortcut (ADR-002 Workstream 1,
+ * not a legacy port) but gated here for the exact same reason as its
+ * closest sibling create-frame/create-container: a canvas-wide,
+ * selection-driven action that should never fire mid-sentence while
+ * typing in the composer or a node's own editable field.
  */
 const GATED_WHILE_TYPING = new Set<ShortcutId>([
   "new-chat",
@@ -47,6 +54,7 @@ const GATED_WHILE_TYPING = new Set<ShortcutId>([
   "toggle-search",
   "create-frame",
   "create-container",
+  "compare-branches",
   "navigate-up",
   "navigate-down",
   "navigate-left",
@@ -104,6 +112,12 @@ export function resolveShortcut(event: ShortcutKeyEvent): ShortcutId | null {
     // bindings (graphlink_window.py:312-313), not one with a modifier.
     case "g":
       return event.shiftKey ? "create-container" : "create-frame";
+    // ADR-002 Workstream 1: Ctrl+Shift+C only (never bare Ctrl+C, which
+    // must stay the browser's native copy shortcut) - "compare-branches"
+    // is a new binding, not a legacy port, so there's no existing key to
+    // match.
+    case "c":
+      return event.shiftKey ? "compare-branches" : null;
     default:
       return null;
   }


### PR DESCRIPTION
## Problem

The previous PR (#197) added the ability to branch from an earlier message, so a real second branch (two children under one parent) can now exist. There was no way to do anything with two divergent branches once they existed - no way to compare what they each concluded.

## Change

- New Ctrl+Shift+C shortcut ("compare-branches") reuses React Flow's own native multi-select - the same mechanism Create Frame/Container already use - to gather 2+ selected chat node ids and dispatch a new `compareBranches` intent.
- `backend/canvas.py`'s `compare_branches` validates the selection (dedupes, requires 2+ distinct real chat-kind nodes, rejecting with a notification otherwise), gathers each source's own full `chat_branch_history`, and formats them via a new `_format_branches_for_comparison` helper (built on the existing `_history_turn_text`, so an R8a multimodal `content_parts`-shaped turn flattens correctly instead of stringifying a raw list).
- A new `BranchComparisonAgent` (`graphlink_note_agent.py`, mirroring the existing `KeyTakeawayAgent`/`ExplainerAgent` shape) produces a structured comparison: agreements, differences, unique findings, unresolved questions.
- The result lands in a new note, linked back to every source branch by reusing the existing generic `item_ids` field (previously frame/container-only) rather than adding a new one, and marked with a new `is_branch_comparison` flag - deliberately kept distinct from the legacy `is_summary_note` flag, since that's a different, never-ported feature (an arbitrary multi-select summary), not branch comparison specifically.
- `AgentDispatcher.start_branch_comparison` has its own busy-guard (`_branch_comparison_requests`), independent from Key Takeaway/Explainer's own `_note_requests`, so an in-flight run of one feature can never block the other.
- The note gets a new badge (⇄, tooltip shows source count), distinct from the existing "Summary Note" badge.

## Test plan

- [x] `python -m pytest -q` (full suite, repo root) - 1103/1103 passing, including 18 new backend tests: validation/dedup edge cases, the branch-history formatter (including a dedicated test feeding an actual multimodal `content_parts`-shaped turn through it), the dispatcher's busy-guard independence from note-generation, and note-linking/positioning
- [x] `npx tsc --noEmit`, `npx vitest run` (925/925), `npx eslint .`, `npx vite build` - all clean; new frontend tests cover the store intent, the shortcut resolution (including an explicit regression guard that bare Ctrl+C stays unbound - it must never shadow the browser's native copy shortcut), and the note badge
- [x] **Independent adversarial review** of the diff before commit (a separate agent instance, briefed only on the change description, told to try to break it): checked (A) backend validation/data-integrity correctness (dedup-then-minimum logic, the multimodal content flattening, position math, busy-guard separation), (B) frontend correctness (the Ctrl+C non-shadowing, live selection reads, the badge's null-safety and distinctness from the existing Summary Note badge, the reused `itemIds` field never leaking into frame/container geometry code), (C) test coverage honesty (ran the new tests independently), and (D) regression risk on existing Key Takeaway/Explainer Note/shortcut behavior. It found one real gap - no test fed an actual `content_parts`-shaped turn through the formatter, only plain strings - which is now closed; everything else came back confirmed safe
- [ ] Live interactive UI verification (select 2+ nodes, press the shortcut, inspect the resulting note) was not possible - the browser preview pane is backgrounded in this environment, which stops React Flow from measuring/hit-testing nodes at all (a known constraint from prior PRs, not specific to this change); relying on the test suite above as the verification of record for the UI layer