### PR TITLE
Delete dead Qt-era code and stop Dependabot PR spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,70 @@
-# ADR-015 stage 15.2: supply-chain hygiene. Three ecosystems, matching the
-# three real dependency surfaces in this repo - the Python backend
-# (requirements.txt / pyproject.toml), the web_ui SPA (package-lock.json),
-# and the CI workflow's own actions (now SHA-pinned; Dependabot is what
-# actually bumps those pins over time, using the "# v4"-style version
-# comments left next to each SHA).
+# ADR-015 stage 15.2: supply-chain hygiene.
+#
+# Deliberately tuned for a solo-maintainer repo. The first version of this
+# file used weekly + ungrouped + default limits, and opened 13 separate PRs
+# the moment it merged - including major-version jumps (vite 6->8,
+# typescript 5->7) that would have broken the build. That is noise, not
+# safety, and noise gets ignored, which defeats the point.
+#
+# What changed:
+# - groups: one PR per ecosystem instead of one per package.
+# - schedule: monthly, not weekly.
+# - ignore major bumps: a major version of vite/typescript/react is a
+#   deliberate migration to plan, never a bot-authored PR to rubber-stamp.
+#   Minor/patch (where security fixes actually land) still flow through.
+# - open-pull-requests-limit: 1 per ecosystem, so a stale PR blocks new
+#   noise instead of stacking on top of it.
+#
+# Security alerts are NOT affected by any of this - GitHub's security
+# updates ignore these limits and still open promptly when a real CVE
+# lands. This file only governs routine version bumps.
 version: 2
 updates:
-  # Labels below are scoped to labels that already exist on this repo
-  # (verified via `gh api repos/dovvnloading/Graphlink/labels`) - a label
-  # Dependabot can't find is silently not applied, so this list is
-  # deliberately not aspirational.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
 
   - package-ecosystem: "npm"
     directory: "/web_ui"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      frontend-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "github_actions"

--- a/graphlink_chat_agent.py
+++ b/graphlink_chat_agent.py
@@ -1,20 +1,29 @@
 """Qt-free chat-agent core (Qt-removal plan R4.2 prerequisite).
 
-`resolve_branch_system_prompt`/`ChatWorker`/`ChatAgent` moved out of
-graphlink_agents_core.py: that module's unconditional
-`from PySide6.QtCore import QThread, Signal, QPointF` (needed only by its
-`*WorkerThread` classes) meant importing anything from it - including these
-three Qt-free symbols - pulled PySide6 into the process. That made them
-unimportable from backend/ despite containing zero Qt code themselves,
-exactly the R4.1 problem R4.1 itself didn't reach (it only split
-graphlink_config.py).
-
-graphlink_agents_core.py re-exports all three unchanged for its own
-ChatWorkerThread (which calls resolve_branch_system_prompt) and every
-legacy Qt call site - see its own import line.
+`ChatWorker`/`ChatAgent` moved out of graphlink_agents_core.py: that
+module's unconditional `from PySide6.QtCore import QThread, Signal,
+QPointF` (needed only by its `*WorkerThread` classes) meant importing
+anything from it - including these Qt-free symbols - pulled PySide6 into
+the process. That made them unimportable from backend/ despite containing
+zero Qt code themselves, exactly the R4.1 problem R4.1 itself didn't reach
+(it only split graphlink_config.py).
 
 This file must stay Qt-free forever - it exists to be importable from
 backend/, which test_no_qt_anywhere.py holds to zero tolerance.
+
+ADR-002 stage 2.1: this module used to also define
+`resolve_branch_system_prompt`, a Qt-era fallback (walked live
+QGraphicsScene objects - parent_node/scene()/system_prompt_connections)
+for when ChatWorker.run() was called without a pre-resolved system prompt.
+Deleted as confirmed-dead: every real caller (backend/agents.py's
+_call_chat_agent and _call_chat_agent_stream, both via ChatAgent.__init__'s
+self.system_prompt, which is never empty/None) always passes
+resolved_system_prompt, so the fallback branch was unreachable in the
+current backend and would have crashed immediately if it were ever
+reached (it dereferences QGraphicsScene APIs that do not exist on a
+backend SceneNode). The real, live equivalent is
+AgentDispatcher._resolve_branch_system_prompt in backend/agents.py - an
+independent reimplementation against SceneDocument, not this function.
 """
 
 import json
