### PR TITLE
ADR-002 stage 2.5 (PR9b/~16): pycoder shim removal

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -1882,12 +1882,12 @@ class AgentDispatcher:
                 current_code = code_match.group(1).strip()
 
                 # -- human-approval gate --------------------------------------
-                node.pycoder_code = current_code
-                node.pycoder_approved_fingerprint = _fingerprint_changes({"code": current_code})
-                node.pycoder_awaiting_approval = True
+                node.state.pycoder_code = current_code
+                node.state.pycoder_approved_fingerprint = _fingerprint_changes({"code": current_code})
+                node.state.pycoder_awaiting_approval = True
                 await bus.publish("scene")
                 approved = await approval_future
-                node.pycoder_awaiting_approval = False
+                node.state.pycoder_awaiting_approval = False
 
                 if not approved:
                     on_failure("Py-Coder run cancelled: execution was not approved.")
@@ -1913,7 +1913,7 @@ class AgentDispatcher:
                     # execute call); this exists to fail loudly rather than
                     # silently execute unapproved content if a future change
                     # ever breaks that invariant.
-                    if _fingerprint_changes({"code": current_code}) != node.pycoder_approved_fingerprint:
+                    if _fingerprint_changes({"code": current_code}) != node.state.pycoder_approved_fingerprint:
                         on_failure(
                             "Py-Coder execution blocked: the approved code no longer matches what is about to run."
                         )
@@ -1984,12 +1984,12 @@ class AgentDispatcher:
                             return
                         repair_future: asyncio.Future = asyncio.get_running_loop().create_future()
                         handle.approval_future = repair_future
-                        node.pycoder_code = current_code
-                        node.pycoder_approved_fingerprint = _fingerprint_changes({"code": current_code})
-                        node.pycoder_awaiting_approval = True
+                        node.state.pycoder_code = current_code
+                        node.state.pycoder_approved_fingerprint = _fingerprint_changes({"code": current_code})
+                        node.state.pycoder_awaiting_approval = True
                         await bus.publish("scene")
                         approved = await repair_future
-                        node.pycoder_awaiting_approval = False
+                        node.state.pycoder_awaiting_approval = False
                         if not approved:
                             on_failure("Py-Coder run cancelled: repaired code was not approved.")
                             await bus.publish("scene")

