### PR TITLE
Add focus-within reveal to group-node-controls-chip

### DIFF
--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -5452,7 +5452,8 @@ mark.document-view-search-match-current {
 }
 
 .group-node:hover .group-node-controls-chip,
-.group-node.selected .group-node-controls-chip {
+.group-node.selected .group-node-controls-chip,
+.group-node-controls-chip:focus-within {
   opacity: 1;
   transform: translateX(0);
   pointer-events: auto;


### PR DESCRIPTION
## Problem

`.group-node-controls-chip` (Ungroup, color picker, etc.) is hidden by default (opacity:0, pointer-events:none) and only revealed on hover or when the group node is selected. A keyboard user tabbing onto one of its buttons gets no visual indication of focus before Enter/Space activates it - the chip stays invisible the whole time.

## Change

Added `.group-node-controls-chip:focus-within` to the existing reveal rule's selector list in `web_ui/src/app/styles.css`, reusing the same opacity/transform/pointer-events declaration already used for hover/selected. No JSX changes needed.

## Test plan

- `npx tsc --noEmit`, `npx vitest run` (1092 tests, including `GroupNodeView.test.tsx`), `npx vite build` all pass.
- Verified in a live browser: the CSSOM rule matches as expected, and focusing a button inside the chip flips its `pointer-events` from `none` to `auto` via the new `:focus-within` selector.