### PR TITLE
ADR-002 stage 2.5 (PR1/~16, backend-only): node-state foundation + image pilot migration

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -85,6 +85,7 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
+from backend.domain.node_states import ImageState
 
 
 

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -84,6 +84,7 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
+from backend.domain.node_states import ImageState
 
 
 def _estimate_tokens(text: str) -> int:
@@ -140,7 +141,8 @@ class SceneDocument(BranchOps, GroupOps):
     # already in.
     final_deliverable_node_id: str | None = None
     # R3.21: in-memory, session-scoped store for image-node bytes, keyed by
-    # asset id (see SceneNode.image_asset_id) -> (raw_bytes, mime_type).
+    # asset id (see backend/domain/node_states.py's ImageState.image_asset_id,
+    # ADR-002 stage 2.5) -> (raw_bytes, mime_type).
     # TRANSPORT DECISION: images travel to the client via a dedicated GET
     # /api/assets/{id} HTTP route (backend/assets.py), NEVER inlined into
     # scene_payload(). scene_payload() resends every node on every
@@ -526,7 +528,7 @@ class SceneDocument(BranchOps, GroupOps):
             title=title,
             kind="image",
             content=str(prompt),
-            image_asset_id=asset_id,
+            state=ImageState(image_asset_id=asset_id),
         )
         self.nodes[node_id] = node
         self.connect(parent_id, node_id)
@@ -1584,8 +1586,15 @@ class SceneDocument(BranchOps, GroupOps):
                 # R3.21: an image node's bytes must not outlive the node -
                 # evict its image_assets entry too, or a long session's
                 # deleted images would accumulate in memory forever.
-                if node.image_asset_id:
-                    self.image_assets.pop(node.image_asset_id, None)
+                # ADR-002 stage 2.5: image_asset_id lives on node.state now
+                # (ImageState), not directly on SceneNode - getattr rather
+                # than a `node.kind == "image"` check since node.state is
+                # None for every non-image kind (nothing to evict either
+                # way), same duck-typed posture as this file's other
+                # cross-kind scans.
+                image_asset_id = getattr(node.state, "image_asset_id", None)
+                if image_asset_id:
+                    self.image_assets.pop(image_asset_id, None)
                 # R6.2: a chart node's rendered PNG lives in the SAME
                 # image_assets dict (reused, not a parallel store - see
                 # chart_asset_id's own field comment on SceneNode) - same
@@ -1679,7 +1688,7 @@ class SceneDocument(BranchOps, GroupOps):
                     "byteSize": n.byte_size,
                     "previewLabel": n.preview_label,
                     "isDocked": n.is_docked,
-                    "imageAssetId": n.image_asset_id,
+                    "imageAssetId": n.state.image_asset_id if isinstance(n.state, ImageState) else "",
                     "history": [
                         {"role": m["role"], "content": m["content"]} for m in n.history
                     ],

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from backend.domain.node_states import NodeState
+
 # Dark-theme grid swatches. The Qt bridge derived 3 of 5 from the live
 # QPalette; the backend is Qt-free by law (test_no_qt_anywhere.py), so until
 # the R2 theme service exists these are the dark theme's actual values,
@@ -228,11 +230,6 @@ class SceneNode:
     # time from this flag (scan nodes whose parent edge points at it), never
     # stored on the parent itself. Unused (default) for every other kind.
     is_docked: bool = False
-    # R3.21 (doc/QT_REMOVAL_PLAN.md): the image node's real persisted shape -
-    # an opaque reference key into SceneDocument.image_assets. Image bytes
-    # never live on the node itself (see the transport-decision comment on
-    # image_assets below). Unused (default) for every other kind.
-    image_asset_id: str = ""
     # R3.25 (doc/QT_REMOVAL_PLAN.md): the ConversationNode's real persisted
     # shape - graphlink_conversation_node.py's conversation_history, a
     # growing list of {"role": "user"|"assistant", "content": text} dicts
@@ -246,8 +243,8 @@ class SceneNode:
     # marker - the id of the AgentDispatcher request currently generating a
     # reply for this node, or None when idle. Generic across any kind that
     # ever gets its own real dispatch slot (not conversation-only, the same
