### PR TITLE
ADR-002 stage 2.5 (PR6/~8, backend-only, batched): document, web_research, chart, frame+container

### DIFF
--- a/backend/assets.py
+++ b/backend/assets.py
@@ -80,13 +80,13 @@ def register_assets(app: FastAPI, bus: EventBus) -> None:
             return JSONResponse({"error": "unknown chart"}, status_code=404)
 
         png_bytes = render_chart_png(
-            node.chart_type,
-            node.chart_data,
-            node.chart_width,
-            node.chart_height,
+            node.state.chart_type,
+            node.state.chart_data,
+            node.state.chart_width,
+            node.state.chart_height,
             dpi_scale=CHART_EXPORT_DPI_SCALE,
         )
-        title = node.chart_data.get("title") if isinstance(node.chart_data, dict) else ""
+        title = node.state.chart_data.get("title") if isinstance(node.state.chart_data, dict) else ""
         filename = _sanitize_chart_filename(title)
         return Response(
             content=png_bytes,

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -85,7 +85,7 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
-from backend.domain.node_states import ArtifactState, CodeState, HtmlState, ImageState
+from backend.domain.node_states import ArtifactState, CodeState, DocumentState, HtmlState, ImageState, WebResearchState
 
 
 

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -84,7 +84,18 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
-from backend.domain.node_states import ArtifactState, CodeState, HtmlState, ImageState, NoteState
+from backend.domain.node_states import (
+    ArtifactState,
+    ChartState,
+    CodeState,
+    ContainerState,
+    DocumentState,
+    FrameState,
+    HtmlState,
+    ImageState,
+    NoteState,
+    WebResearchState,
+)
 
 
 def _estimate_tokens(text: str) -> int:
@@ -347,8 +358,8 @@ class SceneDocument(BranchOps, GroupOps):
         DocumentNode.__init__: `self.title = title`, no slicing), and none
         of the legacy view-layer formatting (byte-size/duration strings,
         preview_label auto-fill, audio-preview suppression) happens here -
-        see the R3.9 comment on the SceneNode dataclass fields for those
-        exact rules.
+        see DocumentState's own docstring (backend/domain/node_states.py)
+        for those exact rules.
         """
         if parent_id not in self.nodes:
             raise SceneError(f"unknown parent node: {parent_id}")
@@ -367,12 +378,14 @@ class SceneDocument(BranchOps, GroupOps):
             title=str(title),
             kind="document",
             content=str(content),
-            attachment_kind=normalized_kind,
-            file_path=str(file_path),
-            mime_type=str(mime_type),
-            duration_seconds=duration_seconds,
-            byte_size=byte_size,
-            preview_label=str(preview_label),
+            state=DocumentState(
+                attachment_kind=normalized_kind,
+                file_path=str(file_path),
+                mime_type=str(mime_type),
+                duration_seconds=duration_seconds,
+                byte_size=byte_size,
+                preview_label=str(preview_label),
+            ),
         )
         self.nodes[node_id] = node
         self.connect(parent_id, node_id)
@@ -641,6 +654,7 @@ class SceneDocument(BranchOps, GroupOps):
             y=float(y),
             title="Web Research",
             kind="web_research",
+            state=WebResearchState(),
         )
         self.nodes[node_id] = node
         self.connect(parent_id, node_id)
@@ -658,11 +672,11 @@ class SceneDocument(BranchOps, GroupOps):
         if node.kind != "web_research":
             raise SceneError(f"node is not a web_research node: {node_id}")
         node.content = str(query)
-        node.research_stage = ""
-        node.research_completed = 0
-        node.research_total = 0
-        node.research_active_source_id = None
-        node.research_error = ""
+        node.state.research_stage = ""
+        node.state.research_completed = 0
+        node.state.research_total = 0
+        node.state.research_active_source_id = None
+        node.state.research_error = ""
         return node
 
     def apply_web_research_progress(self, node_id: str, event) -> SceneNode | None:
@@ -676,10 +690,10 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             return None
-        node.research_stage = event.stage.value
-        node.research_completed = event.completed
-        node.research_total = event.total
-        node.research_active_source_id = event.source_id
+        node.state.research_stage = event.stage.value
+        node.state.research_completed = event.completed
+        node.state.research_total = event.total
+        node.state.research_active_source_id = event.source_id
         return node
 
     def complete_web_research_run(self, node_id: str, result_wire: dict) -> SceneNode:
@@ -690,10 +704,10 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
-        node.research_stage = "completed"
-        node.research_error = ""
-        node.research_active_source_id = None
-        node.research_result = result_wire
+        node.state.research_stage = "completed"
+        node.state.research_error = ""
+        node.state.research_active_source_id = None
+        node.state.research_result = result_wire
         return node
 
     def fail_web_research_run(self, node_id: str, *, cancelled: bool, message: str) -> SceneNode:
@@ -703,9 +717,9 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
-        node.research_stage = "cancelled" if cancelled else "failed"
-        node.research_error = message
-        node.research_active_source_id = None
+        node.state.research_stage = "cancelled" if cancelled else "failed"
+        node.state.research_error = message
+        node.state.research_active_source_id = None
         return node
 
     # -- R5.2: artifact/drafter node -----------------------------------------
@@ -1313,19 +1327,22 @@ class SceneDocument(BranchOps, GroupOps):
             y=float(y),
             title=title,
             kind="chart",
-            chart_type=normalized_type,
-            chart_data=safe_chart_data,
-            chart_error=str(chart_error),
-            chart_source_node_id=parent_id or "",
+            state=ChartState(
+                chart_type=normalized_type,
+                chart_data=safe_chart_data,
+                chart_error=str(chart_error),
+                chart_source_node_id=parent_id or "",
+            ),
         )
 
         png_bytes = render_chart_png(
-            node.chart_type, node.chart_data, node.chart_width, node.chart_height, dpi_scale=1.0,
+            node.state.chart_type, node.state.chart_data, node.state.chart_width, node.state.chart_height,
+            dpi_scale=1.0,
         )
         asset_id = f"chart{uuid.uuid4().hex}"
         self.image_assets[asset_id] = (png_bytes, "image/png")
-        node.chart_asset_id = asset_id
-        node.chart_asset_version = 1
+        node.state.chart_asset_id = asset_id
+        node.state.chart_asset_version = 1
 
         self.nodes[node_id] = node
         if parent_id is not None:
@@ -1364,7 +1381,7 @@ class SceneDocument(BranchOps, GroupOps):
         clamped_width = min(CHART_MAX_WIDTH, max(CHART_MIN_WIDTH, requested_width))
         clamped_height = min(CHART_MAX_HEIGHT, max(CHART_MIN_HEIGHT, requested_height))
 
-        if node.chart_aspect_locked and requested_width > 0 and requested_height > 0:
+        if node.state.chart_aspect_locked and requested_width > 0 and requested_height > 0:
             aspect_ratio = requested_width / requested_height
             width_from_height = clamped_height * aspect_ratio
             height_from_width = clamped_width / aspect_ratio
@@ -1380,14 +1397,15 @@ class SceneDocument(BranchOps, GroupOps):
             clamped_width = min(CHART_MAX_WIDTH, max(CHART_MIN_WIDTH, clamped_width))
             clamped_height = min(CHART_MAX_HEIGHT, max(CHART_MIN_HEIGHT, clamped_height))
 
-        node.chart_width = clamped_width
-        node.chart_height = clamped_height
+        node.state.chart_width = clamped_width
+        node.state.chart_height = clamped_height
 
         png_bytes = render_chart_png(
-            node.chart_type, node.chart_data, node.chart_width, node.chart_height, dpi_scale=1.0,
+            node.state.chart_type, node.state.chart_data, node.state.chart_width, node.state.chart_height,
+            dpi_scale=1.0,
         )
-        self.image_assets[node.chart_asset_id] = (png_bytes, "image/png")
-        node.chart_asset_version += 1
+        self.image_assets[node.state.chart_asset_id] = (png_bytes, "image/png")
+        node.state.chart_asset_version += 1
 
     def toggle_chart_aspect_lock(self, node_id: str) -> None:
         """Chart kind only (SceneError otherwise). Flips chart_aspect_locked.
@@ -1399,7 +1417,7 @@ class SceneDocument(BranchOps, GroupOps):
             raise SceneError(f"unknown node: {node_id}")
         if node.kind != "chart":
             raise SceneError(f"node is not a chart node: {node_id}")
