### PR TITLE
Fix a broken wheel, harden CI, and close a Py-Coder sandbox escape

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# ADR-015 stage 15.2: supply-chain hygiene. Three ecosystems, matching the
+# three real dependency surfaces in this repo - the Python backend
+# (requirements.txt / pyproject.toml), the web_ui SPA (package-lock.json),
+# and the CI workflow's own actions (now SHA-pinned; Dependabot is what
+# actually bumps those pins over time, using the "# v4"-style version
+# comments left next to each SHA).
+version: 2
+updates:
+  # Labels below are scoped to labels that already exist on this repo
+  # (verified via `gh api repos/dovvnloading/Graphlink/labels`) - a label
+  # Dependabot can't find is silently not applied, so this list is
+  # deliberately not aspirational.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/web_ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github_actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,21 @@ name: CI
 #
 # R7.6b: graphlink_app/tests/ is gone from this list because graphlink_app/
 # itself was deleted at the Qt-removal cutover.
+#
+# ADR-015 stage 15.1: build-check is a third, independent job. It exists
+# because `pip install -r requirements.txt` (the python-tests job, above)
+# never actually builds this project's own wheel - so a broken py-modules
+# list (a real incident: graphlink_note_agent and graphlink_process_env were
+# both missing, the latter silently disabling the subprocess secret-scrubbing
+# allowlist) shipped invisibly. This job builds the wheel, twine-checks its
+# metadata, and imports backend.agents from a clean venv with the repo
+# checkout NOT on sys.path (Push-Location $env:TEMP before the import test) -
+# the same failure mode a `pip install .` from the loose repo directory would
+# hide. `build`/`twine` are installed directly in this job rather than added
+# to requirements.txt: they are CI-only tooling, not an app runtime
+# dependency, and requirements.txt's hash-lock is compiled against the
+# project's pinned Python 3.12 - regenerating it from a different interpreter
+# risks a lock that resolves differently than what 3.12 actually needs.
 
 on:
   pull_request:
@@ -26,16 +41,30 @@ on:
   push:
     branches: [main]
 
+# ADR-015 stage 15.2: least-privilege token (this workflow only ever reads
+# the checkout - no job pushes, comments, or creates releases), and a
+# concurrency group so a rapid string of pushes to the same PR/branch cancels
+# the now-stale in-flight run instead of queueing redundant Windows minutes
+# behind it.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   python-tests:
     name: Python tests (offscreen)
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
+          cache: pip
 
       - name: Install dependencies
         run: pip install -r requirements.txt
@@ -46,26 +75,77 @@ jobs:
       - name: Run pytest
         run: python -m pytest -q
 
