### PR TITLE
Redesign node cards, stage 3: elevation, avatar chip, quick actions

### DIFF
--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -24,7 +24,7 @@ afterEach(() => {
 // useStore(zoom) read - not RF's node-mounting/measurement pipeline - a
 // bare ReactFlowProvider is enough, and the component renders immediately
 // visible with no jsdom polyfills required.
-function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
+function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}, selected: boolean = false) {
   const onToggleCollapse = vi.fn();
   const onDelete = vi.fn();
   const onUndockChild = vi.fn();
@@ -42,7 +42,7 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}) {
   const onCollapseBranch = vi.fn();
   const props = {
     id: "n0",
-    selected: false,
+    selected,
     data: {
       content: "Hello **world**",
       isUser: true,
@@ -555,6 +555,101 @@ describe("ChatNodeView Collapse Branch (ADR-002 Workstream 1)", () => {
     await user.click(item);
 
     expect(onCollapseBranch).toHaveBeenCalledWith(false);
+  });
+});
+
+// Node redesign, stage 3 ("card chrome"): the avatar chip and the header's
+// hover-revealed quick-action row (Copy/Branch from Here/Open Document
+// View) - all 3 buttons deliberately call the SAME handlers the card menu
+// below already uses, just reached without a right-click first.
+describe("ChatNodeView Stage 3 card chrome: avatar + quick actions", () => {
+  it("renders the avatar chip with 'U' for a user node and 'A' for an assistant node, both aria-hidden", () => {
+    const { container: userContainer } = renderChatNode({ isUser: true });
+    const userAvatar = userContainer.querySelector(".chat-node-avatar");
+    expect(userAvatar).toHaveTextContent("U");
+    expect(userAvatar).toHaveAttribute("aria-hidden", "true");
+
+    const { container: assistantContainer } = renderChatNode({ isUser: false });
+    expect(assistantContainer.querySelector(".chat-node-avatar")).toHaveTextContent("A");
+  });
+
+  it("the quick-action Copy button copies data.content directly (not routed through the card menu) and flashes a check glyph", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    renderChatNode({ content: "Hello **world**" });
+
+    const copyBtn = screen.getByRole("button", { name: "Copy text" });
+    expect(copyBtn.querySelector("path")).toBeNull(); // rest state: the copy glyph is two rects, no path
+
+    await user.click(copyBtn);
+
+    expect(writeText).toHaveBeenCalledWith("Hello **world**");
+    await waitFor(() => expect(copyBtn.querySelector("path")).not.toBeNull()); // check glyph flashed
+  });
+
+  it("the quick-action Branch from Here button calls onBranchFromHere directly, without opening the card menu", async () => {
+    const user = userEvent.setup();
+    const { onBranchFromHere } = renderChatNode();
+
+    await user.click(screen.getByRole("button", { name: "Branch from here" }));
+    expect(onBranchFromHere).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("the quick-action Open Document View button calls onOpenDocumentView directly, without opening the card menu", async () => {
+    const user = userEvent.setup();
+    const { onOpenDocumentView } = renderChatNode();
+
+    await user.click(screen.getByRole("button", { name: "Open Document View" }));
+    expect(onOpenDocumentView).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("all three quick-action buttons carry the nodrag class", () => {
+    renderChatNode();
+    for (const name of ["Copy text", "Branch from here", "Open Document View"]) {
+      expect(screen.getByRole("button", { name })).toHaveClass("nodrag");
+    }
+  });
+
+  it("the check glyph reverts back to the copy glyph 1500ms after copying", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    renderChatNode();
+
+    const copyBtn = screen.getByRole("button", { name: "Copy text" });
+    await user.click(copyBtn);
+    await waitFor(() => expect(copyBtn.querySelector("path")).not.toBeNull());
+
+    await waitFor(() => expect(copyBtn.querySelector("path")).toBeNull(), { timeout: 2000 });
+  });
+
+  it("adds the selected class to the card when the selected prop is true", () => {
+    const { container } = renderChatNode({}, true);
+    expect(container.querySelector(".chat-node")).toHaveClass("selected");
+  });
+
+  // An adversarial review (node redesign stage 3) found that the avatar chip
+  // and quick-actions row, stacked with the header's existing conditional
+  // badges (model/synthesis/docked/final - which can legitimately all
+  // co-occur on one node), overflowed the 290px collapsed pill and pushed
+  // the collapse button itself outside .scene-node's overflow:hidden clip,
+  // making it unclickable. Both are now suppressed while collapsed.
+  describe("suppressed while collapsed (overflow fix)", () => {
+    it("hides the avatar chip and the quick-actions row, but keeps the collapse button, when isCollapsed is true", () => {
+      const { container } = renderChatNode({ isCollapsed: true, model: "claude-opus-4-1-20250805" });
+      expect(container.querySelector(".chat-node-avatar")).toBeNull();
+      expect(container.querySelector(".chat-node-quick-actions")).toBeNull();
+      expect(screen.getByRole("button", { name: "Expand" })).toBeInTheDocument();
+    });
+
+    it("shows the avatar chip and the quick-actions row again once expanded", () => {
+      const { container } = renderChatNode({ isCollapsed: false });
+      expect(container.querySelector(".chat-node-avatar")).not.toBeNull();
+      expect(container.querySelector(".chat-node-quick-actions")).not.toBeNull();
+    });
   });
 });
 

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { CHAT_SCROLL_REPORT_DEBOUNCE_MS, LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { downloadTextFile } from "./downloadTextFile";
 import { GROUP_MONO_COLORS, GROUP_NAMED_COLORS } from "./GroupColorPicker";
@@ -491,10 +491,65 @@ export function makeDebouncedScrollReport(
   };
 }
 
+// Node redesign, stage 3 ("card chrome"): hand-authored stroke icons for
+// the header's hover-revealed quick-action row, matching the SAME
+// convention this codebase already established twice (GroupNodeView.tsx's
+// own GroupIcon, Composer.tsx's own Icon) rather than a fourth, different
+// icon approach - fill:none/stroke:currentColor, one small file-local
+// component per file that needs icons, not a shared icon library.
+type ChatNodeIconName = "copy" | "check" | "branch" | "document";
+
+const CHAT_NODE_ICON_PATHS: Record<ChatNodeIconName, ReactNode> = {
+  copy: (
+    <>
+      <rect x="2.5" y="2.5" width="8" height="8" rx="1.2" />
+      <rect x="5.5" y="5.5" width="8" height="8" rx="1.2" />
+    </>
+  ),
+  check: <path d="M3.5 8.5 6.5 11.5 12.5 4.5" />,
+  branch: (
+    <>
+      <circle cx="4.5" cy="3.5" r="1.4" />
+      <circle cx="4.5" cy="12.5" r="1.4" />
+      <circle cx="11.5" cy="8" r="1.4" />
+      <path d="M4.5 4.9V11.1" />
+      <path d="M4.5 8H7a3 3 0 0 0 3-3" />
+    </>
+  ),
+  document: (
+    <>
+      <path d="M4 2h5l3 3v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1Z" />
+      <path d="M9 2v3h3" />
+    </>
+  ),
+};
+
+function ChatNodeIcon({ name }: { name: ChatNodeIconName }) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 16 16" className="chat-node-icon">
+      {CHAT_NODE_ICON_PATHS[name]}
+    </svg>
+  );
+}
+
 export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
   const zoom = useStore((s) => s.transform[2]);
   const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
   const collapsed = data.isCollapsed || lodCollapsed;
+  const [copied, setCopied] = useState(false);
+
+  // Node redesign, stage 3: the header's hover-revealed quick-action Copy
+  // button - deliberately a SEPARATE, direct navigator.clipboard call, not
+  // routed through the card menu's own "Copy Text" item (ChatNodeMenu,
+  // below), since this one needs its own transient "copied" flash feedback
+  // (matching the established pattern DocumentViewPanel.tsx/NodeMarkdown.tsx's
+  // own CodeBlock already use) independent of the menu's lifecycle.
+  function onQuickCopy() {
+    navigator.clipboard.writeText(data.content).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
 
   // R6.3: restore the saved scroll position once on mount (an empty dep
@@ -533,6 +588,25 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
       <Handle type="target" position={Position.Top} className="scene-node-handle" />
       <div className="scene-node-title chat-node-role">
         <span className="chat-node-role-group">
+          {/* Node redesign, stage 3: a small avatar chip - purely visual
+              (aria-hidden, the real role text right after it already
+              carries the semantics) - so scanning a dense graph of many
+              chat nodes doesn't depend on reading "You"/"Assistant" text
+              at small zoom levels. User/Assistant differentiated by the
+              same background shade .chat-node.user already tints its own
+              title bar with, not a new color - this app's palette stays
+              deliberately greyscale. Suppressed while collapsed - an
+              adversarial review measured a real overflow: the collapsed
+              pill is only 290px, and this chip stacked with the header's
+              existing conditional badges (model/synthesis/docked/final,
+              which can legitimately all co-occur) plus the quick-actions
+              row below pushed the collapse button entirely outside
+              .scene-node's overflow:hidden clip, making it unclickable. */}
+          {!collapsed && (
+            <span className="chat-node-avatar" aria-hidden="true">
+              {data.isUser ? "U" : "A"}
+            </span>
+          )}
           <span>{data.isUser ? "You" : "Assistant"}</span>
           {/* ADR-002 Workstream 1 ("Branch status and lifecycle"): always
               rendered (unlike every other badge here, which is conditional)
@@ -585,14 +659,65 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
             </span>
           )}
         </span>
-        <button
-          type="button"
-          className="chat-node-collapse-btn"
-          aria-label={data.isCollapsed ? "Expand" : "Collapse"}
-          onClick={data.onToggleCollapse}
-        >
-          {data.isCollapsed ? "▸" : "▾"}
-        </button>
+        {/* A single wrapper span, not two separate top-level flex children -
+            .chat-node-role's own layout is justify-content:space-between
+            (see .chat-node-role-group's own comment above for why a 3rd
+            top-level child gets pushed to the CENTER by that, not grouped
+            with the collapse button on the right where it belongs). */}
+        <span className="chat-node-title-actions">
+          {/* Node redesign, stage 3: hover-revealed quick actions - the 3
+              most-reached-for items from the card menu below (Copy Text,
+              Branch from here, Open Document View), surfaced without a
+              right-click. Hidden by default (opacity:0, matching
+              .group-node-controls-chip's own established hover-reveal
+              convention exactly) and revealed on hover OR while selected,
+              so they're still discoverable without a mouse hovering right
+              there after a click-to-select. nodrag on every button - these
+              sit inside a React Flow node, and without it a click here
+              would also start dragging the card. */}
+          {/* Suppressed while collapsed - same overflow reason as the
+              avatar chip's own comment above; this row alone was the
+              larger contributor to the measured overflow. */}
+          {!collapsed && (
+            <span className="chat-node-quick-actions">
+              <button
+                type="button"
+                className="chat-node-quick-action nodrag"
+                onClick={onQuickCopy}
+                title="Copy text"
+                aria-label="Copy text"
+              >
+                <ChatNodeIcon name={copied ? "check" : "copy"} />
+              </button>
+              <button
+                type="button"
+                className="chat-node-quick-action nodrag"
+                onClick={data.onBranchFromHere}
+                title="Branch from here"
+                aria-label="Branch from here"
+              >
+                <ChatNodeIcon name="branch" />
+              </button>
+              <button
+                type="button"
+                className="chat-node-quick-action nodrag"
+                onClick={data.onOpenDocumentView}
+                title="Open Document View"
+                aria-label="Open Document View"
+              >
+                <ChatNodeIcon name="document" />
+              </button>
+            </span>
+          )}
+          <button
+            type="button"
+            className="chat-node-collapse-btn"
+            aria-label={data.isCollapsed ? "Expand" : "Collapse"}
+            onClick={data.onToggleCollapse}
+          >
+            {data.isCollapsed ? "▸" : "▾"}
+          </button>
+        </span>
       </div>
       {!collapsed && (
         <div className="scene-node-body chat-node-content" ref={contentRef} onScroll={onScroll}>

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -234,10 +234,28 @@ body,
      its own font-size. Falls back to the pre-existing literal when unset
      (e.g. in tests that render a node outside SceneCanvas). */
   font-family: var(--gl-node-font-family, inherit);
+  /* Node redesign, stage 3 ("card chrome"): every node kind was a
+     perfectly flat rectangle - no elevation at all, and "selected" was
+     only a marginally lighter border color, easy to miss in a dense graph.
+     Mirrors .group-node's own established elevation/selected-ring
+     convention (styles.css, R6.1 frame/container) exactly, rather than
+     inventing a second, different depth system for a different node
+     category - a 3-tier ladder (rest/hover/selected), shadow tokens that
+     already existed and were completely unused by node cards. */
+  box-shadow: var(--gl-shadow-1);
+  transition:
+    border-color var(--gl-motion-fast) var(--gl-motion-ease),
+    box-shadow var(--gl-motion-base) var(--gl-motion-ease);
+}
+
+.scene-node:hover {
+  border-color: var(--gl-surface-border-strong, var(--gl-surface-text-muted));
+  box-shadow: var(--gl-shadow-2);
 }
 
 .scene-node.selected {
   border-color: var(--gl-surface-border-strong, var(--gl-surface-text-muted));
+  box-shadow: 0 0 0 1px var(--gl-surface-border-strong), var(--gl-shadow-3);
 }
 
 .scene-node-title {
@@ -742,6 +760,100 @@ body,
   display: flex;
   align-items: center;
   gap: 6px;
+}
+
+/* Node redesign, stage 3 ("card chrome"): a small avatar chip so scanning a
+   dense graph of many chat nodes doesn't depend on reading "You"/"Assistant"
+   text at small zoom levels. Purely visual (aria-hidden in the JSX - the
+   role text right after it already carries the semantics), differentiated
+   by the same background-shade tokens .chat-node-docked-badge already pairs
+   below - this app's palette stays deliberately greyscale, not a new color
+   per role. */
+.chat-node-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--gl-surface-text-secondary);
+  background-color: var(--gl-neutral-button-hover);
+  border-radius: 999px;
+}
+
+.chat-node.user .chat-node-avatar {
+  color: var(--gl-surface-window);
+  background-color: var(--gl-surface-text-muted);
+}
+
+/* Wraps the hover-revealed quick actions together with the pre-existing
+   collapse button so the pair acts as ONE combined flex child on the right
+   of .chat-node-role's space-between layout - same reasoning as
+   .chat-node-role-group's own comment above, mirrored for the right side. */
+.chat-node-title-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+/* The 3 most-reached-for items from the card menu (Copy Text, Branch from
+   here, Open Document View), surfaced without a right-click. Hidden by
+   default and revealed on hover or while selected - mirrors
+   .group-node-controls-chip's own established hover-reveal convention
+   exactly rather than inventing a second one. */
+.chat-node-quick-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  transform: translateX(4px);
+  pointer-events: none;
+  transition:
+    opacity var(--gl-motion-fast) var(--gl-motion-ease),
+    transform var(--gl-motion-fast) var(--gl-motion-ease);
+}
+
+.chat-node:hover .chat-node-quick-actions,
+.chat-node.selected .chat-node-quick-actions,
+.chat-node-quick-actions:focus-within {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.chat-node-quick-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  color: var(--gl-surface-text-muted);
+  background: transparent;
+  border: none;
+  border-radius: var(--gl-radius-sm);
+  cursor: pointer;
+  transition:
+    background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    color var(--gl-motion-fast) var(--gl-motion-ease);
+}
+
+.chat-node-quick-action:hover {
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.chat-node-icon {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 /* Small pill on ChatNodeView showing how many thinking-node children are


### PR DESCRIPTION
## Problem

Node cards had no visual depth or hierarchy (flat rectangles, selection only barely visible via border color), and reaching the 3 most common chat-node actions (Copy, Branch from Here, Open Document View) always required a right-click.

## Change

- Universal elevation for every node kind: `.scene-node` now has a 3-tier shadow ladder (rest / hover / selected), mirroring the elevation convention `.group-node` already used.
- `ChatNodeView`: a small avatar chip ("U"/"A") next to the role label, and a hover-revealed quick-action row (Copy text / Branch from here / Open Document View) in the title bar, reusing the same handlers the existing right-click menu already wires.
- Both the avatar and quick-actions are suppressed while a chat node is collapsed - an adversarial review caught that, combined with existing conditional badges (model/synthesis/docked/final), they could overflow the 290px collapsed pill and push the collapse button outside the card's clickable area.
- Added a `:focus-within` fallback so keyboard users tabbing onto a quick-action button reveal the row instead of interacting with an invisible control.

## Test plan

- `npx tsc --noEmit`, `npx vitest run` (1092 tests), `npx eslint .`, `npx vite build` all pass.
- Added coverage for the avatar chip, all 3 quick actions, the copy-glyph flash and its revert, `selected` state, and the collapsed-state suppression fix.
- Manually verified in a live browser: elevation shadows render, the collapsed-state fix removes the avatar/quick-actions from the DOM and keeps the card within its 290px width, and Open Document View / Branch from Here / Copy correctly fire their handlers.