### PR TITLE
ADR-002 stage 2.5 (PR10a/~16): code_sandbox domain move + transitional property shim

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -88,6 +88,7 @@ from backend.domain.model import (
 from backend.domain.node_states import (
     ArtifactState,
     ChatState,
+    CodeSandboxState,
     CodeState,
     DocumentState,
     GitlinkState,

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -88,6 +88,7 @@ from backend.domain.node_states import (
     ArtifactState,
     ChartState,
     ChatState,
+    CodeSandboxState,
     CodeState,
     ContainerState,
     DocumentState,
@@ -1178,7 +1179,7 @@ class SceneDocument(BranchOps, GroupOps):
             y=float(y),
             title="Virtual Environment Runner",
             kind="code_sandbox",
-            code_sandbox_sandbox_id=uuid.uuid4().hex[:12],
+            state=CodeSandboxState(code_sandbox_sandbox_id=uuid.uuid4().hex[:12]),
         )
         self.nodes[node_id] = node
         self.connect(parent_id, node_id)
@@ -1188,7 +1189,9 @@ class SceneDocument(BranchOps, GroupOps):
         node = self.nodes.get(node_id)
         if node is None:
             raise SceneError(f"unknown node: {node_id}")
-        node.code_sandbox_requirements = str(requirements_text)
+        if node.kind != "code_sandbox":
+            raise SceneError(f"node is not a code_sandbox node: {node_id}")
+        node.state.code_sandbox_requirements = str(requirements_text)
         return node
 
     def start_code_sandbox_run(self, node_id: str, input_text: str) -> SceneNode:
@@ -1204,8 +1207,8 @@ class SceneDocument(BranchOps, GroupOps):
             raise SceneError(f"unknown node: {node_id}")
         if node.kind != "code_sandbox":
             raise SceneError(f"node is not a code_sandbox node: {node_id}")
-        node.code_sandbox_prompt = str(input_text)
-        node.code_sandbox_error = ""
+        node.state.code_sandbox_prompt = str(input_text)
+        node.state.code_sandbox_error = ""
         return node
 
     def complete_code_sandbox_run(self, node_id: str, code: str, output: str, analysis: str) -> SceneNode | None:
@@ -1214,30 +1217,35 @@ class SceneDocument(BranchOps, GroupOps):
         an unrecovered failure after exhausting its own repair attempts
         surfaces as a failed run, see AgentDispatcher.start_code_sandbox_run,
         not as a "succeeded but flagged" result the way Py-Coder's repair
-        loop does)."""
+        loop does). Not kind-guarded: only ever reached via run_code_
+        sandbox's own on_success closure (backend/api/
+        intents_code_sandbox.py), whose node_id was already validated by
+        start_code_sandbox_run's own guard earlier in the same request -
+        same posture as complete_pycoder_run/complete_gitlink_run."""
         node = self.nodes.get(node_id)
         if node is None:
             return None
-        node.code_sandbox_code = str(code)
-        node.code_sandbox_output = str(output)
-        node.code_sandbox_analysis = str(analysis)
-        node.code_sandbox_awaiting_approval = False
-        node.code_sandbox_approval_requirements = ""
-        node.code_sandbox_approved_fingerprint = None
-        node.code_sandbox_error = ""
+        node.state.code_sandbox_code = str(code)
+        node.state.code_sandbox_output = str(output)
+        node.state.code_sandbox_analysis = str(analysis)
+        node.state.code_sandbox_awaiting_approval = False
+        node.state.code_sandbox_approval_requirements = ""
+        node.state.code_sandbox_approved_fingerprint = None
+        node.state.code_sandbox_error = ""
         return node
 
     def fail_code_sandbox_run(self, node_id: str, message: str) -> SceneNode | None:
         """Land a failed (or denied-approval, or cancelled) run - mirrors
         fail_pycoder_run exactly (same stale-while-revalidate posture, same
-        unconditional awaiting_approval clear)."""
+        unconditional awaiting_approval clear). Not kind-guarded - see
+        complete_code_sandbox_run's own comment."""
         node = self.nodes.get(node_id)
         if node is None:
             return None
