### PR TITLE
Redesign node cards, stages 1+2: shared markdown renderer + typography fix

### DIFF
--- a/web_ui/src/app/canvas/ArtifactNodeView.tsx
+++ b/web_ui/src/app/canvas/ArtifactNodeView.tsx
@@ -1,9 +1,7 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
 
 /**
@@ -11,21 +9,20 @@ import { NodeMenu } from "./NodeMenu";
  * React card. One vertical card, same overall shell as its plugin-node
  * siblings (ConversationNodeView/WebResearchNodeView): collapse/expand OR-ed
  * with LOD, a card menu with outside-click/Escape dismiss, the shared
- * react-markdown + remarkGfm + rehypeHighlight pipeline. Deliberately NOT a
- * literal two-pane split-view clone of the legacy widget - every prior
- * node/plugin port in this codebase re-composes the legacy widget's layout
- * into one card instead, and this follows that same convention: a document
- * preview on top, the instruction turn history below it, then the
- * instruction input at the bottom.
+ * NodeMarkdown.tsx renderer (node redesign stage 1) every text-bearing node
+ * kind now uses. Deliberately NOT a literal two-pane split-view clone of the
+ * legacy widget - every prior node/plugin port in this codebase re-composes
+ * the legacy widget's layout into one card instead, and this follows that
+ * same convention: a document preview on top, the instruction turn history
+ * below it, then the instruction input at the bottom.
  *
- * Security note, not a style preference: this reuses react-markdown/
- * remarkGfm/rehypeHighlight UNCHANGED - no rehype-raw, no
- * dangerouslySetInnerHTML anywhere in this file. Without rehype-raw,
- * react-markdown never interprets embedded HTML in either the document
- * preview or a turn bubble as live markup; it renders as inert text. That is
- * the same raw-text-can-never-become-a-live-DOM-element guarantee the legacy
- * app's escape-then-render pipeline gave, achieved here by construction
- * instead of an explicit escape step.
+ * Security note, not a style preference: NodeMarkdown.tsx's own pipeline has
+ * no rehype-raw, no dangerouslySetInnerHTML anywhere in this file or that
+ * one. Without rehype-raw, react-markdown never interprets embedded HTML in
+ * either the document preview or a turn bubble as live markup; it renders as
+ * inert text. That is the same raw-text-can-never-become-a-live-DOM-element
+ * guarantee the legacy app's escape-then-render pipeline gave, achieved here
+ * by construction instead of an explicit escape step.
  *
  * Card menu mirrors WebResearchNodeMenu's own posture: Collapse/Expand +
  * Delete Node only - no "Open Document View" placeholder (that is a legacy
@@ -118,9 +115,7 @@ function ArtifactBubble({ message }: { message: ArtifactMessage }) {
           shared-class convention ConversationBubble's own -content div
           establishes across every sibling node kind. */}
       <div className="chat-node-content artifact-node-bubble-content">
-        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-          {message.content}
-        </ReactMarkdown>
+        <NodeMarkdown content={message.content} />
       </div>
     </div>
   );
