### PR TITLE
ADR-002 stage 2.5 (PR7/~4, backend-only): chat kind migration

### DIFF
--- a/backend/api/intents_branches.py
+++ b/backend/api/intents_branches.py
@@ -195,8 +195,8 @@ def register_branches_intents(
         already established) so full provenance survives even though only
         one edge can be structural. Provider/model are stamped from
         composer_document.route() - the same route a plain send would
-        actually use - onto the result node (see SceneNode.provider/model's
-        own comment)."""
+        actually use - onto the result node (see ChatState's own comment,
+        backend/domain/node_states.py)."""
         ids = list(dict.fromkeys(str(i) for i in (node_ids or [])))  # de-dupe, preserve order
         if len(ids) < 2:
             notifications.show("Select at least 2 branches to synthesize.", "warning")

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -85,7 +85,15 @@ from backend.domain.model import (
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,
 )
-from backend.domain.node_states import ArtifactState, CodeState, DocumentState, HtmlState, ImageState, WebResearchState
+from backend.domain.node_states import (
+    ArtifactState,
+    ChatState,
+    CodeState,
+    DocumentState,
+    HtmlState,
+    ImageState,
+    WebResearchState,
+)
 
 
 

--- a/backend/domain/branches.py
+++ b/backend/domain/branches.py
@@ -60,24 +60,25 @@ class BranchOps:
         already-created CHAT node as the output of the Synthesize Branches
         agent - mirrors mark_branch_comparison_note's own "extra setter call
         right after creation" shape, adapted for a chat-kind result instead
