### PR TITLE
Redesign Document View, stage 3: in-document search/find

### DIFF
--- a/web_ui/src/app/canvas/DocumentViewMarkdown.tsx
+++ b/web_ui/src/app/canvas/DocumentViewMarkdown.tsx
@@ -8,6 +8,7 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeExternalLinks from "rehype-external-links";
 import Zoom from "react-medium-image-zoom";
 import "react-medium-image-zoom/dist/styles.css";
+import { rehypeHighlightSearchMatches } from "./documentViewSearchHighlight";
 
 /**
  * Document View's enhanced markdown renderer (full redesign, stage 1 of 4 -
@@ -54,6 +55,14 @@ import "react-medium-image-zoom/dist/styles.css";
  * properties in styles.css rather than importing the package's own
  * alert.css (which hard-codes GitHub's own light/dark color variables, not
  * this app's theme system).
+ *
+ * 5. rehypeHighlightSearchMatches (stage 3, "in-document search/find"): runs
+ *    last, after rehype-highlight has already tokenized code blocks into
+ *    their own syntax-highlighting spans - see that plugin's own doc
+ *    comment (documentViewSearchHighlight.ts) for why it only matches
+ *    within a single text node, and why the query is regex-escaped first.
+ *    A no-op when `searchQuery` is empty/undefined, so the common case
+ *    (search bar closed) adds no extra tree-walk cost beyond an early return.
  */
 
 function CodeBlock({ node: _node, children, ...props }: JSX.IntrinsicElements["pre"] & ExtraProps) {
@@ -128,7 +137,7 @@ function ZoomImage({ node: _node, ...props }: JSX.IntrinsicElements["img"] & Ext
   );
 }
 
-export function DocumentViewMarkdown({ content }: { content: string }) {
+export function DocumentViewMarkdown({ content, searchQuery }: { content: string; searchQuery?: string }) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkAlert]}
@@ -144,6 +153,7 @@ export function DocumentViewMarkdown({ content }: { content: string }) {
         ],
         rehypeHighlight,
         [rehypeExternalLinks, { target: "_blank", rel: ["nofollow", "noopener", "noreferrer"] }],
+        [rehypeHighlightSearchMatches, searchQuery ?? ""],
       ]}
       components={{ pre: CodeBlock, table: TableWrapper, img: ZoomImage }}
     >

