### PR TITLE
Add "Synthesize Branches": combine 2+ selected branches into one result

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -74,7 +74,7 @@ import graphlink_task_config as config
 from graphlink_artifact_agent import ArtifactAgent
 from graphlink_chart_agent import ChartDataAgent
 from graphlink_chat_agent import ChatAgent
-from graphlink_note_agent import BranchComparisonAgent, ExplainerAgent, KeyTakeawayAgent
+from graphlink_note_agent import BranchComparisonAgent, BranchSynthesisAgent, ExplainerAgent, KeyTakeawayAgent
 from graphlink_licensing import SettingsManager  # type hint only
 from graphlink_plugins.common.github_client import GitHubRestClient
 from graphlink_plugins.gitlink.agent import GitlinkAgent, _fingerprint_changes, _is_repo_text_path
@@ -363,6 +363,11 @@ class AgentDispatcher:
         # must never block the other. Same "request_id -> True, no task/
         # cancel_event" shape - this is directly awaited, not scheduled.
         self._branch_comparison_requests: dict[str, bool] = {}
+        # ADR-002 Workstream 1 ("Synthesize Branches") - a THIRD independent
+        # busy-guard, same reasoning as _branch_comparison_requests above:
+        # Compare and Synthesize are unrelated user gestures over the same
+        # underlying selection, so one running must never block the other.
+        self._branch_synthesis_requests: dict[str, bool] = {}
         # R5.4: Py-Coder's REPL subprocess outlives any single run (state
         # persists between calls, same as legacy's own PyCoderReplManager -
         # see that class's own docstring in graphlink_plugins/pycoder/domain.py
@@ -2462,6 +2467,71 @@ class AgentDispatcher:
         finally:
             self._branch_comparison_requests.pop(request_id, None)
 
+    async def start_branch_synthesis(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        source_text: str,
+        instructions: str,
+        on_success,
+        on_failure,
+    ) -> None:
+        """ADR-002 Workstream 1 ("Synthesize Branches"): mirrors start_branch_
+        comparison's own shape exactly (directly awaited - the result is a
+        brand new chat node and there is no pre-existing node to attach a
+        spinner to; single dict-registry busy guard; WATCHDOG_TIMEOUT_
+        SECONDS; on_success/on_failure callbacks) but with its own
+        _branch_synthesis_requests guard rather than reusing
+        _branch_comparison_requests - see that field's own comment for why.
+        source_text is already the fully-formatted multi-branch block
+        (backend/canvas.py's _format_branches_for_comparison, reused
+        verbatim here - a labeled-branches text block is equally valid
+        input whether the agent on the other end compares or synthesizes);
+        instructions is the user's own free text steering the synthesis."""
+        if self._branch_synthesis_requests:
+            notifications_state.show("A branch synthesis is already being generated.", "info")
+            await bus.publish("notification")
+            return
+
+        request_id = uuid.uuid4().hex
+        self._branch_synthesis_requests[request_id] = True
+
+        async def _invoke(fn, *a):
+            if inspect.iscoroutinefunction(fn):
+                await fn(*a)
+            else:
+                fn(*a)
+
+        try:
+            text = await asyncio.wait_for(
+                asyncio.to_thread(_call_branch_synthesis_agent, source_text, instructions),
+                timeout=WATCHDOG_TIMEOUT_SECONDS,
+            )
+            if not str(text or "").strip():
+                message = "Branch synthesis returned an empty response. Please try again."
+                await _invoke(on_failure, message)
+                notifications_state.show(message, "error")
+                await bus.publish("notification")
+            else:
+                await _invoke(on_success, text)
+        except asyncio.TimeoutError:
+            message = (
+                "Branch synthesis stopped responding before the request completed. "
+                "Please try again."
+            )
+            await _invoke(on_failure, message)
+            notifications_state.show(message, "error")
+            await bus.publish("notification")
+        except Exception as exc:
+            logger.exception("branch synthesis dispatch failed")
+            message = f"Branch synthesis failed: {exc}"
+            await _invoke(on_failure, message)
+            notifications_state.show(message, "error")
+            await bus.publish("notification")
+        finally:
+            self._branch_synthesis_requests.pop(request_id, None)
+
 
 # R8a: the two note agents, keyed by the `note_kind` start_note_generation
 # takes. Kept as data rather than an if/elif so adding a third note agent is
