### PR TITLE
ADR-002 stage 2.5 (PR9a/~16): pycoder domain move + transitional property shim

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -93,6 +93,7 @@ from backend.domain.node_states import (
     GitlinkState,
     HtmlState,
     ImageState,
+    PycoderState,
     WebResearchState,
 )
 

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -96,6 +96,7 @@ from backend.domain.node_states import (
     HtmlState,
     ImageState,
     NoteState,
+    PycoderState,
     WebResearchState,
 )
 
@@ -1067,6 +1068,7 @@ class SceneDocument(BranchOps, GroupOps):
             y=float(y),
             title="Py-Coder",
             kind="pycoder",
+            state=PycoderState(),
         )
         self.nodes[node_id] = node
         self.connect(parent_id, node_id)
@@ -1079,9 +1081,11 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "pycoder":
+            raise SceneError(f"node is not a pycoder node: {node_id}")
         if mode not in ("ai_driven", "manual"):
             raise SceneError(f"unknown pycoder mode: {mode}")
-        node.pycoder_mode = str(mode)
+        node.state.pycoder_mode = str(mode)
         return node
 
     def start_pycoder_run(self, node_id: str, input_text: str) -> SceneNode:
@@ -1096,11 +1100,11 @@ class SceneDocument(BranchOps, GroupOps):
             raise SceneError(f"unknown node: {node_id}")
         if node.kind != "pycoder":
             raise SceneError(f"node is not a pycoder node: {node_id}")
-        if node.pycoder_mode == "manual":
-            node.pycoder_code = str(input_text)
+        if node.state.pycoder_mode == "manual":
+            node.state.pycoder_code = str(input_text)
         else:
-            node.pycoder_prompt = str(input_text)
-        node.pycoder_error = ""
+            node.state.pycoder_prompt = str(input_text)
+        node.state.pycoder_error = ""
         return node
 
     def complete_pycoder_run(
@@ -1112,17 +1116,21 @@ class SceneDocument(BranchOps, GroupOps):
         definition once a result lands), and any stale error banner is
         cleared. Silent no-op if the node is gone - same posture as
         fail_web_research_run's own liveness handling for a background
-        result landing after deletion."""
+        result landing after deletion. Not kind-guarded: only ever reached
+        via run_pycoder's own on_success closure (backend/api/
+        intents_pycoder.py), whose node_id was already validated by
+        start_pycoder_run's own guard earlier in the same request - same
+        posture as complete_gitlink_run/complete_gitlink_apply."""
         node = self.nodes.get(node_id)
         if node is None:
             return None
-        node.pycoder_code = str(code)
-        node.pycoder_output = str(output)
-        node.pycoder_analysis = str(analysis)
-        node.pycoder_last_run_failed = bool(last_run_failed)
-        node.pycoder_awaiting_approval = False
-        node.pycoder_approved_fingerprint = None
-        node.pycoder_error = ""
+        node.state.pycoder_code = str(code)
+        node.state.pycoder_output = str(output)
+        node.state.pycoder_analysis = str(analysis)
+        node.state.pycoder_last_run_failed = bool(last_run_failed)
+        node.state.pycoder_awaiting_approval = False
+        node.state.pycoder_approved_fingerprint = None
+        node.state.pycoder_error = ""
         return node
 
     def fail_pycoder_run(self, node_id: str, message: str) -> SceneNode | None:
@@ -1132,13 +1140,14 @@ class SceneDocument(BranchOps, GroupOps):
         forever. Deliberately does NOT clear pycoder_code/pycoder_output/
         pycoder_analysis - a failed re-run must never wipe out a previously
         completed result, only the error banner reflects the new failure
-        (stale-while-revalidate, same posture as fail_gitlink_run)."""
+        (stale-while-revalidate, same posture as fail_gitlink_run). Not
+        kind-guarded - see complete_pycoder_run's own comment."""
         node = self.nodes.get(node_id)
         if node is None:
             return None
-        node.pycoder_awaiting_approval = False
-        node.pycoder_approved_fingerprint = None
-        node.pycoder_error = str(message)
+        node.state.pycoder_awaiting_approval = False
+        node.state.pycoder_approved_fingerprint = None
+        node.state.pycoder_error = str(message)
         return node
 
     # -- R5.4: Execution Sandbox node ------------------------------------------
