### PR TITLE
Add branch status and lifecycle: mark/collapse branches, Final Deliverable

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -418,6 +418,27 @@ class SceneNode:
     # feature. Chat-kind only in practice; unused (default empty string) for
     # every other kind and for ordinary (non-synthesis) chat nodes.
     synthesis_instructions: str = ""
+    # ADR-002 Workstream 1 ("Branch status and lifecycle"): the final,
+    # sequenced item after fork/compare/synthesize. One of exactly "active"
+    # (the default - every existing and newly-created chat node starts
+    # here, no migration needed), "accepted", "rejected", "superseded".
+    # Chat-kind only, mirroring is_branch_synthesis's own chat-only scoping
+    # - "a branch" is fundamentally a chain of chat nodes in this data
+    # model (see chat_branch_history/get_branch_root, both of which only
+    # ever walk chat-kind edges). Deliberately PER-NODE with NO write-time
+    # inheritance/cascade to ancestors or descendants - every other
+    # status-like flag on this dataclass (is_collapsed, is_docked,
+    # is_branch_synthesis, is_branch_comparison below) is scoped exactly
+    # this way, and there is no materialized "Branch" object anywhere in
+    # this file to cascade through even if inheritance were wanted (a
+    # branch is discovered by walking _branch_parent_edge upward on
+    # demand, never stored as a set - see that method's own comment).
+    # "Reduce a graph to its accepted paths" is delivered by a separate,
+    # frontend-only, read-time subtree derivation over this field
+    # (SceneCanvas.tsx's computeNonAcceptedNodeIds) - the same posture
+    # "Hide Other Branches" already uses for a different subtree question,
+    # not by inventing write-time cascade bookkeeping here.
+    branch_status: str = "active"
     # R5.1: the Web Research node's real persisted shape - `content` (reused,
     # same pattern as code/thinking/html) holds the query text; these six
     # fields track one research run's live progress/outcome. Unused
@@ -825,6 +846,17 @@ class SceneDocument:
     # Qt-free stand-in for "the currently active branch" until real node
     # selection exists. None means the next message starts a fresh root.
     last_chat_node_id: str | None = None
+    # ADR-002 Workstream 1 ("Branch status and lifecycle"): the one node
+    # currently marked as this document's Final Deliverable, or None if
+    # none is marked. A document-level singular pointer, mirroring
+    # last_chat_node_id above, rather than a per-node SceneNode flag -
+    # deliberately, since "Final Deliverable" is inherently singular ("the
+    # one true output of this document") and a pointer makes exclusivity
+    # free (set_final_deliverable just overwrites it) instead of requiring
+    # a hunt for whichever other node currently holds the flag to clear it
+    # first. Reset in clear_for_load below, same list last_chat_node_id is
+    # already in.
+    final_deliverable_node_id: str | None = None
     # R3.21: in-memory, session-scoped store for image-node bytes, keyed by
     # asset id (see SceneNode.image_asset_id) -> (raw_bytes, mime_type).
     # TRANSPORT DECISION: images travel to the client via a dedicated GET
@@ -915,6 +947,7 @@ class SceneDocument:
         self.image_assets.clear()
         self.pins.clear()
         self.last_chat_node_id = None
+        self.final_deliverable_node_id = None
         self.zoom_factor = 1.0
         self.scroll_x = 0.0
         self.scroll_y = 0.0
@@ -1970,6 +2003,53 @@ class SceneDocument:
         node.provider = provider
         node.model = model
 
