### PR TITLE
ADR-005 stage 5.2: Windows Job Object resource guard for executed code

### DIFF
--- a/backend/tests/test_execution_guard.py
+++ b/backend/tests/test_execution_guard.py
@@ -1,0 +1,516 @@
+"""ADR-005 stage 5.2: the Windows Job Object resource guard
+(graphlink_execution_guard.py) and its wiring into Py-Coder's PythonREPL
+and the Code Sandbox's VirtualEnvSandbox.
+
+The stage's own exit criterion is "Memory bomb killed at cap; orphan test:
+stop kills the whole tree" - TestJobObjectMechanism below proves both,
+against real subprocesses, not mocks (a mock cannot prove an OS-level
+resource cap actually enforces anything). TestPythonReplUsesTheGuard and
+TestVirtualEnvSandboxUsesTheGuard then prove each wired call site actually
+creates/assigns/closes a guard at the right moments - fast, mock-based for
+the call-site plumbing, plus one real end-to-end test per surface proving
+the full wiring genuinely kills a grandchild process on stop (the same
+property TestJobObjectMechanism proves for the guard in isolation).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import graphlink_execution_guard as guard_module
+from graphlink_execution_guard import ExecutionResourceGuard, create_execution_guard
+from graphlink_plugins.code_sandbox.domain import VirtualEnvSandbox
+from graphlink_plugins.pycoder.domain import PythonREPL
+
+WINDOWS_ONLY = pytest.mark.skipif(
+    sys.platform != "win32", reason="Job Object mechanism is Windows-only in this stage (POSIX is ADR-005 5.3)"
+)
+
+
+class _FakeGuard:
+    """Records assign()/close() calls without touching any real OS
+    resource - used for fast call-site tests (does start()/stop() call the
+    guard correctly?), distinct from the slow, real-mechanism tests below
+    (does the guard itself actually enforce anything?)."""
+
+    def __init__(self):
+        self.assigned_pids = []
+        self.closed = False
+
+    def assign(self, pid):
+        self.assigned_pids.append(pid)
+
+    def close(self):
+        self.closed = True
+
+
+# -- The guard mechanism itself, against real subprocesses ------------------
+
+
+@WINDOWS_ONLY
+class TestJobObjectMechanism:
+    def test_a_memory_bomb_is_killed_at_the_cap(self):
+        guard = create_execution_guard(memory_limit_bytes=100 * 1024 * 1024, active_process_limit=64)
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "x = bytearray(500 * 1024 * 1024); import time; time.sleep(5)"],
+            creationflags=subprocess.CREATE_NO_WINDOW,
+        )
+        guard.assign(proc.pid)
+        try:
+            returncode = proc.wait(timeout=10)
+            assert returncode != 0, "a 500 MiB allocation against a 100 MiB job cap should have been killed"
+        finally:
+            guard.close()
+
+    def test_a_fork_bomb_is_capped_by_the_active_process_limit(self, tmp_path):
+        counter_path = tmp_path / "forkcount.txt"
+        bomb_script = tmp_path / "forkbomb.py"
+        bomb_script.write_text(
+            "import subprocess, sys, time\n"
+            f"path = r'{counter_path}'\n"
+            "n = int(sys.argv[1]) if len(sys.argv) > 1 else 0\n"
+            "with open(path, 'a') as fh:\n"
+            "    fh.write('x')\n"
+            "if n < 200:\n"
+            "    subprocess.Popen([sys.executable, __file__, str(n + 1)])\n"
+            "time.sleep(3)\n",
+            encoding="utf-8",
+        )
+        guard = create_execution_guard(active_process_limit=5)
+        proc = subprocess.Popen(
+            [sys.executable, str(bomb_script)], creationflags=subprocess.CREATE_NO_WINDOW
+        )
+        try:
+            guard.assign(proc.pid)
+            time.sleep(4)
+            count = len(counter_path.read_text(encoding="utf-8")) if counter_path.exists() else 0
+            assert count < 200, f"active-process cap of 5 did not stop the fork bomb - {count} processes ran"
+        finally:
+            guard.close()
+
+    def test_closing_the_guard_kills_a_grandchild_process_too(self, tmp_path):
+        marker = tmp_path / "marker.txt"
+        grandchild_script = tmp_path / "grandchild.py"
+        grandchild_script.write_text(
+            "import time\n"
+            f"with open(r'{marker}', 'w') as m:\n"
+            "    while True:\n"
+            "        m.write('x'); m.flush(); time.sleep(0.2)\n",
+            encoding="utf-8",
+        )
+        parent_script = tmp_path / "parent.py"
+        parent_script.write_text(
+            "import subprocess, sys, time\n"
+            f"subprocess.Popen([sys.executable, r'{grandchild_script}'])\n"
+            "time.sleep(30)\n",
+            encoding="utf-8",
+        )
+
+        guard = create_execution_guard()
+        proc = subprocess.Popen([sys.executable, str(parent_script)], creationflags=subprocess.CREATE_NO_WINDOW)
+        guard.assign(proc.pid)
+
+        time.sleep(1.5)
+        assert marker.exists(), "grandchild never started writing"
+        size_before = marker.stat().st_size
+        time.sleep(1)
+        assert marker.stat().st_size > size_before, "grandchild isn't actively writing before close()"
+
+        guard.close()  # the actual mechanism PythonREPL.stop()/VirtualEnvSandbox.stop() use
+        time.sleep(1.5)
+        size_after_close = marker.stat().st_size
+        time.sleep(1.5)
+        assert marker.stat().st_size == size_after_close, "grandchild kept writing after guard.close()"
+
+    def test_close_is_idempotent(self):
+        guard = create_execution_guard()
+        guard.close()
+        guard.close()  # must not raise
+
+    def test_assign_on_an_already_dead_pid_does_not_raise(self):
+        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        proc.wait()
+        guard = create_execution_guard()
+        guard.assign(proc.pid)  # pid may already be reused/invalid - must not raise
+        guard.close()
+
+    def test_create_execution_guard_returns_the_null_guard_on_non_windows(self, monkeypatch):
+        monkeypatch.setattr(guard_module.sys, "platform", "linux")
+        guard = create_execution_guard()
+        assert type(guard) is ExecutionResourceGuard
+        guard.assign(12345)  # no-op, must not raise
+        guard.close()  # no-op, must not raise
+
+
+class TestNullGuardNeverRaises:
+    def test_assign_and_close_are_no_ops_on_any_input(self):
+        guard = ExecutionResourceGuard()
+        guard.assign(-1)
+        guard.assign(0)
+        guard.close()
+        guard.close()
+
+
+# -- PythonREPL wiring --------------------------------------------------------
+
+
+class TestPythonReplUsesTheGuard:
+    def test_starting_the_repl_assigns_it_to_a_guard(self):
+        fake = _FakeGuard()
+        with patch("graphlink_plugins.pycoder.domain.create_execution_guard", return_value=fake):
+            repl = PythonREPL(node_id="guard-assign-test")
+            try:
+                repl.start()
+                assert repl.guard is fake
+                assert fake.assigned_pids == [repl.process.pid]
+            finally:
+                repl.stop()
+
+    def test_stopping_the_repl_closes_the_guard(self):
+        fake = _FakeGuard()
+        with patch("graphlink_plugins.pycoder.domain.create_execution_guard", return_value=fake):
+            repl = PythonREPL(node_id="guard-close-test")
+            repl.start()
+            repl.stop()
+            assert fake.closed is True
+            assert repl.guard is None
+
+    @WINDOWS_ONLY
+    def test_a_real_stop_kills_a_grandchild_the_repl_itself_spawned(self, tmp_path):
+        marker = tmp_path / "marker.txt"
+        grandchild_script = tmp_path / "grandchild.py"
+        grandchild_script.write_text(
+            "import time\n"
+            f"with open(r'{marker}', 'w') as m:\n"
+            "    while True:\n"
+            "        m.write('x'); m.flush(); time.sleep(0.2)\n",
+            encoding="utf-8",
+        )
+
+        repl = PythonREPL(node_id="guard-real-tree-test")
+        # stdin/stdout/stderr=DEVNULL: a background child spawned from
+        # inside the REPL otherwise inherits the REPL's own stdin PIPE
+        # handle, which - a pre-existing PythonREPL characteristic,
+        # confirmed unrelated to this stage's guard (reproduces identically
+        # with the guard replaced by a no-op) - can leave a detached,
+        # non-waited grandchild hung at interpreter startup. Real exec'd
+        # code that wants a genuinely detached background process needs
+        # the same redirection for the same reason.
+        repl.execute(
+            "import subprocess, sys; subprocess.Popen([sys.executable, r'"
+            f"{grandchild_script}'], stdin=subprocess.DEVNULL, "
+            "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)"
+        )
+
+        time.sleep(1.5)
+        assert marker.exists(), "grandchild never started writing"
+        size_before = marker.stat().st_size
+        time.sleep(1)
+        assert marker.stat().st_size > size_before
+
+        repl.stop()
+        time.sleep(1.5)
+        size_after_stop = marker.stat().st_size
+        time.sleep(1.5)
+        assert marker.stat().st_size == size_after_stop, "grandchild kept writing after repl.stop()"
+
+
+# -- VirtualEnvSandbox wiring -------------------------------------------------
+
+
+class TestVirtualEnvSandboxUsesTheGuard:
+    def test_a_normally_completed_subprocess_assigns_and_closes_the_guard(self):
+        fake = _FakeGuard()
+        with patch("graphlink_plugins.code_sandbox.domain.create_execution_guard", return_value=fake):
+            sandbox = VirtualEnvSandbox("guard-normal-test")
+            output, code = sandbox._run_subprocess(
+                [sys.executable, "-c", "print('ok')"],
+                should_continue=lambda: True,
+                timeout_seconds=10,
+            )
+            assert code == 0
+            assert len(fake.assigned_pids) == 1
+            assert fake.closed is True
+            assert sandbox.guard is None
+
+    def test_a_should_continue_stop_closes_the_guard(self):
+        fake = _FakeGuard()
+        with patch("graphlink_plugins.code_sandbox.domain.create_execution_guard", return_value=fake):
+            sandbox = VirtualEnvSandbox("guard-stop-test")
+            flag = {"go": True}
+
+            def runner():
+                with pytest.raises(InterruptedError):
+                    sandbox._run_subprocess(
+                        [sys.executable, "-c", "import time; time.sleep(5)"],
+                        should_continue=lambda: flag["go"],
+                        timeout_seconds=30,
+                    )
+
+            t = threading.Thread(target=runner)
+            t.start()
+            time.sleep(0.5)
+            flag["go"] = False
+            t.join(timeout=10)
+
+            assert fake.closed is True
+            assert sandbox.guard is None
+
+    def test_calling_stop_in_isolation_closes_the_guard(self):
+        # Deliberately NOT run through a real, concurrently-running
+        # _run_subprocess() call (unlike the two tests above): that call's
+        # own `finally` block closes the guard too, as a safety net, which
+        # would mask stop()'s OWN close() call behind a race - by the time
+        # a background thread's finally block is observed to have run,
+        # stop() may have simply been blocked (in its own
+        # current_process.wait(timeout=3)) long enough for the OTHER
+        # thread's independent cleanup to win the race first. Confirmed by
+        # mutation: a threaded version of this test asserting only after
+        # stop() returned still passed with stop()'s own guard.close() call
+        # removed entirely. Directly setting sandbox.guard/current_process
+        # and calling stop() with nothing else running isolates stop()'s
+        # own behavior from that safety net.
+        fake = _FakeGuard()
+        sandbox = VirtualEnvSandbox("guard-explicit-stop-test")
+        sandbox.guard = fake
+        sandbox.current_process = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"]
+        )
+        try:
+            sandbox.stop()
+            assert fake.closed is True
+            assert sandbox.guard is None
+        finally:
+            if sandbox.current_process and sandbox.current_process.poll() is None:
+                sandbox.current_process.kill()
+
+    @WINDOWS_ONLY
+    def test_a_real_stop_kills_a_grandchild_the_sandbox_itself_spawned(self, tmp_path):
+        marker = tmp_path / "marker.txt"
+        grandchild_script = tmp_path / "grandchild.py"
+        grandchild_script.write_text(
+            "import time\n"
+            f"with open(r'{marker}', 'w') as m:\n"
+            "    while True:\n"
+            "        m.write('x'); m.flush(); time.sleep(0.2)\n",
+            encoding="utf-8",
+        )
+        parent_script = tmp_path / "parent.py"
+        parent_script.write_text(
+            "import subprocess, sys, time\n"
+            f"subprocess.Popen([sys.executable, r'{grandchild_script}'])\n"
+            "time.sleep(20)\n",
+            encoding="utf-8",
+        )
+
+        sandbox = VirtualEnvSandbox("guard-real-tree-test")
+        flag = {"go": True}
+
+        def runner():
+            with pytest.raises(InterruptedError):
+                sandbox._run_subprocess(
+                    [sys.executable, str(parent_script)],
+                    should_continue=lambda: flag["go"],
+                    timeout_seconds=30,
+                )
+
+        t = threading.Thread(target=runner)
+        t.start()
+        time.sleep(1.5)
+        assert marker.exists(), "grandchild never started writing"
+        size_before = marker.stat().st_size
+        time.sleep(1)
+        assert marker.stat().st_size > size_before
+
+        flag["go"] = False
+        t.join(timeout=10)
+
+        time.sleep(1.5)
+        size_after_stop = marker.stat().st_size
+        time.sleep(1.5)
+        assert marker.stat().st_size == size_after_stop, "grandchild kept writing after sandbox stop"
+
+
+# -- Adversarial-review-driven regression tests ------------------------------
+# The four classes below pin the fixes for findings the ADR-005 stage 5.2
+# review confirmed against the ORIGINAL diff (each independently reproduced
+# with real handle counts / real crashes before being fixed): PythonREPL's
+# restart path leaking the previous guard's Job Object handle, concurrent
+# stop() calls crashing/double-closing, and the two fail-open fallback
+# paths in graphlink_execution_guard.py being completely unexercised.
+
+
+class TestPythonReplRestartDoesNotLeakTheOldGuard:
+    def test_restarting_a_dead_repl_closes_the_old_guard_first(self):
+        guards_created = []
+
+        def factory():
+            fake = _FakeGuard()
+            guards_created.append(fake)
+            return fake
+
+        with patch("graphlink_plugins.pycoder.domain.create_execution_guard", side_effect=factory):
+            repl = PythonREPL(node_id="restart-leak-test")
+            repl.execute("1 + 1")
+            assert len(guards_created) == 1
+            first_guard = guards_created[0]
+            assert first_guard.closed is False
+
+            # The process dies WITHOUT going through stop() - e.g. an
+            # external kill, or (plausible given this same stage's own new
+            # memory cap) the OS terminating it for exceeding
+            # JobMemoryLimit sometime after the previous execute() call
+            # already returned.
+            repl.process.kill()
+            repl.process.wait()
+
+            repl.execute("2 + 2")  # execute()'s poll()-based restart path
+            assert len(guards_created) == 2
+            assert first_guard.closed is True, (
+                "start() must close any pre-existing guard before "
+                "overwriting self.guard, or the old Job Object handle leaks"
+            )
+            repl.stop()
+            assert guards_created[1].closed is True
+
+
+class TestPythonReplConcurrentStopIsSafe:
+    # Both tests below deterministically FORCE the race rather than merely
+    # hoping enough concurrent threads happen to interleave at the right
+    # instant - the actual hazard is a check-then-write on a couple of
+    # attributes, a window far too narrow for unforced thread scheduling to
+    # reliably hit. Confirmed empirically: a naive version of this test
+    # spawning 5-10 plain concurrent threads with no forced interleaving
+    # passed 0/5 times even with the lock removed entirely from
+    # PythonREPL.stop()/graphlink_execution_guard's close(). Forcing the
+    # interleaving by having the TEST itself hold the lock a second thread
+    # must wait for is what makes this a real regression pin rather than a
+    # test that merely looks like one.
+
+    def test_stop_is_serialized_by_the_repls_own_lock(self):
+        repl = PythonREPL(node_id="concurrent-stop-lock-test")
+        repl.execute("1 + 1")
+
+        repl._lock.acquire()
+        try:
+            entered = threading.Event()
+
+            def stopper():
+                entered.set()
+                repl.stop()
+
+            t = threading.Thread(target=stopper)
+            t.start()
+            assert entered.wait(timeout=5)
+            time.sleep(0.3)  # let the thread actually reach the lock
+            assert t.is_alive(), (
+                "a second stop() call must block on self._lock while this "
+                "thread holds it, not race past the process/guard cleanup - "
+                "this is what prevents the real production crash "
+                "('NoneType' object has no attribute 'kill') from one "
+                "thread nulling self.process out from under another"
+            )
+        finally:
+            repl._lock.release()
+        t.join(timeout=10)
+
+        assert repl.process is None
+        assert repl.guard is None
+
+    @WINDOWS_ONLY
+    def test_guard_close_is_serialized_by_its_own_lock(self):
+        # Isolates the guard module's own thread-safety, independent of
+        # PythonREPL entirely - protects every caller of
+        # graphlink_execution_guard, not just this one.
+        guard = create_execution_guard()
+
+        guard._lock.acquire()
+        try:
+            entered = threading.Event()
+
+            def closer():
+                entered.set()
+                guard.close()
+
+            t = threading.Thread(target=closer)
+            t.start()
+            assert entered.wait(timeout=5)
+            time.sleep(0.3)
+            assert t.is_alive(), "a second close() call must block on self._lock, not race the check-then-null of self._handle"
+            assert guard._handle is not None, "the handle must not be nulled while another close() holds the lock"
+        finally:
+            guard._lock.release()
+        t.join(timeout=10)
+
+        assert guard._handle is None
+
+
+@WINDOWS_ONLY
+class TestFailOpenFallbackPaths:
+    def test_create_job_object_failure_falls_back_to_the_null_guard(self, monkeypatch):
+        monkeypatch.setattr(guard_module._kernel32, "CreateJobObjectW", lambda *a: None)
+        guard = create_execution_guard()
+        assert type(guard) is ExecutionResourceGuard
+        guard.assign(os.getpid())  # no-op, must not raise
+        guard.close()
+
+    def test_set_information_job_object_failure_falls_back_and_closes_the_handle(self, monkeypatch):
+        closed_handles = []
+        real_create = guard_module._kernel32.CreateJobObjectW
+        real_close = guard_module._kernel32.CloseHandle
+
+        def recording_close(handle):
+            closed_handles.append(handle)
+            return real_close(handle)
+
+        monkeypatch.setattr(guard_module._kernel32, "SetInformationJobObject", lambda *a: 0)
+        monkeypatch.setattr(guard_module._kernel32, "CloseHandle", recording_close)
+
+        guard = create_execution_guard()
+
+        assert type(guard) is ExecutionResourceGuard
+        assert len(closed_handles) == 1, "the job handle CreateJobObjectW allocated must be closed on this fallback path, not leaked"
+
+
+@WINDOWS_ONLY
+class TestRealDefaultsReachTheWin32Api:
+    def test_create_execution_guard_with_no_arguments_applies_the_real_default_caps(self, monkeypatch):
+        # The three real, non-mocked TestJobObjectMechanism tests above all
+        # pass EXPLICIT non-default cap values - this is the one test that
+        # confirms the module's actual shipped defaults (what
+        # PythonREPL.start()/VirtualEnvSandbox._run_subprocess() call with
+        # zero arguments in production) really reach SetInformationJobObject
+        # with the right flags/values, by inspecting the real struct passed
+        # to the real Win32 call rather than mocking it away.
+        captured = {}
+        real_set_info = guard_module._kernel32.SetInformationJobObject
+
+        def recording_set_info(handle, info_class, info_ptr, info_size):
+            info = guard_module.ctypes.cast(
+                info_ptr, guard_module.ctypes.POINTER(guard_module._JOBOBJECT_EXTENDED_LIMIT_INFORMATION)
+            ).contents
+            captured["LimitFlags"] = info.BasicLimitInformation.LimitFlags
+            captured["JobMemoryLimit"] = info.JobMemoryLimit
+            captured["ActiveProcessLimit"] = info.BasicLimitInformation.ActiveProcessLimit
+            return real_set_info(handle, info_class, info_ptr, info_size)
+
+        monkeypatch.setattr(guard_module._kernel32, "SetInformationJobObject", recording_set_info)
+
+        guard = create_execution_guard()
+        try:
+            assert captured["JobMemoryLimit"] == guard_module.DEFAULT_MEMORY_LIMIT_BYTES
+            assert captured["ActiveProcessLimit"] == guard_module.DEFAULT_ACTIVE_PROCESS_LIMIT
+            assert captured["LimitFlags"] & guard_module._JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            assert captured["LimitFlags"] & guard_module._JOB_OBJECT_LIMIT_JOB_MEMORY
+            assert captured["LimitFlags"] & guard_module._JOB_OBJECT_LIMIT_ACTIVE_PROCESS
+        finally:
+            guard.close()

--- a/backend/tests/test_packaging_py_modules.py
+++ b/backend/tests/test_packaging_py_modules.py
@@ -1,0 +1,74 @@
+"""Ratchet: pyproject.toml's [tool.setuptools] py-modules list must stay in
+exact sync with the loose top-level *.py modules at the repo root.
+
+WHY THIS EXISTS. setuptools' auto-discovery only finds real packages
+(backend/, graphlink_plugins/ - handled by packages.find); every loose
+top-level module has to be named explicitly in py-modules or it is silently
+omitted from the built wheel. Nothing in the ordinary local verification
+loop catches an omission: `pytest -q` and `npm run check` both import from
+the repo checkout, where every top-level file is importable regardless of
+whether it is packaged. The break only surfaces when the wheel is built and
+imported from somewhere the checkout is not on sys.path.
+
+This has now bitten this project twice. The first time (pre-ADR-015)
+graphlink_note_agent and graphlink_process_env were both missing, the
+latter silently disabling the subprocess secret-scrubbing env allowlist in
+the shipped wheel - which is why .github/workflows/ci.yml grew its
+`build-check` job. The second time, ADR-005 stage 5.2 added
+graphlink_execution_guard.py without listing it, and the wheel shipped
+without the module that both code-execution surfaces import at module
+scope; build-check caught it, but only after a push.
+
+The build-check job stays (it validates far more than this list - real wheel
+metadata, a real clean-venv install, a real import). This test just moves
+THIS specific, entirely-static failure mode left, so it fails in the same
+`pytest -q` run that a developer already runs before pushing rather than
+minutes later in CI.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _declared_py_modules() -> set[str]:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
+        config = tomllib.load(handle)
+    return set(config["tool"]["setuptools"]["py-modules"])
+
+
+def _actual_top_level_modules() -> set[str]:
+    # Every loose *.py at the repo root is application code that ships.
+    # There is deliberately no allowlist of exceptions here: if a genuinely
+    # non-shipping top-level module is ever added (a one-off script, say),
+    # the right move is to put it in a directory rather than to weaken this
+    # invariant - a silently-unpackaged module is exactly the failure this
+    # test exists to prevent, and an exception list is where that protection
+    # would quietly erode.
+    return {path.stem for path in REPO_ROOT.glob("*.py")}
+
+
+def test_every_top_level_module_is_declared_in_py_modules():
+    missing = _actual_top_level_modules() - _declared_py_modules()
+
+    assert not missing, (
+        "top-level module(s) exist at the repo root but are NOT listed in "
+        f"pyproject.toml's py-modules: {sorted(missing)}. They would be "
+        "silently omitted from the built wheel - anything importing them "
+        "raises ModuleNotFoundError once installed. Add them to the "
+        "py-modules list."
+    )
+
+
+def test_py_modules_lists_no_module_that_no_longer_exists():
+    stale = _declared_py_modules() - _actual_top_level_modules()
+
+    assert not stale, (
+        "pyproject.toml's py-modules lists module(s) with no matching file "
+        f"at the repo root: {sorted(stale)}. A renamed or deleted module "
+        "left in this list makes the wheel build fail (or silently ship "
+        "nothing for that entry). Remove them."
+    )