-    # way is_docked/image_asset_id are generic fields even though today only
-    # one kind populates them); unused (default None) for every other kind.
+    # way is_docked is a generic field even though today only one kind
+    # populates it); unused (default None) for every other kind.
     pending_request_id: str | None = None
     # ADR-002 Workstream 1 ("Synthesize Branches"): the provider/model that
     # produced this node's content, e.g. "Anthropic Claude" / "claude-sonnet-5"
@@ -661,6 +658,12 @@ class SceneNode:
     # exists) - this is purely the data-model capability so R6.4's session
     # loader has somewhere to put it when an OLD saved session has it.
     content_parts: list[dict[str, Any]] | None = None
+    # ADR-002 stage 2.5 (backend-only): the typed per-kind payload - see
+    # backend/domain/node_states.py's own docstring. None for a kind not
+    # yet migrated, or for a kind (placeholder/thinking/conversation) that
+    # has no kind-specific fields at all; otherwise the NodeState subclass
+    # matching this node's own kind (e.g. ImageState for kind="image").
+    state: NodeState | None = None
 
 
 @dataclass

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -1,0 +1,38 @@
+"""ADR-002 stage 2.5 (backend-only): typed per-kind SceneNode state.
+
+SceneNode used to carry all ~95 fields for every one of its 16 kinds
+regardless of which kind actually used them. This module holds one
+dataclass per kind - only the fields that kind actually uses - attached to
+SceneNode.state. Migration proceeds kind-by-kind (see each state class's
+own relocation note); a kind not yet migrated still keeps its fields
+directly on SceneNode.
+
+Wire-compatibility constraint: SceneDocument.scene_payload() must keep
+emitting the exact same flat per-node shape it does today. This module
+introduces no wire-layer change by itself - it only relocates where a
+field lives in memory; scene_payload's own per-kind read expressions are
+updated in lockstep with each kind's migration, in backend/domain/graph.py.
+
+kind values with no state class (no kind-specific fields at all, so
+node.state stays None for them permanently): placeholder, thinking,
+conversation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class NodeState:
+    """Marker base for all per-kind node state payloads."""
+
+
+@dataclass
+class ImageState(NodeState):
+    """Relocated verbatim from SceneNode.image_asset_id (former
+    backend/domain/model.py field, R3.21) - the opaque reference key into
+    SceneDocument.image_assets. See that dict's own docstring for the
+    transport-decision reasoning (image bytes never live on the node
+    itself)."""
+
+    image_asset_id: str = ""

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -184,7 +184,14 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from backend.canvas import SceneDocument, SceneNode, SUPPORTED_CHART_TYPES, _content_codec, _placeholder_chart_data
+from backend.canvas import (
+    ImageState,
+    SceneDocument,
+    SceneNode,
+    SUPPORTED_CHART_TYPES,
+    _content_codec,
+    _placeholder_chart_data,
+)
 from graphlink_chart_data import ChartDataError, canonicalize_chart_data
 from graphlink_navigation_pins import NavigationPinRecord
 
@@ -396,7 +403,7 @@ def _restore_image_payload(payload: dict[str, Any], document: SceneDocument) -> 
     import uuid as _uuid
 
     x, y = _position(payload)
-    node = SceneNode(id="", x=x, y=y, title="Image", kind="image")
+    node = SceneNode(id="", x=x, y=y, title="Image", kind="image", state=ImageState())
     raw_b64 = payload.get("image_bytes")
     if isinstance(raw_b64, str) and raw_b64:
         try:
@@ -406,7 +413,7 @@ def _restore_image_payload(payload: dict[str, Any], document: SceneDocument) -> 
         if image_bytes:
             asset_id = f"img{_uuid.uuid4().hex}"
             document.image_assets[asset_id] = (image_bytes, "image/png")
-            node.image_asset_id = asset_id
+            node.state.image_asset_id = asset_id
     node.content = str(payload.get("prompt", ""))
     return node
 

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -232,7 +232,7 @@ def _serialize_document_node(node: SceneNode) -> dict[str, Any]:
 
 
 def _serialize_image_node(node: SceneNode, document: SceneDocument) -> dict[str, Any]:
-    asset = document.image_assets.get(node.image_asset_id)
+    asset = document.image_assets.get(node.state.image_asset_id)
     image_bytes = asset[0] if asset is not None else b""
     return {
         "node_type": "image",

--- a/backend/tests/test_assets.py
+++ b/backend/tests/test_assets.py
@@ -42,7 +42,7 @@ def test_get_asset_returns_exact_bytes_and_stored_mime_type():
         0, 0, b"\x89PNG\r\n\x1a\nsome raw image bytes", "a test image", parent.id, mime_type="image/png"
     )
 
-    response = client.get(f"/api/assets/{node.image_asset_id}")
+    response = client.get(f"/api/assets/{node.state.image_asset_id}")
 
     assert response.status_code == 200
     assert response.content == b"\x89PNG\r\n\x1a\nsome raw image bytes"
@@ -56,7 +56,7 @@ def test_get_asset_respects_the_mime_type_it_was_stored_with():
     parent = document.add_node(0, 0, "parent")
     node = document.add_image_node(0, 0, b"jpeg-ish bytes", "prompt", parent.id, mime_type="image/jpeg")
 
-    response = client.get(f"/api/assets/{node.image_asset_id}")
+    response = client.get(f"/api/assets/{node.state.image_asset_id}")
 
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/jpeg"
@@ -79,11 +79,11 @@ def test_get_asset_scopes_by_session_query_param():
     node = document_a.add_image_node(0, 0, b"session-a bytes", "prompt", parent.id)
 
     # The default session has no such asset.
-    default_response = client.get(f"/api/assets/{node.image_asset_id}")
+    default_response = client.get(f"/api/assets/{node.state.image_asset_id}")
     assert default_response.status_code == 404
 
     # The session it was actually created under does.
-    scoped_response = client.get(f"/api/assets/{node.image_asset_id}?session=session-a")
+    scoped_response = client.get(f"/api/assets/{node.state.image_asset_id}?session=session-a")
     assert scoped_response.status_code == 200
     assert scoped_response.content == b"session-a bytes"
 
@@ -107,12 +107,12 @@ def test_asset_ids_do_not_collide_across_sessions_with_identical_creation_order(
     parent_b = document_b.add_node(0, 0, "parent")
     node_b = document_b.add_image_node(0, 0, b"session-b bytes", "prompt", parent_b.id)
 
-    assert node_a.image_asset_id != node_b.image_asset_id
+    assert node_a.state.image_asset_id != node_b.state.image_asset_id
 
-    response_a = client.get(f"/api/assets/{node_a.image_asset_id}?session=session-b")
+    response_a = client.get(f"/api/assets/{node_a.state.image_asset_id}?session=session-b")
     assert response_a.status_code == 404
 
-    response_b = client.get(f"/api/assets/{node_b.image_asset_id}?session=session-a")
+    response_b = client.get(f"/api/assets/{node_b.state.image_asset_id}?session=session-a")
     assert response_b.status_code == 404
 
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -596,7 +596,7 @@ def test_add_image_node_creates_a_real_image_kind_node():
     assert node.kind == "image"
     assert node.content == "a cat wearing a hat"
     assert node.title == "a cat wearing a hat"
-    assert node.image_asset_id != ""
+    assert node.state.image_asset_id != ""
     assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
 
 
@@ -611,7 +611,7 @@ def test_add_image_node_stores_the_asset_retrievable_with_correct_bytes_and_mime
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     node = doc.add_image_node(0, 0, b"raw-png-bytes", "prompt", parent.id, mime_type="image/png")
-    asset = doc.get_image_asset(node.image_asset_id)
+    asset = doc.get_image_asset(node.state.image_asset_id)
     assert asset == (b"raw-png-bytes", "image/png")
 
 
@@ -643,7 +643,7 @@ def test_scene_payload_includes_image_asset_id_defaulted_for_other_kinds():
     rows = {n["id"]: n for n in doc.scene_payload()["nodes"]}
     assert rows["n0"]["imageAssetId"] == ""
     assert rows[parent.id]["imageAssetId"] == ""
-    assert rows[image_node.id]["imageAssetId"] == image_node.image_asset_id
+    assert rows[image_node.id]["imageAssetId"] == image_node.state.image_asset_id
     assert rows[image_node.id]["imageAssetId"] != ""
 
 
@@ -651,7 +651,7 @@ def test_image_node_deletion_goes_through_remove_nodes_and_evicts_the_asset():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     node = doc.add_image_node(10, 10, b"doomed bytes", "doomed image", parent.id)
-    asset_id = node.image_asset_id
+    asset_id = node.state.image_asset_id
     assert not hasattr(doc, "delete_image_node"), "image nodes are not branch points - no special delete method"
 
     assert doc.get_image_asset(asset_id) is not None
@@ -672,9 +672,52 @@ def test_non_image_node_deletion_does_not_touch_image_assets():
     doc.remove_nodes([code_node.id])
 
     assert code_node.id not in doc.nodes
-    assert doc.get_image_asset(image_node.image_asset_id) == (b"keep me", "image/png"), (
+    assert doc.get_image_asset(image_node.state.image_asset_id) == (b"keep me", "image/png"), (
         "deleting a node with no image_asset_id must not touch image_assets at all"
     )
+
+
+def test_deleting_one_node_of_every_kind_does_not_raise():
+    """ADR-002 stage 2.5 regression net: remove_nodes() has generic,
+    kind-agnostic cross-kind scans (the image_asset_id/chart_asset_id
+    eviction above being the first two) that used to rely on every
+    SceneNode carrying every kind's fields with a safe default. As fields
+    migrate onto per-kind node.state objects one kind at a time, a scan
+    that isn't updated in lockstep raises AttributeError the moment ANY
+    node of a DIFFERENT kind is deleted - not just that scan's own kind.
+    This creates one node of every real, currently-creatable kind and
+    deletes them all in a single remove_nodes call, so a future migration
+    PR that misses a cross-kind scan fails here immediately, independent
+    of any kind-specific test suite."""
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    frame_member = doc.add_code_node(0, 0, "x = 1", "python", parent_id=parent.id)
+    container_member = doc.add_code_node(0, 0, "y = 2", "python", parent_id=parent.id)
+    nodes = [
+        parent,
+        doc.add_node(0, 0, "placeholder"),
+        doc.add_chat_node(0, 0, "hi", True),
+        frame_member,
+        container_member,
+        doc.add_document_node(0, 0, "doc", "content", "document", parent.id),
+        doc.add_thinking_node(0, 0, "thinking...", parent.id),
+        doc.add_html_node(0, 0, "<p>hi</p>", parent.id),
+        doc.add_image_node(0, 0, b"bytes", "prompt", parent.id),
+        doc.add_conversation_node(0, 0, parent.id),
+        doc.add_web_research_node(0, 0, parent.id),
+        doc.add_artifact_node(0, 0, parent.id),
+        doc.add_gitlink_node(0, 0, parent.id),
+        doc.add_pycoder_node(0, 0, parent.id),
+        doc.add_code_sandbox_node(0, 0, parent.id),
+        doc.add_note(0, 0),
+        doc.add_chart_node(0, 0, parent.id, "bar", {"labels": ["a"], "values": [1.0]}),
+        doc.create_frame([frame_member.id]),
+        doc.create_container([container_member.id]),
+    ]
+
+    doc.remove_nodes([n.id for n in nodes])
+
+    assert doc.nodes == {}
 
 
 def test_add_image_node_intent_creates_a_real_node_and_publishes():
@@ -690,7 +733,7 @@ def test_add_image_node_intent_creates_a_real_node_and_publishes():
         )
         assert document.nodes[node_id].kind == "image"
         assert document.nodes[node_id].content == "a generated image"
-        asset = document.get_image_asset(document.nodes[node_id].image_asset_id)
+        asset = document.get_image_asset(document.nodes[node_id].state.image_asset_id)
         assert asset == (image_bytes, "image/jpeg"), "base64 payload must decode back to the exact original bytes"
         assert any(
             e.source == parent_id and e.target == node_id for e in document.edges.values()
@@ -1286,7 +1329,7 @@ def test_remove_associated_content_children_evicts_image_assets_via_remove_nodes
     doc = SceneDocument()
     chat = doc.add_chat_node(0, 0, "assistant reply", False)
     image_node = doc.add_image_node(10, 10, b"doomed bytes", "prompt", chat.id)
-    asset_id = image_node.image_asset_id
+    asset_id = image_node.state.image_asset_id
     assert doc.get_image_asset(asset_id) is not None
 
     doc.remove_associated_content_children(chat.id)
@@ -2774,7 +2817,7 @@ def test_add_generated_image_reply_gains_exactly_one_image_asset_entry():
     assets_before = dict(doc.image_assets)
     _, new_image_node = doc.add_generated_image_reply(chat.id, "a cat", b"png-bytes", mime_type="image/jpeg")
     assert len(doc.image_assets) == len(assets_before) + 1
-    assert doc.get_image_asset(new_image_node.image_asset_id) == (b"png-bytes", "image/jpeg")
+    assert doc.get_image_asset(new_image_node.state.image_asset_id) == (b"png-bytes", "image/jpeg")
 
 
 def test_add_generated_image_reply_leaves_last_chat_node_id_untouched():
@@ -2903,7 +2946,7 @@ def test_generate_image_intent_full_success_round_trip_creates_two_nodes_and_rep
         new_image = next(n for n in document.nodes.values() if n.kind == "image")
         assert new_chat.content == 'Generated image for prompt: "a cat wearing a hat"'
         assert new_image.content == "a cat wearing a hat"
-        assert document.get_image_asset(new_image.image_asset_id) == (b"real-png-bytes", "image/png")
+        assert document.get_image_asset(new_image.state.image_asset_id) == (b"real-png-bytes", "image/png")
         assert recorder.topics_seen().count("scene") > scene_publishes_before
         assert image_slots(dispatcher) == {}
 
@@ -2927,7 +2970,7 @@ def test_regenerate_image_intent_full_success_round_trip_creates_two_nodes_using
         assert old_image.id in document.nodes
         new_image = next(n for n in document.nodes.values() if n.kind == "image" and n.id != old_image.id)
         assert new_image.content == "a cat"
-        assert document.get_image_asset(new_image.image_asset_id) == (b"new-png-bytes", "image/png")
+        assert document.get_image_asset(new_image.state.image_asset_id) == (b"new-png-bytes", "image/png")
 
     asyncio.run(run())
 

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -1,0 +1,138 @@
+"""ADR-002 stage 2.5 (backend-only) migration gate. Grows one entry per
+kind as each kind's fields move from SceneNode directly onto
+backend/domain/node_states.py's per-kind state classes.
+
+AST-based, same philosophy as tests/test_domain_purity.py: for every field
+name a kind has already migrated, no code anywhere in backend/ or its own
+tests may access that name as a BARE attribute (node.image_asset_id) -
+every access must go through .state (node.state.image_asset_id, or an
+arbitrarily-nested .state.image_asset_id, e.g.
+document.nodes[id].state.image_asset_id). This is the direct proof that a
+migration PR actually finished moving every call site, not just that the
+domain model compiles. Checks both dot-attribute syntax (ast.Attribute)
+and the string-literal equivalent (getattr(node, "image_asset_id", ...) /
+setattr(node, "image_asset_id", ...)) - an adversarial-review finding on
+this same gate's own PR: a walk over ast.Attribute alone can't see a field
+name smuggled in as a getattr/setattr string argument.
+
+test_scene_node_core_field_count (asserting the final <=15-field core
+exactly) is deferred to the stage's own exit PR, once every kind that has
+kind-specific fields has migrated - see backend/domain/node_states.py's
+own docstring for the full kind list and which 3 kinds need no state class
+at all.
+
+test_scene_payload_key_set_is_unchanged_by_the_migration is the wire-
+compat tripwire this whole stage's backend-only constraint depends on:
+scene_payload() is one flat dict literal (backend/domain/graph.py) that
+emits the SAME 86 keys for every node regardless of kind - a golden,
+hardcoded snapshot of that sorted key list, captured pre-migration. As
+long as this test keeps passing, no migration PR has silently added,
+renamed, or dropped a wire key while moving where a field lives in
+memory.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from backend.domain.graph import SceneDocument
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_DIRS = (REPO_ROOT / "backend", REPO_ROOT / "tests")
+
+# Grows by one entry per migration PR. Field names here must NEVER appear
+# as a bare `X.<field>` attribute access anywhere under SCAN_DIRS - only
+# `X.state.<field>` (or a longer chain ending in `.state.<field>`).
+MIGRATED_KIND_FIELDS = {
+    "image": ["image_asset_id"],
+}
+
+
+def _all_migrated_fields() -> set[str]:
+    fields: set[str] = set()
+    for names in MIGRATED_KIND_FIELDS.values():
+        fields.update(names)
+    return fields
+
+
+def _source_files():
+    for scan_dir in SCAN_DIRS:
+        for path in sorted(scan_dir.rglob("*.py")):
+            yield path
+
+
+def _is_via_state(value_node: ast.expr) -> bool:
+    """True if `value_node` is itself an attribute access ending in
+    `.state` (arbitrarily deep, e.g. `document.nodes[id].state`) - the one
+    legitimate shape for a migrated field access, whether reached via dot
+    syntax or getattr/setattr's own first argument."""
+    return isinstance(value_node, ast.Attribute) and value_node.attr == "state"
+
+
+def _string_constant(node: ast.expr) -> str | None:
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
+
+
+def test_migrated_kind_fields_accessed_only_via_state():
+    migrated_fields = _all_migrated_fields()
+    offenders = []
+    for path in _source_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute):
+                if node.attr not in migrated_fields or _is_via_state(node.value):
+                    continue
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno} bare .{node.attr} access")
+            elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id not in ("getattr", "setattr") or len(node.args) < 2:
+                    continue
+                field_name = _string_constant(node.args[1])
+                if field_name not in migrated_fields or _is_via_state(node.args[0]):
+                    continue
+                offenders.append(
+                    f"{path.relative_to(REPO_ROOT)}:{node.lineno} bare "
+                    f"{node.func.id}(..., {field_name!r}, ...) access"
+                )
+    assert not offenders, (
+        "ADR-002 stage 2.5: migrated field accessed without going through "
+        "node.state:\n" + "\n".join(offenders)
+    )
+
+
+# Captured from SceneDocument.scene_payload()'s real output pre-migration
+# (a single chat node, ADR-002 stage 2.5 PR1/image baseline) - sorted, 86
+# keys. scene_payload emits this SAME key set for every node regardless of
+# kind (one flat dict literal, no per-kind branching), so one representative
+# node is sufficient; the point is the KEY SET, not per-kind values.
+_EXPECTED_SCENE_NODE_WIRE_KEYS = sorted([
+    "artifactContent", "attachmentKind", "branchStatus", "byteSize",
+    "chartAspectLocked", "chartAssetId", "chartAssetVersion", "chartData",
+    "chartError", "chartHeight", "chartSourceNodeId", "chartType", "chartWidth",
+    "chatScrollValue", "code", "codeSandboxAnalysis", "codeSandboxApprovalRequirements",
+    "codeSandboxAwaitingApproval", "codeSandboxCode", "codeSandboxError",
+    "codeSandboxOutput", "codeSandboxPrompt", "codeSandboxRequirements", "color",
+    "content", "contentParts", "durationSeconds", "filePath", "gitlinkBranch",
+    "gitlinkChangeFingerprint", "gitlinkChangeState", "gitlinkContextStats",
+    "gitlinkContextSummary", "gitlinkContextVersion", "gitlinkError",
+    "gitlinkLocalRoot", "gitlinkPendingChanges", "gitlinkPreviewText",
+    "gitlinkProposalMarkdown", "gitlinkRepo", "gitlinkRepoFilePaths",
+    "gitlinkScopeMode", "gitlinkSelectedPaths", "gitlinkTaskPrompt", "groupHeight",
+    "groupWidth", "headerColor", "history", "htmlSplitterState", "id",
+    "imageAssetId", "isBranchComparison", "isBranchSynthesis", "isCollapsed",
+    "isDocked", "isFinalDeliverable", "isLocked", "isSummaryNote",
+    "isSystemPrompt", "isUser", "itemIds", "kind", "language", "mimeType",
+    "model", "pendingRequestId", "previewLabel", "provider", "pycoderAnalysis",
+    "pycoderAwaitingApproval", "pycoderCode", "pycoderError",
+    "pycoderLastRunFailed", "pycoderMode", "pycoderOutput", "pycoderPrompt",
+    "researchActiveSourceId", "researchCompleted", "researchError",
+    "researchResult", "researchStage", "researchTotal", "synthesisInstructions",
+    "title", "x", "y",
+])
+
+
+def test_scene_payload_key_set_is_unchanged_by_the_migration():
+    doc = SceneDocument()
+    doc.add_chat_node(0, 0, "hi", True)
+    row = doc.scene_payload()["nodes"][0]
+    assert sorted(row.keys()) == _EXPECTED_SCENE_NODE_WIRE_KEYS