-        of a note-kind one (see SceneNode.is_branch_synthesis's own comment
-        for why this is a distinct method/flag rather than reusing Compare
-        Branches')."""
+        of a note-kind one (see ChatState's own comment, backend/domain/
+        node_states.py, for why this is a distinct method/flag rather than
+        reusing Compare Branches')."""
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
         if node.kind != "chat":
             raise SceneError(f"node is not a chat node: {node_id}")
-        node.is_branch_synthesis = True
+        node.state.is_branch_synthesis = True
         node.item_ids = list(source_node_ids)
-        node.synthesis_instructions = str(instructions)
-        node.provider = provider
-        node.model = model
+        node.state.synthesis_instructions = str(instructions)
+        node.state.provider = provider
+        node.state.model = model
 
     #: ADR-002 Workstream 1 ("Branch status and lifecycle"): the exactly-4
-    #: legal values for SceneNode.branch_status - shared by the setter's
-    #: validation and session_load.py's own defensive downgrade-to-"active"
-    #: read-back, so the one legal set is never duplicated out of sync.
+    #: legal values for ChatState's own branch_status (backend/domain/
+    #: node_states.py) - shared by the setter's validation and
+    #: session_load.py's own defensive downgrade-to-"active" read-back, so
+    #: the one legal set is never duplicated out of sync.
     BRANCH_STATUS_VALUES = frozenset({"active", "accepted", "rejected", "superseded"})
 
     def set_branch_status(self, node_id: str, status: str) -> None:
@@ -100,7 +101,7 @@ class BranchOps:
         status = str(status)
         if status not in self.BRANCH_STATUS_VALUES:
             raise SceneError(f"invalid branch status: {status}")
-        node.branch_status = status
+        node.state.branch_status = status
 
     def set_final_deliverable(self, node_id: str, is_final: bool) -> None:
         """ADR-002 Workstream 1 ("Branch status and lifecycle"): sets or
@@ -316,9 +317,17 @@ class BranchOps:
             # attachments has content_parts=None and this is byte-identical
             # to before: a plain string, exactly as every other consumer of
             # this history already expects.
+            #
+            # ADR-002 stage 2.5: is_user/content_parts live on node.state
+            # now (ChatState), not directly on SceneNode - getattr with the
+            # field's own original default (False/None) rather than a
+            # node.kind == "chat" check, since this method's own docstring
+            # promises to stop quietly on a stray non-chat node/edge shape,
+            # never raise. Same duck-typed posture as remove_nodes's own
+            # image_asset_id/chart_asset_id reads (backend/domain/graph.py).
             history.append({
-                "role": "user" if node.is_user else "assistant",
-                "content": node.content_parts if node.content_parts else node.content,
+                "role": "user" if getattr(node.state, "is_user", False) else "assistant",
+                "content": getattr(node.state, "content_parts", None) or node.content,
             })
             parent_edge = self._branch_parent_edge(current_id)
             current_id = parent_edge.source if parent_edge is not None else None

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -87,6 +87,7 @@ from backend.domain.model import (
 from backend.domain.node_states import (
     ArtifactState,
     ChartState,
+    ChatState,
     CodeState,
     ContainerState,
     DocumentState,
@@ -266,8 +267,9 @@ class SceneDocument(BranchOps, GroupOps):
 
         R8a: content_parts is the real multimodal attachment payload
         (image_bytes/audio_file parts) - the data-model capability
-        SceneNode.content_parts has carried since R6.3, finally populated by
-        a real caller. Optional and additive: every existing caller keeps
+        ChatState.content_parts (backend/domain/node_states.py) has carried
+        since R6.3, finally populated by a real caller. Optional and
+        additive: every existing caller keeps
         passing only (x, y, content, is_user, parent_id) and gets exactly
         the plain-text node it always did."""
         if parent_id is not None and parent_id not in self.nodes:
@@ -281,8 +283,7 @@ class SceneDocument(BranchOps, GroupOps):
             title=title,
             kind="chat",
             content=str(content),
-            is_user=bool(is_user),
-            content_parts=content_parts,
+            state=ChatState(is_user=bool(is_user), content_parts=content_parts),
         )
         self.nodes[node_id] = node
         if parent_id is not None:
@@ -1510,7 +1511,7 @@ class SceneDocument(BranchOps, GroupOps):
             raise SceneError(f"unknown node: {node_id}")
         if node.kind != "chat":
             raise SceneError(f"node is not a chat node: {node_id}")
-        node.chat_scroll_value = float(value)
+        node.state.chat_scroll_value = float(value)
 
     def set_node_docked(self, node_id: str, docked: bool) -> None:
         """R3.13: a single generic setter handling both dock (docked=True)
@@ -1702,7 +1703,7 @@ class SceneDocument(BranchOps, GroupOps):
                     "title": n.title,
                     "kind": n.kind,
                     "content": n.content,
-                    "isUser": n.is_user,
+                    "isUser": n.state.is_user if isinstance(n.state, ChatState) else False,
                     "isCollapsed": n.is_collapsed,
                     "code": n.state.code if isinstance(n.state, CodeState) else "",
                     "language": n.state.language if isinstance(n.state, CodeState) else "",
@@ -1719,16 +1720,20 @@ class SceneDocument(BranchOps, GroupOps):
                     ],
                     "pendingRequestId": n.pending_request_id,
                     # ADR-002 Workstream 1 ("Synthesize Branches") - see
-                    # SceneNode.provider/model/is_branch_synthesis/
-                    # synthesis_instructions's own comments.
-                    "provider": n.provider,
-                    "model": n.model,
-                    "isBranchSynthesis": n.is_branch_synthesis,
-                    "synthesisInstructions": n.synthesis_instructions,
+                    # ChatState's own comment, backend/domain/node_states.py.
+                    "provider": n.state.provider if isinstance(n.state, ChatState) else None,
+                    "model": n.state.model if isinstance(n.state, ChatState) else None,
+                    "isBranchSynthesis": n.state.is_branch_synthesis if isinstance(n.state, ChatState) else False,
+                    "synthesisInstructions": (
+                        n.state.synthesis_instructions if isinstance(n.state, ChatState) else ""
+                    ),
                     # ADR-002 Workstream 1 ("Branch status and lifecycle") -
-                    # see SceneNode.branch_status/SceneDocument.
-                    # final_deliverable_node_id's own comments.
-                    "branchStatus": n.branch_status,
+                    # see ChatState's own comment/SceneDocument.
+                    # final_deliverable_node_id's own comment. "active" (not
+                    # "") is the correct non-chat fallback - it is
+                    # branch_status's own real pre-migration default, not an
+                    # empty placeholder.
+                    "branchStatus": n.state.branch_status if isinstance(n.state, ChatState) else "active",
                     "isFinalDeliverable": n.id == self.final_deliverable_node_id,
                     "researchStage": n.state.research_stage if isinstance(n.state, WebResearchState) else "",
                     "researchCompleted": n.state.research_completed if isinstance(n.state, WebResearchState) else 0,
@@ -1817,7 +1822,7 @@ class SceneDocument(BranchOps, GroupOps):
                     "chartSourceNodeId": n.state.chart_source_node_id if isinstance(n.state, ChartState) else "",
                     # R6.3: HTML splitter + chat scroll gaps.
                     "htmlSplitterState": n.state.html_splitter_state if isinstance(n.state, HtmlState) else None,
-                    "chatScrollValue": n.chat_scroll_value,
+                    "chatScrollValue": n.state.chat_scroll_value if isinstance(n.state, ChatState) else 0.0,
                     # R6.3: null (not []) when content_parts is None - "no
                     # multimodal content" must stay distinguishable from
                     # "multimodal content that happens to be empty". Any
@@ -1828,7 +1833,7 @@ class SceneDocument(BranchOps, GroupOps):
                     # own output shape exactly, while n.content_parts itself
                     # (in memory) keeps holding real bytes, per the field's
                     # own contract.
-                    "contentParts": _content_parts_wire(n.content_parts),
+                    "contentParts": _content_parts_wire(n.state.content_parts if isinstance(n.state, ChatState) else None),
                 }
                 for n in self.nodes.values()
             ],
@@ -1887,8 +1892,9 @@ class SceneDocument(BranchOps, GroupOps):
 
 
 def _content_parts_wire(parts: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:
-    """R6.3: scene_payload()'s wire-side transform for SceneNode.content_parts
-    - a pure mapping function, NOT a SceneDocument method (same posture as
+    """R6.3: scene_payload()'s wire-side transform for ChatState's own
+    content_parts (backend/domain/node_states.py) - a pure mapping
+    function, NOT a SceneDocument method (same posture as
     _research_result_wire below). None stays None (never []), so "no
     multimodal content" and "multimodal content that happens to be empty"
     remain distinguishable on the wire. Any part that is a dict carrying raw

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -163,7 +163,6 @@ class SceneNode:
     # no separate field, same reuse pattern as R3.5's code text and R3.13's
     # thinking text living in this same field.
     content: str = ""
-    is_user: bool = False
     is_collapsed: bool = False
     # R3.13 (doc/QT_REMOVAL_PLAN.md): the ThinkingNode/docked-child increment -
     # whether this node is currently docked into its parent's collapsed
@@ -187,57 +186,6 @@ class SceneNode:
     # way is_docked is a generic field even though today only one kind
     # populates it); unused (default None) for every other kind.
     pending_request_id: str | None = None
-    # ADR-002 Workstream 1 ("Synthesize Branches"): the provider/model that
-    # produced this node's content, e.g. "Anthropic Claude" / "claude-sonnet-5"
-    # - resolved from ComposerDocument.route() at creation time. Generic
-    # (like pending_request_id above) rather than synthesis-only, since any
-    # future agent-authored node could reasonably want the same provenance;
-    # today only synthesize_branches populates it. None means "not recorded"
-    # (every node created before this field existed, and every ordinary chat
-    # reply, which already shows its route live in the Composer rather than
-    # per-message).
-    provider: str | None = None
-    model: str | None = None
-    # ADR-002 Workstream 1 ("Synthesize Branches"): marks a chat-kind node as
-    # the output of the Synthesize Branches agent (as opposed to an ordinary
-    # user/assistant message) - the chat-node equivalent of NoteState's own
-    # is_branch_comparison (backend/domain/node_states.py), which does the
-    # same job for note-kind nodes. A distinct flag rather than reusing
-    # is_branch_comparison: that flag's own kind-check
-    # (mark_branch_comparison_note raises for a non-note node) would need
-    # loosening for no benefit, and the two features render completely
-    # different UI (a badge on a note vs. a badge + the instructions/
-    # provider/model fields below on a chat node).
-    is_branch_synthesis: bool = False
-    # ADR-002 Workstream 1 ("Synthesize Branches"): the free-text instructions
-    # the user typed to steer the synthesis (e.g. "merge the best parts of
-    # each"), recorded on the result node so its provenance is fully
-    # inspectable later - the ADR's own acceptance criterion for this
-    # feature. Chat-kind only in practice; unused (default empty string) for
-    # every other kind and for ordinary (non-synthesis) chat nodes.
-    synthesis_instructions: str = ""
-    # ADR-002 Workstream 1 ("Branch status and lifecycle"): the final,
-    # sequenced item after fork/compare/synthesize. One of exactly "active"
-    # (the default - every existing and newly-created chat node starts
-    # here, no migration needed), "accepted", "rejected", "superseded".
-    # Chat-kind only, mirroring is_branch_synthesis's own chat-only scoping
-    # - "a branch" is fundamentally a chain of chat nodes in this data
-    # model (see chat_branch_history/get_branch_root, both of which only
-    # ever walk chat-kind edges). Deliberately PER-NODE with NO write-time
-    # inheritance/cascade to ancestors or descendants - every other
-    # status-like flag on this dataclass (is_collapsed, is_docked,
-    # is_branch_synthesis) - and NoteState's own is_branch_comparison
-    # (backend/domain/node_states.py) - is scoped exactly this way, and
-    # there is no materialized "Branch" object anywhere in
-    # this file to cascade through even if inheritance were wanted (a
-    # branch is discovered by walking _branch_parent_edge upward on
-    # demand, never stored as a set - see that method's own comment).
-    # "Reduce a graph to its accepted paths" is delivered by a separate,
-    # frontend-only, read-time subtree derivation over this field
-    # (SceneCanvas.tsx's computeNonAcceptedNodeIds) - the same posture
-    # "Hide Other Branches" already uses for a different subtree question,
-    # not by inventing write-time cascade bookkeeping here.
-    branch_status: str = "active"
     # R5.3: the Gitlink node's real persisted shape - reads a GitHub repo (or
     # a local checkout) into structured XML context, proposes an LLM change
     # set, and only writes to disk after an explicit, fingerprint-verified
@@ -423,32 +371,6 @@ class SceneNode:
     # membership use above. Unused (default empty list) for every other
     # case.
     item_ids: list[str] = field(default_factory=list)
-    # R6.3: ChatNode's persisted scroll position within its own content
-    # area (legacy's own scroll_value field). Unlike HtmlState's own
-    # html_splitter_state (backend/domain/node_states.py, ADR-002 stage
-    # 2.5), 0.0 (scrolled to the top) IS the genuine default for a node
-    # that has never been scrolled, so this is a plain float, not an
-    # Optional - there is no "unset" state worth distinguishing here. chat
-    # kind only; unused (default 0.0) for every other kind.
-    chat_scroll_value: float = 0.0
-    # R6.3: the RAW (already-decoded - "data" holds real Python bytes, never
-    # base64 text) multimodal parts list for a chat node whose legacy
-    # raw_content was a list of typed parts (e.g. an inline pasted image)
-    # rather than a plain string - see content_codec.py's own
-    # process_content_for_serialization/_for_deserialization, which this
-    # increment does not call directly (see scene_payload()'s own comment
-    # for the wire-side base64 encoding step this field feeds). None for the
-    # overwhelmingly common plain-text case, where `content` above is the
-    # only source of truth. ADDITIVE, not a replacement for `content`: even
-    # when this is populated, `content` continues to hold a flattened-text
-    # mirror (join of the text-type parts, or a placeholder like "[Image]"
-    # for non-text parts) so every existing piece of code that already reads
-    # `content` as a plain string keeps working unchanged. chat kind only;
-    # unused (default None) for every other kind. Nothing in this increment
-    # creates multimodal content yet (no image-paste-into-composer feature
-    # exists) - this is purely the data-model capability so R6.4's session
-    # loader has somewhere to put it when an OLD saved session has it.
-    content_parts: list[dict[str, Any]] | None = None
     # ADR-002 stage 2.5 (backend-only): the typed per-kind payload - see
     # backend/domain/node_states.py's own docstring. None for a kind not
     # yet migrated, or for a kind (placeholder/thinking/conversation) that

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -21,6 +21,7 @@ conversation.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 
 class NodeState:
@@ -315,3 +316,86 @@ class ContainerState(NodeState):
 
     group_width: float | None = None
     group_height: float | None = None
+
+
+@dataclass
+class ChatState(NodeState):
+    """Relocated verbatim from SceneNode's eight chat-only fields (former
+    backend/domain/model.py fields). SceneNode's own `content` field
+    (core, not duplicated here) holds the chat message text - is_user/
+    content_parts describe HOW that text should render, never a second
+    copy of it.
+
+    - is_user: True for a user-authored message, False for an assistant
+      reply - graphlink_session/serializers.py's own raw_content/is_user/
+      is_collapsed shape, minus everything Qt-only (paint state, scroll
+      position, docked-child widgets).
+    - chat_scroll_value: persisted scroll position within this node's own
+      content area (legacy's own scroll_value field). Unlike HtmlState's
+      own html_splitter_state, 0.0 (scrolled to the top) IS the genuine
+      default for a node that has never been scrolled, so this is a plain
+      float, not an Optional - there is no "unset" state worth
+      distinguishing here.
+    - content_parts: the RAW (already-decoded - "data" holds real Python
+      bytes, never base64 text) multimodal parts list for a chat node
+      whose legacy raw_content was a list of typed parts (e.g. an inline
+      pasted image) rather than a plain string - see content_codec.py's
+      own process_content_for_serialization/_for_deserialization, which
+      this class does not call directly (see scene_payload()'s own
+      comment for the wire-side base64 encoding step this field feeds).
+      None for the overwhelmingly common plain-text case, where `content`
+      is the only source of truth. ADDITIVE, not a replacement for
+      `content`: even when this is populated, `content` continues to hold
+      a flattened-text mirror (join of the text-type parts, or a
+      placeholder like "[Image]" for non-text parts) so every existing
+      piece of code that already reads `content` as a plain string keeps
+      working unchanged.
+    - provider/model: the provider/model that produced this node's
+      content, e.g. "Anthropic Claude" / "claude-sonnet-5" - resolved from
+      ComposerDocument.route() at creation time. Not literally restricted
+      to synthesize_branches specifically, even though today only that one
+      flow populates it - any future agent-authored chat node could
+      reasonably want the same provenance recorded. None means "not
+      recorded" (every node created before this field existed, and every
+      ordinary chat reply, which already shows its route live in the
+      Composer rather than per-message).
+    - is_branch_synthesis: ADR-002 Workstream 1 ("Synthesize Branches") -
+      marks this node as the output of the Synthesize Branches agent (as
+      opposed to an ordinary user/assistant message) - the chat-node
+      equivalent of NoteState's own is_branch_comparison, which does the
+      same job for note-kind nodes. A distinct flag rather than reusing
+      is_branch_comparison: that flag's own kind-check
+      (mark_branch_comparison_note raises for a non-note node) would need
+      loosening for no benefit, and the two features render completely
+      different UI (a badge on a note vs. a badge + the instructions/
+      provider/model fields on a chat node).
+    - synthesis_instructions: the free-text instructions the user typed to
+      steer the synthesis (e.g. "merge the best parts of each"), recorded
+      on the result node so its provenance is fully inspectable later -
+      the ADR's own acceptance criterion for this feature.
+    - branch_status: ADR-002 Workstream 1 ("Branch status and lifecycle") -
+      the final, sequenced item after fork/compare/synthesize. One of
+      exactly "active" (the default - every existing and newly-created
+      chat node starts here), "accepted", "rejected", "superseded".
+      Chat-kind only, mirroring is_branch_synthesis's own chat-only
+      scoping - "a branch" is fundamentally a chain of chat nodes in this
+      data model (see chat_branch_history/get_branch_root, both of which
+      only ever walk chat-kind edges). Deliberately PER-NODE with NO
+      write-time inheritance/cascade to ancestors or descendants - there
+      is no materialized "Branch" object anywhere to cascade through even
+      if inheritance were wanted (a branch is discovered by walking
+      _branch_parent_edge upward on demand, never stored as a set).
+      "Reduce a graph to its accepted paths" is delivered by a separate,
+      frontend-only, read-time subtree derivation over this field
+      (SceneCanvas.tsx's own computeNonAcceptedNodeIds) - the same posture
+      "Hide Other Branches" already uses for a different subtree question,
+      not by inventing write-time cascade bookkeeping here."""
+
+    is_user: bool = False
+    chat_scroll_value: float = 0.0
+    content_parts: list[dict[str, Any]] | None = None
+    provider: str | None = None
+    model: str | None = None
+    is_branch_synthesis: bool = False
+    synthesis_instructions: str = ""
+    branch_status: str = "active"

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -186,6 +186,7 @@ from typing import Any
 
 from backend.canvas import (
     ArtifactState,
+    ChatState,
     CodeState,
     DocumentState,
     HtmlState,
@@ -339,15 +340,8 @@ def _restore_chat_payload(payload: dict[str, Any]) -> SceneNode:
     return SceneNode(
         id="", x=x, y=y, title="Chat", kind="chat",
         content=content_text,
-        content_parts=content_parts,
-        # Legacy's own restore-time default is True (data.get("is_user",
-        # True)) - deliberately NOT False, unlike every other bool field on
-        # this dataclass. Getting this backwards would silently relabel
-        # every AI response in an old save as if the user had typed it.
-        is_user=bool(payload.get("is_user", True)),
         is_collapsed=bool(payload.get("is_collapsed", False)),
         history=_restore_history(payload.get("conversation_history")),
-        chat_scroll_value=float(payload.get("scroll_value", 0.0) or 0.0),
         # ADR-002 Workstream 1 ("Branch status and lifecycle") - confirmed,
         # pre-existing gap fixed inline: provider/model/is_branch_synthesis/
         # synthesis_instructions (Synthesize Branches) already synced live
@@ -361,14 +355,24 @@ def _restore_chat_payload(payload: dict[str, Any]) -> SceneNode:
         # new field; an unrecognized/future value downgrades to "active"
         # rather than crashing the load, the same defensive posture this
         # function already uses for every other field.
-        provider=payload.get("provider"),
-        model=payload.get("model"),
-        is_branch_synthesis=bool(payload.get("is_branch_synthesis", False)),
-        synthesis_instructions=str(payload.get("synthesis_instructions", "") or ""),
-        branch_status=(
-            payload.get("branch_status")
-            if payload.get("branch_status") in SceneDocument.BRANCH_STATUS_VALUES
-            else "active"
+        state=ChatState(
+            content_parts=content_parts,
+            # Legacy's own restore-time default is True (data.get("is_user",
+            # True)) - deliberately NOT False, unlike every other bool field
+            # on this dataclass. Getting this backwards would silently
+            # relabel every AI response in an old save as if the user had
+            # typed it.
+            is_user=bool(payload.get("is_user", True)),
+            chat_scroll_value=float(payload.get("scroll_value", 0.0) or 0.0),
+            provider=payload.get("provider"),
+            model=payload.get("model"),
+            is_branch_synthesis=bool(payload.get("is_branch_synthesis", False)),
+            synthesis_instructions=str(payload.get("synthesis_instructions", "") or ""),
+            branch_status=(
+                payload.get("branch_status")
+                if payload.get("branch_status") in SceneDocument.BRANCH_STATUS_VALUES
+                else "active"
+            ),
         ),
     )
 

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -181,16 +181,16 @@ def _serialize_history(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
 # nodes at all, mirroring session_load.py's equivalent restorers.
 
 def _serialize_chat_node(node: SceneNode) -> dict[str, Any]:
-    if node.content_parts is not None:
-        raw_content = _content_codec.process_content_for_serialization(node.content_parts)
+    if node.state.content_parts is not None:
+        raw_content = _content_codec.process_content_for_serialization(node.state.content_parts)
     else:
         raw_content = node.content
     return {
         "node_type": "chat",
         "raw_content": raw_content,
-        "is_user": bool(node.is_user),
+        "is_user": bool(node.state.is_user),
         "conversation_history": _serialize_history(node.history),
-        "scroll_value": node.chat_scroll_value,
+        "scroll_value": node.state.chat_scroll_value,
         "is_collapsed": bool(node.is_collapsed),
         # ADR-002 Workstream 1 ("Branch status and lifecycle") - confirmed,
         # pre-existing gap fixed inline: provider/model/is_branch_synthesis/
@@ -202,12 +202,12 @@ def _serialize_chat_node(node: SceneNode) -> dict[str, Any]:
         # synthesis result's provenance and its badge. branch_status is
         # this same pass's own new field, added alongside rather than in a
         # separate edit.
-        "provider": node.provider,
-        "model": node.model,
-        "is_branch_synthesis": bool(node.is_branch_synthesis),
-        "synthesis_instructions": node.synthesis_instructions,
+        "provider": node.state.provider,
+        "model": node.state.model,
+        "is_branch_synthesis": bool(node.state.is_branch_synthesis),
+        "synthesis_instructions": node.state.synthesis_instructions,
         "item_ids": list(node.item_ids),
-        "branch_status": node.branch_status,
+        "branch_status": node.state.branch_status,
     }
 
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -99,7 +99,7 @@ def test_add_chat_node_creates_a_real_chat_kind_node():
     node = doc.add_chat_node(10, 20, "Hello there, this is a real message", True)
     assert node.kind == "chat"
     assert node.content == "Hello there, this is a real message"
-    assert node.is_user is True
+    assert node.state.is_user is True
     assert node.is_collapsed is False
     assert node.title == "Hello there, this is a real message"[:60]
 
@@ -1117,7 +1117,7 @@ def test_send_message_starts_a_root_branch():
     doc = SceneDocument()
     node = doc.send_message("hello there")
     assert node.kind == "chat"
-    assert node.is_user is True
+    assert node.state.is_user is True
     assert node.content == "hello there"
     assert doc.last_chat_node_id == node.id
 
@@ -1296,7 +1296,7 @@ def test_update_chat_node_content_mutates_content_only_leaves_title_and_flags_un
     assert returned is node
     assert node.content == "new content"
     assert node.title == original_title
-    assert node.is_user is False
+    assert node.state.is_user is False
     assert node.is_collapsed is False
     assert node.kind == "chat"
 
@@ -1420,7 +1420,7 @@ def test_regenerate_response_sets_output_and_context_tokens_and_publishes_token_
             entry = next(iter(chat_slots(dispatcher).values()))
             await entry["task"]
 
-        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.is_user is False)
+        assistant_node = next(n for n in document.nodes.values() if n.kind == "chat" and n.state.is_user is False)
 
         def regenerated_reply(task, messages, **kwargs):
             return {"message": {"content": "a fresh regenerated reply"}}
@@ -1599,7 +1599,7 @@ def test_send_with_no_staged_attachments_is_byte_identical_to_before_r8a():
             user_id = await bus.dispatch_intent("scene", "sendMessage", ["plain hello"])
 
         user_node = document.nodes[user_id]
-        assert user_node.content_parts is None
+        assert user_node.state.content_parts is None
         assert user_node.content == "plain hello"
         assert composer_document.staged_attachments == []
 
@@ -1634,14 +1634,14 @@ def test_send_with_a_staged_image_produces_real_multimodal_content_parts():
         # existing consumer of .content (title, chat-library preview, copy,
         # export) keeps working unchanged.
         assert user_node.content == "what is this?"
-        assert user_node.content_parts == [
+        assert user_node.state.content_parts == [
             {"type": "text", "text": "what is this?"},
             {"type": "image_bytes", "data": real_bytes},
         ]
         # The REAL call api_provider.chat received - this is what proves the
         # attachment reached the model, not just the node's own storage.
         sent_content = capture_reply.seen_messages[-1]["content"]
-        assert sent_content == user_node.content_parts
+        assert sent_content == user_node.state.content_parts
         # Staging is consumed exactly once - popped and cleared by Send.
         assert composer_document.staged_attachments == []
 
@@ -1674,7 +1674,7 @@ def test_send_with_a_staged_document_merges_extracted_text_into_plain_content():
             await entry["task"]
 
         user_node = document.nodes[user_id]
-        assert user_node.content_parts is None, "a text-only attachment must never create content_parts"
+        assert user_node.state.content_parts is None, "a text-only attachment must never create content_parts"
         assert user_node.content.startswith("please review")
         assert "notes.txt" in user_node.content
         assert "file body here" in user_node.content
@@ -2171,13 +2171,13 @@ def test_send_message_intent_dispatches_a_real_agent_reply():
             await entry["task"]
 
         assert document.nodes[node_id].content == "what is this graph about?"
-        assert document.nodes[node_id].is_user is True
+        assert document.nodes[node_id].state.is_user is True
 
         reply_nodes = [n for n in document.nodes.values() if n.kind == "chat" and n.id != node_id]
         assert len(reply_nodes) == 1
         reply_node = reply_nodes[0]
         assert reply_node.content == "a real agent reply"
-        assert reply_node.is_user is False
+        assert reply_node.state.is_user is False
         assert any(e.source == node_id and e.target == reply_node.id for e in document.edges.values())
         assert document.last_chat_node_id == reply_node.id
         assert recorder.topics_seen().count("scene") >= 2, "user node + reply node both publish scene"
@@ -2807,7 +2807,7 @@ def test_add_generated_image_reply_new_chat_node_content_is_the_exact_wrapper_st
     chat = doc.add_chat_node(0, 0, "draw a cat", True)
     new_chat_node, new_image_node = doc.add_generated_image_reply(chat.id, "a cat wearing a hat", b"png-bytes")
     assert new_chat_node.content == 'Generated image for prompt: "a cat wearing a hat"'
-    assert new_chat_node.is_user is False
+    assert new_chat_node.state.is_user is False
     assert new_image_node.content == "a cat wearing a hat"
 
 
@@ -6536,10 +6536,10 @@ def test_set_chat_scroll_value_accepts_chat_kind_and_rejects_others():
     doc = SceneDocument()
     chat_node = doc.add_chat_node(0, 0, "hi", True)
     other_node = doc.add_node(0, 0, "placeholder")
-    assert chat_node.chat_scroll_value == 0.0
+    assert chat_node.state.chat_scroll_value == 0.0
 
     doc.set_chat_scroll_value(chat_node.id, 123.0)
-    assert chat_node.chat_scroll_value == 123.0
+    assert chat_node.state.chat_scroll_value == 123.0
     payload_node = next(n for n in doc.scene_payload()["nodes"] if n["id"] == chat_node.id)
     assert payload_node["chatScrollValue"] == 123.0
 
@@ -6558,7 +6558,7 @@ def test_set_chat_scroll_value_intent_mutates_and_publishes_scene():
         recorder.messages.clear()
 
         await bus.dispatch_intent("scene", "setChatScrollValue", [chat_id, 88.0])
-        assert document.nodes[chat_id].chat_scroll_value == 88.0
+        assert document.nodes[chat_id].state.chat_scroll_value == 88.0
         assert recorder.topics_seen().count("scene") == 1
 
         with pytest.raises(Exception):
@@ -6576,7 +6576,7 @@ def test_scene_payload_round_trips_content_parts_with_base64_encoded_image_bytes
     doc = SceneDocument()
     chat_node = doc.add_chat_node(0, 0, "look at this", True)
     raw_image_bytes = b"\x89PNG\r\n raw bytes here"
-    chat_node.content_parts = [
+    chat_node.state.content_parts = [
         {"type": "text", "text": "look at this"},
         {"type": "image_bytes", "data": raw_image_bytes},
     ]
@@ -6590,8 +6590,8 @@ def test_scene_payload_round_trips_content_parts_with_base64_encoded_image_bytes
 
     # The in-memory field itself must be untouched by building the wire
     # payload - still real bytes, never mutated into base64 text in place.
-    assert chat_node.content_parts[1]["data"] == raw_image_bytes
-    assert isinstance(chat_node.content_parts[1]["data"], bytes)
+    assert chat_node.state.content_parts[1]["data"] == raw_image_bytes
+    assert isinstance(chat_node.state.content_parts[1]["data"], bytes)
 
 
 def test_scene_payload_content_parts_is_none_not_empty_list_when_unset():
@@ -6601,7 +6601,7 @@ def test_scene_payload_content_parts_is_none_not_empty_list_when_unset():
     # null, never [].
     doc = SceneDocument()
     chat_node = doc.add_chat_node(0, 0, "plain text only", True)
-    assert chat_node.content_parts is None
+    assert chat_node.state.content_parts is None
 
     payload_node = next(n for n in doc.scene_payload()["nodes"] if n["id"] == chat_node.id)
     assert payload_node["contentParts"] is None
@@ -7048,11 +7048,11 @@ def test_synthesize_branches_creates_a_chat_node_continuing_from_the_first_sourc
         assert node_id is not None
         node = document.nodes[node_id]
         assert node.kind == "chat"
-        assert node.is_user is False
+        assert node.state.is_user is False
         assert node.content == "Combined answer drawing on both branches."
-        assert node.is_branch_synthesis is True
+        assert node.state.is_branch_synthesis is True
         assert node.item_ids == [first.id, second.id]
-        assert node.synthesis_instructions == "merge the best of both"
+        assert node.state.synthesis_instructions == "merge the best of both"
         # Continues the branch tree from the FIRST selected source, not a
         # parentless node like Compare Branches' note.
         parent_edge = document._branch_parent_edge(node.id)
@@ -7088,8 +7088,8 @@ def test_synthesize_branches_stamps_provider_and_model_from_the_composer_route(m
         # wired - route()'s own honest "no settings manager wired" fallback
         # (see backend/composer.py) reports Ollama (Local) with an empty
         # model, which is exactly what should land on the node.
-        assert node.provider == "Ollama (Local)"
-        assert node.model == ""
+        assert node.state.provider == "Ollama (Local)"
+        assert node.state.model == ""
 
     asyncio.run(run())
 
@@ -7220,10 +7220,10 @@ def test_mark_branch_synthesis_rejects_an_unknown_node_id():
 def test_set_branch_status_accepts_every_legal_value():
     doc = SceneDocument()
     node = doc.add_chat_node(0, 0, "hi", True)
-    assert node.branch_status == "active"
+    assert node.state.branch_status == "active"
     for status in ("accepted", "rejected", "superseded", "active"):
         doc.set_branch_status(node.id, status)
-        assert doc.nodes[node.id].branch_status == status
+        assert doc.nodes[node.id].state.branch_status == status
 
 
 def test_set_branch_status_rejects_an_invalid_value():
@@ -7231,7 +7231,7 @@ def test_set_branch_status_rejects_an_invalid_value():
     node = doc.add_chat_node(0, 0, "hi", True)
     with pytest.raises(SceneError):
         doc.set_branch_status(node.id, "archived")
-    assert doc.nodes[node.id].branch_status == "active", "a rejected call must not mutate the node"
+    assert doc.nodes[node.id].state.branch_status == "active", "a rejected call must not mutate the node"
 
 
 def test_set_branch_status_rejects_a_non_chat_node():
@@ -7254,8 +7254,8 @@ def test_set_branch_status_has_no_effect_on_sibling_branches():
     first = doc.add_chat_node(0, 160, "first", False, parent_id=root.id)
     second = doc.add_chat_node(460, 160, "second", False, parent_id=root.id)
     doc.set_branch_status(first.id, "accepted")
-    assert doc.nodes[first.id].branch_status == "accepted"
-    assert doc.nodes[second.id].branch_status == "active", "marking one branch must never touch its sibling"
+    assert doc.nodes[first.id].state.branch_status == "accepted"
+    assert doc.nodes[second.id].state.branch_status == "active", "marking one branch must never touch its sibling"
 
 
 def test_set_final_deliverable_marks_and_unmarks():
@@ -7422,7 +7422,7 @@ def test_set_branch_status_intent_dispatches_and_publishes_scene():
 
         await bus.dispatch_intent("scene", "setBranchStatus", [node.id, "accepted"])
 
-        assert document.nodes[node.id].branch_status == "accepted"
+        assert document.nodes[node.id].state.branch_status == "accepted"
         assert recorder.topics_seen().count("scene") > scene_publishes_before
 
     asyncio.run(run())

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -368,7 +368,7 @@ def test_load_chat_intent_restores_a_real_node_into_the_canvas_document(db_path)
 
     assert len(document.nodes) == 1
     node = next(iter(document.nodes.values()))
-    assert node.kind == "chat" and node.content == "Hi" and node.is_user is True
+    assert node.kind == "chat" and node.content == "Hi" and node.state.is_user is True
     assert notifications.visible and notifications.msg_type == "success"
     scene_messages = [m for m in recorder.messages if m["topic"] == "scene"]
     assert scene_messages, "loadChat must publish a fresh scene snapshot"

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -36,7 +36,7 @@ def _restore(nodes=None, notes=None, pins=None, **chat_data_extra):
 def test_chat_node_is_user_defaults_true_when_key_missing():
     document = _restore(nodes=[{"node_type": "chat", "raw_content": "hey", "position": {"x": 0, "y": 0}}])
     node = next(iter(document.nodes.values()))
-    assert node.is_user is True
+    assert node.state.is_user is True
 
 
 def test_chat_node_raw_content_falls_back_to_legacy_text_key():
@@ -583,23 +583,23 @@ def test_restore_chat_payload_restores_synthesis_provenance_scalars():
         ),
     ])
     node = next(iter(document.nodes.values()))
-    assert node.provider == "Anthropic Claude"
-    assert node.model == "claude-sonnet-5"
-    assert node.is_branch_synthesis is True
-    assert node.synthesis_instructions == "merge them"
-    assert node.branch_status == "accepted"
+    assert node.state.provider == "Anthropic Claude"
+    assert node.state.model == "claude-sonnet-5"
+    assert node.state.is_branch_synthesis is True
+    assert node.state.synthesis_instructions == "merge them"
+    assert node.state.branch_status == "accepted"
 
 
 def test_restore_chat_payload_downgrades_an_unrecognized_branch_status_to_active():
     document = _restore(nodes=[_chat("n0", branch_status="archived")])
     node = next(iter(document.nodes.values()))
-    assert node.branch_status == "active"
+    assert node.state.branch_status == "active"
 
 
 def test_restore_chat_payload_defaults_branch_status_to_active_when_absent():
     document = _restore(nodes=[_chat("n0")])
     node = next(iter(document.nodes.values()))
-    assert node.branch_status == "active"
+    assert node.state.branch_status == "active"
 
 
 def test_restore_notes_restores_is_branch_comparison():

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -349,8 +349,8 @@ def test_round_trip_preserves_every_edge_topologically():
     doc.connect(user.id, code.id)  # extra manual connection
 
     doc2 = _round_trip(doc)
-    user2 = next(n for n in doc2.nodes.values() if n.kind == "chat" and n.is_user)
-    ai2 = next(n for n in doc2.nodes.values() if n.kind == "chat" and not n.is_user)
+    user2 = next(n for n in doc2.nodes.values() if n.kind == "chat" and n.state.is_user)
+    ai2 = next(n for n in doc2.nodes.values() if n.kind == "chat" and not n.state.is_user)
     code2 = next(n for n in doc2.nodes.values() if n.kind == "code")
 
     assert len(doc2.edges) == len(doc.edges) == 3
@@ -445,12 +445,12 @@ def test_round_trip_preserves_synthesize_branches_full_shape():
     second2 = next(n for n in doc2.nodes.values() if n.content == "second branch reply")
     result2 = next(n for n in doc2.nodes.values() if n.content == "Combined answer")
 
-    assert result2.provider == "Anthropic Claude"
-    assert result2.model == "claude-sonnet-5"
-    assert result2.is_branch_synthesis is True
-    assert result2.synthesis_instructions == "merge them"
+    assert result2.state.provider == "Anthropic Claude"
+    assert result2.state.model == "claude-sonnet-5"
+    assert result2.state.is_branch_synthesis is True
+    assert result2.state.synthesis_instructions == "merge them"
     assert set(result2.item_ids) == {first2.id, second2.id}
-    assert result2.branch_status == "accepted"
+    assert result2.state.branch_status == "accepted"
     assert doc2.final_deliverable_node_id == result2.id
 
 

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -17,9 +17,10 @@ name smuggled in as a getattr/setattr string argument.
 
 _KNOWN_NON_NODE_FIELD_ACCESS_SHAPES carves out a small, explicit,
 shape-based allowlist for the rare migrated field names (PR4's "code",
-PR6's "byte_size"/"mime_type"/"duration_seconds") that collide with an
-unrelated attribute on a genuinely different type elsewhere in the
-codebase - see its own comment for exactly which shapes and why.
+PR6's "byte_size"/"mime_type"/"duration_seconds", PR7's "provider") that
+collide with an unrelated attribute on a genuinely different type
+elsewhere in the codebase - see its own comment for exactly which shapes
+and why.
 
 test_scene_node_core_field_count (asserting the final <=15-field core
 exactly) is deferred to the stage's own exit PR, once every kind that has
@@ -75,6 +76,10 @@ MIGRATED_KIND_FIELDS = {
         "group_manual_x", "group_manual_y", "group_width", "group_height",
     ],
     "container": ["group_width", "group_height"],
+    "chat": [
+        "is_user", "chat_scroll_value", "content_parts", "provider", "model",
+        "is_branch_synthesis", "synthesis_instructions", "branch_status",
+    ],
 }
 
 
@@ -149,6 +154,17 @@ _KNOWN_NON_NODE_FIELD_ACCESS_SHAPES = {
     ),
     "mime_type": ({"root": "staged", "file": None},),
     "duration_seconds": ({"root": "staged", "file": None},),
+    # PR7's "chat" kind reuses "provider" (never "model" - confirmed no
+    # non-SceneNode ".model" access exists anywhere in SCAN_DIRS), which
+    # collides with two wholly unrelated types: a ResearchSource's own
+    # .provider (backend/canvas.py's _research_result_wire, iterating
+    # result.sources) and a ModelDescriptor's own .provider
+    # (backend/settings.py, iterating a get_available_model_descriptors()
+    # list) - neither is ever a SceneNode.
+    "provider": (
+        {"root": "s", "file": "canvas.py"},
+        {"root": "descriptor", "file": "settings.py"},
+    ),
 }
 
 
@@ -228,10 +244,26 @@ _EXPECTED_SCENE_NODE_WIRE_KEYS = sorted([
 ])
 
 
+def _non_owning_kind_node(doc):
+    """A node whose kind owns NONE of the currently-migrated fields, so
+    every scene_payload() isinstance guard hits its else-branch - the
+    right representative for both tests below. "thinking" is used
+    deliberately, not "chat": PR7 migrated chat's own 8 fields, so a chat
+    node can no longer serve this role - it would always hit the
+    isinstance-true branch for its OWN fields, silently skipping exactly
+    the class of bug these two tests exist to catch. "thinking" has zero
+    kind-specific fields (node.state stays None for it permanently, per
+    node_states.py's own docstring) and always will, since there is
+    nothing left to migrate off it - a stable choice regardless of which
+    kind migrates next."""
+    parent = doc.add_node(0, 0)
+    return doc.add_thinking_node(0, 0, "reasoning", parent_id=parent.id)
+
+
 def test_scene_payload_key_set_is_unchanged_by_the_migration():
     doc = SceneDocument()
-    doc.add_chat_node(0, 0, "hi", True)
-    row = doc.scene_payload()["nodes"][0]
+    _non_owning_kind_node(doc)
+    row = doc.scene_payload()["nodes"][-1]
     assert sorted(row.keys()) == _EXPECTED_SCENE_NODE_WIRE_KEYS
 
 
@@ -281,13 +313,21 @@ _EXPECTED_NON_OWNING_KIND_WIRE_DEFAULTS = {
     "isLocked": True,
     "groupWidth": None,
     "groupHeight": None,
+    "isUser": False,
+    "chatScrollValue": 0.0,
+    "contentParts": None,
+    "provider": None,
+    "model": None,
+    "isBranchSynthesis": False,
+    "synthesisInstructions": "",
+    "branchStatus": "active",
 }
 
 
 def test_migrated_field_wire_fallbacks_match_pre_migration_defaults():
     doc = SceneDocument()
-    doc.add_chat_node(0, 0, "hi", True)
-    row = doc.scene_payload()["nodes"][0]
+    _non_owning_kind_node(doc)
+    row = doc.scene_payload()["nodes"][-1]
     mismatches = [
         f"{key}: got {row[key]!r}, expected {expected!r}"
         for key, expected in _EXPECTED_NON_OWNING_KIND_WIRE_DEFAULTS.items()


### PR DESCRIPTION
## Problem

Continuing ADR-002 stage 2.5's kind-by-kind migration (PR1-6 moved image/html/artifact/code/note/document/web_research/chart/frame/container). Next up: `chat`'s 8 fields - the riskiest kind migrated so far.

## Change

Moves `is_user`/`chat_scroll_value`/`content_parts`/`provider`/`model`/`is_branch_synthesis`/`synthesis_instructions`/`branch_status` onto a new `ChatState` dataclass. Two independent risk factors made this different from prior PRs:

**Generic field-name collisions.** `provider`/`model` are common enough to collide with unrelated types elsewhere. A dedicated read-only reconnaissance pass (before writing any code) searched the whole repo and found exactly two real collisions inside the AST migration gate's scan directories - `_research_result_wire`'s `ResearchSource.provider` and a settings-page `ModelDescriptor.provider` loop, neither ever a `SceneNode`. Confirmed no `model` collision exists anywhere. Verified the exemption's precision mechanically: with it removed, the gate flags exactly those two sites and nothing else.

**A duck-typed, explicitly-defensive method.** `chat_branch_history()`'s own docstring promises "a bad/unknown node_id or a stray edge shape should stop the walk quietly rather than raise" - it doesn't strictly guarantee every visited node is chat-kind. Its `is_user`/`content_parts` reads changed to `getattr(node.state, "field", default)` rather than `node.state.field`, preserving the exact original silent-defaulting behavior instead of introducing a new way to raise. Verified the getattr defaults are byte-identical to the old bare-field defaults, and empirically simulated a stray non-chat node through the real walk to confirm no crash.

`scene_payload()`'s 8 wire-key fallbacks were each individually checked against their real pre-migration default, not assumed - `branchStatus` in particular falls back to `"active"`, not `""` (exactly the PR6 bug class).

Also strengthens the shared wire-fallback regression test itself: it used to build a `chat` node as its "doesn't own any migrated field" baseline, which broke the moment chat's own fields got migrated in this PR (a chat baseline can never exercise its own fallback branch). Switched to a `thinking` node - permanently valid, since `node_states.py` confirms thinking never gets kind-specific fields. Verified this switch is what actually lets the `branchStatus` regression get caught at all.

## Test plan

- [x] `python -c "import backend.canvas"` succeeds
- [x] `pyflakes` clean (same pre-existing re-export-facade warnings as PR1-6)
- [x] Full `pytest -q` from repo root: 1228 passed (same count as PR6's end state - existing tests got stronger, no net-new test functions)
- [x] Mutation-tested: `add_chat_node`'s state construction, `chat_branch_history`'s getattr fix specifically (reverted to a form that raises instead of defaulting), and the `branchStatus` `"active"` vs `""` fallback (caught by the strengthened regression test, proving the baseline-node fix works)
- [x] Independent two-reviewer adversarial review pass + skeptical synthesis, with explicit focus on both novel risk areas: both confirmed sound via independent re-derivation (one reviewer mechanically re-ran the AST gate with the exemption removed to prove exact scope, the other empirically simulated the duck-typed walk); 5 documentation-staleness nits found and fixed