### PR TITLE
Redesign Document View, stage 1: content rendering upgrades

### DIFF
--- a/web_ui/eslint.config.js
+++ b/web_ui/eslint.config.js
@@ -21,6 +21,18 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      // Document View redesign (stage 1): react-markdown's component
+      // overrides always receive a `node` prop (its own hast node) that
+      // must never be spread onto the real DOM element it's rendering -
+      // the standard, widely-adopted convention for "destructured but
+      // deliberately discarded" is a leading underscore, which this
+      // codebase had no prior need for (nothing previously discarded a
+      // destructured prop this way) and @typescript-eslint's recommended
+      // preset does not ignore by default.
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", destructuredArrayIgnorePattern: "^_" },
+      ],
     },
   },
   {

--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -13,8 +13,13 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
+        "react-medium-image-zoom": "^5.4.8",
+        "rehype-autolink-headings": "^7.1.0",
+        "rehype-external-links": "^3.0.0",
         "rehype-highlight": "^7.0.2",
-        "remark-gfm": "^4.0.1"
+        "rehype-slug": "^6.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-github-blockquote-alert": "^2.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -3596,6 +3601,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3628,6 +3639,19 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
@@ -3663,6 +3687,19 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3788,6 +3825,18 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -5579,6 +5628,22 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-medium-image-zoom": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/react-medium-image-zoom/-/react-medium-image-zoom-5.4.8.tgz",
+      "integrity": "sha512-72CIldEUaPejjcaDOYIeDsGlWzNKpmxyKgiPi1LBCkWCIGHDLlA2KTeo2uNtmN/m72Y3k/2uWDfon9SDiPbHaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/rpearce"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -5603,6 +5668,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/rehype-autolink-headings": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-highlight": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
@@ -5614,6 +5715,23 @@
         "lowlight": "^3.0.0",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5636,6 +5754,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-github-blockquote-alert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/remark-github-blockquote-alert/-/remark-github-blockquote-alert-2.1.0.tgz",
+      "integrity": "sha512-J392jmIP684d7iGsENN0uguL10IGbRdc8bTUSrd/jOLzdWkwg721Fj3JPQGN8tF6fTIrE5HHOIA3nBuwuaeuPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/remark-parse": {

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -22,8 +22,13 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
+    "react-medium-image-zoom": "^5.4.8",
+    "rehype-autolink-headings": "^7.1.0",
+    "rehype-external-links": "^3.0.0",
     "rehype-highlight": "^7.0.2",
-    "remark-gfm": "^4.0.1"
+    "rehype-slug": "^6.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-github-blockquote-alert": "^2.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -121,8 +121,8 @@ describe("ChatNodeView", () => {
     const hideBranches = screen.getByRole("menuitem", { name: "Hide Other Branches" });
     expect(hideBranches).not.toBeDisabled();
     expect(hideBranches).not.toHaveAttribute("title");
-    // R8a: these three were disabled stubs until their agents/dialog were
-    // wired up (Open Document View: the shared DocumentViewDialog; Key
+    // R8a: these three were disabled stubs until their agents/panel were
+    // wired up (Open Document View: the shared DocumentViewPanel; Key
     // Takeaway/Explainer Note: ported back from the deleted Qt app). This
     // assertion is deliberately inverted rather than removed - it was the
     // guard that encoded the stub as correct, so it has to now encode the

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -44,7 +44,7 @@ import { NodeMenu } from "./NodeMenu";
  * Chart already use. Both now dispatch real intents that drop the agent's
  * output into a new note beside this node (graphlink_note_agent.py).
  * "Open Document View" is likewise no longer deferred as of this change: it
- * now opens DocumentViewDialog.tsx with this node's own content
+ * now opens DocumentViewPanel.tsx with this node's own content
  * (frontend-only, no backend intent - the content is already client-side).
  * "Export" is
  * likewise no longer deferred as of R7.5a: it downloads the node's raw
@@ -370,7 +370,7 @@ function ChatNodeMenu({
           ))}
         </>
       )}
