### PR TITLE
Add content fade + Show more/less to chat node cards

### DIFF
--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -2,7 +2,13 @@ import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ChatNodeView, makeDebouncedScrollReport, type ChatFlowNode } from "./ChatNodeView";
+import {
+  CHAT_CONTENT_COLLAPSED_MAX_HEIGHT,
+  ChatNodeView,
+  contentExceedsCollapsedHeight,
+  makeDebouncedScrollReport,
+  type ChatFlowNode,
+} from "./ChatNodeView";
 
 // R7.5a: jsdom implements neither URL.createObjectURL nor
 // URL.revokeObjectURL - same hand-installed-fakes pattern
@@ -40,47 +46,61 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}, selected:
   const onSetBranchStatus = vi.fn();
   const onSetFinalDeliverable = vi.fn();
   const onCollapseBranch = vi.fn();
-  const props = {
-    id: "n0",
-    selected,
-    data: {
-      content: "Hello **world**",
-      isUser: true,
-      isCollapsed: false,
-      dockedChildren: [],
-      chatScrollValue: 0,
-      onToggleCollapse,
-      onDelete,
-      onUndockChild,
-      onRegenerate,
-      onGenerateImage,
-      onGenerateChart,
-      onGenerateKeyTakeaway,
-      onGenerateExplainerNote,
-      onOpenDocumentView,
-      onScrollChange,
-      isBranchFocusActive: false,
-      onToggleBranchFocus,
-      onBranchFromHere,
-      branchStatus: "active",
-      isFinalDeliverable: false,
-      onSetBranchStatus,
-      onSetFinalDeliverable,
-      onCollapseBranch,
-      ...overrides,
-    },
-  } as unknown as NodeProps<ChatFlowNode>;
+  function buildProps(dataOverrides: Partial<ChatFlowNode["data"]>) {
+    return {
+      id: "n0",
+      selected,
+      data: {
+        content: "Hello **world**",
+        isUser: true,
+        isCollapsed: false,
+        dockedChildren: [],
+        chatScrollValue: 0,
+        onToggleCollapse,
+        onDelete,
+        onUndockChild,
+        onRegenerate,
+        onGenerateImage,
+        onGenerateChart,
+        onGenerateKeyTakeaway,
+        onGenerateExplainerNote,
+        onOpenDocumentView,
+        onScrollChange,
+        isBranchFocusActive: false,
+        onToggleBranchFocus,
+        onBranchFromHere,
+        branchStatus: "active",
+        isFinalDeliverable: false,
+        onSetBranchStatus,
+        onSetFinalDeliverable,
+        onCollapseBranch,
+        ...dataOverrides,
+      },
+    } as unknown as NodeProps<ChatFlowNode>;
+  }
 
-  const { container } = render(
+  const { container, rerender } = render(
     <ReactFlowProvider>
-      <ChatNodeView {...props} />
+      <ChatNodeView {...buildProps(overrides)} />
     </ReactFlowProvider>,
   );
+  // Re-renders with a fresh set of data overrides (merged over the same
+  // defaults above) - only needed by tests that must trigger a NEW commit
+  // (e.g. the content-overflow measurement effect below, keyed on
+  // data.content) after first mutating the rendered DOM directly.
+  function rerenderWithData(dataOverrides: Partial<ChatFlowNode["data"]>) {
+    rerender(
+      <ReactFlowProvider>
+        <ChatNodeView {...buildProps(dataOverrides)} />
+      </ReactFlowProvider>,
+    );
+  }
   return {
     onToggleCollapse, onDelete, onUndockChild, onRegenerate, onGenerateImage,
     onGenerateChart, onGenerateKeyTakeaway, onGenerateExplainerNote,
     onOpenDocumentView, onScrollChange, onToggleBranchFocus, onBranchFromHere,
     onSetBranchStatus, onSetFinalDeliverable, onCollapseBranch, container,
+    rerenderWithData,
   };
 }
 
@@ -650,6 +670,69 @@ describe("ChatNodeView Stage 3 card chrome: avatar + quick actions", () => {
       expect(container.querySelector(".chat-node-avatar")).not.toBeNull();
       expect(container.querySelector(".chat-node-quick-actions")).not.toBeNull();
     });
