### PR TITLE
ADR-004 stage 4.5: SSRF IP-pinning + robots.txt/crawl-delay etiquette

### DIFF
--- a/backend/tests/test_web_research_crawl_etiquette.py
+++ b/backend/tests/test_web_research_crawl_etiquette.py
@@ -1,0 +1,285 @@
+"""Tests for graphlink_plugins/web_research/crawl_etiquette.py (ADR-004
+stage 4.5) - robots.txt Disallow rules and polite per-host rate limiting for
+the Web Research fetch path.
+
+time.monotonic()/time.sleep() are monkeypatched throughout for fast,
+deterministic tests - a fake clock advanced explicitly between calls,
+rather than real (even if short) waits.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import graphlink_plugins.web_research.crawl_etiquette as etiquette_module
+from graphlink_plugins.web_research.crawl_etiquette import CrawlEtiquette, RobotsDisallowedError
+
+
+class _FakeClock:
+    def __init__(self, start: float = 1_000.0):
+        self.now = start
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += seconds
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    fake = _FakeClock()
+    monkeypatch.setattr(etiquette_module.time, "monotonic", fake.monotonic)
+    monkeypatch.setattr(etiquette_module.time, "sleep", fake.sleep)
+    return fake
+
+
+def _fetcher(status_code: int, body: bytes):
+    def fetch(url):
+        return (status_code, body)
+    return fetch
+
+
+ROBOTS_WITH_DISALLOW_AND_DELAY = b"""User-agent: *
+Disallow: /private/
+Crawl-delay: 5
+"""
+
+ROBOTS_ALLOW_ALL_NO_DELAY = b"""User-agent: *
+Disallow:
+"""
+
+
+class TestRobotsDisallow:
+    def test_an_allowed_path_does_not_raise(self, clock):
+        etq = CrawlEtiquette()
+        etq.gate("https://example.com/public/page", _fetcher(200, ROBOTS_WITH_DISALLOW_AND_DELAY))
+
+    def test_a_disallowed_path_raises(self, clock):
+        etq = CrawlEtiquette()
+        with pytest.raises(RobotsDisallowedError, match="disallows"):
+            etq.gate("https://example.com/private/secret", _fetcher(200, ROBOTS_WITH_DISALLOW_AND_DELAY))
+
+    def test_robots_txt_is_only_fetched_once_per_origin(self, clock):
+        calls = []
+
+        def counting_fetch(url):
+            calls.append(url)
+            return (200, ROBOTS_ALLOW_ALL_NO_DELAY)
+
+        etq = CrawlEtiquette(default_crawl_delay_seconds=0)
+        etq.gate("https://example.com/page-a", counting_fetch)
+        etq.gate("https://example.com/page-b", counting_fetch)
+        etq.gate("https://example.com/page-c", counting_fetch)
+
+        assert calls == ["https://example.com/robots.txt"]
+
+    def test_different_paths_on_different_origins_each_get_their_own_robots_txt(self, clock):
+        calls = []
+
+        def counting_fetch(url):
+            calls.append(url)
+            return (200, ROBOTS_ALLOW_ALL_NO_DELAY)
+
+        etq = CrawlEtiquette(default_crawl_delay_seconds=0)
+        etq.gate("https://a.example/page", counting_fetch)
+        etq.gate("https://b.example/page", counting_fetch)
+
+        assert calls == ["https://a.example/robots.txt", "https://b.example/robots.txt"]
+
+    def test_a_404_on_robots_txt_means_everything_is_allowed(self, clock):
+        etq = CrawlEtiquette()
+        etq.gate("https://example.com/anything", _fetcher(404, b""))  # must not raise
+
+    @pytest.mark.parametrize("status_code", [401, 403])
+    def test_401_or_403_on_robots_txt_disallows_everything(self, clock, status_code):
+        etq = CrawlEtiquette()
+        with pytest.raises(RobotsDisallowedError):
+            etq.gate("https://example.com/anything", _fetcher(status_code, b""))
+
+    def test_a_5xx_on_robots_txt_is_treated_as_no_explicit_rules(self, clock):
+        etq = CrawlEtiquette()
+        etq.gate("https://example.com/anything", _fetcher(503, b""))  # must not raise
+
+    def test_a_redirect_status_on_robots_txt_is_treated_as_no_explicit_rules(self, clock):
+        # providers.py never follows redirects for robots.txt itself (see
+        # its own _fetch_robots_bytes docstring) - a 3xx status simply
+        # isn't handled specially here either, matching "no rules found".
+        etq = CrawlEtiquette()
+        etq.gate("https://example.com/anything", _fetcher(301, b""))  # must not raise
+
+    def test_a_network_failure_fetching_robots_txt_fails_open(self, clock):
+        def failing_fetch(url):
+            raise ConnectionError("boom")
+
+        etq = CrawlEtiquette()
+        etq.gate("https://example.com/anything", failing_fetch)  # must not raise
+
+    def test_a_fetcher_returning_none_fails_open(self, clock):
+        etq = CrawlEtiquette()
+        etq.gate("https://example.com/anything", lambda url: None)  # must not raise
+
+    def test_unparseable_robots_txt_body_fails_open_rather_than_crashing(self, clock):
+        etq = CrawlEtiquette()
+        # Invalid UTF-8 - decode uses errors="replace", so this shouldn't
+        # even hit the except path, but confirms no exception either way.
+        etq.gate("https://example.com/anything", _fetcher(200, b"\xff\xfe\x00garbage"))
+
+    def test_a_network_failure_is_not_permanently_cached_and_gets_retried(self, clock):
+        # Regression for an adversarial-review finding: caching a single
+        # timeout/network-failure as "no rules, forever, for this run" gave
+        # a malicious site a deterministic way to disable its own robots.txt
+        # enforcement with one deliberately-stalled request. A later gate()
+        # call for the same origin must re-attempt the fetch, not trust a
+        # single earlier failure.
+        calls = []
+
+        def failing_fetch(url):
+            calls.append(url)
+            raise ConnectionError("boom")
+
+        etq = CrawlEtiquette(default_crawl_delay_seconds=0)
+        etq.gate("https://example.com/page-a", failing_fetch)
+        etq.gate("https://example.com/page-b", failing_fetch)
+        etq.gate("https://example.com/page-c", failing_fetch)
+
+        assert calls == [
+            "https://example.com/robots.txt",
+            "https://example.com/robots.txt",
+            "https://example.com/robots.txt",
+        ]
+
+    def test_a_successful_fetch_after_earlier_failures_is_cached_normally(self, clock):
+        attempts = {"count": 0}
+
+        def flaky_then_ok(url):
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                raise ConnectionError("boom")
+            return (200, ROBOTS_WITH_DISALLOW_AND_DELAY)
+
+        etq = CrawlEtiquette()
+        etq.gate("https://example.com/public/a", flaky_then_ok)
+        etq.gate("https://example.com/public/b", flaky_then_ok)
+        with pytest.raises(RobotsDisallowedError):
+            etq.gate("https://example.com/private/c", flaky_then_ok)  # 3rd attempt succeeds, rules now apply
+
+        assert attempts["count"] == 3  # not re-fetched again after the successful 3rd attempt
+
+
+class TestPoliteDelay:
+    """gate() itself never sleeps (adversarial-review fix - see its own
+    docstring on why an uninterruptible internal sleep was a real bug: it
+    bypassed the fetch's cancellation token and total-timeout budget). It
+    returns the number of seconds still owed instead, which
+    RequestsDocumentFetcher._wait_politely actually sleeps out - covered by
+    its own tests in test_web_research_providers_fetcher.py."""
+
+    def test_no_delay_on_the_very_first_fetch_to_a_host(self, clock):
+        etq = CrawlEtiquette(default_crawl_delay_seconds=5.0)
+        owed = etq.gate("https://example.com/page", _fetcher(200, ROBOTS_ALLOW_ALL_NO_DELAY))
+        assert owed == 0.0
+
+    def test_the_default_delay_is_owed_on_a_second_fetch_to_the_same_host(self, clock):
+        etq = CrawlEtiquette(default_crawl_delay_seconds=5.0)
+        etq.gate("https://example.com/page-a", _fetcher(200, ROBOTS_ALLOW_ALL_NO_DELAY))
+        etq.record_fetch("https://example.com/page-a")
+
+        clock.advance(1.0)  # only 1s of the 5s owed has passed
+        owed = etq.gate("https://example.com/page-b", _fetcher(200, ROBOTS_ALLOW_ALL_NO_DELAY))
+
+        assert owed == pytest.approx(4.0)
+
+    def test_no_delay_if_enough_time_has_already_passed(self, clock):
+        etq = CrawlEtiquette(default_crawl_delay_seconds=5.0)
+        etq.gate("https://example.com/page-a", _fetcher(200, ROBOTS_ALLOW_ALL_NO_DELAY))
+        etq.record_fetch("https://example.com/page-a")
+
+        clock.advance(10.0)  # well past the 5s owed
+        owed = etq.gate("https://example.com/page-b", _fetcher(200, ROBOTS_ALLOW_ALL_NO_DELAY))
+
+        assert owed == 0.0
+
+    def test_a_larger_robots_txt_crawl_delay_wins_over_the_default(self, clock):
+        etq = CrawlEtiquette(default_crawl_delay_seconds=1.0)
+        etq.gate("https://example.com/page-a", _fetcher(200, ROBOTS_WITH_DISALLOW_AND_DELAY))  # Crawl-delay: 5
+        etq.record_fetch("https://example.com/page-a")
+
+        clock.advance(0.0)
+        owed = etq.gate("https://example.com/page-b", _fetcher(200, ROBOTS_WITH_DISALLOW_AND_DELAY))
+
+        assert owed == pytest.approx(5.0)
+
+    def test_the_default_wins_when_it_is_larger_than_robots_txt_own_crawl_delay(self, clock):
+        # Never LESS polite than our own baseline, even if the site itself
+        # asked for a shorter delay.
+        etq = CrawlEtiquette(default_crawl_delay_seconds=10.0)
+        etq.gate("https://example.com/page-a", _fetcher(200, ROBOTS_WITH_DISALLOW_AND_DELAY))  # Crawl-delay: 5
+        etq.record_fetch("https://example.com/page-a")
+
+        clock.advance(0.0)
+        owed = etq.gate("https://example.com/page-b", _fetcher(200, ROBOTS_WITH_DISALLOW_AND_DELAY))
+
+        assert owed == pytest.approx(10.0)
+
+    def test_a_robots_txt_crawl_delay_larger_than_the_max_ceiling_is_clamped(self, clock):
+        etq = CrawlEtiquette(default_crawl_delay_seconds=1.0, max_crawl_delay_seconds=3.0)
+        etq.gate("https://example.com/page-a", _fetcher(200, ROBOTS_WITH_DISALLOW_AND_DELAY))  # Crawl-delay: 5
+        etq.record_fetch("https://example.com/page-a")
+
+        clock.advance(0.0)
+        owed = etq.gate("https://example.com/page-b", _fetcher(200, ROBOTS_WITH_DISALLOW_AND_DELAY))
+
+        assert owed == pytest.approx(3.0)  # clamped, not the robots.txt-declared 5.0
+
+    def test_a_huge_crawl_delay_digit_string_does_not_raise_and_is_clamped(self, clock):
+        # Regression: RobotFileParser.crawl_delay() returns a real Python
+        # int for a numeric Crawl-delay directive, of UNBOUNDED size for a
+        # many-digit value - float() on a sufficiently huge int raises
+        # OverflowError rather than saturating. gate() must not propagate
+        # that; a malformed-but-huge value should fail open on that one
+        # directive (same as any other malformed robots.txt content) and
+        # still be bounded by max_crawl_delay_seconds via the plain default.
+        huge_delay_robots = b"User-agent: *\nDisallow:\nCrawl-delay: " + b"9" * 350 + b"\n"
+        etq = CrawlEtiquette(default_crawl_delay_seconds=1.0, max_crawl_delay_seconds=3.0)
+        etq.gate("https://example.com/page-a", _fetcher(200, huge_delay_robots))
+        etq.record_fetch("https://example.com/page-a")
+
+        clock.advance(0.0)
+        owed = etq.gate("https://example.com/page-b", _fetcher(200, huge_delay_robots))
+
+        assert owed == pytest.approx(1.0)  # falls back to the default, not an exception
+
+    def test_different_hosts_never_delay_each_other(self, clock):
+        etq = CrawlEtiquette(default_crawl_delay_seconds=5.0)
+        etq.gate("https://a.example/page", _fetcher(200, ROBOTS_ALLOW_ALL_NO_DELAY))
+        etq.record_fetch("https://a.example/page")
+
+        clock.advance(0.0)
+        owed = etq.gate("https://b.example/page", _fetcher(200, ROBOTS_ALLOW_ALL_NO_DELAY))
+
+        assert owed == 0.0
+
+    def test_record_fetch_without_a_prior_gate_call_still_seeds_the_next_delay(self, clock):
+        etq = CrawlEtiquette(default_crawl_delay_seconds=5.0)
+        etq.record_fetch("https://example.com/page-a")
+
+        clock.advance(2.0)
+        owed = etq.gate("https://example.com/page-b", _fetcher(200, ROBOTS_ALLOW_ALL_NO_DELAY))
+
+        assert owed == pytest.approx(3.0)
+
+    def test_same_host_different_ports_are_tracked_as_separate_origins(self, clock):
+        etq = CrawlEtiquette(default_crawl_delay_seconds=5.0)
+        etq.gate("https://example.com:8443/page", _fetcher(200, ROBOTS_ALLOW_ALL_NO_DELAY))
+        etq.record_fetch("https://example.com:8443/page")
+
+        clock.advance(0.0)
+        owed = etq.gate("https://example.com/page", _fetcher(200, ROBOTS_ALLOW_ALL_NO_DELAY))
+
+        assert owed == 0.0  # default port 443 is a DIFFERENT origin from :8443, no delay owed

--- a/backend/tests/test_web_research_fetch_policy.py
+++ b/backend/tests/test_web_research_fetch_policy.py
@@ -1,0 +1,187 @@
+"""Tests for graphlink_plugins/web_research/fetch_policy.py - the SSRF
+network boundary for Web Research source fetching (ADR-004 stage 4.5,
+audit finding M6).
+
+No prior test coverage existed for this module at all (confirmed by recon
+before this stage - the only reference in graphlink_app/tests/ was already
+deleted by the Qt-removal cutover), so this covers both the pre-existing
+scheme/private-range/localhost checks and the new ValidatedTarget/IP-pinning
+return value stage 4.5 adds.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from graphlink_plugins.web_research.fetch_policy import (
+    FetchPolicy,
+    URLPolicyError,
+    ValidatedTarget,
+    _is_public_address,
+    canonicalize_url,
+)
+
+
+def _fake_resolver(*addresses: str):
+    """Stands in for socket.getaddrinfo - same call signature FetchPolicy
+    uses (host, port, type=...), same (family, type, proto, canonname,
+    sockaddr) record shape, so _resolve_addresses' own record[4][0]
+    extraction works unchanged against it."""
+
+    def resolver(host, port, type=None):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port)) for address in addresses]
+
+    return resolver
+
+
+def _raising_resolver(exc: Exception):
+    def resolver(host, port, type=None):
+        raise exc
+
+    return resolver
+
+
+class TestCanonicalizeUrl:
+    def test_lowercases_scheme_and_host(self):
+        assert canonicalize_url("HTTPS://Example.COM/Path") == "https://example.com/Path"
+
+    def test_strips_the_default_port_for_the_scheme(self):
+        assert canonicalize_url("https://example.com:443/") == "https://example.com/"
+        assert canonicalize_url("http://example.com:80/") == "http://example.com/"
+
+    def test_keeps_a_non_default_port(self):
+        assert canonicalize_url("https://example.com:8443/") == "https://example.com:8443/"
+
+    def test_defaults_an_empty_path_to_a_single_slash(self):
+        assert canonicalize_url("https://example.com") == "https://example.com/"
+
+    def test_drops_the_fragment(self):
+        assert canonicalize_url("https://example.com/page#section") == "https://example.com/page"
+
+    def test_rejects_a_url_with_userinfo(self):
+        assert canonicalize_url("https://user:pass@example.com/") == ""
+
+    def test_rejects_a_url_with_no_scheme_or_hostname(self):
+        assert canonicalize_url("not-a-url") == ""
+        assert canonicalize_url("") == ""
+
+    def test_rejects_an_invalid_port(self):
+        assert canonicalize_url("https://example.com:not-a-port/") == ""
+
+
+class TestIsPublicAddress:
+    @pytest.mark.parametrize(
+        "address",
+        ["8.8.8.8", "1.1.1.1", "93.184.216.34", "2606:4700:4700::1111"],
+    )
+    def test_true_for_real_public_addresses(self, address):
+        assert _is_public_address(address) is True
+
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "127.0.0.1",  # loopback
+            "10.0.0.1",  # private
+            "172.16.0.1",  # private
+            "192.168.1.1",  # private
+            "169.254.1.1",  # link-local
+            "0.0.0.0",  # unspecified
+            "224.0.0.1",  # multicast
+            "::1",  # loopback (IPv6)
+            "fc00::1",  # unique local (private, IPv6)
+            "fe80::1",  # link-local (IPv6)
+        ],
+    )
+    def test_false_for_non_public_addresses(self, address):
+        assert _is_public_address(address) is False
+
+    def test_false_for_a_non_ip_string(self):
+        assert _is_public_address("not-an-ip") is False
+
+
+class TestFetchPolicyValidate:
+    def test_a_public_ip_literal_succeeds_and_pins_that_exact_ip(self):
+        policy = FetchPolicy()
+        result = policy.validate("https://8.8.8.8/path")
+        assert isinstance(result, ValidatedTarget)
+        assert result.canonical_url == "https://8.8.8.8/path"
+        assert result.pinned_ip == "8.8.8.8"
+
+    @pytest.mark.parametrize("literal", ["127.0.0.1", "10.0.0.5", "192.168.1.1", "169.254.1.1", "0.0.0.0"])
+    def test_a_non_public_ip_literal_is_rejected(self, literal):
+        policy = FetchPolicy()
+        with pytest.raises(URLPolicyError, match="non-public"):
+            policy.validate(f"https://{literal}/path")
+
+    @pytest.mark.parametrize("host", ["localhost", "LOCALHOST", "localhost.localdomain"])
+    def test_localhost_hostnames_are_blocked_before_even_resolving(self, host):
+        policy = FetchPolicy(resolver=_raising_resolver(AssertionError("must not resolve localhost")))
+        with pytest.raises(URLPolicyError, match="[Ll]ocal"):
+            policy.validate(f"https://{host}/path")
+
+    def test_a_hostname_resolving_to_a_public_address_succeeds_and_pins_it(self):
+        policy = FetchPolicy(resolver=_fake_resolver("93.184.216.34"))
+        result = policy.validate("https://example.com/path")
+        assert result.canonical_url == "https://example.com/path"
+        assert result.pinned_ip == "93.184.216.34"
+
+    def test_a_hostname_resolving_to_a_private_address_is_rejected(self):
+        # The DNS-rebinding scenario stage 4.5 is really about: a hostname
+        # that resolves somewhere unsafe must never reach the connect step.
+        policy = FetchPolicy(resolver=_fake_resolver("127.0.0.1"))
+        with pytest.raises(URLPolicyError, match="non-public"):
+            policy.validate("https://attacker.example/path")
+
+    def test_if_any_resolved_address_is_non_public_the_whole_host_is_rejected(self):
+        # Conservative-by-design: a host that resolves to BOTH a public and
+        # a private address is blocked entirely, not just steered to the
+        # public one - preserved from the pre-stage-4.5 behavior.
+        policy = FetchPolicy(resolver=_fake_resolver("93.184.216.34", "127.0.0.1"))
+        with pytest.raises(URLPolicyError, match="non-public"):
+            policy.validate("https://mixed.example/path")
+
+    def test_pins_the_first_address_when_multiple_public_addresses_resolve(self):
+        policy = FetchPolicy(resolver=_fake_resolver("93.184.216.34", "1.1.1.1"))
+        result = policy.validate("https://multi.example/path")
+        assert result.pinned_ip == "93.184.216.34"
+
+    def test_a_disallowed_scheme_is_rejected(self):
+        policy = FetchPolicy(allowed_schemes=("https",))
+        with pytest.raises(URLPolicyError, match="scheme"):
+            policy.validate("http://example.com/path")
+
+    def test_a_url_with_userinfo_is_rejected(self):
+        policy = FetchPolicy()
+        with pytest.raises(URLPolicyError):
+            policy.validate("https://user:pass@example.com/path")
+
+    def test_a_malformed_url_is_rejected(self):
+        policy = FetchPolicy()
+        with pytest.raises(URLPolicyError, match="malformed"):
+            policy.validate("not a url at all")
+
+    def test_a_dns_resolution_failure_is_surfaced_clearly(self):
+        policy = FetchPolicy(resolver=_raising_resolver(OSError("name resolution failed")))
+        with pytest.raises(URLPolicyError, match="Could not resolve"):
+            policy.validate("https://nonexistent.example/path")
+
+    def test_an_empty_resolution_result_is_rejected(self):
+        policy = FetchPolicy(resolver=lambda host, port, type=None: [])
+        with pytest.raises(URLPolicyError, match="did not resolve"):
+            policy.validate("https://empty.example/path")
+
+    def test_repeated_validation_of_the_same_dns_rebinding_host_never_succeeds_via_the_public_answer_alone(self):
+        # Simulates the actual TOCTOU scenario stage 4.5 closes: an
+        # attacker's DNS server answers PUBLIC on one lookup and PRIVATE on
+        # the next. Both individual validate() calls must independently
+        # enforce the policy against whatever THEY were told - there is no
+        # cross-call memory that could be tricked into treating a
+        # previously-validated host as permanently safe.
+        first = FetchPolicy(resolver=_fake_resolver("93.184.216.34"))
+        assert first.validate("https://rebinding.example/path").pinned_ip == "93.184.216.34"
+
+        second = FetchPolicy(resolver=_fake_resolver("127.0.0.1"))
+        with pytest.raises(URLPolicyError, match="non-public"):
+            second.validate("https://rebinding.example/path")