-      {/* R8a: real. Opens the shared DocumentViewDialog (frontend-only, no
+      {/* R8a: real. Opens the shared DocumentViewPanel (frontend-only, no
           backend intent) with this node's own content - already client-side. */}
       <button
         type="button"

--- a/web_ui/src/app/canvas/ConversationNodeView.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.tsx
@@ -29,9 +29,9 @@ import { NodeMenu } from "./NodeMenu";
  * reply of its own), and Send is additionally disabled while that same
  * field is set, so a second send can't be issued mid-flight for this node.
  * (R8a) Open Document View is real too: it opens the shared
- * DocumentViewDialog (frontend-only, no backend intent) with this node's
+ * DocumentViewPanel (frontend-only, no backend intent) with this node's
  * entire history formatted as a numbered markdown transcript - see
- * DocumentViewDialog.tsx / SceneCanvas.tsx's toFlowNodes for the transcript
+ * DocumentViewPanel.tsx / SceneCanvas.tsx's toFlowNodes for the transcript
  * formatter.
  *
  * Card menu deliberately does NOT include "Hide Other Branches" or "Include
@@ -91,7 +91,7 @@ function ConversationNodeMenu({
       {/* Order verified against the legacy PluginNodeContextMenu's own
           construction order for this node kind: Open Document View,
           Collapse/Expand, Delete Node - nothing else. */}
-      {/* R8a: real. Opens the shared DocumentViewDialog (frontend-only, no
+      {/* R8a: real. Opens the shared DocumentViewPanel (frontend-only, no
           backend intent) with this node's entire history formatted as a
           numbered markdown transcript. */}
       <button

--- a/web_ui/src/app/canvas/DocumentViewMarkdown.test.tsx
+++ b/web_ui/src/app/canvas/DocumentViewMarkdown.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { DocumentViewMarkdown } from "./DocumentViewMarkdown";
+
+// Document View full redesign, stage 1 ("content rendering upgrades"):
+// heading anchors (rehype-slug + rehype-autolink-headings), safe external
+// links (rehype-external-links), a code-block copy button + language
+// badge, a wide-table scroll wrapper, image zoom, and GitHub-style
+// callouts. See DocumentViewMarkdown.tsx's own doc comment for the full
+// plugin-pipeline rationale.
+
+describe("DocumentViewMarkdown", () => {
+  it("renders plain markdown content", () => {
+    render(<DocumentViewMarkdown content={"# Heading\n\nA paragraph."} />);
+    expect(screen.getByRole("heading", { name: "Heading" })).toBeInTheDocument();
+  });
+
+  describe("heading anchors", () => {
+    it("assigns a stable slug id to headings", () => {
+      render(<DocumentViewMarkdown content="## My Section" />);
+      const heading = screen.getByRole("heading", { name: /My Section/ });
+      expect(heading).toHaveAttribute("id", "my-section");
+    });
+
+    it("appends a hover-revealed anchor link pointing at the heading's own id", () => {
+      render(<DocumentViewMarkdown content="## My Section" />);
+      const heading = screen.getByRole("heading", { name: /My Section/ });
+      const anchor = heading.querySelector(".document-view-heading-anchor");
+      expect(anchor).not.toBeNull();
+      expect(anchor).toHaveAttribute("href", "#my-section");
+      // Decorative - must never intercept keyboard/screen-reader navigation
+      // away from the heading's own real text.
+      expect(anchor).toHaveAttribute("aria-hidden", "true");
+      expect(anchor).toHaveAttribute("tabindex", "-1");
+    });
+  });
+
+  describe("external link hardening", () => {
+    it("adds target=_blank and a safe rel to an absolute http(s) link", () => {
+      render(<DocumentViewMarkdown content="[external](https://example.com/page)" />);
+      const link = screen.getByRole("link", { name: "external" });
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link?.getAttribute("rel")).toContain("noopener");
+      expect(link?.getAttribute("rel")).toContain("noreferrer");
+      expect(link?.getAttribute("rel")).toContain("nofollow");
+    });
+
+    it("does NOT touch a same-document fragment link (must not open a new tab for in-page navigation)", () => {
+      render(<DocumentViewMarkdown content="## My Section\n\n[jump](#my-section)" />);
+      const link = screen.getByRole("link", { name: "jump" });
+      expect(link).not.toHaveAttribute("target");
+      expect(link).not.toHaveAttribute("rel");
+    });
+  });
+
+  describe("code blocks", () => {
+    function mockClipboard(): ReturnType<typeof vi.fn> {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        configurable: true,
+        writable: true,
+      });
+      return writeText;
+    }
+
+    it("renders a language badge for a fenced code block", () => {
+      render(<DocumentViewMarkdown content={"```typescript\nconst x = 1;\n```"} />);
+      expect(screen.getByText("typescript")).toBeInTheDocument();
+    });
+
+    it("falls back to a plain 'text' badge when no language is given", () => {
+      render(<DocumentViewMarkdown content={"```\nplain block\n```"} />);
+      expect(screen.getByText("text")).toBeInTheDocument();
+    });
+
+    it("copies the code block's raw text (not the syntax-highlighting markup) and flashes 'Copied'", async () => {
+      const user = userEvent.setup();
+      const writeText = mockClipboard();
+      render(<DocumentViewMarkdown content={"```python\nprint('hi')\n```"} />);
+
+      await user.click(screen.getByRole("button", { name: "Copy code" }));
+
+      // A fenced code block's own textContent legitimately ends with a
+      // trailing newline (the line before the closing ``` fence) -
+      // preserving it exactly (not trimming) is the correct copy-paste
+      // behavior, matching what selecting the block's own text would give.
+      expect(writeText).toHaveBeenCalledWith("print('hi')\n");
+      expect(await screen.findByText("Copied")).toBeInTheDocument();
+    });
+  });
+
+  describe("tables", () => {
+    it("wraps a table in a horizontally-scrollable container", () => {
+      const table = "| A | B |\n| - | - |\n| 1 | 2 |";
+      const { container } = render(<DocumentViewMarkdown content={table} />);
+      const wrapper = container.querySelector(".document-view-table-wrapper");
+      expect(wrapper).not.toBeNull();
+      expect(wrapper?.querySelector("table")).not.toBeNull();
+    });
+  });
+
+  describe("images", () => {
+    it("wraps an image in the zoom component, preserving its src/alt", () => {
+      const { container } = render(<DocumentViewMarkdown content="![a diagram](https://example.com/diagram.png)" />);
+      expect(container.querySelector("[data-rmiz]")).not.toBeNull();
+      const img = screen.getByAltText("a diagram") as HTMLImageElement;
+      expect(img.src).toBe("https://example.com/diagram.png");
+    });
+  });
+
+  describe("GitHub-style callouts", () => {
+    it("renders a > [!NOTE] blockquote as a styled alert with the NOTE title", () => {
+      const { container } = render(
+        <DocumentViewMarkdown content={"> [!NOTE]\n> Useful information."} />,
+      );
+      const alert = container.querySelector(".markdown-alert-note");
+      expect(alert).not.toBeNull();
+      expect(alert).toHaveTextContent("NOTE");
+      expect(alert).toHaveTextContent("Useful information.");
+    });
+
+    it("renders each of the 5 alert types with its own distinct class", () => {
+      const content = [
+        "> [!NOTE]\n> a",
+        "> [!TIP]\n> b",
+        "> [!IMPORTANT]\n> c",
+        "> [!WARNING]\n> d",
+        "> [!CAUTION]\n> e",
+      ].join("\n\n");
+      const { container } = render(<DocumentViewMarkdown content={content} />);
+      for (const type of ["note", "tip", "important", "warning", "caution"]) {
+        expect(container.querySelector(`.markdown-alert-${type}`)).not.toBeNull();
+      }
+    });
+
+    it("leaves an ordinary blockquote (no [!TYPE] marker) unstyled as a plain blockquote", () => {
+      const { container } = render(<DocumentViewMarkdown content="> just a quote, not an alert" />);
+      expect(container.querySelector(".markdown-alert")).toBeNull();
+      expect(container.querySelector("blockquote")).not.toBeNull();
+    });
+  });
+});