--- a/backend/api/intents_pycoder.py
+++ b/backend/api/intents_pycoder.py
@@ -76,7 +76,7 @@ def register_pycoder_intents(
 
         await agent_dispatcher.start_pycoder_run(
             bus=bus, notifications_state=notifications, node=node, node_id=node_id,
-            mode=node.pycoder_mode, prompt=node.pycoder_prompt, code=node.pycoder_code,
+            mode=node.state.pycoder_mode, prompt=node.state.pycoder_prompt, code=node.state.pycoder_code,
             conversation_history=branch_history,
             on_success=_on_success, on_failure=_on_failure,
         )

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -1048,7 +1048,7 @@ class SceneDocument(BranchOps, GroupOps):
     # confirmed genuinely dead code (grepped the whole repo: their only
     # references were this definition and their own dedicated unit tests,
     # zero real call sites). The human-approval gate that actually runs
-    # mutates node.pycoder_code/pycoder_awaiting_approval directly inline
+    # mutates node.state.pycoder_code/pycoder_awaiting_approval directly inline
     # inside AgentDispatcher.start_pycoder_run (backend/agents.py) - these two
     # SceneDocument methods were a second, never-wired copy of that same
     # mutation, built ahead of the live dispatch path and then never rewired

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -216,96 +216,15 @@ class SceneNode:
     # matching this node's own kind (e.g. ImageState for kind="image").
     state: NodeState | None = None
 
-    # -- ADR-002 stage 2.5 PR9a: transitional pycoder property shim --------
-    #
-    # PycoderState (backend/domain/node_states.py) now owns all 9 pycoder_*
-    # fields - see that class's own docstring. Same transitional shim as the
-    # gitlink block above: exists ONLY so backend/agents.py and the existing
-    # test suite keep working completely unchanged for the rest of this PR.
-    # Removed in the shim-removal follow-up PR, once every external site is
-    # converted to `.state.pycoder_x` directly and "pycoder" is added to
-    # tests/test_node_state_migration.py's MIGRATED_KIND_FIELDS.
-
-    @property
-    def pycoder_mode(self) -> str:
-        return self.state.pycoder_mode
-
-    @pycoder_mode.setter
-    def pycoder_mode(self, value: str) -> None:
-        self.state.pycoder_mode = value
-
-    @property
-    def pycoder_prompt(self) -> str:
-        return self.state.pycoder_prompt
-
-    @pycoder_prompt.setter
-    def pycoder_prompt(self, value: str) -> None:
-        self.state.pycoder_prompt = value
-
-    @property
-    def pycoder_code(self) -> str:
-        return self.state.pycoder_code
-
-    @pycoder_code.setter
-    def pycoder_code(self, value: str) -> None:
-        self.state.pycoder_code = value
-
-    @property
-    def pycoder_output(self) -> str:
-        return self.state.pycoder_output
-
-    @pycoder_output.setter
-    def pycoder_output(self, value: str) -> None:
-        self.state.pycoder_output = value
-
-    @property
-    def pycoder_analysis(self) -> str:
-        return self.state.pycoder_analysis
-
-    @pycoder_analysis.setter
-    def pycoder_analysis(self, value: str) -> None:
-        self.state.pycoder_analysis = value
-
-    @property
-    def pycoder_last_run_failed(self) -> bool:
-        return self.state.pycoder_last_run_failed
-
-    @pycoder_last_run_failed.setter
-    def pycoder_last_run_failed(self, value: bool) -> None:
-        self.state.pycoder_last_run_failed = value
-
-    @property
-    def pycoder_awaiting_approval(self) -> bool:
-        return self.state.pycoder_awaiting_approval
-
-    @pycoder_awaiting_approval.setter
-    def pycoder_awaiting_approval(self, value: bool) -> None:
-        self.state.pycoder_awaiting_approval = value
-
-    @property
-    def pycoder_approved_fingerprint(self) -> str | None:
-        return self.state.pycoder_approved_fingerprint
-
-    @pycoder_approved_fingerprint.setter
-    def pycoder_approved_fingerprint(self, value: str | None) -> None:
-        self.state.pycoder_approved_fingerprint = value
-
-    @property
-    def pycoder_error(self) -> str:
-        return self.state.pycoder_error
-
-    @pycoder_error.setter
-    def pycoder_error(self, value: str) -> None:
-        self.state.pycoder_error = value
-
     # -- ADR-002 stage 2.5 PR10a: transitional code_sandbox property shim --
     #
     # CodeSandboxState (backend/domain/node_states.py) now owns all 10
     # code_sandbox_* fields - see that class's own docstring. Same
-    # transitional shim as the gitlink/pycoder blocks above: exists ONLY so
+    # transitional shim as gitlink's and pycoder's own (both already removed
+    # in their own shim-removal follow-up PRs, PR8b/PR9b): exists ONLY so
     # backend/agents.py and the existing test suite keep working completely
-    # unchanged for the rest of this PR. Removed in the shim-removal
-    # follow-up PR, once every external site is converted to
+    # unchanged for the rest of this PR. Removed in code_sandbox's own
+    # shim-removal follow-up PR, once every external site is converted to
     # `.state.code_sandbox_x` directly and "code_sandbox" is added to
     # tests/test_node_state_migration.py's MIGRATED_KIND_FIELDS.
 

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -3661,8 +3661,15 @@ def test_agents_never_imports_qt():
 
 
 def _make_pycoder_node(**overrides):
-    defaults = dict(
-        pending_request_id=None,
+    """Duck-types a SceneNode for AgentDispatcher's pycoder methods, which
+    never check isinstance(node, SceneNode) (see this module's own
+    docstring). ADR-002 stage 2.5 PR9b: pycoder_* fields now live on
+    node.state (a nested SimpleNamespace here), matching real SceneNode
+    instances post-shim-removal - node.pending_request_id stays a
+    top-level attribute, matching the real dataclass's own core field.
+    Callers keep passing pycoder_* kwargs flat; this splits them into the
+    nested state automatically, so no call site needs to change shape."""
+    state_defaults = dict(
         pycoder_mode="ai_driven",
         pycoder_prompt="",
         pycoder_code="",
@@ -3673,8 +3680,13 @@ def _make_pycoder_node(**overrides):
         pycoder_approved_fingerprint=None,
         pycoder_error="",
     )
-    defaults.update(overrides)
-    return SimpleNamespace(**defaults)
+    node_overrides = {"pending_request_id": None}
+    for key, value in overrides.items():
+        if key in state_defaults:
+            state_defaults[key] = value
+        else:
+            node_overrides[key] = value
+    return SimpleNamespace(state=SimpleNamespace(**state_defaults), **node_overrides)
 
 
 def _make_code_sandbox_node(**overrides):
@@ -3937,7 +3949,7 @@ def test_pycoder_ai_driven_no_code_generated_calls_on_success_with_placeholder_a
             "Here is a direct answer, no code needed.",
             False,
         )]