--- a/graphlink_execution_guard.py
+++ b/graphlink_execution_guard.py
@@ -1,0 +1,277 @@
+"""ADR-005 stage 5.2: Windows Job Object resource guard for executed code
+(Py-Coder's persistent REPL and the Code Sandbox's venv/pip/script children).
+
+THE THREAT (audit finding H2). Neither execution surface enforced any
+memory, process-count, or lifecycle limit beyond wall-clock timeouts and a
+human clicking Stop - a script that allocates until OOM, or that forks
+itself repeatedly, was bounded only by the host's own limits. "Stop" only
+ever killed the one directly-tracked child process, never anything that
+child itself had spawned - a process that had already forked survived
+being "stopped."
+
+THE FIX. Every subprocess this app spawns for executed code is assigned to
+a Windows Job Object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE plus a
+committed-memory cap and an active-process-count cap. Because Windows job
+objects are inherited by any further child process a job member spawns
+(the default, unless a process explicitly opts out via
+JOB_OBJECT_LIMIT_BREAKAWAY_OK, which this module never sets), killing the
+job kills the entire process tree in one call - closing the
+"Stop only kills the direct child" gap, not just the memory-bomb one. All
+three mechanisms here (memory cap, active-process cap, whole-tree kill)
+were empirically proven against real memory-bomb, fork-bomb, and
+orphan-grandchild scripts before this module was written, not assumed
+from the Win32 API documentation alone.
+
+This is a **resource + lifecycle** boundary, not a security VM - see
+doc/adr/THREAT_MODEL.md's "Executed code is a resource boundary, not a
+security boundary" section. It does not stop a deliberately malicious
+script from doing anything within its resource caps; it stops a runaway
+or hostile dependency from taking down the host, and it makes "Stop"
+actually mean stop.
+
+SCOPE OF THIS STAGE (5.2), deliberately narrower than ADR-005 Decision #2's
+full description: CPU-rate control and settings-driven (as opposed to
+hardcoded) caps are NOT implemented here. CPU-rate control was never
+empirically verified against a real CPU-bound busy-loop before this stage
+shipped - the same discipline this ADR-004/ADR-005 effort holds itself to
+everywhere else - so it is left for a follow-up rather than shipped
+unverified. Settings-driven caps + approval-dialog disclosure of the real
+limits is a UI-facing change orthogonal to this module's own correctness,
+also left for a follow-up. Neither is silently dropped - both are named
+here so a future stage does not have to rediscover the gap.
+
+The POSIX tier (process groups + rlimit) is explicitly ADR-005 stage 5.3,
+not this one - on non-Windows platforms, ExecutionResourceGuard.assign()/
+close() are no-ops, matching the pre-existing (unenforced) behavior
+exactly. This is not a regression: no platform loses a protection it had
+before this module existed.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import threading
+import sys
+
+logger = logging.getLogger(__name__)
+
+# ADR-005 Decision #2's own example figure ("up to 2 GB RAM"). A generous
+# default: real Py-Coder/Sandbox workloads (pandas, matplotlib, a venv's own
+# interpreter + pip's dependency resolver) comfortably fit under it; a true
+# memory bomb still dies well before threatening the host.
+DEFAULT_MEMORY_LIMIT_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
+
+# Generous enough for legitimate multi-process work (pip install spawning
+# its own build-backend/resolver subprocesses, a venv's bootstrap), but
+# bounds a fork bomb to a small, fixed number of processes rather than an
+# unbounded spiral - verified empirically against a real fork-bomb script
+# (200-generation bomb capped at exactly the limit, not 200+).
+DEFAULT_ACTIVE_PROCESS_LIMIT = 64
+
+
+class ExecutionResourceGuard:
+    """No-op base: what non-Windows platforms get in this stage (the POSIX
+    tier is ADR-005 stage 5.3), and what Windows itself falls back to if
+    job-object creation fails for any reason. A guard that cannot enforce
+    limits must never block execution outright - the pre-existing,
+    unenforced behavior is the safe fallback, not a hard failure, matching
+    this codebase's established graceful-degradation precedent (DPAPI
+    falling back to plaintext off-Windows rather than refusing to save)."""
+
+    def assign(self, pid: int) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+if sys.platform == "win32":
+    import ctypes.wintypes as _wintypes
+
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    # Adversarial-review fix: explicit .restype/.argtypes on every function
+    # this module calls. Without them, ctypes defaults an undeclared
+    # restype to a 4-byte c_long - harmless for the four BOOL-returning
+    # calls (BOOL is itself 4 bytes) but silently wrong for
+    # CreateJobObjectW/OpenProcess, both of which return HANDLE (a pointer,
+    # 8 bytes on 64-bit Windows). In practice real per-process kernel
+    # handle-table values stay small enough that the truncation was a
+    # no-op, but it is real latent fragility with no Python exception to
+    # ever surface it - declaring the real types removes it outright.
+    _kernel32.CreateJobObjectW.restype = _wintypes.HANDLE
+    _kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, _wintypes.LPCWSTR]
+    _kernel32.OpenProcess.restype = _wintypes.HANDLE
+    _kernel32.OpenProcess.argtypes = [_wintypes.DWORD, _wintypes.BOOL, _wintypes.DWORD]
+    _kernel32.AssignProcessToJobObject.restype = _wintypes.BOOL
+    _kernel32.AssignProcessToJobObject.argtypes = [_wintypes.HANDLE, _wintypes.HANDLE]
+    _kernel32.SetInformationJobObject.restype = _wintypes.BOOL
+    _kernel32.SetInformationJobObject.argtypes = [
+        _wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, _wintypes.DWORD,
+    ]
+    _kernel32.TerminateJobObject.restype = _wintypes.BOOL
+    _kernel32.TerminateJobObject.argtypes = [_wintypes.HANDLE, _wintypes.UINT]
+    _kernel32.CloseHandle.restype = _wintypes.BOOL
+    _kernel32.CloseHandle.argtypes = [_wintypes.HANDLE]
+
+    _JobObjectExtendedLimitInformation = 9
+    _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+    _JOB_OBJECT_LIMIT_JOB_MEMORY = 0x00000200
+    _JOB_OBJECT_LIMIT_ACTIVE_PROCESS = 0x00000008
+    # Adversarial-review fix: was 0x1F0FFF, winnt.h's stale pre-Vista
+    # PROCESS_ALL_ACCESS value (and broader than this module needs even by
+    # its real modern definition, 0x1FFFFF). AssignProcessToJobObject's own
+    # documented requirement is only PROCESS_SET_QUOTA (0x100) |
+    # PROCESS_TERMINATE (0x001) - requesting exactly that, not "all
+    # access," is both least-privilege and more likely to succeed under a
+    # host's process-access restriction policy (EDR/AppLocker-style tools
+    # that deny full-access OpenProcess calls but permit narrowly-scoped
+    # ones).
+    _PROCESS_SET_QUOTA = 0x0100
+    _PROCESS_TERMINATE = 0x0001
+    _PROCESS_ACCESS_FOR_JOB_ASSIGNMENT = _PROCESS_SET_QUOTA | _PROCESS_TERMINATE
+
+    class _IO_COUNTERS(ctypes.Structure):
+        _fields_ = [
+            ("ReadOperationCount", ctypes.c_ulonglong),
+            ("WriteOperationCount", ctypes.c_ulonglong),
+            ("OtherOperationCount", ctypes.c_ulonglong),
+            ("ReadTransferCount", ctypes.c_ulonglong),
+            ("WriteTransferCount", ctypes.c_ulonglong),
+            ("OtherTransferCount", ctypes.c_ulonglong),
+        ]
+
+    class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", ctypes.c_longlong),
+            ("PerJobUserTimeLimit", ctypes.c_longlong),
+            ("LimitFlags", _wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", _wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", _wintypes.DWORD),
+            ("SchedulingClass", _wintypes.DWORD),
+        ]
+
+    class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+            ("IoInfo", _IO_COUNTERS),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    class _WindowsJobObjectGuard(ExecutionResourceGuard):
+        def __init__(self, handle) -> None:
+            self._handle = handle
+            # Adversarial-review fix: without a lock, two threads calling
+            # close() concurrently on the SAME guard can both pass the
+            # `self._handle is None` check before either one nulls it,
+            # both read the same real handle value, and both call
+            # CloseHandle() on it - a handle-recycling hazard, since once
+            # the first CloseHandle succeeds that numeric handle can be
+            # reassigned to any other resource in the process before the
+            # second CloseHandle runs. Reproduced live: two threads racing
+            # a real close() call produced CloseHandle() invoked twice on
+            # the identical handle value. Reachable in production via
+            # PythonREPL's own concurrent-stop() scenario (see that
+            # class's docstring) - fixing it here protects every caller of
+            # this module, not just the one that happened to add its own
+            # locking.
+            self._lock = threading.Lock()
+
+        def assign(self, pid: int) -> None:
+            if self._handle is None:
+                return
+            proc_handle = _kernel32.OpenProcess(_PROCESS_ACCESS_FOR_JOB_ASSIGNMENT, False, pid)
+            if not proc_handle:
+                logger.warning(
+                    "execution guard: OpenProcess failed for pid %s (error %s) - "
+                    "this child will run WITHOUT resource caps",
+                    pid, ctypes.get_last_error(),
+                )
+                return
+            try:
+                if not _kernel32.AssignProcessToJobObject(self._handle, proc_handle):
+                    logger.warning(
+                        "execution guard: AssignProcessToJobObject failed for pid "
+                        "%s (error %s) - this child will run WITHOUT resource caps",
+                        pid, ctypes.get_last_error(),
+                    )
+            finally:
+                _kernel32.CloseHandle(proc_handle)
+
+        def close(self) -> None:
+            with self._lock:
+                if self._handle is None:
+                    return
+                handle, self._handle = self._handle, None
+            # Unconditionally kills anything still alive in the job - the
+            # orphan/whole-tree-kill path. A harmless no-op if the job is
+            # already empty (the normal "process exited cleanly" path).
+            # The actual Win32 calls happen OUTSIDE the lock (they release
+            # the GIL and can block briefly) - only the check-and-null of
+            # self._handle needs to be atomic, so a second concurrent
+            # close() call can return immediately once it sees None rather
+            # than waiting on these calls to finish.
+            if not _kernel32.TerminateJobObject(handle, 1):
+                logger.debug(
+                    "execution guard: TerminateJobObject reported failure "
+                    "(error %s) - likely just an already-empty job",
+                    ctypes.get_last_error(),
+                )
+            _kernel32.CloseHandle(handle)
+
+    def _create_windows_job_object_guard(
+        memory_limit_bytes: int, active_process_limit: int
+    ) -> ExecutionResourceGuard:
+        handle = _kernel32.CreateJobObjectW(None, None)
+        if not handle:
+            logger.warning(
+                "execution guard: CreateJobObjectW failed (error %s) - "
+                "falling back to no resource caps for this run",
+                ctypes.get_last_error(),
+            )
+            return ExecutionResourceGuard()
+
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        flags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if memory_limit_bytes:
+            flags |= _JOB_OBJECT_LIMIT_JOB_MEMORY
+            info.JobMemoryLimit = memory_limit_bytes
+        if active_process_limit:
+            flags |= _JOB_OBJECT_LIMIT_ACTIVE_PROCESS
+            info.BasicLimitInformation.ActiveProcessLimit = active_process_limit
+        info.BasicLimitInformation.LimitFlags = flags
+
+        if not _kernel32.SetInformationJobObject(
+            handle, _JobObjectExtendedLimitInformation, ctypes.byref(info), ctypes.sizeof(info)
+        ):
+            logger.warning(
+                "execution guard: SetInformationJobObject failed (error %s) - "
+                "falling back to no resource caps for this run",
+                ctypes.get_last_error(),
+            )
+            _kernel32.CloseHandle(handle)
+            return ExecutionResourceGuard()
+
+        return _WindowsJobObjectGuard(handle)
+
+
+def create_execution_guard(
+    memory_limit_bytes: int = DEFAULT_MEMORY_LIMIT_BYTES,
+    active_process_limit: int = DEFAULT_ACTIVE_PROCESS_LIMIT,
+) -> ExecutionResourceGuard:
+    """One guard per subprocess-management lifecycle (a Py-Coder REPL's
+    single long-lived child; one Code Sandbox subprocess invocation).
+    Call `.assign(process.pid)` immediately after `subprocess.Popen(...)`
+    returns, and `.close()` exactly once when that process is done with -
+    whether it exited on its own or is being forcibly stopped. Safe to call
+    `.close()` on a guard whose process already exited cleanly."""
+    if sys.platform == "win32":
+        return _create_windows_job_object_guard(memory_limit_bytes, active_process_limit)
+    return ExecutionResourceGuard()

--- a/graphlink_plugins/code_sandbox/domain.py
+++ b/graphlink_plugins/code_sandbox/domain.py
@@ -49,6 +49,7 @@ from pathlib import Path
 
 import api_provider
 import graphlink_task_config as config
+from graphlink_execution_guard import create_execution_guard
 from graphlink_process_env import safe_subprocess_env
 
 
@@ -173,6 +174,11 @@ class VirtualEnvSandbox:
         self.requirements_hash_file = self.base_dir / ".requirements.sha256"
         self.script_path = self.base_dir / "sandbox_entry.py"
         self.current_process = None
+        # ADR-005 stage 5.2: the resource guard for whichever subprocess
+        # _run_subprocess currently owns - see stop()'s own comment for why
+        # closing this, not just terminating/killing current_process, is
+        # what makes "Stop" actually kill the whole tree.
+        self.guard = None
 
     @property
     def python_executable(self):
@@ -181,6 +187,18 @@ class VirtualEnvSandbox:
         return self.venv_dir / "bin" / "python"
 
     def stop(self):
+        # ADR-005 stage 5.2: close the resource guard FIRST - on Windows
+        # this terminates the whole job (the tracked process AND anything
+        # it has itself spawned), closing the pre-existing gap where
+        # terminate()/kill() alone only ever stopped the one directly-
+        # tracked process, never its own children. Still followed by the
+        # existing terminate/kill logic unconditionally: a safe no-op if
+        # the guard already killed it, and the only thing that actually
+        # stops the direct child on non-Windows in this stage (the POSIX
+        # process-group tier is ADR-005 stage 5.3).
+        if self.guard:
+            self.guard.close()
+            self.guard = None
         if self.current_process and self.current_process.poll() is None:
             try:
                 self.current_process.terminate()
@@ -205,6 +223,13 @@ class VirtualEnvSandbox:
             **_subprocess_kwargs(),
         )
         self.current_process = process
+        # ADR-005 stage 5.2: assign the freshly-started child to a resource
+        # guard immediately - see graphlink_execution_guard's own docstring
+        # for the memory/process-count caps this closes (audit H2) and why
+        # assigning right after Popen() returns, rather than using
+        # CREATE_SUSPENDED, is an accepted tradeoff.
+        self.guard = create_execution_guard()
+        self.guard.assign(process.pid)
         output_queue = queue.Queue()
         done_signal = object()
 
@@ -272,6 +297,14 @@ class VirtualEnvSandbox:
         finally:
             if reader_thread.is_alive():
                 reader_thread.join(timeout=0.5)
+            # Normal-completion path: stop() (called on the
+            # should_continue()==False/timeout/exception paths above) has
+            # already closed the guard by this point and cleared it, so
+            # this is a no-op there - it only actually fires here when the
+            # subprocess exited cleanly on its own.
+            if self.guard:
+                self.guard.close()
+                self.guard = None
             self.current_process = None
 
     def ensure_base_environment(self, should_continue, emit_line=None):

--- a/graphlink_plugins/pycoder/domain.py
+++ b/graphlink_plugins/pycoder/domain.py
@@ -34,12 +34,14 @@ import re
 import subprocess
 import sys
 import tempfile
+import threading
 import uuid
 from enum import Enum
 from pathlib import Path
 
 import api_provider
 import graphlink_task_config as config
+from graphlink_execution_guard import create_execution_guard
 from graphlink_process_env import safe_subprocess_env
 
 
@@ -87,13 +89,50 @@ class PythonREPL:
         self.process = None
         self.last_run_failed = False
         self._boundary_prefix = ""
+        # ADR-005 stage 5.2: the resource guard for whichever process
+        # `start()` currently owns - see stop()'s own comment for why
+        # closing this, not just process.kill(), is what makes "Stop"
+        # actually kill the whole tree.
+        self.guard = None
+        # Adversarial-review fix: serializes start()/stop() against
+        # concurrent calls on the SAME PythonREPL instance. This is a real,
+        # reproduced scenario, not theoretical - backend/agents.py wraps
+        # execute() in asyncio.wait_for(asyncio.to_thread(...)), and a
+        # timed-out wait_for does NOT stop the underlying worker thread; on
+        # timeout, agents.py's own cleanup calls stop() from a NEW thread
+        # while the ORIGINAL execute() call's thread may still be blocked
+        # reading the (now-killed) process's stdout, whose own EOF-handling
+        # path also calls stop() - two concurrent, unsynchronized stop()
+        # calls on one instance previously crashed with
+        # "AttributeError: 'NoneType' object has no attribute 'kill'" (one
+        # thread nulling self.process between the other's `if self.process`
+        # check and its later self.process.kill() call) and could
+        # double-close the same real OS job handle.
+        self._lock = threading.RLock()
         safe_id = re.sub(r"[^A-Za-z0-9_-]", "_", node_id or "default")
         self.cwd = Path(tempfile.gettempdir()) / "graphlink_pycoder_repls" / safe_id
 
     def start(self):
-        nonce = uuid.uuid4().hex
-        self._boundary_prefix = f"---GRAPHLINK_EXEC_BOUNDARY:{nonce}:"
-        script = f"""
+        with self._lock:
+            # Adversarial-review fix: execute() calls start() again to
+            # restart a dead REPL process (poll() is not None) WITHOUT
+            # going through stop() first - stop() is what normally closes
+            # self.guard, so that restart path used to silently overwrite
+            # self.guard with a fresh one, orphaning the old Job Object
+            # handle for the life of the backend process. Reproduced: 20
+            # forced crash-restarts (killing the process directly,
+            # bypassing stop()) leaked 20 unclosed job handles and grew
+            # this process's real OS handle count by +16. Closing any
+            # pre-existing guard here, mirroring stop()'s own
+            # close-then-null pattern, makes EVERY path that (re)assigns
+            # self.guard symmetric with cleanup, not just the one stop()
+            # already covered.
+            if self.guard:
+                self.guard.close()
+                self.guard = None
+            nonce = uuid.uuid4().hex
+            self._boundary_prefix = f"---GRAPHLINK_EXEC_BOUNDARY:{nonce}:"
+            script = f"""
 import sys, traceback, base64
 env = {{}}
 while True:
@@ -109,30 +148,41 @@ while True:
     status = "ERROR" if failed else "OK"
     print("\\n---GRAPHLINK_EXEC_BOUNDARY:{nonce}:" + status + "---", flush=True)
 """
