### PR TITLE
Fix npm audit CI failure: bump undici to 7.29.0

### DIFF
--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -6544,9 +6544,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Problem

Five `undici` advisories (high severity, affecting 7.0.0–7.28.0) were published after #258 merged, so the Phase 0.5 npm audit gate is again failing the Frontend check on every PR — currently blocking #259. Time-based, not caused by any recent change. `undici` is a transitive dependency via `jsdom`.

- [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) — downstream response desynchronization via retry interceptor
- [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) — cross-user information disclosure / parse-time crash
- [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) — CRLF injection via blob-like body `type`
- [GHSA-jr45-8vmc-qm54](https://github.com/advisories/GHSA-jr45-8vmc-qm54) — cross-user disclosure via Cache-Control whitespace
- [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) — cookie attribute injection

## Change

Bumps `undici` 7.28.0 → 7.29.0. Three lines: version, resolved, integrity (plus `engines`, unchanged in value). `package.json` untouched.

Same surgical approach as #258 rather than `npm audit fix`: the local npm silently drops nested optional entries under `@tailwindcss/oxide-wasm32-wasi` on every full lockfile rewrite, producing a lockfile that its own `npm ci` then rejects. Patching the single entry in place leaves the rest of the lockfile byte-identical.

## Test plan

Ran CI's own three frontend steps locally, in order:
- `npm ci` — clean install strictly from the patched lockfile, integrity verified (this is the step that catches a corrupted rewrite)
- `npm run check` — builds clean
- `npm audit --audit-level=high` — 0 vulnerabilities