### PR TITLE
Switch chats.db to WAL mode, closing the journal-sidecar permission gap

### DIFF
--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -119,24 +119,62 @@ def _connect(db_path: Path) -> sqlite3.Connection:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path, timeout=30)
     conn.execute("PRAGMA foreign_keys = ON")
-    # ADR-004 stage 4.4: chats.db holds real conversation content, POSIX
-    # 0600 like session.dat (graphlink_settings_store.py's own
-    # SettingsManager). sqlite3.connect() creates the file itself with no
-    # mode parameter exposed anywhere in the stdlib API, so there is no
-    # earlier hook than right here, after connect() returns, to fix it up
-    # - and since EVERY read/write helper in this file goes through this
-    # one shared function (get_all_chats, rename_chat, delete_chat,
-    # load_chat_row, load_notes_rows, load_pins_rows,
-    # save_chat_atomically_row), doing it here rather than at each of
-    # those call sites both closes the gap for new files and self-heals a
-    # pre-stage-4.4 chats.db on its very next connection - unconditional,
-    # not "only if just created". No-op on Windows (see SettingsManager's
-    # own __init__ comment for why POSIX permission bits don't apply
-    # there).
-    try:
-        os.chmod(db_path, 0o600)
-    except OSError:
-        logger.warning("could not chmod %s to 0600 - continuing with existing permissions", db_path)
+    # ADR-004 stage 4.4 follow-up (adversarial-review finding): WAL mode,
+    # not SQLite's default rollback-journal. journal_mode is a database-
+    # level setting persisted in the file header, not a per-connection
+    # default - this PRAGMA only needs to actually FLIP the mode once ever
+    # (every later connection, including from a pre-existing chats.db,
+    # inherits it automatically; re-issuing it when already WAL is a cheap
+    # no-op). The rollback journal materializes a `<db>-journal` sidecar
+    # ONLY transiently, mid-transaction (SQLite creates and deletes it
+    # around each write with no Python-level hook to chmod it before it's
+    # gone), which meant it was the one piece of ADR-004 stage 4.4's own
+    # permission hardening that couldn't be closed.
+    #
+    # WAL's `<db>-wal`/`<db>-shm` sidecars behave differently, verified
+    # empirically (this module opens-does-work-closes a fresh connection
+    # per call, never holding one open, so the exact lifecycle mattered):
+    # once a database is GENUINELY already in WAL mode, connecting to it
+    # again - even for a pure read, before any write - immediately
+    # re-attaches both sidecars, which is exactly when the chmod loop
+    # below (positioned right after this PRAGMA) catches them. They still
+    # get removed when the sole connection closes, same as the rollback-
+    # journal case, but the WINDOW during which they exist now starts
+    # right when the loop below runs rather than only after a caller's own
+    # later write - so this closes the gap for the entire steady-state
+    # lifetime of a chats.db, not just some of it. One narrow, accepted
+    # exception remains: the VERY FIRST connection that ever switches a
+    # given chats.db into WAL mode needs an actual write before the
+    # sidecars exist at all, by which point this loop has already run and
+    # found nothing - a one-time-ever, single-connection window per
+    # database (pinned explicitly by
+    # TestChatsDbUsesWalModeForChmoddableSidecars's own bootstrap-gap test
+    # in backend/tests/test_chat_library.py), not a persistent exposure.
+    #
+    # This also happens to be a piece of ADR-009 stage 9.1's own planned
+    # "sqlite hygiene: WAL mode" bullet, done ahead of that stage's larger
+    # bundle (user_version/migration runner/FK indexes/one-time DDL) since
+    # it's purely additive and doesn't block any of that later work.
+    conn.execute("PRAGMA journal_mode = WAL")
+    # chats.db holds real conversation content, POSIX 0600 like
+    # session.dat (graphlink_settings_store.py's own SettingsManager).
+    # sqlite3.connect()/the PRAGMA above create these files with no mode
+    # parameter exposed anywhere in the stdlib API, so there is no earlier
+    # hook than right here to fix them up - and since EVERY read/write
+    # helper in this file goes through this one shared function
+    # (get_all_chats, rename_chat, delete_chat, load_chat_row,
+    # load_notes_rows, load_pins_rows, save_chat_atomically_row), doing it
+    # here rather than at each of those call sites both closes the gap for
+    # new files and self-heals a pre-existing chats.db (and its sidecars)
+    # on their very next connection - unconditional, not "only if just
+    # created". No-op on Windows (see SettingsManager's own __init__
+    # comment for why POSIX permission bits don't apply there).
+    for path in (db_path, db_path.with_name(db_path.name + "-wal"), db_path.with_name(db_path.name + "-shm")):
+        if path.exists():
+            try:
+                os.chmod(path, 0o600)
+            except OSError:
+                logger.warning("could not chmod %s to 0600 - continuing with existing permissions", path)
     return conn
 
 

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -119,6 +119,129 @@ class TestChatsDbPermissionsAreRestricted:
         assert get_all_chats(db_path) == []
 
 