@@ -23,39 +32,6 @@ import graphlink_task_config as config
 import api_provider
 from graphlink_token_estimator import TokenEstimator
 from graphlink_memory import trim_history
-
-
-def resolve_branch_system_prompt(current_node, default_system_prompt):
-    """Resolve the effective system prompt for a chat branch.
-
-    Walks up to the branch root and, if a system-prompt note is attached there, uses its
-    content instead of the default. This reads live QGraphicsScene objects
-    (``parent_node``/``scene()``/``system_prompt_connections``/``prompt_note.content``),
-    so it MUST run on the GUI thread - QGraphicsScene is not thread-safe, and doing this
-    walk from a worker thread races node deletion / scene.clear() and can crash or read
-    torn state. Callers resolve it here on the UI thread and hand the resulting string
-    to the worker, which never touches the scene.
-
-    Returns the final system prompt string (the default if nothing overrides it).
-    """
-    final_system_prompt = default_system_prompt
-    if not (default_system_prompt or "").strip():
-        return default_system_prompt
-    if not current_node:
-        return final_system_prompt
-
-    root_node = current_node
-    while root_node.parent_node:
-        root_node = root_node.parent_node
-
-    if root_node.scene():
-        for conn in root_node.scene().system_prompt_connections:
-            if conn.end_node == root_node:
-                prompt_note = conn.start_node
-                if prompt_note.content:
-                    final_system_prompt = prompt_note.content
-                break
-    return final_system_prompt
 
 
 class ChatWorker:
@@ -81,11 +57,13 @@ class ChatWorker:
 
         Args:
             conversation_history (list): The list of messages in the conversation.
-            current_node (QGraphicsItem): The current node context. Only used to resolve the
-                branch system prompt when `resolved_system_prompt` is not supplied.
+            current_node: Kept for signature compatibility with every real caller
+                (backend/agents.py) and ChatAgent.get_response, which forwards it
+                unchanged - no longer read inside this method (ADR-002 stage 2.1:
+                its only use was the deleted Qt-era fallback branch below).
             resolved_system_prompt (str, optional): The branch system prompt already
