### PR TITLE
ADR-002 stage 2.5 (PR5/~16, backend-only): note kind migration

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -553,7 +553,7 @@ class AgentDispatcher:
             if (
                 source_node is not None
                 and getattr(source_node, "kind", None) == "note"
-                and getattr(source_node, "is_system_prompt", False)
+                and getattr(source_node.state, "is_system_prompt", False)
             ):
                 return source_node.content
         return None

--- a/backend/domain/branches.py
+++ b/backend/domain/branches.py
@@ -45,7 +45,7 @@ class BranchOps:
             raise SceneError(f"unknown node: {node_id}")
         if node.kind != "note":
             raise SceneError(f"node is not a note node: {node_id}")
-        node.is_branch_comparison = True
+        node.state.is_branch_comparison = True
         node.item_ids = list(source_node_ids)
 
     def mark_branch_synthesis(

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -84,7 +84,7 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
-from backend.domain.node_states import ArtifactState, CodeState, HtmlState, ImageState
+from backend.domain.node_states import ArtifactState, CodeState, HtmlState, ImageState, NoteState
 
 
 def _estimate_tokens(text: str) -> int:
@@ -1235,8 +1235,10 @@ class SceneDocument(BranchOps, GroupOps):
             title="Note",
             kind="note",
             content="Add note...",
-            is_system_prompt=bool(is_system_prompt),
-            is_summary_note=bool(is_summary_note),
+            state=NoteState(
+                is_system_prompt=bool(is_system_prompt),
+                is_summary_note=bool(is_summary_note),
+            ),
         )
         self.nodes[node_id] = node
         return node
@@ -1768,11 +1770,11 @@ class SceneDocument(BranchOps, GroupOps):
                     # above - see those fields' own comments on SceneNode.
                     "color": n.color,
                     "headerColor": n.header_color,
-                    "isSystemPrompt": n.is_system_prompt,
-                    "isSummaryNote": n.is_summary_note,
+                    "isSystemPrompt": n.state.is_system_prompt if isinstance(n.state, NoteState) else False,
+                    "isSummaryNote": n.state.is_summary_note if isinstance(n.state, NoteState) else False,
                     # ADR-002 Workstream 1 ("Compare Branches") - see
-                    # SceneNode.is_branch_comparison's own comment.
-                    "isBranchComparison": n.is_branch_comparison,
+                    # NoteState's own comment, backend/domain/node_states.py.
+                    "isBranchComparison": n.state.is_branch_comparison if isinstance(n.state, NoteState) else False,
                     "itemIds": list(n.item_ids),
                     "isLocked": n.is_locked,
                     "groupWidth": n.group_width,

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -255,13 +255,14 @@ class SceneNode:
     model: str | None = None
     # ADR-002 Workstream 1 ("Synthesize Branches"): marks a chat-kind node as
     # the output of the Synthesize Branches agent (as opposed to an ordinary
-    # user/assistant message) - the chat-node equivalent of is_branch_
-    # comparison below, which does the same job for note-kind nodes. A
-    # distinct flag rather than reusing is_branch_comparison: that flag's
-    # own kind-check (mark_branch_comparison_note raises for a non-note
-    # node) would need loosening for no benefit, and the two features
-    # render completely different UI (a badge on a note vs. a badge + the
-    # instructions/provider/model fields below on a chat node).
+    # user/assistant message) - the chat-node equivalent of NoteState's own
+    # is_branch_comparison (backend/domain/node_states.py), which does the
+    # same job for note-kind nodes. A distinct flag rather than reusing
+    # is_branch_comparison: that flag's own kind-check
+    # (mark_branch_comparison_note raises for a non-note node) would need
+    # loosening for no benefit, and the two features render completely
+    # different UI (a badge on a note vs. a badge + the instructions/
+    # provider/model fields below on a chat node).
     is_branch_synthesis: bool = False
     # ADR-002 Workstream 1 ("Synthesize Branches"): the free-text instructions
     # the user typed to steer the synthesis (e.g. "merge the best parts of