+class TestChatsDbUsesWalModeForChmoddableSidecars:
+    """ADR-004 stage 4.4 follow-up (adversarial-review finding): the default
+    rollback-journal mode materializes a `<db>-journal` sidecar ONLY
+    transiently, mid-transaction (SQLite creates and deletes it around each
+    write), so it was never reachable by a Python-level chmod call - the
+    one gap in this module's own POSIX-permission hardening. WAL mode's
+    `<db>-wal`/`<db>-shm` sidecars are different: once a database is
+    genuinely in WAL mode, connecting to it AGAIN (even for a pure read,
+    before any write) immediately re-attaches them - which is when
+    _connect()'s chmod loop, positioned right after the PRAGMA, catches
+    them (empirically verified - see the probes this test class's
+    behavior is modeled on). They still get cleaned up when the sole
+    connection closes (this module opens-does-work-closes a fresh
+    connection per call, never holding one open), so this is "chmod them
+    every time they're freshly attached," not "they now live forever" -
+    but since that happens on every connection from the second one
+    onward, it closes the exposure for the entire steady-state lifetime
+    of a chats.db, unlike the rollback-journal's zero coverage.
+
+    One narrow, accepted residual gap remains and is pinned explicitly
+    below: the VERY FIRST connection that ever switches a given chats.db
+    into WAL mode needs an actual write before the sidecars exist at all
+    (the PRAGMA alone doesn't create them yet) - by which point
+    _connect()'s chmod loop has already run and found nothing. This is a
+    one-time-ever, single-connection window per database, not a
+    persistent or repeatable exposure - the same shape of accepted
+    residual risk this codebase already documents elsewhere for other
+    narrow, structurally-unavoidable creation-moment races."""
+
+    def test_journal_mode_is_actually_wal(self, db_path):
+        conn = chat_library_module._connect(db_path)
+        try:
+            mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        finally:
+            conn.close()
+
+        assert mode == "wal"
+
+    def test_the_very_first_ever_wal_connection_has_a_narrow_bootstrap_gap(self, db_path, monkeypatch):
+        # Pinned, not just tolerated: documents the one accepted residual
+        # window from this class's own docstring. A brand-new chats.db has
+        # never been WAL before, so establishing WAL mode on this very
+        # first connection needs a real write before the sidecars exist -
+        # _connect()'s chmod loop runs before that write happens (it's
+        # issued by the CALLER, after _connect() returns), so it can't
+        # catch them yet. If this test starts failing, the gap has closed
+        # for real and this whole comment (and the class docstring) should
+        # be updated, not just re-asserted.
+        calls = []
+        monkeypatch.setattr(os, "chmod", lambda path, mode: calls.append((path, mode)))
+
+        get_all_chats(db_path)  # brand-new db_path - the very first WAL connection ever
+
+        wal_path = db_path.with_name(db_path.name + "-wal")
+        shm_path = db_path.with_name(db_path.name + "-shm")
+        assert (wal_path, 0o600) not in calls
+        assert (shm_path, 0o600) not in calls
+
+    def test_chmod_is_invoked_on_the_sidecars_from_the_second_connection_onward(self, db_path, monkeypatch):
+        get_all_chats(db_path)  # bootstrap: establishes WAL mode for this db_path
+
+        calls = []
+        monkeypatch.setattr(os, "chmod", lambda path, mode: calls.append((path, mode)))
+        get_all_chats(db_path)  # this db is now genuinely WAL - sidecars re-attach immediately
+
+        wal_path = db_path.with_name(db_path.name + "-wal")
+        shm_path = db_path.with_name(db_path.name + "-shm")
+        assert (wal_path, 0o600) in calls
+        assert (shm_path, 0o600) in calls
+
+    def test_posix_permission_bits_on_the_sidecars_are_actually_0600(self, db_path):
+        if sys.platform == "win32":
+            pytest.skip("chmod is a no-op on Windows - see class docstring")
+
+        get_all_chats(db_path)  # bootstrap: establishes WAL mode for this db_path
+
+        # A live connection (not get_all_chats, which closes immediately)
+        # so the sidecars still exist when we inspect their real bits -
+        # this module's connect-per-call pattern deletes them the instant
+        # the sole connection closes.
+        conn = chat_library_module._connect(db_path)
+        try:
+            wal_path = db_path.with_name(db_path.name + "-wal")
+            shm_path = db_path.with_name(db_path.name + "-shm")
+            assert stat.S_IMODE(wal_path.stat().st_mode) == 0o600
+            assert stat.S_IMODE(shm_path.stat().st_mode) == 0o600
+        finally:
+            conn.close()
+
+    def test_self_heals_stale_sidecars_left_behind_by_a_crash(self, db_path):
+        if sys.platform == "win32":
+            pytest.skip("chmod is a no-op on Windows - see class docstring")
+
+        get_all_chats(db_path)  # bootstrap: establishes WAL mode, then cleanly closes
+        wal_path = db_path.with_name(db_path.name + "-wal")
+        shm_path = db_path.with_name(db_path.name + "-shm")
+        # A real crash (kill -9 / power loss) mid-write leaves these behind
+        # instead of letting SQLite's normal close-time checkpoint clean
+        # them up - simulated here directly, since forcing an actual
+        # process-level crash isn't something a test can safely do.
+        wal_path.write_bytes(b"")
+        shm_path.write_bytes(b"")
+        os.chmod(wal_path, 0o644)
+        os.chmod(shm_path, 0o644)
+
+        conn = chat_library_module._connect(db_path)
+        try:
+            assert stat.S_IMODE(wal_path.stat().st_mode) == 0o600
+            assert stat.S_IMODE(shm_path.stat().st_mode) == 0o600
+        finally:
+            conn.close()
+
+    def test_a_chmod_failure_on_a_sidecar_does_not_crash_the_connection(self, db_path, monkeypatch):
+        get_all_chats(db_path)  # bootstrap so the sidecars are reachable this time
+
+        def _boom(path, mode):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(os, "chmod", _boom)
+
+        assert get_all_chats(db_path) == []
+
+
 def test_get_all_chats_reads_real_rows(db_path):
     first_id = _insert_chat(db_path, "First")
     second_id = _insert_chat(db_path, "Second")


