### PR TITLE
Add typed SessionContext, close a real cross-instance test gap found by adversarial review

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -44,6 +44,7 @@ from backend.crash_recovery import maybe_show_crash_notice
 from backend.events import EventBus, SessionBus, UnknownIntentError, UnknownTopicError
 from backend.notifications import register_notifications
 from backend.plugins import register_plugins
+from backend.session_context import SessionContext, attach_session_context, get_session_context
 from backend.settings import register_settings
 from backend.token_counter import register_token_counter
 
@@ -161,24 +162,30 @@ def _configure_session(
     composer_document = register_composer(bus, token_counter, settings_manager, notifications_state)
 
     # R4 (doc/QT_REMOVAL_PLAN.md): the agent-dispatch service - one
-    # AgentDispatcher per session (never a module-level singleton). Bolted
-    # onto the bus (same pattern as canvas_document below) so ws_endpoint's
+    # AgentDispatcher per session (never a module-level singleton). Reachable
+    # via SessionContext (backend/session_context.py) so ws_endpoint's
     # disconnect handler can reach it and cancel any in-flight request when
     # this session's last connection drops - see AgentDispatcher.cancel_all's
     # own docstring for why that matters.
     agent_dispatcher = register_agents(bus, composer_document, notifications_state, settings_manager)
-    bus.agent_dispatcher = agent_dispatcher
 
     # R1 (doc/QT_REMOVAL_PLAN.md): scene document + grid topics.
-    # R3.21: stash the document on its own SessionBus so backend/assets.py's
+    # R3.21: the document is reachable via SessionContext so backend/assets.py's
     # GET /api/assets/{id} route (registered once, globally, on the app) can
-    # reach the SAME per-session SceneDocument register_canvas() built here -
+    # reach the SAME per-session SceneDocument register_canvas() builds here -
     # there was previously no way to get from a session id back to its
-    # canvas document outside this closure. SessionBus has no fixed attribute
-    # set (no __slots__), so this is a plain, minimal bolt-on attribute, not
-    # a SessionBus API change.
-    bus.canvas_document = register_canvas(
+    # canvas document outside this closure.
+    canvas_document = register_canvas(
         bus, notifications_state, agent_dispatcher, composer_document, token_counter
+    )
+
+    # ADR-002 stage 2.1d: ONE typed reference from here on
+    # (backend/session_context.py), replacing what used to be two loose
+    # dynamic bus attributes (bus.agent_dispatcher/bus.canvas_document) that
+    # any OTHER module reading them had no way to know might not exist on a
+    # SessionBus built outside this function.
+    attach_session_context(
+        bus, SessionContext(agent_dispatcher=agent_dispatcher, canvas_document=canvas_document)
     )
 
     # R2.5: about, plugins, settings, chat library.
@@ -186,7 +193,7 @@ def _configure_session(
     # R5.1: register_plugins needs the same session's canvas_document (built
     # just above) so "Web Research" can create a real node - this ordering
     # (canvas_document exists before register_plugins runs) is load-bearing.
-    register_plugins(bus, notifications_state, bus.canvas_document)
+    register_plugins(bus, notifications_state, canvas_document)
     # R7.4a: register_settings now takes notifications_state too, so the
     # API-provider page's save-validation/init-failure paths can surface a
     # real banner (same load-bearing ordering precedent as register_plugins/
@@ -197,7 +204,7 @@ def _configure_session(
     # (built above) so loadChat can actually restore a session into it, and
     # notifications_state so a failed/empty load can surface a real banner -
     # same load-bearing ordering precedent as register_plugins above.
-    register_chat_library(bus, chat_db_path, bus.canvas_document, notifications_state)
+    register_chat_library(bus, chat_db_path, canvas_document, notifications_state)
 
 
 def create_app(
@@ -286,19 +293,35 @@ def create_app(
             # another tab/window on the same session should not lose its
             # in-flight request just because a different tab closed.
             if session.connection_count == 0:
-                session.agent_dispatcher.cancel_all()
-                # R5.4: a DELIBERATE, SCOPED extension of this disconnect
-                # contract, applied ONLY to the Py-Coder/Execution Sandbox
-                # approval-pause slots - not retrofitted onto the
-                # pre-existing web_research/artifact/gitlink slots (a real,
-                # separate, out-of-scope gap: every one of those already
-                # self-terminates via asyncio.wait_for(..., timeout=...), so
-                # cancel_all() alone is enough for them). An approval pause
-                # has NO timeout by design (the whole point is "wait for a
-                # human, however long that takes"), so without this
-                # extension an abandoned tab's in-flight approval would hang
-                # forever, permanently locking node.pending_request_id.
-                session.agent_dispatcher.cancel_all_pending_approvals()
+                # ADR-002 stage 2.1d adversarial review finding: guarded to
+                # match the exact R6.7 precedent above (bus.session()'s own
+                # try/except) - an uncaught exception inside this finally
+                # block would otherwise vanish into uvicorn's own
+                # "uvicorn.error" logger, which does not propagate to root
+                # and never reaches graphlink.log. get_session_context()
+                # cannot actually raise here today (session only ever
+                # reaches this point via a successful bus.session() call
+                # above, which guarantees a SessionContext is already
+                # attached), but the cost of guarding it is one log line
+                # against a failure mode that is otherwise silent forever.
+                try:
+                    agent_dispatcher = get_session_context(session).agent_dispatcher
+                except Exception:
+                    logger.exception("post-disconnect cleanup failed for session_id=%r", session.session_id)
+                else:
+                    agent_dispatcher.cancel_all()
+                    # R5.4: a DELIBERATE, SCOPED extension of this disconnect
+                    # contract, applied ONLY to the Py-Coder/Execution Sandbox
+                    # approval-pause slots - not retrofitted onto the
+                    # pre-existing web_research/artifact/gitlink slots (a real,
+                    # separate, out-of-scope gap: every one of those already
+                    # self-terminates via asyncio.wait_for(..., timeout=...), so
+                    # cancel_all() alone is enough for them). An approval pause
+                    # has NO timeout by design (the whole point is "wait for a
+                    # human, however long that takes"), so without this
+                    # extension an abandoned tab's in-flight approval would hang
+                    # forever, permanently locking node.pending_request_id.
+                    agent_dispatcher.cancel_all_pending_approvals()
 
     resolved_spa = SPA_DIST_DIR if spa_dir is None else spa_dir
     if resolved_spa.is_dir():

--- a/backend/assets.py
+++ b/backend/assets.py
@@ -14,9 +14,10 @@ parallel asset store.
 This route needs to reach the SAME SceneDocument instance register_canvas()
 built for a given session - not a fresh one - so it goes through the same
 EventBus.session(session_id) lookup /ws already uses (and defaults to
-"default" the same way), then reads the document off the SessionBus. See
-backend/app.py's _configure_session for the (small) structural change that
-makes the document reachable there.
+"default" the same way), then reads the document via
+backend/session_context.py's get_session_context(), which is what makes
+the document reachable here at all - see backend/app.py's
+_configure_session for where it's attached.
 
 R6.2 ALSO adds a second, genuinely new route: GET /api/assets/chart/{node_id}
 /export. Unlike the cached display PNG above, chart export is a real 3x-
@@ -33,6 +34,7 @@ from fastapi import FastAPI, Response
 from fastapi.responses import JSONResponse
 
 from backend.events import EventBus
+from backend.session_context import get_session_context
 from graphlink_chart_rendering import render_chart_png
 
 # 3x the display resolution - mirrors legacy ChartItem.EXPORT_SCALE exactly.
@@ -63,7 +65,7 @@ def register_assets(app: FastAPI, bus: EventBus) -> None:
 
     @app.get("/api/assets/{asset_id}")
     async def get_asset(asset_id: str, session: str = "default") -> Response:
-        document = bus.session(session).canvas_document
+        document = get_session_context(bus.session(session)).canvas_document
         asset = document.get_image_asset(asset_id)
         if asset is None:
             return JSONResponse({"error": "unknown asset"}, status_code=404)
@@ -72,7 +74,7 @@ def register_assets(app: FastAPI, bus: EventBus) -> None:
 
     @app.get("/api/assets/chart/{node_id}/export")
     async def export_chart(node_id: str, session: str = "default") -> Response:
-        document = bus.session(session).canvas_document
+        document = get_session_context(bus.session(session)).canvas_document
         node = document.nodes.get(node_id)
         if node is None or node.kind != "chart":
             return JSONResponse({"error": "unknown chart"}, status_code=404)

--- a/backend/session_context.py
+++ b/backend/session_context.py
@@ -1,0 +1,93 @@
+"""SessionContext - ADR-002 stage 2.1d.
+
+SessionBus (backend/events.py) is deliberately a generic pub/sub
+primitive with no fixed attribute set. Two pieces of real session state -
+the AgentDispatcher and the SceneDocument - are nonetheless read from
+OTHER modules than the one that creates them: backend/app.py creates
+both (in _configure_session), and backend/assets.py plus backend/app.py's
+own disconnect-cleanup path read them back. Before this module, that
+cross-module read was a bare dynamic attribute (bus.agent_dispatcher,
+bus.canvas_document) with no guard - a SessionBus built without going
+through _configure_session (any test that constructs one directly) has
+neither attribute, and a read raised a bare AttributeError several
+frames from the real cause.
+
+This module is the one typed seam for that cross-module read.
+
+Deliberately narrower than originally scoped: backend/chat_library.py's
+bus.chat_mutation_guard/bus.chat_save_state and backend/autosave.py's
+bus.autosave_guarded_tick/bus.autosave_task were also proposed for this
+treatment. A repo-wide grep before writing this module found zero
+PRODUCTION/cross-module readers of any of the four (backend/chat_library.py
+and backend/autosave.py's own test files DO read them extensively -
+~20 sites in backend/tests/test_chat_library.py alone - but no non-test
+module anywhere in the repo ever does, unlike agent_dispatcher/
+canvas_document, which backend/app.py and backend/assets.py both read).
+Moving all four here would force every test that calls
+register_chat_library/register_autosave against a bare SessionBus (close
+to a dozen) to also construct a SessionContext first, for no production
+benefit - so they stay exactly as they are, plain dynamic bus attributes.
+
+One concrete seam where this narrower scope could age: backend/autosave.py's
+own docstring on bus.autosave_task names a "future graceful-shutdown path"
+that would cancel it on last-disconnect - symmetric to how this module's
+agent_dispatcher already gets cancelled there (backend/app.py's
+ws_endpoint). No such code exists today (confirmed by the same grep), but
+if it's ever added, autosave_task would need exactly this treatment too.
+
+Lives in its own leaf module rather than backend/events.py: SessionBus
+must stay free of the domain layer (SceneDocument lives in
+backend/canvas.py, AgentDispatcher in backend/agents.py; both already
+import backend.events for SessionBus's own type hint, so the reverse
+import would cycle). This module imports events.py, canvas.py, and
+agents.py - none of which import it back.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from backend.agents import AgentDispatcher
+from backend.canvas import SceneDocument
+from backend.events import SessionBus
+
+_ATTR = "_session_context"
+
+
+@dataclass(frozen=True)
+class SessionContext:
+    """Frozen (ADR-002 stage 2.1d adversarial review finding): agent_dispatcher/
+    canvas_document are ALSO captured independently by closure inside
+    register_canvas/register_plugins/register_chat_library at
+    _configure_session time, while backend/assets.py instead re-reads via
+    get_session_context() fresh on every request. Nothing today reassigns
+    either field on an existing SessionContext, but if something ever did,
+    those two paths would silently fork onto different objects - frozen
+    makes that structurally impossible rather than merely currently
+    unexercised."""
+
+    agent_dispatcher: AgentDispatcher
+    canvas_document: SceneDocument
+
+
+class SessionNotConfiguredError(RuntimeError):
+    """Raised by get_session_context() when nothing was ever attached -
+    e.g. a SessionBus built directly instead of through
+    backend.app._configure_session (the only real caller of
+    attach_session_context in production)."""
+
+
+def attach_session_context(bus: SessionBus, context: SessionContext) -> None:
+    setattr(bus, _ATTR, context)
+
+
+def get_session_context(bus: SessionBus) -> SessionContext:
+    context = getattr(bus, _ATTR, None)
+    if context is None:
+        raise SessionNotConfiguredError(
+            f"SessionBus {bus.session_id!r} has no SessionContext attached - "
+            "it was not built via backend.app._configure_session. If this is "
+            "a test constructing a SessionBus directly, call "
+            "attach_session_context(bus, SessionContext(...)) first."
+        )
+    return context

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from backend import BACKEND_VERSION
 from backend.app import create_app
+from backend.session_context import get_session_context
 
 # R7.2: api_provider/graphlink_task_config sit at the repo root, a sibling
 # of backend/ - already importable, no ordering constraint.
@@ -177,7 +178,7 @@ def test_disconnect_cancels_any_in_flight_chat_request(monkeypatch):
         assert call_started.is_set(), "fake_chat never started - dispatch did not fire"
 
         session = client.app.state.bus.session("cancel-test")
-        in_flight = list(session.agent_dispatcher._requests.values())
+        in_flight = list(get_session_context(session).agent_dispatcher._requests.values())
         assert len(in_flight) == 1
         cancel_event = in_flight[0]["cancel_event"]
         assert not cancel_event.is_set()
@@ -242,8 +243,9 @@ def test_disconnect_auto_denies_any_pending_pycoder_approval(monkeypatch):
         ws.receive_json()  # (2) awaiting-approval publish
 
         session = client.app.state.bus.session("pycoder-disconnect-test")
-        assert session.agent_dispatcher._pycoder_requests, "runPyCoder never created a request entry"
-        entry = next(iter(session.agent_dispatcher._pycoder_requests.values()))
+        agent_dispatcher = get_session_context(session).agent_dispatcher
+        assert agent_dispatcher._pycoder_requests, "runPyCoder never created a request entry"
+        entry = next(iter(agent_dispatcher._pycoder_requests.values()))
         approval_future = entry["approval_future"]
         assert not approval_future.done(), "the pipeline must genuinely be parked on the gate here"
     # Exiting the `with` block closes the websocket, running ws_endpoint's

--- a/backend/tests/test_assets.py
+++ b/backend/tests/test_assets.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from backend.app import create_app
+from backend.session_context import get_session_context
 
 
 def make_client(tmp_path: Path | None = None) -> TestClient:
@@ -35,7 +36,7 @@ def make_client(tmp_path: Path | None = None) -> TestClient:
 def test_get_asset_returns_exact_bytes_and_stored_mime_type():
     client = make_client()
     bus = client.app.state.bus
-    document = bus.session("default").canvas_document
+    document = get_session_context(bus.session("default")).canvas_document
     parent = document.add_node(0, 0, "parent")
     node = document.add_image_node(
         0, 0, b"\x89PNG\r\n\x1a\nsome raw image bytes", "a test image", parent.id, mime_type="image/png"
@@ -51,7 +52,7 @@ def test_get_asset_returns_exact_bytes_and_stored_mime_type():
 def test_get_asset_respects_the_mime_type_it_was_stored_with():
     client = make_client()
     bus = client.app.state.bus
-    document = bus.session("default").canvas_document
+    document = get_session_context(bus.session("default")).canvas_document
     parent = document.add_node(0, 0, "parent")
     node = document.add_image_node(0, 0, b"jpeg-ish bytes", "prompt", parent.id, mime_type="image/jpeg")
 
@@ -73,7 +74,7 @@ def test_get_asset_for_unknown_id_returns_404_json():
 def test_get_asset_scopes_by_session_query_param():
     client = make_client()
     bus = client.app.state.bus
-    document_a = bus.session("session-a").canvas_document
+    document_a = get_session_context(bus.session("session-a")).canvas_document
     parent = document_a.add_node(0, 0, "parent")
     node = document_a.add_image_node(0, 0, b"session-a bytes", "prompt", parent.id)
 
@@ -98,11 +99,11 @@ def test_asset_ids_do_not_collide_across_sessions_with_identical_creation_order(
     client = make_client()
     bus = client.app.state.bus
 
-    document_a = bus.session("session-a").canvas_document
+    document_a = get_session_context(bus.session("session-a")).canvas_document
     parent_a = document_a.add_node(0, 0, "parent")
     node_a = document_a.add_image_node(0, 0, b"session-a bytes", "prompt", parent_a.id)
 
-    document_b = bus.session("session-b").canvas_document
+    document_b = get_session_context(bus.session("session-b")).canvas_document
     parent_b = document_b.add_node(0, 0, "parent")
     node_b = document_b.add_image_node(0, 0, b"session-b bytes", "prompt", parent_b.id)
 
@@ -123,7 +124,7 @@ _CHART_DATA = {"type": "bar", "title": "Widgets Sold", "labels": ["Q1", "Q2"], "
 def test_export_chart_returns_a_real_higher_resolution_png():
     client = make_client()
     bus = client.app.state.bus
-    document = bus.session("default").canvas_document
+    document = get_session_context(bus.session("default")).canvas_document
     parent = document.add_node(0, 0, "parent")
     chart = document.add_chart_node(0, 0, parent.id, "bar", dict(_CHART_DATA))
 
@@ -144,7 +145,7 @@ def test_export_chart_returns_a_real_higher_resolution_png():
 def test_export_chart_content_disposition_uses_the_sanitized_title():
     client = make_client()
     bus = client.app.state.bus
-    document = bus.session("default").canvas_document
+    document = get_session_context(bus.session("default")).canvas_document
     parent = document.add_node(0, 0, "parent")
     chart = document.add_chart_node(
         0, 0, parent.id, "bar", {"type": "bar", "title": "Q1 Sales / Report!!", "labels": ["a"], "values": [1.0]}
@@ -167,7 +168,7 @@ def test_export_chart_for_unknown_node_returns_404_json():
 def test_export_chart_for_a_non_chart_node_returns_404_json():
     client = make_client()
     bus = client.app.state.bus
-    document = bus.session("default").canvas_document
+    document = get_session_context(bus.session("default")).canvas_document
     node = document.add_node(0, 0, "plain node")
 
     response = client.get(f"/api/assets/chart/{node.id}/export")
@@ -179,7 +180,7 @@ def test_export_chart_for_a_non_chart_node_returns_404_json():
 def test_export_chart_scopes_by_session_query_param():
     client = make_client()
     bus = client.app.state.bus
-    document_a = bus.session("session-a").canvas_document
+    document_a = get_session_context(bus.session("session-a")).canvas_document
     parent_a = document_a.add_node(0, 0, "parent")
     chart_a = document_a.add_chart_node(0, 0, parent_a.id, "bar", dict(_CHART_DATA))
 

--- a/backend/tests/test_session_context.py
+++ b/backend/tests/test_session_context.py
@@ -1,0 +1,120 @@
+"""backend/session_context.py tests (ADR-002 stage 2.1d).
+
+The module's whole reason to exist is turning a bare AttributeError
+(several frames from the real cause) into a clear, named error when a
+SessionBus is read for agent_dispatcher/canvas_document without ever
+having gone through backend.app._configure_session. These tests prove
+both directions: the round-trip works, and the failure mode is the
+intended one, not an accident of whatever getattr happens to do.
+"""
+
+import pytest
+
+from backend.agents import AgentDispatcher
+from backend.canvas import SceneDocument
+from backend.events import SessionBus
+from backend.session_context import (
+    SessionContext,
+    SessionNotConfiguredError,
+    attach_session_context,
+    get_session_context,
+)
+
+
+class _FakeSettingsManager:
+    def get(self, *_a, **_k):
+        return None
+
+
+def _make_context() -> SessionContext:
+    return SessionContext(
+        agent_dispatcher=AgentDispatcher(_FakeSettingsManager()),
+        canvas_document=SceneDocument(),
+    )
+
+
+def test_get_session_context_raises_a_named_error_when_nothing_was_attached():
+    bus = SessionBus("unconfigured-session")
+
+    with pytest.raises(SessionNotConfiguredError) as exc_info:
+        get_session_context(bus)
+
+    # The whole point of this module: the error must be immediately
+    # actionable (names the session, names the real fix), not a bare
+    # AttributeError several frames from where the real cause is.
+    assert "unconfigured-session" in str(exc_info.value)
+    assert "_configure_session" in str(exc_info.value)
+
+
+def test_attach_then_get_round_trips_the_exact_same_object():
+    bus = SessionBus("configured-session")
+    context = _make_context()
+
+    attach_session_context(bus, context)
+
+    assert get_session_context(bus) is context
+
+
+def test_get_session_context_reflects_a_re_attach_not_the_first_one():
+    # Guards against a caching bug: a second attach_session_context call on
+    # the same bus (shouldn't happen in production - _configure_session
+    # runs once per session - but a test fixture might reset state) must
+    # not leave get_session_context returning the stale first object.
+    bus = SessionBus("reattached-session")
+    first = _make_context()
+    second = _make_context()
+
+    attach_session_context(bus, first)
+    attach_session_context(bus, second)
+
+    assert get_session_context(bus) is second
+    assert get_session_context(bus) is not first
+
+
+def test_session_context_fields_are_exactly_what_was_passed_in():
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    document = SceneDocument()
+    bus = SessionBus("field-identity-session")
+
+    attach_session_context(bus, SessionContext(agent_dispatcher=dispatcher, canvas_document=document))
+
+    context = get_session_context(bus)
+    assert context.agent_dispatcher is dispatcher
+    assert context.canvas_document is document
+
+
+def test_two_different_sessionbus_instances_do_not_share_context():
+    # Regression guard for the attribute-name-collision class of bug: the
+    # attachment must be per-INSTANCE (a real bus attribute), not keyed by
+    # session_id in some shared dict that two SessionBus objects with
+    # different ids could cross-read.
+    bus_a = SessionBus("session-a")
+    bus_b = SessionBus("session-b")
+    context_a = _make_context()
+
+    attach_session_context(bus_a, context_a)
+
+    assert get_session_context(bus_a) is context_a
+    with pytest.raises(SessionNotConfiguredError):
+        get_session_context(bus_b)
+
+
+def test_two_sessionbus_instances_with_the_identical_session_id_do_not_share_context():
+    # The case that actually distinguishes real per-instance storage from a
+    # session_id-keyed shared dict, which the different-ids test above
+    # cannot: a session torn down and rebuilt with the SAME session_id
+    # (a real production shape - EventBus never evicts by design, but a
+    # future eviction/reconnect path could construct a fresh SessionBus for
+    # an id that was already in use) must get a genuinely fresh, unattached
+    # context - never the previous instance's dispatcher/document bleeding
+    # through because the two objects happen to share a session_id string.
+    # Confirmed via mutation testing that the different-ids test alone does
+    # NOT catch a session_id-keyed dict implementation - this one does.
+    first_bus = SessionBus("dup-id")
+    first_context = _make_context()
+    attach_session_context(first_bus, first_context)
+
+    second_bus = SessionBus("dup-id")
+
+    with pytest.raises(SessionNotConfiguredError):
+        get_session_context(second_bus)


### PR DESCRIPTION
## Summary

`SessionBus` had two dynamic attributes (`agent_dispatcher`, `canvas_document`) read from other modules with no guard — a bare `AttributeError` several frames from the real cause if a `SessionBus` was ever built without going through `_configure_session`. This adds a typed, guarded accessor. Scope was deliberately narrowed from the original plan after re-verifying against current code, and the change went through a genuine 4-reviewer adversarial pass before shipping, which caught one real test gap.

## What Changed

- New `backend/session_context.py`: a **frozen** `SessionContext` dataclass (`agent_dispatcher`, `canvas_document`) plus `attach_session_context()`/`get_session_context()` — the latter raises a named `SessionNotConfiguredError` naming the session id and pointing at `_configure_session`, instead of a bare `AttributeError`.
- Wired into `backend/app.py`'s `_configure_session`; every read site in `backend/app.py` and `backend/assets.py` migrated.
- `backend/tests/test_app_ws.py` (3 sites) and `backend/tests/test_assets.py` (9 sites) updated to match — both already went through the real `create_app()` path, so no test-construction changes were needed there.
- New `backend/tests/test_session_context.py` (6 tests) for the module itself.

**Deliberately narrower than originally scoped**: four other dynamic attributes (`chat_mutation_guard`/`chat_save_state` in `chat_library.py`, `autosave_guarded_tick`/`autosave_task` in `autosave.py`) were also proposed for this treatment in the initial research pass. Re-verified against current code before implementing and found they have **zero production/cross-module readers** — only their own owning files' test suites read them (extensively, by design, to inspect internal state). Moving those four would have forced close to a dozen existing tests to also construct a `SessionContext` for no production benefit, so they're untouched.

## Why — and what adversarial review actually caught

This is stage 2.1d of ADR-002, the highest-risk piece of that stage. Given the scope, I ran 4 independent reviewers in parallel after implementing, each trying to break a different part of the change (re-verify the "zero readers" claim, hunt for missed migration sites anywhere in the repo, stress-test the new tests for whether they'd catch a real regression, and review the design for concurrency/mutability issues).

**One real, confirmed gap came out of it**: the original `test_two_different_sessionbus_instances_do_not_share_context` used two *different* session ids, so it couldn't distinguish real per-instance storage from a session-id-keyed shared dict — the exact anti-pattern its own docstring warned against. I verified this myself independently: temporarily replaced the implementation with that exact anti-pattern, confirmed the old test still passed against it, added a new test using the *same* session id on two distinct `SessionBus` instances, confirmed *that* one correctly failed against the buggy implementation, then restored the real code (`diff` confirmed byte-identical).

Two lower-severity hardening items also came out of the design review and are applied here:
- `SessionContext` is now `frozen=True` — closures inside `register_canvas`/`register_plugins`/`register_chat_library` capture the object at registration time, while `assets.py` re-reads it fresh per request; nothing today reassigns a field, but frozen makes a future silent fork between those two paths structurally impossible rather than merely unexercised.
- The disconnect-cleanup call site in `backend/app.py` now wraps `get_session_context()` in a try/except matching the exact pattern its sibling `bus.session()` call already uses (an existing R6.7 finding: an uncaught exception in this handler vanishes into uvicorn's own logger, never reaching `graphlink.log`). Provably unreachable today, but matches an established precedent for defense-in-depth at negligible cost.

One reviewer also observed a single intermittent test failure during the review itself — traced to two reviewers concurrently mutating the same file in the same (non-isolated) working directory during independent mutation tests, not a defect in the shipped code. Ran the full suite 4 additional times on the final, clean state after all fixes to confirm: 1185/1185 passed every time.

## Validation

- [x] `python -m compileall -q .` passes (repo root)
- [x] `python -m pytest -q` passes (repo root) — 1,185 passed, run 4x consecutively with zero flakes on the final state
- [ ] `cd web_ui && npm run check` — not run; no `web_ui/` files touched
- [ ] App launches — not exercised via a real launch; covered by the existing `test_app_ws.py`/`test_assets.py` integration tests instead, which already exercise the real `create_app()` → `_configure_session` path
- [x] Relevant workflow exercised: real wheel build + clean-venv install + import from outside the repo (confirms `backend/session_context.py` is auto-included via `packages.find`, no `pyproject.toml` change needed); the confirmed test gap above was independently reproduced and re-verified fixed, not just reported

## UI Notes

- [x] No screenshots needed

## Additional Context

This closes stage 2.1d, the last piece of ADR-002 stage 2.1 (backend decomposition foundations). The four other dynamic attributes noted above are deliberately left as-is — `backend/session_context.py`'s own docstring names the one concrete seam (a future autosave graceful-shutdown path, referenced but not implemented anywhere today) where that decision could need revisiting.