### PR TITLE
ADR-002 stage 2.5 (PR8a/~16): gitlink domain move + transitional property shim

### DIFF
--- a/backend/api/intents_gitlink.py
+++ b/backend/api/intents_gitlink.py
@@ -71,7 +71,7 @@ def register_gitlink_intents(
         # requiring the user to type a path by hand. A cancelled dialog is
         # a quiet no-op, matching every other pick_folder call site.
         node = document.nodes.get(node_id)
-        if node is None:
+        if node is None or node.kind != "gitlink":
             return
         directory = node.gitlink_local_root or os.path.expanduser("~")
         try:
@@ -87,7 +87,11 @@ def register_gitlink_intents(
 
     async def import_gitlink_snapshot(node_id, repo, branch):
         node = document.nodes.get(node_id)
-        if node is None or node.pending_request_id:
+        if node is None or node.kind != "gitlink":
+            notifications.show("This node no longer exists.", "warning")
+            await bus.publish("notification")
+            return None
+        if node.pending_request_id:
             notifications.show("Gitlink is busy for this node.", "info")
             await bus.publish("notification")
             return None
@@ -102,7 +106,11 @@ def register_gitlink_intents(
 
     async def build_gitlink_context(node_id, scope_mode, selected_paths):
         node = document.nodes.get(node_id)
-        if node is None or node.pending_request_id:
+        if node is None or node.kind != "gitlink":
+            notifications.show("This node no longer exists.", "warning")
+            await bus.publish("notification")
+            return None
+        if node.pending_request_id:
             notifications.show("Gitlink is busy for this node.", "info")
             await bus.publish("notification")
             return None
@@ -171,7 +179,7 @@ def register_gitlink_intents(
 
     async def apply_gitlink_changes(node_id, fingerprint):
         node = document.nodes.get(node_id)
-        if node is None:
+        if node is None or node.kind != "gitlink":
             notifications.show("This node no longer exists.", "warning")
             await bus.publish("notification")
             return None

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -90,6 +90,7 @@ from backend.domain.node_states import (
     ChatState,
     CodeState,
     DocumentState,
+    GitlinkState,
     HtmlState,
     ImageState,
     WebResearchState,

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -92,6 +92,7 @@ from backend.domain.node_states import (
     ContainerState,
     DocumentState,
     FrameState,
+    GitlinkState,
     HtmlState,
     ImageState,
     NoteState,
@@ -812,6 +813,7 @@ class SceneDocument(BranchOps, GroupOps):
             y=float(y),
             title="Gitlink",
             kind="gitlink",
+            state=GitlinkState(),
         )
         self.nodes[node_id] = node
         self.connect(parent_id, node_id)
@@ -826,7 +828,9 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
-        node.gitlink_local_root = str(local_root)
+        if node.kind != "gitlink":
+            raise SceneError(f"node is not a gitlink node: {node_id}")
+        node.state.gitlink_local_root = str(local_root)
         return node
 
     def store_gitlink_repo_tree(self, node_id: str, repo: str, branch: str, file_paths: list[str]) -> SceneNode:
@@ -836,9 +840,11 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
-        node.gitlink_repo = str(repo)
-        node.gitlink_branch = str(branch)
-        node.gitlink_repo_file_paths = list(file_paths)
+        if node.kind != "gitlink":
+            raise SceneError(f"node is not a gitlink node: {node_id}")
+        node.state.gitlink_repo = str(repo)
+        node.state.gitlink_branch = str(branch)
+        node.state.gitlink_repo_file_paths = list(file_paths)
         return node
 
     def store_gitlink_snapshot_root(self, node_id: str, repo: str, branch: str, local_root: str) -> SceneNode:
@@ -849,10 +855,12 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
-        node.gitlink_repo = str(repo)
-        node.gitlink_branch = str(branch)
-        node.gitlink_local_root = str(local_root)
-        node.gitlink_imported_root = str(local_root)
+        if node.kind != "gitlink":
+            raise SceneError(f"node is not a gitlink node: {node_id}")
+        node.state.gitlink_repo = str(repo)
+        node.state.gitlink_branch = str(branch)
+        node.state.gitlink_local_root = str(local_root)
+        node.state.gitlink_imported_root = str(local_root)
         return node
 
     def store_gitlink_context(
@@ -884,12 +892,14 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
-        node.gitlink_scope_mode = str(scope_mode)
-        node.gitlink_selected_paths = list(selected_paths)
-        node.gitlink_context_xml = str(context_xml)
-        node.gitlink_context_stats = {str(k): str(v) for k, v in (context_stats or {}).items()}
-        node.gitlink_context_summary = str(context_summary)
-        node.gitlink_context_version += 1
+        if node.kind != "gitlink":
+            raise SceneError(f"node is not a gitlink node: {node_id}")
+        node.state.gitlink_scope_mode = str(scope_mode)
+        node.state.gitlink_selected_paths = list(selected_paths)
+        node.state.gitlink_context_xml = str(context_xml)
+        node.state.gitlink_context_stats = {str(k): str(v) for k, v in (context_stats or {}).items()}
+        node.state.gitlink_context_summary = str(context_summary)
+        node.state.gitlink_context_version += 1
         return node
 
     def fetch_gitlink_context_xml(self, node_id: str) -> str:
@@ -900,7 +910,9 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
-        return node.gitlink_context_xml
+        if node.kind != "gitlink":
+            raise SceneError(f"node is not a gitlink node: {node_id}")
+        return node.state.gitlink_context_xml
 
     def start_gitlink_run(self, node_id: str, task_prompt: str) -> SceneNode:
         """Begin one Generate Change Set run: stores the task prompt and
@@ -915,8 +927,8 @@ class SceneDocument(BranchOps, GroupOps):
             raise SceneError(f"unknown node: {node_id}")
         if node.kind != "gitlink":
             raise SceneError(f"node is not a gitlink node: {node_id}")
-        node.gitlink_task_prompt = str(task_prompt)
-        node.gitlink_error = ""
+        node.state.gitlink_task_prompt = str(task_prompt)
+        node.state.gitlink_error = ""
         return node
 
     def complete_gitlink_run(
@@ -949,17 +961,17 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
-        node.gitlink_proposal_markdown = str(proposal_markdown)
-        node.gitlink_pending_changes = list(pending_changes or [])
-        node.gitlink_preview_text = str(preview_text)
-        if node.gitlink_pending_changes:
-            node.gitlink_change_state = "previewed"
-            node.gitlink_change_fingerprint = fingerprint
-            node.gitlink_change_local_root = str(local_root).strip()
+        node.state.gitlink_proposal_markdown = str(proposal_markdown)
+        node.state.gitlink_pending_changes = list(pending_changes or [])
+        node.state.gitlink_preview_text = str(preview_text)
+        if node.state.gitlink_pending_changes:
+            node.state.gitlink_change_state = "previewed"
+            node.state.gitlink_change_fingerprint = fingerprint
+            node.state.gitlink_change_local_root = str(local_root).strip()
         else:
-            node.gitlink_change_state = "draft"
-            node.gitlink_change_fingerprint = None
-            node.gitlink_change_local_root = None
+            node.state.gitlink_change_state = "draft"
+            node.state.gitlink_change_fingerprint = None
+            node.state.gitlink_change_local_root = None
         return node
 
     def fail_gitlink_run(self, node_id: str, message: str) -> SceneNode | None:
@@ -974,7 +986,7 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             return None
-        node.gitlink_error = str(message)
+        node.state.gitlink_error = str(message)
         return node
 
     def complete_gitlink_apply(self, node_id: str, written_files: int) -> SceneNode:
@@ -995,11 +1007,11 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
-        node.gitlink_change_state = "applied"
-        node.gitlink_error = ""
-        node.gitlink_pending_changes = []
-        node.gitlink_change_fingerprint = None
-        node.gitlink_change_local_root = None
+        node.state.gitlink_change_state = "applied"
+        node.state.gitlink_error = ""
+        node.state.gitlink_pending_changes = []
+        node.state.gitlink_change_fingerprint = None
+        node.state.gitlink_change_local_root = None
         return node
 
     def fail_gitlink_apply(self, node_id: str, message: str) -> SceneNode | None:
@@ -1014,10 +1026,10 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             return None
-        node.gitlink_change_state = "previewed"
-        node.gitlink_change_fingerprint = None
-        node.gitlink_change_local_root = None
-        node.gitlink_error = str(message)
+        node.state.gitlink_change_state = "previewed"
+        node.state.gitlink_change_fingerprint = None
+        node.state.gitlink_change_local_root = None
+        node.state.gitlink_error = str(message)
         return node
 
     # -- R5.4: Py-Coder node --------------------------------------------------
@@ -1744,30 +1756,50 @@ class SceneDocument(BranchOps, GroupOps):
                     "researchError": n.state.research_error if isinstance(n.state, WebResearchState) else "",
                     "researchResult": n.state.research_result if isinstance(n.state, WebResearchState) else None,
                     "artifactContent": n.state.artifact_content if isinstance(n.state, ArtifactState) else "",
-                    "gitlinkRepo": n.gitlink_repo,
-                    "gitlinkBranch": n.gitlink_branch,
-                    "gitlinkScopeMode": n.gitlink_scope_mode,
-                    "gitlinkLocalRoot": n.gitlink_local_root,
-                    "gitlinkRepoFilePaths": list(n.gitlink_repo_file_paths),
-                    "gitlinkSelectedPaths": list(n.gitlink_selected_paths),
-                    "gitlinkTaskPrompt": n.gitlink_task_prompt,
-                    # gitlinkContextXml is DELIBERATELY OMITTED - see the
-                    # field's own comment on SceneNode. Served on demand via
-                    # the fetchGitlinkContext intent instead.
-                    "gitlinkContextStats": dict(n.gitlink_context_stats),
-                    "gitlinkContextSummary": n.gitlink_context_summary,
+                    "gitlinkRepo": n.state.gitlink_repo if isinstance(n.state, GitlinkState) else "",
+                    "gitlinkBranch": n.state.gitlink_branch if isinstance(n.state, GitlinkState) else "",
+                    "gitlinkScopeMode": (
+                        n.state.gitlink_scope_mode if isinstance(n.state, GitlinkState) else "selected"
+                    ),
+                    "gitlinkLocalRoot": n.state.gitlink_local_root if isinstance(n.state, GitlinkState) else "",
+                    "gitlinkRepoFilePaths": (
+                        list(n.state.gitlink_repo_file_paths) if isinstance(n.state, GitlinkState) else []
+                    ),
+                    "gitlinkSelectedPaths": (
+                        list(n.state.gitlink_selected_paths) if isinstance(n.state, GitlinkState) else []
+                    ),
+                    "gitlinkTaskPrompt": n.state.gitlink_task_prompt if isinstance(n.state, GitlinkState) else "",
+                    # gitlinkContextXml is DELIBERATELY OMITTED - see
+                    # GitlinkState's own comment. Served on demand via the
+                    # fetchGitlinkContext intent instead.
+                    "gitlinkContextStats": (
+                        dict(n.state.gitlink_context_stats) if isinstance(n.state, GitlinkState) else {}
+                    ),
+                    "gitlinkContextSummary": (
+                        n.state.gitlink_context_summary if isinstance(n.state, GitlinkState) else ""
+                    ),
                     # R5.3 post-review FIX 6: UNLIKE gitlinkContextXml (and
                     # unlike gitlink_change_local_root, never on the wire at
-                    # all), this genuinely needs to be here - see the field's
-                    # own comment on SceneNode for why gitlinkContextSummary
+                    # all), this genuinely needs to be here - see
+                    # GitlinkState's own comment for why gitlinkContextSummary
                     # alone cannot be trusted as a lazy-fetch-once cache key.
-                    "gitlinkContextVersion": n.gitlink_context_version,
-                    "gitlinkProposalMarkdown": n.gitlink_proposal_markdown,
-                    "gitlinkPendingChanges": [dict(c) for c in n.gitlink_pending_changes],
-                    "gitlinkPreviewText": n.gitlink_preview_text,
-                    "gitlinkChangeFingerprint": n.gitlink_change_fingerprint,
-                    "gitlinkChangeState": n.gitlink_change_state,
-                    "gitlinkError": n.gitlink_error,
+                    "gitlinkContextVersion": (
+                        n.state.gitlink_context_version if isinstance(n.state, GitlinkState) else 0
+                    ),
+                    "gitlinkProposalMarkdown": (
+                        n.state.gitlink_proposal_markdown if isinstance(n.state, GitlinkState) else ""
+                    ),
+                    "gitlinkPendingChanges": (
+                        [dict(c) for c in n.state.gitlink_pending_changes] if isinstance(n.state, GitlinkState) else []
+                    ),
+                    "gitlinkPreviewText": n.state.gitlink_preview_text if isinstance(n.state, GitlinkState) else "",
+                    "gitlinkChangeFingerprint": (
+                        n.state.gitlink_change_fingerprint if isinstance(n.state, GitlinkState) else None
+                    ),
+                    "gitlinkChangeState": (
+                        n.state.gitlink_change_state if isinstance(n.state, GitlinkState) else "draft"
+                    ),
+                    "gitlinkError": n.state.gitlink_error if isinstance(n.state, GitlinkState) else "",
                     "pycoderMode": n.pycoder_mode,
                     "pycoderPrompt": n.pycoder_prompt,
                     "pycoderCode": n.pycoder_code,

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -186,85 +186,6 @@ class SceneNode:
     # way is_docked is a generic field even though today only one kind
     # populates it); unused (default None) for every other kind.
     pending_request_id: str | None = None
-    # R5.3: the Gitlink node's real persisted shape - reads a GitHub repo (or
-    # a local checkout) into structured XML context, proposes an LLM change
-    # set, and only writes to disk after an explicit, fingerprint-verified
-    # approval. Unused (default) for every other kind.
-    gitlink_repo: str = ""
-    gitlink_branch: str = ""
-    gitlink_scope_mode: str = "selected"
-    gitlink_local_root: str = ""
-    # Mirrors legacy repo_state["imported_root"] - remembers which local path
-    # a prior Import Repo Snapshot produced, so a later run can reuse it
-    # without re-downloading. Server-side bookkeeping ONLY: deliberately
-    # absent from scene_payload()/SceneNodeRow - there is no wire field for
-    # it, nothing on the frontend ever needs to read it directly (gitlink_
-    # local_root is what's shown/edited).
-    gitlink_imported_root: str = ""
-    gitlink_repo_file_paths: list[str] = field(default_factory=list)
-    gitlink_selected_paths: list[str] = field(default_factory=list)
-    gitlink_task_prompt: str = ""
-    # DESIGNED ceiling of 180,000 chars (repository.py's MAX_CONTEXT_CHARS) -
-    # an order of magnitude above this node's other fields' implicit
-    # ceilings. scene_payload() resends every node on roughly 20 undebounced
-    # triggers (see the image_assets comment above) - inlining a 180KB text
-    # blob there would reproduce that exact cost on every unrelated
-    # mutation for the rest of the session. EXCLUDED from scene_payload() on
-    # purpose; served on demand via the read-only fetchGitlinkContext intent
-    # instead (see fetch_gitlink_context_xml below). Deleted automatically
-    # when the node is deleted - no separate eviction bookkeeping needed
-    # (unlike image_assets, this never leaves this dataclass instance).
-    gitlink_context_xml: str = ""
-    # repository.py's build_context_bundle returns a mixed int/str dict
-    # (scanned_files/loaded_files/included_files/load_errors/
-    # context_omissions are ints; source_root/summary are strings) -
-    # store_gitlink_context stringifies every value before assigning here so
-    # the wire field this feeds (scene_payload()'s "gitlinkContextStats") stays
-    # honestly dict[str, str] end to end, matching how graphlink_scene_payload.py's
-    # SceneNodeRow types it for codegen. DEVIATION from a literal-verbatim
-    # forward: unlike R5.1's providerSnapshot (typed dict[str, str] but always
-    # populated as {} at runtime, so the type is never really exercised),
-    # gitlink_context_stats IS genuinely populated with int values at
-    # runtime - forwarding it unmodified would make the generated
-    # validateSceneState() reject every real context-build result. The
-    # str-coercion here is load-bearing, not a defensive formality.
-    gitlink_context_stats: dict[str, str] = field(default_factory=dict)
-    gitlink_context_summary: str = ""
-    # R5.3 post-review FIX 6: a genuine MONOTONIC per-node counter,
-    # incremented unconditionally every time store_gitlink_context lands a
-    # successful Build Context result (see that method below) - unlike
-    # gitlink_context_summary (built purely from aggregate file counts, per
-    # repository.py's build_context_bundle - never from paths/content), this
-    # can never collide. Without this field, two DIFFERENT Build Context
-    # results (e.g. selecting a different single file each time) could
-    # produce an IDENTICAL summary string, tricking the frontend's
-    # lazy-fetch-once guard (keyed on data.gitlinkContextSummary) into
-    # skipping a real refetch and showing stale XML. UNLIKE
-    # gitlink_context_xml/gitlink_change_local_root, this DOES need to be on
-    # the wire (see scene_payload() below) - the frontend reads it to detect
-    # "a new build landed" even when the summary text happens to repeat.
-    gitlink_context_version: int = 0
-    gitlink_proposal_markdown: str = ""
-    gitlink_pending_changes: list[dict[str, Any]] = field(default_factory=list)
-    gitlink_preview_text: str = ""
-    gitlink_change_fingerprint: str | None = None
-    # R5.3 post-review FIX 2: the local_root the approved change set's WRITE
-    # DESTINATION was bound to at Run time (see complete_gitlink_run below).
-    # _fingerprint_changes only hashes file content/paths/operations, never
-    # local_root - deliberately NOT modified, since it is reused verbatim
-    # from gitlink/agent.py, shared with the legacy Qt app. Without this
-    # separate binding, a still-valid fingerprint would let previously-
-    # reviewed content be written into a directory that was never diffed or
-    # shown to the user, if gitlink_local_root changes between Run and
-    # Apply (see start_gitlink_apply's fourth check in backend/agents.py).
-    # Plain internal bookkeeping field, like gitlink_context_xml: NEVER
-    # added to scene_payload()/the codegen dataclass source - the frontend
-    # never reads this directly, only the backend enforces it.
-    gitlink_change_local_root: str | None = None
-    # draft | previewed | applying | applied - see complete_gitlink_run/
-    # fail_gitlink_apply below for the transitions.
-    gitlink_change_state: str = "draft"
-    gitlink_error: str = ""
     # R5.4: the Py-Coder node's real persisted shape - reads a natural-
     # language ask (ai_driven mode) or hand-typed code (manual mode), runs it
     # in a persistent REPL subprocess, and reports the AI's analysis of the
@@ -377,6 +298,173 @@ class SceneNode:
     # has no kind-specific fields at all; otherwise the NodeState subclass
     # matching this node's own kind (e.g. ImageState for kind="image").
     state: NodeState | None = None
+
+    # -- ADR-002 stage 2.5 PR8a: transitional gitlink property shim --------
+    #
+    # GitlinkState (backend/domain/node_states.py) now owns all 19 gitlink_*
+    # fields - see that class's own docstring for what each one means. The
+    # properties below exist ONLY so backend/agents.py, backend/api/
+    # intents_gitlink.py, and the existing test suite keep working completely
+    # unchanged for the rest of this PR; each is a plain, unconditional
+    # delegation to self.state. Safe by construction, not by luck: every real
+    # `node.gitlink_x` call site was swept before this PR and is only ever
+    # reached on a node already established as kind="gitlink" (no getattr/
+    # hasattr-style defensive access anywhere touches these fields). Removed
+    # in the shim-removal follow-up PR, once every external site is converted
+    # to `.state.gitlink_x` directly and "gitlink" is added to
+    # tests/test_node_state_migration.py's MIGRATED_KIND_FIELDS.
+
+    @property
+    def gitlink_repo(self) -> str:
+        return self.state.gitlink_repo
+
+    @gitlink_repo.setter
+    def gitlink_repo(self, value: str) -> None:
+        self.state.gitlink_repo = value
+
+    @property
+    def gitlink_branch(self) -> str:
+        return self.state.gitlink_branch
+
+    @gitlink_branch.setter
+    def gitlink_branch(self, value: str) -> None:
+        self.state.gitlink_branch = value
+
+    @property
+    def gitlink_scope_mode(self) -> str:
+        return self.state.gitlink_scope_mode
+
+    @gitlink_scope_mode.setter
+    def gitlink_scope_mode(self, value: str) -> None:
+        self.state.gitlink_scope_mode = value
+
+    @property
+    def gitlink_local_root(self) -> str:
+        return self.state.gitlink_local_root
+
+    @gitlink_local_root.setter
+    def gitlink_local_root(self, value: str) -> None:
+        self.state.gitlink_local_root = value
+
+    @property
+    def gitlink_imported_root(self) -> str:
+        return self.state.gitlink_imported_root
+
+    @gitlink_imported_root.setter
+    def gitlink_imported_root(self, value: str) -> None:
+        self.state.gitlink_imported_root = value
+
+    @property
+    def gitlink_repo_file_paths(self) -> list[str]:
+        return self.state.gitlink_repo_file_paths
+
+    @gitlink_repo_file_paths.setter
+    def gitlink_repo_file_paths(self, value: list[str]) -> None:
+        self.state.gitlink_repo_file_paths = value
+
+    @property
+    def gitlink_selected_paths(self) -> list[str]:
+        return self.state.gitlink_selected_paths
+
+    @gitlink_selected_paths.setter
+    def gitlink_selected_paths(self, value: list[str]) -> None:
+        self.state.gitlink_selected_paths = value
+
+    @property
+    def gitlink_task_prompt(self) -> str:
+        return self.state.gitlink_task_prompt
+
+    @gitlink_task_prompt.setter
+    def gitlink_task_prompt(self, value: str) -> None:
+        self.state.gitlink_task_prompt = value
+
+    @property
+    def gitlink_context_xml(self) -> str:
+        return self.state.gitlink_context_xml
+
+    @gitlink_context_xml.setter
+    def gitlink_context_xml(self, value: str) -> None:
+        self.state.gitlink_context_xml = value
+
+    @property
+    def gitlink_context_stats(self) -> dict[str, str]:
+        return self.state.gitlink_context_stats
+
+    @gitlink_context_stats.setter
+    def gitlink_context_stats(self, value: dict[str, str]) -> None:
+        self.state.gitlink_context_stats = value
+
+    @property
+    def gitlink_context_summary(self) -> str:
+        return self.state.gitlink_context_summary
+
+    @gitlink_context_summary.setter
+    def gitlink_context_summary(self, value: str) -> None:
+        self.state.gitlink_context_summary = value
+
+    @property
+    def gitlink_context_version(self) -> int:
+        return self.state.gitlink_context_version
+
+    @gitlink_context_version.setter
+    def gitlink_context_version(self, value: int) -> None:
+        self.state.gitlink_context_version = value
+
+    @property
+    def gitlink_proposal_markdown(self) -> str:
+        return self.state.gitlink_proposal_markdown
+
+    @gitlink_proposal_markdown.setter
+    def gitlink_proposal_markdown(self, value: str) -> None:
+        self.state.gitlink_proposal_markdown = value
+
+    @property
+    def gitlink_pending_changes(self) -> list[dict[str, Any]]:
+        return self.state.gitlink_pending_changes
+
+    @gitlink_pending_changes.setter
+    def gitlink_pending_changes(self, value: list[dict[str, Any]]) -> None:
+        self.state.gitlink_pending_changes = value
+
+    @property
+    def gitlink_preview_text(self) -> str:
+        return self.state.gitlink_preview_text
+
+    @gitlink_preview_text.setter
+    def gitlink_preview_text(self, value: str) -> None:
+        self.state.gitlink_preview_text = value
+
+    @property
+    def gitlink_change_fingerprint(self) -> str | None:
+        return self.state.gitlink_change_fingerprint
+
+    @gitlink_change_fingerprint.setter
+    def gitlink_change_fingerprint(self, value: str | None) -> None:
+        self.state.gitlink_change_fingerprint = value
+
+    @property
+    def gitlink_change_local_root(self) -> str | None:
+        return self.state.gitlink_change_local_root
+
+    @gitlink_change_local_root.setter
+    def gitlink_change_local_root(self, value: str | None) -> None:
+        self.state.gitlink_change_local_root = value
+
+    @property
+    def gitlink_change_state(self) -> str:
+        return self.state.gitlink_change_state
+
+    @gitlink_change_state.setter
+    def gitlink_change_state(self, value: str) -> None:
+        self.state.gitlink_change_state = value
+
+    @property
+    def gitlink_error(self) -> str:
+        return self.state.gitlink_error
+
+    @gitlink_error.setter
+    def gitlink_error(self, value: str) -> None:
+        self.state.gitlink_error = value
 
 
 @dataclass

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -319,6 +319,122 @@ class ContainerState(NodeState):
 
 
 @dataclass
+class GitlinkState(NodeState):
+    """Relocated verbatim from SceneNode's nineteen gitlink fields (former
+    backend/domain/model.py fields, R5.3) - the Gitlink node's real
+    persisted shape: reads a GitHub repo (or a local checkout) into
+    structured XML context, proposes an LLM change set, and only writes to
+    disk after an explicit, fingerprint-verified approval.
+
+    - gitlink_repo/gitlink_branch/gitlink_scope_mode/gitlink_local_root:
+      the node's live repo/branch/scope-mode/local-checkout-path
+      selection, set by store_gitlink_repo_tree, store_gitlink_snapshot_
+      root, set_gitlink_local_root and store_gitlink_context (backend/
+      domain/graph.py).
+    - gitlink_imported_root: mirrors legacy repo_state["imported_root"] -
+      remembers which local path a prior Import Repo Snapshot produced, so
+      a later run can reuse it without re-downloading. Server-side
+      bookkeeping ONLY: deliberately absent from scene_payload()/
+      SceneNodeRow - there is no wire field for it, nothing on the
+      frontend ever needs to read it directly (gitlink_local_root is
+      what's shown/edited).
+    - gitlink_repo_file_paths/gitlink_selected_paths: the scanned
+      text-file path list and the user's Build-Context selection out of
+      it.
+    - gitlink_task_prompt: the natural-language ask for the current
+      Generate Change Set run.
+    - gitlink_context_xml: DESIGNED ceiling of 180,000 chars (repository.
+      py's MAX_CONTEXT_CHARS) - an order of magnitude above this state's
+      other fields' implicit ceilings. scene_payload() resends every node
+      on roughly 20 undebounced triggers (see SceneDocument.image_assets'
+      own comment) - inlining a 180KB text blob there would reproduce
+      that exact cost on every unrelated mutation for the rest of the
+      session. EXCLUDED from scene_payload() on purpose; served on demand
+      via the read-only fetchGitlinkContext intent instead (see
+      fetch_gitlink_context_xml, backend/domain/graph.py). Deleted
+      automatically when the node is deleted - no separate eviction
+      bookkeeping needed (unlike image_assets, this never leaves this
+      dataclass instance).
+    - gitlink_context_stats: repository.py's build_context_bundle returns
+      a mixed int/str dict (scanned_files/loaded_files/included_files/
+      load_errors/context_omissions are ints; source_root/summary are
+      strings) - store_gitlink_context stringifies every value before
+      assigning here so the wire field this feeds (scene_payload()'s
+      "gitlinkContextStats") stays honestly dict[str, str] end to end,
+      matching how graphlink_scene_payload.py's SceneNodeRow types it for
+      codegen. DEVIATION from a literal-verbatim forward: unlike R5.1's
+      providerSnapshot (typed dict[str, str] but always populated as {}
+      at runtime, so the type is never really exercised),
+      gitlink_context_stats IS genuinely populated with int values at
+      runtime - forwarding it unmodified would make the generated
+      validateSceneState() reject every real context-build result. The
+      str-coercion in store_gitlink_context is load-bearing, not a
+      defensive formality.
+    - gitlink_context_summary: built purely from aggregate file counts
+      (repository.py's build_context_bundle), never from paths/content -
+      two different Build Context results (e.g. selecting a different
+      single file each time) can produce an IDENTICAL summary string.
+    - gitlink_context_version: R5.3 post-review FIX 6 - a genuine
+      MONOTONIC per-node counter, incremented unconditionally every time
+      store_gitlink_context lands a successful Build Context result -
+      unlike gitlink_context_summary above, this can never collide.
+      Without this field, two DIFFERENT Build Context results could
+      produce an identical summary string, tricking the frontend's
+      lazy-fetch-once guard (keyed on data.gitlinkContextSummary) into
+      skipping a real refetch and showing stale XML. UNLIKE
+      gitlink_context_xml/gitlink_change_local_root, this DOES need to be
+      on the wire (see scene_payload()) - the frontend reads it to detect
+      "a new build landed" even when the summary text happens to repeat.
+    - gitlink_proposal_markdown/gitlink_pending_changes/
+      gitlink_preview_text: landed by complete_gitlink_run - the
+      human-readable proposal, the structured change list Apply actually
+      acts on, and the diff-style preview text.
+    - gitlink_change_fingerprint: a fingerprint (see
+      graphlink_plugins.gitlink.agent's _fingerprint_changes) of the
+      currently-previewed gitlink_pending_changes, checked by
+      start_gitlink_apply (backend/agents.py) immediately before writing,
+      so a stale/superseded approval can never be replayed.
+    - gitlink_change_local_root: R5.3 post-review FIX 2 - the local_root
+      the approved change set's WRITE DESTINATION was bound to at Run
+      time (see complete_gitlink_run). _fingerprint_changes only hashes
+      file content/paths/operations, never local_root - this field is
+      deliberately NOT hashed itself, since it is reused verbatim from
+      gitlink/agent.py, shared with the legacy Qt app. Without this
+      separate binding, a still-valid fingerprint would let previously-
+      reviewed content be written into a directory that was never diffed
+      or shown to the user, if gitlink_local_root changes between Run and
+      Apply (see start_gitlink_apply's fourth check in backend/agents.py).
+      Plain internal bookkeeping field, like gitlink_context_xml: NEVER
+      added to scene_payload()/the codegen dataclass source - the
+      frontend never reads this directly, only the backend enforces it.
+    - gitlink_change_state: draft | previewed | applying | applied - see
+      complete_gitlink_run/fail_gitlink_apply (backend/domain/graph.py)
+      for the transitions.
+    - gitlink_error: the current run/apply's error banner text, cleared
+      on the next attempt."""
+
+    gitlink_repo: str = ""
+    gitlink_branch: str = ""
+    gitlink_scope_mode: str = "selected"
+    gitlink_local_root: str = ""
+    gitlink_imported_root: str = ""
+    gitlink_repo_file_paths: list[str] = field(default_factory=list)
+    gitlink_selected_paths: list[str] = field(default_factory=list)
+    gitlink_task_prompt: str = ""
+    gitlink_context_xml: str = ""
+    gitlink_context_stats: dict[str, str] = field(default_factory=dict)
+    gitlink_context_summary: str = ""
+    gitlink_context_version: int = 0
+    gitlink_proposal_markdown: str = ""
+    gitlink_pending_changes: list[dict[str, Any]] = field(default_factory=list)
+    gitlink_preview_text: str = ""
+    gitlink_change_fingerprint: str | None = None
+    gitlink_change_local_root: str | None = None
+    gitlink_change_state: str = "draft"
+    gitlink_error: str = ""
+
+
+@dataclass
 class ChatState(NodeState):
     """Relocated verbatim from SceneNode's eight chat-only fields (former
     backend/domain/model.py fields). SceneNode's own `content` field

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -189,6 +189,7 @@ from backend.canvas import (
     ChatState,
     CodeState,
     DocumentState,
+    GitlinkState,
     HtmlState,
     ImageState,
     SceneDocument,
@@ -538,27 +539,30 @@ def _restore_gitlink_payload(payload: dict[str, Any]) -> SceneNode:
 
     return SceneNode(
         id="", x=x, y=y, title="Gitlink", kind="gitlink",
-        gitlink_task_prompt=str(payload.get("task_prompt", "")),
-        gitlink_repo=str(repo_state.get("repo", "")),
-        gitlink_branch=str(repo_state.get("branch", "")),
-        gitlink_scope_mode=str(repo_state.get("scope_mode", "selected")),
-        gitlink_local_root=str(repo_state.get("local_root", "")),
-        gitlink_imported_root=str(repo_state.get("imported_root", "")),
-        gitlink_repo_file_paths=list(payload.get("repo_file_paths") or []),
-        gitlink_selected_paths=list(payload.get("selected_paths") or []),
-        gitlink_context_xml=str(payload.get("context_xml", "")),
-        gitlink_context_stats={str(k): str(v) for k, v in context_stats.items()},
-        gitlink_pending_changes=pending_changes,
-        # Derived, not persisted - see this module's own docstring for why
-        # the exact legacy rendering can't be recovered, and why a simple
-        # honest summary is the documented substitute.
-        gitlink_proposal_markdown=_build_simple_proposal_markdown(pending_changes),
-        gitlink_preview_text=str(payload.get("preview_text", "")),
-        # Never persisted in legacy either - always reset on restore there
-        # too, matching backend's own complete_gitlink_run contract.
-        gitlink_change_fingerprint=None,
-        gitlink_change_local_root=None,
-        gitlink_change_state="previewed" if pending_changes else "draft",
+        state=GitlinkState(
+            gitlink_task_prompt=str(payload.get("task_prompt", "")),
+            gitlink_repo=str(repo_state.get("repo", "")),
+            gitlink_branch=str(repo_state.get("branch", "")),
+            gitlink_scope_mode=str(repo_state.get("scope_mode", "selected")),
+            gitlink_local_root=str(repo_state.get("local_root", "")),
+            gitlink_imported_root=str(repo_state.get("imported_root", "")),
+            gitlink_repo_file_paths=list(payload.get("repo_file_paths") or []),
+            gitlink_selected_paths=list(payload.get("selected_paths") or []),
+            gitlink_context_xml=str(payload.get("context_xml", "")),
+            gitlink_context_stats={str(k): str(v) for k, v in context_stats.items()},
+            gitlink_pending_changes=pending_changes,
+            # Derived, not persisted - see this module's own docstring for
+            # why the exact legacy rendering can't be recovered, and why a
+            # simple honest summary is the documented substitute.
+            gitlink_proposal_markdown=_build_simple_proposal_markdown(pending_changes),
+            gitlink_preview_text=str(payload.get("preview_text", "")),
+            # Never persisted in legacy either - always reset on restore
+            # there too, matching backend's own complete_gitlink_run
+            # contract.
+            gitlink_change_fingerprint=None,
+            gitlink_change_local_root=None,
+            gitlink_change_state="previewed" if pending_changes else "draft",
+        ),
         history=_restore_history(payload.get("conversation_history")),
         is_collapsed=bool(payload.get("is_collapsed", False)),
     )

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -289,22 +289,22 @@ def _serialize_artifact_node(node: SceneNode) -> dict[str, Any]:
 def _serialize_gitlink_node(node: SceneNode) -> dict[str, Any]:
     return {
         "node_type": "gitlink",
-        "task_prompt": node.gitlink_task_prompt,
+        "task_prompt": node.state.gitlink_task_prompt,
         "repo_state": {
-            "repo": node.gitlink_repo,
-            "branch": node.gitlink_branch,
-            "scope_mode": node.gitlink_scope_mode,
-            "local_root": node.gitlink_local_root,
-            "imported_root": node.gitlink_imported_root,
+            "repo": node.state.gitlink_repo,
+            "branch": node.state.gitlink_branch,
+            "scope_mode": node.state.gitlink_scope_mode,
+            "local_root": node.state.gitlink_local_root,
+            "imported_root": node.state.gitlink_imported_root,
         },
-        "repo_file_paths": list(node.gitlink_repo_file_paths),
-        "selected_paths": list(node.gitlink_selected_paths),
-        "context_xml": node.gitlink_context_xml,
-        "context_stats": dict(node.gitlink_context_stats),
+        "repo_file_paths": list(node.state.gitlink_repo_file_paths),
+        "selected_paths": list(node.state.gitlink_selected_paths),
+        "context_xml": node.state.gitlink_context_xml,
+        "context_stats": dict(node.state.gitlink_context_stats),
         # Inverse of R6.4's own proposal_data["files"] -> gitlink_pending_changes
         # unpack.
-        "proposal_data": {"files": list(node.gitlink_pending_changes)},
-        "preview_text": node.gitlink_preview_text,
+        "proposal_data": {"files": list(node.state.gitlink_pending_changes)},
+        "preview_text": node.state.gitlink_preview_text,
         "conversation_history": _serialize_history(node.history),
         "is_collapsed": bool(node.is_collapsed),
     }

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -321,6 +321,32 @@ _EXPECTED_NON_OWNING_KIND_WIRE_DEFAULTS = {
     "isBranchSynthesis": False,
     "synthesisInstructions": "",
     "branchStatus": "active",
+    # ADR-002 stage 2.5 PR8a: gitlink's 16 wire keys, moved onto GitlinkState
+    # behind a transitional property shim (see SceneNode's own comment,
+    # backend/domain/model.py) - "gitlink" is deliberately NOT yet added to
+    # MIGRATED_KIND_FIELDS above (that AST gate can't tell shimmed property
+    # access from bare field access, and would false-positive on every
+    # still-unconverted external call site the shim exists to leave alone
+    # until the shim-removal PR). This dict is independent of that gate -
+    # it checks scene_payload()'s actual runtime VALUES, which are already
+    # fully correct in this PR, so the values are captured here now rather
+    # than deferred alongside MIGRATED_KIND_FIELDS.
+    "gitlinkRepo": "",
+    "gitlinkBranch": "",
+    "gitlinkScopeMode": "selected",
+    "gitlinkLocalRoot": "",
+    "gitlinkRepoFilePaths": [],
+    "gitlinkSelectedPaths": [],
+    "gitlinkTaskPrompt": "",
+    "gitlinkContextStats": {},
+    "gitlinkContextSummary": "",
+    "gitlinkContextVersion": 0,
+    "gitlinkProposalMarkdown": "",
+    "gitlinkPendingChanges": [],
+    "gitlinkPreviewText": "",
+    "gitlinkChangeFingerprint": None,
+    "gitlinkChangeState": "draft",
+    "gitlinkError": "",
 }
 
 


### PR DESCRIPTION
## Problem

SceneNode still carries all 19 of gitlink's kind-specific fields directly on the dataclass, unlike every other already-migrated kind. Unlike those kinds, gitlink's field-access sites are heavily entangled with backend/agents.py's async dispatch code (~14 sites) and backend/api/intents_gitlink.py (~9 sites), plus ~83 test call sites - converting all of that safely in one PR is a separate, larger effort from the domain-model move itself.

## Change

- Adds `GitlinkState` (backend/domain/node_states.py) with all 19 fields and full docstrings preserving the original field-by-field reasoning.
- Removes the 19 fields from `SceneNode` (backend/domain/model.py) and adds 19 property/setter pairs that transparently delegate `node.gitlink_x` to `node.state.gitlink_x` - a transitional shim so every existing external call site (agents.py, intents_gitlink.py, tests) keeps working unchanged. This is a new pattern in the codebase, reserved specifically for kinds too entangled with async dispatch code to convert in one PR.
- Converts the domain layer itself - `backend/domain/graph.py`'s 11 gitlink methods, `backend/session_save.py`'s serializer, `backend/session_load.py`'s restorer - to real `.state.gitlink_x` access directly, not via the shim.
- Deliberately does **not** add `"gitlink"` to `tests/test_node_state_migration.py`'s `MIGRATED_KIND_FIELDS`: that AST gate can't distinguish shimmed property access from a leftover bare field, and would false-positive on every call site the shim exists to leave alone. That addition is reserved for the shim-removal follow-up PR. The independent wire-fallback regression test (`_EXPECTED_NON_OWNING_KIND_WIRE_DEFAULTS`) is extended with all 16 of gitlink's wire keys, since it doesn't depend on the AST gate.
- Fixes a real regression the domain move introduced: 10 of 11 gitlink-touching methods had no `node.kind` guard. Pre-move this was harmless (fields lived on every SceneNode, a wrong-kind call was a silent no-op). Post-move, the same call would either raise `AttributeError` (on an unmigrated-kind node, since `state` is `None`) or silently write a stray `gitlink_*` attribute onto an unrelated kind's state object (on an already-migrated-but-different-kind node, since plain dataclasses accept arbitrary new attributes). Added the same `node.kind != "gitlink"` guard `start_gitlink_run` already had to the other 5 `graph.py` methods, and equivalent guards at the WS-intent boundary in `intents_gitlink.py` for the 4 handlers that touch gitlink fields before delegating - closing the hole without touching `agents.py` or any `.gitlink_x` access pattern there.

Wire payload is byte-identical. `SceneNode`'s field count drops from 52 to 33.

## Test plan

- `python -m pytest -q` (full suite, repo root): 1228 passed.
- Reproduced the pre-fix regression directly (wrong-kind and unmigrated-kind nodes hitting the unguarded methods), confirmed each now raises `SceneError` instead of crashing or silently corrupting an unrelated node's state.
- Mutation-tested the new `store_gitlink_context` guard: removed it, confirmed the exact AttributeError + silent-attribute-pollution failure mode reproduces, restored it, confirmed the suite passes again.
- Mutation-tested the new gitlink wire-fallback defaults table: broke one fallback value, confirmed `test_migrated_field_wire_fallbacks_match_pre_migration_defaults` catches it, restored it.
- `pyflakes` on every touched file: no new warnings (pre-existing unrelated warnings only).
- Two independent adversarial-review passes plus a skeptical synthesis, run against the actual diff.