### PR TITLE
Add per-bubble avatar + quick actions to conversation node messages

### DIFF
--- a/web_ui/src/app/canvas/ConversationNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.test.tsx
@@ -1,7 +1,7 @@
 import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ConversationNodeView, type ConversationFlowNode } from "./ConversationNodeView";
 
@@ -176,6 +176,138 @@ describe("ConversationNodeView", () => {
     fireEvent.contextMenu(assistantBubble);
     await user.click(screen.getByRole("menuitem", { name: "Delete from History" }));
     expect(onDeleteMessage).toHaveBeenCalledWith(1);
+  });
+
+  // Per-bubble chrome, extending node redesign stage 3's ChatNodeView
+  // treatment here: an avatar chip + visible role label, and a
+  // hover-revealed quick-action row surfacing the SAME 2 items
+  // ConversationBubbleMenu already offers. Quick-action names are
+  // disambiguated per-message ("Copy message N"/"Delete message N from
+  // history") since, unlike ChatNodeView, N of these buttons can share one
+  // node card - an adversarial review flagged the un-disambiguated static
+  // names as a real accessibility gap.
+  describe("per-bubble chrome: avatar + role label + quick actions", () => {
+    it("renders an avatar chip with 'U'/'A' (aria-hidden) plus a visible 'You'/'Assistant' role label for each bubble", () => {
+      renderConversationNode();
+      const userBubble = screen.getByText("world").closest(".conversation-node-bubble") as HTMLElement;
+      const assistantBubble = screen.getByText("Hi there").closest(".conversation-node-bubble") as HTMLElement;
+
+      const userAvatar = userBubble.querySelector(".chat-node-avatar");
+      expect(userAvatar).toHaveTextContent("U");
+      expect(userAvatar).toHaveAttribute("aria-hidden", "true");
+      expect(within(userBubble).getByText("You")).toBeInTheDocument();
+
+      expect(assistantBubble.querySelector(".chat-node-avatar")).toHaveTextContent("A");
+      expect(within(assistantBubble).getByText("Assistant")).toBeInTheDocument();
+    });
+
+    it("the quick-action Copy button on the FIRST (user, index 0) bubble copies its own content and is named for its own position", async () => {
+      const user = userEvent.setup();
+      renderConversationNode();
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+      const userBubble = screen.getByText("world").closest(".conversation-node-bubble") as HTMLElement;
+      const copyBtn = within(userBubble).getByRole("button", { name: "Copy message 1" });
+      expect(copyBtn.querySelector("path")).toBeNull(); // rest state: the copy glyph is two rects, no path
+
+      await user.click(copyBtn);
+
+      expect(writeText).toHaveBeenCalledWith("Hello **world**");
+      await waitFor(() => expect(copyBtn.querySelector("path")).not.toBeNull());
+    });
+
+    it("the quick-action Delete button on the FIRST (user, index 0) bubble calls onDeleteMessage(0), without opening the right-click menu", async () => {
+      const user = userEvent.setup();
+      const { onDeleteMessage } = renderConversationNode();
+
+      const userBubble = screen.getByText("world").closest(".conversation-node-bubble") as HTMLElement;
+      await user.click(within(userBubble).getByRole("button", { name: "Delete message 1 from history" }));
+
+      expect(onDeleteMessage).toHaveBeenCalledOnce();
+      expect(onDeleteMessage).toHaveBeenCalledWith(0);
+      expect(screen.queryByRole("menu")).toBeNull();
+    });
+
+    it("the quick-action buttons on the SECOND (assistant, index 1) bubble copy/delete its own content/index, named for its own position", async () => {
+      const user = userEvent.setup();
+      const { onDeleteMessage } = renderConversationNode();
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+      const assistantBubble = screen.getByText("Hi there").closest(".conversation-node-bubble") as HTMLElement;
+      await user.click(within(assistantBubble).getByRole("button", { name: "Copy message 2" }));
+      expect(writeText).toHaveBeenCalledWith("Hi there");
+
+      await user.click(within(assistantBubble).getByRole("button", { name: "Delete message 2 from history" }));
+      expect(onDeleteMessage).toHaveBeenCalledWith(1);
+    });
+
+    it("both quick-action buttons on every bubble carry the nodrag class", () => {
+      renderConversationNode();
+      const userBubble = screen.getByText("world").closest(".conversation-node-bubble") as HTMLElement;
+      for (const name of ["Copy message 1", "Delete message 1 from history"]) {
+        expect(within(userBubble).getByRole("button", { name })).toHaveClass("nodrag");
+      }
+    });
+
+    // Regression guard for a real bug an adversarial review found: bubbles
+    // are keyed by array index (see the render loop below), so deleting an
+    // earlier message reuses the SAME component instance for whatever
+    // message shifts into that slot - without a reset, a stale "copied"
+    // check-glyph flash leaked onto a message nobody ever copied.
+    it("deleting a copied-from bubble does not leak its 'copied' check glyph onto the message that shifts into its slot", async () => {
+      const user = userEvent.setup();
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+      function Harness() {
+        const [history, setHistory] = useState([
+          { role: "user" as const, content: "Hello **world**" },
+          { role: "assistant" as const, content: "Hi there" },
+        ]);
+        return (
+          <ReactFlowProvider>
+            <ConversationNodeView
+              {...({
+                id: "n0",
+                selected: false,
+                data: {
+                  history,
+                  isCollapsed: false,
+                  pendingRequestId: null,
+                  onToggleCollapse: () => {},
+                  onDelete: () => {},
+                  onSend: () => {},
+                  onDeleteMessage: (index: number) => setHistory((h) => h.filter((_, i) => i !== index)),
+                  onCancel: () => {},
+                  onOpenDocumentView: () => {},
+                },
+              } as unknown as NodeProps<ConversationFlowNode>)}
+            />
+          </ReactFlowProvider>
+        );
+      }
+      render(<Harness />);
+
+      const firstBubble = screen.getByText("world").closest(".conversation-node-bubble") as HTMLElement;
+      await user.click(within(firstBubble).getByRole("button", { name: "Copy message 1" }));
+      await waitFor(() => expect(within(firstBubble).getByRole("button", { name: "Copy message 1" }).querySelector("path")).not.toBeNull());
+
+      await user.click(within(firstBubble).getByRole("button", { name: "Delete message 1 from history" }));
+
+      const survivor = screen.getByText("Hi there").closest(".conversation-node-bubble") as HTMLElement;
+      const survivorCopyBtn = within(survivor).getByRole("button", { name: "Copy message 1" });
+      expect(survivorCopyBtn.querySelector("path")).toBeNull();
+    });
+  });
+
+  it("a single assistant-only message still renders the avatar chip, 'Assistant' role label, and quick actions", () => {
+    renderConversationNode({ history: [{ role: "assistant", content: "Solo reply" }] });
+    const bubble = screen.getByText("Solo reply").closest(".conversation-node-bubble") as HTMLElement;
+    expect(bubble.querySelector(".chat-node-avatar")).toHaveTextContent("A");
+    expect(within(bubble).getByText("Assistant")).toBeInTheDocument();
+    expect(within(bubble).getByRole("button", { name: "Copy message 1" })).toBeInTheDocument();
   });
 
   it("a bubble right-click does not also open the node-level menu", () => {

--- a/web_ui/src/app/canvas/ConversationNodeView.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
@@ -169,6 +169,43 @@ function ConversationBubbleMenu({
   );
 }
 
+// Node redesign follow-up ("per-bubble chrome"): hand-authored stroke icons
+// for the bubble header's hover-revealed quick-action row, matching the SAME
+// file-local-icon-component convention this codebase already established
+// (GroupNodeView.tsx's own GroupIcon, ChatNodeView.tsx's own ChatNodeIcon) -
+// not a shared icon import, even where a glyph (copy/check) is conceptually
+// identical to ChatNodeIcon's own. "trash" is new here: Delete from History
+// has no analogue among ChatNodeView's own quick actions (Branch from
+// Here/Open Document View don't apply to a single message inside a growing
+// conversation node).
+type ConversationBubbleIconName = "copy" | "check" | "trash";
+
+const CONVERSATION_BUBBLE_ICON_PATHS: Record<ConversationBubbleIconName, ReactNode> = {
+  copy: (
+    <>
+      <rect x="2.5" y="2.5" width="8" height="8" rx="1.2" />
+      <rect x="5.5" y="5.5" width="8" height="8" rx="1.2" />
+    </>
+  ),
+  check: <path d="M3.5 8.5 6.5 11.5 12.5 4.5" />,
+  trash: (
+    <>
+      <path d="M3 4.5h10" />
+      <path d="M6 4.5V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v1.5" />
+      <path d="M4.5 4.5l.6 8a1 1 0 0 0 1 .9h3.8a1 1 0 0 0 1-.9l.6-8" />
+      <path d="M6.5 7v4M9.5 7v4" />
+    </>
+  ),
+};
+
+function ConversationBubbleIcon({ name }: { name: ConversationBubbleIconName }) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 16 16" className="chat-node-icon">
+      {CONVERSATION_BUBBLE_ICON_PATHS[name]}
+    </svg>
+  );
+}
+
 // -- bubble ------------------------------------------------------------------
 
 function ConversationBubble({
@@ -181,6 +218,39 @@ function ConversationBubble({
   onDeleteMessage: (index: number) => void;
 }) {
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  // Adversarial review caught a real bug: bubbles are keyed by array index
+  // (see the render loop below), and deleting an earlier message shifts
+  // every later one down a slot - React reconciles the shifted bubble into
+  // the SAME component instance that used to sit at that index, carrying
+  // over its local `copied` state. Without this reset, copying message 0
+  // then deleting it left the check-glyph flash stuck on whatever message
+  // slid into slot 0, even though nobody ever copied ITS content.
+  //
+  // Fixed with React's own "adjusting state when a prop changes" pattern
+  // (setState during render, not inside a useEffect - the lint rule this
+  // codebase enforces, react-hooks/set-state-in-effect, flagged an earlier
+  // draft that called setCopied(false) from an effect keyed on
+  // message.content instead): comparing against a value tracked across
+  // renders and resetting synchronously, before paint, whenever this
+  // instance's message actually changes out from under it.
+  const [trackedContent, setTrackedContent] = useState(message.content);
+  if (message.content !== trackedContent) {
+    setTrackedContent(message.content);
+    setCopied(false);
+  }
+
+  // Same direct navigator.clipboard call (not routed through
+  // ConversationBubbleMenu's own "Copy Message" item) as ChatNodeView's own
+  // quick-action Copy button, for the identical reason: this one needs its
+  // own transient "copied" flash independent of the menu's lifecycle.
+  function onQuickCopy() {
+    navigator.clipboard.writeText(message.content).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
 
   return (
     <div
@@ -194,6 +264,67 @@ function ConversationBubble({
         setMenuPosition({ x: event.clientX, y: event.clientY });
       }}
     >
+      {/* Per-bubble chrome, extending node redesign stage 3's ChatNodeView
+          treatment to conversation-node bubbles: an avatar chip (reuses
+          .chat-node-avatar verbatim - same 16px circular chip, same
+          role-differentiated background shade, styled here via a
+          .conversation-node-bubble.user override in styles.css) and a
+          hover-revealed quick-action row surfacing the SAME 2 items
+          ConversationBubbleMenu below already offers (Copy Message, Delete
+          from History) - there are only 2 in this menu, so both qualify as
+          "most reached for", unlike ChatNodeView's pick of 3 out of a larger
+          menu.
+
+          Unlike ChatNodeView, the avatar here is NOT aria-hidden alone - an
+          adversarial review caught that ChatNodeView's own aria-hidden
+          choice is only safe because a VISIBLE "You"/"Assistant" span sits
+          right next to it (its own comment says so explicitly); this bubble
+          had no such text anywhere, so a screen-reader user had zero way to
+          tell who said what. The new .conversation-node-bubble-role span is
+          that visible, accessible label - the avatar stays aria-hidden
+          exactly because this text now carries the semantics, mirroring
+          ChatNodeView's own reasoning instead of skipping the part that
+          made it valid.
+
+          Quick-action labels also include this bubble's 1-based position
+          (adversarial review finding): with N messages in one node card,
+          unqualified "Copy Message"/"Delete from History" names would be
+          identical across every bubble, leaving a screen-reader user no way
+          to tell which button acts on which message - unlike ChatNodeView,
+          where each button is the only one of its name on that whole node. */}
+      <div className="conversation-node-bubble-header">
+        {/* Grouped together (not 2 separate top-level flex children) for the
+            same reason .chat-node-role-group exists on ChatNodeView's own
+            header - a 3rd top-level child would get pushed to the CENTER
+            by this row's justify-content:space-between, instead of sitting
+            with the avatar on the left where it belongs. */}
+        <span className="conversation-node-bubble-role-group">
+          <span className="chat-node-avatar" aria-hidden="true">
+            {message.role === "user" ? "U" : "A"}
+          </span>
+          <span className="conversation-node-bubble-role">{message.role === "user" ? "You" : "Assistant"}</span>
+        </span>
+        <span className="chat-node-quick-actions">
+          <button
+            type="button"
+            className="chat-node-quick-action nodrag"
+            onClick={onQuickCopy}
+            title={`Copy message ${index + 1}`}
+            aria-label={`Copy message ${index + 1}`}
+          >
+            <ConversationBubbleIcon name={copied ? "check" : "copy"} />
+          </button>
+          <button
+            type="button"
+            className="chat-node-quick-action nodrag"
+            onClick={() => onDeleteMessage(index)}
+            title={`Delete message ${index + 1} from history`}
+            aria-label={`Delete message ${index + 1} from history`}
+          >
+            <ConversationBubbleIcon name="trash" />
+          </button>
+        </span>
+      </div>
       {/* Reuses .chat-node-content's markdown-body rule set (headings,
           lists, code, tables, hljs) - the same shared-class convention
           .chat-node-menu already establishes across every sibling node's

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -827,7 +827,8 @@ body,
   border-radius: 999px;
 }
 
-.chat-node.user .chat-node-avatar {
+.chat-node.user .chat-node-avatar,
+.conversation-node-bubble.user .chat-node-avatar {
   color: var(--gl-surface-window);
   background-color: var(--gl-surface-text-muted);
 }
@@ -861,6 +862,7 @@ body,
 
 .chat-node:hover .chat-node-quick-actions,
 .chat-node.selected .chat-node-quick-actions,
+.conversation-node-bubble:hover .chat-node-quick-actions,
 .chat-node-quick-actions:focus-within {
   opacity: 1;
   transform: translateX(0);
@@ -4072,6 +4074,39 @@ mark.document-view-search-match-current {
 
 .conversation-node-bubble.user {
   background-color: var(--gl-neutral-button-hover);
+}
+
+/* Per-bubble chrome (extends node redesign stage 3's ChatNodeView treatment
+   here): avatar+role-label group on the left, hover-revealed quick actions
+   on the right - the same space-between layout .chat-node-role uses (and
+   the same 2-top-level-children requirement - see
+   .conversation-node-bubble-role-group's own comment below). */
+.conversation-node-bubble-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+/* Groups the avatar with its visible role label, mirroring
+   .chat-node-role-group's own reasoning exactly: a 3rd top-level flex
+   child (the role label, added alongside the avatar) would otherwise get
+   pushed to the CENTER of .conversation-node-bubble-header's space-between
+   layout instead of sitting on the left with the avatar. */
+.conversation-node-bubble-role-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Accessibility fix (adversarial review): the avatar chip is aria-hidden,
+   so a real, visible role label is required for it to be safe to hide -
+   ChatNodeView's own "You"/"Assistant" span played this role there; this
+   bubble had nothing equivalent until now. Small/muted since a bubble's
+   header has far less vertical room than a full node's title bar. */
+.conversation-node-bubble-role {
+  font-size: 0.85em;
+  color: var(--gl-surface-text-muted);
 }
 
 /* Reuses .chat-node-content's full markdown-body rule set (headings, lists,


### PR DESCRIPTION
## Problem

The node redesign gave `ChatNodeView` an avatar chip and hover-revealed quick-action row, but `ConversationNodeView`'s per-message bubbles never got the equivalent treatment, so a conversation node's messages looked plainer than a standalone chat node despite sharing the same markdown rendering.

## Change

- Each `ConversationBubble` now shows an avatar chip + visible "You"/"Assistant" role label, and a hover-revealed quick-action row (Copy, Delete from History) mirroring the existing right-click bubble menu.
- An adversarial review of this diff found and this change fixes three real issues:
  - A stale "copied" checkmark could leak onto the wrong bubble: bubbles are keyed by array index, so deleting an earlier message shifted a later one into a reused component instance that still held `copied = true`. Fixed by resetting that state whenever a bubble's underlying message content changes, using React's render-time state-adjustment pattern (not an effect, which this repo's lint rules flag for exactly this case).
  - The avatar chip was `aria-hidden` with no accompanying visible role text - safe on `ChatNodeView` only because a visible "You"/"Assistant" span sits next to it there. Added the same visible label here.
  - The quick-action buttons had identical accessible names across every bubble in one node card ("Copy Message" x N). Labels now include each message's own position ("Copy message 2").

## Test plan

- `npx tsc --noEmit`, `npx vitest run` (1109 tests, including a regression guard for the copied-state leak and coverage for both the first and second bubble's quick actions), `npx eslint .`, `npx vite build` all pass.
- Verified in a live browser: the avatar chip, correct role-based coloring, and both quick-action buttons render correctly on a real conversation node with the expected CSS selectors applied.