### PR TITLE
ADR-002 stage 2.5 (PR3/~16, backend-only): artifact kind migration

### DIFF
--- a/backend/api/intents_artifact.py
+++ b/backend/api/intents_artifact.py
@@ -53,7 +53,7 @@ def register_artifact_intents(
             bus=bus,
             notifications_state=notifications,
             node=node,
-            current_artifact=node.artifact_content,
+            current_artifact=node.state.artifact_content,
             history=full_history,
             on_reply=_on_reply,
         )

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -85,7 +85,7 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
-from backend.domain.node_states import HtmlState, ImageState
+from backend.domain.node_states import ArtifactState, HtmlState, ImageState
 
 
 

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -84,7 +84,7 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
-from backend.domain.node_states import HtmlState, ImageState
+from backend.domain.node_states import ArtifactState, HtmlState, ImageState
 
 
 def _estimate_tokens(text: str) -> int:
@@ -729,6 +729,7 @@ class SceneDocument(BranchOps, GroupOps):
             y=float(y),
             title="Artifact",
             kind="artifact",
+            state=ArtifactState(),
         )
         self.nodes[node_id] = node
         self.connect(parent_id, node_id)
@@ -756,8 +757,8 @@ class SceneDocument(BranchOps, GroupOps):
     def complete_artifact_generation(self, node_id: str, new_content, ai_message: str) -> SceneNode:
         """Land a successful generation turn: WHOLE-DOCUMENT REPLACE (never an
         append/merge - the model returns the entire document every turn, see
-        the artifact_content field's own comment on SceneNode), plus append a
-        real assistant turn to history. Raises SceneError if the node is
+        ArtifactState's own comment, backend/domain/node_states.py), plus
+        append a real assistant turn to history. Raises SceneError if the node is
         gone - this WS wrapper does NOT pre-check liveness before calling
         this, same posture as send_conversation_message's own _on_reply, not
         web_research's more defensive pre-check pattern (there is no
@@ -766,7 +767,7 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
-        node.artifact_content = str(new_content)
+        node.state.artifact_content = str(new_content)
         node.history.append({"role": "assistant", "content": str(ai_message)})
         return node
 
@@ -1712,7 +1713,7 @@ class SceneDocument(BranchOps, GroupOps):
                     "researchActiveSourceId": n.research_active_source_id,
                     "researchError": n.research_error,
                     "researchResult": n.research_result,
-                    "artifactContent": n.artifact_content,
+                    "artifactContent": n.state.artifact_content if isinstance(n.state, ArtifactState) else "",
                     "gitlinkRepo": n.gitlink_repo,
                     "gitlinkBranch": n.gitlink_branch,
                     "gitlinkScopeMode": n.gitlink_scope_mode,

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -316,15 +316,6 @@ class SceneNode:
     # answer stays visible until this run replaces it on success, or
     # fails/cancels (leaving the stale result annotated by research_error).
     research_result: dict[str, Any] | None = None
-    # R5.2: the Artifact/Drafter node's real persisted shape - the model
-    # returns the WHOLE document every turn (whole-document replace, never a
-    # diff/patch - see complete_artifact_generation), so this field is
-    # bounded by the model's own per-turn output ceiling, not by session
-    # length. The turn-by-turn conversation reuses the existing generic
-    # `history` list field above (already used by ConversationNode) rather
-    # than a new list-typed field - only this one new scalar is needed.
-    # Unused (default) for every other kind.
-    artifact_content: str = ""
     # R5.3: the Gitlink node's real persisted shape - reads a GitHub repo (or
     # a local checkout) into structured XML context, proposes an LLM change
     # set, and only writes to disk after an explicit, fingerprint-verified

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -47,3 +47,18 @@ class HtmlState(NodeState):
     collapsed to one side) must round-trip distinctly from "never set"."""
 
     html_splitter_state: float | None = None