--- a/web_ui/src/app/canvas/DocumentViewMarkdown.tsx
+++ b/web_ui/src/app/canvas/DocumentViewMarkdown.tsx
@@ -1,0 +1,153 @@
+import { useRef, useState, type JSX } from "react";
+import ReactMarkdown, { type ExtraProps } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { remarkAlert } from "remark-github-blockquote-alert";
+import rehypeHighlight from "rehype-highlight";
+import rehypeSlug from "rehype-slug";
+import rehypeAutolinkHeadings from "rehype-autolink-headings";
+import rehypeExternalLinks from "rehype-external-links";
+import Zoom from "react-medium-image-zoom";
+import "react-medium-image-zoom/dist/styles.css";
+
+/**
+ * Document View's enhanced markdown renderer (full redesign, stage 1 of 4 -
+ * "content rendering upgrades"). Extracted out of DocumentViewPanel.tsx into
+ * its own file/component so the render pipeline (plugins + component
+ * overrides) is independently readable and testable, rather than an inline
+ * `<ReactMarkdown>` call buried in the panel's own JSX.
+ *
+ * Deliberately scoped to Document View only - NOT a shared "MarkdownRenderer"
+ * swapped into ChatNodeView/NoteNodeView/etc, which each keep their own,
+ * simpler `<ReactMarkdown remarkPlugins={[remarkGfm]}
+ * rehypePlugins={[rehypeHighlight]}>` untouched. The user's own request was
+ * about "the document viewer" specifically; broadening this to every
+ * markdown surface in the app would be a much larger, different-shaped
+ * change than what was asked for.
+ *
+ * Plugin pipeline, in order (order matters for the first two - autolink
+ * needs the ids rehype-slug just assigned):
+ * 1. rehype-slug: gives every heading a stable `id` (needed by Stage 2's
+ *    table of contents to scroll/highlight by anchor, and usable right now
+ *    as a plain URL fragment).
+ * 2. rehype-autolink-headings: appends a hover-revealed "#" link after each
+ *    heading's own text (the GitHub/Docusaurus/Mintlify convention) -
+ *    `ariaHidden`/`tabIndex: -1` kept explicit (this plugin's own default for
+ *    "append", but overriding `properties` at all replaces that default, so
+ *    it must be restated here) so it never distracts screen-reader/keyboard
+ *    navigation from the real heading text.
+ * 3. rehype-highlight: unchanged from the existing chat/note markdown setup
+ *    - still the source of the `hljs`/`language-xxx` classes the CodeBlock
+ *    override below reads to show a language badge.
+ * 4. rehype-external-links: adds `rel`/`target` only to absolute http(s)
+ *    links (verified directly against its own source - it explicitly skips
+ *    relative paths and `#fragment` links, so the anchor links step 2 just
+ *    added are never touched by this step). `target: "_blank"` is
+ *    deliberate here specifically (most rehype-external-links guidance
+ *    recommends AGAINST setting a target) because this app runs inside a
+ *    native pywebview shell, not a normal browser tab - letting an external
+ *    link navigate the app's own window away from GraphLink would be worse
+ *    than opening a new one.
+ *
+ * remark-github-blockquote-alert adds GitHub's `> [!NOTE]`/`[!TIP]`/
+ * `[!IMPORTANT]`/`[!WARNING]`/`[!CAUTION]` blockquote-alert syntax, styled
+ * via this app's own gl-semantic-status and gl-surface CSS custom
+ * properties in styles.css rather than importing the package's own
+ * alert.css (which hard-codes GitHub's own light/dark color variables, not
+ * this app's theme system).
+ */
+
+function CodeBlock({ node: _node, children, ...props }: JSX.IntrinsicElements["pre"] & ExtraProps) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  // Fenced code blocks are always `pre > code` (one child) - the language
+  // lives on that inner <code> element's own className (rehype-highlight's
+  // "hljs language-xxx" shape), not on this <pre>'s.
+  const codeChild = Array.isArray(children) ? children[0] : children;
+  const codeClassName =
+    codeChild !== null && typeof codeChild === "object" && "props" in codeChild
+      ? ((codeChild.props as { className?: string }).className ?? "")
+      : "";
+  const languageMatch = /language-(\w+)/.exec(codeClassName);
+  const language = languageMatch ? languageMatch[1] : "";
+
+  function onCopy() {
+    // Reading .textContent off the rendered DOM node (rather than trying to
+    // reconstruct the source string by walking React children) sidesteps
+    // rehype-highlight's own deeply-nested syntax-highlighting <span>s -
+    // .textContent flattens through any depth of those for free.
+    const text = preRef.current?.textContent ?? "";
+    if (!text) return;
+    navigator.clipboard?.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <div className="document-view-code-block">
+      <div className="document-view-code-block-header">
+        <span className="document-view-code-block-language">{language || "text"}</span>
+        <button
+          type="button"
+          className="document-view-code-block-copy"
+          onClick={onCopy}
+          title="Copy code"
+          aria-label="Copy code"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre {...props} ref={preRef}>
+        {children}
+      </pre>
+    </div>
+  );
+}
+
+function TableWrapper({ node: _node, ...props }: JSX.IntrinsicElements["table"] & ExtraProps) {
+  // remark-gfm parses pipe tables but neither remark nor rehype ships a
+  // plugin that also contains the resulting <table> in a scrollable
+  // wrapper - a well-documented gap in the ecosystem, not an oversight here.
+  return (
+    <div className="document-view-table-wrapper">
+      <table {...props} />
+    </div>
+  );
+}
+
+function ZoomImage({ node: _node, ...props }: JSX.IntrinsicElements["img"] & ExtraProps) {
+  // wrapElement="span": an <img> can legally appear INLINE inside a
+  // <p> (e.g. "see this diagram: ![...](...)"), and Zoom's own default
+  // wrapper is a <div> - a block element nested inside a <p> is invalid
+  // HTML and would trigger React's own DOM-nesting warning.
+  return (
+    <Zoom wrapElement="span">
+      <img {...props} />
+    </Zoom>
+  );
+}
+
+export function DocumentViewMarkdown({ content }: { content: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkAlert]}
+      rehypePlugins={[
+        rehypeSlug,
+        [
+          rehypeAutolinkHeadings,
+          {
+            behavior: "append",
+            properties: { className: ["document-view-heading-anchor"], ariaHidden: true, tabIndex: -1 },
+            content: { type: "text", value: "#" },
+          },
+        ],
+        rehypeHighlight,
+        [rehypeExternalLinks, { target: "_blank", rel: ["nofollow", "noopener", "noreferrer"] }],
+      ]}
+      components={{ pre: CodeBlock, table: TableWrapper, img: ZoomImage }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/web_ui/src/app/canvas/DocumentViewPanel.tsx
+++ b/web_ui/src/app/canvas/DocumentViewPanel.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
+import { DocumentViewMarkdown } from "./DocumentViewMarkdown";
 
 const DEFAULT_WIDTH = 500;
 const MIN_WIDTH = 320;
@@ -31,7 +29,18 @@ const MAX_WIDTH = 900;
  *
  * Closing it only ever happens via its own Close button, matching legacy
  * exactly - it was never part of Qt's OverlayManager, so no scrim, no
- * Escape-to-close, no focus trap here either.
+ * Escape-to-close, no focus trap here either. (Full redesign, stage 4 of 4,
+ * revisits the Escape-to-close piece specifically - see that stage's own
+ * notes for why it's being added without adopting the rest of the modal
+ * treatment.)
+ *
+ * Full redesign, stage 1 of 4 ("content rendering upgrades"): the markdown
+ * body itself is now rendered by DocumentViewMarkdown.tsx (heading anchors,
+ * a code-block copy button + language badge, wide-table scroll wrapper,
+ * image zoom, GitHub-style callouts) rather than a bare
+ * `<ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>`
+ * - see that component's own doc comment for the full plugin-pipeline
+ * rationale.
  */
 export function DocumentViewPanel({
   isOpen,
@@ -131,9 +140,7 @@ export function DocumentViewPanel({
           </button>
         </header>
         <div className="document-view-panel-scroll chat-node-content">
-          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-            {content ?? ""}
-          </ReactMarkdown>
+          <DocumentViewMarkdown content={content ?? ""} />
         </div>
       </div>
       <div

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2450,6 +2450,154 @@ body,
   opacity: 0.5;
 }
 
+/* Document View full redesign, stage 1 ("content rendering upgrades") -
+   DocumentViewMarkdown.tsx's own component overrides/plugin output. Scoped
+   here rather than folded into .chat-node-content's shared markdown-body
+   rules (styles.css:349+) since only Document View uses these classes
+   today - see that component's own doc comment for why this isn't a
+   shared, app-wide markdown-renderer change. */
+
+.document-view-heading-anchor {
+  margin-left: 6px;
+  text-decoration: none;
+  color: var(--gl-surface-text-muted);
+  font-weight: 400;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+h1:hover > .document-view-heading-anchor,
+h2:hover > .document-view-heading-anchor,
+h3:hover > .document-view-heading-anchor,
+h4:hover > .document-view-heading-anchor,
+h5:hover > .document-view-heading-anchor,
+h6:hover > .document-view-heading-anchor {
+  opacity: 1;
+}
+
+.document-view-code-block {
+  margin: 8px 0;
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.document-view-code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border-bottom: 1px solid var(--gl-surface-border);
+  font-size: 11px;
+}
+
+.document-view-code-block-language {
+  color: var(--gl-surface-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.document-view-code-block-copy {
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.document-view-code-block-copy:hover {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+/* The header bar above already provides the block chrome (border/corners) -
+   the inner <pre> (rendered by .chat-node-content's own shared rule at
+   styles.css:349+) must not double it up. */
+.document-view-code-block pre {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+}
+
+.document-view-table-wrapper {
+  overflow-x: auto;
+  margin: 8px 0;
+}
+
+/* GitHub-style callouts (remark-github-blockquote-alert's own output shape:
+   a <div class="markdown-alert markdown-alert-{type}"> wrapping a
+   <p class="markdown-alert-title"> + the rest of the blockquote content) -
+   styled with this app's own tokens rather than importing the package's
+   own alert.css, which hard-codes GitHub's own color variables, not this
+   app's theme system. Only 4 semantic-status tokens exist
+   (error/info/success/warning) for GitHub's 5 alert types - "important"
+   reuses --gl-palette-selection (an accent color, not a status color, but
+   visually distinct from the other 4) rather than inventing a new token
+   for one alert type. */
+.markdown-alert {
+  margin: 8px 0;
+  padding: 8px 12px;
+  border-left: 3px solid var(--gl-surface-border);
+  border-radius: 4px;
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+}
+
+.markdown-alert > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-alert-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.markdown-alert-title .octicon {
+  fill: currentColor;
+  flex-shrink: 0;
+}
+
+.markdown-alert-note {
+  border-left-color: var(--gl-semantic-status-info);
+}
+.markdown-alert-note .markdown-alert-title {
+  color: var(--gl-semantic-status-info);
+}
+
+.markdown-alert-tip {
+  border-left-color: var(--gl-semantic-status-success);
+}
+.markdown-alert-tip .markdown-alert-title {
+  color: var(--gl-semantic-status-success);
+}
+
+.markdown-alert-important {
+  border-left-color: var(--gl-palette-selection);
+}
+.markdown-alert-important .markdown-alert-title {
+  color: var(--gl-palette-selection);
+}
+
+.markdown-alert-warning {
+  border-left-color: var(--gl-semantic-status-warning);
+}
+.markdown-alert-warning .markdown-alert-title {
+  color: var(--gl-semantic-status-warning);
+}
+
+.markdown-alert-caution {
+  border-left-color: var(--gl-semantic-status-error);
+}
+.markdown-alert-caution .markdown-alert-title {
+  color: var(--gl-semantic-status-error);
+}
+
 .help-rail {
   width: 220px;
   flex-shrink: 0;


### PR DESCRIPTION
## Problem

Document View (the side panel that shows a chat node's message or a conversation node's full transcript) rendered plain markdown with no heading anchors, no safe-link handling, no code-block affordances, no wide-table handling, and no image zoom - a genuinely minimal implementation. Requested: a full redesign, researched against how well-regarded products (Notion, Docusaurus/Mintlify/GitBook docs sites, VS Code's markdown preview, GitHub's own markdown rendering) handle this.

## Change

Stage 1 of a 4-stage redesign (content rendering → table of contents/reading progress → in-document search → drawer UX polish). This stage upgrades the markdown body itself:

- **Heading anchors** (`rehype-slug` + `rehype-autolink-headings`): every heading gets a stable `id` and a hover-revealed `#` link - lays the groundwork for stage 2's table of contents.
- **Safe external links** (`rehype-external-links`): absolute http(s) links get `target="_blank"` + `rel="nofollow noopener noreferrer"`. Real security value here, not just polish - this panel renders AI/web-research-sourced content that can contain arbitrary links, and `target="_blank"` matters specifically because this app runs inside a native pywebview shell, not a browser tab, so an untargeted link would navigate the app's own window away from itself.
- **Code blocks**: a language badge + copy-to-clipboard button (no existing remark/rehype plugin adds this UI - it's DOM interaction, not a tree transform).
- **Wide tables**: a horizontal-scroll wrapper (`remark-gfm` parses tables but doesn't contain overflow on its own - a known ecosystem gap).
- **Images**: click-to-zoom lightbox.
- **GitHub-style callouts** (`> [!NOTE]`/`[!TIP]`/`[!IMPORTANT]`/`[!WARNING]`/`[!CAUTION]`), styled with this app's own design tokens rather than the plugin's bundled CSS (which hard-codes GitHub's own color variables).

Extracted the rendering pipeline into a new `DocumentViewMarkdown.tsx`, scoped to Document View specifically - every other markdown surface in the app (chat nodes, notes, conversation bubbles) keeps its own simpler pipeline untouched; broadening this to a shared app-wide renderer would be a materially different, larger change than what was asked for.

Also fixed while in the area: a few comments in `ChatNodeView.tsx`/`ConversationNodeView.tsx` referred to this panel as "DocumentViewDialog" in prose (it's `DocumentViewPanel`, not a Dialog) - stale naming from before the component was renamed, fixed alongside since it's in the exact files this stage already touches.

### Adversarial review

An independent review pass (fresh context, not told my own conclusions) was briefed to actively try to break: reverse-tabnabbing/link-hardening safety (verified against `rehype-external-links`' own source, not its docs - confirmed it only ever matches absolute http/https URLs, never touching the same-page fragment anchors the heading-anchor feature just added), the `node`-prop-stripping pattern shared by all three new component overrides (a copy-paste slip in any one of the three would only surface as a silent console warning), the copy button's text-extraction correctness against `rehype-highlight`'s syntax-highlighting markup, and heading-anchor id-collision safety specifically for the conversation-transcript formatter's own many-heading output (one heading per turn).

It verified every claim directly against the installed packages' own source code rather than trusting documentation, and additionally checked that `react-markdown`'s own URL sanitization (`javascript:` protocol stripping) still applies independently of the new overrides, and that every other markdown-rendering call site in the app is genuinely untouched. No issues found.

## Test plan

- [x] Backend: `python -m pytest -q` — 1161 passed (unaffected by this frontend-only change; run in full from repo root on the fresh branch as a regression check)
- [x] Frontend: `npx tsc --noEmit`, `npx vitest run` (984 passed), `npx eslint .` (0 errors, pre-existing warnings only), `npx vite build` — all clean on the fresh branch
- [x] New tests (`DocumentViewMarkdown.test.tsx`, 13 tests): heading slug ids + anchor links (including the correct `aria-hidden`/`tabindex` decorative-link treatment), external link hardening vs. same-page fragment links left untouched, code-block language badge + exact-text copy behavior, wide-table scroll wrapper, image zoom wrapper, all 5 callout types plus a plain-blockquote-is-unaffected regression check
- [x] `python contracts/codegen.py --check` — up to date (no backend/wire-contract changes in this stage)