--- a/backend/tests/test_web_research_providers_fetcher.py
+++ b/backend/tests/test_web_research_providers_fetcher.py
@@ -1,0 +1,444 @@
+"""Integration tests for RequestsDocumentFetcher's NEW wiring in ADR-004
+stage 4.5: IP-pinning (via _PinnedHTTPAdapter) and crawl-etiquette
+(robots.txt + polite delay) integrated into the existing fetch loop.
+
+The pre-existing SSRF/redirect/content-type/byte-cap logic this loop
+already had is untouched by stage 4.5 and is exercised incidentally by
+these tests, but not re-covered exhaustively here - see
+test_web_research_fetch_policy.py for the dedicated SSRF boundary tests.
+
+Uses a fake requests.Session/Response (no real sockets) so these tests
+stay fast and network-independent, matching this suite's existing
+MagicMock-based convention (e.g. test_backend_api_key_env_fallback.py's
+own patch("openai.OpenAI", ...)).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from graphlink_plugins.web_research.crawl_etiquette import CrawlEtiquette, RobotsDisallowedError
+from graphlink_plugins.web_research.domain import CancellationToken, ResearchFailure, ResearchLimits, SearchResult
+from graphlink_plugins.web_research.fetch_policy import FetchPolicy, URLPolicyError
+from graphlink_plugins.web_research import providers as providers_module
+from graphlink_plugins.web_research.providers import RequestsDocumentFetcher, _PinnedHTTPAdapter
+
+
+def _search_result(url="https://example.com/page"):
+    return SearchResult(source_id="s1-abc", title="Example", url=url, canonical_url=url)
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, content_type="text/html", body=b"<html>hi</html>", headers=None, location=None):
+        self.status_code = status_code
+        self._body = body
+        self.headers = dict(headers or {})
+        self.headers.setdefault("Content-Type", content_type)
+        if location:
+            self.headers["Location"] = location
+        self.closed = False
+
+    @property
+    def is_redirect(self):
+        return self.status_code in (301, 302, 303, 307, 308) and "Location" in self.headers
+
+    @property
+    def is_permanent_redirect(self):
+        return self.status_code in (301, 308) and "Location" in self.headers
+
+    def iter_content(self, chunk_size=16384):
+        yield self._body
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeSession:
+    """Stands in for requests.Session - context-manager compatible, records
+    every mount() call (to assert on the pinned IP) and every get() call,
+    returns a scripted queue of _FakeResponse objects."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.trust_env = True
+        self.headers = {}
+        self.mounted = []  # (prefix, adapter) pairs, in call order
+        self.get_calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def mount(self, prefix, adapter):
+        self.mounted.append((prefix, adapter))
+
+    def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        if not self._responses:
+            raise AssertionError("no more scripted responses")
+        return self._responses.pop(0)
+
+
+def _real_policy_with_fake_resolver(*addresses):
+    def resolver(host, port, type=None):
+        import socket
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (addr, port)) for addr in addresses]
+
+    return FetchPolicy(resolver=resolver)
+
+
+@pytest.fixture
+def limits():
+    return ResearchLimits()
+
+
+@pytest.fixture
+def token():
+    return CancellationToken()
+
+
+class TestPinnedAdapterIsMountedWithTheValidatedIp:
+    def test_mounts_a_pinned_adapter_for_the_resolved_ip_before_fetching(self, limits, token):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fake_session = _FakeSession([_FakeResponse(status_code=200, content_type="text/html")])
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=CrawlEtiquette(default_crawl_delay_seconds=0))
+
+        # robots.txt fetch also goes through session.get - script it as a 404
+        # (no rules) ahead of the real content response.
+        fake_session._responses.insert(0, _FakeResponse(status_code=404, body=b""))
+
+        with patch.object(providers_module, "requests") as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            result = fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert result.status_code == 200
+        pinned_ips = {
+            adapter._pinned_ip for prefix, adapter in fake_session.mounted if hasattr(adapter, "_pinned_ip")
+        }
+        assert "93.184.216.34" in pinned_ips
+
+
+class TestRobotsIntegration:
+    def test_robots_disallow_turns_into_a_research_failure(self, limits, token):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fake_etiquette = MagicMock(spec=CrawlEtiquette)
+        fake_etiquette.gate.side_effect = RobotsDisallowedError("nope")
+        fake_session = _FakeSession([])
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=fake_etiquette)
+
+        with patch.object(providers_module, "requests") as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "robots_disallowed"
+        # The gate rejected the fetch before any real GET was attempted.
+        assert fake_session.get_calls == []
+
+    def test_record_fetch_is_called_after_a_successful_get(self, limits, token):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fake_etiquette = MagicMock(spec=CrawlEtiquette)
+        fake_etiquette.gate.return_value = 0.0
+        fake_session = _FakeSession([_FakeResponse(status_code=200, content_type="text/plain", body=b"hello")])
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=fake_etiquette)
+
+        with patch.object(providers_module, "requests") as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        fake_etiquette.record_fetch.assert_called_once()
+        fake_etiquette.gate.assert_called_once()
+
+    def test_record_fetch_is_not_called_when_the_get_itself_raises(self, limits, token):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fake_etiquette = MagicMock(spec=CrawlEtiquette)
+        fake_etiquette.gate.return_value = 0.0
+
+        class _RequestException(Exception):
+            pass
+
+        class _RaisingSession(_FakeSession):
+            def get(self, url, **kwargs):
+                raise _RequestException("network unreachable")
+
+        fake_session = _RaisingSession([])
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=fake_etiquette)
+
+        with patch.object(providers_module, "requests") as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = _RequestException
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "fetch_network_error"
+        fake_etiquette.record_fetch.assert_not_called()
+
+    def test_ssrf_validation_runs_before_robots_txt_gating(self, limits, token):
+        # Order of precedence: an SSRF-blocked URL must never even reach the
+        # robots.txt/etiquette layer - validate() first, gate() second.
+        policy = FetchPolicy(resolver=lambda host, port, type=None: [(2, 1, 6, "", ("127.0.0.1", port))])
+        fake_etiquette = MagicMock(spec=CrawlEtiquette)
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=fake_etiquette)
+
+        with pytest.raises(ResearchFailure) as exc_info:
+            fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "url_blocked_by_policy"
+        fake_etiquette.gate.assert_not_called()
+
+    def test_a_proxied_request_is_mapped_to_url_blocked_by_policy_not_a_generic_failure(self, limits, token):
+        # Regression: _PinnedHTTPAdapter raises URLPolicyError (not a
+        # requests.RequestException) when asked to route through a proxy -
+        # it must be caught explicitly, not fall through to the generic
+        # "fetch_failed" handler.
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fake_etiquette = MagicMock(spec=CrawlEtiquette)
+        fake_etiquette.gate.return_value = 0.0
+
+        class _ProxyForcingSession(_FakeSession):
+            def get(self, url, **kwargs):
+                adapter = self.mounted[-1][1]
+                request = requests.PreparedRequest()
+                request.prepare(method="GET", url=url, headers={})
+                adapter.get_connection_with_tls_context(request, verify=True, proxies={"https": "http://proxy.example:8080"})
+                raise AssertionError("should have raised URLPolicyError before this point")
+
+        fake_session = _ProxyForcingSession([])
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=fake_etiquette)
+
+        with patch.object(providers_module, "requests") as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "url_blocked_by_policy"
+
+
+class TestMultiHopCrossHostRedirects:
+    def test_each_hop_is_independently_validated_pinned_and_rate_limited(self, limits, token):
+        # A redirect chain that moves to a DIFFERENT host must re-validate/
+        # re-pin for the new host (not reuse the first hop's IP/adapter),
+        # and crawl-etiquette must track the two hosts as separate origins.
+        def resolver(host, port, type=None):
+            ip = "93.184.216.34" if host == "a.example" else "1.1.1.1"
+            return [(2, 1, 6, "", (ip, port))]
+
+        policy = FetchPolicy(resolver=resolver)
+        etiquette = CrawlEtiquette(default_crawl_delay_seconds=0)
+        fake_session = _FakeSession(
+            [
+                _FakeResponse(status_code=404, body=b""),  # robots.txt for a.example
+                _FakeResponse(status_code=302, location="https://b.example/final"),  # hop 1 content
+                _FakeResponse(status_code=404, body=b""),  # robots.txt for b.example
+                _FakeResponse(status_code=200, content_type="text/html", body=b"<html>done</html>"),  # hop 2 content
+            ]
+        )
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=etiquette)
+
+        with patch.object(providers_module, "requests") as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            result = fetcher.fetch(_search_result(url="https://a.example/start"), limits=limits, token=token)
+
+        assert result.final_url == "https://b.example/final"
+        pinned_ips_in_order = [adapter._pinned_ip for _, adapter in fake_session.mounted if hasattr(adapter, "_pinned_ip")]
+        # robots.txt + content pin for hop 1 (a.example), then robots.txt + content pin for hop 2 (b.example).
+        assert pinned_ips_in_order == ["93.184.216.34", "93.184.216.34", "1.1.1.1", "1.1.1.1"]
+        # Both origins were tracked independently (both got a robots.txt lookup, neither delayed the other).
+        assert set(etiquette._robots.keys()) >= {"https://a.example", "https://b.example"}
+
+
+class _FakeClock:
+    def __init__(self, start=1_000.0):
+        self.now = start
+        self.slept = []
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+class TestWaitPolitely:
+    """Adversarial-review fix: gate()'s old internal time.sleep() was
+    uninterruptible - it ran outside the fetch's own cancellation token and
+    total_timeout_seconds budget, so a malicious/misconfigured Crawl-delay
+    could hang a worker thread indefinitely. _wait_politely replaces that
+    with a chopped-up, re-checked wait - these tests exercise it directly."""
+
+    def test_sleeps_in_small_bounded_increments_not_one_long_sleep(self):
+        clock = _FakeClock()
+        policy = FetchPolicy(total_timeout_seconds=100.0)
+        fetcher = RequestsDocumentFetcher(policy=policy)
+        token = CancellationToken()
+
+        with patch.object(providers_module.time, "monotonic", clock.monotonic), \
+             patch.object(providers_module.time, "sleep", clock.sleep):
+            fetcher._wait_politely(3.0, token=token, started=clock.monotonic(), result=_search_result())
+
+        assert clock.slept == [0.5, 0.5, 0.5, 0.5, 0.5, 0.5]  # POLITE_WAIT_STEP_SECONDS chunks, never one 3.0s sleep
+        assert sum(clock.slept) == pytest.approx(3.0)
+
+    def test_raises_cancelled_promptly_instead_of_completing_the_full_wait(self):
+        clock = _FakeClock()
+        policy = FetchPolicy(total_timeout_seconds=100.0)
+        fetcher = RequestsDocumentFetcher(policy=policy)
+        token = CancellationToken()
+
+        real_sleep = clock.sleep
+
+        def sleep_then_cancel_after_first_step(seconds):
+            real_sleep(seconds)
+            token.cancel()  # simulates the user hitting Stop mid-wait
+
+        with patch.object(providers_module.time, "monotonic", clock.monotonic), \
+             patch.object(providers_module.time, "sleep", sleep_then_cancel_after_first_step):
+            with pytest.raises(Exception):  # RequestCancelled
+                fetcher._wait_politely(30.0, token=token, started=clock.monotonic(), result=_search_result())
+
+        # Cancelled after roughly ONE step, not after waiting out the full 30s.
+        assert len(clock.slept) == 1
+
+    def test_raises_fetch_timeout_instead_of_waiting_past_the_total_budget(self):
+        clock = _FakeClock()
+        policy = FetchPolicy(total_timeout_seconds=1.0)
+        fetcher = RequestsDocumentFetcher(policy=policy)
+        token = CancellationToken()
+        started = clock.monotonic()
+
+        with patch.object(providers_module.time, "monotonic", clock.monotonic), \
+             patch.object(providers_module.time, "sleep", clock.sleep):
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher._wait_politely(30.0, token=token, started=started, result=_search_result())
+
+        assert exc_info.value.code == "fetch_timeout"
+        # Never slept past the 1.0s total budget, despite a 30s delay being owed.
+        assert sum(clock.slept) <= 1.0 + 1e-9
+
+
+class TestEmptyBodyTimeoutEnforcement:
+    def test_an_empty_body_response_still_enforces_the_total_timeout(self, limits, token):
+        # Regression: `for chunk in response.iter_content(...)` never enters
+        # its loop body for a response streaming zero chunks, so the
+        # per-chunk timeout check was never reached - a fetch that already
+        # blew its budget (e.g. waiting out a polite delay) returned a
+        # fully "successful" FetchedPayload with no error at all.
+        clock = _FakeClock()
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        policy = FetchPolicy(resolver=policy.resolver, total_timeout_seconds=1.0)
+        fake_etiquette = MagicMock(spec=CrawlEtiquette)
+        fake_etiquette.gate.return_value = 0.0
+        empty_response = _FakeResponse(status_code=200, content_type="text/html", body=b"")
+        empty_response.iter_content = lambda chunk_size=16384: iter(())  # yields NOTHING, not even one empty chunk
+        fake_session = _FakeSession([empty_response])
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=fake_etiquette)
+
+        def advance_and_get(url, **kwargs):
+            clock.now += 5.0  # simulate 5s having elapsed during the request itself
+            return fake_session._responses.pop(0)
+
+        fake_session.get = advance_and_get
+
+        with patch.object(providers_module, "requests") as fake_requests_module, \
+             patch.object(providers_module.time, "monotonic", clock.monotonic):
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "fetch_timeout"
+
+
+class TestPinnedHTTPAdapterConnectionLogic:
+    """Direct tests of _PinnedHTTPAdapter's own connection-pool construction
+    - distinct from a real-network proof (already established manually
+    before this code was written: pinning to the correct resolved IP
+    succeeds; pinning to a different real site's IP fails TLS hostname
+    verification; pinning to loopback fails cleanly). These tests instead
+    guard the IMPLEMENTATION against regressing that behavior, without
+    needing real sockets: they inspect exactly what host/SNI/hostname-
+    verification arguments the adapter hands to urllib3's pool manager."""
+
+    @staticmethod
+    def _prepared_request(url: str) -> requests.PreparedRequest:
+        req = requests.PreparedRequest()
+        req.prepare(method="GET", url=url, headers={})
+        return req
+
+    def test_the_pool_is_built_with_the_pinned_ip_as_the_connect_host(self):
+        adapter = _PinnedHTTPAdapter("93.184.216.34")
+        adapter.poolmanager = MagicMock()
+        request = self._prepared_request("https://example.com/path")
+
+        adapter.get_connection_with_tls_context(request, verify=True)
+
+        _, kwargs = adapter.poolmanager.connection_from_host.call_args
+        assert kwargs["host"] == "93.184.216.34"
+
+    def test_the_original_hostname_is_used_for_sni_and_hostname_verification(self):
+        adapter = _PinnedHTTPAdapter("93.184.216.34")
+        adapter.poolmanager = MagicMock()
+        request = self._prepared_request("https://example.com/path")
+
+        adapter.get_connection_with_tls_context(request, verify=True)
+
+        _, kwargs = adapter.poolmanager.connection_from_host.call_args
+        pool_kwargs = kwargs["pool_kwargs"]
+        assert pool_kwargs["assert_hostname"] == "example.com"
+        assert pool_kwargs["server_hostname"] == "example.com"
+
+    def test_a_proxied_request_is_rejected_rather_than_silently_unpinned(self):
+        adapter = _PinnedHTTPAdapter("93.184.216.34")
+        adapter.poolmanager = MagicMock()
+        request = self._prepared_request("https://example.com/path")
+
+        with pytest.raises(URLPolicyError, match="[Pp]rox"):
+            adapter.get_connection_with_tls_context(request, verify=True, proxies={"https": "http://proxy.example:8080"})
+
+    def test_send_injects_the_original_host_header_not_the_pinned_ip(self):
+        adapter = _PinnedHTTPAdapter("93.184.216.34")
+        request = self._prepared_request("https://example.com/path")
+
+        with patch.object(_PinnedHTTPAdapter.__bases__[0], "send", return_value="sentinel") as base_send:
+            result = adapter.send(request)
+
+        assert request.headers["Host"] == "example.com"
+        assert result == "sentinel"
+        base_send.assert_called_once()
+
+    def test_send_includes_a_non_default_port_in_the_host_header(self):
+        adapter = _PinnedHTTPAdapter("93.184.216.34")
+        request = self._prepared_request("https://example.com:8443/path")
+
+        with patch.object(_PinnedHTTPAdapter.__bases__[0], "send", return_value="sentinel"):
+            adapter.send(request)
+
+        assert request.headers["Host"] == "example.com:8443"
+
+    def test_hostname_verification_is_still_injected_even_with_verify_false(self):
+        # A caller disabling cert verification entirely doesn't mean the
+        # pinning-related pool kwargs should be skipped - they're harmless
+        # (unused) when verify=False, and this confirms the injection isn't
+        # accidentally gated behind a `verify` check that could silently
+        # drop it for some other verify value in the future.
+        adapter = _PinnedHTTPAdapter("93.184.216.34")
+        adapter.poolmanager = MagicMock()
+        request = self._prepared_request("https://example.com/path")
+
+        adapter.get_connection_with_tls_context(request, verify=False)
+
+        _, kwargs = adapter.poolmanager.connection_from_host.call_args
+        assert kwargs["host"] == "93.184.216.34"
+        assert kwargs["pool_kwargs"]["assert_hostname"] == "example.com"
+        assert kwargs["pool_kwargs"]["server_hostname"] == "example.com"