@@ -175,9 +170,7 @@ export function ArtifactNodeView({ data, selected }: NodeProps<ArtifactFlowNode>
           <div className="artifact-node-document">
             {hasContent ? (
               <div className="chat-node-content artifact-node-document-content">
-                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-                  {data.artifactContent}
-                </ReactMarkdown>
+                <NodeMarkdown content={data.artifactContent} />
               </div>
             ) : (
               <p className="artifact-node-empty">Document is currently empty.</p>

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -1,11 +1,9 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useEffect, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 import { CHAT_SCROLL_REPORT_DEBOUNCE_MS, LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { downloadTextFile } from "./downloadTextFile";
 import { GROUP_MONO_COLORS, GROUP_NAMED_COLORS } from "./GroupColorPicker";
+import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
 
 /**
@@ -598,9 +596,7 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
       </div>
       {!collapsed && (
         <div className="scene-node-body chat-node-content" ref={contentRef} onScroll={onScroll}>
-          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-            {data.content}
-          </ReactMarkdown>
+          <NodeMarkdown content={data.content} />
         </div>
       )}
       <Handle type="source" position={Position.Bottom} className="scene-node-handle" />

--- a/web_ui/src/app/canvas/CodeExecutionApprovalPanel.test.tsx
+++ b/web_ui/src/app/canvas/CodeExecutionApprovalPanel.test.tsx
@@ -41,13 +41,28 @@ describe("CodeExecutionApprovalPanel", () => {
 
   // -- FIX A regression guard: zero passive-dismissal affordances -----------
 
-  it("FIX A: there is no close/X button anywhere - Approve and Deny are the only two buttons rendered", () => {
+  it("FIX A: there is no close/X button anywhere - Deny and Approve are the only two RESOLVING buttons rendered", () => {
+    // The node redesign migrated this panel's code display to NodeMarkdown,
+    // which renders its own "Copy" button inside the code block - a real,
+    // legitimate 3rd button, but not a resolution mechanism: it neither
+    // dismisses the panel nor calls onApprove/onDeny, so FIX A's actual
+    // security property (the ONLY two ways to make this panel go away are
+    // Approve and Deny) still holds - this test now asserts that precisely,
+    // rather than a stale exact-button-count that predates Copy existing.
     renderPanel();
     const buttons = screen.getAllByRole("button");
-    expect(buttons).toHaveLength(2);
-    expect(buttons.map((b) => b.textContent)).toEqual(["Deny", "Approve"]);
+    expect(buttons.map((b) => b.textContent)).toEqual(["Copy", "Deny", "Approve"]);
     expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
     expect(screen.queryByLabelText(/close/i)).toBeNull();
+  });
+
+  it("FIX A: clicking Copy does not resolve the panel (not Approve, not Deny, stays open)", async () => {
+    const user = userEvent.setup();
+    const { onApprove, onDeny } = renderPanel();
+    await user.click(screen.getByRole("button", { name: "Copy code" }));
+    expect(onApprove).not.toHaveBeenCalled();
+    expect(onDeny).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
   it("FIX A: pressing Escape does NOT dismiss the panel and does NOT call onApprove/onDeny", () => {

--- a/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
+++ b/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 import { useFocusEscapeBackstop } from "../overlays/overlays";
+import { NodeMarkdown } from "./NodeMarkdown";
 
 /**
  * The mandatory human-approval gate (Qt-removal plan R5.4, corrected in the
@@ -80,13 +78,24 @@ import { useFocusEscapeBackstop } from "../overlays/overlays";
  * a request other than the one the server is actually holding.
  *
  * Security note, not a style preference: the pending code is rendered
- * through the exact same react-markdown + remarkGfm + rehypeHighlight
- * pipeline every sibling node view uses (see GitlinkNodeView's own
- * toDiffFence/CodeNodeView's own toFencedCodeBlock for the same technique
- * applied to different content) - no rehype-raw, no
- * dangerouslySetInnerHTML anywhere in this file. Fencing it as ```python
- * only affects syntax-colorization; the pipeline never interprets any of it
- * as live markup either way.
+ * through NodeMarkdown.tsx, the shared renderer every node view uses (node
+ * redesign stage 1) - no rehype-raw, no dangerouslySetInnerHTML anywhere in
+ * this file or that one. Fencing it as ```python (toPythonFence below, the
+ * same technique GitlinkNodeView's own toDiffFence/CodeNodeView's own
+ * toFencedCodeBlock use) only affects syntax-colorization; the pipeline
+ * never interprets any of it as live markup either way. Adversarial review
+ * caught this call site as the one the stage-1 migration initially missed:
+ * this is the security-critical human-approval gate for code about to run
+ * with the full privileges of the user's own account, and NodeMarkdown's
+ * own SafeAnchor override is exactly the guard that matters here - the
+ * pending code being reviewed is itself LLM-generated (Py-Coder's
+ * AI-driven mode / Code-Sandbox's own generation step), and a fenced code
+ * block can be broken out of early by an embedded ``` line (toPythonFence
+ * does no backtick-escaping, matching every sibling fence helper), letting
+ * a crafted comment/string smuggle a real markdown link past the fence -
+ * without SafeAnchor, a javascript: href in that smuggled link would have
+ * rendered as a live, clickable anchor in the one dialog whose entire
+ * purpose is a considered human review before approving execution.
  *
  * Requirements disclosure (post-review FIX C): CodeSandboxNode's one
  * mandatory approval step must show the requirements.txt-style manifest that
@@ -133,17 +142,19 @@ const DIALOG_TITLE: Record<CodeExecutionKind, string> = {
 };
 
 /** Wraps the pending code in a markdown fenced ```python code block so
- * ReactMarkdown + rehype-highlight can syntax-highlight it for free - same
- * technique CodeNodeView's own toFencedCodeBlock / GitlinkNodeView's own
- * toDiffFence use for their own content. */
+ * NodeMarkdown's own CodeBlock override can syntax-highlight it for free -
+ * same technique CodeNodeView's own toFencedCodeBlock / GitlinkNodeView's
+ * own toDiffFence use for their own content. */
 function toPythonFence(code: string): string {
   return "```python\n" + code + "\n```";
 }
 
-// Scoped to THIS panel's own three intended focus stops (the code display,
-// Deny, Approve) - deliberately narrower than overlays.tsx's own shared
-// FOCUSABLE selector (which also matches inputs/selects/links/textareas),
-// since nothing else in this panel's markup is ever meant to receive focus.
+// Scoped to THIS panel's own intended focus stops (the code display region,
+// its own Copy button - a real, additional stop since the node redesign
+// migrated this panel to NodeMarkdown's CodeBlock, which renders one - Deny,
+// Approve) - deliberately narrower than overlays.tsx's own shared FOCUSABLE
+// selector (which also matches inputs/selects/links/textareas), since
+// nothing else in this panel's markup is ever meant to receive focus.
 //
 // R8a (UI/UX issue list finding #17): excludes [disabled], the same fix
 // overlays.tsx's own Dialog needed and for the identical reason - `busy`
@@ -205,10 +216,13 @@ export function CodeExecutionApprovalPanel({
     if (awaitingApproval) denyButtonRef.current?.focus();
   }, [awaitingApproval]);
 
-  // Tab focus trap scoped to this panel's own three focusable stops (the
-  // scrollable code display, Deny, Approve) - Tab/Shift+Tab must never let
-  // focus escape to the rest of the page while a mandatory approval is
-  // pending. Deliberately has NO Escape branch at all (unlike overlays.tsx's
+  // Tab focus trap scoped to this panel's own focusable stops (the
+  // scrollable code display region, its Copy button, Deny, Approve) -
+  // Tab/Shift+Tab must never let focus escape to the rest of the page while
+  // a mandatory approval is pending. Computed dynamically via
+  // querySelectorAll below, not a hardcoded count, so it stays correct
+  // regardless of exactly how many focusable elements NodeMarkdown's own
+  // output happens to contain. Deliberately has NO Escape branch at all (unlike overlays.tsx's
   // own Dialog focus trap, which lives alongside that component's Escape-
   // closes-everything effect) - see module doc's FIX A.
   useEffect(() => {
@@ -284,9 +298,7 @@ export function CodeExecutionApprovalPanel({
             role="region"
             aria-label="Pending code"
           >
-            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-              {toPythonFence(code)}
-            </ReactMarkdown>
+            <NodeMarkdown content={toPythonFence(code)} />
           </div>
           <div className="code-exec-approval-actions">
             <button

--- a/web_ui/src/app/canvas/CodeNodeView.test.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.test.tsx
@@ -46,9 +46,19 @@ function renderCodeNode(overrides: Partial<CodeFlowNode["data"]> = {}) {
 }
 
 describe("CodeNodeView", () => {
+  // Node redesign stage 1: NodeMarkdown's own code-block language badge now
+  // ALSO renders the language string (e.g. "python") inside the code block
+  // itself, alongside this view's own title-bar label - both legitimately
+  // say "python" at once, so every query below is scoped to
+  // .code-node-language (the title bar specifically) rather than a bare
+  // screen.getByText, which would now be ambiguous.
+  function titleLabel(container: HTMLElement): HTMLElement {
+    return container.querySelector(".code-node-language") as HTMLElement;
+  }
+
   it("renders the language label and syntax-highlighted code content", () => {
     const { container } = renderCodeNode();
-    expect(screen.getByText("python")).toBeInTheDocument();
+    expect(titleLabel(container)).toHaveTextContent("python");
     // Proves the fenced-code-block-through-ReactMarkdown+rehype-highlight
     // pipeline actually ran (not just plain-text rendering of the raw code).
     expect(container.querySelector(".hljs")).not.toBeNull();
@@ -62,12 +72,12 @@ describe("CodeNodeView", () => {
 
   it("right-click opens a menu with real Copy Code/Delete Code Block/Export/Hide Other Branches", async () => {
     const user = userEvent.setup();
-    const { onDelete } = renderCodeNode();
+    const { onDelete, container } = renderCodeNode();
 
     const writeText = vi.fn();
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
 
-    const label = screen.getByText("python");
+    const label = titleLabel(container);
     fireEvent.contextMenu(label);
     expect(screen.getByRole("menu")).toBeInTheDocument();
 
@@ -84,7 +94,7 @@ describe("CodeNodeView", () => {
 
   it("clicking Export downloads the raw code as a language-appropriate file, then closes the menu (R7.5a)", async () => {
     const user = userEvent.setup();
-    renderCodeNode({ code: "print('hi')", language: "python" });
+    const { container } = renderCodeNode({ code: "print('hi')", language: "python" });
 
     const captured: { anchor?: HTMLAnchorElement } = {};
     const clickSpy = vi
@@ -93,7 +103,7 @@ describe("CodeNodeView", () => {
         captured.anchor = this;
       });
 
-    fireEvent.contextMenu(screen.getByText("python"));
+    fireEvent.contextMenu(titleLabel(container));
     await user.click(screen.getByRole("menuitem", { name: "Export" }));
 
     await waitFor(() => expect(clickSpy).toHaveBeenCalled());
@@ -107,14 +117,14 @@ describe("CodeNodeView", () => {
 
   it("falls back to a .txt extension for an unrecognized language (R7.5a)", async () => {
     const user = userEvent.setup();
-    renderCodeNode({ language: "brainfuck" });
+    const { container } = renderCodeNode({ language: "brainfuck" });
 
     const captured: { anchor?: HTMLAnchorElement } = {};
     vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (this: HTMLAnchorElement) {
       captured.anchor = this;
     });
 
-    fireEvent.contextMenu(screen.getByText("brainfuck"));
+    fireEvent.contextMenu(titleLabel(container));
     await user.click(screen.getByRole("menuitem", { name: "Export" }));
 
     await waitFor(() => expect(captured.anchor).toBeDefined());
@@ -123,9 +133,9 @@ describe("CodeNodeView", () => {
 
   it("Regenerate Response renders enabled and fires onRegenerate then closes the menu when parentChatNodeId is non-null", async () => {
     const user = userEvent.setup();
-    const { onRegenerate } = renderCodeNode({ parentChatNodeId: "chat-1" });
+    const { onRegenerate, container } = renderCodeNode({ parentChatNodeId: "chat-1" });
 
-    fireEvent.contextMenu(screen.getByText("python"));
+    fireEvent.contextMenu(titleLabel(container));
     const regenerate = screen.getByRole("menuitem", { name: "Regenerate Response" });
     expect(regenerate).not.toBeDisabled();
 
@@ -135,16 +145,16 @@ describe("CodeNodeView", () => {
   });
 
   it("Regenerate Response is absent from the DOM entirely (not merely disabled) when parentChatNodeId is null", () => {
-    renderCodeNode({ parentChatNodeId: null });
-    fireEvent.contextMenu(screen.getByText("python"));
+    const { container } = renderCodeNode({ parentChatNodeId: null });
+    fireEvent.contextMenu(titleLabel(container));
     expect(screen.queryByRole("menuitem", { name: "Regenerate Response" })).toBeNull();
   });
 
   it("Hide Other Branches reads 'Hide Other Branches' and calls onToggleBranchFocus then closes the menu when branch focus is inactive (R8a)", async () => {
     const user = userEvent.setup();
-    const { onToggleBranchFocus } = renderCodeNode({ isBranchFocusActive: false });
+    const { onToggleBranchFocus, container } = renderCodeNode({ isBranchFocusActive: false });
 
-    fireEvent.contextMenu(screen.getByText("python"));
+    fireEvent.contextMenu(titleLabel(container));
     const toggle = screen.getByRole("menuitem", { name: "Hide Other Branches" });
     expect(toggle).not.toBeDisabled();
 
@@ -155,9 +165,9 @@ describe("CodeNodeView", () => {
 
   it("Hide Other Branches reads 'Show All Branches' and still calls onToggleBranchFocus when branch focus is active (R8a)", async () => {
     const user = userEvent.setup();
-    const { onToggleBranchFocus } = renderCodeNode({ isBranchFocusActive: true });
+    const { onToggleBranchFocus, container } = renderCodeNode({ isBranchFocusActive: true });
 
-    fireEvent.contextMenu(screen.getByText("python"));
+    fireEvent.contextMenu(titleLabel(container));
     expect(screen.queryByRole("menuitem", { name: "Hide Other Branches" })).toBeNull();
     const toggle = screen.getByRole("menuitem", { name: "Show All Branches" });
 
@@ -168,8 +178,8 @@ describe("CodeNodeView", () => {
 
   it("Escape and outside-click both close the menu", async () => {
     const user = userEvent.setup();
-    renderCodeNode();
-    const label = screen.getByText("python");
+    const { container } = renderCodeNode();
+    const label = titleLabel(container);
 
     fireEvent.contextMenu(label);
     expect(screen.getByRole("menu")).toBeInTheDocument();

--- a/web_ui/src/app/canvas/CodeNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.tsx
@@ -1,10 +1,8 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { downloadTextFile } from "./downloadTextFile";
+import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
 
 /**
@@ -13,8 +11,8 @@ import { NodeMenu } from "./NodeMenu";
  * never generated here). Unlike ChatNodeView, code nodes have no manual
  * collapse toggle - they only ever auto-collapse on zoom (LOD), since there's
  * no per-node state worth toggling by hand. Real: render (syntax-highlighted,
- * via the same react-markdown + rehype-highlight pipeline chat nodes already
- * pull in - no new highlighter dependency), delete (generic cascade-delete;
+ * via the shared NodeMarkdown.tsx renderer every node kind now uses - node
+ * redesign stage 1), delete (generic cascade-delete;
  * code nodes are never branch points, so there's no reparent rule to honor),
  * copy, and (as of R4.3c) Regenerate Response - conditionally rendered
  * (not merely disabled) on parentChatNodeId being non-null, matching
@@ -207,10 +205,8 @@ export function CodeNodeView({ id, data, selected }: NodeProps<CodeFlowNode>) {
         <span>{data.language || "code"}</span>
       </div>
       {!collapsed && (
-        <div className="scene-node-body code-node-content">
-          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-            {toFencedCodeBlock(data.code, data.language)}
-          </ReactMarkdown>
+        <div className="scene-node-body code-node-content chat-node-content">
+          <NodeMarkdown content={toFencedCodeBlock(data.code, data.language)} />
         </div>
       )}
       <Handle type="source" position={Position.Bottom} className="scene-node-handle" />

--- a/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
@@ -1,11 +1,9 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useEffect, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 import type { StreamListener } from "../../lib/ws/transport";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { CodeExecutionApprovalPanel } from "./CodeExecutionApprovalPanel";
+import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
 
 /**
@@ -16,8 +14,8 @@ import { NodeMenu } from "./NodeMenu";
  * UNCHANGED, only the display string moved) - the Code-Sandbox plugin's
  * React card. Same overall shell as every plugin-node sibling
  * (PyCoderNodeView/GitlinkNodeView): collapse/expand OR-ed with LOD, a card
- * menu with outside-click/Escape dismiss, the shared react-markdown +
- * remarkGfm + rehypeHighlight pipeline, no dock-to-parent action.
+ * menu with outside-click/Escape dismiss, the shared NodeMarkdown.tsx
+ * renderer (node redesign stage 1), no dock-to-parent action.
  *
  * Unlike Py-Coder, there is no mode toggle here - backend/canvas.py's own
  * start_code_sandbox_run docstring is explicit that there is "no
@@ -290,9 +288,7 @@ export function CodeSandboxNodeView({ id, data, selected }: NodeProps<CodeSandbo
             <div className="code-sandbox-node-section">
               <span className="code-sandbox-node-section-label">Code</span>
               <div className="chat-node-content code-sandbox-node-code">
-                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-                  {toPythonFence(data.codeSandboxCode)}
-                </ReactMarkdown>
+                <NodeMarkdown content={toPythonFence(data.codeSandboxCode)} />
               </div>
             </div>
           )}
@@ -315,9 +311,7 @@ export function CodeSandboxNodeView({ id, data, selected }: NodeProps<CodeSandbo
             <div className="code-sandbox-node-section">
               <span className="code-sandbox-node-section-label">Analysis</span>
               <div className="chat-node-content code-sandbox-node-analysis">
-                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-                  {data.codeSandboxAnalysis}
-                </ReactMarkdown>
+                <NodeMarkdown content={data.codeSandboxAnalysis} />
               </div>
             </div>
           )}

--- a/web_ui/src/app/canvas/ConversationNodeView.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.tsx
@@ -1,9 +1,7 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
 
 /**
@@ -14,9 +12,9 @@ import { NodeMenu } from "./NodeMenu";
  * the only R3 kind shaped like a real message list rather than one flat text
  * block.
  *
- * Real: render (one ConversationBubble per history entry, same react-markdown
- * + remarkGfm + rehypeHighlight pipeline every other text-bearing node view
- * in this codebase already uses), collapse/expand (manual toggle OR-ed with
+ * Real: render (one ConversationBubble per history entry, the shared
+ * NodeMarkdown.tsx renderer every other text-bearing node view in this
+ * codebase now uses - node redesign stage 1), collapse/expand (manual toggle OR-ed with
  * LOD auto-collapse, same as Chat/Document), delete (generic - a conversation
  * node is never a branch point/reparented, same as code/thinking/html/image),
  * per-bubble copy + delete-from-history, Send (appends a real user message
@@ -201,9 +199,7 @@ function ConversationBubble({
           .chat-node-menu already establishes across every sibling node's
           menu, applied here to markdown styling instead. */}
       <div className="chat-node-content conversation-node-bubble-content">
-        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-          {message.content}
-        </ReactMarkdown>
+        <NodeMarkdown content={message.content} />
       </div>
       {menuPosition && (
         <ConversationBubbleMenu

--- a/web_ui/src/app/canvas/DocumentViewPanel.tsx
+++ b/web_ui/src/app/canvas/DocumentViewPanel.tsx
@@ -121,14 +121,20 @@ const DEFAULT_FONT_SIZE_STEP_INDEX = 1;
  *   precise manual control now," and continuing to drag while a CSS class
  *   was fighting the inline width would be visibly broken.
  * - Font-size stepper: relative `em` multipliers, not absolute pixel values -
- *   see FONT_SIZE_STEPS' own comment for why. Only scales inherited text
- *   (paragraphs, lists, table cells, blockquotes, and code via its own
- *   existing `em`-relative sizing) - headings keep their existing fixed
- *   px hierarchy (15/14/13/12), a deliberate, small, out-of-scope-to-fix
- *   limitation: proportionally scaling headings too would mean touching
- *   `.chat-node-content`'s shared rules, used by every OTHER markdown
- *   surface in the app (chat bubbles, notes), not just this panel - a much
- *   larger blast radius than a "polish" pass warrants.
+ *   see FONT_SIZE_STEPS' own comment for why. At the time this stage
+ *   shipped, `.chat-node-content` h1-h6 were fixed px values independent of
+ *   this stepper (only paragraphs/lists/table cells/blockquotes/code
+ *   scaled) - a deliberate, documented limitation, since proportionally
+ *   scaling headings too would have meant touching a rule set shared by
+ *   every OTHER markdown surface in the app (chat bubbles, notes), a much
+ *   larger blast radius than this "polish" pass warranted at the time.
+ *   A LATER, separate change (the node redesign's own stage 2, fixing an
+ *   unrelated inverted-heading-hierarchy bug in node cards) converted those
+ *   same shared h1-h6 rules to `em`, as a deliberate, independent decision
+ *   for THAT change's own reasons - which means headings in THIS panel now
+ *   scale with this stepper too, incidentally, not because this stage was
+ *   revisited. Documented here so this comment doesn't keep asserting an
+ *   invariant the shared CSS no longer holds.
  *
  * Width, expanded state, and font-size step are NOT reset when `content`
  * changes (unlike stage 2/3's scroll/progress/search state) - they describe

--- a/web_ui/src/app/canvas/GitlinkNodeView.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.tsx
@@ -1,18 +1,16 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useEffect, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { Dialog, useOverlays } from "../overlays/overlays";
+import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
 
 /**
  * The Gitlink node (Qt-removal plan R5.3) - the Gitlink plugin's React card.
  * Same overall shell as every plugin-node sibling (ArtifactNodeView/
  * WebResearchNodeView): collapse/expand OR-ed with LOD, a card menu with
- * outside-click/Escape dismiss, the shared react-markdown + remarkGfm +
- * rehypeHighlight pipeline, no dock-to-parent action. Unlike its siblings,
+ * outside-click/Escape dismiss, the shared NodeMarkdown.tsx renderer (node
+ * redesign stage 1), no dock-to-parent action. Unlike its siblings,
  * this node is a three-tab workflow (Setup / Context / Proposal) rather than
  * one linear scroll - the underlying task (pick a repo, scope a context,
  * generate a change set, review a diff, apply it to real local files) has
@@ -44,9 +42,9 @@ import { NodeMenu } from "./NodeMenu";
  *
  * Security note, not a style preference: the Proposal tab renders BOTH
  * data.gitlinkProposalMarkdown and data.gitlinkPreviewText (a unified diff)
- * through the exact same react-markdown + remarkGfm + rehypeHighlight
- * pipeline every sibling node view uses - no rehype-raw, no
- * dangerouslySetInnerHTML anywhere in this file. The diff text is wrapped in
+ * through the exact same NodeMarkdown.tsx pipeline every sibling node view
+ * uses - no rehype-raw, no dangerouslySetInnerHTML anywhere in this file or
+ * that one. The diff text is wrapped in
  * a fenced ```diff code block first (toDiffFence, mirroring CodeNodeView's
  * own toFencedCodeBlock) purely so rehype-highlight can colorize it - it is
  * never treated as anything but inert text by the markdown pipeline, exactly
@@ -561,9 +559,7 @@ export function GitlinkNodeView({ id, data, selected }: NodeProps<GitlinkFlowNod
             <div className="gitlink-node-proposal-tab" role="tabpanel">
               {data.gitlinkProposalMarkdown ? (
                 <div className="chat-node-content gitlink-node-proposal-markdown">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-                    {data.gitlinkProposalMarkdown}
-                  </ReactMarkdown>
+                  <NodeMarkdown content={data.gitlinkProposalMarkdown} />
                 </div>
               ) : (
                 <p className="gitlink-node-empty">No change set generated yet.</p>
@@ -571,9 +567,7 @@ export function GitlinkNodeView({ id, data, selected }: NodeProps<GitlinkFlowNod
 
               {data.gitlinkPreviewText && (
                 <div className="chat-node-content gitlink-node-proposal-diff">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-                    {toDiffFence(data.gitlinkPreviewText)}
-                  </ReactMarkdown>
+                  <NodeMarkdown content={toDiffFence(data.gitlinkPreviewText)} />
                 </div>
               )}
 

--- a/web_ui/src/app/canvas/NodeMarkdown.test.tsx
+++ b/web_ui/src/app/canvas/NodeMarkdown.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { NodeMarkdown } from "./NodeMarkdown";
+
+// Node redesign, stage 1 ("shared node markdown renderer"): a code-block
+// copy button + language badge, a wide-table scroll wrapper, image zoom,
+// GitHub-style callouts, and safe external links - shared by every
+// text-bearing node kind. See NodeMarkdown.tsx's own doc comment for why
+// heading anchors and search highlighting (both real in
+// DocumentViewMarkdown.tsx) are deliberately NOT here.
+
+describe("NodeMarkdown", () => {
+  it("renders plain markdown content", () => {
+    render(<NodeMarkdown content={"# Heading\n\nA paragraph."} />);
+    expect(screen.getByRole("heading", { name: "Heading" })).toBeInTheDocument();
+    expect(screen.getByText("A paragraph.")).toBeInTheDocument();
+  });
+
+  it("does not assign an id to headings (no ToC, and ids would collide across simultaneously-mounted node cards)", () => {
+    render(<NodeMarkdown content="## My Section" />);
+    const heading = screen.getByRole("heading", { name: "My Section" });
+    expect(heading).not.toHaveAttribute("id");
+  });
+
+  describe("external link hardening", () => {
+    it("adds target=_blank and a safe rel to an absolute http(s) link", () => {
+      render(<NodeMarkdown content="[external](https://example.com/page)" />);
+      const link = screen.getByRole("link", { name: "external" });
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link?.getAttribute("rel")).toContain("noopener");
+      expect(link?.getAttribute("rel")).toContain("noreferrer");
+      expect(link?.getAttribute("rel")).toContain("nofollow");
+    });
+
+  });
+
+  describe("SafeAnchor - only an absolute http(s) href survives as a real link", () => {
+    // This content is routinely LLM-generated (chat responses, web-research
+    // answers, generated notes) and so is exposed to prompt-injection-driven
+    // malicious markdown - a rendered `javascript:` href is a real,
+    // browser-executed risk, not a theoretical one. NodeMarkdown assigns no
+    // heading ids (see its own doc comment), so a same-node `#fragment`
+    // link could never resolve to anything anyway - stripping it is not a
+    // functional regression, and mirrors WebResearchNodeView's own
+    // already-shipped, already-proven http(s)-only allowlist verbatim
+    // rather than loosening it.
+    it("strips the href entirely for a javascript: link, rendering only the plain text", () => {
+      const { container } = render(<NodeMarkdown content="[click me](javascript:alert(1))" />);
+      expect(screen.getByText("click me")).toBeInTheDocument();
+      expect(container.querySelector("a")).toBeNull();
+    });
+
+    it("strips the href entirely for a file: link", () => {
+      const { container } = render(<NodeMarkdown content="[open](file:///etc/passwd)" />);
+      expect(screen.getByText("open")).toBeInTheDocument();
+      expect(container.querySelector("a")).toBeNull();
+    });
+
+    it("strips the href entirely for a data: link", () => {
+      const { container } = render(<NodeMarkdown content="[data](data:text/html,<script>alert(1)</script>)" />);
+      expect(screen.getByText("data")).toBeInTheDocument();
+      expect(container.querySelector("a")).toBeNull();
+    });
+
+    it("also strips a same-node fragment link (dead by construction - no heading ids exist to jump to)", () => {
+      const { container } = render(<NodeMarkdown content="[jump](#somewhere)" />);
+      expect(screen.getByText("jump")).toBeInTheDocument();
+      expect(container.querySelector("a")).toBeNull();
+    });
+
+    it("still renders a real https link as a genuine, hardened anchor", () => {
+      render(<NodeMarkdown content="[real](https://example.com)" />);
+      const link = screen.getByRole("link", { name: "real" });
+      expect(link).toHaveAttribute("href", "https://example.com");
+      expect(link).toHaveAttribute("target", "_blank");
+    });
+
+    // Regression tests: adversarial review found that an earlier draft split
+    // the security decision (SafeAnchor's own case-insensitive scheme check)
+    // from the hardening attributes (previously supplied by a SEPARATE,
+    // case-sensitive rehype-external-links pass) - a mixed-case scheme like
+    // "HTTPS://..." passed SafeAnchor's check but was invisible to the other
+    // plugin's exact-lowercase match, so it rendered as a real, live,
+    // same-tab link with no target/rel at all. SafeAnchor now supplies its
+    // own target/rel directly, so there is exactly one scheme check and its
+    // result determines both whether the link renders AND how hardened it
+    // is - these lock that in.
+    it("strips the href for a mixed/upper-case dangerous scheme, exactly like the lowercase form", () => {
+      const { container } = render(<NodeMarkdown content="[click me](JavaScript:alert(1))" />);
+      expect(screen.getByText("click me")).toBeInTheDocument();
+      expect(container.querySelector("a")).toBeNull();
+    });
+
+    it("still fully hardens a mixed/upper-case http(s) scheme (no silent downgrade to an unhardened link)", () => {
+      render(<NodeMarkdown content="[real](HTTPS://example.com)" />);
+      const link = screen.getByRole("link", { name: "real" });
+      expect(link).toHaveAttribute("href", "HTTPS://example.com");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link.getAttribute("rel")).toContain("noopener");
+      expect(link.getAttribute("rel")).toContain("noreferrer");
+    });
+
+    it("fully hardens a bare-URL GFM autolink (no [text](url) brackets) the same as a bracketed link", () => {
+      render(<NodeMarkdown content="See https://example.com for details." />);
+      const link = screen.getByRole("link", { name: "https://example.com" });
+      expect(link).toHaveAttribute("href", "https://example.com");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link.getAttribute("rel")).toContain("noopener");
+    });
+  });
+
+  describe("code blocks", () => {
+    function mockClipboard(): ReturnType<typeof vi.fn> {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText },
+        configurable: true,
+        writable: true,
+      });
+      return writeText;
+    }
+
+    it("renders a language badge for a fenced code block", () => {
+      render(<NodeMarkdown content={"```typescript\nconst x = 1;\n```"} />);
+      expect(screen.getByText("typescript")).toBeInTheDocument();
+    });
+
+    it("falls back to a plain 'text' badge when no language is given", () => {
+      render(<NodeMarkdown content={"```\nplain block\n```"} />);
+      expect(screen.getByText("text")).toBeInTheDocument();
+    });
+
+    it("copies the code block's raw text and flashes 'Copied'", async () => {
+      const user = userEvent.setup();
+      const writeText = mockClipboard();
+      render(<NodeMarkdown content={"```python\nprint('hi')\n```"} />);
+
+      await user.click(screen.getByRole("button", { name: "Copy code" }));
+
+      expect(writeText).toHaveBeenCalledWith("print('hi')\n");
+      expect(await screen.findByText("Copied")).toBeInTheDocument();
+    });
+
+    it("marks the copy button nodrag, so clicking it inside a React Flow node doesn't start a canvas drag", () => {
+      render(<NodeMarkdown content={"```\nx\n```"} />);
+      expect(screen.getByRole("button", { name: "Copy code" })).toHaveClass("nodrag");
+    });
+  });
+
+  describe("tables", () => {
+    it("wraps a table in a horizontally-scrollable container", () => {
+      const table = "| A | B |\n| - | - |\n| 1 | 2 |";
+      const { container } = render(<NodeMarkdown content={table} />);
+      const wrapper = container.querySelector(".node-md-table-wrapper");
+      expect(wrapper).not.toBeNull();
+      expect(wrapper?.querySelector("table")).not.toBeNull();
+    });
+  });
+
+  describe("images", () => {
+    it("wraps an image in the zoom component, preserving its src/alt", () => {
+      const { container } = render(<NodeMarkdown content="![a diagram](https://example.com/diagram.png)" />);
+      expect(container.querySelector("[data-rmiz]")).not.toBeNull();
+      const img = screen.getByAltText("a diagram") as HTMLImageElement;
+      expect(img.src).toBe("https://example.com/diagram.png");
+    });
+  });
+
+  describe("GitHub-style callouts", () => {
+    it("renders a > [!NOTE] blockquote as a styled alert with the NOTE title", () => {
+      const { container } = render(<NodeMarkdown content={"> [!NOTE]\n> Useful information."} />);
+      const alert = container.querySelector(".markdown-alert-note");
+      expect(alert).not.toBeNull();
+      expect(alert).toHaveTextContent("NOTE");
+      expect(alert).toHaveTextContent("Useful information.");
+    });
+
+    it("renders each of the 5 alert types with its own distinct class", () => {
+      const content = [
+        "> [!NOTE]\n> a",
+        "> [!TIP]\n> b",
+        "> [!IMPORTANT]\n> c",
+        "> [!WARNING]\n> d",
+        "> [!CAUTION]\n> e",
+      ].join("\n\n");
+      const { container } = render(<NodeMarkdown content={content} />);
+      for (const type of ["note", "tip", "important", "warning", "caution"]) {
+        expect(container.querySelector(`.markdown-alert-${type}`)).not.toBeNull();
+      }
+    });
+
+    it("leaves an ordinary blockquote (no [!TYPE] marker) unstyled as a plain blockquote", () => {
+      const { container } = render(<NodeMarkdown content="> just a quote, not an alert" />);
+      expect(container.querySelector(".markdown-alert")).toBeNull();
+      expect(container.querySelector("blockquote")).not.toBeNull();
+    });
+  });
+});

--- a/web_ui/src/app/canvas/NodeMarkdown.tsx
+++ b/web_ui/src/app/canvas/NodeMarkdown.tsx
@@ -1,0 +1,178 @@
+import { useRef, useState, type JSX } from "react";
+import ReactMarkdown, { type ExtraProps } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { remarkAlert } from "remark-github-blockquote-alert";
+import rehypeHighlight from "rehype-highlight";
+import Zoom from "react-medium-image-zoom";
+import "react-medium-image-zoom/dist/styles.css";
+
+/**
+ * Shared markdown renderer for scene NODE cards (node redesign, stage 1 of 4
+ * - "shared node markdown renderer"). Every text-bearing node kind (Chat,
+ * Note, Conversation, Artifact, Code, CodeSandbox, Gitlink, PyCoder,
+ * Thinking, WebResearch - confirmed via grep, not assumed) rendered a bare
+ * `<ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>`
+ * with none of Document View's content-rendering upgrades (code-block copy/
+ * language badge, wide-table scroll wrapper, image zoom, GitHub callouts,
+ * hardened external links). This brings all of those to every node kind at
+ * once, through one shared component, rather than duplicating the pipeline
+ * ten times.
+ *
+ * A SIBLING of DocumentViewMarkdown.tsx, not a shared import from it -
+ * mirrors that file's own doc comment's reasoning in the opposite direction:
+ * the two surfaces have genuinely different needs, not just different class
+ * names. Specifically excluded here, both deliberately:
+ *
+ * - Heading anchors (rehype-slug + rehype-autolink-headings): meaningless
+ *   without a table of contents to link to, AND a real correctness hazard -
+ *   github-slugger's ids are unique only WITHIN one document. Document View
+ *   only ever shows one document at a time, but dozens of node cards render
+ *   simultaneously on the same canvas; two nodes both containing "## Notes"
+ *   would each get `id="notes"`, a genuine DOM-id collision across
+ *   currently-mounted elements that Document View's single-document
+ *   architecture never has to worry about.
+ * - In-document search highlighting (rehypeHighlightSearchMatches): a
+ *   Document-View-panel-specific feature (its own search bar), not
+ *   something node cards have a UI for.
+ *
+ * Component overrides use a `node-md-` class prefix (not `document-view-`)
+ * but are styled to EXTEND `.chat-node-content`'s existing shared base
+ * rules (headings/p/li/code/table/hljs in styles.css) exactly the way
+ * Document View's own `.document-view-code-block`/`.document-view-table-wrapper`
+ * extend that same base class - both surfaces' scroll containers carry the
+ * `chat-node-content` class, so both automatically pick up node redesign
+ * stage 2's typography improvements to that shared base, not just this
+ * stage's own new wrapper chrome.
+ *
+ * SafeAnchor closes a real gap found while wiring this in: WebResearchNodeView
+ * already had a bespoke `a` component override stripping the href from any
+ * non-http(s)-scheme link (its own comment: "answerMarkdown is LLM-generated
+ * from untrusted web evidence, so a javascript:/file: scheme must never be
+ * allowed to navigate") - but every OTHER node kind rendered links with zero
+ * such guard, despite their own content being no less LLM-generated (and so
+ * no less exposed to the same prompt-injection-driven-malicious-markdown
+ * class of risk WebResearchNodeView was specifically defending against).
+ * Baking the same guard into NodeMarkdown's own default `a` override, rather
+ * than leaving it as one view's bespoke fix, closes that gap for all call
+ * sites at once and lets WebResearchNodeView delete its now-redundant copy.
+ *
+ * SafeAnchor is the SOLE source of both the security decision and the
+ * resulting hardening attributes - deliberately not split across two
+ * mechanisms. An earlier draft of this file also ran rehype-external-links
+ * (a separate, hast-level pass) to supply `target="_blank"`/safe `rel` for
+ * genuine http(s) links, relying on SafeAnchor's own `{...props}` spread to
+ * carry those attributes through. Adversarial review found this created a
+ * real gap: SafeAnchor's own scheme check is case-INsensitive (`/i` flag,
+ * matching a user typing "HTTPS://..."), but rehype-external-links' default
+ * `protocols` match is a case-SENSITIVE array `.includes()` check - so a
+ * mixed-case scheme passed SafeAnchor's allowlist (rendered as a real,
+ * clickable link) while silently NEVER receiving target/rel from the other
+ * plugin, since its own protocol comparison never matched. No dangerous
+ * scheme was ever admitted either way (javascript:/file:/data: are rejected
+ * case-insensitively by SafeAnchor itself, independent of the other plugin
+ * entirely) - but a safe-looking http(s) link could end up open in the same
+ * tab with a full Referer leak, silently weaker than intended. Removing
+ * rehype-external-links entirely and having SafeAnchor set its own
+ * `target`/`rel` directly (spread BEFORE them, so they can never be
+ * silently overridden by anything upstream) closes this by construction:
+ * there is now exactly one scheme check, and its result is what determines
+ * both whether the link renders at all AND how hardened it is.
+ */
+
+function CodeBlock({ node: _node, children, ...props }: JSX.IntrinsicElements["pre"] & ExtraProps) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  // Fenced code blocks are always `pre > code` (one child) - the language
+  // lives on that inner <code> element's own className (rehype-highlight's
+  // "hljs language-xxx" shape), not on this <pre>'s. Same extraction as
+  // DocumentViewMarkdown.tsx's own CodeBlock.
+  const codeChild = Array.isArray(children) ? children[0] : children;
+  const codeClassName =
+    codeChild !== null && typeof codeChild === "object" && "props" in codeChild
+      ? ((codeChild.props as { className?: string }).className ?? "")
+      : "";
+  const languageMatch = /language-(\w+)/.exec(codeClassName);
+  const language = languageMatch ? languageMatch[1] : "";
+
+  function onCopy() {
+    const text = preRef.current?.textContent ?? "";
+    if (!text) return;
+    navigator.clipboard?.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <div className="node-md-code-block">
+      <div className="node-md-code-block-header">
+        <span className="node-md-code-block-language">{language || "text"}</span>
+        <button
+          type="button"
+          className="node-md-code-block-copy nodrag"
+          onClick={onCopy}
+          title="Copy code"
+          aria-label="Copy code"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <pre {...props} ref={preRef}>
+        {children}
+      </pre>
+    </div>
+  );
+}
+
+function TableWrapper({ node: _node, ...props }: JSX.IntrinsicElements["table"] & ExtraProps) {
+  // Fixes a real, pre-existing bug, not just a nicety: node cards have a
+  // fixed width (420px for chat nodes) and .chat-node-content only ever set
+  // overflow-y, never overflow-x - a wide table had no way to be scrolled
+  // into view at all, just silently clipped by the card's own edge.
+  return (
+    <div className="node-md-table-wrapper">
+      <table {...props} />
+    </div>
+  );
+}
+
+function ZoomImage({ node: _node, ...props }: JSX.IntrinsicElements["img"] & ExtraProps) {
+  return (
+    <Zoom wrapElement="span">
+      <img {...props} />
+    </Zoom>
+  );
+}
+
+function SafeAnchor({ node: _node, href, children, ...props }: JSX.IntrinsicElements["a"] & ExtraProps) {
+  const isHttpUrl = !!href && /^https?:\/\//i.test(href.trim());
+  if (!isHttpUrl) {
+    // No href at all for a non-http(s) scheme (javascript:, file:, data:,
+    // etc.) - omitting it entirely removes the native middle-click/
+    // "open link in new tab"/"copy link" context-menu escape hatch a mere
+    // onClick+preventDefault guard would leave behind (those browser
+    // affordances read the raw href attribute directly, bypassing onClick).
+    return <>{children}</>;
+  }
+  return (
+    // `{...props}` spread FIRST, then href/target/rel explicit and LAST -
+    // these three are the ones this component's own security decision
+    // governs, so nothing upstream can silently override them.
+    <a {...props} href={href} target="_blank" rel="nofollow noopener noreferrer">
+      {children}
+    </a>
+  );
+}
+
+export function NodeMarkdown({ content }: { content: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkAlert]}
+      rehypePlugins={[rehypeHighlight]}
+      components={{ pre: CodeBlock, table: TableWrapper, img: ZoomImage, a: SafeAnchor }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/web_ui/src/app/canvas/NoteNodeView.tsx
+++ b/web_ui/src/app/canvas/NoteNodeView.tsx
@@ -1,9 +1,7 @@
 import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
 import { useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 import { GroupColorPicker, NOTE_SYSTEM_PROMPT_BORDER_COLOR } from "./GroupColorPicker";
+import { NodeMarkdown } from "./NodeMarkdown";
 
 /**
  * The note node (Qt-removal plan R6.1) - the free-floating markdown sticky
@@ -22,8 +20,8 @@ import { GroupColorPicker, NOTE_SYSTEM_PROMPT_BORDER_COLOR } from "./GroupColorP
  * once created - the Handle elements are what let that edge draw a visible
  * connector line, same as every other kind.
  *
- * Real: render (markdown body, same react-markdown + rehype-highlight
- * pipeline every other node kind pulls in), double-click-to-edit (plain
+ * Real: render (markdown body, the shared NodeMarkdown.tsx renderer every
+ * other node kind now uses - node redesign stage 1), double-click-to-edit (plain
  * textarea, native browser undo - no custom undo/redo stack, confirmed as an
  * accepted simplification), color popover (shared GroupColorPicker), delete.
  * isSystemPrompt gets a dashed border + a small gear badge in the header;
@@ -153,9 +151,14 @@ export function NoteNodeView({ data, selected }: NodeProps<NoteFlowNode>) {
             spellCheck={false}
           />
         ) : (
-          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-            {data.content}
-          </ReactMarkdown>
+          // Nested wrapper (not applied to the outer scene-node-body div,
+          // which is shared with the textarea above) - same established
+          // pattern ArtifactBubble/ConversationBubble already use to scope
+          // .chat-node-content's shared markdown-body rules to just the
+          // rendered markdown, not a sibling edit control.
+          <div className="chat-node-content note-node-markdown">
+            <NodeMarkdown content={data.content} />
+          </div>
         )}
       </div>
       <Handle type="source" position={Position.Bottom} className="scene-node-handle" />

--- a/web_ui/src/app/canvas/PyCoderNodeView.tsx
+++ b/web_ui/src/app/canvas/PyCoderNodeView.tsx
@@ -1,18 +1,16 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { CodeExecutionApprovalPanel } from "./CodeExecutionApprovalPanel";
+import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
 
 /**
  * The Py-Coder node (Qt-removal plan R5.4) - the Py-Coder plugin's React
  * card. Same overall shell as every plugin-node sibling (ArtifactNodeView/
  * GitlinkNodeView): collapse/expand OR-ed with LOD, a card menu with
- * outside-click/Escape dismiss, the shared react-markdown + remarkGfm +
- * rehypeHighlight pipeline, no dock-to-parent action.
+ * outside-click/Escape dismiss, the shared NodeMarkdown.tsx renderer (node
+ * redesign stage 1), no dock-to-parent action.
  *
  * Mode + single input economy: the AI-driven/Manual toggle commits
  * IMMEDIATELY on click via data.onSetMode (backend/canvas.py registers a
@@ -258,9 +256,7 @@ export function PyCoderNodeView({ id, data, selected }: NodeProps<PyCoderFlowNod
             <div className="pycoder-node-section">
               <span className="pycoder-node-section-label">Code</span>
               <div className="chat-node-content pycoder-node-code">
-                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-                  {toPythonFence(data.pycoderCode)}
-                </ReactMarkdown>
+                <NodeMarkdown content={toPythonFence(data.pycoderCode)} />
               </div>
             </div>
           )}
@@ -269,9 +265,7 @@ export function PyCoderNodeView({ id, data, selected }: NodeProps<PyCoderFlowNod
             <div className="pycoder-node-section">
               <span className="pycoder-node-section-label">Output</span>
               <div className="chat-node-content pycoder-node-output">
-                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-                  {toPlainFence(data.pycoderOutput)}
-                </ReactMarkdown>
+                <NodeMarkdown content={toPlainFence(data.pycoderOutput)} />
               </div>
             </div>
           )}
@@ -280,9 +274,7 @@ export function PyCoderNodeView({ id, data, selected }: NodeProps<PyCoderFlowNod
             <div className="pycoder-node-section">
               <span className="pycoder-node-section-label">Analysis</span>
               <div className="chat-node-content pycoder-node-analysis">
-                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-                  {data.pycoderAnalysis}
-                </ReactMarkdown>
+                <NodeMarkdown content={data.pycoderAnalysis} />
               </div>
             </div>
           )}

--- a/web_ui/src/app/canvas/ThinkingNodeView.tsx
+++ b/web_ui/src/app/canvas/ThinkingNodeView.tsx
@@ -1,9 +1,7 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
 
 /**
@@ -25,8 +23,8 @@ import { NodeMenu } from "./NodeMenu";
  * "Undock" item here, matching the legacy menu (only ChatNode's menu offers
  * the reverse direction).
  *
- * Real: render (markdown thinking text, same react-markdown + rehype-
- * highlight pipeline every other node kind pulls in), delete (generic
+ * Real: render (markdown thinking text, the shared NodeMarkdown.tsx renderer
+ * every other node kind now uses - node redesign stage 1), delete (generic
  * cascade-delete - a thinking node is never a branch point/reparented, same
  * as CodeNode), copy, dock, and now Hide Other Branches / Show All Branches -
  * a scene-wide toggle (SceneCanvas.tsx owns the graph walk and the dimming
@@ -136,10 +134,8 @@ export function ThinkingNodeView({ data, selected }: NodeProps<ThinkingFlowNode>
         <span>Thinking</span>
       </div>
       {!collapsed && (
-        <div className="scene-node-body thinking-node-content">
-          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-            {data.thinkingText}
-          </ReactMarkdown>
+        <div className="scene-node-body thinking-node-content chat-node-content">
+          <NodeMarkdown content={data.thinkingText} />
         </div>
       )}
       <Handle type="source" position={Position.Bottom} className="scene-node-handle" />

--- a/web_ui/src/app/canvas/WebResearchNodeView.test.tsx
+++ b/web_ui/src/app/canvas/WebResearchNodeView.test.tsx
@@ -281,9 +281,13 @@ describe("WebResearchNodeView", () => {
 
   // -- markdown link safety ------------------------------------------------
 
-  it("opens a real http(s) link via window.open on click", async () => {
-    const user = userEvent.setup();
-    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+  // Node redesign stage 1: this view's own bespoke onClick+window.open
+  // anchor override was removed in favor of NodeMarkdown.tsx's shared
+  // SafeAnchor, which renders a real http(s) link declaratively (a native
+  // href + target="_blank"/rel, supplied by rehypeExternalLinks) rather
+  // than intercepting the click - so there is no window.open call to
+  // assert on anymore, just the resulting anchor's own attributes.
+  it("renders a real http(s) link as a genuine, hardened anchor (no onClick/window.open interception)", () => {
     renderWebResearchNode({
       researchStage: "completed",
       researchResult: makeResult({
@@ -291,25 +295,11 @@ describe("WebResearchNodeView", () => {
       }),
     });
 
-    await user.click(screen.getByText("real link"));
-    expect(openSpy).toHaveBeenCalledTimes(1);
-    expect(openSpy).toHaveBeenCalledWith("https://example.com/page", "_blank", "noopener,noreferrer");
-    openSpy.mockRestore();
-  });
-
-  it("never calls window.open for a javascript: href", async () => {
-    const user = userEvent.setup();
-    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
-    renderWebResearchNode({
-      researchStage: "completed",
-      researchResult: makeResult({
-        answerMarkdown: "[bad link](javascript:alert(1))",
-      }),
-    });
-
-    await user.click(screen.getByText("bad link"));
-    expect(openSpy).not.toHaveBeenCalled();
-    openSpy.mockRestore();
+    const link = screen.getByRole("link", { name: "real link" });
+    expect(link).toHaveAttribute("href", "https://example.com/page");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+    expect(link.getAttribute("rel")).toContain("noreferrer");
   });
 
   it("renders a non-http(s) link with no href at all, so middle-click/context-menu has no raw href to bypass onClick with", () => {

--- a/web_ui/src/app/canvas/WebResearchNodeView.tsx
+++ b/web_ui/src/app/canvas/WebResearchNodeView.tsx
@@ -1,16 +1,14 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
 
 /**
  * The web-research node (Qt-removal plan R5.1) - the Web Research plugin's
  * React card. Same overall shape as ConversationNodeView (collapse/expand
  * OR-ed with LOD, a card menu with outside-click/Escape dismiss, the shared
- * react-markdown + remarkGfm + rehypeHighlight pipeline), but instead of a
+ * NodeMarkdown.tsx renderer (node redesign stage 1)), but instead of a
  * growing message list this node drives ONE research run at a time and
  * renders it as: a query input + Run/Cancel, an in-progress stage stepper,
  * and - once a result exists - the synthesized answer, its warnings, and its
@@ -298,44 +296,18 @@ export function WebResearchNodeView({ data, selected }: NodeProps<WebResearchFlo
             <div className="web-research-node-result">
               {/* Reuses .chat-node-content's full markdown-body rule set
                   verbatim (same shared-class convention
-                  ConversationBubble's own -content div establishes), with a
-                  custom anchor renderer: answerMarkdown is LLM-generated from
-                  untrusted web evidence, so a javascript:/file: scheme must
-                  never be allowed to navigate - only a real http(s) link ever
-                  reaches window.open, everything else is inert. The href
-                  attribute itself is only set for http(s) links - an
-                  onClick-only guard leaves the raw (unsafe) href on the DOM
-                  node, which the browser's own middle-click/auxclick and
-                  "open link in new tab"/"copy link" context-menu actions read
-                  directly, bypassing onClick entirely. Omitting href for
-                  every other scheme removes that native escape hatch. */}
+                  ConversationBubble's own -content div establishes).
+                  answerMarkdown is LLM-generated from untrusted web
+                  evidence, so a javascript:/file: scheme must never be
+                  allowed to navigate - this view USED to carry its own
+                  bespoke anchor override for exactly that reason, but
+                  NodeMarkdown.tsx's own SafeAnchor now provides the
+                  identical http(s)-only allowlist (and every OTHER node
+                  kind's markdown gets the same protection too, which none
+                  of them had before - see NodeMarkdown.tsx's own doc
+                  comment), so this view no longer needs a special case. */}
               <div className="chat-node-content web-research-node-answer">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeHighlight]}
-                  components={{
-                    a: ({ href, children }) => {
-                      const isHttpUrl = !!href && /^https?:\/\//i.test(href.trim());
-                      if (!isHttpUrl) {
-                        // No href at all - nothing for middle-click/context-menu to act on.
-                        return <>{children}</>;
-                      }
-                      return (
-                        <a
-                          href={href}
-                          onClick={(event) => {
-                            event.preventDefault();
-                            window.open(href, "_blank", "noopener,noreferrer");
-                          }}
-                        >
-                          {children}
-                        </a>
-                      );
-                    },
-                  }}
-                >
-                  {data.researchResult.answerMarkdown}
-                </ReactMarkdown>
+                <NodeMarkdown content={data.researchResult.answerMarkdown} />
               </div>
 
               {data.researchResult.warnings.length > 0 && (

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -346,9 +346,22 @@ body,
   background-color: var(--gl-neutral-button-hover);
 }
 
+/* Markdown body inside a chat bubble - the same rule set as the document
+   viewer's own .document-viewer-markdown, duplicated here since that island
+   builds to a separate bundle and isn't importable into the SPA.
+   Document View's own scroll container also carries this class
+   (DocumentViewPanel.tsx: "document-view-panel-scroll chat-node-content"),
+   so every change here is shared by both surfaces - deliberately, not
+   incidentally (node redesign stage 2's own comment below explains why).
+   Kept as ONE rule block (adversarial review flagged an earlier draft that
+   split this into two non-adjacent .chat-node-content{} blocks with no
+   selector-duplication lint to catch a future silent conflict between
+   them) - if a future change needs to add more properties here, add them
+   to THIS block, not a new one further down the file. */
 .chat-node-content {
   max-height: 560px;
   overflow-y: auto;
+  line-height: 1.55;
 }
 
 .chat-node-content > :first-child {
@@ -359,26 +372,36 @@ body,
   margin-bottom: 0;
 }
 
-/* Markdown body inside a chat bubble - the same rule set as the document
-   viewer's own .document-viewer-markdown, duplicated here since that island
-   builds to a separate bundle and isn't importable into the SPA. */
+/* Node redesign, stage 2 ("typography and heading hierarchy"): headings
+   were fixed px values (15/14/13/12) set independently of this element's
+   own font-size, which itself is driven by the user-configurable
+   --gl-node-font-size custom property (SceneCanvas.tsx, View popover) -
+   defaulting to 9pt (~12px) but adjustable up to 16pt (~21px). At many
+   real settings, and always at the low end of that range, those fixed
+   heading sizes rendered SMALLER than or barely larger than the body text
+   they were supposed to head - an inverted hierarchy, not a style choice.
+   `em` here scales relative to whatever this element's own computed
+   font-size actually is (inherited from --gl-node-font-size, or the
+   fallback below in a context with no such variable, e.g. an isolated
+   component test), so headings are now ALWAYS meaningfully larger than
+   body text, at any font-size setting. */
 .chat-node-content h1,
 .chat-node-content h2,
 .chat-node-content h3,
 .chat-node-content h4,
 .chat-node-content h5,
 .chat-node-content h6 {
-  margin: 0 0 8px 0;
+  margin: 14px 0 6px 0;
   font-weight: 700;
   line-height: 1.3;
 }
 
-.chat-node-content h1 { font-size: 15px; }
-.chat-node-content h2 { font-size: 14px; }
-.chat-node-content h3 { font-size: 13px; }
+.chat-node-content h1 { font-size: 1.5em; }
+.chat-node-content h2 { font-size: 1.3em; }
+.chat-node-content h3 { font-size: 1.15em; }
 .chat-node-content h4,
 .chat-node-content h5,
-.chat-node-content h6 { font-size: 12px; }
+.chat-node-content h6 { font-size: 1.05em; }
 
 .chat-node-content p {
   margin: 0 0 10px 0;
@@ -400,7 +423,7 @@ body,
 
 .chat-node-content blockquote {
   margin: 0 0 10px 0;
-  padding-left: 10px;
+  padding: 2px 0 2px 10px;
   border-left: 3px solid var(--gl-surface-border);
   color: var(--gl-surface-text-muted);
 }
@@ -414,7 +437,9 @@ body,
 .chat-node-content code {
   font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
   font-size: 0.9em;
+  color: var(--gl-surface-text-primary);
   background-color: var(--gl-neutral-button-hover);
+  border: 1px solid var(--gl-surface-border);
   border-radius: 3px;
   padding: 2px 4px;
 }
@@ -430,6 +455,7 @@ body,
 
 .chat-node-content pre code {
   background-color: transparent;
+  border: none;
   border-radius: 0;
   padding: 0;
   font-size: 0.85em;
@@ -2541,6 +2567,66 @@ h6:hover > .document-view-heading-anchor {
 }
 
 .document-view-table-wrapper {
+  overflow-x: auto;
+  margin: 8px 0;
+}
+
+/* Node redesign, stage 1 ("shared node markdown renderer") -
+   NodeMarkdown.tsx's own component overrides, shared by every text-bearing
+   node kind. Deliberately parallel to .document-view-code-block/
+   .document-view-table-wrapper just above (same shape, same reasoning -
+   the header bar supplies the block's own chrome, so the inner <pre>
+   rendered by .chat-node-content's shared rule must not double it up) but
+   NOT the same selector: two independent class families sharing one base
+   class (chat-node-content) is the established pattern here, not a
+   duplication to collapse - Document View has no per-user font-size lever,
+   nodes do (--gl-node-font-size), so this version's own chrome text sizes
+   in `em` to track it, where Document View's own uses a fixed px. */
+.node-md-code-block {
+  margin: 8px 0;
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.node-md-code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border-bottom: 1px solid var(--gl-surface-border);
+  font-size: 0.85em;
+}
+
+.node-md-code-block-language {
+  color: var(--gl-surface-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.node-md-code-block-copy {
+  padding: 2px 8px;
+  font-size: 1em;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-background);
+  border: 1px solid var(--gl-neutral-button-border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.node-md-code-block-copy:hover {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.node-md-code-block pre {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+}
+
+.node-md-table-wrapper {
   overflow-x: auto;
   margin: 8px 0;
 }


### PR DESCRIPTION
## Problem

Every text-bearing node card (Chat, Note, Conversation, Artifact, Code, CodeSandbox, Gitlink, PyCoder, Thinking, WebResearch) rendered markdown through a bare `react-markdown` call with none of Document View's content-rendering upgrades: no code-block copy button, no wide-table scroll wrapper (tables were silently clipped by the card's fixed width, a real bug), no image zoom, no GitHub-style callouts. Headings were also fixed pixel sizes independent of the user-configurable node font-size setting, so at low settings a heading could render smaller than the body text underneath it.

## Change

- **`NodeMarkdown.tsx`** (new): a shared renderer for all node kinds - code-block language badge + copy button, table scroll wrapper, image zoom, GitHub callouts, and a hardened anchor override restricted to absolute `http(s)` links. Wired into all 10 node views plus the code-execution approval dialog (11 call sites total).
- **Security fix included**: only `WebResearchNodeView` previously guarded against non-`http(s)` link schemes (`javascript:`, `file:`, etc.) in its LLM-generated content. Every other node kind - including the human-approval dialog shown immediately before running AI-generated code with the user's own account privileges - had no such guard. That protection is now the shared default everywhere.
- **`styles.css`**: `.chat-node-content` headings converted from fixed px to relative `em` sizing, so the heading hierarchy holds at any font-size setting instead of only some of them. Also improved line-height and heading spacing. This class is shared with Document View's own scroll container, so both surfaces get more consistent typography.

## Adversarial review

A multi-dimension review (4 independent reviewers, each finding independently re-verified against the real code) raised 7 findings; all were addressed in one pass:

1. The anchor-hardening component's case-insensitive scheme check disagreed with a separate rehype plugin's case-sensitive one, so a mixed-case scheme (`HTTPS://…`) rendered as a real link with neither `target="_blank"` nor safe `rel` attributes - silently weaker than intended. Fixed by making the component fully self-sufficient (it now sets those attributes directly instead of depending on a second mechanism with different matching rules).
2. The code-execution approval dialog - the one surface whose entire purpose is a considered human review before running AI-generated code - was missed by the initial migration and still used the unhardened pipeline. Fixed; it now gets the same copy button and link hardening as every other node kind.
3–7. A handful of lower-severity findings: a stale doc comment that no longer matched actual behavior after the heading conversion, two CSS rule blocks for the same selector that should have been one, four node views whose comments still described the old rendering pipeline, and a test-coverage gap around mixed-case schemes and bare-URL autolinks. All fixed, with regression tests added for the security-relevant ones.

## Test plan

- [x] `NodeMarkdown.test.tsx` (20 tests): code-block copy/badge, table wrapper, image zoom, GitHub callouts, and the anchor-hardening allowlist including mixed-case schemes and GFM bare-URL autolinks.
- [x] `CodeExecutionApprovalPanel.test.tsx`: updated for the new Copy button, with a new test confirming it cannot resolve the approval dialog (not Approve, not Deny).
- [x] `CodeNodeView.test.tsx`: fixed a real query collision the new language badge introduced (a code block's language and the node's own title can now legitimately show the same text).
- [x] Full suite green: `tsc --noEmit`, `vitest run` (1083/1083), `eslint` (0 errors), `vite build`, backend `pytest -q` (1161/1161, unaffected - no backend changes), `contracts/codegen.py --check`.