+    #: ADR-002 Workstream 1 ("Branch status and lifecycle"): the exactly-4
+    #: legal values for SceneNode.branch_status - shared by the setter's
+    #: validation and session_load.py's own defensive downgrade-to-"active"
+    #: read-back, so the one legal set is never duplicated out of sync.
+    BRANCH_STATUS_VALUES = frozenset({"active", "accepted", "rejected", "superseded"})
+
+    def set_branch_status(self, node_id: str, status: str) -> None:
+        """ADR-002 Workstream 1 ("Branch status and lifecycle"): marks a
+        single chat node's own branch_status - deliberately no "has
+        siblings" / "is a fork root" requirement (any chat node may be
+        marked, mirroring mark_branch_comparison_note's own kind-only
+        validation), and deliberately no side effect on any OTHER node -
+        marking one branch Accepted does not auto-reject its siblings, the
+        first cross-node side-effecting setter would have been a new kind
+        of mutation nothing else in this file does, and Synthesize Branches
+        already established that 2+ branches can be simultaneously
+        legitimate (its own item_ids records multiple sources at once) -
+        forcing exclusivity here would fight that existing workflow."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "chat":
+            raise SceneError(f"node is not a chat node: {node_id}")
+        status = str(status)
+        if status not in self.BRANCH_STATUS_VALUES:
+            raise SceneError(f"invalid branch status: {status}")
+        node.branch_status = status
+
+    def set_final_deliverable(self, node_id: str, is_final: bool) -> None:
+        """ADR-002 Workstream 1 ("Branch status and lifecycle"): sets or
+        clears final_deliverable_node_id - EXCLUSIVE by construction (the
+        single-pointer shape means marking a new node silently supersedes
+        whichever one held it before; no separate "clear the old one" step
+        needed, unlike a per-node flag would require). Orthogonal to
+        branch_status on purpose - no validation ties them together (a
+        "rejected" node CAN technically be marked Final Deliverable; this
+        is not blocked, though not a realistic path either)."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "chat":
+            raise SceneError(f"node is not a chat node: {node_id}")
+        if is_final:
+            self.final_deliverable_node_id = node_id
+        elif self.final_deliverable_node_id == node_id:
+            self.final_deliverable_node_id = None
+
     def _bbox_of_members(self, item_ids: list[str]) -> tuple[float, float, float, float]:
         """Compute the padded union rect (x, y, width, height) enclosing
         every member id's ESTIMATED footprint - GROUP_MEMBER_DEFAULT_WIDTH/
@@ -2468,6 +2548,39 @@ class SceneDocument:
             return edge
         return None
 
+    def _chat_subtree_ids(self, root_id: str) -> list[str]:
+        """ADR-002 Workstream 1 ("Branch status and lifecycle"): the
+        DOWNWARD counterpart to _branch_parent_edge's upward walk above -
+        every chat-kind node's id in root_id's own subtree (root_id
+        itself, plus every descendant reachable through chat-kind edges),
+        via BFS. No such downward/forward walk existed anywhere in this
+        file before this feature - every other edge scan here is either
+        this file's own upward parent-walk pattern or an explicitly
+        one-hop-only scan (delete_chat_node's direct-children reparent,
+        send_message's sibling-fan-out count) - so this is new, not a
+        rename of something existing. Chat-kind only: a code/document/
+        thinking/image node hanging directly off a chat node in this
+        subtree is NOT included - collapsing a branch does not cascade
+        into its content children, matching how a single chat node's own
+        collapse already never cascades into ITS children either."""
+        result = [root_id]
+        visited = {root_id}
+        frontier = [root_id]
+        while frontier:
+            next_frontier = []
+            for nid in frontier:
+                for edge in self.edges.values():
+                    if edge.source != nid:
+                        continue
+                    target = self.nodes.get(edge.target)
+                    if target is None or target.kind != "chat" or target.id in visited:
+                        continue
+                    visited.add(target.id)
+                    result.append(target.id)
+                    next_frontier.append(target.id)
+            frontier = next_frontier
+        return result
+
     def delete_chat_node(self, node_id: str) -> None:
         """Delete one chat node WITHOUT orphaning its branch: children are
         re-parented to the deleted node's own parent (or become roots if it
@@ -2506,6 +2619,15 @@ class SceneDocument:
             # The active branch continues from wherever it now ends: the
             # deleted node's own parent (None if it had none either).
             self.last_chat_node_id = parent_id
+
+        # ADR-002 Workstream 1 ("Branch status and lifecycle") - found by
+        # adversarial review: unlike last_chat_node_id above, this is
+        # cleared entirely rather than re-pointed to the parent. The parent
+        # was never itself marked Final Deliverable, so silently promoting
+        # it would misattribute a status the user never gave it; requiring
+        # a fresh, explicit re-mark is the safe behavior.
+        if self.final_deliverable_node_id == node_id:
+            self.final_deliverable_node_id = None
 
         del self.nodes[node_id]
         self._detach_node_from_membership(node_id)
@@ -2785,6 +2907,31 @@ class SceneDocument:
         if node.kind in ("frame", "container"):
             self._recompute_group_bounds(node_id)
 
+    def collapse_branch(self, node_id: str, collapsed: bool) -> None:
+        """ADR-002 Workstream 1 ("Branch status and lifecycle"): "Collapse
+        a rejected branch without deleting it" - reuses the existing,
+        already-fully-wired is_collapsed field verbatim (wire sync, save,
+        load, and ChatNodeView.tsx's collapsed-pill rendering all already
+        work for it), applied across node_id's own chat-kind subtree via
+        _chat_subtree_ids instead of just node_id itself - the one
+        genuinely new piece this needs. Deliberately NOT automatic when a
+        branch is marked "rejected" via set_branch_status: status (a
+        semantic label) and collapse (a view state) are kept decoupled on
+        purpose, so a branch can be Rejected-but-still-expanded during
+        review, and marking status never has a side effect on any other
+        node's state (matching set_branch_status's own "no implicit side
+        effects" posture). Bulk-sets uniformly across the whole subtree,
+        so a node that had previously been individually expanded/collapsed
+        differently loses that distinction the first time this runs - an
+        accepted, stated tradeoff, not solved here."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "chat":
+            raise SceneError(f"node is not a chat node: {node_id}")
+        for nid in self._chat_subtree_ids(node_id):
+            self.nodes[nid].is_collapsed = bool(collapsed)
+
     def set_all_conversational_collapsed(self, collapsed: bool) -> None:
         """R7.5e: Collapse All / Expand All - the bulk counterpart to
         set_chat_collapsed above. Mirrors legacy's
@@ -3041,6 +3188,11 @@ class SceneDocument:
                     "model": n.model,
                     "isBranchSynthesis": n.is_branch_synthesis,
                     "synthesisInstructions": n.synthesis_instructions,
+                    # ADR-002 Workstream 1 ("Branch status and lifecycle") -
+                    # see SceneNode.branch_status/SceneDocument.
+                    # final_deliverable_node_id's own comments.
+                    "branchStatus": n.branch_status,
+                    "isFinalDeliverable": n.id == self.final_deliverable_node_id,
                     "researchStage": n.research_stage,
                     "researchCompleted": n.research_completed,
                     "researchTotal": n.research_total,
@@ -3559,6 +3711,25 @@ def register_canvas(
 
     async def set_chat_collapsed(node_id, collapsed):
         document.set_chat_collapsed(node_id, collapsed)
+        await publish_scene()
+
+    # ADR-002 Workstream 1 ("Branch status and lifecycle"): three plain
+    # setter intents, same "no try/except SceneError guard, a bad node_id
+    # propagates as a generic WS intent error" posture as set_chat_collapsed
+    # immediately above (see send_artifact_message's own comment on this
+    # accepted pattern for simple setters, as opposed to the defensive
+    # pre-check pattern used where a delete could realistically race an
+    # in-flight agent dispatch - none of these three ever dispatch an agent).
+    async def set_branch_status(node_id, status):
+        document.set_branch_status(node_id, status)
+        await publish_scene()
+
+    async def set_final_deliverable(node_id, is_final):
+        document.set_final_deliverable(node_id, is_final)
+        await publish_scene()
+
+    async def collapse_branch(node_id, collapsed):
+        document.collapse_branch(node_id, collapsed)
         await publish_scene()
 
     async def collapse_all_nodes():
@@ -4796,6 +4967,9 @@ def register_canvas(
     bus.register_intent("scene", "setNodeDocked", set_node_docked)
     bus.register_intent("scene", "deleteChatNode", delete_chat_node)
     bus.register_intent("scene", "setChatCollapsed", set_chat_collapsed)
+    bus.register_intent("scene", "setBranchStatus", set_branch_status)
+    bus.register_intent("scene", "setFinalDeliverable", set_final_deliverable)
+    bus.register_intent("scene", "collapseBranch", collapse_branch)
     bus.register_intent("scene", "collapseAllNodes", collapse_all_nodes)
     bus.register_intent("scene", "expandAllNodes", expand_all_nodes)
     bus.register_intent("scene", "setChatScrollValue", set_chat_scroll_value)

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -336,6 +336,28 @@ def _restore_chat_payload(payload: dict[str, Any]) -> SceneNode:
         is_collapsed=bool(payload.get("is_collapsed", False)),
         history=_restore_history(payload.get("conversation_history")),
         chat_scroll_value=float(payload.get("scroll_value", 0.0) or 0.0),
+        # ADR-002 Workstream 1 ("Branch status and lifecycle") - confirmed,
+        # pre-existing gap fixed inline: provider/model/is_branch_synthesis/
+        # synthesis_instructions (Synthesize Branches) already synced live
+        # to the frontend via scene_payload() but were silently dropped on
+        # load (session_save.py's own docstring at the matching fix has the
+        # full story). item_ids (also part of a synthesis node's real
+        # shape) is deliberately NOT set here - it references OTHER nodes
+        # by their original id, which isn't resolvable until every node has
+        # a new id; see _restore_branch_provenance_item_ids's own second-
+        # pass restoration below. branch_status is this same pass's own
+        # new field; an unrecognized/future value downgrades to "active"
+        # rather than crashing the load, the same defensive posture this
+        # function already uses for every other field.
+        provider=payload.get("provider"),
+        model=payload.get("model"),
+        is_branch_synthesis=bool(payload.get("is_branch_synthesis", False)),
+        synthesis_instructions=str(payload.get("synthesis_instructions", "") or ""),
+        branch_status=(
+            payload.get("branch_status")
+            if payload.get("branch_status") in SceneDocument.BRANCH_STATUS_VALUES
+            else "active"
+        ),
     )
 
 
@@ -678,6 +700,18 @@ def _restore_notes(document: SceneDocument, notes_data: list) -> dict[int, str]:
             )
             document.set_note_content(note.id, str(note_payload.get("content", "")))
             document.set_group_color(note.id, note_payload.get("color"), note_payload.get("header_color"))
+            # ADR-002 Workstream 1 ("Branch status and lifecycle") -
+            # confirmed, pre-existing gap fixed inline: is_branch_comparison
+            # (Compare Branches) already synced live to the frontend via
+            # scene_payload() but was silently dropped on load. A plain
+            # scalar poke, not a document method call, matching this
+            # function's own established posture for fields that don't
+            # need a dedicated setter (_restore_web_payload/_restore_image_
+            # payload already assign SceneNode fields directly the same
+            # way). item_ids is deliberately NOT set here - same
+            # not-yet-resolvable-reference reasoning as the chat-kind case;
+            # see _restore_branch_provenance_item_ids below.
+            note.is_branch_comparison = bool(note_payload.get("is_branch_comparison", False))
         except Exception:
             continue
         notes_map[index] = note.id
@@ -898,6 +932,56 @@ def _restore_system_prompt_and_summary_connections(
                     continue
 
 
+def _restore_branch_provenance_item_ids(
+    document: SceneDocument,
+    node_payloads: list,
+    all_nodes_map: dict[int, str],
+    nodes_by_id: dict[str, str],
+    notes_data: list,
+    notes_map: dict[int, str],
+) -> None:
+    """ADR-002 Workstream 1 ("Branch status and lifecycle") - confirmed,
+    pre-existing gap fixed inline: a Synthesize Branches chat node's or a
+    Compare Branches note's own item_ids (the source branch node ids - see
+    SceneNode.item_ids's own comment on backend/canvas.py) reference OTHER
+    nodes by their ORIGINAL saved id, which is re-minted on load - the same
+    "translate through nodes_by_id, once every node has a resolved new id"
+    idiom _restore_system_prompt_and_summary_connections above already
+    uses. Runs as its own pass AFTER both the main node-restore loop and
+    _restore_notes have already completed (not inline inside
+    _restore_chat_payload/_restore_notes themselves, which run too early -
+    a synthesis/comparison result's own sources may not have a resolved new
+    id yet at that point). An id no longer present in nodes_by_id (a source
+    deleted before save, or a genuinely stale/corrupt reference) is
+    silently dropped from the restored list rather than aborting the load -
+    matching this file's own established defensive posture elsewhere."""
+    for index, node_payload in enumerate(node_payloads):
+        if not isinstance(node_payload, dict) or not node_payload.get("is_branch_synthesis"):
+            continue
+        new_id = all_nodes_map.get(index)
+        if new_id is None or new_id not in document.nodes:
+            continue
+        raw_item_ids = node_payload.get("item_ids")
+        if isinstance(raw_item_ids, list):
+            document.nodes[new_id].item_ids = [
+                nodes_by_id[str(i)] for i in raw_item_ids if str(i) in nodes_by_id
+            ]
+
+    if not isinstance(notes_data, list):
+        return
+    for index, note_payload in enumerate(notes_data):
+        if not isinstance(note_payload, dict) or not note_payload.get("is_branch_comparison"):
+            continue
+        new_id = notes_map.get(index)
+        if new_id is None or new_id not in document.nodes:
+            continue
+        raw_item_ids = note_payload.get("item_ids")
+        if isinstance(raw_item_ids, list):
+            document.nodes[new_id].item_ids = [
+                nodes_by_id[str(i)] for i in raw_item_ids if str(i) in nodes_by_id
+            ]
+
+
 def _restore_pins(document: SceneDocument, pins_data: list) -> None:
     if not isinstance(pins_data, list) or not pins_data:
         return
@@ -983,6 +1067,14 @@ def restore_chat_into_document(
 
     notes_map = _restore_notes(document, notes_data)
 
+    # ADR-002 Workstream 1 ("Branch status and lifecycle") - confirmed,
+    # pre-existing gap fixed inline: must run AFTER both the main
+    # node-restore loop and _restore_notes above, since it translates
+    # cross-node references (a synthesis/comparison result's own source
+    # ids) that aren't resolvable until every node it might reference has
+    # its own new id - see that function's own docstring.
+    _restore_branch_provenance_item_ids(document, node_payloads, all_nodes_map, nodes_by_id, notes_data, notes_map)
+
     charts_map, charts_by_id = _restore_charts(document, chat_data.get("charts", []), all_nodes_map, nodes_by_id)
 
     node_slot_count = len(node_payloads)
@@ -1014,3 +1106,19 @@ def restore_chat_into_document(
         document.total_session_tokens = int(total_tokens)
     except (TypeError, ValueError):
         document.total_session_tokens = 0
+
+    # ADR-002 Workstream 1 ("Branch status and lifecycle"): translated
+    # through nodes_by_id, same as every other cross-node reference above -
+    # a missing/stale/deleted-before-save reference is silently treated as
+    # "no deliverable marked" rather than aborting the load. The kind_by_
+    # new_id check (found by adversarial review) mirrors SceneDocument.
+    # set_final_deliverable's own chat-kind-only validation - without it, a
+    # malformed/hand-edited save file pointing this at a non-chat node would
+    # load successfully and violate that invariant for the rest of the
+    # session, since this path (unlike the live setter) has no SceneError
+    # to raise against.
+    raw_final_id = chat_data.get("final_deliverable_node_id")
+    if raw_final_id and str(raw_final_id) in nodes_by_id:
+        final_new_id = nodes_by_id[str(raw_final_id)]
+        if kind_by_new_id.get(final_new_id) == "chat":
+            document.final_deliverable_node_id = final_new_id

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -192,6 +192,22 @@ def _serialize_chat_node(node: SceneNode) -> dict[str, Any]:
         "conversation_history": _serialize_history(node.history),
         "scroll_value": node.chat_scroll_value,
         "is_collapsed": bool(node.is_collapsed),
+        # ADR-002 Workstream 1 ("Branch status and lifecycle") - confirmed,
+        # pre-existing gap fixed inline: provider/model/is_branch_synthesis/
+        # synthesis_instructions/item_ids (Synthesize Branches - item_ids
+        # here is the source branch node ids, the SAME generic-field reuse
+        # Compare Branches' own note.item_ids already established) already
+        # synced live to the frontend via scene_payload() but were never
+        # written here, so a Save-then-Load cycle silently dropped a
+        # synthesis result's provenance and its badge. branch_status is
+        # this same pass's own new field, added alongside rather than in a
+        # separate edit.
+        "provider": node.provider,
+        "model": node.model,
+        "is_branch_synthesis": bool(node.is_branch_synthesis),
+        "synthesis_instructions": node.synthesis_instructions,
+        "item_ids": list(node.item_ids),
+        "branch_status": node.branch_status,
     }
 
 
@@ -360,6 +376,17 @@ def _serialize_note(node: SceneNode) -> dict[str, Any]:
         # persisted format (no SQL column for them ever existed; see
         # session_load.py's own docstring), so there is nothing to write
         # back regardless of whether this backend tracked them.
+        #
+        # ADR-002 Workstream 1 ("Branch status and lifecycle") - confirmed,
+        # pre-existing gap fixed inline: is_branch_comparison/item_ids
+        # (Compare Branches) already synced live to the frontend via
+        # scene_payload() but were never written here, so a Save-then-Load
+        # cycle silently dropped a comparison note's badge and its
+        # source-branch references. Unlike the dead legacy fields above,
+        # this is a real, currently-populated field this backend itself
+        # introduced - genuinely missing, not deliberately excluded.
+        "is_branch_comparison": bool(node.is_branch_comparison),
+        "item_ids": list(node.item_ids),
     }
 
 
@@ -664,6 +691,12 @@ def build_chat_data(document: SceneDocument) -> dict[str, Any]:
             "zoom_factor": document.zoom_factor,
             "scroll_position": {"x": document.scroll_x, "y": document.scroll_y},
         },
+        # ADR-002 Workstream 1 ("Branch status and lifecycle"): a document-
+        # level singular pointer, same "own top-level key, not per-node"
+        # shape as total_session_tokens/view_state above - see
+        # SceneDocument.final_deliverable_node_id's own comment for why
+        # this is not a per-node field.
+        "final_deliverable_node_id": document.final_deliverable_node_id,
         "notes_data": [_serialize_note(n) for n in notes],
         "pins_data": [_serialize_pin(r) for r in document.pins.records],
         # The 12 basic connection lists all draw from the SAME classified

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -7146,3 +7146,252 @@ def test_mark_branch_synthesis_rejects_an_unknown_node_id():
     doc = SceneDocument()
     with pytest.raises(SceneError):
         doc.mark_branch_synthesis("does-not-exist", ["x", "y"], "instructions", None, None)
+
+
+# -- ADR-002 Workstream 1: "Branch status and lifecycle" ---------------------
+#
+# The fourth and final sequenced item ("fork -> compare -> synthesize ->
+# status/lifecycle UI"): marking a branch Active/Accepted/Rejected/Superseded,
+# a document-level Final Deliverable pointer, and collapsing a whole
+# chat-kind subtree without deleting it.
+
+
+def test_set_branch_status_accepts_every_legal_value():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "hi", True)
+    assert node.branch_status == "active"
+    for status in ("accepted", "rejected", "superseded", "active"):
+        doc.set_branch_status(node.id, status)
+        assert doc.nodes[node.id].branch_status == status
+
+
+def test_set_branch_status_rejects_an_invalid_value():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "hi", True)
+    with pytest.raises(SceneError):
+        doc.set_branch_status(node.id, "archived")
+    assert doc.nodes[node.id].branch_status == "active", "a rejected call must not mutate the node"
+
+
+def test_set_branch_status_rejects_a_non_chat_node():
+    doc = SceneDocument()
+    note = doc.add_note(0, 0)
+    with pytest.raises(SceneError):
+        doc.set_branch_status(note.id, "accepted")
+
+
+def test_set_branch_status_rejects_an_unknown_node_id():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.set_branch_status("does-not-exist", "accepted")
+
+
+def test_set_branch_status_has_no_effect_on_sibling_branches():
+    # Deliberately no auto-exclusivity - see set_branch_status's own comment.
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    first = doc.add_chat_node(0, 160, "first", False, parent_id=root.id)
+    second = doc.add_chat_node(460, 160, "second", False, parent_id=root.id)
+    doc.set_branch_status(first.id, "accepted")
+    assert doc.nodes[first.id].branch_status == "accepted"
+    assert doc.nodes[second.id].branch_status == "active", "marking one branch must never touch its sibling"
+
+
+def test_set_final_deliverable_marks_and_unmarks():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "hi", True)
+    assert doc.final_deliverable_node_id is None
+    doc.set_final_deliverable(node.id, True)
+    assert doc.final_deliverable_node_id == node.id
+    doc.set_final_deliverable(node.id, False)
+    assert doc.final_deliverable_node_id is None
+
+
+def test_set_final_deliverable_is_exclusive_marking_a_new_node_supersedes_the_old_one():
+    doc = SceneDocument()
+    first = doc.add_chat_node(0, 0, "first", True)
+    second = doc.add_chat_node(0, 160, "second", True)
+    doc.set_final_deliverable(first.id, True)
+    assert doc.final_deliverable_node_id == first.id
+    doc.set_final_deliverable(second.id, True)
+    assert doc.final_deliverable_node_id == second.id, "the new mark must silently supersede the old one"
+
+
+def test_set_final_deliverable_unmarking_a_different_node_than_the_current_one_is_a_no_op():
+    doc = SceneDocument()
+    first = doc.add_chat_node(0, 0, "first", True)
+    second = doc.add_chat_node(0, 160, "second", True)
+    doc.set_final_deliverable(first.id, True)
+    doc.set_final_deliverable(second.id, False)
+    assert doc.final_deliverable_node_id == first.id, "unmarking a node that doesn't hold the pointer must not clear it"
+
+
+def test_set_final_deliverable_rejects_a_non_chat_node():
+    doc = SceneDocument()
+    note = doc.add_note(0, 0)
+    with pytest.raises(SceneError):
+        doc.set_final_deliverable(note.id, True)
+
+
+def test_set_final_deliverable_rejects_an_unknown_node_id():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.set_final_deliverable("does-not-exist", True)
+
+
+def test_chat_subtree_ids_includes_root_and_every_chat_descendant():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    child = doc.add_chat_node(0, 160, "child", False, parent_id=root.id)
+    grandchild = doc.add_chat_node(0, 320, "grandchild", True, parent_id=child.id)
+    sibling = doc.add_chat_node(460, 160, "sibling", False, parent_id=root.id)
+    ids = set(doc._chat_subtree_ids(root.id))
+    assert ids == {root.id, child.id, grandchild.id, sibling.id}
+
+
+def test_chat_subtree_ids_starting_from_a_child_excludes_its_own_ancestors_and_siblings():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    child = doc.add_chat_node(0, 160, "child", False, parent_id=root.id)
+    sibling = doc.add_chat_node(460, 160, "sibling", False, parent_id=root.id)
+    ids = set(doc._chat_subtree_ids(child.id))
+    assert ids == {child.id}
+    assert root.id not in ids
+    assert sibling.id not in ids
+
+
+def test_chat_subtree_ids_excludes_non_chat_content_children():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    doc.add_code_node(0, 160, "print(1)", "python", parent_id=root.id)
+    ids = set(doc._chat_subtree_ids(root.id))
+    assert ids == {root.id}
+
+
+def test_collapse_branch_collapses_the_whole_chat_subtree_but_not_content_children():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    child = doc.add_chat_node(0, 160, "child", False, parent_id=root.id)
+    code = doc.add_code_node(0, 320, "print(1)", "python", parent_id=child.id)
+
+    doc.collapse_branch(root.id, True)
+
+    assert doc.nodes[root.id].is_collapsed is True
+    assert doc.nodes[child.id].is_collapsed is True
+    assert doc.nodes[code.id].is_collapsed is False, "collapse must not cascade into non-chat content children"
+
+
+def test_collapse_branch_expand_reverses_it():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    child = doc.add_chat_node(0, 160, "child", False, parent_id=root.id)
+    doc.collapse_branch(root.id, True)
+    doc.collapse_branch(root.id, False)
+    assert doc.nodes[root.id].is_collapsed is False
+    assert doc.nodes[child.id].is_collapsed is False
+
+
+def test_collapse_branch_rejects_a_non_chat_node():
+    doc = SceneDocument()
+    note = doc.add_note(0, 0)
+    with pytest.raises(SceneError):
+        doc.collapse_branch(note.id, True)
+
+
+def test_collapse_branch_rejects_an_unknown_node_id():
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.collapse_branch("does-not-exist", True)
+
+
+def test_scene_payload_includes_branch_status_and_final_deliverable():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "hi", True)
+    doc.set_branch_status(node.id, "accepted")
+    doc.set_final_deliverable(node.id, True)
+    other = doc.add_chat_node(0, 160, "other", True)
+
+    rows = {n["id"]: n for n in doc.scene_payload()["nodes"]}
+    assert rows[node.id]["branchStatus"] == "accepted"
+    assert rows[node.id]["isFinalDeliverable"] is True
+    assert rows[other.id]["branchStatus"] == "active"
+    assert rows[other.id]["isFinalDeliverable"] is False
+
+
+def test_clear_for_load_resets_final_deliverable_node_id():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "hi", True)
+    doc.set_final_deliverable(node.id, True)
+    doc.clear_for_load()
+    assert doc.final_deliverable_node_id is None
+
+
+def test_delete_chat_node_clears_final_deliverable_node_id_when_the_marked_node_is_deleted():
+    # Found by adversarial review: unlike last_chat_node_id, which
+    # re-points to the deleted node's own parent, final_deliverable_node_id
+    # is cleared entirely rather than silently promoted onto a node the
+    # user never actually marked.
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    child = doc.add_chat_node(0, 160, "child", False, parent_id=root.id)
+    doc.set_final_deliverable(child.id, True)
+
+    doc.delete_chat_node(child.id)
+
+    assert doc.final_deliverable_node_id is None
+
+
+def test_delete_chat_node_leaves_final_deliverable_node_id_untouched_when_a_different_node_is_deleted():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    child = doc.add_chat_node(0, 160, "child", False, parent_id=root.id)
+    other = doc.add_chat_node(460, 160, "other", False, parent_id=root.id)
+    doc.set_final_deliverable(child.id, True)
+
+    doc.delete_chat_node(other.id)
+
+    assert doc.final_deliverable_node_id == child.id
+
+
+def test_set_branch_status_intent_dispatches_and_publishes_scene():
+    async def run():
+        bus, document, recorder, _ = make_bus_with_dispatcher()
+        node = document.add_chat_node(0, 0, "hi", True)
+        scene_publishes_before = recorder.topics_seen().count("scene")
+
+        await bus.dispatch_intent("scene", "setBranchStatus", [node.id, "accepted"])
+
+        assert document.nodes[node.id].branch_status == "accepted"
+        assert recorder.topics_seen().count("scene") > scene_publishes_before
+
+    asyncio.run(run())
+
+
+def test_set_final_deliverable_intent_dispatches_and_publishes_scene():
+    async def run():
+        bus, document, recorder, _ = make_bus_with_dispatcher()
+        node = document.add_chat_node(0, 0, "hi", True)
+        scene_publishes_before = recorder.topics_seen().count("scene")
+
+        await bus.dispatch_intent("scene", "setFinalDeliverable", [node.id, True])
+
+        assert document.final_deliverable_node_id == node.id
+        assert recorder.topics_seen().count("scene") > scene_publishes_before
+
+    asyncio.run(run())
+
+
+def test_collapse_branch_intent_dispatches_and_publishes_scene():
+    async def run():
+        bus, document, recorder, _ = make_bus_with_dispatcher()
+        root = document.add_chat_node(0, 0, "root", True)
+        child = document.add_chat_node(0, 160, "child", False, parent_id=root.id)
+        scene_publishes_before = recorder.topics_seen().count("scene")
+
+        await bus.dispatch_intent("scene", "collapseBranch", [root.id, True])
+
+        assert document.nodes[root.id].is_collapsed is True
+        assert document.nodes[child.id].is_collapsed is True
+        assert recorder.topics_seen().count("scene") > scene_publishes_before
+
+    asyncio.run(run())

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -561,3 +561,161 @@ def test_resolve_node_payload_list_tolerates_double_nested_legacy_shape():
     document = SceneDocument()
     restore_chat_into_document(document, {"data": {"data": {"nodes": [_chat("nested")]}}}, [], [])
     assert len(document.nodes) == 1