--- a/graphlink_plugins/web_research/crawl_etiquette.py
+++ b/graphlink_plugins/web_research/crawl_etiquette.py
@@ -1,0 +1,173 @@
+"""Crawl etiquette for the Web Research fetch path (ADR-004 stage 4.5, the
+robots.txt/rate-limiting half of audit finding M6 - fetch_policy.py/
+providers.py's PinnedHTTPAdapter already close the other half, the
+validate-then-connect DNS-rebinding TOCTOU).
+
+Honors robots.txt Disallow rules and a per-host Crawl-delay, falling back
+to a fixed polite delay when a host's robots.txt sets none. Deliberately
+does NOT use urllib.robotparser.RobotFileParser.read() - that method
+fetches robots.txt via urllib.request.urlopen internally, which has none
+of fetch_policy.py's SSRF protections (no scheme allowlist, no IP-literal/
+private-range check, no size cap) and would reintroduce exactly the kind
+of unvalidated outbound request this ADR stage exists to close. Instead,
+the caller fetches robots.txt through the SAME pinned-IP mechanism the
+main content fetch uses (see providers.py) and hands the raw bytes here;
+only the PARSING (RobotFileParser.parse()) is reused from the stdlib.
+"""
+
+from __future__ import annotations
+
+import time
+import urllib.robotparser
+from dataclasses import dataclass, field
+from typing import Callable
+from urllib.parse import urlsplit
+
+
+class RobotsDisallowedError(ValueError):
+    """Raised when robots.txt disallows fetching a URL for our user agent."""
+
+
+# Returns (status_code, body_bytes) on a completed HTTP response (any status,
+# including 4xx/5xx - the caller already applied SSRF/IP-pinning validation
+# to reach this point), or None if the request could not complete at all
+# (network error, timeout, DNS failure). None means "robots.txt state
+# unknown" - handled as fail-open below, same as a real crawler tolerating a
+# transiently-unreachable robots.txt rather than refusing to ever crawl a
+# site again.
+RobotsFetcher = Callable[[str], "tuple[int, bytes] | None"]
+
+
+@dataclass
+class CrawlEtiquette:
+    user_agent: str = "Graphlink-WebResearch/1.0"
+    default_crawl_delay_seconds: float = 2.0
+    # Adversarial-review finding: a malicious/misconfigured robots.txt could
+    # otherwise demand an ARBITRARILY large Crawl-delay (a many-digit number
+    # is valid input to RobotFileParser.crawl_delay(), which returns a real
+    # Python int of unbounded size) - this caps how polite gate() will ever
+    # ask the caller to be, regardless of what a site's robots.txt claims.
+    max_crawl_delay_seconds: float = 30.0
+
+    # Keyed by "scheme://host[:port]" (the robots.txt origin, per RFC 9309 -
+    # rules never cross origins). None means "checked, robots.txt was
+    # unreachable or the parse failed" (fail-open: no explicit rules, but the
+    # fixed default delay still applies below).
+    _robots: dict = field(default_factory=dict, repr=False, compare=False)
+    _last_fetch_at: dict = field(default_factory=dict, repr=False, compare=False)
+
+    @staticmethod
+    def _origin(url: str) -> str:
+        parsed = urlsplit(url)
+        netloc = parsed.hostname or ""
+        if parsed.port:
+            netloc = f"{netloc}:{parsed.port}"
+        return f"{parsed.scheme}://{netloc}"
+
+    def _robots_url(self, url: str) -> str:
+        return f"{self._origin(url)}/robots.txt"
+
+    def _load_robots(self, url: str, fetch: RobotsFetcher) -> "urllib.robotparser.RobotFileParser | None":
+        origin = self._origin(url)
+        if origin in self._robots:
+            return self._robots[origin]
+
+        parser = urllib.robotparser.RobotFileParser()
+        try:
+            outcome = fetch(self._robots_url(url))
+        except Exception:
+            outcome = None
+
+        if outcome is None:
+            # Unreachable (network error/timeout/blocked by our own SSRF
+            # policy) - fail open, matching real crawlers tolerating a
+            # transiently-down robots.txt rather than refusing to crawl the
+            # site at all. The fixed default delay below still applies.
+            #
+            # Deliberately NOT cached (unlike every other outcome below):
+            # an adversarial-review finding pointed out that caching a
+            # single timeout/network-failure as "no rules, permanently, for
+            # the rest of this run" gives a malicious site a deterministic,
+            # one-shot way to disable its own robots.txt enforcement for
+            # the whole research run - just let /robots.txt stall past
+            # ROBOTS_TXT_TIMEOUT_SECONDS once. Leaving this uncached means
+            # the NEXT gate() call for this origin (a later redirect hop or
+            # a later source on the same host) re-attempts the fetch
+            # instead of trusting a single failed attempt forever.
+            return None
+
+        status_code, body = outcome
+        if status_code == 200:
+            try:
+                parser.parse(body.decode("utf-8", errors="replace").splitlines())
+            except Exception:
+                self._robots[origin] = None
+                return None
+            self._robots[origin] = parser
+            return parser
+        if status_code in (401, 403):
+            # Mirrors RobotFileParser.read()'s own convention: a robots.txt
+            # we're not authorized to see is treated as "no bots wanted here
+            # at all", not as "no rules exist".
+            parser.disallow_all = True
+            self._robots[origin] = parser
+            return parser
+        # Any other non-200 (404 included) - no robots.txt in effect,
+        # standard convention: everything is allowed, no explicit delay.
+        self._robots[origin] = None
+        return None
+
+    def gate(self, url: str, fetch_robots: RobotsFetcher) -> float:
+        """Call once per actual fetch attempt (i.e. once per redirect hop -
+        the same granularity FetchPolicy.validate() is already called at).
+        Raises RobotsDisallowedError if this URL is off-limits for our user
+        agent; otherwise returns the number of seconds still owed before the
+        caller's real request would be polite (0.0 if none).
+
+        Deliberately does NOT sleep itself (adversarial-review fix): an
+        earlier version called time.sleep() directly here, which is
+        uninterruptible - it ran outside this fetch's own CancellationToken
+        checks and total_timeout_seconds budget, so a malicious/
+        misconfigured Crawl-delay (or even just this class's own default)
+        could hang the calling worker thread for the full delay with no way
+        for the user's Stop button or the fetch's own timeout to cut it
+        short. The caller (RequestsDocumentFetcher.fetch()) is responsible
+        for an interruptible, budget-aware wait using the returned value -
+        see that method's own comment on why. The returned value is capped
+        at max_crawl_delay_seconds regardless of what robots.txt asks for,
+        as defense in depth even if a caller ever waited on it blindly."""
+        parser = self._load_robots(url, fetch_robots)
+        if parser is not None and not parser.can_fetch(self.user_agent, url):
+            raise RobotsDisallowedError(f"robots.txt disallows fetching {url}.")
+
+        origin = self._origin(url)
+        # The LARGER of our own baseline and whatever this host's own
+        # robots.txt asks for - never less polite than either one. A host
+        # asking for MORE delay than our default gets it; a host that says
+        # nothing, or asks for LESS than our default, still gets our
+        # baseline rather than being crawled faster than we'd crawl an
+        # unlisted host. Always capped at max_crawl_delay_seconds - a
+        # malicious robots.txt cannot demand more than that (adversarial-
+        # review finding: RobotFileParser.crawl_delay() happily returns an
+        # arbitrary-precision int for a many-digit Crawl-delay value, and
+        # float() on a sufficiently huge int raises OverflowError rather
+        # than saturating - caught and ignored below, same as any other
+        # malformed-robots.txt case: fail open on this one directive only).
+        delay = self.default_crawl_delay_seconds
+        if parser is not None:
+            robots_delay = parser.crawl_delay(self.user_agent)
+            if robots_delay is not None:
+                try:
+                    delay = max(delay, float(robots_delay))
+                except (OverflowError, ValueError, TypeError):
+                    pass
+        delay = min(delay, self.max_crawl_delay_seconds)
+
+        last = self._last_fetch_at.get(origin)
+        if last is None:
+            return 0.0
+        owed = delay - (time.monotonic() - last)
+        return max(0.0, owed)
+
+    def record_fetch(self, url: str) -> None:
+        self._last_fetch_at[self._origin(url)] = time.monotonic()

