### PR TITLE
Fix secrets migration double-wrapping undecryptable blobs into garbage

### DIFF
--- a/backend/tests/test_backend_secrets_at_rest.py
+++ b/backend/tests/test_backend_secrets_at_rest.py
@@ -30,6 +30,7 @@ These tests run on real DPAPI (Windows dev machines and the windows-latest
 CI runner).
 """
 
+import base64
 import json
 import os
 import stat
@@ -181,6 +182,62 @@ class TestLegacyPlaintextMigration:
 
         stored_twice = json.loads(state_file.read_text(encoding="utf-8"))["github_access_token"]
         assert stored_twice == stored_once
+
+    @staticmethod
+    def _corrupt_a_real_blob(secret: str) -> str:
+        """A real DPAPI blob (genuinely encrypted, then had a byte flipped) -
+        stands in for a session.dat migrated from a different Windows
+        account, or one damaged on disk. Still has the "dpapi:" prefix and
+        still decodes as valid base64 (so it passes graphlink_secrets'
+        cheap structural checks), but CryptUnprotectData can no longer
+        decrypt it - the exact shape that used to fool migration's old
+        "try to decrypt to decide if it's already encrypted" heuristic."""
+        real_blob = graphlink_secrets.protect(secret)
+        prefix, encoded = real_blob.split(":", 1)
+        raw_bytes = bytearray(base64.b64decode(encoded))
+        raw_bytes[0] ^= 0xFF
+        return f"{prefix}:{base64.b64encode(bytes(raw_bytes)).decode('ascii')}"
+
+    def test_a_foreign_or_corrupted_blob_is_left_alone_by_migration_not_double_wrapped(self, tmp_path):
+        # Regression for an adversarial-review finding: migration used to
+        # call protect() unconditionally on every stored secret, and
+        # protect()'s own idempotency check tries to DECRYPT the value to
+        # decide "already encrypted, leave alone". For a blob this account
+        # genuinely can't decrypt, that attempt fails, so the OLD code
+        # concluded it must be plaintext and RE-ENCRYPTED (double-wrapped)
+        # it under this account's key - turning the documented, tested
+        # "not configured" (unprotect() returning "" for an undecryptable
+        # blob) into a silently garbage "configured" key instead.
+        corrupted_blob = self._corrupt_a_real_blob("sk-genuine-secret")
+        assert graphlink_secrets.unprotect(corrupted_blob) == ""  # sanity: genuinely undecryptable
+
+        state_file = tmp_path / "session.dat"
+        self._write_legacy_state(state_file, openai_api_key=corrupted_blob)
+
+        manager = SettingsManager(state_file)
+
+        assert manager.get_openai_key() == ""  # clean "not configured" - not garbage
+        raw = json.loads(state_file.read_text(encoding="utf-8"))
+        assert raw["openai_api_key"] == corrupted_blob  # untouched on disk - no double-wrap
+
+    def test_a_foreign_or_corrupted_blob_stays_untouched_across_repeated_launches(self, tmp_path):
+        # Not a byte-for-byte file comparison - _load_state fills in
+        # unrelated missing default fields on this legacy-shaped fixture
+        # regardless of secrets, so the file IS rewritten for THAT reason.
+        # What must stay constant across every launch is the stored secret
+        # value itself: still the original corrupted blob, never
+        # re-wrapped, never replaced with "".
+        corrupted_blob = self._corrupt_a_real_blob("sk-genuine-secret")
+        state_file = tmp_path / "session.dat"
+        self._write_legacy_state(state_file, github_access_token=corrupted_blob)
+
+        SettingsManager(state_file)
+        first_stored = json.loads(state_file.read_text(encoding="utf-8"))["github_access_token"]
+        manager = SettingsManager(state_file)  # a second, then third launch
+        second_stored = json.loads(state_file.read_text(encoding="utf-8"))["github_access_token"]
+
+        assert first_stored == second_stored == corrupted_blob
+        assert manager.get_github_token() == ""
 
 
 class TestGracefulDegradationWithoutDpapi:

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -142,10 +142,52 @@ class SettingsManager:
         plaintext value, re-protect it and persist immediately so the plaintext leaves
         disk on the first launch after upgrading, not whenever the user next happens
         to touch a setting. Where DPAPI is unavailable, protect() returns the value
-        unchanged, so nothing is rewritten and nothing regresses."""
+        unchanged, so nothing is rewritten and nothing regresses.
+
+        Adversarial-review fix: only ever acts on a value that has NO "dpapi:"
+        prefix at all (a cheap, unambiguous check - graphlink_secrets.is_protected).
+        A value that already carries the prefix is left untouched here,
+        regardless of whether it happens to be currently decryptable.
+
+        This closes a real bug: the previous version called protect() on
+        every stored value unconditionally. protect()'s own idempotency
+        check (_is_encrypted_blob) tries to DECRYPT the value to decide
+        "already encrypted, leave alone" - and for a genuine DPAPI blob
+        that simply isn't decryptable right now (session.dat copied to a
+        different Windows account/machine, or a corrupted blob), decryption
+        fails, so protect() concluded it must be plaintext and
+        RE-ENCRYPTED (double-wrapped) it under the current account's key.
+        From then on the getter would successfully decrypt this new
+        wrapper and return the literal base64 text of the original
+        undecryptable blob as if it were the real secret - silent garbage,
+        not the documented, tested "" that unprotect() promises for an
+        undecryptable blob (test_undecryptable_blob_returns_empty_not_garbage).
+        A user migrating a profile to a new PC would see no warning
+        (secrets_encrypted_at_rest() stays True - DPAPI genuinely works on
+        the new account) but their provider would silently fail to
+        authenticate with garbage instead of cleanly prompting for a new
+        key.
+
+        Accepted tradeoff: a secret that is somehow stored as literal
+        PLAINTEXT that itself happens to start with "dpapi:" (e.g. typed as
+        a proxy master key while DPAPI was unavailable) will no longer be
+        auto-migrated to real encryption here - protect()'s own
+        prefix-collision handling (see its docstring) only ever mattered
+        for a value passed to protect() directly, e.g. from a fresh save;
+        there is no way to distinguish that case from a genuine
+        undecryptable blob without attempting decryption, which is exactly
+        the ambiguous check that caused the bug this closes. Silently
+        risking a corrupted credential turning into an accepted garbage
+        key is worse than a contrived, unmigrated edge case whose getter
+        already cleanly returns "" today whenever its literal text isn't
+        also valid base64 (the overwhelmingly common case for real typed
+        text) - so this tradeoff was deliberately made in the safer
+        direction."""
         migrated = False
         for key in self.SECRET_KEYS:
             current_value = str(self.state.get(key, "") or "")
+            if not current_value or graphlink_secrets.is_protected(current_value):
+                continue
             protected_value = self._protect_and_track(current_value)
             if protected_value != current_value:
                 self.state[key] = protected_value


### PR DESCRIPTION
## Problem

`SettingsManager._migrate_plaintext_secrets()` calls `graphlink_secrets.protect()` unconditionally on every stored secret at launch. `protect()`'s own idempotency check (`_is_encrypted_blob`) tries to *decrypt* the value to decide "already encrypted, leave alone".

For a genuine DPAPI blob this account can't decrypt (`session.dat` copied to a different Windows account/machine, or a corrupted blob), that decrypt attempt fails - so the old code concluded it must be plaintext and re-encrypted (double-wrapped) it under the current account's key. The getter (`get_openai_key()` etc.) then successfully decrypted this *new* wrapper and returned the literal base64 text of the original undecryptable blob as if it were the real secret - silent garbage, not the documented, tested `""` that `unprotect()` promises for an undecryptable blob (`test_undecryptable_blob_returns_empty_not_garbage`).

Concrete impact: a user who migrates their profile to a new PC sees no warning (`secretsEncryptedAtRest` stays `True` - DPAPI genuinely works on the new account), but their configured provider silently fails to authenticate with garbage instead of cleanly prompting to re-enter the key.

Found by an adversarial-review pass during ADR-004 stage 4.4 and deliberately deferred to its own PR rather than rushed into that diff, since the naive fix regresses an existing, deliberately-tested `protect()` behavior (a plaintext secret that itself starts with `"dpapi:"` is supposed to get encrypted).

## Change

`_migrate_plaintext_secrets()` now skips any stored value that already carries the `"dpapi:"` prefix entirely (`graphlink_secrets.is_protected()` - a cheap, unambiguous prefix check), rather than attempting to decrypt it to decide whether to touch it.

**Accepted tradeoff:** a secret stored as literal plaintext that itself happens to start with `"dpapi:"` will no longer auto-migrate to real encryption. This is an extremely narrow edge case with no existing migration-level test coverage, and a self-correcting one (the user just re-enters the key) - preferable to the silent-garbage-credential risk this closes.

## Test plan

- [x] New regression tests in `backend/tests/test_backend_secrets_at_rest.py`: a corrupted/foreign blob stays `""` (not garbage) after migration, and stays byte-unchanged on disk across repeated launches
- [x] Existing migration tests still pass unmodified (`test_plaintext_secrets_are_encrypted_on_first_load`, `test_already_encrypted_secrets_are_not_double_wrapped`, `test_migration_does_not_rewrite_when_nothing_needs_migrating`)
- [x] Mutation-verified: reverted the fix, confirmed both new tests fail with the expected corruption, restored
- [x] `pytest -q` from repo root: 1335 passed, 5 skipped (Windows-only permission-bit guards)
- [x] `npm run check`: 1137 passed, clean build (unaffected - pure backend fix)