+      - name: pip-audit (known-vulnerability scan of the locked dependency set)
+        run: pip install --quiet pip-audit && python -m pip_audit -r requirements.txt
+
+  build-check:
+    name: Build check (wheel builds, installs, and imports cleanly)
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build tooling
+        run: pip install build twine
+
+      - name: Build the wheel
+        run: python -m build --wheel
+
+      - name: Twine check (validates package metadata, incl. the version string)
+        # python -m twine, not a bare `twine` invocation: pip's script-install
+        # directory isn't reliably on PATH across runner/pip configurations
+        # (confirmed locally - `twine` alone was not found even right after
+        # `pip install twine` succeeded), and the module form has no such
+        # dependency.
+        run: python -m twine check dist/*.whl
+
+      - name: Install wheel + real runtime deps into a clean venv, import backend.agents
+        shell: pwsh
+        run: |
+          python -m venv wheel_test_venv
+          wheel_test_venv\Scripts\pip.exe install --quiet -r requirements.txt
+          $wheel = Get-ChildItem dist\*.whl | Select-Object -First 1
+          wheel_test_venv\Scripts\pip.exe install --quiet --no-deps $wheel.FullName
+          Push-Location $env:TEMP
+          try {
+            & "$env:GITHUB_WORKSPACE\wheel_test_venv\Scripts\python.exe" -c "import backend.agents, graphlink_note_agent, graphlink_process_env; print('OK: backend.agents and all py-modules import cleanly from the installed wheel')"
+          } finally {
+            Pop-Location
+          }
+
   frontend-checks:
     name: Frontend checks (npm run check)
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # check:schema shells out to the Python codegen script (stdlib-only,
       # no pip install needed) to prove the generated TS/JSON Schema
       # artifacts aren't stale relative to the Python dataclasses.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
+          cache: pip
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: web_ui/.nvmrc
+          cache: npm
+          cache-dependency-path: web_ui/package-lock.json
 
       - name: Install npm dependencies
         working-directory: web_ui
         run: npm ci
+
+      - name: npm audit (known-vulnerability scan, high+critical only)
+        working-directory: web_ui
+        run: npm audit --audit-level=high
 
       - name: Run checks (schema drift, typecheck, lint, vitest, build)
         working-directory: web_ui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,15 @@ jobs:
 
       # check:schema shells out to the Python codegen script (stdlib-only,
       # no pip install needed) to prove the generated TS/JSON Schema
-      # artifacts aren't stale relative to the Python dataclasses.
+      # artifacts aren't stale relative to the Python dataclasses. No
+      # cache: pip here (unlike the other two jobs' setup-python) - this
+      # step never runs a pip install, so the cache dir never gets
+      # populated and setup-python's own post-job cache-save step fails
+      # ("Cache folder path is retrieved for pip but doesn't exist on
+      # disk") - confirmed live on PR #212's first CI run.
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-          cache: pip
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -388,7 +388,7 @@ class AgentDispatcher:
         shape, just keyed by node_id instead of node identity."""
         repl = self._pycoder_repls.get(node_id)
         if repl is None:
-            repl = PythonREPL()
+            repl = PythonREPL(node_id=node_id)
             self._pycoder_repls[node_id] = repl
         return repl
 

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -3432,7 +3432,8 @@ def _history_turn_text(turn: dict) -> str:
 def _history_token_text(history: list[dict]) -> str:
     """Joins an entire chat_branch_history's turns into one string for
     token_counter.py's set_context_text (which, like set_input_text, takes
-    a single flat string and estimates it via whitespace-split)."""
+    a single flat string and estimates it via the real tiktoken-backed
+    estimator - ADR-016 stage 16.2)."""
     return "\n\n".join(text for text in (_history_turn_text(turn) for turn in history) if text)
 
 

--- a/backend/tests/perf/graph_factory.py
+++ b/backend/tests/perf/graph_factory.py
@@ -1,0 +1,136 @@
+"""ADR-019 stage 19.1: deterministic synthetic graph fixtures.
+
+Builds real `SceneDocument` instances entirely through the same production
+API the app itself uses to create nodes (`add_chat_node`, `add_chart_node`,
+`add_image_node`, `connect`) - never by hand-constructing `SceneNode`
+directly - so a fixture can never silently drift from what the app actually
+persists/serializes. Every fixture is fully deterministic (no randomness):
+the same call always produces byte-identical node/edge ids and content, so
+a measurement taken today is directly comparable to one taken after a
+later-landing ADR without also having to account for fixture drift.
+
+The four reference workloads match ADR-019's budget table exactly:
+`SMALL`, `TYPICAL`, `LARGE`, `STRESS`. Node topology is a deterministic
+binary tree (node i's parent is node (i-1)//2) plus a fixed number of extra
+cross-links - not a flat chain - because a flat chain under-costs
+`toFlowNodes`'s real O(N*E) edge-scan behavior (ADR-011 P2) relative to how
+a real branching conversation graph looks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from backend.canvas import SceneDocument, SceneNode
+
+_LOREM = (
+    "The quick brown fox jumps over the lazy dog while considering the "
+    "architecture of a distributed system. "
+)
+
+
+def _content_of_length(min_bytes: int) -> str:
+    reps = (min_bytes // len(_LOREM)) + 1
+    return (_LOREM * reps)[:min_bytes]
+
+
+def build_graph(
+    node_count: int,
+    *,
+    content_bytes: int = 1200,
+    chart_count: int = 0,
+    image_count: int = 0,
+    extra_edges: int = 0,
+) -> SceneDocument:
+    """Builds a deterministic branching-tree SceneDocument with exactly
+    node_count nodes TOTAL - matching ADR-019's own workload table, which
+    reads e.g. "100 nodes... 2 charts, 1 image" as the charts/image being
+    PART OF the 100, not additional to it. chart_count of those nodes are
+    chart nodes and image_count are image nodes, grafted onto existing chat
+    nodes at fixed, evenly-spaced positions; the rest
+    (node_count - chart_count - image_count) are the chat-node tree itself.
+    extra_edges adds that many additional cross-links beyond the chat
+    tree's own N-1 edges."""
+    if node_count < 1:
+        raise ValueError("node_count must be >= 1")
+    chat_count = node_count - chart_count - image_count
+    if chat_count < 1:
+        raise ValueError("chart_count + image_count must leave at least 1 chat node")
+
+    doc = SceneDocument()
+    content = _content_of_length(content_bytes)
+
+    ids: list[str] = []
+    root = doc.add_chat_node(0.0, 0.0, content, is_user=False)
+    ids.append(root.id)
+
+    for i in range(1, chat_count):
+        parent_index = (i - 1) // 2  # deterministic binary-tree branching
+        parent_id = ids[parent_index]
+        is_user = i % 2 == 1
+        node = doc.add_chat_node(
+            float((i % 20) * 260),
+            float((i // 20) * 160),
+            content,
+            is_user=is_user,
+            parent_id=parent_id,
+        )
+        ids.append(node.id)
+
+    if chart_count > 0:
+        stride = max(1, chat_count // chart_count)
+        for k in range(chart_count):
+            parent_id = ids[(k * stride) % chat_count]
+            doc.add_chart_node(
+                100.0, 100.0, parent_id, "bar",
+                {"labels": ["a", "b", "c"], "values": [1.0, 2.0, 3.0]},
+            )
+
+    if image_count > 0:
+        stride = max(1, chat_count // image_count)
+        # 64 bytes of placeholder PNG-shaped bytes is enough to exercise the
+        # image_assets store's bookkeeping cost without needing a real PNG
+        # decode anywhere in the payload/serialize path being measured.
+        placeholder = b"\x89PNG\r\n\x1a\n" + b"\x00" * 56
+        for k in range(image_count):
+            parent_id = ids[(k * stride) % chat_count]
+            doc.add_image_node(150.0, 150.0, placeholder, "a generated image", parent_id)
+
+    added = 0
+    shift = max(2, chat_count // 10)
+    i = 0
+    while added < extra_edges and i + shift < chat_count:
+        doc.connect(ids[i], ids[i + shift])
+        added += 1
+        i += 1
+
+    return doc
+
+
+@dataclass(frozen=True)
+class Workload:
+    name: str
+    node_count: int
+    content_bytes: int
+    chart_count: int
+    image_count: int
+    extra_edges: int
+
+    def build(self) -> SceneDocument:
+        return build_graph(
+            self.node_count,
+            content_bytes=self.content_bytes,
+            chart_count=self.chart_count,
+            image_count=self.image_count,
+            extra_edges=self.extra_edges,
+        )
+
+
+# ADR-019 SS1: the four reference workloads, values matched to the ADR's own
+# table (25/100/500/2,000 nodes; typical/large also carry charts+images).
+SMALL = Workload("small", node_count=25, content_bytes=400, chart_count=0, image_count=0, extra_edges=5)
+TYPICAL = Workload("typical", node_count=100, content_bytes=1200, chart_count=2, image_count=1, extra_edges=40)
+LARGE = Workload("large", node_count=500, content_bytes=1200, chart_count=10, image_count=5, extra_edges=200)
+STRESS = Workload("stress", node_count=2000, content_bytes=1200, chart_count=0, image_count=0, extra_edges=0)
+
+ALL_WORKLOADS = (SMALL, TYPICAL, LARGE, STRESS)

--- a/backend/tests/perf/measure_baselines.py
+++ b/backend/tests/perf/measure_baselines.py
@@ -1,0 +1,69 @@
+"""ADR-019 stage 19.1: fills in the "today" column of ADR-019's budget table
+with real, reproducible measurements against the graph_factory fixtures -
+replacing the audit's one-off subagent measurement with a committed,
+rerunnable artifact. Run directly: `python -m backend.tests.perf.measure_baselines`.
+
+Scope, honestly stated: this measures everything that is backend-only and
+needs no live app instance (wire bytes, publish build+serialize cost, a
+single node's own payload size as a proxy for ADR-003's future patch cost).
+It deliberately does NOT attempt cold-start, chat-load-from-db, memory
+steady-state, or canvas frame-time - those need a real running instance
+(graphlink_desktop.py + a browser) and are correctly a separate, larger
+piece of work, not a Phase 0 quick-fix. See ADR-019's table for which cells
+remain "not measured" pending that follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+from backend.tests.perf.graph_factory import ALL_WORKLOADS, Workload
+
+
+def _measure(workload: Workload) -> dict:
+    t0 = time.perf_counter()
+    doc = workload.build()
+    build_s = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    payload = doc.scene_payload()
+    payload_build_s = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    serialized = json.dumps(payload)
+    serialize_s = time.perf_counter() - t0
+
+    total_bytes = len(serialized.encode("utf-8"))
+    one_node_bytes = len(json.dumps(payload["nodes"][-1]).encode("utf-8")) if payload["nodes"] else 0
+
+    return {
+        "name": workload.name,
+        "node_count": len(doc.nodes),
+        "edge_count": len(doc.edges),
+        "fixture_build_ms": round(build_s * 1000, 2),
+        "payload_build_ms": round(payload_build_s * 1000, 2),
+        "serialize_ms": round(serialize_s * 1000, 2),
+        "publish_total_ms": round((payload_build_s + serialize_s) * 1000, 2),
+        "full_snapshot_kib": round(total_bytes / 1024, 1),
+        "single_node_payload_kib": round(one_node_bytes / 1024, 3),
+    }
+
+
+def main() -> None:
+    results = [_measure(w) for w in ALL_WORKLOADS]
+    print(f"{'workload':<10} {'nodes':>6} {'edges':>6} {'build_ms':>9} {'payload_ms':>11} "
+          f"{'serialize_ms':>13} {'total_ms':>9} {'snapshot_KiB':>13} {'one_node_KiB':>13}")
+    for r in results:
+        print(
+            f"{r['name']:<10} {r['node_count']:>6} {r['edge_count']:>6} "
+            f"{r['fixture_build_ms']:>9} {r['payload_build_ms']:>11} "
+            f"{r['serialize_ms']:>13} {r['publish_total_ms']:>9} "
+            f"{r['full_snapshot_kib']:>13} {r['single_node_payload_kib']:>13}"
+        )
+    print()
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/perf/test_graph_factory.py
+++ b/backend/tests/perf/test_graph_factory.py
@@ -1,0 +1,55 @@
+"""Structural guard for the ADR-019 graph factory itself - NOT a timing/perf
+test (that is stage 19.2/19.3's pytest-benchmark work, deliberately not
+added here). This just proves the fixtures stay buildable and roughly the
+right shape if SceneDocument's node-creation API changes underneath them,
+so the factory can't silently rot into an inaccurate baseline generator."""
+
+from backend.tests.perf.graph_factory import ALL_WORKLOADS, LARGE, SMALL, STRESS, TYPICAL, build_graph
+
+
+def test_each_reference_workload_builds_the_expected_node_count():
+    for workload in ALL_WORKLOADS:
+        doc = workload.build()
+        assert len(doc.nodes) == workload.node_count
+
+
+def test_typical_workload_contains_the_expected_chart_and_image_nodes():
+    doc = TYPICAL.build()
+    kinds = [n.kind for n in doc.nodes.values()]
+    assert kinds.count("chart") == TYPICAL.chart_count
+    assert kinds.count("image") == TYPICAL.image_count
+    assert kinds.count("chat") == TYPICAL.node_count - TYPICAL.chart_count - TYPICAL.image_count
+    assert len(doc.nodes) == TYPICAL.node_count
+
+
+def test_large_workload_contains_the_expected_chart_and_image_nodes():
+    doc = LARGE.build()
+    kinds = [n.kind for n in doc.nodes.values()]
+    assert kinds.count("chart") == LARGE.chart_count
+    assert kinds.count("image") == LARGE.image_count
+
+
+def test_tree_topology_gives_every_non_root_node_exactly_one_parent_edge():
+    # SMALL has no charts/images, so every edge beyond the tree's own N-1
+    # is one of the deterministic extra cross-links - this isolates the
+    # tree-shape guarantee from that additive noise.
+    doc = build_graph(SMALL.node_count, content_bytes=SMALL.content_bytes, extra_edges=0)
+    assert len(doc.edges) == SMALL.node_count - 1
+
+
+def test_fixtures_are_fully_deterministic_across_two_builds():
+    a = SMALL.build()
+    b = SMALL.build()
+    assert [n.id for n in a.nodes.values()] == [n.id for n in b.nodes.values()]
+    assert a.scene_payload() == b.scene_payload()
+
+
+def test_stress_workload_has_no_charts_or_images_by_design():
+    # STRESS exists to answer "does it degrade or fall over", not to also
+    # carry the render-cost noise chart/image nodes add (see measure_
+    # baselines.py's own module docstring on add_chart_node's synchronous
+    # render cost) - keeping it plain-chat-only isolates node-count scaling.
+    doc = STRESS.build()
+    kinds = [n.kind for n in doc.nodes.values()]
+    assert kinds.count("chart") == 0
+    assert kinds.count("image") == 0

--- a/backend/tests/test_backend_composer.py
+++ b/backend/tests/test_backend_composer.py
@@ -323,10 +323,16 @@ def test_capabilities_cancellation_is_a_genuine_permanent_capability():
 # -- token counter -------------------------------------------------------------
 
 
-def test_estimate_tokens_is_whitespace_split():
+def test_estimate_tokens_uses_the_real_tiktoken_estimator():
+    # ADR-016 stage 16.2: real BPE tokenization, not a whitespace word count.
+    # These are cl100k_base's actual counts (not word counts) - verified
+    # directly against graphlink_token_estimator.TokenEstimator, not assumed.
+    # Multi-space runs are the clearest tell: BPE tokenizes extra whitespace
+    # as its own token(s), which a word count (str.split() collapses runs)
+    # would never show - "  extra   spaces  " is 2 words but 5 real tokens.
     assert estimate_tokens("") == 0
     assert estimate_tokens("one two three") == 3
-    assert estimate_tokens("  extra   spaces  ") == 2
+    assert estimate_tokens("  extra   spaces  ") == 5
 
 
 def test_token_counter_payload_totals_all_three():

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -2262,7 +2262,14 @@ def test_send_message_sets_context_tokens_from_prior_history_not_the_new_message
         # contextTokens is set synchronously, before the reply dispatch even
         # starts (unlike outputTokens, which needs the reply to complete) -
         # no need to await the dispatcher's background task here.
-        expected = estimate_tokens("first message") + estimate_tokens("first reply")
+        #
+        # ADR-016 stage 16.2: expected must match _history_token_text's own
+        # "\n\n".join(...) of the two turns, not a sum of two separate
+        # estimate_tokens() calls - that sum-of-parts shortcut only held
+        # under the old whitespace-split estimator (str.split() treats "\n\n"
+        # as zero-width, so the sum happened to equal the joined count); real
+        # BPE tokenization is not additive across a separator like this.
+        expected = estimate_tokens("first message\n\nfirst reply")
         assert bus.token_counter.context_tokens == expected
 
     asyncio.run(run())

--- a/backend/token_counter.py
+++ b/backend/token_counter.py
@@ -2,13 +2,18 @@
 
 TokenCounterBridge was always a passive display - window_actions.py pushed
 counts into it via update_counts() after real tokenization elsewhere.
-inputTokens tracks the live composer draft (a whitespace-split estimate -
-tiktoken is not a dependency yet; swap in real tokenization here if it ever
-becomes one). outputTokens/contextTokens are set by backend/canvas.py's
-send_message/regenerate_response intents once a reply completes -
-outputTokens from the reply text itself, contextTokens from the prior
-branch history the reply was generated from (excluding, for a fresh send,
-the message just typed - inputTokens already owns that text).
+inputTokens tracks the live composer draft. outputTokens/contextTokens are
+set by backend/canvas.py's send_message/regenerate_response intents once a
+reply completes - outputTokens from the reply text itself, contextTokens
+from the prior branch history the reply was generated from (excluding, for
+a fresh send, the message just typed - inputTokens already owns that text).
+
+ADR-016 stage 16.2 (partial): estimate_tokens delegates to
+graphlink_token_estimator's tiktoken-backed TokenEstimator instead of a
+whitespace word count - tiktoken has been a real dependency since it was
+added for graphlink_chart_agent.py; this counter just hadn't been updated
+to use it. Still a pre-flight estimate, not the provider's own reported
+usage (that real-usage accounting is the rest of ADR-016).
 """
 
 from __future__ import annotations
@@ -17,10 +22,11 @@ from dataclasses import dataclass
 from typing import Any
 
 from backend.events import SessionBus
+from graphlink_token_estimator import TokenEstimator
 
 
 def estimate_tokens(text: str) -> int:
-    return len(text.split())
+    return TokenEstimator().count_tokens(text)
 
 
 @dataclass

--- a/graphlink_plugins/pycoder/domain.py
+++ b/graphlink_plugins/pycoder/domain.py
@@ -35,9 +35,11 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 import uuid
 import weakref
 from enum import Enum
+from pathlib import Path
 
 import api_provider
 import graphlink_task_config as config
@@ -74,11 +76,22 @@ class PythonREPL:
     matched as an exact full line, so program output that happens to contain
     the marker text can no longer truncate the result or desync every
     subsequent call (audit finding B4).
+
+    ADR-005 stage 5.1: the subprocess runs with cwd set to a per-node scratch
+    directory, never the app's own working directory. Without this, LLM-
+    generated code with a relative path (open("config.json", "w")) could
+    clobber real application files, and python -c's sys.path[0] == '' would
+    make every app module (including graphlink_secrets) directly importable
+    by executed code. Mirrors VirtualEnvSandbox's own base_dir pattern in
+    graphlink_plugins/code_sandbox/domain.py exactly (same safe-id
+    sanitization, same tempdir root convention, sibling directory name).
     """
-    def __init__(self):
+    def __init__(self, node_id=None):
         self.process = None
         self.last_run_failed = False
         self._boundary_prefix = ""
+        safe_id = re.sub(r"[^A-Za-z0-9_-]", "_", node_id or "default")
+        self.cwd = Path(tempfile.gettempdir()) / "graphlink_pycoder_repls" / safe_id
 
     def start(self):
         nonce = uuid.uuid4().hex
@@ -108,6 +121,11 @@ while True:
         if sys.platform == 'win32':
             kwargs['creationflags'] = subprocess.CREATE_NO_WINDOW
 
+        # ADR-005 stage 5.1: cwd= a scratch dir, never the app's own cwd (see
+        # this class's own docstring). mkdir here, not in __init__, so a REPL
+        # that is constructed but never started never touches the filesystem.
+        self.cwd.mkdir(parents=True, exist_ok=True)
+
         self.process = subprocess.Popen(
             [sys.executable, '-c', script],
             stdin=subprocess.PIPE,
@@ -115,6 +133,7 @@ while True:
             stderr=subprocess.STDOUT,
             text=True,
             bufsize=1,
+            cwd=str(self.cwd),
             **kwargs
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,8 @@ py-modules = [
     "graphlink_memory",
     "graphlink_model_catalog",
     "graphlink_navigation_pins",
+    "graphlink_note_agent",
+    "graphlink_process_env",
     "graphlink_prompts",
     "graphlink_secrets",
     "graphlink_task_config",


### PR DESCRIPTION
## Summary

A `pip install .`/`python -m build` of this project currently produces a broken wheel — two hard runtime imports are missing from `pyproject.toml`, and one of them silently disables a security-relevant subprocess env allowlist. Separately, Py-Coder's REPL runs AI-generated code with the app's own working directory. This PR fixes both, adds CI gates so each class of bug can't ship silently again, replaces a fake token counter with a real one, and adds real dependency-vulnerability scanning plus SHA-pinned actions.

## What Changed

- Added `graphlink_note_agent` and `graphlink_process_env` to `pyproject.toml`'s `py-modules` — the wheel was missing both; `process_env` specifically owns the subprocess environment allowlist that keeps provider API keys out of AI-generated code's environment.
- Added a `build-check` CI job: builds the wheel, `twine check`s it, installs it into a clean venv, and imports it from outside the repo checkout — this is the gate that would have caught the above.
- Fixed Py-Coder's `PythonREPL` to run in a per-node scratch directory (mirrors `VirtualEnvSandbox`'s existing pattern) instead of the backend's own cwd — a relative-path write from executed code could previously land in the repo, and `python -c`'s `sys.path[0] == ''` made every app module directly importable.
- `backend/token_counter.py::estimate_tokens` now delegates to the existing tiktoken-backed `TokenEstimator` instead of a whitespace word count. Fixed one downstream test that assumed token counts sum across a joined transcript (true for a word count, not true for real BPE tokenization across a `"\n\n"` join).
- Added `pip-audit` and `npm audit --audit-level=high` to CI (both clean against the current locks).
- Added `.github/dependabot.yml` (pip / npm / github-actions), SHA-pinned all `actions/*` currently on mutable `@v4`/`@v5` tags, added `permissions: contents: read`, a `concurrency` cancel-in-progress group, per-job `timeout-minutes`, and pip/npm caching.
- Added `backend/tests/perf/` — a deterministic synthetic-graph fixture (built entirely through the app's own production node-creation API) used to get real, reproducible baseline numbers for wire payload size and publish cost at 25/100/500/2,000-node graphs.

## Why

These came out of a full-repo audit. The wheel bug is live today and would ship silently since CI never builds a distribution. The Py-Coder cwd gap is a real sandbox-escape class (relative-path writes, importable app modules). The rest are standard supply-chain hygiene that a repo storing API keys and executing AI-generated code should have.

## Validation

- [x] `python -m compileall -q .` passes (repo root)
- [x] `python -m pytest -q` passes (repo root) — 1,167 passed (up from 1,161 pre-change)
- [x] `cd web_ui && npm run check` passes (unaffected — no web_ui changes in this PR)
- [x] Relevant workflow was exercised manually: built the real wheel and imported it from a clean venv outside the repo; spawned a real Py-Coder subprocess and confirmed `os.getcwd()` and a relative-path write both land in the scratch dir, not the repo
- [ ] App launches (not exercised — this PR is backend/CI-only; no runtime behavior visible in the desktop shell changed)

## UI Notes

- [x] No screenshots needed

## Additional Context

Follow-up work (not in this PR): a full performance-budget baseline still needs cold-start/chat-load/memory numbers, which require a live running instance rather than a unit-level measurement — tracked separately, not silently dropped.