### PR DESCRIPTION
## Problem

`SceneNode` (`backend/domain/model.py`) carries ~95 fields for 16 different node kinds, even though most fields are kind-specific - every node instance wastes ~1,976 B/node of dead fields on the wire regardless of kind. ADR-002 stage 2.5's target is a small core dataclass plus one typed state dataclass per kind. Scoped as backend-only for now: internal structure changes, wire payload stays byte-identical, no frontend coordination needed.

## Change

Foundation + the first (pilot) kind migration, combined into one PR:

- New `backend/domain/node_states.py`: `NodeState` marker base class, `ImageState` dataclass (`image_asset_id: str = ""`).
- `SceneNode` gets a new additive `state: NodeState | None = None` field; `image_asset_id` is removed from `SceneNode` entirely.
- `add_image_node`/`_restore_image_payload`/`_serialize_image_node` construct/read through `node.state` instead of a bare field.
- `scene_payload()`'s `imageAssetId` wire read becomes `n.state.image_asset_id if isinstance(n.state, ImageState) else ""` - every non-image node keeps emitting `""` exactly as its old bare-field default did.

`image` was chosen as the pilot: 1 field, a maximally distinctive/greppable name, and zero touches in `agents.py` or any `intents_*.py` file.

**A real bug caught and fixed before shipping:** `remove_nodes()` had an unconditional `if node.image_asset_id:` scan that ran on every deleted node regardless of kind - once the field left `SceneNode`, deleting any non-image node would raise `AttributeError`. Rewritten as `getattr(node.state, "image_asset_id", None)`. Added a regression test that creates one node of every currently-creatable kind and deletes them all in a single call, so this exact failure class is caught immediately in any of the next ~15 migration PRs, not just in that PR's own kind-specific tests.

