### PR TITLE
Harden the R5.4 CODESANDBOX FIX regression guard

### DIFF
--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -5414,6 +5414,155 @@ def test_code_sandbox_installs_the_frozen_manifest_not_a_live_edit_made_during_g
     asyncio.run(run())
 
 
+def test_code_sandbox_repair_gate_rediscloses_the_frozen_manifest_not_a_live_edit(monkeypatch):
+    """R5.4 CODESANDBOX FIX, repair-gate coverage: start_code_sandbox_run
+    freezes `manifest` once, but USES it at two separate approval gates -
+    the initial gate (covered by the two sibling tests above) and the
+    repair re-gate, which re-discloses the manifest and re-fingerprints
+    every repaired code variant before it may run (the ADR-002 P0
+    fresh-gate-per-repair fix). The repair gate sits after real awaits
+    (execute_code, the repair agent call), so the same ungated
+    setCodeSandboxRequirements edit can land before it opens - and
+    mutating EITHER of the repair gate's two freeze sites (its
+    `approval_requirements = manifest` re-disclosure, or its
+    `_fingerprint_changes({..., "manifest": manifest})` computation) to a
+    live re-read passed the entire suite silently before this test
+    existed: the sibling tests never reach the repair loop (their
+    execution succeeds on the first attempt, or they deny the initial
+    gate), and the repair-loop tests in test_agents.py run with the live
+    field and the frozen manifest both equal (""), making frozen and live
+    reads indistinguishable there.
+
+    Same threading.Event race as the siblings, but the block is on the
+    REPAIR agent call: generation succeeds instantly with code whose
+    first execution fails, the initial gate is approved with the frozen
+    "numpy" disclosure intact, and the live edit to "requests" lands
+    while the repair agent is provably in flight - after the initial
+    approval resolved (so the initial gate's own freeze cannot mask the
+    result) and before the repair gate opened. The repair gate must then
+    re-disclose "numpy" and fingerprint against "numpy", and the approved
+    repaired code must actually execute (which also proves the loop-top
+    fingerprint re-check compared against the frozen manifest - a live
+    comparison there would blocklist the run instead)."""
+    entered_repair = threading.Event()
+    release_repair = threading.Event()
+
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nbroken\n[/TOOL]",
+    )
+
+    def _blocking_repair(self, code, error, manifest, original_prompt=None):
+        entered_repair.set()
+        release_repair.wait(timeout=5)
+        return "print('repaired')"
+
+    monkeypatch.setattr(agents_module.SandboxRepairAgent, "get_response", _blocking_repair)
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "ok",
+    )
+
+    class _RecordingSandbox:
+        def __init__(self, sandbox_id):
+            self.sandbox_id = sandbox_id
+            self.sync_requirements_calls = []
+            self.execute_calls = []
+
+        def ensure_base_environment(self, should_continue, emit_line=None):
+            pass
+
+        def sync_requirements(self, manifest, should_continue, emit_line=None):
+            self.sync_requirements_calls.append(manifest)
+
+        def execute_code(self, code, should_continue, emit_line=None):
+            self.execute_calls.append(code)
+            if len(self.execute_calls) == 1:
+                return "Traceback (most recent call last):\nboom", 1
+            return "ran ok", 0
+
+    sandbox_holder = {}
+
+    def _make_sandbox(sandbox_id):
+        sandbox = _RecordingSandbox(sandbox_id)
+        sandbox_holder["sandbox"] = sandbox
+        return sandbox
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _make_sandbox)
+
+    async def run():
+        bus, document, _recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        sandbox_node = document.add_code_sandbox_node(0, 0, parent.id)
+
+        await bus.dispatch_intent("scene", "setCodeSandboxRequirements", [sandbox_node.id, "numpy"])
+        await bus.dispatch_intent("scene", "runCodeSandbox", [sandbox_node.id, "do something"])
+        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
+
+        # Initial gate: opens with the frozen disclosure, live field still
+        # untouched - approve it so execution proceeds and fails.
+        for _ in range(200):
+            if sandbox_node.state.code_sandbox_awaiting_approval or entry["task"].done():
+                break
+            await asyncio.sleep(0.005)
+        assert sandbox_node.state.code_sandbox_awaiting_approval is True
+        assert sandbox_node.state.code_sandbox_approval_requirements == "numpy"
+        assert dispatcher.approve_code_execution(request_id) is True
+
+        # The failing first execution sends the run into the repair agent,
+        # which blocks - the repair window.
+        for _ in range(200):
+            if entered_repair.is_set():
+                break
+            await asyncio.sleep(0.005)
+        assert entered_repair.is_set(), "the repair agent call never actually started"
+        assert sandbox_node.state.code_sandbox_awaiting_approval is False, (
+            "the repair gate must not have opened yet - the edit below has to land "
+            "during the repair window, not after the re-disclosure"
+        )
+
+        await bus.dispatch_intent("scene", "setCodeSandboxRequirements", [sandbox_node.id, "requests"])
+        assert sandbox_node.state.code_sandbox_requirements == "requests"
+
+        release_repair.set()
+
+        # Repair gate: must re-disclose and re-fingerprint the FROZEN
+        # manifest, not the live edit made during the repair window.
+        for _ in range(200):
+            if sandbox_node.state.code_sandbox_awaiting_approval or entry["task"].done():
+                break
+            await asyncio.sleep(0.005)
+        assert sandbox_node.state.code_sandbox_awaiting_approval is True, "must be parked on the repair gate"
+        assert sandbox_node.state.code_sandbox_code == "print('repaired')"
+        assert sandbox_node.state.code_sandbox_approval_requirements == "numpy", (
+            "the repair gate's re-disclosure must be the frozen manifest this run "
+            "actually installed and executes under, never a live edit made while "
+            "the repair agent was still in flight"
+        )
+        expected_fingerprint = agents_module._fingerprint_changes(
+            {"code": "print('repaired')", "manifest": "numpy"}
+        )
+        assert sandbox_node.state.code_sandbox_approved_fingerprint == expected_fingerprint, (
+            "the repair gate's fingerprint must be computed from the frozen "
+            "manifest ('numpy'), not the live draft field ('requests')"
+        )
+
+        assert dispatcher.approve_code_execution(request_id) is True
+        await entry["task"]
+
+        sandbox = sandbox_holder["sandbox"]
+        assert sandbox.execute_calls == ["broken", "print('repaired')"], (
+            "the approved repaired code must actually have executed - if the "
+            "loop-top fingerprint re-check had compared against a live re-read "
+            "it would have blocked this approved run instead"
+        )
+        assert sandbox.sync_requirements_calls == ["numpy"]
+        assert sandbox_node.state.code_sandbox_awaiting_approval is False
+        assert sandbox_node.state.code_sandbox_approval_requirements == ""
+
+    asyncio.run(run())
+
+
 # -- R6.1: Notes/Frames/Containers -------------------------------------------
 
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -5191,18 +5191,45 @@ def test_code_sandbox_approval_requirements_snapshot_is_decoupled_from_the_live_
     asyncio.to_thread call to SandboxGenerationAgent). A setCodeSandboxRequirements
     intent - ungated by any busy check - can land during that await window
     and change the LIVE node.state.code_sandbox_requirements field before the