+
+
+@dataclass
+class ArtifactState(NodeState):
+    """Relocated verbatim from SceneNode.artifact_content (former
+    backend/domain/model.py field, R5.2) - the Artifact/Drafter node's
+    whole-document text. The model returns the WHOLE document every turn
+    (never a diff/patch - see complete_artifact_generation), so this
+    field is bounded by the model's own per-turn output ceiling, not by
+    session length. The turn-by-turn conversation reuses SceneNode's own
+    generic `history` list field (already used by ConversationNode)
+    rather than a second list-typed field here - only this one scalar is
+    needed."""
+
+    artifact_content: str = ""

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -185,6 +185,7 @@ import re
 from typing import Any
 
 from backend.canvas import (
+    ArtifactState,
     HtmlState,
     ImageState,
     SceneDocument,
@@ -493,7 +494,7 @@ def _restore_artifact_payload(payload: dict[str, Any]) -> SceneNode:
         # which every other kind already reuses for "the node's primary
         # editable text" - reused the same way here, not left to drop.
         content=str(payload.get("instruction", "")),
-        artifact_content=str(payload.get("content", "")),
+        state=ArtifactState(artifact_content=str(payload.get("content", ""))),
         history=_restore_history(payload.get("conversation_history")),
         is_collapsed=bool(payload.get("is_collapsed", False)),
     )

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -280,7 +280,7 @@ def _serialize_artifact_node(node: SceneNode) -> dict[str, Any]:
     return {
         "node_type": "artifact",
         "instruction": node.content,
-        "content": node.artifact_content,
+        "content": node.state.artifact_content,
         "conversation_history": _serialize_history(node.history),
         "is_collapsed": bool(node.is_collapsed),
     }

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -3554,7 +3554,7 @@ def test_add_artifact_node_creates_a_real_artifact_kind_node():
     node = doc.add_artifact_node(10, 20, parent.id)
     assert node.kind == "artifact"
     assert node.title == "Artifact"
-    assert node.artifact_content == ""
+    assert node.state.artifact_content == ""
     assert node.history == []
     assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
 
@@ -3621,7 +3621,7 @@ def test_complete_artifact_generation_replaces_content_and_appends_assistant_tur
     )
 
     assert returned is node
-    assert node.artifact_content == "# Project Brief\n\nDraft content."
+    assert node.state.artifact_content == "# Project Brief\n\nDraft content."
     assert node.history == [
         {"role": "user", "content": "draft a project brief"},
         {"role": "assistant", "content": "Here's a first draft."},

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -174,7 +174,7 @@ def test_artifact_node_reuses_instruction_as_content_and_content_as_artifact_con
          "position": {"x": 0, "y": 0}, "parent_node_index": 0},
     ])
     node = next(n for n in document.nodes.values() if n.kind == "artifact")
-    assert node.content == "write a poem" and node.artifact_content == "roses are red"
+    assert node.content == "write a poem" and node.state.artifact_content == "roses are red"
 
 
 def test_gitlink_node_unpacks_repo_state_and_synthesizes_proposal_markdown():

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -47,6 +47,7 @@ SCAN_DIRS = (REPO_ROOT / "backend", REPO_ROOT / "tests")
 MIGRATED_KIND_FIELDS = {
     "image": ["image_asset_id"],
     "html": ["html_splitter_state"],
+    "artifact": ["artifact_content"],
 }
 
 


### PR DESCRIPTION
## Problem

Continuing ADR-002 stage 2.5's kind-by-kind migration (PR1/#244 moved `image`, PR2/#245 moved `html`). Next up: `artifact`'s single field, `artifact_content`.

## Change

Moves `artifact_content` off `SceneNode` onto a new `ArtifactState` dataclass, following the established pattern. This field's default (`""`) matches PR1's `image_asset_id` shape, not PR2's `None`.

The one asymmetry this kind surfaces relative to `html`: `complete_artifact_generation` (and its callers `append_artifact_user_message`/`send_artifact_message`) have no `node.kind` guard at all, unlike `html`'s kind-checked setter. Traced the full call chain (WS intent → domain method) before shipping: the frontend only ever sources this `node_id` from a node it has already identified as artifact-kind, node ids are monotonic and never reused, and no clone/duplicate-node feature exists - so no reachable path can hit this with a wrong-kind node today. Left unguarded rather than adding a new check, matching this stage's "pure structural move, no drive-by behavior changes" discipline; a hypothetical future misuse now fails as an `AttributeError` caught by the WS dispatch's blanket exception handler - a strict improvement over silently writing to an unused field on the wrong node.

`backend/api/intents_artifact.py` is this PR's one `intents_*.py` touch site (`node.artifact_content` → `node.state.artifact_content`) - the first kind in this series with a real external call site beyond domain/session code.

## Test plan

- [x] `python -c "import backend.canvas"` succeeds
- [x] `pyflakes` clean (same pre-existing re-export-facade warning shape as PR1/PR2)
- [x] Full `pytest -q` from repo root: 1227 passed (same count as PR1/PR2 - zero new tests needed, existing shared gates cover this kind)
- [x] Mutation-tested the `complete_artifact_generation` fix and the AST gate's new `artifact` entry: reverted each, confirmed the expected test failed with the exact expected error, restored
- [x] Repo-wide grep confirms zero remaining bare `node.artifact_content` access anywhere
- [x] Independent two-reviewer adversarial review pass + skeptical synthesis, with an explicit focus on the missing-kind-guard question: traced the full call chain (including the frontend's `n.kind === "artifact"` gate in `SceneCanvas.tsx`) and confirmed no reachable path exploits it; one cosmetic stale-comment cross-reference found and fixed