-        node.code_sandbox_awaiting_approval = False
-        node.code_sandbox_approval_requirements = ""
-        node.code_sandbox_approved_fingerprint = None
-        node.code_sandbox_error = str(message)
+        node.state.code_sandbox_awaiting_approval = False
+        node.state.code_sandbox_approval_requirements = ""
+        node.state.code_sandbox_approved_fingerprint = None
+        node.state.code_sandbox_error = str(message)
         return node
 
     # -- R6.1: Notes/Frames/Containers ----------------------------------------
@@ -1821,27 +1829,40 @@ class SceneDocument(BranchOps, GroupOps):
                         n.state.pycoder_awaiting_approval if isinstance(n.state, PycoderState) else False
                     ),
                     "pycoderError": n.state.pycoder_error if isinstance(n.state, PycoderState) else "",
-                    # codeSandboxSandboxId is DELIBERATELY OMITTED - see the
-                    # field's own comment on SceneNode (pure internal
+                    # codeSandboxSandboxId is DELIBERATELY OMITTED - see
+                    # CodeSandboxState's own comment (pure internal
                     # directory-naming key, mirrors gitlink_imported_root's
                     # own "server-side bookkeeping only" precedent).
-                    "codeSandboxRequirements": n.code_sandbox_requirements,
-                    "codeSandboxPrompt": n.code_sandbox_prompt,
-                    "codeSandboxCode": n.code_sandbox_code,
-                    "codeSandboxOutput": n.code_sandbox_output,
-                    "codeSandboxAnalysis": n.code_sandbox_analysis,
-                    "codeSandboxAwaitingApproval": n.code_sandbox_awaiting_approval,
+                    "codeSandboxRequirements": (
+                        n.state.code_sandbox_requirements if isinstance(n.state, CodeSandboxState) else ""
+                    ),
+                    "codeSandboxPrompt": (
+                        n.state.code_sandbox_prompt if isinstance(n.state, CodeSandboxState) else ""
+                    ),
+                    "codeSandboxCode": n.state.code_sandbox_code if isinstance(n.state, CodeSandboxState) else "",
+                    "codeSandboxOutput": (
+                        n.state.code_sandbox_output if isinstance(n.state, CodeSandboxState) else ""
+                    ),
+                    "codeSandboxAnalysis": (
+                        n.state.code_sandbox_analysis if isinstance(n.state, CodeSandboxState) else ""
+                    ),
+                    "codeSandboxAwaitingApproval": (
+                        n.state.code_sandbox_awaiting_approval if isinstance(n.state, CodeSandboxState) else False
+                    ),
                     # R5.4 CODESANDBOX FIX: the frozen-at-approval-time
                     # snapshot, deliberately distinct from
                     # codeSandboxRequirements above (that one is the user's
                     # still-live, still-editable draft for the NEXT run) -
-                    # see the field's own comment on SceneNode.
-                    "codeSandboxApprovalRequirements": n.code_sandbox_approval_requirements,
-                    "codeSandboxError": n.code_sandbox_error,
+                    # see CodeSandboxState's own comment.
+                    "codeSandboxApprovalRequirements": (
+                        n.state.code_sandbox_approval_requirements if isinstance(n.state, CodeSandboxState) else ""
+                    ),
+                    "codeSandboxError": n.state.code_sandbox_error if isinstance(n.state, CodeSandboxState) else "",
                     # R6.1: Notes/Frames/Containers. groupManualWidth/Height
                     # are DELIBERATELY OMITTED, same "server-side bookkeeping
                     # only" posture as codeSandboxSandboxId/gitlinkImportedRoot