-    approval panel is ever shown. Uses the REAL AgentDispatcher
-    (make_bus_with_dispatcher) driven through the real runCodeSandbox/
-    setCodeSandboxRequirements WS intents, and genuinely parks on the
-    approval gate (same polling idiom as
+    approval panel is ever shown.
+
+    The race genuinely needs to happen DURING that await, not merely before
+    the test asserts the gate is open - an earlier version of this test
+    dispatched the competing edit only after polling for
+    code_sandbox_awaiting_approval, by which point the mocked
+    SandboxGenerationAgent.get_response (an instant, non-yielding lambda)
+    had already returned and the gate had already opened; that version kept
+    passing even with the frozen `manifest` read at agents.py's approval-gate
+    site replaced with a live re-read of node.state.code_sandbox_requirements
+    (i.e. with the R5.4 fix itself reverted), because by the time the
+    competing edit landed there was nothing left to race against. This
+    version blocks get_response on a threading.Event (asyncio.to_thread runs
+    it on a worker thread, so a thread-level primitive, not an asyncio one,
+    is required to signal across it) so the test can observe the generation
+    call is genuinely in flight - i.e. that `manifest` has already been
+    captured from the live field but the approval gate has not yet opened -
+    before dispatching the competing edit, then release it. Uses the REAL
+    AgentDispatcher (make_bus_with_dispatcher) driven through the real
+    runCodeSandbox/setCodeSandboxRequirements WS intents, and genuinely
+    parks on the approval gate (same polling idiom as
     test_remove_nodes_cancels_the_dispatchers_code_sandbox_request_when_deleted_mid_approval_pause
     above), proving node.state.code_sandbox_approval_requirements - the frozen
-    snapshot this pending approval genuinely refers to - stays "numpy" even
-    after a fresh setCodeSandboxRequirements changes the live draft field to
-    "requests"."""
+    snapshot this pending approval genuinely refers to - lands as "numpy"
+    even though the live draft field was changed to "requests" while the
+    generation call was still in flight."""
+    entered_generation = threading.Event()
+    release_generation = threading.Event()
+
+    def _blocking_get_response(self, history, prompt, manifest):
+        entered_generation.set()
+        # Bounded wait, not an unconditional block: if the test's own logic
+        # is wrong and never releases this, the test fails on the assertion
+        # below rather than hanging the suite.
+        release_generation.wait(timeout=5)
+        return "[TOOL:PYTHON]\nprint(1)\n[/TOOL]"
+
     monkeypatch.setattr(
-        agents_module.SandboxGenerationAgent, "get_response",
-        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint(1)\n[/TOOL]",
+        agents_module.SandboxGenerationAgent, "get_response", _blocking_get_response,
     )
 
     async def run():
@@ -5212,29 +5239,67 @@ def test_code_sandbox_approval_requirements_snapshot_is_decoupled_from_the_live_
 
         await bus.dispatch_intent("scene", "setCodeSandboxRequirements", [sandbox_node.id, "numpy"])
 
+        # start_code_sandbox_run schedules the real work as a background
+        # task (agents.py's own self._runs.attach_task(handle,
+        # asyncio.create_task(_run()))) and returns immediately once that
+        # task is created - this await does NOT block until the run
+        # finishes, so control returns here while the worker thread is
+        # about to (or already has) called the blocked get_response.
         await bus.dispatch_intent("scene", "runCodeSandbox", [sandbox_node.id, "do something"])
-        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
 
+        for _ in range(200):
+            if entered_generation.is_set():
+                break
+            await asyncio.sleep(0.005)
+        assert entered_generation.is_set(), (
+            "the generation call never actually started - this test would silently "
+            "pass without exercising the race at all if it did not"
+        )
+        # At this exact point: `manifest` was already captured from the live
+        # field ("numpy") before this call started, but
+        # code_sandbox_approval_requirements has NOT been set yet - the gate
+        # has not opened. This is the real race window.
+        assert sandbox_node.state.code_sandbox_awaiting_approval is False, (
+            "the gate must not have opened yet - otherwise the edit below lands "
+            "after the freeze, not during it, and this test proves nothing"
+        )
+
+        # A fresh live-draft edit arrives WHILE the generation call - and
+        # therefore the freeze window - is still genuinely in flight.
+        await bus.dispatch_intent("scene", "setCodeSandboxRequirements", [sandbox_node.id, "requests"])
+        assert sandbox_node.state.code_sandbox_requirements == "requests"
+
+        # Let the still-blocked generation call return, so the gate can open.
+        release_generation.set()
+
+        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
         for _ in range(200):
             if sandbox_node.state.code_sandbox_awaiting_approval or entry["task"].done():
                 break
             await asyncio.sleep(0.005)
         assert sandbox_node.state.code_sandbox_awaiting_approval is True, "must genuinely be parked on the approval gate"
-        assert sandbox_node.state.code_sandbox_approval_requirements == "numpy", (
-            "the frozen snapshot must be populated the instant the approval gate opens"
-        )
-
-        # A fresh live-draft edit arrives WHILE this approval is still
-        # pending - exactly the real race this fix closes.
-        await bus.dispatch_intent("scene", "setCodeSandboxRequirements", [sandbox_node.id, "requests"])
 
         assert sandbox_node.state.code_sandbox_approval_requirements == "numpy", (
-            "the disclosed approval snapshot must stay the frozen manifest this "
-            "pending approval genuinely refers to, unaffected by a later live edit"
+            "the disclosed approval snapshot must reflect the manifest captured BEFORE "
+            "the generation call started - not the live field's value, which was "
+            "already changed to 'requests' for the entire duration of that call"
         )
         assert sandbox_node.state.code_sandbox_requirements == "requests", (
             "the live draft field must still reflect the user's newest edit, "
             "proving the two fields are genuinely decoupled"
+        )
+        # The approval fingerprint (agents.py's start_code_sandbox_run) is
+        # computed from the SAME frozen `manifest` local as the disclosure
+        # string above, not a live re-read - verify it independently rather
+        # than trusting that it happens to agree, since a prior adversarial
+        # review found this site had only fragile, accidental test coverage
+        # elsewhere (a fixture-default coincidence, not a targeted assertion).
+        expected_fingerprint = agents_module._fingerprint_changes(
+            {"code": sandbox_node.state.code_sandbox_code, "manifest": "numpy"}
+        )
+        assert sandbox_node.state.code_sandbox_approved_fingerprint == expected_fingerprint, (
+            "the approval fingerprint must be computed from the frozen manifest "
+            "('numpy'), not the live draft field ('requests')"
         )
 
         # Deny, so the background task completes cleanly without touching a
@@ -5244,6 +5309,106 @@ def test_code_sandbox_approval_requirements_snapshot_is_decoupled_from_the_live_
         assert sandbox_node.state.code_sandbox_approval_requirements == "", (
             "must be cleared once the approval resolves, mirroring "
             "code_sandbox_awaiting_approval's own clear"
+        )
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_installs_the_frozen_manifest_not_a_live_edit_made_during_generation(monkeypatch):
+    """R5.4 CODESANDBOX FIX, install-site coverage: the disclosure string
+    (code_sandbox_approval_requirements) and the approval fingerprint are
+    not the only places `manifest` (frozen before the one real await in
+    AgentDispatcher.start_code_sandbox_run) must be used instead of a live
+    re-read of node.state.code_sandbox_requirements - the ACTUAL `pip
+    install` argument, passed to sandbox.sync_requirements, is frozen from
+    the exact same local. A previous version of the sibling test above
+    (test_code_sandbox_approval_requirements_snapshot_is_decoupled_from_the_live_draft_field)
+    only ever denied the approval, so it never reached sync_requirements at
+    all; an adversarial review found that mutating sync_requirements's call
+    site to read the live field instead of `manifest` passed the entire
+    suite silently - the sandbox would install whatever the user most
+    recently typed, not what was disclosed and approved. This test uses the
+    identical threading.Event race as that sibling test, but APPROVES
+    instead of denying, and asserts on a fake VirtualEnvSandbox's recorded
+    sync_requirements argument."""
+    entered_generation = threading.Event()
+    release_generation = threading.Event()
+
+    def _blocking_get_response(self, history, prompt, manifest):
+        entered_generation.set()
+        release_generation.wait(timeout=5)
+        return "[TOOL:PYTHON]\nprint(1)\n[/TOOL]"
+
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response", _blocking_get_response,
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "ok",
+    )
+
+    class _RecordingSandbox:
+        def __init__(self, sandbox_id):
+            self.sandbox_id = sandbox_id
+            self.sync_requirements_calls = []
+
+        def ensure_base_environment(self, should_continue, emit_line=None):
+            pass
+
+        def sync_requirements(self, manifest, should_continue, emit_line=None):
+            self.sync_requirements_calls.append(manifest)
+
+        def execute_code(self, code, should_continue, emit_line=None):
+            return "ran ok", 0
+
+    sandbox_holder = {}
+
+    def _make_sandbox(sandbox_id):
+        sandbox = _RecordingSandbox(sandbox_id)
+        sandbox_holder["sandbox"] = sandbox
+        return sandbox
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _make_sandbox)
+
+    async def run():
+        bus, document, _recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        sandbox_node = document.add_code_sandbox_node(0, 0, parent.id)
+
+        await bus.dispatch_intent("scene", "setCodeSandboxRequirements", [sandbox_node.id, "numpy"])
+        await bus.dispatch_intent("scene", "runCodeSandbox", [sandbox_node.id, "do something"])
+
+        for _ in range(200):
+            if entered_generation.is_set():
+                break
+            await asyncio.sleep(0.005)
+        assert entered_generation.is_set(), "the generation call never actually started"
+        assert sandbox_node.state.code_sandbox_awaiting_approval is False
+
+        # The live-draft edit lands while `manifest` is already captured as
+        # "numpy" but before the gate has opened - the exact race window.
+        await bus.dispatch_intent("scene", "setCodeSandboxRequirements", [sandbox_node.id, "requests"])
+        assert sandbox_node.state.code_sandbox_requirements == "requests"
+
+        release_generation.set()
+
+        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
+        for _ in range(200):
+            if sandbox_node.state.code_sandbox_awaiting_approval or entry["task"].done():
+                break
+            await asyncio.sleep(0.005)
+        assert sandbox_node.state.code_sandbox_awaiting_approval is True
+
+        # Approve (not deny) so execution proceeds to sync_requirements.
+        assert dispatcher.approve_code_execution(request_id) is True
+        await entry["task"]
+
+        sandbox = sandbox_holder["sandbox"]
+        assert sandbox.sync_requirements_calls == ["numpy"], (
+            "the sandbox must install the manifest that was frozen and disclosed "
+            "BEFORE the generation call started, never a live edit made while that "
+            "call was still in flight - installing 'requests' here would mean the "
+            "sandbox ran a package set the user never actually approved"
         )
 
     asyncio.run(run())

