### PR TITLE
ADR-002 stage 2.5 exit: lock SceneNode core at 14 fields

### DIFF
--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -22,9 +22,10 @@ collide with an unrelated attribute on a genuinely different type
 elsewhere in the codebase - see its own comment for exactly which shapes
 and why.
 
-test_scene_node_core_field_count (asserting the final <=15-field core
-exactly) is deferred to the stage's own exit PR, once every kind that has
-kind-specific fields has migrated - see backend/domain/node_states.py's
+test_scene_node_core_field_count is this stage's exit gate: it locks
+SceneNode's dataclass field count at exactly 14 (down from the original
+~95), the value PR10b (code_sandbox shim removal, the last kind with
+per-kind fields) actually reached - see backend/domain/node_states.py's
 own docstring for the full kind list and which 3 kinds need no state class
 at all.
 
@@ -41,9 +42,11 @@ memory.
 from __future__ import annotations
 
 import ast
+from dataclasses import fields as dataclass_fields
 from pathlib import Path
 
 from backend.domain.graph import SceneDocument
+from backend.domain.model import SceneNode
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCAN_DIRS = (REPO_ROOT / "backend", REPO_ROOT / "tests")
@@ -230,6 +233,31 @@ def test_migrated_kind_fields_accessed_only_via_state():
         "ADR-002 stage 2.5: migrated field accessed without going through "
         "node.state:\n" + "\n".join(offenders)
     )
+
+
+# The stage's exit shape: id/x/y/title/kind (identity+position+display),
+# content/is_collapsed/is_docked/history (the few fields still genuinely
+# shared across several kinds, not worth their own 1-field state classes),
+# pending_request_id (generic in-flight marker), color/header_color/
+# item_ids (note/frame/container's shared group fields), and state itself
+# (the per-kind payload). Order matches declaration order in
+# backend/domain/model.py.
+_EXPECTED_SCENE_NODE_CORE_FIELDS = [
+    "id", "x", "y", "title", "kind", "content", "is_collapsed", "is_docked",
+    "history", "pending_request_id", "color", "header_color", "item_ids", "state",
+]
+
+
+def test_scene_node_core_field_count():
+    """ADR-002 stage 2.5 exit gate (backend-only half - see the ADR's own
+    status table for why the wire-payload shrink is a separate, deferred
+    stage): SceneNode's dataclass field count is locked at exactly 14.
+    Asserts the exact field NAME set in order, not just len(...) == 14, so
+    a future PR that swaps one field for a different unrelated one (same
+    count, silently different shape) still fails this gate instead of
+    passing it by coincidence."""
+    actual = [f.name for f in dataclass_fields(SceneNode)]
+    assert actual == _EXPECTED_SCENE_NODE_CORE_FIELDS
 
 
 # Captured from SceneDocument.scene_payload()'s real output pre-migration


### PR DESCRIPTION
## Problem

ADR-002 stage 2.5's field-count exit criterion (SceneNode core ≤ 15 fields) had no test locking it in. After PR10b (code_sandbox shim removal) reached 14 fields, nothing prevented a future PR from silently re-adding fields to the core dataclass.

## Change

Adds `test_scene_node_core_field_count` to `tests/test_node_state_migration.py`, asserting the exact ordered field name list on `SceneNode` (not just a count), so a same-count-but-different-shape swap still fails the gate.

Verified by mutation: added a stray extra field, confirmed the new test fails with the expected message, reverted (net-zero diff on `backend/domain/model.py`).

This closes the backend-only half of stage 2.5. The per-kind wire-payload shrink remains a separate, deferred stage — `test_scene_payload_key_set_is_unchanged_by_the_migration` still locks the flat 86-key wire shape unchanged.

## Test plan

- [x] `pytest tests/test_node_state_migration.py -q` — 4 passed
- [x] Mutation check: stray field added → test fails; reverted → zero diff
- [x] Full suite (`pytest -q` from repo root): 1236 passed