### PR TITLE
ADR-004 stage 4.1: per-launch capability token gating /api and /ws

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -27,7 +27,7 @@ import os
 import time
 from pathlib import Path
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -37,6 +37,14 @@ from backend import BACKEND_VERSION
 from backend.about import register_about
 from backend.agents import bootstrap_provider_state, register_agents
 from backend.assets import register_assets
+from backend.auth import (
+    AUTH_HEADER,
+    AUTH_QUERY_PARAM,
+    extract_presented_token,
+    is_guarded_path,
+    resolve_configured_token,
+    token_matches,
+)
 from backend.canvas import register_canvas
 from backend.chat_library import register_chat_library
 from backend.composer import register_composer
@@ -212,8 +220,22 @@ def create_app(
     settings_state_file: Path | None = None,
     chat_db_path: Path | None = None,
     previous_run_crashed: bool = False,
+    auth_token: str | None = None,
 ) -> FastAPI:
     app = FastAPI(title="Graphlink backend", version=BACKEND_VERSION)
+    # ADR-004 stage 4.1: the per-launch capability token gating /api/* and
+    # /ws - see backend/auth.py's own docstring for the threat (audit C5) and
+    # why a token rather than accounts. None means "auth disabled", which is
+    # what a bare create_app() in a test gets; the real launch path always
+    # passes one (asserted by tests/test_graphlink_desktop.py, so shipping
+    # with auth off is a test failure rather than a silent regression).
+    resolved_auth_token = resolve_configured_token(auth_token)
+    app.state.auth_token = resolved_auth_token
+    if resolved_auth_token is None:
+        logger.warning(
+            "no capability token configured - /api and /ws are UNAUTHENTICATED "
+            "(expected only in tests; the desktop shell always mints one)"
+        )
     # ONE SettingsManager for the whole app (it owns a single shared
     # ~/.graphlink/session.dat file), shared across every session rather
     # than reconstructed per-session - see backend/settings.py's docstring.
@@ -229,8 +251,45 @@ def create_app(
     )
     app.state.bus = bus
 
+    @app.middleware("http")
+    async def require_capability_token(request: Request, call_next):
+        """ADR-004 stage 4.1: gate every /api/* request on the capability
+        token. Registered as middleware rather than a per-route dependency
+        so a future route added under /api/ is covered by construction -
+        forgetting a decorator is exactly how this kind of guard rots.
+
+        Deliberately does NOT gate the SPA bootstrap (GET /, /assets/*, the
+        client-side-route catch-all): the initial page load cannot carry a
+        header, and those routes only serve the public build output. See
+        backend/auth.py's docstring.
+
+        Note this never sees WebSocket connections - Starlette's HTTP
+        middleware stack only runs for scope["type"] == "http", so /ws is
+        guarded separately inside ws_endpoint below. That is a real
+        constraint of the framework, not a stylistic split, and it is why
+        the two checks cannot be collapsed into one place.
+        """
+        if resolved_auth_token is not None and is_guarded_path(request.url.path):
+            presented = extract_presented_token(
+                request.headers.get(AUTH_HEADER),
+                request.query_params.get(AUTH_QUERY_PARAM),
+            )
+            if not token_matches(resolved_auth_token, presented):
+                # Uniform 401 with no detail: never distinguish "no token"
+                # from "wrong token" from "malformed header", so this is not
+                # an oracle for probing the token's shape.
+                logger.warning("rejected unauthenticated request: %s", request.url.path)
+                return JSONResponse({"error": "unauthorized"}, status_code=401)
+        return await call_next(request)
+
     @app.get("/api/health")
     async def health() -> JSONResponse:
+        # Gated like every other /api route (ADR-004 §1 says "every /api/*
+        # request", and this is deliberately not carved out): the only real
+        # caller is graphlink_desktop.py's own startup poll, which minted the
+        # token and passes it. Leaving it open would hand any local process a
+        # free "is Graphlink running, and what version" fingerprinting oracle
+        # for no benefit the shell needs.
         return JSONResponse({"status": "ok", "app": "graphlink", "version": BACKEND_VERSION})
 
     # R3.21: GET /api/assets/{id} - the image-node byte-serving route (see