--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -143,7 +143,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -506,7 +505,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -555,7 +553,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1851,6 +1848,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "dev": true,
@@ -2040,7 +2058,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2228,7 +2247,6 @@
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2244,7 +2262,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2256,7 +2273,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2312,7 +2328,6 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -2699,7 +2714,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2740,6 +2754,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2750,6 +2765,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2853,7 +2869,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -3080,7 +3095,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3224,7 +3238,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.392",
@@ -3338,7 +3353,6 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -4606,6 +4620,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5746,7 +5761,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5799,6 +5813,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5833,7 +5848,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5846,7 +5860,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5860,7 +5873,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6497,7 +6511,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6760,7 +6773,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7064,7 +7076,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -143,6 +143,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -505,6 +506,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -553,6 +555,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1848,27 +1851,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "dev": true,
@@ -2058,8 +2040,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2247,6 +2228,7 @@
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2262,6 +2244,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2273,6 +2256,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2328,6 +2312,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -2714,6 +2699,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2754,7 +2740,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2765,7 +2750,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2837,9 +2821,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2869,6 +2853,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -3095,6 +3080,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3238,8 +3224,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.392",
@@ -3353,6 +3338,7 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -4620,7 +4606,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5761,6 +5746,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5769,9 +5755,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -5789,7 +5775,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5813,7 +5799,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5848,6 +5833,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5860,6 +5846,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5873,8 +5860,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6511,6 +6497,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6773,6 +6760,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7076,6 +7064,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Problem