-        # ADR-002 P0: env= is explicit-allowlist, not inherited - see
-        # graphlink_process_env's own module doc. Without this, the REPL
-        # subprocess would inherit the backend's full os.environ, including
-        # any provider API key configured as an environment variable.
-        kwargs = {'env': safe_subprocess_env()}
-        # Hide the console window on Windows
-        if sys.platform == 'win32':
-            kwargs['creationflags'] = subprocess.CREATE_NO_WINDOW
+            # ADR-002 P0: env= is explicit-allowlist, not inherited - see
+            # graphlink_process_env's own module doc. Without this, the REPL
+            # subprocess would inherit the backend's full os.environ,
+            # including any provider API key configured as an environment
+            # variable.
+            kwargs = {'env': safe_subprocess_env()}
+            # Hide the console window on Windows
+            if sys.platform == 'win32':
+                kwargs['creationflags'] = subprocess.CREATE_NO_WINDOW
 
-        # ADR-005 stage 5.1: cwd= a scratch dir, never the app's own cwd (see
-        # this class's own docstring). mkdir here, not in __init__, so a REPL
-        # that is constructed but never started never touches the filesystem.
-        self.cwd.mkdir(parents=True, exist_ok=True)
+            # ADR-005 stage 5.1: cwd= a scratch dir, never the app's own cwd
+            # (see this class's own docstring). mkdir here, not in
+            # __init__, so a REPL that is constructed but never started
+            # never touches the filesystem.
+            self.cwd.mkdir(parents=True, exist_ok=True)
 
