### PR TITLE
Replace Settings' native selects with the app's custom dropdown pattern

### DIFF
--- a/web_ui/src/app/chrome/CustomSelect.test.tsx
+++ b/web_ui/src/app/chrome/CustomSelect.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { CustomSelect } from "./CustomSelect";
+
+const OPTIONS = [
+  { id: "a", label: "Option A" },
+  { id: "b", label: "Option B", description: "The second choice" },
+  { id: "c", label: "Option C" },
+];
+
+describe("CustomSelect", () => {
+  it("shows the selected option's label on the trigger, not the placeholder", () => {
+    render(<CustomSelect ariaLabel="Pick one" value="b" options={OPTIONS} onChange={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Pick one" })).toHaveTextContent("Option B");
+  });
+
+  it("falls back to the placeholder when the current value matches no option", () => {
+    render(<CustomSelect ariaLabel="Pick one" value="nonexistent" options={OPTIONS} onChange={vi.fn()} placeholder="Choose…" />);
+    expect(screen.getByRole("button", { name: "Pick one" })).toHaveTextContent("Choose…");
+  });
+
+  it("the panel is closed by default and opens on trigger click, listing every option", async () => {
+    const user = userEvent.setup();
+    render(<CustomSelect ariaLabel="Pick one" value="a" options={OPTIONS} onChange={vi.fn()} />);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Pick one" }));
+
+    const panel = screen.getByRole("dialog", { name: "Pick one" });
+    expect(panel).toBeInTheDocument();
+    for (const option of OPTIONS) {
+      // A regex, not an exact string: an option WITH a description (like
+      // Option B here) gets its description text folded into its own
+      // accessible name too (both are plain text inside the same <button>,
+      // no aria-hidden on either) - matching Composer.tsx's own Reasoning
+      // picker exactly, which this component deliberately reuses verbatim.
+      expect(screen.getByRole("button", { name: new RegExp("^" + option.label) })).toBeInTheDocument();
+    }
+  });
+
+  it("renders a portaled panel as a direct child of document.body, not nested under the trigger", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<CustomSelect ariaLabel="Pick one" value="a" options={OPTIONS} onChange={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Pick one" }));
+
+    const panel = screen.getByRole("dialog", { name: "Pick one" });
+    expect(container.contains(panel)).toBe(false);
+    expect(document.body.contains(panel)).toBe(true);
+  });
+
+  it("renders an option's description when given one", async () => {
+    const user = userEvent.setup();
+    render(<CustomSelect ariaLabel="Pick one" value="a" options={OPTIONS} onChange={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Pick one" }));
+
+    expect(screen.getByText("The second choice")).toBeInTheDocument();
+  });
+
+  it("marks the currently-selected option with the active class, and no other option", async () => {
+    const user = userEvent.setup();
+    render(<CustomSelect ariaLabel="Pick one" value="b" options={OPTIONS} onChange={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Pick one" }));
+
+    // Option B's own accessible name also folds in its description text -
+    // see the "listing every option" test's own comment.
+    expect(screen.getByRole("button", { name: /^Option B/ })).toHaveClass("active");
+    expect(screen.getByRole("button", { name: "Option A" })).not.toHaveClass("active");
+    expect(screen.getByRole("button", { name: "Option C" })).not.toHaveClass("active");
+  });
+
+  it("clicking an option calls onChange with its id and closes the panel", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<CustomSelect ariaLabel="Pick one" value="a" options={OPTIONS} onChange={onChange} />);
+    await user.click(screen.getByRole("button", { name: "Pick one" }));
+
+    await user.click(screen.getByRole("button", { name: "Option C" }));
+
+    expect(onChange).toHaveBeenCalledWith("c");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("clicking outside the panel closes it without calling onChange", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <div>
+        <CustomSelect ariaLabel="Pick one" value="a" options={OPTIONS} onChange={onChange} />
+        <button type="button">Elsewhere</button>
+      </div>,
+    );
+    await user.click(screen.getByRole("button", { name: "Pick one" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Elsewhere" }));
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("Escape closes the panel and calls event.preventDefault(), so a parent's own Escape-closes-everything listener (overlays.tsx's own contract) does not also fire", async () => {
+    const user = userEvent.setup();
+    const parentEscapeHandler = vi.fn();
+    // Mirrors overlays.tsx's own OverlayProvider Escape listener: bubble
+    // phase, gated on event.defaultPrevented - the exact contract this
+    // component's own Escape handler (capture phase, preventDefault) must
+    // satisfy so opening a CustomSelect inside an already-open Settings
+    // Dialog can close ITS OWN panel without also closing the dialog.
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && !event.defaultPrevented) parentEscapeHandler();
+    });
+
+    render(<CustomSelect ariaLabel="Pick one" value="a" options={OPTIONS} onChange={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Pick one" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(parentEscapeHandler).not.toHaveBeenCalled();
+  });
+
+  it("Escape returns focus to the trigger button", async () => {
+    const user = userEvent.setup();
+    render(<CustomSelect ariaLabel="Pick one" value="a" options={OPTIONS} onChange={vi.fn()} />);
+    const trigger = screen.getByRole("button", { name: "Pick one" });
+    await user.click(trigger);
+    await user.keyboard("{Escape}");
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it("a disabled select cannot be opened", async () => {
+    const user = userEvent.setup();
+    render(<CustomSelect ariaLabel="Pick one" value="a" options={OPTIONS} onChange={vi.fn()} disabled />);
+
+    const trigger = screen.getByRole("button", { name: "Pick one" });
+    expect(trigger).toBeDisabled();
+    await user.click(trigger);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("sets aria-haspopup and aria-expanded reflecting the panel's real open state", async () => {
+    const user = userEvent.setup();
+    render(<CustomSelect ariaLabel="Pick one" value="a" options={OPTIONS} onChange={vi.fn()} />);
+    const trigger = screen.getByRole("button", { name: "Pick one" });
+
+    expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/web_ui/src/app/chrome/CustomSelect.tsx
+++ b/web_ui/src/app/chrome/CustomSelect.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * A custom-styled select, matching the app's existing custom dropdown
+ * convention (Composer.tsx's own Reasoning/Model pickers) rather than a
+ * native OS `<select>` - built for Settings' own selects (API Provider,
+ * per-task Ollama model mode, Llama.cpp scanned-model pickers), which were
+ * the one place in the app still using bare `<select className="settings-
+ * select">` while everywhere else (Composer, View/Plugins/Pins) already has
+ * a styled, app-consistent dropdown.
+ *
+ * Deliberately NOT built on the shared Popover/useOverlays() system
+ * (../overlays/overlays), even though every other floating panel in the app
+ * is. That system is single-open BY DESIGN (opening any one surface closes
+ * whatever else is open) - correct for app-chrome popovers that are never
+ * expected to coexist with a modal dialog, but WRONG here: this component's
+ * whole reason to exist is being usable INSIDE an already-open Dialog
+ * (Settings). Routing through useOverlays() would make opening a dropdown
+ * flip the registry's openSurface away from "settings", which Settings'
+ * own <Dialog name="settings"> reads as "I'm not open anymore" and
+ * unmounts entirely - the same class of bug CodeExecutionApprovalPanel.tsx's
+ * own module doc already identified and avoided for an analogous reason
+ * (two of ITS panels can be open at once; here, one of THESE needs to be
+ * open ALONGSIDE an already-open dialog). This component keeps its own
+ * fully independent open/closed state instead, mirroring NodeMenu.tsx's
+ * posture (also deliberately outside the overlay registry, for the same
+ * "must nest inside/alongside other things" reason) rather than Popover's.
+ *
+ * Visually reuses .overlay-popover/.overlay-popover-anchored and
+ * .reasoning-option/-label/-description VERBATIM for the panel and its
+ * option rows - not a lookalike reimplementation, the literal same classes
+ * Composer's own Reasoning/Model pickers render through Popover, so this is
+ * pixel-identical to the rest of the app's custom dropdowns by
+ * construction. Only the trigger button (.custom-select-trigger) is new
+ * CSS, styled to fill the same box .settings-select's native <select> used
+ * to occupy.
+ *
+ * Positioning mirrors overlays.tsx's own useAnchoredPlacement (flip above
+ * the trigger if there's no room below, clamp horizontally) but reads a
+ * local ref directly instead of a named data-overlay-trigger lookup, since
+ * this component has no registry entry to look itself up by.
+ */
+
+const ANCHOR_MARGIN = 8;
+const ANCHOR_GAP = 4;
+
+export interface CustomSelectOption {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export function CustomSelect({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  disabled,
+  placeholder = "Select…",
+}: {
+  value: string;
+  options: CustomSelectOption[];
+  onChange: (id: string) => void;
+  ariaLabel: string;
+  disabled?: boolean;
+  placeholder?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [placement, setPlacement] = useState<{ top: number; left: number; minWidth: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    const trigger = triggerRef.current;
+    const panel = panelRef.current;
+    if (!trigger || !panel) return;
+    const triggerRect = trigger.getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+    const top =
+      triggerRect.bottom + panelRect.height + ANCHOR_GAP > window.innerHeight
+        ? Math.max(ANCHOR_MARGIN, triggerRect.top - panelRect.height - ANCHOR_GAP)
+        : triggerRect.bottom + ANCHOR_GAP;
+    const left = Math.min(
+      Math.max(ANCHOR_MARGIN, triggerRect.left),
+      window.innerWidth - panelRect.width - ANCHOR_MARGIN,
+    );
+    setPlacement({ top, left, minWidth: triggerRect.width });
+  }, [open]);
+
+  useOutsideDismiss(open, triggerRef, panelRef, () => setOpen(false));
+
+  const selected = options.find((option) => option.id === value);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="custom-select-trigger"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        onClick={() => setOpen((isOpen) => !isOpen)}
+      >
+        <span className="custom-select-value">{selected ? selected.label : placeholder}</span>
+        <ChevronIcon />
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={panelRef}
+            role="dialog"
+            aria-modal="false"
+            aria-label={ariaLabel}
+            tabIndex={-1}
+            className="overlay-popover overlay-popover-anchored custom-select-panel"
+            style={placement ? { top: placement.top, left: placement.left, minWidth: placement.minWidth } : undefined}
+          >
+            {options.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                className={"reasoning-option" + (option.id === value ? " active" : "")}
+                onClick={() => {
+                  onChange(option.id);
+                  setOpen(false);
+                  triggerRef.current?.focus();
+                }}
+              >
+                <span className="reasoning-option-label">{option.label}</span>
+                {option.description && <span className="reasoning-option-description">{option.description}</span>}
+              </button>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+function ChevronIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="icon custom-select-chevron">
+      <path d="m7 10 5 5 5-5" />
+    </svg>
+  );
+}
+
+// Outside-pointerdown + Escape dismiss, scoped to this instance's own
+// trigger/panel refs - deliberately NOT the shared overlays.tsx listeners
+// (see this file's own module doc for why). Escape calls
+// event.preventDefault() so the SAME keypress doesn't also bubble up into
+// overlays.tsx's own document-level Escape handler and close the whole
+// parent Dialog (Settings) - that handler explicitly checks
+// event.defaultPrevented for exactly this "something more specific already
+// claimed it" case (see its own comment).
+function useOutsideDismiss(
+  open: boolean,
+  triggerRef: RefObject<HTMLButtonElement | null>,
+  panelRef: RefObject<HTMLDivElement | null>,
+  close: () => void,
+) {
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(event: PointerEvent) {
+      const target = event.target as Node;
+      if (panelRef.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      close();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      close();
+      triggerRef.current?.focus();
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+}

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -130,6 +130,21 @@ async function goToLlamaCpp(
   act(() => push({ ...snapshot, ...overrides, activeSection: "llama.cpp (local)" }));
 }
 
+// Settings' selects are CustomSelect.tsx (chrome/CustomSelect.tsx), not
+// native <select> - opening one and picking an option is a click on the
+// trigger button (named via aria-label, matching the field's own visible
+// label) followed by a click on the option button that appears (findBy,
+// not getBy: the option panel portals to document.body asynchronously
+// after the trigger click).
+async function chooseCustomOption(
+  user: ReturnType<typeof userEvent.setup>,
+  triggerName: string,
+  optionName: string,
+) {
+  await user.click(screen.getByRole("button", { name: triggerName }));
+  await user.click(await screen.findByRole("button", { name: optionName }));
+}
+
 describe("SettingsDialog", () => {
   it("navigating sections fires setActiveSection with the clicked section's key", async () => {
     const { user, intents } = setup();
@@ -203,7 +218,7 @@ describe("SettingsDialog", () => {
     const { user, push, intents } = setup();
     await goToOllama(user, push);
 
-    await user.selectOptions(screen.getByLabelText("Chat Naming Model"), "Use chat model");
+    await chooseCustomOption(user, "Chat Naming Model", "Use chat model");
 
     expect(intents).toContainEqual(["app-settings", "setOllamaModelAssignment", ["task_title", "inherit"]]);
   });
@@ -212,16 +227,15 @@ describe("SettingsDialog", () => {
     const { user, push } = setup();
     await goToOllama(user, push);
 
-    const chatSelect = screen.getByLabelText("Chat Model") as HTMLSelectElement;
-    const optionLabels = Array.from(chatSelect.options).map((o) => o.textContent);
-    expect(optionLabels).not.toContain("Use chat model");
+    await user.click(screen.getByRole("button", { name: "Chat Model" }));
+    expect(screen.queryByRole("button", { name: "Use chat model" })).toBeNull();
   });
 
   it("switching a task to explicit reveals a text field; typing fires setOllamaModelAssignment", async () => {
     const { user, push, intents } = setup();
     await goToOllama(user, push);
 
-    await user.selectOptions(screen.getByLabelText("Chart Generation Model"), "Custom model ID...");
+    await chooseCustomOption(user, "Chart Generation Model", "Custom model ID...");
     await user.type(screen.getByLabelText("Chart Generation Model (custom model ID)"), "x");
 
     expect(intents).toContainEqual(["app-settings", "setOllamaModelAssignment", ["task_chart", "x"]]);
@@ -291,7 +305,7 @@ describe("SettingsDialog", () => {
     const { user, push, intents } = setup();
     await goToApiEndpoint(user, push);
 
-    await user.selectOptions(screen.getByLabelText("API Provider"), "Anthropic Claude");
+    await chooseCustomOption(user, "API Provider", "Anthropic Claude");
 
     expect(intents).toContainEqual(["app-settings", "setViewingApiProvider", ["Anthropic Claude"]]);
   });
@@ -493,7 +507,10 @@ describe("SettingsDialog", () => {
     expect(screen.queryByLabelText("Scanned Chat Model")).toBeNull();
 
     await goToLlamaCpp(user, push, { llamaCppScannedModels: ["C:/models/a.gguf"] });
-    await user.selectOptions(screen.getByLabelText("Scanned Chat Model"), "C:/models/a.gguf");
+    // basename(path) is what the option is actually labeled - see
+    // CustomSelect's options={state.llamaCppScannedModels.map(...)} call in
+    // SettingsDialog.tsx, not the raw path.
+    await chooseCustomOption(user, "Scanned Chat Model", "a.gguf");
 
     expect(intents).toContainEqual(["app-settings", "setLlamaCppChatModelPath", ["C:/models/a.gguf"]]);
   });
@@ -505,7 +522,9 @@ describe("SettingsDialog", () => {
       llamaCppChatModelPath: "C:/models/not-in-the-scanned-list.gguf",
     });
 
-    expect(screen.getByLabelText("Scanned Chat Model")).toHaveValue("");
+    // CustomSelect's trigger is a <button>, not a native <select> - its
+    // "current value" is its own displayed text, not a .value DOM property.
+    expect(screen.getByRole("button", { name: "Scanned Chat Model" })).toHaveTextContent("Select a scanned model...");
   });
 
   it("Chat Model File shows 'No file selected' by default and Browse fires pickLlamaCppChatModelFile", async () => {

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -3,6 +3,7 @@ import type { WsTransport } from "../../lib/ws/transport";
 import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
 import type { AppSettingsState } from "../../lib/bridge-core/generated/app-settings-state";
 import { Dialog } from "../overlays/overlays";
+import { CustomSelect } from "./CustomSelect";
 
 /**
  * The settings dialog (Qt-removal plan R2.5d, extended R7.4a-c) - settings
@@ -290,20 +291,15 @@ function ApiProviderPage({
 
   return (
     <div className="settings-general-page">
-      <label className="settings-field">
+      <div className="settings-field">
         <span className="settings-field-label">API Provider</span>
-        <select
-          className="settings-select"
+        <CustomSelect
+          ariaLabel="API Provider"
           value={viewingProvider}
-          onChange={(event) => transport.intent("app-settings", "setViewingApiProvider", [event.target.value])}
-        >
-          {API_PROVIDERS.map((provider) => (
-            <option key={provider} value={provider}>
-              {provider}
-            </option>
-          ))}
-        </select>
-      </label>
+          options={API_PROVIDERS.map((provider) => ({ id: provider, label: provider }))}
+          onChange={(id) => transport.intent("app-settings", "setViewingApiProvider", [id])}
+        />
+      </div>
 
       <p className="settings-update-status">
         {viewingProvider === state.activeApiProvider
@@ -474,26 +470,28 @@ function OllamaTaskField({
     setUiMode(isSpecial ? value : "explicit");
   }
 
+  const modeOptions = [
+    ...(task !== "task_chat" ? [{ id: "inherit", label: "Use chat model" }] : []),
+    { id: "auto", label: "Auto - choose a compatible installed model" },
+    { id: "explicit", label: "Custom model ID..." },
+  ];
+
   return (
     <>
-      <label className="settings-field">
+      <div className="settings-field">
         <span className="settings-field-label">{OLLAMA_TASK_LABELS[task]}</span>
-        <select
-          className="settings-select"
+        <CustomSelect
+          ariaLabel={OLLAMA_TASK_LABELS[task]}
           value={uiMode}
-          onChange={(event) => {
-            const nextMode = event.target.value;
+          options={modeOptions}
+          onChange={(nextMode) => {
             setUiMode(nextMode);
             if (nextMode !== "explicit") {
               transport.intent("app-settings", "setOllamaModelAssignment", [task, nextMode]);
             }
           }}
-        >
-          {task !== "task_chat" && <option value="inherit">Use chat model</option>}
-          <option value="auto">Auto - choose a compatible installed model</option>
-          <option value="explicit">Custom model ID...</option>
-        </select>
-      </label>
+        />
+      </div>
       {uiMode === "explicit" && (
         <label className="settings-field">
           <span className="settings-field-label">{OLLAMA_TASK_LABELS[task]} (custom model ID)</span>
@@ -740,21 +738,18 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
       </datalist>
 
       {state.llamaCppScannedModels.length > 0 && (
-        <label className="settings-field">
+        <div className="settings-field">
           <span className="settings-field-label">Scanned Chat Model</span>
-          <select
-            className="settings-select"
+          <CustomSelect
+            ariaLabel="Scanned Chat Model"
             value={scannedChatValue}
-            onChange={(event) => transport.intent("app-settings", "setLlamaCppChatModelPath", [event.target.value])}
-          >
-            <option value="">Select a scanned model...</option>
-            {state.llamaCppScannedModels.map((path) => (
-              <option key={path} value={path}>
-                {basename(path)}
-              </option>
-            ))}
-          </select>
-        </label>
+            options={[
+              { id: "", label: "Select a scanned model..." },
+              ...state.llamaCppScannedModels.map((path) => ({ id: path, label: basename(path) })),
+            ]}
+            onChange={(path) => transport.intent("app-settings", "setLlamaCppChatModelPath", [path])}
+          />
+        </div>
       )}
 
       <div className="settings-field">
@@ -770,21 +765,18 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
       </div>
 
       {state.llamaCppScannedModels.length > 0 && (
-        <label className="settings-field">
+        <div className="settings-field">
           <span className="settings-field-label">Scanned Naming Model</span>
-          <select
-            className="settings-select"
+          <CustomSelect
+            ariaLabel="Scanned Naming Model"
             value={scannedTitleValue}
-            onChange={(event) => transport.intent("app-settings", "setLlamaCppTitleModelPath", [event.target.value])}
-          >
-            <option value="">Select a scanned model...</option>
-            {state.llamaCppScannedModels.map((path) => (
-              <option key={path} value={path}>
-                {basename(path)}
-              </option>
-            ))}
-          </select>
-        </label>
+            options={[
+              { id: "", label: "Select a scanned model..." },
+              ...state.llamaCppScannedModels.map((path) => ({ id: path, label: basename(path) })),
+            ]}
+            onChange={(path) => transport.intent("app-settings", "setLlamaCppTitleModelPath", [path])}
+          />
+        </div>
       )}
 
       <div className="settings-field">

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -20,6 +20,7 @@
   --gl-z-search: 22; /* search overlay, above the other app layers */
   --gl-z-notification: 30; /* banner must beat app layers, not dialogs */
   --gl-z-scrim: 40; /* modal scrim + the dialog it dims for */
+  --gl-z-dialog-popover: 45; /* CustomSelect.tsx's own dropdown panel - must render above an already-open modal dialog (Settings), unlike --gl-z-app-layer's own popovers, which are never open at the same time as a dialog */
   --gl-z-node-menu: 60; /* PORTALED node context menus (NodeMenu.tsx) */
   --gl-z-approval: 80; /* blocking code-execution prompt - outranks all */
 
@@ -3547,6 +3548,64 @@ mark.document-view-search-match-current {
   background-color: var(--gl-surface-inset, var(--gl-surface-window));
   border: 1px solid var(--gl-surface-border);
   border-radius: 6px;
+}
+
+/* CustomSelect.tsx's own trigger button - fills the exact same box
+   .settings-select's native <select> used to occupy (same padding/font-
+   size/colors/border/radius), but as a real button with a chevron so it
+   can open .custom-select-panel below instead of the browser's own
+   unstyleable native dropdown. */
+.custom-select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.custom-select-trigger:hover:enabled {
+  border-color: var(--gl-surface-border-strong, var(--gl-surface-text-muted));
+}
+
+.custom-select-trigger:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.custom-select-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.custom-select-chevron {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Reuses .overlay-popover/.overlay-popover-anchored verbatim for
+   background/border/shadow/position:fixed (see CustomSelect.tsx's own doc
+   comment) - only the z-index needs overriding here, since this panel must
+   render above an already-open modal Settings dialog
+   (--gl-z-scrim), unlike every OTHER consumer of .overlay-popover-anchored
+   (View/Plugins/Pins), which is never open at the same time as a dialog. */
+.custom-select-panel {
+  z-index: var(--gl-z-dialog-popover);
 }
 
 .settings-checkbox-row {


### PR DESCRIPTION
## Problem

Settings had 4 select fields (API Provider, per-task Ollama model mode, 2 Llama.cpp scanned-model pickers) still using a bare native `<select>`, the one place in the app where dropdowns didn't match the custom-styled pattern Composer's Reasoning/Model pickers already established.

## Change

- Added `CustomSelect.tsx`: a trigger button that opens a floating option panel, reusing `.overlay-popover`/`.reasoning-option` CSS verbatim so it's visually identical to the existing pattern.
- Wired it into all 4 Settings call sites, replacing the native selects one-for-one (same options, same order, same conditional behavior - e.g. the per-task Ollama select still omits "Use chat model" for the chat task itself, and switching to "Custom model ID..." still reveals the same text field).
- Deliberately does not use the shared `overlays.tsx` `Popover`/`useOverlays()` registry: that registry is single-open, and opening a select through it while nested inside Settings' own modal `Dialog` would flip the registry away from `"settings"` and unmount the whole dialog. `CustomSelect` keeps independent local open state, its own outside-click and Escape dismissal (Escape calls `preventDefault()` so it doesn't also bubble into the dialog's own close-on-Escape handler), and portals its panel above the modal via a new z-index tier (`--gl-z-dialog-popover: 45`, between the modal scrim and portaled node menus).

## Test plan

- `npx tsc --noEmit`, `npx vitest run` (1122 tests, including 12 new tests for `CustomSelect` and the 5 Settings tests rewritten from native-select interaction to click-based), `npx eslint .`, `npx vite build` all pass.
- Verified in a live browser: opening a dropdown inside Settings keeps the dialog mounted, the panel renders with the correct position/z-index/styling, and selecting an option updates the field and closes the panel.