+
+
+# -- ADR-002 Workstream 1: "Branch status and lifecycle" ---------------------
+#
+# Includes the confirmed, pre-existing gap fixed inline in this same pass:
+# provider/model/is_branch_synthesis/synthesis_instructions/item_ids
+# (Synthesize Branches) and is_branch_comparison/item_ids (Compare Branches)
+# already synced live to the frontend but were silently dropped on load
+# before this fix - see backend/session_save.py's own comment on the
+# matching serializers.
+
+
+def test_restore_chat_payload_restores_synthesis_provenance_scalars():
+    document = _restore(nodes=[
+        _chat(
+            "n0", raw_content="Combined answer", is_user=False,
+            provider="Anthropic Claude", model="claude-sonnet-5",
+            is_branch_synthesis=True, synthesis_instructions="merge them",
+            branch_status="accepted",
+        ),
+    ])
+    node = next(iter(document.nodes.values()))
+    assert node.provider == "Anthropic Claude"
+    assert node.model == "claude-sonnet-5"
+    assert node.is_branch_synthesis is True
+    assert node.synthesis_instructions == "merge them"
+    assert node.branch_status == "accepted"
+
+
+def test_restore_chat_payload_downgrades_an_unrecognized_branch_status_to_active():
+    document = _restore(nodes=[_chat("n0", branch_status="archived")])
+    node = next(iter(document.nodes.values()))
+    assert node.branch_status == "active"
+
+
+def test_restore_chat_payload_defaults_branch_status_to_active_when_absent():
+    document = _restore(nodes=[_chat("n0")])
+    node = next(iter(document.nodes.values()))
+    assert node.branch_status == "active"
+
+
+def test_restore_notes_restores_is_branch_comparison():
+    document = _restore(notes=[
+        {"content": "cmp", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
+         "is_branch_comparison": True},
+    ])
+    note = next(iter(document.nodes.values()))
+    assert note.is_branch_comparison is True
+
+
+def test_restore_notes_defaults_is_branch_comparison_to_false_when_absent():
+    document = _restore(notes=[
+        {"content": "plain", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1}},
+    ])
+    note = next(iter(document.nodes.values()))
+    assert note.is_branch_comparison is False
+
+
+def test_restore_translates_a_synthesis_nodes_item_ids_to_the_re_minted_source_ids():
+    document = _restore(nodes=[
+        _chat("src-1", raw_content="first branch reply"),
+        _chat("src-2", raw_content="second branch reply"),
+        _chat(
+            "result", raw_content="Combined answer", is_user=False,
+            is_branch_synthesis=True, item_ids=["src-1", "src-2"],
+        ),
+    ])
+    src1 = next(n for n in document.nodes.values() if n.content == "first branch reply")
+    src2 = next(n for n in document.nodes.values() if n.content == "second branch reply")
+    result = next(n for n in document.nodes.values() if n.content == "Combined answer")
+    assert set(result.item_ids) == {src1.id, src2.id}
+    assert src1.id != "src-1", "ids must be re-minted on load, not reused verbatim - a weak assertion here would miss a translation bug"
+
+
+def test_restore_translates_a_comparison_notes_item_ids_to_the_re_minted_source_ids():
+    document = _restore(
+        nodes=[
+            _chat("src-1", raw_content="first branch reply"),
+            _chat("src-2", raw_content="second branch reply"),
+        ],
+        notes=[
+            {"content": "Branch Comparison", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
+             "is_branch_comparison": True, "item_ids": ["src-1", "src-2"]},
+        ],
+    )
+    src1 = next(n for n in document.nodes.values() if n.content == "first branch reply")
+    src2 = next(n for n in document.nodes.values() if n.content == "second branch reply")
+    note = next(n for n in document.nodes.values() if n.kind == "note")
+    assert set(note.item_ids) == {src1.id, src2.id}
+
+
+def test_restore_drops_a_synthesis_item_id_that_does_not_resolve_to_any_node():
+    document = _restore(nodes=[
+        _chat(
+            "result", raw_content="Combined answer", is_user=False,
+            is_branch_synthesis=True, item_ids=["deleted-before-save", "also-missing"],
+        ),
+    ])
+    result = next(iter(document.nodes.values()))
+    assert result.item_ids == []
+
+
+def test_restore_only_translates_item_ids_for_a_flagged_synthesis_or_comparison_node():
+    # An ordinary chat/note node's item_ids (unset, empty by default) must
+    # not be touched by the second-pass translation just because OTHER
+    # nodes in the same load happen to be flagged.
+    document = _restore(
+        nodes=[
+            _chat("src-1", raw_content="source"),
+            _chat("ordinary", raw_content="just a normal reply"),
+            _chat(
+                "result", raw_content="Combined answer", is_user=False,
+                is_branch_synthesis=True, item_ids=["src-1"],
+            ),
+        ],
+    )
+    ordinary = next(n for n in document.nodes.values() if n.content == "just a normal reply")
+    assert ordinary.item_ids == []
+
+
+def test_restore_translates_final_deliverable_node_id():
+    # "legacy-uuid-1234" (not "n0"/"n1"/...) is deliberate: a fresh
+    # SceneDocument's own id counter also happens to mint "n0" first, so a
+    # payload id of "n0" would coincidentally match the real new id even if
+    # translation were silently broken - this id can never collide.
+    document = _restore(
+        nodes=[_chat("legacy-uuid-1234", raw_content="the deliverable")],
+        final_deliverable_node_id="legacy-uuid-1234",
+    )
+    node = next(iter(document.nodes.values()))
+    assert document.final_deliverable_node_id == node.id
+    assert node.id != "legacy-uuid-1234", "ids must be re-minted on load - a weak assertion here would miss a translation bug"
+
+
+def test_restore_final_deliverable_node_id_defaults_to_none_when_absent():
+    document = _restore(nodes=[_chat("n0")])
+    assert document.final_deliverable_node_id is None
+
+
+def test_restore_final_deliverable_node_id_stale_reference_is_dropped():
+    document = _restore(nodes=[_chat("n0")], final_deliverable_node_id="does-not-exist")
+    assert document.final_deliverable_node_id is None
+
+
+def test_restore_final_deliverable_node_id_rejects_a_resolved_non_chat_node():
+    # Found by adversarial review: the live setter (SceneDocument.
+    # set_final_deliverable) rejects non-chat nodes; this defends the same
+    # invariant against a malformed/hand-edited save file that references
+    # one, which this load path has no SceneError to raise against.
+    document = _restore(
+        nodes=[
+            _chat("parent"),
+            {"node_type": "code", "id": "code-1", "code": "print(1)", "language": "python",
+             "position": {"x": 0, "y": 0}, "parent_content_node_index": 0},
+        ],
+        final_deliverable_node_id="code-1",
+    )
+    assert document.final_deliverable_node_id is None

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -373,3 +373,100 @@ def test_round_trip_preserves_gitlink_field_values():
     assert node2.gitlink_branch == "dev"
     assert node2.gitlink_pending_changes == [{"path": "a.py"}, {"path": "b.py"}]
     assert node2.gitlink_change_state == "previewed"
