### PR TITLE
ADR-002 stage 2.7 (2/2): split register_chat_library, add 300-line ratchet test

### DIFF
--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -513,6 +513,65 @@ def _new_save_state() -> dict[str, Any]:
     return {"digest": None, "chat_id": None}
 
 
+def make_serialize_mutating_intent(
+    bus: SessionBus,
+    mutation_in_progress: dict[str, Any],
+    notifications: NotificationState | None,
+):
+    """Factory for the reentrancy-guard decorator register_chat_library's
+    own loadChat/saveChat/newChat intents are registered through - see
+    register_chat_library's own docstring (right below its call site) for
+    the full OWNERSHIP audit-fix story this implements. Lifted out to a
+    top-level factory - matching _new_mutation_guard/_new_save_state/
+    _busy_message's own "one definition ... so it can never drift apart"
+    precedent already established in this file - purely to keep
+    register_chat_library itself under ADR-002's 300-line registration-
+    function cap (stage 2.7). Captures nothing register_chat_library's own
+    callers couldn't already reach via bus.chat_mutation_guard, which is
+    the SAME dict passed in here as mutation_in_progress."""
+
+    def _claim_guard(owner: str) -> None:
+        mutation_in_progress["active"] = True
+        mutation_in_progress["owner"] = owner
+        mutation_in_progress["released"].clear()
+
+    def _release_guard() -> None:
+        mutation_in_progress["active"] = False
+        mutation_in_progress["owner"] = None
+        mutation_in_progress["released"].set()
+
+    def _serialize_mutating_intent(handler):
+        async def wrapped(*args, **kwargs):
+            if mutation_in_progress["active"] and mutation_in_progress["owner"] == AUTOSAVE_OWNER:
+                # Yield to the user: wait the tick out rather than discarding
+                # their click. On timeout we fall through to the same
+                # drop-and-warn below, so a stuck tick degrades to exactly the
+                # pre-fix behavior instead of hanging.
+                with contextlib.suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(
+                        mutation_in_progress["released"].wait(),
+                        timeout=AUTOSAVE_YIELD_TIMEOUT_SECONDS,
+                    )
+
+            if mutation_in_progress["active"]:
+                # Re-checked, not assumed: several intents can be released
+                # from the wait above at once, and only the first may claim.
+                if notifications is not None:
+                    notifications.show(_busy_message(mutation_in_progress["owner"]), "warning")
+                    await bus.publish("notification")
+                return
+
+            _claim_guard(USER_OWNER)
+            try:
+                await handler(*args, **kwargs)
+            finally:
+                _release_guard()
+
+        return wrapped
+
+    return _serialize_mutating_intent
+
+
 def chat_library_payload(db_path: Path) -> dict[str, Any]:
     try:
         rows = get_all_chats(db_path)
