### PR TITLE
Fix Gemini branch not baking its env-resolved key into API_KEY

### DIFF
--- a/api_provider.py
+++ b/api_provider.py
@@ -2577,7 +2577,21 @@ def initialize_api(provider: str, api_key: str, base_url: str = None):
         base_url = None
 
     elif provider == config.API_PROVIDER_GEMINI:
-        if not (api_key or _first_env_api_key(_GEMINI_API_KEY_ENV_VARS)):
+        # Bake the env-resolved key into `api_key` the same way the OpenAI/
+        # Anthropic branches above do - it's what ends up in the
+        # module-global API_KEY below, which _snapshot_provider_state()
+        # freezes into api_key for the whole request. Previously this
+        # branch only did a presence CHECK (`if not (api_key or
+        # _first_env_api_key(...))`) without ever reassigning `api_key`,
+        # so an env-only Gemini key left API_KEY - and every request
+        # snapshot's api_key field - as the original empty string. That
+        # defeated the snapshot-consistency guarantee _get_gemini_api_key's
+        # snapshot_key parameter exists for (see its own comment): the
+        # snapshot's api_key OR-branch never fired, silently falling
+        # through to a LIVE re-read of API_KEY and then os.environ at
+        # actual-call time instead of the value frozen at request entry.
+        api_key = api_key or _first_env_api_key(_GEMINI_API_KEY_ENV_VARS)
+        if not api_key:
             raise RuntimeError("Gemini API key not configured. Open Settings and save your Gemini API key.")
         client = {"provider": config.API_PROVIDER_GEMINI}
     else:

--- a/backend/tests/test_backend_api_key_env_fallback.py
+++ b/backend/tests/test_backend_api_key_env_fallback.py
@@ -135,6 +135,63 @@ class TestEnvApiKeyConfigured:
         assert "sk-should-never-leak" not in repr(result)
 
 
+class TestGeminiEnvKeyIsBakedIntoTheModuleGlobal:
+    """Regression for an adversarial-review finding (spun off from ADR-004
+    stage 4.4): the OpenAI and Anthropic branches of initialize_api() both
+    reassign `api_key = api_key or _first_env_api_key(...)` before it gets
+    stored into the module-global API_KEY. The Gemini branch used to only
+    do a presence CHECK without ever reassigning `api_key`, so an env-only
+    Gemini key left API_KEY - and every request snapshot's frozen api_key
+    field (_snapshot_provider_state) - as the original empty string,
+    defeating the snapshot-consistency guarantee _get_gemini_api_key's own
+    snapshot_key parameter exists for."""
+
+    def test_env_only_gemini_key_is_baked_into_the_module_global_api_key(self, monkeypatch):
+        _reset_api_provider_state(monkeypatch)
+        monkeypatch.delenv("GRAPHLINK_GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GRAPHITE_GEMINI_API_KEY", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "from-gemini-env")
+
+        api_provider.initialize_api(config.API_PROVIDER_GEMINI, "", None)
+
+        assert api_provider.API_KEY == "from-gemini-env"
+
+    def test_env_only_gemini_key_survives_after_the_env_var_is_later_removed(self, monkeypatch):
+        # Mirrors the OpenAI/Anthropic behavior this asymmetry broke for
+        # Gemini specifically: once initialize_api() has run, later removing
+        # the env var (rotation/cleanup mid-session) must not un-configure a
+        # request already using the value captured at init time - the whole
+        # point of _snapshot_provider_state's frozen-at-request-entry design.
+        _reset_api_provider_state(monkeypatch)
+        monkeypatch.delenv("GRAPHLINK_GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GRAPHITE_GEMINI_API_KEY", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "from-gemini-env")
+        api_provider.initialize_api(config.API_PROVIDER_GEMINI, "", None)
+
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        snapshot = api_provider._snapshot_provider_state()
+
+        assert api_provider._get_gemini_api_key(snapshot.api_key) == "from-gemini-env"
+
+    def test_anthropic_already_had_this_correctly_for_comparison(self, monkeypatch):
+        # Same scenario as the two tests above, run against Anthropic - this
+        # already passed before the Gemini fix (the OpenAI/Anthropic
+        # branches never had the bug), kept here as a living comparison
+        # point so a future regression in either provider is caught by the
+        # same shape of test.
+        _reset_api_provider_state(monkeypatch)
+        monkeypatch.delenv("GRAPHLINK_ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("GRAPHITE_ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "from-anthropic-env")
+        api_provider.initialize_api(config.API_PROVIDER_ANTHROPIC, "", None)
+        assert api_provider.API_KEY == "from-anthropic-env"
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        snapshot = api_provider._snapshot_provider_state()
+
+        assert api_provider._get_anthropic_api_key(snapshot.api_key) == "from-anthropic-env"
+
+
 class TestLegacyGraphiteEnvVarStillWorks:
     """The app was renamed from Graphite to Graphlink; GRAPHITE_*_API_KEY env vars set
     before the rename must keep working so existing power-user shell configs don't


### PR DESCRIPTION
## Problem

`initialize_api()`'s OpenAI and Anthropic branches both reassign `api_key = api_key or _first_env_api_key(...)` before it's stored into the module-global `API_KEY`. The Gemini branch only did a presence check (`if not (api_key or _first_env_api_key(...))`) without ever reassigning `api_key` - so an env-only Gemini key left `API_KEY` as the original empty string.

`_snapshot_provider_state()` freezes `API_KEY` into `api_key` for the whole request specifically so `chat()`/`generate_image()` never need to re-read live global/env state mid-request. For Gemini's env-only case, `_get_gemini_api_key(snapshot_key=state.api_key)`'s first OR-branch never fired (the snapshot held `""`), silently falling through to a live re-read of `API_KEY` and then `os.environ` at actual-call time - defeating that consistency guarantee.

Concretely: removing `GEMINI_API_KEY` after a successful `initialize_api()` broke the next Gemini request ("Gemini API key not configured"), while the equivalent Anthropic scenario (removing `ANTHROPIC_API_KEY` after init) kept working off the value captured at init time.

This is pre-existing (the `if not (...)` pattern predates ADR-004 stage 4.4's refactor of the env-var lookup, which only swapped the inline OR-chain for `_first_env_api_key`) and orthogonal to that stage's actual diff - found by its adversarial-review pass and deliberately deferred to its own PR.

## Change

The Gemini branch of `initialize_api()` now reassigns `api_key` the same way OpenAI/Anthropic do, before it's stored into `API_KEY`.

## Test plan

- [x] New tests in `backend/tests/test_backend_api_key_env_fallback.py`: `API_KEY` holds the resolved value after an env-only Gemini `initialize_api()` call; a request still succeeds via the snapshot after the env var is later removed (mirrored against Anthropic for comparison)
- [x] Mutation-verified: reverted the fix, confirmed both new tests fail reproducing the exact described failure (`RuntimeError: Gemini API key not configured`), restored
- [x] `pytest -q` from repo root: 1338 passed, 5 skipped (Windows-only permission-bit guards)
- [x] `npm run check`: 1137 passed, clean build (unaffected - pure backend fix)