-        assert node.pycoder_awaiting_approval is False, "no code ever means no approval gate"
+        assert node.state.pycoder_awaiting_approval is False, "no code ever means no approval gate"
 
     asyncio.run(run())
 
@@ -3968,7 +3980,7 @@ def test_pycoder_ai_driven_denied_approval_calls_on_failure_with_the_exact_legac
         await entry["task"]
 
         assert failures == ["Py-Coder run cancelled: execution was not approved."]
-        assert node.pycoder_awaiting_approval is False
+        assert node.state.pycoder_awaiting_approval is False
         assert pycoder_slots(dispatcher) == {}
         assert node.pending_request_id is None
 
@@ -4002,7 +4014,7 @@ def test_pycoder_ai_driven_approved_executes_successfully(monkeypatch):
         await entry["task"]
 
         assert successes == [("print(2)", "2", "the answer is 2", False)]
-        assert node.pycoder_awaiting_approval is False
+        assert node.state.pycoder_awaiting_approval is False
         assert fake_repl.calls == ["print(2)"]
         assert pycoder_slots(dispatcher) == {}
         assert node.pending_request_id is None
@@ -4032,8 +4044,11 @@ def test_pycoder_ai_driven_repair_loop_exhausts_retries_calls_on_success_with_la
     # shared builtin SimpleNamespace type) counts how many times
     # pycoder_awaiting_approval transitions to True, since its final value is
     # always False by the time the run completes and would hide a regression
-    # back to "one gate, reused for every repair".
-    class _CountingNode(SimpleNamespace):
+    # back to "one gate, reused for every repair". ADR-002 stage 2.5 PR9b:
+    # pycoder_awaiting_approval now lives on node.state (see
+    # _make_pycoder_node's own docstring), so this wraps the STATE object,
+    # not the node itself.
+    class _CountingState(SimpleNamespace):
         def __setattr__(self, name, value):
             if name == "pycoder_awaiting_approval" and value is True:
                 self.__dict__["gate_open_count"] = self.__dict__.get("gate_open_count", 0) + 1
@@ -4041,7 +4056,8 @@ def test_pycoder_ai_driven_repair_loop_exhausts_retries_calls_on_success_with_la
 
     async def run():
         bus, notifications, dispatcher = _make_code_exec_env()
