### PR TITLE
ADR-002 stage 2.5 (PR4/~16, backend-only): code kind migration

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -85,7 +85,7 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
-from backend.domain.node_states import ArtifactState, HtmlState, ImageState
+from backend.domain.node_states import ArtifactState, CodeState, HtmlState, ImageState
 
 
 

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -84,7 +84,7 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
-from backend.domain.node_states import ArtifactState, HtmlState, ImageState
+from backend.domain.node_states import ArtifactState, CodeState, HtmlState, ImageState
 
 
 def _estimate_tokens(text: str) -> int:
@@ -305,8 +305,7 @@ class SceneDocument(BranchOps, GroupOps):
             y=float(y),
             title=title,
             kind="code",
-            code=str(code),
-            language=str(language),
+            state=CodeState(code=str(code), language=str(language)),
         )
         self.nodes[node_id] = node
         if parent_id is not None:
@@ -1681,8 +1680,8 @@ class SceneDocument(BranchOps, GroupOps):
                     "content": n.content,
                     "isUser": n.is_user,
                     "isCollapsed": n.is_collapsed,
-                    "code": n.code,
-                    "language": n.language,
+                    "code": n.state.code if isinstance(n.state, CodeState) else "",
+                    "language": n.state.language if isinstance(n.state, CodeState) else "",
                     "attachmentKind": n.attachment_kind,
                     "filePath": n.file_path,
                     "mimeType": n.mime_type,

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -164,10 +164,6 @@ class SceneNode:
     content: str = ""
     is_user: bool = False
     is_collapsed: bool = False