-        node.chart_aspect_locked = not node.chart_aspect_locked
+        node.state.chart_aspect_locked = not node.state.chart_aspect_locked
 
     def update_chat_node_content(self, node_id: str, content: str) -> SceneNode:
         """The regenerate primitive: mutate an EXISTING chat node's content in
@@ -1521,7 +1539,7 @@ class SceneDocument(BranchOps, GroupOps):
             # the live bbox stay in agreement. See _recompute_group_bounds
             # for how this anchor is unioned with live content so it still
             # can never clip a member.
-            node.group_manual_x, node.group_manual_y = node.x, node.y
+            node.state.group_manual_x, node.state.group_manual_y = node.x, node.y
             self._recompute_group_bounds(node_id)
         # R6.1: keep every frame/container this node is a member of enclosing
         # it - a node is a member of at most one frame AND at most one
@@ -1563,7 +1581,7 @@ class SceneDocument(BranchOps, GroupOps):
             node.x, node.y = float(x), float(y)
             moved_ids.add(node_id)
             if node.kind == "frame":
-                node.group_manual_x, node.group_manual_y = node.x, node.y
+                node.state.group_manual_x, node.state.group_manual_y = node.x, node.y
         affected_groups: set[str] = set()
         for moved_id in moved_ids:
             moved_node = self.nodes.get(moved_id)
@@ -1600,10 +1618,14 @@ class SceneDocument(BranchOps, GroupOps):
                     self.image_assets.pop(image_asset_id, None)
                 # R6.2: a chart node's rendered PNG lives in the SAME
                 # image_assets dict (reused, not a parallel store - see
-                # chart_asset_id's own field comment on SceneNode) - same
-                # leak-prevention reasoning as image_asset_id just above.
-                if node.chart_asset_id:
-                    self.image_assets.pop(node.chart_asset_id, None)
+                # ChartState's own docstring, backend/domain/node_states.py)
+                # - same leak-prevention reasoning as image_asset_id just
+                # above, and the same ADR-002 stage 2.5 getattr posture
+                # (chart_asset_id lives on node.state now, None for every
+                # non-chart kind).
+                chart_asset_id = getattr(node.state, "chart_asset_id", None)
+                if chart_asset_id:
+                    self.image_assets.pop(chart_asset_id, None)
                 self._detach_node_from_membership(node_id)
 
     # -- edges -------------------------------------------------------------
@@ -1684,12 +1706,12 @@ class SceneDocument(BranchOps, GroupOps):
                     "isCollapsed": n.is_collapsed,
                     "code": n.state.code if isinstance(n.state, CodeState) else "",
                     "language": n.state.language if isinstance(n.state, CodeState) else "",
-                    "attachmentKind": n.attachment_kind,
-                    "filePath": n.file_path,
-                    "mimeType": n.mime_type,
-                    "durationSeconds": n.duration_seconds,
-                    "byteSize": n.byte_size,
-                    "previewLabel": n.preview_label,
+                    "attachmentKind": n.state.attachment_kind if isinstance(n.state, DocumentState) else "",
+                    "filePath": n.state.file_path if isinstance(n.state, DocumentState) else "",
+                    "mimeType": n.state.mime_type if isinstance(n.state, DocumentState) else "",
+                    "durationSeconds": n.state.duration_seconds if isinstance(n.state, DocumentState) else None,
+                    "byteSize": n.state.byte_size if isinstance(n.state, DocumentState) else None,
+                    "previewLabel": n.state.preview_label if isinstance(n.state, DocumentState) else "",
                     "isDocked": n.is_docked,
                     "imageAssetId": n.state.image_asset_id if isinstance(n.state, ImageState) else "",
                     "history": [
@@ -1708,12 +1730,14 @@ class SceneDocument(BranchOps, GroupOps):
                     # final_deliverable_node_id's own comments.
                     "branchStatus": n.branch_status,
                     "isFinalDeliverable": n.id == self.final_deliverable_node_id,
-                    "researchStage": n.research_stage,
-                    "researchCompleted": n.research_completed,
-                    "researchTotal": n.research_total,
-                    "researchActiveSourceId": n.research_active_source_id,
-                    "researchError": n.research_error,
-                    "researchResult": n.research_result,
+                    "researchStage": n.state.research_stage if isinstance(n.state, WebResearchState) else "",
+                    "researchCompleted": n.state.research_completed if isinstance(n.state, WebResearchState) else 0,
+                    "researchTotal": n.state.research_total if isinstance(n.state, WebResearchState) else 0,
+                    "researchActiveSourceId": (
+                        n.state.research_active_source_id if isinstance(n.state, WebResearchState) else None
+                    ),
+                    "researchError": n.state.research_error if isinstance(n.state, WebResearchState) else "",
+                    "researchResult": n.state.research_result if isinstance(n.state, WebResearchState) else None,
                     "artifactContent": n.state.artifact_content if isinstance(n.state, ArtifactState) else "",
                     "gitlinkRepo": n.gitlink_repo,
                     "gitlinkBranch": n.gitlink_branch,
@@ -1776,19 +1800,21 @@ class SceneDocument(BranchOps, GroupOps):
                     # NoteState's own comment, backend/domain/node_states.py.
                     "isBranchComparison": n.state.is_branch_comparison if isinstance(n.state, NoteState) else False,
                     "itemIds": list(n.item_ids),
-                    "isLocked": n.is_locked,
-                    "groupWidth": n.group_width,
-                    "groupHeight": n.group_height,
+                    "isLocked": n.state.is_locked if isinstance(n.state, FrameState) else True,
+                    "groupWidth": n.state.group_width if isinstance(n.state, (FrameState, ContainerState)) else None,
+                    "groupHeight": (
+                        n.state.group_height if isinstance(n.state, (FrameState, ContainerState)) else None
+                    ),
                     # R6.2: Chart node.
-                    "chartType": n.chart_type,
-                    "chartData": dict(n.chart_data),
-                    "chartError": n.chart_error,
-                    "chartAssetId": n.chart_asset_id,
-                    "chartAssetVersion": n.chart_asset_version,
-                    "chartWidth": n.chart_width,
-                    "chartHeight": n.chart_height,
-                    "chartAspectLocked": n.chart_aspect_locked,
-                    "chartSourceNodeId": n.chart_source_node_id,
+                    "chartType": n.state.chart_type if isinstance(n.state, ChartState) else "",
+                    "chartData": dict(n.state.chart_data) if isinstance(n.state, ChartState) else {},
+                    "chartError": n.state.chart_error if isinstance(n.state, ChartState) else "",
+                    "chartAssetId": n.state.chart_asset_id if isinstance(n.state, ChartState) else "",
+                    "chartAssetVersion": n.state.chart_asset_version if isinstance(n.state, ChartState) else 0,
+                    "chartWidth": n.state.chart_width if isinstance(n.state, ChartState) else 680.0,
+                    "chartHeight": n.state.chart_height if isinstance(n.state, ChartState) else 500.0,
+                    "chartAspectLocked": n.state.chart_aspect_locked if isinstance(n.state, ChartState) else True,
+                    "chartSourceNodeId": n.state.chart_source_node_id if isinstance(n.state, ChartState) else "",
                     # R6.3: HTML splitter + chat scroll gaps.
                     "htmlSplitterState": n.state.html_splitter_state if isinstance(n.state, HtmlState) else None,
                     "chatScrollValue": n.chat_scroll_value,

--- a/backend/domain/groups.py
+++ b/backend/domain/groups.py
@@ -29,6 +29,7 @@ from backend.domain.model import (
     SceneError,
     SceneNode,
 )
+from backend.domain.node_states import ContainerState, FrameState
 
 
 class GroupOps:
@@ -115,29 +116,37 @@ class GroupOps:
         if node is None or node.kind not in ("frame", "container"):
             return
         if node.is_collapsed:
-            node.group_width = GROUP_COLLAPSED_WIDTH
-            node.group_height = GROUP_COLLAPSED_HEIGHT
+            node.state.group_width = GROUP_COLLAPSED_WIDTH
+            node.state.group_height = GROUP_COLLAPSED_HEIGHT
             return
         bx, by, bw, bh = self._bbox_of_members(node.item_ids)
         has_manual = node.kind == "frame" and (
-            node.group_manual_width is not None
-            or node.group_manual_height is not None
-            or node.group_manual_x is not None
-            or node.group_manual_y is not None
+            node.state.group_manual_width is not None
+            or node.state.group_manual_height is not None
+            or node.state.group_manual_x is not None
+            or node.state.group_manual_y is not None
         )
         if has_manual:
-            width = node.group_manual_width if node.group_manual_width is not None else (node.group_width or bw)
-            height = node.group_manual_height if node.group_manual_height is not None else (node.group_height or bh)
-            if node.group_manual_x is not None and node.group_manual_y is not None:
-                anchor_x, anchor_y = node.group_manual_x, node.group_manual_y
+            width = (
+                node.state.group_manual_width
+                if node.state.group_manual_width is not None
+                else (node.state.group_width or bw)
+            )
+            height = (
+                node.state.group_manual_height
+                if node.state.group_manual_height is not None
+                else (node.state.group_height or bh)
+            )
+            if node.state.group_manual_x is not None and node.state.group_manual_y is not None:
+                anchor_x, anchor_y = node.state.group_manual_x, node.state.group_manual_y
             else:
                 anchor_x = bx + bw / 2.0 - width / 2.0
                 anchor_y = by + bh / 2.0 - height / 2.0
-            node.x, node.y, node.group_width, node.group_height = self._union_rect(
+            node.x, node.y, node.state.group_width, node.state.group_height = self._union_rect(
                 (anchor_x, anchor_y, width, height), (bx, by, bw, bh)
             )
             return
-        node.x, node.y, node.group_width, node.group_height = bx, by, bw, bh
+        node.x, node.y, node.state.group_width, node.state.group_height = bx, by, bw, bh
 
     def _detach_from_existing_group(self, member_id: str, group_kind: str) -> None:
         """Part of create_frame/create_container's shared validation: if
@@ -196,8 +205,8 @@ class GroupOps:
             kind="frame",
             content="Add note...",
             item_ids=ids,
-            is_locked=True,
             is_collapsed=False,
+            state=FrameState(is_locked=True),
         )
         self.nodes[node_id] = node
         self._recompute_group_bounds(node_id)