+
+
+# -- ADR-002 Workstream 1: "Branch status and lifecycle" ---------------------
+#
+# Includes the confirmed, pre-existing gap fixed inline in this same pass -
+# see backend/session_save.py's own comment on _serialize_chat_node/
+# _serialize_note. These round-trip tests (build_chat_data ->
+# restore_chat_into_document) are the strongest possible signal that fields
+# already synced live to the frontend now ALSO survive a real Save then Load,
+# which is exactly the gap that was silently failing before this fix.
+
+
+def test_chat_node_serializes_synthesis_provenance_and_branch_status():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    first = doc.add_chat_node(0, 160, "first", False, parent_id=root.id)
+    second = doc.add_chat_node(460, 160, "second", False, parent_id=root.id)
+    result = doc.add_chat_node(0, 320, "Combined answer", False, parent_id=first.id)
+    doc.mark_branch_synthesis(result.id, [first.id, second.id], "merge them", "Anthropic Claude", "claude-sonnet-5")
+    doc.set_branch_status(result.id, "accepted")
+
+    payload = next(p for p in build_chat_data(doc)["nodes"] if p.get("raw_content") == "Combined answer")
+    assert payload["provider"] == "Anthropic Claude"
+    assert payload["model"] == "claude-sonnet-5"
+    assert payload["is_branch_synthesis"] is True
+    assert payload["synthesis_instructions"] == "merge them"
+    assert set(payload["item_ids"]) == {first.id, second.id}
+    assert payload["branch_status"] == "accepted"
+
+
+def test_note_serializes_branch_comparison_provenance():
+    doc = SceneDocument()
+    first = doc.add_chat_node(0, 0, "first", True)
+    second = doc.add_chat_node(0, 160, "second", True)
+    note = doc.add_note(0, 0)
+    doc.mark_branch_comparison_note(note.id, [first.id, second.id])
+
+    note_payload = build_chat_data(doc)["notes_data"][0]
+    assert note_payload["is_branch_comparison"] is True
+    assert set(note_payload["item_ids"]) == {first.id, second.id}
+
+
+def test_final_deliverable_node_id_serializes_at_the_top_level():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "hi", True)
+    doc.set_final_deliverable(node.id, True)
+    chat_data = build_chat_data(doc)
+    assert chat_data["final_deliverable_node_id"] == node.id
+
+
+def test_final_deliverable_node_id_serializes_as_none_when_unmarked():
+    doc = SceneDocument()
+    doc.add_chat_node(0, 0, "hi", True)
+    chat_data = build_chat_data(doc)
+    assert chat_data["final_deliverable_node_id"] is None
+
+
+def test_round_trip_preserves_synthesize_branches_full_shape():
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root question", True)
+    first = doc.add_chat_node(0, 160, "first branch reply", False, parent_id=root.id)
+    second = doc.add_chat_node(460, 160, "second branch reply", False, parent_id=root.id)
+    result = doc.add_chat_node(0, 320, "Combined answer", False, parent_id=first.id)
+    doc.mark_branch_synthesis(result.id, [first.id, second.id], "merge them", "Anthropic Claude", "claude-sonnet-5")
+    doc.set_branch_status(result.id, "accepted")
+    doc.set_final_deliverable(result.id, True)
+
+    doc2 = _round_trip(doc)
+    first2 = next(n for n in doc2.nodes.values() if n.content == "first branch reply")
+    second2 = next(n for n in doc2.nodes.values() if n.content == "second branch reply")
+    result2 = next(n for n in doc2.nodes.values() if n.content == "Combined answer")
+
+    assert result2.provider == "Anthropic Claude"
+    assert result2.model == "claude-sonnet-5"
+    assert result2.is_branch_synthesis is True
+    assert result2.synthesis_instructions == "merge them"
+    assert set(result2.item_ids) == {first2.id, second2.id}
+    assert result2.branch_status == "accepted"
+    assert doc2.final_deliverable_node_id == result2.id
+
+
+def test_round_trip_preserves_compare_branches_full_shape():
+    doc = SceneDocument()
+    first = doc.add_chat_node(0, 0, "first branch reply", True)
+    second = doc.add_chat_node(0, 160, "second branch reply", True)
+    note = doc.add_note(0, 0)
+    doc.set_note_content(note.id, "Branch Comparison\n\nAgreements:\n• both agree")
+    doc.mark_branch_comparison_note(note.id, [first.id, second.id])
+
+    doc2 = _round_trip(doc)
+    first2 = next(n for n in doc2.nodes.values() if n.content == "first branch reply")
+    second2 = next(n for n in doc2.nodes.values() if n.content == "second branch reply")
+    note2 = next(n for n in doc2.nodes.values() if n.kind == "note")
+
+    assert note2.is_branch_comparison is True
+    assert set(note2.item_ids) == {first2.id, second2.id}
+    assert note2.content == "Branch Comparison\n\nAgreements:\n• both agree"

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -37,6 +37,9 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   const onScrollChange = vi.fn();
   const onToggleBranchFocus = vi.fn();
   const onBranchFromHere = vi.fn();
+  const onSetBranchStatus = vi.fn();
+  const onSetFinalDeliverable = vi.fn();
+  const onCollapseBranch = vi.fn();
   const props = {
     id: "n0",
     selected: false,
@@ -59,6 +62,11 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
       isBranchFocusActive: false,
       onToggleBranchFocus,
       onBranchFromHere,
+      branchStatus: "active",
+      isFinalDeliverable: false,
+      onSetBranchStatus,
+      onSetFinalDeliverable,
+      onCollapseBranch,
       ...overrides,
     },
   } as unknown as NodeProps<ChatFlowNode>;
@@ -71,7 +79,8 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   return {
     onToggleCollapse, onDelete, onUndockChild, onRegenerate, onGenerateImage,
     onGenerateChart, onGenerateKeyTakeaway, onGenerateExplainerNote,
-    onOpenDocumentView, onScrollChange, onToggleBranchFocus, onBranchFromHere, container,
+    onOpenDocumentView, onScrollChange, onToggleBranchFocus, onBranchFromHere,
+    onSetBranchStatus, onSetFinalDeliverable, onCollapseBranch, container,
   };
 }
 
@@ -445,6 +454,107 @@ describe("ChatNodeView Synthesize Branches provenance (ADR-002 Workstream 1)", (
       model: null,
     });
     expect(screen.queryByText("claude-sonnet-5")).toBeNull();
