### PR TITLE
Redesign Document View, stage 2: table of contents + reading progress

### DIFF
--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@xyflow/react": "^12.11.2",
+        "github-slugger": "^2.0.0",
         "html-to-image": "^1.11.13",
+        "mdast-util-to-string": "^4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -19,7 +21,10 @@
         "rehype-highlight": "^7.0.2",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
-        "remark-github-blockquote-alert": "^2.1.0"
+        "remark-github-blockquote-alert": "^2.1.0",
+        "remark-parse": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -18,7 +18,9 @@
   },
   "dependencies": {
     "@xyflow/react": "^12.11.2",
+    "github-slugger": "^2.0.0",
     "html-to-image": "^1.11.13",
+    "mdast-util-to-string": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
@@ -28,7 +30,10 @@
     "rehype-highlight": "^7.0.2",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
-    "remark-github-blockquote-alert": "^2.1.0"
+    "remark-github-blockquote-alert": "^2.1.0",
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/web_ui/src/app/canvas/DocumentViewPanel.test.tsx
+++ b/web_ui/src/app/canvas/DocumentViewPanel.test.tsx
@@ -144,4 +144,58 @@ describe("DocumentViewPanel", () => {
       expect(await screen.findByText("Copied")).toBeInTheDocument();
     });
   });
+
+  // Document View full redesign, stage 2 ("table of contents + reading
+  // progress"). The outline toggle's own detailed behavior (opening,
+  // active-section highlighting, scroll-to-heading) is covered in
+  // DocumentViewToc.test.tsx - these tests only cover DocumentViewPanel's
+  // own wiring: whether the toggle shows up at all for a given content
+  // shape, the reading-progress bar's scroll-driven width, and the
+  // reset-on-new-content behavior.
+  describe("table of contents + reading progress (stage 2)", () => {
+    it("shows the Outline toggle when the content has 2+ headings", () => {
+      renderPanel({ content: "# One\n\n## Two" });
+      expect(screen.getByRole("button", { name: "Outline" })).toBeInTheDocument();
+    });
+
+    it("shows no Outline toggle when the content has fewer than 2 headings", () => {
+      renderPanel({ content: "just a paragraph, no headings" });
+      expect(screen.queryByRole("button", { name: "Outline" })).toBeNull();
+    });
+
+    it("renders a reading-progress bar starting at 0", () => {
+      renderPanel({ content: "some content" });
+      const bar = screen.getByRole("progressbar", { name: "Reading progress" });
+      expect(bar).toHaveAttribute("aria-valuenow", "0");
+    });
+
+    it("updates the reading-progress bar as the content area scrolls", () => {
+      const { container } = renderPanel({ content: "some content" });
+      const scrollArea = container.querySelector(".document-view-panel-scroll") as HTMLDivElement;
+      Object.defineProperty(scrollArea, "scrollHeight", { value: 1000, configurable: true });
+      Object.defineProperty(scrollArea, "clientHeight", { value: 500, configurable: true });
+      scrollArea.scrollTop = 250;
+
+      fireEvent.scroll(scrollArea);
+
+      const bar = screen.getByRole("progressbar", { name: "Reading progress" });
+      // 250 / (1000 - 500) * 100 = 50
+      expect(bar).toHaveAttribute("aria-valuenow", "50");
+    });
+
+    it("resets scroll position and reading progress when content changes to a new document", () => {
+      const { container, rerender } = renderPanel({ content: "first document" });
+      const scrollArea = container.querySelector(".document-view-panel-scroll") as HTMLDivElement;
+      Object.defineProperty(scrollArea, "scrollHeight", { value: 1000, configurable: true });
+      Object.defineProperty(scrollArea, "clientHeight", { value: 500, configurable: true });
+      scrollArea.scrollTop = 400;
+      fireEvent.scroll(scrollArea);
+      expect(screen.getByRole("progressbar", { name: "Reading progress" })).toHaveAttribute("aria-valuenow", "80");
+
+      rerender(<DocumentViewPanel isOpen content="a completely different document" sourceLabel={null} onClose={vi.fn()} />);
+
+      expect(scrollArea.scrollTop).toBe(0);
+      expect(screen.getByRole("progressbar", { name: "Reading progress" })).toHaveAttribute("aria-valuenow", "0");
+    });
+  });
 });