@@ -211,8 +220,8 @@ class GroupOps:
         node's frame membership. UNLIKE create_frame, item_ids here may
         include note/frame/container ids too - container membership can
         nest (a container may hold another container or a frame as one of
-        its members). is_locked is left at its dataclass default (True) but
-        is MEANINGLESS for containers - see the field's own comment; no
+        its members). ContainerState has no is_locked concept at all (see
+        that class's own docstring, backend/domain/node_states.py) - no
         toggle_container_lock exists and none should be added."""
         ids = list(item_ids)
         for member_id in ids:
@@ -230,6 +239,7 @@ class GroupOps:
             content="New Container",
             item_ids=ids,
             is_collapsed=False,
+            state=ContainerState(),
         )
         self.nodes[node_id] = node
         self._recompute_group_bounds(node_id)
@@ -271,7 +281,7 @@ class GroupOps:
             raise SceneError(f"unknown node: {node_id}")
         if node.kind != "frame":
             raise SceneError(f"node is not a frame node: {node_id}")
-        node.is_locked = not node.is_locked
+        node.state.is_locked = not node.state.is_locked
         self._recompute_group_bounds(node_id)
 
     def toggle_group_collapsed(self, node_id: str) -> None:
@@ -304,8 +314,8 @@ class GroupOps:
         if node.kind != "frame":
             raise SceneError(f"node is not a frame node: {node_id}")
         _, _, min_width, min_height = self._bbox_of_members(node.item_ids)
-        node.group_manual_width = max(float(width), min_width)
-        node.group_manual_height = max(float(height), min_height)
+        node.state.group_manual_width = max(float(width), min_width)
+        node.state.group_manual_height = max(float(height), min_height)
         self._recompute_group_bounds(node_id)
 
     def fit_frame_to_content(self, node_id: str) -> None:
@@ -321,10 +331,10 @@ class GroupOps:
             raise SceneError(f"unknown node: {node_id}")
         if node.kind != "frame":
             raise SceneError(f"node is not a frame node: {node_id}")
-        node.group_manual_width = None
-        node.group_manual_height = None
-        node.group_manual_x = None
-        node.group_manual_y = None
+        node.state.group_manual_width = None
+        node.state.group_manual_height = None
+        node.state.group_manual_x = None
+        node.state.group_manual_y = None
         self._recompute_group_bounds(node_id)
 
     def ungroup(self, node_id: str) -> None:

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -107,9 +107,10 @@ GROUP_INELIGIBLE_FRAME_MEMBER_KINDS = frozenset({"note", "frame", "container"})
 # backend is the actual source of truth for the stored size, so it clamps
 # independently rather than trusting whatever the client sends).
 # DEFAULT_WIDTH/DEFAULT_HEIGHT are NOT repeated here - they live directly as
-# SceneNode.chart_width/chart_height's own dataclass field defaults below,
-# and add_chart_node reads them off a freshly-constructed node rather than a
-# second literal, so the two can never drift apart.
+# ChartState's own dataclass field defaults (backend/domain/node_states.py,
+# ADR-002 stage 2.5), and add_chart_node reads them off a freshly-
+# constructed node's state rather than a second literal, so the two can
+# never drift apart.
 CHART_MIN_WIDTH = 440.0
 CHART_MIN_HEIGHT = 320.0
 CHART_MAX_WIDTH = 2400.0
@@ -164,62 +165,6 @@ class SceneNode:
     content: str = ""
     is_user: bool = False
     is_collapsed: bool = False
-    # R3.9 (doc/QT_REMOVAL_PLAN.md): the document node's real persisted shape -
-    # graphlink_scene.py's add_document_node()/graphlink_node_document.py's
-    # DocumentNode.__init__ attachment metadata (title/content above, plus
-    # these six fields). The backend stores these VERBATIM, exactly as
-    # passed in - none of the legacy view-layer formatting below happens
-    # here; reproducing it is the frontend's job (same as the paint()/menu
-    # code it replaces). Formatting rules extracted from
-    # graphlink_nodes/graphlink_node_document.py + graphlink_audio.py, for
-    # the frontend to reproduce exactly in TypeScript:
-    #
-    # - Byte-size formatting (DocumentNode._format_byte_size): if byte_size
-    #   is falsy (None or 0) -> "Unknown". Else repeatedly divide by 1024.0
-    #   walking units ("B","KB","MB","GB","TB"), stopping at the first unit
-    #   where size < 1024.0 (or unit == "TB"); "B" formats as a bare integer
-    #   ("512 B"), every other unit formats with exactly one decimal place
-    #   ("1.5 MB").
-    # - Duration formatting (graphlink_audio.format_duration): None ->
-    #   "Unknown". Else round(seconds) to the nearest whole second, clamp
-    #   negative to 0, divmod into hours/minutes/seconds; if hours > 0 format
-    #   "H:MM:SS" (hours unpadded, minutes/seconds zero-padded to 2 digits),
-    #   else "M:SS" (minutes unpadded, seconds zero-padded).
-    # - Metadata rows (DocumentNode._build_metadata_rows), in this exact
-    #   order, each omitted entirely when its value is empty/None: Type
-    #   ("Audio file" if attachment_kind=="audio" else "Document", always
-    #   present) / Duration (formatted, only if duration_seconds is not
-    #   None) / Format (mime_type, only if truthy) / Size (formatted byte
-    #   size, only if byte_size is truthy) / Path (file_path, only if
-    #   truthy).
-    # - preview_label auto-fill (DocumentNode._build_preview_label), used
-    #   only when the caller didn't supply one: for attachment_kind=="audio"
-    #   -> "Audio | {duration formatted, or 'Audio' if duration_seconds is
-    #   None}"; otherwise derived from title's file extension via
-    #   os.path.splitext: ".pdf" -> "PDF", ".docx" -> "DOCX", any other
-    #   extension -> that extension uppercased without its dot, no extension
-    #   -> "Document".
-    # - Audio-preview-suppression heuristic
-    #   (DocumentNode._should_show_audio_preview): normalize both `content`
-    #   and the auto-built `audio_details` block the same way (join
-    #   right-stripped lines with "\n", strip the whole string, lowercase).
-    #   Hide the content-preview panel (show only the metadata table) when:
-    #   normalized content is empty; OR normalized content == normalized
-    #   audio_details (content is nothing but the auto-generated metadata
-    #   block); OR normalized content startswith "audio attachment" AND
-    #   contains "duration:" (catches legacy-saved sessions whose persisted
-    #   content is an older/differently-valued metadata block). Otherwise
-    #   show the preview. `audio_details` itself is the joined lines: "Audio
-    #   attachment", then "Duration: {formatted}" if duration_seconds is not
-    #   None, "Format: {mime_type}" if truthy, "Size: {formatted byte size}"
-    #   if byte_size truthy, "Path: {file_path}" if truthy - same
-    #   presence/order rules as the metadata rows above.
-    attachment_kind: str = ""
-    file_path: str = ""
-    mime_type: str = ""
-    duration_seconds: float | None = None
-    byte_size: int | None = None
-    preview_label: str = ""
     # R3.13 (doc/QT_REMOVAL_PLAN.md): the ThinkingNode/docked-child increment -
     # whether this node is currently docked into its parent's collapsed
     # docked-child slot. A parent's set of docked children is derived at read
@@ -293,27 +238,6 @@ class SceneNode:
     # "Hide Other Branches" already uses for a different subtree question,
     # not by inventing write-time cascade bookkeeping here.
     branch_status: str = "active"
-    # R5.1: the Web Research node's real persisted shape - `content` (reused,
-    # same pattern as code/thinking/html) holds the query text; these six
-    # fields track one research run's live progress/outcome. Unused
-    # (default) for every other kind.
-    #
-    # research_stage is one of the empty-string sentinel ("" - never run) or
-    # the 9 ResearchStage enum values from
-    # graphlink_plugins/web_research/domain.py's own .value strings:
-    # "preparing" | "searching" | "fetching" | "extracting" | "validating" |
-    # "synthesizing" | "completed" | "cancelled" | "failed".
-    research_stage: str = ""
-    research_completed: int = 0
-    research_total: int = 0
-    research_active_source_id: str | None = None
-    research_error: str = ""
-    # The wire-shaped (camelCase) ResearchResult, or None before the first
-    # run ever completes. Deliberate stale-while-revalidate: a NEW run does
-    # NOT clear this on start (see start_web_research_run) - the previous
-    # answer stays visible until this run replaces it on success, or
-    # fails/cancels (leaving the stale result annotated by research_error).
-    research_result: dict[str, Any] | None = None
     # R5.3: the Gitlink node's real persisted shape - reads a GitHub repo (or
     # a local checkout) into structured XML context, proposes an LLM change
     # set, and only writes to disk after an explicit, fingerprint-verified
@@ -499,108 +423,6 @@ class SceneNode:
     # membership use above. Unused (default empty list) for every other
     # case.
     item_ids: list[str] = field(default_factory=list)
-    # frame kind only - legacy default is LOCKED (True), unlike every other
-    # bool field on this dataclass (which all default False). Containers
-    # have no lock concept at all - see create_container's own docstring for
-    # why no lock toggle is exposed for them. Unused for every other kind.
-    is_locked: bool = True
-    # frame kind only - the MANUAL resize override recorded by resize_frame,
-    # cleared back to None by fit_frame_to_content. This pair (unlike
-    # group_width/group_height just below) is the single, stable source of
-    # truth for "is this frame currently manually sized": it is NEVER
-    # auto-populated by _recompute_group_bounds's own auto-fit branch, only
-    # ever written by resize_frame/fit_frame_to_content, so its None-ness
-    # survives a collapse/expand round-trip untouched (unlike group_width/
-    # group_height, which DO get temporarily overwritten with the fixed
-    # collapsed-pill size while is_collapsed - see toggle_group_collapsed).
-    # Deliberately excluded from scene_payload()/the wire - pure internal
-    # bookkeeping, mirrors gitlink_imported_root's own "server-side only"
-    # precedent. Unused (always None) for container kind - containers have
-    # no manual-resize capability (no resize_container method exists).
-    group_manual_width: float | None = None
-    group_manual_height: float | None = None
-    # frame kind only - the position counterpart to group_manual_width/
-    # height above: set by move_node whenever a frame is dragged directly
-    # (locked whole-group drag OR an independently-dragged unlocked frame),
-    # cleared back to None by fit_frame_to_content. Exists so an unlocked
-    # frame's own drag actually sticks - without an explicit anchor, the
-    # very next member move would recompute the frame straight back to
-    # bbox-of-members-centered, silently undoing the drag (legacy let an
-    # unlocked frame's outline be repositioned independently of its
-    # members; this is that same capability, ported). See
-    # _recompute_group_bounds for how this anchor is unioned with the live
-    # bbox so it still can never clip a member, matching legacy's own
-    # rect.united() guarantee. Same wire/kind-scoping posture as
-    # group_manual_width/height above (server-side only, unused for
-    # container).
-    group_manual_x: float | None = None
-    group_manual_y: float | None = None
-    # frame/container's current effective on-canvas size, kept live by
-    # _recompute_group_bounds: the fixed GROUP_COLLAPSED_WIDTH/HEIGHT pill
-    # while is_collapsed, else group_manual_width/height verbatim while a
-    # frame has a manual override active, else the padded bbox-of-members
-    # auto-fit size. THIS is the field the contract names group_width/
-    # group_height and exposes on the wire as groupWidth/groupHeight -
-    # group_manual_width/height above exist purely so a frame's manual
-    # override survives a collapse/expand round-trip without the collapsed-
-    # pill overwrite (this field) destroying it. Unused (default None) for
-    # every other kind.
-    group_width: float | None = None
-    group_height: float | None = None
-    # R6.2: Chart node - graphlink_canvas_chart_item.py's ChartItem, ported
-    # to a backend-rendered PNG (see graphlink_chart_rendering.py's own
-    # module docstring for why - matplotlib+FigureCanvasAgg was already
-    # Qt-free upstream; only the QImage-wrapping step needed replacing).
-    #
-    # chart_type is one of SUPPORTED_CHART_TYPES (graphlink_chart_data.py):
-    # "bar" | "line" | "pie" | "histogram" | "sankey". Unused (default "")
-    # for every other kind.
-    chart_type: str = ""
-    # ALREADY-canonicalized chart data (canonicalize_chart_data's own output
-    # shape) - add_chart_node below does NOT call canonicalize_chart_data
-    # itself; the caller (backend/agents.py's generateChart intent, via
-    # AgentDispatcher.start_chart_generation) is responsible for that, so it
-    # can catch ChartDataError itself and still create a placeholder chart
-    # with chart_error set on failure, matching legacy's never-hard-fail
-    # contract, rather than add_chart_node raising and aborting node
-    # creation entirely.
-    chart_data: dict[str, Any] = field(default_factory=dict)
-    # Non-empty if generation/canonicalization degraded to a placeholder -
-    # the chart still has a real (if minimal) chart_asset_id and renders
-    # SOMETHING, never a blank/broken state (mirrors ChartDataAgent's own
-    # get_response/repair_chart_data/heuristic_chart_data degrade-gracefully
-    # chain, which never hard-fails outright for a genuine LLM response).
-    chart_error: str = ""
-    # Opaque key into the EXISTING SceneDocument.image_assets dict (REUSED,
-    # not a parallel store - same dict R3.21's image nodes already use, see
-    # that field's own transport-decision comment on image_assets) - the
-    # rendered display-resolution PNG. Export (the 3x-resolution download)
-    # re-renders fresh rather than reading this asset - see backend/assets.py.
-    chart_asset_id: str = ""
-    # Incremented every time chart_asset_id's bytes are (re)written (by
-    # add_chart_node's initial render, or resize_chart's re-render) - lets
-    # the frontend cache-bust the <img> src with a version query param after
-    # a resize re-render, since the asset id itself never changes.
-    chart_asset_version: int = 0
-    # Legacy ChartItem.DEFAULT_WIDTH/DEFAULT_HEIGHT - add_chart_node reads
-    # these dataclass defaults directly (not a second literal) when
-    # rendering a freshly-created chart's first PNG, so the two can never
-    # drift apart. resize_chart clamps any later change into
-    # [CHART_MIN_WIDTH, CHART_MAX_WIDTH] / [CHART_MIN_HEIGHT, CHART_MAX_HEIGHT].
-    chart_width: float = 680.0
-    chart_height: float = 500.0
-    # Legacy ChartItem.aspect_ratio_locked's own default (True, unlike most
-    # bool fields on this dataclass which default False) - resize_chart
-    # consults this to decide whether to re-derive a dimension after
-    # clamping; toggle_chart_aspect_lock flips it without touching size or
-    # re-rendering.
-    chart_aspect_locked: bool = True
-    # Provenance: which node's content the chart data was generated from -
-    # always the parent branch-point edge's source in this implementation
-    # (legacy's rarer "different node" case is a known, accepted
-    # simplification, not replicated). Unused (default "") for every other
-    # kind.
-    chart_source_node_id: str = ""
     # R6.3: ChatNode's persisted scroll position within its own content
     # area (legacy's own scroll_value field). Unlike HtmlState's own
     # html_splitter_state (backend/domain/node_states.py, ADR-002 stage

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -20,7 +20,7 @@ conversation.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 class NodeState:
@@ -89,3 +89,229 @@ class NoteState(NodeState):
     is_system_prompt: bool = False
     is_summary_note: bool = False
     is_branch_comparison: bool = False
+
+
+@dataclass
+class DocumentState(NodeState):
+    """Relocated verbatim from SceneNode's six document-attachment fields
+    (former backend/domain/model.py fields, R3.9) - graphlink_scene.py's
+    add_document_node()/graphlink_node_document.py's DocumentNode.__init__
+    attachment metadata (title/content live on SceneNode's own core).
+    Stored VERBATIM, exactly as passed in - none of the legacy view-layer
+    formatting below happens here; reproducing it is the frontend's job
+    (same as the paint()/menu code it replaces). Formatting rules
+    extracted from graphlink_nodes/graphlink_node_document.py +
+    graphlink_audio.py, for the frontend to reproduce exactly in
+    TypeScript:
+
+    - Byte-size formatting (DocumentNode._format_byte_size): if byte_size
+      is falsy (None or 0) -> "Unknown". Else repeatedly divide by 1024.0
+      walking units ("B","KB","MB","GB","TB"), stopping at the first unit
+      where size < 1024.0 (or unit == "TB"); "B" formats as a bare integer
+      ("512 B"), every other unit formats with exactly one decimal place
+      ("1.5 MB").
+    - Duration formatting (graphlink_audio.format_duration): None ->
+      "Unknown". Else round(seconds) to the nearest whole second, clamp
+      negative to 0, divmod into hours/minutes/seconds; if hours > 0 format
+      "H:MM:SS" (hours unpadded, minutes/seconds zero-padded to 2 digits),
+      else "M:SS" (minutes unpadded, seconds zero-padded).
+    - Metadata rows (DocumentNode._build_metadata_rows), in this exact
+      order, each omitted entirely when its value is empty/None: Type
+      ("Audio file" if attachment_kind=="audio" else "Document", always
+      present) / Duration (formatted, only if duration_seconds is not
+      None) / Format (mime_type, only if truthy) / Size (formatted byte
+      size, only if byte_size is truthy) / Path (file_path, only if
+      truthy).
+    - preview_label auto-fill (DocumentNode._build_preview_label), used
+      only when the caller didn't supply one: for attachment_kind=="audio"
+      -> "Audio | {duration formatted, or 'Audio' if duration_seconds is
+      None}"; otherwise derived from title's file extension via
+      os.path.splitext: ".pdf" -> "PDF", ".docx" -> "DOCX", any other
+      extension -> that extension uppercased without its dot, no extension
+      -> "Document".
+    - Audio-preview-suppression heuristic
+      (DocumentNode._should_show_audio_preview): normalize both `content`
+      and the auto-built `audio_details` block the same way (join
+      right-stripped lines with "\\n", strip the whole string, lowercase).
+      Hide the content-preview panel (show only the metadata table) when:
+      normalized content is empty; OR normalized content == normalized
+      audio_details (content is nothing but the auto-generated metadata
+      block); OR normalized content startswith "audio attachment" AND
+      contains "duration:" (catches legacy-saved sessions whose persisted
+      content is an older/differently-valued metadata block). Otherwise
+      show the preview. `audio_details` itself is the joined lines: "Audio
+      attachment", then "Duration: {formatted}" if duration_seconds is not
+      None, "Format: {mime_type}" if truthy, "Size: {formatted byte size}"
+      if byte_size truthy, "Path: {file_path}" if truthy - same
+      presence/order rules as the metadata rows above."""
+
+    attachment_kind: str = ""
+    file_path: str = ""
+    mime_type: str = ""
+    duration_seconds: float | None = None
+    byte_size: int | None = None
+    preview_label: str = ""
+
+
+@dataclass
+class WebResearchState(NodeState):
+    """Relocated verbatim from SceneNode's six web-research fields (former
+    backend/domain/model.py fields, R5.1) - one research run's live
+    progress/outcome. SceneNode's own `content` field (reused, same
+    pattern as code/thinking/html) holds the query text - not duplicated
+    here. research_stage is one of the empty-string sentinel ("" - never
+    run) or the 9 ResearchStage enum values from
+    graphlink_plugins/web_research/domain.py's own .value strings:
+    "preparing" | "searching" | "fetching" | "extracting" | "validating" |
+    "synthesizing" | "completed" | "cancelled" | "failed".
+    research_result is the wire-shaped (camelCase) ResearchResult, or None
+    before the first run ever completes - deliberate stale-while-
+    revalidate (a NEW run does not clear this on start; see
+    start_web_research_run's own docstring)."""
+
+    research_stage: str = ""
+    research_completed: int = 0
+    research_total: int = 0
+    research_active_source_id: str | None = None
+    research_error: str = ""
+    research_result: dict | None = None
+
+
+@dataclass
+class ChartState(NodeState):
+    """Relocated verbatim from SceneNode's nine chart fields (former
+    backend/domain/model.py fields, R6.2) - graphlink_canvas_chart_item.py's
+    ChartItem, ported to a backend-rendered PNG (see
+    graphlink_chart_rendering.py's own module docstring for why -
+    matplotlib+FigureCanvasAgg was already Qt-free upstream; only the
+    QImage-wrapping step needed replacing).
+
+    - chart_type: one of SUPPORTED_CHART_TYPES (graphlink_chart_data.py):
+      "bar" | "line" | "pie" | "histogram" | "sankey".
+    - chart_data: ALREADY-canonicalized (canonicalize_chart_data's own
+      output shape) - add_chart_node does NOT call canonicalize_chart_data
+      itself; the caller (backend/agents.py's generateChart intent, via
+      AgentDispatcher.start_chart_generation) is responsible for that, so
+      it can catch ChartDataError itself and still create a placeholder
+      chart with chart_error set on failure, matching legacy's never-
+      hard-fail contract, rather than add_chart_node raising and aborting
+      node creation entirely.
+    - chart_error: non-empty if generation/canonicalization degraded to a
+      placeholder - the chart still has a real (if minimal) chart_asset_id
+      and renders SOMETHING, never a blank/broken state (mirrors
+      ChartDataAgent's own get_response/repair_chart_data/
+      heuristic_chart_data degrade-gracefully chain, which never
+      hard-fails outright for a genuine LLM response).
+    - chart_asset_id: opaque key into the EXISTING
+      SceneDocument.image_assets dict (REUSED, not a parallel store - same
+      dict R3.21's image nodes already use, see that field's own
+      transport-decision comment on image_assets) - the rendered
+      display-resolution PNG. Export (the 3x-resolution download)
+      re-renders fresh rather than reading this asset - see
+      backend/assets.py.
+    - chart_asset_version: incremented every time chart_asset_id's bytes
+      are (re)written (by add_chart_node's initial render, or
+      resize_chart's re-render) - lets the frontend cache-bust the <img>
+      src with a version query param after a resize re-render, since the
+      asset id itself never changes.
+    - chart_width/chart_height: default to legacy ChartItem.DEFAULT_WIDTH/
+      DEFAULT_HEIGHT - add_chart_node reads these dataclass defaults
+      directly off a freshly-constructed node's state (not a second
+      literal) when rendering a freshly-created chart's first PNG, so the
+      two can never drift apart. resize_chart clamps any later change into
+      [CHART_MIN_WIDTH, CHART_MAX_WIDTH] / [CHART_MIN_HEIGHT,
+      CHART_MAX_HEIGHT] (backend/domain/model.py).
+    - chart_aspect_locked: legacy ChartItem.aspect_ratio_locked's own
+      default (True, unlike most bool fields in this module which default
+      False) - resize_chart consults this to decide whether to re-derive a
+      dimension after clamping; toggle_chart_aspect_lock flips it without
+      touching size or re-rendering.
+    - chart_source_node_id: provenance - which node's content the chart
+      data was generated from, always the parent branch-point edge's
+      source in this implementation (legacy's rarer "different node" case
+      is a known, accepted simplification, not replicated)."""
+
+    chart_type: str = ""
+    chart_data: dict = field(default_factory=dict)
+    chart_error: str = ""
+    chart_asset_id: str = ""
+    chart_asset_version: int = 0
+    chart_width: float = 680.0
+    chart_height: float = 500.0
+    chart_aspect_locked: bool = True
+    chart_source_node_id: str = ""
+
+
+@dataclass
+class FrameState(NodeState):
+    """Relocated verbatim from SceneNode's frame-only fields (former
+    backend/domain/model.py fields, R6.1).
+
+    - is_locked: legacy default is LOCKED (True), unlike every other bool
+      field in this module (which all default False). Containers have no
+      lock concept at all - see create_container's own docstring for why
+      no lock toggle is exposed for them.
+    - group_manual_width/group_manual_height: the MANUAL resize override
+      recorded by resize_frame, cleared back to None by
+      fit_frame_to_content. This pair (unlike group_width/group_height
+      below) is the single, stable source of truth for "is this frame
+      currently manually sized": it is NEVER auto-populated by
+      _recompute_group_bounds's own auto-fit branch, only ever written by
+      resize_frame/fit_frame_to_content, so its None-ness survives a
+      collapse/expand round-trip untouched (unlike group_width/
+      group_height, which DO get temporarily overwritten with the fixed
+      collapsed-pill size while is_collapsed - see toggle_group_collapsed).
+      Deliberately excluded from scene_payload()/the wire - pure internal
+      bookkeeping, mirrors gitlink_imported_root's own "server-side only"
+      precedent.
+    - group_manual_x/group_manual_y: the position counterpart to
+      group_manual_width/height above - set by move_node whenever a frame
+      is dragged directly (locked whole-group drag OR an independently-
+      dragged unlocked frame), cleared back to None by
+      fit_frame_to_content. Exists so an unlocked frame's own drag
+      actually sticks - without an explicit anchor, the very next member
+      move would recompute the frame straight back to bbox-of-members-
+      centered, silently undoing the drag (legacy let an unlocked frame's
+      outline be repositioned independently of its members; this is that
+      same capability, ported). See _recompute_group_bounds for
+      how this anchor is unioned with the live bbox so it still can never
+      clip a member, matching legacy's own rect.united() guarantee. Same
+      wire/kind-scoping posture as group_manual_width/height above
+      (server-side only).
+    - group_width/group_height: the frame's current effective on-canvas
+      size, kept live by _recompute_group_bounds - the fixed
+      GROUP_COLLAPSED_WIDTH/HEIGHT pill while is_collapsed, else
+      group_manual_width/height verbatim while a manual override is
+      active, else the padded bbox-of-members auto-fit size. THIS is the
+      pair the wire contract names group_width/group_height and exposes as
+      groupWidth/groupHeight - group_manual_width/height above exist
+      purely so a frame's manual override survives a collapse/expand
+      round-trip without the collapsed-pill overwrite (this pair)
+      destroying it.
+
+    NOT shared with ContainerState despite group_width/group_height being
+    common to both: is_locked/group_manual_* are explicitly meaningless
+    for containers (no lock concept, no manual-resize capability - no
+    resize_container method exists), so forcing them onto a shared base
+    would resurrect the exact "every kind carries fields it never uses"
+    problem this migration exists to remove."""
+
+    is_locked: bool = True
+    group_manual_width: float | None = None
+    group_manual_height: float | None = None
+    group_manual_x: float | None = None
+    group_manual_y: float | None = None
+    group_width: float | None = None
+    group_height: float | None = None
+
+
+@dataclass
+class ContainerState(NodeState):
+    """Relocated verbatim from SceneNode's group_width/group_height fields
+    (former backend/domain/model.py fields, R6.1), as they apply to
+    container kind specifically - see FrameState's own docstring for why
+    this is a separate class rather than a shared base with FrameState,
+    despite the field-name overlap."""
+
+    group_width: float | None = None
+    group_height: float | None = None

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -187,11 +187,13 @@ from typing import Any
 from backend.canvas import (
     ArtifactState,
     CodeState,
+    DocumentState,
     HtmlState,
     ImageState,
     SceneDocument,
     SceneNode,
     SUPPORTED_CHART_TYPES,
+    WebResearchState,
     _content_codec,
     _placeholder_chart_data,
 )
@@ -387,12 +389,14 @@ def _restore_document_payload(payload: dict[str, Any]) -> SceneNode:
     return SceneNode(
         id="", x=x, y=y, title=str(payload.get("title", "") or "Document"), kind="document",
         content=str(payload.get("content", "")),
-        attachment_kind=str(payload.get("attachment_kind", "document")),
-        file_path=str(payload.get("file_path", "")),
-        mime_type=str(payload.get("mime_type", "")),
-        duration_seconds=payload.get("duration_seconds"),
-        byte_size=payload.get("byte_size"),
-        preview_label=str(payload.get("preview_label", "") or ""),
+        state=DocumentState(
+            attachment_kind=str(payload.get("attachment_kind", "document")),
+            file_path=str(payload.get("file_path", "")),
+            mime_type=str(payload.get("mime_type", "")),
+            duration_seconds=payload.get("duration_seconds"),
+            byte_size=payload.get("byte_size"),
+            preview_label=str(payload.get("preview_label", "") or ""),
+        ),
         is_collapsed=bool(payload.get("is_collapsed", False)),
         is_docked=bool(payload.get("is_docked", False)),
     )
@@ -461,10 +465,11 @@ def _restore_web_payload(payload: dict[str, Any]) -> SceneNode:
         content=str(payload.get("query", "")),
         history=_restore_history(payload.get("conversation_history")),
         is_collapsed=bool(payload.get("is_collapsed", False)),
+        state=WebResearchState(),
     )
     research_result = payload.get("research_result")
     if isinstance(research_result, dict) and research_result:
-        node.research_result = _snake_to_camel_deep(research_result)
+        node.state.research_result = _snake_to_camel_deep(research_result)
     else:
         summary = payload.get("summary")
         sources = payload.get("sources")
@@ -475,7 +480,7 @@ def _restore_web_payload(payload: dict[str, Any]) -> SceneNode:
             # entirely. Synthesized as a minimal, best-effort
             # ResearchResult-shaped dict from the flat summary/sources pair
             # that IS present.
-            node.research_result = _snake_to_camel_deep({
+            node.state.research_result = _snake_to_camel_deep({
                 "request_id": "legacy",
                 "original_query": payload.get("query", ""),
                 "effective_query": payload.get("query", ""),
@@ -773,7 +778,7 @@ def _restore_charts(
             # late, since the requested (width, height) would already have
             # been silently overridden to preserve the default 680x500 ratio.
             aspect_locked = bool(chart_payload.get("aspect_ratio_locked", True))
-            if aspect_locked != chart.chart_aspect_locked:
+            if aspect_locked != chart.state.chart_aspect_locked:
                 document.toggle_chart_aspect_lock(chart.id)
             size = chart_payload.get("size")
             if isinstance(size, dict) and "width" in size and "height" in size:
@@ -808,7 +813,7 @@ def _restore_frames(
             frame = document.create_frame(member_ids)
             document.set_group_label(frame.id, str(frame_payload.get("note", "") or ""))
             document.set_group_color(frame.id, frame_payload.get("color"), frame_payload.get("header_color"))
-            if bool(frame_payload.get("is_locked", True)) != frame.is_locked:
+            if bool(frame_payload.get("is_locked", True)) != frame.state.is_locked:
                 document.toggle_frame_lock(frame.id)
             # R6.4 translation, NOT a gap: deserialize_frame sets
             # frame._user_resized = True whenever the payload's "rect" key

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -220,12 +220,12 @@ def _serialize_document_node(node: SceneNode) -> dict[str, Any]:
         "node_type": "document",
         "title": node.title,
         "content": node.content,
-        "attachment_kind": node.attachment_kind,
-        "file_path": node.file_path,
-        "mime_type": node.mime_type,
-        "duration_seconds": node.duration_seconds,
-        "byte_size": node.byte_size,
-        "preview_label": node.preview_label,
+        "attachment_kind": node.state.attachment_kind,
+        "file_path": node.state.file_path,
+        "mime_type": node.state.mime_type,
+        "duration_seconds": node.state.duration_seconds,
+        "byte_size": node.state.byte_size,
+        "preview_label": node.state.preview_label,
         "is_collapsed": bool(node.is_collapsed),
         "is_docked": bool(node.is_docked),
     }
@@ -264,7 +264,7 @@ def _serialize_html_node(node: SceneNode) -> dict[str, Any]:
 
 
 def _serialize_web_node(node: SceneNode) -> dict[str, Any]:
-    research_result = _camel_to_snake_deep(node.research_result) if node.research_result else {}
+    research_result = _camel_to_snake_deep(node.state.research_result) if node.state.research_result else {}
     return {
         # R6.5 translation (inverse of R6.4's own): backend kind
         # "web_research" -> legacy node_type "web".
@@ -404,8 +404,8 @@ def _serialize_pin(record) -> dict[str, Any]:
 
 def _serialize_frame(node: SceneNode, frame_source_index: dict[str, int]) -> dict[str, Any]:
     item_indices = [frame_source_index[i] for i in node.item_ids if i in frame_source_index]
-    width = node.group_width if node.group_width is not None else 0.0
-    height = node.group_height if node.group_height is not None else 0.0
+    width = node.state.group_width if node.state.group_width is not None else 0.0
+    height = node.state.group_height if node.state.group_height is not None else 0.0
     return {
         "id": node.id,
         "items": item_indices,
@@ -422,7 +422,7 @@ def _serialize_frame(node: SceneNode, frame_source_index: dict[str, int]) -> dic
         # (unlike legacy's QGraphicsItem coordinate model).
         "rect": {"x": node.x, "y": node.y, "width": width, "height": height},
         "expanded_rect": {"x": node.x, "y": node.y, "width": width, "height": height},
-        "is_locked": bool(node.is_locked),
+        "is_locked": bool(node.state.is_locked),
         "is_collapsed": bool(node.is_collapsed),
         "color": node.color,
         "header_color": node.header_color,
@@ -431,8 +431,8 @@ def _serialize_frame(node: SceneNode, frame_source_index: dict[str, int]) -> dic
 
 def _serialize_container(node: SceneNode, all_items_index: dict[str, int]) -> dict[str, Any]:
     item_indices = [all_items_index[i] for i in node.item_ids if i in all_items_index]
-    width = node.group_width if node.group_width is not None else 0.0
-    height = node.group_height if node.group_height is not None else 0.0
+    width = node.state.group_width if node.state.group_width is not None else 0.0
+    height = node.state.group_height if node.state.group_height is not None else 0.0
     return {
         "id": node.id,
         "items": item_indices,
@@ -453,20 +453,20 @@ def _serialize_chart(
     parent_index = nodes_index.get(parent_id) if parent_id is not None else None
     return {
         "id": node.id,
-        "data": dict(node.chart_data),
+        "data": dict(node.state.chart_data),
         "position": _position(node),
-        "size": {"width": node.chart_width, "height": node.chart_height},
-        "aspect_ratio_locked": bool(node.chart_aspect_locked),
+        "size": {"width": node.state.chart_width, "height": node.state.chart_height},
+        "aspect_ratio_locked": bool(node.state.chart_aspect_locked),
         "parent_node_index": parent_index,
         "parent_node_id": parent_id,
         # chart_source_node_id is always derived from parent_id in this
-        # backend (add_chart_node's own contract - see that field's comment
-        # on SceneNode) - legacy's rarer differs-from-parent case was
-        # already documented there as an accepted simplification, so
-        # source_node_id is simply the same id, never a genuinely distinct
-        # value.
+        # backend (add_chart_node's own contract - see ChartState's own
+        # docstring, backend/domain/node_states.py) - legacy's rarer
+        # differs-from-parent case was already documented there as an
+        # accepted simplification, so source_node_id is simply the same
+        # id, never a genuinely distinct value.
         "source_node_id": parent_id,
-        "data_error": node.chart_error or None,
+        "data_error": node.state.chart_error or None,
     }
 
 

--- a/backend/tests/test_assets.py
+++ b/backend/tests/test_assets.py
@@ -128,7 +128,7 @@ def test_export_chart_returns_a_real_higher_resolution_png():
     parent = document.add_node(0, 0, "parent")
     chart = document.add_chart_node(0, 0, parent.id, "bar", dict(_CHART_DATA))
 
-    display_bytes, _ = document.get_image_asset(chart.chart_asset_id)
+    display_bytes, _ = document.get_image_asset(chart.state.chart_asset_id)
     response = client.get(f"/api/assets/chart/{chart.id}/export")
 
     assert response.status_code == 200

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -288,12 +288,12 @@ def test_add_document_node_creates_a_real_document_kind_node():
     assert node.kind == "document"
     assert node.title == "report.pdf"
     assert node.content == "some extracted text"
-    assert node.attachment_kind == "document"
-    assert node.file_path == "C:/files/report.pdf"
-    assert node.mime_type == "application/pdf"
-    assert node.duration_seconds is None
-    assert node.byte_size == 2048
-    assert node.preview_label == "PDF"
+    assert node.state.attachment_kind == "document"
+    assert node.state.file_path == "C:/files/report.pdf"
+    assert node.state.mime_type == "application/pdf"
+    assert node.state.duration_seconds is None
+    assert node.state.byte_size == 2048
+    assert node.state.preview_label == "PDF"
     assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
 
 
@@ -301,7 +301,7 @@ def test_add_document_node_normalizes_attachment_kind_casing():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     node = doc.add_document_node(0, 0, "voice.wav", "", "Audio", parent.id)
-    assert node.attachment_kind == "audio"
+    assert node.state.attachment_kind == "audio"
 
 
 def test_add_document_node_requires_a_parent_id():
@@ -369,10 +369,10 @@ def test_add_document_node_intent_creates_a_real_node_and_publishes():
             [10, 10, "audio.mp3", "", "audio", parent_id, "", "audio/mpeg", 125.4, 4096, ""],
         )
         assert document.nodes[node_id].kind == "document"
-        assert document.nodes[node_id].attachment_kind == "audio"
-        assert document.nodes[node_id].mime_type == "audio/mpeg"
-        assert document.nodes[node_id].duration_seconds == 125.4
-        assert document.nodes[node_id].byte_size == 4096
+        assert document.nodes[node_id].state.attachment_kind == "audio"
+        assert document.nodes[node_id].state.mime_type == "audio/mpeg"
+        assert document.nodes[node_id].state.duration_seconds == 125.4
+        assert document.nodes[node_id].state.byte_size == 4096
         assert any(
             e.source == parent_id and e.target == node_id for e in document.edges.values()
         )
@@ -3054,21 +3054,21 @@ def test_start_web_research_run_sets_content_and_resets_progress_fields():
     parent = doc.add_node(0, 0, "parent")
     node = doc.add_web_research_node(0, 0, parent.id)
     # Simulate a previous run's leftover progress state.
-    node.research_stage = "fetching"
-    node.research_completed = 2
-    node.research_total = 4
-    node.research_active_source_id = "s1-old"
-    node.research_error = "stale error"
+    node.state.research_stage = "fetching"
+    node.state.research_completed = 2
+    node.state.research_total = 4
+    node.state.research_active_source_id = "s1-old"
+    node.state.research_error = "stale error"
 
     returned = doc.start_web_research_run(node.id, "what is the capital of France?")
 
     assert returned is node
     assert node.content == "what is the capital of France?"
-    assert node.research_stage == ""
-    assert node.research_completed == 0
-    assert node.research_total == 0
-    assert node.research_active_source_id is None
-    assert node.research_error == ""
+    assert node.state.research_stage == ""
+    assert node.state.research_completed == 0
+    assert node.state.research_total == 0
+    assert node.state.research_active_source_id is None
+    assert node.state.research_error == ""
 
 
 def test_start_web_research_run_does_not_clear_a_stale_previous_result():
@@ -3079,11 +3079,11 @@ def test_start_web_research_run_does_not_clear_a_stale_previous_result():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     node = doc.add_web_research_node(0, 0, parent.id)
-    node.research_result = {"answerMarkdown": "a previous stale answer"}
+    node.state.research_result = {"answerMarkdown": "a previous stale answer"}
 
     doc.start_web_research_run(node.id, "a follow-up question")
 
-    assert node.research_result == {"answerMarkdown": "a previous stale answer"}
+    assert node.state.research_result == {"answerMarkdown": "a previous stale answer"}
 
 
 def test_start_web_research_run_unknown_node_raises_scene_error():
@@ -3109,10 +3109,10 @@ def test_apply_web_research_progress_updates_stage_completed_total_source_id_fro
     returned = doc.apply_web_research_progress(node.id, fake_event)
 
     assert returned is node
-    assert node.research_stage == "fetching"
-    assert node.research_completed == 1
-    assert node.research_total == 4
-    assert node.research_active_source_id == "s1-abc123"
+    assert node.state.research_stage == "fetching"
+    assert node.state.research_completed == 1
+    assert node.state.research_total == 4
+    assert node.state.research_active_source_id == "s1-abc123"
 
 
 def test_apply_web_research_progress_is_a_silent_noop_for_a_deleted_or_unknown_node():
@@ -3127,17 +3127,17 @@ def test_complete_web_research_run_sets_result_and_clears_error_and_active_sourc
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     node = doc.add_web_research_node(0, 0, parent.id)
-    node.research_error = "a previous error"
-    node.research_active_source_id = "s1-still-active"
+    node.state.research_error = "a previous error"
+    node.state.research_active_source_id = "s1-still-active"
     result_wire = {"answerMarkdown": "the answer", "sources": []}
 
     returned = doc.complete_web_research_run(node.id, result_wire)
 
     assert returned is node
-    assert node.research_stage == "completed"
-    assert node.research_error == ""
-    assert node.research_active_source_id is None
-    assert node.research_result == result_wire
+    assert node.state.research_stage == "completed"
+    assert node.state.research_error == ""
+    assert node.state.research_active_source_id is None
+    assert node.state.research_result == result_wire
 
 
 def test_complete_web_research_run_unknown_node_raises_scene_error():
@@ -3149,14 +3149,14 @@ def test_fail_web_research_run_sets_cancelled_stage_and_message():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     node = doc.add_web_research_node(0, 0, parent.id)
-    node.research_active_source_id = "s1-in-flight"
+    node.state.research_active_source_id = "s1-in-flight"
 
     returned = doc.fail_web_research_run(node.id, cancelled=True, message="Web research cancelled.")
 
     assert returned is node
-    assert node.research_stage == "cancelled"
-    assert node.research_error == "Web research cancelled."
-    assert node.research_active_source_id is None
+    assert node.state.research_stage == "cancelled"
+    assert node.state.research_error == "Web research cancelled."
+    assert node.state.research_active_source_id is None
 
 
 def test_fail_web_research_run_sets_failed_stage_and_message():
@@ -3167,19 +3167,19 @@ def test_fail_web_research_run_sets_failed_stage_and_message():
     returned = doc.fail_web_research_run(node.id, cancelled=False, message="The search provider failed.")
 
     assert returned is node
-    assert node.research_stage == "failed"
-    assert node.research_error == "The search provider failed."
+    assert node.state.research_stage == "failed"
+    assert node.state.research_error == "The search provider failed."
 
 
 def test_fail_web_research_run_does_not_clear_a_stale_previous_result():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     node = doc.add_web_research_node(0, 0, parent.id)
-    node.research_result = {"answerMarkdown": "a previous stale answer"}
+    node.state.research_result = {"answerMarkdown": "a previous stale answer"}
 
     doc.fail_web_research_run(node.id, cancelled=False, message="boom")
 
-    assert node.research_result == {"answerMarkdown": "a previous stale answer"}
+    assert node.state.research_result == {"answerMarkdown": "a previous stale answer"}
 
 
 def test_fail_web_research_run_unknown_node_raises_scene_error():
@@ -3491,8 +3491,8 @@ def test_run_web_research_on_a_different_node_while_one_is_busy_does_not_clobber
         # Give node_b a pre-existing failed state to prove it survives.
         document.start_web_research_run(node_b.id, "node b's original query")
         document.fail_web_research_run(node_b.id, cancelled=False, message="node b failed earlier")
-        assert node_b.research_stage == "failed"
-        assert node_b.research_error == "node b failed earlier"
+        assert node_b.state.research_stage == "failed"
+        assert node_b.state.research_error == "node b failed earlier"
 
         started = threading.Event()
         release = threading.Event()
@@ -3526,8 +3526,8 @@ def test_run_web_research_on_a_different_node_while_one_is_busy_does_not_clobber
                 "scene", "runWebResearch", [node_b.id, "a brand new query for b"]
             )
             assert result_b is None
-            assert node_b.research_stage == "failed", "node_b's terminal state must survive the bounce"
-            assert node_b.research_error == "node b failed earlier"
+            assert node_b.state.research_stage == "failed", "node_b's terminal state must survive the bounce"
+            assert node_b.state.research_error == "node b failed earlier"
             assert node_b.content == "node b's original query", "node_b's content must not be overwritten"
 
             notice = await bus.publish("notification")
@@ -3539,8 +3539,8 @@ def test_run_web_research_on_a_different_node_while_one_is_busy_does_not_clobber
             entry = next(iter(web_research_slots(dispatcher).values()))
             await entry["task"]
 
-        assert node_a.research_stage == "completed"
-        assert node_a.research_result["answerMarkdown"] == "node a's result"
+        assert node_a.state.research_stage == "completed"
+        assert node_a.state.research_result["answerMarkdown"] == "node a's result"
 
     asyncio.run(run())
 
@@ -5363,7 +5363,7 @@ def test_create_frame_sets_correct_defaults_and_initial_bbox():
 
     assert frame.kind == "frame"
     assert frame.content == "Add note..."
-    assert frame.is_locked is True
+    assert frame.state.is_locked is True
     assert frame.is_collapsed is False
     assert frame.item_ids == [m1.id, m2.id]
     # Padded union rect: member footprints default to 220x120, so m1 spans
@@ -5372,8 +5372,8 @@ def test_create_frame_sets_correct_defaults_and_initial_bbox():
     # GROUP_PADDING_TOP=50 pads the top.
     assert frame.x == pytest.approx(-40.0)
     assert frame.y == pytest.approx(-50.0)
-    assert frame.group_width == pytest.approx(600.0)
-    assert frame.group_height == pytest.approx(510.0)
+    assert frame.state.group_width == pytest.approx(600.0)
+    assert frame.state.group_height == pytest.approx(510.0)
 
 
 def test_create_container_sets_correct_defaults():
@@ -5383,7 +5383,7 @@ def test_create_container_sets_correct_defaults():
     assert container.kind == "container"
     assert container.content == "New Container"
     assert container.item_ids == [m1.id]
-    assert container.group_width is not None and container.group_height is not None
+    assert container.state.group_width is not None and container.state.group_height is not None
 
 
 def test_create_frame_detaches_member_from_its_existing_frame():
@@ -5450,8 +5450,8 @@ def test_bbox_auto_grow_recompute_on_member_move():
     # union x:[0,1220]/y:[0,1120].
     assert node.x == pytest.approx(-40.0)
     assert node.y == pytest.approx(-50.0)
-    assert node.group_width == pytest.approx(1300.0)
-    assert node.group_height == pytest.approx(1210.0)
+    assert node.state.group_width == pytest.approx(1300.0)
+    assert node.state.group_height == pytest.approx(1210.0)
 
 
 def test_bbox_auto_grow_recompute_via_move_node_also_covers_container():
@@ -5472,11 +5472,11 @@ def test_moving_a_non_member_node_does_not_touch_unrelated_groups():
     m1 = doc.add_node(0, 0)
     frame = doc.create_frame([m1.id])
     bystander = doc.add_node(999, 999)
-    before = (doc.nodes[frame.id].x, doc.nodes[frame.id].y, doc.nodes[frame.id].group_width)
+    before = (doc.nodes[frame.id].x, doc.nodes[frame.id].y, doc.nodes[frame.id].state.group_width)
 
     doc.move_node(bystander.id, -50, -50)
 
-    after = (doc.nodes[frame.id].x, doc.nodes[frame.id].y, doc.nodes[frame.id].group_width)
+    after = (doc.nodes[frame.id].x, doc.nodes[frame.id].y, doc.nodes[frame.id].state.group_width)
     assert before == after
 
 
@@ -5485,19 +5485,19 @@ def test_toggle_group_collapsed_shrinks_to_pill_size_and_restores_on_expand():
     m1, m2 = doc.add_node(0, 0), doc.add_node(300, 300)
     frame = doc.create_frame([m1.id, m2.id])
     expanded_x, expanded_y = frame.x, frame.y
-    expanded_w, expanded_h = frame.group_width, frame.group_height
+    expanded_w, expanded_h = frame.state.group_width, frame.state.group_height
 
     doc.toggle_group_collapsed(frame.id)
     node = doc.nodes[frame.id]
     assert node.is_collapsed is True
-    assert node.group_width == 260.0
-    assert node.group_height == 50.0
+    assert node.state.group_width == 260.0
+    assert node.state.group_height == 50.0
 
     doc.toggle_group_collapsed(frame.id)
     node = doc.nodes[frame.id]
     assert node.is_collapsed is False
-    assert node.group_width == pytest.approx(expanded_w)
-    assert node.group_height == pytest.approx(expanded_h)
+    assert node.state.group_width == pytest.approx(expanded_w)
+    assert node.state.group_height == pytest.approx(expanded_h)
     assert node.x == pytest.approx(expanded_x)
     assert node.y == pytest.approx(expanded_y)
 
@@ -5507,8 +5507,8 @@ def test_toggle_group_collapsed_works_for_containers_too():
     m1 = doc.add_node(0, 0)
     container = doc.create_container([m1.id])
     doc.toggle_group_collapsed(container.id)
-    assert doc.nodes[container.id].group_width == 260.0
-    assert doc.nodes[container.id].group_height == 50.0
+    assert doc.nodes[container.id].state.group_width == 260.0
+    assert doc.nodes[container.id].state.group_height == 50.0
 
 
 def test_toggle_group_collapsed_rejects_non_group_kind():
@@ -5525,8 +5525,8 @@ def test_resize_frame_sets_manual_override_and_recenters():
 
     doc.resize_frame(frame.id, 800, 700)
     node = doc.nodes[frame.id]
-    assert node.group_width == 800.0
-    assert node.group_height == 700.0
+    assert node.state.group_width == 800.0
+    assert node.state.group_height == 700.0
     # bbox-of-members center is (260, 205) - see
     # test_create_frame_sets_correct_defaults_and_initial_bbox for the raw
     # bbox this is derived from (x=-40,y=-50,w=600,h=510).
@@ -5541,8 +5541,8 @@ def test_resize_frame_clamps_below_bbox_minimum():
 
     doc.resize_frame(frame.id, 1, 1)
     node = doc.nodes[frame.id]
-    assert node.group_width == pytest.approx(600.0), "must clamp up to the auto-fit bbox width"
-    assert node.group_height == pytest.approx(510.0), "must clamp up to the auto-fit bbox height"
+    assert node.state.group_width == pytest.approx(600.0), "must clamp up to the auto-fit bbox width"
+    assert node.state.group_height == pytest.approx(510.0), "must clamp up to the auto-fit bbox height"
 
 
 def test_resize_frame_grows_to_re_enclose_a_member_that_moves_far_outside_it():
@@ -5568,8 +5568,8 @@ def test_resize_frame_grows_to_re_enclose_a_member_that_moves_far_outside_it():
     # rather than clipping the member outside a frozen 800x700 box.
     assert node.x == pytest.approx(-40.0)
     assert node.y == pytest.approx(-50.0)
-    assert node.group_width == pytest.approx(1300.0)
-    assert node.group_height == pytest.approx(1210.0)
+    assert node.state.group_width == pytest.approx(1300.0)
+    assert node.state.group_height == pytest.approx(1210.0)
 
 
 def test_resize_frame_grows_only_the_axis_that_actually_needs_it():
@@ -5592,8 +5592,8 @@ def test_resize_frame_grows_only_the_axis_that_actually_needs_it():
     # right=max(810,860)=860, bottom=max(555,460)=555.
     assert node.x == pytest.approx(-40.0)
     assert node.y == pytest.approx(-145.0)
-    assert node.group_width == pytest.approx(900.0)
-    assert node.group_height == pytest.approx(700.0)
+    assert node.state.group_width == pytest.approx(900.0)
+    assert node.state.group_height == pytest.approx(700.0)
 
 
 def test_moving_a_frame_directly_pins_a_manual_position_anchor():
@@ -5611,15 +5611,15 @@ def test_moving_a_frame_directly_pins_a_manual_position_anchor():
     doc.move_node(frame.id, 100, 100)
 
     node = doc.nodes[frame.id]
-    assert node.group_manual_x == pytest.approx(100.0)
-    assert node.group_manual_y == pytest.approx(100.0)
+    assert node.state.group_manual_x == pytest.approx(100.0)
+    assert node.state.group_manual_y == pytest.approx(100.0)
     # Anchor rect (100,100,600,510) unioned with the untouched member bbox
     # (-40,-50,600,510): left=min(100,-40)=-40, top=min(100,-50)=-50,
     # right=max(700,560)=700, bottom=max(610,460)=610.
     assert node.x == pytest.approx(-40.0)
     assert node.y == pytest.approx(-50.0)
-    assert node.group_width == pytest.approx(740.0)
-    assert node.group_height == pytest.approx(660.0)
+    assert node.state.group_width == pytest.approx(740.0)
+    assert node.state.group_height == pytest.approx(660.0)
 
 
 def test_manual_position_anchor_survives_a_member_move_and_still_grows():
@@ -5637,12 +5637,12 @@ def test_manual_position_anchor_survives_a_member_move_and_still_grows():
     # bbox x=-40,y=250,w=600,h=610. Anchor rect (100,100,740,660) union
     # bbox (-40,250,600,610): left=min(100,-40)=-40, top=min(100,250)=100,
     # right=max(840,560)=840, bottom=max(760,860)=860.
-    assert node.group_manual_x == pytest.approx(100.0)
-    assert node.group_manual_y == pytest.approx(100.0)
+    assert node.state.group_manual_x == pytest.approx(100.0)
+    assert node.state.group_manual_y == pytest.approx(100.0)
     assert node.x == pytest.approx(-40.0)
     assert node.y == pytest.approx(100.0)
-    assert node.group_width == pytest.approx(880.0)
-    assert node.group_height == pytest.approx(760.0)
+    assert node.state.group_width == pytest.approx(880.0)
+    assert node.state.group_height == pytest.approx(760.0)
 
 
 def test_fit_frame_to_content_clears_manual_position_anchor_too():
@@ -5654,20 +5654,23 @@ def test_fit_frame_to_content_clears_manual_position_anchor_too():
     doc.fit_frame_to_content(frame.id)
 
     node = doc.nodes[frame.id]
-    assert node.group_manual_x is None
-    assert node.group_manual_y is None
+    assert node.state.group_manual_x is None
+    assert node.state.group_manual_y is None
     # Back to a pure auto-fit bbox of the (untouched) members.
     assert node.x == pytest.approx(-40.0)
     assert node.y == pytest.approx(-50.0)
-    assert node.group_width == pytest.approx(600.0)
-    assert node.group_height == pytest.approx(510.0)
+    assert node.state.group_width == pytest.approx(600.0)
+    assert node.state.group_height == pytest.approx(510.0)
 
 
 def test_moving_a_container_does_not_pin_a_manual_position_anchor():
     # Containers have no manual-position concept, matching legacy (no lock,
     # no independent-drag distinction for Container - it always owns and
     # moves its children as one unit) and mirroring how group_manual_width/
-    # height are already frame-only.
+    # height are already frame-only. ADR-002 stage 2.5 (PR6) strengthened
+    # this from "stayed None at runtime" to "structurally absent" -
+    # ContainerState (backend/domain/node_states.py) has no
+    # group_manual_x/y fields at all, unlike FrameState.
     doc = SceneDocument()
     m1 = doc.add_node(0, 0)
     container = doc.create_container([m1.id])
@@ -5675,8 +5678,8 @@ def test_moving_a_container_does_not_pin_a_manual_position_anchor():
     doc.move_node(container.id, 100, 100)
 
     node = doc.nodes[container.id]
-    assert node.group_manual_x is None
-    assert node.group_manual_y is None
+    assert not hasattr(node.state, "group_manual_x")
+    assert not hasattr(node.state, "group_manual_y")
 
 
 def test_move_nodes_updates_every_position_in_one_batch():
@@ -5726,8 +5729,8 @@ def test_move_nodes_recomputes_a_group_exactly_once_using_the_fully_settled_posi
     # correct locked-group drag always should.
     assert node.x == pytest.approx(-40.0 + 50.0)
     assert node.y == pytest.approx(-50.0 + 50.0)
-    assert node.group_width == pytest.approx(600.0)
-    assert node.group_height == pytest.approx(510.0)
+    assert node.state.group_width == pytest.approx(600.0)
+    assert node.state.group_height == pytest.approx(510.0)
 
 
 def test_move_nodes_recomputes_a_container_holding_a_moved_member():
@@ -5777,19 +5780,19 @@ def test_fit_frame_to_content_clears_manual_override():
     doc.fit_frame_to_content(frame.id)
 
     node = doc.nodes[frame.id]
-    assert node.group_manual_width is None
-    assert node.group_manual_height is None
+    assert node.state.group_manual_width is None
+    assert node.state.group_manual_height is None
     # Back to a pure auto-fit bbox of the CURRENT member positions.
     assert node.x == pytest.approx(-40.0)
     assert node.y == pytest.approx(-50.0)
-    assert node.group_width == pytest.approx(1300.0)
-    assert node.group_height == pytest.approx(1210.0)
+    assert node.state.group_width == pytest.approx(1300.0)
+    assert node.state.group_height == pytest.approx(1210.0)
 
     # And a further member move now auto-grows again (manual mode is truly
     # off, not just temporarily bypassed).
     doc.move_node(m1.id, -1000, -1000)
     node = doc.nodes[frame.id]
-    assert node.group_width > 1300.0
+    assert node.state.group_width > 1300.0
 
 
 def test_resize_frame_and_fit_frame_to_content_reject_container_kind():
@@ -5861,11 +5864,11 @@ def test_set_chat_collapsed_recomputes_frame_geometry_when_called_against_a_fram
     m1, m2 = doc.add_node(0, 0), doc.add_node(300, 300)
     frame = doc.create_frame([m1.id, m2.id])
     doc.set_chat_collapsed(frame.id, True)
-    assert (doc.nodes[frame.id].group_width, doc.nodes[frame.id].group_height) == (260, 50)
+    assert (doc.nodes[frame.id].state.group_width, doc.nodes[frame.id].state.group_height) == (260, 50)
 
     doc.set_chat_collapsed(frame.id, False)
 
-    assert doc.nodes[frame.id].group_width != 260 or doc.nodes[frame.id].group_height != 50
+    assert doc.nodes[frame.id].state.group_width != 260 or doc.nodes[frame.id].state.group_height != 50
 
 
 def test_deleting_a_member_node_removes_it_from_its_frame_and_recomputes():
@@ -5881,8 +5884,8 @@ def test_deleting_a_member_node_removes_it_from_its_frame_and_recomputes():
     # Recomputed bbox now covers only m2: x:[300,520]/y:[300,420].
     assert node.x == pytest.approx(300 - 40.0)
     assert node.y == pytest.approx(300 - 50.0)
-    assert node.group_width == pytest.approx(220 + 80.0)
-    assert node.group_height == pytest.approx(120 + 90.0)
+    assert node.state.group_width == pytest.approx(220 + 80.0)
+    assert node.state.group_height == pytest.approx(120 + 90.0)
 
 
 def test_deleting_the_last_member_auto_deletes_the_now_empty_frame():
@@ -5994,13 +5997,13 @@ def test_toggle_frame_lock_flips_is_locked_and_defaults_true():
     doc = SceneDocument()
     m1 = doc.add_node(0, 0)
     frame = doc.create_frame([m1.id])
-    assert frame.is_locked is True
+    assert frame.state.is_locked is True
 
     doc.toggle_frame_lock(frame.id)
-    assert doc.nodes[frame.id].is_locked is False
+    assert doc.nodes[frame.id].state.is_locked is False
 
     doc.toggle_frame_lock(frame.id)
-    assert doc.nodes[frame.id].is_locked is True
+    assert doc.nodes[frame.id].state.is_locked is True
 
 
 def test_toggle_frame_lock_rejects_container_kind():
@@ -6032,8 +6035,8 @@ def test_scene_payload_exposes_note_frame_and_container_fields():
     assert frame_row["isLocked"] is True
     assert frame_row["color"] == "#4a7c59"
     assert frame_row["headerColor"] == "#2f5b3c"
-    assert frame_row["groupWidth"] == frame.group_width
-    assert frame_row["groupHeight"] == frame.group_height
+    assert frame_row["groupWidth"] == frame.state.group_width
+    assert frame_row["groupHeight"] == frame.state.group_height
     # groupManualWidth/Height are deliberately NOT on the wire (internal
     # bookkeeping only, same posture as codeSandboxSandboxId).
     assert "groupManualWidth" not in frame_row
@@ -6065,7 +6068,7 @@ def test_note_frame_container_ws_intents_mutate_and_publish():
         assert document.nodes[frame_id].color == "#123456"
 
         await bus.dispatch_intent("scene", "toggleFrameLock", [frame_id])
-        assert document.nodes[frame_id].is_locked is False
+        assert document.nodes[frame_id].state.is_locked is False
 
         await bus.dispatch_intent("scene", "toggleGroupCollapsed", [frame_id])
         assert document.nodes[frame_id].is_collapsed is True
@@ -6074,10 +6077,10 @@ def test_note_frame_container_ws_intents_mutate_and_publish():
         assert document.nodes[frame_id].is_collapsed is False
 
         await bus.dispatch_intent("scene", "resizeFrame", [frame_id, 900, 800])
-        assert document.nodes[frame_id].group_width == 900
+        assert document.nodes[frame_id].state.group_width == 900
 
         await bus.dispatch_intent("scene", "fitFrameToContent", [frame_id])
-        assert document.nodes[frame_id].group_manual_width is None
+        assert document.nodes[frame_id].state.group_manual_width is None
 
         await bus.dispatch_intent("scene", "ungroup", [frame_id])
         assert frame_id not in document.nodes
@@ -6100,14 +6103,14 @@ def test_add_chart_node_creates_a_real_rendered_chart_connected_to_its_parent():
     chart = doc.add_chart_node(50, 60, parent.id, "bar", dict(_CHART_DATA))
 
     assert chart.kind == "chart"
-    assert chart.chart_type == "bar"
-    assert chart.chart_data == _CHART_DATA
-    assert chart.chart_source_node_id == parent.id
-    assert chart.chart_asset_version == 1
-    assert chart.chart_width == 680.0 and chart.chart_height == 500.0
-    assert chart.chart_aspect_locked is True
+    assert chart.state.chart_type == "bar"
+    assert chart.state.chart_data == _CHART_DATA
+    assert chart.state.chart_source_node_id == parent.id
+    assert chart.state.chart_asset_version == 1
+    assert chart.state.chart_width == 680.0 and chart.state.chart_height == 500.0
+    assert chart.state.chart_aspect_locked is True
     assert any(e.source == parent.id and e.target == chart.id for e in doc.edges.values())
-    asset = doc.get_image_asset(chart.chart_asset_id)
+    asset = doc.get_image_asset(chart.state.chart_asset_id)
     assert asset is not None
     png_bytes, mime_type = asset
     assert mime_type == "image/png"
@@ -6143,34 +6146,34 @@ def test_resize_chart_clamps_to_legacy_min_max_bounds():
     doc.toggle_chart_aspect_lock(chart.id)  # unlock so width/height are independent
 
     doc.resize_chart(chart.id, 10.0, 10.0)
-    assert chart.chart_width == 440.0 and chart.chart_height == 320.0
+    assert chart.state.chart_width == 440.0 and chart.state.chart_height == 320.0
 
     doc.resize_chart(chart.id, 999999.0, 999999.0)
-    assert chart.chart_width == 2400.0 and chart.chart_height == 1800.0
+    assert chart.state.chart_width == 2400.0 and chart.state.chart_height == 1800.0
 
 
 def test_resize_chart_preserves_aspect_ratio_when_locked():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     chart = doc.add_chart_node(0, 0, parent.id, "bar", dict(_CHART_DATA))
-    assert chart.chart_aspect_locked is True
+    assert chart.state.chart_aspect_locked is True
 
     doc.resize_chart(chart.id, 1000.0, 500.0)  # 2:1 ratio, within bounds
 
-    assert chart.chart_width / chart.chart_height == pytest.approx(2.0, rel=1e-6)
+    assert chart.state.chart_width / chart.state.chart_height == pytest.approx(2.0, rel=1e-6)
 
 
 def test_resize_chart_rerenders_and_bumps_asset_version_overwriting_same_id():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     chart = doc.add_chart_node(0, 0, parent.id, "bar", dict(_CHART_DATA))
-    original_asset_id = chart.chart_asset_id
+    original_asset_id = chart.state.chart_asset_id
     original_bytes, _ = doc.get_image_asset(original_asset_id)
 
     doc.resize_chart(chart.id, 900.0, 900.0)
 
-    assert chart.chart_asset_id == original_asset_id, "same id, overwritten in place"
-    assert chart.chart_asset_version == 2
+    assert chart.state.chart_asset_id == original_asset_id, "same id, overwritten in place"
+    assert chart.state.chart_asset_version == 2
     new_bytes, _ = doc.get_image_asset(original_asset_id)
     assert new_bytes != original_bytes
 
@@ -6186,15 +6189,15 @@ def test_toggle_chart_aspect_lock_flips_flag_without_touching_size():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     chart = doc.add_chart_node(0, 0, parent.id, "bar", dict(_CHART_DATA))
-    width_before, height_before = chart.chart_width, chart.chart_height
+    width_before, height_before = chart.state.chart_width, chart.state.chart_height
 
     doc.toggle_chart_aspect_lock(chart.id)
 
-    assert chart.chart_aspect_locked is False
-    assert (chart.chart_width, chart.chart_height) == (width_before, height_before)
+    assert chart.state.chart_aspect_locked is False
+    assert (chart.state.chart_width, chart.state.chart_height) == (width_before, height_before)
 
     doc.toggle_chart_aspect_lock(chart.id)
-    assert chart.chart_aspect_locked is True
+    assert chart.state.chart_aspect_locked is True
 
 
 def test_toggle_chart_aspect_lock_rejects_a_non_chart_node():
@@ -6208,7 +6211,7 @@ def test_removing_a_chart_node_cleans_up_its_asset_from_image_assets():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     chart = doc.add_chart_node(0, 0, parent.id, "bar", dict(_CHART_DATA))
-    asset_id = chart.chart_asset_id
+    asset_id = chart.state.chart_asset_id
     assert doc.get_image_asset(asset_id) is not None
 
     doc.remove_nodes([chart.id])
@@ -6227,7 +6230,7 @@ def test_scene_payload_exposes_all_chart_fields():
     assert row["chartType"] == "bar"
     assert row["chartData"] == _CHART_DATA
     assert row["chartError"] == "degraded"
-    assert row["chartAssetId"] == chart.chart_asset_id
+    assert row["chartAssetId"] == chart.state.chart_asset_id
     assert row["chartAssetVersion"] == 1
     assert row["chartWidth"] == 680.0
     assert row["chartHeight"] == 500.0

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -109,7 +109,7 @@ def test_document_node_field_mapping():
     ])
     node = next(n for n in document.nodes.values() if n.kind == "document")
     assert node.title == "report.pdf" and node.content == "body text"
-    assert node.byte_size == 2048 and node.is_docked is True and node.is_collapsed is True
+    assert node.state.byte_size == 2048 and node.is_docked is True and node.is_collapsed is True
 
 
 def test_thinking_node_field_mapping():
@@ -225,7 +225,7 @@ def test_web_node_research_result_translates_snake_case_to_camel_case():
         },
     ])
     node = next(n for n in document.nodes.values() if n.kind == "web_research")
-    result = node.research_result
+    result = node.state.research_result
     assert result["requestId"] == "req-1"
     assert result["answerMarkdown"] == "Use fresh tomatoes."
     assert result["sources"][0]["sourceId"] == "s1"
@@ -239,8 +239,8 @@ def test_web_node_falls_back_to_summary_and_sources_for_older_shape_sessions():
          "research_result": {}, "position": {"x": 0, "y": 0}, "parent_node_index": 0},
     ])
     node = next(n for n in document.nodes.values() if n.kind == "web_research")