+  });
+});
+
+// Node redesign, stage 3's own deferred sub-item ("content fade + Show
+// more"), implemented later: replaces .chat-node-content's hard 560px
+// scroll-only cutoff with a fade + toggle. jsdom never lays out real
+// content (scrollHeight is always 0), so these tests override scrollHeight
+// directly on the rendered content div, then trigger a fresh measurement by
+// re-rendering with a new data.content (the measurement effect's own
+// dependency) - the override survives the re-render since React reuses the
+// same DOM node.
+describe("ChatNodeView content fade + Show more/Show less", () => {
+  it("renders no fade or Show more button when content fits within the collapsed cap (jsdom's real, always-0 scrollHeight)", () => {
+    const { container } = renderChatNode();
+    expect(container.querySelector(".chat-node-content-fade")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+  });
+
+  it("shows a fade and a Show more button once the content's real scrollHeight exceeds the collapsed cap", () => {
+    const { container, rerenderWithData } = renderChatNode({ content: "first" });
+    const contentEl = container.querySelector(".chat-node-content") as HTMLDivElement;
+    Object.defineProperty(contentEl, "scrollHeight", { value: 900, configurable: true });
+
+    rerenderWithData({ content: "second" });
+
+    expect(container.querySelector(".chat-node-content-fade")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Show more" })).toBeInTheDocument();
+  });
+
+  it("clicking Show more expands the content and hides the fade; clicking Show less collapses it back", async () => {
+    const user = userEvent.setup();
+    const { container, rerenderWithData } = renderChatNode({ content: "first" });
+    const contentEl = container.querySelector(".chat-node-content") as HTMLDivElement;
+    Object.defineProperty(contentEl, "scrollHeight", { value: 900, configurable: true });
+    rerenderWithData({ content: "second" });
+
+    await user.click(screen.getByRole("button", { name: "Show more" }));
+    expect(contentEl).toHaveClass("expanded");
+    expect(container.querySelector(".chat-node-content-fade")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Show less" }));
+    expect(contentEl).not.toHaveClass("expanded");
+    expect(container.querySelector(".chat-node-content-fade")).not.toBeNull();
+  });
+
+  it("the Show more/Show less toggle carries the nodrag class", () => {
+    const { container, rerenderWithData } = renderChatNode({ content: "first" });
+    const contentEl = container.querySelector(".chat-node-content") as HTMLDivElement;
+    Object.defineProperty(contentEl, "scrollHeight", { value: 900, configurable: true });
+    rerenderWithData({ content: "second" });
+
+    expect(screen.getByRole("button", { name: "Show more" })).toHaveClass("nodrag");
+  });
+});
+
+describe("contentExceedsCollapsedHeight", () => {
+  it("is false at or under the collapsed cap", () => {
+    expect(contentExceedsCollapsedHeight(0)).toBe(false);
+    expect(contentExceedsCollapsedHeight(CHAT_CONTENT_COLLAPSED_MAX_HEIGHT)).toBe(false);
+  });
+
+  it("is true once over the collapsed cap", () => {
+    expect(contentExceedsCollapsedHeight(CHAT_CONTENT_COLLAPSED_MAX_HEIGHT + 1)).toBe(true);
   });
 });
 

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -532,6 +532,21 @@ function ChatNodeIcon({ name }: { name: ChatNodeIconName }) {
   );
 }
 
+// Node redesign, stage 3's own deferred sub-item ("content fade + Show more,
+// replacing the hard 560px cutoff"), implemented now: must match
+// .chat-node-content's own max-height in styles.css exactly, or the fade/
+// button would appear (or fail to appear) at the wrong point.
+export const CHAT_CONTENT_COLLAPSED_MAX_HEIGHT = 560;
+
+/** Pure comparison, exported standalone for the same direct-unit-testability
+ * reason makeDebouncedScrollReport above already is - jsdom never lays out
+ * real content (scrollHeight is always 0 there), so the actual measurement
+ * can only be exercised in a real browser, but this comparison itself can be
+ * tested with plain numbers. */
+export function contentExceedsCollapsedHeight(scrollHeight: number): boolean {
+  return scrollHeight > CHAT_CONTENT_COLLAPSED_MAX_HEIGHT;
+}
+
 export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
   const zoom = useStore((s) => s.transform[2]);
   const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
@@ -576,6 +591,45 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
   function onScroll(event: React.UIEvent<HTMLDivElement>) {
     makeDebouncedScrollReport(scrollTimerRef, data.onScrollChange)(event.currentTarget.scrollTop);
   }
+
+  // Node redesign, stage 3's own deferred sub-item, implemented now: content
+  // taller than the collapsed cap gets a fade + "Show more" toggle instead of
+  // just an internal scrollbar with no indication there's more below.
+  // Measures contentRef itself (the capped, overflow-y:auto element), not a
+  // separate inner wrapper - scrollHeight already reports the element's true,
+  // UNCAPPED content height regardless of its own max-height-clipped
+  // clientHeight, so no extra DOM node is needed (and none was added: an
+  // earlier draft wrapped NodeMarkdown in its own measurement div, which
+  // broke the .chat-node-content > :first-child/:last-child margin-reset
+  // rules just below by making them target that wrapper instead of the
+  // markdown's own first/last element - caught before this ever shipped).
+  const [contentExpanded, setContentExpanded] = useState(false);
+  const [contentOverflows, setContentOverflows] = useState(false);
+
+  useEffect(() => {
+    const contentEl = contentRef.current;
+    if (!contentEl) return undefined;
+
+    function measure() {
+      setContentOverflows(contentExceedsCollapsedHeight(contentEl!.scrollHeight));
+    }
+    measure();
+
+    // Catches height changes a single measurement on mount would miss - e.g.
+    // an embedded image (NodeMarkdown's own ZoomImage) has no intrinsic
+    // height until it finishes loading, well after this effect first runs.
+    // Observing contentEl itself still works once content crosses the
+    // 560px cap: at that crossing point the element's OWN rendered height
+    // changes (uncapped natural size -> capped 560px), which is exactly
+    // the resize event this needs to catch; further growth past the cap
+    // doesn't change the boolean this is tracking, so no further event is
+    // needed. vitest.setup.ts's ResizeObserver stub never fires its
+    // callback, so only the synchronous measure() call above is exercised
+    // in tests; this is a real-browser-only refinement on top of it.
+    const observer = new ResizeObserver(measure);
+    observer.observe(contentEl);
+    return () => observer.disconnect();
+  }, [data.content]);
 
   return (
     <div
@@ -720,8 +774,26 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
         </span>
       </div>
       {!collapsed && (
-        <div className="scene-node-body chat-node-content" ref={contentRef} onScroll={onScroll}>
-          <NodeMarkdown content={data.content} />
+        <div className="chat-node-content-shell">
+          <div
+            className={`scene-node-body chat-node-content${contentExpanded ? " expanded" : ""}`}
+            ref={contentRef}
+            onScroll={onScroll}
+          >
+            <NodeMarkdown content={data.content} />
+          </div>
+          {contentOverflows && !contentExpanded && (
+            <div className="chat-node-content-fade" aria-hidden="true" />
+          )}
+          {contentOverflows && (
+            <button
+              type="button"
+              className="chat-node-show-more nodrag"
+              onClick={() => setContentExpanded((expanded) => !expanded)}
+            >
+              {contentExpanded ? "Show less" : "Show more"}
+            </button>
+          )}
         </div>
       )}
       <Handle type="source" position={Position.Bottom} className="scene-node-handle" />

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -390,6 +390,49 @@ body,
   margin-bottom: 0;
 }
 
+/* Node redesign, stage 3's own deferred sub-item ("content fade + Show
+   more"), implemented now: replaces the hard 560px scroll-only cutoff with
+   a fade + toggle, matching how most chat UIs handle a long message.
+   Scoped to ChatNodeView only - .thinking-node-content/.code-node-content
+   share the base .chat-node-content rule above but never render this
+   wrapper/fade/button, so they keep their existing scroll-only behavior
+   unchanged. */
+.chat-node-content-shell {
+  position: relative;
+}
+
+.chat-node-content.expanded {
+  max-height: none;
+}
+
+.chat-node-content-fade {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 48px;
+  background: linear-gradient(to bottom, transparent, var(--gl-surface-node-body));
+  pointer-events: none;
+}
+
+.chat-node-show-more {
+  display: block;
+  width: 100%;
+  padding: 4px 0;
+  font-size: 0.85em;
+  font-family: inherit;
+  color: var(--gl-surface-text-muted);
+  background: transparent;
+  border: none;
+  border-top: 1px solid var(--gl-surface-border);
+  cursor: pointer;
+}
+
+.chat-node-show-more:hover {
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-hover);
+}
+
 /* Node redesign, stage 2 ("typography and heading hierarchy"): headings
    were fixed px values (15/14/13/12) set independently of this element's
    own font-size, which itself is driven by the user-configurable


### PR DESCRIPTION
## Problem

`.chat-node-content` has a hard 560px max-height cutoff. Content taller than that just scrolled internally with an ordinary scrollbar and no other indication there was more content below - a deferred item from the earlier card-chrome stage that was never picked back up.

## Change

- A bottom fade overlay plus a Show more/Show less toggle replace the bare scroll cutoff, matching how most chat UIs surface a long message.
- Scoped to `ChatNodeView` only - `ThinkingNodeView`/`CodeNodeView` share the same base `.chat-node-content` rule but render neither the fade nor the toggle, so their existing scroll-only behavior is unchanged.
- Overflow detection measures the existing scrollable content div's own `scrollHeight` directly (no extra wrapper element), so the pre-existing `:first-child`/`:last-child` margin-reset rules keep targeting the markdown's own first/last element rather than a new wrapper.
- A `ResizeObserver` re-measures after mount to catch height changes a one-time check would miss (e.g. an embedded image with no intrinsic size until it loads).

## Test plan

- `npx tsc --noEmit`, `npx vitest run` (1102 tests, including new coverage for the fade/toggle appearing only when content overflows, the expand/collapse cycle, and the pure height-comparison helper), `npx eslint .`, `npx vite build` all pass.
- Verified in a live browser: a long message shows the fade and "Show more"; clicking it removes the cap and hides the fade; "Show less" restores both; a short message shows neither.