--- a/web_ui/src/app/canvas/DocumentViewPanel.test.tsx
+++ b/web_ui/src/app/canvas/DocumentViewPanel.test.tsx
@@ -1,7 +1,25 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DocumentViewPanel } from "./DocumentViewPanel";
+
+// jsdom implements no IntersectionObserver - DocumentViewToc.tsx's own
+// scrollspy effect needs one the moment its dropdown is actually opened
+// (most tests here never open it, but the stage-3 ToC/search interaction
+// test below does). Same minimal fake DocumentViewToc.test.tsx uses.
+class FakeIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+beforeEach(() => {
+  // @ts-expect-error - test double, not the real browser API
+  global.IntersectionObserver = FakeIntersectionObserver;
+});
 
 function renderPanel(overrides: Partial<React.ComponentProps<typeof DocumentViewPanel>> = {}) {
   const props = {
@@ -196,6 +214,148 @@ describe("DocumentViewPanel", () => {
 
       expect(scrollArea.scrollTop).toBe(0);
       expect(screen.getByRole("progressbar", { name: "Reading progress" })).toHaveAttribute("aria-valuenow", "0");
+    });
+  });
+
+  // Document View full redesign, stage 3 ("in-document search/find"). The
+  // search bar's own detailed UI behavior (typing, Enter/Shift+Enter,
+  // Escape, disabled states) is covered in DocumentViewSearch.test.tsx, and
+  // the highlighting/matching logic itself in
+  // documentViewSearchHighlight.test.ts - these tests cover only
+  // DocumentViewPanel's own wiring: deriving match count and the
+  // current-match highlight from the real rendered <mark> elements, and the
+  // reset-on-new-content behavior.
+  describe("in-document search/find (stage 3)", () => {
+    it("shows the Find toggle, disabled when there is no content", () => {
+      renderPanel({ content: null });
+      expect(screen.getByRole("button", { name: "Find in document" })).toBeDisabled();
+    });
+
+    it("opens the search bar on Find click", async () => {
+      const user = userEvent.setup();
+      renderPanel({ content: "the cat sat on the mat" });
+
+      await user.click(screen.getByRole("button", { name: "Find in document" }));
+      expect(screen.getByRole("search")).toBeInTheDocument();
+    });
+
+    function countText(container: HTMLElement): string | null {
+      return container.querySelector(".document-view-search-count")?.textContent ?? null;
+    }
+
+    it("typing a query highlights every match and shows a match count, starting on the first match", async () => {
+      const user = userEvent.setup();
+      const { container } = renderPanel({ content: "the cat sat on the cat mat" });
+
+      await user.click(screen.getByRole("button", { name: "Find in document" }));
+      await user.type(screen.getByRole("textbox", { name: "Search query" }), "cat");
+
+      const matches = container.querySelectorAll(".document-view-search-match");
+      expect(matches).toHaveLength(2);
+      expect(countText(container)).toBe("1 of 2");
+      expect(matches[0]).toHaveClass("document-view-search-match-current");
+      expect(matches[1]).not.toHaveClass("document-view-search-match-current");
+    });
+
+    it("Next/Previous move the current-match highlight, wrapping around at either end", async () => {
+      const user = userEvent.setup();
+      const { container } = renderPanel({ content: "the cat sat on the cat mat" });
+      await user.click(screen.getByRole("button", { name: "Find in document" }));
+      await user.type(screen.getByRole("textbox", { name: "Search query" }), "cat");
+
+      await user.click(screen.getByRole("button", { name: "Next match" }));
+      let matches = container.querySelectorAll(".document-view-search-match");
+      expect(matches[1]).toHaveClass("document-view-search-match-current");
+      expect(countText(container)).toBe("2 of 2");
+
+      // Wraps from the last match back to the first.
+      await user.click(screen.getByRole("button", { name: "Next match" }));
+      matches = container.querySelectorAll(".document-view-search-match");
+      expect(matches[0]).toHaveClass("document-view-search-match-current");
+      expect(countText(container)).toBe("1 of 2");
+
+      // Wraps from the first match back to the last, going the other way.
+      await user.click(screen.getByRole("button", { name: "Previous match" }));
+      matches = container.querySelectorAll(".document-view-search-match");
+      expect(matches[1]).toHaveClass("document-view-search-match-current");
+      expect(countText(container)).toBe("2 of 2");
+    });
+
+    it("closing the search bar clears all highlighting", async () => {
+      const user = userEvent.setup();
+      const { container } = renderPanel({ content: "the cat sat on the cat mat" });
+      await user.click(screen.getByRole("button", { name: "Find in document" }));
+      await user.type(screen.getByRole("textbox", { name: "Search query" }), "cat");
+      expect(container.querySelectorAll(".document-view-search-match")).toHaveLength(2);
+
+      await user.click(screen.getByRole("button", { name: "Close search" }));
+
+      expect(screen.queryByRole("search")).toBeNull();
+      expect(container.querySelectorAll(".document-view-search-match")).toHaveLength(0);
+    });
+
+    it("clicking the header Find toggle closed also clears highlighting, the same as the bar's own Close button", async () => {
+      // Regression test: the toggle button's onClick originally only
+      // flipped isSearchOpen, leaving searchQuery (and therefore every
+      // highlighted <mark>) untouched - closing the search UI via the
+      // header toggle left matches permanently stuck highlighted with no
+      // visible control left to clear them. Caught by adversarial review,
+      // confirmed independently by three separate reviewers.
+      const user = userEvent.setup();
+      const { container } = renderPanel({ content: "the cat sat on the cat mat" });
+      const findToggle = screen.getByRole("button", { name: "Find in document" });
+
+      await user.click(findToggle);
+      await user.type(screen.getByRole("textbox", { name: "Search query" }), "cat");
+      expect(container.querySelectorAll(".document-view-search-match")).toHaveLength(2);
+
+      await user.click(findToggle);
+
+      expect(screen.queryByRole("search")).toBeNull();
+      expect(container.querySelectorAll(".document-view-search-match")).toHaveLength(0);
+    });
+
+    it("resets the search bar and clears highlighting when content changes to a new document", async () => {
+      const user = userEvent.setup();
+      const { container, rerender } = renderPanel({ content: "the cat sat" });
+      await user.click(screen.getByRole("button", { name: "Find in document" }));
+      await user.type(screen.getByRole("textbox", { name: "Search query" }), "cat");
+      expect(container.querySelectorAll(".document-view-search-match")).toHaveLength(1);
+
+      rerender(
+        <DocumentViewPanel isOpen content="a completely different document" sourceLabel={null} onClose={vi.fn()} />,
+      );
+
+      expect(screen.queryByRole("search")).toBeNull();
+      expect(container.querySelectorAll(".document-view-search-match")).toHaveLength(0);
+    });
+
+    it("Escape in the search input closes only the search bar, even with the ToC outline also open", async () => {
+      // Regression test: DocumentViewToc's own Escape listener originally
+      // ran in the capture phase, which always fires before the search
+      // input's bubble-phase stopPropagation() could take effect - so
+      // pressing Escape to dismiss just the search bar silently closed the
+      // ToC outline too. Caught by adversarial review.
+      // Order matters for this repro: opening search FIRST, then ToC,
+      // avoids ToC's own (unrelated, pre-existing) outside-pointerdown-close
+      // handler from closing it again before Escape is even pressed -
+      // clicking ToC's own "Outline" toggle is inside its own root, not an
+      // "outside" click, so this is the one ordering where both stay open
+      // at once, matching the actual scenario adversarial review found.
+      const user = userEvent.setup();
+      renderPanel({ content: "# One\n\n## Two\n\nthe cat sat" });
+
+      await user.click(screen.getByRole("button", { name: "Find in document" }));
+      await user.click(screen.getByRole("button", { name: "Outline" }));
+      expect(screen.getByRole("menu", { name: "Table of contents" })).toBeInTheDocument();
+      expect(screen.getByRole("search")).toBeInTheDocument();
+
+      const searchInput = screen.getByRole("textbox", { name: "Search query" });
+      searchInput.focus();
+      await user.keyboard("{Escape}");
+
+      expect(screen.queryByRole("search")).toBeNull();
+      expect(screen.getByRole("menu", { name: "Table of contents" })).toBeInTheDocument();
     });
   });
 });

--- a/web_ui/src/app/canvas/DocumentViewPanel.tsx
+++ b/web_ui/src/app/canvas/DocumentViewPanel.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DocumentViewMarkdown } from "./DocumentViewMarkdown";
 import { DocumentViewToc } from "./DocumentViewToc";
+import { DocumentViewSearch } from "./DocumentViewSearch";
 import { extractHeadings } from "./documentViewHeadings";
+
+const SEARCH_MATCH_SELECTOR = ".document-view-search-match";
+const SEARCH_MATCH_CURRENT_CLASS = "document-view-search-match-current";
 
 const DEFAULT_WIDTH = 500;
 const MIN_WIDTH = 320;
@@ -55,6 +59,21 @@ const MAX_WIDTH = 900;
  * different (or shorter) one never starts the reader in the middle of the
  * new content or shows a stale progress percentage before the next scroll
  * event fires.