-                    # above - see those fields' own comments on SceneNode.
+                    # above - see those fields' own comments on
+                    # CodeSandboxState/GitlinkState.
                     "color": n.color,
                     "headerColor": n.header_color,
                     "isSystemPrompt": n.state.is_system_prompt if isinstance(n.state, NoteState) else False,

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -186,61 +186,6 @@ class SceneNode:
     # way is_docked is a generic field even though today only one kind
     # populates it); unused (default None) for every other kind.
     pending_request_id: str | None = None
-    # R5.4: the Execution Sandbox node's real persisted shape - runs Python
-    # inside an isolated per-node virtualenv (VirtualEnvSandbox, keyed by
-    # code_sandbox_sandbox_id) with a per-node requirements.txt manifest.
-    # There is no mode field/toggle here (unlike Py-Coder) - the real branch
-    # is "prompt blank AND code already exists -> re-run existing code
-    # as-is; else -> generate from prompt", resolved by the dispatch method
-    # checking code_sandbox_code at call time (see
-    # AgentDispatcher.start_code_sandbox_run in backend/agents.py). Unused
-    # (default) for every other kind.
-    #
-    # code_sandbox_sandbox_id is minted ONCE, at node-creation time (see
-    # add_code_sandbox_node), and is a pure internal directory-naming key -
-    # never shown or edited by the user, never even read by the frontend.
-    # EXCLUDED from scene_payload() and from the codegen SceneNodeRow source,
-    # mirroring gitlink_imported_root's existing "server-side bookkeeping
-    # only, deliberately absent from scene_payload()" precedent exactly.
-    code_sandbox_sandbox_id: str = ""
-    code_sandbox_requirements: str = ""
-    code_sandbox_prompt: str = ""
-    code_sandbox_code: str = ""
-    code_sandbox_output: str = ""
-    code_sandbox_analysis: str = ""
-    code_sandbox_awaiting_approval: bool = False
-    # R5.4 CODESANDBOX FIX (closing the requirements-disclosure staleness
-    # race): a display-only SNAPSHOT of the EXACT requirements manifest
-    # string this specific pending approval refers to - distinct from
-    # code_sandbox_requirements (the user's still-live, still-editable draft
-    # for the NEXT run). The real race this closes: AgentDispatcher.
-    # start_code_sandbox_run (backend/agents.py) reads requirements_manifest
-    # synchronously, at the very top of its own _run(), into a local
-    # `manifest` variable - BEFORE the one real await in that function (the
-    # asyncio.to_thread call to the generation agent). A user can send a new
-    # setCodeSandboxRequirements intent during that await window (it is
-    # ungated by any busy check), changing code_sandbox_requirements to
-    # something different before the approval panel is ever shown. Since the
-    # old approval panel displayed the LIVE code_sandbox_requirements field,
-    # the disclosed package list could differ from the manifest the backend
-    # actually installs a moment later - showing the WRONG list is worse
-    # than showing none for a security disclosure. This field is instead
-    # populated from that SAME already-frozen local `manifest` variable, at
-    # the exact moment code_sandbox_awaiting_approval flips True - exposing a
-    # value already correctly frozen, not re-reading anything live, so this
-    # introduces no new race. Cleared (empty string) everywhere
-    # code_sandbox_awaiting_approval itself is cleared: inline in
-    # start_code_sandbox_run immediately after the approval future resolves,
-    # and in complete_code_sandbox_run/fail_code_sandbox_run below. Unused
-    # (default) for every other kind.
-    code_sandbox_approval_requirements: str = ""
-    # ADR-002 P0: same mechanism as pycoder_approved_fingerprint above,
-    # fingerprinting {"code": code_sandbox_code, "manifest":
-    # code_sandbox_approval_requirements} instead - see that field's own
-    # comment for the full reasoning. Internal bookkeeping only, EXCLUDED
-    # from scene_payload().
-    code_sandbox_approved_fingerprint: str | None = None
-    code_sandbox_error: str = ""
     # R6.1: Notes/Frames/Containers - shared color override for note/frame/
     # container kinds. Hex string like "#4a7c59"; None means "use the kind's
     # own default color", a rendering fallback that is entirely the
