### PR TITLE
ADR-004 stage 4.4: DPAPI-state visibility + POSIX 0600 + env-key surfacing

### DIFF
--- a/api_provider.py
+++ b/api_provider.py
@@ -1480,25 +1480,64 @@ def _extract_gemini_image_bytes(payload: dict) -> bytes:
     raise RuntimeError("Gemini did not return image data.")
 
 
+# ADR-004 stage 4.4: the canonical env var names per cloud provider - was
+# previously 5 independent inline copies of the same "GRAPHLINK_* or
+# GRAPHITE_* or <bare>" OR-chain (this file's own _get_gemini_api_key/
+# _get_anthropic_api_key and all three branches of initialize_api below),
+# a real drift risk (a future renamed/added var updated in one copy but
+# not the other four). Consolidated to one source each; every call site
+# below now reads through _first_env_api_key. env_api_key_configured (also
+# below) is the NEW piece stage 4.4 adds: a presence-only check ("is an
+# env var supplying this provider's key right now"), used solely so the
+# Settings UI can surface "key provided by environment" (ADR-004 §4) - it
+# never returns or logs the key's actual value.
+_OPENAI_API_KEY_ENV_VARS = ("GRAPHLINK_OPENAI_API_KEY", "GRAPHITE_OPENAI_API_KEY", "OPENAI_API_KEY")
+_ANTHROPIC_API_KEY_ENV_VARS = ("GRAPHLINK_ANTHROPIC_API_KEY", "GRAPHITE_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY")
+_GEMINI_API_KEY_ENV_VARS = ("GRAPHLINK_GEMINI_API_KEY", "GRAPHITE_GEMINI_API_KEY", "GEMINI_API_KEY")
+
+_PROVIDER_API_KEY_ENV_VARS = {
+    config.API_PROVIDER_OPENAI: _OPENAI_API_KEY_ENV_VARS,
+    config.API_PROVIDER_ANTHROPIC: _ANTHROPIC_API_KEY_ENV_VARS,
+    config.API_PROVIDER_GEMINI: _GEMINI_API_KEY_ENV_VARS,
+}
+
+
+def _first_env_api_key(env_vars: tuple[str, ...]) -> str | None:
+    """The first non-empty value among `env_vars`, checked in priority
+    order (GRAPHLINK_* wins over GRAPHITE_* wins over the SDK's own bare
+    name), or None if none are set. The single implementation every
+    provider's key-resolution OR-chain now delegates to."""
+    for name in env_vars:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
+def env_api_key_configured(provider: str) -> bool:
+    """True if at least one recognized env var for `provider` is currently
+    set in this process's environment - a presence check ONLY, never the
+    key's value. Note this does NOT mean the env var is necessarily the
+    key actually IN USE: a key saved via Settings always wins over the
+    environment (every OR-chain below tries the stored/argument key
+    first) - callers surfacing this to a user should pair it with the
+    stored-key state to show "environment" only when no stored key
+    exists to take precedence (see backend/settings.py's own
+    _api_key_source)."""
+    return _first_env_api_key(_PROVIDER_API_KEY_ENV_VARS.get(provider, ())) is not None
+
+
 def _get_gemini_api_key(snapshot_key: str | None = None) -> str:
     # `snapshot_key` carries the per-request provider snapshot's key (#9) so a mode
     # switch mid-request can't pair this request with a different provider's key.
-    api_key = (
-        snapshot_key or API_KEY
-        or os.environ.get("GRAPHLINK_GEMINI_API_KEY") or os.environ.get("GRAPHITE_GEMINI_API_KEY")
-        or os.environ.get("GEMINI_API_KEY")
-    )
+    api_key = snapshot_key or API_KEY or _first_env_api_key(_GEMINI_API_KEY_ENV_VARS)
     if not api_key:
         raise RuntimeError("Gemini API key not configured. Open Settings and save your Gemini API key.")
     return api_key
 
 
 def _get_anthropic_api_key(snapshot_key: str | None = None) -> str:
-    api_key = (
-        snapshot_key or API_KEY
-        or os.environ.get("GRAPHLINK_ANTHROPIC_API_KEY") or os.environ.get("GRAPHITE_ANTHROPIC_API_KEY")
-        or os.environ.get("ANTHROPIC_API_KEY")
-    )
+    api_key = snapshot_key or API_KEY or _first_env_api_key(_ANTHROPIC_API_KEY_ENV_VARS)
     if not api_key:
         raise RuntimeError("Anthropic API key not configured. Open Settings and save your Anthropic API key.")
     return api_key
@@ -2508,11 +2547,7 @@ def initialize_api(provider: str, api_key: str, base_url: str = None):
         if not base_url:
             base_url = "https://api.openai.com/v1"
 
-        api_key = (
-            api_key
-            or os.environ.get("GRAPHLINK_OPENAI_API_KEY") or os.environ.get("GRAPHITE_OPENAI_API_KEY")
-            or os.environ.get("OPENAI_API_KEY")
-        )
+        api_key = api_key or _first_env_api_key(_OPENAI_API_KEY_ENV_VARS)
         if not api_key:
             if _is_local_base_url(base_url):
                 api_key = "dummy-key-for-local"
@@ -2522,11 +2557,7 @@ def initialize_api(provider: str, api_key: str, base_url: str = None):
         client = OpenAI(api_key=api_key, base_url=base_url)
 
     elif provider == config.API_PROVIDER_ANTHROPIC:
-        api_key = (
-            api_key
-            or os.environ.get("GRAPHLINK_ANTHROPIC_API_KEY") or os.environ.get("GRAPHITE_ANTHROPIC_API_KEY")
-            or os.environ.get("ANTHROPIC_API_KEY")
-        )
+        api_key = api_key or _first_env_api_key(_ANTHROPIC_API_KEY_ENV_VARS)
         if not api_key:
             raise RuntimeError("Anthropic API key not configured. Open Settings and save your Anthropic API key.")
 
@@ -2546,11 +2577,7 @@ def initialize_api(provider: str, api_key: str, base_url: str = None):
         base_url = None
 
     elif provider == config.API_PROVIDER_GEMINI:
-        if not (
-            api_key
-            or os.environ.get("GRAPHLINK_GEMINI_API_KEY") or os.environ.get("GRAPHITE_GEMINI_API_KEY")
-            or os.environ.get("GEMINI_API_KEY")
-        ):
+        if not (api_key or _first_env_api_key(_GEMINI_API_KEY_ENV_VARS)):
             raise RuntimeError("Gemini API key not configured. Open Settings and save your Gemini API key.")
         client = {"provider": config.API_PROVIDER_GEMINI}
     else:

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -34,11 +34,15 @@ import asyncio
 import contextlib
 import hashlib
 import json
+import logging
+import os
 import re
 import sqlite3
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from backend.canvas import SceneDocument
 from backend.events import SessionBus
@@ -115,6 +119,24 @@ def _connect(db_path: Path) -> sqlite3.Connection:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path, timeout=30)
     conn.execute("PRAGMA foreign_keys = ON")
