### PR TITLE
ADR-002 stage 2.5 (PR2/~16, backend-only): html kind migration

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -85,7 +85,7 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
-from backend.domain.node_states import ImageState
+from backend.domain.node_states import HtmlState, ImageState
 
 
 

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -84,7 +84,7 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
-from backend.domain.node_states import ImageState
+from backend.domain.node_states import HtmlState, ImageState
 
 
 def _estimate_tokens(text: str) -> int:
@@ -455,6 +455,7 @@ class SceneDocument(BranchOps, GroupOps):
             title=title,
             kind="html",
             content=str(html_content),
+            state=HtmlState(),
         )
         self.nodes[node_id] = node
         self.connect(parent_id, node_id)
@@ -470,7 +471,7 @@ class SceneDocument(BranchOps, GroupOps):
             raise SceneError(f"unknown node: {node_id}")
         if node.kind != "html":
             raise SceneError(f"node is not an html node: {node_id}")
-        node.html_splitter_state = float(value)
+        node.state.html_splitter_state = float(value)
 
     def add_image_node(
         self,
@@ -1787,7 +1788,7 @@ class SceneDocument(BranchOps, GroupOps):
                     "chartAspectLocked": n.chart_aspect_locked,
                     "chartSourceNodeId": n.chart_source_node_id,
                     # R6.3: HTML splitter + chat scroll gaps.
-                    "htmlSplitterState": n.html_splitter_state,
+                    "htmlSplitterState": n.state.html_splitter_state if isinstance(n.state, HtmlState) else None,
                     "chatScrollValue": n.chat_scroll_value,
                     # R6.3: null (not []) when content_parts is None - "no
                     # multimodal content" must stay distinguishable from

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -626,16 +626,10 @@ class SceneNode:
     # simplification, not replicated). Unused (default "") for every other
     # kind.
     chart_source_node_id: str = ""
-    # R6.3: HtmlViewNode's persisted draggable code/preview splitter
-    # position - legacy's own splitter_state field, not currently modeled at
-    # all before this increment. None means "use the frontend's own
-    # default", not "0" - a real 0.0 position (fully collapsed to one side)
-    # must round-trip distinctly from "never set". html kind only; unused
-    # (default None) for every other kind.
-    html_splitter_state: float | None = None
     # R6.3: ChatNode's persisted scroll position within its own content
-    # area (legacy's own scroll_value field). Unlike html_splitter_state
-    # above, 0.0 (scrolled to the top) IS the genuine default for a node
+    # area (legacy's own scroll_value field). Unlike HtmlState's own
+    # html_splitter_state (backend/domain/node_states.py, ADR-002 stage
+    # 2.5), 0.0 (scrolled to the top) IS the genuine default for a node
     # that has never been scrolled, so this is a plain float, not an
     # Optional - there is no "unset" state worth distinguishing here. chat
     # kind only; unused (default 0.0) for every other kind.

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -36,3 +36,14 @@ class ImageState(NodeState):
     itself)."""
 
     image_asset_id: str = ""
+
+
+@dataclass
+class HtmlState(NodeState):
+    """Relocated verbatim from SceneNode.html_splitter_state (former
+    backend/domain/model.py field, R6.3) - an HtmlViewNode's persisted
+    draggable code/preview splitter position. None means "use the
+    frontend's own default", not "0" - a real 0.0 position (fully
+    collapsed to one side) must round-trip distinctly from "never set"."""
+
+    html_splitter_state: float | None = None

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -185,6 +185,7 @@ import re
 from typing import Any
 
 from backend.canvas import (
+    HtmlState,
     ImageState,
     SceneDocument,
     SceneNode,
@@ -441,7 +442,7 @@ def _restore_html_payload(payload: dict[str, Any]) -> SceneNode:
     return SceneNode(
         id="", x=x, y=y, title="HTML", kind="html",
         content=str(payload.get("html_content", "")),
-        html_splitter_state=payload.get("splitter_state"),
+        state=HtmlState(html_splitter_state=payload.get("splitter_state")),
         history=_restore_history(payload.get("conversation_history")),
         is_collapsed=bool(payload.get("is_collapsed", False)),
     )

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -257,7 +257,7 @@ def _serialize_html_node(node: SceneNode) -> dict[str, Any]:
     return {
         "node_type": "html",
         "html_content": node.content,
-        "splitter_state": node.html_splitter_state,
+        "splitter_state": node.state.html_splitter_state,
         "conversation_history": _serialize_history(node.history),
         "is_collapsed": bool(node.is_collapsed),
     }

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -6498,10 +6498,10 @@ def test_set_html_splitter_state_accepts_html_kind_and_rejects_others():
     doc = SceneDocument()
     chat_node = doc.add_chat_node(0, 0, "hi", True)
     html_node = doc.add_html_node(0, 0, "<p>hi</p>", chat_node.id)
-    assert html_node.html_splitter_state is None
+    assert html_node.state.html_splitter_state is None
 
     doc.set_html_splitter_state(html_node.id, 0.35)
-    assert html_node.html_splitter_state == 0.35
+    assert html_node.state.html_splitter_state == 0.35
     payload_node = next(n for n in doc.scene_payload()["nodes"] if n["id"] == html_node.id)
     assert payload_node["htmlSplitterState"] == 0.35
 
@@ -6520,7 +6520,7 @@ def test_set_html_splitter_state_intent_mutates_and_publishes_scene():
         recorder.messages.clear()
 
         await bus.dispatch_intent("scene", "setHtmlSplitterState", [html_id, 0.6])
-        assert document.nodes[html_id].html_splitter_state == 0.6
+        assert document.nodes[html_id].state.html_splitter_state == 0.6
         assert recorder.topics_seen().count("scene") == 1
 
         with pytest.raises(Exception):

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -143,7 +143,7 @@ def test_html_node_field_mapping():
          "position": {"x": 0, "y": 0}, "parent_node_index": 0},
     ])
     node = next(n for n in document.nodes.values() if n.kind == "html")
-    assert node.content == "<h1>Hi</h1>" and node.html_splitter_state == 0.4
+    assert node.content == "<h1>Hi</h1>" and node.state.html_splitter_state == 0.4
 
 
 def test_pycoder_mode_translates_enum_member_name_to_lowercase():

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -46,6 +46,7 @@ SCAN_DIRS = (REPO_ROOT / "backend", REPO_ROOT / "tests")
 # `X.state.<field>` (or a longer chain ending in `.state.<field>`).
 MIGRATED_KIND_FIELDS = {
     "image": ["image_asset_id"],
+    "html": ["html_splitter_state"],
 }
 
 


### PR DESCRIPTION
## Problem

Continuing ADR-002 stage 2.5's kind-by-kind migration off the monolithic SceneNode (PR1/#244 moved `image`). Next up: `html`'s single field, `html_splitter_state`.

## Change

Moves `html_splitter_state` off `SceneNode` onto a new `HtmlState` dataclass, following PR1's established pattern exactly.

The one thing this kind surfaces that `image` didn't: `html_splitter_state`'s real default is `None`, not an empty string. `HtmlState`'s own field default and `scene_payload()`'s wire-read fallback both had to match that precisely - verified against the actual pre-migration behavior via `git show`, not assumed. `add_html_node` never set a splitter position at creation time before this change either (relied on the bare field's `None` default), so `state=HtmlState()` at construction is behavior-preserving. `session_load.py`'s restore path passes the persisted value straight into `HtmlState`'s constructor (html's value is known up front from the payload, unlike image's conditional post-construction poke).

No new tests needed - PR1's shared gates (the AST migration-tracking walk, the wire-key golden snapshot, and the "delete one node of every kind" regression test, which already exercises an html node) cover this kind for free. Grew the AST gate's `MIGRATED_KIND_FIELDS` by one entry.

## Test plan

- [x] `python -c "import backend.canvas"` succeeds
- [x] `pyflakes` clean (same pre-existing re-export-facade warning shape as PR1's `ImageState`)
- [x] Full `pytest -q` from repo root: 1227 passed (same count as after PR1 - zero new tests needed, existing shared gates cover this kind)
- [x] Mutation-tested the setter fix and the AST gate's new `html` entry: reverted each, confirmed the expected test failed with the exact expected error, restored
- [x] Repo-wide grep confirms zero remaining bare `node.html_splitter_state` access anywhere
- [x] Independent two-reviewer adversarial review pass + skeptical synthesis: zero code fixes required, pattern confirmed sound and repeatable for the remaining 14 kind migrations