@@ -520,6 +465,97 @@ class SceneNode:
     @pycoder_error.setter
     def pycoder_error(self, value: str) -> None:
         self.state.pycoder_error = value
+
+    # -- ADR-002 stage 2.5 PR10a: transitional code_sandbox property shim --
+    #
+    # CodeSandboxState (backend/domain/node_states.py) now owns all 10
+    # code_sandbox_* fields - see that class's own docstring. Same
+    # transitional shim as the gitlink/pycoder blocks above: exists ONLY so
+    # backend/agents.py and the existing test suite keep working completely
+    # unchanged for the rest of this PR. Removed in the shim-removal
+    # follow-up PR, once every external site is converted to
+    # `.state.code_sandbox_x` directly and "code_sandbox" is added to
+    # tests/test_node_state_migration.py's MIGRATED_KIND_FIELDS.
+
+    @property
+    def code_sandbox_sandbox_id(self) -> str:
+        return self.state.code_sandbox_sandbox_id
+
+    @code_sandbox_sandbox_id.setter
+    def code_sandbox_sandbox_id(self, value: str) -> None:
+        self.state.code_sandbox_sandbox_id = value
+
+    @property
+    def code_sandbox_requirements(self) -> str:
+        return self.state.code_sandbox_requirements
+
+    @code_sandbox_requirements.setter
+    def code_sandbox_requirements(self, value: str) -> None:
+        self.state.code_sandbox_requirements = value
+
+    @property
+    def code_sandbox_prompt(self) -> str:
+        return self.state.code_sandbox_prompt
+
+    @code_sandbox_prompt.setter
+    def code_sandbox_prompt(self, value: str) -> None:
+        self.state.code_sandbox_prompt = value
+
+    @property
+    def code_sandbox_code(self) -> str:
+        return self.state.code_sandbox_code
+
+    @code_sandbox_code.setter
+    def code_sandbox_code(self, value: str) -> None:
+        self.state.code_sandbox_code = value
+
+    @property
+    def code_sandbox_output(self) -> str:
+        return self.state.code_sandbox_output
+
+    @code_sandbox_output.setter
+    def code_sandbox_output(self, value: str) -> None:
+        self.state.code_sandbox_output = value
+
+    @property
+    def code_sandbox_analysis(self) -> str:
+        return self.state.code_sandbox_analysis
+
+    @code_sandbox_analysis.setter
+    def code_sandbox_analysis(self, value: str) -> None:
+        self.state.code_sandbox_analysis = value
+
+    @property
+    def code_sandbox_awaiting_approval(self) -> bool:
+        return self.state.code_sandbox_awaiting_approval
+
+    @code_sandbox_awaiting_approval.setter
+    def code_sandbox_awaiting_approval(self, value: bool) -> None:
+        self.state.code_sandbox_awaiting_approval = value
+
+    @property
+    def code_sandbox_approval_requirements(self) -> str:
+        return self.state.code_sandbox_approval_requirements
+
+    @code_sandbox_approval_requirements.setter
+    def code_sandbox_approval_requirements(self, value: str) -> None:
+        self.state.code_sandbox_approval_requirements = value
+
+    @property
+    def code_sandbox_approved_fingerprint(self) -> str | None:
+        return self.state.code_sandbox_approved_fingerprint
+
+    @code_sandbox_approved_fingerprint.setter
+    def code_sandbox_approved_fingerprint(self, value: str | None) -> None:
+        self.state.code_sandbox_approved_fingerprint = value
+
+    @property
+    def code_sandbox_error(self) -> str:
+        return self.state.code_sandbox_error
+
+    @code_sandbox_error.setter
+    def code_sandbox_error(self, value: str) -> None:
+        self.state.code_sandbox_error = value
 
 
 @dataclass

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -477,6 +477,75 @@ class PycoderState(NodeState):
 
 
 @dataclass