+  });
+});
+
+// ADR-002 Workstream 1 ("Branch status and lifecycle"): the final sequenced
+// item after fork/compare/synthesize - status marking, Final Deliverable,
+// and collapsing a whole branch.
+describe("ChatNodeView branch status badge (ADR-002 Workstream 1)", () => {
+  it("always renders the status dot, even for the default 'active' status", () => {
+    renderChatNode({ branchStatus: "active" });
+    const dot = screen.getByLabelText("Branch status: active");
+    expect(dot).toHaveAttribute("title", "Branch status: active");
+  });
+
+  it("renders a distinct status dot for accepted/rejected/superseded", () => {
+    renderChatNode({ branchStatus: "accepted" });
+    expect(screen.getByLabelText("Branch status: accepted")).toBeInTheDocument();
+  });
+
+  it("renders no Final Deliverable badge when isFinalDeliverable is false", () => {
+    renderChatNode({ isFinalDeliverable: false });
+    expect(screen.queryByLabelText("Final Deliverable")).toBeNull();
+  });
+
+  it("renders the Final Deliverable badge when isFinalDeliverable is true", () => {
+    renderChatNode({ isFinalDeliverable: true });
+    const badge = screen.getByLabelText("Final Deliverable");
+    expect(badge).toHaveTextContent("★");
+  });
+});
+
+describe("ChatNodeView Mark Status menu (ADR-002 Workstream 1)", () => {
+  it("opens the submenu and shows all 4 status options with the current one checked", async () => {
+    const user = userEvent.setup();
+    renderChatNode({ branchStatus: "rejected" });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    await user.click(screen.getByRole("menuitem", { name: "Mark Status" }));
+
+    expect(screen.getByRole("menuitemradio", { name: "Active" })).toHaveAttribute("aria-checked", "false");
+    const rejectedOption = screen.getByRole("menuitemradio", { name: "✓ Rejected" });
+    expect(rejectedOption).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("clicking a status option calls onSetBranchStatus with that value and closes the menu", async () => {
+    const user = userEvent.setup();
+    const { onSetBranchStatus } = renderChatNode({ branchStatus: "active" });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    await user.click(screen.getByRole("menuitem", { name: "Mark Status" }));
+    await user.click(screen.getByRole("menuitemradio", { name: "Accepted" }));
+
+    expect(onSetBranchStatus).toHaveBeenCalledWith("accepted");
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+describe("ChatNodeView Mark as Final Deliverable (ADR-002 Workstream 1)", () => {
+  it("shows 'Mark as Final Deliverable' and calls onSetFinalDeliverable(true) when not yet marked", async () => {
+    const user = userEvent.setup();
+    const { onSetFinalDeliverable } = renderChatNode({ isFinalDeliverable: false });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    const item = screen.getByRole("menuitem", { name: "Mark as Final Deliverable" });
+    await user.click(item);
+
+    expect(onSetFinalDeliverable).toHaveBeenCalledWith(true);
+  });
+
+  it("shows 'Unmark Final Deliverable' and calls onSetFinalDeliverable(false) when already marked", async () => {
+    const user = userEvent.setup();
+    const { onSetFinalDeliverable } = renderChatNode({ isFinalDeliverable: true });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    const item = screen.getByRole("menuitem", { name: "Unmark Final Deliverable" });
+    await user.click(item);
+
+    expect(onSetFinalDeliverable).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("ChatNodeView Collapse Branch (ADR-002 Workstream 1)", () => {
+  it("shows 'Collapse Branch' and calls onCollapseBranch(true) when not collapsed", async () => {
+    const user = userEvent.setup();
+    const { onCollapseBranch } = renderChatNode({ isCollapsed: false });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    const item = screen.getByRole("menuitem", { name: "Collapse Branch" });
+    await user.click(item);
+
+    expect(onCollapseBranch).toHaveBeenCalledWith(true);
+  });
+
+  it("shows 'Expand Branch' and calls onCollapseBranch(false) when already collapsed", async () => {
+    const user = userEvent.setup();
+    const { onCollapseBranch } = renderChatNode({ isCollapsed: true });
+
+    fireEvent.contextMenu(screen.getByText("You"));
+    const item = screen.getByRole("menuitem", { name: "Expand Branch" });
+    await user.click(item);
+
+    expect(onCollapseBranch).toHaveBeenCalledWith(false);
   });
 });
 

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { CHAT_SCROLL_REPORT_DEBOUNCE_MS, LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { downloadTextFile } from "./downloadTextFile";
+import { GROUP_MONO_COLORS, GROUP_NAMED_COLORS } from "./GroupColorPicker";
 import { NodeMenu } from "./NodeMenu";
 
 /**
@@ -105,6 +106,23 @@ export interface ChatNodeData extends Record<string, unknown> {
   isBranchSynthesis: boolean;
   synthesisInstructions: string;
   synthesisSourceNodeIds: string[];
+  // ADR-002 Workstream 1 ("Branch status and lifecycle"): the final
+  // sequenced item after fork/compare/synthesize. branchStatus is one of
+  // exactly "active" (the default)/"accepted"/"rejected"/"superseded" -
+  // per-node, no inheritance from or cascade to any other node (see
+  // backend/canvas.py's SceneNode.branch_status comment). isFinalDeliverable
+  // is server-computed (n.id === the document's one final_deliverable_
+  // node_id pointer), never client-derived, so at most one node in the
+  // whole scene can ever read true. onCollapseBranch("Collapse Branch"/
+  // "Expand Branch" menu item) reuses is_collapsed but flips it across
+  // this node's ENTIRE chat-kind subtree server-side, not just this one
+  // node - deliberately separate from onToggleCollapse above, which is
+  // the existing single-node collapse.
+  branchStatus: string;
+  isFinalDeliverable: boolean;
+  onSetBranchStatus: (status: string) => void;
+  onSetFinalDeliverable: (isFinal: boolean) => void;
+  onCollapseBranch: (collapsed: boolean) => void;
 }
 
 export type ChatFlowNode = Node<ChatNodeData, "chat">;
@@ -127,6 +145,34 @@ const CHART_TYPE_OPTIONS: { value: string; label: string }[] = [
   { value: "sankey", label: "Sankey" },
 ];
 
+// ADR-002 Workstream 1 ("Branch status and lifecycle"): the exactly-4
+// legal values (must match backend/canvas.py's SceneDocument.
+// BRANCH_STATUS_VALUES), in the order they render in the Mark Status
+// submenu.
+const BRANCH_STATUS_OPTIONS: { value: string; label: string }[] = [
+  { value: "active", label: "Active" },
+  { value: "accepted", label: "Accepted" },
+  { value: "rejected", label: "Rejected" },
+  { value: "superseded", label: "Superseded" },
+];
+
+// ADR-002 Workstream 1 ("Branch status and lifecycle"): the status-dot
+// badge's colors REUSE GroupColorPicker.tsx's own named palette verbatim
+// (looked up by name, not by array index, so a future reordering of that
+// palette can't silently retarget these) rather than defining new hex
+// literals - that palette is the one place in this codebase with real,
+// visually-distinct color values for a "pick one of several named
+// semantic colors" concept (the --gl-semantic-status-* CSS token names
+// exist for exactly this kind of status vocabulary, but their current
+// values are indistinguishable placeholder grays - see that token's own
+// definition for why this reuses GroupColorPicker's palette instead).
+const BRANCH_STATUS_COLORS: Record<string, string> = {
+  active: GROUP_MONO_COLORS.find((c) => c.name === "Mid Gray")!.hex,
+  accepted: GROUP_NAMED_COLORS.find((c) => c.name === "Green")!.hex,
+  rejected: GROUP_NAMED_COLORS.find((c) => c.name === "Red")!.hex,
+  superseded: GROUP_NAMED_COLORS.find((c) => c.name === "Orange")!.hex,
+};
+
 function ChatNodeMenu({
   position,
   nodeId,
@@ -146,6 +192,11 @@ function ChatNodeMenu({
   isBranchFocusActive,
   onToggleBranchFocus,
   onBranchFromHere,
+  branchStatus,
+  isFinalDeliverable,
+  onSetBranchStatus,
+  onSetFinalDeliverable,
+  onCollapseBranch,
   onClose,
 }: {
   position: MenuPosition;
@@ -166,9 +217,15 @@ function ChatNodeMenu({
   isBranchFocusActive: boolean;
   onToggleBranchFocus: () => void;
   onBranchFromHere: () => void;
+  branchStatus: string;
+  isFinalDeliverable: boolean;
+  onSetBranchStatus: (status: string) => void;
+  onSetFinalDeliverable: (isFinal: boolean) => void;
+  onCollapseBranch: (collapsed: boolean) => void;
   onClose: () => void;
 }) {
   const [chartMenuOpen, setChartMenuOpen] = useState(false);
+  const [statusMenuOpen, setStatusMenuOpen] = useState(false);
 
 
   return (
@@ -228,6 +285,68 @@ function ChatNodeMenu({
         }}
       >
         Branch from Here
+      </button>
+      {/* ADR-002 Workstream 1 ("Branch status and lifecycle"): the final
+          sequenced item after fork/compare/synthesize, grouped here right
+          after Branch from Here since all three below are branch-lifecycle
+          actions. Mark Status reuses the exact click-to-expand submenu
+          idiom Generate Chart below already established (chartMenuOpen),
+          not a new interaction pattern - role="menuitemradio"/aria-checked
+          marks the currently active status. */}
+      <button
+        type="button"
+        role="menuitem"
+        aria-haspopup="true"
+        aria-expanded={statusMenuOpen}
+        onClick={() => setStatusMenuOpen((open) => !open)}
+      >
+        Mark Status
+      </button>
+      {statusMenuOpen && (
+        <div className="chat-node-submenu" role="menu" aria-label="Branch status">
+          {BRANCH_STATUS_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              role="menuitemradio"
+              aria-checked={option.value === branchStatus}
+              onClick={() => {
+                onSetBranchStatus(option.value);
+                onClose();
+              }}
+            >
+              {option.value === branchStatus ? "✓ " : ""}
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onSetFinalDeliverable(!isFinalDeliverable);
+          onClose();
+        }}
+      >
+        {isFinalDeliverable ? "Unmark Final Deliverable" : "Mark as Final Deliverable"}
+      </button>
+      {/* "Collapse Branch"/"Expand Branch" flips off THIS node's own
+          isCollapsed (same value/direction the plain single-node
+          "Expand"/"Collapse" item above already reads) but applies
+          server-side across the whole chat-kind subtree rooted here, not
+          just this one node - see onCollapseBranch's own comment on
+          ChatNodeData. Deliberately NOT automatic when status is set to
+          "rejected" above - status and collapse stay decoupled. */}
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onCollapseBranch(!isCollapsed);
+          onClose();
+        }}
+      >
+        {isCollapsed ? "Expand Branch" : "Collapse Branch"}
       </button>
       {/* Real (not disabled) - matches the legacy's own `if docked_children:`
           guard exactly. One button per docked child, each undocking that
@@ -417,6 +536,17 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
       <div className="scene-node-title chat-node-role">
         <span className="chat-node-role-group">
           <span>{data.isUser ? "You" : "Assistant"}</span>
+          {/* ADR-002 Workstream 1 ("Branch status and lifecycle"): always
+              rendered (unlike every other badge here, which is conditional)
+              - branchStatus always has a real value ("active" for the vast
+              majority of nodes, never null/undefined), so this is always
+              meaningful to show, not just for a rare marked case. */}
+          <span
+            className="chat-node-status-badge"
+            style={{ backgroundColor: BRANCH_STATUS_COLORS[data.branchStatus] ?? BRANCH_STATUS_COLORS.active }}
+            title={`Branch status: ${data.branchStatus}`}
+            aria-label={`Branch status: ${data.branchStatus}`}
+          />
           {data.dockedChildren.length > 0 && (
             <span className="chat-node-docked-badge" title="Docked items">
               {data.dockedChildren.length}
@@ -440,6 +570,20 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
           {data.model && (
             <span className="chat-node-model-badge" title={data.provider ?? undefined}>
               {data.model}
+            </span>
+          )}
+          {data.isFinalDeliverable && (
+            // ADR-002 Workstream 1 ("Branch status and lifecycle"): reuses
+            // the synthesis badge's "single glyph, no pill" shape - at most
+            // one node in the whole scene can ever show this (server-
+            // computed against the document's one final_deliverable_
+            // node_id pointer).
+            <span
+              className="chat-node-final-badge"
+              title="Final Deliverable"
+              aria-label="Final Deliverable"
+            >
+              ★
             </span>
           )}
         </span>
@@ -480,6 +624,11 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
           isBranchFocusActive={data.isBranchFocusActive}
           onToggleBranchFocus={data.onToggleBranchFocus}
           onBranchFromHere={data.onBranchFromHere}
+          branchStatus={data.branchStatus}
+          isFinalDeliverable={data.isFinalDeliverable}
+          onSetBranchStatus={data.onSetBranchStatus}
+          onSetFinalDeliverable={data.onSetFinalDeliverable}
+          onCollapseBranch={data.onCollapseBranch}
           onClose={() => setMenuPosition(null)}
         />
       )}

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   applyGroupDragDelta,
   computeDimmedNodeIds,
+  computeNonAcceptedNodeIds,
   conversationHistoryToDocumentMarkdown,
   groupDragKindOf,
   handleSelectionChange,
@@ -1593,6 +1594,200 @@ describe("toFlowNodes (ADR-002 Workstream 1 - Synthesize Branches provenance)", 
       synthesisInstructions: undefined,
       synthesisSourceNodeIds: undefined,
     });
+  });
+});
+
+// ADR-002 Workstream 1 ("Branch status and lifecycle"). Same situation as
+// SynthesisTestFields above - branchStatus/isFinalDeliverable aren't in the
+// generated SceneNodeRow type yet (see SceneCanvas.tsx's own
+// SceneNodeBranchLifecycleFields comment).
+interface BranchLifecycleTestFields {
+  branchStatus: string;
+  isFinalDeliverable: boolean;
+}
+
+function withBranchLifecycleFields(
+  node: SceneNodeRow,
+  overrides: Partial<BranchLifecycleTestFields> = {},
+): SceneNodeRow & BranchLifecycleTestFields {
+  return {
+    ...node,
+    branchStatus: "active",
+    isFinalDeliverable: false,
+    ...overrides,
+  } as SceneNodeRow & BranchLifecycleTestFields;
+}
+
+describe("toFlowNodes (ADR-002 Workstream 1 - Branch status and lifecycle)", () => {
+  it("maps a chat node's branchStatus/isFinalDeliverable onto the flow node's data", () => {
+    const scene = baseScene({
+      nodes: [
+        withBranchLifecycleFields(baseNode({ id: "chat-1", kind: "chat", content: "hi" }), {
+          branchStatus: "accepted",
+          isFinalDeliverable: true,
+        }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    expect(chatFlowNode!.data).toMatchObject({ branchStatus: "accepted", isFinalDeliverable: true });
+  });
+
+  it("onSetBranchStatus calls store.setBranchStatus with this node's own id and the given status", () => {
+    const scene = baseScene({
+      nodes: [withBranchLifecycleFields(baseNode({ id: "chat-1", kind: "chat", content: "hi" }))],
+      edges: [],
+    });
+    const store = makeStore();
+    const spy = vi.spyOn(store, "setBranchStatus");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const data = flowNodes.find((n) => n.id === "chat-1")!.data as { onSetBranchStatus: (status: string) => void };
+    data.onSetBranchStatus("rejected");
+    expect(spy).toHaveBeenCalledWith("chat-1", "rejected");
+  });
+
+  it("onSetFinalDeliverable calls store.setFinalDeliverable with this node's own id and the given flag", () => {
+    const scene = baseScene({
+      nodes: [withBranchLifecycleFields(baseNode({ id: "chat-1", kind: "chat", content: "hi" }))],
+      edges: [],
+    });
+    const store = makeStore();
+    const spy = vi.spyOn(store, "setFinalDeliverable");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const data = flowNodes.find((n) => n.id === "chat-1")!.data as { onSetFinalDeliverable: (isFinal: boolean) => void };
+    data.onSetFinalDeliverable(true);
+    expect(spy).toHaveBeenCalledWith("chat-1", true);
+  });
+
+  it("onCollapseBranch calls store.collapseBranch with this node's own id and the given flag", () => {
+    const scene = baseScene({
+      nodes: [withBranchLifecycleFields(baseNode({ id: "chat-1", kind: "chat", content: "hi" }))],
+      edges: [],
+    });
+    const store = makeStore();
+    const spy = vi.spyOn(store, "collapseBranch");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const data = flowNodes.find((n) => n.id === "chat-1")!.data as { onCollapseBranch: (collapsed: boolean) => void };
+    data.onCollapseBranch(true);
+    expect(spy).toHaveBeenCalledWith("chat-1", true);
+  });
+});
+
+describe("computeNonAcceptedNodeIds (ADR-002 Workstream 1 - Focus Accepted Paths)", () => {
+  function lifecycleNode(overrides: Partial<SceneNodeRow & BranchLifecycleTestFields> = {}) {
+    return withBranchLifecycleFields(baseNode(overrides), overrides);
+  }
+
+  it("returns an empty set when no chat node is rejected or superseded", () => {
+    const scene = baseScene({
+      nodes: [
+        lifecycleNode({ id: "root", kind: "chat", branchStatus: "active" }),
+        lifecycleNode({ id: "child", kind: "chat", branchStatus: "accepted" }),
+      ],
+      edges: [{ id: "e1", source: "root", target: "child" }],
+    });
+    expect(computeNonAcceptedNodeIds(scene)).toEqual(new Set());
+  });
+
+  it("excludes a rejected root and every one of its chat-kind descendants", () => {
+    const scene = baseScene({
+      nodes: [
+        lifecycleNode({ id: "root", kind: "chat", branchStatus: "active" }),
+        lifecycleNode({ id: "rejected", kind: "chat", branchStatus: "rejected" }),
+        lifecycleNode({ id: "grandchild", kind: "chat", branchStatus: "active" }),
+        lifecycleNode({ id: "other-branch", kind: "chat", branchStatus: "active" }),
+      ],
+      edges: [
+        { id: "e1", source: "root", target: "rejected" },
+        { id: "e2", source: "rejected", target: "grandchild" },
+        { id: "e3", source: "root", target: "other-branch" },
+      ],
+    });
+    const excluded = computeNonAcceptedNodeIds(scene);
+    expect(excluded).toEqual(new Set(["rejected", "grandchild"]));
+  });
+
+  it("an explicit accepted override reactivates a sub-branch beneath a rejected ancestor", () => {
+    const scene = baseScene({
+      nodes: [
+        lifecycleNode({ id: "root", kind: "chat", branchStatus: "active" }),
+        lifecycleNode({ id: "rejected", kind: "chat", branchStatus: "rejected" }),
+        lifecycleNode({ id: "reactivated", kind: "chat", branchStatus: "accepted" }),
+        lifecycleNode({ id: "below-reactivated", kind: "chat", branchStatus: "active" }),
+      ],
+      edges: [
+        { id: "e1", source: "root", target: "rejected" },
+        { id: "e2", source: "rejected", target: "reactivated" },
+        { id: "e3", source: "reactivated", target: "below-reactivated" },
+      ],
+    });
+    const excluded = computeNonAcceptedNodeIds(scene);
+    // "rejected" itself stays excluded, but its "accepted" child and
+    // everything below that child is reactivated.
+    expect(excluded).toEqual(new Set(["rejected"]));
+  });
+
+  it("pulls in non-chat content nodes via their chat anchor", () => {
+    const scene = baseScene({
+      nodes: [
+        lifecycleNode({ id: "root", kind: "chat", branchStatus: "active" }),
+        lifecycleNode({ id: "rejected", kind: "chat", branchStatus: "rejected" }),
+        baseNode({ id: "code-child", kind: "code" }),
+      ],
+      edges: [
+        { id: "e1", source: "root", target: "rejected" },
+        { id: "e2", source: "rejected", target: "code-child" },
+      ],
+    });
+    const excluded = computeNonAcceptedNodeIds(scene);
+    expect(excluded.has("code-child")).toBe(true);
+  });
+
+  it("does not exclude a node whose branchStatus is superseded from touching an unrelated sibling branch", () => {
+    const scene = baseScene({
+      nodes: [
+        lifecycleNode({ id: "root", kind: "chat", branchStatus: "active" }),
+        lifecycleNode({ id: "superseded", kind: "chat", branchStatus: "superseded" }),
+        lifecycleNode({ id: "sibling", kind: "chat", branchStatus: "active" }),
+      ],
+      edges: [
+        { id: "e1", source: "root", target: "superseded" },
+        { id: "e2", source: "root", target: "sibling" },
+      ],
+    });
+    const excluded = computeNonAcceptedNodeIds(scene);
+    expect(excluded).toEqual(new Set(["superseded"]));
+  });
+
+  // Found by adversarial review: a node with a genuinely healthy (canonical,
+  // tie-break-winning) parent must never be excluded just because it ALSO
+  // happens to receive a second, unrelated edge from a rejected node
+  // elsewhere in the graph - SceneDocument.connect has no cycle/multi-parent
+  // validation, so this is structurally reachable even though the UI has no
+  // direct multi-parent-creation gesture (e.g. an unrelated manual edge).
+  it("does not exclude a node via a second, non-canonical incoming edge from an unrelated rejected node", () => {
+    const scene = baseScene({
+      nodes: [
+        lifecycleNode({ id: "healthy-root", kind: "chat", branchStatus: "active" }),
+        lifecycleNode({ id: "shared", kind: "chat", branchStatus: "active" }),
+        lifecycleNode({ id: "rejected", kind: "chat", branchStatus: "rejected" }),
+      ],
+      edges: [
+        // "shared"'s canonical parent (first edge whose target is "shared").
+        { id: "e1", source: "healthy-root", target: "shared" },
+        // A second, unrelated incoming edge from a rejected node - must not
+        // exclude "shared", since its real parent is healthy.
+        { id: "e2", source: "rejected", target: "shared" },
+      ],
+    });
+    const excluded = computeNonAcceptedNodeIds(scene);
+    expect(excluded).toEqual(new Set(["rejected"]));
   });
 });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -128,6 +128,16 @@ interface SceneNodeSynthesisFields {
 }
 type SceneNodeRowWithSynthesis = SceneNodeRow & SceneNodeSynthesisFields;
 
+// ADR-002 Workstream 1 ("Branch status and lifecycle"). Same situation as
+// SceneNodeSynthesisFields above - the generated SceneNodeRow type hasn't
+// been regenerated yet to carry branchStatus/isFinalDeliverable
+// (backend/canvas.py's scene_payload() contract for this increment).
+interface SceneNodeBranchLifecycleFields {
+  branchStatus: string;
+  isFinalDeliverable: boolean;
+}
+type SceneNodeRowWithBranchLifecycle = SceneNodeRow & SceneNodeBranchLifecycleFields;
+
 /**
  * The React Flow canvas (Qt-removal plan R1) - the QGraphicsScene/ChatView
  * successor. R1 scope: pan/zoom, model-driven grid (size/style/color/opacity
@@ -362,6 +372,105 @@ export function computeDimmedNodeIds(scene: SceneState, originId: string | null)
   return dimmed;
 }
 
+/**
+ * ADR-002 Workstream 1 ("Branch status and lifecycle") - "reduce a complex
+ * graph to its accepted paths." A genuinely separate feature from
+ * computeDimmedNodeIds above (that one is keyed off a single clicked
+ * origin node; this one is keyed off the persisted branchStatus field
+ * across the WHOLE graph, with no origin at all), but architecturally
+ * identical: same downward chat-to-chat BFS shape, same chatAnchorOf-based
+ * inclusion of non-chat content nodes, same opacity-only/edges-untouched
+ * application in toFlowNodes below, same "view-only, not persisted, never
+ * touches scene.nodes' own set" posture.
+ *
+ * Seeds "excluded" from every chat node whose own branchStatus is
+ * "rejected" or "superseded", then walks their descendants (chat-to-chat
+ * edges only) marking each excluded too - UNLESS a descendant's own
+ * branchStatus is "accepted", which is an explicit override: the walk does
+ * not enqueue that node (so nothing below it is excluded via THIS path
+ * either - not via a second BFS pass, simply by never being visited from
+ * here), reactivating a sub-branch without requiring every intermediate
+ * node to be individually re-marked. A LATER rejection further down the
+ * same subtree still re-excludes correctly, since the seeding loop scans
+ * every node's own status independently of BFS reachability, not just
+ * origins the walk happens to pass through.
+ *
+ * The descent from a node to its children follows ONLY the edge parentOf
+ * above also recognizes as canonical for that child (the same "first edge
+ * whose target is this node wins" tie-break computeDimmedNodeIds documents
+ * for the structurally-possible-but-UI-unreachable multi-parent case) -
+ * found necessary by adversarial review: without this check, a chat node
+ * with one legitimate active parent AND a second, unrelated incoming edge
+ * from a rejected/superseded node anywhere else in the graph would get
+ * excluded via that second edge alone, even though its real (tie-break-
+ * winning) parent is perfectly healthy. Only propagating along the
+ * canonical edge keeps this consistent with parentOf's own resolution
+ * elsewhere in this function (chatAnchorOf) rather than disagreeing with
+ * it. A node with no rejected/superseded ancestor on its OWN canonical
+ * chain is never touched, regardless of its own status - being "active" is
+ * not itself excluding, only "rejected"/"superseded" (or a canonical
+ * ancestor being one) is.
+ */
+export function computeNonAcceptedNodeIds(scene: SceneState): Set<string> {
+  // branchStatus isn't on the generated SceneNodeRow type yet (see
+  // SceneNodeBranchLifecycleFields' own comment) - cast once here, rather
+  // than at every read site below.
+  const nodesById = new Map(scene.nodes.map((n) => [n.id, n as SceneNodeRowWithBranchLifecycle]));
+  const parentOf = new Map<string, string>();
+  const childrenOf = new Map<string, string[]>();
+  for (const e of scene.edges) {
+    if (!parentOf.has(e.target)) parentOf.set(e.target, e.source);
+    const siblings = childrenOf.get(e.source);
+    if (siblings) siblings.push(e.target);
+    else childrenOf.set(e.source, [e.target]);
+  }
+
+  const isChat = (id: string) => nodesById.get(id)?.kind === "chat";
+  function chatAnchorOf(id: string): string {
+    if (isChat(id)) return id;
+    const parentId = parentOf.get(id);
+    return parentId && isChat(parentId) ? parentId : id;
+  }
+
+  const excludedChatIds = new Set<string>();
+  const visited = new Set<string>();
+  const queue: string[] = [];
+  for (const node of nodesById.values()) {
+    if (node.kind !== "chat") continue;
+    if (node.branchStatus !== "rejected" && node.branchStatus !== "superseded") continue;
+    excludedChatIds.add(node.id);
+    visited.add(node.id);
+    queue.push(node.id);
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift() as string;
+    for (const childId of childrenOf.get(current) ?? []) {
+      if (!isChat(childId) || visited.has(childId)) continue;
+      // Only follow the edge parentOf also treats as canonical for this
+      // child - see this function's own doc comment for why (a second,
+      // unrelated incoming edge from elsewhere must never exclude a node
+      // whose real parent is healthy).
+      if (parentOf.get(childId) !== current) continue;
+      visited.add(childId);
+      // Explicit override: an "accepted" descendant reactivates this
+      // sub-branch - it is never added to excludedChatIds, and the walk
+      // does not descend further from it (anything strictly between the
+      // rejected/superseded ancestor and this override stays excluded).
+      if (nodesById.get(childId)?.branchStatus === "accepted") continue;
+      excludedChatIds.add(childId);
+      queue.push(childId);
+    }
+  }
+
+  const excluded = new Set<string>();
+  for (const node of scene.nodes) {
+    if (!BRANCH_FOCUS_KINDS.has(node.kind)) continue;
+    if (excludedChatIds.has(chatAnchorOf(node.id))) excluded.add(node.id);
+  }
+  return excluded;
+}
+
 // Exported standalone for direct unit testing (same posture as
 // scaleDragPosition in sceneStore.ts) - covers the parentChatNodeId
 // derivation below without needing a full <ReactFlow> mount.
@@ -371,6 +480,11 @@ export function toFlowNodes(
   onOpenDocumentView: (markdown: string, sourceLabel: string) => void = () => {},
   branchFocusOriginId: string | null = null,
   onToggleBranchFocus: (nodeId: string) => void = () => {},
+  // ADR-002 Workstream 1 ("Branch status and lifecycle") - "Focus Accepted
+  // Paths" (ViewPopover.tsx's checkbox, backed by sceneStore's own
+  // focusAcceptedPaths field - see that field's own comment for why it
+  // lives there rather than as component state here).
+  focusAcceptedPaths = false,
 ): SceneFlowNode[] {
   // Looked up per-chat-node below to build dockedChildren - a docked node is
   // omitted from the returned array entirely (see the "thinking" branch), so
@@ -380,6 +494,13 @@ export function toFlowNodes(
   // see computeDimmedNodeIds' own doc for why it builds its own maps rather
   // than reusing nodesById above.
   const dimmedIds = computeDimmedNodeIds(scene, branchFocusOriginId);
+  // ADR-002 Workstream 1: only computed when the toggle is actually on -
+  // an empty Set otherwise, same "cheap no-op when the feature isn't
+  // active" posture as dimmedIds above already has via branchFocusOriginId
+  // defaulting to null. Composed (unioned) with dimmedIds below rather
+  // than picked between - both dimming lenses can be active at once.
+  const nonAcceptedIds = focusAcceptedPaths ? computeNonAcceptedNodeIds(scene) : new Set<string>();
+  const isDimmed = (id: string) => dimmedIds.has(id) || nonAcceptedIds.has(id);
   const flowNodes: SceneFlowNode[] = [];
 
   for (const n of scene.nodes) {
@@ -406,6 +527,7 @@ export function toFlowNodes(
       }
       const chatR63 = n as SceneNodeRowWithR63;
       const chatSynthesis = n as SceneNodeRowWithSynthesis;
+      const chatLifecycle = n as SceneNodeRowWithBranchLifecycle;
       flowNodes.push({
         id: n.id,
         type: "chat" as const,
@@ -413,7 +535,7 @@ export function toFlowNodes(
         // R8a: "Hide Other Branches" dimming - see computeDimmedNodeIds' own
         // doc above. undefined (not an explicit opacity: 1) when not dimmed,
         // so this never overrides anything else that might set style later.
-        style: dimmedIds.has(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
+        style: isDimmed(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           content: n.content,
           isUser: n.isUser,
@@ -469,6 +591,15 @@ export function toFlowNodes(
           isBranchSynthesis: chatSynthesis.isBranchSynthesis,
           synthesisInstructions: chatSynthesis.synthesisInstructions,
           synthesisSourceNodeIds: chatSynthesis.itemIds,
+          // ADR-002 Workstream 1 ("Branch status and lifecycle") - see
+          // SceneNodeBranchLifecycleFields' own comment. Fire-and-forget,
+          // same posture as onBranchFromHere/onGenerateKeyTakeaway above -
+          // the new value arrives through the next scene snapshot.
+          branchStatus: chatLifecycle.branchStatus,
+          isFinalDeliverable: chatLifecycle.isFinalDeliverable,
+          onSetBranchStatus: (status: string) => store.setBranchStatus(n.id, status),
+          onSetFinalDeliverable: (isFinal: boolean) => store.setFinalDeliverable(n.id, isFinal),
+          onCollapseBranch: (collapsed: boolean) => store.collapseBranch(n.id, collapsed),
           // R6.3: the node's own scroll position within its content area -
           // read on mount by ChatNodeView (restore) and reported (debounced)
           // via the new setChatScrollValue intent on every scroll. Defaults
@@ -493,7 +624,7 @@ export function toFlowNodes(
         id: n.id,
         type: "code" as const,
         position: { x: n.x, y: n.y },
-        style: dimmedIds.has(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
+        style: isDimmed(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           code: n.code,
           language: n.language,
@@ -515,7 +646,7 @@ export function toFlowNodes(
         id: n.id,
         type: "document" as const,
         position: { x: n.x, y: n.y },
-        style: dimmedIds.has(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
+        style: isDimmed(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           title: n.title,
           content: n.content,
@@ -555,7 +686,7 @@ export function toFlowNodes(
         id: n.id,
         type: "thinking" as const,
         position: { x: n.x, y: n.y },
-        style: dimmedIds.has(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
+        style: isDimmed(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           thinkingText: n.content,
           onDock: () => store.setNodeDocked(n.id, true),
@@ -611,7 +742,7 @@ export function toFlowNodes(
         id: n.id,
         type: "image" as const,
         position: { x: n.x, y: n.y },
-        style: dimmedIds.has(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
+        style: isDimmed(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           imageAssetId: n.imageAssetId,
           prompt: n.content,
@@ -1286,6 +1417,11 @@ function CanvasInner({
 }) {
   const scene = useSyncExternalStore(store.subscribe, store.getScene);
   const grid = useSyncExternalStore(store.subscribe, store.getGrid);
+  // ADR-002 Workstream 1 ("Branch status and lifecycle") - "Focus Accepted
+  // Paths", toggled from ViewPopover.tsx's own checkbox (a sibling
+  // component, hence living on sceneStore rather than as useState here -
+  // see that field's own comment).
+  const focusAcceptedPaths = useSyncExternalStore(store.subscribe, store.getFocusAcceptedPaths);
   // Hoisted above onNodesChange: smart guides (R7.5b-3) need node
   // dimensions. Neither the local `nodes` array NOR React Flow's internal
   // store reliably has them here: toFlowNodes rebuilds the array from every
@@ -1412,11 +1548,11 @@ function CanvasInner({
     if (draggingRef.current) return;
     setNodes((current) =>
       withPreservedSelection(
-        toFlowNodes(scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus),
+        toFlowNodes(scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus, focusAcceptedPaths),
         current,
       ),
     );
-  }, [scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus]);
+  }, [scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus, focusAcceptedPaths]);
 
   const edges = useMemo(() => toFlowEdges(scene, hoveredEdgeId), [scene, hoveredEdgeId]);
 

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -603,6 +603,59 @@ describe("SceneStore", () => {
     expect(intents).toEqual([{ topic: "scene", intent: "compareBranches", args: [["n1", "n2", "n3"]] }]);
   });
 
+  it("setBranchStatus sends the scene-topic setBranchStatus intent with [nodeId, status] (ADR-002 Workstream 1)", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setBranchStatus("n1", "accepted");
+    expect(intents).toEqual([{ topic: "scene", intent: "setBranchStatus", args: ["n1", "accepted"] }]);
+  });
+
+  it("setFinalDeliverable sends the scene-topic setFinalDeliverable intent with [nodeId, isFinal] (ADR-002 Workstream 1)", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setFinalDeliverable("n1", true);
+    expect(intents).toEqual([{ topic: "scene", intent: "setFinalDeliverable", args: ["n1", true] }]);
+  });
+
+  it("collapseBranch sends the scene-topic collapseBranch intent with [nodeId, collapsed] (ADR-002 Workstream 1)", () => {
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.collapseBranch("n1", true);
+    expect(intents).toEqual([{ topic: "scene", intent: "collapseBranch", args: ["n1", true] }]);
+  });
+
+  // ADR-002 Workstream 1 ("Branch status and lifecycle"): "Focus Accepted
+  // Paths" - local UI state only (see sceneStore.ts's own comment on why
+  // it lives here rather than as component state), NOT a WS intent -
+  // no transport call is ever expected from these.
+  it("getFocusAcceptedPaths/setFocusAcceptedPaths update state and notify listeners", () => {
+    const { transport } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    const seen = vi.fn();
+    store.subscribe(seen);
+
+    expect(store.getFocusAcceptedPaths()).toBe(false);
+    store.setFocusAcceptedPaths(true);
+    expect(store.getFocusAcceptedPaths()).toBe(true);
+    expect(seen).toHaveBeenCalledTimes(1);
+
+    store.setFocusAcceptedPaths(false);
+    expect(store.getFocusAcceptedPaths()).toBe(false);
+    expect(seen).toHaveBeenCalledTimes(2);
+  });
+
+  it("setFocusAcceptedPaths is a no-op (no re-emit) when the value is unchanged", () => {
+    const { transport } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    const seen = vi.fn();
+    store.subscribe(seen);
+
+    store.setFocusAcceptedPaths(true);
+    expect(seen).toHaveBeenCalledTimes(1);
+    store.setFocusAcceptedPaths(true);
+    expect(seen).toHaveBeenCalledTimes(1);
+  });
+
   it("setGroupLabel sends the scene-topic setGroupLabel intent with [nodeId, text]", () => {
     const { transport, intents } = makeFakeTransport();
     const store = new SceneStore(transport);

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -101,6 +101,16 @@ export class SceneStore {
   // be "a reply to X" and "a synthesis of X, Y" - showing both indicators
   // at once would be confusing and only one intent can actually fire.
   private synthesizeTargetNodeIds: string[] | null = null;
+  // ADR-002 Workstream 1 ("Branch status and lifecycle"): "reduce a complex
+  // graph to its accepted paths" - a view-only review lens, NOT persisted
+  // scene state (same "local UI state only" posture as branchFocusOriginId,
+  // which lives as plain useState inside SceneCanvas.tsx for the sibling
+  // "Hide Other Branches" feature). Lives HERE rather than as component
+  // state because its trigger (a checkbox in ViewPopover.tsx) and its
+  // consumer (SceneCanvas.tsx's toFlowNodes) are two separate components -
+  // the same reason selectedNodeId/replyTargetNodeId already live on this
+  // store rather than in whichever single component happens to set them.
+  private focusAcceptedPaths = false;
 
   constructor(private readonly transport: WsTransport) {}
 
@@ -142,6 +152,7 @@ export class SceneStore {
   getSelectedNodeId = (): string | null => this.selectedNodeId;
   getReplyTargetNodeId = (): string | null => this.replyTargetNodeId;
   getSynthesizeTargetNodeIds = (): string[] | null => this.synthesizeTargetNodeIds;
+  getFocusAcceptedPaths = (): boolean => this.focusAcceptedPaths;
 
   // R5.1: no-op-if-unchanged, same discipline as every other setter here that
   // guards a redundant assignment before paying for an emit() fan-out.
@@ -161,6 +172,12 @@ export class SceneStore {
   setSynthesizeTargetNodeIds(ids: string[] | null): void {
     this.synthesizeTargetNodeIds = ids;
     this.replyTargetNodeId = null;
+    this.emit();
+  }
+
+  setFocusAcceptedPaths(value: boolean): void {
+    if (value === this.focusAcceptedPaths) return;
+    this.focusAcceptedPaths = value;
     this.emit();
   }
 
@@ -712,6 +729,22 @@ export class SceneStore {
   // through the next scene snapshot like any other mutation.
   compareBranches(nodeIds: string[]): void {
     this.transport.intent("scene", "compareBranches", [nodeIds]);
+  }
+
+  // ADR-002 Workstream 1 ("Branch status and lifecycle") - three plain
+  // fire-and-forget setters, same posture as setGroupLabel/setGroupColor
+  // below: the backend validates/does the work, and the new value arrives
+  // through the next scene snapshot like any other mutation.
+  setBranchStatus(nodeId: string, status: string): void {
+    this.transport.intent("scene", "setBranchStatus", [nodeId, status]);
+  }
+
+  setFinalDeliverable(nodeId: string, isFinal: boolean): void {
+    this.transport.intent("scene", "setFinalDeliverable", [nodeId, isFinal]);
+  }
+
+  collapseBranch(nodeId: string, collapsed: boolean): void {
+    this.transport.intent("scene", "collapseBranch", [nodeId, collapsed]);
   }
 
   // Shared setter for frame/container header-note/title text (backend/

--- a/web_ui/src/app/chrome/ViewPopover.test.tsx
+++ b/web_ui/src/app/chrome/ViewPopover.test.tsx
@@ -19,13 +19,17 @@ function OpenViewOnMount({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
-function makeStore(sceneOverrides: Partial<typeof initialSceneState> = {}) {
+function makeStore(
+  sceneOverrides: Partial<typeof initialSceneState> = {},
+  focusAcceptedPaths = false,
+) {
   const listeners = new Set<() => void>();
   const scene = { ...initialSceneState, ...sceneOverrides };
   const setFadeConnections = vi.fn();
   const setSnapToGrid = vi.fn();
   const setOrthogonalConnections = vi.fn();
   const setSmartGuides = vi.fn();
+  const setFocusAcceptedPaths = vi.fn();
   const store = {
     subscribe: (l: () => void) => {
       listeners.add(l);
@@ -35,6 +39,10 @@ function makeStore(sceneOverrides: Partial<typeof initialSceneState> = {}) {
     getGrid: () => initialGridState,
     getDragConfig: () => initialDragSpeedState,
     getFontConfig: () => initialFontControlState,
+    // ADR-002 Workstream 1 ("Branch status and lifecycle"): NOT part of
+    // `scene` - see sceneStore.ts's own comment on why this field is
+    // local UI state rather than backend-synced.
+    getFocusAcceptedPaths: () => focusAcceptedPaths,
     setDragFactor: vi.fn(),
     setGridSize: vi.fn(),
     setGridOpacityPercent: vi.fn(),
@@ -44,11 +52,12 @@ function makeStore(sceneOverrides: Partial<typeof initialSceneState> = {}) {
     setFadeConnections,
     setOrthogonalConnections,
     setSmartGuides,
+    setFocusAcceptedPaths,
     setFontFamily: vi.fn(),
     setFontSize: vi.fn(),
     setFontColor: vi.fn(),
   };
-  return { store, setFadeConnections, setSnapToGrid, setOrthogonalConnections, setSmartGuides };
+  return { store, setFadeConnections, setSnapToGrid, setOrthogonalConnections, setSmartGuides, setFocusAcceptedPaths };
 }
 
 function renderOpen(store: unknown) {
@@ -140,6 +149,33 @@ describe("ViewPopover (R7.5b-3 Smart Guides checkbox)", () => {
 
     expect(setSmartGuides).toHaveBeenCalledWith(true);
     expect(setOrthogonalConnections).not.toHaveBeenCalled();
+    expect(setFadeConnections).not.toHaveBeenCalled();
+  });
+});
+
+// ADR-002 Workstream 1 ("Branch status and lifecycle"): same posture as the
+// other checkbox describe blocks above - only the new control is covered.
+describe("ViewPopover (ADR-002 Workstream 1 Focus Accepted Paths checkbox)", () => {
+  it("reflects focusAcceptedPaths=false as unchecked and =true as checked", () => {
+    const off = makeStore({}, false);
+    const { unmount } = renderOpen(off.store);
+    expect(screen.getByRole("checkbox", { name: "Focus Accepted Paths" })).not.toBeChecked();
+    unmount();
+
+    const on = makeStore({}, true);
+    renderOpen(on.store);
+    expect(screen.getByRole("checkbox", { name: "Focus Accepted Paths" })).toBeChecked();
+  });
+
+  it("calls store.setFocusAcceptedPaths with the new value on toggle, independent of the other toggles", async () => {
+    const user = userEvent.setup();
+    const { store, setFocusAcceptedPaths, setSmartGuides, setFadeConnections } = makeStore({}, false);
+    renderOpen(store);
+
+    await user.click(screen.getByRole("checkbox", { name: "Focus Accepted Paths" }));
+
+    expect(setFocusAcceptedPaths).toHaveBeenCalledWith(true);
+    expect(setSmartGuides).not.toHaveBeenCalled();
     expect(setFadeConnections).not.toHaveBeenCalled();
   });
 });

--- a/web_ui/src/app/chrome/ViewPopover.tsx
+++ b/web_ui/src/app/chrome/ViewPopover.tsx
@@ -14,6 +14,12 @@ export function ViewPopover({ store }: { store: SceneStore }) {
   const grid = useSyncExternalStore(store.subscribe, store.getGrid);
   const dragConfig = useSyncExternalStore(store.subscribe, store.getDragConfig);
   const fontConfig = useSyncExternalStore(store.subscribe, store.getFontConfig);
+  // ADR-002 Workstream 1 ("Branch status and lifecycle"): UNLIKE every
+  // other value read here, this one is NOT part of `scene` (backend-synced
+  // state) - it is sceneStore's own local, unpersisted UI-state field (see
+  // that field's own comment for why: a view-only review lens, the same
+  // posture as "Hide Other Branches", not a real document property).
+  const focusAcceptedPaths = useSyncExternalStore(store.subscribe, store.getFocusAcceptedPaths);
 
   const dragPercent = Math.round(scene.dragFactor * 100);
 
@@ -163,6 +169,26 @@ export function ViewPopover({ store }: { store: SceneStore }) {
             />
           ))}
         </div>
+      </section>
+
+      <section className="view-section" aria-label="Branches">
+        <p className="view-section-title">BRANCHES</p>
+        {/* ADR-002 Workstream 1 ("Branch status and lifecycle"): dims every
+            node outside the accepted paths (rejected/superseded branches
+            and their descendants, unless an explicit "accepted" override
+            reactivates a sub-branch) - the whole-graph counterpart to a
+            single chat node's own "Hide Other Branches" menu action. Same
+            view-check-row pattern as every other toggle in this section,
+            but backed by sceneStore's own local focusAcceptedPaths field
+            rather than `scene` - see that field's own comment. */}
+        <label className="view-check-row">
+          <input
+            type="checkbox"
+            checked={focusAcceptedPaths}
+            onChange={(e) => store.setFocusAcceptedPaths(e.target.checked)}
+          />
+          Focus Accepted Paths
+        </label>
       </section>
     </Popover>
   );

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -761,6 +761,29 @@ body,
   max-width: 140px;
 }
 
+/* ADR-002 Workstream 1 ("Branch status and lifecycle"): a small filled dot,
+   ALWAYS rendered (unlike every other badge above, which is conditional) -
+   backgroundColor is set inline per-node (one of 4 real, visually-distinct
+   colors reused from GroupColorPicker.tsx's own palette - see
+   BRANCH_STATUS_COLORS in ChatNodeView.tsx), so no color rule lives here. */
+.chat-node-status-badge {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ADR-002 Workstream 1 ("Branch status and lifecycle"): the Final
+   Deliverable glyph - same "single glyph, no pill" shape as
+   .chat-node-synthesis-badge above, at most one node in the whole scene
+   ever shows this. */
+.chat-node-final-badge {
+  font-size: 12px;
+  line-height: 1;
+  color: var(--gl-surface-text-muted);
+}
+
 /* -- R3.17/R3.18 html view node -------------------------------------------- */
 
 .html-node {


### PR DESCRIPTION
## Problem

GraphLink's Workstream 1 (branch creation and convergence) shipped fork (#197), Compare Branches (#198), and Synthesize Branches (#199), but a graph still has no way to mark which branches are worth keeping, which are dead ends, or which single result is the actual deliverable — every branch stays visually and semantically identical regardless of outcome.

## Change

Adds the fourth and final sequenced item: **branch status and lifecycle**.

- Chat nodes can be marked **Active / Accepted / Rejected / Superseded** via a new "Mark Status" context-menu submenu and an always-visible colored status-dot badge. Per-node, no write-time cascade to ancestors or descendants — this data model has no materialized "branch" object to cascade through.
- A new document-level **Final Deliverable** pointer (not a per-node flag — mirrors the existing `last_chat_node_id` singular-pointer shape) marks the one accepted output, shown as a ★ badge; marking a new node silently supersedes the old one.
- **Collapse Branch / Expand Branch** collapses a whole chat-kind subtree (reusing the existing `is_collapsed` field) via a new downward BFS helper — the first downward/forward graph walk in `backend/canvas.py` (every prior walk was upward or one-hop only).
- A new **"Focus Accepted Paths"** checkbox in the View popover dims everything outside the accepted paths, architecturally parallel to the existing "Hide Other Branches" dimming but keyed off the persisted status across the whole graph instead of one clicked node; an explicit "accepted" override reactivates a sub-branch beneath a rejected ancestor without re-marking every intermediate node.

### Confirmed pre-existing bug, fixed inline

This stage's design recon surfaced a real, confirmed bug unrelated to its own new code: Compare Branches' (`is_branch_comparison`/`item_ids`) and Synthesize Branches' (`provider`/`model`/`is_branch_synthesis`/`synthesis_instructions`/`item_ids`) own provenance fields synced live to the frontend correctly but were **silently dropped on disk save/reload** — `session_save.py`/`session_load.py` never touched them. Fixed in this same pass (already editing the exact same functions for the new `branch_status`/`final_deliverable_node_id` fields): both already-shipped features' data now round-trips correctly, including a new `_restore_branch_provenance_item_ids` pass that translates a synthesis/comparison node's source-id references through the same old-id→new-id map the existing connection-restoration code already uses.

### Adversarial review

This stage used a two-phase review process, both via multi-agent workflows given the size of the change:

**Design-phase recon** (before implementation): parallel agents researched save/load persistence mechanics, existing collapse/dimming precedent ("Hide Other Branches"), and how "a branch" is structurally defined in this codebase, synthesized into one concrete implementation plan — this is what surfaced the persistence bug above.

**Commit-time review** (before commit): four parallel dimension reviews (backend model/validation, persistence round-trip, frontend state/UI, the new dimming algorithm), each independently verified by a second, skeptical pass that re-read the actual code rather than trusting the report. Found and fixed:

- `delete_chat_node` re-pointed `last_chat_node_id` when the deleted node held it, but had no equivalent for the new `final_deliverable_node_id` — deleting the Final Deliverable node left the document pointing at a dead id. **Fixed:** the pointer is now cleared (not re-pointed to the parent, which was never itself marked).
- The save/load fix's `final_deliverable_node_id` restoration resolved a reference through the id-translation map but never validated the resolved node's kind, unlike the live setter, which rejects non-chat nodes. **Fixed:** the restore path now requires `kind == "chat"` too.
- The new "Focus Accepted Paths" exclusion walk followed every edge into a node, not just the one its own tie-break rule recognizes as canonical — a chat node with one healthy parent could be wrongly dimmed if it also received a second, unrelated edge from a rejected node elsewhere in the graph (structurally possible since `SceneEdge` has no multi-parent validation). **Fixed:** the walk now only descends along the canonical edge, consistent with how the rest of the function already resolves ties.
- That function's own doc comment overclaimed how the "accepted" override works (claimed a second BFS pass that doesn't exist). **Fixed** the comment to match the actual (already-correct) behavior — the imprecision is what concealed the finding above during design.
- **Not fixed, documented instead:** `SceneEdge` has no "kind" tag anywhere in this codebase, so a manually-dragged connection between two unrelated branches is structurally indistinguishable from a real branch-parent edge to *any* branch-tree-reading code in this file, not just this stage's new code. This is a pre-existing, shared architectural gap (would need an edge-kind-tagging system touching every existing edge-walking feature) — explicitly deferred, not a regression this stage introduces.

## Test plan

- [x] Backend: `python -m pytest -q` — 1161 passed (full suite, unnarrowed, run from repo root on the fresh branch)
- [x] Frontend: `npx tsc --noEmit`, `npx vitest run` (970 passed), `npx eslint .` (0 errors, pre-existing warnings only), `npx vite build` — all clean on the fresh branch
- [x] New backend tests: status/Final Deliverable/collapse-branch validation and dispatch, the subtree-BFS helper, `delete_chat_node`'s new cleanup, the persistence round-trip for both the new fields *and* the retrofitted Compare/Synthesize fields (including id-translation and the non-chat-kind rejection)
- [x] New frontend tests: menu items and badges, `sceneStore`'s new local `focusAcceptedPaths` field, the View popover checkbox, and `computeNonAcceptedNodeIds`'s exclusion/override/multi-parent-safety logic (including a regression test for the adversarial-review fix)
- [x] `python contracts/codegen.py --check` — up to date (new fields intentionally follow the same established stale-contract workaround as prior Workstream 1 stages)