-        self.process = subprocess.Popen(
-            [sys.executable, '-c', script],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-            cwd=str(self.cwd),
-            **kwargs
-        )
+            self.process = subprocess.Popen(
+                [sys.executable, '-c', script],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                cwd=str(self.cwd),
+                **kwargs
+            )
+            # ADR-005 stage 5.2: assign the freshly-started REPL to a
+            # resource guard immediately - see graphlink_execution_guard's
+            # own docstring for the memory/process-count caps this closes
+            # (audit H2) and why assigning right after Popen() returns,
+            # rather than using CREATE_SUSPENDED, is an accepted tradeoff
+            # (the child hasn't run any of its own code yet, so the window
+            # for it to spawn an unassigned grandchild first is negligible).
+            self.guard = create_execution_guard()
+            self.guard.assign(self.process.pid)
 
     def execute(self, code):
         if not self.process or self.process.poll() is not None:
@@ -171,10 +221,30 @@ while True:
         return "".join(output).strip()
 
     def stop(self):
-        if self.process:
-            self.process.kill()
-            self.process.wait()
-            self.process = None
+        # Adversarial-review fix: serialized against a concurrent stop()
+        # (or start()) on this same instance via self._lock - see
+        # __init__'s own comment for the real, reproduced crash this
+        # closes ("AttributeError: 'NoneType' object has no attribute
+        # 'kill'" from two threads both inside this method at once, one
+        # nulling self.process out from under the other's later use of it).
+        with self._lock:
+            if self.process:
+                # ADR-005 stage 5.2: close the resource guard FIRST - on
+                # Windows this terminates the whole job (the REPL process
+                # AND anything it has itself spawned), closing the
+                # pre-existing gap where process.kill() alone only ever
+                # killed the one directly-tracked process, never its own
+                # children. Still followed by the existing
+                # process.kill()/wait() unconditionally: a safe no-op if
+                # the guard already killed it, and the only thing that
+                # actually stops the direct child on non-Windows in this
+                # stage (the POSIX process-group tier is ADR-005 stage 5.3).
+                if self.guard:
+                    self.guard.close()
+                    self.guard = None
+                self.process.kill()
+                self.process.wait()
+                self.process = None
 
 
 class PyCoderExecutionAgent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ py-modules = [
     "graphlink_chart_rendering",
     "graphlink_chat_agent",
     "graphlink_desktop",
+    "graphlink_execution_guard",
     "graphlink_grid_view_settings",
     "graphlink_memory",
     "graphlink_model_catalog",


### PR DESCRIPTION
## Problem

Py-Coder's persistent REPL and the Code Sandbox's venv/pip/script
subprocesses had no memory or process-count limit beyond a wall-clock
timeout and a human clicking Stop, and Stop itself only ever killed the
one directly-tracked process - never anything that process had spawned
on its own, so a process that had already forked survived being
"stopped."

## Change

New `graphlink_execution_guard.py`: a raw-ctypes wrapper around the Win32
Job Object API (no new dependency, matching this codebase's existing
DPAPI precedent). Every child process spawned for executed code is
assigned to a job with a committed-memory cap (2 GiB default), an
active-process-count cap (64 default), and kill-on-close semantics.
Because job membership is inherited by further child processes by
default, closing the job kills the whole process tree in one call.
Memory-cap, fork-bomb-cap, and whole-tree-kill were each verified against
real subprocesses before and after being wired into `PythonREPL`
(`graphlink_plugins/pycoder/domain.py`) and `VirtualEnvSandbox`
(`graphlink_plugins/code_sandbox/domain.py`).

Out of scope for this stage, documented rather than silently dropped:
CPU-rate control (never empirically verified, so not shipped unverified)
and settings-driven/UI-configurable caps (hardcoded defaults only). The
POSIX tier (process groups + rlimit) is ADR-005 stage 5.3.

An adversarial review of the diff found and fixed two real bugs before
it shipped:
- `PythonREPL`'s automatic restart path (triggered when its process dies
  between `execute()` calls) overwrote `self.guard` without closing the
  old one first, leaking a Job Object handle per restart - confirmed via
  real OS handle-count growth over repeated forced crash-restarts.