`test_code_sandbox_approval_requirements_snapshot_is_decoupled_from_the_live_draft_field` is meant to be the regression guard for a real, previously-shipped security fix (the "R5.4 CODESANDBOX FIX") closing a requirements-disclosure staleness race in `AgentDispatcher.start_code_sandbox_run`. It was broken: it dispatched the competing `setCodeSandboxRequirements` edit *after* already asserting the approval gate was open, by which point the mocked, instant, non-yielding `SandboxGenerationAgent.get_response` had already returned - so the edit landed after the freeze, not during it. Verified directly: reverting the R5.4 fix to a live re-read still passed the entire 1228-test suite including this test.

Independent adversarial review then found the gap was worse than one broken test: `start_code_sandbox_run` freezes the requirements manifest into a local variable and uses it at **three** sites, and only one had any real coverage.

## Change

- **Fixes the synchronization**: the mocked `get_response` now blocks on a `threading.Event` (`asyncio.to_thread` runs it on a worker thread, so a thread-level primitive is required to signal across it) until the test observes the generation call is genuinely in flight, dispatches the competing edit, then releases it. This is a causal guarantee, not a timing heuristic - the gate-opening code is provably unreachable until the blocked call returns.
- **Closes the fingerprint gap**: adds an assertion to the existing test that `code_sandbox_approved_fingerprint` was computed from the frozen manifest. Previously this site had only fragile, accidental coverage elsewhere (a test fixture default that happened to diverge from a hardcoded call argument, tripping an unrelated defense-in-depth check).
- **Closes the install-argument gap** - the most severe finding: `sandbox.sync_requirements`'s argument (the actual `pip install` call) had **zero** coverage. A new sibling test, `test_code_sandbox_installs_the_frozen_manifest_not_a_live_edit_made_during_generation`, uses the identical race but approves (rather than denies) so execution reaches `sync_requirements`, and asserts a fake sandbox's recorded argument against the frozen value. Without this, the sandbox would install whatever the user most recently typed into the requirements box, not what was disclosed and approved.

No production code changes - this PR is test-only.

## Test plan

- `python -m pytest -q` (full suite, repo root): 1229 passed.
- All three freeze sites (disclosure string, fingerprint, `sync_requirements` argument) independently mutated one at a time in `backend/agents.py`, each confirmed to fail its respective test with the exact expected assertion mismatch, then restored - `git diff --stat backend/agents.py` confirmed empty at every checkpoint (test-only change).
- Confirmed the `sync_requirements` gap was genuinely pre-existing and not introduced by this PR: applied the identical mutation against an unmodified `main` checkout and the full suite passed silently.
- Both the extended and new test run flake-free across 10+ repeated runs each.
- `pyflakes` on the touched file, diffed against the pre-PR baseline: identical warning set.
- Two independent review passes (one general correctness, one deliberately adversarial hunting for further coverage gaps) plus a skeptical synthesis on the original fix; a third independent verification pass on the final extended diff after closing the two gaps it found - all mutation claims re-verified directly, not taken on trust.