@@ -252,6 +311,27 @@ def create_app(
             logger.warning("rejected WS handshake: origin=%r host=%r", origin, host_header)
             await websocket.close(code=1008)
             return
+        # ADR-004 stage 4.1: the capability token, checked IN ADDITION to the
+        # origin check above - defense in depth, and the two defend genuinely
+        # different threats. The origin check stops a malicious PAGE in the
+        # user's browser (which cannot forge Origin); it cannot stop a local
+        # PROCESS, which can send any Origin it likes or omit it entirely
+        # (the deliberately-allowed "absent Origin" branch in
+        # _is_allowed_ws_origin). The token is what closes that second hole -
+        # see backend/auth.py's docstring on audit finding C5.
+        if resolved_auth_token is not None:
+            presented = extract_presented_token(
+                websocket.headers.get(AUTH_HEADER),
+                websocket.query_params.get(AUTH_QUERY_PARAM),
+            )
+            if not token_matches(resolved_auth_token, presented):
+                logger.warning("rejected unauthenticated WS handshake: origin=%r", origin)
+                # 1008 (policy violation), matching the origin rejection just
+                # above - closed before accept(), so no session is created and
+                # an unauthenticated caller cannot reach the C6 session-growth
+                # vector either.
+                await websocket.close(code=1008)
+                return
         session_id = websocket.query_params.get("session", "default")
         try:
             session = bus.session(session_id)

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,150 @@
+"""ADR-004 stage 4.1: the per-launch capability token that gates the whole
+local API surface.
+
+THE THREAT (audit finding C5). Graphlink binds a loopback HTTP/WS port with
+no authentication of any kind, so ANY other process running as the same user
+- a background updater, a rogue npm postinstall script, a browser extension's
+native host, anything - can open /ws and drive all 131 intents. That includes
+runPyCoder, runCodeSandbox, applyGitlinkChanges, and (critically)
+approveCodeExecution: the human-approval gate is itself just another intent on
+the same unauthenticated channel, so a non-browser caller can approve its own
+code execution. The existing WS Origin check (backend/app.py's
+_is_allowed_ws_origin) is a genuinely good defense and stays, but it defends a
+DIFFERENT threat - a malicious PAGE in the user's browser, which cannot forge
+Origin. It does nothing against a local process, which can send any Origin
+header it likes, or none at all (the "absent Origin" branch is deliberately
+allowed there, for reasons that comment explains).
+
+THE FIX. graphlink_desktop.py mints a fresh 256-bit token per launch, hands it
+to create_app(), and passes it to the webview as a URL fragment. Every /api/*
+request and the /ws handshake must present it. A local process that never saw
+the token is rejected; the app's own window has it. Nothing is persisted -
+the token exists only in the running process and the window it spawned, so
+there are no accounts, no credential files, and no revocation story to get
+wrong. This is a capability, not an identity.
+
+WHY A FRAGMENT (rather than a header or a cookie) for delivery to the SPA.
+The initial navigation to http://127.0.0.1:<port>/ is a plain browser page
+load - there is no way to attach a header to it, so the bootstrap HTML and
+its static assets are necessarily unauthenticated (they are also the same
+public build output shipped in the wheel, so they disclose nothing). A URL
+fragment is the narrowest way to get a secret INTO that page: fragments are
+never sent to the server, so the token cannot land in an access log or a
+Referer header, and pywebview's window has no address bar to display it.
+
+TWO PRESENTATION FORMS, deliberately. `Authorization: Bearer <token>` is the
+normal one, used by fetch() and the WS URL's own query string. The `?token=`
+query parameter exists because <img src="/api/assets/..."> cannot set headers
+- image-node and chart bytes are loaded by the browser's own image loader,
+not by our JS - and ADR-004 §1 calls for exactly this ("header or signed query
+for <img>-reachable asset URLs"). On a loopback-only port, with an ephemeral
+per-launch token and no server-side request logging of query strings, the
+usual objections to secrets-in-URLs do not apply here.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+import secrets
+
+# 32 bytes = 256 bits, per ADR-004 §1. token_urlsafe returns ~43 URL-safe
+# ASCII characters for this length, so it needs no escaping in a query
+# string or a URL fragment.
+TOKEN_BYTES = 32
+
+AUTH_HEADER = "authorization"
+BEARER_PREFIX = "bearer "
+AUTH_QUERY_PARAM = "token"
+
+# The dev-workflow escape hatch, matching the GRAPHLINK_DEV_WS_ORIGIN
+# precedent already established for the Origin check (backend/app.py): a
+# developer running `npm run dev` against a separately-started backend has no
+# desktop shell to mint a token for them, so they set this to any value and
+# use the same value from the client. Unset in every real launch - the
+# desktop shell always passes an explicitly minted token instead.
+DEV_AUTH_TOKEN_ENV = "GRAPHLINK_DEV_AUTH_TOKEN"
+
+# Only /api/* is gated. The SPA bootstrap (GET /, /assets/* static files, and
+# the client-side-route catch-all) must stay reachable without a token or the
+# window could never load the page that KNOWS the token - see the module
+# docstring. Those routes serve only the public build output.
+API_PATH_PREFIX = "/api/"
+
+
+def mint_token() -> str:
+    """A fresh capability token. Called once per launch by
+    graphlink_desktop.py - never persisted, never reused across launches."""
+    return secrets.token_urlsafe(TOKEN_BYTES)
+
+
+def resolve_configured_token(explicit_token: str | None) -> str | None:
+    """The token this app instance will require, or None for "auth disabled".
+
+    Precedence, highest first:
+      1. `explicit_token` - what graphlink_desktop.py passes. The real
+         shipped path.
+      2. $GRAPHLINK_DEV_AUTH_TOKEN - the dev-server escape hatch (see
+         DEV_AUTH_TOKEN_ENV).
+      3. None - auth disabled. This is what a bare create_app() in a test
+         gets, so the ~1200-test suite needs no token plumbing to exercise
+         unrelated behavior. create_app() logs a warning in this case, and
+         tests/test_graphlink_desktop.py asserts the real launch path always
+         reaches case 1 - so "shipped with auth accidentally off" is a
+         test failure, not a silent regression.
+    """
+    if explicit_token:
+        return explicit_token
+    env_token = os.environ.get(DEV_AUTH_TOKEN_ENV)
+    if env_token:
+        return env_token
+    return None
+
+
+def extract_presented_token(
+    header_value: str | None, query_token: str | None
+) -> str | None:
+    """Pull the token out of a request, header first then query parameter.
+
+    The header form tolerates any casing of the "Bearer" scheme (RFC 6750
+    says the scheme is case-insensitive) but requires the scheme to be
+    present - a bare `Authorization: <token>` is not accepted, so a caller
+    cannot accidentally match by sending some unrelated credential.
+    """
+    if header_value:
+        if header_value.lower().startswith(BEARER_PREFIX):
+            candidate = header_value[len(BEARER_PREFIX):].strip()
+            if candidate:
+                return candidate
+        # A present-but-malformed Authorization header falls through to the
+        # query parameter rather than short-circuiting to "no token": the two
+        # forms are alternatives, not a priority chain that can dead-end.
+    if query_token:
+        return query_token
+    return None
+
+
+def token_matches(expected: str, presented: str | None) -> bool:
+    """Constant-time comparison, so a local attacker cannot recover the token
+    byte-by-byte from response timing.
+
+    Encodes to bytes first: hmac.compare_digest raises TypeError on a str
+    containing non-ASCII, and `presented` is wholly attacker-controlled - a
+    raise here would surface as a 500 (an oracle distinguishing "malformed"
+    from "wrong") instead of a uniform 401.
+    """
+    if not presented:
+        return False
+    return hmac.compare_digest(expected.encode("utf-8"), presented.encode("utf-8"))
+
+
+def is_guarded_path(path: str) -> bool:
+    """True for the paths the capability token gates - /api/* only.
+
+    Exact-prefix matching on "/api/", so a client-side SPA route that merely
+    STARTS with the letters "api" (e.g. "/apidocs", or a future
+    "/api-reference" marketing page) is not accidentally gated, and - more
+    importantly - cannot be used to reach a real /api route by prefix
+    confusion in the other direction.
+    """
+    return path == "/api" or path.startswith(API_PATH_PREFIX)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,262 @@
+"""ADR-004 stage 4.1: capability-token tests.
+
+The exit criterion for this stage is "tokenless local WS/HTTP client is
+rejected; window still works" - so the tests are organized around exactly
+those two halves: every guarded surface must REJECT a caller without the
+token, and must ACCEPT the app's own window (which presents it, in each of
+the two forms the different browser APIs force on us).
+
+The complementary invariant - that the shipped launch path always supplies
+a real token, so create_app()'s test-friendly "None disables auth" default
+can never silently become the shipped behavior - lives in
+tests/test_graphlink_desktop.py, next to the code that mints it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app import create_app
+from backend.auth import (
+    DEV_AUTH_TOKEN_ENV,
+    extract_presented_token,
+    is_guarded_path,
+    mint_token,
+    resolve_configured_token,
+    token_matches,
+)
+
+TOKEN = "test-capability-token-abc123"
+
+
+@pytest.fixture
+def authed_client():
+    return TestClient(create_app(auth_token=TOKEN))
+
+
+# -- the unit layer: token primitives ---------------------------------------
+
+
+def test_mint_token_is_long_and_unique_per_call():
+    tokens = {mint_token() for _ in range(50)}
+    assert len(tokens) == 50, "a per-launch capability must never repeat"
+    # secrets.token_urlsafe(32) is ~43 chars; the floor guards against a
+    # future refactor swapping in something trivially guessable.
+    assert all(len(token) >= 32 for token in tokens)
+    # URL-safe by construction, so it needs no escaping in the fragment the
+    # desktop shell puts it in, nor in the query param the asset URLs use.
+    assert all("=" not in token and "&" not in token and "#" not in token for token in tokens)
+
+
+def test_token_matches_rejects_wrong_empty_and_none():
+    assert token_matches(TOKEN, TOKEN) is True
+    assert token_matches(TOKEN, "wrong") is False
+    assert token_matches(TOKEN, "") is False
+    assert token_matches(TOKEN, None) is False
+
+
+def test_token_matches_does_not_raise_on_a_non_ascii_presented_token():
+    # hmac.compare_digest raises TypeError on non-ASCII str. `presented` is
+    # wholly attacker-controlled, so a raise here would surface as a 500 -
+    # an oracle distinguishing "malformed" from "wrong" - instead of the
+    # uniform 401 every other rejection produces.
+    assert token_matches(TOKEN, "tökén-with-non-ascii") is False
+
+
+def test_token_matches_rejects_a_prefix_of_the_real_token():
+    # Guards the obvious catastrophic implementation slip (startswith rather
+    # than a full comparison), which would let an attacker walk the token
+    # one character at a time.
+    assert token_matches(TOKEN, TOKEN[:-1]) is False
+    assert token_matches(TOKEN, TOKEN + "x") is False
+
+
+def test_extract_presented_token_reads_the_bearer_header_case_insensitively():
+    assert extract_presented_token("Bearer abc", None) == "abc"
+    assert extract_presented_token("bearer abc", None) == "abc"
+    assert extract_presented_token("BEARER abc", None) == "abc"
+
+
+def test_extract_presented_token_requires_the_bearer_scheme_but_falls_back_to_query():
+    # A bare credential with no scheme is not accepted as the header form,
+    # so an unrelated Authorization header can never accidentally match...
+    assert extract_presented_token("abc", None) is None
+    # ...but it must not short-circuit either: the two forms are
+    # alternatives, so a malformed header still lets a valid query param
+    # through rather than dead-ending the request.
+    assert extract_presented_token("Basic dXNlcjpwdw==", "abc") == "abc"
+
+
+def test_extract_presented_token_prefers_the_header_over_the_query_param():
+    assert extract_presented_token("Bearer from-header", "from-query") == "from-header"
+
+
+def test_is_guarded_path_covers_api_without_catching_lookalike_prefixes():
+    assert is_guarded_path("/api/health") is True
+    assert is_guarded_path("/api/assets/abc") is True
+    assert is_guarded_path("/api") is True
+    # The SPA bootstrap must stay reachable or the window can never load the
+    # page that knows the token.
+    assert is_guarded_path("/") is False
+    assert is_guarded_path("/assets/index-abc.js") is False
+    # Prefix confusion in both directions: a client-side route that merely
+    # starts with "api" is not gated, and cannot be used to reach a real
+    # /api route.
+    assert is_guarded_path("/apidocs") is False
+    assert is_guarded_path("/api-reference") is False
+
+
+def test_resolve_configured_token_precedence(monkeypatch):
+    monkeypatch.delenv(DEV_AUTH_TOKEN_ENV, raising=False)
+    assert resolve_configured_token("explicit") == "explicit"
+    assert resolve_configured_token(None) is None
+
+    monkeypatch.setenv(DEV_AUTH_TOKEN_ENV, "from-env")
+    assert resolve_configured_token(None) == "from-env"
+    # An explicit token (what the desktop shell passes) always wins over the
+    # dev escape hatch, so a stray env var on a developer's machine cannot
+    # weaken a real launch.
+    assert resolve_configured_token("explicit") == "explicit"
+
+
+# -- the HTTP surface -------------------------------------------------------
+
+
+def test_api_requests_without_a_token_are_rejected(authed_client):
+    assert authed_client.get("/api/health").status_code == 401
+
+
+def test_api_requests_with_a_wrong_token_are_rejected(authed_client):
+    assert authed_client.get("/api/health", headers={"Authorization": "Bearer wrong"}).status_code == 401
+    assert authed_client.get("/api/health?token=wrong").status_code == 401
+
+
+def test_api_rejection_body_is_uniform_and_leaks_nothing(authed_client):
+    no_token = authed_client.get("/api/health")
+    wrong_token = authed_client.get("/api/health?token=wrong")
+    malformed = authed_client.get("/api/health", headers={"Authorization": "Basic xyz"})
+
+    # Identical status AND body for all three: never an oracle telling an
+    # attacker whether they got the shape right, only the value wrong.
+    assert no_token.status_code == wrong_token.status_code == malformed.status_code == 401
+    assert no_token.json() == wrong_token.json() == malformed.json()
+    assert TOKEN not in no_token.text
+
+
+def test_api_requests_with_the_bearer_header_are_accepted(authed_client):
+    response = authed_client.get("/api/health", headers={"Authorization": f"Bearer {TOKEN}"})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_api_requests_with_the_query_param_are_accepted(authed_client):
+    # The query-param form is what <img src="/api/assets/..."> must use -
+    # the browser's image loader cannot send headers. Losing this breaks
+    # every image and chart node, so it is pinned explicitly.
+    assert authed_client.get(f"/api/health?token={TOKEN}").status_code == 200
+
+
+def test_the_asset_routes_are_gated_too(authed_client):
+    # /api/assets/* is the specific DNS-rebinding-reachable surface audit
+    # finding C6 called out, so it gets its own assertion rather than
+    # relying on /api/health standing in for the whole prefix.
+    assert authed_client.get("/api/assets/some-asset-id").status_code == 401
+    assert authed_client.get("/api/assets/chart/some-node/export").status_code == 401
+    # With the token it reaches the real handler, which 404s on an unknown
+    # asset - a DIFFERENT status, proving the request got past the gate
+    # rather than being rejected for a second reason.
+    assert authed_client.get(f"/api/assets/some-asset-id?token={TOKEN}").status_code == 404
+
+
+def test_the_spa_bootstrap_is_not_gated(tmp_path):
+    # The initial page load cannot carry a header, so if this were gated the
+    # window could never reach the page that knows the token - the app would
+    # be unbootable. Serves only public build output.
+    spa_dir = tmp_path / "spa"
+    (spa_dir / "assets").mkdir(parents=True)
+    (spa_dir / "index.html").write_text("<html>graphlink</html>", encoding="utf-8")
+    (spa_dir / "assets" / "index.js").write_text("console.log(1)", encoding="utf-8")
+
+    client = TestClient(create_app(spa_dir=spa_dir, auth_token=TOKEN))
+
+    assert client.get("/").status_code == 200
+    assert client.get("/assets/index.js").status_code == 200
+
+
+# -- the WebSocket surface --------------------------------------------------
+
+
+def test_ws_handshake_without_a_token_is_rejected(authed_client):
+    # THE audit-C5 case: a local process that never saw the token. The
+    # origin check alone does not stop this - a non-browser caller simply
+    # omits Origin, which _is_allowed_ws_origin deliberately permits.
+    with pytest.raises(Exception):
+        with authed_client.websocket_connect("/ws"):
+            pass
+
+
+def test_ws_handshake_with_a_wrong_token_is_rejected(authed_client):
+    with pytest.raises(Exception):
+        with authed_client.websocket_connect("/ws?token=wrong"):
+            pass
+
+
+def test_ws_handshake_with_the_query_param_is_accepted(authed_client):
+    # The query form is mandatory for WS: the browser's WebSocket
+    # constructor takes a URL and nothing else, so a header is not an
+    # option on this handshake.
+    with authed_client.websocket_connect(f"/ws?token={TOKEN}") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        message = ws.receive_json()
+
+    assert message["kind"] == "state"
+    assert message["topic"] == "system"
+
+
+def test_ws_handshake_with_the_bearer_header_is_accepted(authed_client):
+    with authed_client.websocket_connect("/ws", headers={"Authorization": f"Bearer {TOKEN}"}) as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        message = ws.receive_json()
+
+    assert message["topic"] == "system"
+
+
+def test_an_unauthenticated_ws_handshake_creates_no_session(authed_client):
+    # Closed BEFORE accept(), so a tokenless caller cannot reach the audit-C6
+    # session-growth vector either: every distinct ?session= value would
+    # otherwise mint a permanent, never-evicted SessionBus (document +
+    # dispatcher + autosave task).
+    bus = authed_client.app.state.bus
+    before = len(bus._sessions)
+
+    with pytest.raises(Exception):
+        with authed_client.websocket_connect("/ws?session=attacker-chosen-id"):
+            pass
+
+    assert len(bus._sessions) == before
+
+
+# -- auth disabled (the test/dev default) -----------------------------------
+
+
+def test_auth_disabled_when_no_token_is_configured(monkeypatch):
+    monkeypatch.delenv(DEV_AUTH_TOKEN_ENV, raising=False)
+    client = TestClient(create_app())
+
+    assert client.app.state.auth_token is None
+    assert client.get("/api/health").status_code == 200
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        assert ws.receive_json()["topic"] == "system"
+
+
+def test_the_dev_env_var_supplies_a_token_when_no_explicit_one_is_passed(monkeypatch):
+    # The vite-dev workflow's escape hatch, matching the existing
+    # GRAPHLINK_DEV_WS_ORIGIN precedent - unset in every real launch.
+    monkeypatch.setenv(DEV_AUTH_TOKEN_ENV, "dev-token")
+    client = TestClient(create_app())
+
+    assert client.get("/api/health").status_code == 401
+    assert client.get("/api/health?token=dev-token").status_code == 200

--- a/graphlink_desktop.py
+++ b/graphlink_desktop.py
@@ -16,6 +16,13 @@ becomes graphlink_app.py.
 Environment:
   GRAPHLINK_BACKEND_PORT  pin the backend port (default: OS-assigned free port)
   GRAPHLINK_DEBUG_WEBVIEW set to 1 to enable the webview's devtools
+
+ADR-004 stage 4.1: this entry point also mints the per-launch capability
+token that gates /api/* and /ws (see backend/auth.py). It is passed to
+create_app() and handed to the window as a URL fragment; nothing is
+persisted. A developer running the SPA from a vite dev server instead of
+this shell sets GRAPHLINK_DEV_AUTH_TOKEN (and GRAPHLINK_DEV_WS_ORIGIN) -
+neither is ever set by this file.
 """
 
 from __future__ import annotations
@@ -43,33 +50,50 @@ def _free_port() -> int:
         return probe.getsockname()[1]
 
 
-def _wait_for_health(base_url: str, timeout: float, thread: threading.Thread | None = None) -> bool:
+def _wait_for_health(
+    base_url: str,
+    timeout: float,
+    thread: threading.Thread | None = None,
+    auth_token: str | None = None,
+) -> bool:
     """thread, when supplied, is checked for liveness on every poll
     iteration BEFORE attempting a request - a dead backend thread (e.g.
     create_app()/server.run() raised immediately) is a distinct, terminal
     failure, not "still connecting": without this check, a thread that died
     in the first millisecond still made the caller wait out the full
-    timeout before reporting a misleading "did not become healthy"."""
+    timeout before reporting a misleading "did not become healthy".
+
+    auth_token (ADR-004 stage 4.1) is required because /api/health is gated
+    like every other /api route - this poll is the one legitimate caller,
+    and it has the token because main() minted it just above."""
     deadline = time.monotonic() + timeout
+    headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
     while time.monotonic() < deadline:
         if thread is not None and not thread.is_alive():
             return False
         try:
-            with urllib.request.urlopen(f"{base_url}/api/health", timeout=1.0) as response:
+            request = urllib.request.Request(f"{base_url}/api/health", headers=headers)
+            with urllib.request.urlopen(request, timeout=1.0) as response:
                 if response.status == 200:
                     return True
         except OSError:
+            # HTTPError (a 401 from a token mismatch) is a subclass of
+            # OSError, so a broken token shows up here as "never became
+            # healthy" rather than as a crash - the same terminal outcome,
+            # logged by the caller.
             time.sleep(0.1)
     return False
 
 
-def _start_backend(port: int, previous_run_crashed: bool = False) -> tuple[uvicorn.Server, threading.Thread]:
+def _start_backend(
+    port: int, previous_run_crashed: bool = False, auth_token: str | None = None
+) -> tuple[uvicorn.Server, threading.Thread]:
     import uvicorn
 
     from backend.app import create_app
 
     config = uvicorn.Config(
-        create_app(previous_run_crashed=previous_run_crashed),
+        create_app(previous_run_crashed=previous_run_crashed, auth_token=auth_token),
         host="127.0.0.1",
         port=port,
         log_level="warning",
@@ -102,6 +126,7 @@ def main() -> int:
     # basicConfig call - see backend/crash_recovery.py's own docstring for
     # why these two calls (and the sentinel check/mark_running below) live
     # here, in the real entry point, rather than inside create_app().
+    from backend.auth import mint_token
     from backend.crash_recovery import (
         configure_logging,
         install_exception_handlers,
@@ -136,8 +161,18 @@ def main() -> int:
         port = _free_port()
     base_url = f"http://127.0.0.1:{port}"
 
-    server, backend_thread = _start_backend(port, previous_run_crashed=crashed)
-    if not _wait_for_health(base_url, STARTUP_TIMEOUT_SECONDS, thread=backend_thread):
+    # ADR-004 stage 4.1: one fresh capability token per launch, never
+    # persisted - see backend/auth.py's docstring for the threat it closes
+    # (audit C5: any local process can drive all 131 intents, including the
+    # approve-code-execution gate itself).
+    auth_token = mint_token()
+
+    server, backend_thread = _start_backend(
+        port, previous_run_crashed=crashed, auth_token=auth_token
+    )
+    if not _wait_for_health(
+        base_url, STARTUP_TIMEOUT_SECONDS, thread=backend_thread, auth_token=auth_token
+    ):
         logger.error("backend did not become healthy at %s within %.0fs", base_url, STARTUP_TIMEOUT_SECONDS)
         _shutdown_backend(server, backend_thread)
         mark_clean_exit()
@@ -146,9 +181,17 @@ def main() -> int:
 
     import webview  # pywebview - the native (non-Qt, non-browser) window
 
+    # The token reaches the SPA as a URL FRAGMENT, which the browser never
+    # sends to the server - so it cannot land in an access log or a Referer
+    # header the way a query string could, and this window has no address bar
+    # to display it. web_ui/src/lib/auth/token.ts reads it once at module
+    # load. Never logged here either: `base_url` (without the fragment) is
+    # what goes to the log line above, deliberately.
+    window_url = f"{base_url}/#token={auth_token}"
+
     webview.create_window(
         "Graphlink",
-        url=base_url,
+        url=window_url,
         width=1440,
         height=900,
         min_size=(960, 600),

--- a/tests/test_graphlink_desktop.py
+++ b/tests/test_graphlink_desktop.py
@@ -170,6 +170,8 @@ def desktop_harness(tmp_path, monkeypatch):
         webview_start_calls=[],
         webview_start_side_effect=None,
         wait_for_health_result=True,
+        start_backend_auth_tokens=[],
+        wait_for_health_auth_tokens=[],
     )
 
     spa_index = tmp_path / "web_ui" / "dist" / "app" / "index.html"
@@ -193,10 +195,16 @@ def desktop_harness(tmp_path, monkeypatch):
     fake_server = _FakeServer()
     fake_thread = _FakeThread(alive=True)
 
-    def fake_start_backend(port, previous_run_crashed=False):
+    def fake_start_backend(port, previous_run_crashed=False, auth_token=None):
+        # ADR-004 stage 4.1: recorded, not ignored - the token main() mints
+        # is exactly what test_main_always_starts_the_backend_with_a_
+        # capability_token below asserts on, so "shipped with auth
+        # accidentally disabled" is a test failure rather than silent.
+        state.start_backend_auth_tokens.append(auth_token)
         return fake_server, fake_thread
 
-    def fake_wait_for_health(base_url, timeout, thread=None):
+    def fake_wait_for_health(base_url, timeout, thread=None, auth_token=None):
+        state.wait_for_health_auth_tokens.append(auth_token)
         return state.wait_for_health_result
 
     def fake_shutdown_backend(server, thread):
@@ -257,7 +265,12 @@ def test_main_uses_the_pinned_port_when_env_var_is_a_valid_integer(desktop_harne
 
     assert result == 0
     (_args, kwargs) = desktop_harness.webview_create_window_calls[0]
-    assert kwargs["url"] == "http://127.0.0.1:54321"
+    # Asserts the ORIGIN only. This used to compare the whole URL string,
+    # but ADR-004 stage 4.1 appends a "/#token=<token>" fragment - and this
+    # test is about the port env var, not the token (which has its own
+    # dedicated test below). Splitting on "#" keeps it testing its own
+    # concern instead of re-asserting an unrelated one.
+    assert kwargs["url"].split("#", 1)[0].rstrip("/") == "http://127.0.0.1:54321"
 
 
 def test_main_clears_the_crash_sentinel_even_when_webview_start_raises(desktop_harness):
@@ -301,3 +314,60 @@ def test_main_shuts_down_the_backend_when_the_health_check_times_out(desktop_har
     assert desktop_harness.shutdown_calls == [(desktop_harness.fake_server, desktop_harness.fake_thread)]
     assert desktop_harness.mark_clean_exit_calls == 1
     assert desktop_harness.webview_create_window_calls == [], "must never reach the window if never healthy"
+
+
+# -- ADR-004 stage 4.1: capability-token security invariants --------------
+#
+# These are the tests that make "the shipped app runs with auth enabled" a
+# checked property rather than a convention. create_app(auth_token=None)
+# deliberately DISABLES auth so the ~1200-test suite needs no token
+# plumbing to exercise unrelated behavior (see backend/auth.py's
+# resolve_configured_token) - which means the only thing standing between
+# that convenience and shipping an unauthenticated app is this file
+# asserting the real launch path always supplies a real token.
+
+
+def test_main_always_starts_the_backend_with_a_capability_token(desktop_harness):
+    result = graphlink_desktop.main()
+
+    assert result == 0
+    assert len(desktop_harness.start_backend_auth_tokens) == 1
+    token = desktop_harness.start_backend_auth_tokens[0]
+    assert token, "the shipped launch path must never start the backend with auth disabled"
+    # secrets.token_urlsafe(32) is ~43 URL-safe characters; asserting a real
+    # length floor (not just truthiness) catches a future refactor that
+    # replaces the mint with something trivially guessable like "dev" or "".
+    assert len(token) >= 32
+
+
+def test_main_mints_a_different_token_on_every_launch(desktop_harness):
+    graphlink_desktop.main()
+    graphlink_desktop.main()
+
+    first, second = desktop_harness.start_backend_auth_tokens
+    assert first != second, "a per-launch capability must not be stable across launches"
+
+
+def test_main_authenticates_its_own_health_poll_with_the_same_token(desktop_harness):
+    # /api/health is gated like every other /api route, so the startup poll
+    # is itself an authenticated caller - if these two ever diverge, the app
+    # deadlocks at boot ("backend did not become healthy") rather than
+    # failing loudly, which is exactly the kind of bug worth pinning.
+    graphlink_desktop.main()
+
+    assert desktop_harness.start_backend_auth_tokens == desktop_harness.wait_for_health_auth_tokens
+
+
+def test_main_passes_the_token_to_the_window_as_a_url_fragment(desktop_harness):
+    graphlink_desktop.main()
+
+    (_args, kwargs) = desktop_harness.webview_create_window_calls[0]
+    token = desktop_harness.start_backend_auth_tokens[0]
+    url = kwargs["url"]
+    # A FRAGMENT specifically, not a query string: fragments are never sent
+    # to the server, so the token cannot land in an access log or a Referer
+    # header. Asserting the "#" placement (not just "token is in the url")
+    # is the whole point - a query-string regression would still contain
+    # the substring while losing the property.
+    assert f"#token={token}" in url
+    assert url.split("#", 1)[0].endswith("/"), "the fragment must not corrupt the page path"

--- a/web_ui/src/app/canvas/ChartNodeView.tsx
+++ b/web_ui/src/app/canvas/ChartNodeView.tsx
@@ -1,5 +1,6 @@
 import { Handle, NodeResizer, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useEffect, useRef, useState } from "react";
+import { withAuthToken } from "../../lib/auth/token";
 import {
   CHART_MAX_HEIGHT,
   CHART_MAX_WIDTH,
@@ -84,7 +85,11 @@ export type ChartFlowNode = Node<ChartNodeData, "chart">;
  * as a different URL and actually refetches instead of serving a cached
  * response. */
 export function chartAssetUrl(chartAssetId: string, version: number): string {
-  return `/api/assets/${chartAssetId}?v=${version}`;
+  // ADR-004 stage 4.1: the capability token appends AFTER the `v` param
+  // (withAuthToken picks "&" because a query string already exists), same
+  // browser-image-loader-cannot-send-headers reason as ImageNodeView's own
+  // assetUrl. A no-op when no token is present.
+  return withAuthToken(`/api/assets/${chartAssetId}?v=${version}`);
 }
 
 /** The dedicated export endpoint (a real 3x-resolution re-render - see
@@ -93,7 +98,9 @@ export function chartAssetUrl(chartAssetId: string, version: number): string {
  * mirrors this app's single-session-per-window assumption everywhere else
  * (see lib/ws/transport.ts's own defaultWsUrl default parameter). */
 export function chartExportUrl(nodeId: string): string {
-  return `/api/assets/chart/${nodeId}/export?session=default`;
+  // ADR-004 stage 4.1: this one is a plain <a href> the user clicks, so it
+  // has no way to carry a header either - same query-param treatment.
+  return withAuthToken(`/api/assets/chart/${nodeId}/export?session=default`);
 }
 
 function chartTypeBadgeLabel(chartType: string): string {

--- a/web_ui/src/app/canvas/ImageNodeView.tsx
+++ b/web_ui/src/app/canvas/ImageNodeView.tsx
@@ -1,5 +1,6 @@
 import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useState } from "react";
+import { withAuthToken } from "../../lib/auth/token";
 import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { NodeMenu } from "./NodeMenu";
 
@@ -63,7 +64,11 @@ interface MenuPosition {
  * below and both menu actions (Copy Image, Export Image) all call this, so
  * they can never disagree with each other about the endpoint shape. */
 function assetUrl(imageAssetId: string): string {
-  return `/api/assets/${imageAssetId}`;
+  // ADR-004 stage 4.1: carries the capability token as a query param, since
+  // the <img> render below is loaded by the browser's own image loader and
+  // cannot be given an Authorization header. A no-op when no token is
+  // present (vitest, vite-dev).
+  return withAuthToken(`/api/assets/${imageAssetId}`);
 }
 
 /** A reasonable download filename for Export Image: the prompt, slugified,

--- a/web_ui/src/lib/auth/token.test.ts
+++ b/web_ui/src/lib/auth/token.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { authHeaders, getAuthToken, withAuthToken } from "./token";
+
+/**
+ * ADR-004 stage 4.1. These tests set window.location.hash directly rather
+ * than mocking the module, because "reads the real fragment the desktop
+ * shell wrote" is the actual contract under test - a mocked getAuthToken
+ * would pass even if the parsing were wrong.
+ */
+
+function setFragment(fragment: string): void {
+  window.location.hash = fragment;
+}
+
+afterEach(() => {
+  setFragment("");
+});
+
+describe("getAuthToken", () => {
+  it("reads the token graphlink_desktop.py puts in the URL fragment", () => {
+    setFragment("#token=abc123");
+    expect(getAuthToken()).toBe("abc123");
+  });
+
+  it("returns null when there is no fragment at all", () => {
+    // The normal case for vitest and for the vite-dev workflow - every
+    // helper here must degrade to a no-op rather than throwing.
+    expect(getAuthToken()).toBeNull();
+  });
+
+  it("returns null when the fragment carries other keys but no token", () => {
+    setFragment("#something=else");
+    expect(getAuthToken()).toBeNull();
+  });
+
+  it("finds the token alongside other fragment keys", () => {
+    setFragment("#other=1&token=abc123");
+    expect(getAuthToken()).toBe("abc123");
+  });
+
+  it("treats an empty token value as absent", () => {
+    setFragment("#token=");
+    expect(getAuthToken()).toBeNull();
+  });
+});
+
+describe("withAuthToken", () => {
+  it("appends with ? when the url has no query string", () => {
+    setFragment("#token=abc123");
+    expect(withAuthToken("/api/assets/xyz")).toBe("/api/assets/xyz?token=abc123");
+  });
+
+  it("appends with & when the url already has a query string", () => {
+    // The chart asset URL case: /api/assets/{id}?v={version} must keep its
+    // cache-buster and gain the token, not lose one to the other.
+    setFragment("#token=abc123");
+    expect(withAuthToken("/api/assets/xyz?v=7")).toBe("/api/assets/xyz?v=7&token=abc123");
+  });
+
+  it("returns the url untouched when there is no token", () => {
+    // Why every pre-existing URL-builder test still passes unchanged: with
+    // no fragment, this is the identity function.
+    expect(withAuthToken("/api/assets/xyz?v=7")).toBe("/api/assets/xyz?v=7");
+  });
+
+  it("percent-encodes the token so an exotic value cannot break the query string", () => {
+    setFragment("#token=" + encodeURIComponent("a&b=c"));
+    expect(withAuthToken("/api/assets/xyz")).toBe("/api/assets/xyz?token=a%26b%3Dc");
+  });
+});
+
+describe("authHeaders", () => {
+  it("builds a Bearer header when a token is present", () => {
+    setFragment("#token=abc123");
+    expect(authHeaders()).toEqual({ Authorization: "Bearer abc123" });
+  });
+
+  it("is an empty object when there is no token, so it can always be spread", () => {
+    expect(authHeaders()).toEqual({});
+  });
+});

--- a/web_ui/src/lib/auth/token.ts
+++ b/web_ui/src/lib/auth/token.ts
@@ -1,0 +1,86 @@
+/**
+ * ADR-004 stage 4.1: the client half of the per-launch capability token.
+ *
+ * graphlink_desktop.py mints a 256-bit token per launch and opens the window
+ * at `http://127.0.0.1:<port>/#token=<token>`. Every /api/* request and the
+ * /ws handshake must carry it back, or the backend answers 401 / closes the
+ * socket - see backend/auth.py's own docstring for the threat this closes
+ * (audit C5: any other local process can otherwise drive all 131 intents,
+ * including the approve-code-execution gate itself).
+ *
+ * WHY THE FRAGMENT IS READ ON EVERY CALL rather than cached at module load:
+ * a property read plus a short string split is free next to the network
+ * request it is about to authenticate, and not caching removes a whole class
+ * of bug (a stale cache after any navigation, and cross-test leakage in
+ * vitest where the module registry is shared but `window.location` is not).
+ *
+ * WHY THE FRAGMENT IS NOT STRIPPED after reading. Stripping it (via
+ * history.replaceState) would hide the token from devtools, but it would
+ * also mean any page reload - Ctrl+R in a debug window, or a programmatic
+ * location.reload() - permanently loses the token and bricks the window
+ * until the app is relaunched. In a pywebview window there is no address bar
+ * to leak it to and no other origin to leak it at, so keeping it is the
+ * clearly better trade. Fragments are never sent to the server, so this
+ * still keeps the token out of access logs and Referer headers, which is the
+ * property that actually matters.
+ *
+ * Every function here degrades to a no-op when there is no token in the URL.
+ * That is the normal case for two legitimate callers: the vitest suite (no
+ * fragment, and the backend under test has auth disabled), and a developer
+ * running the vite dev server, who instead sets GRAPHLINK_DEV_AUTH_TOKEN on
+ * the backend and appends the same value to the URL by hand.
+ */
+
+const TOKEN_FRAGMENT_KEY = "token";
+
+/**
+ * The capability token from the URL fragment, or null when there isn't one.
+ *
+ * Parsed with URLSearchParams over the fragment body so a future second
+ * fragment key cannot break this, and so percent-encoding is handled for
+ * free - though `secrets.token_urlsafe` (backend/auth.py) only ever produces
+ * characters that need no escaping.
+ */
+export function getAuthToken(): string | null {
+  if (typeof window === "undefined" || !window.location) return null;
+  const hash = window.location.hash;
+  if (!hash || hash.length < 2) return null;
+  const params = new URLSearchParams(hash.slice(1));
+  const token = params.get(TOKEN_FRAGMENT_KEY);
+  return token ? token : null;
+}
+
+/**
+ * Append the token to a URL as a `token=` query parameter.
+ *
+ * The query-parameter form (rather than an Authorization header) is
+ * mandatory for the asset endpoints: `<img src="/api/assets/...">` is loaded
+ * by the browser's own image loader, which cannot be given headers. Using
+ * the SAME builder for the fetch() call sites too - rather than headers
+ * there and a query param here - keeps one URL shape per endpoint, so the
+ * <img> tag and the fetch of the same asset can never diverge.
+ *
+ * Picks the separator from whether the URL already has a query string, so it
+ * composes correctly with existing params (e.g. chart's `?v=<version>`
+ * cache-buster).
+ */
+export function withAuthToken(url: string): string {
+  const token = getAuthToken();
+  if (!token) return url;
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}${TOKEN_FRAGMENT_KEY}=${encodeURIComponent(token)}`;
+}
+
+/**
+ * `Authorization: Bearer <token>` headers for a fetch(), or an empty object
+ * when there is no token - so a call site can always spread this into its
+ * RequestInit without branching.
+ *
+ * Not used by the asset paths (see withAuthToken above on why those carry
+ * the token in the URL instead); provided for any future /api call made with
+ * fetch() where the header form is the more natural fit.
+ */
+export function authHeaders(): Record<string, string> {
+  const token = getAuthToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -20,6 +20,8 @@
  * the UI without any component doing anything.
  */
 
+import { withAuthToken } from "../auth/token";
+
 export type ConnectionStatus = "connecting" | "open" | "closed";
 
 export type StateListener = (payload: Record<string, unknown>) => void;
@@ -46,7 +48,14 @@ export interface WsTransportOptions {
 
 export function defaultWsUrl(sessionId = "default"): string {
   const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
-  return `${proto}//${window.location.host}/ws?session=${encodeURIComponent(sessionId)}`;
+  // ADR-004 stage 4.1: the capability token rides in the query string
+  // rather than a header - the browser WebSocket constructor takes a URL and
+  // nothing else, so a header is not an option on this handshake. The
+  // backend accepts either form (backend/auth.py's extract_presented_token).
+  // A no-op when there is no token (vitest, and the vite-dev workflow).
+  return withAuthToken(
+    `${proto}//${window.location.host}/ws?session=${encodeURIComponent(sessionId)}`,
+  );
 }
 
 export class WsTransport {


### PR DESCRIPTION
## Problem

The loopback HTTP/WS port has no authentication (audit finding C5). Any other process running as the same user can open `/ws` and drive all 131 intents — including `runPyCoder`, `runCodeSandbox`, `applyGitlinkChanges`, and `approveCodeExecution`. That last one is the sharp edge: the human-approval gate is itself an intent on the same unauthenticated channel, so a non-browser caller can approve its own code execution.

The existing WS Origin check is good and stays untouched, but it defends a different threat — a malicious page in the user's browser, which cannot forge `Origin`. It does nothing against a local process, which can send any `Origin` it likes or omit it entirely (a branch `_is_allowed_ws_origin` deliberately allows).

## Change

`graphlink_desktop.py` mints a 256-bit token per launch, passes it to `create_app()`, and hands it to the window as a URL **fragment**. Fragments are never sent to the server, so the token can't reach an access log or a `Referer` header, and the pywebview window has no address bar to display it. Nothing is persisted — the token lives only in the running process and the window it spawned.

New `backend/auth.py` owns the primitives (mint, extract, constant-time compare, path matching). Enforcement is in two places because Starlette's HTTP middleware never sees WebSocket scopes:

- `/api/*` — HTTP middleware, chosen over per-route dependencies so a future `/api` route is covered by construction rather than by remembering a decorator.
- `/ws` — inside `ws_endpoint`, after the origin check. Closed before `accept()`, so an unauthenticated caller also can't reach the C6 session-growth vector.

Both accept `Authorization: Bearer` or `?token=`. The query form is **mandatory, not a convenience**: `<img src="/api/assets/...">` is loaded by the browser's own image loader and cannot carry headers, and the same applies to the chart export `<a href>`.

Frontend: new `web_ui/src/lib/auth/token.ts` reads the fragment; the four existing URL builders (`defaultWsUrl`, `assetUrl`, `chartAssetUrl`, `chartExportUrl`) route through it. Every helper is a no-op when no token is present, which is why all pre-existing URL-builder tests pass unchanged.

`/api/health` is gated too rather than carved out — its only caller is the shell's own startup poll, which has the token, and leaving it open would hand any local process a free "is Graphlink running, and what version" oracle.

### Design note worth reviewing

`create_app()` with no token **disables** auth, so the existing suite needs no token plumbing to exercise unrelated behavior. The thing that stops that convenience from silently becoming the shipped behavior is `tests/test_graphlink_desktop.py`, which asserts the real launch path always mints a token, that it differs per launch, and that it reaches the window as a fragment rather than a query string.

The dev-server workflow gets `GRAPHLINK_DEV_AUTH_TOKEN`, matching the existing `GRAPHLINK_DEV_WS_ORIGIN` precedent. Neither is ever set by the shipped launch path.

## Test plan

- [x] `backend/tests/test_auth.py` (new, 23 tests): rejection without/with a wrong token on both surfaces; acceptance in both presentation forms; uniform 401 body so it isn't an oracle; asset routes gated; SPA bootstrap *not* gated; no session created by a rejected handshake; prefix-confusion cases (`/apidocs` not gated); non-ASCII token doesn't raise
- [x] `web_ui/src/lib/auth/token.test.ts` (new, 11 tests): fragment parsing, `?`-vs-`&` separator selection, percent-encoding, no-token no-op
- [x] Mutation-verified: disabling HTTP gating fails 6 tests, disabling WS gating fails 3 — both reverted to a clean diff
- [x] Full backend suite: 1265 passed
- [x] Full frontend `npm run check`: tsc clean, 0 lint errors, 1133 passed