--- a/web_ui/src/app/canvas/DocumentViewPanel.tsx
+++ b/web_ui/src/app/canvas/DocumentViewPanel.tsx
@@ -1,5 +1,7 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DocumentViewMarkdown } from "./DocumentViewMarkdown";
+import { DocumentViewToc } from "./DocumentViewToc";
+import { extractHeadings } from "./documentViewHeadings";
 
 const DEFAULT_WIDTH = 500;
 const MIN_WIDTH = 320;
@@ -41,6 +43,18 @@ const MAX_WIDTH = 900;
  * `<ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>`
  * - see that component's own doc comment for the full plugin-pipeline
  * rationale.
+ *
+ * Full redesign, stage 2 of 4 ("table of contents + reading progress"): a
+ * DocumentViewToc.tsx outline toggle in the header (self-hidden under 2
+ * headings - see its own doc comment) and a thin reading-progress bar
+ * (scroll percentage through `.document-view-panel-scroll`, computed here
+ * rather than in a separate component since it needs the exact same scroll
+ * container the ToC's own scroll-to-heading logic needs a ref to anyway).
+ * Both reset - scroll position back to the top, progress back to 0 - the
+ * moment `content` changes, so switching from a long document to a
+ * different (or shorter) one never starts the reader in the middle of the
+ * new content or shows a stale progress percentage before the next scroll
+ * event fires.
  */
 export function DocumentViewPanel({
   isOpen,
@@ -106,6 +120,43 @@ export function DocumentViewPanel({
     });
   }, [content]);
 
+  // Stage 2: table of contents + reading progress. Extracted from the raw
+  // markdown source (not queried from the rendered DOM) - see
+  // documentViewHeadings.ts's own doc comment for why this is both simpler
+  // and available before the very first paint.
+  const headings = useMemo(() => extractHeadings(content ?? ""), [content]);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [readingProgress, setReadingProgress] = useState(0);
+
+  const onScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
+    const el = event.currentTarget;
+    const scrollable = el.scrollHeight - el.clientHeight;
+    setReadingProgress(scrollable > 0 ? Math.min(100, Math.max(0, (el.scrollTop / scrollable) * 100)) : 0);
+  }, []);
+
+  // A new document (or the panel closing and a different one opening next)
+  // must never start the reader mid-scroll from whatever the PREVIOUS
+  // document left scrollTop at, and the progress bar must not show a stale
+  // percentage until the next real scroll event fires. Split across two
+  // mechanisms, each satisfying a different lint rule this project
+  // enforces: the `readingProgress` reset uses React's own recommended
+  // "adjust state when a prop changes" pattern - a plain conditional
+  // during render, not a useEffect, avoiding the extra
+  // render-then-effect-then-rerender cascade a `useEffect([content])`
+  // calling setState would cause (react-hooks/set-state-in-effect). The
+  // scrollTop reset can't join that same conditional - refs may never be
+  // read or written during render (react-hooks/refs) - so it stays in its
+  // own plain effect below, which itself calls no setState at all.
+  const [lastRenderedContent, setLastRenderedContent] = useState(content);
+  if (content !== lastRenderedContent) {
+    setLastRenderedContent(content);
+    setReadingProgress(0);
+  }
+
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = 0;
+  }, [content]);
+
   return (
     <aside
       className={[
@@ -125,6 +176,7 @@ export function DocumentViewPanel({
             <span className="document-view-panel-title">Document View</span>
             {sourceLabel && <span className="document-view-panel-subtitle">{sourceLabel}</span>}
           </div>
+          <DocumentViewToc headings={headings} scrollContainerRef={scrollRef} />
           <button
             type="button"
             className="document-view-panel-copy"
@@ -139,7 +191,17 @@ export function DocumentViewPanel({
             Close
           </button>
         </header>
-        <div className="document-view-panel-scroll chat-node-content">
+        <div
+          className="document-view-panel-progress"
+          role="progressbar"
+          aria-label="Reading progress"
+          aria-valuenow={Math.round(readingProgress)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div className="document-view-panel-progress-fill" style={{ width: `${readingProgress}%` }} />
+        </div>
+        <div className="document-view-panel-scroll chat-node-content" ref={scrollRef} onScroll={onScroll}>
           <DocumentViewMarkdown content={content ?? ""} />
         </div>
       </div>

--- a/web_ui/src/app/canvas/DocumentViewToc.test.tsx
+++ b/web_ui/src/app/canvas/DocumentViewToc.test.tsx
@@ -1,0 +1,177 @@
+import { createRef } from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DocumentViewToc } from "./DocumentViewToc";
+import type { DocumentHeading } from "./documentViewHeadings";
+
+// Document View full redesign, stage 2 ("table of contents + reading
+// progress"): the outline toggle + dropdown. jsdom implements neither
+// IntersectionObserver nor real layout (getBoundingClientRect always
+// returns all-zero rects) - both are hand-faked below, the standard
+// pattern for testing scrollspy/IntersectionObserver-driven components.
+
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+  callback: IntersectionObserverCallback;
+  observed: Element[] = [];
+  disconnected = false;
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    FakeIntersectionObserver.instances.push(this);
+  }
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+  unobserve() {}
+  disconnect() {
+    this.disconnected = true;
+  }
+  takeRecords() {
+    return [];
+  }
+}
+
+beforeEach(() => {
+  FakeIntersectionObserver.instances = [];
+  // @ts-expect-error - test double, not the real browser API
+  global.IntersectionObserver = FakeIntersectionObserver;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const HEADINGS: DocumentHeading[] = [
+  { depth: 1, text: "Title", id: "title" },
+  { depth: 2, text: "Section One", id: "section-one" },
+  { depth: 3, text: "Subsection", id: "subsection" },
+];
+
+function renderToc(headings: DocumentHeading[] = HEADINGS) {
+  const scrollContainerRef = createRef<HTMLDivElement>();
+  const utils = render(
+    <div>
+      <DocumentViewToc headings={headings} scrollContainerRef={scrollContainerRef} />
+      {/* Real target elements for scroll-to / IntersectionObserver wiring to find by id. */}
+      <div ref={scrollContainerRef}>
+        {headings.map((h) => (
+          <div key={h.id} id={h.id}>
+            {h.text}
+          </div>
+        ))}
+      </div>
+    </div>,
+  );
+  return { ...utils, scrollContainerRef };
+}
+
+describe("DocumentViewToc", () => {
+  it("renders nothing when there are fewer than 2 headings", () => {
+    const { container } = renderToc([{ depth: 1, text: "Only One", id: "only-one" }]);
+    expect(container.querySelector(".document-view-toc")).toBeNull();
+  });
+
+  it("renders the Outline toggle when there are 2 or more headings", () => {
+    renderToc();
+    expect(screen.getByRole("button", { name: "Outline" })).toBeInTheDocument();
+  });
+
+  it("opens the dropdown on click, listing every heading's text", async () => {
+    const user = userEvent.setup();
+    renderToc();
+    const toggle = screen.getByRole("button", { name: "Outline" });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("menu", { name: "Table of contents" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Title" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Section One" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Subsection" })).toBeInTheDocument();
+  });
+
+  it("clicking the toggle again closes the dropdown", async () => {
+    const user = userEvent.setup();
+    renderToc();
+    const toggle = screen.getByRole("button", { name: "Outline" });
+    await user.click(toggle);
+    await user.click(toggle);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("Escape closes the dropdown", async () => {
+    const user = userEvent.setup();
+    renderToc();
+    await user.click(screen.getByRole("button", { name: "Outline" }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("a click outside the dropdown closes it", async () => {
+    const user = userEvent.setup();
+    renderToc();
+    await user.click(screen.getByRole("button", { name: "Outline" }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("clicking a heading scrolls the container by the heading's own offset and closes the dropdown", async () => {
+    const user = userEvent.setup();
+    const { scrollContainerRef } = renderToc();
+    const container = scrollContainerRef.current as HTMLDivElement;
+    container.scrollTop = 50;
+    vi.spyOn(container, "getBoundingClientRect").mockReturnValue({ top: 100 } as DOMRect);
+    vi.spyOn(document.getElementById("subsection")!, "getBoundingClientRect").mockReturnValue({
+      top: 340,
+    } as DOMRect);
+
+    await user.click(screen.getByRole("button", { name: "Outline" }));
+    await user.click(screen.getByRole("menuitem", { name: "Subsection" }));
+
+    // 50 (starting scrollTop) + (340 - 100) = 290
+    expect(container.scrollTop).toBe(290);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("sets up an IntersectionObserver over every heading element once opened, and highlights the one it reports as active", async () => {
+    const user = userEvent.setup();
+    renderToc();
+    await user.click(screen.getByRole("button", { name: "Outline" }));
+
+    const observer = FakeIntersectionObserver.instances.at(-1)!;
+    expect(observer.observed.map((el) => el.id)).toEqual(["title", "section-one", "subsection"]);
+
+    const sectionOneEl = document.getElementById("section-one")!;
+    act(() => {
+      observer.callback(
+        [
+          {
+            target: sectionOneEl,
+            isIntersecting: true,
+            boundingClientRect: { top: 10 },
+          } as unknown as IntersectionObserverEntry,
+        ],
+        observer as unknown as IntersectionObserver,
+      );
+    });
+
+    expect(screen.getByRole("menuitem", { name: "Section One" }).className).toContain("active");
+    expect(screen.getByRole("menuitem", { name: "Title" }).className).not.toContain("active");
+  });
+
+  it("disconnects the observer when the dropdown closes", async () => {
+    const user = userEvent.setup();
+    renderToc();
+    await user.click(screen.getByRole("button", { name: "Outline" }));
+    const observer = FakeIntersectionObserver.instances.at(-1)!;
+
+    await user.click(screen.getByRole("button", { name: "Outline" }));
+    expect(observer.disconnected).toBe(true);
+  });
+});

--- a/web_ui/src/app/canvas/DocumentViewToc.tsx
+++ b/web_ui/src/app/canvas/DocumentViewToc.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+import type { DocumentHeading } from "./documentViewHeadings";
+
+/**
+ * Document View full redesign, stage 2 ("table of contents + reading
+ * progress") - the outline toggle + dropdown. A small, self-contained
+ * dropdown (own useState + outside-click/Escape handling), not the app's
+ * shared overlay registry (`overlays.tsx`'s Popover) and not NodeMenu -
+ * DocumentViewPanel.tsx's own doc comment already documents its deliberate
+ * choice not to use the overlay system, and NodeMenu's portal-based
+ * positioning exists specifically to escape React Flow's transformed
+ * coordinate space, which this panel (a plain flex sibling in App.tsx, not
+ * an RF node) was never inside in the first place.
+ *
+ * Auto-hidden entirely when there are fewer than 2 headings - the same
+ * threshold Notion's own floating table of contents uses (a single heading
+ * isn't worth an outline control at all).
+ */
+export function DocumentViewToc({
+  headings,
+  scrollContainerRef,
+}: {
+  headings: DocumentHeading[];
+  scrollContainerRef: RefObject<HTMLDivElement | null>;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const hasEnoughHeadings = headings.length >= 2;
+
+  // Active-section tracking, only while the dropdown is actually open - no
+  // point paying for continuous IntersectionObserver callbacks while the
+  // user can't even see the highlight. rootMargin shrinks the effective
+  // "visible" area to the TOP 30% of the scroll container, so the
+  // highlighted section tracks whatever the reader is currently AT (near
+  // the top), not merely whatever happens to be anywhere on screen - the
+  // same technique behind every "on this page" scrollspy implementation
+  // researched for this stage.
+  useEffect(() => {
+    if (!isOpen || !hasEnoughHeadings) return;
+    const root = scrollContainerRef.current;
+    if (!root) return;
+    const elements = headings
+      .map((h) => document.getElementById(h.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (elements.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((entry) => entry.isIntersecting);
+        if (visible.length === 0) return;
+        const topMost = visible.reduce((a, b) =>
+          a.boundingClientRect.top <= b.boundingClientRect.top ? a : b,
+        );
+        setActiveId(topMost.target.id);
+      },
+      { root, rootMargin: "0px 0px -70% 0px", threshold: 0 },
+    );
+    for (const el of elements) observer.observe(el);
+    return () => observer.disconnect();
+  }, [isOpen, hasEnoughHeadings, headings, scrollContainerRef]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function onPointerDown(event: PointerEvent) {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) setIsOpen(false);
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setIsOpen(false);
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [isOpen]);
+
+  function onSelectHeading(id: string) {
+    const container = scrollContainerRef.current;
+    const target = document.getElementById(id);
+    if (container && target) {
+      // Manual scrollTop math (not target.scrollIntoView()) keeps the
+      // scroll scoped to exactly this container - scrollIntoView can walk
+      // up to an OUTER scrollable ancestor in edge cases, which would be
+      // wrong here (this panel's own scroll area, not the whole page,
+      // should move).
+      const containerRect = container.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      container.scrollTop += targetRect.top - containerRect.top;
+    }
+    setIsOpen(false);
+  }
+
+  if (!hasEnoughHeadings) return null;
+
+  return (
+    <div className="document-view-toc" ref={rootRef}>
+      <button
+        type="button"
+        className="document-view-toc-toggle"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((open) => !open)}
+        title="Table of contents"
+      >
+        Outline
+      </button>
+      {isOpen && (
+        <div className="document-view-toc-dropdown" role="menu" aria-label="Table of contents">
+          {headings.map((heading) => (
+            <button
+              key={heading.id}
+              type="button"
+              role="menuitem"
+              className={
+                "document-view-toc-item" +
+                ` document-view-toc-depth-${Math.min(heading.depth, 3)}` +
+                (heading.id === activeId ? " active" : "")
+              }
+              onClick={() => onSelectHeading(heading.id)}
+            >
+              {heading.text}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/documentViewHeadings.test.ts
+++ b/web_ui/src/app/canvas/documentViewHeadings.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { extractHeadings } from "./documentViewHeadings";
+
+describe("extractHeadings", () => {
+  it("extracts depth, text, and a slug id for each heading", () => {
+    const headings = extractHeadings("# Title\n\n## Section One\n\n### Subsection");
+    expect(headings).toEqual([
+      { depth: 1, text: "Title", id: "title" },
+      { depth: 2, text: "Section One", id: "section-one" },
+      { depth: 3, text: "Subsection", id: "subsection" },
+    ]);
+  });
+
+  it("flattens inline formatting within a heading's own text", () => {
+    const headings = extractHeadings("## **Bold** and *italic* heading");
+    expect(headings).toEqual([{ depth: 2, text: "Bold and italic heading", id: "bold-and-italic-heading" }]);
+  });
+
+  it("de-duplicates identical heading text with a numeric suffix, matching github-slugger's own behavior", () => {
+    const headings = extractHeadings("## Summary\n\nfirst\n\n## Summary\n\nsecond");
+    expect(headings.map((h) => h.id)).toEqual(["summary", "summary-1"]);
+  });
+
+  it("ignores non-heading content (paragraphs, lists, code blocks)", () => {
+    const headings = extractHeadings("# Real Heading\n\nA paragraph.\n\n- item one\n- item two\n\n```js\n// not a heading\n```");
+    expect(headings).toEqual([{ depth: 1, text: "Real Heading", id: "real-heading" }]);
+  });
+
+  it("returns an empty array for content with no headings", () => {
+    expect(extractHeadings("Just a plain paragraph, nothing else.")).toEqual([]);
+  });
+
+  it("returns an empty array for empty content", () => {
+    expect(extractHeadings("")).toEqual([]);
+  });
+
+  it("matches the conversation-transcript formatter's own numbered heading shape without collisions", () => {
+    // Mirrors SceneCanvas.tsx's conversationHistoryToDocumentMarkdown output
+    // shape exactly (`### {index+1}. {role}`) - every heading is unique by
+    // construction (the leading number), so no de-dup suffix should ever
+    // appear here.
+    const transcript = "## Conversation Transcript\n\n### 1. User\n\nhi\n\n### 2. Assistant\n\nhello";
+    const headings = extractHeadings(transcript);
+    expect(headings.map((h) => h.id)).toEqual(["conversation-transcript", "1-user", "2-assistant"]);
+  });
+
+  it("omits a heading that is only an image, rather than fabricating a dead-link entry", () => {
+    // Caught by adversarial review: mdast-util-to-string special-cases
+    // `image` nodes and returns their alt text by default, but the actual
+    // rendered heading (flattened via hast-util-to-string inside
+    // rehype-slug) treats an <img> as a childless leaf and contributes
+    // nothing - so this heading renders with an empty id. Extracting
+    // "Alt Text" here would produce a ToC entry that scrolls to nothing;
+    // the existing `!text` guard now correctly drops it instead, since
+    // includeImageAlt:false makes its extracted text empty too.
+    expect(extractHeadings("## ![Alt Text](img.png)")).toEqual([]);
+  });
+
+  it("excludes image alt text from a heading's extracted text and id when mixed with real text", () => {
+    // Same bug as above, but with surrounding text so the heading isn't
+    // dropped entirely - the id must match what rehype-slug assigns the
+    // real rendered heading (whose <img> also contributes nothing).
+    const headings = extractHeadings("## Some ![alt text](img.png) Heading");
+    expect(headings).toEqual([{ depth: 2, text: "Some  Heading", id: "some--heading" }]);
+  });
+
+  it("strips GFM strikethrough syntax from the extracted text, matching the rendered heading", () => {
+    // Caught by adversarial review: without remark-gfm, the extraction
+    // parser doesn't understand `~~...~~` as strikethrough, so it would
+    // leak the literal tildes into the ToC label while the real pipeline
+    // (which does use remark-gfm) renders it struck-through with no tildes.
+    const headings = extractHeadings("## Hello ~~World~~");
+    expect(headings).toEqual([{ depth: 2, text: "Hello World", id: "hello-world" }]);
+  });
+});

--- a/web_ui/src/app/canvas/documentViewHeadings.ts
+++ b/web_ui/src/app/canvas/documentViewHeadings.ts
@@ -1,0 +1,75 @@
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import { visit } from "unist-util-visit";
+import { toString as mdastToString } from "mdast-util-to-string";
+import GithubSlugger from "github-slugger";
+
+/**
+ * Document View full redesign, stage 2 ("table of contents + reading
+ * progress"). Extracts a flat heading outline directly from the RAW
+ * markdown source, via its own separate remark parse pass - not by
+ * querying the rendered DOM after DocumentViewMarkdown.tsx paints. This
+ * means the table of contents is available (and its ids are guaranteed to
+ * match what will actually render) the instant new content arrives, with
+ * no render-then-query round trip and no dependency on DOM measurement.
+ *
+ * The id each heading gets here MUST exactly match the id
+ * rehype-slug (stage 1) assigns the corresponding rendered heading, or
+ * clicking a table-of-contents entry would scroll to nothing. This is
+ * guaranteed by using the exact same mechanism rehype-slug itself uses
+ * internally (confirmed by reading its own source, not assumed): a fresh
+ * `GithubSlugger` instance per call (matching rehype-slug's own
+ * `slugs.reset()` once per document), fed each heading's flattened text in
+ * top-to-bottom document order (matching rehype-slug's own `visit(tree,
+ * 'element', ...)` traversal) - walking the raw mdast tree
+ * (`mdast-util-to-string`) rather than the rendered hast tree (rehype-slug's
+ * own `hast-util-to-string`).
+ *
+ * Those two flattening utilities are NOT drop-in equivalents, and getting
+ * this wrong was a real bug caught by adversarial review: `mdast-util-to-
+ * string` special-cases `image` nodes and returns their `alt` text by
+ * default, while `hast-util-to-string` treats a hast `img` as a childless
+ * leaf and contributes nothing for it (confirmed by reading both packages'
+ * source). A heading like `## ![Alt Text](img.png)` would otherwise extract
+ * as `"Alt Text"` while actually rendering with an empty id - a dead ToC
+ * link. `includeImageAlt: false` below forces the same "contributes
+ * nothing" behavior on this side to match.
+ *
+ * remark-gfm IS included here (unlike the comment in an earlier draft of
+ * this file assumed) - not because GFM syntax affects heading *detection*
+ * (it doesn't), but because it affects the extracted *text*: without it, a
+ * heading like `## Hello ~~World~~` would extract its literal tildes into
+ * the ToC label while actually rendering with strikethrough styling and no
+ * tildes. Parity with what DocumentViewMarkdown.tsx actually renders was
+ * the whole point of extracting from source rather than guessing, so the
+ * same remark-gfm pass belongs here too.
+ */
+export interface DocumentHeading {
+  depth: number;
+  text: string;
+  id: string;
+}
+
+const headingParser = unified().use(remarkParse).use(remarkGfm);
+
+interface HeadingNode {
+  type: "heading";
+  depth: number;
+  children: unknown[];
+}
+
+export function extractHeadings(markdown: string): DocumentHeading[] {
+  const tree = headingParser.parse(markdown);
+  const slugger = new GithubSlugger();
+  const headings: DocumentHeading[] = [];
+
+  visit(tree, "heading", (node) => {
+    const heading = node as unknown as HeadingNode;
+    const text = mdastToString(node, { includeImageAlt: false }).trim();
+    if (!text) return;
+    headings.push({ depth: heading.depth, text, id: slugger.slug(text) });
+  });
+
+  return headings;
+}

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2598,6 +2598,107 @@ h6:hover > .document-view-heading-anchor {
   color: var(--gl-semantic-status-error);
 }
 
+/* Document View full redesign, stage 2 ("table of contents + reading
+   progress") - DocumentViewToc.tsx's own toggle + dropdown, and
+   DocumentViewPanel.tsx's reading-progress bar. */
+
+.document-view-toc {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.document-view-toc-toggle {
+  padding: 6px 14px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.document-view-toc-toggle:hover {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.document-view-toc-toggle[aria-expanded="true"] {
+  background-color: var(--gl-neutral-button-hover);
+  border-color: var(--gl-palette-selection);
+}
+
+/* z-index matches --gl-z-app-layer's own documented tier ("app-bar
+   popovers, plugin picker, pin overlay") - this dropdown is the same kind
+   of small, anchored, non-portaled popover, just scoped to Document
+   View's own chrome instead of the app bar. */
+.document-view-toc-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: var(--gl-z-app-layer);
+  min-width: 220px;
+  max-width: 320px;
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  background-color: var(--gl-surface-window);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+  /* Same box-shadow as .overlay-popover's shared chrome (and every other
+     floating/popover surface in this file) - reused verbatim rather than
+     an ad-hoc value, matching this stylesheet's own no-raw-colors policy
+     (see the file's own top-of-file comment) which pins a small, shared
+     set of raw-color exceptions rather than tolerating a new one per
+     component. */
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+}
+
+.document-view-toc-item {
+  text-align: left;
+  padding: 5px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.document-view-toc-item:hover {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.document-view-toc-item.active {
+  color: var(--gl-palette-selection);
+  font-weight: 600;
+}
+
+.document-view-toc-depth-2 {
+  padding-left: 20px;
+}
+
+.document-view-toc-depth-3 {
+  padding-left: 32px;
+}
+
+.document-view-panel-progress {
+  flex-shrink: 0;
+  height: 2px;
+  background-color: var(--gl-surface-border);
+}
+
+.document-view-panel-progress-fill {
+  height: 100%;
+  background-color: var(--gl-palette-selection);
+  transition: width 80ms linear;
+}
+
 .help-rail {
   width: 220px;
   flex-shrink: 0;

--- a/web_ui/src/lib/no-raw-colors.test.ts
+++ b/web_ui/src/lib/no-raw-colors.test.ts
@@ -127,6 +127,10 @@ const PINNED_APP_CSS_LITERALS: Record<string, string[]> = {
     "rgba(0, 0, 0, 0.45)",
     "rgba(0, 0, 0, 0.55)",
     "rgba(0, 0, 0, 0.45)",
+    // Document View full redesign, stage 2: .document-view-toc-dropdown's
+    // box-shadow (DocumentViewToc.tsx's outline popover) - same shared
+    // popover shadow reuse as every entry above.
+    "rgba(0, 0, 0, 0.45)",
     "rgba(0, 0, 0, 0.45)",
     // R6.1 follow-up: .group-node-ghost-preview's box-shadow (the
     // collapsed-container hover preview, GroupNodeView.tsx) - same shared


### PR DESCRIPTION
## Problem

Document View (the slide-out panel showing a chat node's message or a full conversation transcript as rendered markdown) had no way to navigate a long document except scrolling, and no indication of how far through it the reader was.

## Change

- `documentViewHeadings.ts`: a pure `extractHeadings(markdown)` function that parses the raw markdown source (independent of rendering) to produce a flat heading outline with slugged ids, using the same `github-slugger` mechanism `rehype-slug` (stage 1) uses internally, so the ids it produces are guaranteed to match the actual rendered heading anchors.
- `DocumentViewToc.tsx`: an "Outline" toggle in the panel header (hidden under 2 headings), opening a dropdown that lists every heading (indented by depth), highlights the currently-visible section via `IntersectionObserver`, and scrolls to a heading on click.
- `DocumentViewPanel.tsx`: a thin reading-progress bar tracking scroll percentage through the document; both the progress bar and scroll position reset when the panel is shown a different document.

## Adversarial review

An independent review verified the core correctness guarantee (that extracted heading ids match what actually renders) by reading `rehype-slug`, `mdast-util-to-string`, and `hast-util-to-string`'s installed source directly and running real repro cases. It found two genuine divergences between the extraction pass and the render pipeline:

1. `mdast-util-to-string` includes an image's `alt` text by default; the actual render (via `hast-util-to-string`) treats an `<img>` as a childless leaf and includes nothing. A heading containing an image would extract a non-empty id while rendering with an empty one, making that ToC entry a dead link. Fixed with `includeImageAlt: false`, plus regression tests for both the image-only and mixed-content cases.
2. The extraction parser omitted `remark-gfm`, so GFM syntax (e.g. `~~strikethrough~~`) leaked into the ToC label as literal markdown instead of matching the rendered text. Fixed by adding `remark-gfm` to the extraction parser, plus a regression test.

Everything else the review checked (IntersectionObserver teardown, scroll-to-heading math, the render-phase/effect split used to reset state without violating this project's `react-hooks/set-state-in-effect` and `react-hooks/refs` lint rules, auto-hide/depth-cap behavior) held up against the actual code.

## Test plan

- [x] `documentViewHeadings.test.ts` (10 tests): heading extraction, slug ids, GFM/image-alt edge cases, de-dup suffixes, matches the conversation-transcript formatter's heading shape.
- [x] `DocumentViewToc.test.tsx` (9 tests): toggle visibility, dropdown open/close (click, Escape, outside-click), scroll-to-heading math, IntersectionObserver wiring/highlighting/teardown.
- [x] `DocumentViewPanel.test.tsx`: added coverage for the Outline toggle's visibility, the reading-progress bar, and reset-on-content-change.
- [x] Full suite green: `tsc --noEmit`, `vitest run` (1010/1010), `eslint` (0 errors), `vite build`, backend `pytest -q` (1161/1161), `contracts/codegen.py --check`.