@@ -572,17 +631,6 @@ def register_chat_library(
     # is strictly better - the Save just works.
     # `released` is set on every release and cleared on every claim.
     _mutation_in_progress = _new_mutation_guard()
-
-    def _claim_guard(owner: str) -> None:
-        _mutation_in_progress["active"] = True
-        _mutation_in_progress["owner"] = owner
-        _mutation_in_progress["released"].clear()
-
-    def _release_guard() -> None:
-        _mutation_in_progress["active"] = False
-        _mutation_in_progress["owner"] = None
-        _mutation_in_progress["released"].set()
-
     bus.chat_mutation_guard = _mutation_in_progress
 
     # R6.6 + audit fix: see _new_save_state's own docstring for what this
@@ -601,34 +649,7 @@ def register_chat_library(
         _last_saved["digest"] = _content_digest(chat_data, notes_data, pins_data)
         _last_saved["chat_id"] = int(chat_id) if chat_id is not None else None
 
-    def _serialize_mutating_intent(handler):
-        async def wrapped(*args, **kwargs):
-            if _mutation_in_progress["active"] and _mutation_in_progress["owner"] == AUTOSAVE_OWNER:
-                # Yield to the user: wait the tick out rather than discarding
-                # their click. On timeout we fall through to the same
-                # drop-and-warn below, so a stuck tick degrades to exactly the
-                # pre-fix behavior instead of hanging.
-                with contextlib.suppress(asyncio.TimeoutError):
-                    await asyncio.wait_for(
-                        _mutation_in_progress["released"].wait(),
-                        timeout=AUTOSAVE_YIELD_TIMEOUT_SECONDS,
-                    )
-
-            if _mutation_in_progress["active"]:
-                # Re-checked, not assumed: several intents can be released
-                # from the wait above at once, and only the first may claim.
-                if notifications is not None:
-                    notifications.show(_busy_message(_mutation_in_progress["owner"]), "warning")
-                    await bus.publish("notification")
-                return
-
-            _claim_guard(USER_OWNER)
-            try:
-                await handler(*args, **kwargs)
-            finally:
-                _release_guard()
-
-        return wrapped
+    _serialize_mutating_intent = make_serialize_mutating_intent(bus, _mutation_in_progress, notifications)
 
     # Writes run in worker threads (asyncio.to_thread) so a slow disk/WAL
     # commit never stalls the event loop. No Python-side lock is needed:

--- a/tests/test_register_function_length.py
+++ b/tests/test_register_function_length.py
@@ -1,0 +1,67 @@
+"""ADR-002 stage 2.7 exit gate: every `register*` function under backend/
+stays at or under 300 lines.
+
+Stage 2.6 set this cap (backend/canvas.py's own former ~1572-line
+register_canvas, split into backend/api/intents_*.py) but its own exit
+criterion was written over EVERY registration function while its scope
+only ever named register_canvas - so register_settings (901 lines) and
+register_chat_library (319 lines) both silently busted the cap for a full
+stage before stage 2.7 found and split them. AST-based, same philosophy
+as tests/test_node_state_migration.py: measuring the diff instead of
+grepping catches this class of "the exit criterion was met for the one
+named site, not for the property it actually describes" gap, and keeps it
+caught - a future PR that grows any register* function past 300 lines
+(a new feature area bolted onto an existing one, say) fails this test
+immediately instead of silently re-accumulating the debt stage 2.6/2.7
+just paid down.
+
+Matches ANY function or async function whose name starts with "register",
+at any nesting depth (ast.walk, not just module-level) - the same
+matching a manual line-count audit would need to do to be trustworthy,
+and the same shape the register_settings/register_chat_library splits
+were actually measured against while doing this work.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_DIR = REPO_ROOT / "backend"
+MAX_REGISTER_FUNCTION_LINES = 300
+
+
+def _register_functions():
+    for path in sorted(SCAN_DIR.rglob("*.py")):
+        if "__pycache__" in path.parts or "tests" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("register"):
+                length = node.end_lineno - node.lineno + 1
+                yield path, node, length
+
+
+def test_no_register_function_exceeds_the_300_line_cap():
+    offenders = [
+        f"{path.relative_to(REPO_ROOT)}:{node.lineno} {node.name} is {length} lines "
+        f"(cap: {MAX_REGISTER_FUNCTION_LINES})"
+        for path, node, length in _register_functions()
+        if length > MAX_REGISTER_FUNCTION_LINES
+    ]
+    assert not offenders, (
+        "ADR-002 stage 2.6/2.7: a register* function under backend/ exceeds "
+        f"the {MAX_REGISTER_FUNCTION_LINES}-line cap - split it the same way "
+        "register_canvas/register_settings/register_chat_library were split:\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_at_least_one_register_function_is_found():
+    # A collection bug (wrong glob, wrong name-matching predicate) would
+    # make the test above vacuously pass with zero offenders - this
+    # asserts the scan actually found the real, large population of
+    # register* functions backend/ is known to have, not an empty list.
+    count = sum(1 for _ in _register_functions())
+    assert count >= 20, f"expected at least 20 register* functions under backend/, found {count}"


### PR DESCRIPTION
## Problem

`register_chat_library` was 319 lines — over the ADR-002 300-line registration-function cap. Its exit criterion also never had a test enforcing it repo-wide, which is exactly how this function (and `register_settings`, #262) both went unnoticed for a full stage.

## Change

`register_chat_library`'s 5 intents (rename/delete/load/save/new) are tightly coupled through shared state (`_mutation_in_progress`, `_last_saved`) — unlike `register_settings`' genuinely independent dialog pages, there's no natural per-page split. Instead, the shared guard/wrapper-factory logic (`_claim_guard`/`_release_guard`/`_serialize_mutating_intent`, ~56 lines) lifts into a top-level factory function, `make_serialize_mutating_intent`, matching this file's own existing `_new_mutation_guard`/`_new_save_state`/`_busy_message` precedent for "one definition, shared." `register_chat_library` is now 281 lines.

Adds `tests/test_register_function_length.py`: an AST-based test asserting every `register*` function under `backend/` stays ≤ 300 lines, repo-wide — the ratchet stage 2.6 always described but never enforced.

## Test plan

- [x] `pytest backend/tests/test_chat_library.py backend/tests/test_autosave.py -q` — 59 passed
- [x] Mutation check: padded the largest `register*` function 30 lines past the cap, confirmed the new test fails with the expected message, reverted (zero diff)
- [x] Full suite (`pytest -q` from repo root): 1238 passed