**New migration-tracking gate:** `tests/test_node_state_migration.py` (same AST-walk technique as the existing `tests/test_domain_purity.py`) grows a `MIGRATED_KIND_FIELDS` entry per PR and fails if a migrated field is ever accessed as a bare attribute outside a `.state.` chain anywhere in `backend/`/`tests/` - checks both dot-attribute syntax and the `getattr`/`setattr` string-literal equivalent. Also adds a golden snapshot of `scene_payload()`'s full 86-key wire shape as a tripwire for the whole stage's wire-compatibility constraint.

## Test plan

- [x] `python -c "import backend.canvas"` succeeds
- [x] `pyflakes` clean on all touched/new files (pre-existing re-export-facade warnings unaffected)
- [x] Full `pytest -q` from repo root: 1227 passed (1224 baseline + 3 new tests)
- [x] Mutation-tested every new/changed regression test: reverted the fix, confirmed the relevant test failed with the exact expected error, restored - done for the `remove_nodes` fix, the AST-gate's dot-attribute detection, and its `getattr`/`setattr` detection
- [x] Repo-wide grep confirms zero remaining bare `node.image_asset_id` access anywhere (Python or TS/wire-contract surface)
- [x] Independent two-reviewer adversarial review pass + skeptical synthesis: one real stale-comment fix applied, one gate-hardening suggestion applied; no other issues found