@@ -280,8 +281,9 @@ class SceneNode:
     # ever walk chat-kind edges). Deliberately PER-NODE with NO write-time
     # inheritance/cascade to ancestors or descendants - every other
     # status-like flag on this dataclass (is_collapsed, is_docked,
-    # is_branch_synthesis, is_branch_comparison below) is scoped exactly
-    # this way, and there is no materialized "Branch" object anywhere in
+    # is_branch_synthesis) - and NoteState's own is_branch_comparison
+    # (backend/domain/node_states.py) - is scoped exactly this way, and
+    # there is no materialized "Branch" object anywhere in
     # this file to cascade through even if inheritance were wanted (a
     # branch is discovered by walking _branch_parent_edge upward on
     # demand, never stored as a set - see that method's own comment).
@@ -485,20 +487,6 @@ class SceneNode:
     # from its body fill) - None means "derive from color/default", again
     # entirely a frontend rendering decision. Unused for every other kind.
     header_color: str | None = None
-    # note kind only - the legacy system-prompt / summary-note badge flags.
-    # Both default False; unused for every other kind.
-    is_system_prompt: bool = False
-    is_summary_note: bool = False
-    # ADR-002 Workstream 1 ("Compare Branches") - note kind only, a NEW badge
-    # flag alongside the two above, marking a note as the output of the
-    # Compare Branches agent rather than a plain/system-prompt/summary note.
-    # Deliberately NOT is_summary_note: that flag is legacy's own "Group
-    # Summary" concept (an arbitrary multi-select of any node kinds,
-    # summarized - never ported, since it depended on a multi-select model
-    # the app didn't have yet), which is semantically a different feature
-    # from comparing conversation branches specifically. Reusing it here
-    # would make a future real port of Group Summary collide with this one.
-    is_branch_comparison: bool = False
     # frame/container membership: the ids of the member nodes this group
     # currently encloses. In this implementation a node can be a member of
     # AT MOST ONE frame AND AT MOST ONE container simultaneously (never two

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -73,3 +73,19 @@ class CodeState(NodeState):
 
     code: str = ""
     language: str = ""
+
+
+@dataclass
+class NoteState(NodeState):
+    """Relocated verbatim from SceneNode.is_system_prompt/is_summary_note/
+    is_branch_comparison (former backend/domain/model.py fields) - a
+    note's three mutually-independent badge flags. is_system_prompt/
+    is_summary_note are the legacy system-prompt/summary-note badges;
+    is_branch_comparison (ADR-002 Workstream 1, "Compare Branches") marks
+    a note as the output of the Compare Branches agent - deliberately a
+    separate flag from is_summary_note rather than reusing it, since that
+    flag is legacy's own unrelated "Group Summary" concept."""
+
+    is_system_prompt: bool = False
+    is_summary_note: bool = False
+    is_branch_comparison: bool = False

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -259,7 +259,7 @@ def register_plugins(
                     if edge.target == root.id
                     and edge.source in canvas_document.nodes
                     and canvas_document.nodes[edge.source].kind == "note"
-                    and canvas_document.nodes[edge.source].is_system_prompt
+                    and canvas_document.nodes[edge.source].state.is_system_prompt
                 ),
                 None,
             )

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -723,7 +723,7 @@ def _restore_notes(document: SceneDocument, notes_data: list) -> dict[int, str]:
             # way). item_ids is deliberately NOT set here - same
             # not-yet-resolvable-reference reasoning as the chat-kind case;
             # see _restore_branch_provenance_item_ids below.
-            note.is_branch_comparison = bool(note_payload.get("is_branch_comparison", False))
+            note.state.is_branch_comparison = bool(note_payload.get("is_branch_comparison", False))
         except Exception:
             continue
         notes_map[index] = note.id

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -369,8 +369,8 @@ def _serialize_note(node: SceneNode) -> dict[str, Any]:
         "size": {"width": 220.0, "height": 140.0},
         "color": node.color,
         "header_color": node.header_color,