-        node = _CountingNode(**_make_pycoder_node(pycoder_mode="ai_driven").__dict__, gate_open_count=0)
+        node = _make_pycoder_node(pycoder_mode="ai_driven")
+        node.state = _CountingState(**vars(node.state), gate_open_count=0)
         successes = []
 
         await dispatcher.start_pycoder_run(
@@ -4059,7 +4075,7 @@ def test_pycoder_ai_driven_repair_loop_exhausts_retries_calls_on_success_with_la
         assert analysis.startswith("**PROCESS FAILED**")
         assert len(fake_repl.calls) == 4, "max_retries=4, matching legacy exactly"
         assert repair_calls == [1, 1, 1], "3 repairs between the 4 execute attempts"
-        assert node.gate_open_count == 4, (
+        assert node.state.gate_open_count == 4, (
             "ADR-002 P0: one gate for the original code, plus one fresh gate per repaired "
             "variant (3) - repaired code must never run under the original approval"
         )
@@ -4096,23 +4112,23 @@ def test_pycoder_ai_driven_repair_gate_denied_stops_immediately_without_further_
 
         # Approve the FIRST gate (the original code) only.
         for _ in range(200):
-            if node.pycoder_awaiting_approval:
+            if node.state.pycoder_awaiting_approval:
                 break
             await asyncio.sleep(0.005)
         assert dispatcher.approve_code_execution(request_id) is True
 
         # Wait for the SECOND gate (the repaired code) to open, then deny it.
         for _ in range(200):
-            if len(fake_repl.calls) >= 1 and node.pycoder_awaiting_approval:
+            if len(fake_repl.calls) >= 1 and node.state.pycoder_awaiting_approval:
                 break
             await asyncio.sleep(0.005)
-        assert node.pycoder_awaiting_approval is True, "the repaired variant must open its own gate"
+        assert node.state.pycoder_awaiting_approval is True, "the repaired variant must open its own gate"
         assert dispatcher.deny_code_execution(request_id) is True
         await entry["task"]
 
         assert failures == ["Py-Coder run cancelled: repaired code was not approved."]
         assert len(fake_repl.calls) == 1, "denying the repair gate must prevent the repaired code from ever running"
-        assert node.pycoder_awaiting_approval is False
+        assert node.state.pycoder_awaiting_approval is False
         assert pycoder_slots(dispatcher) == {}
         assert node.pending_request_id is None
 
@@ -4120,7 +4136,7 @@ def test_pycoder_ai_driven_repair_gate_denied_stops_immediately_without_further_
 
 
 def test_pycoder_execution_blocked_when_approved_fingerprint_does_not_match(monkeypatch):
-    """ADR-002 P0 defense-in-depth: if node.pycoder_approved_fingerprint
+    """ADR-002 P0 defense-in-depth: if node.state.pycoder_approved_fingerprint
     ever disagrees with the code about to execute (simulating a future bug
     that mutates current_code without opening a fresh gate), the run must
     fail loudly instead of silently executing unapproved content."""
@@ -4143,12 +4159,12 @@ def test_pycoder_execution_blocked_when_approved_fingerprint_does_not_match(monk
         )
         request_id, entry = next(iter(pycoder_slots(dispatcher).items()))
         for _ in range(200):
-            if node.pycoder_awaiting_approval:
+            if node.state.pycoder_awaiting_approval:
                 break
             await asyncio.sleep(0.005)
         # Tamper with the fingerprint the way a hypothetical future bug that
         # mutated the code without re-gating would leave it mismatched.
-        node.pycoder_approved_fingerprint = "not-the-real-fingerprint"
+        node.state.pycoder_approved_fingerprint = "not-the-real-fingerprint"
         assert dispatcher.approve_code_execution(request_id) is True
         await entry["task"]
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -4492,14 +4492,14 @@ def test_add_pycoder_node_creates_child_with_defaults():
     node = doc.add_pycoder_node(10, 20, parent.id)
     assert node.kind == "pycoder"
     assert node.title == "Py-Coder"
-    assert node.pycoder_mode == "ai_driven"
-    assert node.pycoder_prompt == ""
-    assert node.pycoder_code == ""
-    assert node.pycoder_output == ""
-    assert node.pycoder_analysis == ""
-    assert node.pycoder_last_run_failed is False
-    assert node.pycoder_awaiting_approval is False
-    assert node.pycoder_error == ""
+    assert node.state.pycoder_mode == "ai_driven"
+    assert node.state.pycoder_prompt == ""
+    assert node.state.pycoder_code == ""
+    assert node.state.pycoder_output == ""
+    assert node.state.pycoder_analysis == ""
+    assert node.state.pycoder_last_run_failed is False
+    assert node.state.pycoder_awaiting_approval is False
+    assert node.state.pycoder_error == ""
     assert any(e.source == parent.id and e.target == node.id for e in doc.edges.values())
 
 
@@ -4526,7 +4526,7 @@ def test_set_pycoder_mode_sets_the_field():
     node = doc.add_pycoder_node(0, 0, parent.id)
     returned = doc.set_pycoder_mode(node.id, "manual")
     assert returned is node
-    assert node.pycoder_mode == "manual"
+    assert node.state.pycoder_mode == "manual"
 
 
 def test_set_pycoder_mode_rejects_unknown_mode():
@@ -4546,13 +4546,13 @@ def test_start_pycoder_run_ai_driven_stores_prompt_and_clears_error():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     node = doc.add_pycoder_node(0, 0, parent.id)
-    node.pycoder_error = "a previous error"
+    node.state.pycoder_error = "a previous error"
 
     returned = doc.start_pycoder_run(node.id, "sort this list")
 
     assert returned is node
-    assert node.pycoder_prompt == "sort this list"
-    assert node.pycoder_error == ""
+    assert node.state.pycoder_prompt == "sort this list"
+    assert node.state.pycoder_error == ""
 
 
 def test_start_pycoder_run_manual_stores_code_not_prompt():
@@ -4563,8 +4563,8 @@ def test_start_pycoder_run_manual_stores_code_not_prompt():
 
     doc.start_pycoder_run(node.id, "print('hi')")
 
-    assert node.pycoder_code == "print('hi')"
-    assert node.pycoder_prompt == ""
+    assert node.state.pycoder_code == "print('hi')"
+    assert node.state.pycoder_prompt == ""
 
 
 def test_start_pycoder_run_unknown_node_raises_scene_error():
@@ -4584,18 +4584,18 @@ def test_complete_pycoder_run_sets_all_fields_and_clears_approval_and_error():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     node = doc.add_pycoder_node(0, 0, parent.id)
-    node.pycoder_awaiting_approval = True
-    node.pycoder_error = "stale error"
+    node.state.pycoder_awaiting_approval = True
+    node.state.pycoder_error = "stale error"
 
     returned = doc.complete_pycoder_run(node.id, "print(1)", "1", "analysis text", False)
 
     assert returned is node
-    assert node.pycoder_code == "print(1)"
-    assert node.pycoder_output == "1"
-    assert node.pycoder_analysis == "analysis text"
-    assert node.pycoder_last_run_failed is False
-    assert node.pycoder_awaiting_approval is False
-    assert node.pycoder_error == ""
+    assert node.state.pycoder_code == "print(1)"
+    assert node.state.pycoder_output == "1"
+    assert node.state.pycoder_analysis == "analysis text"
+    assert node.state.pycoder_last_run_failed is False
+    assert node.state.pycoder_awaiting_approval is False
+    assert node.state.pycoder_error == ""
 
 
 def test_complete_pycoder_run_is_a_silent_noop_for_a_deleted_node():
@@ -4606,21 +4606,21 @@ def test_fail_pycoder_run_sets_error_clears_approval_but_preserves_output():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
     node = doc.add_pycoder_node(0, 0, parent.id)
-    node.pycoder_code = "print(1)"
-    node.pycoder_output = "1"
-    node.pycoder_analysis = "old analysis"
-    node.pycoder_awaiting_approval = True
+    node.state.pycoder_code = "print(1)"
+    node.state.pycoder_output = "1"
+    node.state.pycoder_analysis = "old analysis"
+    node.state.pycoder_awaiting_approval = True
 
     returned = doc.fail_pycoder_run(node.id, "execution timed out")
 
     assert returned is node
-    assert node.pycoder_error == "execution timed out"
-    assert node.pycoder_awaiting_approval is False
+    assert node.state.pycoder_error == "execution timed out"
+    assert node.state.pycoder_awaiting_approval is False
     # stale-while-revalidate: a failed run must not wipe out a previously
     # completed result.
-    assert node.pycoder_code == "print(1)"
-    assert node.pycoder_output == "1"
-    assert node.pycoder_analysis == "old analysis"
+    assert node.state.pycoder_code == "print(1)"
+    assert node.state.pycoder_output == "1"
+    assert node.state.pycoder_analysis == "old analysis"
 
 
 def test_fail_pycoder_run_is_a_silent_noop_for_a_deleted_node():
@@ -4817,7 +4817,7 @@ def test_set_pycoder_mode_intent_publishes_scene():
 
         await bus.dispatch_intent("scene", "setPyCoderMode", [node.id, "manual"])
 
-        assert document.nodes[node.id].pycoder_mode == "manual"
+        assert document.nodes[node.id].state.pycoder_mode == "manual"
 
     asyncio.run(run())
 
@@ -4874,7 +4874,7 @@ def test_run_pycoder_intent_dispatches_with_correct_node_fields():
         result = await bus.dispatch_intent("scene", "runPyCoder", [node.id, "sort this list"])
 
         assert result == node.id
-        assert document.nodes[node.id].pycoder_prompt == "sort this list"
+        assert document.nodes[node.id].state.pycoder_prompt == "sort this list"
         assert len(fake_dispatcher.calls) == 1
         call = fake_dispatcher.calls[0]
         assert call["mode"] == "ai_driven"
@@ -5128,10 +5128,10 @@ def test_remove_nodes_cancels_the_dispatchers_pycoder_request_when_deleted_mid_a
         # test_code_sandbox_blank_prompt_with_existing_code_reuses_it_...
         # uses for the equivalent code_sandbox gate.
         for _ in range(200):
-            if pycoder_node.pycoder_awaiting_approval or entry["task"].done():
+            if pycoder_node.state.pycoder_awaiting_approval or entry["task"].done():
                 break
             await asyncio.sleep(0.005)
-        assert pycoder_node.pycoder_awaiting_approval is True, "must genuinely be parked on the approval gate"
+        assert pycoder_node.state.pycoder_awaiting_approval is True, "must genuinely be parked on the approval gate"
         assert request_id in pycoder_slots(dispatcher)
 
         await bus.dispatch_intent("scene", "removeNodes", [[pycoder_node.id]])

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -153,7 +153,7 @@ def test_pycoder_mode_translates_enum_member_name_to_lowercase():
          "output": "1", "analysis": "ok", "position": {"x": 0, "y": 0}, "parent_node_index": 0},
     ])
     node = next(n for n in document.nodes.values() if n.kind == "pycoder")
-    assert node.pycoder_mode == "manual"
+    assert node.state.pycoder_mode == "manual"
 
 
 def test_code_sandbox_field_mapping():

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -78,7 +78,7 @@ def test_pycoder_mode_translates_back_to_uppercase_enum_member_name():
     doc = SceneDocument()
     parent = doc.add_chat_node(0, 0, "p", is_user=False)
     node = doc.add_pycoder_node(10, 10, parent.id)
-    node.pycoder_mode = "manual"
+    node.state.pycoder_mode = "manual"
     chat_data = build_chat_data(doc)
     payload = next(n for n in chat_data["nodes"] if n["node_type"] == "pycoder")
     assert payload["mode"] == "MANUAL"

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -88,6 +88,11 @@ MIGRATED_KIND_FIELDS = {
         "gitlink_pending_changes", "gitlink_preview_text", "gitlink_change_fingerprint",
         "gitlink_change_local_root", "gitlink_change_state", "gitlink_error",
     ],
+    "pycoder": [
+        "pycoder_mode", "pycoder_prompt", "pycoder_code", "pycoder_output", "pycoder_analysis",
+        "pycoder_last_run_failed", "pycoder_awaiting_approval", "pycoder_approved_fingerprint",
+        "pycoder_error",
+    ],
 }
 
 


### PR DESCRIPTION
## Problem

PR9a introduced a transitional property shim so pycoder's field relocation didn't require touching backend/agents.py's async dispatch code in the same PR. That shim - 9 property/setter pairs on SceneNode - is now dead weight to be removed, with every external call site converted to the real `.state.pycoder_x` access the rest of the migration already uses. This mirrors PR8b, which did the identical thing for gitlink and merged cleanly.

## Change

- Converts every remaining `node.pycoder_x` access outside the domain layer to `node.state.pycoder_x`: `backend/agents.py`'s `start_pycoder_run` (9 sites, across its two human-approval-gate instances - the initial gate and the repair-loop gate that opens a fresh approval per repaired code variant), `backend/api/intents_pycoder.py` (3 sites), and roughly 50 sites across 4 test files.
- Deletes the 9 property/setter pairs from `SceneNode` (`backend/domain/model.py`).
- Adds `"pycoder"` to `tests/test_node_state_migration.py`'s `MIGRATED_KIND_FIELDS`. Used the AST gate itself as the conversion checklist, exactly as PR8b established.
- Adversarial review diffed `backend/agents.py`'s pre- and post-conversion versions of `start_pycoder_run` line by line and confirmed every change is a pure `node.pycoder_x` -> `node.state.pycoder_x` token substitution, with the zero-await re-check-before-execute invariant intact in both approval-gate instances.
- Learned from PR8b's mid-flight discovery: `backend/tests/test_agents.py`'s `_make_pycoder_node` helper duck-types a SceneNode as a `types.SimpleNamespace` for testing `AgentDispatcher`'s pycoder methods directly (agents.py never checks `isinstance(node, SceneNode)` for pycoder). Restructured it to a nested `state=SimpleNamespace(...)` shape *before* running the suite this time, rather than discovering the break via failing tests. A second local helper, a `_CountingState` subclass (renamed from `_CountingNode`) that counts how many times `pycoder_awaiting_approval` opens - the regression guard for the ADR-002 P0 fresh-gate-per-repair fix - was rewired to wrap the nested state object instead of the top-level node, since that's what `agents.py` now mutates.

Wire payload and all runtime behavior are unchanged - this is a pure storage-location and access-syntax change.

## Test plan

- `python -m pytest -q` (full suite, repo root): 1228 passed.
- AST migration gate passes clean: zero bare `.pycoder_x` access anywhere under `backend/` or `tests/`.
- Mutation-tested the `_make_pycoder_node`/`_CountingState` restructuring directly: reverted it to the old flat/top-level shape, confirmed the exact expected `AttributeError` reproduces across 6 tests, restored it, confirmed all pass again.
- `pyflakes` on every touched file, diffed against the pre-PR baseline: identical warning set - zero new warnings.
- Two independent adversarial-review passes plus a skeptical synthesis, with one reviewer specifically diffing `agents.py`'s pre/post versions line-by-line and independently re-running the mutation test itself - verdict SHIP AS-IS, no findings.