-                resolved on the GUI thread. When provided, the scene is NOT walked here -
-                this is how the worker-thread path avoids touching QGraphicsScene (#20).
+                resolved by the caller (AgentDispatcher._resolve_branch_system_prompt
+                in backend/agents.py). Every real caller supplies this.
             on_chunk (callable, optional): Qt-removal R4.4 token streaming. When provided,
                 routes through api_provider.chat_stream(...) instead of api_provider.chat(...),
                 invoking on_chunk(delta, reset) as incremental text arrives. Additive and
@@ -98,11 +76,7 @@ class ChatWorker:
         Raises:
             Exception: Propagates exceptions from the API provider.
         """
-        if resolved_system_prompt is not None:
-            final_system_prompt = resolved_system_prompt
-        else:
-            # Legacy/direct path (no pre-resolution): safe only on the GUI thread.
-            final_system_prompt = resolve_branch_system_prompt(current_node, self.system_prompt)
+        final_system_prompt = resolved_system_prompt
         use_system_prompt = bool((final_system_prompt or "").strip())
 
         try:

--- a/graphlink_memory.py
+++ b/graphlink_memory.py
@@ -33,50 +33,6 @@ def assign_history(target_node, history):
         target_node.conversation_history = clone_history(history)
 
 
-def resolve_context_anchor(node):
-    cursor = node
-    seen = set()
-    fallback = None
-
-    while cursor and id(cursor) not in seen:
-        seen.add(id(cursor))
-
-        if hasattr(cursor, "conversation_history"):
-            if fallback is None:
-                fallback = cursor
-            if getattr(cursor, "conversation_history", None):
-                return cursor
-
-        cursor = getattr(cursor, "parent_content_node", None) or getattr(cursor, "parent_node", None)
-
-    return fallback
-
-
-def resolve_branch_parent(node):
-    if node is None:
-        return None
-
-    if hasattr(node, "children"):
-        return node
-
-    parent_content_node = getattr(node, "parent_content_node", None)
-    if parent_content_node is not None and hasattr(parent_content_node, "children"):
-        return parent_content_node
-
-    parent_node = getattr(node, "parent_node", None)
-    if parent_node is not None and hasattr(parent_node, "children"):
-        return parent_node
-
-    return None
-
-
-def get_node_history(node):
-    context_anchor = resolve_context_anchor(node)
-    if not context_anchor or not hasattr(context_anchor, "conversation_history"):
-        return []
-    return clone_history(getattr(context_anchor, "conversation_history", []))
-
-
 def trim_history(history, token_estimator, max_tokens=8000, system_prompt_estimate=500, reserve_tokens=0):
     normalized_history = clone_history(history)
     current_tokens = max(0, system_prompt_estimate) + max(0, reserve_tokens)

--- a/graphlink_plugins/pycoder/domain.py
+++ b/graphlink_plugins/pycoder/domain.py
@@ -4,11 +4,11 @@ REPL and the three LLM-calling agents without ever pulling the Qt stack into
 the FastAPI process.
 
 Moved here VERBATIM (same code, same behavior) from graphlink_agents_pycoder.py:
-PyCoderStage, PyCoderStatus, PythonREPL, PyCoderReplManager,
-PyCoderExecutionAgent, PyCoderRepairAgent, PyCoderAnalysisAgent - all of these
-were already pure/Qt-free in the legacy file (confirmed by reading it directly
-before this split: zero Qt references anywhere in this block). The ONLY
-change from the legacy source is the config import: `graphlink_config` (which
+PyCoderStage, PyCoderStatus, PythonREPL, PyCoderExecutionAgent,
+PyCoderRepairAgent, PyCoderAnalysisAgent - all of these were already
+pure/Qt-free in the legacy file (confirmed by reading it directly before
+this split: zero Qt references anywhere in this block). The ONLY change
+from the legacy source is the config import: `graphlink_config` (which
 transitively imports Qt's GUI/widget modules at module scope) becomes
 `graphlink_task_config` (the R4.1 Qt-free split), mirroring the exact same
 swap graphlink_plugins/gitlink/agent.py already made for the same reason.
@@ -18,16 +18,14 @@ CodeExecutionWorker, PyCoderExecutionWorker, PyCoderAgentWorker - the three
 Qt worker-thread subclasses. They still import these classes below (via this
 module) directly rather than defining them inline.
 
-backend/agents.py's own new AgentDispatcher pipeline (R5.4) does NOT use
-PyCoderReplManager - that class's weakref.WeakKeyDictionary keying strategy
-is bound to a live scene-graph node object's own identity, which does not
-survive the port (a backend SceneNode's node_id is a plain string, never
-weakly referenceable, and no GC signal reaches the session layer when a
-SceneNode dataclass instance is dropped). PyCoderReplManager is kept here, unmodified,
-purely so the legacy Qt app's own graphlink_window_actions.py can keep using
-it exactly as before. The new backend instead does explicit, string-keyed
-REPL lifecycle management on AgentDispatcher itself (see that module's
-_pycoder_repls/get_pycoder_repl/dispose_pycoder_repl).
+backend/agents.py's own new AgentDispatcher pipeline (R5.4) does not use
+PyCoderReplManager - it does explicit, string-keyed REPL lifecycle
+management on AgentDispatcher itself instead (see that module's
+_pycoder_repls/get_pycoder_repl/dispose_pycoder_repl). ADR-002 stage 2.1:
+PyCoderReplManager itself is deleted as confirmed-dead code - its only
+remaining caller was the legacy Qt app's graphlink_window_actions.py,
+which no longer exists anywhere in the repo (deleted at the R7.6b
+Qt-removal cutover).
 """
 
 import base64
@@ -37,7 +35,6 @@ import subprocess
 import sys
 import tempfile
 import uuid
-import weakref
 from enum import Enum
 from pathlib import Path
 
@@ -178,50 +175,6 @@ while True:
             self.process.kill()
             self.process.wait()
             self.process = None
-
-
-class PyCoderReplManager:
-    """Owns the PythonREPL subprocess for each PyCoderNode, keyed by node
-    identity. PyCoderNode used to construct and stop its own REPL directly;
-    ownership moves here so the node no longer manages a live subprocess.
-
-    A weakref.finalize callback registered at REPL-creation time stops the
-    subprocess once the owning node is garbage collected, regardless of
-    whether stop()/dispose() was ever called first. This is load-bearing,
-    not just a safety net: ChatScene.clear() (the "New Chat"/chat-switch
-    path) never calls PyCoderNode.dispose() at all - only Python's own GC,
-    via this finalizer, stops the REPL on that path. dispose() (the
-    individual right-click-delete path) still calls stop() directly for
-    immediate, deterministic cleanup rather than waiting on GC.
-
-    A plain dict keyed by node would keep every node alive forever (the
-    dict entry itself would be a strong reference), which would prevent the
-    very GC this manager relies on - hence WeakKeyDictionary.
-
-    R5.4: this class stays legacy-only (the Qt app's graphlink_window_actions.py
-    is its only remaining caller) - see this module's own docstring for why
-    the new backend's AgentDispatcher does not use it.
-    """
-
-    def __init__(self):
-        self._repls = weakref.WeakKeyDictionary()
-        self._finalizers = weakref.WeakKeyDictionary()
-
-    def get_repl(self, node):
-        repl = self._repls.get(node)
-        if repl is None:
-            repl = PythonREPL()
-            self._repls[node] = repl
-            self._finalizers[node] = weakref.finalize(node, repl.stop)
-        return repl
-
-    def stop(self, node):
-        finalizer = self._finalizers.pop(node, None)
-        if finalizer is not None:
-            finalizer.detach()
-        repl = self._repls.pop(node, None)
-        if repl is not None:
-            repl.stop()
 
 
 class PyCoderExecutionAgent:

--- a/graphlink_prompts.py
+++ b/graphlink_prompts.py
@@ -150,47 +150,11 @@ Vertex is a rigorous, honest, and effective process in service of the system it 
 Vertex is a node that earns its place in the graph.
 """
 
-THINKING_INSTRUCTIONS_PROMPT = """
-All reasoning MUST be written only inside <think> and </think> tags. 
-The final answer must appear AFTER </think>, never inside it.
-
-Inside <think>, follow this exact reasoning discipline:
-
-1. Break the problem into its essential parts. 
-   - Identify what is actually being asked.
-   - Identify constraints and any assumptions you must make.
-
-2. Form a short, direct plan for solving it.
-   - 2 to 5 steps, max.
-   - No filler, no narrative, no wandering.
-
-3. Execute the plan step-by-step.
-   - Do the actual calculations, logic, comparisons, or checks.
-   - Keep it literal and compact.
-
-4. Verify the result.
-   - A quick check that the output is correct, reasonable, or internally consistent.
-
-Rules inside <think>:
-- No emotional language.
-- No storytelling.
-- No repetition.
-- No restating the prompt.
-- Only objective reasoning.
-
-After </think>, give the final answer in one clear sentence.
-
----------------------------------------
-EXAMPLE
----------------------------------------
-
-User Query: "How many letters r are in the word strawberry?"
-
-<think>
-1. The task is to count occurrences of 'r' in 'strawberry'. No case issues.
-2. Plan: iterate the characters, count each 'r'.
-3. Execution: s(no), t(no), r(1), a(no), w(no), b(no), e(no), r(2), r(3), y(no).
-4. Verification: manual scan confirms total is 3.
-</think>
-There are 3 letters r in the word strawberry.
-"""
+# ADR-002 stage 2.1: THINKING_INSTRUCTIONS_PROMPT deleted as confirmed-dead
+# code (never imported anywhere; backend/agents.py:109 imports only
+# BASE_SYSTEM_PROMPT from this module). It documented a legacy branch -
+# prefixing this ahead of BASE_SYSTEM_PROMPT when a provider's reasoning
+# mode is "Thinking" - that was never implemented in the current backend
+# (see the reference to it in AgentDispatcher.persona()'s own docstring,
+# backend/agents.py, which still describes the branch as out of scope for
+# its increment).


### PR DESCRIPTION
## Summary

Two small, unrelated-but-both-cleanup changes: removes four blocks of confirmed-dead Qt-era code, and retunes the Dependabot config that opened 13 PRs the moment #212 merged.

## What Changed

**Dead code removed** (each verified dead against current code, not assumed from an older audit):

- `graphlink_chat_agent.resolve_branch_system_prompt` — dereferenced QGraphicsScene APIs a backend `SceneNode` doesn't have, so it would raise immediately if reached. Both real callers always pass `resolved_system_prompt`, so the fallback branch was unreachable. The live equivalent is `AgentDispatcher._resolve_branch_system_prompt`, an independent reimplementation against `SceneDocument`.
- `graphlink_memory.resolve_context_anchor` / `resolve_branch_parent` / `get_node_history` — duck-typed Qt-era node attributes (`parent_content_node`, `parent_node`, `children`) that `SceneNode` doesn't have. Zero callers repo-wide.
- `PyCoderReplManager` — its only caller was the Qt app's `graphlink_window_actions.py`, deleted at the R7.6b cutover. Its now-unused `weakref` import goes too.
- `THINKING_INSTRUCTIONS_PROMPT` — never imported anywhere.

**Dependabot retuned**: grouped into one PR per ecosystem (was one per package), monthly (was weekly), capped at 1 open PR per ecosystem, and semver-major bumps ignored. Security updates are unaffected by these limits.

## Why

The dead code is a landmine — `resolve_branch_system_prompt` in particular looks callable but would crash on any backend node, and its name is one underscore away from the live method that actually does the job.

The Dependabot config in #212 shipped with default settings and immediately opened 13 PRs, including major-version jumps (vite 6→8, typescript 5→7, `@vitejs/plugin-react` 4→6) that would have broken the build. Those 13 have been closed; this prevents a repeat.

## Validation

- [x] `python -m compileall -q .` passes (repo root)
- [x] `python -m pytest -q` passes (repo root) — 1,167 passed, unchanged from before
- [ ] `cd web_ui && npm run check` — not run; no `web_ui/` files touched
- [ ] App launches — not exercised; deletions are of code with no reachable callers
- [x] Relevant workflow was exercised: verified each deletion candidate's call sites with anchored greps before removing (the first broad grep produced false positives from the similarly-named live `_resolve_branch_system_prompt`)

## UI Notes

- [x] No screenshots needed

## Additional Context

`ChatWorker.run` keeps its now-unused `current_node` parameter for signature compatibility with callers that pass it positionally.

This is stage 2.1a of ADR-002. The other three parts of that stage (module rename, boot-sequence hardening, typed session context) are deliberately **not** in this PR — each is substantial enough to warrant its own review.