### PR TITLE
ADR-002 stage 2.3: RunLifecycle primitive (chat/chart/note pilots)

### DIFF
--- a/GRAPHLINK_REPO_NAVIGATION.md
+++ b/GRAPHLINK_REPO_NAVIGATION.md
@@ -136,7 +136,9 @@ Several `backend/` modules (`composer.py`, `chat_library.py`, `plugins.py`, `ses
 - `backend/settings.py`
   - `SettingsManager`-backed `register_settings()`: the `app-settings` topic and every settings intent (General, Ollama, Llama.cpp, API Endpoint, Integrations, GitHub token). Reads defaults from `graphlink_task_config.py`'s task-keyed model dict.
 - `backend/agents.py` (now the largest file in the repo, ~156KB)
-  - `AgentDispatcher` (one instance per session, never a module-level singleton) - owns in-flight request tracking/cancellation for chat/conversation requests (`self._requests`) and image generation (a separate slot), `bootstrap_provider_state()` (process-global `api_provider` state, set up once per process from the shared `SettingsManager`), and `register_agents()`.
+  - `AgentDispatcher` (one instance per session, never a module-level singleton) - owns in-flight request tracking/cancellation across its 13 dispatch surfaces, `bootstrap_provider_state()` (process-global `api_provider` state, set up once per process from the shared `SettingsManager`), and `register_agents()`. As of ADR-002 stage 2.3, 3 pilot surfaces (chat/conversation, chart, note) claim into one shared `self._runs` (a `backend/run_lifecycle.py` `RunRegistry`) instead of their own private dict; the remaining 9 surfaces (image, web research, artifact, gitlink x2, pycoder, code sandbox, branch comparison, branch synthesis) still keep independent dicts, deferred to stage 2.4.
+- `backend/run_lifecycle.py`
+  - `RunHandle`/`RunRegistry` (claim/release/cancel/cancel_all/is_busy) and `run_single_shot()` - the ADR-002 stage 2.3 primitive `backend/agents.py`'s pilot surfaces claim into, see that module's own docstring.
 - `backend/response_parsing.py`
   - `parse_response()` - splits a flat LLM reply into ordered thinking/text/code parts, shared by the ordinary send path and the regenerate path (both in `backend/canvas.py`). `ConversationNode` is the one confirmed exception - it never routes through this parser.
 - `graphlink_task_config.py`, `graphlink_settings_store.py`, `graphlink_prompts.py`, `graphlink_model_catalog.py` (repo root)

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -109,6 +109,7 @@ from graphlink_plugins.web_research.service import WebResearchService
 from graphlink_prompts import BASE_SYSTEM_PROMPT
 
 from backend.events import SessionBus  # type hint only
+from backend.run_lifecycle import RunRegistry, run_single_shot
 
 logger = logging.getLogger(__name__)
 
@@ -259,14 +260,21 @@ class AgentDispatcher:
 
     def __init__(self, settings_manager: SettingsManager):
         self._settings_manager = settings_manager
-        # request_id -> {"cancel_event": threading.Event, "task": asyncio.Task}
-        self._requests: dict[str, dict] = {}
+        # ADR-002 stage 2.3: the chat/conversation, chart, and note pilot
+        # surfaces below claim into this ONE shared registry instead of
+        # three independent dicts - see backend/run_lifecycle.py's own
+        # docstring for the full reasoning and for why the other 9
+        # dispatch surfaces still keep their own dict for now (deferred to
+        # stage 2.4). "chat" is one shared kind for both start_chat_reply
+        # and start_conversation_reply, mirroring the single dict they
+        # already shared before this migration.
+        self._runs = RunRegistry()
         # R4.4a: an INDEPENDENT in-flight slot for image generation, separate
-        # from self._requests (chat/conversation). Preserves legacy's real,
+        # from self._runs's "chat" kind (chat/conversation). Preserves legacy's real,
         # verified concurrent capability - graphlink_window.py's
         # self.chat_thread/self.image_gen_thread are separate, never-aliased
         # attributes, so a chat request and an image-generation request
-        # genuinely run concurrently today. Reusing self._requests for image
+        # genuinely run concurrently today. Reusing chat's "kind" for image
         # generation too would be a real, visible behavior regression (a user
         # could no longer send a chat message while an image generates), so
         # this stays a second, independent dict rather than a new key inside
@@ -277,25 +285,25 @@ class AgentDispatcher:
         # not a deliberate concurrent-multi-image feature; start_image_reply
         # below gives an honest "already generating" refusal instead of
         # replicating that hazard. request_id -> {"task": asyncio.Task} - no
-        # "cancel_event" key here, unlike self._requests: image generation
-        # has no cancellation at all (see start_image_reply's own docstring).
+        # "cancel_event" key here, unlike chat: image generation has no
+        # cancellation at all (see start_image_reply's own docstring).
         self._image_requests: dict[str, dict] = {}
         # R5.1: a THIRD independent in-flight-request slot, separate from both
-        # self._requests (chat/conversation) and self._image_requests - a web
+        # chat (self._runs) and self._image_requests - a web
         # research run and a chat/image request must be able to run
         # concurrently, same reasoning R4.4a used for _image_requests being
-        # independent from _requests. request_id -> {"cancel_token":
+        # independent from chat. request_id -> {"cancel_token":
         # CancellationToken, "task": asyncio.Task}.
         self._web_research_requests: dict[str, dict] = {}
         # R5.2: a FOURTH independent in-flight-request slot, separate from
-        # self._requests (chat/conversation), self._image_requests, and
+        # chat (self._runs), self._image_requests, and
         # self._web_research_requests - an artifact-generation request must be
         # able to run concurrently with any of those three, same reasoning as
         # every prior independent slot above. request_id -> {"cancel_event":
         # threading.Event, "task": asyncio.Task}.
         self._artifact_requests: dict[str, dict] = {}
         # R5.3: a FIFTH independent in-flight-request slot, separate from
-        # self._requests/self._image_requests/self._web_research_requests/
+        # chat/self._image_requests/self._web_research_requests/
         # self._artifact_requests - a Gitlink Generate Change Set run must be
         # able to run concurrently with any of those four, same reasoning as
         # every prior independent slot above. request_id -> {"cancel_event":
@@ -327,38 +335,24 @@ class AgentDispatcher:
         # Sandbox Run must be able to run concurrently with any of the seven
         # slots above. Same shape as self._pycoder_requests.
         self._code_sandbox_requests: dict[str, dict] = {}
-        # R6.2: a NINTH independent in-flight-request GUARD - unlike the
-        # eight dict-of-tasks slots above, start_chart_generation is
-        # DIRECTLY AWAITED by its caller rather than scheduled via
-        # asyncio.create_task (see that method's own docstring for why: it
-        # is a single combined create+generate action with no pre-existing
-        # node to attach a spinner to, so the caller genuinely needs the
-        # result - including the brand new node id - back in the same round
-        # trip, the same shape as the Gitlink read-only helpers just below).
-        # request_id -> True; this dict's only job is answering "is a chart
-        # generation already running for this session", so two overlapping
-        # generateChart calls (e.g. two tabs on the same session) cannot
-        # race each other - there is no task/cancel_event to store since
-        # there is no background task and no cancellation primitive (same
-        # reasoning as self._image_requests: ChartDataAgent.get_response has
-        # no checkpoint to insert one at, and its own legacy caller,
-        # ChartWorkerThread, has no stop() method either).
-        self._chart_requests: dict[str, bool] = {}
-        # R8a: a TENTH independent in-flight-request GUARD, same directly-
-        # awaited shape (and therefore same dict-of-sentinels rather than
-        # dict-of-tasks) as self._chart_requests above, for the same reason:
-        # Key Takeaway / Explainer Note each create a brand new note node, so
-        # the caller needs the result back in the same round trip and there is
-        # no pre-existing node to hang a spinner on. ONE guard covers both
-        # agents deliberately - they are the same user-facing gesture
+        # R6.2/R8a, migrated to self._runs by ADR-002 stage 2.3: chart
+        # generation ("chart" kind) and Key Takeaway/Explainer Note
+        # generation ("note" kind, ONE guard covering both agents
+        # deliberately - they are the same user-facing gesture
         # ("summarise this node into a note") differing only in prompt, and
-        # letting a takeaway and an explainer run concurrently would race two
-        # notes onto overlapping canvas positions for no benefit.
-        # request_id -> True; no task/cancel_event to store, since the legacy
-        # workers these replace had no stop() either.
-        self._note_requests: dict[str, bool] = {}
+        # letting a takeaway and an explainer run concurrently would race
+        # two notes onto overlapping canvas positions for no benefit) are
+        # both DIRECTLY AWAITED by their caller rather than scheduled via
+        # asyncio.create_task (see start_chart_generation's own docstring
+        # for why: each is a single combined create+generate action with no
+        # pre-existing node to attach a spinner to, so the caller genuinely
+        # needs the result - including the brand new node id - back in the
+        # same round trip). Neither has a cancel_event: ChartDataAgent/the
+        # note agents have no cancellation checkpoint of their own, and
+        # their legacy callers had no stop() method either.
+        #
         # ADR-002 Workstream 1 ("Compare Branches") - a SEPARATE busy-guard
-        # from _note_requests above: comparing branches and generating a Key
+        # from note generation above: comparing branches and generating a Key
         # Takeaway/Explainer Note are unrelated features, so one running
         # must never block the other. Same "request_id -> True, no task/
         # cancel_event" shape - this is directly awaited, not scheduled.
@@ -548,25 +542,25 @@ class AgentDispatcher:
         return None
 
     def cancel(self, request_id: str) -> bool:
-        entry = self._requests.get(request_id)
-        if entry is None:
-            return False
-        entry["cancel_event"].set()
-        return True
+        return self._runs.cancel(request_id)
 
     def cancel_all(self) -> None:
         """Trip the cancel event on every in-flight request for this
-        session. Called when a session's last WS connection disconnects
-        (backend/app.py's ws_endpoint) - without this, a client that sends a
-        message and immediately closes the tab leaves the real outbound LLM
-        call (potentially a billed API request) running server-side,
-        untethered, for up to WATCHDOG_TIMEOUT_SECONDS with no way for the
-        client to ever cancel it (cancelChatRequest needs a live socket).
-        Same cooperative-cancellation semantics as cancel() - this does not
-        forcibly kill the in-flight thread, it only requests it stop at its
-        next checkpoint, same as the timeout path already does."""
-        for entry in self._requests.values():
-            entry["cancel_event"].set()
+        session that has one. Called when a session's last WS connection
+        disconnects (backend/app.py's ws_endpoint) - without this, a client
+        that sends a message and immediately closes the tab leaves the real
+        outbound LLM call (potentially a billed API request) running
+        server-side, untethered, for up to WATCHDOG_TIMEOUT_SECONDS with no
+        way for the client to ever cancel it (cancelChatRequest needs a live
+        socket). Same cooperative-cancellation semantics as cancel() - this
+        does not forcibly kill the in-flight thread, it only requests it
+        stop at its next checkpoint, same as the timeout path already does.
+
+        Delegates to self._runs.cancel_all(), which walks every claimed
+        handle (chat/chart/note as of ADR-002 stage 2.3) and silently
+        no-ops on kinds with no cancel_event - see
+        backend/run_lifecycle.py's own docstring."""
+        self._runs.cancel_all()
 
     def cancel_web_research(self, request_id: str) -> bool:
         entry = self._web_research_requests.get(request_id)
@@ -631,7 +625,7 @@ class AgentDispatcher:
         every other caller (including start_conversation_reply) omits them,
         which simply falls back to persona()'s existing resolution, byte-
         identical to this method's pre-R6.1 behavior."""
-        if self._requests:
+        if self._runs.is_busy("chat"):
             # Single-request-per-session guard: never start a second
             # concurrent request while one is already in flight.
             notifications_state.show("A response is already being generated.", "info")
@@ -649,8 +643,12 @@ class AgentDispatcher:
             await bus.publish("notification")
             return
 
-        request_id = uuid.uuid4().hex
+        # Claimed SYNCHRONOUSLY, with no `await` between the is_busy() check
+        # above and this claim - see backend/run_lifecycle.py's own
+        # docstring for why that ordering is load-bearing, not incidental.
         cancel_event = threading.Event()
+        handle = self._runs.claim("chat", node_id=node_id, cancel_event=cancel_event)
+        request_id = handle.request_id
 
         async def _run():
             on_begin(request_id)
@@ -801,7 +799,7 @@ class AgentDispatcher:
                 # Unconditional on every exit path (success, timeout, cancel,
                 # other error) so the caller's state always returns to a
                 # usable idle state.
-                self._requests.pop(request_id, None)
+                self._runs.release(request_id)
                 on_end()
                 await bus.publish(state_topic)
 
@@ -812,8 +810,12 @@ class AgentDispatcher:
         # loop (backend/app.py) - if this handler awaited the full chat call
         # inline, no further message on that same socket (including a
         # cancelChatRequest intent) would even be read off the wire until the
-        # handler returned, making cooperative cancellation impossible.
-        self._requests[request_id] = {"cancel_event": cancel_event, "task": asyncio.create_task(_run())}
+        # handler returned, making cooperative cancellation impossible. The
+        # claim itself already landed above, before this task was even
+        # created - this line only attaches the task reference (anti-GC
+        # only, see backend/run_lifecycle.py - never used for real
+        # cancellation).
+        self._runs.attach_task(handle, asyncio.create_task(_run()))
 
     async def start_chat_reply(
         self,
@@ -906,9 +908,9 @@ class AgentDispatcher:
         a ConversationNode's pending_request_id do; the frontend shows a
         transient "Generating image..." notification instead of a per-node
         spinner). Guarded by self._image_requests, a dict kept fully
-        SEPARATE from self._requests (chat/conversation) - see that field's
-        own comment in __init__ for why this must stay independent rather
-        than reusing the existing single-slot guard.
+        SEPARATE from chat/conversation's own slot (self._runs's "chat"
+        kind) - see that field's own comment in __init__ for why this must
+        stay independent rather than reusing the existing single-slot guard.
 
         No cancel_event is constructed or passed - api_provider.generate_image
         has no cancellation_event parameter at all and its body has no
@@ -926,7 +928,7 @@ class AgentDispatcher:
             # Single in-flight-image-request-per-session guard, mirroring
             # _dispatch's own "A response is already being generated." guard
             # in shape but tracked on the independent self._image_requests
-            # dict, never self._requests.
+            # dict, never chat's own slot.
             notifications_state.show("An image is already being generated.", "info")
             await bus.publish("notification")
             return
@@ -997,9 +999,9 @@ class AgentDispatcher:
         exactly one caller (backend/canvas.py's run_web_research), so
         on_begin/on_end are inlined here directly rather than taking
         _dispatch's generic parameters. Guarded by self._web_research_requests,
-        a dict kept fully SEPARATE from both self._requests (chat/
-        conversation) and self._image_requests - see that field's own
-        comment in __init__ for why this must stay independent.
+        a dict kept fully SEPARATE from both chat/conversation's own slot
+        (self._runs's "chat" kind) and self._image_requests - see that
+        field's own comment in __init__ for why this must stay independent.
 
         Cooperative cancellation only, via a CancellationToken (not a
         threading.Event, since WebResearchService.run's own pipeline stages
@@ -1128,9 +1130,10 @@ class AgentDispatcher:
         returns a two-element tuple and must run its own fail-closed
         tag-parsing/raise (see ArtifactAgent.get_response) before any
         mutation callback fires. Guarded by self._artifact_requests, a dict
-        kept fully SEPARATE from self._requests (chat/conversation),
-        self._image_requests, and self._web_research_requests - see that
-        field's own comment in __init__ for why this must stay independent.
+        kept fully SEPARATE from chat/conversation's own slot (self._runs's
+        "chat" kind), self._image_requests, and self._web_research_requests
+        - see that field's own comment in __init__ for why this must stay
+        independent.
 
         Cooperative cancellation only, via a threading.Event (not the
         CancellationToken web-research uses - ArtifactAgent has no such
@@ -2253,12 +2256,11 @@ class AgentDispatcher:
         shows a blocking loading animation for the duration, not a
         fire-and-forget spinner elsewhere - the same UX this mirrors.
 
-        Still guarded by self._chart_requests (see that field's own comment
-        in __init__), now storing a plain sentinel rather than a task
-        reference - there is no background task to hold onto, only a
-        "one generation in flight for this session" marker, so two
-        overlapping generateChart calls (e.g. from two tabs open on the same
-        session) cannot race each other.
+        Still guarded by self._runs's "chart" kind (ADR-002 stage 2.3 -
+        see backend/run_lifecycle.py) - there is no background task to
+        hold onto, only a "one generation in flight for this session"
+        marker, so two overlapping generateChart calls (e.g. from two tabs
+        open on the same session) cannot race each other.
 
         No cancel_event: ChartDataAgent has no cancellation checkpoint of
         its own, and its own legacy caller (ChartWorkerThread) has no
@@ -2289,49 +2291,40 @@ class AgentDispatcher:
         double Artifact's own single-call shape, but nowhere near Web
         Research's ~10-call chain that justified ITS own 900s bump, and 420s
         already carries ample headroom for two calls at any realistic
-        per-call latency."""
-        if self._chart_requests:
-            notifications_state.show("A chart is already being generated.", "info")
-            await bus.publish("notification")
-            return
+        per-call latency.
 
-        request_id = uuid.uuid4().hex
-        self._chart_requests[request_id] = True
-
-        async def _invoke(fn, *a):
-            if inspect.iscoroutinefunction(fn):
-                await fn(*a)
-            else:
-                fn(*a)
-
-        try:
-            result = await asyncio.wait_for(
-                asyncio.to_thread(_call_chart_agent, source_text, chart_type),
-                timeout=WATCHDOG_TIMEOUT_SECONDS,
-            )
-            if isinstance(result, dict) and "error" in result:
-                message = str(result["error"])
-                await _invoke(on_failure, message)
-                notifications_state.show(f"Chart generation failed: {message}", "error")
-                await bus.publish("notification")
-            else:
-                await _invoke(on_success, result)
-        except asyncio.TimeoutError:
-            message = (
+        ADR-002 stage 2.3: the guard/timeout/exception/notify skeleton
+        below now lives once, shared with start_note_generation, in
+        backend/run_lifecycle.py's run_single_shot - see that function's
+        own docstring. Every message string and every branch's exact
+        behavior (including the asymmetry where a top-level "error" key
+        hands on_failure the RAW error text but prefixes the toast
+        notification with "Chart generation failed: ") is unchanged from
+        this method's pre-2.3 body."""
+        await run_single_shot(
+            self._runs,
+            kind="chart",
+            bus=bus,
+            notifications_state=notifications_state,
+            node_id=node_id,
+            timeout=WATCHDOG_TIMEOUT_SECONDS,
+            call=lambda: _call_chart_agent(source_text, chart_type),
+            validate=lambda result: (
+                str(result["error"]) if isinstance(result, dict) and "error" in result else None
+            ),
+            on_success=on_success,
+            on_failure=on_failure,
+            busy_message="A chart is already being generated.",
+            timeout_message=(
                 "Chart generation stopped responding before the request completed. "
                 "Please try again."
-            )
-            await _invoke(on_failure, message)
-            notifications_state.show(message, "error")
-            await bus.publish("notification")
-        except Exception as exc:
-            logger.exception("chart generation dispatch failed (parent node %s)", node_id)
-            message = f"Chart generation failed: {exc}"
-            await _invoke(on_failure, message)
-            notifications_state.show(message, "error")
-            await bus.publish("notification")
-        finally:
-            self._chart_requests.pop(request_id, None)
+            ),
+            exception_prefix="Chart generation failed",
+            log_exception=lambda exc: logger.exception(
+                "chart generation dispatch failed (parent node %s)", node_id
+            ),
+            validate_notify=lambda message: f"Chart generation failed: {message}",
+        )
 
     async def start_note_generation(
         self,
@@ -2357,53 +2350,41 @@ class AgentDispatcher:
         which agent class runs and how failures are worded - the guard,
         timeout, callback and cleanup logic are identical, and duplicating
         them would be two places to fix every future bug in.
+
+        ADR-002 stage 2.3: that shared skeleton now lives once, in
+        backend/run_lifecycle.py's run_single_shot, shared with
+        start_chart_generation too - see that function's own docstring.
+        Every message string and every branch's exact behavior is
+        unchanged from this method's pre-2.3 body.
         """
         label = NOTE_AGENT_LABELS.get(note_kind, "Note")
 
-        if self._note_requests:
-            notifications_state.show(f"A {label.lower()} is already being generated.", "info")
-            await bus.publish("notification")
-            return
-
-        request_id = uuid.uuid4().hex
-        self._note_requests[request_id] = True
-
-        async def _invoke(fn, *a):
-            if inspect.iscoroutinefunction(fn):
-                await fn(*a)
-            else:
-                fn(*a)
-
-        try:
-            text = await asyncio.wait_for(
-                asyncio.to_thread(_call_note_agent, note_kind, source_text),
-                timeout=WATCHDOG_TIMEOUT_SECONDS,
-            )
-            if not str(text or "").strip():
+        await run_single_shot(
+            self._runs,
+            kind="note",
+            bus=bus,
+            notifications_state=notifications_state,
+            node_id=node_id,
+            timeout=WATCHDOG_TIMEOUT_SECONDS,
+            call=lambda: _call_note_agent(note_kind, source_text),
+            validate=lambda text: (
                 # An agent that returns nothing usable must not silently
                 # create an empty note - that reads as a broken feature.
-                message = f"{label} generation returned an empty response. Please try again."
-                await _invoke(on_failure, message)
-                notifications_state.show(message, "error")
-                await bus.publish("notification")
-            else:
-                await _invoke(on_success, text)
-        except asyncio.TimeoutError:
-            message = (
+                f"{label} generation returned an empty response. Please try again."
+                if not str(text or "").strip() else None
+            ),
+            on_success=on_success,
+            on_failure=on_failure,
+            busy_message=f"A {label.lower()} is already being generated.",
+            timeout_message=(
                 f"{label} generation stopped responding before the request completed. "
                 "Please try again."
-            )
-            await _invoke(on_failure, message)
-            notifications_state.show(message, "error")
-            await bus.publish("notification")
-        except Exception as exc:
-            logger.exception("%s generation dispatch failed (source node %s)", label, node_id)
-            message = f"{label} generation failed: {exc}"
-            await _invoke(on_failure, message)
-            notifications_state.show(message, "error")
-            await bus.publish("notification")
-        finally:
-            self._note_requests.pop(request_id, None)
+            ),
+            exception_prefix=f"{label} generation failed",
+            log_exception=lambda exc: logger.exception(
+                "%s generation dispatch failed (source node %s)", label, node_id
+            ),
+        )
 
     async def start_branch_comparison(
         self,
@@ -2419,8 +2400,8 @@ class AgentDispatcher:
         brand new note node and there is no pre-existing node to attach a
         spinner to; single dict-registry busy guard; WATCHDOG_TIMEOUT_
         SECONDS; on_success/on_failure callbacks) but with its own
-        _branch_comparison_requests guard rather than reusing
-        _note_requests - see that field's own comment for why. source_text
+        _branch_comparison_requests guard rather than reusing the "note"
+        kind in self._runs - see that field's own comment for why. source_text
         is already the fully-formatted multi-branch block
         (backend/canvas.py's _format_branches_for_comparison) - this method
         itself is agnostic to how many branches went into it."""

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -740,7 +740,7 @@ def register_canvas(
         # prompt) pair from a different source-node kind, then both funnel
         # through this one dispatch + success-primitive call. Runs on
         # agent_dispatcher's INDEPENDENT self._image_requests slot, never
-        # self._requests - see backend/agents.py's AgentDispatcher docstring
+        # its "chat" run kind - see backend/agents.py's AgentDispatcher docstring
         # for why chat and image generation must be able to run concurrently.
         async def _on_reply(image_bytes):
             if parent_chat_node_id not in document.nodes:

--- a/backend/run_lifecycle.py
+++ b/backend/run_lifecycle.py
@@ -1,0 +1,226 @@
+"""ADR-002 stage 2.3: the RunLifecycle primitive.
+
+AgentDispatcher (backend/agents.py) grew 12 independent in-flight-request
+dicts across its 13 dispatch surfaces (one per R4.4/R5.x/R6.x/R8a/ADR-002
+increment), each hand-copying the same "single slot per kind, uuid4
+request_id, pop-in-finally" shape with small, undocumented variations -
+audit findings S2 (13x duplicated skeleton) and C3 (cancel_all() walks
+only ONE of the twelve dicts, so a client that disconnects mid-flight on
+any of the other eleven leaves that call running server-side, untethered,
+until its own watchdog timeout). This module replaces that pattern with
+ONE registry every dispatch surface claims into and releases from, so
+cancel_all() can walk every in-flight run regardless of kind.
+
+Stage 2.3 migrates the 3 pilot surfaces named in ADR-002 (chat/
+conversation, chart, note) - see that document for why the remaining 9
+slots (image, web research, artifact, gitlink x2, pycoder, code sandbox,
+branch comparison, branch synthesis) are deliberately deferred to stage
+2.4 rather than folded in here: several of those have real per-kind
+shape differences (approval futures, cancellation tokens instead of
+threading.Event, no-cancel-at-all) that deserve their own migration and
+verification pass rather than being rushed alongside this one.
+
+Two access shapes coexist because the pilots themselves have two
+genuinely different dispatch shapes:
+
+- chat/conversation (AgentDispatcher._dispatch) is fire-and-forget: it
+  claims a slot SYNCHRONOUSLY in the calling coroutine, then schedules a
+  background asyncio.Task and returns immediately without awaiting it -
+  the WS read loop must keep reading further messages (including a
+  cancelChatRequest intent) while that task runs. Claim and release
+  happen in DIFFERENT coroutines (the scheduling coroutine claims; the
+  scheduled task releases in its own `finally`), so this surface uses
+  RunRegistry.claim()/.release() directly.
+- chart/note are directly awaited by their own caller (there is no
+  pre-existing node to attach a spinner to - the caller needs the
+  result, including a brand new node id, back in the same round trip).
+  Claim and release happen in the SAME coroutine, so these two share
+  run_single_shot() below, one function replacing two near-identical
+  ~50-line try/except/finally bodies.
+
+Claiming is always synchronous (RunRegistry.claim() is a plain method,
+never `async def`) - this is load-bearing, not a style choice. Every
+pilot's busy pre-check (`if registry.is_busy(kind):`) and its own claim
+must happen in the same synchronous stretch, with no `await` in between,
+exactly as every pre-existing dict-based guard already did - an `await`
+between the two would let a second coroutine observe "not busy" before
+the first one's claim lands, admitting two concurrent runs of the same
+kind. See AgentDispatcher._dispatch's own call site for the pattern this
+preserves.
+
+RunHandle.task, where present, is held ONLY to keep the asyncio.Task
+alive (the event loop holds only a weak reference to scheduled tasks) -
+never call .cancel() on it. None of the 12 pre-existing dicts' task
+references were ever cancelled directly either; the only cancellation
+mechanism anywhere in this codebase is cooperative, via
+RunHandle.cancel_event, which callers other than the run itself trip and
+the run's own code observes at its next checkpoint. cancel_all() below
+preserves this exactly: it walks every claimed handle and sets
+cancel_event on the ones that have one, silently no-oping on kinds (like
+chart/note) that have none - the same honestly-documented "this kind
+cannot be cancelled" limitation those two already had before this
+migration, just visible in one place now instead of being invisible to
+cancel_all() entirely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from backend.events import SessionBus  # type hint only
+
+
+@dataclass
+class RunHandle:
+    """One claimed slot in a RunRegistry.
+
+    `kind` is the busy-guard bucket (e.g. "chat", "chart", "note") - one
+    in-flight run per kind per AgentDispatcher, mirroring exactly what
+    each pre-existing independent dict already enforced. `node_id` is
+    informational only (logging/introspection) - it is NEVER consulted
+    by RunRegistry.is_busy/claim, because every pilot's busy check is
+    session-wide, not per-node (a second chat send while one is already
+    running is rejected regardless of which node either one targets)."""
+
+    kind: str
+    request_id: str
+    node_id: str | None = None
+    cancel_event: threading.Event | None = None
+    task: asyncio.Task | None = None
+
+
+class RunRegistry:
+    """One in-flight-run registry per AgentDispatcher (session-scoped,
+    like the dicts it replaces - never a module-level singleton)."""
+
+    def __init__(self) -> None:
+        self._handles: dict[str, RunHandle] = {}
+
+    def is_busy(self, kind: str) -> bool:
+        return any(handle.kind == kind for handle in self._handles.values())
+
+    def claim(
+        self,
+        kind: str,
+        *,
+        node_id: str | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> RunHandle:
+        """Synchronous by design - see this module's own docstring for
+        why callers must call this in the same synchronous stretch as
+        their own is_busy() pre-check."""
+        handle = RunHandle(
+            kind=kind,
+            request_id=uuid.uuid4().hex,
+            node_id=node_id,
+            cancel_event=cancel_event,
+        )
+        self._handles[handle.request_id] = handle
+        return handle
+
+    def attach_task(self, handle: RunHandle, task: asyncio.Task) -> None:
+        handle.task = task
+
+    def release(self, request_id: str) -> None:
+        self._handles.pop(request_id, None)
+
+    def get(self, request_id: str) -> RunHandle | None:
+        return self._handles.get(request_id)
+
+    def values(self):
+        return self._handles.values()
+
+    def cancel(self, request_id: str) -> bool:
+        handle = self._handles.get(request_id)
+        if handle is None or handle.cancel_event is None:
+            return False
+        handle.cancel_event.set()
+        return True
+
+    def cancel_all(self) -> None:
+        """See this module's own docstring for why kinds with no
+        cancel_event (chart, note) are silently skipped rather than
+        treated as an error."""
+        for handle in self._handles.values():
+            if handle.cancel_event is not None:
+                handle.cancel_event.set()
+
+
+async def _invoke(fn, *args) -> None:
+    if inspect.iscoroutinefunction(fn):
+        await fn(*args)
+    else:
+        fn(*args)
+
+
+async def run_single_shot(
+    registry: RunRegistry,
+    *,
+    kind: str,
+    bus: SessionBus,
+    notifications_state,
+    node_id: str | None,
+    timeout: float,
+    call: Callable[[], Any],
+    validate: Callable[[Any], str | None],
+    on_success,
+    on_failure,
+    busy_message: str,
+    timeout_message: str,
+    exception_prefix: str,
+    log_exception: Callable[[BaseException], None],
+    validate_notify: Callable[[str], str] | None = None,
+) -> None:
+    """Shared skeleton for a "directly-awaited, single combined
+    create+generate action" dispatch surface - start_chart_generation and
+    start_note_generation today; see this module's own docstring for why
+    chat/conversation cannot share this same function.
+
+    `call`: zero-arg callable, run inside asyncio.to_thread. `validate`:
+    inspects a SUCCESSFUL `call` result and returns a human-readable
+    failure message when it is well-formed but not usable (e.g. chart's
+    top-level "error" key, note's empty-string check) - this is a
+    success-path check, not an exception. `validate_notify`: separately
+    formats that same message for the toast notification only, for a
+    surface whose notification text differs from the message it hands to
+    on_failure (chart prefixes its toast with "Chart generation failed: ";
+    every other branch - including note's own validate failure - uses
+    the identical string for both, the default identity mapping).
+    `log_exception`: called with the caught exception, from inside the
+    `except Exception` handler, so a `logger.exception(...)` callback
+    still resolves the right traceback (Python's active-exception state
+    stays valid for the whole dynamic extent of the except block, across
+    nested calls) even though it fires through this shared frame."""
+    if registry.is_busy(kind):
+        notifications_state.show(busy_message, "info")
+        await bus.publish("notification")
+        return
+
+    handle = registry.claim(kind, node_id=node_id)
+    try:
+        result = await asyncio.wait_for(asyncio.to_thread(call), timeout=timeout)
+        message = validate(result)
+        if message is not None:
+            await _invoke(on_failure, message)
+            notify_message = validate_notify(message) if validate_notify else message
+            notifications_state.show(notify_message, "error")
+            await bus.publish("notification")
+        else:
+            await _invoke(on_success, result)
+    except asyncio.TimeoutError:
+        await _invoke(on_failure, timeout_message)
+        notifications_state.show(timeout_message, "error")
+        await bus.publish("notification")
+    except Exception as exc:
+        log_exception(exc)
+        message = f"{exception_prefix}: {exc}"
+        await _invoke(on_failure, message)
+        notifications_state.show(message, "error")
+        await bus.publish("notification")
+    finally:
+        registry.release(handle.request_id)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -36,3 +36,26 @@ def _chat_stream_delegates_to_patched_chat(monkeypatch):
 
     monkeypatch.setattr(api_provider, "chat_stream", _generic_chat_stream)
     yield
+
+
+def chat_slots(dispatcher):
+    """ADR-002 stage 2.3 test adapter: reproduces the pre-migration
+    dict[request_id, {"cancel_event": ..., "task": ...}] shape that every
+    chat/conversation test in this suite was written against, filtered to
+    AgentDispatcher._runs's "chat" kind - see backend/run_lifecycle.py for
+    the real (RunHandle-based) production shape this is adapting. Returns
+    a plain dict so callers can keep using .values()/.items()/.keys()/
+    subscript/len()/== {} exactly as they did against the old dict."""
+    return {
+        handle.request_id: {"cancel_event": handle.cancel_event, "task": handle.task}
+        for handle in dispatcher._runs.values()
+        if handle.kind == "chat"
+    }
+
+
+def busy_count(dispatcher, kind):
+    """ADR-002 stage 2.3 test adapter: the count-based equivalent of the
+    old dict-of-sentinels' len()/truthiness checks for a "directly-
+    awaited, single-shot" kind (chart, note) now living in
+    AgentDispatcher._runs."""
+    return sum(1 for handle in dispatcher._runs.values() if handle.kind == kind)

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -31,6 +31,7 @@ from backend.canvas import SceneDocument, register_canvas
 from backend.composer import ComposerDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
+from backend.tests.conftest import busy_count, chat_slots
 
 import api_provider
 import graphlink_task_config as config
@@ -132,11 +133,11 @@ def test_successful_reply_calls_on_reply_with_the_agent_text(monkeypatch):
         # The reply happens inside a scheduled (not awaited) task - grab the
         # task reference start_chat_reply left in the registry and await it
         # directly rather than assuming start_chat_reply itself blocks.
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assert replies == ["canned reply"]
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert composer_document.request_state == "idle"
 
     asyncio.run(run())
@@ -163,7 +164,7 @@ def test_provider_not_configured_returns_quickly_with_an_error_notification(monk
             on_reply=lambda text: None,
         )
 
-        assert dispatcher._requests == {}, "no task/thread work started"
+        assert chat_slots(dispatcher) == {}, "no task/thread work started"
         assert chat_calls == [], "api_provider.chat was never reached"
         assert notifications.visible is True
         assert notifications.msg_type == "error"
@@ -198,7 +199,7 @@ def test_cancellation_mid_flight_fires_info_notification_and_clears_registry(mon
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=lambda text: None,
         )
-        request_id, entry = next(iter(dispatcher._requests.items()))
+        request_id, entry = next(iter(chat_slots(dispatcher).items()))
 
         # Wait until the worker thread has actually entered chat() before
         # cancelling, so this is a genuine mid-flight cancel.
@@ -207,7 +208,7 @@ def test_cancellation_mid_flight_fires_info_notification_and_clears_registry(mon
 
         await entry["task"]
 
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert notifications.visible is True
         assert notifications.msg_type == "info"
         assert notifications.message == "Request cancelled."
@@ -241,10 +242,10 @@ def test_timeout_fires_the_exact_message_and_clears_registry(monkeypatch):
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=lambda text: None,
         )
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert notifications.visible is True
         assert notifications.msg_type == "error"
         assert notifications.message == (
@@ -293,13 +294,13 @@ def test_concurrent_calls_second_rejected_first_completes_third_succeeds(monkeyp
         )
         assert notifications.visible is True
         assert notifications.message == "A response is already being generated."
-        assert len(dispatcher._requests) == 1
+        assert len(chat_slots(dispatcher)) == 1
 
         release.set()
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
         assert replies == ["first reply"]
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
 
         # Third call, after the first has fully completed, succeeds normally.
         monkeypatch.setattr(api_provider, "chat", lambda task, messages, **kwargs: {"message": {"content": "third reply"}})
@@ -310,7 +311,7 @@ def test_concurrent_calls_second_rejected_first_completes_third_succeeds(monkeyp
             conversation_history=[{"role": "user", "content": "third"}],
             on_reply=replies.append,
         )
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
         assert replies == ["first reply", "third reply"]
 
@@ -454,7 +455,7 @@ def test_send_message_uses_the_branch_attached_system_prompt_note_instead_of_the
         document.connect(note.id, root.id)
 
         await bus.dispatch_intent("scene", "sendMessage", ["continue the branch"])
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assert captured["persona_text"] == "Custom branch persona."
@@ -484,7 +485,7 @@ def test_send_message_falls_back_to_the_default_persona_when_no_note_is_attached
         register_canvas(bus, notifications, dispatcher, composer_document)
 
         await bus.dispatch_intent("scene", "sendMessage", ["first message, no note attached"])
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assert captured["persona_text"] == dispatcher.persona()
@@ -521,7 +522,7 @@ def test_regenerate_response_also_resolves_the_branch_attached_system_prompt_not
         document.connect(note.id, root.id)
 
         await bus.dispatch_intent("scene", "regenerateResponse", [assistant_reply.id])
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assert captured["persona_text"] == "Custom branch persona."
@@ -672,22 +673,22 @@ def test_two_sessions_concurrent_inflight_no_cross_contamination(monkeypatch):
         await asyncio.to_thread(b_started.wait, 5)
         assert a_started.is_set() and b_started.is_set()
 
-        assert len(dispatcher_a._requests) == 1
-        assert len(dispatcher_b._requests) == 1
-        assert set(dispatcher_a._requests.keys()).isdisjoint(dispatcher_b._requests.keys())
+        assert len(chat_slots(dispatcher_a)) == 1
+        assert len(chat_slots(dispatcher_b)) == 1
+        assert set(chat_slots(dispatcher_a).keys()).isdisjoint(chat_slots(dispatcher_b).keys())
         assert composer_a.request_state == "generating"
         assert composer_b.request_state == "generating"
 
         # Release out of start order - completion order must not matter.
         b_release.set()
-        await next(iter(dispatcher_b._requests.values()))["task"]
+        await next(iter(chat_slots(dispatcher_b).values()))["task"]
         a_release.set()
-        await next(iter(dispatcher_a._requests.values()))["task"]
+        await next(iter(chat_slots(dispatcher_a).values()))["task"]
 
         assert replies_a == ["reply for A"]
         assert replies_b == ["reply for B"]
-        assert dispatcher_a._requests == {}
-        assert dispatcher_b._requests == {}
+        assert chat_slots(dispatcher_a) == {}
+        assert chat_slots(dispatcher_b) == {}
         assert composer_a.request_state == "idle"
         assert composer_b.request_state == "idle"
         assert notif_a.visible is False
@@ -697,8 +698,8 @@ def test_two_sessions_concurrent_inflight_no_cross_contamination(monkeypatch):
 
 
 def test_rapid_fire_double_send_same_session_second_is_rejected(monkeypatch):
-    """start_chat_reply has no `await` between the `if self._requests:`
-    emptiness check and the dict insertion at the bottom - so two calls
+    """start_chat_reply has no `await` between the `if self._runs.is_busy
+    ("chat"):` check and the registry claim right after it - so two calls
     fired back-to-back on the same dispatcher, with no await of the first's
     completion in between, must never both be admitted. This is the closest
     this transport model gets to "two sendMessage frames arriving one right
@@ -724,11 +725,11 @@ def test_rapid_fire_double_send_same_session_second_is_rejected(monkeypatch):
             conversation_history=[{"role": "user", "content": "two"}], on_reply=replies.append,
         )
 
-        assert len(dispatcher._requests) == 1, "both calls must never be admitted concurrently"
+        assert len(chat_slots(dispatcher)) == 1, "both calls must never be admitted concurrently"
         assert notifications.message == "A response is already being generated."
 
         release.set()
-        await next(iter(dispatcher._requests.values()))["task"]
+        await next(iter(chat_slots(dispatcher).values()))["task"]
         assert replies == ["first"]
 
     asyncio.run(run())
@@ -784,11 +785,11 @@ def test_conversation_reply_sets_then_clears_pending_request_id_and_calls_on_rep
         assert node.pending_request_id is not None, "set mid-flight, before the blocking call returns"
 
         release.set()
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assert replies == ["canned reply"]
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert node.pending_request_id is None
 
     asyncio.run(run())
@@ -810,7 +811,7 @@ def test_conversation_reply_publishes_scene_not_app_composer_on_begin_and_end(mo
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=lambda text: None,
         )
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assert "app-composer" not in recorder.topics
@@ -842,7 +843,7 @@ def test_conversation_reply_provider_not_configured_returns_quickly_with_an_erro
             on_reply=lambda text: None,
         )
 
-        assert dispatcher._requests == {}, "no task/thread work started"
+        assert chat_slots(dispatcher) == {}, "no task/thread work started"
         assert chat_calls == [], "api_provider.chat was never reached"
         assert node.pending_request_id is None, "never touched on the fail-fast path"
         assert notifications.visible is True
@@ -877,14 +878,14 @@ def test_conversation_reply_cancellation_mid_flight_fires_info_notification_and_
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=lambda text: None,
         )
-        request_id, entry = next(iter(dispatcher._requests.items()))
+        request_id, entry = next(iter(chat_slots(dispatcher).items()))
 
         await asyncio.to_thread(started.wait, 5)
         assert dispatcher.cancel(request_id) is True
 
         await entry["task"]
 
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert node.pending_request_id is None
         assert notifications.visible is True
         assert notifications.msg_type == "info"
@@ -913,10 +914,10 @@ def test_conversation_reply_timeout_fires_the_exact_message_and_clears_registry(
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=lambda text: None,
         )
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert node.pending_request_id is None
         assert notifications.visible is True
         assert notifications.msg_type == "error"
@@ -951,10 +952,10 @@ def test_conversation_on_reply_raising_still_clears_pending_request_id_and_frees
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=raising_on_reply,
         )
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert node.pending_request_id is None
         assert notifications.visible is True
         assert notifications.msg_type == "error"
@@ -972,7 +973,7 @@ def test_conversation_on_reply_raising_still_clears_pending_request_id_and_frees
             conversation_history=[{"role": "user", "content": "hi again"}],
             on_reply=replies.append,
         )
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
         assert replies == ["next reply"]
         assert node.pending_request_id is None
@@ -1022,15 +1023,15 @@ def test_composer_call_in_flight_blocks_a_concurrent_conversation_call_on_the_sa
         assert notifications.visible is True
         assert notifications.message == "A response is already being generated."
         assert node.pending_request_id is None, "the bounced call must never touch the node"
-        assert len(dispatcher._requests) == 1, "only the composer's original request stays in flight"
+        assert len(chat_slots(dispatcher)) == 1, "only the composer's original request stays in flight"
 
         release.set()
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assert composer_replies == ["composer reply"]
         assert conversation_replies == [], "the bounced call never ran at all"
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
 
     asyncio.run(run())
 
@@ -1072,15 +1073,15 @@ def test_conversation_call_in_flight_blocks_a_concurrent_composer_call_on_the_sa
         assert notifications.visible is True
         assert notifications.message == "A response is already being generated."
         assert composer_document.request_state == "idle", "the bounced call must never touch composer state"
-        assert len(dispatcher._requests) == 1, "only the conversation node's original request stays in flight"
+        assert len(chat_slots(dispatcher)) == 1, "only the conversation node's original request stays in flight"
 
         release.set()
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assert conversation_replies == ["conversation reply"]
         assert composer_replies == [], "the bounced call never ran at all"
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert node.pending_request_id is None
 
     asyncio.run(run())
@@ -1162,8 +1163,8 @@ def test_start_image_reply_second_call_while_in_flight_is_rejected_with_info_not
 
 def test_image_request_and_chat_request_run_concurrently_both_dicts_non_empty(monkeypatch):
     """THE key concurrency-slot regression guard (R4.4a): a chat/composer
-    request occupies self._requests while an image-generation request
-    occupies the SEPARATE self._image_requests dict at the same time -
+    request occupies self._runs's "chat" kind while an image-generation
+    request occupies the SEPARATE self._image_requests dict at the same time -
     neither blocks nor is blocked by the other, and both dicts are
     simultaneously non-empty at least once, proving these are two genuinely
     independent slots rather than aliases of the same guard (the whole point
@@ -1209,12 +1210,12 @@ def test_image_request_and_chat_request_run_concurrently_both_dicts_non_empty(mo
         # THE key assertion: both slots are genuinely occupied at the same
         # time - neither request bounced the other, and neither notification
         # fired.
-        assert len(dispatcher._requests) == 1
+        assert len(chat_slots(dispatcher)) == 1
         assert len(dispatcher._image_requests) == 1
         assert notifications.visible is False, "neither call should have been rejected"
 
         chat_release.set()
-        chat_entry = next(iter(dispatcher._requests.values()))
+        chat_entry = next(iter(chat_slots(dispatcher).values()))
         await chat_entry["task"]
         image_release.set()
         image_entry = next(iter(dispatcher._image_requests.values()))
@@ -1222,7 +1223,7 @@ def test_image_request_and_chat_request_run_concurrently_both_dicts_non_empty(mo
 
         assert chat_replies == ["chat reply"]
         assert image_replies == [b"image-bytes"]
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert dispatcher._image_requests == {}
         assert composer_document.request_state == "idle"
 
@@ -1375,11 +1376,11 @@ def test_streaming_happy_path_recorder_receives_ordered_stream_frames_and_on_rep
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=replies.append,
         )
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assert replies == ["Hello"]
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert composer_document.request_state == "idle"
 
         assert recorder.frames, "must have received at least one stream frame"
@@ -1422,7 +1423,7 @@ def test_cancel_mid_stream_no_on_reply_and_stream_frames_still_end_with_done_tru
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=replies.append,
         )
-        request_id, entry = next(iter(dispatcher._requests.items()))
+        request_id, entry = next(iter(chat_slots(dispatcher).items()))
 
         await asyncio.to_thread(started.wait, 5)
         assert dispatcher.cancel(request_id) is True
@@ -1430,7 +1431,7 @@ def test_cancel_mid_stream_no_on_reply_and_stream_frames_still_end_with_done_tru
         await entry["task"]
 
         assert replies == [], "cancel discards everything - no partial-text on_reply, matching R4.2 precedent"
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert notifications.visible is True
         assert notifications.msg_type == "info"
         assert notifications.message == "Request cancelled."
@@ -1461,11 +1462,11 @@ def test_stream_error_mid_way_generic_notification_and_stream_frames_still_end_d
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=replies.append,
         )
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assert replies == []
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert notifications.visible is True
         assert notifications.msg_type == "error"
         assert notifications.message == "AI response failed: boom"
@@ -1500,7 +1501,7 @@ def test_throttle_batches_many_small_chunks_into_materially_fewer_publish_stream
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=replies.append,
         )
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assert replies == [expected]
@@ -1548,7 +1549,7 @@ def test_completion_handoff_parity_streaming_send_message_creates_identical_node
         document = register_canvas(bus, notifications, dispatcher, composer_document)
 
         user_node_id = await bus.dispatch_intent("scene", "sendMessage", ["plan it out"])
-        entry = next(iter(dispatcher._requests.values()))
+        entry = next(iter(chat_slots(dispatcher).values()))
         await entry["task"]
 
         assistant_nodes = [
@@ -1582,8 +1583,8 @@ def test_completion_handoff_parity_streaming_send_message_creates_identical_node
 
 def test_image_request_runs_independently_while_a_chat_stream_is_paused_mid_flight(monkeypatch):
     """R4.4 spec section 6, item 8: cross-slot concurrency during an active
-    stream. A chat stream paused mid-flight (self._requests) must not block,
-    or be blocked by, a concurrent image-generation request
+    stream. A chat stream paused mid-flight (self._runs's "chat" kind) must
+    not block, or be blocked by, a concurrent image-generation request
     (self._image_requests) - the two independent slots this dispatcher
     already guarantees (R4.4a) must keep holding under streaming too."""
     chat_started = threading.Event()
@@ -1618,7 +1619,7 @@ def test_image_request_runs_independently_while_a_chat_stream_is_paused_mid_flig
         # actually broadcast it before asserting.
         await asyncio.sleep(0.15)
 
-        assert len(dispatcher._requests) == 1
+        assert len(chat_slots(dispatcher)) == 1
         assert recorder.frames, "at least the first buffered delta should have flushed by now"
 
         await dispatcher.start_image_reply(
@@ -1631,15 +1632,15 @@ def test_image_request_runs_independently_while_a_chat_stream_is_paused_mid_flig
         # still-paused chat stream.
         assert image_replies == [b"image-bytes"]
         assert dispatcher._image_requests == {}
-        assert len(dispatcher._requests) == 1, "the chat stream is still in flight, untouched by the image request"
+        assert len(chat_slots(dispatcher)) == 1, "the chat stream is still in flight, untouched by the image request"
         assert notifications.visible is False, "neither request was rejected"
 
         chat_release.set()
-        chat_entry = next(iter(dispatcher._requests.values()))
+        chat_entry = next(iter(chat_slots(dispatcher).values()))
         await chat_entry["task"]
 
         assert chat_replies == ["final chat reply"]
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert recorder.frames[-1]["done"] is True, "stream frames kept recording throughout the image request"
 
     asyncio.run(run())
@@ -1975,8 +1976,8 @@ def test_cancel_web_research_returns_false_for_an_unknown_request_id():
 
 def test_web_research_request_and_chat_request_run_concurrently_both_dicts_non_empty(monkeypatch):
     """THE key concurrency-slot regression guard (R5.1, mirrors R4.4a's own
-    chat/image guard test): a chat/composer request occupies self._requests
-    while a web-research request occupies the SEPARATE
+    chat/image guard test): a chat/composer request occupies self._runs's
+    "chat" kind while a web-research request occupies the SEPARATE
     self._web_research_requests dict at the same time - neither blocks nor is
     blocked by the other, and both dicts are simultaneously non-empty at
     least once."""
@@ -2029,12 +2030,12 @@ def test_web_research_request_and_chat_request_run_concurrently_both_dicts_non_e
         # THE key assertion: both slots are genuinely occupied at the same
         # time - neither request bounced the other, and neither notification
         # fired.
-        assert len(dispatcher._requests) == 1
+        assert len(chat_slots(dispatcher)) == 1
         assert len(dispatcher._web_research_requests) == 1
         assert notifications.visible is False, "neither call should have been rejected"
 
         chat_release.set()
-        chat_entry = next(iter(dispatcher._requests.values()))
+        chat_entry = next(iter(chat_slots(dispatcher).values()))
         await chat_entry["task"]
         research_release.set()
         research_entry = next(iter(dispatcher._web_research_requests.values()))
@@ -2042,7 +2043,7 @@ def test_web_research_request_and_chat_request_run_concurrently_both_dicts_non_e
 
         assert chat_replies == ["chat reply"]
         assert research_successes == [SimpleNamespace(answer_markdown="research result")]
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert dispatcher._web_research_requests == {}
         assert composer_document.request_state == "idle"
 
@@ -2408,8 +2409,8 @@ def test_cancel_artifact_returns_false_for_an_unknown_request_id():
 def test_artifact_request_and_chat_request_run_concurrently_both_dicts_non_empty(monkeypatch):
     """THE key concurrency-slot regression guard (R5.2, mirrors R4.4a/R5.1's
     own chat/image and chat/web-research guards): a chat/composer request
-    occupies self._requests while an artifact-generation request occupies the
-    SEPARATE self._artifact_requests dict at the same time - neither blocks
+    occupies self._runs's "chat" kind while an artifact-generation request
+    occupies the SEPARATE self._artifact_requests dict at the same time - neither blocks
     nor is blocked by the other, and both dicts are simultaneously non-empty
     at least once."""
     chat_started = threading.Event()
@@ -2458,12 +2459,12 @@ def test_artifact_request_and_chat_request_run_concurrently_both_dicts_non_empty
         # THE key assertion: both slots are genuinely occupied at the same
         # time - neither request bounced the other, and neither notification
         # fired.
-        assert len(dispatcher._requests) == 1
+        assert len(chat_slots(dispatcher)) == 1
         assert len(dispatcher._artifact_requests) == 1
         assert notifications.visible is False, "neither call should have been rejected"
 
         chat_release.set()
-        chat_entry = next(iter(dispatcher._requests.values()))
+        chat_entry = next(iter(chat_slots(dispatcher).values()))
         await chat_entry["task"]
         artifact_release.set()
         artifact_entry = next(iter(dispatcher._artifact_requests.values()))
@@ -2471,7 +2472,7 @@ def test_artifact_request_and_chat_request_run_concurrently_both_dicts_non_empty
 
         assert chat_replies == ["chat reply"]
         assert artifact_replies == [("artifact document", "artifact message")]
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert dispatcher._artifact_requests == {}
         assert composer_document.request_state == "idle"
 
@@ -3361,8 +3362,8 @@ def test_gitlink_apply_no_changes_payload_in_intent_signature():
 def test_gitlink_request_and_other_kind_request_run_concurrently(monkeypatch):
     """Mirrors the other cross-kind concurrency tests: a Gitlink Run request
     must run concurrently with (neither blocking nor blocked by) a chat/
-    composer request - self._gitlink_requests and self._requests are two
-    genuinely independent slots."""
+    composer request - self._gitlink_requests and self._runs's "chat" kind
+    are two genuinely independent slots."""
     chat_started = threading.Event()
     chat_release = threading.Event()
     gitlink_started = threading.Event()
@@ -3409,12 +3410,12 @@ def test_gitlink_request_and_other_kind_request_run_concurrently(monkeypatch):
         await asyncio.to_thread(chat_started.wait, 5)
         await asyncio.to_thread(gitlink_started.wait, 5)
 
-        assert len(dispatcher._requests) == 1
+        assert len(chat_slots(dispatcher)) == 1
         assert len(dispatcher._gitlink_requests) == 1
         assert notifications.visible is False, "neither call should have been rejected"
 
         chat_release.set()
-        chat_entry = next(iter(dispatcher._requests.values()))
+        chat_entry = next(iter(chat_slots(dispatcher).values()))
         await chat_entry["task"]
         gitlink_release.set()
         gitlink_entry = next(iter(dispatcher._gitlink_requests.values()))
@@ -3422,7 +3423,7 @@ def test_gitlink_request_and_other_kind_request_run_concurrently(monkeypatch):
 
         assert chat_replies == ["chat reply"]
         assert len(gitlink_successes) == 1
-        assert dispatcher._requests == {}
+        assert chat_slots(dispatcher) == {}
         assert dispatcher._gitlink_requests == {}
 
     asyncio.run(run())
@@ -4708,7 +4709,7 @@ def test_start_chart_generation_calls_on_success_with_the_parsed_result_then_cle
 
         assert successes == [{"type": "bar", "title": "T", "labels": ["A", "B"], "values": [1, 2]}]
         assert failures == []
-        assert dispatcher._chart_requests == {}
+        assert busy_count(dispatcher, "chart") == 0
         assert notifications.visible is False
 
     asyncio.run(run())
@@ -4763,13 +4764,13 @@ def test_start_chart_generation_second_call_while_in_flight_is_rejected(monkeypa
         assert notifications.visible is True
         assert notifications.msg_type == "info"
         assert notifications.message == "A chart is already being generated."
-        assert len(dispatcher._chart_requests) == 1
+        assert busy_count(dispatcher, "chart") == 1
 
         release.set()
         await first_call_task
 
         assert successes == [{"type": "bar", "title": "T", "labels": ["A"], "values": [1]}]
-        assert dispatcher._chart_requests == {}
+        assert busy_count(dispatcher, "chart") == 0
 
     asyncio.run(run())
 
@@ -4801,7 +4802,7 @@ def test_start_chart_generation_top_level_error_key_calls_on_failure_and_shows_n
 
         assert successes == [], "on_success must never be called on a top-level error-key response"
         assert failures == ["Could not find sufficient data to generate a bar chart."]
-        assert dispatcher._chart_requests == {}
+        assert busy_count(dispatcher, "chart") == 0
         assert notifications.visible is True
         assert notifications.msg_type == "error"
         assert notifications.message == (
@@ -4837,9 +4838,82 @@ def test_start_chart_generation_timeout_fires_the_exact_message_and_clears_the_s
 
         assert successes == []
         assert len(failures) == 1 and "stopped responding" in failures[0]
-        assert dispatcher._chart_requests == {}, "the slot must not leak/deadlock future requests"
+        assert busy_count(dispatcher, "chart") == 0, "the slot must not leak/deadlock future requests"
         assert notifications.visible is True
         assert notifications.msg_type == "error"
+
+    asyncio.run(run())
+
+
+def test_chart_request_and_chat_request_run_concurrently_both_busy(monkeypatch):
+    """ADR-002 stage 2.3 regression guard: chat and chart now claim into
+    the SAME self._runs registry (previously two fully disjoint dicts),
+    so this isolation is no longer structural by construction - it
+    depends entirely on RunRegistry.is_busy()'s kind filter being correct.
+    Mirrors every OTHER cross-kind concurrency test in this file (e.g.
+    test_image_request_and_chat_request_run_concurrently_both_dicts_non_empty
+    above): both must be simultaneously in flight, neither blocking nor
+    blocked by the other, and neither bounced by a busy notification."""
+    chat_started = threading.Event()
+    chat_release = threading.Event()
+    chart_started = threading.Event()
+    chart_release = threading.Event()
+
+    def blocking_chat(task, messages, **kwargs):
+        chat_started.set()
+        chat_release.wait(5)
+        return {"message": {"content": "chat reply"}}
+
+    def blocking_get_response(self, text, chart_type):
+        chart_started.set()
+        chart_release.wait(5)
+        return '{"type": "bar", "title": "T", "labels": ["A"], "values": [1]}'
+
+    _configure_fake_ollama(monkeypatch, blocking_chat)
+    monkeypatch.setattr(agents_module.ChartDataAgent, "get_response", blocking_get_response)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        chat_replies = []
+        chart_successes = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=chat_replies.append,
+        )
+        # start_chart_generation is directly awaited by ITS caller (unlike
+        # chat's fire-and-forget shape) - the test itself schedules it as a
+        # background task to race it against the still-in-flight chat
+        # request, mirroring test_start_chart_generation_second_call_
+        # while_in_flight_is_rejected's own approach above.
+        chart_task = asyncio.create_task(
+            dispatcher.start_chart_generation(
+                bus=bus, notifications_state=notifications, node_id="n1",
+                chart_type="bar", source_text="text", on_success=chart_successes.append,
+                on_failure=lambda message: None,
+            )
+        )
+
+        await asyncio.to_thread(chat_started.wait, 5)
+        await asyncio.to_thread(chart_started.wait, 5)
+
+        # THE key assertion: both are genuinely in flight at the same time -
+        # neither bounced the other with a busy notification.
+        assert len(chat_slots(dispatcher)) == 1
+        assert busy_count(dispatcher, "chart") == 1
+        assert notifications.visible is False, "neither call should have been rejected"
+
+        chat_release.set()
+        chat_entry = next(iter(chat_slots(dispatcher).values()))
+        await chat_entry["task"]
+        chart_release.set()
+        await chart_task
+
+        assert chat_replies == ["chat reply"]
+        assert chart_successes == [{"type": "bar", "title": "T", "labels": ["A"], "values": [1]}]
 
     asyncio.run(run())
 
@@ -4877,7 +4951,7 @@ def test_start_note_generation_takeaway_calls_on_success_then_clears_the_slot(mo
         )
         assert successes == ["Key Takeaway\n\nMain Points:\n• from the source node's text"]
         assert failures == []
-        assert dispatcher._note_requests == {}
+        assert busy_count(dispatcher, "note") == 0
         assert notifications.visible is False
 
     asyncio.run(run())
@@ -4907,7 +4981,7 @@ def test_start_note_generation_rejects_a_second_concurrent_run(monkeypatch):
 
     async def run():
         bus, notifications, dispatcher = _make_note_env()
-        dispatcher._note_requests["already-running"] = True
+        seed = dispatcher._runs.claim("note")
         successes = []
         await dispatcher.start_note_generation(
             bus=bus, notifications_state=notifications, node_id="n1",
@@ -4917,9 +4991,10 @@ def test_start_note_generation_rejects_a_second_concurrent_run(monkeypatch):
         assert successes == [], "the busy guard must not run a second agent"
         assert notifications.visible is True
         assert notifications.msg_type == "info"
-        # The pre-existing sentinel must survive - the guard rejects, it
+        # The pre-existing claim must survive - the guard rejects, it
         # must never clear someone else's in-flight slot.
-        assert dispatcher._note_requests == {"already-running": True}
+        assert dispatcher._runs.get(seed.request_id) is seed
+        assert busy_count(dispatcher, "note") == 1
 
     asyncio.run(run())
 
@@ -4938,7 +5013,7 @@ def test_start_note_generation_empty_response_fails_instead_of_creating_a_blank_
         assert successes == [], "an empty agent response must not become a note"
         assert len(failures) == 1
         assert notifications.msg_type == "error"
-        assert dispatcher._note_requests == {}
+        assert busy_count(dispatcher, "note") == 0
 
     asyncio.run(run())
 
@@ -4960,7 +5035,75 @@ def test_start_note_generation_agent_exception_surfaces_and_clears_the_slot(monk
         assert successes == []
         assert "model exploded" in failures[0]
         assert notifications.msg_type == "error"
-        assert dispatcher._note_requests == {}, "the slot must not leak after a failure"
+        assert busy_count(dispatcher, "note") == 0, "the slot must not leak after a failure"
+
+    asyncio.run(run())
+
+
+def test_note_request_and_chat_request_run_concurrently_both_busy(monkeypatch):
+    """ADR-002 stage 2.3 regression guard, note's counterpart to
+    test_chart_request_and_chat_request_run_concurrently_both_busy above -
+    same reasoning: chat and note now claim into the SAME self._runs
+    registry, so this isolation depends entirely on RunRegistry.is_busy()'s
+    kind filter rather than being structural by construction."""
+    chat_started = threading.Event()
+    chat_release = threading.Event()
+    note_started = threading.Event()
+    note_release = threading.Event()
+
+    def blocking_chat(task, messages, **kwargs):
+        chat_started.set()
+        chat_release.wait(5)
+        return {"message": {"content": "chat reply"}}
+
+    def blocking_get_response(self, text):
+        note_started.set()
+        note_release.wait(5)
+        return "Key Takeaway\n\nMain Points:\n• done"
+
+    _configure_fake_ollama(monkeypatch, blocking_chat)
+    monkeypatch.setattr(agents_module.KeyTakeawayAgent, "get_response", blocking_get_response)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        chat_replies = []
+        note_successes = []
+
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=chat_replies.append,
+        )
+        # start_note_generation is directly awaited by ITS caller (same
+        # shape as chart) - schedule it as a background task to race it
+        # against the still-in-flight chat request.
+        note_task = asyncio.create_task(
+            dispatcher.start_note_generation(
+                bus=bus, notifications_state=notifications, node_id="n1",
+                note_kind="takeaway", source_text="x", on_success=note_successes.append,
+                on_failure=lambda message: None,
+            )
+        )
+
+        await asyncio.to_thread(chat_started.wait, 5)
+        await asyncio.to_thread(note_started.wait, 5)
+
+        # THE key assertion: both are genuinely in flight at the same time -
+        # neither bounced the other with a busy notification.
+        assert len(chat_slots(dispatcher)) == 1
+        assert busy_count(dispatcher, "note") == 1
+        assert notifications.visible is False, "neither call should have been rejected"
+
+        chat_release.set()
+        chat_entry = next(iter(chat_slots(dispatcher).values()))
+        await chat_entry["task"]
+        note_release.set()
+        await note_task
+
+        assert chat_replies == ["chat reply"]
+        assert note_successes == ["Key Takeaway\n\nMain Points:\n• done"]
 
     asyncio.run(run())
 
@@ -5021,7 +5164,7 @@ def test_start_branch_comparison_does_not_share_a_busy_slot_with_note_generation
 
     async def run():
         bus, notifications, dispatcher = _make_note_env()
-        dispatcher._note_requests["unrelated-takeaway"] = True
+        dispatcher._runs.claim("note")
         successes = []
         await dispatcher.start_branch_comparison(
             bus=bus, notifications_state=notifications, source_text="x",

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from backend import BACKEND_VERSION
 from backend.app import create_app
 from backend.session_context import get_session_context
+from backend.tests.conftest import chat_slots
 
 # R7.2: api_provider/graphlink_task_config sit at the repo root, a sibling
 # of backend/ - already importable, no ordering constraint.
@@ -178,7 +179,7 @@ def test_disconnect_cancels_any_in_flight_chat_request(monkeypatch):
         assert call_started.is_set(), "fake_chat never started - dispatch did not fire"
 
         session = client.app.state.bus.session("cancel-test")
-        in_flight = list(get_session_context(session).agent_dispatcher._requests.values())
+        in_flight = list(chat_slots(get_session_context(session).agent_dispatcher).values())
         assert len(in_flight) == 1
         cancel_event = in_flight[0]["cancel_event"]
         assert not cancel_event.is_set()

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -37,6 +37,7 @@ from backend.attachments import StagedAttachment
 from backend.composer import ComposerDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
+from backend.tests.conftest import chat_slots
 
 import api_provider
 import graphlink_task_config as task_config
@@ -920,7 +921,7 @@ def test_send_conversation_message_intent_dispatches_a_real_agent_reply():
             assert rows[node_id]["pendingRequestId"] == document.nodes[node_id].pending_request_id
 
             release.set()
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assert document.nodes[node_id].history == [
@@ -960,7 +961,7 @@ def test_send_conversation_message_reply_with_code_fence_lands_raw_and_unparsed(
             await bus.dispatch_intent(
                 "scene", "sendConversationMessage", [node_id, "show me some code"]
             )
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assert document.nodes[node_id].history == [
@@ -1324,7 +1325,7 @@ def test_regenerate_response_intent_mutates_the_existing_node_in_place_not_a_new
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["hi"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
@@ -1339,7 +1340,7 @@ def test_regenerate_response_intent_mutates_the_existing_node_in_place_not_a_new
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", regenerated_reply):
             returned_id = await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assert returned_id == assistant_node.id, "the same node id, never a new node"
@@ -1366,7 +1367,7 @@ def test_regenerate_response_sets_output_and_context_tokens_and_publishes_token_
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             await bus.dispatch_intent("scene", "sendMessage", ["hi there"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.is_user is False)
@@ -1379,7 +1380,7 @@ def test_regenerate_response_sets_output_and_context_tokens_and_publishes_token_
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", regenerated_reply):
             await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assert bus.token_counter.output_tokens == estimate_tokens("a fresh regenerated reply")
@@ -1408,7 +1409,7 @@ def test_regenerate_response_does_not_stream_unlike_an_ordinary_send():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["hi"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
@@ -1422,7 +1423,7 @@ def test_regenerate_response_does_not_stream_unlike_an_ordinary_send():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", regenerated_reply):
             await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         stream_frames = [m for m in recorder.messages if m.get("kind") == "stream"]
@@ -1444,7 +1445,7 @@ def test_regenerate_response_replaces_code_child_not_accumulates():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["write code"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
@@ -1458,7 +1459,7 @@ def test_regenerate_response_replaces_code_child_not_accumulates():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", second_reply):
             await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         code_nodes = [n for n in document.nodes.values() if n.kind == "code"]
@@ -1480,7 +1481,7 @@ def test_regenerate_response_document_and_image_children_torn_down_but_never_rec
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["attach files"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
@@ -1497,7 +1498,7 @@ def test_regenerate_response_document_and_image_children_torn_down_but_never_rec
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", plain_reply):
             await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assert document_node.id not in document.nodes
@@ -1575,7 +1576,7 @@ def test_send_with_a_staged_image_produces_real_multimodal_content_parts():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", capture_reply):
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["what is this?"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         user_node = document.nodes[user_id]
@@ -1619,7 +1620,7 @@ def test_send_with_a_staged_document_merges_extracted_text_into_plain_content():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", capture_reply):
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["please review"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         user_node = document.nodes[user_id]
@@ -1656,7 +1657,7 @@ def test_send_republishes_app_composer_immediately_so_staged_chips_clear_on_send
             composer_publishes = [m for m in recorder.messages if m.get("topic") == "app-composer"]
             assert composer_publishes, "send_message must republish app-composer synchronously, before the reply"
             assert composer_publishes[-1]["payload"]["context"]["items"] == []
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
     asyncio.run(run())
@@ -1674,7 +1675,7 @@ def test_regenerate_response_empty_reply_keeps_original_content_and_notifies():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["show me code"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
@@ -1689,7 +1690,7 @@ def test_regenerate_response_empty_reply_keeps_original_content_and_notifies():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", empty_reply):
             await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assert document.nodes[assistant_node.id].content == "Here's code:", "original content is kept"
@@ -1716,7 +1717,7 @@ def test_regenerate_response_reasoning_only_reply_uses_generated_content_not_rea
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["think about it"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
@@ -1729,7 +1730,7 @@ def test_regenerate_response_reasoning_only_reply_uses_generated_content_not_rea
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", reasoning_only_reply):
             await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         # The critical differentiator: regenerate's ternary is 1-way, unlike
@@ -1758,7 +1759,7 @@ def test_regenerate_response_node_deleted_mid_flight_is_a_silent_noop():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["hi"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
@@ -1782,7 +1783,7 @@ def test_regenerate_response_node_deleted_mid_flight_is_a_silent_noop():
             document.remove_nodes([assistant_node.id])
 
             release.set()
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assert assistant_node.id not in document.nodes
@@ -1799,7 +1800,7 @@ def test_regenerate_response_unknown_node_id_shows_notification_not_a_crash():
         result = await bus.dispatch_intent("scene", "regenerateResponse", ["ghost"])
 
         assert result is None
-        assert dispatcher._requests == {}, "no dispatch was ever scheduled"
+        assert chat_slots(dispatcher) == {}, "no dispatch was ever scheduled"
         notice = await bus.publish("notification")
         assert notice["visible"] is True
         assert notice["msgType"] == "warning"
@@ -1820,7 +1821,7 @@ def test_regenerate_response_shares_the_single_in_flight_guard():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["hi"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
@@ -1840,20 +1841,20 @@ def test_regenerate_response_shares_the_single_in_flight_guard():
             # Occupy the single in-flight slot with an ordinary sendMessage.
             await bus.dispatch_intent("scene", "sendMessage", ["second message"])
             await asyncio.to_thread(started.wait, 5)
-            assert len(dispatcher._requests) == 1
+            assert len(chat_slots(dispatcher)) == 1
 
             returned = await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
             # Validation (a real chat node with a parent) still succeeds - the
             # guard lives one layer deeper, inside AgentDispatcher._dispatch.
             assert returned == assistant_node.id
-            assert len(dispatcher._requests) == 1, "still just the original sendMessage in flight"
+            assert len(chat_slots(dispatcher)) == 1, "still just the original sendMessage in flight"
 
             notice = await bus.publish("notification")
             assert notice["visible"] is True
             assert notice["message"] == "A response is already being generated."
 
             release.set()
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
     asyncio.run(run())
@@ -1877,7 +1878,7 @@ def test_regenerate_response_of_a_non_tip_node_leaves_last_chat_node_id_untouche
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             user1_id = await bus.dispatch_intent("scene", "sendMessage", ["first"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         old_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user1_id)
@@ -1890,7 +1891,7 @@ def test_regenerate_response_of_a_non_tip_node_leaves_last_chat_node_id_untouche
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", second_reply):
             await bus.dispatch_intent("scene", "sendMessage", ["second"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         tip_id = document.last_chat_node_id
@@ -1904,7 +1905,7 @@ def test_regenerate_response_of_a_non_tip_node_leaves_last_chat_node_id_untouche
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", regenerated_reply):
             await bus.dispatch_intent("scene", "regenerateResponse", [old_node.id])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assert document.last_chat_node_id == tip_id, \
@@ -1918,8 +1919,8 @@ def test_regenerate_response_shares_the_single_in_flight_guard_in_reverse():
     # Mirror of test_regenerate_response_shares_the_single_in_flight_guard:
     # this occupies the slot with a regenerateResponse first, then asserts a
     # concurrent ordinary sendMessage is bounced. Both directions exercise
-    # the exact same AgentDispatcher._dispatch guard (`if self._requests:`),
-    # caller-agnostic - see backend/tests/test_agents.py's own cross-channel
+    # the exact same AgentDispatcher._dispatch guard (`if self._runs.is_busy
+    # ("chat"):`), caller-agnostic - see backend/tests/test_agents.py's own cross-channel
     # guard tests for the underlying primitive this is layered on top of.
     async def run():
         bus, document, recorder, dispatcher = make_bus_with_dispatcher()
@@ -1932,7 +1933,7 @@ def test_regenerate_response_shares_the_single_in_flight_guard_in_reverse():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["hi"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.id != user_id)
@@ -1952,21 +1953,21 @@ def test_regenerate_response_shares_the_single_in_flight_guard_in_reverse():
             # Occupy the single in-flight slot with a regenerateResponse this time.
             await bus.dispatch_intent("scene", "regenerateResponse", [assistant_node.id])
             await asyncio.to_thread(started.wait, 5)
-            assert len(dispatcher._requests) == 1
+            assert len(chat_slots(dispatcher)) == 1
 
             returned = await bus.dispatch_intent("scene", "sendMessage", ["second message"])
             # sendMessage's own domain mutation (a new user ChatNode) still
             # happens unconditionally - the guard lives one layer deeper,
             # inside AgentDispatcher._dispatch, same as the forward direction.
             assert returned is not None
-            assert len(dispatcher._requests) == 1, "still just the original regenerateResponse in flight"
+            assert len(chat_slots(dispatcher)) == 1, "still just the original regenerateResponse in flight"
 
             notice = await bus.publish("notification")
             assert notice["visible"] is True
             assert notice["message"] == "A response is already being generated."
 
             release.set()
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
     asyncio.run(run())
@@ -2116,7 +2117,7 @@ def test_send_message_intent_dispatches_a_real_agent_reply():
             # The reply lands inside a scheduled (not awaited) background
             # task - grab it from the dispatcher's registry and await it
             # directly rather than assuming the intent itself blocks for it.
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assert document.nodes[node_id].content == "what is this graph about?"
@@ -2147,10 +2148,10 @@ def test_send_message_intent_with_branch_from_node_id_overrides_the_parent():
             return {"message": {"content": "reply"}}
 
         async def send(text, *extra_args):
-            pending_before = set(dispatcher._requests.keys())
+            pending_before = set(chat_slots(dispatcher).keys())
             node_id = await bus.dispatch_intent("scene", "sendMessage", [text, *extra_args])
-            new_request_id = next(iter(set(dispatcher._requests.keys()) - pending_before))
-            await dispatcher._requests[new_request_id]["task"]
+            new_request_id = next(iter(set(chat_slots(dispatcher).keys()) - pending_before))
+            await chat_slots(dispatcher)[new_request_id]["task"]
             return node_id
 
         with patch.object(api_provider, "USE_API_MODE", False), \
@@ -2220,7 +2221,7 @@ def test_send_message_sets_output_tokens_from_the_reply_and_publishes_token_coun
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", fake_chat):
             await bus.dispatch_intent("scene", "sendMessage", ["hello there"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assert bus.token_counter.output_tokens == estimate_tokens("four word reply here")
@@ -2247,7 +2248,7 @@ def test_send_message_sets_context_tokens_from_prior_history_not_the_new_message
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", first_reply):
             await bus.dispatch_intent("scene", "sendMessage", ["first message"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         def second_reply(task, messages, **kwargs):
@@ -2293,7 +2294,7 @@ def test_send_message_reply_that_is_genuinely_empty_creates_no_assistant_node():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", fake_chat):
             node_id = await bus.dispatch_intent("scene", "sendMessage", ["hello"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         reply_nodes = [n for n in document.nodes.values() if n.id != node_id]
@@ -2319,7 +2320,7 @@ def test_send_message_reply_with_code_fence_creates_code_child_and_edge():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", fake_chat):
             user_node_id = await bus.dispatch_intent("scene", "sendMessage", ["write me a hello world"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_nodes = [
@@ -2360,7 +2361,7 @@ def test_send_message_reply_that_is_only_thinking_uses_reasoning_placeholder():
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", fake_chat):
             user_node_id = await bus.dispatch_intent("scene", "sendMessage", ["what are you thinking?"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_nodes = [
@@ -2409,7 +2410,7 @@ def test_send_message_reply_with_thinking_text_and_code_creates_both_children_on
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", fake_chat):
             user_node_id = await bus.dispatch_intent("scene", "sendMessage", ["plan it out"])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         assistant_nodes = [
@@ -6432,7 +6433,7 @@ def test_total_session_tokens_starts_at_zero_and_grows_after_send_message_and_re
                 patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
                 patch.object(api_provider, "chat", fake_chat):
             await bus.dispatch_intent("scene", "sendMessage", [user_text])
-            entry = next(iter(dispatcher._requests.values()))
+            entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
         expected = estimate_tokens(user_text) + estimate_tokens(reply_text)

--- a/backend/tests/test_dispatch_claim_ordering.py
+++ b/backend/tests/test_dispatch_claim_ordering.py
@@ -1,0 +1,94 @@
+"""ADR-002 stage 2.3: a permanent static gate on AgentDispatcher._dispatch's
+claim ordering.
+
+Risk #1 from the stage 2.3 design review: the registry claim
+(`self._runs.claim("chat", ...)`) must happen in the SAME synchronous
+stretch as the `is_busy("chat")` pre-check, with zero `await` in between -
+see backend/run_lifecycle.py's own docstring for why. This is a real
+invariant, but it is NOT meaningfully provable with a dynamic race test:
+asyncio coroutines only yield control at an `await` expression, so as long
+as that stretch genuinely contains none, two concurrently-scheduled
+`_dispatch()` calls cannot interleave there no matter how a test tries to
+race them - there is no scheduler-level "unlucky timing" to trigger.
+(Confirmed directly: temporarily inserting a real `await asyncio.sleep(0)`
+between the two did NOT make the existing
+test_rapid_fire_double_send_same_session_second_is_rejected fail, because
+that test calls the two dispatches sequentially, each one's whole
+synchronous prefix completing atomically before the next begins - it
+already can't observe this cross-await interleaving hazard.) The only
+regression that could ever violate this is a future EDIT adding an
+`await` in that stretch - a static property, checked statically here,
+the same AST-based-permanent-gate approach as tests/test_domain_purity.py.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+AGENTS_PY = Path(__file__).resolve().parents[1] / "agents.py"
+
+
+def _find_dispatch_method():
+    tree = ast.parse(AGENTS_PY.read_text(encoding="utf-8"), filename=str(AGENTS_PY))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "AgentDispatcher":
+            for item in node.body:
+                if isinstance(item, ast.AsyncFunctionDef) and item.name == "_dispatch":
+                    return item
+    raise AssertionError("AgentDispatcher._dispatch not found - did it move or get renamed?")
+
+
+def _statement_calls(stmt, attr_name: str) -> bool:
+    return any(
+        isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute) and n.func.attr == attr_name
+        for n in ast.walk(stmt)
+    )
+
+
+def _awaits_reaching_claim(statements):
+    """Collects every `ast.Await` that lies on a control-flow path capable
+    of reaching code AFTER `statements` (i.e. the claim) - skipping the
+    body of an `if <cond>: ...; return` block with no `else`, since EVERY
+    path through that specific shape either exits immediately (the
+    `await`, if any, inside it never precedes a claim - the caller
+    returned) or never entered the block at all (condition was false, no
+    statements ran)."""
+    offenders = []
+    for stmt in statements:
+        if isinstance(stmt, ast.If) and not stmt.orelse and stmt.body and isinstance(stmt.body[-1], (ast.Return, ast.Raise)):
+            continue
+        offenders.extend(n for n in ast.walk(stmt) if isinstance(n, ast.Await))
+    return offenders
+
+
+def test_no_await_between_the_chat_busy_check_and_the_registry_claim():
+    dispatch = _find_dispatch_method()
+    body = dispatch.body
+
+    busy_check_index = next(
+        (i for i, stmt in enumerate(body) if isinstance(stmt, ast.If) and _statement_calls(stmt.test, "is_busy")),
+        None,
+    )
+    claim_index = next((i for i, stmt in enumerate(body) if _statement_calls(stmt, "claim")), None)
+
+    assert busy_check_index is not None, "no `if ...is_busy(...):` guard found in _dispatch - did the guard move?"
+    assert claim_index is not None, "no `...claim(...)` call found in _dispatch - did the claim move?"
+    assert busy_check_index < claim_index, "the busy check must precede the claim, not follow it"
+
+    # Both boundary statements are included, not just what lies strictly
+    # between them - an `await` written directly on the busy-check or the
+    # claim statement itself (e.g. a future edit turning `claim(...)` into
+    # `await claim(...)`) must be caught too. Safe to include the
+    # busy-check's own `If`: it matches _awaits_reaching_claim's own
+    # "if ...: ...; return" exemption for the same reason the
+    # is_configured() guard below it does, so it is correctly skipped
+    # rather than double-flagging that check's own early-return await.
+    between = body[busy_check_index : claim_index + 1]
+    offenders = [f"line {n.lineno}" for n in _awaits_reaching_claim(between)]
+    assert not offenders, (
+        "an `await` was found on a path between _dispatch's chat busy-check and its registry "
+        f"claim (at {', '.join(offenders)}) - this reopens the exact concurrent-double-admit "
+        "race RunRegistry.claim()'s synchronous-by-design contract exists to close. See this "
+        "test module's own docstring, and backend/run_lifecycle.py's."
+    )

--- a/backend/tests/test_run_lifecycle.py
+++ b/backend/tests/test_run_lifecycle.py
@@ -1,0 +1,142 @@
+"""ADR-002 stage 2.3: RunHandle/RunRegistry, the primitive replacing 3 of
+AgentDispatcher's 12 independent in-flight-request dicts (chat/
+conversation, chart, note - see backend/run_lifecycle.py's own docstring).
+
+run_single_shot (the shared chart/note skeleton) is deliberately NOT
+covered by a separate unit-test suite here: its only two callers,
+start_chart_generation and start_note_generation, already exercise every
+one of its branches (busy/success/validate-fail/timeout/exception) end to
+end in backend/tests/test_agents.py, including exact message-string
+assertions - a second, isolated suite would just re-test the same
+branches through a fake bus/registry with no additional signal. This file
+covers what only the registry itself can prove: claim/release bookkeeping,
+kind-scoped busy checks, and cancel semantics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from backend.run_lifecycle import RunHandle, RunRegistry
+
+
+def test_claim_returns_a_handle_with_a_fresh_uuid4_request_id():
+    registry = RunRegistry()
+    handle = registry.claim("chat")
+    assert isinstance(handle, RunHandle)
+    assert handle.kind == "chat"
+    assert handle.request_id
+    other = registry.claim("chat")
+    assert other.request_id != handle.request_id
+
+
+def test_is_busy_is_false_before_any_claim():
+    registry = RunRegistry()
+    assert registry.is_busy("chat") is False
+
+
+def test_is_busy_is_true_after_a_claim_of_that_kind():
+    registry = RunRegistry()
+    registry.claim("chart")
+    assert registry.is_busy("chart") is True
+
+
+def test_is_busy_is_scoped_per_kind_not_global():
+    registry = RunRegistry()
+    registry.claim("chart")
+    assert registry.is_busy("note") is False, "an in-flight chart run must not read as a busy note slot"
+    assert registry.is_busy("chat") is False
+
+
+def test_claim_captures_node_id_purely_for_introspection():
+    registry = RunRegistry()
+    handle = registry.claim("chart", node_id="n-42")
+    assert handle.node_id == "n-42"
+    # node_id is NEVER part of the busy-check key - every pilot's guard is
+    # session-wide, not per-node (see this module's own docstring).
+    assert registry.is_busy("chart") is True
+
+
+def test_release_removes_the_handle_and_clears_is_busy():
+    registry = RunRegistry()
+    handle = registry.claim("note")
+    registry.release(handle.request_id)
+    assert registry.is_busy("note") is False
+    assert registry.get(handle.request_id) is None
+
+
+def test_release_of_an_unknown_request_id_is_a_safe_noop():
+    registry = RunRegistry()
+    registry.release("never-claimed")  # must not raise
+
+
+def test_get_returns_the_claimed_handle():
+    registry = RunRegistry()
+    handle = registry.claim("chat")
+    assert registry.get(handle.request_id) is handle
+
+
+def test_get_returns_none_for_an_unknown_request_id():
+    registry = RunRegistry()
+    assert registry.get("never-claimed") is None
+
+
+def test_cancel_sets_the_cancel_event_and_returns_true():
+    registry = RunRegistry()
+    cancel_event = threading.Event()
+    handle = registry.claim("chat", cancel_event=cancel_event)
+    assert registry.cancel(handle.request_id) is True
+    assert cancel_event.is_set()
+
+
+def test_cancel_returns_false_for_an_unknown_request_id():
+    registry = RunRegistry()
+    assert registry.cancel("never-claimed") is False
+
+
+def test_cancel_returns_false_for_a_handle_with_no_cancel_event():
+    # chart/note's own shape - no cancellation checkpoint of their own,
+    # see backend/run_lifecycle.py's own docstring.
+    registry = RunRegistry()
+    handle = registry.claim("chart")
+    assert registry.cancel(handle.request_id) is False
+
+
+def test_cancel_all_trips_every_cancel_event_and_skips_handles_without_one():
+    registry = RunRegistry()
+    chat_cancel = threading.Event()
+    registry.claim("chat", cancel_event=chat_cancel)
+    chart_handle = registry.claim("chart")  # no cancel_event
+
+    registry.cancel_all()  # must not raise on the cancel_event-less handle
+
+    assert chat_cancel.is_set()
+    assert registry.get(chart_handle.request_id) is not None, "cancel_all() must not release anything"
+
+
+def test_cancel_all_on_an_empty_registry_is_a_safe_noop():
+    RunRegistry().cancel_all()  # must not raise
+
+
+def test_attach_task_stores_the_task_without_touching_the_registry():
+    async def _noop():
+        return None
+
+    async def run():
+        registry = RunRegistry()
+        handle = registry.claim("chat")
+        task = asyncio.create_task(_noop())
+        registry.attach_task(handle, task)
+        assert handle.task is task
+        assert registry.get(handle.request_id) is handle
+        await task
+
+    asyncio.run(run())
+
+
+def test_values_lists_every_claimed_handle_regardless_of_kind():
+    registry = RunRegistry()
+    a = registry.claim("chat")
+    b = registry.claim("chart")
+    assert {h.request_id for h in registry.values()} == {a.request_id, b.request_id}


### PR DESCRIPTION
## Problem

AgentDispatcher (backend/agents.py) had grown 12 independent in-flight-request dicts across its 13 dispatch surfaces, one added per feature increment. Each hand-copied the same guard/claim/timeout/cleanup shape with small, undocumented variations. This left two real gaps:

- `cancel_all()` only ever walked one of the twelve dicts (chat). A client that disconnects mid-flight on any of the other eleven surfaces leaves that call running server-side, untethered, until its own watchdog timeout.
- The duplicated skeleton meant every future fix to guard/timeout/cleanup behavior had to be applied in up to 13 places by hand.

## Change

Adds `backend/run_lifecycle.py`: `RunHandle`/`RunRegistry`, a single shared claim/release/cancel/cancel_all/is_busy registry, plus `run_single_shot()`, a skeleton shared by the two structurally-identical "directly-awaited, single combined create+generate action" surfaces.

Migrates the 3 pilot surfaces named in ADR-002 onto it:
- **chat/conversation** (`AgentDispatcher._dispatch`, shared by `start_chat_reply`/`start_conversation_reply`) - fire-and-forget, claims synchronously before scheduling a background task.
- **chart** (`start_chart_generation`) - directly awaited, migrated onto `run_single_shot()`.
- **note** (`start_note_generation`) - directly awaited, migrated onto `run_single_shot()`.

The remaining 9 surfaces (image, web research, artifact, gitlink x2, pycoder, code sandbox, branch comparison, branch synthesis) deliberately keep their own dicts for now - several have real per-kind shape differences (approval futures, cancellation tokens, no-cancel-at-all) that deserve their own migration pass, deferred to ADR-002 stage 2.4.

Every notification/exception message string for chart and note is preserved byte-for-byte - verified branch by branch (busy/success/validate-fail/timeout/exception) against the pre-migration code, including an intentional asymmetry in chart's error-key branch (raw text to the callback, a prefixed string to the toast).

The claim-before-schedule ordering that prevents a concurrent double-admit is enforced by a permanent AST-based test (`test_dispatch_claim_ordering.py`), not a dynamic race test - asyncio only preempts at `await` points, so a dynamic test structurally cannot observe this hazard; only a static check on the actual code shape can. This was proven directly: a real mutation (inserting an `await` at the claim site) was confirmed to slip past the pre-existing sequential-call test and be caught by the new AST gate, then reverted.

~130 existing test call sites that reached into the old dicts directly (`dispatcher._requests`, `_chart_requests`, `_note_requests`) were rewritten against two small test-only adapters in `conftest.py` (`chat_slots`, `busy_count`). Two new tests prove chat and chart/note no longer share a busy slot now that they claim into the same registry - this isolation was structural by dict-separation before, and now depends on `RunRegistry.is_busy()`'s kind filter; both new tests were mutation-tested to confirm they'd actually catch a kind-isolation regression.

This change went through an adversarial multi-reviewer pass; all confirmed findings (a stale docstring reference, a blind spot in the AST gate's own scan boundary, and the two missing cross-kind concurrency tests) were fixed and re-verified before this PR.

## Test plan

- [x] Full suite (`python -m pytest -q` from repo root): 1206 passed
- [x] New `backend/tests/test_run_lifecycle.py` - 16 unit tests for `RunHandle`/`RunRegistry`
- [x] New `backend/tests/test_dispatch_claim_ordering.py` - permanent AST gate, mutation-tested (both at the general ordering level and at its own scan-boundary blind spot)
- [x] New cross-kind concurrency tests proving chat/chart and chat/note stay mutually non-blocking, mutation-tested
- [x] Every rewritten test call site re-verified to preserve original assertion intent