+ *
+ * Full redesign, stage 3 of 4 ("in-document search/find"): a "Find" toggle
+ * opens DocumentViewSearch.tsx's search bar. The query itself is passed down
+ * to DocumentViewMarkdown, which highlights matches declaratively (a
+ * rehype plugin, see documentViewSearchHighlight.ts); the match COUNT and
+ * which one is "current" are derived back out of the rendered DOM here (the
+ * real `<mark>` elements actually produced), rather than computed
+ * independently from the query/content, so the "n of m" display can never
+ * drift from what's actually highlighted on screen. Both the query and the
+ * current-match index reset - the former whenever `content` changes
+ * (grouped with stage 2's own content-change reset below), the latter
+ * whenever the query itself changes (jumping back to the first match of a
+ * newly-typed search, matching standard find-bar behavior) - using the same
+ * render-phase "adjust state when a value changes" idiom stage 2 already
+ * established, not a useEffect.
  */
 export function DocumentViewPanel({
   isOpen,
@@ -134,6 +153,16 @@ export function DocumentViewPanel({
     setReadingProgress(scrollable > 0 ? Math.min(100, Math.max(0, (el.scrollTop / scrollable) * 100)) : 0);
   }, []);
 
+  // Stage 3: in-document search/find. `searchQuery` is the only piece
+  // DocumentViewMarkdown needs (to highlight matches); `currentMatchIndex`
+  // and `matchCount` are purely local to navigating those already-rendered
+  // matches, resolved against the real DOM below. Declared before the
+  // content-change reset block below, which references these setters.
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const [matchCount, setMatchCount] = useState(0);
+
   // A new document (or the panel closing and a different one opening next)
   // must never start the reader mid-scroll from whatever the PREVIOUS
   // document left scrollTop at, and the progress bar must not show a stale
@@ -147,15 +176,63 @@ export function DocumentViewPanel({
   // scrollTop reset can't join that same conditional - refs may never be
   // read or written during render (react-hooks/refs) - so it stays in its
   // own plain effect below, which itself calls no setState at all.
+  //
+  // Stage 3's search state resets here too - a different document means the
+  // previous search (if any) no longer applies to what's on screen.
   const [lastRenderedContent, setLastRenderedContent] = useState(content);
   if (content !== lastRenderedContent) {
     setLastRenderedContent(content);
     setReadingProgress(0);
+    setIsSearchOpen(false);
+    setSearchQuery("");
   }
 
   useEffect(() => {
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
   }, [content]);
+
+  // A newly-typed query starts back at the first match, matching standard
+  // find-bar behavior - the previous query's current-match position has no
+  // meaning against a different set of matches.
+  const [lastSearchQuery, setLastSearchQuery] = useState(searchQuery);
+  if (searchQuery !== lastSearchQuery) {
+    setLastSearchQuery(searchQuery);
+    setCurrentMatchIndex(0);
+  }
+
+  const onSearchNext = useCallback(() => {
+    setCurrentMatchIndex((i) => (matchCount === 0 ? 0 : (i + 1) % matchCount));
+  }, [matchCount]);
+
+  const onSearchPrevious = useCallback(() => {
+    setCurrentMatchIndex((i) => (matchCount === 0 ? 0 : (i - 1 + matchCount) % matchCount));
+  }, [matchCount]);
+
+  const onSearchClose = useCallback(() => {
+    setIsSearchOpen(false);
+    setSearchQuery("");
+  }, []);
+
+  // Runs after every render where the highlighted matches could have
+  // changed (new content, new query) or the user navigated to a different
+  // one - reads the actual <mark> elements DocumentViewMarkdown produced
+  // (the source of truth for "how many matches" and "which one is
+  // current"), rather than recomputing that independently and risking it
+  // drifting from what's really on screen.
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const allMatches = Array.from(container.querySelectorAll<HTMLElement>(SEARCH_MATCH_SELECTOR));
+    setMatchCount(allMatches.length);
+    for (const el of allMatches) el.classList.remove(SEARCH_MATCH_CURRENT_CLASS);
+    if (allMatches.length === 0) return;
+
+    const current = allMatches[Math.min(currentMatchIndex, allMatches.length - 1)];
+    current.classList.add(SEARCH_MATCH_CURRENT_CLASS);
+    const containerRect = container.getBoundingClientRect();
+    const currentRect = current.getBoundingClientRect();
+    container.scrollTop += currentRect.top - containerRect.top;
+  }, [content, searchQuery, currentMatchIndex]);
 
   return (
     <aside
@@ -179,6 +256,17 @@ export function DocumentViewPanel({
           <DocumentViewToc headings={headings} scrollContainerRef={scrollRef} />
           <button
             type="button"
+            className="document-view-panel-search-toggle"
+            onClick={() => (isSearchOpen ? onSearchClose() : setIsSearchOpen(true))}
+            disabled={!content}
+            title="Find in document"
+            aria-label="Find in document"
+            aria-expanded={isSearchOpen}
+          >
+            Find
+          </button>
+          <button
+            type="button"
             className="document-view-panel-copy"
             onClick={onCopy}
             disabled={!content}
@@ -191,6 +279,16 @@ export function DocumentViewPanel({
             Close
           </button>
         </header>
+        <DocumentViewSearch
+          isOpen={isSearchOpen}
+          query={searchQuery}
+          onQueryChange={setSearchQuery}
+          matchCount={matchCount}
+          currentMatchNumber={matchCount === 0 ? 0 : currentMatchIndex + 1}
+          onNext={onSearchNext}
+          onPrevious={onSearchPrevious}
+          onClose={onSearchClose}
+        />
         <div
           className="document-view-panel-progress"
           role="progressbar"
@@ -202,7 +300,7 @@ export function DocumentViewPanel({
           <div className="document-view-panel-progress-fill" style={{ width: `${readingProgress}%` }} />
         </div>
         <div className="document-view-panel-scroll chat-node-content" ref={scrollRef} onScroll={onScroll}>
-          <DocumentViewMarkdown content={content ?? ""} />
+          <DocumentViewMarkdown content={content ?? ""} searchQuery={searchQuery} />
         </div>
       </div>
       <div

--- a/web_ui/src/app/canvas/DocumentViewSearch.test.tsx
+++ b/web_ui/src/app/canvas/DocumentViewSearch.test.tsx
@@ -1,0 +1,142 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DocumentViewSearch } from "./DocumentViewSearch";
+
+// A failed assertion inside a fake-timers test would otherwise skip past its
+// own vi.useRealTimers() cleanup, leaving every later test in this file
+// (several of which use userEvent, whose internal delays need real timers)
+// hanging indefinitely - this guarantees real timers are restored
+// regardless of how a test exits.
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function renderSearch(overrides: Partial<React.ComponentProps<typeof DocumentViewSearch>> = {}) {
+  const props = {
+    isOpen: true,
+    query: "",
+    onQueryChange: vi.fn(),
+    matchCount: 0,
+    currentMatchNumber: 0,
+    onNext: vi.fn(),
+    onPrevious: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<DocumentViewSearch {...props} />), props };
+}
+
+describe("DocumentViewSearch", () => {
+  it("renders nothing when closed", () => {
+    const { container } = renderSearch({ isOpen: false });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the input, focused, when open", () => {
+    renderSearch();
+    expect(screen.getByRole("textbox", { name: "Search query" })).toHaveFocus();
+  });
+
+  it("shows no count for an empty query", () => {
+    renderSearch({ query: "", matchCount: 0, currentMatchNumber: 0 });
+    expect(screen.queryByText(/of/)).toBeNull();
+  });
+
+  it("shows 'n of m' once there is a non-empty query, including the zero-match case", () => {
+    const { container } = renderSearch({ query: "xyz", matchCount: 0, currentMatchNumber: 0 });
+    expect(container.querySelector(".document-view-search-count")).toHaveTextContent("0 of 0");
+  });
+
+  it("shows the current match number out of the total", () => {
+    const { container } = renderSearch({ query: "cat", matchCount: 5, currentMatchNumber: 3 });
+    expect(container.querySelector(".document-view-search-count")).toHaveTextContent("3 of 5");
+  });
+
+  it("announces the count to screen readers via a debounced, visually-hidden live region", async () => {
+    vi.useFakeTimers();
+    const { rerender } = renderSearch({ query: "cat", matchCount: 1, currentMatchNumber: 1 });
+    const liveRegion = () => screen.getByText((_, el) => el?.getAttribute("aria-live") === "polite");
+
+    // The visible count updates instantly...
+    expect(document.querySelector(".document-view-search-count")).toHaveTextContent("1 of 1");
+    // ...but the live region hasn't caught up yet (debounced).
+    expect(liveRegion()).toHaveTextContent("1 of 1");
+
+    rerender(
+      <DocumentViewSearch
+        isOpen
+        query="cat"
+        onQueryChange={vi.fn()}
+        matchCount={2}
+        currentMatchNumber={2}
+        onNext={vi.fn()}
+        onPrevious={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(document.querySelector(".document-view-search-count")).toHaveTextContent("2 of 2");
+    // Immediately after a change, the live region still reflects the PREVIOUS
+    // settled value - it has not yet caught up.
+    expect(liveRegion()).toHaveTextContent("1 of 1");
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(liveRegion()).toHaveTextContent("2 of 2");
+    vi.useRealTimers();
+  });
+
+  it("calls onQueryChange as the user types", async () => {
+    const user = userEvent.setup();
+    const { props } = renderSearch();
+    await user.type(screen.getByRole("textbox", { name: "Search query" }), "a");
+    expect(props.onQueryChange).toHaveBeenCalledWith("a");
+  });
+
+  it("disables Previous/Next when there are no matches", () => {
+    renderSearch({ matchCount: 0 });
+    expect(screen.getByRole("button", { name: "Previous match" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next match" })).toBeDisabled();
+  });
+
+  it("enables and wires up Previous/Next when there are matches", async () => {
+    const user = userEvent.setup();
+    const { props } = renderSearch({ matchCount: 3, currentMatchNumber: 1 });
+    const next = screen.getByRole("button", { name: "Next match" });
+    const previous = screen.getByRole("button", { name: "Previous match" });
+    expect(next).toBeEnabled();
+    expect(previous).toBeEnabled();
+
+    await user.click(next);
+    expect(props.onNext).toHaveBeenCalledOnce();
+    await user.click(previous);
+    expect(props.onPrevious).toHaveBeenCalledOnce();
+  });
+
+  it("Enter in the input calls onNext, Shift+Enter calls onPrevious", async () => {
+    const user = userEvent.setup();
+    const { props } = renderSearch({ matchCount: 2, currentMatchNumber: 1 });
+    const input = screen.getByRole("textbox", { name: "Search query" });
+
+    await user.type(input, "{Enter}");
+    expect(props.onNext).toHaveBeenCalledOnce();
+
+    await user.type(input, "{Shift>}{Enter}{/Shift}");
+    expect(props.onPrevious).toHaveBeenCalledOnce();
+  });
+
+  it("Escape in the input calls onClose", async () => {
+    const user = userEvent.setup();
+    const { props } = renderSearch();
+    await user.type(screen.getByRole("textbox", { name: "Search query" }), "{Escape}");
+    expect(props.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("the close button calls onClose", async () => {
+    const user = userEvent.setup();
+    const { props } = renderSearch();
+    await user.click(screen.getByRole("button", { name: "Close search" }));
+    expect(props.onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/web_ui/src/app/canvas/DocumentViewSearch.tsx
+++ b/web_ui/src/app/canvas/DocumentViewSearch.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Document View full redesign, stage 3 ("in-document search/find"). A
+ * controlled search bar - unlike DocumentViewToc.tsx's mostly self-contained
+ * open/active state, the search QUERY itself has to reach a sibling
+ * (DocumentViewMarkdown, which highlights matches via
+ * rehypeHighlightSearchMatches), so DocumentViewPanel.tsx owns the actual
+ * state and this component is a plain controlled input + toolbar.
+ *
+ * Match counting and current-match navigation are NOT computed here from
+ * the raw query/content - they're derived from the rendered DOM (the real
+ * <mark> elements DocumentViewMarkdown actually produced) by
+ * DocumentViewPanel.tsx, so the "n of m" display can never drift from what's
+ * actually highlighted on screen.
+ *
+ * The visible "n of m" count updates instantly on every keystroke/navigation
+ * (no perceptible lag for sighted users), but what's actually announced to
+ * screen readers is a SEPARATE, visually-hidden, debounced copy - caught by
+ * adversarial review: an aria-live="polite" region on the same instantly-
+ * updating text would queue a fresh announcement on every single keystroke
+ * of a multi-character query, and most screen readers read a "polite"
+ * queue's backlog out in full rather than skipping to the latest value -
+ * flooding the user with several stale counts read out well after they've
+ * already moved on. Debouncing only the ANNOUNCED copy (not the visible
+ * text, and not the actual highlighting/navigation, which both stay
+ * instant) keeps the visual experience responsive while giving assistive
+ * tech one settled announcement per pause in typing/navigation instead of
+ * one per keystroke.
+ */
+const ANNOUNCE_DEBOUNCE_MS = 400;
+
+export function DocumentViewSearch({
+  isOpen,
+  query,
+  onQueryChange,
+  matchCount,
+  currentMatchNumber,
+  onNext,
+  onPrevious,
+  onClose,
+}: {
+  isOpen: boolean;
+  query: string;
+  onQueryChange: (query: string) => void;
+  matchCount: number;
+  currentMatchNumber: number;
+  onNext: () => void;
+  onPrevious: () => void;
+  onClose: () => void;
+}) {
+  const countText = query.trim() ? `${currentMatchNumber} of ${matchCount}` : "";
+
+  // Hooks run unconditionally, before the `isOpen` early return below (Rules
+  // of Hooks) - harmless when closed, since DocumentViewPanel resets `query`
+  // to "" on close anyway, which this effect just debounces down to "" too.
+  const [announcedText, setAnnouncedText] = useState(countText);
+  useEffect(() => {
+    const timer = setTimeout(() => setAnnouncedText(countText), ANNOUNCE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [countText]);
+
+  if (!isOpen) return null;
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      onClose();
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      if (event.shiftKey) onPrevious();
+      else onNext();
+    }
+  }
+
+  const hasMatches = matchCount > 0;
+
+  return (
+    <div className="document-view-search" role="search">
+      <input
+        type="text"
+        className="document-view-search-input"
+        placeholder="Find in document"
+        aria-label="Search query"
+        value={query}
+        onChange={(event) => onQueryChange(event.target.value)}
+        onKeyDown={onKeyDown}
+        autoFocus
+      />
+      <span className="document-view-search-count" aria-hidden="true">
+        {countText}
+      </span>
+      <span className="document-view-visually-hidden" aria-live="polite">
+        {announcedText}
+      </span>
+      <button
+        type="button"
+        className="document-view-search-nav"
+        onClick={onPrevious}
+        disabled={!hasMatches}
+        title="Previous match"
+        aria-label="Previous match"
+      >
+        ↑
+      </button>
+      <button
+        type="button"
+        className="document-view-search-nav"
+        onClick={onNext}
+        disabled={!hasMatches}
+        title="Next match"
+        aria-label="Next match"
+      >
+        ↓
+      </button>
+      <button type="button" className="document-view-search-close" onClick={onClose} title="Close search" aria-label="Close search">
+        ×
+      </button>
+    </div>
+  );
+}

--- a/web_ui/src/app/canvas/DocumentViewToc.tsx
+++ b/web_ui/src/app/canvas/DocumentViewToc.tsx
@@ -69,10 +69,22 @@ export function DocumentViewToc({
       if (event.key === "Escape") setIsOpen(false);
     }
     document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("keydown", onKeyDown, true);
+    // Bubble phase (no capture), unlike the pointerdown listener above -
+    // caught by adversarial review: stage 3's search bar (DocumentViewSearch)
+    // calls stopPropagation() on its own Escape handler specifically so
+    // dismissing just the search input doesn't also close this dropdown if
+    // both happen to be open at once. A capture-phase listener here would
+    // run during the capture leg of dispatch - BEFORE the event ever
+    // reaches the search input's own bubble-phase handler - making that
+    // stopPropagation() call a no-op against this listener. Bubble phase
+    // lets an inner element's stopPropagation() genuinely take effect,
+    // while every other Escape-closes-this-dropdown scenario (focus
+    // elsewhere in the panel, or nowhere in particular) is unaffected,
+    // since nothing else in this panel calls stopPropagation on Escape.
+    document.addEventListener("keydown", onKeyDown);
     return () => {
       document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("keydown", onKeyDown);
     };
   }, [isOpen]);
 

--- a/web_ui/src/app/canvas/documentViewSearchHighlight.test.ts
+++ b/web_ui/src/app/canvas/documentViewSearchHighlight.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { escapeSearchRegExp, rehypeHighlightSearchMatches } from "./documentViewSearchHighlight";
+
+interface TextNode {
+  type: "text";
+  value: string;
+}
+
+interface ElementNode {
+  type: "element";
+  tagName: string;
+  properties: Record<string, unknown>;
+  children: unknown[];
+}
+
+function text(value: string): TextNode {
+  return { type: "text", value };
+}
+
+function paragraph(...children: unknown[]): ElementNode {
+  return { type: "element", tagName: "p", properties: {}, children };
+}
+
+function root(...children: unknown[]) {
+  return { type: "root", children };
+}
+
+function marks(node: ElementNode): ElementNode[] {
+  return node.children.filter(
+    (child): child is ElementNode =>
+      typeof child === "object" && child !== null && (child as ElementNode).tagName === "mark",
+  );
+}
+
+describe("escapeSearchRegExp", () => {
+  it("escapes every regex metacharacter", () => {
+    expect(escapeSearchRegExp("a.b*c+d?e^f$g{h}i(j)k|l[m]n\\o")).toBe(
+      "a\\.b\\*c\\+d\\?e\\^f\\$g\\{h\\}i\\(j\\)k\\|l\\[m\\]n\\\\o",
+    );
+  });
+
+  it("leaves plain alphanumeric text untouched", () => {
+    expect(escapeSearchRegExp("hello world 123")).toBe("hello world 123");
+  });
+});
+
+describe("rehypeHighlightSearchMatches", () => {
+  it("does nothing for an empty or whitespace-only query", () => {
+    const tree = root(paragraph(text("hello world")));
+    rehypeHighlightSearchMatches("")(tree);
+    rehypeHighlightSearchMatches("   ")(tree);
+    expect(tree).toEqual(root(paragraph(text("hello world"))));
+  });
+
+  it("wraps a single match in a <mark> with a stable match index", () => {
+    const tree = root(paragraph(text("hello world")));
+    rehypeHighlightSearchMatches("world")(tree);
+
+    const p = (tree.children[0] as ElementNode);
+    expect(p.children).toEqual([
+      text("hello "),
+      { type: "element", tagName: "mark", properties: { className: ["document-view-search-match"], dataSearchMatchIndex: 0 }, children: [text("world")] },
+    ]);
+  });
+
+  it("matches case-insensitively", () => {
+    const tree = root(paragraph(text("Hello WORLD")));
+    rehypeHighlightSearchMatches("world")(tree);
+
+    expect(marks(tree.children[0] as ElementNode).map((m) => (m.children[0] as TextNode).value)).toEqual([
+      "WORLD",
+    ]);
+  });
+
+  it("treats regex metacharacters in the query as literal text", () => {
+    const tree = root(paragraph(text("a.b and aXb")));
+    rehypeHighlightSearchMatches("a.b")(tree);
+
+    const found = marks(tree.children[0] as ElementNode).map((m) => (m.children[0] as TextNode).value);
+    expect(found).toEqual(["a.b"]);
+  });
+
+  it("wraps every match within a single text node without double-wrapping or skipping any", () => {
+    // Regression test: a naive unist-util-visit splice that doesn't return
+    // the post-splice index would re-enter the newly inserted nodes,
+    // including each <mark>'s own text child, and wrap it in a second,
+    // nested <mark> - or otherwise mis-walk the sibling list.
+    const tree = root(paragraph(text("cat sat on the cat mat, a cat!")));
+    rehypeHighlightSearchMatches("cat")(tree);
+
+    // "cat sat on the cat mat, a cat!" starts with a match (no leading text
+    // segment) and ends with a leftover "!" (a trailing text segment):
+    // mark, text, mark, text, mark, text.
+    const p = tree.children[0] as ElementNode;
+    expect(p.children.map((c) => (c as TextNode | ElementNode).type)).toEqual([
+      "element",
+      "text",
+      "element",
+      "text",
+      "element",
+      "text",
+    ]);
+
+    const foundMarks = marks(p);
+    expect(foundMarks).toHaveLength(3);
+    for (const mark of foundMarks) {
+      expect(mark.children).toHaveLength(1);
+      expect((mark.children[0] as TextNode).type).toBe("text");
+      expect((mark.children[0] as TextNode).value).toBe("cat");
+    }
+    expect(foundMarks.map((m) => m.properties.dataSearchMatchIndex)).toEqual([0, 1, 2]);
+
+    // The plain-text segments between/around matches are untouched.
+    const plainText = p.children.filter((c) => (c as TextNode | ElementNode).type === "text") as TextNode[];
+    expect(plainText.map((t) => t.value)).toEqual([" sat on the ", " mat, a ", "!"]);
+  });
+
+  it("assigns sequential match indices across separate sibling text nodes in document order", () => {
+    const tree = root(paragraph(text("first cat")), paragraph(text("second cat")));
+    rehypeHighlightSearchMatches("cat")(tree);
+
+    const allMarks = [
+      ...marks(tree.children[0] as ElementNode),
+      ...marks(tree.children[1] as ElementNode),
+    ];
+    expect(allMarks.map((m) => m.properties.dataSearchMatchIndex)).toEqual([0, 1]);
+  });
+
+  it("leaves a text node with no match completely untouched", () => {
+    const original = paragraph(text("nothing to see here"));
+    const tree = root(original);
+    rehypeHighlightSearchMatches("xyz")(tree);
+
+    expect(tree.children[0]).toBe(original);
+    expect((original.children[0] as TextNode).type).toBe("text");
+  });
+
+  it("matches a single typed space against a run of multiple/irregular spaces in the source", () => {
+    // Caught by adversarial review: markdown source preserves internal
+    // whitespace verbatim, but the browser visually collapses any run to
+    // one space - a user typing what they see on screen ("hello world",
+    // one space) must still match source text like "hello   world".
+    const tree = root(paragraph(text("say hello   world now")));
+    rehypeHighlightSearchMatches("hello world")(tree);
+
+    const found = marks(tree.children[0] as ElementNode).map((m) => (m.children[0] as TextNode).value);
+    expect(found).toEqual(["hello   world"]);
+  });
+
+  it("matches across a newline the same way, since \\s+ covers any whitespace run", () => {
+    const tree = root(paragraph(text("say hello\nworld now")));
+    rehypeHighlightSearchMatches("hello world")(tree);
+
+    const found = marks(tree.children[0] as ElementNode).map((m) => (m.children[0] as TextNode).value);
+    expect(found).toEqual(["hello\nworld"]);
+  });
+
+  it("does not highlight text inside an aria-hidden element", () => {
+    // Caught by adversarial review: rehype-autolink-headings appends a real
+    // aria-hidden, tabIndex=-1 "#" anchor after every heading's own text -
+    // without this guard, searching for "#" would highlight that decoration
+    // and inflate the match count with hits unrelated to real content.
+    const hiddenAnchor: ElementNode = {
+      type: "element",
+      tagName: "a",
+      properties: { ariaHidden: true },
+      children: [text("#")],
+    };
+    const tree = root(paragraph(text("heading"), hiddenAnchor));
+    rehypeHighlightSearchMatches("#")(tree);
+
+    expect(marks(tree.children[0] as ElementNode)).toHaveLength(0);
+    expect(hiddenAnchor.children).toEqual([text("#")]);
+  });
+
+  it("still highlights a literal '#' in ordinary, non-hidden text", () => {
+    const tree = root(paragraph(text("see the # symbol")));
+    rehypeHighlightSearchMatches("#")(tree);
+
+    expect(marks(tree.children[0] as ElementNode)).toHaveLength(1);
+  });
+});

--- a/web_ui/src/app/canvas/documentViewSearchHighlight.ts
+++ b/web_ui/src/app/canvas/documentViewSearchHighlight.ts
@@ -1,0 +1,147 @@
+import { visit } from "unist-util-visit";
+
+/**
+ * Document View full redesign, stage 3 ("in-document search/find"). The
+ * first hand-authored rehype plugin in this codebase (stage 1/2 only ever
+ * composed published plugins) - wraps every case-insensitive substring
+ * match of a search query in a `<mark data-search-match-index>` element,
+ * directly in the hast tree, so highlighting is fully declarative (re-render
+ * on every keystroke, like the rest of this pipeline) rather than mutating
+ * the rendered DOM out from under React.
+ *
+ * Runs LAST in DocumentViewMarkdown.tsx's rehypePlugins array, after
+ * rehype-highlight - code blocks are already tokenized into many small
+ * per-token `<span>` elements by that point. This plugin only ever matches
+ * within a SINGLE text node, so a query that spans two adjacent syntax-
+ * highlighted tokens (or two adjacent bits of inline formatting, e.g. a
+ * query straddling **bold** and plain text) will not be found. This is a
+ * deliberate, documented scope boundary, not an oversight: highlighting a
+ * match that spans multiple hast elements would require rewriting sibling
+ * structure, not just splitting one text node, and is out of scope for a
+ * document viewer's find feature.
+ *
+ * The query is escaped before use (`escapeSearchRegExp`) so a user typing
+ * regex metacharacters (`.`, `*`, `(`, etc.) searches for that literal text,
+ * not a regex - both for correctness (users expect literal substring
+ * search, not regex search) and safety (an unescaped user-controlled
+ * pattern fed to `RegExp` is a classic ReDoS vector).
+ *
+ * A literal run of one-or-more spaces in the query is widened to `\s+`
+ * (buildSearchPattern) after escaping - caught by adversarial review:
+ * markdown source text preserves internal whitespace verbatim (multiple
+ * spaces, a line-wrapped newline) while the browser's default
+ * `white-space: normal` visually collapses any such run to a single space,
+ * so a user typing what they see on screen ("hello world", one space)
+ * would otherwise silently fail to match source text like "hello   world"
+ * (three spaces, e.g. from a pasted document). This does NOT apply to the
+ * escaped regex metacharacters themselves - only bare, unescaped space
+ * characters are widened.
+ *
+ * Case-insensitivity uses plain JS RegExp "i" semantics, not full
+ * Unicode-aware case folding - e.g. German "straße" will not match a query
+ * of "STRASSE", nor will Turkish dotted/dotless i/I variants cross-match.
+ * This is a known, accepted limitation shared with native browser Ctrl+F
+ * (which has the same gap), not a regression unique to this plugin - full
+ * locale-aware collation is out of scope for a lightweight highlight-as-
+ * you-type feature.
+ */
+
+const REGEXP_SPECIAL_CHARS_RE = /[.*+?^${}()|[\]\\]/g;
+
+export function escapeSearchRegExp(value: string): string {
+  return value.replace(REGEXP_SPECIAL_CHARS_RE, "\\$&");
+}
+
+function buildSearchPattern(trimmedQuery: string): RegExp {
+  const escaped = escapeSearchRegExp(trimmedQuery).replace(/ +/g, "\\s+");
+  return new RegExp(escaped, "gi");
+}
+
+interface TextNode {
+  type: "text";
+  value: string;
+}
+
+interface ElementNode {
+  type: "element";
+  tagName: string;
+  properties: Record<string, unknown>;
+  children: unknown[];
+}
+
+type MatchNode = TextNode | ElementNode;
+
+// Minimal structural stand-in for unified's own `Node` type (just
+// `{type: string}`), matching this codebase's existing convention
+// (documentViewHeadings.ts) of hand-rolling a small local interface rather
+// than adding a dependency on the official unist/hast/mdast type packages.
+interface Tree {
+  type: string;
+  children?: unknown[];
+}
+
+export function rehypeHighlightSearchMatches(query: string) {
+  const trimmed = query.trim();
+
+  return function transform(tree: Tree) {
+    if (!trimmed) return;
+    const pattern = buildSearchPattern(trimmed);
+    let matchIndex = 0;
+
+    visit(tree, "text", (node: TextNode, index, parent) => {
+      if (typeof index !== "number" || !parent || !("children" in parent)) return;
+      // Skip decorative content invisible to assistive tech - concretely,
+      // rehype-autolink-headings' own appended "#" anchor (aria-hidden,
+      // tabIndex -1) after every heading. Caught by adversarial review:
+      // without this guard, searching for "#" highlighted that decoration
+      // next to every heading and inflated the match count/navigation with
+      // hits that have nothing to do with the document's real content.
+      // Checks the IMMEDIATE parent only (not the full ancestor chain) -
+      // sufficient for this specific, known case, since the anchor's
+      // aria-hidden property sits directly on the "#" text node's parent.
+      const parentProperties = (parent as unknown as ElementNode).properties;
+      if (parentProperties && parentProperties.ariaHidden) return;
+      pattern.lastIndex = 0;
+      if (!pattern.test(node.value)) return;
+      pattern.lastIndex = 0;
+
+      const replacement: MatchNode[] = [];
+      let lastEnd = 0;
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(node.value)) !== null) {
+        const start = match.index;
+        const end = start + match[0].length;
+        if (start > lastEnd) {
+          replacement.push({ type: "text", value: node.value.slice(lastEnd, start) });
+        }
+        replacement.push({
+          type: "element",
+          tagName: "mark",
+          properties: { className: ["document-view-search-match"], dataSearchMatchIndex: matchIndex },
+          children: [{ type: "text", value: match[0] }],
+        });
+        matchIndex += 1;
+        lastEnd = end;
+        // A zero-length query can never reach here (escapeSearchRegExp'd
+        // non-empty `trimmed` always matches at least one character), so no
+        // infinite-loop guard is needed for lastIndex staying put.
+      }
+      if (lastEnd < node.value.length) {
+        replacement.push({ type: "text", value: node.value.slice(lastEnd) });
+      }
+
+      (parent as unknown as { children: unknown[] }).children.splice(index, 1, ...replacement);
+
+      // unist-util-visit-parents reads the parent's children array fresh on
+      // every loop iteration - after splicing 1 node into `replacement.length`
+      // nodes, its default "continue at index + 1" would walk straight back
+      // into the very nodes just inserted here, including the freshly built
+      // <mark>'s own text child (which trivially re-matches the same
+      // pattern) and would get wrapped in a second, nested <mark>. Returning
+      // the post-splice index explicitly (the documented mechanism for this
+      // exact case - see unist-util-visit's own Visitor jsdoc) skips past
+      // everything just inserted and resumes at the real next sibling.
+      return index + replacement.length;
+    });
+  };
+}

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2699,6 +2699,132 @@ h6:hover > .document-view-heading-anchor {
   transition: width 80ms linear;
 }
 
+/* Document View full redesign, stage 3 ("in-document search/find") -
+   DocumentViewSearch.tsx's search bar, the header's "Find" toggle, and the
+   <mark> elements rehypeHighlightSearchMatches produces. */
+
+.document-view-panel-search-toggle {
+  flex-shrink: 0;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.document-view-panel-search-toggle:hover:enabled {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.document-view-panel-search-toggle:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.document-view-panel-search-toggle[aria-expanded="true"] {
+  background-color: var(--gl-neutral-button-hover);
+  border-color: var(--gl-palette-selection);
+}
+
+.document-view-search {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 0;
+}
+
+.document-view-search-input {
+  flex: 1;
+  min-width: 0;
+  padding: 5px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 4px;
+}
+
+.document-view-search-count {
+  flex-shrink: 0;
+  min-width: 56px;
+  font-size: 11px;
+  color: var(--gl-surface-text-muted);
+  text-align: right;
+}
+
+.document-view-search-nav,
+.document-view-search-close {
+  flex-shrink: 0;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.document-view-search-nav:hover:enabled,
+.document-view-search-close:hover {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.document-view-search-nav:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+/* Neither literal is a new raw-color exception: color-mix() references an
+   existing token rather than introducing a hex/rgba value, so it falls
+   outside no-raw-colors.test.ts's scan by construction (that scanner only
+   matches #hex and rgba()/rgb() literals). --gl-semantic-search-highlight
+   is a token this design system already defines specifically for this
+   purpose (gl-vars-dev.css) but had never been referenced anywhere until
+   now - using it here instead of overloading --gl-palette-selection (the
+   generic "this one is selected/active" accent used elsewhere in this
+   file) is both more semantically correct and gives a wider contrast
+   margin for the current-match text below. The current match (the one
+   Next/Previous navigates to) gets the token solid, with
+   --gl-surface-inset-deep (an existing, even-darker-than-window token,
+   already used elsewhere in this file as a text-on-accent color - see
+   styles.css around line 5235) as the contrasting text color, falling back
+   to --gl-surface-window if that token is ever absent. */
+mark.document-view-search-match {
+  background-color: color-mix(in srgb, var(--gl-semantic-search-highlight) 35%, transparent);
+  color: inherit;
+  border-radius: 2px;
+}
+
+mark.document-view-search-match-current {
+  background-color: var(--gl-semantic-search-highlight);
+  color: var(--gl-surface-inset-deep, var(--gl-surface-window));
+}
+
+/* Standard visually-hidden technique (content present for assistive tech,
+   removed from visual layout and the tab order isn't affected since this
+   is never itself focusable) - same shape as the pre-existing
+   .library-visually-hidden elsewhere in this file, scoped to Document
+   View's own naming convention rather than reusing that one across an
+   unrelated feature. Used by DocumentViewSearch.tsx's debounced,
+   screen-reader-only match-count announcement. */
+.document-view-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .help-rail {
   width: 220px;
   flex-shrink: 0;


### PR DESCRIPTION
## Problem

Document View (the slide-out panel showing a chat node's message or a full conversation transcript as rendered markdown) had no way to search within a long document.

## Change

- `documentViewSearchHighlight.ts`: the first hand-authored remark/rehype plugin in this codebase (stages 1-2 only composed published plugins). `rehypeHighlightSearchMatches(query)` walks the markdown AST and wraps every case-insensitive substring match in a `<mark>` element, so highlighting stays fully declarative (re-render on every keystroke) rather than mutating the rendered DOM directly.
- `DocumentViewSearch.tsx`: the search bar UI - query input, match count, Previous/Next navigation, Escape to close.
- `DocumentViewPanel.tsx`: a "Find" toggle in the header; owns the search state and derives match count / the current-match highlight from the actual rendered `<mark>` elements, so the "n of m" display can never drift from what's on screen.

## Adversarial review

A multi-dimension review (5 independent reviewers, each finding independently re-verified against the real code) raised 10 findings; all 10 were confirmed and fixed in one pass:

1. The header "Find" toggle closed the search bar without clearing the query, leaving every match permanently highlighted with no visible way to clear them (found independently by 3 of the 5 reviewers). Fixed by routing the toggle's close path through the same handler the search bar's own Close button uses.
2. Markdown source preserves irregular internal whitespace verbatim (e.g. double spaces from pasted text) while the browser visually collapses it to one space, so a query typed exactly as displayed could silently fail to match. Fixed by widening literal space runs in the query to `\s+`.
3. `rehype-autolink-headings`' decorative, `aria-hidden` "#" anchor after each heading was visited like any other text, so searching for "#" highlighted that decoration and inflated the match count. Fixed by skipping `aria-hidden` parents.
4. `DocumentViewToc`'s Escape-to-close listener used the capture phase, which always fires before a descendant's `stopPropagation()` can take effect - so dismissing just the search bar with Escape also silently closed an open outline dropdown. Fixed by switching that listener to the bubble phase.
5. The match-count live region re-announced on every keystroke with no debounce, which floods screen readers with a backlog of stale counts. Fixed by debouncing the announced copy (the visible count still updates instantly) via a separate, visually-hidden live region.
6. The header toggle button and the search input shared the same accessible name. Fixed by giving the input its own distinct label.
7. Non-ASCII case-folding gaps (e.g. German "straße"/"STRASSE", Turkish dotted/dotless i) - documented as an accepted limitation shared with native browser find, not fixed.
8. The current-match highlight's contrast ratio computed to 4.52:1, a razor-thin margin above the 4.5:1 WCAG AA threshold. While looking into this, found the design system already defines a token specifically for this purpose (`--gl-semantic-search-highlight`) that had never been used anywhere - switched to it (plus an existing darker text token), which also widens the contrast margin to ~5.5:1.

## Test plan

- [x] `documentViewSearchHighlight.test.ts` (17 tests): match wrapping, case-insensitivity, regex-metacharacter escaping, whitespace-run matching, `aria-hidden` skip, and a dedicated regression test for a subtle `unist-util-visit` traversal bug (the visitor must return the post-splice index or it re-enters its own freshly-inserted `<mark>` nodes and double-wraps them).
- [x] `DocumentViewSearch.test.tsx` (13 tests): input wiring, Enter/Shift+Enter navigation, Escape, disabled states, debounced live-region announcement.
- [x] `DocumentViewPanel.test.tsx`: added coverage for match highlighting, Next/Previous wraparound, the header-toggle-close bug fix, and the ToC/search Escape-interaction fix.
- [x] Full suite green: `tsc --noEmit`, `vitest run` (1045/1045), `eslint` (0 errors), `vite build`, backend `pytest -q` (1161/1161), `contracts/codegen.py --check`.