### PR TITLE
ADR-005 stage 5.3: scratch-dir 0700 perms + GC on delete/evict/age

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -98,6 +98,8 @@ from graphlink_plugins.code_sandbox.domain import (
     _extract_python_block,
     _normalize_requirements,
 )
+from graphlink_scratch_dirs import EXECUTION_SANDBOX_ROOT, PYCODER_REPL_ROOT
+from graphlink_scratch_dirs import remove_scratch_dir_for_id
 from graphlink_plugins.web_research.domain import (
     CancellationToken,
     ProgressEvent,
@@ -377,29 +379,121 @@ class AgentDispatcher:
         # SceneNode state, not a live object.
         self._pycoder_repls: dict[str, PythonREPL] = {}
 
-    def get_pycoder_repl(self, node_id: str) -> PythonREPL:
+    def get_pycoder_repl(self, node_id: str, repl_id: str) -> PythonREPL:
         """Lazy-create-or-reuse - mirrors PyCoderReplManager.get_repl's own
-        shape, just keyed by node_id instead of node identity."""
+        shape, keyed by node_id (transient, session-scoped: this dict and
+        node_id are both rebuilt from scratch together on every session
+        reload, so reusing node_id here is safe even though it is not
+        durable across reloads - see PythonREPL.cwd's own docstring for
+        why the ON-DISK directory needs a different, stable identity
+        instead). repl_id is node.state.pycoder_repl_id, minted once at
+        node creation (ADR-005 stage 5.3 review-fix) - passed through to
+        PythonREPL so its scratch cwd survives a reload even though this
+        node's own id would not."""
         repl = self._pycoder_repls.get(node_id)
         if repl is None:
-            repl = PythonREPL(node_id=node_id)
+            repl = PythonREPL(repl_id=repl_id)
             self._pycoder_repls[node_id] = repl
         return repl
 
-    async def dispose_pycoder_repl(self, node_id: str) -> None:
+    async def dispose_pycoder_repl(
+        self, node_id: str, *, repl_id: str | None = None, remove_scratch_dir: bool = False
+    ) -> None:
         """Explicit teardown of one node's REPL subprocess. Tolerates a
         missing node_id silently (pop with a default) - called from exactly
-        two places: backend/canvas.py's remove_nodes WS-intent wrapper (for
-        every deleted pycoder node), and start_pycoder_run's own
-        execute-timeout guard below (a hung REPL must not be left alive).
-        NOT called on disconnect/session-end - the REPL persists across
-        disconnects exactly like every other piece of node state in
+        two places: backend/api/intents_nodes.py's remove_nodes WS-intent
+        wrapper (for every deleted pycoder node), and start_pycoder_run's
+        own execute-timeout guard below (a hung REPL must not be left
+        alive). NOT called on disconnect/session-end - the REPL persists
+        across disconnects exactly like every other piece of node state in
         SceneDocument already does; only explicit node deletion (or process
         shutdown) ends it. stop() does a blocking kill()+wait(), so it runs
-        inside asyncio.to_thread rather than directly on the event loop."""
+        inside asyncio.to_thread rather than directly on the event loop.
+
+        ADR-005 stage 5.3: remove_scratch_dir=True additionally deletes the
+        REPL's scratch directory from disk - correct ONLY for the real
+        node-deletion caller, where the node is gone for good. The
+        execute-timeout guard passes the default False: a timeout means
+        this one run misbehaved, not that the node's accumulated scratch
+        files should be thrown away.
+
+        Review-fix: removal is keyed off the passed-in repl_id (recomputed
+        via remove_scratch_dir_for_id), NOT off whatever `repl` this pop
+        happened to find - the two are NOT reliably the same thing. A REPL
+        already popped by an earlier execute timeout (this method's OTHER
+        caller, which never repopulates the dict - only a fresh
+        get_pycoder_repl call does, i.e. running Py-Coder again) leaves
+        node_id absent from _pycoder_repls; a subsequent real delete used
+        to make this pop return None and silently skip the directory
+        removal entirely; with a deterministic recompute the removal still
+        happens even though there is no live object left to ask. Callers
+        that pass remove_scratch_dir=True must also pass repl_id (the
+        node's stable pycoder_repl_id, not its node_id)."""
         repl = self._pycoder_repls.pop(node_id, None)
         if repl is not None:
             await asyncio.to_thread(repl.stop)
+        if remove_scratch_dir and repl_id:
+            await asyncio.to_thread(remove_scratch_dir_for_id, PYCODER_REPL_ROOT, repl_id)
+
+    def dispose_all_pycoder_repls(self) -> None:
+        """Bulk, non-blocking teardown for every currently-tracked REPL
+        subprocess - called from backend/app.py's _evict_idle_session right
+        before the SessionBus itself is dropped from EventBus._sessions.
+        Its one caller (_evict_idle_session, via EventBus's own
+        synchronous sweep_idle_sessions/_eviction_loop chain) runs on the
+        live asyncio event loop, so - review-fix - each repl.stop() (a
+        documented-blocking kill()+wait(), possibly a Windows Job-Object
+        guard.close() too) is fired on its own daemon thread rather than
+        called inline: this method's async sibling dispose_pycoder_repl
+        explicitly offloads the identical call via asyncio.to_thread for
+        exactly this reason, and calling it directly here would stall
+        every other connected client's WS/HTTP handling for however long
+        the OS takes to kill+reap each process. Not awaited/joined - unlike
+        the delete path, nothing here needs the stop to have completed
+        before returning (this method deliberately never removes any
+        directory afterward, see below), so there is nothing to wait for.
+        PythonREPL.stop()'s own RLock already makes firing these
+        concurrently (with each other, and with any other in-flight
+        start()/stop() on the same instance) safe (the stage 5.2
+        concurrent-stop() fix covers exactly that race).
+
+        Deliberately does NOT remove each REPL's scratch directory, unlike
+        the node-delete path above: eviction means "no one is currently
+        connected", not "this node's work should be discarded" - the
+        directory is exactly the kind of state a REPL restart already
+        preserves across process restarts by design (see PythonREPL's own
+        cwd docstring), and a reconnecting user may expect their files
+        still there. What eviction genuinely leaks if left alone is the
+        subprocess itself: once this SessionBus is gone from
+        EventBus._sessions, nothing else holds a reference that could ever
+        call stop() on it again."""
+        for node_id in list(self._pycoder_repls.keys()):
+            repl = self._pycoder_repls.pop(node_id, None)
+            if repl is not None:
+                threading.Thread(target=repl.stop, daemon=True).start()
+
+    async def remove_code_sandbox_scratch_dir(self, sandbox_id: str) -> None:
+        """ADR-005 stage 5.3: node-delete counterpart of
+        dispose_pycoder_repl's remove_scratch_dir=True, for Execution
+        Sandbox. Unlike Py-Coder's REPL, VirtualEnvSandbox is never cached
+        on this dispatcher (see this class's own __init__ docstring) - the
+        only state that survives a run is the plain sandbox_id string on
+        the node itself - so there is no live object to ask for its
+        base_dir; the path is recomputed the same deterministic way
+        VirtualEnvSandbox.__init__ builds it (remove_scratch_dir_for_id
+        also refuses to act on a blank sandbox_id, rather than rmtree-ing
+        the shared "default" bucket a blank id resolves to - see that
+        function's own docstring). A venv tree can be large, so the
+        removal runs in a thread, same reasoning as dispose_pycoder_repl's
+        own stop()/rmtree calls.
+
+        Best-effort: an in-flight run for this node may still be exiting
+        when a delete races it (cancelled moments earlier by remove_nodes'
+        own code_exec_cancels loop), in which case removal can fail (e.g. a
+        file still open on Windows) and is simply logged - the age sweep in
+        graphlink_scratch_dirs.py is the backstop for anything left behind
+        here."""
+        await asyncio.to_thread(remove_scratch_dir_for_id, EXECUTION_SANDBOX_ROOT, sandbox_id)
 
     def cancel_pycoder(self, request_id: str) -> bool:
         """Cooperative cancel, same honestly-documented limitation as every
@@ -1829,7 +1923,7 @@ class AgentDispatcher:
                         await bus.publish("scene")
                         return
 
-                    repl = self.get_pycoder_repl(node_id)
+                    repl = self.get_pycoder_repl(node_id, node.state.pycoder_repl_id)
                     try:
                         output = await asyncio.wait_for(
                             asyncio.to_thread(repl.execute, manual_code),
@@ -1905,7 +1999,7 @@ class AgentDispatcher:
                     await bus.publish("scene")
                     return
 
-                repl = self.get_pycoder_repl(node_id)
+                repl = self.get_pycoder_repl(node_id, node.state.pycoder_repl_id)
                 retry_count = 0
                 max_retries = 4
                 last_error = None

--- a/backend/api/intents_nodes.py
+++ b/backend/api/intents_nodes.py
@@ -114,9 +114,33 @@ def register_node_intents(
         # R5.4: a deleted Py-Coder node's REPL subprocess must not outlive
         # it - kind is captured BEFORE document.remove_nodes pops the node,
         # since afterward there is nothing left to read it from.
+        # ADR-005 stage 5.3 (review-fix): pycoder_repl_id is captured
+        # alongside node_id, not derived from it - the on-disk scratch dir
+        # is keyed by the node's STABLE repl id, not its (reload-volatile)
+        # node id, so dispose_pycoder_repl needs both: node_id to find/pop
+        # any live in-memory REPL, repl_id to deterministically locate and
+        # remove the directory even if no live REPL is currently tracked
+        # (e.g. a prior execute timeout already popped it) - see that
+        # method's own docstring.
         pycoder_ids = [
-            node_id for node_id in ids
+            (node_id, document.nodes[node_id].state.pycoder_repl_id)
+            for node_id in ids
             if document.nodes.get(node_id) is not None and document.nodes[node_id].kind == "pycoder"
+        ]
+        # ADR-005 stage 5.3: a deleted Execution Sandbox node's on-disk
+        # venv must not outlive it either - same capture-before-pop timing
+        # as pycoder_ids above. sandbox_id is minted once at node creation
+        # (graph.py's add_code_sandbox_node) or self-healed on session
+        # load if a saved payload was ever missing it (see
+        # session_load.py's _restore_code_sandbox_payload), so it is
+        # always non-blank for a real code_sandbox node reached through
+        # this app's own code paths - remove_code_sandbox_scratch_dir
+        # additionally refuses to act on a blank id anyway, as defense in
+        # depth against a payload this app didn't produce.
+        sandbox_ids = [
+            document.nodes[node_id].state.code_sandbox_sandbox_id
+            for node_id in ids
+            if document.nodes.get(node_id) is not None and document.nodes[node_id].kind == "code_sandbox"
         ]
         # R5.4 post-review FIX 2: a deleted pycoder/code_sandbox node's
         # DISPATCHER-SIDE in-flight request must not outlive it either - captured
@@ -139,8 +163,6 @@ def register_node_intents(
             and document.nodes[node_id].pending_request_id
         ]
         document.remove_nodes(ids)
-        for node_id in pycoder_ids:
-            await agent_dispatcher.dispose_pycoder_repl(node_id)
         for kind, request_id in code_exec_cancels:
             # cancel_pycoder/cancel_code_sandbox resolve any pending
             # approval_future with False (exactly like a manual Cancel/Deny)
@@ -149,10 +171,34 @@ def register_node_intents(
             # it was only ever the synchronous busy-claim placeholder, never
             # a real dispatcher request_id, or the request already finished
             # on its own between the capture above and here).
+            #
+            # Review-fix: done BEFORE the scratch-dir removal below, but be
+            # precise about what that ordering actually buys - it differs
+            # by kind. For code_sandbox, VirtualEnvSandbox._run_subprocess
+            # polls should_continue() roughly every 100ms, so tripping
+            # cancel_event here gives a real, if brief, head start before
+            # remove_code_sandbox_scratch_dir's rmtree runs (removal is
+            # still best-effort regardless - see that method's own
+            # docstring - this only improves the odds). For pycoder,
+            # PythonREPL.execute() blocks on a plain readline() with no
+            # polling hook at all, so cancel_pycoder has NO effect on a
+            # call already in flight - what actually stops that subprocess
+            # is dispose_pycoder_repl's own kill()+wait() a moment later,
+            # which happens regardless of this ordering. Kept first anyway
+            # because it IS the only thing that matters for a run still
+            # parked on the approval gate (resolving approval_future(False)
+            # before it can even start), which is what code_exec_cancels
+            # exists for in the first place.
             if kind == "pycoder":
                 agent_dispatcher.cancel_pycoder(request_id)
             else:
                 agent_dispatcher.cancel_code_sandbox(request_id)
+        for node_id, repl_id in pycoder_ids:
+            # ADR-005 stage 5.3: remove_scratch_dir=True - this IS real node
+            # deletion, unlike the execute-timeout caller of the same method.
+            await agent_dispatcher.dispose_pycoder_repl(node_id, repl_id=repl_id, remove_scratch_dir=True)
+        for sandbox_id in sandbox_ids:
+            await agent_dispatcher.remove_code_sandbox_scratch_dir(sandbox_id)
         await publish_scene()
 
     async def connect_nodes(source, target):

--- a/backend/app.py
+++ b/backend/app.py
@@ -267,6 +267,13 @@ def _evict_idle_session(bus: SessionBus) -> bool:
         return False
     context.agent_dispatcher.cancel_all()
     context.agent_dispatcher.cancel_all_pending_approvals()
+    # ADR-005 stage 5.3: without this, any Py-Coder REPL subprocess left
+    # idle (not in-flight - the check above already vetoed eviction if one
+    # were) is orphaned the moment `del self._sessions[session_id]` below
+    # drops the last reference able to ever call stop() on it - see
+    # AgentDispatcher.dispose_all_pycoder_repls' own docstring for why this
+    # does NOT also remove each REPL's scratch directory.
+    context.agent_dispatcher.dispose_all_pycoder_repls()
     autosave_task = getattr(bus, "autosave_task", None)
     if autosave_task is not None and not autosave_task.done():
         autosave_task.cancel()

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -1059,7 +1059,10 @@ class SceneDocument(BranchOps, GroupOps):
         """The Py-Coder node's creation primitive - same required-parent
         posture as every R5 sibling (Web Research/Artifact/Gitlink): never
         exists unparented. Title is always the fixed literal "Py-Coder"
-        (matches backend/plugins.py's own plugin display name)."""
+        (matches backend/plugins.py's own plugin display name).
+        pycoder_repl_id is minted here, ONCE, exactly like
+        code_sandbox_sandbox_id below - see PycoderState's own docstring
+        for why node.id itself is not durable enough for this."""
         if parent_id not in self.nodes:
             raise SceneError(f"unknown parent node: {parent_id}")
         node_id = f"n{next(self._counter)}"
@@ -1069,7 +1072,7 @@ class SceneDocument(BranchOps, GroupOps):
             y=float(y),
             title="Py-Coder",
             kind="pycoder",
-            state=PycoderState(),
+            state=PycoderState(pycoder_repl_id=uuid.uuid4().hex[:12]),
         )
         self.nodes[node_id] = node
         self.connect(parent_id, node_id)

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -463,7 +463,23 @@ class PycoderState(NodeState):
       pycoder_awaiting_approval itself is cleared, so a
       resolved/denied/superseded approval can never be replayed.
       Internal bookkeeping only - EXCLUDED from scene_payload(), same
-      posture as CodeSandboxState's own sandbox_id."""
+      posture as CodeSandboxState's own sandbox_id.
+    - pycoder_repl_id: ADR-005 stage 5.3 (review-fix) - minted ONCE, at
+      node-creation time (see add_pycoder_node), mirroring
+      CodeSandboxState.code_sandbox_sandbox_id exactly: a stable,
+      internal directory-naming key for PythonREPL's own scratch cwd,
+      independent of this node's own `id`. Needed because SceneNode.id is
+      NOT durable - session_load.py's register_restored_node reassigns a
+      fresh sequential id, purely by array position, on every session
+      load - so keying the on-disk REPL directory by node.id let a reload
+      silently swap which directory a node's REPL resolved to (one node
+      could lose its own accumulated files, or inherit a different node's
+      leftovers) any time a node ahead of it in save order was deleted
+      before the next load. code_sandbox_sandbox_id never had this
+      problem because it was already a separate, stable field; pycoder
+      had no equivalent until this field was added. Internal bookkeeping
+      only - EXCLUDED from scene_payload(), same posture as
+      code_sandbox_sandbox_id."""
 
     pycoder_mode: str = "ai_driven"
     pycoder_prompt: str = ""
@@ -474,6 +490,7 @@ class PycoderState(NodeState):
     pycoder_awaiting_approval: bool = False
     pycoder_approved_fingerprint: str | None = None
     pycoder_error: str = ""
+    pycoder_repl_id: str = ""
 
 
 @dataclass

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -182,6 +182,7 @@ literal values for the same concept):
 from __future__ import annotations
 
 import re
+import uuid
 from typing import Any
 
 from backend.canvas import (
@@ -584,6 +585,15 @@ def _restore_pycoder_payload(payload: dict[str, Any]) -> SceneNode:
             pycoder_code=str(payload.get("code", "")),
             pycoder_output=str(payload.get("output", "")),
             pycoder_analysis=str(payload.get("analysis", "")),
+            # ADR-005 stage 5.3 (review-fix): self-healing, not a blank
+            # fallback - a payload missing this field (predates this fix,
+            # or is otherwise malformed) mints a FRESH stable id here
+            # rather than defaulting to "", which would route every such
+            # node's REPL scratch dir to the same shared "default" bucket
+            # (see graphlink_scratch_dirs.remove_scratch_dir_for_id's own
+            # docstring for why that is actively dangerous, not just an
+            # untidy fallback, once node-delete GC can rmtree it).
+            pycoder_repl_id=str(payload.get("pycoder_repl_id") or uuid.uuid4().hex[:12]),
         ),
         history=_restore_history(payload.get("conversation_history")),
         is_collapsed=bool(payload.get("is_collapsed", False)),
@@ -600,7 +610,12 @@ def _restore_code_sandbox_payload(payload: dict[str, Any]) -> SceneNode:
             code_sandbox_code=str(payload.get("code", "")),
             code_sandbox_output=str(payload.get("output", "")),
             code_sandbox_analysis=str(payload.get("analysis", "")),
-            code_sandbox_sandbox_id=str(payload.get("sandbox_id", "")),
+            # ADR-005 stage 5.3 (review-fix): self-healing, same reasoning
+            # as pycoder_repl_id above - a blank/missing sandbox_id used to
+            # fall back to "" (routing to the shared "default" bucket);
+            # minting a fresh id here instead means two nodes can no
+            # longer collide on load, even from a malformed payload.
+            code_sandbox_sandbox_id=str(payload.get("sandbox_id") or uuid.uuid4().hex[:12]),
         ),
         history=_restore_history(payload.get("conversation_history")),
         is_collapsed=bool(payload.get("is_collapsed", False)),

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -320,6 +320,10 @@ def _serialize_pycoder_node(node: SceneNode) -> dict[str, Any]:
         "code": node.state.pycoder_code,
         "output": node.state.pycoder_output,
         "analysis": node.state.pycoder_analysis,
+        # ADR-005 stage 5.3 (review-fix): round-trips the stable REPL
+        # scratch-dir key - see PycoderState.pycoder_repl_id's own
+        # docstring for why node.id alone cannot be used for this.
+        "pycoder_repl_id": node.state.pycoder_repl_id,
         "conversation_history": _serialize_history(node.history),
         "is_collapsed": bool(node.is_collapsed),
     }

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -47,6 +47,7 @@ import api_provider
 import graphlink_task_config as config
 from graphlink_settings_store import SettingsManager
 from graphlink_plugins.web_research.domain import RequestCancelled, ResearchFailure
+from graphlink_scratch_dirs import EXECUTION_SANDBOX_ROOT
 
 
 class _FakeSettingsManager:
@@ -3801,6 +3802,7 @@ def _make_pycoder_node(**overrides):
         pycoder_awaiting_approval=False,
         pycoder_approved_fingerprint=None,
         pycoder_error="",
+        pycoder_repl_id="fake-repl-id",
     )
     node_overrides = {"pending_request_id": None}
     for key, value in overrides.items():
@@ -3907,7 +3909,7 @@ class _FakeRepl:
 def test_pycoder_manual_mode_blank_code_calls_on_failure_without_creating_a_repl(monkeypatch):
     repl_created = []
     monkeypatch.setattr(
-        AgentDispatcher, "get_pycoder_repl", lambda self, node_id: repl_created.append(node_id) or _FakeRepl()
+        AgentDispatcher, "get_pycoder_repl", lambda self, node_id, repl_id=None: repl_created.append(node_id) or _FakeRepl()
     )
 
     async def run():
@@ -3933,7 +3935,7 @@ def test_pycoder_manual_mode_blank_code_calls_on_failure_without_creating_a_repl
 
 def test_pycoder_manual_mode_success_executes_once_and_analyzes(monkeypatch):
     fake_repl = _FakeRepl(script=[("42", False)])
-    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id, repl_id=None: fake_repl)
     monkeypatch.setattr(
         agents_module.PyCoderAnalysisAgent, "get_response",
         lambda self, original_prompt, code, code_output: f"analysis of {code_output}",
@@ -3962,7 +3964,7 @@ def test_pycoder_manual_mode_success_executes_once_and_analyzes(monkeypatch):
 
 def test_pycoder_manual_mode_reports_last_run_failed_from_the_repl(monkeypatch):
     fake_repl = _FakeRepl(script=[("Traceback...", True)])
-    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id, repl_id=None: fake_repl)
     monkeypatch.setattr(
         agents_module.PyCoderAnalysisAgent, "get_response",
         lambda self, original_prompt, code, code_output: "explains the error",
@@ -4225,7 +4227,7 @@ def test_pycoder_ai_driven_approved_executes_successfully(monkeypatch):
         lambda self, history, prompt: "[TOOL:PYTHON]\nprint(2)\n[/TOOL]",
     )
     fake_repl = _FakeRepl(script=[("2", False)])
-    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id, repl_id=None: fake_repl)
     monkeypatch.setattr(
         agents_module.PyCoderAnalysisAgent, "get_response",
         lambda self, original_prompt, code, code_output: "the answer is 2",
@@ -4269,7 +4271,7 @@ def test_pycoder_ai_driven_repair_loop_exhausts_retries_calls_on_success_with_la
         lambda self, original_prompt, code, code_output: "explains the persistent failure",
     )
     fake_repl = _FakeRepl(script=[("err", True)])  # every execute() call fails
-    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id, repl_id=None: fake_repl)
 
     # ADR-002 P0 regression guard: every repaired variant must open its own
     # fresh gate - a local SimpleNamespace subclass (NOT a patch on the
@@ -4336,7 +4338,7 @@ def test_pycoder_ai_driven_repair_gate_denied_stops_immediately_without_further_
         lambda self, code, error, is_final_attempt: "still broken",
     )
     fake_repl = _FakeRepl(script=[("err", True)])  # every execute() call fails
-    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id, repl_id=None: fake_repl)
 
     async def run():
         bus, notifications, dispatcher = _make_code_exec_env()
@@ -4404,7 +4406,7 @@ def test_pycoder_ai_driven_repair_gate_discloses_the_repaired_code_not_the_origi
         lambda self, code, error, is_final_attempt: "print('repaired')",
     )
     fake_repl = _FakeRepl(script=[("err", True)])  # every execute() call fails
-    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id, repl_id=None: fake_repl)
 
     async def run():
         bus, notifications, dispatcher = _make_code_exec_env()
@@ -4453,7 +4455,7 @@ def test_pycoder_execution_blocked_when_approved_fingerprint_does_not_match(monk
         lambda self, history, prompt: "[TOOL:PYTHON]\nprint(1)\n[/TOOL]",
     )
     fake_repl = _FakeRepl(script=[("1", False)])
-    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: fake_repl)
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id, repl_id=None: fake_repl)
 
     async def run():
         bus, notifications, dispatcher = _make_code_exec_env()
@@ -5103,7 +5105,7 @@ def test_cancel_all_trips_a_pycoder_run_that_is_mid_execution_past_the_approval_
             release.wait(5)
             return "output"
 
-    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id: _BlockingRepl())
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id, repl_id=None: _BlockingRepl())
 
     async def run():
         bus, notifications, dispatcher = _make_code_exec_env()
@@ -5217,10 +5219,26 @@ def test_cancel_all_pending_approvals_auto_denies_every_undone_future_in_both_di
 
 def test_get_pycoder_repl_returns_the_same_instance_for_the_same_node_id():
     dispatcher = AgentDispatcher(_FakeSettingsManager())
-    first = dispatcher.get_pycoder_repl("n1")
-    second = dispatcher.get_pycoder_repl("n1")
+    first = dispatcher.get_pycoder_repl("n1", "repl-1")
+    second = dispatcher.get_pycoder_repl("n1", "repl-1")
     assert first is second
-    assert dispatcher.get_pycoder_repl("n2") is not first
+    assert dispatcher.get_pycoder_repl("n2", "repl-2") is not first
+
+
+def test_get_pycoder_repl_is_keyed_by_node_id_not_repl_id():
+    # ADR-005 stage 5.3 (review-fix): the in-memory dict lookup is
+    # node_id-keyed (session-scoped, safe to reuse - see get_pycoder_repl's
+    # own docstring); repl_id only affects the constructed PythonREPL's
+    # on-disk cwd, not which dict entry is returned. A lookup on the same
+    # node_id must reuse the SAME live REPL even if a caller (incorrectly,
+    # or via some future bug) passed a different repl_id the second time -
+    # the repl_id argument on that second call must simply be ignored, not
+    # cause a second REPL to be created.
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    first = dispatcher.get_pycoder_repl("n1", "repl-1")
+    second = dispatcher.get_pycoder_repl("n1", "some-other-repl-id")
+    assert first is second
+    assert first.cwd.name == "repl-1"
 
 
 def test_dispose_pycoder_repl_tolerates_a_missing_node_id_silently():
@@ -5248,6 +5266,81 @@ def test_dispose_pycoder_repl_stops_and_removes_the_repl():
 
         assert fake_repl.stopped is True
         assert "n1" not in dispatcher._pycoder_repls
+
+    asyncio.run(run())
+
+
+def test_dispose_all_pycoder_repls_stops_every_tracked_repl_and_clears_the_dict():
+    class _StoppableRepl:
+        def __init__(self):
+            self.stopped = False
+
+        def stop(self):
+            self.stopped = True
+
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    repl_a = _StoppableRepl()
+    repl_b = _StoppableRepl()
+    dispatcher._pycoder_repls["n1"] = repl_a
+    dispatcher._pycoder_repls["n2"] = repl_b
+
+    dispatcher.dispose_all_pycoder_repls()
+
+    assert dispatcher._pycoder_repls == {}
+    # stop() runs on a background thread (see the method's own docstring
+    # for why) - give it a moment to actually land before asserting.
+    for _ in range(50):
+        if repl_a.stopped and repl_b.stopped:
+            break
+        time.sleep(0.02)
+    assert repl_a.stopped is True
+    assert repl_b.stopped is True
+
+
+def test_dispose_all_pycoder_repls_does_not_block_the_caller_on_a_slow_stop():
+    # ADR-005 stage 5.3 (review-fix): its one real caller
+    # (_evict_idle_session) runs on the live asyncio event loop - a
+    # blocking inline repl.stop() would stall every other connected
+    # client's WS/HTTP handling for however long the OS takes to kill and
+    # reap the process. Proven here with a repl.stop() that would take
+    # noticeably longer than "instant" if called inline.
+    class _SlowRepl:
+        def __init__(self):
+            self.stopped = threading.Event()
+
+        def stop(self):
+            time.sleep(0.5)
+            self.stopped.set()
+
+    dispatcher = AgentDispatcher(_FakeSettingsManager())
+    slow_repl = _SlowRepl()
+    dispatcher._pycoder_repls["n1"] = slow_repl
+
+    start = time.monotonic()
+    dispatcher.dispose_all_pycoder_repls()
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.2, "must return almost immediately, not block on the slow stop()"
+    assert slow_repl.stopped.wait(timeout=2.0), "the background thread must still actually call stop()"
+
+
+def test_remove_code_sandbox_scratch_dir_refuses_a_blank_sandbox_id():
+    # ADR-005 stage 5.3 (review-fix): a blank sandbox_id resolves to the
+    # shared "default" bucket - rmtree-ing it because one blank-id node
+    # was deleted would take a DIFFERENT still-live blank-id node's
+    # directory down with it. See graphlink_scratch_dirs.
+    # remove_scratch_dir_for_id's own docstring.
+    async def run():
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+        shared_default = EXECUTION_SANDBOX_ROOT / "default"
+        shared_default.mkdir(parents=True, exist_ok=True)
+        (shared_default / "someone_elses_venv_marker.txt").write_text("data", encoding="utf-8")
+        try:
+            await dispatcher.remove_code_sandbox_scratch_dir("")
+            assert shared_default.exists(), "a blank sandbox_id must never remove the shared bucket"
+        finally:
+            import shutil
+            shutil.rmtree(shared_default, ignore_errors=True)
 
     asyncio.run(run())
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -49,6 +49,7 @@ from backend.tests.conftest import (
 import api_provider
 import graphlink_task_config as task_config
 from graphlink_navigation_pins import NavigationPinRecord
+from graphlink_scratch_dirs import EXECUTION_SANDBOX_ROOT, safe_scratch_id
 from graphlink_plugins.web_research.domain import ResearchCitation, ResearchResult, ResearchSource
 from backend.token_counter import estimate_tokens, register_token_counter
 
@@ -5064,7 +5065,7 @@ def test_remove_nodes_disposes_the_repl_for_every_deleted_pycoder_node():
         other_node = document.add_gitlink_node(0, 0, parent.id)
         # Populate a REPL for this node id, so there is something real to
         # tear down.
-        repl = dispatcher.get_pycoder_repl(pycoder_node.id)
+        repl = dispatcher.get_pycoder_repl(pycoder_node.id, pycoder_node.state.pycoder_repl_id)
         assert pycoder_node.id in dispatcher._pycoder_repls
 
         await bus.dispatch_intent("scene", "removeNodes", [[pycoder_node.id, other_node.id]])
@@ -5084,7 +5085,7 @@ def test_remove_nodes_does_not_touch_the_repl_dict_when_no_pycoder_node_is_delet
         parent = document.add_node(0, 0, "parent")
         pycoder_node = document.add_pycoder_node(0, 0, parent.id)
         other_node = document.add_gitlink_node(0, 0, parent.id)
-        dispatcher.get_pycoder_repl(pycoder_node.id)
+        dispatcher.get_pycoder_repl(pycoder_node.id, pycoder_node.state.pycoder_repl_id)
 
         await bus.dispatch_intent("scene", "removeNodes", [[other_node.id]])
 
@@ -5093,6 +5094,121 @@ def test_remove_nodes_does_not_touch_the_repl_dict_when_no_pycoder_node_is_delet
         assert pycoder_node.id in dispatcher._pycoder_repls, (
             "a still-live pycoder node's REPL must not be disposed just "
             "because a DIFFERENT node was deleted"
+        )
+
+    asyncio.run(run())
+
+
+def test_remove_nodes_deletes_the_pycoder_scratch_dir_for_every_deleted_pycoder_node():
+    """ADR-005 stage 5.3: node delete must GC the REPL's on-disk cwd, not
+    just the in-memory PythonREPL/subprocess (proven above). The directory
+    is created here directly (not via repl.start(), which would spawn a
+    real subprocess) to simulate files a prior run already left behind -
+    dispose_pycoder_repl's remove_scratch_dir=True path doesn't care how
+    the directory came to exist."""
+    async def run():
+        bus, document, _recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        pycoder_node = document.add_pycoder_node(0, 0, parent.id)
+        repl = dispatcher.get_pycoder_repl(pycoder_node.id, pycoder_node.state.pycoder_repl_id)
+        repl.cwd.mkdir(parents=True, exist_ok=True)
+        (repl.cwd / "leftover.txt").write_text("data", encoding="utf-8")
+        assert repl.cwd.is_dir()
+
+        await bus.dispatch_intent("scene", "removeNodes", [[pycoder_node.id]])
+
+        assert not repl.cwd.exists(), "the REPL's scratch dir must not outlive its deleted node"
+
+    asyncio.run(run())
+
+
+def test_remove_nodes_leaves_the_pycoder_scratch_dir_when_a_different_node_is_deleted():
+    async def run():
+        bus, document, _recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        pycoder_node = document.add_pycoder_node(0, 0, parent.id)
+        other_node = document.add_gitlink_node(0, 0, parent.id)
+        repl = dispatcher.get_pycoder_repl(pycoder_node.id, pycoder_node.state.pycoder_repl_id)
+        repl.cwd.mkdir(parents=True, exist_ok=True)
+
+        await bus.dispatch_intent("scene", "removeNodes", [[other_node.id]])
+
+        assert repl.cwd.is_dir(), (
+            "a still-live pycoder node's scratch dir must not be removed just "
+            "because a DIFFERENT node was deleted"
+        )
+
+    asyncio.run(run())
+
+
+def test_remove_nodes_deletes_the_pycoder_scratch_dir_even_if_the_repl_was_already_disposed():
+    """ADR-005 stage 5.3 (review-fix): the exact bug an adversarial review
+    caught. dispose_pycoder_repl's remove_scratch_dir=True path used to
+    silently no-op if _pycoder_repls.pop(node_id) returned None (e.g.
+    because an earlier execute() timeout had already popped and disposed
+    it - AgentDispatcher.dispose_pycoder_repl's own execute-timeout caller,
+    exercised by test_agents.py's
+    test_pycoder_manual_mode_execute_timeout_disposes_the_repl_and_calls_on_failure).
+    Fixed by recomputing the scratch path deterministically from repl_id
+    rather than depending on a live tracked REPL object - this test proves
+    the fix by making sure the dict entry is ALREADY gone before delete."""
+    async def run():
+        bus, document, _recorder, dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        pycoder_node = document.add_pycoder_node(0, 0, parent.id)
+        repl = dispatcher.get_pycoder_repl(pycoder_node.id, pycoder_node.state.pycoder_repl_id)
+        repl.cwd.mkdir(parents=True, exist_ok=True)
+        (repl.cwd / "leftover.txt").write_text("data", encoding="utf-8")
+        # Simulate the prior-timeout scenario: the dict entry is gone, but
+        # the on-disk directory (and its files) are still there.
+        del dispatcher._pycoder_repls[pycoder_node.id]
+        assert pycoder_node.id not in dispatcher._pycoder_repls
+        assert repl.cwd.is_dir()
+
+        await bus.dispatch_intent("scene", "removeNodes", [[pycoder_node.id]])
+
+        assert not repl.cwd.exists(), (
+            "the scratch dir must still be removed even with no live REPL tracked for this node"
+        )
+
+    asyncio.run(run())
+
+
+def test_remove_nodes_deletes_the_code_sandbox_scratch_dir_for_every_deleted_sandbox_node():
+    """ADR-005 stage 5.3's Execution Sandbox twin. Unlike pycoder, there is
+    no live VirtualEnvSandbox/REPL object on the dispatcher for a
+    code_sandbox node (see AgentDispatcher.remove_code_sandbox_scratch_dir's
+    own docstring) - the directory is created directly here to simulate a
+    venv a prior run already built, and the path is recomputed the same
+    deterministic way VirtualEnvSandbox itself would."""
+    async def run():
+        bus, document, _recorder, _dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        sandbox_node = document.add_code_sandbox_node(0, 0, parent.id)
+        sandbox_dir = EXECUTION_SANDBOX_ROOT / safe_scratch_id(sandbox_node.state.code_sandbox_sandbox_id)
+        (sandbox_dir / "venv").mkdir(parents=True, exist_ok=True)
+
+        await bus.dispatch_intent("scene", "removeNodes", [[sandbox_node.id]])
+
+        assert not sandbox_dir.exists(), "the sandbox's venv dir must not outlive its deleted node"
+
+    asyncio.run(run())
+
+
+def test_remove_nodes_leaves_the_code_sandbox_scratch_dir_when_a_different_node_is_deleted():
+    async def run():
+        bus, document, _recorder, _dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        sandbox_node = document.add_code_sandbox_node(0, 0, parent.id)
+        other_node = document.add_gitlink_node(0, 0, parent.id)
+        sandbox_dir = EXECUTION_SANDBOX_ROOT / safe_scratch_id(sandbox_node.state.code_sandbox_sandbox_id)
+        sandbox_dir.mkdir(parents=True, exist_ok=True)
+
+        await bus.dispatch_intent("scene", "removeNodes", [[other_node.id]])
+
+        assert sandbox_dir.is_dir(), (
+            "a still-live code_sandbox node's scratch dir must not be removed "
+            "just because a DIFFERENT node was deleted"
         )
 
     asyncio.run(run())

--- a/backend/tests/test_execution_guard.py
+++ b/backend/tests/test_execution_guard.py
@@ -180,7 +180,7 @@ class TestPythonReplUsesTheGuard:
     def test_starting_the_repl_assigns_it_to_a_guard(self):
         fake = _FakeGuard()
         with patch("graphlink_plugins.pycoder.domain.create_execution_guard", return_value=fake):
-            repl = PythonREPL(node_id="guard-assign-test")
+            repl = PythonREPL(repl_id="guard-assign-test")
             try:
                 repl.start()
                 assert repl.guard is fake
@@ -191,7 +191,7 @@ class TestPythonReplUsesTheGuard:
     def test_stopping_the_repl_closes_the_guard(self):
         fake = _FakeGuard()
         with patch("graphlink_plugins.pycoder.domain.create_execution_guard", return_value=fake):
-            repl = PythonREPL(node_id="guard-close-test")
+            repl = PythonREPL(repl_id="guard-close-test")
             repl.start()
             repl.stop()
             assert fake.closed is True
@@ -209,7 +209,7 @@ class TestPythonReplUsesTheGuard:
             encoding="utf-8",
         )
 
-        repl = PythonREPL(node_id="guard-real-tree-test")
+        repl = PythonREPL(repl_id="guard-real-tree-test")
         # stdin/stdout/stderr=DEVNULL: a background child spawned from
         # inside the REPL otherwise inherits the REPL's own stdin PIPE
         # handle, which - a pre-existing PythonREPL characteristic,
@@ -372,7 +372,7 @@ class TestPythonReplRestartDoesNotLeakTheOldGuard:
             return fake
 
         with patch("graphlink_plugins.pycoder.domain.create_execution_guard", side_effect=factory):
-            repl = PythonREPL(node_id="restart-leak-test")
+            repl = PythonREPL(repl_id="restart-leak-test")
             repl.execute("1 + 1")
             assert len(guards_created) == 1
             first_guard = guards_created[0]
@@ -410,7 +410,7 @@ class TestPythonReplConcurrentStopIsSafe:
     # test that merely looks like one.
 
     def test_stop_is_serialized_by_the_repls_own_lock(self):
-        repl = PythonREPL(node_id="concurrent-stop-lock-test")
+        repl = PythonREPL(repl_id="concurrent-stop-lock-test")
         repl.execute("1 + 1")
 
         repl._lock.acquire()
@@ -527,3 +527,131 @@ class TestRealDefaultsReachTheWin32Api:
             assert captured["LimitFlags"] & guard_module._JOB_OBJECT_LIMIT_ACTIVE_PROCESS
         finally:
             guard.close()
+
+
+# -- ADR-005 stage 5.3 (review-fix): the 0700/touch-on-use wiring, proven at
+# the REAL call sites -------------------------------------------------------
+#
+# An adversarial review found that reverting graphlink_plugins/pycoder/
+# domain.py's and graphlink_plugins/code_sandbox/domain.py's own
+# prepare_scratch_dir(...) call sites back to a bare .mkdir(...) passed the
+# entire pre-existing test suite with zero failures - the only coverage that
+# existed was of prepare_scratch_dir/touch_scratch_dir_usage in isolation
+# (backend/tests/test_scratch_dirs.py), never of the actual wiring. These
+# tests close that gap: spy-based tests that run everywhere (proving the
+# real call sites actually call the real functions), plus POSIX-only tests
+# that check real mode bits/mtimes after calling the real, unmocked methods.
+
+POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="0700 has no POSIX meaning on Windows")
+
+
+class TestPycoderScratchDirWiring:
+    def test_starting_the_repl_calls_prepare_scratch_dir_on_its_own_cwd(self):
+        calls = []
+        repl = PythonREPL(repl_id="wiring-prepare-test")
+        # The mock below only records the call - it doesn't actually mkdir,
+        # so the directory Popen(cwd=...) needs must exist beforehand.
+        repl.cwd.mkdir(parents=True, exist_ok=True)
+        try:
+            with patch(
+                "graphlink_plugins.pycoder.domain.prepare_scratch_dir",
+                side_effect=calls.append,
+            ):
+                repl.start()
+            assert calls == [repl.cwd]
+        finally:
+            repl.stop()
+
+    def test_executing_code_calls_touch_scratch_dir_usage_on_its_own_cwd(self):
+        calls = []
+        with patch(
+            "graphlink_plugins.pycoder.domain.touch_scratch_dir_usage",
+            side_effect=calls.append,
+        ):
+            repl = PythonREPL(repl_id="wiring-touch-test")
+            try:
+                repl.execute("1 + 1")
+                assert calls == [repl.cwd]
+            finally:
+                repl.stop()
+
+    @POSIX_ONLY
+    def test_the_real_repl_cwd_is_actually_0700_after_start(self):
+        import stat
+
+        repl = PythonREPL(repl_id="wiring-real-mode-test")
+        try:
+            repl.start()
+            assert stat.S_IMODE(repl.cwd.stat().st_mode) == 0o700
+        finally:
+            repl.stop()
+
+
+class TestCodeSandboxScratchDirWiring:
+    def test_ensure_base_environment_calls_prepare_scratch_dir_on_base_dir(self):
+        calls = []
+        sandbox = VirtualEnvSandbox("wiring-prepare-venv-test")
+        # Fakes an already-built venv so ensure_base_environment returns
+        # right after prepare_scratch_dir, without actually creating one -
+        # matches this file's own established "keep it cheap" precedent
+        # (TestVirtualEnvSandboxUsesTheGuard exercises _run_subprocess
+        # directly rather than a real multi-second venv build).
+        sandbox.python_executable.parent.mkdir(parents=True, exist_ok=True)
+        sandbox.python_executable.write_text("", encoding="utf-8")
+        try:
+            with patch(
+                "graphlink_plugins.code_sandbox.domain.prepare_scratch_dir",
+                side_effect=calls.append,
+            ):
+                sandbox.ensure_base_environment(should_continue=lambda: True)
+            assert calls == [sandbox.base_dir]
+        finally:
+            import shutil
+            shutil.rmtree(sandbox.base_dir, ignore_errors=True)
+
+    def test_execute_code_calls_prepare_scratch_dir_on_base_dir(self):
+        calls = []
+        sandbox = VirtualEnvSandbox("wiring-prepare-execute-test")
+        sandbox._run_subprocess = lambda *a, **k: ("", 0)  # skip the real subprocess entirely
+        # The mock below only records the call - it doesn't actually mkdir,
+        # so script_path.write_text's own parent directory must exist first.
+        sandbox.base_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            with patch(
+                "graphlink_plugins.code_sandbox.domain.prepare_scratch_dir",
+                side_effect=calls.append,
+            ):
+                sandbox.execute_code("print(1)", should_continue=lambda: True)
+            assert calls == [sandbox.base_dir]
+        finally:
+            import shutil
+            shutil.rmtree(sandbox.base_dir, ignore_errors=True)
+
+    def test_run_subprocess_calls_touch_scratch_dir_usage_on_cwd(self, tmp_path):
+        calls = []
+        sandbox = VirtualEnvSandbox("wiring-touch-venv-test")
+        with patch(
+            "graphlink_plugins.code_sandbox.domain.touch_scratch_dir_usage",
+            side_effect=calls.append,
+        ):
+            sandbox._run_subprocess(
+                [sys.executable, "-c", "print('ok')"],
+                should_continue=lambda: True,
+                cwd=tmp_path,
+                timeout_seconds=10,
+            )
+        assert calls == [tmp_path]
+
+    @POSIX_ONLY
+    def test_the_real_base_dir_is_actually_0700_after_ensure_base_environment(self):
+        import stat
+
+        sandbox = VirtualEnvSandbox("wiring-real-mode-venv-test")
+        sandbox.python_executable.parent.mkdir(parents=True, exist_ok=True)
+        sandbox.python_executable.write_text("", encoding="utf-8")
+        try:
+            sandbox.ensure_base_environment(should_continue=lambda: True)
+            assert stat.S_IMODE(sandbox.base_dir.stat().st_mode) == 0o700
+        finally:
+            import shutil
+            shutil.rmtree(sandbox.base_dir, ignore_errors=True)

--- a/backend/tests/test_scratch_dirs.py
+++ b/backend/tests/test_scratch_dirs.py
@@ -1,0 +1,330 @@
+"""ADR-005 stage 5.3: graphlink_scratch_dirs.py's own unit tests -
+permissioning (prepare_scratch_dir) and the three GC entry points
+(remove_scratch_dir, gc_stale_by_age, sweep_stale_scratch_dirs_on_launch).
+
+chmod's real effect is POSIX-only (os.chmod on Windows only ever toggles the
+read-only attribute, never real permission bits) - same split this codebase
+already uses for graphlink_settings_store.py/chat_library.py's own 0600 file
+chmods: a platform-independent "chmod was invoked with 0o700" spy test that
+runs everywhere, plus a POSIX-only real-stat test skipped on Windows.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import time
+
+import pytest
+
+import graphlink_scratch_dirs as scratch_dirs
+
+POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX chmod semantics only apply on POSIX")
+
+
+# -- safe_scratch_id -----------------------------------------------------
+
+
+class TestSafeScratchId:
+    def test_alnum_and_hyphen_underscore_pass_through_unchanged(self):
+        assert scratch_dirs.safe_scratch_id("node-123_ABC") == "node-123_ABC"
+
+    def test_disallowed_characters_are_replaced_with_underscore(self):
+        assert scratch_dirs.safe_scratch_id("../../etc/passwd") == "______etc_passwd"
+        assert scratch_dirs.safe_scratch_id("n1:n2 n3") == "n1_n2_n3"
+
+    def test_blank_or_none_falls_back_to_default(self):
+        assert scratch_dirs.safe_scratch_id("") == "default"
+        assert scratch_dirs.safe_scratch_id(None) == "default"
+
+
+# -- prepare_scratch_dir ---------------------------------------------------
+
+
+class TestPrepareScratchDir:
+    def test_creates_the_directory_including_parents(self, tmp_path):
+        target = tmp_path / "a" / "b" / "c"
+
+        scratch_dirs.prepare_scratch_dir(target)
+
+        assert target.is_dir()
+
+    def test_is_idempotent_against_an_existing_directory(self, tmp_path):
+        target = tmp_path / "existing"
+        target.mkdir()
+
+        scratch_dirs.prepare_scratch_dir(target)  # must not raise
+
+        assert target.is_dir()
+
+    def test_chmod_is_invoked_with_0700_on_posix(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(scratch_dirs.sys, "platform", "linux")
+        calls = []
+        monkeypatch.setattr(scratch_dirs.os, "chmod", lambda path, mode: calls.append((path, mode)))
+
+        target = tmp_path / "sandbox"
+        scratch_dirs.prepare_scratch_dir(target)
+
+        assert (target, 0o700) in calls
+
+    def test_chmod_is_not_invoked_on_windows(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(scratch_dirs.sys, "platform", "win32")
+        calls = []
+        monkeypatch.setattr(scratch_dirs.os, "chmod", lambda path, mode: calls.append((path, mode)))
+
+        scratch_dirs.prepare_scratch_dir(tmp_path / "sandbox")
+
+        assert calls == []
+
+    def test_a_chmod_failure_does_not_raise(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(scratch_dirs.sys, "platform", "linux")
+
+        def _boom(path, mode):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(scratch_dirs.os, "chmod", _boom)
+
+        scratch_dirs.prepare_scratch_dir(tmp_path / "sandbox")  # must not raise
+
+    @POSIX_ONLY
+    def test_the_real_directory_is_actually_0700_on_posix(self, tmp_path):
+        target = tmp_path / "sandbox"
+
+        scratch_dirs.prepare_scratch_dir(target)
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o700
+
+    @POSIX_ONLY
+    def test_re_running_on_an_existing_looser_directory_tightens_it_back_to_0700(self, tmp_path):
+        target = tmp_path / "sandbox"
+        target.mkdir()
+        os.chmod(target, 0o755)
+
+        scratch_dirs.prepare_scratch_dir(target)
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o700
+
+
+# -- remove_scratch_dir -----------------------------------------------------
+
+
+class TestRemoveScratchDir:
+    def test_removes_an_existing_directory_and_its_contents(self, tmp_path):
+        target = tmp_path / "sandbox"
+        target.mkdir()
+        (target / "file.txt").write_text("data", encoding="utf-8")
+        (target / "nested").mkdir()
+        (target / "nested" / "inner.txt").write_text("data", encoding="utf-8")
+
+        scratch_dirs.remove_scratch_dir(target)
+
+        assert not target.exists()
+
+    def test_a_missing_directory_is_a_silent_no_op(self, tmp_path):
+        scratch_dirs.remove_scratch_dir(tmp_path / "never-existed")  # must not raise
+
+    def test_an_os_error_that_survives_the_retry_is_logged_and_swallowed(self, tmp_path, monkeypatch):
+        target = tmp_path / "sandbox"
+        target.mkdir()
+        calls = []
+
+        def _boom(path):
+            calls.append(path)
+            raise PermissionError("file still in use")
+
+        monkeypatch.setattr(scratch_dirs.shutil, "rmtree", _boom)
+        monkeypatch.setattr(scratch_dirs.time, "sleep", lambda _seconds: None)
+
+        scratch_dirs.remove_scratch_dir(target)  # must not raise
+
+        assert len(calls) == 2, "one retry, not zero and not unbounded"
+
+    def test_retries_once_after_a_transient_failure_then_succeeds(self, tmp_path, monkeypatch):
+        # ADR-005 stage 5.3 (review-fix): a still-terminating subprocess can
+        # briefly hold a handle open even after it has been asked to stop
+        # (e.g. code_sandbox's cooperative, ~100ms-polled cancel) - one
+        # retry meaningfully improves the odds of a clean removal without
+        # any architectural change.
+        target = tmp_path / "sandbox"
+        target.mkdir()
+        real_rmtree = scratch_dirs.shutil.rmtree
+        attempts = {"count": 0}
+        sleep_calls = []
+
+        def _flaky_rmtree(path):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise PermissionError("file still in use")
+            real_rmtree(path)
+
+        monkeypatch.setattr(scratch_dirs.shutil, "rmtree", _flaky_rmtree)
+        monkeypatch.setattr(scratch_dirs.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+
+        scratch_dirs.remove_scratch_dir(target)
+
+        assert not target.exists(), "the second attempt must actually remove the directory"
+        assert attempts["count"] == 2
+        assert sleep_calls == [0.25]
+
+
+# -- remove_scratch_dir_for_id -----------------------------------------
+
+
+class TestRemoveScratchDirForId:
+    def test_removes_the_directory_derived_from_the_raw_id(self, tmp_path):
+        root = tmp_path / "root"
+        target = root / "n1"
+        target.mkdir(parents=True)
+
+        scratch_dirs.remove_scratch_dir_for_id(root, "n1")
+
+        assert not target.exists()
+
+    def test_sanitizes_the_raw_id_the_same_way_prepare_scratch_dir_callers_do(self, tmp_path):
+        root = tmp_path / "root"
+        target = root / scratch_dirs.safe_scratch_id("weird:id/../x")
+        target.mkdir(parents=True)
+
+        scratch_dirs.remove_scratch_dir_for_id(root, "weird:id/../x")
+
+        assert not target.exists()
+
+    def test_refuses_to_touch_the_shared_default_bucket_for_a_blank_id(self, tmp_path):
+        # ADR-005 stage 5.3 (review-fix): a blank id resolves to the same
+        # "default" directory a DIFFERENT blank-id node could also be
+        # using - rmtree-ing it because ONE such node was deleted would
+        # destroy the other's still-live directory too.
+        root = tmp_path / "root"
+        shared_default = root / "default"
+        shared_default.mkdir(parents=True)
+        (shared_default / "someone_elses_file.txt").write_text("data", encoding="utf-8")
+
+        scratch_dirs.remove_scratch_dir_for_id(root, "")
+
+        assert shared_default.exists(), "a blank id must never trigger removal of the shared bucket"
+        assert (shared_default / "someone_elses_file.txt").exists()
+
+    def test_refuses_to_touch_the_shared_default_bucket_for_none(self, tmp_path):
+        root = tmp_path / "root"
+        shared_default = root / "default"
+        shared_default.mkdir(parents=True)
+
+        scratch_dirs.remove_scratch_dir_for_id(root, None)
+
+        assert shared_default.exists()
+
+
+# -- touch_scratch_dir_usage --------------------------------------------
+
+
+class TestTouchScratchDirUsage:
+    def test_bumps_mtime_to_now(self, tmp_path):
+        target = tmp_path / "sandbox"
+        target.mkdir()
+        old_time = time.time() - 1000
+        os.utime(target, (old_time, old_time))
+        assert target.stat().st_mtime < time.time() - 500
+
+        scratch_dirs.touch_scratch_dir_usage(target)
+
+        assert target.stat().st_mtime > time.time() - 5
+
+    def test_a_missing_directory_does_not_raise(self, tmp_path):
+        scratch_dirs.touch_scratch_dir_usage(tmp_path / "never-existed")  # must not raise
+
+    def test_an_os_error_is_logged_and_swallowed(self, tmp_path, monkeypatch):
+        def _boom(path, times):
+            raise OSError("disk unavailable")
+
+        monkeypatch.setattr(scratch_dirs.os, "utime", _boom)
+
+        scratch_dirs.touch_scratch_dir_usage(tmp_path)  # must not raise
+
+    def test_used_directory_survives_an_age_sweep_that_would_otherwise_reap_it(self, tmp_path):
+        # ADR-005 stage 5.3 (review-fix): the actual bug this closes - a
+        # directory created long ago but genuinely still in active use
+        # must not be indistinguishable, to gc_stale_by_age, from one
+        # abandoned the day after creation.
+        root = tmp_path / "root"
+        target = _touch_dir_with_age(root, "actively-used", age_seconds=1000)
+
+        scratch_dirs.touch_scratch_dir_usage(target)
+        removed = scratch_dirs.gc_stale_by_age(root, max_age_seconds=100)
+
+        assert removed == []
+        assert target.exists()
+
+
+# -- gc_stale_by_age ----------------------------------------------------
+
+
+def _touch_dir_with_age(root, name, age_seconds):
+    path = root / name
+    path.mkdir(parents=True)
+    stamp = time.time() - age_seconds
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+class TestGcStaleByAge:
+    def test_a_root_that_does_not_exist_yet_is_a_silent_no_op(self, tmp_path):
+        assert scratch_dirs.gc_stale_by_age(tmp_path / "never-created", max_age_seconds=60) == []
+
+    def test_removes_only_children_older_than_max_age(self, tmp_path):
+        root = tmp_path / "root"
+        old_dir = _touch_dir_with_age(root, "old", age_seconds=1000)
+        fresh_dir = _touch_dir_with_age(root, "fresh", age_seconds=10)
+
+        removed = scratch_dirs.gc_stale_by_age(root, max_age_seconds=100)
+
+        assert removed == [old_dir]
+        assert not old_dir.exists()
+        assert fresh_dir.exists()
+
+    def test_nothing_removed_when_every_child_is_within_the_age_window(self, tmp_path):
+        root = tmp_path / "root"
+        fresh_dir = _touch_dir_with_age(root, "fresh", age_seconds=5)
+
+        removed = scratch_dirs.gc_stale_by_age(root, max_age_seconds=scratch_dirs.DEFAULT_MAX_AGE_SECONDS)
+
+        assert removed == []
+        assert fresh_dir.exists()
+
+
+# -- sweep_stale_scratch_dirs_on_launch --------------------------------
+
+
+class TestSweepStaleScratchDirsOnLaunch:
+    def test_sweeps_both_roots(self, tmp_path, monkeypatch):
+        pycoder_root = tmp_path / "pycoder"
+        sandbox_root = tmp_path / "sandbox"
+        old_pycoder_dir = _touch_dir_with_age(pycoder_root, "old-node", age_seconds=1000)
+        old_sandbox_dir = _touch_dir_with_age(sandbox_root, "old-sandbox", age_seconds=1000)
+        monkeypatch.setattr(scratch_dirs, "PYCODER_REPL_ROOT", pycoder_root)
+        monkeypatch.setattr(scratch_dirs, "EXECUTION_SANDBOX_ROOT", sandbox_root)
+
+        scratch_dirs.sweep_stale_scratch_dirs_on_launch(max_age_seconds=100)
+
+        assert not old_pycoder_dir.exists()
+        assert not old_sandbox_dir.exists()
+
+    def test_a_failure_sweeping_one_root_does_not_stop_the_other(self, tmp_path, monkeypatch):
+        pycoder_root = tmp_path / "pycoder"
+        sandbox_root = tmp_path / "sandbox"
+        old_sandbox_dir = _touch_dir_with_age(sandbox_root, "old-sandbox", age_seconds=1000)
+        monkeypatch.setattr(scratch_dirs, "PYCODER_REPL_ROOT", pycoder_root)
+        monkeypatch.setattr(scratch_dirs, "EXECUTION_SANDBOX_ROOT", sandbox_root)
+
+        real_gc = scratch_dirs.gc_stale_by_age
+
+        def _flaky_gc(root, max_age_seconds=scratch_dirs.DEFAULT_MAX_AGE_SECONDS):
+            if root == pycoder_root:
+                raise OSError("network share unavailable")
+            return real_gc(root, max_age_seconds)
+
+        monkeypatch.setattr(scratch_dirs, "gc_stale_by_age", _flaky_gc)
+
+        scratch_dirs.sweep_stale_scratch_dirs_on_launch(max_age_seconds=100)  # must not raise
+
+        assert not old_sandbox_dir.exists(), "the second root must still be swept despite the first raising"

--- a/backend/tests/test_session_lifecycle.py
+++ b/backend/tests/test_session_lifecycle.py
@@ -446,3 +446,45 @@ def test_evict_idle_session_returns_true_for_a_never_configured_bus():
     # veto forever.
     bus = SessionBus("s1")
     assert _evict_idle_session(bus) is True
+
+
+def test_evict_idle_session_disposes_every_live_pycoder_repl():
+    """ADR-005 stage 5.3: without this, a REPL subprocess left idle (not
+    in-flight - has_in_flight_runs() already vetoed eviction above if one
+    were) is orphaned the instant EventBus.sweep_idle_sessions drops this
+    SessionBus - nothing else would ever hold a reference able to call
+    stop() on it again. get_pycoder_repl without ever calling start()
+    mirrors test_canvas.py's own dispose_pycoder_repl tests - there is no
+    real subprocess to tear down, only the dict entry, which is exactly
+    what this asserts."""
+    bus = SessionBus("s1")
+    context, _tmp = _real_session_context()
+    attach_session_context(bus, context)
+    context.agent_dispatcher.get_pycoder_repl("node-1", "repl-1")
+    assert "node-1" in context.agent_dispatcher._pycoder_repls
+
+    result = _evict_idle_session(bus)
+
+    assert result is True
+    assert context.agent_dispatcher._pycoder_repls == {}, (
+        "every live REPL must be torn down before the session itself is evicted"
+    )
+
+
+def test_evict_idle_session_does_not_remove_the_repls_scratch_dir():
+    """See AgentDispatcher.dispose_all_pycoder_repls' own docstring:
+    eviction means "no one is currently connected", not "discard this
+    node's work" - unlike explicit node deletion (test_canvas.py's own
+    scratch-dir GC tests), the directory must survive a mere idle eviction
+    so a reconnecting user finds their files still there."""
+    bus = SessionBus("s1")
+    context, _tmp = _real_session_context()
+    attach_session_context(bus, context)
+    repl = context.agent_dispatcher.get_pycoder_repl("node-1", "repl-1")
+    repl.cwd.mkdir(parents=True, exist_ok=True)
+    (repl.cwd / "leftover.txt").write_text("data", encoding="utf-8")
+
+    result = _evict_idle_session(bus)
+
+    assert result is True
+    assert repl.cwd.is_dir(), "eviction must not delete the REPL's scratch directory"

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -167,6 +167,70 @@ def test_code_sandbox_field_mapping():
     assert node.state.code_sandbox_requirements == "numpy" and node.state.code_sandbox_sandbox_id == "sbx-1"
 
 
+def test_pycoder_repl_id_round_trips_when_present_in_the_payload():
+    # ADR-005 stage 5.3 (review-fix): pycoder_repl_id is the stable
+    # scratch-dir key - a saved payload that already has one must restore
+    # it verbatim, not mint a new one (that would orphan the node's
+    # existing REPL scratch directory on every single load).
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "pycoder", "mode": "MANUAL", "prompt": "", "code": "x=1",
+         "output": "1", "analysis": "ok", "pycoder_repl_id": "repl-abc123",
+         "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "pycoder")
+    assert node.state.pycoder_repl_id == "repl-abc123"
+
+
+def test_pycoder_repl_id_self_heals_when_missing_from_a_legacy_payload():
+    # A payload predating this field (or otherwise malformed) must NOT
+    # fall back to a blank id - see graphlink_scratch_dirs.
+    # remove_scratch_dir_for_id's own docstring for why a blank id is
+    # actively dangerous, not just untidy: it resolves to a shared
+    # "default" bucket every such node would collide on.
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "pycoder", "mode": "MANUAL", "prompt": "", "code": "x=1",
+         "output": "", "analysis": "", "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "pycoder")
+    assert node.state.pycoder_repl_id, "a missing pycoder_repl_id must self-heal to a fresh non-blank id"
+
+
+def test_two_legacy_pycoder_payloads_missing_repl_id_do_not_collide():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "pycoder", "mode": "MANUAL", "code": "a", "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+        {"node_type": "pycoder", "mode": "MANUAL", "code": "b", "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    pycoder_nodes = [n for n in document.nodes.values() if n.kind == "pycoder"]
+    assert len(pycoder_nodes) == 2
+    first, second = pycoder_nodes
+    assert first.state.pycoder_repl_id != second.state.pycoder_repl_id
+
+
+def test_code_sandbox_sandbox_id_self_heals_when_missing_from_a_legacy_payload():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "code_sandbox", "prompt": "build x", "requirements": "",
+         "code": "", "output": "", "analysis": "", "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    node = next(n for n in document.nodes.values() if n.kind == "code_sandbox")
+    assert node.state.code_sandbox_sandbox_id, "a missing sandbox_id must self-heal to a fresh non-blank id"
+
+
+def test_two_legacy_code_sandbox_payloads_missing_sandbox_id_do_not_collide():
+    document = _restore(nodes=[
+        _chat("parent"),
+        {"node_type": "code_sandbox", "prompt": "a", "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+        {"node_type": "code_sandbox", "prompt": "b", "position": {"x": 0, "y": 0}, "parent_node_index": 0},
+    ])
+    sandbox_nodes = [n for n in document.nodes.values() if n.kind == "code_sandbox"]
+    assert len(sandbox_nodes) == 2
+    first, second = sandbox_nodes
+    assert first.state.code_sandbox_sandbox_id != second.state.code_sandbox_sandbox_id
+
+
 def test_artifact_node_reuses_instruction_as_content_and_content_as_artifact_content():
     document = _restore(nodes=[
         _chat("parent"),

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -84,6 +84,76 @@ def test_pycoder_mode_translates_back_to_uppercase_enum_member_name():
     assert payload["mode"] == "MANUAL"
 
 
+def test_pycoder_repl_id_survives_a_real_save_load_round_trip():
+    # ADR-005 stage 5.3 (review-fix): the whole point of pycoder_repl_id -
+    # a scratch-dir key stable ACROSS a reload - is worthless if save/load
+    # doesn't actually preserve it. Uses the real round trip (not a
+    # hand-built payload dict) as the strongest possible signal, matching
+    # this file's own stated testing philosophy.
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    node = doc.add_pycoder_node(10, 10, parent.id)
+    minted_repl_id = node.state.pycoder_repl_id
+    assert minted_repl_id, "a repl id must be minted at creation time"
+
+    doc2 = _round_trip(doc)
+
+    restored = next(n for n in doc2.nodes.values() if n.kind == "pycoder")
+    assert restored.state.pycoder_repl_id == minted_repl_id
+
+
+def test_two_pycoder_nodes_get_different_repl_ids():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    a = doc.add_pycoder_node(10, 10, parent.id)
+    b = doc.add_pycoder_node(20, 20, parent.id)
+    assert a.state.pycoder_repl_id != b.state.pycoder_repl_id
+
+
+def test_reload_after_deleting_an_earlier_node_does_not_swap_pycoder_scratch_dirs():
+    """The exact bug an adversarial review caught before this stage shipped:
+    node.id is reassigned fresh, purely by array position, on every load
+    (register_restored_node) - so deleting a node ahead of a pycoder node
+    in save order used to shift every later node's id on the NEXT load,
+    which (before pycoder_repl_id existed) silently pointed that pycoder
+    node's on-disk scratch dir at whatever directory the id it inherited
+    happened to name - potentially another node's leftover files, or an
+    empty one that orphaned its own.
+
+    Reproduces the concrete scenario from the finding: parent(chat) -> B
+    (pycoder) -> C (pycoder), delete parent's OTHER child positioned ahead
+    of B in save order, then round-trip. B and C's ids shift, but their
+    pycoder_repl_id (and therefore PythonREPL.cwd) must not."""
+    from graphlink_plugins.pycoder.domain import PythonREPL
+
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", is_user=False)
+    decoy = doc.add_chat_node(10, 10, "decoy", is_user=False)  # ahead of B in save order
+    node_b = doc.add_pycoder_node(20, 20, parent.id)
+    node_c = doc.add_pycoder_node(30, 30, parent.id)
+    node_b.state.pycoder_code = "b's code"
+    node_c.state.pycoder_code = "c's code"
+    repl_id_b = node_b.state.pycoder_repl_id
+    repl_id_c = node_c.state.pycoder_repl_id
+    cwd_b_before = PythonREPL(repl_id=repl_id_b).cwd
+    cwd_c_before = PythonREPL(repl_id=repl_id_c).cwd
+    assert cwd_b_before != cwd_c_before
+
+    doc.remove_nodes([decoy.id])  # shifts every later node's array position
+    doc2 = _round_trip(doc)
+
+    pycoder_nodes = [n for n in doc2.nodes.values() if n.kind == "pycoder"]
+    restored_b = next(n for n in pycoder_nodes if n.state.pycoder_code == "b's code")
+    restored_c = next(n for n in pycoder_nodes if n.state.pycoder_code == "c's code")
+    # The whole point: ids ARE free to have shifted (that volatility is
+    # what caused the bug) - what must NOT have shifted is which on-disk
+    # directory each node's REPL resolves to.
+    assert restored_b.state.pycoder_repl_id == repl_id_b
+    assert restored_c.state.pycoder_repl_id == repl_id_c
+    assert PythonREPL(repl_id=restored_b.state.pycoder_repl_id).cwd == cwd_b_before
+    assert PythonREPL(repl_id=restored_c.state.pycoder_repl_id).cwd == cwd_c_before
+
+
 def test_gitlink_node_packs_repo_state_and_proposal_data():
     doc = SceneDocument()
     parent = doc.add_chat_node(0, 0, "p", is_user=False)

--- a/graphlink_desktop.py
+++ b/graphlink_desktop.py
@@ -134,11 +134,21 @@ def main() -> int:
         mark_running,
         previous_run_crashed,
     )
+    from graphlink_scratch_dirs import sweep_stale_scratch_dirs_on_launch
 
     configure_logging()
     install_exception_handlers()
     crashed = previous_run_crashed()
     mark_running()
+    # ADR-005 stage 5.3: the age-sweep GC trigger - a crash/abandoned-
+    # session cleanup net for scratch dirs that node-delete/session-evict
+    # never got to (e.g. a hard kill). Best-effort and non-fatal, same
+    # posture as every other call in this boot sequence - see that
+    # function's own docstring in graphlink_scratch_dirs.py.
+    try:
+        sweep_stale_scratch_dirs_on_launch()
+    except Exception:
+        logger.exception("scratch-dir age sweep failed at launch")
 
     spa_index = REPO_ROOT / "web_ui" / "dist" / "app" / "index.html"
     if not spa_index.is_file():

--- a/graphlink_plugins/code_sandbox/domain.py
+++ b/graphlink_plugins/code_sandbox/domain.py
@@ -41,7 +41,6 @@ import queue
 import re
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 from enum import Enum
@@ -51,6 +50,12 @@ import api_provider
 import graphlink_task_config as config
 from graphlink_execution_guard import create_execution_guard
 from graphlink_process_env import safe_subprocess_env
+from graphlink_scratch_dirs import (
+    EXECUTION_SANDBOX_ROOT,
+    prepare_scratch_dir,
+    safe_scratch_id,
+    touch_scratch_dir_usage,
+)
 
 
 class SandboxStage(Enum):
@@ -167,8 +172,7 @@ Error Output:
 
 class VirtualEnvSandbox:
     def __init__(self, sandbox_id):
-        safe_id = re.sub(r"[^A-Za-z0-9_-]", "_", sandbox_id or "default")
-        self.base_dir = Path(tempfile.gettempdir()) / "graphlink_execution_sandboxes" / safe_id
+        self.base_dir = EXECUTION_SANDBOX_ROOT / safe_scratch_id(sandbox_id)
         self.venv_dir = self.base_dir / "venv"
         self.requirements_file = self.base_dir / "requirements.txt"
         self.requirements_hash_file = self.base_dir / ".requirements.sha256"
@@ -236,6 +240,14 @@ class VirtualEnvSandbox:
         # code yet). On POSIX this records the process-group id close()
         # will kill.
         self.guard.assign(process.pid)
+        # ADR-005 stage 5.3 (review-fix): mark base_dir as actively used -
+        # every real call site (venv creation, pip install, script
+        # execution) routes through here, so this is the one choke point
+        # that needs it. See touch_scratch_dir_usage's own docstring for
+        # why an in-place file rewrite (sync_requirements/execute_code's
+        # normal, repeated-use pattern) never bumps this on its own.
+        if cwd:
+            touch_scratch_dir_usage(Path(cwd))
         output_queue = queue.Queue()
         done_signal = object()
 
@@ -314,7 +326,9 @@ class VirtualEnvSandbox:
             self.current_process = None
 
     def ensure_base_environment(self, should_continue, emit_line=None):
-        self.base_dir.mkdir(parents=True, exist_ok=True)
+        # ADR-005 stage 5.3: chmod 0700 on POSIX - see
+        # graphlink_scratch_dirs.prepare_scratch_dir's own docstring.
+        prepare_scratch_dir(self.base_dir)
         if self.python_executable.exists():
             return
 
@@ -392,7 +406,7 @@ class VirtualEnvSandbox:
         self.requirements_hash_file.write_text(manifest_hash, encoding="utf-8")
 
     def execute_code(self, code, should_continue, emit_line=None):
-        self.base_dir.mkdir(parents=True, exist_ok=True)
+        prepare_scratch_dir(self.base_dir)
         self.script_path.write_text(code, encoding="utf-8")
         if emit_line:
             emit_line(f"[Sandbox] Running {self.script_path.name} in the virtualenv...\n")

--- a/graphlink_plugins/pycoder/domain.py
+++ b/graphlink_plugins/pycoder/domain.py
@@ -33,16 +33,20 @@ import json
 import re
 import subprocess
 import sys
-import tempfile
 import threading
 import uuid
 from enum import Enum
-from pathlib import Path
 
 import api_provider
 import graphlink_task_config as config
 from graphlink_execution_guard import create_execution_guard
 from graphlink_process_env import safe_subprocess_env
+from graphlink_scratch_dirs import (
+    PYCODER_REPL_ROOT,
+    prepare_scratch_dir,
+    safe_scratch_id,
+    touch_scratch_dir_usage,
+)
 
 
 class PyCoderStage(Enum):
@@ -84,8 +88,21 @@ class PythonREPL:
     by executed code. Mirrors VirtualEnvSandbox's own base_dir pattern in
     graphlink_plugins/code_sandbox/domain.py exactly (same safe-id
     sanitization, same tempdir root convention, sibling directory name).
+
+    ADR-005 stage 5.3 (review-fix): that scratch directory is keyed by
+    repl_id, NOT by this node's own id - node.id is reassigned fresh,
+    purely by array position, every time a session is (re)loaded
+    (backend/domain/graph.py's register_restored_node), so keying by it
+    let a reload silently swap which on-disk directory a node's REPL
+    resolved to (one node losing its own accumulated files, or inheriting
+    a different node's leftovers, any time an earlier node in save order
+    was deleted before the next load). repl_id is
+    node.state.pycoder_repl_id - minted once at node creation and
+    round-tripped through session save/load independent of node.id
+    churn, mirroring CodeSandboxState.code_sandbox_sandbox_id exactly
+    (see PycoderState's own docstring for the full mechanism).
     """
-    def __init__(self, node_id=None):
+    def __init__(self, repl_id=None):
         self.process = None
         self.last_run_failed = False
         self._boundary_prefix = ""
@@ -109,8 +126,7 @@ class PythonREPL:
         # check and its later self.process.kill() call) and could
         # double-close the same real OS job handle.
         self._lock = threading.RLock()
-        safe_id = re.sub(r"[^A-Za-z0-9_-]", "_", node_id or "default")
-        self.cwd = Path(tempfile.gettempdir()) / "graphlink_pycoder_repls" / safe_id
+        self.cwd = PYCODER_REPL_ROOT / safe_scratch_id(repl_id)
 
     def start(self):
         with self._lock:
@@ -159,10 +175,12 @@ while True:
                 kwargs['creationflags'] = subprocess.CREATE_NO_WINDOW
 
             # ADR-005 stage 5.1: cwd= a scratch dir, never the app's own cwd
-            # (see this class's own docstring). mkdir here, not in
+            # (see this class's own docstring). Created here, not in
             # __init__, so a REPL that is constructed but never started
-            # never touches the filesystem.
-            self.cwd.mkdir(parents=True, exist_ok=True)
+            # never touches the filesystem. ADR-005 stage 5.3: chmod 0700
+            # on POSIX - see graphlink_scratch_dirs.prepare_scratch_dir's
+            # own docstring for why.
+            prepare_scratch_dir(self.cwd)
 
             # ADR-005 stage 5.2/5.3: the guard is created BEFORE Popen so
             # its popen_kwargs() can reach the spawn itself. On Windows
@@ -194,6 +212,12 @@ while True:
     def execute(self, code):
         if not self.process or self.process.poll() is not None:
             self.start()
+
+        # ADR-005 stage 5.3 (review-fix): mark this cwd as actively used -
+        # see touch_scratch_dir_usage's own docstring for why the age
+        # sweep would otherwise treat a REPL run daily for months exactly
+        # like one abandoned the day after creation.
+        touch_scratch_dir_usage(self.cwd)
 
         encoded_code = base64.b64encode(code.encode('utf-8')).decode('utf-8')
         try:

--- a/graphlink_scratch_dirs.py
+++ b/graphlink_scratch_dirs.py
@@ -1,0 +1,201 @@
+"""ADR-005 stage 5.3: shared location, permissioning, and garbage collection
+for the two per-node scratch directories LLM-generated/executed code can
+read and write - Py-Coder's REPL cwd (graphlink_plugins/pycoder/domain.py)
+and Execution Sandbox's venv base_dir (graphlink_plugins/code_sandbox/
+domain.py).
+
+Location stays under tempfile.gettempdir(), unchanged from stage 5.1 - an
+earlier draft of this stage's ADR entry proposed moving both under
+~/.graphlink (the app's own persistent data dir) for consistency with
+session.dat/chats.db, but the actual security gap this stage closes
+(0700 below) does not depend on location: a directory's own POSIX mode
+governs who can list/read/enter it regardless of the parent's permissions,
+so a mode-1777 shared /tmp does not expose a 0700 child. Moving location
+would also mix ephemeral execution scratch space (already reused across
+runs by design - see prepare_scratch_dir's own docstring) into the same
+directory tree as the app's small, deliberately-backed-up config/secrets
+files, for no security benefit. Kept simple instead.
+
+GC is needed because nothing else ever removes these directories on its
+own: Py-Coder's REPL persists across disconnects by design (see
+PythonREPL's own docstring) and is torn down only by explicit node
+deletion; Execution Sandbox's VirtualEnvSandbox is reconstructed fresh per
+run and never even holds a reference to a previous run's directory. Three
+triggers, matching this stage's exit criterion:
+  - node delete (backend/api/intents_nodes.py's remove_nodes) - exact,
+    synchronous removal of the one deleted node's own directory.
+  - session evict (backend/app.py's _evict_idle_session) - process-only,
+    via AgentDispatcher.dispose_all_pycoder_repls(); deliberately does NOT
+    call remove_scratch_dir here, see that method's own docstring for why.
+  - age sweep on launch (graphlink_desktop.py's main()) - a crash/
+    abandoned-session cleanup net for whatever the first two triggers
+    never got to (e.g. a hard process kill, no clean node-delete ever
+    happened), not the primary mechanism.
+"""
+
+import logging
+import os
+import re
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PYCODER_REPL_ROOT = Path(tempfile.gettempdir()) / "graphlink_pycoder_repls"
+EXECUTION_SANDBOX_ROOT = Path(tempfile.gettempdir()) / "graphlink_execution_sandboxes"
+
+# A generous default: this is a crash/abandoned-session net, not the
+# primary GC path (delete/evict are) - it should never race a normal,
+# still-in-use scratch dir just because a user stepped away for a day.
+DEFAULT_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+
+
+def safe_scratch_id(raw_id: str) -> str:
+    """The exact sanitization PythonREPL/VirtualEnvSandbox already applied
+    to node_id/sandbox_id inline before this module existed - factored out
+    here so any caller that only has the raw id (not a live REPL/Sandbox
+    object to read .cwd/.base_dir from) can still compute the identical
+    directory name, e.g. backend/api/intents_nodes.py's remove_nodes for a
+    deleted code_sandbox node's sandbox_id."""
+    return re.sub(r"[^A-Za-z0-9_-]", "_", raw_id or "default")
+
+
+def prepare_scratch_dir(path: Path) -> None:
+    """mkdir -p, then chmod 0700 on POSIX (no-op on Windows, matching every
+    other chmod call site in this codebase - os.chmod there only ever
+    toggles the read-only attribute, not real ACLs - see
+    graphlink_settings_store.py's own chmod calls). A refused chmod is
+    logged and otherwise ignored: a permissions tightening that can't be
+    applied must not stop code execution from running, the same fail-open
+    stance graphlink_settings_store.py's 0600 file chmods already take."""
+    path.mkdir(parents=True, exist_ok=True)
+    if sys.platform == "win32":
+        return
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        logger.warning("could not chmod %s to 0700 - continuing with existing permissions", path)
+
+
+def remove_scratch_dir(path: Path) -> None:
+    """Best-effort recursive delete, with one short retry: a directory
+    whose owning subprocess is still exiting (e.g. code_sandbox's
+    cooperative, ~100ms-polled cancel, which does not block the caller -
+    see AgentDispatcher.remove_code_sandbox_scratch_dir's own docstring)
+    can briefly hold an open file handle even after this is called - one
+    retry after a short delay meaningfully improves the odds with no
+    architectural change (no live object reference needed, no wait/poll
+    loop threaded through the caller). A missing directory is silently
+    fine (nothing to do, no retry needed); any other failure that
+    survives the retry too (e.g. a genuine permissions error) is logged
+    and swallowed rather than raised - GC must never be the reason a node
+    delete/session evict/launch sweep itself fails. Leftover directories
+    a failed removal leaves behind are still caught later by the age
+    sweep."""
+    for attempt in (1, 2):
+        try:
+            shutil.rmtree(path)
+            return
+        except FileNotFoundError:
+            return
+        except OSError:
+            if attempt == 2:
+                logger.warning("could not remove scratch dir %s - leaving it in place", path)
+                return
+            time.sleep(0.25)
+
+
+def remove_scratch_dir_for_id(root: Path, raw_id: str) -> None:
+    """Node-delete GC entry point: recomputes the deterministic scratch
+    path from a raw (unsanitized) id and removes it - the same pattern
+    PythonREPL.cwd/VirtualEnvSandbox.base_dir already use to build their
+    own path, so this works whether or not a live REPL/Sandbox object is
+    currently around to ask (closes a real bug: a REPL already popped
+    from AgentDispatcher._pycoder_repls - e.g. by a prior execute timeout
+    - used to make a later real node-delete's removal silently no-op,
+    since it only ever looked in that dict).
+
+    Refuses to act on a blank/falsy raw_id: safe_scratch_id("") resolves
+    to the literal "default" bucket, which is not this node's own
+    directory - it is a shared fallback that more than one blank-id node
+    could collide on (reachable via a malformed/hand-edited session
+    payload; session_load.py's restore functions now self-heal a missing
+    id on load specifically to avoid this in the normal case, but cannot
+    guarantee every payload was produced by this app). Destructively
+    rmtree-ing that shared bucket because ONE node with a blank id was
+    deleted would take another still-live node's directory down with
+    it."""
+    if not raw_id:
+        logger.warning("refusing to remove the shared scratch bucket for a blank id under %s", root)
+        return
+    remove_scratch_dir(root / safe_scratch_id(raw_id))
+
+
+def touch_scratch_dir_usage(path: Path) -> None:
+    """Bumps `path`'s own mtime to now, marking it as actively used for
+    gc_stale_by_age's purposes. Needed because ordinary use of these
+    directories - PythonREPL.execute() re-running the same subprocess,
+    VirtualEnvSandbox writing to already-existing files - never adds,
+    removes, or renames a direct child of the directory itself, the one
+    thing that would otherwise bump its own mtime automatically: venv
+    creation and script/requirements writes all open an EXISTING file for
+    truncate+rewrite after the very first run, which does not touch the
+    parent directory's own mtime on either POSIX or NTFS. Without this, a
+    directory used daily for months looks exactly as stale to the age
+    sweep as one abandoned the day after creation. Called at the start of
+    every real use (PythonREPL.execute(), VirtualEnvSandbox._run_subprocess),
+    not just creation. Best-effort: a failure (e.g. the directory was
+    removed by a concurrent GC trigger between use and this call) is
+    logged and swallowed, never allowed to interrupt the actual
+    execution/subprocess run this is called alongside."""
+    try:
+        os.utime(path, None)
+    except OSError:
+        logger.warning("could not refresh mtime for %s - it may look falsely stale to the age sweep", path)
+
+
+def gc_stale_by_age(root: Path, max_age_seconds: float = DEFAULT_MAX_AGE_SECONDS) -> list:
+    """Removes every immediate child of `root` whose mtime is older than
+    max_age_seconds. Directory mtime updates whenever a direct child is
+    added/removed/renamed - not on writes deep inside a nested
+    subdirectory - so this is an approximation of "last touched", not an
+    exact usage timestamp; acceptable for a crash-cleanup net, the same
+    honest approximation the rest of this codebase already accepts for the
+    session-idle TTL (also a monotonic-time heuristic, not real usage
+    tracking). Safe against a root that does not exist yet (a fresh
+    install/profile that has never created either scratch root). Returns
+    the list of paths removed, for logging by the caller."""
+    if not root.is_dir():
+        return []
+    cutoff = time.time() - max_age_seconds
+    removed = []
+    for child in root.iterdir():
+        try:
+            mtime = child.stat().st_mtime
+        except OSError:
+            continue
+        if mtime < cutoff:
+            remove_scratch_dir(child)
+            removed.append(child)
+    return removed
+
+
+def sweep_stale_scratch_dirs_on_launch(max_age_seconds: float = DEFAULT_MAX_AGE_SECONDS) -> None:
+    """The one-time-per-launch age sweep - called from
+    graphlink_desktop.py's main(), see this module's own docstring for why
+    this trigger exists alongside delete/evict. Iterates both scratch
+    roots; a failure sweeping one root is logged and does not stop the
+    other from being swept, and neither failure is allowed to abort app
+    startup (matching mark_running()/configure_logging()'s own
+    best-effort-and-log stance in backend/crash_recovery.py)."""
+    for root in (PYCODER_REPL_ROOT, EXECUTION_SANDBOX_ROOT):
+        try:
+            removed = gc_stale_by_age(root, max_age_seconds)
+        except OSError:
+            logger.warning("scratch-dir age sweep failed for %s", root, exc_info=True)
+            continue
+        if removed:
+            logger.info("age-swept %d stale scratch dir(s) under %s", len(removed), root)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ py-modules = [
     "graphlink_note_agent",
     "graphlink_process_env",
     "graphlink_prompts",
+    "graphlink_scratch_dirs",
     "graphlink_secrets",
     "graphlink_settings_store",
     "graphlink_task_config",

--- a/tests/test_graphlink_desktop.py
+++ b/tests/test_graphlink_desktop.py
@@ -36,6 +36,7 @@ import pytest
 
 import graphlink_desktop
 import backend.crash_recovery as crash_recovery_module
+import graphlink_scratch_dirs as scratch_dirs_module
 
 
 class _FakeThread:
@@ -172,6 +173,8 @@ def desktop_harness(tmp_path, monkeypatch):
         wait_for_health_result=True,
         start_backend_auth_tokens=[],
         wait_for_health_auth_tokens=[],
+        sweep_scratch_calls=0,
+        sweep_scratch_side_effect=None,
     )
 
     spa_index = tmp_path / "web_ui" / "dist" / "app" / "index.html"
@@ -191,6 +194,19 @@ def desktop_harness(tmp_path, monkeypatch):
 
     monkeypatch.setattr(crash_recovery_module, "mark_running", fake_mark_running)
     monkeypatch.setattr(crash_recovery_module, "mark_clean_exit", fake_mark_clean_exit)
+
+    def fake_sweep_stale_scratch_dirs_on_launch(*_a, **_k):
+        state.sweep_scratch_calls += 1
+        if state.sweep_scratch_side_effect is not None:
+            raise state.sweep_scratch_side_effect
+
+    # ADR-005 stage 5.3: same real-module-object patching reasoning as
+    # crash_recovery_module above - main() does a fresh `from
+    # graphlink_scratch_dirs import sweep_stale_scratch_dirs_on_launch`
+    # every call, so patching graphlink_desktop's own name would miss it.
+    monkeypatch.setattr(
+        scratch_dirs_module, "sweep_stale_scratch_dirs_on_launch", fake_sweep_stale_scratch_dirs_on_launch
+    )
 
     fake_server = _FakeServer()
     fake_thread = _FakeThread(alive=True)
@@ -314,6 +330,30 @@ def test_main_shuts_down_the_backend_when_the_health_check_times_out(desktop_har
     assert desktop_harness.shutdown_calls == [(desktop_harness.fake_server, desktop_harness.fake_thread)]
     assert desktop_harness.mark_clean_exit_calls == 1
     assert desktop_harness.webview_create_window_calls == [], "must never reach the window if never healthy"
+
+
+# -- ADR-005 stage 5.3: launch-time scratch-dir age sweep -------------------
+
+
+def test_main_sweeps_stale_scratch_dirs_exactly_once_per_launch(desktop_harness):
+    result = graphlink_desktop.main()
+
+    assert result == 0
+    assert desktop_harness.sweep_scratch_calls == 1
+
+
+def test_main_still_boots_when_the_scratch_dir_sweep_raises(desktop_harness):
+    # Regression guard, same shape as the bad-port-env-var fix above: a
+    # best-effort cleanup step must never be the reason the app fails to
+    # launch, or leaves the crash sentinel in a false "still running" state.
+    desktop_harness.sweep_scratch_side_effect = OSError("disk unavailable")
+
+    result = graphlink_desktop.main()
+
+    assert result == 0
+    assert desktop_harness.sweep_scratch_calls == 1
+    assert desktop_harness.mark_clean_exit_calls == 1
+    assert len(desktop_harness.webview_create_window_calls) == 1, "must still reach the window"
 
 
 # -- ADR-004 stage 4.1: capability-token security invariants --------------

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -94,7 +94,7 @@ MIGRATED_KIND_FIELDS = {
     "pycoder": [
         "pycoder_mode", "pycoder_prompt", "pycoder_code", "pycoder_output", "pycoder_analysis",
         "pycoder_last_run_failed", "pycoder_awaiting_approval", "pycoder_approved_fingerprint",
-        "pycoder_error",
+        "pycoder_error", "pycoder_repl_id",
     ],
     "code_sandbox": [
         "code_sandbox_sandbox_id", "code_sandbox_requirements", "code_sandbox_prompt",


### PR DESCRIPTION
## Problem

Py-Coder's REPL scratch directory and Execution Sandbox's venv directory (added in ADR-005 stage 5.1) had no permission hardening and nothing ever cleaned them up. On a shared POSIX machine, a directory created under a mode-1777 `/tmp` inherits the process umask (typically world-readable). Nothing removed these directories on node delete, session eviction, or ever, so they accumulated indefinitely.

## Change

- New `graphlink_scratch_dirs.py`: `prepare_scratch_dir` (mkdir + chmod 0700 on POSIX, no-op on Windows), `remove_scratch_dir` (best-effort rmtree with one retry), `remove_scratch_dir_for_id` (deterministic path recompute, refuses to touch a blank-id's shared bucket), `touch_scratch_dir_usage` (mtime refresh so active use isn't mistaken for staleness), `gc_stale_by_age`, `sweep_stale_scratch_dirs_on_launch`.
- GC wired to three triggers with deliberately different scope:
  - **Node delete** (`remove_nodes`): exact removal of the deleted node's own directory.
  - **Session evict** (`_evict_idle_session`): stops orphaned REPL subprocesses only — does *not* delete files, since eviction means "no one's connected," not "discard this work."
  - **Age sweep** (`graphlink_desktop.main()`): a 7-day crash/abandoned-session backstop.

## Adversarial review

A 17-agent, 4-lens review found 11 confirmed issues before this shipped, all fixed in this PR:

- **HIGH** — Py-Coder's scratch dir was keyed by the node's own `id`, which is reassigned on every session reload (`register_restored_node`). A node could silently lose its own files or inherit a different node's leftovers after a reload. Fixed with a stable `pycoder_repl_id` field, minted once at creation, mirroring `code_sandbox_sandbox_id` (which never had this problem). Proven with a dedicated end-to-end regression test.
- **HIGH** — `dispose_pycoder_repl`'s directory removal silently no-op'd if the REPL wasn't currently tracked in memory (e.g. already popped by a prior execute timeout). Fixed to recompute the path deterministically instead.
- **HIGH** — the age sweep used directory mtime, which never updates on in-place file rewrites (Execution Sandbox's normal usage pattern) — an actively-used sandbox looked identical to an abandoned one. Fixed with an explicit touch-on-use call.
- **HIGH** — reverting the real `prepare_scratch_dir` call sites back to a bare `mkdir` passed the entire existing suite with zero failures. Closed with real wiring tests (spy-based + POSIX real-mode-bit checks).
- **MEDIUM ×2** — a blank/missing id fell back to a shared `"default"` directory; this stage's new delete-triggered `rmtree` turned that into active cross-node data destruction. Fixed at the root (self-healing mint-on-load) plus defense in depth (refuse to remove a blank-id path).
- **MEDIUM** — `dispose_all_pycoder_repls` called blocking `repl.stop()` inline on the live event loop. Fixed to fire on background threads.
- **MEDIUM + LOW** — a stale/overclaiming comment and two lower-severity coverage/robustness gaps, all corrected.

Full details and reasoning are recorded in the project's private ADR-005 doc.

## Test plan

- [x] Full local suite: 1526 passed, 14 skipped (up from 1475/10 baseline; all new)
- [x] Real wheel build → twine check → clean-venv install → import from outside the repo, replicating CI's `build-check` job
- [x] 8 targeted mutations, each breaking exactly its intended test, then reverted clean
- [x] `npm run check` unaffected (backend-only change, no UI)