@@ -1800,14 +1809,18 @@ class SceneDocument(BranchOps, GroupOps):
                         n.state.gitlink_change_state if isinstance(n.state, GitlinkState) else "draft"
                     ),
                     "gitlinkError": n.state.gitlink_error if isinstance(n.state, GitlinkState) else "",
-                    "pycoderMode": n.pycoder_mode,
-                    "pycoderPrompt": n.pycoder_prompt,
-                    "pycoderCode": n.pycoder_code,
-                    "pycoderOutput": n.pycoder_output,
-                    "pycoderAnalysis": n.pycoder_analysis,
-                    "pycoderLastRunFailed": n.pycoder_last_run_failed,
-                    "pycoderAwaitingApproval": n.pycoder_awaiting_approval,
-                    "pycoderError": n.pycoder_error,
+                    "pycoderMode": n.state.pycoder_mode if isinstance(n.state, PycoderState) else "ai_driven",
+                    "pycoderPrompt": n.state.pycoder_prompt if isinstance(n.state, PycoderState) else "",
+                    "pycoderCode": n.state.pycoder_code if isinstance(n.state, PycoderState) else "",
+                    "pycoderOutput": n.state.pycoder_output if isinstance(n.state, PycoderState) else "",
+                    "pycoderAnalysis": n.state.pycoder_analysis if isinstance(n.state, PycoderState) else "",
+                    "pycoderLastRunFailed": (
+                        n.state.pycoder_last_run_failed if isinstance(n.state, PycoderState) else False
+                    ),
+                    "pycoderAwaitingApproval": (
+                        n.state.pycoder_awaiting_approval if isinstance(n.state, PycoderState) else False
+                    ),
+                    "pycoderError": n.state.pycoder_error if isinstance(n.state, PycoderState) else "",
                     # codeSandboxSandboxId is DELIBERATELY OMITTED - see the
                     # field's own comment on SceneNode (pure internal
                     # directory-naming key, mirrors gitlink_imported_root's

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -186,33 +186,6 @@ class SceneNode:
     # way is_docked is a generic field even though today only one kind
     # populates it); unused (default None) for every other kind.
     pending_request_id: str | None = None
-    # R5.4: the Py-Coder node's real persisted shape - reads a natural-
-    # language ask (ai_driven mode) or hand-typed code (manual mode), runs it
-    # in a persistent REPL subprocess, and reports the AI's analysis of the
-    # result. pending_request_id (generic, above) is reused unchanged as the
-    # busy marker for the ENTIRE span from Run-click through generation,
-    # through the human-approval pause, through execution, through analysis -
-    # same posture as Gitlink's Run/Apply. Unused (default) for every other
-    # kind.
-    pycoder_mode: str = "ai_driven"  # "ai_driven" | "manual"
-    pycoder_prompt: str = ""  # last natural-language ask (ai_driven only)
-    pycoder_code: str = ""  # current/last code - the thing that actually executes
-    pycoder_output: str = ""  # last REPL stdout
-    pycoder_analysis: str = ""  # AI's analysis of the last output
-    pycoder_last_run_failed: bool = False
-    pycoder_awaiting_approval: bool = False
-    # ADR-002 P0: a fingerprint (see graphlink_plugins.gitlink.agent's
-    # _fingerprint_changes, reused here rather than reinvented) of exactly
-    # what the CURRENT pycoder_awaiting_approval gate is asking about -
-    # {"code": pycoder_code}. Set the instant the gate opens (mirrors
-    # gitlink_change_fingerprint's own timing), checked immediately before
-    # the code it covers actually executes (AgentDispatcher.start_pycoder_
-    # run), and cleared everywhere pycoder_awaiting_approval itself is
-    # cleared, so a resolved/denied/superseded approval can never be
-    # replayed. Internal bookkeeping only - EXCLUDED from scene_payload(),
-    # same posture as code_sandbox_sandbox_id.
-    pycoder_approved_fingerprint: str | None = None
-    pycoder_error: str = ""
     # R5.4: the Execution Sandbox node's real persisted shape - runs Python
     # inside an isolated per-node virtualenv (VirtualEnvSandbox, keyed by
     # code_sandbox_sandbox_id) with a per-node requirements.txt manifest.