+    # ADR-004 stage 4.4: chats.db holds real conversation content, POSIX
+    # 0600 like session.dat (graphlink_settings_store.py's own
+    # SettingsManager). sqlite3.connect() creates the file itself with no
+    # mode parameter exposed anywhere in the stdlib API, so there is no
+    # earlier hook than right here, after connect() returns, to fix it up
+    # - and since EVERY read/write helper in this file goes through this
+    # one shared function (get_all_chats, rename_chat, delete_chat,
+    # load_chat_row, load_notes_rows, load_pins_rows,
+    # save_chat_atomically_row), doing it here rather than at each of
+    # those call sites both closes the gap for new files and self-heals a
+    # pre-stage-4.4 chats.db on its very next connection - unconditional,
+    # not "only if just created". No-op on Windows (see SettingsManager's
+    # own __init__ comment for why POSIX permission bits don't apply
+    # there).
+    try:
+        os.chmod(db_path, 0o600)
+    except OSError:
+        logger.warning("could not chmod %s to 0600 - continuing with existing permissions", db_path)
     return conn
 
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -187,6 +187,15 @@ def settings_payload(manager: SettingsManager) -> dict[str, Any]:
         "enableSystemPrompt": manager.get_enable_system_prompt(),
         "notificationPreferences": manager.get_notification_preferences(),
         "githubTokenConfigured": bool(manager.get_github_token()),
+        # ADR-004 stage 4.4: closes audit finding H12 - before this, a
+        # DPAPI failure was observable only as an absence (no "dpapi:"
+        # prefix ever appearing in session.dat), never as a signal the
+        # user could see. False means every secret SettingsManager saves
+        # from here on is being written in PLAINTEXT, not encrypted - the
+        # Settings UI renders a persistent badge when this is false. See
+        # graphlink_secrets.dpapi_available's own docstring for exactly
+        # what this does and doesn't mean.
+        "secretsEncryptedAtRest": manager.secrets_encrypted_at_rest(),
     }
 
 
