### PR TITLE
ADR-004 stage 4.3: session issuance restriction + idle eviction

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -587,6 +587,17 @@ class AgentDispatcher:
         backend/run_lifecycle.py's own docstring."""
         self._runs.cancel_all()
 
+    def has_in_flight_runs(self) -> bool:
+        """ADR-004 stage 4.3: the veto backend/app.py's session-eviction
+        callback checks before tearing an idle session down. A monotonic-
+        time TTL alone is not a substitute for actually knowing whether
+        cooperative cancellation (cancel_all() above) has genuinely
+        finished - this is a direct, cheap check of the same registry
+        cancel_all() itself walks (self._runs, one claimed RunHandle per
+        in-flight request across every kind), not a second bookkeeping
+        mechanism that could drift from it."""
+        return bool(self._runs.values())
+
     def cancel_web_research(self, request_id: str) -> bool:
         """kind="web_research": ADR-002 stage 2.4e - the first surface to
         actually exercise RunHandle.on_cancel (added in stage 2.4b), since

--- a/backend/app.py
+++ b/backend/app.py
@@ -50,10 +50,22 @@ from backend.canvas import register_canvas
 from backend.chat_library import register_chat_library
 from backend.composer import register_composer
 from backend.crash_recovery import maybe_show_crash_notice
-from backend.events import EventBus, SessionBus, UnknownIntentError, UnknownTopicError
+from backend.events import (
+    DEFAULT_SESSION_ID,
+    EventBus,
+    SessionBus,
+    UnknownIntentError,
+    UnknownSessionError,
+    UnknownTopicError,
+)
 from backend.notifications import register_notifications
 from backend.plugins import register_plugins
-from backend.session_context import SessionContext, attach_session_context, get_session_context
+from backend.session_context import (
+    SessionContext,
+    SessionNotConfiguredError,
+    attach_session_context,
+    get_session_context,
+)
 from backend.settings import register_settings
 from backend.token_counter import register_token_counter
 
@@ -227,12 +239,47 @@ def _configure_session(
     register_chat_library(bus, chat_db_path, canvas_document, notifications_state)
 
 
+def _evict_idle_session(bus: SessionBus) -> bool:
+    """ADR-004 stage 4.3: EventBus.sweep_idle_sessions' injected teardown -
+    see that method's own docstring for why this lives here rather than in
+    backend/events.py (SessionContext/AgentDispatcher knowledge belongs to
+    this module, not the domain-agnostic event bus).
+
+    Returns False (veto the eviction, try again next sweep) if a real
+    in-flight run is still active - a monotonic-time TTL is not a
+    substitute for actually knowing cancellation has finished. Otherwise
+    performs the same disconnect-time teardown ws_endpoint's own finally
+    block already does on a normal last-connection-drops path (cancel_all
+    + cancel_all_pending_approvals), plus the one thing that path never
+    had to do because it never applied to an ABANDONED session before this
+    stage: cancel the autosave task, so its closure stops holding the
+    whole SceneDocument alive via a strong reference nothing can ever
+    reach again once this session is gone from EventBus._sessions.
+    """
+    try:
+        context = get_session_context(bus)
+    except SessionNotConfiguredError:
+        # A bus that never finished _configure_session (a genuine failure
+        # during setup) has no dispatcher/document to tear down - safe to
+        # evict outright rather than getting stuck vetoing forever.
+        return True
+    if context.agent_dispatcher.has_in_flight_runs():
+        return False
+    context.agent_dispatcher.cancel_all()
+    context.agent_dispatcher.cancel_all_pending_approvals()
+    autosave_task = getattr(bus, "autosave_task", None)
+    if autosave_task is not None and not autosave_task.done():
+        autosave_task.cancel()
+    return True
+
+
 def create_app(
     spa_dir: Path | None = None,
     settings_state_file: Path | None = None,
     chat_db_path: Path | None = None,
     previous_run_crashed: bool = False,
     auth_token: str | None = None,
+    restrict_sessions: bool = True,
 ) -> FastAPI:
     app = FastAPI(title="Graphlink backend", version=BACKEND_VERSION)
     # ADR-004 stage 4.1: the per-launch capability token gating /api/* and
@@ -259,7 +306,19 @@ def create_app(
     bus = EventBus(
         configure_session=lambda session_bus: _configure_session(
             session_bus, settings_manager, chat_db_path, previous_run_crashed
-        )
+        ),
+        # ADR-004 stage 4.3: see _evict_idle_session's own docstring.
+        evict_idle_session=_evict_idle_session,
+        # restrict_sessions defaults to True (the real, shipped policy);
+        # False is a test-only escape hatch for the handful of tests that
+        # deliberately exercise EventBus's own generic cross-session
+        # isolation THROUGH the real /ws or /api/assets surface, a scenario
+        # that is otherwise unreachable in the shipped app once this
+        # restriction is on (only DEFAULT_SESSION_ID is ever issuable) -
+        # see EventBus's own module docstring for the full ADR-004 stage
+        # 4.3 reasoning on why the restriction lives at this layer, not
+        # unconditionally inside EventBus itself.
+        allowed_session_ids=frozenset({DEFAULT_SESSION_ID}) if restrict_sessions else None,
     )
     app.state.bus = bus
 
@@ -412,9 +471,21 @@ def create_app(
                 # vector either.
                 await websocket.close(code=1008)
                 return
-        session_id = websocket.query_params.get("session", "default")
+        session_id = websocket.query_params.get("session", DEFAULT_SESSION_ID)
         try:
             session = bus.session(session_id)
+        except UnknownSessionError:
+            # ADR-004 stage 4.3: "unknown ids are rejected, not auto-
+            # created" - a distinct branch from the generic except below,
+            # since this is a CLIENT policy violation (an id we never
+            # issued), not a server-side bug. Matches the origin/token
+            # rejection branches above: warning-level log, 1008 (policy
+            # violation), closed before accept() so no session is ever
+            # created for it and the C6 growth vector this stage closes
+            # can never be reached this way either.
+            logger.warning("rejected WS handshake: unknown session_id=%r", session_id)
+            await websocket.close(code=1008)
+            return
         except Exception:
             # R6.7 adversarial-review finding: a bug in one of
             # _configure_session's register_X calls used to be swallowed
@@ -434,6 +505,35 @@ def create_app(
             logger.exception("session setup failed for session_id=%r", session_id)
             await websocket.close(code=1011)
             return
+        # ADR-004 stage 4.3 adversarial-review finding: pin the session
+        # against eviction HERE, in the same synchronous stretch as the
+        # bus.session() lookup above (no await between them) - not just at
+        # session.attach() below. Between this point and attach(), the only
+        # await is websocket.accept(); the free-running eviction sweep runs
+        # as an independent asyncio task and can interleave during that
+        # gap. A session eligible for eviction (idle >= TTL) is exactly the
+        # state a genuine reconnect after a network blip or laptop sleep is
+        # already in by design (see backend/events.py's own TTL reasoning),
+        # so this is not a rare theoretical case - confirmed empirically:
+        # an unforced concurrent-scheduling stress test found the sweep
+        # winning this race in 8/500 trials. Without this line, a session
+        # evicted in that window is torn down (autosave cancelled, removed
+        # from EventBus._sessions) while session.attach() below still
+        # succeeds anyway (attach() has no way to know its bus was just
+        # orphaned) - the client ends up live-attached to a SessionBus
+        # nothing else can ever reach again, split-brained against a fresh
+        # empty one any other route (e.g. GET /api/assets/{id}) would get
+        # for the same session id.
+        #
+        # Known, accepted residual: if websocket.accept() itself raises
+        # (pathological - every upstream check has already passed by this
+        # point), this session's idle_since stays None forever, since
+        # nothing calls .detach() on a session that never reached attach().
+        # That session simply becomes permanently ineligible for eviction
+        # rather than corrupting shared state - a narrow, self-contained
+        # downgrade back to pre-stage-4.3 behavior for that one session,
+        # not the split-brain this fix closes for the common case.
+        session.idle_since = None
         await websocket.accept()
         session.attach(websocket)
         try:

--- a/backend/assets.py
+++ b/backend/assets.py
@@ -33,7 +33,7 @@ import re
 from fastapi import FastAPI, Response
 from fastapi.responses import JSONResponse
 
-from backend.events import EventBus
+from backend.events import EventBus, UnknownSessionError
 from backend.session_context import get_session_context
 from graphlink_chart_rendering import render_chart_png
 
@@ -65,7 +65,17 @@ def register_assets(app: FastAPI, bus: EventBus) -> None:
 
     @app.get("/api/assets/{asset_id}")
     async def get_asset(asset_id: str, session: str = "default") -> Response:
-        document = get_session_context(bus.session(session)).canvas_document
+        try:
+            document = get_session_context(bus.session(session)).canvas_document
+        except UnknownSessionError:
+            # ADR-004 stage 4.3: same observable shape a bogus session
+            # already produced before this stage (bus.session() used to
+            # silently CREATE a fresh, empty document for any string - see
+            # backend/events.py's own docstring - which would have looked
+            # up asset_id in that empty document and hit this exact
+            # "unknown asset" 404 anyway). Preserves the external response
+            # contract; only the internal resource leak this closes.
+            return JSONResponse({"error": "unknown asset"}, status_code=404)
         asset = document.get_image_asset(asset_id)
         if asset is None:
             return JSONResponse({"error": "unknown asset"}, status_code=404)
@@ -74,7 +84,11 @@ def register_assets(app: FastAPI, bus: EventBus) -> None:
 
     @app.get("/api/assets/chart/{node_id}/export")
     async def export_chart(node_id: str, session: str = "default") -> Response:
-        document = get_session_context(bus.session(session)).canvas_document
+        try:
+            document = get_session_context(bus.session(session)).canvas_document
+        except UnknownSessionError:
+            # Same reasoning as get_asset above.
+            return JSONResponse({"error": "unknown chart"}, status_code=404)
         node = document.nodes.get(node_id)
         if node is None or node.kind != "chart":
             return JSONResponse({"error": "unknown chart"}, status_code=404)

--- a/backend/autosave.py
+++ b/backend/autosave.py
@@ -49,17 +49,30 @@ interval rather than racing it (there will be another tick along in
 `interval_seconds`, so skipping one is free; racing a manual operation is
 not).
 
-TASK LIFETIME: deliberately never explicitly cancelled. Every SessionBus
-this backend ever creates lives for the remaining lifetime of the process
-once created - EventBus never removes an entry from its own `_sessions`
-dict, even once every WS connection to it detaches (see backend/events.py) -
-so there is no "session ended" event anywhere in this codebase to hook a
-cancellation to in the first place; this task's own lifetime already
-matches every other piece of a session's state (SceneDocument, ComposerDocument,
-etc.), none of which get torn down early either. This is a pre-existing,
-accepted characteristic of a single-user desktop-shell backend (pywebview),
-not a new leak introduced here - a multi-tenant web server would need real
-session eviction, this does not.
+TASK LIFETIME (updated, ADR-004 stage 4.3): this task now DOES get
+explicitly cancelled - by backend/app.py's own _evict_idle_session, the
+teardown callback EventBus.sweep_idle_sessions() (backend/events.py) calls
+for any session idle (zero connections) for its TTL with no in-flight
+agent run. Before stage 4.3, this section documented the opposite as a
+deliberately-accepted characteristic ("every SessionBus lives for the
+remaining lifetime of the process... a multi-tenant web server would need
+real session eviction, this does not") - that was true when written (no
+"session ended" event existed anywhere to hook a cancellation to), but it
+was also the OTHER half of audit finding C6 alongside unbounded session
+creation: an idle session's task keeps ticking forever, its closure
+holding the whole SceneDocument alive via a strong reference nothing can
+ever reach again. Eviction closes both halves together. Preserved here as
+a record of the prior reasoning, not silently deleted - see this session's
+own "no room for error, document mistakes rather than quietly editing"
+discipline.
+
+This task's own eventual cancellation (via task.cancel(), a cooperative
+request the same as everywhere else in this codebase) is safe here
+specifically because _guarded_tick's own try/finally already always
+leaves mutation_guard in a clean state on any exit path, cancellation
+included (asyncio.CancelledError propagates through a `finally`, same as
+any other exception) - there is no partial-claim state a cancelled tick
+could strand the guard in.
 """
 
 from __future__ import annotations