@@ -465,6 +438,88 @@ class SceneNode:
     @gitlink_error.setter
     def gitlink_error(self, value: str) -> None:
         self.state.gitlink_error = value
+
+    # -- ADR-002 stage 2.5 PR9a: transitional pycoder property shim --------
+    #
+    # PycoderState (backend/domain/node_states.py) now owns all 9 pycoder_*
+    # fields - see that class's own docstring. Same transitional shim as the
+    # gitlink block above: exists ONLY so backend/agents.py and the existing
+    # test suite keep working completely unchanged for the rest of this PR.
+    # Removed in the shim-removal follow-up PR, once every external site is
+    # converted to `.state.pycoder_x` directly and "pycoder" is added to
+    # tests/test_node_state_migration.py's MIGRATED_KIND_FIELDS.
+
+    @property
+    def pycoder_mode(self) -> str:
+        return self.state.pycoder_mode
+
+    @pycoder_mode.setter
+    def pycoder_mode(self, value: str) -> None:
+        self.state.pycoder_mode = value
+
+    @property
+    def pycoder_prompt(self) -> str:
+        return self.state.pycoder_prompt
+
+    @pycoder_prompt.setter
+    def pycoder_prompt(self, value: str) -> None:
+        self.state.pycoder_prompt = value
+
+    @property
+    def pycoder_code(self) -> str:
+        return self.state.pycoder_code
+
+    @pycoder_code.setter
+    def pycoder_code(self, value: str) -> None:
+        self.state.pycoder_code = value
+
+    @property
+    def pycoder_output(self) -> str:
+        return self.state.pycoder_output
+
+    @pycoder_output.setter
+    def pycoder_output(self, value: str) -> None:
+        self.state.pycoder_output = value
+
+    @property
+    def pycoder_analysis(self) -> str:
+        return self.state.pycoder_analysis
+
+    @pycoder_analysis.setter
+    def pycoder_analysis(self, value: str) -> None:
+        self.state.pycoder_analysis = value
+
+    @property
+    def pycoder_last_run_failed(self) -> bool:
+        return self.state.pycoder_last_run_failed
+
+    @pycoder_last_run_failed.setter
+    def pycoder_last_run_failed(self, value: bool) -> None:
+        self.state.pycoder_last_run_failed = value
+
+    @property
+    def pycoder_awaiting_approval(self) -> bool:
+        return self.state.pycoder_awaiting_approval
+
+    @pycoder_awaiting_approval.setter
+    def pycoder_awaiting_approval(self, value: bool) -> None:
+        self.state.pycoder_awaiting_approval = value
+
+    @property
+    def pycoder_approved_fingerprint(self) -> str | None:
+        return self.state.pycoder_approved_fingerprint
+
+    @pycoder_approved_fingerprint.setter
+    def pycoder_approved_fingerprint(self, value: str | None) -> None:
+        self.state.pycoder_approved_fingerprint = value
+
+    @property
+    def pycoder_error(self) -> str:
+        return self.state.pycoder_error
+
+    @pycoder_error.setter
+    def pycoder_error(self, value: str) -> None:
+        self.state.pycoder_error = value
 
 
 @dataclass

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -435,6 +435,48 @@ class GitlinkState(NodeState):
 
 
 @dataclass