- Unsynchronized access to the guard's handle, combined with a real
  production path (`backend/agents.py` wraps `execute()` in
  `asyncio.wait_for(asyncio.to_thread(...))`, and a timed-out `wait_for`
  does not stop the underlying thread) where a timeout handler and the
  still-running original call can both end up calling `stop()`
  concurrently, could crash or double-close the same OS handle. Fixed
  with locking in both `PythonREPL` and the guard itself, confirmed by
  forcing the exact interleaving rather than hoping concurrent threads
  would happen to race into it.
- Also addressed: explicit `.restype`/`.argtypes` on the six Win32 calls
  (an undeclared `HANDLE` return type silently truncates to 4 bytes),
  and narrowing the process-access rights requested from a stale
  pre-Vista "all access" value to the two rights actually needed.

## Test plan

- `backend/tests/test_execution_guard.py` (20 tests): real memory-bomb,
  fork-bomb, and orphan-process kill tests against the guard module
  directly; fast mock-based tests proving each wiring call site
  assigns/closes a guard at the right moment plus one real end-to-end
  test per surface; deterministic (lock-held-by-the-test) regression
  tests for the restart-leak and concurrent-stop fixes; tests for both
  Win32 fail-open fallback paths; a test confirming the real shipped
  default cap values actually reach the Win32 API.
- Every fix (wiring call sites, the two concurrency locks, the
  fail-open-fallback handle cleanup) mutation-tested: temporarily
  reverted, confirmed the specific test fails, restored - `git diff`
  clean after every revert.
- Full suite green: `pytest -q` (1458 passed, 7 skipped) and
  `npm run check` in `web_ui/` (1137 passed; this stage is backend-only,
  no UI changes).