-    # R3.5: the code node's real persisted shape - unused/defaulted for
-    # every other kind.
-    code: str = ""
-    language: str = ""
     # R3.9 (doc/QT_REMOVAL_PLAN.md): the document node's real persisted shape -
     # graphlink_scene.py's add_document_node()/graphlink_node_document.py's
     # DocumentNode.__init__ attachment metadata (title/content above, plus

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -62,3 +62,14 @@ class ArtifactState(NodeState):
     needed."""
 
     artifact_content: str = ""
+
+
+@dataclass
+class CodeState(NodeState):
+    """Relocated verbatim from SceneNode.code/SceneNode.language (former
+    backend/domain/model.py fields, R3.5) - a code-block node's raw text
+    and its declared language label (used for both the title's language
+    prefix and the frontend's syntax-highlighting choice)."""
+
+    code: str = ""
+    language: str = ""

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -186,6 +186,7 @@ from typing import Any
 
 from backend.canvas import (
     ArtifactState,
+    CodeState,
     HtmlState,
     ImageState,
     SceneDocument,
@@ -374,8 +375,10 @@ def _restore_code_payload(payload: dict[str, Any]) -> SceneNode:
     x, y = _position(payload)
     return SceneNode(
         id="", x=x, y=y, title="Code", kind="code",
-        code=str(payload.get("code", "")),
-        language=str(payload.get("language", "")),
+        state=CodeState(
+            code=str(payload.get("code", "")),
+            language=str(payload.get("language", "")),
+        ),
     )
 
 

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -212,7 +212,7 @@ def _serialize_chat_node(node: SceneNode) -> dict[str, Any]:
 
 
 def _serialize_code_node(node: SceneNode) -> dict[str, Any]:
-    return {"node_type": "code", "code": node.code, "language": node.language}
+    return {"node_type": "code", "code": node.state.code, "language": node.state.language}
 
 
 def _serialize_document_node(node: SceneNode) -> dict[str, Any]:

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -212,8 +212,8 @@ def test_add_code_node_creates_a_real_code_kind_node():
     doc = SceneDocument()
     node = doc.add_code_node(10, 20, "print('hi')", "python")
     assert node.kind == "code"
-    assert node.code == "print('hi')"
-    assert node.language == "python"
+    assert node.state.code == "print('hi')"
+    assert node.state.language == "python"
     assert node.title == "python: print('hi')"
 
 
@@ -1514,7 +1514,7 @@ def test_regenerate_response_replaces_code_child_not_accumulates():
 
         code_nodes = [n for n in document.nodes.values() if n.kind == "code"]
         assert len(code_nodes) == 1, "the old code child must be replaced, not accumulated"
-        assert code_nodes[0].code == "print('two')"
+        assert code_nodes[0].state.code == "print('two')"
 
     asyncio.run(run())
 
@@ -2141,8 +2141,8 @@ def test_add_code_node_intent_creates_a_real_node_and_publishes():
             "scene", "addCodeNode", [0, 0, "def f(): pass", "python"]
         )
         assert document.nodes[node_id].kind == "code"
-        assert document.nodes[node_id].code == "def f(): pass"
-        assert document.nodes[node_id].language == "python"
+        assert document.nodes[node_id].state.code == "def f(): pass"
+        assert document.nodes[node_id].state.language == "python"
         assert recorder.topics_seen().count("scene") == 1, "the mutation publishes"
 
     asyncio.run(run())
@@ -2383,8 +2383,8 @@ def test_send_message_reply_with_code_fence_creates_code_child_and_edge():
         code_nodes = [n for n in document.nodes.values() if n.kind == "code"]
         assert len(code_nodes) == 1
         code_node = code_nodes[0]
-        assert code_node.language == "python"
-        assert code_node.code == "print('hi')"
+        assert code_node.state.language == "python"
+        assert code_node.state.code == "print('hi')"
 
         assert any(
             e.source == assistant_node.id and e.target == code_node.id

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -71,7 +71,7 @@ def test_code_node_restores_and_connects_when_parent_resolves():
     assert len(document.nodes) == 2
     code_node = next(n for n in document.nodes.values() if n.kind == "code")
     chat_node = next(n for n in document.nodes.values() if n.kind == "chat")
-    assert code_node.code == "print(1)" and code_node.language == "python"
+    assert code_node.state.code == "print(1)" and code_node.state.language == "python"
     assert any(e.source == chat_node.id and e.target == code_node.id for e in document.edges.values())
 
 

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -15,6 +15,12 @@ setattr(node, "image_asset_id", ...)) - an adversarial-review finding on
 this same gate's own PR: a walk over ast.Attribute alone can't see a field
 name smuggled in as a getattr/setattr string argument.
 
+_KNOWN_NON_NODE_FIELD_ACCESS_SHAPES carves out a small, explicit,
+shape-based allowlist for the rare migrated field name (PR4's "code") that
+collides with an unrelated attribute on a genuinely different type
+elsewhere in the codebase - see its own comment for exactly which shapes
+and why.
+
 test_scene_node_core_field_count (asserting the final <=15-field core
 exactly) is deferred to the stage's own exit PR, once every kind that has
 kind-specific fields has migrated - see backend/domain/node_states.py's
@@ -48,6 +54,7 @@ MIGRATED_KIND_FIELDS = {
     "image": ["image_asset_id"],
     "html": ["html_splitter_state"],
     "artifact": ["artifact_content"],
+    "code": ["code", "language"],
 }
 
 
@@ -72,6 +79,61 @@ def _is_via_state(value_node: ast.expr) -> bool:
     return isinstance(value_node, ast.Attribute) and value_node.attr == "state"
 
 
+def _root_name(expr: ast.expr) -> str | None:
+    """Unwraps arbitrarily-nested Subscript/Attribute layers down to the
+    base Name, e.g. `failures[0]` -> "failures"."""
+    while isinstance(expr, (ast.Subscript, ast.Attribute)):
+        expr = expr.value
+    return expr.id if isinstance(expr, ast.Name) else None
+
+
+# PR4's "code" kind reuses two field names ("code", "language") common
+# enough to collide with unrelated attributes on genuinely different
+# types elsewhere in this codebase - unlike every other kind's
+# distinctively-prefixed field names (gitlink_*, pycoder_*, etc.), which
+# need no such allowance. Listed by exact SHAPE (and, where the shape
+# alone isn't distinctive enough, the one file that shape's real usage is
+# confined to), not by line number (which would rot on the next unrelated
+# edit to either file) - each entry here must be hand-verified against its
+# real type before being added; this is a liability, not a convenience,
+# kept as small and as tightly scoped as the name collision forces it to
+# be. A "file" of None applies repo-wide; a real filename restricts the
+# exemption to that one file, so e.g. a FUTURE test elsewhere naming an
+# unrelated list of real SceneNode/CodeState objects `failures` is still
+# caught, not silently exempted just because the root name matches.
+_KNOWN_NON_NODE_FIELD_ACCESS_SHAPES = {
+    "code": (
+        # pytest.raises(...) as exc_info: exc_info.value.code is
+        # ExceptionInfo's own wrapped-exception .code (websocket close
+        # codes in test_ws_origin.py/test_crash_recovery_notice.py),
+        # never SceneNode's - the ".value" immediately inside the access
+        # is the tell, regardless of what exc_info itself is named or
+        # which file uses the idiom, so this one is repo-wide.
+        {"root": "__attr_value__", "file": None},
+        # on_failure=failures.append callbacks collect exception-like
+        # ResearchFailure/etc objects (never SceneNode) into a list
+        # literally named `failures` - but ONLY in
+        # backend/tests/test_agents.py; failures[i].code there is that
+        # object's own .code, e.g. "watchdog_timeout".
+        {"root": "failures", "file": "test_agents.py"},
+    ),
+    "language": (),
+}
+
+
+def _is_known_non_node_field_access(attribute_node: ast.Attribute, path: Path) -> bool:
+    for shape in _KNOWN_NON_NODE_FIELD_ACCESS_SHAPES.get(attribute_node.attr, ()):
+        if shape["file"] is not None and path.name != shape["file"]:
+            continue
+        if shape["root"] == "__attr_value__":
+            if isinstance(attribute_node.value, ast.Attribute) and attribute_node.value.attr == "value":
+                return True
+            continue
+        if _root_name(attribute_node.value) == shape["root"]:
+            return True
+    return False
+
+
 def _string_constant(node: ast.expr) -> str | None:
     return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
 
@@ -84,6 +146,8 @@ def test_migrated_kind_fields_accessed_only_via_state():
         for node in ast.walk(tree):
             if isinstance(node, ast.Attribute):
                 if node.attr not in migrated_fields or _is_via_state(node.value):
+                    continue
+                if _is_known_non_node_field_access(node, path):
                     continue
                 offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno} bare .{node.attr} access")
             elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):