+class PycoderState(NodeState):
+    """Relocated verbatim from SceneNode's nine pycoder fields (former
+    backend/domain/model.py fields, R5.4) - the Py-Coder node's real
+    persisted shape: reads a natural-language ask (ai_driven mode) or
+    hand-typed code (manual mode), runs it in a persistent REPL
+    subprocess, and reports the AI's analysis of the result.
+    SceneNode's own pending_request_id field (core, not duplicated here)
+    is reused unchanged as the busy marker for the ENTIRE span from
+    Run-click through generation, through the human-approval pause,
+    through execution, through analysis - same posture as Gitlink's
+    Run/Apply.
+
+    - pycoder_mode: "ai_driven" | "manual".
+    - pycoder_prompt: last natural-language ask (ai_driven only).
+    - pycoder_code: current/last code - the thing that actually executes.
+    - pycoder_output: last REPL stdout.
+    - pycoder_analysis: AI's analysis of the last output.
+    - pycoder_approved_fingerprint: ADR-002 P0 - a fingerprint (see
+      graphlink_plugins.gitlink.agent's _fingerprint_changes, reused here
+      rather than reinvented) of exactly what the CURRENT
+      pycoder_awaiting_approval gate is asking about - {"code":
+      pycoder_code}. Set the instant the gate opens (mirrors
+      gitlink_change_fingerprint's own timing), checked immediately
+      before the code it covers actually executes
+      (AgentDispatcher.start_pycoder_run), and cleared everywhere
+      pycoder_awaiting_approval itself is cleared, so a
+      resolved/denied/superseded approval can never be replayed.
+      Internal bookkeeping only - EXCLUDED from scene_payload(), same
+      posture as CodeSandboxState's own sandbox_id."""
+
+    pycoder_mode: str = "ai_driven"
+    pycoder_prompt: str = ""
+    pycoder_code: str = ""
+    pycoder_output: str = ""
+    pycoder_analysis: str = ""
+    pycoder_last_run_failed: bool = False
+    pycoder_awaiting_approval: bool = False
+    pycoder_approved_fingerprint: str | None = None
+    pycoder_error: str = ""
+
+
+@dataclass
 class ChatState(NodeState):
     """Relocated verbatim from SceneNode's eight chat-only fields (former
     backend/domain/model.py fields). SceneNode's own `content` field

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -192,6 +192,7 @@ from backend.canvas import (
     GitlinkState,
     HtmlState,
     ImageState,
+    PycoderState,
     SceneDocument,
     SceneNode,
     SUPPORTED_CHART_TYPES,
@@ -573,14 +574,16 @@ def _restore_pycoder_payload(payload: dict[str, Any]) -> SceneNode:
     raw_mode = str(payload.get("mode", "AI_DRIVEN") or "AI_DRIVEN")
     return SceneNode(
         id="", x=x, y=y, title="Py-Coder", kind="pycoder",
-        # R6.4 translation: legacy persists the enum MEMBER NAME
-        # ("AI_DRIVEN"/"MANUAL", uppercase, via node.mode.name); backend
-        # wants "ai_driven"/"manual" (lowercase).
-        pycoder_mode=raw_mode.lower(),
-        pycoder_prompt=str(payload.get("prompt", "")),
-        pycoder_code=str(payload.get("code", "")),
-        pycoder_output=str(payload.get("output", "")),
-        pycoder_analysis=str(payload.get("analysis", "")),
+        state=PycoderState(
+            # R6.4 translation: legacy persists the enum MEMBER NAME
+            # ("AI_DRIVEN"/"MANUAL", uppercase, via node.mode.name); backend
+            # wants "ai_driven"/"manual" (lowercase).
+            pycoder_mode=raw_mode.lower(),
+            pycoder_prompt=str(payload.get("prompt", "")),
+            pycoder_code=str(payload.get("code", "")),
+            pycoder_output=str(payload.get("output", "")),
+            pycoder_analysis=str(payload.get("analysis", "")),
+        ),
         history=_restore_history(payload.get("conversation_history")),
         is_collapsed=bool(payload.get("is_collapsed", False)),
     )

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -315,11 +315,11 @@ def _serialize_pycoder_node(node: SceneNode) -> dict[str, Any]:
         "node_type": "pycoder",
         # Inverse of R6.4's own lowercase translation: legacy persists the
         # enum MEMBER NAME, uppercase.
-        "mode": node.pycoder_mode.upper(),
-        "prompt": node.pycoder_prompt,
-        "code": node.pycoder_code,
-        "output": node.pycoder_output,
-        "analysis": node.pycoder_analysis,
+        "mode": node.state.pycoder_mode.upper(),
+        "prompt": node.state.pycoder_prompt,
+        "code": node.state.pycoder_code,
+        "output": node.state.pycoder_output,
+        "analysis": node.state.pycoder_analysis,
         "conversation_history": _serialize_history(node.history),
         "is_collapsed": bool(node.is_collapsed),
     }

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -347,6 +347,20 @@ _EXPECTED_NON_OWNING_KIND_WIRE_DEFAULTS = {
     "gitlinkChangeFingerprint": None,
     "gitlinkChangeState": "draft",
     "gitlinkError": "",
+    # ADR-002 stage 2.5 PR9a: pycoder's 8 wire keys (pycoder_approved_
+    # fingerprint is excluded from scene_payload(), same posture as
+    # gitlink_context_xml), moved onto PycoderState behind the same
+    # transitional property shim as gitlink - "pycoder" is likewise
+    # deliberately NOT yet added to MIGRATED_KIND_FIELDS above, for the
+    # identical AST-gate-can't-tell-shim-from-bare-access reason.
+    "pycoderMode": "ai_driven",
+    "pycoderPrompt": "",
+    "pycoderCode": "",
+    "pycoderOutput": "",
+    "pycoderAnalysis": "",
+    "pycoderLastRunFailed": False,
+    "pycoderAwaitingApproval": False,
+    "pycoderError": "",
 }
 
 


### PR DESCRIPTION
## Problem

SceneNode still carries all 9 of pycoder's kind-specific fields directly on the dataclass. Pycoder was flagged in the original stage 2.5 scoping as one of the two highest-risk kinds to migrate (with code_sandbox), because its approval-gate flow in backend/agents.py spans an await while waiting on human approval - converting its field access in the same PR as the domain-model move risked introducing a stale-read bug across that suspend.

## Change

- Adds `PycoderState` (backend/domain/node_states.py) with all 9 fields and full docstrings preserving the original field-by-field reasoning.
- Removes the 9 fields from `SceneNode` (backend/domain/model.py) and adds 9 property/setter pairs delegating `node.pycoder_x` to `node.state.pycoder_x` - the same transitional shim pattern PR8a introduced for gitlink, so `backend/agents.py` and `backend/api/intents_pycoder.py` keep working unchanged.
- Converts the domain layer itself - `backend/domain/graph.py`'s 5 pycoder methods, `backend/session_save.py`'s serializer, `backend/session_load.py`'s restorer - to real `.state.pycoder_x` access directly, not via the shim.
- A dedicated reconnaissance pass plus adversarial review traced every `await` in `agents.py`'s pycoder approval-gate flow end to end: the approval fingerprint is always re-read fresh with zero await between that read and the code executing, the entire suspend window is exclusively owned by one coroutine via `node.pending_request_id`, and no other code path can write the fields the resumed coroutine re-reads. A property shim adds no yield point (getters/setters are always synchronous), so it cannot change this flow's behavior. No fix was needed for the risk this kind was originally flagged for.
- Deliberately does **not** add `"pycoder"` to `tests/test_node_state_migration.py`'s `MIGRATED_KIND_FIELDS`, for the same reason established in PR8a (the AST gate can't distinguish shimmed property access from a leftover bare field). The independent wire-fallback regression test is extended with all 8 of pycoder's wire keys (`pycoder_approved_fingerprint` is correctly excluded, same posture as `gitlink_context_xml`).
- Applies PR8a's guard-scoping precedent: added the `node.kind != "pycoder"` guard `set_pycoder_mode` was missing (reachable directly from the `setPyCoderMode` WS intent with an arbitrary node_id), while leaving `complete_pycoder_run`/`fail_pycoder_run` unguarded - both are only ever reached via `run_pycoder`'s own `on_success`/`on_failure` closures with a node_id already validated by `start_pycoder_run` earlier in the same request, mirroring gitlink's `complete_gitlink_run`/`fail_gitlink_run`.

Wire payload is byte-identical. `SceneNode`'s field count drops from 33 to 24.

## Test plan

- `python -m pytest -q` (full suite, repo root): 1228 passed.
- Directly reproduced the new `set_pycoder_mode` guard against wrong-kind nodes (note, gitlink), confirmed `SceneError` instead of silent cross-object corruption; confirmed the real pycoder path still works end to end through the shim.
- Mutation-tested the new pycoder wire-fallback defaults table: broke one fallback value, confirmed `test_migrated_field_wire_fallbacks_match_pre_migration_defaults` catches it, restored it.
- `pyflakes` on every touched file: no new warnings (pre-existing unrelated warnings only).
- Two independent adversarial-review passes plus a skeptical synthesis, run against the actual diff, with dedicated scrutiny on the approval-gate mid-coroutine mutation question - verdict SHIP AS-IS, no bugs found.