+class CodeSandboxState(NodeState):
+    """Relocated verbatim from SceneNode's ten code_sandbox fields (former
+    backend/domain/model.py fields, R5.4) - the Execution Sandbox node's
+    real persisted shape: runs Python inside an isolated per-node
+    virtualenv (VirtualEnvSandbox, keyed by code_sandbox_sandbox_id) with
+    a per-node requirements.txt manifest. There is no mode field/toggle
+    here (unlike Py-Coder) - the real branch is "prompt blank AND code
+    already exists -> re-run existing code as-is; else -> generate from
+    prompt", resolved by the dispatch method checking code_sandbox_code
+    at call time (see AgentDispatcher.start_code_sandbox_run in
+    backend/agents.py).
+
+    - code_sandbox_sandbox_id: minted ONCE, at node-creation time (see
+      add_code_sandbox_node), and is a pure internal directory-naming
+      key - never shown or edited by the user, never even read by the
+      frontend. EXCLUDED from scene_payload() and from the codegen
+      SceneNodeRow source, mirroring gitlink_imported_root's own
+      "server-side bookkeeping only" precedent exactly.
+    - code_sandbox_requirements/code_sandbox_prompt/code_sandbox_code/
+      code_sandbox_output/code_sandbox_analysis: the user's live,
+      still-editable requirements manifest and prompt/code draft, and
+      the last run's stdout/analysis.
+    - code_sandbox_approval_requirements: R5.4 CODESANDBOX FIX (closing
+      the requirements-disclosure staleness race) - a display-only
+      SNAPSHOT of the EXACT requirements manifest string this specific
+      pending approval refers to - distinct from code_sandbox_
+      requirements (the user's still-live, still-editable draft for the
+      NEXT run). The real race this closes: AgentDispatcher.
+      start_code_sandbox_run (backend/agents.py) reads requirements_
+      manifest synchronously, at the very top of its own _run(), into a
+      local `manifest` variable - BEFORE the one real await in that
+      function (the asyncio.to_thread call to the generation agent). A
+      user can send a new setCodeSandboxRequirements intent during that
+      await window (it is ungated by any busy check), changing
+      code_sandbox_requirements to something different before the
+      approval panel is ever shown. Since the old approval panel
+      displayed the LIVE code_sandbox_requirements field, the disclosed
+      package list could differ from the manifest the backend actually
+      installs a moment later - showing the WRONG list is worse than
+      showing none for a security disclosure. This field is instead
+      populated from that SAME already-frozen local `manifest` variable,
+      at the exact moment code_sandbox_awaiting_approval flips True -
+      exposing a value already correctly frozen, not re-reading
+      anything live, so this introduces no new race. Cleared (empty
+      string) everywhere code_sandbox_awaiting_approval itself is
+      cleared: inline in start_code_sandbox_run immediately after the
+      approval future resolves, and in complete_code_sandbox_run/
+      fail_code_sandbox_run.
+    - code_sandbox_approved_fingerprint: ADR-002 P0 - same mechanism as
+      pycoder_approved_fingerprint, fingerprinting {"code":
+      code_sandbox_code, "manifest": code_sandbox_approval_requirements}
+      instead - see that field's own reasoning above. Internal
+      bookkeeping only, EXCLUDED from scene_payload().
+    - code_sandbox_error: the current run's error banner text, cleared
+      on the next attempt."""
+
+    code_sandbox_sandbox_id: str = ""
+    code_sandbox_requirements: str = ""
+    code_sandbox_prompt: str = ""
+    code_sandbox_code: str = ""
+    code_sandbox_output: str = ""
+    code_sandbox_analysis: str = ""
+    code_sandbox_awaiting_approval: bool = False
+    code_sandbox_approval_requirements: str = ""
+    code_sandbox_approved_fingerprint: str | None = None
+    code_sandbox_error: str = ""
+
+
+@dataclass
 class ChatState(NodeState):
     """Relocated verbatim from SceneNode's eight chat-only fields (former
     backend/domain/model.py fields). SceneNode's own `content` field

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -187,6 +187,7 @@ from typing import Any
 from backend.canvas import (
     ArtifactState,
     ChatState,
+    CodeSandboxState,
     CodeState,
     DocumentState,
     GitlinkState,
@@ -593,12 +594,14 @@ def _restore_code_sandbox_payload(payload: dict[str, Any]) -> SceneNode:
     x, y = _position(payload)
     return SceneNode(
         id="", x=x, y=y, title="Virtual Environment Runner", kind="code_sandbox",
-        code_sandbox_requirements=str(payload.get("requirements", "")),
-        code_sandbox_prompt=str(payload.get("prompt", "")),
-        code_sandbox_code=str(payload.get("code", "")),
-        code_sandbox_output=str(payload.get("output", "")),
-        code_sandbox_analysis=str(payload.get("analysis", "")),
-        code_sandbox_sandbox_id=str(payload.get("sandbox_id", "")),
+        state=CodeSandboxState(
+            code_sandbox_requirements=str(payload.get("requirements", "")),
+            code_sandbox_prompt=str(payload.get("prompt", "")),
+            code_sandbox_code=str(payload.get("code", "")),
+            code_sandbox_output=str(payload.get("output", "")),
+            code_sandbox_analysis=str(payload.get("analysis", "")),
+            code_sandbox_sandbox_id=str(payload.get("sandbox_id", "")),
+        ),
         history=_restore_history(payload.get("conversation_history")),
         is_collapsed=bool(payload.get("is_collapsed", False)),
     )

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -328,12 +328,12 @@ def _serialize_pycoder_node(node: SceneNode) -> dict[str, Any]:
 def _serialize_code_sandbox_node(node: SceneNode) -> dict[str, Any]:
     return {
         "node_type": "code_sandbox",
-        "prompt": node.code_sandbox_prompt,
-        "requirements": node.code_sandbox_requirements,
-        "code": node.code_sandbox_code,
-        "output": node.code_sandbox_output,
-        "analysis": node.code_sandbox_analysis,
-        "sandbox_id": node.code_sandbox_sandbox_id,
+        "prompt": node.state.code_sandbox_prompt,
+        "requirements": node.state.code_sandbox_requirements,
+        "code": node.state.code_sandbox_code,
+        "output": node.state.code_sandbox_output,
+        "analysis": node.state.code_sandbox_analysis,
+        "sandbox_id": node.state.code_sandbox_sandbox_id,
         "conversation_history": _serialize_history(node.history),
         "is_collapsed": bool(node.is_collapsed),
     }

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -361,6 +361,21 @@ _EXPECTED_NON_OWNING_KIND_WIRE_DEFAULTS = {
     "pycoderLastRunFailed": False,
     "pycoderAwaitingApproval": False,
     "pycoderError": "",
+    # ADR-002 stage 2.5 PR10a: code_sandbox's 8 wire keys (code_sandbox_
+    # sandbox_id/code_sandbox_approved_fingerprint are excluded from
+    # scene_payload(), same posture as gitlink_context_xml), moved onto
+    # CodeSandboxState behind the same transitional property shim as
+    # gitlink/pycoder - "code_sandbox" is likewise deliberately NOT yet
+    # added to MIGRATED_KIND_FIELDS above, for the identical AST-gate
+    # reason.
+    "codeSandboxRequirements": "",
+    "codeSandboxPrompt": "",
+    "codeSandboxCode": "",
+    "codeSandboxOutput": "",
+    "codeSandboxAnalysis": "",
+    "codeSandboxAwaitingApproval": False,
+    "codeSandboxApprovalRequirements": "",
+    "codeSandboxError": "",
 }
 
 


### PR DESCRIPTION
## Problem

SceneNode still carries all 10 of code_sandbox's kind-specific fields directly on the dataclass - the last of the three highest-risk kinds (with gitlink and pycoder, both already migrated) left to move.

## Change

- Adds `CodeSandboxState` (backend/domain/node_states.py) with all 10 fields and full docstrings, preserving the documented "R5.4 CODESANDBOX FIX" requirements-disclosure-staleness race fix verbatim.
- Removes the 10 fields from `SceneNode` (backend/domain/model.py) and adds 10 property/setter pairs delegating `node.code_sandbox_x` to `node.state.code_sandbox_x` - the same transitional shim pattern used for gitlink and pycoder, so `backend/agents.py` and `backend/api/intents_code_sandbox.py` keep working unchanged.
- Converts the domain layer itself - `backend/domain/graph.py`'s 5 code_sandbox methods, `backend/session_save.py`'s serializer, `backend/session_load.py`'s restorer - to real `.state.code_sandbox_x` access directly, not via the shim.
- `code_sandbox_approval_requirements` has documented history of a real, already-fixed race: the approval panel could show a stale package list if a user changed the live requirements during an in-flight await. The fix captures requirements into a local variable before the one real await and populates the disclosure field from that frozen local, never re-reading the live field. A dedicated recon pass plus adversarial review confirmed `backend/agents.py` has zero diff in this PR and that a property shim - always synchronous, incapable of introducing a yield point - cannot interact with or reopen this race.
- Unlike gitlink/pycoder, `scene_payload()` runs unconditionally on every node in the document on every publish. Its 8 code_sandbox wire keys were still plain unguarded reads pre-migration; converting all 8 to the `isinstance(n.state, CodeSandboxState)`-guarded pattern was mandatory here, not just wire-compat hygiene - leaving any unconverted would make `scene_payload()` raise `AttributeError` on essentially every call once any node exists. Verified directly by constructing a document with mixed-kind nodes and calling `scene_payload()`.
- Deliberately does **not** add `"code_sandbox"` to `tests/test_node_state_migration.py`'s `MIGRATED_KIND_FIELDS`, for the same reason established in the prior two PRs. The independent wire-fallback regression test is extended with all 8 wire keys.
- Applies the established guard-scoping precedent: added the `node.kind != "code_sandbox"` guard `set_code_sandbox_requirements` was missing (reachable directly from a WS intent with an arbitrary node_id, and explicitly documented as ungated by any busy check), while leaving `complete_code_sandbox_run`/`fail_code_sandbox_run` unguarded since both are only reached via `run_code_sandbox`'s own `on_success`/`on_failure` closures with a node_id already validated by `start_code_sandbox_run`.

Wire payload is byte-identical. `SceneNode`'s field count drops from 24 to 14 - the target core size from the original stage 2.5 exit-gate plan.

## Test plan

- `python -m pytest -q` (full suite, repo root): 1228 passed.
- Directly reproduced the new `set_code_sandbox_requirements` guard against a wrong-kind node, confirmed `SceneError`; confirmed the real code_sandbox path still works end to end through the shim.
- Constructed a `SceneDocument` with mixed-kind nodes (including a stateless node) and called `scene_payload()` directly to confirm no `AttributeError`.
- Mutation-tested the new code_sandbox wire-fallback defaults table: broke one fallback value, confirmed the regression test catches it, restored it.
- `pyflakes` on every touched file: no new warnings (pre-existing unrelated warnings only).
- Two independent adversarial-review passes plus a skeptical synthesis, run against the actual diff, with dedicated scrutiny on the scene_payload conversion and the R5.4 CODESANDBOX FIX race - verdict SHIP AS-IS, no bugs found.