@@ -213,6 +222,20 @@ def _catalog_state_for(state: SettingsSessionState, provider: str) -> dict[str, 
     return state.api_catalog_state.get(provider, _DEFAULT_API_CATALOG_STATE)
 
 
+def _api_key_source(stored: bool, provider: str) -> str:
+    """ADR-004 stage 4.4: the single source of truth for whether a
+    provider's key is "stored", "environment", or "none" - reused by
+    _build_settings_payload for each of the 3 cloud providers below.
+    `stored` is passed in (not recomputed) so this stays a pure function
+    of state the caller already has, matching every other per-provider
+    helper in this module."""
+    if stored:
+        return "stored"
+    if api_provider.env_api_key_configured(provider):
+        return "environment"
+    return "none"
+
+
 def _build_settings_payload(manager: SettingsManager, state: SettingsSessionState) -> dict[str, Any]:
     payload = settings_payload(manager)
     payload["activeSection"] = state.active_section
@@ -220,10 +243,27 @@ def _build_settings_payload(manager: SettingsManager, state: SettingsSessionStat
     payload["activeApiProvider"] = manager.get_api_provider()
     payload["viewingApiProvider"] = viewing_provider
     payload["apiBaseUrl"] = manager.get_api_base_url()
+    openai_key = manager.get_openai_key()
+    anthropic_key = manager.get_anthropic_key()
+    gemini_key = manager.get_gemini_key()
     payload["apiKeyConfigured"] = {
-        "openai": bool(manager.get_openai_key()),
-        "anthropic": bool(manager.get_anthropic_key()),
-        "gemini": bool(manager.get_gemini_key()),
+        "openai": bool(openai_key),
+        "anthropic": bool(anthropic_key),
+        "gemini": bool(gemini_key),
+    }
+    # ADR-004 stage 4.4: "key provided by environment" surfacing - the env
+    # var fallback itself (api_provider.py) stays load-bearing (it's what
+    # the subprocess allowlist story depends on), this only makes it
+    # observable. "stored" whenever apiKeyConfigured is already true for
+    # that provider (a saved key always wins over the environment - see
+    # api_provider.env_api_key_configured's own docstring on why this
+    # checks stored-first, not "env is set" alone, which would be
+    # misleading for a provider that also has a stored key silently
+    # overriding it).
+    payload["apiKeySource"] = {
+        "openai": _api_key_source(bool(openai_key), config.API_PROVIDER_OPENAI),
+        "anthropic": _api_key_source(bool(anthropic_key), config.API_PROVIDER_ANTHROPIC),
+        "gemini": _api_key_source(bool(gemini_key), config.API_PROVIDER_GEMINI),
     }
     payload["apiModels"] = manager.get_api_models(viewing_provider)
     payload["apiModelCatalog"] = _api_model_catalog_for_wire(manager, viewing_provider)

--- a/backend/tests/test_backend_api_key_env_fallback.py
+++ b/backend/tests/test_backend_api_key_env_fallback.py
@@ -88,6 +88,53 @@ class TestOpenAiApiKeyEnvFallback:
         fake_openai_cls.assert_called_once_with(api_key="dummy-key-for-local", base_url="http://localhost:11434/v1")
 
 
+class TestEnvApiKeyConfigured:
+    """ADR-004 stage 4.4: env_api_key_configured() is a NEW public presence-only
+    check (added alongside the _first_env_api_key refactor above) that
+    backend/settings.py's _api_key_source uses to surface "key provided by an
+    environment variable" in the Settings UI - it must never leak the key's
+    value, only whether one is set."""
+
+    def test_true_when_any_recognized_openai_env_var_is_set(self, monkeypatch):
+        monkeypatch.delenv("GRAPHLINK_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("GRAPHITE_OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-some-value")
+
+        assert api_provider.env_api_key_configured(config.API_PROVIDER_OPENAI) is True
+
+    def test_false_when_no_openai_env_var_is_set(self, monkeypatch):
+        monkeypatch.delenv("GRAPHLINK_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("GRAPHITE_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        assert api_provider.env_api_key_configured(config.API_PROVIDER_OPENAI) is False
+
+    def test_true_for_anthropic_and_gemini_too(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-value")
+        monkeypatch.setenv("GEMINI_API_KEY", "AIza-value")
+
+        assert api_provider.env_api_key_configured(config.API_PROVIDER_ANTHROPIC) is True
+        assert api_provider.env_api_key_configured(config.API_PROVIDER_GEMINI) is True
+
+    def test_an_empty_string_env_var_does_not_count_as_configured(self, monkeypatch):
+        monkeypatch.delenv("GRAPHLINK_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("GRAPHITE_OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "")
+
+        assert api_provider.env_api_key_configured(config.API_PROVIDER_OPENAI) is False
+
+    def test_unknown_provider_returns_false_rather_than_raising(self):
+        assert api_provider.env_api_key_configured("not-a-real-provider") is False
+
+    def test_never_exposes_the_actual_key_value(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-should-never-leak")
+
+        result = api_provider.env_api_key_configured(config.API_PROVIDER_OPENAI)
+
+        assert result is True
+        assert "sk-should-never-leak" not in repr(result)
+
+
 class TestLegacyGraphiteEnvVarStillWorks:
     """The app was renamed from Graphite to Graphlink; GRAPHITE_*_API_KEY env vars set
     before the rename must keep working so existing power-user shell configs don't

--- a/backend/tests/test_backend_secrets_at_rest.py
+++ b/backend/tests/test_backend_secrets_at_rest.py
@@ -31,6 +31,11 @@ CI runner).
 """
 
 import json
+import os
+import stat
+import sys
+
+import pytest
 
 import graphlink_secrets
 from graphlink_settings_store import SettingsManager
@@ -197,3 +202,310 @@ class TestGracefulDegradationWithoutDpapi:
         reloaded = SettingsManager(state_file)
         assert reloaded.get_github_token() == "ghp_plain_fallback"
         assert state_file.stat().st_mtime_ns == mtime_before
+
+
+class TestDpapiAvailableProbe:
+    """ADR-004 stage 4.4: dpapi_available() closes audit finding H12 - before
+    this, a DPAPI failure was observable only as an absence (no "dpapi:"
+    prefix ever appearing on disk), never as a signal a user could see. It
+    must verify a REAL round-trip, not just that the encrypt call returned
+    something non-None."""
+
+    def test_reflects_real_dpapi_state_with_no_monkeypatching(self):
+        # Matches this file's own module docstring: these tests run on real
+        # DPAPI (Windows dev machines and the windows-latest CI runner).
+        assert graphlink_secrets.dpapi_available() is True
+
+    def test_true_when_the_probe_round_trips(self, monkeypatch):
+        monkeypatch.setattr(graphlink_secrets, "_dpapi_call", lambda data, encrypt: data)
+        assert graphlink_secrets.dpapi_available() is True
+
+    def test_false_when_the_encrypt_call_fails(self, monkeypatch):
+        monkeypatch.setattr(graphlink_secrets, "_dpapi_call", lambda data, encrypt: None if encrypt else data)
+        assert graphlink_secrets.dpapi_available() is False
+
+    def test_false_when_the_decrypt_call_fails(self, monkeypatch):
+        monkeypatch.setattr(
+            graphlink_secrets,
+            "_dpapi_call",
+            lambda data, encrypt: b"encrypted-blob" if encrypt else None,
+        )
+        assert graphlink_secrets.dpapi_available() is False
+
+    def test_false_when_the_round_trip_returns_a_mismatched_value(self, monkeypatch):
+        # A pathological case where CryptUnprotectData "succeeds" (non-None)
+        # but returns something other than the original probe -
+        # dpapi_available must verify the value itself, not just presence.
+        monkeypatch.setattr(
+            graphlink_secrets,
+            "_dpapi_call",
+            lambda data, encrypt: b"encrypted-blob" if encrypt else b"not-the-probe",
+        )
+        assert graphlink_secrets.dpapi_available() is False
+
+
+class TestSecretsEncryptedAtRestFlag:
+    """ADR-004 stage 4.4: SettingsManager.secrets_encrypted_at_rest() is what
+    backend/settings.py's wire payload surfaces as secretsEncryptedAtRest,
+    rendered as a persistent Settings UI badge when False."""
+
+    def test_true_when_dpapi_is_available(self, tmp_path):
+        manager = SettingsManager(tmp_path / "session.dat")
+        assert manager.secrets_encrypted_at_rest() is True
+
+    def test_false_when_dpapi_is_unavailable(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(graphlink_secrets, "_dpapi_call", lambda data, encrypt: None)
+        manager = SettingsManager(tmp_path / "session.dat")
+        assert manager.secrets_encrypted_at_rest() is False
+
+    def test_flag_is_not_recomputed_merely_by_reading_it(self, tmp_path, monkeypatch):
+        manager = SettingsManager(tmp_path / "session.dat")
+        assert manager.secrets_encrypted_at_rest() is True
+
+        # DPAPI "goes down" mid-process (e.g. a group policy change) - just
+        # calling secrets_encrypted_at_rest() again must NOT re-probe or
+        # flip it; it only updates from a REAL secret-mutating call (see
+        # TestSecretsEncryptedAtRestTracksRealOutcomes below).
+        monkeypatch.setattr(graphlink_secrets, "_dpapi_call", lambda data, encrypt: None)
+
+        assert manager.secrets_encrypted_at_rest() is True
+
+
+class TestSecretsEncryptedAtRestTracksRealOutcomes:
+    """ADR-004 stage 4.4 (adversarial-review fix): an adversarial review
+    found the flag could silently diverge from reality - cached True while
+    a real save actually fell back to plaintext (DPAPI failing between
+    construction and that save), or stuck False even after DPAPI recovered
+    and a real save succeeded. _protect_and_track closes this by updating
+    the flag from the REAL outcome of every secret-mutating call, not just
+    the one-time construction probe."""
+
+    @staticmethod
+    def _toggle(monkeypatch, up=True):
+        # Routes through the REAL _dpapi_call (genuine WinAPI round-trip,
+        # matching this file's own convention of running on real DPAPI)
+        # when "up", and simulates a failure by returning None when not -
+        # this lets a single test move DPAPI from "working" to "failing"
+        # (or back) mid-test, which a single monkeypatch.setattr can't.
+        state = {"up": up}
+        real_call = graphlink_secrets._dpapi_call
+
+        def toggling_call(data, encrypt):
+            if not state["up"]:
+                return None
+            return real_call(data, encrypt)
+
+        monkeypatch.setattr(graphlink_secrets, "_dpapi_call", toggling_call)
+        return state
+
+    def test_a_real_save_that_falls_back_to_plaintext_flips_the_flag_to_false(self, tmp_path, monkeypatch):
+        dpapi = self._toggle(monkeypatch, up=True)
+        state_file = tmp_path / "session.dat"
+        manager = SettingsManager(state_file)
+        assert manager.secrets_encrypted_at_rest() is True
+
+        dpapi["up"] = False  # DPAPI transiently fails between construction and this save
+        manager.set_api_settings("OpenAI-Compatible", "https://x/v1", "sk-real-secret", "", "")
+
+        assert manager.secrets_encrypted_at_rest() is False
+        raw = json.loads(state_file.read_text(encoding="utf-8"))
+        assert raw["openai_api_key"] == "sk-real-secret"  # plaintext on disk, matching the flag
+
+    def test_a_real_save_that_succeeds_after_recovery_flips_the_flag_to_true(self, tmp_path, monkeypatch):
+        dpapi = self._toggle(monkeypatch, up=False)
+        state_file = tmp_path / "session.dat"
+        manager = SettingsManager(state_file)
+        assert manager.secrets_encrypted_at_rest() is False
+
+        dpapi["up"] = True  # DPAPI recovers before this save
+        manager.set_api_settings("OpenAI-Compatible", "https://x/v1", "sk-real-secret", "", "")
+
+        assert manager.secrets_encrypted_at_rest() is True
+        raw = json.loads(state_file.read_text(encoding="utf-8"))
+        assert raw["openai_api_key"].startswith("dpapi:")
+
+    def test_saving_an_empty_secret_does_not_change_the_flag_either_way(self, tmp_path, monkeypatch):
+        dpapi = self._toggle(monkeypatch, up=True)
+        manager = SettingsManager(tmp_path / "session.dat")
+        assert manager.secrets_encrypted_at_rest() is True
+
+        dpapi["up"] = False
+        manager.set_github_token("")  # nothing real was protected - no evidence either way
+
+        assert manager.secrets_encrypted_at_rest() is True
+
+    def test_set_github_token_also_tracks_the_flag_not_just_set_api_settings(self, tmp_path, monkeypatch):
+        dpapi = self._toggle(monkeypatch, up=True)
+        manager = SettingsManager(tmp_path / "session.dat")
+
+        dpapi["up"] = False
+        manager.set_github_token("ghp_real_token")
+
+        assert manager.secrets_encrypted_at_rest() is False
+
+    def test_migrating_a_legacy_plaintext_secret_reflects_the_real_encrypt_outcome(self, tmp_path, monkeypatch):
+        state_file = tmp_path / "session.dat"
+        state_file.write_text(json.dumps({"openai_api_key": "sk-legacy-plaintext"}), encoding="utf-8")
+        self._toggle(monkeypatch, up=True)
+
+        manager = SettingsManager(state_file)
+
+        assert manager.secrets_encrypted_at_rest() is True
+        assert manager.get_openai_key() == "sk-legacy-plaintext"
+
+    def test_migrating_an_already_encrypted_secret_while_dpapi_is_down_reports_false_not_a_stale_true(
+        self, tmp_path, monkeypatch
+    ):
+        # Regression for a bug found in an EARLIER version of this fix
+        # (caught during manual browser verification, not the automated
+        # review): _protect_and_track originally inferred the outcome from
+        # whether `protected` still looked like a "dpapi:"-prefixed value.
+        # _migrate_plaintext_secrets feeds the ALREADY-STORED (possibly
+        # already-encrypted) value from disk into _protect_and_track on
+        # every launch - and protect() on an already-encrypted secret that
+        # fails to re-verify falls back to returning that input UNCHANGED,
+        # which still carries the "dpapi:" prefix from before. A
+        # shape-based check kept reporting encrypted==True on this exact
+        # path even while DPAPI was fully down. Re-probing via
+        # dpapi_available() instead of inspecting the output's shape closes
+        # this.
+        state_file = tmp_path / "session.dat"
+        SettingsManager(state_file).set_github_token("ghp_already_encrypted")
+        raw = json.loads(state_file.read_text(encoding="utf-8"))
+        assert raw["github_access_token"].startswith("dpapi:")  # real DPAPI on this box - genuinely encrypted
+
+        monkeypatch.setattr(graphlink_secrets, "_dpapi_call", lambda data, encrypt: None)
+        manager = SettingsManager(state_file)  # fresh launch; migration re-touches the stored value
+
+        assert manager.secrets_encrypted_at_rest() is False
+
+
+class TestSessionFilePermissionsAreRestricted:
+    """ADR-004 stage 4.4: session.dat holds the encrypted-or-plaintext API
+    keys/GitHub token, so it gets POSIX 0600 on every launch (self-heal) and
+    on every save (the atomic-write temp file). chmod's real effect is
+    POSIX-only (see graphlink_settings_store.py's own __init__ comment on
+    why Windows os.chmod only toggles the read-only attribute, not real
+    per-owner permission bits) - so the platform-independent assertion here
+    is "chmod(path, 0o600) was actually invoked", with a POSIX-only
+    bit-for-bit check layered on top where it's meaningful."""
+
+    def test_chmod_is_invoked_with_0600_on_the_real_state_file(self, tmp_path, monkeypatch):
+        calls = []
+        monkeypatch.setattr(os, "chmod", lambda path, mode: calls.append((path, mode)))
+
+        state_file = tmp_path / "session.dat"
+        SettingsManager(state_file)
+
+        assert (state_file, 0o600) in calls
+
+    def test_posix_permission_bits_are_actually_0600(self, tmp_path):
+        if sys.platform == "win32":
+            pytest.skip("chmod is a no-op on Windows - see class docstring")
+
+        state_file = tmp_path / "session.dat"
+        SettingsManager(state_file)
+
+        assert stat.S_IMODE(state_file.stat().st_mode) == 0o600
+
+    def test_self_heals_a_pre_existing_file_with_looser_permissions(self, tmp_path):
+        if sys.platform == "win32":
+            pytest.skip("chmod is a no-op on Windows - see class docstring")
+
+        state_file = tmp_path / "session.dat"
+        state_file.write_text("{}", encoding="utf-8")
+        os.chmod(state_file, 0o644)
+
+        SettingsManager(state_file)
+
+        assert stat.S_IMODE(state_file.stat().st_mode) == 0o600
+
+    def test_a_chmod_failure_does_not_crash_construction(self, tmp_path, monkeypatch):
+        def _boom(path, mode):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(os, "chmod", _boom)
+
+        manager = SettingsManager(tmp_path / "session.dat")
+
+        assert manager.get_show_token_counter() is False
+
+
+class TestCorruptedStateBackupIsAlsoChmodded:
+    """ADR-004 stage 4.4 (adversarial-review fix): _backup_corrupt_state_file
+    preserves an unreadable session.dat "for forensic recovery" by renaming
+    it aside - a rename preserves the source inode's mode bits exactly, so
+    without an explicit chmod this backup (which can hold the same
+    encrypted-or-plaintext secrets the live file had, and is never touched
+    again by anything else in the codebase) inherited whatever looser
+    permissions the original corrupt file happened to have."""
+
+    def test_chmod_is_invoked_on_the_backup_file(self, tmp_path, monkeypatch):
+        calls = []
+        monkeypatch.setattr(os, "chmod", lambda path, mode: calls.append((path, mode)))
+
+        state_file = tmp_path / "session.dat"
+        state_file.write_text("{not valid json", encoding="utf-8")
+
+        SettingsManager(state_file)
+
+        backup_path = next(tmp_path.glob("session.dat.corrupted-*"))
+        assert (backup_path, 0o600) in calls
+
+    def test_posix_permission_bits_on_the_backup_are_actually_0600(self, tmp_path):
+        if sys.platform == "win32":
+            pytest.skip("chmod is a no-op on Windows - see class docstring")
+
+        state_file = tmp_path / "session.dat"
+        state_file.write_text("{not valid json", encoding="utf-8")
+        os.chmod(state_file, 0o644)
+
+        SettingsManager(state_file)
+
+        backup_path = next(tmp_path.glob("session.dat.corrupted-*"))
+        assert stat.S_IMODE(backup_path.stat().st_mode) == 0o600
+
+    def test_a_chmod_failure_on_the_backup_does_not_crash_construction(self, tmp_path, monkeypatch):
+        def _boom(path, mode):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(os, "chmod", _boom)
+        state_file = tmp_path / "session.dat"
+        state_file.write_text("{not valid json", encoding="utf-8")
+
+        manager = SettingsManager(state_file)
+
+        assert manager.get_show_token_counter() is False
+
+
+class TestTmpFileIsChmoddedBeforeContentIsWritten:
+    """ADR-004 stage 4.4 (adversarial-review fix): the original code
+    wrote+fsync'd the full pending state to session.dat.tmp and only THEN
+    chmod'd it. A crash (power loss, OOM-kill) in that window left an
+    orphaned tmp file holding the pending secret values at loose,
+    umask-default permissions - and nothing in the codebase ever revisits
+    that exact filename except the NEXT successful save, so the exposure
+    could persist across many launches. Chmod'ing the file immediately
+    after it's opened (while still empty, before any secret bytes are
+    written) closes that window."""
+
+    def test_tmp_file_chmod_happens_while_the_file_is_still_empty(self, tmp_path, monkeypatch):
+        # No platform skip needed (unlike the permission-bit tests
+        # elsewhere in this file) - this test only checks CALL ORDERING via
+        # a spy, which is platform-independent even though chmod's real
+        # POSIX effect is not.
+        state_file = tmp_path / "session.dat"
+        observed_sizes_at_tmp_chmod_time = []
+        real_chmod = os.chmod
+
+        def spy_chmod(path, mode):
+            if str(path).endswith(".tmp"):
+                observed_sizes_at_tmp_chmod_time.append(os.path.getsize(path))
+            real_chmod(path, mode)
+
+        monkeypatch.setattr(os, "chmod", spy_chmod)
+
+        SettingsManager(state_file)
+
+        assert observed_sizes_at_tmp_chmod_time
+        assert all(size == 0 for size in observed_sizes_at_tmp_chmod_time)

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -4,7 +4,10 @@ saveChat/newChat)."""
 import asyncio
 import contextlib
 import json
+import os
 import sqlite3
+import stat
+import sys
 import threading
 import time
 
@@ -70,6 +73,50 @@ class Recorder:
 def test_get_all_chats_creates_table_on_a_fresh_db(db_path):
     assert get_all_chats(db_path) == []
     assert db_path.exists()
+
+
+class TestChatsDbPermissionsAreRestricted:
+    """ADR-004 stage 4.4: chats.db holds real conversation content, so
+    _connect() gives it POSIX 0600 on every connection - unconditional (not
+    "only if just created"), since every read/write helper in this module
+    routes through that one shared function. chmod's real effect is
+    POSIX-only (see _connect's own comment on why Windows os.chmod only
+    toggles the read-only attribute, not real per-owner permission bits)."""
+
+    def test_chmod_is_invoked_with_0600_on_the_real_db_file(self, db_path, monkeypatch):
+        calls = []
+        monkeypatch.setattr(os, "chmod", lambda path, mode: calls.append((path, mode)))
+
+        get_all_chats(db_path)
+
+        assert (db_path, 0o600) in calls
+
+    def test_posix_permission_bits_are_actually_0600(self, db_path):
+        if sys.platform == "win32":
+            pytest.skip("chmod is a no-op on Windows - see class docstring")
+
+        get_all_chats(db_path)
+
+        assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+
+    def test_self_heals_a_pre_existing_db_with_looser_permissions(self, db_path):
+        if sys.platform == "win32":
+            pytest.skip("chmod is a no-op on Windows - see class docstring")
+
+        _insert_chat(db_path, "Pre-existing")
+        os.chmod(db_path, 0o644)
+
+        get_all_chats(db_path)
+
+        assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+
+    def test_a_chmod_failure_does_not_crash_the_connection(self, db_path, monkeypatch):
+        def _boom(path, mode):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(os, "chmod", _boom)
+
+        assert get_all_chats(db_path) == []
 
 
 def test_get_all_chats_reads_real_rows(db_path):

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -39,6 +39,7 @@ def test_settings_payload_shape_matches_generated_validator_shape(manager):
         "enableSystemPrompt",
         "notificationPreferences",
         "githubTokenConfigured",
+        "secretsEncryptedAtRest",
     }
 
 
@@ -788,6 +789,67 @@ def test_api_key_never_appears_in_the_settings_payload(manager, monkeypatch):
     payload = recorder.messages[-1]["payload"]
     assert payload["apiKeyConfigured"] == {"openai": True, "anthropic": False, "gemini": False}
     assert "sk-super-secret-key" not in str(payload)
+
+
+class TestApiKeySourceHelper:
+    """ADR-004 stage 4.4: _api_key_source is the single source of truth for
+    whether a provider's key is "stored", "environment", or "none" - a
+    stored key always wins over the environment, matching every OR-chain in
+    api_provider.py that tries the stored/argument key first."""
+
+    def test_stored_wins_even_when_the_environment_is_also_set(self, monkeypatch):
+        monkeypatch.setattr(api_provider, "env_api_key_configured", lambda provider: True)
+
+        assert settings_module._api_key_source(True, config.API_PROVIDER_OPENAI) == "stored"
+
+    def test_environment_when_nothing_is_stored_but_the_environment_is_set(self, monkeypatch):
+        monkeypatch.setattr(api_provider, "env_api_key_configured", lambda provider: True)
+
+        assert settings_module._api_key_source(False, config.API_PROVIDER_OPENAI) == "environment"
+
+    def test_none_when_neither_is_stored_nor_set_in_the_environment(self, monkeypatch):
+        monkeypatch.setattr(api_provider, "env_api_key_configured", lambda provider: False)
+
+        assert settings_module._api_key_source(False, config.API_PROVIDER_OPENAI) == "none"
+
+    def test_passes_the_right_provider_through_to_env_api_key_configured(self, monkeypatch):
+        seen = []
+        monkeypatch.setattr(api_provider, "env_api_key_configured", lambda provider: seen.append(provider) or False)
+
+        settings_module._api_key_source(False, config.API_PROVIDER_ANTHROPIC)
+
+        assert seen == [config.API_PROVIDER_ANTHROPIC]
+
+
+def test_api_key_source_on_the_wire_reports_environment_only_when_nothing_is_stored(manager, monkeypatch):
+    monkeypatch.setattr(api_provider, "initialize_api", lambda *a, **k: None)
+    monkeypatch.setattr(
+        api_provider,
+        "env_api_key_configured",
+        lambda provider: provider in (config.API_PROVIDER_OPENAI, config.API_PROVIDER_ANTHROPIC),
+    )
+    bus = SessionBus("settings-api-key-source-test")
+    register_settings(bus, manager)
+    recorder = Recorder()
+    bus.attach(recorder)
+    asyncio.run(bus.publish("app-settings"))
+
+    payload = recorder.messages[0]["payload"]
+    # OpenAI/Anthropic: env is set, nothing stored -> "environment". Gemini:
+    # neither -> "none".
+    assert payload["apiKeySource"] == {"openai": "environment", "anthropic": "environment", "gemini": "none"}
+
+    # Now save an OpenAI key - a stored key must flip that provider (and
+    # only that provider) to "stored", even though its env var is still set.
+    asyncio.run(
+        bus.dispatch_intent(
+            "app-settings",
+            "saveApiConfiguration",
+            [config.API_PROVIDER_OPENAI, "https://x/v1", "sk-test", _six_task_models()],
+        )
+    )
+    payload = recorder.messages[-1]["payload"]
+    assert payload["apiKeySource"] == {"openai": "stored", "anthropic": "environment", "gemini": "none"}
 
 
 def test_reset_api_settings_intent_clears_everything(manager, monkeypatch):

--- a/contracts/graphlink_app_settings_payload.py
+++ b/contracts/graphlink_app_settings_payload.py
@@ -39,11 +39,20 @@ class AppSettingsStatePayload:
     enableSystemPrompt: bool
     notificationPreferences: dict[str, bool]
     githubTokenConfigured: bool
+    # ADR-004 stage 4.4: True unless DPAPI is unavailable/failing on this
+    # system, in which case every secret SettingsManager saves is being
+    # written in plaintext - the Settings UI renders a persistent badge
+    # when this is false (closes audit finding H12's silence).
+    secretsEncryptedAtRest: bool
     # R7.4a: API-provider page.
     activeApiProvider: str
     viewingApiProvider: str
     apiBaseUrl: str
     apiKeyConfigured: dict[str, bool]
+    # ADR-004 stage 4.4: "stored" | "environment" | "none" per provider -
+    # surfaces api_provider.py's own env-var key fallback (previously
+    # invisible to the user) without exposing the key's value.
+    apiKeySource: dict[str, str]
     apiModels: dict[str, str]
     apiModelCatalog: list[ApiModelDescriptorPayload]
     apiCatalogStatus: str

--- a/graphlink_secrets.py
+++ b/graphlink_secrets.py
@@ -99,6 +99,28 @@ def _is_encrypted_blob(value: str) -> bool:
     return _dpapi_call(blob, encrypt=False) is not None
 
 
+def dpapi_available() -> bool:
+    """ADR-004 stage 4.4: True only if DPAPI genuinely round-trips a probe
+    value right now on this system - not merely `sys.platform == "win32"`,
+    which would be wrong the moment the underlying WinAPI call itself
+    fails for some other reason (a locked-down environment, a missing
+    crypto provider, group policy restricting DPAPI, etc.) that
+    `_dpapi_call` already catches and turns into a plain `None`.
+
+    This is the answer to "is protect() about to silently return
+    plaintext instead of encrypting?" - SettingsManager calls this once at
+    construction (see its own docstring) and surfaces it to the Settings
+    UI, closing audit finding H12: before this, a DPAPI failure was
+    observable only as an absence (no `dpapi:`-prefixed value ever
+    appearing on disk), never as a signal a user could actually see.
+    """
+    probe = b"graphlink-dpapi-availability-probe"
+    encrypted = _dpapi_call(probe, encrypt=True)
+    if encrypted is None:
+        return False
+    return _dpapi_call(encrypted, encrypt=False) == probe
+
+
 def protect(value: str) -> str:
     """Encrypt a secret for storage. Empty stays empty; a value that is already a real
     encrypted blob passes through unchanged (idempotent - so the migration pass doesn't

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
@@ -11,6 +12,8 @@ from graphlink_model_catalog import (
     assignment_values,
     normalize_model_id,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _is_llama_cpp_gguf_path(path_value) -> bool:
@@ -59,7 +62,78 @@ class SettingsManager:
         self.state = self._load_state()
         if self._state_needs_save:
             self._save_state()
+        # ADR-004 stage 4.4: this is only the INITIAL value - not re-probed
+        # on every settings_payload read, since dpapi_available() does a
+        # real WinAPI round-trip. It IS kept honest afterward: every real
+        # secret save routes through _protect_and_track (see that method's
+        # own docstring), which updates this flag from the actual outcome
+        # of that specific protect() call - a fix for an adversarial-review
+        # finding where a construction-time-only probe could silently
+        # diverge from reality (DPAPI failing or recovering between
+        # construction and a later save left the UI banner stuck on a
+        # stale answer). This initial probe must still run BEFORE
+        # _migrate_plaintext_secrets below so that call's own
+        # protect()-driven migration and this flag agree on the same
+        # DPAPI state from the very first observation.
+        self._secrets_encrypted_at_rest = graphlink_secrets.dpapi_available()
         self._migrate_plaintext_secrets()
+        # ADR-004 stage 4.4: self-heal permissions on every launch, not
+        # just on the next write - see _save_state's own comment for why
+        # POSIX 0600 matters here (session.dat holds the encrypted-or-
+        # plaintext API keys/GitHub token). No-op on Windows: os.chmod
+        # there only toggles the read-only attribute bit, which a
+        # freshly-written settings file never has anyway - real access
+        # control on Windows comes from the per-user profile + DPAPI's own
+        # account binding, not POSIX permission bits.
+        if self.state_file.exists():
+            try:
+                os.chmod(self.state_file, 0o600)
+            except OSError:
+                logger.warning(
+                    "could not chmod %s to 0600 - continuing with existing permissions", self.state_file
+                )
+
+    def secrets_encrypted_at_rest(self) -> bool:
+        """ADR-004 stage 4.4: the flag backend/settings.py's wire payload
+        surfaces as secretsEncryptedAtRest, and the Settings UI renders as
+        a persistent badge when False ("API keys are stored unencrypted on
+        this system") - see graphlink_secrets.dpapi_available's own
+        docstring for what the INITIAL value means, and _protect_and_track's
+        docstring for how it's kept accurate across real secret saves after
+        that."""
+        return self._secrets_encrypted_at_rest
+
+    def _protect_and_track(self, value: str) -> str:
+        """graphlink_secrets.protect(), plus refreshing the cached
+        secrets_encrypted_at_rest() flag from a REAL probe taken at the
+        same moment - adversarial-review fix for stage 4.4: the flag was
+        originally computed only once, from a synthetic probe at
+        construction, and never revisited. DPAPI genuinely failing (or
+        recovering) between construction and a later real secret save left
+        the flag - and the Settings UI banner it drives - stuck on a stale,
+        wrong answer for the rest of the process's life: a save could
+        silently fall back to plaintext while the banner kept claiming
+        everything was encrypted, or vice versa after a real recovery.
+
+        Deliberately re-probes via dpapi_available() rather than inferring
+        the outcome from `protected`'s shape (e.g. "does it start with
+        dpapi:") - a first attempt at this did exactly that and had its own
+        bug: protect() on an ALREADY-encrypted value that fails to
+        re-verify falls back to returning the input UNCHANGED, which still
+        carries the "dpapi:" prefix from before, so a shape check alone
+        would keep reporting encrypted==True even while DPAPI was fully
+        down for a re-saved existing secret. A fresh, value-independent
+        probe has no such blind spot.
+
+        Skipped for an empty value - saving a blank field is not a
+        meaningful moment to re-probe, and doing so 2-3x per
+        set_api_settings call (once per provider field) even when nothing
+        was actually typed would be pure waste."""
+        normalized = str(value or "")
+        protected = graphlink_secrets.protect(normalized)
+        if normalized:
+            self._secrets_encrypted_at_rest = graphlink_secrets.dpapi_available()
+        return protected
 
     def _migrate_plaintext_secrets(self):
         """Encrypt any legacy plaintext secret still on disk from before #14 was fixed.
@@ -72,7 +146,7 @@ class SettingsManager:
         migrated = False
         for key in self.SECRET_KEYS:
             current_value = str(self.state.get(key, "") or "")
-            protected_value = graphlink_secrets.protect(current_value)
+            protected_value = self._protect_and_track(current_value)
             if protected_value != current_value:
                 self.state[key] = protected_value
                 migrated = True
@@ -217,6 +291,17 @@ class SettingsManager:
             timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
             backup_path = self.state_file.with_name(f"{self.state_file.name}.corrupted-{timestamp}")
             self.state_file.replace(backup_path)
+            # ADR-004 stage 4.4 (adversarial-review fix): Path.replace is a
+            # rename, which preserves the source inode's mode bits exactly -
+            # this backup can hold the same encrypted-or-plaintext secrets
+            # the live file had, and is never touched again by any other
+            # code path (kept indefinitely "for forensic recovery"), so it
+            # needs its own explicit chmod rather than inheriting whatever
+            # permissions the original file happened to have.
+            try:
+                os.chmod(backup_path, 0o600)
+            except OSError:
+                logger.warning("could not chmod %s to 0600 - continuing with existing permissions", backup_path)
             print(
                 f"Warning: {self.state_file} could not be read ({error}). "
                 f"Backed it up to {backup_path} and reset settings to defaults."
@@ -353,6 +438,23 @@ class SettingsManager:
         tmp_path = self.state_file.with_name(self.state_file.name + ".tmp")
         try:
             with open(tmp_path, 'w') as f:
+                # ADR-004 stage 4.4 (adversarial-review fix): chmod the temp
+                # file immediately after opening it, BEFORE writing any
+                # content - chmod'ing only after fsync left a window where a
+                # crash (power loss, OOM-kill) between the write and the
+                # chmod orphaned a fully-written tmp file, holding the
+                # pending secret values, at umask-default (loose)
+                # permissions. Nothing on the next launch ever revisits that
+                # exact filename except the NEXT successful save, so the
+                # exposure could persist across many launches. Chmod'ing the
+                # file while it's still empty (right after open() creates
+                # it, before any secret bytes land) closes that window
+                # entirely. No-op on Windows (see __init__'s own comment on
+                # why POSIX permission bits don't apply there).
+                try:
+                    os.chmod(tmp_path, 0o600)
+                except OSError:
+                    logger.warning("could not chmod %s to 0600 before writing - continuing", tmp_path)
                 json.dump(data_to_save, f, indent=4)
                 f.flush()
                 os.fsync(f.fileno())
@@ -756,9 +858,9 @@ class SettingsManager:
     ):
         self.state["api_provider"] = provider
         self.state["api_base_url"] = base_url
-        self.state["openai_api_key"] = graphlink_secrets.protect(openai_key)
-        self.state["anthropic_api_key"] = graphlink_secrets.protect(anthropic_key)
-        self.state["gemini_api_key"] = graphlink_secrets.protect(gemini_key)
+        self.state["openai_api_key"] = self._protect_and_track(openai_key)
+        self.state["anthropic_api_key"] = self._protect_and_track(anthropic_key)
+        self.state["gemini_api_key"] = self._protect_and_track(gemini_key)
         self._save_state()
 
     def set_api_models(self, models_dict: dict, provider: str | None = None):
@@ -810,7 +912,7 @@ class SettingsManager:
         self._save_state()
 
     def set_github_token(self, token: str):
-        self.state["github_access_token"] = graphlink_secrets.protect(token)
+        self.state["github_access_token"] = self._protect_and_track(token)
         self._save_state()
 
     def reset_api_settings(self):

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -21,10 +21,12 @@ const snapshot = {
   enableSystemPrompt: true,
   notificationPreferences: { info: true, success: true, warning: true, error: true },
   githubTokenConfigured: false,
+  secretsEncryptedAtRest: true,
   activeApiProvider: "OpenAI-Compatible",
   viewingApiProvider: "OpenAI-Compatible",
   apiBaseUrl: "https://api.openai.com/v1",
   apiKeyConfigured: { openai: false, anthropic: false, gemini: false },
+  apiKeySource: { openai: "none", anthropic: "none", gemini: "none" },
   apiModels: {},
   apiModelCatalog: [],
   apiCatalogStatus: "idle",
@@ -299,6 +301,51 @@ describe("SettingsDialog", () => {
 
     const keyField = screen.getByPlaceholderText("A key is configured - enter a new one to replace it");
     expect(keyField).toHaveValue("");
+  });
+
+  it("shows a persistent unencrypted-secrets warning when DPAPI is unavailable, regardless of section", async () => {
+    const { user, push } = setup();
+    await user.click(screen.getByText("open settings"));
+    act(() => push({ ...snapshot, secretsEncryptedAtRest: false }));
+
+    // getByRole("alert") - not just getByText - pins the adversarial-review
+    // fix that gave this banner role="alert" so screen readers actually
+    // encounter it (the dialog's focus trap otherwise skips straight past
+    // a non-focusable <p> to the rail buttons).
+    expect(screen.getByRole("alert")).toHaveTextContent(/API keys are stored unencrypted on this system/);
+
+    await user.click(screen.getByRole("button", { name: "Integrations" }));
+    expect(screen.getByRole("alert")).toHaveTextContent(/API keys are stored unencrypted on this system/);
+  });
+
+  it("hides the unencrypted-secrets warning when secrets are encrypted at rest", async () => {
+    const { user, push } = setup();
+    await user.click(screen.getByText("open settings"));
+    act(() => push({ ...snapshot, secretsEncryptedAtRest: true }));
+
+    expect(screen.queryByText(/API keys are stored unencrypted on this system/)).toBeNull();
+  });
+
+  it("shows an environment-variable hint next to the API Key field when that provider's key comes from the environment", async () => {
+    const { user, push } = setup();
+    await goToApiEndpoint(user, push, {
+      apiKeySource: { openai: "environment", anthropic: "none", gemini: "none" },
+    });
+
+    expect(
+      screen.getByText("Key provided by an environment variable, not Settings."),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the environment-variable hint when the viewed provider's key is stored or absent", async () => {
+    const { user, push } = setup();
+    await goToApiEndpoint(user, push, {
+      apiKeySource: { openai: "stored", anthropic: "none", gemini: "none" },
+    });
+
+    expect(
+      screen.queryByText("Key provided by an environment variable, not Settings."),
+    ).toBeNull();
   });
 
   it("switching the provider select fires setViewingApiProvider", async () => {

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -94,10 +94,17 @@ const initialState: AppSettingsState = {
   enableSystemPrompt: true,
   notificationPreferences: {},
   githubTokenConfigured: false,
+  // ADR-004 stage 4.4: optimistic default (true = encrypted) so the
+  // persistent badge below never flashes a false warning before the
+  // first real snapshot arrives - the real backend value replaces this
+  // on the very first "app-settings" publish, same as every other field
+  // here.
+  secretsEncryptedAtRest: true,
   activeApiProvider: API_PROVIDER_OPENAI,
   viewingApiProvider: API_PROVIDER_OPENAI,
   apiBaseUrl: DEFAULT_OPENAI_BASE_URL,
   apiKeyConfigured: { openai: false, anthropic: false, gemini: false },
+  apiKeySource: { openai: "none", anthropic: "none", gemini: "none" },
   apiModels: {},
   apiModelCatalog: [],
   apiCatalogStatus: "idle",
@@ -288,6 +295,12 @@ function ApiProviderPage({
   };
 
   const requiredTasks = API_TASK_FIELDS.filter(({ task }) => !(isAnthropic && task === TASK_IMAGE_GEN));
+  // ADR-004 stage 4.4: the same provider-key derivation apiKeyConfigured's
+  // placeholder below already needed, factored out so apiKeySource's new
+  // "provided by environment" hint reads the identical key - one place
+  // deciding "which of the 3 wire dicts' entries describes the viewed
+  // provider", not two that could silently diverge.
+  const viewingProviderKey = isOpenAi ? "openai" : isAnthropic ? "anthropic" : "gemini";
 
   return (
     <div className="settings-general-page">
@@ -326,15 +339,29 @@ function ApiProviderPage({
           type="password"
           className="settings-select"
           placeholder={
-            (state.apiKeyConfigured as Record<string, boolean>)[
-              isOpenAi ? "openai" : isAnthropic ? "anthropic" : "gemini"
-            ]
+            (state.apiKeyConfigured as Record<string, boolean>)[viewingProviderKey]
               ? "A key is configured - enter a new one to replace it"
               : "Enter your API key..."
           }
           value={draftApiKey}
           onChange={(event) => setDraftApiKey(event.target.value)}
         />
+        {/* ADR-004 stage 4.4: surfaces api_provider.py's own env-var key
+            fallback, previously invisible. apiKeySource[viewingProviderKey]
+            reflects the VIEWED provider (per its own dropdown), which may
+            not be the ACTIVE one - so this is a prediction ("if you saved/
+            activated this provider, its key would come from the
+            environment"), not a claim that the environment is supplying a
+            key to a live request right now. "stored" whenever a saved key
+            already exists (a stored key always wins over the environment -
+            see backend/settings.py's own _api_key_source). Saving a key
+            here will switch this to "stored" on the next snapshot, same as
+            apiKeyConfigured already does. */}
+        {(state.apiKeySource as Record<string, string>)[viewingProviderKey] === "environment" && (
+          <span className="settings-field-hint">
+            Key provided by an environment variable, not Settings.
+          </span>
+        )}
       </label>
 
       {(isOpenAi || isAnthropic) && (
@@ -863,6 +890,25 @@ export function SettingsDialog({ transport }: { transport: WsTransport }) {
 
   return (
     <Dialog name="settings" title="Settings" className="settings-dialog">
+      {/* ADR-004 stage 4.4: persistent (visible regardless of which
+          section tab is active, not a one-time toast) - a DPAPI failure
+          means every API key/GitHub token this dialog saves from now on
+          is written to disk in PLAINTEXT, a fact worth surfacing no
+          matter which page a user happens to be on when it's true. Hidden
+          entirely in the common case (secretsEncryptedAtRest is true).
+          role="alert" (adversarial-review fix) matches every other warning/
+          error banner in this codebase (BridgeErrorState.tsx, the 3
+          node-view banner-error divs) - without it, the dialog's own focus
+          trap moves focus straight to the rail buttons on open (this <p>
+          isn't focusable), so screen-reader users could tab straight past
+          this security-relevant text and never encounter it, and a later
+          flip from encrypted to unencrypted while the dialog is already
+          open would render with no assistive-tech announcement at all. */}
+      {!state.secretsEncryptedAtRest && (
+        <p className="settings-update-status settings-secrets-warning" data-level="warning" role="alert">
+          API keys are stored unencrypted on this system (Windows DPAPI is unavailable or failing here).
+        </p>
+      )}
       <div className="settings-shell">
         <nav className="settings-rail" aria-label="Settings sections">
           {SECTIONS.map((section) => (

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -3463,15 +3463,23 @@ mark.document-view-search-match-current {
 }
 
 .settings-dialog .overlay-dialog-body {
+  display: flex;
+  flex-direction: column;
   padding: 0;
   flex: 1;
   min-height: 0;
   overflow: hidden;
 }
 
+/* ADR-004 stage 4.4: the optional .settings-secrets-warning banner is now
+   a sibling before this element (see SettingsDialog.tsx) - flex:1 +
+   min-height:0 lets it share .overlay-dialog-body's column with that
+   banner instead of always claiming a fixed 100%, which would push the
+   rail/page below the dialog's clipped (overflow:hidden) bottom edge. */
 .settings-shell {
   display: flex;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
 }
 
 .settings-rail {
@@ -3644,6 +3652,33 @@ mark.document-view-search-match-current {
 .settings-update-status {
   margin: 0;
   font-size: 12px;
+  color: var(--gl-surface-text-muted);
+}
+
+/* ADR-004 stage 4.4: persistent banner shown above .settings-shell when
+   DPAPI is unavailable/failing, so every secret is being saved in
+   plaintext. Reuses .settings-update-status's own 12px/margin:0 baseline
+   (see SettingsDialog.tsx) but layers on padding/background/border so it
+   reads as a standing alert rather than routine status text, and pins
+   flex-shrink:0 so .settings-shell's flex:1 never squeezes it. Uses the
+   warning (not error) semantic color - unlike .code-exec-approval-warning,
+   this is a degraded-but-functional state, not a blocked action. */
+.settings-secrets-warning {
+  flex-shrink: 0;
+  padding: 10px 16px;
+  line-height: 1.4;
+  color: var(--gl-semantic-status-warning, currentColor);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+  border-bottom: 1px solid var(--gl-surface-border);
+}
+
+/* ADR-004 stage 4.4: small note under the API Key input when the key
+   actually in effect is coming from an environment variable rather than a
+   saved Settings value (see SettingsDialog.tsx's apiKeySource check). Sits
+   inside .settings-field's own flex column, so its 6px gap already
+   provides the spacing above - only font styling is needed here. */
+.settings-field-hint {
+  font-size: 11px;
   color: var(--gl-surface-text-muted);
 }
 

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
@@ -23,6 +23,12 @@
       },
       "type": "object"
     },
+    "apiKeySource": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
     "apiModelCatalog": {
       "items": {
         "additionalProperties": false,
@@ -162,6 +168,9 @@
     "schemaVersion": {
       "type": "integer"
     },
+    "secretsEncryptedAtRest": {
+      "type": "boolean"
+    },
     "showTokenCounter": {
       "type": "boolean"
     },
@@ -177,10 +186,12 @@
     "enableSystemPrompt",
     "notificationPreferences",
     "githubTokenConfigured",
+    "secretsEncryptedAtRest",
     "activeApiProvider",
     "viewingApiProvider",
     "apiBaseUrl",
     "apiKeyConfigured",
+    "apiKeySource",
     "apiModels",
     "apiModelCatalog",
     "apiCatalogStatus",

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
@@ -18,10 +18,12 @@ export interface AppSettingsState {
   enableSystemPrompt: boolean;
   notificationPreferences: Record<string, boolean>;
   githubTokenConfigured: boolean;
+  secretsEncryptedAtRest: boolean;
   activeApiProvider: string;
   viewingApiProvider: string;
   apiBaseUrl: string;
   apiKeyConfigured: Record<string, boolean>;
+  apiKeySource: Record<string, string>;
   apiModels: Record<string, string>;
   apiModelCatalog: ApiModelDescriptor[];
   apiCatalogStatus: string;
@@ -134,6 +136,11 @@ function checkAppSettingsState(value: unknown, path: string, errors: string[]): 
     else { if (typeof fieldValue !== "boolean") errors.push(`${path}.githubTokenConfigured` + ": expected boolean"); }
   }
   {
+    const fieldValue = value["secretsEncryptedAtRest"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.secretsEncryptedAtRest: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.secretsEncryptedAtRest` + ": expected boolean"); }
+  }
+  {
     const fieldValue = value["activeApiProvider"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.activeApiProvider: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.activeApiProvider` + ": expected string"); }
@@ -153,6 +160,12 @@ function checkAppSettingsState(value: unknown, path: string, errors: string[]): 
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.apiKeyConfigured: missing required field`);
     else { if (!isRecord(fieldValue)) errors.push(`${path}.apiKeyConfigured` + ": expected object");
     else Object.entries(fieldValue as Record<string, unknown>).forEach(([k, v]) => { if (typeof v !== "boolean") errors.push(`${path}.apiKeyConfigured` + `[${JSON.stringify(k)}]` + ": expected boolean"); }); }
+  }
+  {
+    const fieldValue = value["apiKeySource"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.apiKeySource: missing required field`);
+    else { if (!isRecord(fieldValue)) errors.push(`${path}.apiKeySource` + ": expected object");
+    else Object.entries(fieldValue as Record<string, unknown>).forEach(([k, v]) => { if (typeof v !== "string") errors.push(`${path}.apiKeySource` + `[${JSON.stringify(k)}]` + ": expected string"); }); }
   }
   {
     const fieldValue = value["apiModels"];


### PR DESCRIPTION
## Problem

Three related secrets-handling gaps (audit finding H12):

1. A DPAPI failure on save silently falls back to plaintext, with no way for the user to know their API keys are no longer encrypted at rest.
2. `session.dat` and `chats.db` had no POSIX permission hardening.
3. `api_provider.py`'s environment-variable API-key fallback was completely invisible to the user - a key sourced from `OPENAI_API_KEY` looked identical in Settings to "not configured".

## Change

- `graphlink_secrets.dpapi_available()`: a real `CryptProtectData`/`CryptUnprotectData` round-trip probe. Surfaced via `SettingsManager.secrets_encrypted_at_rest()` → wire payload `secretsEncryptedAtRest` → a persistent `role="alert"` banner in the Settings dialog when false.
- `session.dat` (self-heal + atomic-write temp file) and `chats.db` (unconditional, in the one shared `_connect`) both get `os.chmod(..., 0o600)`.
- `api_provider.py`'s env-var fallback consolidated into one canonical env-var table + `env_api_key_configured()` (presence-only, never exposes the value). `backend/settings.py`'s new `_api_key_source()` reports `"stored"` / `"environment"` / `"none"` per provider, wired as `apiKeySource` and shown as a hint next to the API Key field.

An adversarial-review pass (4 lenses, 28 agents) found 12 confirmed findings; 8 survived refutation. Fixed 4 directly in scope:
- `secretsEncryptedAtRest` was cached once at construction and could go stale (in either direction) after a real secret save — fixed by re-probing DPAPI on every secret-mutating call via a new `_protect_and_track()` helper, rather than inferring the outcome from `protect()`'s output shape (a first version of that inference had its own bug, caught during manual browser verification and regression-pinned).
- The `session.dat.corrupted-<timestamp>` forensic backup inherited the original file's loose permissions instead of getting its own `chmod`.
- The atomic-write temp file was `chmod`'d *after* secrets were already written to it, not before - reordered to close the crash window.
- The new warning banner had no `role="alert"`, unlike every other warning banner in this codebase.

3 pre-existing/orthogonal findings (migration double-wrap of undecryptable blobs, Gemini's env-key not baked into the module-global, the SQLite journal sidecar's permissions) were deliberately deferred as follow-up tasks rather than scope-creeping this diff.

## Test plan

- [x] `pytest -q` from repo root: 1333 passed, 5 skipped (Windows-only `sys.platform` guards for POSIX-only permission-bit assertions)
- [x] `npm run check` (schema + typecheck + lint + test + build): 1137 tests passed, clean build
- [x] Every fix mutation-verified (temporarily broken, confirmed the regression test fails with the expected message, restored, confirmed a clean diff)
- [x] Browser-verified: forced DPAPI failure renders the alert banner with `role="alert"`; forced an env-sourced key renders the hint next to the API Key field; no layout clipping or console errors