--- a/graphlink_plugins/web_research/fetch_policy.py
+++ b/graphlink_plugins/web_research/fetch_policy.py
@@ -31,6 +31,18 @@ def canonicalize_url(url: str) -> str:
     return urlunsplit((scheme, netloc, path, parsed.query, ""))
 
 
+@dataclass(frozen=True)
+class ValidatedTarget:
+    """FetchPolicy.validate()'s result: the canonical URL (for the Host
+    header, TLS SNI, and cert hostname verification) plus the ONE public IP
+    address the caller must actually connect the socket to. Keeping both
+    together, rather than the URL alone, is what closes the DNS-rebinding
+    TOCTOU - see validate()'s own comment."""
+
+    canonical_url: str
+    pinned_ip: str
+
+
 def _is_public_address(address: str) -> bool:
     try:
         parsed = ipaddress.ip_address(address)
@@ -81,7 +93,7 @@ class FetchPolicy:
             raise URLPolicyError(f"Source host did not resolve: {parsed.hostname}")
         return addresses
 
-    def validate(self, url: str) -> str:
+    def validate(self, url: str) -> ValidatedTarget:
         canonical = canonicalize_url(url)
         if not canonical:
             raise URLPolicyError("Source URL is malformed or contains credentials.")
@@ -96,7 +108,16 @@ class FetchPolicy:
             parsed.port
         except ValueError as exc:
             raise URLPolicyError("Source URL has an invalid port.") from exc