### PR DESCRIPTION
## Problem

`chat_library.py`'s `_connect()` gives `chats.db` POSIX 0600 (ADR-004 stage 4.4), but SQLite's default rollback-journal mode materializes a `<db>-journal` sidecar only transiently, mid-transaction - SQLite creates and deletes it around each write with no Python-level hook to chmod it before it's gone.

Since `chats.db` holds real, unencrypted conversation content (unlike `session.dat`'s API keys, it has no encryption-at-rest option at all - `chat_library.py` never imports `graphlink_secrets`), POSIX permissions were the *sole* protection layer this data got, and the journal sidecar was the one gap in that protection.

An adversarial-review pass during ADR-004 stage 4.4 empirically confirmed this: opened a second raw sqlite3 connection, ran `BEGIN IMMEDIATE` + an INSERT with literal sensitive text, deliberately didn't commit (materializing a real `chats.db-journal` file), then called the real `_connect()` while it existed - confirmed the only chmod call targeted `chats.db` itself, never the journal.

## Change

Switched `_connect()` to `PRAGMA journal_mode = WAL`. Verified empirically (this module opens-does-work-closes a fresh connection per call, never holding one open, so the exact sidecar lifecycle mattered):

- Once a `chats.db` is genuinely already in WAL mode, reconnecting to it - even for a pure read, before any write - immediately re-attaches the `<db>-wal`/`<db>-shm` sidecars, which is exactly when the existing chmod loop (now covering both sidecars, not just the main file) catches them.
- They still get removed when the sole connection closes, same as before, but the window during which they exist now starts right when that loop runs instead of only after a caller's own later write - closing the exposure for the entire steady-state lifetime of a `chats.db`.
- One narrow, accepted exception: the very first connection that ever switches a given `chats.db` into WAL mode needs an actual write before the sidecars exist at all, by which point the chmod loop has already run and found nothing - a one-time-ever, single-connection window per database, not a persistent exposure. Pinned by its own regression test.

This also pre-empts a piece of **ADR-009 stage 9.1**'s own planned "sqlite hygiene: WAL mode" bullet, done here ahead of that stage's larger bundle (`user_version`/migration runner/FK indexes/one-time DDL) since it's purely additive and doesn't block any of that later work.

## Test plan

- [x] New `TestChatsDbUsesWalModeForChmoddableSidecars` class in `backend/tests/test_chat_library.py`: journal_mode is really `wal`; the one-time bootstrap gap is explicitly pinned (not just tolerated); chmod is invoked on both sidecars from the second connection onward; real POSIX bits are 0600; stale sidecars left behind by a simulated crash get self-healed; a chmod failure on a sidecar doesn't crash the connection
- [x] Mutation-verified: reverted the PRAGMA (tests correctly failed with `journal_mode == 'delete'`), reverted the sidecar-loop to just the main file (tests correctly failed to find the sidecar chmod calls), restored both
- [x] `pytest -q` from repo root: 1342 passed, 7 skipped (Windows-only permission-bit guards)
- [x] `npm run check`: 1137 passed, clean build (unaffected - pure backend fix)