### PR TITLE
ADR-005 stage 5.3: POSIX rlimit + process-group resource tier

### DIFF
--- a/backend/tests/test_execution_guard.py
+++ b/backend/tests/test_execution_guard.py
@@ -42,9 +42,15 @@ class _FakeGuard:
     guard correctly?), distinct from the slow, real-mechanism tests below
     (does the guard itself actually enforce anything?)."""
 
-    def __init__(self):
+    def __init__(self, popen_kwargs=None):
         self.assigned_pids = []
         self.closed = False
+        self.popen_kwargs_calls = 0
+        self._popen_kwargs = popen_kwargs or {}
+
+    def popen_kwargs(self):
+        self.popen_kwargs_calls += 1
+        return dict(self._popen_kwargs)
 
     def assign(self, pid):
         self.assigned_pids.append(pid)
@@ -143,12 +149,19 @@ class TestJobObjectMechanism:
         guard.assign(proc.pid)  # pid may already be reused/invalid - must not raise
         guard.close()
 
-    def test_create_execution_guard_returns_the_null_guard_on_non_windows(self, monkeypatch):
-        monkeypatch.setattr(guard_module.sys, "platform", "linux")
+    def test_the_windows_guard_contributes_no_popen_kwargs(self):
+        # The Windows tier applies its cap to an ALREADY-running process via
+        # assign(), so it must not perturb the Popen call at all - if this
+        # ever returned something, both execution surfaces would silently
+        # start passing an unexpected kwarg into their subprocess spawn.
+        # (The platform-dispatch counterpart of this - that a POSIX host
+        # gets the rlimit/process-group kwargs instead - is asserted in
+        # test_execution_guard_posix.py, which only runs there.)
         guard = create_execution_guard()
-        assert type(guard) is ExecutionResourceGuard
-        guard.assign(12345)  # no-op, must not raise
-        guard.close()  # no-op, must not raise
+        try:
+            assert guard.popen_kwargs() == {}
+        finally:
+            guard.close()
 
 
 class TestNullGuardNeverRaises:

--- a/backend/tests/test_execution_guard_posix.py
+++ b/backend/tests/test_execution_guard_posix.py
@@ -1,0 +1,322 @@
+"""ADR-005 stage 5.3: the POSIX resource-guard tier.
+
+READ THIS BEFORE TRUSTING THE POSIX TIER. This project's development
+machine and its only CI runner are both Windows. `create_execution_guard()`
+therefore never returns `_PosixResourceGuard` in either place, and every
+test in `TestPosixEnforcementIsReal` below is skipped there. Those are the
+tests that would actually prove the caps fire - a memory bomb dying at
+RLIMIT_AS, a fork bomb capped by RLIMIT_NPROC, `killpg` reaping a whole
+process tree. Until someone runs this file on a real POSIX host, the
+enforcement is *written against documented stdlib behaviour but not
+observed working*, and this codebase should not claim otherwise. That is a
+deliberate, disclosed gap, not an oversight - contrast ADR-005 stage 5.2's
+Windows tier, which was proven against real memory-bomb / fork-bomb /
+orphan-grandchild processes before it shipped.
+
+What DOES run everywhere is `TestPosixGuardLogic`. The POSIX classes live
+inside the module's `else:` branch, which on Windows is never executed at
+all - meaning a typo or NameError in that whole block would be invisible to
+every test AND to CI, since the only CI runner is Windows. That is an
+unacceptable blind spot for code that cannot otherwise be verified, so the
+`posix_guard_module` fixture below loads a SECOND, independent copy of
+graphlink_execution_guard.py with `sys.platform` faked to "linux", forcing
+the POSIX branch to actually execute. (An independent load via
+`spec_from_file_location`, deliberately NOT `importlib.reload` of the real
+module: reload would mutate the module every other test shares, and would
+leave the real `create_execution_guard` pointing at the POSIX factory if a
+teardown were ever missed.) That turns "never executed anywhere" into "its
+decisions are asserted on every push" - which rlimits it sets and to what
+values, that close() targets the process GROUP rather than the bare pid,
+that an already-dead group is not an error. It still cannot catch a wrong
+assumption about how the kernel behaves; only TestPosixEnforcementIsReal
+can do that, and only on a POSIX host.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import graphlink_execution_guard as guard_module
+
+POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX resource guard: rlimits/process groups do not exist on Windows",
+)
+
+
+@pytest.fixture(scope="module")
+def posix_guard_module():
+    """An independently-loaded copy of graphlink_execution_guard with the
+    POSIX branch forced to execute - see the module docstring for why this
+    is a separate load rather than a reload. Never registered in
+    sys.modules, so nothing else in the suite can observe it."""
+    spec = importlib.util.spec_from_file_location(
+        "graphlink_execution_guard__posix_probe",
+        pathlib.Path(guard_module.__file__),
+    )
+    module = importlib.util.module_from_spec(spec)
+    with patch.object(sys, "platform", "linux"):
+        spec.loader.exec_module(module)
+    assert hasattr(module, "_PosixResourceGuard"), (
+        "forcing sys.platform=linux did not define the POSIX guard - the "
+        "module's platform branching changed shape"
+    )
+    return module
+
+
+@contextlib.contextmanager
+def _patched_group_kill(module, **kwargs):
+    """Fake out BOTH POSIX-only names close() touches.
+
+    `os.killpg` and `signal.SIGKILL` are both absent on Windows, where these
+    tests still run via the forced-load fixture - and SIGKILL is evaluated
+    as an ARGUMENT before killpg is even called, so patching killpg alone
+    still raises AttributeError. Deliberately faked here in the test rather
+    than papered over with a `getattr(signal, "SIGKILL", ...)` fallback in
+    the guard itself: on every platform that actually runs this code the
+    name exists, so such a fallback would be dead production code added
+    purely to serve a test."""
+    with patch.object(module.signal, "SIGKILL", 9, create=True):
+        with patch.object(module.os, "killpg", create=True, **kwargs) as killpg:
+            yield killpg
+
+
+def _make_posix_guard(module, **overrides):
+    kwargs = {
+        "memory_limit_bytes": 2 * 1024 * 1024 * 1024,
+        "active_process_limit": 64,
+        "cpu_seconds": 60,
+        "file_size_limit_bytes": 1024 * 1024 * 1024,
+    }
+    kwargs.update(overrides)
+    return module._PosixResourceGuard(**kwargs)
+
+
+class TestPosixGuardLogic:
+    """Runs on EVERY platform, via the forced-load fixture above. Asserts
+    the guard's decisions, not kernel behaviour - see the module docstring."""
+
+    def test_the_posix_branch_actually_executes(self, posix_guard_module):
+        # The blind-spot canary: if the POSIX block ever fails to load
+        # (typo, bad import, syntax that only bites at exec time), this
+        # fails on Windows CI rather than silently shipping broken code to
+        # the one platform nobody here can run.
+        assert posix_guard_module._PosixResourceGuard is not None
+        guard = posix_guard_module.create_execution_guard()
+        assert type(guard).__name__ == "_PosixResourceGuard"
+
+    def test_popen_kwargs_request_a_dedicated_process_group(self, posix_guard_module):
+        guard = _make_posix_guard(posix_guard_module)
+        kwargs = guard.popen_kwargs()
+        # process_group=0 -> setpgid(0, 0) in the child, done in C inside
+        # subprocess's own fork-exec helper rather than via preexec_fn.
+        # This is what makes close()'s killpg able to reap the whole tree.
+        assert kwargs["process_group"] == 0
+
+    def test_popen_kwargs_install_the_rlimit_hook(self, posix_guard_module):
+        guard = _make_posix_guard(posix_guard_module)
+        kwargs = guard.popen_kwargs()
+        assert kwargs["preexec_fn"] == guard._apply_child_limits
+
+    def test_close_kills_the_process_group_not_just_the_pid(self, posix_guard_module):
+        guard = _make_posix_guard(posix_guard_module)
+        guard.assign(4242)
+        with _patched_group_kill(posix_guard_module) as killpg:
+            guard.close()
+        killpg.assert_called_once()
+        assert killpg.call_args[0][0] == 4242, (
+            "close() must target the process GROUP id - killing only the "
+            "tracked pid is exactly the 'Stop left orphans behind' gap this "
+            "tier exists to close"
+        )
+
+    def test_close_is_idempotent_and_only_kills_once(self, posix_guard_module):
+        guard = _make_posix_guard(posix_guard_module)
+        guard.assign(4242)
+        with _patched_group_kill(posix_guard_module) as killpg:
+            guard.close()
+            guard.close()
+        assert killpg.call_count == 1
+
+    def test_close_before_assign_does_not_kill_anything(self, posix_guard_module):
+        guard = _make_posix_guard(posix_guard_module)
+        with _patched_group_kill(posix_guard_module) as killpg:
+            guard.close()
+        killpg.assert_not_called()
+
+    def test_an_already_dead_group_is_not_an_error(self, posix_guard_module):
+        guard = _make_posix_guard(posix_guard_module)
+        guard.assign(4242)
+        with _patched_group_kill(posix_guard_module, side_effect=ProcessLookupError):
+            guard.close()  # the normal clean-exit path; must not raise
+
+    def test_every_configured_rlimit_is_applied_with_its_value(self, posix_guard_module):
+        guard = _make_posix_guard(
+            posix_guard_module,
+            memory_limit_bytes=111,
+            active_process_limit=222,
+            cpu_seconds=333,
+            file_size_limit_bytes=444,
+        )
+        fake_resource = MagicMock()
+        fake_resource.RLIMIT_AS = "AS"
+        fake_resource.RLIMIT_CPU = "CPU"
+        fake_resource.RLIMIT_NPROC = "NPROC"
+        fake_resource.RLIMIT_FSIZE = "FSIZE"
+
+        with patch.object(posix_guard_module, "_resource", fake_resource):
+            guard._apply_child_limits()
+
+        applied = {call.args[0]: call.args[1] for call in fake_resource.setrlimit.call_args_list}
+        assert applied == {
+            "AS": (111, 111),
+            "CPU": (333, 333),
+            "NPROC": (222, 222),
+            "FSIZE": (444, 444),
+        }
+
+    def test_a_rlimit_the_kernel_refuses_does_not_abort_the_run(self, posix_guard_module):
+        # Fail-open, matching the Windows tier's stance when job creation
+        # fails: a limit we cannot set must not stop the user's code from
+        # running at all.
+        guard = _make_posix_guard(posix_guard_module)
+        fake_resource = MagicMock()
+        fake_resource.RLIMIT_AS = "AS"
+        fake_resource.RLIMIT_CPU = "CPU"
+        fake_resource.RLIMIT_NPROC = "NPROC"
+        fake_resource.RLIMIT_FSIZE = "FSIZE"
+        fake_resource.setrlimit.side_effect = ValueError("kernel says no")
+
+        with patch.object(posix_guard_module, "_resource", fake_resource):
+            guard._apply_child_limits()  # must not raise
+
+    def test_a_rlimit_absent_on_this_kernel_is_skipped(self, posix_guard_module):
+        # RLIMIT_NPROC genuinely does not exist on some POSIX systems.
+        guard = _make_posix_guard(posix_guard_module)
+        fake_resource = MagicMock(spec=["RLIMIT_AS", "setrlimit"])
+        fake_resource.RLIMIT_AS = "AS"
+
+        with patch.object(posix_guard_module, "_resource", fake_resource):
+            guard._apply_child_limits()
+
+        applied = [call.args[0] for call in fake_resource.setrlimit.call_args_list]
+        assert applied == ["AS"]
+
+    def test_no_rlimits_are_attempted_when_the_resource_module_is_absent(self, posix_guard_module):
+        # The stdlib `resource` module is POSIX-only; the guard imports it
+        # defensively. If it is missing, the process-group half must still
+        # work rather than the whole guard blowing up.
+        guard = _make_posix_guard(posix_guard_module)
+        with patch.object(posix_guard_module, "_resource", None):
+            guard._apply_child_limits()  # must not raise
+        assert guard.popen_kwargs()["process_group"] == 0
+
+
+@POSIX_ONLY
+class TestPosixEnforcementIsReal:
+    """The tests that actually prove the kernel enforces what we asked for.
+    THESE HAVE NEVER RUN in this project's CI - see the module docstring.
+    They are written so that the first person to run them on a POSIX host
+    gets a real answer rather than having to invent the harness."""
+
+    def test_a_memory_bomb_is_killed_at_the_address_space_cap(self):
+        guard = guard_module._PosixResourceGuard(
+            memory_limit_bytes=100 * 1024 * 1024,
+            active_process_limit=64,
+            cpu_seconds=60,
+            file_size_limit_bytes=1024 * 1024 * 1024,
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "x = bytearray(500 * 1024 * 1024); import time; time.sleep(5)"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            **guard.popen_kwargs(),
+        )
+        guard.assign(proc.pid)
+        try:
+            assert proc.wait(timeout=30) != 0, (
+                "a 500 MiB allocation under a 100 MiB RLIMIT_AS should have failed"
+            )
+        finally:
+            guard.close()
+
+    def test_closing_the_guard_kills_a_grandchild_process_too(self, tmp_path):
+        marker = tmp_path / "marker.txt"
+        grandchild = tmp_path / "grandchild.py"
+        grandchild.write_text(
+            "import time\n"
+            f"with open(r'{marker}', 'w') as m:\n"
+            "    while True:\n"
+            "        m.write('x'); m.flush(); time.sleep(0.2)\n",
+            encoding="utf-8",
+        )
+        parent = tmp_path / "parent.py"
+        parent.write_text(
+            "import subprocess, sys, time\n"
+            f"subprocess.Popen([sys.executable, r'{grandchild}'])\n"
+            "time.sleep(30)\n",
+            encoding="utf-8",
+        )
+
+        guard = _make_posix_guard(guard_module)
+        proc = subprocess.Popen(
+            [sys.executable, str(parent)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            **guard.popen_kwargs(),
+        )
+        guard.assign(proc.pid)
+
+        time.sleep(1.5)
+        assert marker.exists(), "grandchild never started writing"
+        size_before = marker.stat().st_size
+        time.sleep(1)
+        assert marker.stat().st_size > size_before
+
+        guard.close()
+        time.sleep(1.5)
+        settled = marker.stat().st_size
+        time.sleep(1.5)
+        assert marker.stat().st_size == settled, (
+            "grandchild kept writing after guard.close() - killpg did not "
+            "reap the whole process group"
+        )
+
+    def test_a_fork_bomb_is_capped_by_the_process_limit(self, tmp_path):
+        counter = tmp_path / "forkcount.txt"
+        bomb = tmp_path / "forkbomb.py"
+        bomb.write_text(
+            "import subprocess, sys, time\n"
+            f"path = r'{counter}'\n"
+            "n = int(sys.argv[1]) if len(sys.argv) > 1 else 0\n"
+            "with open(path, 'a') as fh:\n"
+            "    fh.write('x')\n"
+            "if n < 200:\n"
+            "    try:\n"
+            "        subprocess.Popen([sys.executable, __file__, str(n + 1)])\n"
+            "    except Exception:\n"
+            "        pass\n"
+            "time.sleep(3)\n",
+            encoding="utf-8",
+        )
+
+        guard = _make_posix_guard(guard_module, active_process_limit=5)
+        proc = subprocess.Popen(
+            [sys.executable, str(bomb)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            **guard.popen_kwargs(),
+        )
+        guard.assign(proc.pid)
+        try:
+            time.sleep(5)
+            count = len(counter.read_text(encoding="utf-8")) if counter.exists() else 0
+            assert count < 200, f"RLIMIT_NPROC did not cap the fork bomb - {count} processes ran"
+        finally:
+            guard.close()

--- a/graphlink_execution_guard.py
+++ b/graphlink_execution_guard.py
@@ -40,11 +40,13 @@ limits is a UI-facing change orthogonal to this module's own correctness,
 also left for a follow-up. Neither is silently dropped - both are named
 here so a future stage does not have to rediscover the gap.
 
-The POSIX tier (process groups + rlimit) is explicitly ADR-005 stage 5.3,
-not this one - on non-Windows platforms, ExecutionResourceGuard.assign()/
-close() are no-ops, matching the pre-existing (unenforced) behavior
-exactly. This is not a regression: no platform loses a protection it had
-before this module existed.
+THE POSIX TIER (ADR-005 stage 5.3) is implemented below too - a dedicated
+process group so close() can kill the whole tree via killpg(), plus
+resource.setrlimit caps for address space, CPU seconds, process count and
+file size. Read the long comment on that block before trusting it: unlike
+the Windows tier, it has NOT been executed on a POSIX host (this project's
+dev machine and its only CI runner are both Windows), so it is
+unverified-in-practice by design and says so rather than implying parity.
 """
 
 from __future__ import annotations
@@ -78,6 +80,17 @@ class ExecutionResourceGuard:
     unenforced behavior is the safe fallback, not a hard failure, matching
     this codebase's established graceful-degradation precedent (DPAPI
     falling back to plaintext off-Windows rather than refusing to save)."""
+
+    def popen_kwargs(self) -> dict:
+        """Extra kwargs to merge into the `subprocess.Popen(...)` call this
+        guard is about to govern. Empty for Windows (a job object is applied
+        to an ALREADY-running process via assign()) and for the no-op base,
+        but load-bearing on POSIX, where `resource.setrlimit` has to run
+        inside the child between fork and exec - there is no way to impose
+        an address-space limit on a process that is already running. Callers
+        must therefore create the guard BEFORE Popen, pass these kwargs into
+        it, and call assign() with the resulting pid afterwards."""
+        return {}
 
     def assign(self, pid: int) -> None:
         pass
@@ -261,6 +274,152 @@ if sys.platform == "win32":
 
         return _WindowsJobObjectGuard(handle)
 
+    # The platform decision is made ONCE, here at import time, and bound to
+    # a single name the public factory calls. Deliberately not re-checked
+    # via `sys.platform` inside create_execution_guard(): the classes below
+    # only EXIST on their own platform, so a runtime re-check could route to
+    # a name that was never defined (a latent NameError, and one that a test
+    # monkeypatching sys.platform would trip over immediately).
+    _create_platform_guard = _create_windows_job_object_guard
+
+
+else:
+    # ADR-005 stage 5.3: the POSIX tier. Two independent mechanisms, both
+    # applied at spawn time rather than after the fact:
+    #
+    #   1. A dedicated PROCESS GROUP (`process_group=0` -> setpgid(0, 0) in
+    #      the child). This is what makes close() able to kill the whole
+    #      tree via killpg() rather than just the one tracked pid - the
+    #      POSIX analogue of the Windows job object's kill-on-close, and the
+    #      same "Stop actually stops everything it spawned" property.
+    #      Deliberately uses subprocess's own `process_group=` kwarg (Python
+    #      3.11+, implemented in C inside the fork-exec helper) rather than
+    #      doing setsid() from preexec_fn: preexec_fn runs arbitrary Python
+    #      between fork and exec, which CPython's own docs call out as
+    #      unsafe in the presence of threads (it can deadlock on a lock held
+    #      by another thread at fork time) - and BOTH call sites here are
+    #      threaded (the sandbox's reader thread, agents.py's
+    #      asyncio.to_thread). Keeping the group setup in C-level code
+    #      removes that hazard for the mechanism that matters most.
+    #
+    #   2. resource.setrlimit caps (address space, CPU seconds, process
+    #      count, file size). These have no subprocess kwarg equivalent, so
+    #      they DO require preexec_fn. The callback is kept deliberately
+    #      tiny and allocation-free for the thread-safety reason above.
+    #
+    # HONESTY NOTE, because this matters for how much to trust this code:
+    # unlike the Windows tier in stage 5.2 - which was proven against real
+    # memory-bomb, fork-bomb and orphan-grandchild processes before it
+    # shipped - this POSIX tier has NOT been executed on a POSIX host. The
+    # development machine and the only CI runner are both windows-latest,
+    # so `create_execution_guard()` never returns this class in either
+    # place and its enforcement tests are skipped there. It is written
+    # against documented stdlib behaviour and unit-tested for the parts
+    # that can be exercised anywhere (which kwargs it contributes, which
+    # rlimits it would set, that close() targets the group not the pid),
+    # but the real caps have not been observed firing. Treat it as
+    # unverified-in-practice until someone runs the POSIX-gated tests in
+    # backend/tests/test_execution_guard_posix.py on a real POSIX box.
+    import os
+    import signal
+
+    try:
+        import resource as _resource
+    except ImportError:  # pragma: no cover - POSIX-only import
+        _resource = None
+
+    # ADR-005 Decision #2 names a CPU cap ("60 s CPU") alongside the memory
+    # cap. RLIMIT_CPU is the POSIX way to express it and costs nothing to
+    # set here - note this is CPU-seconds consumed, not wall-clock, so it
+    # is complementary to (not a replacement for) the existing wall-clock
+    # timeouts in both execution surfaces.
+    DEFAULT_CPU_SECONDS = 60
+
+    # Bounds a single runaway write; well above any legitimate sandbox
+    # output while still stopping a disk-filling loop.
+    DEFAULT_FILE_SIZE_LIMIT_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB
+
+    class _PosixResourceGuard(ExecutionResourceGuard):
+        def __init__(
+            self,
+            memory_limit_bytes: int,
+            active_process_limit: int,
+            cpu_seconds: int,
+            file_size_limit_bytes: int,
+        ) -> None:
+            self._memory_limit_bytes = memory_limit_bytes
+            self._active_process_limit = active_process_limit
+            self._cpu_seconds = cpu_seconds
+            self._file_size_limit_bytes = file_size_limit_bytes
+            self._pgid = None
+            # Same check-then-null race the Windows guard's own close() has
+            # to defend against (see its comment) - an external stop() can
+            # race the run loop's own cleanup on a different thread.
+            self._lock = threading.Lock()
+
+        def _apply_child_limits(self) -> None:  # pragma: no cover - runs post-fork
+            """Runs in the forked child, before exec. Deliberately minimal:
+            no allocation, no logging, no imports - see the preexec_fn
+            thread-safety note on this module's POSIX block."""
+            if _resource is None:
+                return
+            for limit_name, value in (
+                ("RLIMIT_AS", self._memory_limit_bytes),
+                ("RLIMIT_CPU", self._cpu_seconds),
+                ("RLIMIT_NPROC", self._active_process_limit),
+                ("RLIMIT_FSIZE", self._file_size_limit_bytes),
+            ):
+                if not value:
+                    continue
+                limit = getattr(_resource, limit_name, None)
+                if limit is None:
+                    continue
+                try:
+                    _resource.setrlimit(limit, (value, value))
+                except (ValueError, OSError):
+                    # A limit the kernel refuses (already lower, or not
+                    # supported on this platform - RLIMIT_NPROC is absent on
+                    # some systems) must not abort the run: the same
+                    # fail-open stance the Windows tier takes when job
+                    # creation fails.
+                    pass
+
+        def popen_kwargs(self) -> dict:
+            return {
+                "process_group": 0,
+                "preexec_fn": self._apply_child_limits,
+            }
+
+        def assign(self, pid: int) -> None:
+            # With process_group=0 the child leads its own group, so the
+            # group id IS the child pid - that is what close() kills.
+            with self._lock:
+                self._pgid = pid
+
+        def close(self) -> None:
+            with self._lock:
+                pgid, self._pgid = self._pgid, None
+            if pgid is None:
+                return
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError):
+                # Already gone (the normal clean-exit path), or never
+                # actually became a group leader. Nothing to clean up.
+                pass
+
+    # Same single-source-of-truth dispatch the Windows branch uses - see
+    # its comment.
+    def _create_platform_guard(
+        memory_limit_bytes: int, active_process_limit: int
+    ) -> ExecutionResourceGuard:
+        return _PosixResourceGuard(
+            memory_limit_bytes=memory_limit_bytes,
+            active_process_limit=active_process_limit,
+            cpu_seconds=DEFAULT_CPU_SECONDS,
+            file_size_limit_bytes=DEFAULT_FILE_SIZE_LIMIT_BYTES,
+        )
+
 
 def create_execution_guard(
     memory_limit_bytes: int = DEFAULT_MEMORY_LIMIT_BYTES,
@@ -268,10 +427,13 @@ def create_execution_guard(
 ) -> ExecutionResourceGuard:
     """One guard per subprocess-management lifecycle (a Py-Coder REPL's
     single long-lived child; one Code Sandbox subprocess invocation).
-    Call `.assign(process.pid)` immediately after `subprocess.Popen(...)`
-    returns, and `.close()` exactly once when that process is done with -
-    whether it exited on its own or is being forcibly stopped. Safe to call
-    `.close()` on a guard whose process already exited cleanly."""
-    if sys.platform == "win32":
-        return _create_windows_job_object_guard(memory_limit_bytes, active_process_limit)
-    return ExecutionResourceGuard()
+
+    Call order matters, and is the same on every platform:
+      1. `guard = create_execution_guard()`
+      2. `Popen(..., **guard.popen_kwargs())` - POSIX applies its rlimits
+         between fork and exec, so the guard must exist BEFORE the spawn.
+      3. `guard.assign(process.pid)`
+      4. `guard.close()` exactly once when that process is done with -
+         whether it exited on its own or is being forcibly stopped. Safe to
+         call on a guard whose process already exited cleanly."""
+    return _create_platform_guard(memory_limit_bytes, active_process_limit)

--- a/graphlink_plugins/code_sandbox/domain.py
+++ b/graphlink_plugins/code_sandbox/domain.py
@@ -213,6 +213,13 @@ class VirtualEnvSandbox:
     def _run_subprocess(self, args, should_continue, emit_line=None, cwd=None, timeout_seconds=None):
         output_chunks = []
         start_time = time.monotonic()
+        # ADR-005 stage 5.2/5.3: the guard is created BEFORE Popen so its
+        # popen_kwargs() can reach the spawn itself. Empty on Windows (the
+        # job object is applied to an already-running process by assign()
+        # below); on POSIX it carries the process-group request and the
+        # rlimit preexec hook, which must be in place between fork and
+        # exec - see graphlink_execution_guard's own docstring.
+        self.guard = create_execution_guard()
         process = subprocess.Popen(
             args,
             cwd=str(cwd) if cwd else None,
@@ -220,15 +227,14 @@ class VirtualEnvSandbox:
             stderr=subprocess.STDOUT,
             text=True,
             bufsize=1,
+            **self.guard.popen_kwargs(),
             **_subprocess_kwargs(),
         )
         self.current_process = process
-        # ADR-005 stage 5.2: assign the freshly-started child to a resource
-        # guard immediately - see graphlink_execution_guard's own docstring
-        # for the memory/process-count caps this closes (audit H2) and why
-        # assigning right after Popen() returns, rather than using
-        # CREATE_SUSPENDED, is an accepted tradeoff.
-        self.guard = create_execution_guard()
+        # Windows applies its cap here, after the child exists (an accepted
+        # tradeoff over CREATE_SUSPENDED - the child has not run its own
+        # code yet). On POSIX this records the process-group id close()
+        # will kill.
         self.guard.assign(process.pid)
         output_queue = queue.Queue()
         done_signal = object()

--- a/graphlink_plugins/pycoder/domain.py
+++ b/graphlink_plugins/pycoder/domain.py
@@ -164,6 +164,15 @@ while True:
             # never touches the filesystem.
             self.cwd.mkdir(parents=True, exist_ok=True)
 
+            # ADR-005 stage 5.2/5.3: the guard is created BEFORE Popen so
+            # its popen_kwargs() can reach the spawn itself. On Windows
+            # that dict is empty (a job object is applied to an already-
+            # running process by assign() below); on POSIX it carries the
+            # process-group request and the rlimit preexec hook, which have
+            # to be in place between fork and exec - see
+            # graphlink_execution_guard's own docstring.
+            self.guard = create_execution_guard()
+
             self.process = subprocess.Popen(
                 [sys.executable, '-c', script],
                 stdin=subprocess.PIPE,
@@ -172,16 +181,14 @@ while True:
                 text=True,
                 bufsize=1,
                 cwd=str(self.cwd),
+                **self.guard.popen_kwargs(),
                 **kwargs
             )
-            # ADR-005 stage 5.2: assign the freshly-started REPL to a
-            # resource guard immediately - see graphlink_execution_guard's
-            # own docstring for the memory/process-count caps this closes
-            # (audit H2) and why assigning right after Popen() returns,
-            # rather than using CREATE_SUSPENDED, is an accepted tradeoff
-            # (the child hasn't run any of its own code yet, so the window
-            # for it to spawn an unassigned grandchild first is negligible).
-            self.guard = create_execution_guard()
+            # Windows applies its cap here, after the child exists. An
+            # accepted tradeoff over CREATE_SUSPENDED: the child hasn't run
+            # any of its own code yet, so the window for it to spawn an
+            # unassigned grandchild first is negligible. On POSIX this
+            # records the process-group id that close() will kill.
             self.guard.assign(self.process.pid)
 
     def execute(self, code):


### PR DESCRIPTION
## Problem

Stage 5.2 gave Windows a real resource guard (memory cap, process-count
cap, kill-the-whole-tree on stop). Every other platform got the no-op
base class — executed code ran with no limits at all, and "Stop" killed
only the one directly-tracked process, leaving anything it had spawned
behind.

## Change

Implements the POSIX tier of `graphlink_execution_guard.py`:

- **Process group** via subprocess's own `process_group=0` kwarg, so
  `close()` reaps the entire tree with `killpg` — the POSIX analogue of
  the job object's kill-on-close. Deliberately uses the C-level kwarg
  rather than `setsid()` from `preexec_fn`: preexec_fn runs arbitrary
  Python between fork and exec, which CPython documents as unsafe in
  threaded programs, and both call sites here are threaded (the sandbox's
  reader thread, `agents.py`'s `asyncio.to_thread`).
- **rlimits** for `RLIMIT_AS`, `RLIMIT_CPU`, `RLIMIT_NPROC`,
  `RLIMIT_FSIZE`. These have no kwarg equivalent so they do use
  `preexec_fn`, with the callback kept minimal for the same reason. A
  limit the kernel refuses, or one absent on the platform, fails open —
  matching the Windows tier's stance when job creation fails.

The guard contract grows `popen_kwargs()`, because rlimits must be
imposed between fork and exec — you cannot cap the address space of a
process that is already running. Both execution surfaces now create the
guard *before* `Popen` instead of after. On Windows that dict is empty
and behaviour is byte-for-byte unchanged.

Also fixes a latent bug found while wiring this: `create_execution_guard`
was branching on `sys.platform` at call time, while the classes it
returns are defined at *import* time — so a platform mismatch could route
to a name that was never defined. Dispatch is now bound once at import.

## Honest limitation

Unlike the Windows tier — proven against real memory-bomb, fork-bomb and
orphan-grandchild processes before it shipped — **this tier has never
executed on a POSIX host.** The dev machine and the only CI runner are
both Windows. The module docstring and the test file both say so plainly
rather than implying parity. The three tests that would actually prove
the caps fire are written and POSIX-gated, ready to give a real answer
the first time someone runs them on a POSIX box.

That leaves a blind spot worth closing on its own: the POSIX classes live
in a branch that never executes on Windows, so a typo there would be
invisible to every test *and* to CI. `test_execution_guard_posix.py`
loads a second, independent copy of the module with `sys.platform` faked
(a fresh `spec_from_file_location` load, not a `reload` — nothing else in
the suite can observe it), forcing that branch to execute. That converts
"never runs anywhere" into 11 assertions that run on every push.

## Test plan

- `backend/tests/test_execution_guard_posix.py`: 11 tests running on all
  platforms via the forced-load fixture (which rlimits are set and to
  what values, that `close()` targets the group not the pid, idempotency,
  close-before-assign, refused/absent rlimits failing open, `resource`
  module absent), plus 3 POSIX-gated real-enforcement tests.
- Mutation-tested: changed `killpg` → `kill` and confirmed the
  group-targeting tests fail; restored and confirmed green.
- Existing stage 5.2 tests updated for the new contract and still pass,
  including the concurrency regression tests.
- Full suite: `pytest -q` — 1475 passed, 10 skipped. Wheel build +
  `twine check` + the packaging ratchet all green (no new top-level
  module this time).