-        "is_system_prompt": bool(node.is_system_prompt),
-        "is_summary_note": bool(node.is_summary_note),
+        "is_system_prompt": bool(node.state.is_system_prompt),
+        "is_summary_note": bool(node.state.is_summary_note),
         # Note provenance fields (role/source_ids/operation_id/
         # source_revisions/provider_snapshot) - dead even in legacy's own
         # persisted format (no SQL column for them ever existed; see
@@ -385,7 +385,7 @@ def _serialize_note(node: SceneNode) -> dict[str, Any]:
         # source-branch references. Unlike the dead legacy fields above,
         # this is a real, currently-populated field this backend itself
         # introduced - genuinely missing, not deliberately excluded.
-        "is_branch_comparison": bool(node.is_branch_comparison),
+        "is_branch_comparison": bool(node.state.is_branch_comparison),
         "item_ids": list(node.item_ids),
     }
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -5258,16 +5258,16 @@ def test_add_note_creates_a_note_with_correct_defaults():
     assert note.kind == "note"
     assert note.content == "Add note..."
     assert note.x == 10 and note.y == 20
-    assert note.is_system_prompt is False
-    assert note.is_summary_note is False
+    assert note.state.is_system_prompt is False
+    assert note.state.is_summary_note is False
     assert note.item_ids == []
 
 
 def test_add_note_accepts_system_prompt_and_summary_flags():
     doc = SceneDocument()
     note = doc.add_note(0, 0, is_system_prompt=True, is_summary_note=True)
-    assert note.is_system_prompt is True
-    assert note.is_summary_note is True
+    assert note.state.is_system_prompt is True
+    assert note.state.is_summary_note is True
 
 
 def test_add_note_has_no_parent_requirement():
@@ -6907,7 +6907,7 @@ def test_compare_branches_creates_a_note_linked_to_all_sources(monkeypatch):
         note = document.nodes[note_id]
         assert note.kind == "note"
         assert note.content == "Branch Comparison\n\nAgreements:\n• both agree"
-        assert note.is_branch_comparison is True
+        assert note.state.is_branch_comparison is True
         assert note.item_ids == [first.id, second.id]
         assert note.color == NOTE_AGENT_BODY_COLOR
         assert note.header_color == NOTE_AGENT_HEADER_COLOR

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -519,7 +519,7 @@ def test_execute_plugin_system_prompt_creates_a_note_attached_to_the_branch_root
     assert result is not None
     note = canvas_document.nodes[result]
     assert note.kind == "note"
-    assert note.is_system_prompt is True
+    assert note.state.is_system_prompt is True
     # Positioned above the ROOT (not `mid`), roughly matching legacy's
     # "200px above" placement.
     assert note.x == root.x
@@ -545,7 +545,7 @@ def test_execute_plugin_system_prompt_on_a_rootless_node_attaches_to_itself():
     assert result is not None
     note = canvas_document.nodes[result]
     assert note.kind == "note"
-    assert note.is_system_prompt is True
+    assert note.state.is_system_prompt is True
     assert any(e.source == note.id and e.target == lone.id for e in canvas_document.edges.values())
 
 

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -294,7 +294,7 @@ def test_notes_restore_position_content_and_flags():
     note = next(iter(document.nodes.values()))
     assert note.kind == "note" and note.content == "sys prompt"
     assert (note.x, note.y) == (12.0, 34.0)
-    assert note.color == "#abcdef" and note.is_system_prompt is True
+    assert note.color == "#abcdef" and note.state.is_system_prompt is True
 
 
 # -- charts ---------------------------------------------------------------
@@ -608,7 +608,7 @@ def test_restore_notes_restores_is_branch_comparison():
          "is_branch_comparison": True},
     ])
     note = next(iter(document.nodes.values()))
-    assert note.is_branch_comparison is True
+    assert note.state.is_branch_comparison is True
 
 
 def test_restore_notes_defaults_is_branch_comparison_to_false_when_absent():