### PR DESCRIPTION
## Problem

Continuing ADR-002 stage 2.5's kind-by-kind migration (PR1-3 moved `image`/`html`/`artifact`). Next up: `code`'s two fields, `code` and `language`.

## Change

Moves `code`/`language` off `SceneNode` onto a new `CodeState` dataclass. Code nodes have no post-creation mutator - confirmed no `delete_code_node`/`set_code` exists, and the regenerate flow deletes-and-recreates rather than editing in place - so this is the simplest field motion in the series: just the constructor kwargs and two read sites.

**The real complexity:** `code`/`language` are the first field names in this migration to collide with unrelated attributes elsewhere - pytest's own `ExceptionInfo.value.code` (websocket close codes in a couple of test files) and `ResearchFailure.code` on exception objects collected into `test_agents.py`'s `on_failure=failures.append` lists. A naive `MIGRATED_KIND_FIELDS` entry produced 5 false positives in the AST migration gate.

Fixed by adding a small, explicit, shape-based exemption mechanism to the gate rather than weakening it generally: exemptions are matched by AST shape (an immediate `.value` parent, or a specific root variable name) and, where the shape alone isn't distinctive enough, scoped to the one file that shape's real usage is confined to - so a hypothetical future `failures` list holding real `SceneNode`/`CodeState` objects in a *different* file would still be caught. Mutation-tested this file-scoping specifically by injecting the same `failures[0].code` shape into `test_canvas.py` and confirming the gate still flags it there.

Backed by a second, independent safety net regardless of gate coverage: `SceneNode` has no `code`/`language` attribute at all anymore, so any bare access on a real node fails loudly with `AttributeError`, not silently.

## Test plan

- [x] `python -c "import backend.canvas"` succeeds
- [x] `pyflakes` clean (same pre-existing re-export-facade warning shape as PR1-3)
- [x] Full `pytest -q` from repo root: 1227 passed (same count as PR1-3)
- [x] Mutation-tested three separate failure modes: reverting the constructor fix (fails as a real `TypeError`, caught by 6 tests), reverting the wire-key read (caught by both the AST gate and the wire-snapshot test), and the exemption's file-scoping itself (confirmed a real regression in a different file is still caught)
- [x] Repo-wide grep confirms zero remaining bare `node.code`/`node.language` access anywhere, carefully distinguished from unrelated `code_sandbox_code`/`pycoder_code`/local variables
- [x] Independent two-reviewer adversarial review pass + skeptical synthesis, with explicit focus on the new exemption mechanism's precision: confirmed it exempts exactly the 5 real, hand-verified collisions and nothing broader; one optional hardening (file-scoping) applied before shipping