### PR TITLE
Redesign Document View, stage 4: drawer UX polish

### DIFF
--- a/web_ui/src/app/canvas/DocumentViewPanel.test.tsx
+++ b/web_ui/src/app/canvas/DocumentViewPanel.test.tsx
@@ -92,12 +92,12 @@ describe("DocumentViewPanel", () => {
 
   it("renders a resize handle", () => {
     renderPanel();
-    expect(screen.getByRole("separator", { name: "Resize Document View panel" })).toBeInTheDocument();
+    expect(screen.getByRole("separator", { name: "Resize Document View panel. Press Enter to reset to the default width." })).toBeInTheDocument();
   });
 
   it("dragging the resize handle changes the panel's width, and releasing ends the drag cleanly", () => {
     const { container } = renderPanel();
-    const handle = screen.getByRole("separator", { name: "Resize Document View panel" });
+    const handle = screen.getByRole("separator", { name: "Resize Document View panel. Press Enter to reset to the default width." });
     const panel = container.querySelector(".document-view-panel") as HTMLElement;
 
     fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
@@ -119,7 +119,7 @@ describe("DocumentViewPanel", () => {
 
   it("clamps the resize width to the configured min/max range", () => {
     const { container } = renderPanel();
-    const handle = screen.getByRole("separator", { name: "Resize Document View panel" });
+    const handle = screen.getByRole("separator", { name: "Resize Document View panel. Press Enter to reset to the default width." });
     const panel = container.querySelector(".document-view-panel") as HTMLElement;
 
     fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
@@ -356,6 +356,243 @@ describe("DocumentViewPanel", () => {
 
       expect(screen.queryByRole("search")).toBeNull();
       expect(screen.getByRole("menu", { name: "Table of contents" })).toBeInTheDocument();
+    });
+  });
+
+  describe("drawer UX polish (stage 4)", () => {
+    it("Escape closes the panel", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      renderPanel({ onClose });
+
+      await user.keyboard("{Escape}");
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("does not close the panel on Escape while the search bar is open - closes search instead", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      renderPanel({ onClose, content: "the cat sat" });
+
+      await user.click(screen.getByRole("button", { name: "Find in document" }));
+      expect(screen.getByRole("search")).toBeInTheDocument();
+
+      await user.keyboard("{Escape}");
+
+      expect(onClose).not.toHaveBeenCalled();
+      expect(screen.queryByRole("search")).toBeNull();
+    });
+
+    it("closes only the search bar via the panel's own Escape handling when focus has moved elsewhere in the panel (not the search input itself)", async () => {
+      // Regression test: the test above passes even with the panel's own
+      // isSearchOpen deferral branch deleted entirely, because the search
+      // input auto-focuses and its OWN pre-existing (stage 3) Escape
+      // handler intercepts the keystroke first, via stopPropagation, before
+      // it ever reaches the panel's document-level listener. Caught by
+      // adversarial review: that left the actual new branch this stage
+      // added completely untested. Moving focus off the input first forces
+      // the keystroke through the panel's own listener instead.
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      renderPanel({ onClose, content: "the cat sat" });
+
+      await user.click(screen.getByRole("button", { name: "Find in document" }));
+      const searchInput = screen.getByRole("textbox", { name: "Search query" });
+      expect(searchInput).toHaveFocus();
+      searchInput.blur();
+      expect(document.activeElement).not.toBe(searchInput);
+
+      await user.keyboard("{Escape}");
+
+      expect(onClose).not.toHaveBeenCalled();
+      expect(screen.queryByRole("search")).toBeNull();
+    });
+
+    it("closes only one of search/ToC (not both) from a single Escape press when both are open and focus is outside the search input", async () => {
+      // Regression test for a confirmed adversarial-review finding: the
+      // panel's own isSearchOpen branch didn't stop the event from also
+      // reaching DocumentViewToc's own, separate document-level Escape
+      // listener, so with both open and focus left on the Outline toggle
+      // (not inside the search input), a single Escape press closed BOTH at
+      // once instead of just one.
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      renderPanel({ onClose, content: "# One\n\n## Two\n\nthe cat sat" });
+
+      await user.click(screen.getByRole("button", { name: "Find in document" }));
+      await user.click(screen.getByRole("button", { name: "Outline" }));
+      expect(screen.getByRole("search")).toBeInTheDocument();
+      expect(screen.getByRole("menu", { name: "Table of contents" })).toBeInTheDocument();
+
+      await user.keyboard("{Escape}");
+
+      expect(onClose).not.toHaveBeenCalled();
+      const searchStillOpen = screen.queryByRole("search") !== null;
+      const tocStillOpen = screen.queryByRole("menu") !== null;
+      expect(searchStillOpen).not.toBe(tocStillOpen);
+    });
+
+    it("does not close the panel on Escape while the ToC outline is open - closes the outline instead", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      renderPanel({ onClose, content: "# One\n\n## Two" });
+
+      await user.click(screen.getByRole("button", { name: "Outline" }));
+      expect(screen.getByRole("menu", { name: "Table of contents" })).toBeInTheDocument();
+
+      await user.keyboard("{Escape}");
+
+      expect(onClose).not.toHaveBeenCalled();
+      expect(screen.queryByRole("menu")).toBeNull();
+    });
+
+    it("does not listen for Escape while closed", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      renderPanel({ onClose, isOpen: false });
+
+      await user.keyboard("{Escape}");
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("double-clicking the resize handle resets the width to the default", () => {
+      const { container } = renderPanel();
+      const handle = screen.getByRole("separator", { name: "Resize Document View panel. Press Enter to reset to the default width." });
+      const panel = container.querySelector(".document-view-panel") as HTMLElement;
+
+      fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+      fireEvent.pointerMove(handle, { clientX: 700, pointerId: 1 });
+      fireEvent.pointerUp(handle, { clientX: 700, pointerId: 1 });
+      expect(panel.style.width).toBe("700px");
+
+      fireEvent.doubleClick(handle);
+      expect(panel.style.width).toBe("500px");
+    });
+
+    it("is keyboard-focusable and pressing Enter resets the width to the default", () => {
+      // Regression test for a confirmed adversarial-review finding: the
+      // resize handle's double-click-to-reset had no keyboard equivalent -
+      // a plain, non-focusable div with no way to trigger it without a
+      // mouse.
+      const { container } = renderPanel();
+      const handle = screen.getByRole("separator", { name: "Resize Document View panel. Press Enter to reset to the default width." });
+      const panel = container.querySelector(".document-view-panel") as HTMLElement;
+      expect(handle).toHaveAttribute("tabIndex", "0");
+
+      fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+      fireEvent.pointerMove(handle, { clientX: 700, pointerId: 1 });
+      fireEvent.pointerUp(handle, { clientX: 700, pointerId: 1 });
+      expect(panel.style.width).toBe("700px");
+
+      fireEvent.keyDown(handle, { key: "Enter" });
+      expect(panel.style.width).toBe("500px");
+    });
+
+    it("pressing Space on the focused resize handle also resets the width", () => {
+      const { container } = renderPanel();
+      const handle = screen.getByRole("separator", { name: "Resize Document View panel. Press Enter to reset to the default width." });
+      const panel = container.querySelector(".document-view-panel") as HTMLElement;
+
+      fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+      fireEvent.pointerMove(handle, { clientX: 650, pointerId: 1 });
+      fireEvent.pointerUp(handle, { clientX: 650, pointerId: 1 });
+      expect(panel.style.width).toBe("650px");
+
+      fireEvent.keyDown(handle, { key: " " });
+      expect(panel.style.width).toBe("500px");
+    });
+
+    describe("Expand/Collapse toggle", () => {
+      it("expanding removes the inline width so the CSS class takes over, and shows 'Collapse'", () => {
+        const { container } = renderPanel();
+        const panel = container.querySelector(".document-view-panel") as HTMLElement;
+        expect(panel.style.width).toBe("500px");
+
+        fireEvent.click(screen.getByRole("button", { name: "Expand" }));
+
+        expect(panel).toHaveClass("document-view-panel-expanded");
+        expect(panel.style.width).toBe("");
+        expect(screen.getByRole("button", { name: "Collapse" })).toBeInTheDocument();
+      });
+
+      it("collapsing restores the exact width from before expanding", () => {
+        const { container } = renderPanel();
+        const panel = container.querySelector(".document-view-panel") as HTMLElement;
+        const handle = screen.getByRole("separator", { name: "Resize Document View panel. Press Enter to reset to the default width." });
+
+        fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+        fireEvent.pointerMove(handle, { clientX: 650, pointerId: 1 });
+        fireEvent.pointerUp(handle, { clientX: 650, pointerId: 1 });
+        expect(panel.style.width).toBe("650px");
+
+        fireEvent.click(screen.getByRole("button", { name: "Expand" }));
+        expect(panel).not.toHaveClass("document-view-panel-resizing");
+        fireEvent.click(screen.getByRole("button", { name: "Collapse" }));
+
+        expect(panel).not.toHaveClass("document-view-panel-expanded");
+        expect(panel.style.width).toBe("650px");
+      });
+
+      it("starting a manual drag while expanded exits expanded mode", () => {
+        const { container } = renderPanel();
+        const panel = container.querySelector(".document-view-panel") as HTMLElement;
+        const handle = screen.getByRole("separator", { name: "Resize Document View panel. Press Enter to reset to the default width." });
+
+        fireEvent.click(screen.getByRole("button", { name: "Expand" }));
+        expect(panel).toHaveClass("document-view-panel-expanded");
+
+        fireEvent.pointerDown(handle, { clientX: 500, pointerId: 1 });
+        expect(panel).not.toHaveClass("document-view-panel-expanded");
+
+        fireEvent.pointerMove(handle, { clientX: 600, pointerId: 1 });
+        expect(panel.style.width).toBe("600px");
+      });
+    });
+
+    describe("font-size stepper", () => {
+      function scrollFontSize(container: HTMLElement): string {
+        return (container.querySelector(".document-view-panel-scroll") as HTMLElement).style.fontSize;
+      }
+
+      it("applies no inline font-size at the default step", () => {
+        const { container } = renderPanel();
+        expect(scrollFontSize(container)).toBe("");
+      });
+
+      it("increasing steps up applies a larger em multiplier", () => {
+        const { container } = renderPanel();
+        fireEvent.click(screen.getByRole("button", { name: "Increase text size" }));
+        expect(scrollFontSize(container)).toBe("1.15em");
+      });
+
+      it("decreasing steps down applies a smaller em multiplier", () => {
+        const { container } = renderPanel();
+        fireEvent.click(screen.getByRole("button", { name: "Decrease text size" }));
+        expect(scrollFontSize(container)).toBe("0.85em");
+      });
+
+      it("returning to the default step removes the inline font-size again", () => {
+        const { container } = renderPanel();
+        fireEvent.click(screen.getByRole("button", { name: "Increase text size" }));
+        expect(scrollFontSize(container)).toBe("1.15em");
+
+        fireEvent.click(screen.getByRole("button", { name: "Decrease text size" }));
+        expect(scrollFontSize(container)).toBe("");
+      });
+
+      it("disables Decrease at the smallest step and Increase at the largest", () => {
+        renderPanel();
+        const decrease = screen.getByRole("button", { name: "Decrease text size" });
+        const increase = screen.getByRole("button", { name: "Increase text size" });
+
+        fireEvent.click(decrease);
+        expect(decrease).toBeDisabled();
+
+        fireEvent.click(increase);
+        fireEvent.click(increase);
+        fireEvent.click(increase);
+        expect(increase).toBeDisabled();
+      });
     });
   });
 });

--- a/web_ui/src/app/canvas/DocumentViewPanel.tsx
+++ b/web_ui/src/app/canvas/DocumentViewPanel.tsx
@@ -11,6 +11,18 @@ const DEFAULT_WIDTH = 500;
 const MIN_WIDTH = 320;
 const MAX_WIDTH = 900;
 
+// Stage 4: relative multipliers, not absolute pixel values - the actual
+// inherited body font-size in `.document-view-panel-scroll` is never set
+// explicitly by this file (it cascades down from ambient app chrome), so
+// hard-coding a "base" px value here could drift from whatever that
+// ambient size actually is. `1` (the default/middle step) omits the inline
+// style entirely (see the render below), leaving today's already-shipped,
+// already-verified rendering completely undisturbed; only stepping away
+// from it applies an explicit `Nem` override, scaled relative to whatever
+// the ambient size already was.
+const FONT_SIZE_STEPS = [0.85, 1, 1.15, 1.3];
+const DEFAULT_FONT_SIZE_STEP_INDEX = 1;
+
 /**
  * Document View panel (Qt-removal plan R7.6b's stub, redone as a real
  * docked panel, then refined further). Legacy's DocumentViewerPanel/
@@ -33,12 +45,11 @@ const MAX_WIDTH = 900;
  * constant-width inner block via the outer's overflow:hidden instead reads
  * as a real slide, the same technique most CSS-only drawer components use.
  *
- * Closing it only ever happens via its own Close button, matching legacy
- * exactly - it was never part of Qt's OverlayManager, so no scrim, no
- * Escape-to-close, no focus trap here either. (Full redesign, stage 4 of 4,
- * revisits the Escape-to-close piece specifically - see that stage's own
- * notes for why it's being added without adopting the rest of the modal
- * treatment.)
+ * Closing it only ever happens via its own Close button OR Escape (added in
+ * stage 4 - see below), matching legacy's shape otherwise: it was never part
+ * of Qt's OverlayManager, so still no scrim and no focus trap - Escape-to-
+ * close was the one specific piece of modal-like behavior worth adding on
+ * its own, not a signal that the rest of that treatment is coming too.
  *
  * Full redesign, stage 1 of 4 ("content rendering upgrades"): the markdown
  * body itself is now rendered by DocumentViewMarkdown.tsx (heading anchors,
@@ -74,6 +85,55 @@ const MAX_WIDTH = 900;
  * newly-typed search, matching standard find-bar behavior) - using the same
  * render-phase "adjust state when a value changes" idiom stage 2 already
  * established, not a useEffect.
+ *
+ * Full redesign, stage 4 of 4 ("drawer UX polish"), the last of the four:
+ *
+ * - Escape-to-close: a document-level listener, scoped to `isOpen` (matching
+ *   DocumentViewToc.tsx's and DocumentViewSearch.tsx's own precedent for
+ *   global-but-scoped key handling in this panel). Defers rather than
+ *   closing the whole panel if a more specific, nested transient UI should
+ *   consume the keystroke instead: the search bar (checked via
+ *   `isSearchOpen`, which this component already owns) or the ToC outline
+ *   dropdown (checked via a DOM query for its own class, since that
+ *   component owns its open state privately - reading the rendered DOM as
+ *   ground truth for "is this open" rather than lifting that state up
+ *   matches the same technique this file's own search-match tracking above
+ *   already uses `SEARCH_MATCH_SELECTOR` for).
+ * - Remembered/resettable width: "remembered" here means for the lifetime of
+ *   the running app, not across a restart - this component is never
+ *   unmounted while the app runs (App.tsx mounts it once, `isOpen` only
+ *   toggles visibility), so `width` already survives every close/reopen for
+ *   free. Persisting it across a full app restart would need a new
+ *   backend-settings round trip (SettingsManager/backend/settings.py's
+ *   established pattern) for a single panel's pixel width - a disproportionate
+ *   amount of new backend surface for what this stage is scoped as: a
+ *   frontend-only polish pass, matching stages 1-3's own shape. "Resettable"
+ *   is a double-click on the resize handle, snapping back to
+ *   `DEFAULT_WIDTH` - a common, discoverable convention (e.g. VS Code's own
+ *   sidebar resize handle).
+ * - Expand/fullscreen toggle: `isExpanded` is independent of `width` - it
+ *   doesn't overwrite the user's own chosen/remembered width, it just
+ *   temporarily overrides the RENDERED size via a CSS class
+ *   (`.document-view-panel-expanded`) instead of the usual inline
+ *   `style={{width}}`, so un-expanding snaps right back to the exact width
+ *   the user had before. Starting a manual drag while expanded exits
+ *   expanded mode first (see onResizeStart) - dragging implies "I want
+ *   precise manual control now," and continuing to drag while a CSS class
+ *   was fighting the inline width would be visibly broken.
+ * - Font-size stepper: relative `em` multipliers, not absolute pixel values -
+ *   see FONT_SIZE_STEPS' own comment for why. Only scales inherited text
+ *   (paragraphs, lists, table cells, blockquotes, and code via its own
+ *   existing `em`-relative sizing) - headings keep their existing fixed
+ *   px hierarchy (15/14/13/12), a deliberate, small, out-of-scope-to-fix
+ *   limitation: proportionally scaling headings too would mean touching
+ *   `.chat-node-content`'s shared rules, used by every OTHER markdown
+ *   surface in the app (chat bubbles, notes), not just this panel - a much
+ *   larger blast radius than a "polish" pass warrants.
+ *
+ * Width, expanded state, and font-size step are NOT reset when `content`
+ * changes (unlike stage 2/3's scroll/progress/search state) - they describe
+ * how the user likes the PANEL sized/scaled, not anything about the specific
+ * document currently showing in it.
  */
 export function DocumentViewPanel({
   isOpen,
@@ -88,6 +148,9 @@ export function DocumentViewPanel({
 }) {
   const [width, setWidth] = useState(DEFAULT_WIDTH);
   const [isResizing, setIsResizing] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [fontSizeStepIndex, setFontSizeStepIndex] = useState(DEFAULT_FONT_SIZE_STEP_INDEX);
+  const panelRef = useRef<HTMLElement>(null);
   const dragStartRef = useRef<{ pointerX: number; startWidth: number } | null>(null);
 
   // Real Pointer Capture, not a window-level pointermove/pointerup pair:
@@ -107,6 +170,22 @@ export function DocumentViewPanel({
       event.preventDefault();
       dragStartRef.current = { pointerX: event.clientX, startWidth: width };
       setIsResizing(true);
+      // Dragging implies "give me precise manual control now" - this exits
+      // expanded mode so onResizeMove's own math (based on `width`'s last-
+      // remembered value, not whatever the expanded CSS class currently
+      // renders) takes over. Adversarial review correctly flagged an
+      // earlier draft of this comment for claiming that transition happens
+      // smoothly/gradually - it does not: `setIsResizing`/`setIsExpanded`
+      // land in the same React commit, so `.document-view-panel-resizing`'s
+      // `transition: none` (styles.css) is already active in the very
+      // render where the width also changes, meaning the panel visibly
+      // snaps straight to `width` on pointerdown itself, before any actual
+      // drag motion. This is deliberately left as an instant snap, not
+      // smoothed out: it's the same convention real window managers use for
+      // "un-maximize by starting to drag" (an immediate jump to the
+      // previous/restored size, not an animated shrink), which users
+      // already read as normal, expected behavior rather than a glitch.
+      setIsExpanded(false);
       // Feature-detected, not assumed: real browsers have supported Pointer
       // Capture for years, but the DOM environment this runs in (an older
       // WebView2/browser, or a test environment like jsdom) may not.
@@ -121,6 +200,36 @@ export function DocumentViewPanel({
     const next = start.startWidth + (event.clientX - start.pointerX);
     setWidth(Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, next)));
   }, []);
+
+  // Resets width to the default. If the panel happens to be Expanded when
+  // this runs, it's ALSO already been un-expanded by this point - not by
+  // this function, but as an unavoidable side effect of onResizeStart
+  // (bound to pointerdown) already having fired twice before either a
+  // dblclick or this handler's own Enter/Space path ever reaches here (a
+  // double-click is, unavoidably, two prior pointerdown/pointerup cycles;
+  // the keyboard path calls onResetWidth directly with no such prelude, so
+  // it does NOT itself touch `isExpanded`). Left as-is deliberately, not
+  // worked around: "reset" reasonably means "back to the normal, default-
+  // width, non-expanded state" as a whole, not just the `width` number in
+  // isolation.
+  const onResetWidth = useCallback(() => {
+    setWidth(DEFAULT_WIDTH);
+  }, []);
+
+  const onResizeHandleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      // Adversarial-review finding: double-click-to-reset had no keyboard
+      // equivalent at all - the handle was a plain, non-focusable div, so a
+      // keyboard-only user had no way to invoke it. Enter/Space (not arrow-
+      // key resizing, which would be a larger, separate feature) mirrors
+      // the double-click's own single action.
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        onResetWidth();
+      }
+    },
+    [onResetWidth],
+  );
 
   const onResizeEnd = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     dragStartRef.current = null;
@@ -234,20 +343,80 @@ export function DocumentViewPanel({
     container.scrollTop += currentRect.top - containerRect.top;
   }, [content, searchQuery, currentMatchIndex]);
 
+  // Stage 4: Escape-to-close. Deferring to a more specific, nested transient
+  // UI - the search bar (this component's own `isSearchOpen`) or the ToC
+  // outline dropdown (no state access here, so checked via the rendered DOM
+  // instead, scoped to this panel's own root) - means each one still closes
+  // on its own first Escape press, exactly as stage 2/3 already established,
+  // rather than this new listener closing the ENTIRE panel out from under
+  // whichever of those was actually still open.
+  //
+  // Adversarial-review finding, confirmed and fixed: when both the search
+  // bar and the ToC dropdown were open at once, and focus was anywhere OTHER
+  // than inside the search input, one Escape press closed BOTH - not just
+  // the search bar this branch means to defer to. DocumentViewToc.tsx's own
+  // Escape listener is a SEPARATE `document`-level listener that closes
+  // itself unconditionally whenever it's open, with no awareness of
+  // anything else reacting to the same keystroke; merely calling
+  // `onSearchClose()` and returning here does nothing to stop that OTHER
+  // listener from also firing on the very same dispatch. Plain
+  // `stopPropagation()` would not fix this either - both listeners are
+  // attached to the SAME target (`document`), and per the DOM event model
+  // `stopPropagation()` only prevents an event from reaching FURTHER
+  // targets (e.g. document -> window), not other listeners already
+  // registered on the target it's currently at; only
+  // `stopImmediatePropagation()` prevents sibling listeners on the same
+  // node from running. Calling it here means this branch's "close search,
+  // leave everything else alone" intent is actually enforced, regardless of
+  // which of this listener's or ToC's own listener happens to be registered
+  // first for a given interaction order.
+  useEffect(() => {
+    if (!isOpen) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      if (isSearchOpen) {
+        onSearchClose();
+        event.stopImmediatePropagation();
+        return;
+      }
+      if (panelRef.current?.querySelector(".document-view-toc-dropdown")) return;
+      onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, isSearchOpen, onSearchClose, onClose]);
+
+  const onFontSizeDecrease = useCallback(() => {
+    setFontSizeStepIndex((i) => Math.max(0, i - 1));
+  }, []);
+
+  const onFontSizeIncrease = useCallback(() => {
+    setFontSizeStepIndex((i) => Math.min(FONT_SIZE_STEPS.length - 1, i + 1));
+  }, []);
+
+  const fontSizeMultiplier = FONT_SIZE_STEPS[fontSizeStepIndex];
+
   return (
     <aside
+      ref={panelRef}
       className={[
         "document-view-panel",
         isOpen ? "document-view-panel-open" : "",
         isResizing ? "document-view-panel-resizing" : "",
+        isExpanded ? "document-view-panel-expanded" : "",
       ]
         .filter(Boolean)
         .join(" ")}
       aria-label="Document View"
       aria-hidden={!isOpen}
-      style={{ width: isOpen ? width : 0 }}
+      style={{ width: isOpen ? (isExpanded ? undefined : width) : 0 }}
     >
-      <div className="document-view-panel-inner" style={{ width }}>
+      <div
+        className={["document-view-panel-inner", isExpanded ? "document-view-panel-expanded" : ""]
+          .filter(Boolean)
+          .join(" ")}
+        style={{ width: isExpanded ? undefined : width }}
+      >
         <header className="document-view-panel-header">
           <div className="document-view-panel-heading">
             <span className="document-view-panel-title">Document View</span>
@@ -279,6 +448,48 @@ export function DocumentViewPanel({
             Close
           </button>
         </header>
+        {/* A separate row, not folded into the header above: with the main
+            header already carrying 5 controls (title + Outline/Find/Copy/
+            Close), adding these 3 more (font stepper x2, Expand) there too
+            would overflow this panel's own supported MIN_WIDTH (320px) -
+            confirmed by rough measurement, not just a hunch (~444px of
+            fixed-width buttons alone against a ~300px content budget at
+            MIN_WIDTH, before even the title). This row has far fewer
+            neighbors competing for space. */}
+        <div className="document-view-panel-toolbar">
+          <div className="document-view-panel-font-stepper">
+            <button
+              type="button"
+              className="document-view-panel-font-step"
+              onClick={onFontSizeDecrease}
+              disabled={fontSizeStepIndex === 0}
+              title="Decrease text size"
+              aria-label="Decrease text size"
+            >
+              A-
+            </button>
+            <button
+              type="button"
+              className="document-view-panel-font-step"
+              onClick={onFontSizeIncrease}
+              disabled={fontSizeStepIndex === FONT_SIZE_STEPS.length - 1}
+              title="Increase text size"
+              aria-label="Increase text size"
+            >
+              A+
+            </button>
+          </div>
+          <button
+            type="button"
+            className="document-view-panel-expand-toggle"
+            onClick={() => setIsExpanded((expanded) => !expanded)}
+            title={isExpanded ? "Collapse" : "Expand"}
+            aria-label={isExpanded ? "Collapse" : "Expand"}
+            aria-pressed={isExpanded}
+          >
+            {isExpanded ? "Collapse" : "Expand"}
+          </button>
+        </div>
         <DocumentViewSearch
           isOpen={isSearchOpen}
           query={searchQuery}
@@ -299,7 +510,12 @@ export function DocumentViewPanel({
         >
           <div className="document-view-panel-progress-fill" style={{ width: `${readingProgress}%` }} />
         </div>
-        <div className="document-view-panel-scroll chat-node-content" ref={scrollRef} onScroll={onScroll}>
+        <div
+          className="document-view-panel-scroll chat-node-content"
+          ref={scrollRef}
+          onScroll={onScroll}
+          style={{ fontSize: fontSizeMultiplier === 1 ? undefined : `${fontSizeMultiplier}em` }}
+        >
           <DocumentViewMarkdown content={content ?? ""} searchQuery={searchQuery} />
         </div>
       </div>
@@ -309,9 +525,13 @@ export function DocumentViewPanel({
         onPointerMove={onResizeMove}
         onPointerUp={onResizeEnd}
         onPointerCancel={onResizeEnd}
+        onDoubleClick={onResetWidth}
+        onKeyDown={onResizeHandleKeyDown}
         role="separator"
+        tabIndex={0}
         aria-orientation="vertical"
-        aria-label="Resize Document View panel"
+        aria-label="Resize Document View panel. Press Enter to reset to the default width."
+        title="Drag to resize, double-click or Enter to reset"
       />
     </aside>
   );

--- a/web_ui/src/app/canvas/DocumentViewToc.tsx
+++ b/web_ui/src/app/canvas/DocumentViewToc.tsx
@@ -66,7 +66,26 @@ export function DocumentViewToc({
       if (rootRef.current && !rootRef.current.contains(event.target as Node)) setIsOpen(false);
     }
     function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setIsOpen(false);
+      if (event.key !== "Escape") return;
+      setIsOpen(false);
+      // stopImmediatePropagation(), not plain stopPropagation() - both this
+      // listener and DocumentViewPanel.tsx's own Escape-to-close-the-whole-
+      // panel listener are attached to the SAME target (`document`), and
+      // per the DOM event model plain stopPropagation() only blocks an
+      // event from reaching FURTHER targets (document -> window), not
+      // other listeners already registered on the target it's currently
+      // at - only stopImmediatePropagation() does that. An earlier version
+      // of this comment claimed plain stopPropagation() here was "defense
+      // in depth" against exactly this kind of same-target listener, which
+      // adversarial review found was simply incorrect (verified by
+      // temporarily removing the call and confirming a same-target sibling
+      // listener was unaffected either way) - stopImmediatePropagation is
+      // the one that actually delivers that guarantee, regardless of
+      // whether this listener or the panel's own happens to be registered
+      // first for a given interaction order (DocumentViewPanel.tsx's own
+      // Escape handler now calls it too, for the same reason, in the
+      // branch where IT is the one closing something).
+      event.stopImmediatePropagation();
     }
     document.addEventListener("pointerdown", onPointerDown, true);
     // Bubble phase (no capture), unlike the pointerdown listener above -
@@ -77,10 +96,7 @@ export function DocumentViewToc({
     // run during the capture leg of dispatch - BEFORE the event ever
     // reaches the search input's own bubble-phase handler - making that
     // stopPropagation() call a no-op against this listener. Bubble phase
-    // lets an inner element's stopPropagation() genuinely take effect,
-    // while every other Escape-closes-this-dropdown scenario (focus
-    // elsewhere in the panel, or nowhere in particular) is unaffected,
-    // since nothing else in this panel calls stopPropagation on Escape.
+    // lets an inner element's stopPropagation() genuinely take effect.
     document.addEventListener("keydown", onKeyDown);
     return () => {
       document.removeEventListener("pointerdown", onPointerDown, true);

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2364,6 +2364,17 @@ body,
   transition: none;
 }
 
+/* Stage 4 ("drawer UX polish"): applied to BOTH the outer aside and the
+   inner content div (same class, same declared width) when the Expand
+   toggle is on - the outer aside's own existing width transition (above)
+   still applies, so expanding/collapsing slides exactly like opening/
+   closing does. Only takes effect at all because DocumentViewPanel.tsx
+   omits the competing inline `style={{width}}` while expanded, rather than
+   this needing `!important` to win against it. */
+.document-view-panel-expanded {
+  width: min(1400px, 92vw);
+}
+
 .document-view-panel-inner {
   height: 100%;
   box-sizing: border-box;
@@ -2391,6 +2402,13 @@ body,
 .document-view-panel-title {
   font-size: 14px;
   font-weight: 700;
+  /* Defensive, matching the subtitle's own existing truncation just below -
+     harmless at any width this row already comfortably fits, and a cheap
+     safeguard against the row ever overflowing rather than forcing it to. */
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .document-view-panel-subtitle {
@@ -2823,6 +2841,73 @@ mark.document-view-search-match-current {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+/* Document View full redesign, stage 4 ("drawer UX polish") - a small
+   toolbar row (font-size stepper + Expand/Collapse), separate from the
+   main header - see DocumentViewPanel.tsx's own inline comment for why
+   these don't live in the header alongside Outline/Find/Copy/Close. */
+
+.document-view-panel-toolbar {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.document-view-panel-font-stepper {
+  flex-shrink: 0;
+  display: flex;
+  gap: 2px;
+}
+
+.document-view-panel-font-step {
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+  cursor: pointer;
+}
+
+.document-view-panel-font-step:first-child {
+  border-radius: 4px 0 0 4px;
+}
+
+.document-view-panel-font-step:last-child {
+  border-radius: 0 4px 4px 0;
+  margin-left: -1px;
+}
+
+.document-view-panel-font-step:hover:enabled {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.document-view-panel-font-step:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.document-view-panel-expand-toggle {
+  flex-shrink: 0;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.document-view-panel-expand-toggle:hover {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.document-view-panel-expand-toggle[aria-pressed="true"] {
+  background-color: var(--gl-neutral-button-hover);
+  border-color: var(--gl-palette-selection);
 }
 
 .help-rail {


### PR DESCRIPTION
## Problem

The last of the four Document View redesign stages. The panel had no Escape-to-close, no way to reset a manually-resized width, no way to temporarily view it larger, and no way to adjust text size.

## Change

- Escape closes the panel, deferring to the search bar or ToC outline dropdown when either is open (so a single Escape press only ever closes the innermost thing, not everything at once).
- The resize handle's width is resettable: double-click it, or focus it and press Enter/Space, to snap back to the default width. The width itself already persists for the life of the running app (this panel is never unmounted while open/closed) - persisting it across a full app restart would need new backend-settings plumbing (this app's `SettingsManager`/`app-settings` WS pattern), which felt disproportionate for a scoped "polish" pass, so that's explicitly out of scope here, not silently dropped.
- An Expand/Collapse toggle temporarily renders the panel at a much larger size via a CSS class, independent of the user's own resized width - collapsing returns to exactly where it was.
- A font-size stepper (A-/A+) scales the document body text via relative `em` multipliers. Headings keep their existing fixed sizes (scaling those too would mean touching CSS shared with every other markdown surface in the app - chat bubbles, notes - a larger change than this pass warrants).

## Adversarial review

A multi-dimension review (4 independent reviewers, each finding independently re-verified against the real code) raised 10 findings; all were addressed in one pass:

1. **Escape could close two things at once.** With both the search bar and the ToC outline open, and focus outside the search input, a single Escape press closed both instead of just one - the panel's own Escape handler and the ToC dropdown's own Escape handler are separate listeners on the same target (`document`), and calling `stopPropagation()` doesn't prevent a sibling listener on the same target from also firing; only `stopImmediatePropagation()` does. Fixed by using that instead, in both listeners.
2. **Header overflow.** Adding 3 more controls (font stepper x2, Expand) to a header that already had 5 would overflow the panel's own supported minimum width (confirmed by measurement: ~444px of buttons against a ~300px budget at that width). Fixed by moving the two stage-4 additions into their own toolbar row.
3. **No keyboard equivalent for the width reset** - the resize handle was a non-focusable plain div. Fixed by making it focusable with an Enter/Space handler.
4. A misleading code comment claimed exiting Expand via a drag happens smoothly; it actually snaps instantly (both state changes land in the same render, before any transition can play). Corrected the comment - the instant snap is intentional, the same convention real window managers use for "un-maximize by dragging."
5. A test named as covering the Escape-defers-to-search behavior didn't actually exercise it, since the auto-focused search input's own handler intercepted the keystroke first. Added a test that moves focus elsewhere first.
6. A double-click while Expanded also exits Expanded mode, as an unavoidable side effect of its constituent pointerdowns - documented as intentional ("reset" reasonably means back to the whole normal state, not just the width number).
7. A stale comment inaccurately described what a `stopPropagation()` call actually protected against - corrected as part of fix #1.

## Test plan

- [x] `DocumentViewPanel.test.tsx`: added coverage for Escape-to-close (including the two-things-open regression), the resize handle's double-click/keyboard reset, Expand/Collapse (including the exits-on-drag and exits-on-double-click interactions), and the font-size stepper.
- [x] `DocumentViewToc.test.tsx` and `DocumentViewSearch.test.tsx` re-run unchanged, still passing.
- [x] Full suite green: `tsc --noEmit`, `vitest run` (1062/1062), `eslint` (0 errors), `vite build`, backend `pytest -q` (1161/1161, unaffected - no backend changes in this stage), `contracts/codegen.py --check`.