@@ -616,7 +616,7 @@ def test_restore_notes_defaults_is_branch_comparison_to_false_when_absent():
         {"content": "plain", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1}},
     ])
     note = next(iter(document.nodes.values()))
-    assert note.is_branch_comparison is False
+    assert note.state.is_branch_comparison is False
 
 
 def test_restore_translates_a_synthesis_nodes_item_ids_to_the_re_minted_source_ids():

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -467,6 +467,6 @@ def test_round_trip_preserves_compare_branches_full_shape():
     second2 = next(n for n in doc2.nodes.values() if n.content == "second branch reply")
     note2 = next(n for n in doc2.nodes.values() if n.kind == "note")
 
-    assert note2.is_branch_comparison is True
+    assert note2.state.is_branch_comparison is True
     assert set(note2.item_ids) == {first2.id, second2.id}
     assert note2.content == "Branch Comparison\n\nAgreements:\n• both agree"

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -55,6 +55,7 @@ MIGRATED_KIND_FIELDS = {
     "html": ["html_splitter_state"],
     "artifact": ["artifact_content"],
     "code": ["code", "language"],
+    "note": ["is_system_prompt", "is_summary_note", "is_branch_comparison"],
 }
 
 


### PR DESCRIPTION
## Problem

Continuing ADR-002 stage 2.5's kind-by-kind migration (PR1-4 moved `image`/`html`/`artifact`/`code`). Next up: `note`'s three fields, `is_system_prompt`/`is_summary_note`/`is_branch_comparison`.

## Change

Moves all three off `SceneNode` onto a new `NoteState` dataclass. The first kind whose fields are touched from outside domain/session code in more than one place: `branches.py`'s kind-guarded `mark_branch_comparison_note`, `plugins.py`'s System Prompt dedup check (already kind-guarded via a short-circuit `and` chain), and `agents.py`'s `_resolve_branch_system_prompt`.

The last one is genuinely novel: `agents.py` deliberately never imports `SceneDocument`/`SceneNode` (avoids a circular import with `canvas.py`) and resolves fields via `getattr` for that reason. Its `is_system_prompt` lookup changed from the fully duck-typed `getattr(source_node, "is_system_prompt", False)` to `getattr(source_node.state, "is_system_prompt", False)` - a direct, non-defensive `.state` access. Verified this is safe rather than a regression: `source_node` always comes from a real `SceneDocument.nodes` dict, and `state` is an unconditional dataclass field on every `SceneNode` regardless of kind, so this can never raise `AttributeError` today. Also confirmed there is no available form that's both fully duck-typed-safe *and* recognized by the migration gate's `_is_via_state` check (which only matches a literal attribute chain ending in `.state`, not a nested `getattr(x, "state", None)` call) - the shipped form is the correct trade-off given that structural constraint, not a shortcut.

Also fixed two stale `"is_branch_comparison below"` comment cross-references in `model.py` that the field's own removal left dangling.

Confirmed `backend/chat_library.py`'s own, unrelated SQLite notes table (same field names, entirely different system) poses no collision risk for the migration gate - it only ever touches these names via dict `.get()`/subscript/literal syntax, never dot-attribute access.

## Test plan

- [x] `python -c "import backend.canvas"` succeeds
- [x] `pyflakes` clean (same pre-existing re-export-facade warning shape as PR1-4)
- [x] Full `pytest -q` from repo root: 1227 passed (same count as PR1-4)
- [x] Mutation-tested the `branches.py` setter fix and the `agents.py` `getattr` fix specifically (confirming the gate's `getattr`/`setattr` detection branch catches it, not just the dot-attribute branch)
- [x] Repo-wide grep confirms zero remaining bare access to any of the three fields anywhere
- [x] Independent two-reviewer adversarial review pass + skeptical synthesis, with explicit focus on the `agents.py` duck-typing trade-off: confirmed safe and structurally necessary, not a shortcut; two real stale-comment issues found and fixed