-    assert node.research_result["answerMarkdown"] == "the answer"
-    assert node.research_result["sources"] == [{"title": "t"}]
+    assert node.state.research_result["answerMarkdown"] == "the answer"
+    assert node.state.research_result["sources"] == [{"title": "t"}]
 
 
 def test_web_node_kind_is_web_research_not_web():
@@ -310,8 +310,8 @@ def test_chart_restores_with_size_and_aspect_lock_override():
         }],
     )
     chart = next(n for n in document.nodes.values() if n.kind == "chart")
-    assert chart.chart_width == 600.0 and chart.chart_height == 400.0
-    assert chart.chart_aspect_locked is False
+    assert chart.state.chart_width == 600.0 and chart.state.chart_height == 400.0
+    assert chart.state.chart_aspect_locked is False
 
 
 def test_chart_aspect_lock_is_applied_before_resize_not_after():
@@ -335,7 +335,7 @@ def test_chart_aspect_lock_is_applied_before_resize_not_after():
         }],
     )
     chart = next(n for n in document.nodes.values() if n.kind == "chart")
-    assert (chart.chart_width, chart.chart_height) == (440.0, 320.0)
+    assert (chart.state.chart_width, chart.state.chart_height) == (440.0, 320.0)
 
 
 def test_malformed_chart_is_skipped_without_aborting_the_rest_of_the_load():