-        for address in self._resolve_addresses(parsed):
+        addresses = self._resolve_addresses(parsed)
+        for address in addresses:
             if not _is_public_address(address):
                 raise URLPolicyError("Source resolves to a non-public network address.")
-        return canonical
+        # ADR-004 stage 4.5 (audit finding M6): callers used to discard the
+        # validated address(es) entirely and let the HTTP client re-resolve
+        # the hostname to actually connect - a validate-then-connect TOCTOU
+        # a DNS-rebinding attacker can exploit (return a public IP here,
+        # then a private/loopback one for the real connection moments
+        # later). Returning the FIRST validated address alongside the
+        # canonical URL lets the caller pin its actual socket connection to
+        # this exact, already-checked IP instead of resolving again.
+        return ValidatedTarget(canonical_url=canonical, pinned_ip=addresses[0])

--- a/graphlink_plugins/web_research/providers.py
+++ b/graphlink_plugins/web_research/providers.py
@@ -14,6 +14,7 @@ from urllib.parse import urljoin, urlsplit
 import api_provider
 import graphlink_task_config as config
 
+from .crawl_etiquette import CrawlEtiquette, RobotsDisallowedError
 from .domain import (
     CancellationToken,
     FetchedDocument,
@@ -103,14 +104,104 @@ class DuckDuckGoSearchProvider:
         return normalized
 
 
+if REQUESTS_AVAILABLE:
+    from requests.adapters import HTTPAdapter
+    from requests.utils import select_proxy
+
+    class _PinnedHTTPAdapter(HTTPAdapter):
+        """ADR-004 stage 4.5 (audit finding M6): routes the connection to a
+        specific, pre-validated IP instead of letting urllib3 re-resolve the
+        hostname itself - this is what actually closes the validate-then-
+        connect DNS-rebinding TOCTOU FetchPolicy.validate() alone cannot
+        (see that method's own comment). The original hostname is still used
+        for the Host header, TLS SNI, and certificate hostname verification,
+        so this only pins WHERE the TCP connection goes, not WHAT server
+        identity is trusted - a rebinding attacker who gets connected to a
+        different real IP still fails TLS hostname verification the instant
+        that IP's certificate doesn't match the original hostname (verified
+        empirically before this was written: pinning to a different real
+        site's IP raises requests.exceptions.SSLError with a hostname-
+        mismatch CertificateError, exactly like a browser would refuse it).
+
+        Deliberately per-instance, not shared/reused across requests: a new
+        adapter is constructed and mounted for each redirect hop (mirroring
+        FetchPolicy.validate() being called fresh per hop too), since a
+        redirect can move to a different host with a different pinned IP."""
+
+        def __init__(self, pinned_ip: str, *args, **kwargs):
+            self._pinned_ip = pinned_ip
+            super().__init__(*args, **kwargs)
+
+        def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+            if select_proxy(request.url, proxies):
+                # trust_env=False on the session already keeps this fetcher
+                # off ambient proxy config; an explicit proxy override isn't
+                # a scenario this research fetcher needs to support, and
+                # correctly pinning a connection THROUGH a proxy is a
+                # different, more involved mechanism than a direct pin.
+                raise URLPolicyError("Proxied source fetches are not supported by policy.")
+            original_host = urlsplit(request.url).hostname
+            host_params, pool_kwargs = self.build_connection_pool_key_attributes(request, verify, cert)
+            pool_kwargs["assert_hostname"] = original_host
+            pool_kwargs["server_hostname"] = original_host
+            host_params["host"] = self._pinned_ip
+            return self.poolmanager.connection_from_host(**host_params, pool_kwargs=pool_kwargs)
+
+        def send(self, request, **kwargs):
+            # http.client auto-generates the Host header from the
+            # CONNECTION's own host (the pinned IP, per get_connection_
+            # with_tls_context above) unless an explicit Host header is
+            # already present on the request - inject the real one so
+            # virtual-hosted/SNI-routed sites and CDNs still resolve to the
+            # intended site rather than whatever the IP's default vhost is.
+            original = urlsplit(request.url)
+            request.headers["Host"] = (
+                original.hostname if not original.port or original.port in (80, 443)
+                else f"{original.hostname}:{original.port}"
+            )
+            return super().send(request, **kwargs)
+else:
+    _PinnedHTTPAdapter = None
+
+
 class RequestsDocumentFetcher:
     """Bounded, credential-free HTTP fetcher with redirect/IP enforcement."""
 
     USER_AGENT = "Graphlink-WebResearch/1.0 (+local-first research client)"
     ALLOWED_CONTENT_TYPES = {"text/html", "text/plain", "application/json"}
+    ROBOTS_TXT_MAX_BYTES = 64 * 1024
+    ROBOTS_TXT_TIMEOUT_SECONDS = 5.0
+    # How finely the polite-delay wait below is chopped up so it stays
+    # interruptible - see _wait_politely's own docstring.
+    POLITE_WAIT_STEP_SECONDS = 0.5
 
-    def __init__(self, policy: FetchPolicy | None = None):
+    def __init__(self, policy: FetchPolicy | None = None, etiquette: CrawlEtiquette | None = None):
         self.policy = policy or FetchPolicy()
+        self.etiquette = etiquette or CrawlEtiquette(user_agent=self.USER_AGENT)
+
+    def _wait_politely(self, owed: float, *, token: CancellationToken, started: float, result: SearchResult) -> None:
+        """Sleeps out CrawlEtiquette.gate()'s returned delay in small,
+        interruptible increments - adversarial-review fix: gate() used to
+        call time.sleep() internally, which is uninterruptible and ran
+        outside this fetch's own CancellationToken checks and
+        total_timeout_seconds budget. A malicious/misconfigured Crawl-delay
+        (or even just an ordinary polite default) could hang the worker
+        thread this runs on (see backend/agents.py's
+        asyncio.to_thread(service.run, ...)) for however long the delay
+        was, with the user's Stop button and the app's own fetch timeout
+        both powerless to cut it short. Chopping the wait into small steps
+        and re-checking cancellation/budget between each one closes both
+        gaps at once, and never sleeps past whichever bound is tighter."""
+        deadline = time.monotonic() + owed
+        while True:
+            token.raise_if_cancelled()
+            remaining_budget = self.policy.total_timeout_seconds - (time.monotonic() - started)
+            if remaining_budget <= 0:
+                raise ResearchFailure("Source fetch exceeded the total time limit.", code="fetch_timeout", source_id=result.source_id)
+            remaining_wait = deadline - time.monotonic()
+            if remaining_wait <= 0:
+                return
+            time.sleep(max(0.0, min(self.POLITE_WAIT_STEP_SECONDS, remaining_wait, remaining_budget)))
 
     def fetch(self, result: SearchResult, *, limits: ResearchLimits, token: CancellationToken) -> FetchedPayload:
         if not REQUESTS_AVAILABLE:
@@ -132,10 +223,18 @@ class RequestsDocumentFetcher:
                     if time.monotonic() - started > self.policy.total_timeout_seconds:
                         raise ResearchFailure("Source fetch exceeded the total time limit.", code="fetch_timeout", source_id=result.source_id)
                     try:
-                        current_url = self.policy.validate(current_url)
+                        validated = self.policy.validate(current_url)
                     except URLPolicyError as exc:
                         raise ResearchFailure(str(exc), code="url_blocked_by_policy", retryable=False, source_id=result.source_id) from exc
+                    current_url = validated.canonical_url
 
+                    try:
+                        owed = self.etiquette.gate(current_url, lambda robots_url: self._fetch_robots_bytes(robots_url, session))
+                    except RobotsDisallowedError as exc:
+                        raise ResearchFailure(str(exc), code="robots_disallowed", retryable=False, source_id=result.source_id) from exc
+                    self._wait_politely(owed, token=token, started=started, result=result)
+
+                    session.mount(f"{urlsplit(current_url).scheme}://", _PinnedHTTPAdapter(validated.pinned_ip))
                     try:
                         response = session.get(
                             current_url,
@@ -143,8 +242,12 @@ class RequestsDocumentFetcher:
                             allow_redirects=False,
                             stream=True,
                         )
+                    except URLPolicyError as exc:
+                        raise ResearchFailure(str(exc), code="url_blocked_by_policy", retryable=False, source_id=result.source_id) from exc
                     except requests.RequestException as exc:
                         raise ResearchFailure("The source could not be fetched.", code="fetch_network_error", source_id=result.source_id) from exc
+                    else:
+                        self.etiquette.record_fetch(current_url)
 
                     try:
                         if response.is_redirect or response.is_permanent_redirect:
@@ -190,6 +293,19 @@ class RequestsDocumentFetcher:
                                 truncated = True
                                 break
                             body.extend(chunk)
+                        # Adversarial-review fix: the per-chunk check above
+                        # never runs at all for a response that streams
+                        # ZERO chunks (an empty body - e.g. Content-Length:
+                        # 0) - `for chunk in response.iter_content(...)`
+                        # simply never enters its loop body, so a fetch that
+                        # already blew through total_timeout_seconds (e.g.
+                        # while waiting out this hop's own polite delay
+                        # above) returned a fully "successful" FetchedPayload
+                        # with no error at all. One more check here,
+                        # unconditional on how many chunks were seen, closes
+                        # that silent bypass.
+                        if time.monotonic() - started > self.policy.total_timeout_seconds:
+                            raise ResearchFailure("Source fetch exceeded the total time limit.", code="fetch_timeout", source_id=result.source_id)
                         return FetchedPayload(
                             source_id=result.source_id,
                             requested_url=result.url,
@@ -207,6 +323,48 @@ class RequestsDocumentFetcher:
         except Exception as exc:
             raise ResearchFailure("The source could not be processed.", code="fetch_failed", source_id=result.source_id) from exc
         raise ResearchFailure("The source returned too many redirects.", code="redirect_limit", source_id=result.source_id)
+
+    def _fetch_robots_bytes(self, robots_url: str, session) -> "tuple[int, bytes] | None":
+        """Fetches robots.txt through the SAME SSRF-safe, IP-pinned
+        mechanism the main content fetch uses - see _PinnedHTTPAdapter's
+        own docstring for why urllib.robotparser.RobotFileParser.read()'s
+        internal urlopen() call is deliberately never used anywhere in this
+        module. Bounded and unconditional: never itself gated by
+        CrawlEtiquette (that would be circular), never follows redirects
+        (a robots.txt that redirects is treated the same as one that 404s -
+        no explicit rules found, CrawlEtiquette's own fail-open/no-rules
+        handling applies either way). Returns None on anything that
+        prevents a completed response (blocked by policy, network error,
+        timeout) - a completed response, whatever its status code, always
+        returns (status_code, body)."""
+        try:
+            validated = self.policy.validate(robots_url)
+        except URLPolicyError:
+            return None
+        try:
+            session.mount(f"{urlsplit(validated.canonical_url).scheme}://", _PinnedHTTPAdapter(validated.pinned_ip))
+            response = session.get(
+                validated.canonical_url,
+                timeout=(self.policy.connect_timeout_seconds, self.ROBOTS_TXT_TIMEOUT_SECONDS),
+                allow_redirects=False,
+                stream=True,
+            )
+        except requests.RequestException:
+            return None
+        try:
+            body = bytearray()
+            for chunk in response.iter_content(chunk_size=8 * 1024):
+                if not chunk:
+                    continue
+                remaining = self.ROBOTS_TXT_MAX_BYTES - len(body)
+                if remaining <= 0:
+                    break
+                body.extend(chunk[:remaining])
+            return response.status_code, bytes(body)
+        except requests.RequestException:
+            return None
+        finally:
+            response.close()
 
 
 class BeautifulSoupContentExtractor:


### PR DESCRIPTION
## Problem

The web-research fetch path's SSRF policy validated a hostname's resolved
IP address (rejecting loopback/private/link-local/reserved ranges), then
discarded that IP and returned only a canonical URL string. The actual
HTTP connection was made by `requests`, which re-resolves the hostname
independently. This is a validate-then-connect TOCTOU: a malicious DNS
server can return a public IP when queried for validation and a
private/loopback IP when queried again for the real connection,
bypassing the SSRF check entirely.

Separately, the fetch path had no `robots.txt` or rate-limiting support.

## Change

- `fetch_policy.py`: `FetchPolicy.validate()` now returns a
  `ValidatedTarget(canonical_url, pinned_ip)` instead of a bare URL string,
  pinning the first resolved address that passed the SSRF check.
- `providers.py`: new `_PinnedHTTPAdapter(requests.adapters.HTTPAdapter)`
  forces the real TCP connection to the pinned IP while injecting the
  original hostname for TLS SNI/certificate verification and the `Host`
  header, so the connection target and the SSRF-validated target are
  provably the same address. A fresh adapter is mounted per redirect hop.
  Verified empirically against real HTTPS sites: pinning the correct IP
  succeeds; pinning a different site's IP fails TLS hostname verification;
  pinning loopback fails cleanly.
- New `crawl_etiquette.py`: honors `robots.txt` `Disallow` rules and a
  per-host `Crawl-delay` (falling back to a fixed default), fetched
  through the same pinned-IP mechanism as real content rather than
  `urllib.robotparser.RobotFileParser.read()`, whose internal `urlopen()`
  call has none of `fetch_policy.py`'s SSRF protections.
- An adversarial review of this diff surfaced and fixed five issues before
  it landed: the crawl-delay wait was an uninterruptible internal
  `time.sleep()` that ignored both cancellation and the fetch's own
  timeout budget; the timeout budget check never ran for empty-body
  responses; an unbounded `Crawl-delay` value could raise an uncaught
  `OverflowError`; a proxy-rejection error fell through to the wrong
  failure code; and a robots.txt network failure was cached as permanent
  "no rules" instead of being retried on the next fetch.

## Test plan

- `backend/tests/test_web_research_fetch_policy.py` (new): IP-pinning
  correctness, including an explicit DNS-rebinding scenario, plus the
  existing SSRF public/private-address checks.
- `backend/tests/test_web_research_crawl_etiquette.py` (new): robots.txt
  allow/disallow, per-origin caching, crawl-delay computation and
  clamping, and the network-failure-not-cached fix.
- `backend/tests/test_web_research_providers_fetcher.py` (new): pinned
  adapter mounting, robots/etiquette integration, multi-hop cross-host
  redirect re-pinning, interruptible/budget-aware polite waiting, and
  direct `_PinnedHTTPAdapter` connection-logic tests.
- Every fix mutation-tested (temporarily reverted, confirmed the specific
  test fails as expected, restored).
- Full suite green: `pytest -q` (1425 passed, 7 skipped) and
  `npm run check` in `web_ui/` (1101 passed).