### PR TITLE
ADR-005 stage 5.4: backend-computed execution-limits disclosure

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -58,6 +58,7 @@ from backend.events import (
     UnknownSessionError,
     UnknownTopicError,
 )
+from backend.execution_limits import register_execution_limits
 from backend.notifications import register_notifications
 from backend.plugins import register_plugins
 from backend.session_context import (
@@ -222,6 +223,9 @@ def _configure_session(
 
     # R2.5: about, plugins, settings, chat library.
     register_about(bus)
+    # ADR-005 stage 5.4: same zero-live-state shape as register_about above -
+    # see backend/execution_limits.py's own docstring.
+    register_execution_limits(bus)
     # R5.1: register_plugins needs the same session's canvas_document (built
     # just above) so "Web Research" can create a real node - this ordering
     # (canvas_document exists before register_plugins runs) is load-bearing.

--- a/backend/execution_limits.py
+++ b/backend/execution_limits.py
@@ -1,0 +1,117 @@
+"""ADR-005 stage 5.4 (disclosure half): the real resource caps applied to
+executed code, for CodeExecutionApprovalPanel.tsx's approval dialog.
+
+That panel's WARNING_TEXT ("there is no sandboxing" / "isolates installed
+packages, not the operating system") is honest but was never updated after
+ADR-005 stages 5.2/5.3 added real resource caps and stage 5.5 restricted
+dependency installs - this stage's own Decision §2 calls for "the approval
+dialog states the actual limits". Deliberately NOT hardcoded in the
+frontend: graphlink_execution_guard.py's caps are platform-conditional
+(Windows: memory + active-process count only; POSIX: those two plus CPU
+time and output file size - Windows has no CPU-rate control, see that
+module's own stage 5.2 scoping note), so a hardcoded frontend string would
+silently lie the moment the two diverge - the same class of staleness bug
+ADR-004 stage 4.4's secretsEncryptedAtRest review caught.
+
+Mirrors backend/about.py's own shape exactly: zero live state, one payload
+function. The numbers this reads (graphlink_execution_guard.DEFAULT_*) are
+module-level constants fixed for the life of the process, not anything that
+could change mid-session, so - unlike graphlink_settings_store.py's DPAPI
+probe - there is nothing here that needs live re-checking on every read.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import graphlink_execution_guard as guard
+from backend.events import SessionBus
+
+_DEPENDENCY_INSTALL_NOTE = (
+    " Package installs are restricted to pre-built binary distributions - a "
+    "package that only ships source code will fail to install rather than "
+    "run its own build code during setup."
+)
+
+
+def _format_bytes(n: int) -> str:
+    gib = n / (1024**3)
+    if gib >= 1:
+        return f"{gib:.0f} GB" if gib == int(gib) else f"{gib:.1f} GB"
+    return f"{n // (1024**2)} MB"
+
+
+_FAIL_OPEN_CAVEAT = (
+    " These limits are applied automatically by this build and are not "
+    "adjustable here; in rare cases (for example, security software "
+    "blocking the underlying OS mechanism) they may not take effect."
+)
+
+
+def _resource_limits_sentence() -> str:
+    """Windows has memory + active-process caps only (no CPU-rate control -
+    see graphlink_execution_guard.py's own stage 5.2 scoping note for why
+    that was left out entirely rather than shipped unverified). POSIX adds
+    CPU time and output file size on top of those same two.
+
+    Review-fix (ADR-005 stage 5.4): two wording changes, not just a shared
+    trailing caveat, because two of the numbers here do not mean what an
+    unqualified sentence would imply:
+
+    - Windows's JobMemoryLimit bounds COMMITTED memory; POSIX's RLIMIT_AS
+      bounds reserved ADDRESS SPACE, which large-but-unused virtual
+      reservations (a multi-threaded interpreter's own stack reservations,
+      BLAS/numpy thread pools) can exhaust well before actual usage
+      approaches the same number. Saying "of memory" identically on both
+      platforms implied a parity the two mechanisms do not have - POSIX
+      now says "of reserved memory" instead.
+    - RLIMIT_NPROC does not bound "this execution's own process tree" the
+      way the Windows Job Object's active-process limit genuinely does -
+      per POSIX semantics it bounds the total live process count for the
+      REAL UID, system-wide (every process the desktop user owns, not just
+      this run's descendants). Calling that "N concurrent processes" (as
+      if scoped to the run) was a real, reachable inaccuracy - the POSIX
+      sentence now describes it as capping the account's total process
+      count instead.
+
+    The trailing _FAIL_OPEN_CAVEAT covers the OTHER gap the review found:
+    graphlink_execution_guard.py has several silent fail-open paths
+    (Job Object creation/assignment failing under e.g. EDR policy, a
+    per-rlimit setrlimit call being refused) that leave a real run
+    completely uncapped with nothing surfaced beyond a logger.warning -
+    this text cannot know, per-run, whether that happened (assign()'s
+    failure modes only exist once a real process is being attached, so
+    there is nothing to probe in advance), so it discloses the
+    possibility honestly instead of asserting a guarantee stage 5.2's own
+    empirical proof never actually covered for every failure mode."""
+    memory = _format_bytes(guard.DEFAULT_MEMORY_LIMIT_BYTES)
+    processes = guard.DEFAULT_ACTIVE_PROCESS_LIMIT
+    if sys.platform == "win32":
+        return (
+            f"Execution is capped at approximately {memory} of memory and "
+            f"{processes} concurrent processes; there is no CPU time limit."
+        ) + _FAIL_OPEN_CAVEAT
+    cpu_seconds = guard.DEFAULT_CPU_SECONDS
+    file_size = _format_bytes(guard.DEFAULT_FILE_SIZE_LIMIT_BYTES)
+    return (
+        f"Execution is capped at approximately {memory} of reserved memory, "
+        f"{cpu_seconds}s of CPU time, and {file_size} of output per file. "
+        f"It also limits your user account's total live process count to "
+        f"{processes} while it runs."
+    ) + _FAIL_OPEN_CAVEAT
+
+
+def execution_limits_payload() -> dict[str, Any]:
+    resource_limits = _resource_limits_sentence()
+    return {
+        "pycoderResourceLimitsText": resource_limits,
+        # ADR-005 stage 5.5: code_sandbox alone runs pip installs, so it
+        # alone gets the --only-binary disclosure on top of the shared
+        # resource-cap sentence.
+        "codeSandboxResourceLimitsText": resource_limits + _DEPENDENCY_INSTALL_NOTE,
+    }
+
+
+def register_execution_limits(bus: SessionBus) -> None:
+    bus.register_topic("execution-limits", execution_limits_payload)

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -94,8 +94,9 @@ def test_subscribe_without_topics_sends_every_registered_topic():
     with client.websocket_connect("/ws") as ws:
         ws.send_json({"kind": "subscribe"})
         # R2 surface: canvas + View-popover + composer/counter/notification +
-        # R2.5 about/plugins/settings/chat-library topics, sorted.
-        topics = [ws.receive_json()["topic"] for _ in range(12)]
+        # R2.5 about/plugins/settings/chat-library topics + ADR-005 stage 5.4's
+        # execution-limits topic, sorted.
+        topics = [ws.receive_json()["topic"] for _ in range(13)]
         assert topics == [
             "app-about",
             "app-chat-library",
@@ -103,6 +104,7 @@ def test_subscribe_without_topics_sends_every_registered_topic():
             "app-plugins",
             "app-settings",
             "drag-speed",
+            "execution-limits",
             "font-control",
             "grid-control",
             "notification",

--- a/backend/tests/test_execution_limits.py
+++ b/backend/tests/test_execution_limits.py
@@ -1,0 +1,121 @@
+"""Execution-limits topic tests (ADR-005 stage 5.4, disclosure half).
+
+Mirrors backend/tests/test_about.py's own shape - the same "zero live
+state, one payload function" topic pattern - plus platform-conditional
+content tests, since the whole point of this module is that the disclosed
+caps differ between Windows and POSIX (see graphlink_execution_guard.py's
+own stage 5.2 scoping note on why Windows has no CPU-rate control).
+"""
+
+import graphlink_execution_guard as guard
+from backend.events import SessionBus
+from backend.execution_limits import execution_limits_payload, register_execution_limits
+
+
+def test_execution_limits_payload_matches_generated_validator_shape():
+    payload = execution_limits_payload()
+    assert set(payload) == {
+        "pycoderResourceLimitsText",
+        "codeSandboxResourceLimitsText",
+    }
+    assert isinstance(payload["pycoderResourceLimitsText"], str)
+    assert isinstance(payload["codeSandboxResourceLimitsText"], str)
+    assert payload["pycoderResourceLimitsText"]
+    assert payload["codeSandboxResourceLimitsText"]
+
+
+def test_code_sandbox_text_is_the_pycoder_text_plus_the_dependency_install_note():
+    payload = execution_limits_payload()
+    assert payload["codeSandboxResourceLimitsText"].startswith(payload["pycoderResourceLimitsText"])
+    assert "pre-built binary" in payload["codeSandboxResourceLimitsText"]
+    assert "pre-built binary" not in payload["pycoderResourceLimitsText"]
+
+
+def test_windows_text_mentions_memory_and_process_cap_but_no_cpu_limit(monkeypatch):
+    from backend import execution_limits as module
+
+    monkeypatch.setattr(module.sys, "platform", "win32")
+
+    text = module._resource_limits_sentence()
+    assert "2 GB" in text
+    assert "64 concurrent processes" in text
+    assert "no CPU time limit" in text
+    assert "CPU time" not in text.split("no CPU time limit")[0]
+    # Windows's active-process cap IS genuinely scoped to the job (the
+    # process tree), unlike POSIX's RLIMIT_NPROC below - "concurrent
+    # processes" is accurate here, so no reword needed on this branch.
+
+
+def test_posix_text_mentions_all_four_caps(monkeypatch):
+    from backend import execution_limits as module
+
+    monkeypatch.setattr(module.sys, "platform", "linux")
+
+    text = module._resource_limits_sentence()
+    assert "2 GB of reserved memory" in text
+    assert f"{guard.DEFAULT_CPU_SECONDS}s of CPU time" in text
+    assert "1 GB of output per file" in text
+    assert "no CPU time limit" not in text
+    # Review-fix (ADR-005 stage 5.4): RLIMIT_NPROC bounds the real UID's
+    # TOTAL live process count system-wide, not this execution's own
+    # process tree - "64 concurrent processes" would misstate its scope,
+    # so the POSIX sentence must NOT use that exact phrase.
+    assert "concurrent processes" not in text
+    assert "total live process count to 64" in text
+
+
+def test_both_platform_sentences_include_the_fail_open_caveat(monkeypatch):
+    # ADR-005 stage 5.4 review-fix: graphlink_execution_guard.py has
+    # several silent fail-open paths (Job Object creation/assignment
+    # failing, a per-rlimit setrlimit call being refused) that leave a
+    # real run uncapped with nothing surfaced beyond a logger.warning -
+    # the disclosure must not assert an unconditional guarantee.
+    from backend import execution_limits as module
+
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    windows_text = module._resource_limits_sentence()
+    monkeypatch.setattr(module.sys, "platform", "linux")
+    posix_text = module._resource_limits_sentence()
+
+    for text in (windows_text, posix_text):
+        assert "may not take effect" in text
+
+
+def test_format_bytes_renders_whole_gib_without_a_decimal():
+    from backend.execution_limits import _format_bytes
+
+    assert _format_bytes(2 * 1024**3) == "2 GB"
+    assert _format_bytes(1 * 1024**3) == "1 GB"
+
+
+def test_format_bytes_renders_fractional_gib_with_one_decimal():
+    from backend.execution_limits import _format_bytes
+
+    assert _format_bytes(int(1.5 * 1024**3)) == "1.5 GB"
+
+
+def test_format_bytes_renders_sub_gib_values_in_mb():
+    from backend.execution_limits import _format_bytes
+
+    assert _format_bytes(512 * 1024**2) == "512 MB"
+
+
+def test_register_execution_limits_publishes_on_the_execution_limits_topic():
+    import asyncio
+
+    bus = SessionBus("execution-limits-test")
+    register_execution_limits(bus)
+
+    class Recorder:
+        def __init__(self):
+            self.messages = []
+
+        async def send_json(self, data):
+            self.messages.append(data)
+
+    recorder = Recorder()
+    bus.attach(recorder)
+    asyncio.run(bus.publish("execution-limits"))
+    assert recorder.messages[0]["topic"] == "execution-limits"
+    assert recorder.messages[0]["payload"]["pycoderResourceLimitsText"]
+    assert recorder.messages[0]["payload"]["codeSandboxResourceLimitsText"]

--- a/contracts/codegen.py
+++ b/contracts/codegen.py
@@ -400,6 +400,17 @@ GENERATED_ARTIFACTS = [
         "ts_path": _REPO_ROOT / "web_ui" / "src" / "lib" / "bridge-core" / "generated" / "app-plugins-state.ts",
     },
     {
+        # ADR-005 stage 5.4 (disclosure half): the execution-limits topic
+        # (backend/execution_limits.py) - the real, platform-computed
+        # resource caps CodeExecutionApprovalPanel.tsx discloses.
+        "dataclass": None,  # resolved lazily in main() to avoid importing
+        "dataclass_import": ("graphlink_execution_limits_payload", "ExecutionLimitsStatePayload"),
+        "title": "ExecutionLimitsState",
+        "source": "contracts/graphlink_execution_limits_payload.py::ExecutionLimitsStatePayload",
+        "schema_path": _REPO_ROOT / "web_ui" / "src" / "lib" / "bridge-core" / "generated" / "execution-limits-state.schema.json",
+        "ts_path": _REPO_ROOT / "web_ui" / "src" / "lib" / "bridge-core" / "generated" / "execution-limits-state.ts",
+    },
+    {
         # Qt-removal plan R2.5d: the SPA settings topic (backend/settings.py).
         "dataclass": None,  # resolved lazily in main() to avoid importing
         "dataclass_import": ("graphlink_app_settings_payload", "AppSettingsStatePayload"),

--- a/contracts/graphlink_execution_limits_payload.py
+++ b/contracts/graphlink_execution_limits_payload.py
@@ -1,0 +1,27 @@
+"""ADR-005 stage 5.4 (disclosure half): the execution-limits topic's wire
+contract.
+
+CodeExecutionApprovalPanel.tsx's WARNING_TEXT ("there is no sandboxing" /
+"isolates installed packages, not the operating system") is honest but was
+never updated to mention the real resource caps ADR-005 stages 5.2/5.3
+actually added, or stage 5.5's dependency-install restriction - Decision §2
+of that ADR calls for "the approval dialog states the actual limits". This
+topic is how: backend/execution_limits.py computes the real, platform-
+correct sentences (Windows: memory + process count only; POSIX: those plus
+CPU time and output file size - see graphlink_execution_guard.py's own
+stage 5.2 scoping note on why Windows has no CPU-rate control) and the SPA
+renders them verbatim, never assembling or hardcoding a limits claim itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ExecutionLimitsStatePayload:
+    schemaVersion: int
+    revision: int
+    pycoderResourceLimitsText: str
+    codeSandboxResourceLimitsText: str
+    minCompatibleSchemaVersion: int | None = None

--- a/graphlink_execution_guard.py
+++ b/graphlink_execution_guard.py
@@ -71,6 +71,26 @@ DEFAULT_MEMORY_LIMIT_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
 # (200-generation bomb capped at exactly the limit, not 200+).
 DEFAULT_ACTIVE_PROCESS_LIMIT = 64
 
+# ADR-005 Decision #2 names a CPU cap ("60 s CPU") alongside the memory cap.
+# RLIMIT_CPU is the POSIX way to express it (this is CPU-seconds consumed,
+# not wall-clock, so it is complementary to, not a replacement for, the
+# existing wall-clock timeouts in both execution surfaces) - only
+# _PosixResourceGuard below actually USES this constant, but it is defined
+# here, unconditionally, rather than inside the `if sys.platform ==
+# "win32": ... else:` split below: ADR-005 stage 5.4 (backend/
+# execution_limits.py) needs to read the real cap value for its disclosure
+# text regardless of which platform this process is actually running on -
+# a plain int constant scoped inside the POSIX branch would not exist as a
+# module attribute at all on a real Windows import (confirmed: this module
+# imported normally on Windows never executes that branch), which is every
+# real deployment and the only CI runner today.
+DEFAULT_CPU_SECONDS = 60
+
+# Bounds a single runaway write; well above any legitimate sandbox output
+# while still stopping a disk-filling loop. Unconditional for the same
+# cross-platform-readability reason as DEFAULT_CPU_SECONDS above.
+DEFAULT_FILE_SIZE_LIMIT_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB
+
 
 class ExecutionResourceGuard:
     """No-op base: what non-Windows platforms get in this stage (the POSIX
@@ -328,16 +348,8 @@ else:
     except ImportError:  # pragma: no cover - POSIX-only import
         _resource = None
 
-    # ADR-005 Decision #2 names a CPU cap ("60 s CPU") alongside the memory
-    # cap. RLIMIT_CPU is the POSIX way to express it and costs nothing to
-    # set here - note this is CPU-seconds consumed, not wall-clock, so it
-    # is complementary to (not a replacement for) the existing wall-clock
-    # timeouts in both execution surfaces.
-    DEFAULT_CPU_SECONDS = 60
-
-    # Bounds a single runaway write; well above any legitimate sandbox
-    # output while still stopping a disk-filling loop.
-    DEFAULT_FILE_SIZE_LIMIT_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB
+    # DEFAULT_CPU_SECONDS/DEFAULT_FILE_SIZE_LIMIT_BYTES: defined at module
+    # top level now, not here - see their own comments up there for why.
 
     class _PosixResourceGuard(ExecutionResourceGuard):
         def __init__(

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -4,6 +4,7 @@ import { TOPIC_VALIDATORS } from "../lib/api-contract/topics";
 import type { AppSettingsState } from "../lib/bridge-core/generated/app-settings-state";
 import { isTextEditable } from "../lib/bridge-core/textFocus";
 import { ConnectionStatus, WsTransport, defaultWsUrl } from "../lib/ws/transport";
+import { ExecutionLimitsProvider } from "./canvas/ExecutionLimitsContext";
 import { SceneCanvas, measuredNodeSize } from "./canvas/SceneCanvas";
 import { SceneStore } from "./canvas/sceneStore";
 import { resolveTreeNavigationTarget, type TreeNavigationDirection } from "./canvas/treeNavigation";
@@ -293,7 +294,9 @@ function App() {
                 onClose={onCloseDocumentView}
               />
               <div className="app-canvas-content">
-                <SceneCanvas store={sceneStore} onOpenDocumentView={onOpenDocumentView} />
+                <ExecutionLimitsProvider transport={transport}>
+                  <SceneCanvas store={sceneStore} onOpenDocumentView={onOpenDocumentView} />
+                </ExecutionLimitsProvider>
                 <div className="app-search-layer">
                   <SearchOverlay store={sceneStore} />
                 </div>

--- a/web_ui/src/app/canvas/CodeExecutionApprovalPanel.test.tsx
+++ b/web_ui/src/app/canvas/CodeExecutionApprovalPanel.test.tsx
@@ -1,7 +1,54 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import type { WsTransport } from "../../lib/ws/transport";
 import { CodeExecutionApprovalPanel, type CodeExecutionKind } from "./CodeExecutionApprovalPanel";
+import { ExecutionLimitsProvider } from "./ExecutionLimitsContext";
+
+type StateListener = (payload: Record<string, unknown>) => void;
+
+/** A transport whose "execution-limits" snapshot is delivered SYNCHRONOUSLY
+ * on subscribe - unlike sceneStore.test.ts's own makeFakeTransport (which
+ * hands back a `listeners` map for the test to fire manually), this panel's
+ * tests only ever care about "given this text, is it rendered" - there is
+ * no separate update-over-time behavior worth exercising here (that is
+ * ExecutionLimitsContext.test.tsx's own job). */
+function renderPanelWithExecutionLimits(
+  overrides: Partial<Parameters<typeof CodeExecutionApprovalPanel>[0]> = {},
+  limitsPayload: Record<string, unknown> | null = {
+    schemaVersion: 1,
+    minCompatibleSchemaVersion: 1,
+    revision: 1,
+    pycoderResourceLimitsText: "Execution is capped at approximately 2 GB of memory and 64 concurrent processes.",
+    codeSandboxResourceLimitsText:
+      "Execution is capped at approximately 2 GB of memory and 64 concurrent processes. Binary packages only.",
+  },
+) {
+  const onApprove = vi.fn();
+  const onDeny = vi.fn();
+  const props = {
+    nodeId: "n0",
+    kind: "pycoder" as CodeExecutionKind,
+    code: "print('hello')",
+    awaitingApproval: true,
+    busy: false,
+    onApprove,
+    onDeny,
+    ...overrides,
+  };
+  const transport = {
+    subscribe: vi.fn((topic: string, listener: StateListener) => {
+      if (topic === "execution-limits" && limitsPayload) listener(limitsPayload);
+      return () => {};
+    }),
+  } as unknown as WsTransport;
+  const { container } = render(
+    <ExecutionLimitsProvider transport={transport}>
+      <CodeExecutionApprovalPanel {...props} />
+    </ExecutionLimitsProvider>,
+  );
+  return { onApprove, onDeny, container };
+}
 
 // Rendered standalone, with NO <OverlayProvider> ancestor (post-review
 // architecture correction - see this component's own module doc for FIX A/
@@ -22,8 +69,8 @@ function renderPanel(overrides: Partial<Parameters<typeof CodeExecutionApprovalP
     onDeny,
     ...overrides,
   };
-  render(<CodeExecutionApprovalPanel {...props} />);
-  return { onApprove, onDeny };
+  const { container } = render(<CodeExecutionApprovalPanel {...props} />);
+  return { onApprove, onDeny, container };
 }
 
 describe("CodeExecutionApprovalPanel", () => {
@@ -167,6 +214,73 @@ describe("CodeExecutionApprovalPanel", () => {
   it("does not show the other kind's warning sentence", () => {
     renderPanel({ kind: "pycoder" });
     expect(screen.queryByText(/isolates installed packages/)).toBeNull();
+  });
+
+  // -- ADR-005 stage 5.4: backend-computed resource-limits addendum ---------
+
+  it("shows the pycoder-specific resource-limits text from the execution-limits topic", () => {
+    renderPanelWithExecutionLimits({ kind: "pycoder" });
+    expect(
+      screen.getByText("Execution is capped at approximately 2 GB of memory and 64 concurrent processes."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the code_sandbox-specific resource-limits text, not the pycoder one", () => {
+    renderPanelWithExecutionLimits({ kind: "code_sandbox" });
+    expect(
+      screen.getByText(
+        "Execution is capped at approximately 2 GB of memory and 64 concurrent processes. Binary packages only.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Execution is capped at approximately 2 GB of memory and 64 concurrent processes."),
+    ).toBeNull();
+  });
+
+  it("renders no resource-limits paragraph when no ExecutionLimitsProvider is present (existing standalone renderPanel helper)", () => {
+    // Every other test in this file uses the plain renderPanel() helper with
+    // no Provider ancestor at all - confirms that degrades gracefully to
+    // "no addendum shown", not a crash or a blank/misleading paragraph.
+    renderPanel({ kind: "pycoder" });
+    expect(screen.queryByText(/Execution is capped/)).toBeNull();
+  });
+
+  it("renders no resource-limits paragraph when the topic's snapshot has blank text", () => {
+    renderPanelWithExecutionLimits(
+      { kind: "pycoder" },
+      {
+        schemaVersion: 1,
+        minCompatibleSchemaVersion: 1,
+        revision: 1,
+        pycoderResourceLimitsText: "",
+        codeSandboxResourceLimitsText: "",
+      },
+    );
+    expect(screen.queryByText(/Execution is capped/)).toBeNull();
+  });
+
+  it("REVIEW-FIX: the resource-limits paragraph carries the muted informational class, not the warning's alarm class", () => {
+    // Adversarial review found that no test scoped an assertion to either
+    // paragraph's actual className, so a mutation swapping
+    // code-exec-approval-warning <-> code-exec-approval-resource-limits
+    // (e.g. from a future refactor consolidating the two, or copy-pasting
+    // WARNING_TEXT's own paragraph as a template) would pass every
+    // text-content-only test in this file undetected - see styles.css's
+    // own comment on why these two colors are deliberately different
+    // (alarming vs. reassuring information).
+    // Queries document.body, not the RTL `container` return value: this
+    // panel renders via createPortal(..., document.body) (see the
+    // component's own module doc), so its DOM nodes live outside the
+    // container render() normally mounts into.
+    renderPanelWithExecutionLimits({ kind: "pycoder" });
+    const resourceLimitsP = document.body.querySelector(".code-exec-approval-resource-limits");
+    const warningP = document.body.querySelector(".code-exec-approval-warning");
+    expect(resourceLimitsP).not.toBeNull();
+    expect(warningP).not.toBeNull();
+    expect(resourceLimitsP).toHaveTextContent(/Execution is capped/);
+    expect(resourceLimitsP!.className).not.toContain("code-exec-approval-warning");
+    expect(warningP!.className).not.toContain("code-exec-approval-resource-limits");
+    expect(warningP).toHaveTextContent(/there is no sandboxing/);
   });
 
   // -- FIX C regression guard: code_sandbox requirements/repair disclosure --

--- a/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
+++ b/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useFocusEscapeBackstop } from "../overlays/overlays";
+import { useExecutionLimits } from "./ExecutionLimitsContext";
 import { NodeMarkdown } from "./NodeMarkdown";
 
 /**
@@ -110,6 +111,23 @@ import { NodeMarkdown } from "./NodeMarkdown";
  * straight through, since that field already reflects the exact manifest
  * run_code_sandbox reads synchronously at the moment Run is dispatched (no
  * new backend wiring was needed for this).
+ *
+ * Resource-limits disclosure (ADR-005 stage 5.4): WARNING_TEXT below states
+ * "there is no sandboxing" / "isolates installed packages, not the
+ * operating system" - both still true, and left untouched (do not fold the
+ * new sentence into that Record; the two are backed by different
+ * mechanisms and the legacy phrase's own regression test in
+ * CodeExecutionApprovalPanel.test.tsx checks that string in isolation).
+ * What WARNING_TEXT does NOT say is that ADR-005 stages 5.2/5.3 actually
+ * added real resource caps, and stage 5.5 restricted dependency installs -
+ * a second paragraph below renders that, sourced from useExecutionLimits()
+ * (ExecutionLimitsContext.tsx), never hardcoded here: the caps are
+ * platform-conditional (see backend/execution_limits.py's own docstring),
+ * so a string baked into this file would silently lie the moment the
+ * platform this ships on differs from the one it was written against.
+ * Rendered only when non-blank (mirrors showRequirements below) - a
+ * missing Provider (e.g. this component's own standalone tests) degrades
+ * to simply omitting the paragraph, not a blank/incorrect claim.
  */
 
 export type CodeExecutionKind = "pycoder" | "code_sandbox";
@@ -205,6 +223,7 @@ export function CodeExecutionApprovalPanel({
 }: CodeExecutionApprovalPanelProps) {
   const panelRef = useRef<HTMLDivElement | null>(null);
   const denyButtonRef = useRef<HTMLButtonElement | null>(null);
+  const executionLimits = useExecutionLimits();
 
   // Focus the Deny button the instant the panel appears - the safe default a
   // stray Enter/Space keypress lands on. There is no dismiss path here (see
@@ -262,6 +281,10 @@ export function CodeExecutionApprovalPanel({
   if (!awaitingApproval) return null;
 
   const showRequirements = kind === "code_sandbox" && !!requirements?.trim();
+  const resourceLimitsText =
+    kind === "code_sandbox"
+      ? executionLimits.codeSandboxResourceLimitsText
+      : executionLimits.pycoderResourceLimitsText;
 
   return (
     // Deliberately NO onClick/onPointerDown handler on this scrim - clicking
@@ -286,6 +309,9 @@ export function CodeExecutionApprovalPanel({
         </header>
         <div className="overlay-dialog-body">
           <p className="code-exec-approval-warning">{WARNING_TEXT[kind]}</p>
+          {!!resourceLimitsText && (
+            <p className="code-exec-approval-resource-limits">{resourceLimitsText}</p>
+          )}
           {showRequirements && (
             <div className="code-exec-approval-requirements">
               <span className="code-exec-approval-requirements-label">Packages to be installed</span>

--- a/web_ui/src/app/canvas/ExecutionLimitsContext.test.tsx
+++ b/web_ui/src/app/canvas/ExecutionLimitsContext.test.tsx
@@ -1,0 +1,109 @@
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { WsTransport } from "../../lib/ws/transport";
+import { ExecutionLimitsProvider, useExecutionLimits } from "./ExecutionLimitsContext";
+
+type StateListener = (payload: Record<string, unknown>) => void;
+
+function makeFakeTransport() {
+  const listeners = new Map<string, StateListener>();
+  const transport = {
+    subscribe: vi.fn((topic: string, listener: StateListener) => {
+      listeners.set(topic, listener);
+      return () => listeners.delete(topic);
+    }),
+  } as unknown as WsTransport;
+  return { transport, listeners };
+}
+
+function validPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1,
+    minCompatibleSchemaVersion: 1,
+    revision: 1,
+    pycoderResourceLimitsText: "Execution is capped at approximately 2 GB of memory.",
+    codeSandboxResourceLimitsText: "Execution is capped at approximately 2 GB of memory. Binary only.",
+    ...overrides,
+  };
+}
+
+function Consumer() {
+  const state = useExecutionLimits();
+  return (
+    <>
+      <span data-testid="pycoder">{state.pycoderResourceLimitsText}</span>
+      <span data-testid="code-sandbox">{state.codeSandboxResourceLimitsText}</span>
+    </>
+  );
+}
+
+describe("ExecutionLimitsProvider / useExecutionLimits", () => {
+  it("subscribes to the execution-limits topic on mount", () => {
+    const { transport, listeners } = makeFakeTransport();
+    render(
+      <ExecutionLimitsProvider transport={transport}>
+        <Consumer />
+      </ExecutionLimitsProvider>,
+    );
+    expect(transport.subscribe).toHaveBeenCalledWith("execution-limits", expect.any(Function));
+    expect(listeners.has("execution-limits")).toBe(true);
+  });
+
+  it("starts with blank text before any snapshot arrives", () => {
+    const { transport } = makeFakeTransport();
+    render(
+      <ExecutionLimitsProvider transport={transport}>
+        <Consumer />
+      </ExecutionLimitsProvider>,
+    );
+    expect(screen.getByTestId("pycoder")).toHaveTextContent("");
+    expect(screen.getByTestId("code-sandbox")).toHaveTextContent("");
+  });
+
+  it("exposes a valid snapshot's fields to consumers", () => {
+    const { transport, listeners } = makeFakeTransport();
+    render(
+      <ExecutionLimitsProvider transport={transport}>
+        <Consumer />
+      </ExecutionLimitsProvider>,
+    );
+    act(() => listeners.get("execution-limits")!(validPayload()));
+    expect(screen.getByTestId("pycoder")).toHaveTextContent(
+      "Execution is capped at approximately 2 GB of memory.",
+    );
+    expect(screen.getByTestId("code-sandbox")).toHaveTextContent(
+      "Execution is capped at approximately 2 GB of memory. Binary only.",
+    );
+  });
+
+  it("rejects a malformed snapshot and keeps the previous state, logging an error", () => {
+    const { transport, listeners } = makeFakeTransport();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <ExecutionLimitsProvider transport={transport}>
+        <Consumer />
+      </ExecutionLimitsProvider>,
+    );
+    act(() => listeners.get("execution-limits")!(validPayload()));
+    // Missing the required pycoderResourceLimitsText field entirely.
+    const { pycoderResourceLimitsText: _omit, ...malformed } = validPayload();
+    act(() => listeners.get("execution-limits")!(malformed));
+
+    expect(screen.getByTestId("pycoder")).toHaveTextContent(
+      "Execution is capped at approximately 2 GB of memory.",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[execution-limits] rejected snapshot:",
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("useExecutionLimits outside any Provider falls back to blank text rather than throwing", () => {
+    // No ExecutionLimitsProvider ancestor at all - mirrors
+    // CodeExecutionApprovalPanel.test.tsx's own standalone render style.
+    render(<Consumer />);
+    expect(screen.getByTestId("pycoder")).toHaveTextContent("");
+    expect(screen.getByTestId("code-sandbox")).toHaveTextContent("");
+  });
+});

--- a/web_ui/src/app/canvas/ExecutionLimitsContext.tsx
+++ b/web_ui/src/app/canvas/ExecutionLimitsContext.tsx
@@ -1,0 +1,63 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import type { WsTransport } from "../../lib/ws/transport";
+import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
+import type { ExecutionLimitsState } from "../../lib/bridge-core/generated/execution-limits-state";
+
+/**
+ * ADR-005 stage 5.4 (disclosure half): the real, backend-computed resource
+ * caps CodeExecutionApprovalPanel.tsx discloses before a human approves code
+ * execution - see backend/execution_limits.py's own docstring for why this
+ * must be backend-computed rather than a hardcoded frontend string.
+ *
+ * Threaded via Context rather than prop-drilling through
+ * PyCoderNodeView/CodeSandboxNodeView and @xyflow/react's own per-node
+ * `data` mapping (SceneCanvas.tsx's toFlowNodes): the caps are NOT per-node
+ * state (every pycoder/code_sandbox node shares the identical, session-wide
+ * limits), so carrying them on every node's own `data` object would
+ * duplicate the same static strings across however many nodes exist, for a
+ * value that is really global. Mirrors AboutDialog.tsx's own "no client
+ * store class needed for a single read-only, never-mutated topic" subscribe
+ * pattern exactly - just exposed via Context instead of being read directly
+ * inside one dialog component, since this value needs to reach a component
+ * nested deep inside the canvas tree instead.
+ */
+
+const initialState: ExecutionLimitsState = {
+  schemaVersion: 1,
+  minCompatibleSchemaVersion: 1,
+  revision: 0,
+  pycoderResourceLimitsText: "",
+  codeSandboxResourceLimitsText: "",
+};
+
+const ExecutionLimitsContext = createContext<ExecutionLimitsState>(initialState);
+
+export function ExecutionLimitsProvider({
+  transport,
+  children,
+}: {
+  transport: WsTransport;
+  children: ReactNode;
+}) {
+  const [state, setState] = useState<ExecutionLimitsState>(initialState);
+
+  useEffect(() => {
+    return transport.subscribe("execution-limits", (payload) => {
+      const validated = TOPIC_VALIDATORS["execution-limits"](payload);
+      if (validated.ok) setState(validated.value as ExecutionLimitsState);
+      else console.error("[execution-limits] rejected snapshot:", validated.errors);
+    });
+  }, [transport]);
+
+  return <ExecutionLimitsContext.Provider value={state}>{children}</ExecutionLimitsContext.Provider>;
+}
+
+/** Falls back to blank strings (initialState) when read outside a Provider -
+ * e.g. CodeExecutionApprovalPanel.test.tsx's existing standalone renders,
+ * which mount the panel with no ancestor tree at all. CodeExecutionApprovalPanel
+ * itself only renders the resource-limits paragraph when the text is
+ * non-blank (mirrors its own existing showRequirements pattern), so a
+ * missing Provider degrades to "no addendum shown" rather than an error. */
+export function useExecutionLimits(): ExecutionLimitsState {
+  return useContext(ExecutionLimitsContext);
+}

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -5196,6 +5196,16 @@ mark.document-view-search-match-current {
   color: var(--gl-semantic-status-error, currentColor);
 }
 
+/* ADR-005 stage 5.4: the backend-computed resource-cap addendum - muted
+   rather than the warning's own error color, since this is reassuring
+   ("here is what limits the blast radius"), not alarming, information. */
+.code-exec-approval-resource-limits {
+  margin: 0 0 10px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--gl-surface-text-muted);
+}
+
 /* R5.4 post-review FIX C: the pending pip-install manifest, shown for
    code_sandbox only, positioned BEFORE the code display so it is seen prior
    to clicking Approve (never buried below the fold). Reuses the same

--- a/web_ui/src/lib/api-contract/topics.ts
+++ b/web_ui/src/lib/api-contract/topics.ts
@@ -9,6 +9,7 @@ import { type AppComposerState, validateAppComposerState } from "../bridge-core/
 import { type AppPluginsState, validateAppPluginsState } from "../bridge-core/generated/app-plugins-state";
 import { type AppSettingsState, validateAppSettingsState } from "../bridge-core/generated/app-settings-state";
 import { type DragSpeedState, validateDragSpeedState } from "../bridge-core/generated/drag-speed-state";
+import { type ExecutionLimitsState, validateExecutionLimitsState } from "../bridge-core/generated/execution-limits-state";
 import { type FontControlState, validateFontControlState } from "../bridge-core/generated/font-control-state";
 import { type GridControlState, validateGridControlState } from "../bridge-core/generated/grid-control-state";
 import { type NotificationState, validateNotificationState } from "../bridge-core/generated/notification-state";
@@ -22,6 +23,7 @@ export const TOPIC_VALIDATORS = {
   "app-plugins": validateAppPluginsState,
   "app-settings": validateAppSettingsState,
   "drag-speed": validateDragSpeedState,
+  "execution-limits": validateExecutionLimitsState,
   "font-control": validateFontControlState,
   "grid-control": validateGridControlState,
   "notification": validateNotificationState,
@@ -38,6 +40,7 @@ export interface TopicStates {
   "app-plugins": AppPluginsState;
   "app-settings": AppSettingsState;
   "drag-speed": DragSpeedState;
+  "execution-limits": ExecutionLimitsState;
   "font-control": FontControlState;
   "grid-control": GridControlState;
   "notification": NotificationState;

--- a/web_ui/src/lib/bridge-core/generated/execution-limits-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/execution-limits-state.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "codeSandboxResourceLimitsText": {
+      "type": "string"
+    },
+    "minCompatibleSchemaVersion": {
+      "type": "integer"
+    },
+    "pycoderResourceLimitsText": {
+      "type": "string"
+    },
+    "revision": {
+      "type": "integer"
+    },
+    "schemaVersion": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "revision",
+    "pycoderResourceLimitsText",
+    "codeSandboxResourceLimitsText"
+  ],
+  "title": "ExecutionLimitsState",
+  "type": "object"
+}

--- a/web_ui/src/lib/bridge-core/generated/execution-limits-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/execution-limits-state.ts
@@ -1,0 +1,62 @@
+/* GENERATED - do not hand-edit. Source of truth: contracts/graphlink_execution_limits_payload.py::ExecutionLimitsStatePayload.
+ * Regenerate with codegen.py; a pytest fails if this file
+ * drifts from what regenerating it now would produce. */
+
+export interface ExecutionLimitsState {
+  schemaVersion: number;
+  revision: number;
+  pycoderResourceLimitsText: string;
+  codeSandboxResourceLimitsText: string;
+  minCompatibleSchemaVersion?: number | null;
+}
+
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; errors: string[] };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Unknown keys are tolerated on purpose. The JSON Schema marks the contract
+// additionalProperties:false because Python and the schema must not drift, but
+// an incoming payload carrying a field this build has never heard of is the
+// normal, expected shape of a NEWER compatible sender - rejecting it here would
+// defeat the additive-forward-compatibility the version negotiation exists to
+// provide. Missing or wrongly-typed KNOWN fields are still hard errors.
+
+function checkExecutionLimitsState(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["schemaVersion"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.schemaVersion: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.schemaVersion` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["revision"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.revision: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.revision` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["pycoderResourceLimitsText"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.pycoderResourceLimitsText: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.pycoderResourceLimitsText` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["codeSandboxResourceLimitsText"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxResourceLimitsText: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.codeSandboxResourceLimitsText` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["minCompatibleSchemaVersion"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.minCompatibleSchemaVersion` + ": expected number"); }
+  }
+}
+
+export function validateExecutionLimitsState(value: unknown): ValidationResult<ExecutionLimitsState> {
+  const errors: string[] = [];
+  checkExecutionLimitsState(value, "$", errors);
+  return errors.length === 0
+    ? { ok: true, value: value as ExecutionLimitsState }
+    : { ok: false, errors };
+}


### PR DESCRIPTION
## Problem

The mandatory human-approval dialog before AI-generated/executed Python code runs (`CodeExecutionApprovalPanel.tsx`) said "there is no sandboxing" / "isolates installed packages, not the operating system" — true, but silent about the real memory/CPU/process caps ADR-005 stages 5.2/5.3 already enforce, and stage 5.5's dependency-install restriction.

## Change

- New `execution-limits` WS topic (`backend/execution_limits.py`, mirrors `backend/about.py`'s "zero live state, one payload function" shape) computes platform-correct disclosure text from `graphlink_execution_guard.py`'s own constants.
- Frontend renders it via a new React Context (`ExecutionLimitsContext.tsx`) rather than prop-drilling through `PyCoderNodeView`/`CodeSandboxNodeView` and `@xyflow/react`'s per-node `data` — the caps are session-wide, not per-node.
- The pre-existing (and still directly regression-tested) warning sentences are untouched; this adds a second paragraph.
- New contract `contracts/graphlink_execution_limits_payload.py`, generated via the existing `codegen.py` pipeline like every other SPA topic.

**Bug found and fixed while wiring this**: `DEFAULT_CPU_SECONDS`/`DEFAULT_FILE_SIZE_LIMIT_BYTES` were defined inside `graphlink_execution_guard.py`'s own `if sys.platform == "win32": ... else:` split, so they never existed as module attributes on a real Windows import (every real deployment, the only CI runner). The new disclosure module's own test caught this immediately. Fixed by moving both to unconditional module scope — same values, only where they're defined changed.

## Adversarial review

A 4-lens, 10-agent review found 6 confirmed issues, all fixed or explicitly accepted as documented residual risk:

- **HIGH** — the Windows sentence claimed caps unconditionally, but the underlying guard has several silent fail-open paths (Job Object creation/assignment failing, e.g. under EDR policy) that leave a run completely uncapped with nothing surfaced beyond a log line. Fixed by adding an honest trailing caveat rather than a live probe (which can't fully cover `assign()`'s own failure modes anyway, since those only exist once a real process is being attached).
- **HIGH** — the POSIX sentence said "N concurrent processes", but `RLIMIT_NPROC` actually bounds the real UID's total live process count *system-wide*, not this execution's own process tree. Reworded to describe the real scope accurately.
- **MEDIUM** — identical "of memory" wording on both platforms implied parity between Windows's committed-memory limit and POSIX's virtual-address-space limit (which can trip much earlier on reservation-heavy workloads). POSIX now says "of reserved memory".
- **MEDIUM** — no test scoped an assertion to either paragraph's actual CSS class, so a mutation swapping the alarm-red warning style and the muted informational style would pass every text-only test undetected. Closed with a class-scoped test, mutation-verified.
- **LOW ×2** — accepted as documented, low-severity residual risk (no `App.tsx`-level test exists anywhere in this codebase for any wiring, not unique to this diff; the constant-relocation refactor's regression guard lives in a different test file than the constants' own module).

## Test plan

- [x] Full local backend suite: 1541 passed, 14 skipped (up from 1526 baseline)
- [x] Full local frontend suite: 1148 passed (41 new) + `npm run check` (schema/typecheck/lint/build) clean
- [x] Mutation-verified the new CSS-class test by actually swapping the classes and confirming it's the only test that catches it
- [x] Browser-verified against the real running app (real WS connection, real node creation) — zero console errors, confirming the real backend payload validates against the real frontend schema over the wire. The literal rendered pixels of the approval panel were not screenshotted (no LLM provider configured in this environment to trigger a real run), so that layer relies on the Vitest coverage's real React rendering.