@@ -371,7 +371,7 @@ def test_frame_membership_uses_items_key_not_item_indices():
     frame = next(n for n in document.nodes.values() if n.kind == "frame")
     member_kinds = {document.nodes[i].kind for i in frame.item_ids}
     assert member_kinds == {"chat"}
-    assert frame.group_manual_width is not None and frame.group_manual_height is not None
+    assert frame.state.group_manual_width is not None and frame.state.group_manual_height is not None
 
 
 def test_frame_falls_back_to_legacy_nodes_key():
@@ -397,7 +397,7 @@ def test_frame_unlocked_flag_is_applied():
         frames=[{"items": [0], "note": "Unlocked", "position": {"x": 0, "y": 0}, "is_locked": False}],
     )
     frame = next(n for n in document.nodes.values() if n.kind == "frame")
-    assert frame.is_locked is False
+    assert frame.state.is_locked is False
 
 
 # -- containers (nest frames/notes/charts, offset math) ----------------------

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -117,7 +117,7 @@ def test_research_result_translates_camel_case_back_to_snake_case():
     doc = SceneDocument()
     parent = doc.add_chat_node(0, 0, "p", is_user=False)
     node = doc.add_web_research_node(10, 10, parent.id)
-    node.research_result = {
+    node.state.research_result = {
         "requestId": "r1", "originalQuery": "q", "effectiveQuery": "q2",
         "answerMarkdown": "answer", "sources": [{"sourceId": "s1", "canonicalUrl": "u"}],
         "citations": [{"sourceId": "s1", "claimContext": "c"}], "warnings": [], "providerSnapshot": {},

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -16,10 +16,10 @@ this same gate's own PR: a walk over ast.Attribute alone can't see a field
 name smuggled in as a getattr/setattr string argument.
 
 _KNOWN_NON_NODE_FIELD_ACCESS_SHAPES carves out a small, explicit,
-shape-based allowlist for the rare migrated field name (PR4's "code") that
-collides with an unrelated attribute on a genuinely different type
-elsewhere in the codebase - see its own comment for exactly which shapes
-and why.
+shape-based allowlist for the rare migrated field names (PR4's "code",
+PR6's "byte_size"/"mime_type"/"duration_seconds") that collide with an
+unrelated attribute on a genuinely different type elsewhere in the
+codebase - see its own comment for exactly which shapes and why.
 
 test_scene_node_core_field_count (asserting the final <=15-field core
 exactly) is deferred to the stage's own exit PR, once every kind that has
@@ -56,6 +56,25 @@ MIGRATED_KIND_FIELDS = {
     "artifact": ["artifact_content"],
     "code": ["code", "language"],
     "note": ["is_system_prompt", "is_summary_note", "is_branch_comparison"],
+    "document": [
+        "attachment_kind", "file_path", "mime_type", "duration_seconds", "byte_size", "preview_label",
+    ],
+    "web_research": [
+        "research_stage", "research_completed", "research_total",
+        "research_active_source_id", "research_error", "research_result",
+    ],
+    "chart": [
+        "chart_type", "chart_data", "chart_error", "chart_asset_id", "chart_asset_version",
+        "chart_width", "chart_height", "chart_aspect_locked", "chart_source_node_id",
+    ],
+    # is_locked/group_manual_* are frame-only; group_width/group_height are
+    # shared with "container" below (both entries list them - harmless
+    # duplication, _all_migrated_fields() unions into one set either way).
+    "frame": [
+        "is_locked", "group_manual_width", "group_manual_height",
+        "group_manual_x", "group_manual_y", "group_width", "group_height",
+    ],
+    "container": ["group_width", "group_height"],
 }
 
 
@@ -119,6 +138,17 @@ _KNOWN_NON_NODE_FIELD_ACCESS_SHAPES = {
         {"root": "failures", "file": "test_agents.py"},
     ),
     "language": (),
+    # PR6's "document" kind reuses byte_size/mime_type/duration_seconds,
+    # names that collide with backend/attachments.py's own, wholly
+    # unrelated StagedAttachment dataclass (a composer-staging concept,
+    # never a SceneNode) - confirmed via grep that every "staged = ..."
+    # binding repo-wide holds a StagedAttachment, never a SceneNode.
+    "byte_size": (
+        {"root": "staged", "file": None},
+        {"root": "self", "file": "attachments.py"},
+    ),
+    "mime_type": ({"root": "staged", "file": None},),
+    "duration_seconds": ({"root": "staged", "file": None},),
 }
 
 
@@ -203,3 +233,67 @@ def test_scene_payload_key_set_is_unchanged_by_the_migration():
     doc.add_chat_node(0, 0, "hi", True)
     row = doc.scene_payload()["nodes"][0]
     assert sorted(row.keys()) == _EXPECTED_SCENE_NODE_WIRE_KEYS
+
+
+# Every migrated field's wire VALUE for a node of a kind that does NOT own
+# it - captured from each field's own former bare-SceneNode-field default,
+# verified against git history at that field's own pre-migration commit,
+# NOT from the per-kind state class's own "zero value" default (those
+# usually, but do not always, coincide). This is the direct regression net
+# for a real bug an adversarial review caught on this exact migration
+# (ADR-002 stage 2.5 PR6): scene_payload()'s isinstance-guarded fallback
+# for isLocked/chartWidth/chartHeight/chartAspectLocked was written as
+# False/0.0/0.0/False (the type's zero value) instead of the field's real
+# original default True/680.0/500.0/True - a wire-compat regression the
+# key-set-only test above cannot see, since the key was always present,
+# only its fallback VALUE for a non-owning node's row was wrong. Grows one
+# entry per migrated field, alongside MIGRATED_KIND_FIELDS above.
+_EXPECTED_NON_OWNING_KIND_WIRE_DEFAULTS = {
+    "imageAssetId": "",
+    "htmlSplitterState": None,
+    "artifactContent": "",
+    "code": "",
+    "language": "",
+    "isSystemPrompt": False,
+    "isSummaryNote": False,
+    "isBranchComparison": False,
+    "attachmentKind": "",
+    "filePath": "",
+    "mimeType": "",
+    "durationSeconds": None,
+    "byteSize": None,
+    "previewLabel": "",
+    "researchStage": "",
+    "researchCompleted": 0,
+    "researchTotal": 0,
+    "researchActiveSourceId": None,
+    "researchError": "",
+    "researchResult": None,
+    "chartType": "",
+    "chartData": {},
+    "chartError": "",
+    "chartAssetId": "",
+    "chartAssetVersion": 0,
+    "chartWidth": 680.0,
+    "chartHeight": 500.0,
+    "chartAspectLocked": True,
+    "chartSourceNodeId": "",
+    "isLocked": True,
+    "groupWidth": None,
+    "groupHeight": None,
+}
+
+
+def test_migrated_field_wire_fallbacks_match_pre_migration_defaults():
+    doc = SceneDocument()
+    doc.add_chat_node(0, 0, "hi", True)
+    row = doc.scene_payload()["nodes"][0]
+    mismatches = [
+        f"{key}: got {row[key]!r}, expected {expected!r}"
+        for key, expected in _EXPECTED_NON_OWNING_KIND_WIRE_DEFAULTS.items()
+        if row.get(key) != expected
+    ]
+    assert not mismatches, (
+        "ADR-002 stage 2.5: migrated field's non-owning-kind wire fallback "
+        "does not match its pre-migration SceneNode default:\n" + "\n".join(mismatches)
+    )


### PR DESCRIPTION
## Problem

First batched PR in this migration series. Continuing ADR-002 stage 2.5's typed-per-kind-state migration (PR1-5 moved image/html/artifact/code/note, one kind per PR), but batching the remaining low-risk kinds together instead of continuing to ship one PR per trivial field move - these four share the property that justifies batching: none touch `agents.py`'s async-mutation code, none need a transitional shim, and (frame/container aside, which share `_recompute_group_bounds`) they're structurally independent of each other. The still-upcoming gitlink/pycoder/code_sandbox trio stays separate, since those carry real state-machine/process complexity these don't.

## Change

Moves `document`'s 6 fields, `web_research`'s 6, `chart`'s 9, and `frame`/`container`'s 7 (with `group_width`/`group_height` duplicated on `ContainerState` since containers share that concept but not `is_locked`/manual-resize) onto five new `node_states.py` dataclasses. `DocumentState`'s docstring now carries the full legacy formatting-rule documentation (byte-size/duration strings, metadata-row ordering, preview_label auto-fill, audio-preview-suppression heuristic) that used to live as a large comment block on `SceneNode` directly - moved completely, not summarized.

Also fixes a second instance of the exact `remove_nodes` bug PR1 first found for `image_asset_id`: `chart_asset_id`'s unconditional field read would have raised `AttributeError` on every node deletion of any kind. Same `getattr(node.state, ...)` fix, mutation-tested.

**A genuine wire-compatibility bug was caught by adversarial review after initial implementation and fixed before this PR:** `scene_payload()`'s isinstance-guarded fallbacks for `isLocked`/`chartWidth`/`chartHeight`/`chartAspectLocked` were written as the type's zero-value instead of each field's real pre-migration default (`True`/`680.0`/`500.0`/`True`) - a non-frame node's row would have reported `isLocked=False`, a non-chart node's row a 0x0 unlocked chart size. Verified against git history at each field's own pre-migration commit and fixed. More importantly, closed the actual test-coverage gap that let it ship: added `test_migrated_field_wire_fallbacks_match_pre_migration_defaults`, which checks every migrated field's non-owning-kind wire *value* (not just key presence, which the existing snapshot test already covered), mutation-tested by reintroducing the exact bug and confirming it's caught with a clear diagnostic.

Also fixes a test-logic issue a blind mechanical rename would have gotten wrong: `test_moving_a_container_does_not_pin_a_manual_position_anchor` used to assert `group_manual_x/y` stayed `None` on a container; since `ContainerState` structurally has no such fields at all now, rewritten to `assert not hasattr(...)` - a stronger, structurally-guaranteed invariant.

Extends the AST migration gate's exemption mechanism (first introduced in PR4 for `code`/`language`) to `byte_size`/`mime_type`/`duration_seconds`, which collide with `backend/attachments.py`'s own `StagedAttachment` dataclass (a composer-staging concept, never a `SceneNode`).

## Test plan

- [x] `python -c "import backend.canvas"` succeeds
- [x] `pyflakes` clean (same pre-existing re-export-facade warnings as PR1-5)
- [x] Full `pytest -q` from repo root: 1228 passed (1227 baseline + 1 new regression test)
- [x] Mutation-tested: the `remove_nodes` `chart_asset_id` fix (12 tests caught it), `add_web_research_node`'s state construction (11 tests caught it), the `StagedAttachment` exemption's file-scoping precision, and the new wire-fallback regression test itself (reintroduced the exact original bug, confirmed all 4 mismatches caught with a clear diagnostic)
- [x] Independently re-verified all four fixed default values against git history at the pre-migration commit, not just trusted the review
- [x] Adversarial review pass (one reviewer hit a transient API server error and returned nothing; the other completed and found the wire-default bug above, which is now fixed and covered by a new regression test)