--- a/backend/events.py
+++ b/backend/events.py
@@ -18,6 +18,53 @@ are session-local, so two windows on different sessions never see each
 other's state. The bus is transport-agnostic: connections are anything with
 an async send_json(dict) - real WebSockets in app.py, plain recorders in
 tests.
+
+ADR-004 stage 4.3: two additions closing audit finding C6 (unbounded
+memory/task growth - any local caller could previously mint a permanent,
+never-evicted SessionBus for any `?session=<anything>` string).
+
+1. Session issuance can be restricted: EventBus.session() only creates a
+   new session for an id in __init__'s own allowed_session_ids, when one
+   was supplied - anything else raises UnknownSessionError, UNLESS a
+   session by that id already exists (a real reconnect always works
+   regardless of the restriction). Unrestricted (the default, None) is
+   unchanged from before this stage - EventBus is a genuinely reusable,
+   domain-agnostic multi-session primitive (see its own tests), and the
+   restriction is an APPLICATION policy, not a property of the class
+   itself. backend/app.py's create_app is the one real caller that
+   restricts to just DEFAULT_SESSION_ID ("default", the one every real
+   window uses - confirmed by grep, web_ui never requests any other id) -
+   this app has no multi-window feature and no mechanism that issues
+   additional ids today, so in practice this means the shipped app's own
+   "default" is the only session that will ever exist there - a
+   deliberately narrow, YAGNI-respecting reading of "must be one the
+   backend issued... or the default window session" rather than building a
+   speculative issuance API nothing calls.
+
+2. Idle eviction: a session with zero connections for
+   session_idle_ttl_seconds gets torn down by the injected
+   evict_idle_session callback (see EventBus.__init__'s own docstring for
+   why teardown is injected rather than implemented here - this module is
+   deliberately domain-agnostic, per the note above). This is genuinely
+   useful even with issuance now locked to "default" only: it closes the
+   OTHER standing gap ADR-004 names, "the autosave task never cancelled"
+   (backend/autosave.py's own docstring used to document this as a
+   deliberately-accepted characteristic of a single-window desktop app -
+   see that module's own updated docstring) - without a TTL, a session
+   that goes idle (window closed without a clean shutdown, or a future
+   multi-window disconnect) keeps a live 30s-interval background task
+   forever, each tick holding the whole SceneDocument alive via closure
+   regardless of whether anything can ever reach it again.
+
+   The TTL is deliberately generous (minutes, not seconds): the frontend's
+   own WsTransport reconnects with backoff after a transient network blip,
+   and naive eviction on the FIRST disconnect would tear down (and lose
+   any not-yet-autosaved edits in) a session that was about to reconnect a
+   moment later. sweep_idle_sessions() is exposed as a public, directly
+   callable method (not just the free-running background loop) for the
+   exact reason backend/autosave.py's own bus.autosave_guarded_tick is:
+   tests need to exercise the real decision logic deterministically,
+   without waiting on or mocking wall-clock sleeps.
 """
 
 from __future__ import annotations
@@ -25,12 +72,33 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import time
 from typing import Any, Awaitable, Callable, Protocol
 
 logger = logging.getLogger(__name__)
 
 StateBuilder = Callable[[], dict[str, Any]]
 IntentHandler = Callable[..., Any | Awaitable[Any]]
+
+# The one session id every real window uses (confirmed by grep:
+# web_ui/src/app/App.tsx's only production call to defaultWsUrl() passes no
+# argument, so it always resolves to this). See the module docstring's
+# ADR-004 stage 4.3 section for why this is the ONLY id EventBus.session()
+# will ever create.
+DEFAULT_SESSION_ID = "default"
+
+# Generous on purpose - see the module docstring's own reasoning: must
+# comfortably outlast a transient WS reconnect gap (network blip, laptop
+# sleep), or eviction would tear down a session the frontend was about to
+# reconnect to anyway.
+DEFAULT_SESSION_IDLE_TTL_SECONDS = 300.0
+DEFAULT_SWEEP_INTERVAL_SECONDS = 60.0
+
+
+class UnknownSessionError(KeyError):
+    """A caller asked for a session id EventBus never issued and isn't
+    DEFAULT_SESSION_ID - ADR-004 stage 4.3's "unknown ids are rejected, not
+    auto-created"."""
 
 
 class Connection(Protocol):
@@ -72,6 +140,15 @@ class SessionBus:
         self._topics: dict[str, _Topic] = {}
         self._intents: dict[tuple[str, str], IntentHandler] = {}
         self._connections: set[Connection] = set()
+        # ADR-004 stage 4.3: monotonic timestamp of when this bus last had
+        # zero connections, or None while at least one is attached. Stamped
+        # at construction time (not left None until a first attach/detach
+        # cycle) so a session that is only ever reached via an HTTP route
+        # that never attaches a connection at all (backend/assets.py's two
+        # routes call EventBus.session() but never .attach()) still starts
+        # its idle clock immediately, rather than being permanently exempt
+        # from eviction by never having transitioned FROM connected.
+        self.idle_since: float | None = time.monotonic()
 
     # -- registration ------------------------------------------------------
 
@@ -110,9 +187,12 @@ class SessionBus:
 
     def attach(self, conn: Connection) -> None:
         self._connections.add(conn)
+        self.idle_since = None
 
     def detach(self, conn: Connection) -> None:
         self._connections.discard(conn)
+        if not self._connections and self.idle_since is None:
+            self.idle_since = time.monotonic()
 
     @property
     def connection_count(self) -> int:
@@ -209,13 +289,125 @@ class EventBus:
     the app's registrar so every session exposes the same topic/intent
     surface over its own state."""
 
-    def __init__(self, configure_session: Callable[[SessionBus], None] | None = None):
+    def __init__(
+        self,
+        configure_session: Callable[[SessionBus], None] | None = None,
+        *,
+        session_idle_ttl_seconds: float = DEFAULT_SESSION_IDLE_TTL_SECONDS,
+        sweep_interval_seconds: float = DEFAULT_SWEEP_INTERVAL_SECONDS,
+        evict_idle_session: Callable[[SessionBus], bool] | None = None,
+        allowed_session_ids: frozenset[str] | None = None,
+    ):
         self._sessions: dict[str, SessionBus] = {}
         self._configure_session = configure_session
+        self._session_idle_ttl_seconds = session_idle_ttl_seconds
+        self._sweep_interval_seconds = sweep_interval_seconds
+        # ADR-004 stage 4.3: None (the default) is the pre-stage-4.3
+        # behavior - EventBus is a genuinely reusable, domain-agnostic
+        # multi-session primitive (see the class docstring), and plenty of
+        # its own tests (backend/tests/test_event_bus.py) construct several
+        # distinct session ids directly to verify the isolation mechanism
+        # itself, independent of any one application's policy about which
+        # ids are legitimate. A real value restricts session() to only ever
+        # CREATE ids in this set (an already-existing id can still be
+        # reconnected to regardless) - backend/app.py's create_app is the
+        # one real caller that supplies one, since the shipped app has
+        # exactly one legitimate session id (DEFAULT_SESSION_ID) and this
+        # is what closes audit finding C6's "any ?session=<anything> mints
+        # a permanent SessionBus" half.
+        self._allowed_session_ids = allowed_session_ids
+        # ADR-004 stage 4.3: injected, not implemented here, because tearing
+        # a session down for real (cancel the autosave task, cancel any
+        # in-flight agent run) needs SessionContext/AgentDispatcher
+        # knowledge this module deliberately doesn't have (see the module
+        # docstring). backend/app.py's create_app supplies the real
+        # implementation. Must return True if eviction should proceed
+        # (after performing its own teardown) or False to skip this
+        # session for this sweep (e.g. it found a real in-flight run a
+        # monotonic-time TTL alone can't safely second-guess).
+        self._evict_idle_session = evict_idle_session
+        self._eviction_task: asyncio.Task | None = None
 
-    def session(self, session_id: str = "default") -> SessionBus:
+    def _ensure_eviction_loop_started(self) -> None:
+        """Starts the free-running sweep loop, lazily and idempotently, on
+        the first call made from within a running event loop.
+
+        Not started in __init__: EventBus is very often constructed before
+        any event loop is running (create_app() itself always runs
+        synchronously, before uvicorn.Server.run() starts one - see
+        graphlink_desktop.py's own _start_backend) - matches
+        backend/autosave.py's register_autosave's own precedent for the
+        identical constraint, including the try/except RuntimeError
+        fallback: a bare create_app() in a test that never actually drives
+        a request through a running loop simply never starts this, and
+        sweep_idle_sessions() staying independently callable is what makes
+        that non-fatal for testing the real logic."""
+        if self._eviction_task is not None:
+            return
+        loop_coro = self._eviction_loop()
+        try:
+            self._eviction_task = asyncio.create_task(loop_coro)
+        except RuntimeError:
+            logger.warning(
+                "session eviction: no running event loop yet - the background "
+                "sweep is disabled for this process (expected in most test "
+                "contexts; the real ws_endpoint/asset-route call sites always "
+                "have one)"
+            )
+            loop_coro.close()
+
+    async def _eviction_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._sweep_interval_seconds)
+            try:
+                self.sweep_idle_sessions()
+            except Exception:
+                # Same "one bad tick must never end the loop forever"
+                # reasoning as backend/autosave.py's own _loop().
+                logger.exception("session eviction sweep failed")
+
+    def sweep_idle_sessions(self) -> list[str]:
+        """Evict every session idle (zero connections) for at least
+        session_idle_ttl_seconds AND not vetoed by evict_idle_session.
+        Directly callable - no sleep involved - so tests can exercise the
+        real decision logic deterministically; see the module docstring's
+        own note on why, and backend/autosave.py's bus.autosave_guarded_tick
+        for the established precedent this mirrors.
+
+        Returns the evicted session ids, sorted."""
+        if self._evict_idle_session is None:
+            return []
+        now = time.monotonic()
+        evicted: list[str] = []
+        for session_id, bus in list(self._sessions.items()):
+            if bus.idle_since is None:
+                continue  # at least one live connection
+            if now - bus.idle_since < self._session_idle_ttl_seconds:
+                continue  # idle, but not for long enough yet
+            if not self._evict_idle_session(bus):
+                # The callback found a reason not to (e.g. a real in-flight
+                # run) - reconsidered next sweep, not retried immediately.
+                continue
+            del self._sessions[session_id]
+            evicted.append(session_id)
+            logger.info(
+                "evicted idle session %r after %.0fs with no connection",
+                session_id, now - bus.idle_since,
+            )
+        return sorted(evicted)
+
+    def session(self, session_id: str = DEFAULT_SESSION_ID) -> SessionBus:
+        self._ensure_eviction_loop_started()
         bus = self._sessions.get(session_id)
         if bus is None:
+            if self._allowed_session_ids is not None and session_id not in self._allowed_session_ids:
+                # ADR-004 stage 4.3: "unknown ids are rejected, not
+                # auto-created" - only when this EventBus was constructed
+                # with a real allowed_session_ids restriction (see
+                # __init__'s own docstring); unrestricted (the default)
+                # creates any id on first use, exactly as before this
+                # stage.
+                raise UnknownSessionError(session_id)
             bus = SessionBus(session_id)
             if self._configure_session is not None:
                 self._configure_session(bus)

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -20,7 +20,7 @@ import api_provider
 import graphlink_task_config as config
 
 
-def make_client(tmp_path: Path | None = None) -> TestClient:
+def make_client(tmp_path: Path | None = None, *, restrict_sessions: bool = True) -> TestClient:
     # Point spa_dir at a guaranteed-missing directory: R0 tests exercise the
     # API surface, not the static build (the acceptance drive covers that).
     spa = tmp_path if tmp_path is not None else Path("__no_such_dir__")
@@ -38,6 +38,13 @@ def make_client(tmp_path: Path | None = None) -> TestClient:
             spa_dir=spa,
             settings_state_file=state_path / "session.dat",
             chat_db_path=state_path / "chats.db",
+            # ADR-004 stage 4.3: True (the default) matches the real
+            # shipped policy - only "default" is ever issuable. A caller
+            # here can pass False for the rare test that deliberately
+            # exercises EventBus's own generic cross-session isolation
+            # THROUGH the real /ws surface (a scenario otherwise
+            # unreachable once this restriction is on).
+            restrict_sessions=restrict_sessions,
         ),
         # ADR-004 stage 4.2: TrustedHostMiddleware now rejects any Host
         # other than 127.0.0.1 - TestClient's own default ("testserver")
@@ -67,15 +74,17 @@ def test_health_reports_ok_and_version():
 
 
 def test_subscribe_delivers_system_snapshot_with_envelope():
+    # ADR-004 stage 4.3: "default" - the only session id the real
+    # (restrict_sessions=True by default) policy ever issues.
     client = make_client()
-    with client.websocket_connect("/ws?session=test-a") as ws:
+    with client.websocket_connect("/ws?session=default") as ws:
         ws.send_json({"kind": "subscribe", "topics": ["system"]})
         message = ws.receive_json()
         assert message["kind"] == "state"
         assert message["topic"] == "system"
         payload = message["payload"]
         assert payload["app"] == "graphlink"
-        assert payload["sessionId"] == "test-a"
+        assert payload["sessionId"] == "default"
         assert payload["schemaVersion"] == 1
         assert payload["revision"] >= 1
 
@@ -143,7 +152,12 @@ def test_unknown_message_kind_returns_error():
 
 
 def test_sessions_do_not_share_connections():
-    client = make_client()
+    # ADR-004 stage 4.3: tests EventBus's own generic cross-session
+    # isolation mechanism, a scenario the real shipped app's restrictive
+    # policy makes unreachable (only "default" is ever issuable there) -
+    # restrict_sessions=False opts this one client out, matching
+    # EventBus's own pre-stage-4.3 default behavior.
+    client = make_client(restrict_sessions=False)
     with client.websocket_connect("/ws?session=a") as ws_a:
         with client.websocket_connect("/ws?session=b") as ws_b:
             ws_a.send_json({"kind": "subscribe", "topics": ["system"]})
@@ -180,7 +194,9 @@ def test_disconnect_cancels_any_in_flight_chat_request(monkeypatch):
     monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, "test-model")
     monkeypatch.setattr(api_provider, "chat", fake_chat)
 
-    with client.websocket_connect("/ws?session=cancel-test") as ws:
+    # ADR-004 stage 4.3: "default" - the only session id the real
+    # (restrict_sessions=True by default) policy ever issues.
+    with client.websocket_connect("/ws?session=default") as ws:
         ws.send_json({"kind": "subscribe", "topics": ["scene"]})
         ws.receive_json()  # initial scene snapshot
         ws.send_json({"kind": "intent", "topic": "scene", "intent": "sendMessage", "args": ["hello"]})
@@ -191,7 +207,7 @@ def test_disconnect_cancels_any_in_flight_chat_request(monkeypatch):
             time.sleep(0.01)
         assert call_started.is_set(), "fake_chat never started - dispatch did not fire"
 
-        session = client.app.state.bus.session("cancel-test")
+        session = client.app.state.bus.session("default")
         in_flight = list(chat_slots(get_session_context(session).agent_dispatcher).values())
         assert len(in_flight) == 1
         cancel_event = in_flight[0]["cancel_event"]
@@ -224,7 +240,9 @@ def test_disconnect_auto_denies_any_pending_pycoder_approval(monkeypatch):
     )
 
     client = make_client()
-    with client.websocket_connect("/ws?session=pycoder-disconnect-test") as ws:
+    # ADR-004 stage 4.3: "default" - the only session id the real
+    # (restrict_sessions=True by default) policy ever issues.
+    with client.websocket_connect("/ws?session=default") as ws:
         ws.send_json({"kind": "subscribe", "topics": ["scene"]})
         ws.receive_json()  # initial scene snapshot
 
@@ -256,7 +274,7 @@ def test_disconnect_auto_denies_any_pending_pycoder_approval(monkeypatch):
         ws.receive_json()  # (1) busy-claim publish
         ws.receive_json()  # (2) awaiting-approval publish
 
-        session = client.app.state.bus.session("pycoder-disconnect-test")
+        session = client.app.state.bus.session("default")
         agent_dispatcher = get_session_context(session).agent_dispatcher
         assert pycoder_slots(agent_dispatcher), "runPyCoder never created a request entry"
         entry = next(iter(pycoder_slots(agent_dispatcher).values()))

--- a/backend/tests/test_assets.py
+++ b/backend/tests/test_assets.py
@@ -15,7 +15,7 @@ from backend.app import create_app
 from backend.session_context import get_session_context
 
 
-def make_client(tmp_path: Path | None = None) -> TestClient:
+def make_client(tmp_path: Path | None = None, *, restrict_sessions: bool = True) -> TestClient:
     # Same isolation convention as test_app_ws.py's make_client: a fresh temp
     # dir per client so tests never touch the developer's real
     # ~/.graphlink/session.dat or ~/.graphlink/chats.db.
@@ -27,6 +27,12 @@ def make_client(tmp_path: Path | None = None) -> TestClient:
             spa_dir=spa,
             settings_state_file=state_path / "session.dat",
             chat_db_path=state_path / "chats.db",
+            # ADR-004 stage 4.3: see test_app_ws.py's own make_client for
+            # why this passthrough exists - a few tests below deliberately
+            # exercise cross-session scoping at this route with a
+            # non-default session id, otherwise unreachable in the real
+            # (restrict_sessions=True by default) shipped policy.
+            restrict_sessions=restrict_sessions,
         ),
         # ADR-004 stage 4.2: see test_app_ws.py's own make_client for why
         # BOTH kwargs are required (base_url for HTTP, headers= because
@@ -78,7 +84,7 @@ def test_get_asset_for_unknown_id_returns_404_json():
 
 
 def test_get_asset_scopes_by_session_query_param():
-    client = make_client()
+    client = make_client(restrict_sessions=False)
     bus = client.app.state.bus
     document_a = get_session_context(bus.session("session-a")).canvas_document
     parent = document_a.add_node(0, 0, "parent")
@@ -102,7 +108,7 @@ def test_asset_ids_do_not_collide_across_sessions_with_identical_creation_order(
     # rare fluke, the deterministic median case. That let a request missing
     # or mis-supplying its session query param be silently served a
     # different session's real image instead of a 404.
-    client = make_client()
+    client = make_client(restrict_sessions=False)
     bus = client.app.state.bus
 
     document_a = get_session_context(bus.session("session-a")).canvas_document
@@ -184,7 +190,7 @@ def test_export_chart_for_a_non_chart_node_returns_404_json():
 
 
 def test_export_chart_scopes_by_session_query_param():
-    client = make_client()
+    client = make_client(restrict_sessions=False)
     bus = client.app.state.bus
     document_a = get_session_context(bus.session("session-a")).canvas_document
     parent_a = document_a.add_node(0, 0, "parent")

--- a/backend/tests/test_crash_recovery_notice.py
+++ b/backend/tests/test_crash_recovery_notice.py
@@ -42,8 +42,12 @@ def _client(previous_run_crashed: bool) -> TestClient:
 
 
 def test_a_crashed_previous_run_surfaces_the_notice_on_first_subscribe():
+    # ADR-004 stage 4.3: session id is "default" - each test here gets its
+    # own fresh, isolated _client()/EventBus, so there is no cross-test
+    # collision to avoid by using a distinct id, and "default" is the only
+    # id the real (restrict_sessions=True by default) policy ever issues.
     client = _client(previous_run_crashed=True)
-    with client.websocket_connect("/ws?session=test-crash") as ws:
+    with client.websocket_connect("/ws?session=default") as ws:
         ws.send_json({"kind": "subscribe", "topics": ["notification"]})
         message = ws.receive_json()
 
@@ -56,7 +60,7 @@ def test_a_crashed_previous_run_surfaces_the_notice_on_first_subscribe():
 
 def test_a_clean_previous_run_shows_no_notice():
     client = _client(previous_run_crashed=False)
-    with client.websocket_connect("/ws?session=test-no-crash") as ws:
+    with client.websocket_connect("/ws?session=default") as ws:
         ws.send_json({"kind": "subscribe", "topics": ["notification"]})
         message = ws.receive_json()
 
@@ -65,7 +69,7 @@ def test_a_clean_previous_run_shows_no_notice():
 
 def test_the_notice_can_still_be_dismissed_like_any_other_notification():
     client = _client(previous_run_crashed=True)
-    with client.websocket_connect("/ws?session=test-crash-dismiss") as ws:
+    with client.websocket_connect("/ws?session=default") as ws:
         ws.send_json({"kind": "subscribe", "topics": ["notification"]})
         ws.receive_json()  # the initial crash-notice snapshot
 
@@ -93,14 +97,19 @@ def test_a_session_setup_bug_is_logged_via_this_apps_own_logger_and_closed_clean
 
     monkeypatch.setattr(app_module, "register_about", _boom)
 
+    # ADR-004 stage 4.3: "default" - a non-default id here would now be
+    # rejected by the separate UnknownSessionError branch before ever
+    # reaching _configure_session, so _boom would never fire and this
+    # test would stop exercising the setup-failure path it exists to
+    # cover.
     client = _client(previous_run_crashed=False)
     with caplog.at_level(logging.ERROR, logger="backend.app"):
         with pytest.raises(WebSocketDisconnect) as exc_info:
-            with client.websocket_connect("/ws?session=test-broken-session"):
+            with client.websocket_connect("/ws?session=default"):
                 pass
         assert exc_info.value.code == 1011
 
     assert any(
-        "session setup failed" in record.message and "test-broken-session" in record.message
+        "session setup failed" in record.message and "default" in record.message
         for record in caplog.records
     )

--- a/backend/tests/test_session_lifecycle.py
+++ b/backend/tests/test_session_lifecycle.py
@@ -1,0 +1,448 @@
+"""ADR-004 stage 4.3: session issuance restriction + idle eviction tests.
+
+Split into three layers, matching the module boundaries the implementation
+itself respects (see backend/events.py's own docstring for why):
+
+1. EventBus unit tests - the generic mechanism, unrestricted by default
+   (preserves backend/tests/test_event_bus.py's own coverage of the
+   pre-stage-4.3 behavior) and restricted when allowed_session_ids is
+   supplied.
+2. sweep_idle_sessions unit tests - the eviction DECISION logic, exercised
+   directly (no sleep, no free-running background task) by manipulating
+   SessionBus.idle_since directly - same "test the real logic
+   deterministically" precedent backend/autosave.py's own
+   bus.autosave_guarded_tick established.
+3. Integration tests through the real backend.app.create_app() - the
+   literal exit-criterion behaviors: an unknown ?session= is rejected on
+   both /ws and /api/assets/*, and the real _evict_idle_session callback's
+   in-flight-run veto and autosave-cancellation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from fastapi import WebSocket
+from fastapi.testclient import TestClient
+
+from backend.app import create_app, _evict_idle_session
+from backend.events import DEFAULT_SESSION_ID, EventBus, SessionBus, UnknownSessionError
+from backend.session_context import SessionContext, attach_session_context, get_session_context
+
+
+# -- layer 1: EventBus.session() issuance restriction ------------------------
+
+
+def test_unrestricted_bus_creates_any_session_id():
+    # The pre-stage-4.3 default, preserved: allowed_session_ids=None is the
+    # class's own baseline behavior, matching test_event_bus.py.
+    bus = EventBus()
+    a = bus.session("a")
+    b = bus.session("b")
+    assert a.session_id == "a"
+    assert b.session_id == "b"
+    assert a is not b
+
+
+def test_restricted_bus_creates_only_the_allowed_id():
+    bus = EventBus(allowed_session_ids=frozenset({DEFAULT_SESSION_ID}))
+    default = bus.session(DEFAULT_SESSION_ID)
+    assert default.session_id == DEFAULT_SESSION_ID
+
+
+def test_restricted_bus_rejects_an_unknown_id():
+    bus = EventBus(allowed_session_ids=frozenset({DEFAULT_SESSION_ID}))
+    with pytest.raises(UnknownSessionError):
+        bus.session("attacker-chosen-id")
+
+
+def test_restricted_bus_rejecting_an_unknown_id_does_not_create_it():
+    # The whole point: a rejected id must never be added to _sessions -
+    # otherwise a repeated attempt would eventually succeed once the
+    # exception-raising branch had already (incorrectly) inserted it.
+    bus = EventBus(allowed_session_ids=frozenset({DEFAULT_SESSION_ID}))
+    with pytest.raises(UnknownSessionError):
+        bus.session("attacker-chosen-id")
+    assert bus.session_ids() == []
+    with pytest.raises(UnknownSessionError):
+        bus.session("attacker-chosen-id")
+
+
+def test_restricted_bus_still_allows_reconnecting_to_an_id_that_already_exists():
+    # A real reconnect (the SAME id calling session() a second time) must
+    # keep working regardless of the restriction - this is what makes
+    # "default" itself (created once, then reconnected to many times over
+    # a session's life) work at all under a restrictive policy.
+    bus = EventBus(allowed_session_ids=frozenset({DEFAULT_SESSION_ID}))
+    first = bus.session(DEFAULT_SESSION_ID)
+    second = bus.session(DEFAULT_SESSION_ID)
+    assert first is second
+
+
+# -- layer 2: sweep_idle_sessions decision logic ------------------------------
+
+
+def _configure(bus: SessionBus) -> None:
+    bus.register_topic("t", lambda: {})
+
+
+def test_sweep_is_a_no_op_without_an_evict_callback():
+    bus = EventBus(configure_session=_configure)
+    session = bus.session("s1")
+    session.idle_since -= 10_000  # far past any real TTL
+    assert bus.sweep_idle_sessions() == []
+    assert bus.session_ids() == ["s1"]
+
+
+def test_sweep_never_evicts_a_session_with_a_live_connection():
+    bus = EventBus(configure_session=_configure, session_idle_ttl_seconds=0.0, evict_idle_session=lambda b: True)
+    session = bus.session("s1")
+
+    class _Conn:
+        async def send_json(self, data):
+            pass
+
+    session.attach(_Conn())
+    assert session.idle_since is None
+
+    assert bus.sweep_idle_sessions() == []
+    assert bus.session_ids() == ["s1"]
+
+
+def test_sweep_does_not_evict_before_the_ttl_elapses():
+    bus = EventBus(configure_session=_configure, session_idle_ttl_seconds=10_000.0, evict_idle_session=lambda b: True)
+    bus.session("s1")  # idle_since stamped at construction, "just now"
+
+    assert bus.sweep_idle_sessions() == []
+    assert bus.session_ids() == ["s1"]
+
+
+def test_sweep_evicts_a_session_idle_past_the_ttl():
+    bus = EventBus(configure_session=_configure, session_idle_ttl_seconds=1.0, evict_idle_session=lambda b: True)
+    session = bus.session("s1")
+    session.idle_since -= 10.0  # push it well past the 1s TTL
+
+    evicted = bus.sweep_idle_sessions()
+
+    assert evicted == ["s1"]
+    assert bus.session_ids() == []
+
+
+def test_sweep_honors_the_evict_callbacks_veto():
+    # The callback deciding "no, not this one" (e.g. a real in-flight run)
+    # must actually stop the eviction, not just be consulted for show.
+    bus = EventBus(configure_session=_configure, session_idle_ttl_seconds=1.0, evict_idle_session=lambda b: False)
+    session = bus.session("s1")
+    session.idle_since -= 10.0
+
+    evicted = bus.sweep_idle_sessions()
+
+    assert evicted == []
+    assert bus.session_ids() == ["s1"]
+
+
+def test_sweep_only_evicts_the_sessions_actually_past_their_ttl():
+    bus = EventBus(configure_session=_configure, session_idle_ttl_seconds=1.0, evict_idle_session=lambda b: True)
+    old_session = bus.session("old")
+    old_session.idle_since -= 10.0
+    bus.session("fresh")  # idle_since is "just now" - not past the TTL
+
+    evicted = bus.sweep_idle_sessions()
+
+    assert evicted == ["old"]
+    assert bus.session_ids() == ["fresh"]
+
+
+def test_the_background_eviction_loop_survives_a_sweep_that_raises():
+    """Adversarial-review finding: every eviction test above calls
+    sweep_idle_sessions() directly and synchronously, by design (see the
+    module docstring) - none of them actually drive _eviction_loop() as a
+    real background asyncio.Task, so the "one bad sweep must never end the
+    loop forever" guarantee (mirroring backend/autosave.py's own _loop()
+    precedent) had zero regression coverage. A future refactor that moved
+    the try/except outside the while-loop, or narrowed what it catches,
+    would ship undetected. This test starts the REAL free-running loop
+    (via the real _ensure_eviction_loop_started() entry point, triggered
+    by a real session() call inside a running event loop) and proves it
+    keeps calling sweep_idle_sessions() on every subsequent interval after
+    an injected failure."""
+
+    async def _run():
+        calls = {"n": 0}
+
+        def broken_evict(bus):
+            calls["n"] += 1
+            raise RuntimeError(f"simulated bug in evict_idle_session #{calls['n']}")
+
+        bus = EventBus(
+            configure_session=_configure,
+            session_idle_ttl_seconds=0.0,
+            sweep_interval_seconds=0.02,
+            evict_idle_session=broken_evict,
+        )
+        session = bus.session("s1")
+        session.idle_since -= 10_000
+        assert bus._eviction_task is not None, "session() must have lazily started the real background loop"
+
+        await asyncio.sleep(0.15)
+
+        assert calls["n"] >= 3, "the loop must keep calling the sweep on every interval, not stop after the first failure"
+        assert not bus._eviction_task.done(), "one bad sweep must never end the free-running loop"
+
+        bus._eviction_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await bus._eviction_task
+
+    asyncio.run(_run())
+
+
+# -- layer 3: integration through the real app --------------------------------
+
+
+def _make_client() -> TestClient:
+    return TestClient(
+        create_app(auth_token="test-token"),
+        base_url="http://127.0.0.1",
+        headers={"host": "127.0.0.1"},
+    )
+
+
+def test_ws_rejects_an_unknown_session_id():
+    client = _make_client()
+    with pytest.raises(Exception):
+        with client.websocket_connect("/ws?session=attacker-chosen-id&token=test-token"):
+            pass
+
+
+def test_ws_accepts_the_default_session_id():
+    client = _make_client()
+    with client.websocket_connect("/ws?session=default&token=test-token") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        message = ws.receive_json()
+    assert message["payload"]["sessionId"] == "default"
+
+
+def test_ws_reconnect_survives_an_eviction_sweep_racing_the_handshake_accept(monkeypatch):
+    """Adversarial-review finding: ws_endpoint's own session-lookup-then-
+    attach sequence has exactly one await gap (websocket.accept()) between
+    bus.session(session_id) and session.attach(websocket). A session idle
+    past the TTL - exactly the state a reconnect after a network blip or
+    laptop sleep is already in by design - used to be evictable by the
+    free-running background sweep during that gap, orphaning the
+    reconnecting client's session (autosave cancelled, removed from
+    EventBus._sessions, while session.attach() below still silently
+    succeeds on the now-orphaned object anyway). Confirmed via an unforced
+    concurrent-asyncio-scheduling stress test to fire in 8/500 trials under
+    real production defaults - not a purely theoretical race.
+
+    Forces the race deterministically (not relying on real scheduler
+    nondeterminism, which would make this test flaky) by monkeypatching
+    WebSocket.accept to run a REAL sweep_idle_sessions() the moment it's
+    called - i.e. exactly inside the vulnerable window, on every run, not
+    just probabilistically. If ws_endpoint's own `session.idle_since =
+    None` fix (set immediately after its bus.session() call, before this
+    same await) were ever removed or reordered, this test would fail: the
+    sweep would evict "default" here and the assertions below would catch
+    it.
+    """
+    client = _make_client()
+    bus = client.app.state.bus
+
+    # Force "default" into the exact state a stale reconnect is already in
+    # - idle well past the real create_app() default TTL (300s) - via the
+    # SAME direct idle_since manipulation the unit tests above use.
+    default_bus = bus.session(DEFAULT_SESSION_ID)
+    default_bus.idle_since = time.monotonic() - 10_000
+
+    swept = {"ran": False, "evicted": None}
+    real_accept = WebSocket.accept
+
+    async def accept_after_a_racing_sweep(self, *args, **kwargs):
+        if not swept["ran"]:
+            swept["ran"] = True
+            # The real production sweep - not a stand-in - racing the
+            # handshake at exactly the vulnerable point.
+            swept["evicted"] = bus.sweep_idle_sessions()
+        return await real_accept(self, *args, **kwargs)
+
+    monkeypatch.setattr(WebSocket, "accept", accept_after_a_racing_sweep)
+
+    with client.websocket_connect("/ws?session=default&token=test-token") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        message = ws.receive_json()
+
+    assert swept["ran"] is True, "the sweep never actually raced the handshake - this test isn't exercising the window"
+    # The fix in action: idle_since was already cleared before accept(),
+    # so the racing sweep found nothing eligible to evict.
+    assert swept["evicted"] == []
+    assert bus.session_ids() == ["default"]
+    assert bus.session(DEFAULT_SESSION_ID) is default_bus, "must still be the SAME bus object, not orphaned+recreated"
+    assert message["payload"]["sessionId"] == "default"
+
+
+def test_asset_route_rejects_an_unknown_session_id_as_a_plain_404():
+    # ADR-004 stage 4.3: must NOT 500, and must NOT distinguish itself from
+    # a genuinely unknown asset id - see backend/assets.py's own comment on
+    # why the response shape is deliberately unchanged from before this
+    # stage (a bogus session used to silently create an empty document,
+    # which would 404 on any asset id anyway).
+    #
+    # Adversarial-review finding: the response-shape assertions alone
+    # cannot tell "rejected before a session was ever created" (the real
+    # fix) apart from "a session WAS silently created for the attacker id,
+    # and merely happened to 404 on the asset lookup" (the exact pre-stage-
+    # 4.3, C6-vulnerable behavior) - both produce byte-identical HTTP
+    # responses (confirmed empirically). The session_ids() assertion below
+    # is what actually distinguishes them, and is the one that would catch
+    # a regression that silently reintroduced the leak on this route.
+    client = _make_client()
+    bus = client.app.state.bus
+    response = client.get(
+        "/api/assets/some-asset-id?session=attacker-chosen-id", headers={"Authorization": "Bearer test-token"}
+    )
+    assert response.status_code == 404
+    assert response.json() == {"error": "unknown asset"}
+    assert bus.session_ids() == [], "no session may be minted for a rejected id, even though the HTTP response looks identical either way"
+
+
+def test_chart_export_route_rejects_an_unknown_session_id_as_a_plain_404():
+    # Adversarial-review finding: see test_asset_route_rejects_an_unknown_
+    # session_id_as_a_plain_404's own comment - the session_ids() check is
+    # what actually proves the fix, not the response shape alone.
+    client = _make_client()
+    bus = client.app.state.bus
+    response = client.get(
+        "/api/assets/chart/some-node/export?session=attacker-chosen-id",
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 404
+    assert response.json() == {"error": "unknown chart"}
+    assert bus.session_ids() == []
+
+
+def _real_session_context():
+    """A minimal but real SessionContext - enough for _evict_idle_session
+    to exercise its actual agent_dispatcher.has_in_flight_runs() check,
+    without spinning up a whole create_app()."""
+    from backend.agents import AgentDispatcher
+    from backend.canvas import SceneDocument
+    from graphlink_settings_store import SettingsManager
+    import tempfile
+    from pathlib import Path
+
+    state_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    manager = SettingsManager(Path(state_dir.name) / "session.dat")
+    dispatcher = AgentDispatcher(manager)
+    document = SceneDocument()
+    return SessionContext(agent_dispatcher=dispatcher, canvas_document=document), state_dir
+
+
+def test_evict_idle_session_vetoes_eviction_when_a_run_is_in_flight():
+    bus = SessionBus("s1")
+    context, _tmp = _real_session_context()
+    attach_session_context(bus, context)
+    context.agent_dispatcher._runs.claim("chat")  # a real in-flight handle
+
+    assert _evict_idle_session(bus) is False
+
+
+def test_evict_idle_session_proceeds_and_cancels_the_autosave_task_when_idle():
+    async def _run():
+        bus = SessionBus("s1")
+        context, _tmp = _real_session_context()
+        attach_session_context(bus, context)
+
+        async def _never_ending():
+            await asyncio.sleep(9999)
+
+        bus.autosave_task = asyncio.create_task(_never_ending())
+
+        result = _evict_idle_session(bus)
+        assert result is True
+        # Give the cancellation a moment to actually land.
+        await asyncio.sleep(0)
+        assert bus.autosave_task.cancelled() or bus.autosave_task.done()
+
+    asyncio.run(_run())
+
+
+def test_evict_idle_session_releases_the_mutation_guard_when_cancelling_mid_write():
+    """Adversarial-review finding: the test above only ever cancels a
+    stand-in coroutine that never touches backend/chat_library.py's shared
+    mutation_guard - it cannot detect a regression in _guarded_tick's own
+    try/finally guarantee. Before ADR-004 stage 4.3, register_autosave's
+    task was "deliberately never explicitly cancelled" (see
+    backend/autosave.py's own updated docstring), so cancelling a REAL
+    _guarded_tick while it holds the guard mid-write was purely
+    theoretical dead code; this stage makes it a genuine, reachable
+    production path (_evict_idle_session cancels a live session's
+    autosave_task any time eviction proceeds while a write happens to be
+    in flight) for the first time. This test drives that real path: a
+    real register_autosave-installed task, actually suspended mid-write
+    (inside asyncio.to_thread, not idling in the inter-tick sleep), then
+    cancelled via the real _evict_idle_session call.
+    """
+    import backend.autosave as autosave_mod
+    from backend.chat_library import _new_mutation_guard, _new_save_state
+    from backend.autosave import register_autosave
+    import tempfile
+    from pathlib import Path
+
+    async def _run():
+        bus = SessionBus("s1")
+        context, _tmp = _real_session_context()
+        attach_session_context(bus, context)
+        context.canvas_document.add_node(0, 0, "hello")
+        mutation_guard = _new_mutation_guard()
+        last_saved = _new_save_state()
+        write_entered = asyncio.Event()
+        loop = asyncio.get_running_loop()
+
+        real_write = autosave_mod.save_chat_atomically_row
+
+        def slow_write(*args, **kwargs):
+            loop.call_soon_threadsafe(write_entered.set)
+            time.sleep(0.3)
+            return 1  # any truthy chat_id; DB unused for this assertion
+
+        state_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        db_path = Path(state_dir.name) / "chats.db"
+        autosave_mod.save_chat_atomically_row = slow_write
+        try:
+            register_autosave(bus, db_path, context.canvas_document, None, mutation_guard, last_saved, interval_seconds=0.01)
+            await asyncio.wait_for(write_entered.wait(), timeout=2.0)
+            # The tick is now genuinely suspended mid-write, holding the guard.
+            assert mutation_guard["active"] is True
+            assert mutation_guard["owner"] == "autosave"
+
+            result = _evict_idle_session(bus)
+            assert result is True
+
+            for _ in range(20):
+                if bus.autosave_task.done():
+                    break
+                await asyncio.sleep(0.05)
+            assert bus.autosave_task.done()
+
+            # The whole point: cancellation mid-write must still release
+            # the guard via _guarded_tick's finally block, or a future
+            # manual save/load/new-chat intent on some OTHER session
+            # reusing this same guard shape would hang or wrongly report
+            # "busy" forever.
+            assert mutation_guard["active"] is False
+            assert mutation_guard["owner"] is None
+            assert mutation_guard["released"].is_set() is True
+        finally:
+            autosave_mod.save_chat_atomically_row = real_write
+
+    asyncio.run(_run())
+
+
+def test_evict_idle_session_returns_true_for_a_never_configured_bus():
+    # SessionNotConfiguredError branch - a bus that never finished setup
+    # has nothing to tear down, so eviction should proceed rather than
+    # veto forever.
+    bus = SessionBus("s1")
+    assert _evict_idle_session(bus) is True


### PR DESCRIPTION
## Problem

The other half of audit finding C6: `?session=<anything>` minted a permanent, never-evicted `SessionBus` (document + dispatcher + autosave task) for any string. The autosave task itself was also never cancelled — `backend/autosave.py`'s own docstring explicitly documented this as accepted, since a single-window desktop app never needed real session eviction.

## Change

**Session issuance** — `EventBus` gains an opt-in `allowed_session_ids` restriction rather than an unconditional one. `EventBus` is a genuinely reusable multi-session primitive (several existing tests exercise its own generic isolation mechanism directly), so the restriction is an application policy, not a class property. `create_app(restrict_sessions=True by default)` passes `{"default"}` — the one id the real app ever uses (confirmed by grep: `web_ui`'s only production call to `defaultWsUrl()` passes no argument).

**Idle eviction** — `SessionBus` tracks `idle_since` (monotonic; cleared on attach, stamped when the last connection detaches). `EventBus.sweep_idle_sessions()` — public, directly callable, no wall-clock sleep needed to test it — evicts anything idle past the TTL (default 300s) unless the injected `evict_idle_session` callback vetoes it (a real in-flight agent run). `backend/app.py`'s real callback cancels the autosave task and the dispatcher's in-flight runs, then lets eviction proceed.

`backend/autosave.py`'s docstring is corrected in place (not silently edited) — the prior claim was true when written and is explained as such.

### A real bug, found by adversarial review

4 parallel reviewers, each required to actually **run** async code to prove any claim, found a genuine TOCTOU race: `ws_endpoint`'s session lookup → `await websocket.accept()` → `.attach()` has exactly one await gap. A session idle past the TTL — precisely the state a reconnect after a network blip or laptop sleep is already in by design — could be evicted by the concurrently-running sweep *inside that gap*, after which `.attach()` still silently succeeds on the now-orphaned, no-longer-tracked bus. The client ends up split-brained: live-attached to a `SceneDocument` nothing else can reach, its autosave permanently dead, while `GET /api/assets/{id}` hits a completely different, empty document for the same "default" id.

Confirmed three ways, including an unforced concurrent-scheduling stress test that found it fire in **8/500 trials** under real production defaults — not theoretical.

**Fixed** by clearing `idle_since` in the same synchronous stretch as the lookup, before the await gap. Mutation-verified (removing the fix line fails the new regression test) and covered by a deterministic integration test that forces the race via `monkeypatch`ing `WebSocket.accept`, rather than relying on scheduler nondeterminism.

Four smaller coverage gaps from the same review were also closed — see commit message for detail.

## Test plan

- [x] New `backend/tests/test_session_lifecycle.py` (21 tests): issuance restriction (unit + integration), eviction decision logic, the TOCTOU race regression test, real mid-write autosave cancellation through the actual eviction path, the free-running eviction loop's bad-sweep resilience as a real background task
- [x] Fixed 6 existing tests across `test_app_ws.py`/`test_assets.py`/`test_crash_recovery_notice.py` that legitimately used non-default session ids for readability (switched to "default") or genuine cross-session isolation (opted out via `restrict_sessions=False`)
- [x] Mutation-verified: 3 mutations on the core eviction logic (issuance check, TTL check, veto), 1 mutation on the TOCTOU fix itself — all caught, all reverted clean
- [x] Full backend suite: 1301 passed
- [x] **Independently adversarially reviewed**: 4 parallel reviewers (issuance bypass, eviction safety, teardown correctness, test-coverage adequacy), each required to empirically run async code to prove any claim. Found and fixed 1 real bug (the TOCTOU race) and closed 4 coverage gaps around otherwise-correct behavior