@@ -2486,6 +2556,13 @@ def _call_branch_comparison_agent(source_text: str) -> str:
     start_branch_comparison above, mirroring _call_note_agent's own shape
     (fresh agent instance per call)."""
     return BranchComparisonAgent().get_response(source_text)
+
+
+def _call_branch_synthesis_agent(source_text: str, instructions: str) -> str:
+    """Runs inside asyncio.to_thread - the blocking driver for
+    start_branch_synthesis above, mirroring _call_branch_comparison_agent's
+    own shape (fresh agent instance per call)."""
+    return BranchSynthesisAgent().get_response(source_text, instructions)
 
 
 def _call_pycoder_execution_agent(conversation_history, user_prompt) -> str:

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -390,6 +390,34 @@ class SceneNode:
     # way is_docked/image_asset_id are generic fields even though today only
     # one kind populates them); unused (default None) for every other kind.
     pending_request_id: str | None = None
+    # ADR-002 Workstream 1 ("Synthesize Branches"): the provider/model that
+    # produced this node's content, e.g. "Anthropic Claude" / "claude-sonnet-5"
+    # - resolved from ComposerDocument.route() at creation time. Generic
+    # (like pending_request_id above) rather than synthesis-only, since any
+    # future agent-authored node could reasonably want the same provenance;
+    # today only synthesize_branches populates it. None means "not recorded"
+    # (every node created before this field existed, and every ordinary chat
+    # reply, which already shows its route live in the Composer rather than
+    # per-message).
+    provider: str | None = None
+    model: str | None = None
+    # ADR-002 Workstream 1 ("Synthesize Branches"): marks a chat-kind node as
+    # the output of the Synthesize Branches agent (as opposed to an ordinary
+    # user/assistant message) - the chat-node equivalent of is_branch_
+    # comparison below, which does the same job for note-kind nodes. A
+    # distinct flag rather than reusing is_branch_comparison: that flag's
+    # own kind-check (mark_branch_comparison_note raises for a non-note
+    # node) would need loosening for no benefit, and the two features
+    # render completely different UI (a badge on a note vs. a badge + the
+    # instructions/provider/model fields below on a chat node).
+    is_branch_synthesis: bool = False
+    # ADR-002 Workstream 1 ("Synthesize Branches"): the free-text instructions
+    # the user typed to steer the synthesis (e.g. "merge the best parts of
+    # each"), recorded on the result node so its provenance is fully
+    # inspectable later - the ADR's own acceptance criterion for this
+    # feature. Chat-kind only in practice; unused (default empty string) for
+    # every other kind and for ordinary (non-synthesis) chat nodes.
+    synthesis_instructions: str = ""
     # R5.1: the Web Research node's real persisted shape - `content` (reused,
     # same pattern as code/thinking/html) holds the query text; these six
     # fields track one research run's live progress/outcome. Unused
@@ -1916,6 +1944,32 @@ class SceneDocument:
         node.is_branch_comparison = True
         node.item_ids = list(source_node_ids)
 
+    def mark_branch_synthesis(
+        self,
+        node_id: str,
+        source_node_ids: list[str],
+        instructions: str,
+        provider: str | None,
+        model: str | None,
+    ) -> None:
+        """ADR-002 Workstream 1 ("Synthesize Branches"): stamps an
+        already-created CHAT node as the output of the Synthesize Branches
+        agent - mirrors mark_branch_comparison_note's own "extra setter call
+        right after creation" shape, adapted for a chat-kind result instead
+        of a note-kind one (see SceneNode.is_branch_synthesis's own comment
+        for why this is a distinct method/flag rather than reusing Compare
+        Branches')."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "chat":
+            raise SceneError(f"node is not a chat node: {node_id}")
+        node.is_branch_synthesis = True
+        node.item_ids = list(source_node_ids)
+        node.synthesis_instructions = str(instructions)
+        node.provider = provider
+        node.model = model
+
     def _bbox_of_members(self, item_ids: list[str]) -> tuple[float, float, float, float]:
         """Compute the padded union rect (x, y, width, height) enclosing
         every member id's ESTIMATED footprint - GROUP_MEMBER_DEFAULT_WIDTH/
@@ -2980,6 +3034,13 @@ class SceneDocument:
                         {"role": m["role"], "content": m["content"]} for m in n.history
                     ],
                     "pendingRequestId": n.pending_request_id,
+                    # ADR-002 Workstream 1 ("Synthesize Branches") - see
+                    # SceneNode.provider/model/is_branch_synthesis/
+                    # synthesis_instructions's own comments.
+                    "provider": n.provider,
+                    "model": n.model,
+                    "isBranchSynthesis": n.is_branch_synthesis,
+                    "synthesisInstructions": n.synthesis_instructions,
                     "researchStage": n.research_stage,
                     "researchCompleted": n.research_completed,
                     "researchTotal": n.research_total,
@@ -4145,6 +4206,89 @@ def register_canvas(
         )
         return result_holder.get("node_id")
 
+    async def synthesize_branches(node_ids, instructions):
+        """ADR-002 Workstream 1 ("Synthesize Branches") - the third
+        sequenced item in that workstream's own "fork -> compare ->
+        synthesize -> status/lifecycle UI" order, following compare_
+        branches above. Same validation contract as that function (2+
+        de-duped ids, every one a real chat node, no auto-selection
+        fallback), plus one more: instructions must be non-blank, since an
+        empty steering prompt would leave the agent nothing to follow.
+
+        Unlike Compare (whose result is a parentless note), Synthesize's
+        result is a real CHAT node continuing the branch tree from the
+        FIRST selected source - a genuine next step in the conversation,
+        not a side annotation - so last_chat_node_id is updated to it
+        exactly like an ordinary send. Every source is still recorded (via
+        item_ids, the same multi-purpose-field reuse Compare's note
+        already established) so full provenance survives even though only
+        one edge can be structural. Provider/model are stamped from
+        composer_document.route() - the same route a plain send would
+        actually use - onto the result node (see SceneNode.provider/model's
+        own comment)."""
+        ids = list(dict.fromkeys(str(i) for i in (node_ids or [])))  # de-dupe, preserve order
+        if len(ids) < 2:
+            notifications.show("Select at least 2 branches to synthesize.", "warning")
+            await bus.publish("notification")
+            return None
+
+        clean_instructions = str(instructions or "").strip()
+        if not clean_instructions:
+            notifications.show("Enter instructions for how to combine the branches.", "warning")
+            await bus.publish("notification")
+            return None
+
+        sources = []
+        for node_id in ids:
+            node = document.nodes.get(node_id)
+            if node is None or node.kind != "chat":
+                notifications.show("Every selected node must be a real chat message to synthesize.", "warning")
+                await bus.publish("notification")
+                return None
+            sources.append(node)
+
+        branches = [
+            (f"Branch {index + 1}", document.chat_branch_history(node.id))
+            for index, node in enumerate(sources)
+        ]
+        formatted = _format_branches_for_comparison(branches)
+
+        parent = sources[0]
+        avg_x = sum(node.x for node in sources) / len(sources)
+        max_y = max(node.y for node in sources)
+        route = composer_document.route()
+
+        result_holder: dict[str, str] = {}
+
+        async def _on_success(text):
+            if any(node_id not in document.nodes for node_id in ids):
+                # A source was deleted mid-flight - same liveness posture as
+                # compare_branches's own on_success guard.
+                return
+            node = document.add_chat_node(
+                avg_x, max_y + MESSAGE_VERTICAL_SPACING, text, False, parent_id=parent.id,
+            )
+            document.mark_branch_synthesis(
+                node.id, ids, clean_instructions, route.get("provider"), route.get("modelLabel"),
+            )
+            document.last_chat_node_id = node.id
+            result_holder["node_id"] = node.id
+            await bus.publish("scene")
+
+        def _on_failure(message):
+            # start_branch_synthesis already surfaced the notification.
+            pass
+
+        await agent_dispatcher.start_branch_synthesis(
+            bus=bus,
+            notifications_state=notifications,
+            source_text=formatted,
+            instructions=clean_instructions,
+            on_success=_on_success,
+            on_failure=_on_failure,
+        )
+        return result_holder.get("node_id")
+
     async def resize_chart(node_id, width, height):
         document.resize_chart(node_id, width, height)
         await publish_scene()
@@ -4683,6 +4827,7 @@ def register_canvas(
     bus.register_intent("scene", "generateKeyTakeaway", generate_key_takeaway)
     bus.register_intent("scene", "generateExplainerNote", generate_explainer_note)
     bus.register_intent("scene", "compareBranches", compare_branches)
+    bus.register_intent("scene", "synthesizeBranches", synthesize_branches)
     bus.register_intent("scene", "resizeChart", resize_chart)
     bus.register_intent("scene", "toggleChartAspectLock", toggle_chart_aspect_lock)
     bus.register_intent("scene", "moveNode", move_node)

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -5069,3 +5069,114 @@ def test_start_branch_comparison_agent_exception_surfaces_and_clears_the_slot(mo
         assert dispatcher._branch_comparison_requests == {}, "the slot must not leak after a failure"
 
     asyncio.run(run())
+
+
+# -- ADR-002 Workstream 1: start_branch_synthesis ("Synthesize Branches") ----
+#
+# Mirrors start_branch_comparison's own test shape exactly - same busy-guard/
+# timeout/empty-response/exception coverage - but against the SEPARATE
+# _branch_synthesis_requests slot, proving Compare and Synthesize's busy
+# states are genuinely independent (see that field's own comment for why).
+
+
+def test_start_branch_synthesis_calls_on_success_then_clears_the_slot(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.BranchSynthesisAgent, "get_response",
+        lambda self, text, instructions: f"Combined from {text} per '{instructions}'",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_note_env()
+        successes, failures = [], []
+        await dispatcher.start_branch_synthesis(
+            bus=bus, notifications_state=notifications,
+            source_text="=== Branch 1 ===\n...", instructions="merge them",
+            on_success=successes.append, on_failure=failures.append,
+        )
+        assert successes == ["Combined from === Branch 1 ===\n... per 'merge them'"]
+        assert failures == []
+        assert dispatcher._branch_synthesis_requests == {}
+        assert notifications.visible is False
+
+    asyncio.run(run())
+
+
+def test_start_branch_synthesis_rejects_a_second_concurrent_run(monkeypatch):
+    monkeypatch.setattr(agents_module.BranchSynthesisAgent, "get_response", lambda self, text, instructions: "ok")
+
+    async def run():
+        bus, notifications, dispatcher = _make_note_env()
+        dispatcher._branch_synthesis_requests["already-running"] = True
+        successes = []
+        await dispatcher.start_branch_synthesis(
+            bus=bus, notifications_state=notifications, source_text="x", instructions="y",
+            on_success=successes.append, on_failure=lambda m: None,
+        )
+        assert successes == [], "the busy guard must not run a second agent"
+        assert notifications.visible is True
+        assert notifications.msg_type == "info"
+        assert dispatcher._branch_synthesis_requests == {"already-running": True}
+
+    asyncio.run(run())
+
+
+def test_start_branch_synthesis_does_not_share_a_busy_slot_with_branch_comparison(monkeypatch):
+    # The whole reason for a SEPARATE dict: an in-flight Compare Branches
+    # call must never block an unrelated Synthesize Branches call, and vice
+    # versa - they are unrelated user gestures over the same kind of
+    # selection.
+    monkeypatch.setattr(
+        agents_module.BranchSynthesisAgent, "get_response",
+        lambda self, text, instructions: "Combined answer.",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_note_env()
+        dispatcher._branch_comparison_requests["unrelated-comparison"] = True
+        successes = []
+        await dispatcher.start_branch_synthesis(
+            bus=bus, notifications_state=notifications, source_text="x", instructions="y",
+            on_success=successes.append, on_failure=lambda m: None,
+        )
+        assert successes == ["Combined answer."], "an in-flight branch comparison must not block this"
+
+    asyncio.run(run())
+
+
+def test_start_branch_synthesis_empty_response_fails_instead_of_creating_a_blank_node(monkeypatch):
+    monkeypatch.setattr(agents_module.BranchSynthesisAgent, "get_response", lambda self, text, instructions: "   ")
+
+    async def run():
+        bus, notifications, dispatcher = _make_note_env()
+        successes, failures = [], []
+        await dispatcher.start_branch_synthesis(
+            bus=bus, notifications_state=notifications, source_text="x", instructions="y",
+            on_success=successes.append, on_failure=failures.append,
+        )
+        assert successes == [], "an empty agent response must not become a node"
+        assert len(failures) == 1
+        assert notifications.msg_type == "error"
+        assert dispatcher._branch_synthesis_requests == {}
+
+    asyncio.run(run())
+
+
+def test_start_branch_synthesis_agent_exception_surfaces_and_clears_the_slot(monkeypatch):
+    def _boom(self, text, instructions):
+        raise RuntimeError("model exploded")
+
+    monkeypatch.setattr(agents_module.BranchSynthesisAgent, "get_response", _boom)
+
+    async def run():
+        bus, notifications, dispatcher = _make_note_env()
+        successes, failures = [], []
+        await dispatcher.start_branch_synthesis(
+            bus=bus, notifications_state=notifications, source_text="x", instructions="y",
+            on_success=successes.append, on_failure=failures.append,
+        )
+        assert successes == []
+        assert "model exploded" in failures[0]
+        assert notifications.msg_type == "error"
+        assert dispatcher._branch_synthesis_requests == {}, "the slot must not leak after a failure"
+
+    asyncio.run(run())

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -6955,3 +6955,194 @@ def test_mark_branch_comparison_note_rejects_an_unknown_node_id():
     doc = SceneDocument()
     with pytest.raises(SceneError):
         doc.mark_branch_comparison_note("does-not-exist", ["x", "y"])
+
+
+# -- ADR-002 Workstream 1: "Synthesize Branches" ------------------------------
+#
+# The third sequenced item ("fork -> compare -> synthesize -> status/
+# lifecycle UI") - takes 2+ existing chat nodes plus the user's own free-text
+# instructions and drops a single agent-authored CHAT node (not a note, unlike
+# Compare Branches) continuing the branch tree from the FIRST selected
+# source, while recording every source (via item_ids, same reuse as Compare's
+# note) plus the instructions and the provider/model that produced it.
+
+
+def test_synthesize_branches_creates_a_chat_node_continuing_from_the_first_source(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.BranchSynthesisAgent, "get_response",
+        lambda self, text, instructions: "Combined answer drawing on both branches.",
+    )
+
+    async def run():
+        bus, document, recorder, _ = make_bus_with_dispatcher()
+        root = document.add_chat_node(0, 0, "root question", True)
+        first = document.add_chat_node(0, 160, "first answer", False, parent_id=root.id)
+        second = document.add_chat_node(460, 160, "second answer", False, parent_id=root.id)
+        scene_publishes_before = recorder.topics_seen().count("scene")
+
+        node_id = await bus.dispatch_intent(
+            "scene", "synthesizeBranches", [[first.id, second.id], "merge the best of both"],
+        )
+
+        assert node_id is not None
+        node = document.nodes[node_id]
+        assert node.kind == "chat"
+        assert node.is_user is False
+        assert node.content == "Combined answer drawing on both branches."
+        assert node.is_branch_synthesis is True
+        assert node.item_ids == [first.id, second.id]
+        assert node.synthesis_instructions == "merge the best of both"
+        # Continues the branch tree from the FIRST selected source, not a
+        # parentless node like Compare Branches' note.
+        parent_edge = document._branch_parent_edge(node.id)
+        assert parent_edge is not None
+        assert parent_edge.source == first.id
+        # Positioned below every source, averaged across all of them.
+        assert node.x == (first.x + second.x) / 2
+        assert node.y == max(first.y, second.y) + MESSAGE_VERTICAL_SPACING
+        assert document.last_chat_node_id == node.id
+        assert recorder.topics_seen().count("scene") > scene_publishes_before
+
+    asyncio.run(run())
+
+
+def test_synthesize_branches_stamps_provider_and_model_from_the_composer_route(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.BranchSynthesisAgent, "get_response",
+        lambda self, text, instructions: "Combined answer.",
+    )
+
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        root = document.add_chat_node(0, 0, "root question", True)
+        first = document.add_chat_node(0, 160, "first answer", False, parent_id=root.id)
+        second = document.add_chat_node(460, 160, "second answer", False, parent_id=root.id)
+
+        node_id = await bus.dispatch_intent(
+            "scene", "synthesizeBranches", [[first.id, second.id], "merge them"],
+        )
+
+        node = document.nodes[node_id]
+        # ComposerDocument() in make_bus_with_dispatcher has no route_reader
+        # wired - route()'s own honest "no settings manager wired" fallback
+        # (see backend/composer.py) reports Ollama (Local) with an empty
+        # model, which is exactly what should land on the node.
+        assert node.provider == "Ollama (Local)"
+        assert node.model == ""
+
+    asyncio.run(run())
+
+
+def test_synthesize_branches_sends_each_branchs_own_full_history_and_the_instructions(monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        agents_module.BranchSynthesisAgent, "get_response",
+        lambda self, text, instructions: seen.append((text, instructions)) or "Combined answer.",
+    )
+
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        root = document.add_chat_node(0, 0, "shared root question", True)
+        first = document.add_chat_node(0, 160, "first branch reply", False, parent_id=root.id)
+        second = document.add_chat_node(460, 160, "second branch reply", False, parent_id=root.id)
+
+        await bus.dispatch_intent(
+            "scene", "synthesizeBranches", [[first.id, second.id], "pick the simpler one"],
+        )
+
+        assert len(seen) == 1
+        formatted, instructions = seen[0]
+        assert "shared root question" in formatted, "each branch's full history must be included, not just its own leaf"
+        assert "first branch reply" in formatted
+        assert "second branch reply" in formatted
+        assert instructions == "pick the simpler one"
+
+    asyncio.run(run())
+
+
+def test_synthesize_branches_rejects_fewer_than_two_ids():
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        only = document.add_chat_node(0, 0, "solo", True)
+        node_count_before = len(document.nodes)
+
+        assert await bus.dispatch_intent("scene", "synthesizeBranches", [[], "combine them"]) is None
+        assert await bus.dispatch_intent("scene", "synthesizeBranches", [[only.id], "combine them"]) is None
+        assert len(document.nodes) == node_count_before, "no node should be created"
+
+    asyncio.run(run())
+
+
+def test_synthesize_branches_dedupes_repeated_ids_before_the_minimum_check():
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        only = document.add_chat_node(0, 0, "solo", True)
+
+        result = await bus.dispatch_intent("scene", "synthesizeBranches", [[only.id, only.id], "combine"])
+        assert result is None, "the same id twice must still fail the real 2-distinct-branches minimum"
+
+    asyncio.run(run())
+
+
+def test_synthesize_branches_rejects_a_non_chat_node(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        agents_module.BranchSynthesisAgent, "get_response",
+        lambda self, text, instructions: calls.append(text) or "should not happen",
+    )
+
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        chat = document.add_chat_node(0, 0, "a real chat node", True)
+        note = document.add_note(0, 0)
+
+        result = await bus.dispatch_intent("scene", "synthesizeBranches", [[chat.id, note.id], "combine"])
+
+        assert result is None
+        assert calls == [], "a non-chat node in the selection must block the agent call entirely"
+
+    asyncio.run(run())
+
+
+def test_synthesize_branches_rejects_an_unknown_node_id():
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        chat = document.add_chat_node(0, 0, "a real chat node", True)
+        result = await bus.dispatch_intent("scene", "synthesizeBranches", [[chat.id, "does-not-exist"], "combine"])
+        assert result is None
+
+    asyncio.run(run())
+
+
+def test_synthesize_branches_rejects_blank_instructions(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        agents_module.BranchSynthesisAgent, "get_response",
+        lambda self, text, instructions: calls.append(text) or "should not happen",
+    )
+
+    async def run():
+        bus, document, _, _ = make_bus_with_dispatcher()
+        first = document.add_chat_node(0, 0, "first", True)
+        second = document.add_chat_node(0, 160, "second", True)
+
+        for blank in ["", "   ", None]:
+            result = await bus.dispatch_intent("scene", "synthesizeBranches", [[first.id, second.id], blank])
+            assert result is None
+
+        assert calls == [], "blank instructions must block the agent call entirely"
+
+    asyncio.run(run())
+
+
+def test_mark_branch_synthesis_rejects_a_non_chat_node():
+    doc = SceneDocument()
+    note = doc.add_note(0, 0)
+    with pytest.raises(SceneError):
+        doc.mark_branch_synthesis(note.id, ["x", "y"], "instructions", "Anthropic Claude", "claude-sonnet-5")
+
+
+def test_mark_branch_synthesis_rejects_an_unknown_node_id():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.mark_branch_synthesis("does-not-exist", ["x", "y"], "instructions", None, None)

--- a/graphlink_note_agent.py
+++ b/graphlink_note_agent.py
@@ -191,6 +191,38 @@ Reference specific claims from the branches, not generic observations. Keep it f
         return self.clean_text(response['message']['content'])
 
 
+class BranchSynthesisAgent:
+    """ADR-002 Workstream 1 ("Synthesize Branches"): combines 2+ independent
+    conversation branches into one answer, steered by the user's own
+    free-text instructions (e.g. "merge the best parts" or "pick whichever
+    branch's approach is simpler and explain why"). Deliberately NOT run
+    through clean_agent_markdown_response like the note agents above: its
+    result becomes a real chat-kind node rendered through the same Markdown
+    pipeline as an ordinary assistant reply (see SceneDocument.synthesize_
+    branches's own docstring), not a plain-text note - stripping markdown
+    from it would be actively wrong, not just unnecessary. No fixed
+    section-header format either, unlike the note agents: the whole point is
+    that the user's instructions shape the output, so a required template
+    would fight them."""
+
+    def __init__(self):
+        self.system_prompt = """You are a branch-synthesis assistant. You will be given two or more independent conversation branches that were explored from the same starting point, plus instructions from the user describing how to combine them. Follow the user's instructions to produce a single, coherent answer that draws on the branches as source material. Reference specific content from the branches rather than generic observations. You may use normal Markdown formatting (headings, bold, code blocks, lists) since your answer will be rendered as a real chat message, not a plain-text note."""
+
+    def get_response(self, formatted_branches_text, instructions):
+        messages = [
+            {'role': 'system', 'content': self.system_prompt},
+            {
+                'role': 'user',
+                'content': (
+                    f"Instructions: {instructions}\n\n"
+                    f"Branches:\n\n{formatted_branches_text}"
+                ),
+            },
+        ]
+        response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
+        return str(response['message']['content'] or "").strip()
+
+
 class ExplainerAgent:
     """Simplifies complex topics into plain language."""
 

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -117,6 +117,8 @@ function GlobalShortcuts({ store }: { store: SceneStore }) {
           return applyGrouping("container");
         case "compare-branches":
           return applyCompareBranches();
+        case "synthesize-branches":
+          return applySynthesizeBranches();
         case "toggle-palette":
           return overlays.toggle("palette", "dialog");
         case "toggle-search":
@@ -152,6 +154,46 @@ function GlobalShortcuts({ store }: { store: SceneStore }) {
       const ids = reactFlow.getNodes().filter((n) => n.selected).map((n) => n.id);
       if (ids.length === 0) return;
       store.compareBranches(ids);
+    }
+
+    // ADR-002 Workstream 1 ("Synthesize Branches"): STAGES the selection
+    // rather than firing an intent immediately (unlike applyCompareBranches
+    // above) - synthesis needs the user's own free-text instructions first,
+    // gathered by the Composer's very next Send (see sceneStore.
+    // setSynthesizeTargetNodeIds's own comment).
+    //
+    // UNLIKE applyCompareBranches/applyGrouping, this function DOES
+    // duplicate synthesize_branches's own "2+ ids, every one a real chat
+    // node" backend validation here, client-side, rather than deferring to
+    // it - a deliberate divergence from this file's usual "let the backend
+    // validate" posture. The reason: an invalid selection here doesn't just
+    // fail an immediate, nothing-lost action (Compare Branches' own near-
+    // miss case) - it stages a pending synthesis that the user then types
+    // real, possibly substantial instructions against. Without this check,
+    // pressing Send on that staged-but-invalid selection fires
+    // synthesizeBranches, and sceneStore.sendMessage/Composer.tsx's send()
+    // both optimistically clear the staged selection and the draft text
+    // immediately (the same fire-and-forget posture every WS intent in this
+    // app uses) - by the time the backend's own rejection notification
+    // arrives, the user's typed instructions are already gone with no
+    // recovery. Catching the same 2-invalid-selection cases HERE, before
+    // any instructions get typed, closes that hole entirely. The backend's
+    // own validation stays exactly as-is (defense in depth for any other
+    // caller), this is additive.
+    function applySynthesizeBranches() {
+      const selected = reactFlow.getNodes().filter((n) => n.selected);
+      if (selected.length === 0) return; // legacy-style bare return: nothing attempted, nothing to report
+      const allChat = selected.every((n) => n.type === "chat");
+      const ids = selected.map((n) => n.id);
+      if (!allChat) {
+        store.showInfoNotification("Every selected node must be a real chat message to synthesize.");
+        return;
+      }
+      if (ids.length < 2) {
+        store.showInfoNotification("Select at least 2 branches to synthesize.");
+        return;
+      }
+      store.setSynthesizeTargetNodeIds(ids);
     }
 
     function onKeyDown(event: KeyboardEvent) {

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -397,6 +397,57 @@ describe("ChatNodeView Branch from Here (ADR-002 Workstream 1)", () => {
   });
 });
 
+// ADR-002 Workstream 1 ("Synthesize Branches"): the result node's own
+// provenance badge/label - both absent for every ordinary chat node (the
+// vast majority), rendered only when the node actually carries them.
+describe("ChatNodeView Synthesize Branches provenance (ADR-002 Workstream 1)", () => {
+  it("renders no synthesis badge or model label for an ordinary chat node", () => {
+    renderChatNode({
+      isBranchSynthesis: false,
+      synthesisInstructions: "",
+      synthesisSourceNodeIds: [],
+      provider: null,
+      model: null,
+    });
+    expect(screen.queryByLabelText("Branch Synthesis")).toBeNull();
+  });
+
+  it("renders the synthesis badge with a tooltip naming the source count and instructions", () => {
+    renderChatNode({
+      isBranchSynthesis: true,
+      synthesisInstructions: "merge the best of both",
+      synthesisSourceNodeIds: ["chat-a", "chat-b"],
+      provider: "Anthropic Claude",
+      model: "claude-sonnet-5",
+    });
+    const badge = screen.getByLabelText("Branch Synthesis");
+    expect(badge).toHaveTextContent("⇄");
+    expect(badge).toHaveAttribute("title", "Branch Synthesis (2 sources): merge the best of both");
+  });
+
+  it("renders the model label with the provider as its tooltip, only when model is set", () => {
+    renderChatNode({
+      isBranchSynthesis: true,
+      synthesisInstructions: "merge them",
+      synthesisSourceNodeIds: ["chat-a", "chat-b"],
+      provider: "Anthropic Claude",
+      model: "claude-sonnet-5",
+    });
+    expect(screen.getByText("claude-sonnet-5")).toHaveAttribute("title", "Anthropic Claude");
+  });
+
+  it("renders no model label when model is null, even if isBranchSynthesis is true", () => {
+    renderChatNode({
+      isBranchSynthesis: true,
+      synthesisInstructions: "merge them",
+      synthesisSourceNodeIds: ["chat-a", "chat-b"],
+      provider: null,
+      model: null,
+    });
+    expect(screen.queryByText("claude-sonnet-5")).toBeNull();
+  });
+});
+
 // R6.3: the node's own scroll position within .chat-node-content.
 describe("ChatNodeView scroll position (R6.3)", () => {
   it("restores the saved chatScrollValue into .chat-node-content's scrollTop once on mount", () => {

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -92,6 +92,19 @@ export interface ChatNodeData extends Record<string, unknown> {
   // (SceneDocument.send_message's branch_from_node_id) once the user
   // types a message and sends it; this callback only stages the pick.
   onBranchFromHere: () => void;
+  // ADR-002 Workstream 1 ("Synthesize Branches"): provenance for a
+  // Synthesize Branches result node - null/false/"" for every ordinary chat
+  // node (the vast majority), which renders no badge/label at all (see the
+  // render guards below). provider/model come from ComposerDocument.route()
+  // at the moment the synthesis ran (backend/canvas.py's synthesize_
+  // branches), NOT a live "current route" - they are a frozen record of
+  // what actually produced this specific node's content, matching the
+  // ADR's own "provider/model provenance" acceptance criterion.
+  provider: string | null;
+  model: string | null;
+  isBranchSynthesis: boolean;
+  synthesisInstructions: string;
+  synthesisSourceNodeIds: string[];
 }
 
 export type ChatFlowNode = Node<ChatNodeData, "chat">;
@@ -407,6 +420,26 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
           {data.dockedChildren.length > 0 && (
             <span className="chat-node-docked-badge" title="Docked items">
               {data.dockedChildren.length}
+            </span>
+          )}
+          {data.isBranchSynthesis && (
+            // ADR-002 Workstream 1 ("Synthesize Branches"): reuses the same
+            // "join/combine" glyph as NoteNodeView's Compare Branches badge
+            // (⇄) - the two features are different renderers (note vs.
+            // chat) so there is no shared component to factor this into,
+            // but the visual vocabulary for "derived from multiple
+            // branches" stays consistent across both.
+            <span
+              className="chat-node-synthesis-badge"
+              title={`Branch Synthesis (${data.synthesisSourceNodeIds.length} sources): ${data.synthesisInstructions}`}
+              aria-label="Branch Synthesis"
+            >
+              ⇄
+            </span>
+          )}
+          {data.model && (
+            <span className="chat-node-model-badge" title={data.provider ?? undefined}>
+              {data.model}
             </span>
           )}
         </span>

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -1520,6 +1520,82 @@ describe("toFlowNodes (R6.3 chat node scroll value)", () => {
   });
 });
 
+// ADR-002 Workstream 1 ("Synthesize Branches"). Same situation as
+// R63TestFields above - provider/model/isBranchSynthesis/
+// synthesisInstructions aren't in the generated SceneNodeRow type yet (see
+// SceneCanvas.tsx's own SceneNodeSynthesisFields comment). itemIds is
+// already declared elsewhere in this file via GroupTestFields (an
+// UNRELATED note-kind reuse) - re-declared here rather than shared since
+// this helper intersects it independently, for the chat-kind reuse.
+interface SynthesisTestFields {
+  provider: string | null;
+  model: string | null;
+  isBranchSynthesis: boolean;
+  synthesisInstructions: string;
+  itemIds: string[];
+}
+
+function withSynthesisFields(
+  node: SceneNodeRow,
+  overrides: Partial<SynthesisTestFields> = {},
+): SceneNodeRow & SynthesisTestFields {
+  return {
+    ...node,
+    provider: null,
+    model: null,
+    isBranchSynthesis: false,
+    synthesisInstructions: "",
+    itemIds: [],
+    ...overrides,
+  } as SceneNodeRow & SynthesisTestFields;
+}
+
+describe("toFlowNodes (ADR-002 Workstream 1 - Synthesize Branches provenance)", () => {
+  it("maps a synthesis result chat node's provider/model/instructions/source ids onto the flow node's data", () => {
+    const scene = baseScene({
+      nodes: [
+        withSynthesisFields(baseNode({ id: "chat-1", kind: "chat", content: "Combined answer" }), {
+          provider: "Anthropic Claude",
+          model: "claude-sonnet-5",
+          isBranchSynthesis: true,
+          synthesisInstructions: "merge the best of both",
+          itemIds: ["chat-a", "chat-b"],
+        }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    expect(chatFlowNode!.data).toMatchObject({
+      provider: "Anthropic Claude",
+      model: "claude-sonnet-5",
+      isBranchSynthesis: true,
+      synthesisInstructions: "merge the best of both",
+      synthesisSourceNodeIds: ["chat-a", "chat-b"],
+    });
+  });
+
+  it("defaults to no provenance for an ordinary chat node (the vast majority - field absent, ahead of codegen regenerating SceneNodeRow)", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hello" })],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    expect(chatFlowNode!.data).toMatchObject({
+      provider: undefined,
+      model: undefined,
+      isBranchSynthesis: undefined,
+      synthesisInstructions: undefined,
+      synthesisSourceNodeIds: undefined,
+    });
+  });
+});
+
 describe("toFlowNodes (R6.3 html node splitter state)", () => {
   it("maps a saved htmlSplitterState onto the flow node's data", () => {
     const scene = baseScene({

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -108,6 +108,26 @@ interface SceneNodeR63Fields {
 }
 type SceneNodeRowWithR63 = SceneNodeRow & SceneNodeR63Fields;
 
+// ADR-002 Workstream 1 ("Synthesize Branches"). Same situation as
+// SceneNodeGroupFields/SceneNodeChartFields/SceneNodeR63Fields above - the
+// generated SceneNodeRow type hasn't been regenerated yet to carry
+// provider/model/isBranchSynthesis/synthesisInstructions (backend/canvas.py's
+// scene_payload() contract for this increment). itemIds is declared again
+// here (already present on SceneNodeGroupFields, for the UNRELATED note-kind
+// Compare Branches reuse) rather than shared between the two interfaces -
+// this one is intersected with SceneNodeRow independently, in the chat-kind
+// branch below, so there is no actual overlap at runtime; see
+// SceneNode.item_ids's own comment on backend/canvas.py for the two,
+// deliberately distinct uses of that one generic field.
+interface SceneNodeSynthesisFields {
+  provider: string | null;
+  model: string | null;
+  isBranchSynthesis: boolean;
+  synthesisInstructions: string;
+  itemIds: string[];
+}
+type SceneNodeRowWithSynthesis = SceneNodeRow & SceneNodeSynthesisFields;
+
 /**
  * The React Flow canvas (Qt-removal plan R1) - the QGraphicsScene/ChatView
  * successor. R1 scope: pan/zoom, model-driven grid (size/style/color/opacity
@@ -385,6 +405,7 @@ export function toFlowNodes(
         if (target?.isDocked) dockedChildren.push({ id: target.id, label: target.title });
       }
       const chatR63 = n as SceneNodeRowWithR63;
+      const chatSynthesis = n as SceneNodeRowWithSynthesis;
       flowNodes.push({
         id: n.id,
         type: "chat" as const,
@@ -438,6 +459,16 @@ export function toFlowNodes(
           // needed here (unlike onToggleBranchFocus, which lives as local
           // state on SceneCanvas itself, not on the store).
           onBranchFromHere: () => store.setReplyTargetNodeId(n.id),
+          // ADR-002 Workstream 1 ("Synthesize Branches"): provenance carried
+          // by the result node - see SceneNodeSynthesisFields' own comment.
+          // provider/model are None/absent for every ordinary chat node
+          // (the vast majority), rendered as no badge at all - see
+          // ChatNodeView.tsx's own guard.
+          provider: chatSynthesis.provider,
+          model: chatSynthesis.model,
+          isBranchSynthesis: chatSynthesis.isBranchSynthesis,
+          synthesisInstructions: chatSynthesis.synthesisInstructions,
+          synthesisSourceNodeIds: chatSynthesis.itemIds,
           // R6.3: the node's own scroll position within its content area -
           // read on mount by ChatNodeView (restore) and reported (debounced)
           // via the new setChatScrollValue intent on every scroll. Defaults

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -812,6 +812,87 @@ describe("SceneStore", () => {
     ]);
   });
 
+  // -- ADR-002 Workstream 1: "Synthesize Branches" ---------------------------
+
+  it("setSynthesizeTargetNodeIds/getSynthesizeTargetNodeIds update state, notify listeners, and clear any pending reply target", () => {
+    const { transport } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    const seen = vi.fn();
+    store.subscribe(seen);
+
+    expect(store.getSynthesizeTargetNodeIds()).toBeNull();
+    store.setSynthesizeTargetNodeIds(["n1", "n2"]);
+    expect(store.getSynthesizeTargetNodeIds()).toEqual(["n1", "n2"]);
+    expect(seen).toHaveBeenCalledTimes(1);
+
+    store.setSynthesizeTargetNodeIds(null);
+    expect(store.getSynthesizeTargetNodeIds()).toBeNull();
+    expect(seen).toHaveBeenCalledTimes(2);
+  });
+
+  it("setSynthesizeTargetNodeIds and setReplyTargetNodeId are mutually exclusive - setting one clears the other", () => {
+    const { transport } = makeFakeTransport();
+    const store = new SceneStore(transport);
+
+    store.setReplyTargetNodeId("n-root");
+    expect(store.getReplyTargetNodeId()).toBe("n-root");
+
+    store.setSynthesizeTargetNodeIds(["n1", "n2"]);
+    expect(store.getSynthesizeTargetNodeIds()).toEqual(["n1", "n2"]);
+    expect(store.getReplyTargetNodeId()).toBeNull();
+
+    store.setReplyTargetNodeId("n-other");
+    expect(store.getReplyTargetNodeId()).toBe("n-other");
+    expect(store.getSynthesizeTargetNodeIds()).toBeNull();
+  });
+
+  it("setReplyTargetNodeId still emits when it clears a pending synthesize target, even if its own id is unchanged (null -> null)", () => {
+    const { transport } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    const seen = vi.fn();
+    store.setSynthesizeTargetNodeIds(["n1", "n2"]);
+    store.subscribe(seen);
+
+    // replyTargetNodeId is already null, but a synthesize target IS pending -
+    // this must still count as a real state change and emit.
+    store.setReplyTargetNodeId(null);
+    expect(seen).toHaveBeenCalledTimes(1);
+    expect(store.getSynthesizeTargetNodeIds()).toBeNull();
+  });
+
+  it("sendMessage with a pending synthesize target fires synthesizeBranches with [nodeIds, text] instead of sendMessage, then clears it", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setSynthesizeTargetNodeIds(["n1", "n2"]);
+
+    store.sendMessage("merge the best of both");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "synthesizeBranches", args: [["n1", "n2"], "merge the best of both"] },
+    ]);
+    expect(store.getSynthesizeTargetNodeIds()).toBeNull();
+
+    // A SECOND send, with no synthesize target pending anymore, must fall
+    // through to an ordinary sendMessage - proving it was genuinely
+    // consumed, not just read.
+    store.sendMessage("a normal follow-up");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "synthesizeBranches", args: [["n1", "n2"], "merge the best of both"] },
+      { topic: "scene", intent: "sendMessage", args: ["a normal follow-up"] },
+    ]);
+  });
+
+  it("sendMessage prefers a pending synthesize target over a pending reply target (the two are already mutually exclusive, but this proves the check order)", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setReplyTargetNodeId("n-root");
+    store.setSynthesizeTargetNodeIds(["n1", "n2"]);
+
+    store.sendMessage("combine them");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "synthesizeBranches", args: [["n1", "n2"], "combine them"] },
+    ]);
+  });
+
   it("showInfoNotification sends the notification-topic showInfo intent, not scene", () => {
     const { transport, intents } = makeFakeTransport();
     const store = new SceneStore(transport);

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -88,6 +88,19 @@ export class SceneStore {
   // indicator, and consumed-then-cleared by sendMessage itself so it never
   // silently applies to a later, unrelated send.
   private replyTargetNodeId: string | null = null;
+  // ADR-002 Workstream 1 ("Synthesize Branches"): which 2+ chat nodes the
+  // NEXT sendMessage should synthesize instead of sending an ordinary
+  // reply - the list-valued sibling of replyTargetNodeId above, same local-
+  // UI-state-only posture. Set by App.tsx's Synthesize Branches shortcut
+  // (which already gathers React Flow's own multi-selection, the same
+  // mechanism compareBranches below uses), read by Composer.tsx to show a
+  // "Synthesizing N branches" indicator, and consumed-then-cleared by
+  // sendMessage itself so it never silently applies to a later, unrelated
+  // send. Mutually exclusive with replyTargetNodeId - setting one clears
+  // the other (see both setters below) since a send cannot simultaneously
+  // be "a reply to X" and "a synthesis of X, Y" - showing both indicators
+  // at once would be confusing and only one intent can actually fire.
+  private synthesizeTargetNodeIds: string[] | null = null;
 
   constructor(private readonly transport: WsTransport) {}
 
@@ -128,6 +141,7 @@ export class SceneStore {
   getFontConfig = (): FontControlState => this.fontConfig;
   getSelectedNodeId = (): string | null => this.selectedNodeId;
   getReplyTargetNodeId = (): string | null => this.replyTargetNodeId;
+  getSynthesizeTargetNodeIds = (): string[] | null => this.synthesizeTargetNodeIds;
 
   // R5.1: no-op-if-unchanged, same discipline as every other setter here that
   // guards a redundant assignment before paying for an emit() fan-out.
@@ -138,8 +152,15 @@ export class SceneStore {
   }
 
   setReplyTargetNodeId(id: string | null): void {
-    if (id === this.replyTargetNodeId) return;
+    if (id === this.replyTargetNodeId && this.synthesizeTargetNodeIds === null) return;
     this.replyTargetNodeId = id;
+    this.synthesizeTargetNodeIds = null;
+    this.emit();
+  }
+
+  setSynthesizeTargetNodeIds(ids: string[] | null): void {
+    this.synthesizeTargetNodeIds = ids;
+    this.replyTargetNodeId = null;
     this.emit();
   }
 
@@ -540,7 +561,21 @@ export class SceneStore {
   // then clears it - so it applies to exactly one send, never lingers onto
   // a later, unrelated one. Callers never pass a branch target directly;
   // they call setReplyTargetNodeId first (see that setter's own comment).
+  //
+  // ADR-002 Workstream 1 ("Synthesize Branches"): checked FIRST, ahead of
+  // replyTargetNodeId - if a synthesis selection is staged, this send's
+  // text is the user's synthesis instructions, not an ordinary message, so
+  // it fires the dedicated synthesizeBranches intent instead of sendMessage
+  // and returns early. The two staging fields are already kept mutually
+  // exclusive by their own setters, so this branch and the replyTargetNodeId
+  // branch below it can never both apply to the same call.
   sendMessage(text: string): void {
+    const synthesizeNodeIds = this.synthesizeTargetNodeIds;
+    if (synthesizeNodeIds !== null) {
+      this.transport.intent("scene", "synthesizeBranches", [synthesizeNodeIds, text]);
+      this.setSynthesizeTargetNodeIds(null);
+      return;
+    }
     const branchFromNodeId = this.replyTargetNodeId;
     const args: unknown[] = [text];
     if (branchFromNodeId !== null) args.push(branchFromNodeId);

--- a/web_ui/src/app/chrome/Composer.test.tsx
+++ b/web_ui/src/app/chrome/Composer.test.tsx
@@ -48,19 +48,29 @@ function makeStore(
   };
 }
 
-function makeSceneStore(overrides: { replyTargetNodeId?: string | null; scene?: object } = {}) {
+function makeSceneStore(
+  overrides: {
+    replyTargetNodeId?: string | null;
+    synthesizeTargetNodeIds?: string[] | null;
+    scene?: object;
+  } = {},
+) {
   const sendMessage = vi.fn();
   const setReplyTargetNodeId = vi.fn();
+  const setSynthesizeTargetNodeIds = vi.fn();
   const scene = { ...initialSceneState, ...overrides.scene };
   const replyTargetNodeId = overrides.replyTargetNodeId ?? null;
+  const synthesizeTargetNodeIds = overrides.synthesizeTargetNodeIds ?? null;
   const sceneStore = {
     sendMessage,
     setReplyTargetNodeId,
+    setSynthesizeTargetNodeIds,
     subscribe: () => () => {},
     getScene: () => scene,
     getReplyTargetNodeId: () => replyTargetNodeId,
+    getSynthesizeTargetNodeIds: () => synthesizeTargetNodeIds,
   };
-  return { sceneStore, sendMessage, setReplyTargetNodeId };
+  return { sceneStore, sendMessage, setReplyTargetNodeId, setSynthesizeTargetNodeIds };
 }
 
 describe("Composer", () => {
@@ -594,6 +604,62 @@ describe("Composer reply target (ADR-002 Workstream 1)", () => {
     );
     await user.click(screen.getByLabelText("Cancel branching from this message"));
     expect(setReplyTargetNodeId).toHaveBeenCalledWith(null);
+  });
+});
+
+describe("Composer synthesize target (ADR-002 Workstream 1)", () => {
+  it("renders nothing when no synthesize target is pending", () => {
+    const { store } = makeStore();
+    const { sceneStore } = makeSceneStore({ synthesizeTargetNodeIds: null });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(screen.queryByLabelText("Synthesizing branches")).toBeNull();
+  });
+
+  it("shows a count when a synthesize target is pending", () => {
+    const { store } = makeStore();
+    const { sceneStore } = makeSceneStore({ synthesizeTargetNodeIds: ["n1", "n2", "n3"] });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={sceneStore} />
+      </OverlayProvider>,
+    );
+    const indicator = screen.getByLabelText("Synthesizing branches");
+    expect(indicator).toBeInTheDocument();
+    expect(screen.getByText("Synthesizing 3 branches")).toBeInTheDocument();
+  });
+
+  it("changes the composer placeholder to steer the user toward instructions, only while synthesizing", () => {
+    const { store } = makeStore();
+    const { sceneStore } = makeSceneStore({ synthesizeTargetNodeIds: ["n1", "n2"] });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={sceneStore} />
+      </OverlayProvider>,
+    );
+    expect(screen.getByPlaceholderText("Describe how to combine these branches…")).toBeInTheDocument();
+  });
+
+  it("the clear button calls sceneStore.setSynthesizeTargetNodeIds(null)", async () => {
+    const user = userEvent.setup();
+    const { store } = makeStore();
+    const { sceneStore, setSynthesizeTargetNodeIds } = makeSceneStore({
+      synthesizeTargetNodeIds: ["n1", "n2"],
+    });
+    render(
+      <OverlayProvider>
+        {/* @ts-expect-error - test double */}
+        <Composer store={store} sceneStore={sceneStore} />
+      </OverlayProvider>,
+    );
+    await user.click(screen.getByLabelText("Cancel synthesizing these branches"));
+    expect(setSynthesizeTargetNodeIds).toHaveBeenCalledWith(null);
   });
 });
 

--- a/web_ui/src/app/chrome/Composer.tsx
+++ b/web_ui/src/app/chrome/Composer.tsx
@@ -77,6 +77,19 @@ export function Composer({
   const replyTargetNodeId = useSyncExternalStore(sceneStore.subscribe, sceneStore.getReplyTargetNodeId);
   const replyTargetNode = replyTargetNodeId ? scene.nodes.find((n) => n.id === replyTargetNodeId) : undefined;
 
+  // ADR-002 Workstream 1 ("Synthesize Branches"): the list-valued sibling of
+  // replyTargetNodeId above - same subscription reasoning (re-renders if a
+  // staged node is deleted mid-pick). sceneStore keeps the two mutually
+  // exclusive (see setSynthesizeTargetNodeIds's own comment), so in practice
+  // at most one of replyTargetNode/synthesizeTargetNodeIds is ever non-empty
+  // - each indicator below still guards on its own value independently
+  // rather than on an explicit else, so that invariant is never load-bearing
+  // for correctness here, only for which one the user happens to see.
+  const synthesizeTargetNodeIds = useSyncExternalStore(
+    sceneStore.subscribe,
+    sceneStore.getSynthesizeTargetNodeIds,
+  );
+
   useLayoutEffect(() => {
     const input = inputRef.current;
     if (!input) return;
@@ -85,6 +98,7 @@ export function Composer({
   }, [composer.draft.text]);
 
   const modelLabel = composer.route.modelLabel || composer.route.modelId || "Select a model";
+  const isSynthesizing = !!synthesizeTargetNodeIds && synthesizeTargetNodeIds.length > 0;
 
   function send() {
     const text = composer.draft.text.trim();
@@ -110,6 +124,28 @@ export function Composer({
             className="composer-reply-target-clear"
             aria-label="Cancel branching from this message"
             onClick={() => sceneStore.setReplyTargetNodeId(null)}
+          >
+            ×
+          </button>
+        </div>
+      )}
+      {isSynthesizing && (
+        // ADR-002 Workstream 1 ("Synthesize Branches"): the selection staged
+        // via App.tsx's Synthesize Branches shortcut, cleared either by this
+        // button or automatically once consumed by the next Send
+        // (sceneStore.ts's sendMessage). No per-node preview (unlike
+        // "Branching from" above) - N branches' worth of previews would
+        // clutter the composer for little benefit; the count is enough
+        // context to confirm the right selection is staged.
+        <div className="composer-synthesize-target" aria-label="Synthesizing branches">
+          <span className="composer-synthesize-target-label">
+            Synthesizing {synthesizeTargetNodeIds!.length} branches
+          </span>
+          <button
+            type="button"
+            className="composer-synthesize-target-clear"
+            aria-label="Cancel synthesizing these branches"
+            onClick={() => sceneStore.setSynthesizeTargetNodeIds(null)}
           >
             ×
           </button>
@@ -154,7 +190,11 @@ export function Composer({
               send();
             }
           }}
-          placeholder="Ask about this graph…"
+          placeholder={
+            isSynthesizing
+              ? "Describe how to combine these branches…"
+              : "Ask about this graph…"
+          }
           aria-label="Message composer"
           rows={1}
           spellCheck

--- a/web_ui/src/app/chrome/shortcuts.test.ts
+++ b/web_ui/src/app/chrome/shortcuts.test.ts
@@ -41,6 +41,17 @@ describe("resolveShortcut", () => {
     expect(resolveShortcut(key("c"))).toBeNull();
   });
 
+  // ADR-002 Workstream 1 ("Synthesize Branches") - a genuinely new binding,
+  // not a legacy port. "M" (Merge/coMbine) since "S" is already save-chat.
+  it("treats Ctrl+Shift+M as Synthesize Branches", () => {
+    expect(resolveShortcut(key("m", { shift: true }))).toBe("synthesize-branches");
+    expect(resolveShortcut(key("M", { shift: true }))).toBe("synthesize-branches");
+  });
+
+  it("does NOT bind bare Ctrl+M", () => {
+    expect(resolveShortcut(key("m"))).toBeNull();
+  });
+
   it("is case-insensitive, since Shift/CapsLock change event.key's case", () => {
     expect(resolveShortcut(key("T"))).toBe("new-chat");
   });
@@ -74,11 +85,11 @@ describe("resolveShortcut", () => {
 describe("isGatedWhileTyping", () => {
   // The exact membership of legacy's GATED_SHORTCUTS
   // (graphlink_web_island_host.py:735-745), which legacy itself
-  // contract-tests, PLUS "compare-branches" (ADR-002 Workstream 1 - a new
-  // shortcut, not a legacy port, gated for the same reason as its closest
-  // sibling create-frame/create-container - see shortcuts.ts's own
-  // comment). Mirrored here so a future edit to the set has to be
-  // deliberate rather than incidental.
+  // contract-tests, PLUS "compare-branches"/"synthesize-branches" (ADR-002
+  // Workstream 1 - new shortcuts, not legacy ports, gated for the same
+  // reason as their closest sibling create-frame/create-container - see
+  // shortcuts.ts's own comment). Mirrored here so a future edit to the set
+  // has to be deliberate rather than incidental.
   const GATED: ShortcutId[] = [
     "new-chat",
     "toggle-library",
@@ -86,6 +97,7 @@ describe("isGatedWhileTyping", () => {
     "create-frame",
     "create-container",
     "compare-branches",
+    "synthesize-branches",
     "navigate-up",
     "navigate-down",
     "navigate-left",
@@ -101,8 +113,8 @@ describe("isGatedWhileTyping", () => {
     expect(isGatedWhileTyping(id)).toBe(false);
   });
 
-  it("gates exactly the 9 legacy combinations plus compare-branches (10 total), no more and no fewer", () => {
+  it("gates exactly the 9 legacy combinations plus compare-branches/synthesize-branches (11 total), no more and no fewer", () => {
     const all: ShortcutId[] = [...GATED, ...EXEMPT];
-    expect(all.filter(isGatedWhileTyping)).toHaveLength(10);
+    expect(all.filter(isGatedWhileTyping)).toHaveLength(11);
   });
 });

--- a/web_ui/src/app/chrome/shortcuts.ts
+++ b/web_ui/src/app/chrome/shortcuts.ts
@@ -24,6 +24,7 @@ export type ShortcutId =
   | "create-frame"
   | "create-container"
   | "compare-branches"
+  | "synthesize-branches"
   | "toggle-palette"
   | "toggle-search"
   | "navigate-up"
@@ -42,11 +43,13 @@ export type ShortcutId =
  * expected mid-sentence, and Ctrl+K is the palette's own summon key (its
  * handler was made idempotent specifically so the exemption is safe).
  *
- * "compare-branches" is a genuinely NEW shortcut (ADR-002 Workstream 1,
- * not a legacy port) but gated here for the exact same reason as its
- * closest sibling create-frame/create-container: a canvas-wide,
- * selection-driven action that should never fire mid-sentence while
- * typing in the composer or a node's own editable field.
+ * "compare-branches" and "synthesize-branches" are genuinely NEW shortcuts
+ * (ADR-002 Workstream 1, not legacy ports) but gated here for the exact
+ * same reason as their closest sibling create-frame/create-container: a
+ * canvas-wide, selection-driven action that should never fire mid-sentence
+ * while typing in the composer or a node's own editable field -
+ * "synthesize-branches" doubly so, since its effect is staging a
+ * selection that then hijacks the very next Send.
  */
 const GATED_WHILE_TYPING = new Set<ShortcutId>([
   "new-chat",
@@ -55,6 +58,7 @@ const GATED_WHILE_TYPING = new Set<ShortcutId>([
   "create-frame",
   "create-container",
   "compare-branches",
+  "synthesize-branches",
   "navigate-up",
   "navigate-down",
   "navigate-left",
@@ -118,6 +122,12 @@ export function resolveShortcut(event: ShortcutKeyEvent): ShortcutId | null {
     // match.
     case "c":
       return event.shiftKey ? "compare-branches" : null;
+    // ADR-002 Workstream 1 ("Synthesize Branches"): Ctrl+Shift+M only, same
+    // "new binding, no legacy key to match" posture as compare-branches
+    // above. "M" for Merge/coMbine - "S" (the mnemonic match for Synthesize)
+    // is already save-chat's key.
+    case "m":
+      return event.shiftKey ? "synthesize-branches" : null;
     default:
       return null;
   }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -735,6 +735,32 @@ body,
   border-radius: 999px;
 }
 
+/* ADR-002 Workstream 1 ("Synthesize Branches"): the "derived from multiple
+   branches" glyph, only rendered on a synthesis-result chat node - same
+   font-size/color vocabulary as .note-node-badge (Compare Branches'
+   sibling), not a pill like .chat-node-docked-badge above, since this is a
+   single glyph rather than a count. */
+.chat-node-synthesis-badge {
+  font-size: 12px;
+  line-height: 1;
+  color: var(--gl-surface-text-muted);
+}
+
+/* ADR-002 Workstream 1 ("Synthesize Branches"): the provider/model
+   provenance label, only rendered when the node actually carries one
+   (today: synthesis results only). Deliberately plain text, not a pill -
+   this can be a full model name/id and a pill would either truncate it or
+   force a fixed width that doesn't fit most names. */
+.chat-node-model-badge {
+  font-size: 10px;
+  line-height: 1;
+  color: var(--gl-surface-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 140px;
+}
+
 /* -- R3.17/R3.18 html view node -------------------------------------------- */
 
 .html-node {
@@ -1500,6 +1526,55 @@ body,
 }
 
 .composer-reply-target-clear:hover {
+  background-color: var(--gl-surface-border);
+  color: var(--gl-surface-text-primary);
+}
+
+/* ADR-002 Workstream 1 ("Synthesize Branches"): the pending synthesis
+   indicator - same chrome/layout as .composer-reply-target above (no
+   separate preview span, just the label, since a count is all this one
+   shows). Kept as a distinct class rather than reusing .composer-reply-
+   target: the two indicators are mutually exclusive at render time (see
+   Composer.tsx), but sharing one class would couple their styling even
+   though they are conceptually different features. */
+.composer-synthesize-target {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px 5px 10px;
+  border-radius: 8px;
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  font-size: 11px;
+  color: var(--gl-surface-text-primary);
+}
+
+.composer-synthesize-target-label {
+  flex: 1;
+  color: var(--gl-surface-text-muted);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.03em;
+}
+
+.composer-synthesize-target-clear {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background-color: transparent;
+  color: var(--gl-surface-text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.composer-synthesize-target-clear:hover {
   background-color: var(--gl-surface-border);
   color: var(--gl-surface-text-primary);
 }


### PR DESCRIPTION
## Problem

GraphLink's Workstream 1 (branch creation and convergence) shipped fork ("Branch from Here", #197) and Compare Branches (#198), but a graph with several diverged branches still has no way to produce a single result from them — the user has to manually re-read each branch and write their own synthesis by hand.

## Change

Adds the third sequenced item: **Synthesize Branches**.

- Select 2+ chat nodes (Ctrl+Shift+M, same React Flow multi-select Compare Branches uses), then type free-text instructions in the composer describing how to combine them.
- A new `BranchSynthesisAgent` (backend/agents.py, graphlink_note_agent.py) combines each selected branch's full history per those instructions. Unlike the note agents, its output is not run through the shared markdown-stripping cleaner — it renders as a real chat message, not a plain-text note.
- The result lands as a real **chat**-kind node (not a note, unlike Compare Branches) continuing the branch tree from the *first* selected source; every source is recorded via the existing generic `item_ids` field, plus a new `synthesis_instructions` field. `last_chat_node_id` moves to the result, so the next ordinary send continues from it.
- Two new generic `SceneNode` fields, `provider`/`model`, are stamped from `ComposerDocument.route()` (the same route a real send uses) and rendered as a badge/label on the result node. The fields are generic — any kind could use them — but only Synthesize populates them today.
- Synthesis generation has its own busy-guard, independent from Compare Branches' and the note agents', so none of the three can block each other.
- Frontend: a new `sceneStore.synthesizeTargetNodeIds` staging field (list-valued, mutually exclusive with the existing `replyTargetNodeId`), a "Synthesizing N branches" composer indicator with a steering placeholder, and a provenance badge/model label on the resulting chat node.

### Adversarial review

Before commit, an independent review pass (fresh context, not told my own conclusions) was run against this diff, briefed to actively try to break: backend validation completeness/ordering, busy-guard independence, result-node parent/position/`last_chat_node_id` correctness, safe defaults for old saved sessions, frontend staging mutual-exclusivity, the stale-codegen type-cast pattern already established by prior stages, wire-contract field-name matching, and source-deletion race safety.

It found one real, confirmed bug: staging an invalid selection (fewer than 2 nodes, or a mix including a non-chat node) via the shortcut succeeded regardless of validity. Because `sceneStore.sendMessage`/`Composer.tsx`'s `send()` both optimistically clear the staged selection and the draft text the instant the intent fires (the same fire-and-forget posture every WS intent in this app uses), the backend's own rejection arrived too late — a user who staged an invalid selection, then typed real synthesis instructions, then hit Send, would silently lose that typed text with no recovery path.

Fixed by duplicating the same "2+ ids, all chat-kind" validation client-side in `App.tsx`'s shortcut handler, so an invalid selection is rejected — with the same notification text the backend itself uses — at shortcut-press time, before any instructions get typed, closing the hole entirely rather than just narrowing its window. The backend's own validation is unchanged (defense in depth).

Two further observations were judged genuinely minor and left as-is: the backend checks blank instructions before the chat-kind check (message-priority only, and unreachable from the real UI since Send is already disabled on blank text); and the new staging setter has no no-op-if-unchanged re-emit guard (a wasted re-render, not a correctness gap).

Everything else the review checked held up: busy-guard independence and cleanup on every path, parent/position/`last_chat_node_id` correctness, safe field defaults for old sessions, staging mutual-exclusivity under every call sequence tried, no wire-contract mismatches, and the deletion-mid-flight liveness guard checking all sources.

## Test plan

- [x] Backend: `python -m pytest -q` — 1118 passed (full suite, unnarrowed, run from repo root on the fresh branch)
- [x] Frontend: `npx tsc --noEmit`, `npx vitest run` (943 passed), `npx eslint .` (0 errors, pre-existing warnings only), `npx vite build` — all clean on the fresh branch
- [x] New backend tests: synthesize_branches validation (minimum count, dedup, chat-kind check, blank instructions), result-node parent/position/provenance stamping, `start_branch_synthesis` busy-guard independence and full lifecycle (success/empty/timeout/exception)
- [x] New frontend tests: staging mutual-exclusivity with `replyTargetNodeId`, `sendMessage`'s synthesize-vs-reply-vs-ordinary branching, the Ctrl+Shift+M binding and typing-gate, the composer indicator, the result-node badge/model label rendering
- [x] `python contracts/codegen.py --check` — up to date (new fields intentionally follow the same established stale-contract workaround as prior Workstream 1 stages)