### PR TITLE
ADR-005 stage 5.5: source-build escalation checkbox

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -551,12 +551,27 @@ class AgentDispatcher:
         a duplicate/stale approve-or-deny message (e.g. a double-click, or a
         message that arrives after cancel_pycoder/cancel_code_sandbox/
         cancel_all_pending_approvals already resolved this same future)
-        would otherwise raise asyncio.InvalidStateError."""
+        would otherwise raise asyncio.InvalidStateError.
+
+        ADR-005 stage 5.5 review-fix: when `handle.approval_snapshot_fn` is
+        set (code_sandbox only - see RunHandle's own doc), snapshot it into
+        `handle.approval_snapshot` HERE, in this same uninterruptible
+        synchronous stretch as `future.set_result()`, never after. This
+        method has no `await` anywhere in its own call chain, so nothing else
+        can run between the read and the resolve - closing a real race an
+        adversarial review found: `future.set_result()` only SCHEDULES the
+        awaiting `_run()` task's resumption rather than running it inline, so
+        a second WS connection's setCodeSandboxAllowSourceBuilds could
+        otherwise land in that gap and silently change what an already-
+        decided approval installs. Only snapshotted on an actual approval -
+        a denied run never consumes it, so there is nothing to protect."""
         handle = self._runs.get(request_id)
         if handle is None or handle.approval_future is None:
             return False
         future = handle.approval_future
         if not future.done():
+            if approved and handle.approval_snapshot_fn is not None:
+                handle.approval_snapshot = handle.approval_snapshot_fn()
             future.set_result(approved)
         return True
 
@@ -2215,8 +2230,16 @@ class AgentDispatcher:
 
         cancel_event = threading.Event()
         approval_future: asyncio.Future = asyncio.get_running_loop().create_future()
+        # ADR-005 stage 5.5 review-fix: see RunHandle.approval_snapshot_fn's
+        # own doc for the race this closes - _resolve_approval calls this
+        # synchronously, atomically with future.set_result(), instead of
+        # this coroutine re-reading node.state after resuming.
         handle = self._runs.claim(
-            "code_sandbox", node_id=node_id, cancel_event=cancel_event, approval_future=approval_future
+            "code_sandbox",
+            node_id=node_id,
+            cancel_event=cancel_event,
+            approval_future=approval_future,
+            approval_snapshot_fn=lambda: node.state.code_sandbox_approval_allow_source_builds,
         )
         request_id = handle.request_id
         node.pending_request_id = request_id
@@ -2286,6 +2309,18 @@ class AgentDispatcher:
                 # -- human-approval gate --------------------------------------
                 node.state.code_sandbox_code = current_code
                 node.state.code_sandbox_awaiting_approval = True
+                # ADR-005 stage 5.5: reset the source-build opt-in to its
+                # safe default every time a gate opens - a stale True from a
+                # previous run's approval must never silently carry forward
+                # into one the user has not actually reviewed. See
+                # CodeSandboxState.code_sandbox_approval_allow_source_builds's
+                # own comment.
+                node.state.code_sandbox_approval_allow_source_builds = False
+                # ADR-005 stage 5.5 review-fix: this is the INITIAL gate, not
+                # a repair re-gate - see the repair re-gate's own identical
+                # write, further down this function, for what this flag is
+                # for.
+                node.state.code_sandbox_approval_is_repair = False
                 # R5.4 CODESANDBOX FIX (closing the requirements-disclosure
                 # staleness race): freeze the DISCLOSED manifest into its own
                 # snapshot field at the exact same moment the approval gate
@@ -2309,6 +2344,22 @@ class AgentDispatcher:
                 )
                 await bus.publish("scene")
                 approved = await approval_future
+                # ADR-005 stage 5.5 review-fix: read the ALREADY-SNAPSHOTTED
+                # value off the handle, never node.state here. An earlier
+                # version of this line re-read node.state.code_sandbox_
+                # approval_allow_source_builds right after the await, which
+                # looked safe (no await in between) but wasn't: this
+                # coroutine only resumes once the event loop gets around to
+                # it after _resolve_approval's future.set_result() call
+                # (backend/agents.py) merely SCHEDULES that resumption - a
+                # second WS connection's setCodeSandboxAllowSourceBuilds
+                # could fully land in that scheduling gap. handle.
+                # approval_snapshot was instead captured by _resolve_approval
+                # itself, atomically with future.set_result(), in a
+                # synchronous stretch nothing else can interleave with - see
+                # RunHandle.approval_snapshot_fn's own doc (backend/
+                # run_lifecycle.py) for the full race this closes.
+                allow_source_builds = bool(handle.approval_snapshot)
                 node.state.code_sandbox_awaiting_approval = False
                 # Cleared here too, immediately once the approval resolves -
                 # mirrors code_sandbox_awaiting_approval's own clear on this
@@ -2316,6 +2367,7 @@ class AgentDispatcher:
                 # fail_code_sandbox_run clear it again downstream, redundant
                 # but harmless, for every other path that lands there).
                 node.state.code_sandbox_approval_requirements = ""
+                node.state.code_sandbox_approval_allow_source_builds = False
 
                 if not approved:
                     on_failure("Sandbox run cancelled: execution was not approved.")
@@ -2328,7 +2380,11 @@ class AgentDispatcher:
                         sandbox.ensure_base_environment, _should_continue, _thread_emit_line
                     )
                     await asyncio.to_thread(
-                        sandbox.sync_requirements, manifest, _should_continue, _thread_emit_line
+                        sandbox.sync_requirements,
+                        manifest,
+                        _should_continue,
+                        _thread_emit_line,
+                        allow_source_builds,
                     )
                 except InterruptedError:
                     notifications_state.show("Sandbox execution cancelled.", "info")
@@ -2388,6 +2444,34 @@ class AgentDispatcher:
                         node.state.code_sandbox_approved_fingerprint = _fingerprint_changes(
                             {"code": current_code, "manifest": manifest}
                         )
+                        # ADR-005 stage 5.5 review-fix: an earlier version of
+                        # this re-gate left code_sandbox_approval_allow_
+                        # source_builds untouched here, reasoning it was
+                        # "still False from the initial gate's own clear
+                        # above" - that assumption was never actually
+                        # enforced: setCodeSandboxAllowSourceBuilds is
+                        # ungated and could set it True during the execute/
+                        # repair window (nothing here was awaiting_approval,
+                        # so nothing rejected the intent), leaving the repair
+                        # panel's checkbox rendered CHECKED without the user
+                        # having touched it this round - a real, adversarial-
+                        # review-confirmed contradiction of this field's own
+                        # documented "reset on every gate-open" invariant.
+                        # Reset explicitly here, matching the initial gate's
+                        # own reset, even though sync_requirements is never
+                        # called again on a repair round (so this has no
+                        # install-level effect) - the value must still be
+                        # honest about being reset, not just impotent.
+                        node.state.code_sandbox_approval_allow_source_builds = False
+                        # ADR-005 stage 5.5 review-fix: distinguishes "this
+                        # panel's checkbox reflects a decision that can still
+                        # affect an install" (initial gate) from "the install
+                        # already happened, checking this now does nothing"
+                        # (any repair gate) - CodeExecutionApprovalPanel.tsx
+                        # uses this to hide the otherwise-genuinely-inert
+                        # checkbox on repair rounds rather than let a user
+                        # take an action that silently has no effect.
+                        node.state.code_sandbox_approval_is_repair = True
                         node.state.code_sandbox_awaiting_approval = True
                         await bus.publish("scene")
                         repair_approved = await repair_future

--- a/backend/api/intents_code_sandbox.py
+++ b/backend/api/intents_code_sandbox.py
@@ -31,6 +31,10 @@ def register_code_sandbox_intents(
         document.set_code_sandbox_requirements(node_id, requirements_text)
         await publish_scene()
 
+    async def set_code_sandbox_allow_source_builds(node_id, allow):
+        document.set_code_sandbox_allow_source_builds(node_id, allow)
+        await publish_scene()
+
     async def run_code_sandbox(node_id, input_text):
         # Same busy-claim-placeholder pattern as run_pycoder (backend/api/
         # intents_pycoder.py, and run_gitlink_change_set before it,
@@ -76,5 +80,8 @@ def register_code_sandbox_intents(
         agent_dispatcher.cancel_code_sandbox(request_id)
 
     bus.register_intent("scene", "setCodeSandboxRequirements", set_code_sandbox_requirements)
+    bus.register_intent(
+        "scene", "setCodeSandboxAllowSourceBuilds", set_code_sandbox_allow_source_builds
+    )
     bus.register_intent("scene", "runCodeSandbox", run_code_sandbox)
     bus.register_intent("scene", "cancelCodeSandboxRequest", cancel_code_sandbox_request)

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -1197,6 +1197,23 @@ class SceneDocument(BranchOps, GroupOps):
         node.state.code_sandbox_requirements = str(requirements_text)
         return node
 
+    def set_code_sandbox_allow_source_builds(self, node_id: str, allow: bool) -> SceneNode:
+        """ADR-005 stage 5.5: the approval panel's own source-build opt-in
+        checkbox, fired on every toggle (same "ungated, fires immediately"
+        posture as set_code_sandbox_requirements above). Setting this outside
+        an open approval gate is harmless, not just permitted - agents.py
+        resets the field to False at the top of every gate-open, so a value
+        set here while no gate is open never reaches an actual run; the
+        approval panel is the only surface that ever renders this control,
+        and it only renders while awaiting_approval is true."""
+        node = self.nodes.get(node_id)
+        if node is None:
+            raise SceneError(f"unknown node: {node_id}")
+        if node.kind != "code_sandbox":
+            raise SceneError(f"node is not a code_sandbox node: {node_id}")
+        node.state.code_sandbox_approval_allow_source_builds = bool(allow)
+        return node
+
     def start_code_sandbox_run(self, node_id: str, input_text: str) -> SceneNode:
         """Begin one Run: stores input_text into code_sandbox_prompt (there is
         no mode-dependent field split here, unlike Py-Coder - see this
@@ -1234,6 +1251,8 @@ class SceneDocument(BranchOps, GroupOps):
         node.state.code_sandbox_awaiting_approval = False
         node.state.code_sandbox_approval_requirements = ""
         node.state.code_sandbox_approved_fingerprint = None
+        node.state.code_sandbox_approval_allow_source_builds = False
+        node.state.code_sandbox_approval_is_repair = False
         node.state.code_sandbox_error = ""
         return node
 
@@ -1248,6 +1267,8 @@ class SceneDocument(BranchOps, GroupOps):
         node.state.code_sandbox_awaiting_approval = False
         node.state.code_sandbox_approval_requirements = ""
         node.state.code_sandbox_approved_fingerprint = None
+        node.state.code_sandbox_approval_allow_source_builds = False
+        node.state.code_sandbox_approval_is_repair = False
         node.state.code_sandbox_error = str(message)
         return node
 
@@ -1859,6 +1880,22 @@ class SceneDocument(BranchOps, GroupOps):
                     # see CodeSandboxState's own comment.
                     "codeSandboxApprovalRequirements": (
                         n.state.code_sandbox_approval_requirements if isinstance(n.state, CodeSandboxState) else ""
+                    ),
+                    # ADR-005 stage 5.5: the user's live source-build opt-in
+                    # for the CURRENT pending approval - see CodeSandboxState.
+                    # code_sandbox_approval_allow_source_builds's own comment.
+                    "codeSandboxApprovalAllowSourceBuilds": (
+                        n.state.code_sandbox_approval_allow_source_builds
+                        if isinstance(n.state, CodeSandboxState)
+                        else False
+                    ),
+                    # ADR-005 stage 5.5 review-fix: True only during a
+                    # repair-loop re-gate - see CodeSandboxState.
+                    # code_sandbox_approval_is_repair's own comment.
+                    "codeSandboxApprovalIsRepair": (
+                        n.state.code_sandbox_approval_is_repair
+                        if isinstance(n.state, CodeSandboxState)
+                        else False
                     ),
                     "codeSandboxError": n.state.code_sandbox_error if isinstance(n.state, CodeSandboxState) else "",
                     # R6.1: Notes/Frames/Containers. groupManualWidth/Height

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -547,6 +547,51 @@ class CodeSandboxState(NodeState):
       code_sandbox_code, "manifest": code_sandbox_approval_requirements}
       instead - see that field's own reasoning above. Internal
       bookkeeping only, EXCLUDED from scene_payload().
+    - code_sandbox_approval_allow_source_builds: ADR-005 stage 5.5's
+      "source-build escalation" - the user's live opt-in, made WHILE this
+      specific approval is pending, to let this one run's dependency
+      install build a source-only package instead of the
+      --only-binary :all: default (VirtualEnvSandbox.sync_requirements,
+      graphlink_plugins/code_sandbox/domain.py). Deliberately NOT part of
+      code_sandbox_approved_fingerprint above: that fingerprint pins
+      CONTENT identity (the code/manifest actually being approved must
+      not silently change before it runs); this field is a permission
+      granted alongside approving that content, decided by the user
+      during the same approval window rather than frozen at gate-open.
+      Reset to False every time a gate opens (both the initial gate AND
+      each repair-loop re-gate in AgentDispatcher.start_code_sandbox_run,
+      backend/agents.py - a review-fix: an earlier version of this stage
+      only reset it at the initial gate, leaving a stale True able to
+      render a repair round's checkbox as checked despite no user action
+      that round) so a source-build opt-in never silently carries over to
+      code the user has not yet seen.
+
+      ADR-005 stage 5.5 review-fix (real race found by a 4-lens
+      adversarial review): AgentDispatcher does NOT read this field again
+      after the approval future resolves. `future.set_result()`
+      (AgentDispatcher._resolve_approval) only SCHEDULES the waiting
+      coroutine's resumption rather than running it inline, so a second
+      WS connection's setCodeSandboxAllowSourceBuilds could land in that
+      scheduling gap and change what an already-decided approval installs.
+      Instead, _resolve_approval snapshots this field into
+      RunHandle.approval_snapshot (backend/run_lifecycle.py) SYNCHRONOUSLY,
+      in the same uninterruptible stretch as future.set_result() itself -
+      see that field's own doc for the full mechanism - and
+      start_code_sandbox_run reads the handle's snapshot, never this field
+      directly, once approval resolves.
+
+      Cleared back to False alongside code_sandbox_approval_requirements
+      at every point that field is cleared.
+    - code_sandbox_approval_is_repair: ADR-005 stage 5.5 review-fix -
+      distinguishes the INITIAL approval gate (False) from any repair-loop
+      re-gate (True). VirtualEnvSandbox.sync_requirements is only ever
+      called once per run, before the repair loop starts, so the source-
+      build checkbox has no dependency install left to affect on any
+      repair round - CodeExecutionApprovalPanel.tsx uses this field to
+      hide that otherwise-genuinely-inert control on repair rounds, rather
+      than let a user take an action that silently does nothing. Reset at
+      every gate-open (False at the initial gate, True at each repair
+      re-gate) alongside the other gate-open fields.
     - code_sandbox_error: the current run's error banner text, cleared
       on the next attempt."""
 
@@ -559,6 +604,8 @@ class CodeSandboxState(NodeState):
     code_sandbox_awaiting_approval: bool = False
     code_sandbox_approval_requirements: str = ""
     code_sandbox_approved_fingerprint: str | None = None
+    code_sandbox_approval_allow_source_builds: bool = False
+    code_sandbox_approval_is_repair: bool = False
     code_sandbox_error: str = ""
 
 

--- a/backend/execution_limits.py
+++ b/backend/execution_limits.py
@@ -29,10 +29,20 @@ import graphlink_execution_guard as guard
 from backend.events import SessionBus
 
 _DEPENDENCY_INSTALL_NOTE = (
-    " Package installs are restricted to pre-built binary distributions - a "
-    "package that only ships source code will fail to install rather than "
-    "run its own build code during setup."
+    " Package installs are restricted to pre-built binary distributions by "
+    "default - a package that only ships source code will fail to install "
+    "rather than run its own build code during setup, unless you "
+    "explicitly allow that for a specific run in the approval dialog."
 )
+# ADR-005 stage 5.5 review-fix: the sentence above used to be unconditional
+# ("restricted to pre-built binary distributions", full stop) - an
+# adversarial review caught that this stage's own source-build escalation
+# checkbox (CodeExecutionApprovalPanel.tsx) renders in the SAME dialog,
+# directly beneath this text, and lets a user do the exact thing this
+# sentence claimed could not happen. The "by default"/"unless you
+# explicitly allow" wording closes that in-dialog contradiction without
+# weakening the substance of the disclosure - the default behavior is
+# still accurately described as restrictive.
 
 
 def _format_bytes(n: int) -> str:

--- a/backend/run_lifecycle.py
+++ b/backend/run_lifecycle.py
@@ -115,7 +115,33 @@ class RunHandle:
     pre-migration cancel_all_pending_approvals). Mutated in place after
     claim() on both kinds (a fresh Future replaces the old one on every
     repair-loop iteration) - callers must always read
-    handle.approval_future fresh, never cache a reference to it."""
+    handle.approval_future fresh, never cache a reference to it.
+
+    `approval_snapshot_fn`/`approval_snapshot` (ADR-005 stage 5.5): closes a
+    real race a 4-lens adversarial review found in the source-build
+    escalation checkbox. That checkbox's value lives in mutable node state
+    (CodeSandboxState.code_sandbox_approval_allow_source_builds), set by its
+    OWN ungated WS intent (setCodeSandboxAllowSourceBuilds) - unlike the
+    code/manifest being approved, which start_code_sandbox_run freezes into
+    a local variable BEFORE `await approval_future` even begins, this value
+    is only known once the user's own Approve click is decided, so it can't
+    be pre-frozen the same way. Naively re-reading node.state AFTER
+    `await approval_future` resolves is NOT safe: `future.set_result()` runs
+    on the resolving connection's own WS-message-handling coroutine and only
+    SCHEDULES (via call_soon) the awaiting `_run()` task's resumption - it
+    does not resume it inline - so a second WS connection on the same
+    session can dispatch setCodeSandboxAllowSourceBuilds and have it fully
+    processed by the event loop in that scheduling gap, silently changing
+    what an already-decided approval installs. `_resolve_approval` (backend/
+    agents.py) has no `await` anywhere in its own call chain, so it - and
+    only it - can read the live checkbox value and call
+    `approval_snapshot_fn()` into `approval_snapshot` in the SAME
+    uninterruptible synchronous stretch as `future.set_result()`: no other
+    coroutine can observe or mutate anything in between. `start_code_sandbox_
+    run` passes `approval_snapshot_fn` at claim() time; callers that resolve
+    an approval read `handle.approval_snapshot` afterward instead of
+    re-reading live state. `None` for every other kind (nothing else has a
+    live-mutable field that needs capturing exactly at approval time)."""
 
     kind: str
     request_id: str
@@ -123,6 +149,8 @@ class RunHandle:
     cancel_event: threading.Event | None = None
     on_cancel: Callable[[], None] | None = None
     approval_future: asyncio.Future | None = None
+    approval_snapshot_fn: Callable[[], Any] | None = None
+    approval_snapshot: Any = None
     task: asyncio.Task | None = None
 
 
@@ -144,6 +172,7 @@ class RunRegistry:
         cancel_event: threading.Event | None = None,
         on_cancel: Callable[[], None] | None = None,
         approval_future: asyncio.Future | None = None,
+        approval_snapshot_fn: Callable[[], Any] | None = None,
     ) -> RunHandle:
         """Synchronous by design - see this module's own docstring for
         why callers must call this in the same synchronous stretch as
@@ -155,6 +184,7 @@ class RunRegistry:
             cancel_event=cancel_event,
             on_cancel=on_cancel,
             approval_future=approval_future,
+            approval_snapshot_fn=approval_snapshot_fn,
         )
         self._handles[handle.request_id] = handle
         return handle

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -3833,6 +3833,7 @@ def _make_code_sandbox_node(**overrides):
         code_sandbox_awaiting_approval=False,
         code_sandbox_approval_requirements="",
         code_sandbox_approved_fingerprint=None,
+        code_sandbox_approval_allow_source_builds=False,
         code_sandbox_error="",
     )
     node_overrides = {"pending_request_id": None}
@@ -4670,7 +4671,7 @@ def test_code_sandbox_approved_full_success_flow_runs_venv_and_analyzes(monkeypa
         def ensure_base_environment(self, should_continue, emit_line=None):
             self.prep_calls.append("ensure_base_environment")
 
-        def sync_requirements(self, manifest, should_continue, emit_line=None):
+        def sync_requirements(self, manifest, should_continue, emit_line=None, allow_source_builds=False):
             self.prep_calls.append(("sync_requirements", manifest))
 
         def execute_code(self, code, should_continue, emit_line=None):
@@ -4705,6 +4706,457 @@ def test_code_sandbox_approved_full_success_flow_runs_venv_and_analyzes(monkeypa
     asyncio.run(run())
 
 
+def _make_recording_sandbox_class():
+    """ADR-005 stage 5.5: a _FakeSandbox twin that records exactly what
+    allow_source_builds value sync_requirements was called with, for the
+    source-build escalation tests below."""
+
+    class _RecordingSandbox:
+        def __init__(self, sandbox_id):
+            self.sandbox_id = sandbox_id
+            self.sync_requirements_calls = []
+            self.on_ensure_base_environment = None
+
+        def ensure_base_environment(self, should_continue, emit_line=None):
+            if self.on_ensure_base_environment is not None:
+                self.on_ensure_base_environment()
+
+        def sync_requirements(self, manifest, should_continue, emit_line=None, allow_source_builds=False):
+            self.sync_requirements_calls.append(allow_source_builds)
+
+        def execute_code(self, code, should_continue, emit_line=None):
+            return "ran", 0
+
+    return _RecordingSandbox
+
+
+def test_code_sandbox_source_builds_defaults_to_false_when_never_toggled(monkeypatch):
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint('ok')\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "ok",
+    )
+    sandbox_holder = {}
+    recording_class = _make_recording_sandbox_class()
+
+    def _make_sandbox(sandbox_id):
+        sandbox = recording_class(sandbox_id)
+        sandbox_holder["sandbox"] = sandbox
+        return sandbox
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _make_sandbox)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="print ok", existing_code="",
+            requirements_manifest="numpy", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
+        dispatcher.approve_code_execution(request_id)
+        await entry["task"]
+
+        assert sandbox_holder["sandbox"].sync_requirements_calls == [False]
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_source_builds_true_is_threaded_through_to_sync_requirements_when_approved(monkeypatch):
+    # ADR-005 stage 5.5: the checkbox is set WHILE the panel is open, i.e.
+    # any time before Approve is clicked - simulated here by setting the
+    # state field directly before calling approve_code_execution, exactly
+    # like a real setCodeSandboxAllowSourceBuilds intent arriving during
+    # that window would.
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint('ok')\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "ok",
+    )
+    sandbox_holder = {}
+    recording_class = _make_recording_sandbox_class()
+
+    def _make_sandbox(sandbox_id):
+        sandbox = recording_class(sandbox_id)
+        sandbox_holder["sandbox"] = sandbox
+        return sandbox
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _make_sandbox)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="print ok", existing_code="",
+            requirements_manifest="some-source-only-pkg", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
+        # Wait for the gate to actually be open before toggling - agents.py
+        # resets the field to False the instant the gate opens (see the
+        # reset test above), so setting it before that reset has run would
+        # just get clobbered, same as a real checkbox click before the
+        # panel has even rendered could never happen.
+        for _ in range(200):
+            if node.state.code_sandbox_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert node.state.code_sandbox_awaiting_approval is True
+        node.state.code_sandbox_approval_allow_source_builds = True
+        dispatcher.approve_code_execution(request_id)
+        await entry["task"]
+
+        assert sandbox_holder["sandbox"].sync_requirements_calls == [True]
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_source_builds_flag_is_reset_the_instant_a_new_gate_opens(monkeypatch):
+    # A stale True left over from some earlier interaction must never
+    # silently carry into a run the user has not actually reviewed yet.
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint('ok')\n[/TOOL]",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node(code_sandbox_approval_allow_source_builds=True)
+
+        # start_code_sandbox_run itself returns quickly (it creates and
+        # attaches _run() as a background task rather than awaiting it) -
+        # same pattern every other test in this module relies on.
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="print ok", existing_code="",
+            requirements_manifest="numpy", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
+        # Yield until the gate has actually opened (awaiting_approval flips
+        # True) before asserting the reset - the background task needs a
+        # tick to run past the generation-agent await.
+        for _ in range(200):
+            if node.state.code_sandbox_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert node.state.code_sandbox_awaiting_approval is True
+        assert node.state.code_sandbox_approval_allow_source_builds is False
+
+        dispatcher.deny_code_execution(request_id)
+        await entry["task"]
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_source_builds_checked_then_denied_does_not_leak_into_the_next_run(monkeypatch):
+    # ADR-005 stage 5.5 test-coverage-gap fix: the reset test above only
+    # proves the GATE-OPEN reset (agents.py's own unconditional reset at
+    # the top of every gate) - it never exercises the POST-APPROVAL-RESOLVE
+    # clear (the line right after `approved = await approval_future`,
+    # which runs whether approved is True or False) via a real check-then-
+    # deny sequence. A future refactor that moved that clear inside an
+    # `if approved:` branch would not be caught by the gate-open-reset test
+    # alone, since that reset happens to independently cover the same
+    # user-visible symptom on the NEXT run - this test exercises the
+    # actual deny path directly.
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint('ok')\n[/TOOL]",
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="print ok", existing_code="",
+            requirements_manifest="numpy", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
+        for _ in range(200):
+            if node.state.code_sandbox_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert node.state.code_sandbox_awaiting_approval is True
+
+        # User checks the box, then denies (changes their mind).
+        node.state.code_sandbox_approval_allow_source_builds = True
+        dispatcher.deny_code_execution(request_id)
+        await entry["task"]
+
+        assert node.state.code_sandbox_approval_allow_source_builds is False, (
+            "denying a checked approval must clear the field - a checked-"
+            "then-denied run must never leave a stale True for whatever "
+            "runs on this node next"
+        )
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_source_builds_toggle_after_approval_resolves_does_not_affect_the_in_flight_run(monkeypatch):
+    # ADR-005 stage 5.5 race-safety proof: agents.py captures allow_source_
+    # builds into a local variable the instant the approval future
+    # resolves, BEFORE the ensure_base_environment/sync_requirements awaits
+    # that follow - a setCodeSandboxAllowSourceBuilds intent arriving in
+    # that window (simulated here via ensure_base_environment's own hook,
+    # the one await between approval and the read this test targets) must
+    # not change what an already-decided run does.
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint('ok')\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "ok",
+    )
+    sandbox_holder = {}
+    recording_class = _make_recording_sandbox_class()
+    node_holder = {}
+
+    def _make_sandbox(sandbox_id):
+        sandbox = recording_class(sandbox_id)
+        sandbox.on_ensure_base_environment = (
+            lambda: setattr(node_holder["node"].state, "code_sandbox_approval_allow_source_builds", True)
+        )
+        sandbox_holder["sandbox"] = sandbox
+        return sandbox
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _make_sandbox)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+        node_holder["node"] = node
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="print ok", existing_code="",
+            requirements_manifest="numpy", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
+        # Approved with the checkbox still unchecked (default False).
+        dispatcher.approve_code_execution(request_id)
+        await entry["task"]
+
+        # The late toggle (fired from inside ensure_base_environment, after
+        # approval resolved) must NOT have reached sync_requirements.
+        assert sandbox_holder["sandbox"].sync_requirements_calls == [False]
+        # The state field itself did change (proving the toggle really
+        # fired) - what's under test is that the ALREADY-RUNNING call used
+        # the frozen local, not this now-True live value.
+        assert node.state.code_sandbox_approval_allow_source_builds is True
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_source_builds_snapshotted_atomically_at_approve_time_not_at_task_resume_time(monkeypatch):
+    # ADR-005 stage 5.5 review-fix: a 4-lens adversarial review found that
+    # capturing allow_source_builds AFTER `await approval_future` resolves
+    # (the previous version of this mechanism) is not actually race-free -
+    # future.set_result() only SCHEDULES the _run() task's resumption
+    # rather than running it inline, so a second WS connection could fully
+    # process a setCodeSandboxAllowSourceBuilds intent in that scheduling
+    # gap. The fix: _resolve_approval snapshots the field into
+    # RunHandle.approval_snapshot SYNCHRONOUSLY, in the same
+    # uninterruptible stretch as future.set_result() itself - see that
+    # field's own doc (backend/run_lifecycle.py).
+    #
+    # This test proves the fix precisely: it mutates the field back to a
+    # DIFFERENT value immediately after calling approve_code_execution,
+    # still on the same synchronous stretch of test code (no `await` in
+    # between) - i.e. strictly BEFORE the _run() task could possibly get a
+    # turn on the event loop to resume and read anything. If the
+    # implementation still re-read node.state after resuming (the old,
+    # race-prone behavior), it would see this post-approve mutation and
+    # install with the WRONG value; reading the snapshotted value instead
+    # proves the capture genuinely happened at approve-time.
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nprint('ok')\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "ok",
+    )
+    sandbox_holder = {}
+    recording_class = _make_recording_sandbox_class()
+
+    def _make_sandbox(sandbox_id):
+        sandbox = recording_class(sandbox_id)
+        sandbox_holder["sandbox"] = sandbox
+        return sandbox
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _make_sandbox)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="print ok", existing_code="",
+            requirements_manifest="some-source-only-pkg", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
+        for _ in range(200):
+            if node.state.code_sandbox_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert node.state.code_sandbox_awaiting_approval is True
+
+        # The checkbox is checked when Approve fires...
+        node.state.code_sandbox_approval_allow_source_builds = True
+        dispatcher.approve_code_execution(request_id)
+        # ...then immediately, synchronously, "unchecked" again - simulating
+        # a competing setCodeSandboxAllowSourceBuilds(False) landing in the
+        # scheduling gap before _run() has resumed. No `await` happens
+        # between the approve call and this line.
+        node.state.code_sandbox_approval_allow_source_builds = False
+
+        await entry["task"]
+
+        assert sandbox_holder["sandbox"].sync_requirements_calls == [True], (
+            "sync_requirements must install with the value snapshotted "
+            "AT APPROVE TIME (True), not whatever node.state held once the "
+            "_run() task actually got a turn to resume"
+        )
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_repair_gate_resets_allow_source_builds_and_marks_is_repair(monkeypatch):
+    # ADR-005 stage 5.5 review-fix: an earlier version of the repair-loop
+    # re-gate left code_sandbox_approval_allow_source_builds untouched,
+    # reasoning it was "still False from the initial gate's own clear" -
+    # that assumption was never enforced (setCodeSandboxAllowSourceBuilds
+    # is ungated and could set it True during the execute/repair window,
+    # which is never awaiting_approval), so a repair round's checkbox could
+    # render CHECKED without the user having touched it that round. The fix
+    # resets it explicitly on every repair re-gate too, and adds
+    # code_sandbox_approval_is_repair so the frontend can hide the
+    # (functionally inert on repair rounds) checkbox entirely.
+    #
+    # Uses a threading.Event-blocked repair-agent call (mirroring test_
+    # canvas.py's own _blocking_get_response race tests) rather than
+    # wall-clock polling for the intermediate state - every mocked agent
+    # call here resolves fast enough that a plain asyncio.sleep(0.005) poll
+    # loop cannot reliably land inside the narrow execute/repair window
+    # before the repair gate has already reopened, as this test's own
+    # first draft (proven by watching it race past the intermediate state
+    # in both directions) discovered empirically.
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nbroken\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderAnalysisAgent, "get_response",
+        lambda self, original_prompt, code, code_output: "explains the failure",
+    )
+
+    entered_repair = threading.Event()
+    release_repair = threading.Event()
+
+    def _blocking_repair(self, code, error, manifest, original_prompt=None):
+        entered_repair.set()
+        release_repair.wait(timeout=5)
+        return "still broken"
+
+    monkeypatch.setattr(agents_module.SandboxRepairAgent, "get_response", _blocking_repair)
+
+    node_holder = {}
+
+    class _FailingSandbox:
+        def __init__(self, sandbox_id):
+            self.sandbox_id = sandbox_id
+
+        def ensure_base_environment(self, should_continue, emit_line=None):
+            pass
+
+        def sync_requirements(self, manifest, should_continue, emit_line=None, allow_source_builds=False):
+            # sync_requirements only ever runs ONCE, before the repair loop
+            # starts - simulates a setCodeSandboxAllowSourceBuilds(True)
+            # intent landing during the execute/repair window, which is
+            # never awaiting_approval so nothing rejects it (ungated,
+            # matching the sibling setCodeSandboxRequirements intent's own
+            # posture).
+            node_holder["node"].state.code_sandbox_approval_allow_source_builds = True
+
+        def execute_code(self, code, should_continue, emit_line=None):
+            return "Traceback (most recent call last):\nboom", 1
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _FailingSandbox)
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_code_sandbox_node()
+        node_holder["node"] = node
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="do something impossible", existing_code="",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
+
+        # Initial gate: verify is_repair is False, then approve.
+        for _ in range(200):
+            if node.state.code_sandbox_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert node.state.code_sandbox_awaiting_approval is True
+        assert node.state.code_sandbox_approval_is_repair is False
+        dispatcher.approve_code_execution(request_id)
+
+        # Wait until the repair agent is genuinely blocked mid-call - proves
+        # sync_requirements already ran (the stray True landed) and
+        # execute_code already failed, but the repair gate has not yet
+        # reopened.
+        for _ in range(200):
+            if entered_repair.is_set():
+                break
+            await asyncio.sleep(0.005)
+        assert entered_repair.is_set(), "the repair agent call never actually started"
+        assert node.state.code_sandbox_approval_allow_source_builds is True, (
+            "sanity check: the stray toggle landed during the execute/repair window"
+        )
+        assert node.state.code_sandbox_awaiting_approval is False
+
+        release_repair.set()
+
+        for _ in range(200):
+            if node.state.code_sandbox_awaiting_approval or entry["task"].done():
+                break
+            await asyncio.sleep(0.005)
+        assert node.state.code_sandbox_awaiting_approval is True, "must be parked on the repair gate"
+        assert node.state.code_sandbox_approval_is_repair is True
+        assert node.state.code_sandbox_approval_allow_source_builds is False, (
+            "the repair re-gate must reset the stray True, not render the "
+            "repair panel's checkbox as checked without user action this round"
+        )
+
+        dispatcher.deny_code_execution(request_id)
+        await entry["task"]
+
+    asyncio.run(run())
+
+
 def test_code_sandbox_repair_loop_requires_a_fresh_approval_for_each_repaired_attempt(monkeypatch):
     """ADR-002 P0: the code_sandbox twin of the pycoder repair-gate test
     above - same confirmed gap, same fix, same shape."""
@@ -4730,7 +5182,7 @@ def test_code_sandbox_repair_loop_requires_a_fresh_approval_for_each_repaired_at
         def ensure_base_environment(self, should_continue, emit_line=None):
             pass
 
-        def sync_requirements(self, manifest, should_continue, emit_line=None):
+        def sync_requirements(self, manifest, should_continue, emit_line=None, allow_source_builds=False):
             pass
 
         def execute_code(self, code, should_continue, emit_line=None):
@@ -4801,7 +5253,7 @@ def test_code_sandbox_repair_gate_denied_stops_immediately_without_further_repai
         def ensure_base_environment(self, should_continue, emit_line=None):
             pass
 
-        def sync_requirements(self, manifest, should_continue, emit_line=None):
+        def sync_requirements(self, manifest, should_continue, emit_line=None, allow_source_builds=False):
             pass
 
         def execute_code(self, code, should_continue, emit_line=None):
@@ -4873,7 +5325,7 @@ def test_code_sandbox_execution_blocked_when_approved_fingerprint_does_not_match
         def ensure_base_environment(self, should_continue, emit_line=None):
             pass
 
-        def sync_requirements(self, manifest, should_continue, emit_line=None):
+        def sync_requirements(self, manifest, should_continue, emit_line=None, allow_source_builds=False):
             pass
 
         def execute_code(self, code, should_continue, emit_line=None):
@@ -4943,7 +5395,7 @@ def test_code_sandbox_run_streams_live_output_lines_in_order_with_a_final_done_f
             if emit_line:
                 emit_line("[Sandbox] Creating virtual environment...\n")
 
-        def sync_requirements(self, manifest, should_continue, emit_line=None):
+        def sync_requirements(self, manifest, should_continue, emit_line=None, allow_source_builds=False):
             if emit_line:
                 emit_line("[Sandbox] No extra dependencies requested.\n")
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -4706,6 +4706,28 @@ def test_set_code_sandbox_requirements_unknown_node_raises_scene_error():
         SceneDocument().set_code_sandbox_requirements("ghost", "numpy")
 
 
+def test_set_code_sandbox_allow_source_builds_sets_the_field():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    node = doc.add_code_sandbox_node(0, 0, parent.id)
+    assert node.state.code_sandbox_approval_allow_source_builds is False
+    returned = doc.set_code_sandbox_allow_source_builds(node.id, True)
+    assert returned is node
+    assert node.state.code_sandbox_approval_allow_source_builds is True
+
+
+def test_set_code_sandbox_allow_source_builds_unknown_node_raises_scene_error():
+    with pytest.raises(SceneError):
+        SceneDocument().set_code_sandbox_allow_source_builds("ghost", True)
+
+
+def test_set_code_sandbox_allow_source_builds_wrong_kind_raises_scene_error():
+    doc = SceneDocument()
+    parent = doc.add_node(0, 0, "parent")
+    with pytest.raises(SceneError):
+        doc.set_code_sandbox_allow_source_builds(parent.id, True)
+
+
 def test_start_code_sandbox_run_stores_prompt_and_clears_error_without_touching_code():
     doc = SceneDocument()
     parent = doc.add_node(0, 0, "parent")
@@ -4804,6 +4826,8 @@ def test_scene_payload_code_sandbox_fields_default_correctly_and_excludes_sandbo
     assert row["codeSandboxAnalysis"] == ""
     assert row["codeSandboxAwaitingApproval"] is False
     assert row["codeSandboxApprovalRequirements"] == ""
+    assert row["codeSandboxApprovalAllowSourceBuilds"] is False
+    assert row["codeSandboxApprovalIsRepair"] is False
     assert row["codeSandboxError"] == ""
 
 
@@ -4819,6 +4843,43 @@ def test_set_pycoder_mode_intent_publishes_scene():
         await bus.dispatch_intent("scene", "setPyCoderMode", [node.id, "manual"])
 
         assert document.nodes[node.id].state.pycoder_mode == "manual"
+
+    asyncio.run(run())
+
+
+def test_set_code_sandbox_allow_source_builds_intent_publishes_scene():
+    async def run():
+        bus, document, recorder, _dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_code_sandbox_node(0, 0, parent.id)
+
+        await bus.dispatch_intent("scene", "setCodeSandboxAllowSourceBuilds", [node.id, True])
+
+        assert document.nodes[node.id].state.code_sandbox_approval_allow_source_builds is True
+
+    asyncio.run(run())
+
+
+def test_set_code_sandbox_allow_source_builds_intent_reaches_the_real_outgoing_scene_payload():
+    # ADR-005 stage 5.5 test-coverage-gap fix: the test above only checks
+    # SceneDocument's own internal state after the intent - it never
+    # inspects the actual outgoing WS payload, so a typo/wrong isinstance
+    # branch/wrong key name in scene_payload()'s own serializer (a
+    # genuinely separate piece of code from the setter) could diverge
+    # silently. This dispatches the real intent and reads the real
+    # recorder.messages payload, mirroring this file's own composer_
+    # publishes[-1]["payload"] pattern elsewhere.
+    async def run():
+        bus, document, recorder, _dispatcher = make_bus_with_dispatcher()
+        parent = document.add_node(0, 0, "parent")
+        node = document.add_code_sandbox_node(0, 0, parent.id)
+
+        await bus.dispatch_intent("scene", "setCodeSandboxAllowSourceBuilds", [node.id, True])
+
+        scene_publishes = [m for m in recorder.messages if m.get("topic") == "scene"]
+        assert scene_publishes, "the intent must republish scene"
+        row = {n["id"]: n for n in scene_publishes[-1]["payload"]["nodes"]}[node.id]
+        assert row["codeSandboxApprovalAllowSourceBuilds"] is True
 
     asyncio.run(run())
 
@@ -5471,7 +5532,7 @@ def test_code_sandbox_installs_the_frozen_manifest_not_a_live_edit_made_during_g
         def ensure_base_environment(self, should_continue, emit_line=None):
             pass
 
-        def sync_requirements(self, manifest, should_continue, emit_line=None):
+        def sync_requirements(self, manifest, should_continue, emit_line=None, allow_source_builds=False):
             self.sync_requirements_calls.append(manifest)
 
         def execute_code(self, code, should_continue, emit_line=None):
@@ -5588,7 +5649,7 @@ def test_code_sandbox_repair_gate_rediscloses_the_frozen_manifest_not_a_live_edi
         def ensure_base_environment(self, should_continue, emit_line=None):
             pass
 
-        def sync_requirements(self, manifest, should_continue, emit_line=None):
+        def sync_requirements(self, manifest, should_continue, emit_line=None, allow_source_builds=False):
             self.sync_requirements_calls.append(manifest)
 
         def execute_code(self, code, should_continue, emit_line=None):

--- a/backend/tests/test_code_sandbox_only_binary.py
+++ b/backend/tests/test_code_sandbox_only_binary.py
@@ -101,6 +101,78 @@ def _build_hostile_sdist(tmp_path, marker_path):
     return sdist_path
 
 
+def _write_benign_source_backend(pkg_dir):
+    """ADR-005 stage 5.5 review-fix: unlike _write_hostile_backend, this
+    PEP 517 backend's build_wheel() hook actually SUCCEEDS - constructing a
+    real, importable wheel via stdlib zipfile from inside the hook itself
+    - so the escalation's own POSITIVE case (a genuine source-only package
+    installs cleanly when allowed) has real coverage, not just the
+    negative/security-proof direction (a hostile hook's side effect fires)
+    TestAllowSourceBuildsEscalation already covers."""
+    (pkg_dir / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [build-system]
+            requires = []
+            build-backend = "benign_source_backend"
+            backend-path = ["."]
+
+            [project]
+            name = "benign-source-pkg"
+            version = "0.0.1"
+            """
+        ),
+        encoding="utf-8",
+    )
+    (pkg_dir / "benign_source_backend.py").write_text(
+        textwrap.dedent(
+            """\
+            import pathlib
+            import zipfile
+
+
+            def get_requires_for_build_wheel(config_settings=None):
+                return []
+
+
+            def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+                wheel_name = "benign_source_pkg-0.0.1-py3-none-any.whl"
+                wheel_path = pathlib.Path(wheel_directory) / wheel_name
+                with zipfile.ZipFile(wheel_path, "w") as zf:
+                    zf.writestr("benign_source_pkg.py", "VALUE = 2\\n")
+                    zf.writestr(
+                        "benign_source_pkg-0.0.1.dist-info/METADATA",
+                        "Metadata-Version: 2.1\\nName: benign-source-pkg\\nVersion: 0.0.1\\n",
+                    )
+                    zf.writestr(
+                        "benign_source_pkg-0.0.1.dist-info/WHEEL",
+                        "Wheel-Version: 1.0\\nGenerator: test\\nRoot-Is-Purelib: true\\nTag: py3-none-any\\n",
+                    )
+                    zf.writestr("benign_source_pkg-0.0.1.dist-info/RECORD", "")
+                return wheel_name
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _build_benign_source_sdist(tmp_path):
+    """A real, pip-installable, genuinely source-only sdist (no wheel ever
+    published) whose build backend actually succeeds - the positive-path
+    twin of _build_hostile_sdist above."""
+    pkg_dir = tmp_path / "benign_source_pkg_src"
+    pkg_dir.mkdir()
+    _write_benign_source_backend(pkg_dir)
+
+    dist_dir = tmp_path / "benign_source_dist"
+    dist_dir.mkdir()
+    sdist_path = dist_dir / "benign_source_pkg-0.0.1.tar.gz"
+    with tarfile.open(sdist_path, "w:gz") as tar:
+        for filename in ("pyproject.toml", "benign_source_backend.py"):
+            tar.add(pkg_dir / filename, arcname=f"benign_source_pkg-0.0.1/{filename}")
+    return sdist_path
+
+
 def _build_benign_wheel(tmp_path):
     """A trivial, real wheel (built directly with stdlib zipfile - a wheel
     is just a zip with a specific layout) so the "does a real wheel still
@@ -258,3 +330,114 @@ class TestPipCommandIncludesTheFlags:
         assert "--only-binary" in args
         assert args[args.index("--only-binary") + 1] == ":all:"
         assert "--no-input" in args
+
+    def test_sync_requirements_omits_only_binary_when_allow_source_builds_is_true(self, tmp_path, monkeypatch):
+        # ADR-005 stage 5.5's source-build escalation - the opt-in must
+        # remove the restriction, not merely relax it, and --no-input must
+        # still be present regardless (defense in depth, unrelated to the
+        # source-build setting - see sync_requirements's own comment).
+        sandbox = VirtualEnvSandbox("flag-check-escalation-test")
+        sandbox.base_dir = tmp_path
+        sandbox.requirements_file = tmp_path / "requirements.txt"
+        sandbox.requirements_hash_file = tmp_path / ".requirements.sha256"
+        sandbox.venv_dir = tmp_path / "venv"
+
+        captured_args = {}
+
+        def fake_run_subprocess(args, **kwargs):
+            captured_args["args"] = args
+            return "", 0
+
+        monkeypatch.setattr(sandbox, "_run_subprocess", fake_run_subprocess)
+
+        sandbox.sync_requirements("some-package==1.0", should_continue=lambda: True, allow_source_builds=True)
+
+        args = captured_args["args"]
+        assert "--only-binary" not in args
+        assert "--no-input" in args
+
+
+class TestAllowSourceBuildsEscalation:
+    def test_allow_source_builds_true_lets_the_hostile_sdist_backend_execute(self, tmp_path):
+        # The mirror image of TestOnlyBinaryBlocksAHostileSdist above, using
+        # the identical hostile sdist fixture: proves the escalation
+        # genuinely removes the restriction (the backend's side effect now
+        # fires), not merely that the flag is accepted without error. The
+        # hostile backend's build_wheel() still deliberately raises after
+        # writing the marker (see _write_hostile_backend), so the overall
+        # install still fails either way - what changes is whether the
+        # backend ever RAN, which the marker file proves directly.
+        marker = tmp_path / "marker.txt"
+        sdist_path = _build_hostile_sdist(tmp_path, marker)
+        find_links_dir = tmp_path / "find_links"
+        find_links_dir.mkdir()
+        (find_links_dir / sdist_path.name).write_bytes(sdist_path.read_bytes())
+
+        sandbox = _make_sandbox_with_real_venv(tmp_path, "hostile-sdist-escalation-test")
+
+        with pytest.raises(RuntimeError, match="Dependency installation failed"):
+            sandbox.sync_requirements(
+                f"hostile-pkg==0.0.1\n--no-index\n--find-links {find_links_dir.as_posix()}",
+                should_continue=lambda: True,
+                allow_source_builds=True,
+            )
+
+        assert marker.exists(), (
+            "allow_source_builds=True should have let pip attempt the sdist build - "
+            "the hostile backend's build_wheel() hook never executed"
+        )
+
+
+class TestAllowSourceBuildsInstallsARealSourceOnlyPackage:
+    def test_allow_source_builds_true_successfully_installs_a_genuine_source_only_package(self, tmp_path):
+        # ADR-005 stage 5.5 test-coverage-gap fix: the escalation test above
+        # only proves the negative/security direction (a hostile backend's
+        # hook executes when allowed) - it says nothing about whether a
+        # LEGITIMATE source-only install actually succeeds under the same
+        # flag. A regression in the pip invocation itself, env stripping
+        # (safe_subprocess_env), or stage 5.3's scratch-dir permissions
+        # could silently break every real source build even with the
+        # escalation correctly enabled, and nothing else in this suite
+        # would notice.
+        sdist_path = _build_benign_source_sdist(tmp_path)
+        find_links_dir = tmp_path / "find_links"
+        find_links_dir.mkdir()
+        (find_links_dir / sdist_path.name).write_bytes(sdist_path.read_bytes())
+
+        sandbox = _make_sandbox_with_real_venv(tmp_path, "benign-source-install-test")
+
+        sandbox.sync_requirements(
+            f"benign-source-pkg==0.0.1\n--no-index\n--find-links {find_links_dir.as_posix()}",
+            should_continue=lambda: True,
+            allow_source_builds=True,
+        )
+
+        python_exe = (
+            sandbox.venv_dir / "Scripts" / "python.exe"
+            if sys.platform == "win32"
+            else sandbox.venv_dir / "bin" / "python"
+        )
+        check = subprocess.run(
+            [str(python_exe), "-c", "import benign_source_pkg; print(benign_source_pkg.VALUE)"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert check.returncode == 0, check.stderr
+        assert check.stdout.strip() == "2"
+
+    def test_the_same_source_only_package_fails_without_the_escalation(self, tmp_path):
+        # Negative control, proving the fixture is genuinely source-only
+        # (no wheel ever published) and the positive test above is
+        # exercising the real --only-binary bypass, not some other reason
+        # the install happened to succeed.
+        sdist_path = _build_benign_source_sdist(tmp_path)
+        find_links_dir = tmp_path / "find_links"
+        find_links_dir.mkdir()
+        (find_links_dir / sdist_path.name).write_bytes(sdist_path.read_bytes())
+
+        sandbox = _make_sandbox_with_real_venv(tmp_path, "benign-source-install-control-test")
+
+        with pytest.raises(RuntimeError, match="Dependency installation failed"):
+            sandbox.sync_requirements(
+                f"benign-source-pkg==0.0.1\n--no-index\n--find-links {find_links_dir.as_posix()}",
+                should_continue=lambda: True,
+            )

--- a/backend/tests/test_execution_limits.py
+++ b/backend/tests/test_execution_limits.py
@@ -31,6 +31,19 @@ def test_code_sandbox_text_is_the_pycoder_text_plus_the_dependency_install_note(
     assert "pre-built binary" not in payload["pycoderResourceLimitsText"]
 
 
+def test_dependency_install_note_does_not_overclaim_given_the_stage_5_5_escalation():
+    # ADR-005 stage 5.5 review-fix: an adversarial review found the note
+    # used to say installs "will fail...rather than run its own build code"
+    # with no qualifier - an unconditional claim the SAME approval dialog's
+    # own source-build escalation checkbox directly contradicts (checking
+    # it and approving does let a source distribution's build code run).
+    # The note must describe this as the DEFAULT, not an absolute guarantee.
+    payload = execution_limits_payload()
+    text = payload["codeSandboxResourceLimitsText"]
+    assert "pre-built binary distributions by default" in text
+    assert "unless you explicitly allow" in text
+
+
 def test_windows_text_mentions_memory_and_process_cap_but_no_cpu_limit(monkeypatch):
     from backend import execution_limits as module
 

--- a/backend/tests/test_security_invariants.py
+++ b/backend/tests/test_security_invariants.py
@@ -51,7 +51,7 @@ def _make_client(**create_app_kwargs) -> TestClient:
 # Every /api/* request and the /ws handshake must present the per-launch
 # capability token. Closes audit finding C5 (backend/auth.py's docstring):
 # without this, any other local process - not just a browser page - can
-# drive all 131 intents, including approveCodeExecution.
+# drive all registered intents, including approveCodeExecution.
 
 
 class TestAuthIsRequired:

--- a/contracts/graphlink_scene_payload.py
+++ b/contracts/graphlink_scene_payload.py
@@ -292,6 +292,17 @@ class SceneNodeRow:
     # comment on CodeSandboxState.code_sandbox_approval_requirements for the
     # full race this closes.
     codeSandboxApprovalRequirements: str = ""
+    # ADR-005 stage 5.5: the user's live source-build opt-in for the CURRENT
+    # pending approval, reset to False every time a new gate opens - see
+    # backend/domain/node_states.py's own comment on CodeSandboxState.
+    # code_sandbox_approval_allow_source_builds for the full race this
+    # closes.
+    codeSandboxApprovalAllowSourceBuilds: bool = False
+    # ADR-005 stage 5.5 review-fix: True only while the CURRENT pending
+    # approval is a repair-loop re-gate, not the initial gate - see
+    # backend/domain/node_states.py's own comment on CodeSandboxState.
+    # code_sandbox_approval_is_repair for why the frontend needs this.
+    codeSandboxApprovalIsRepair: bool = False
     codeSandboxError: str = ""
 
 

--- a/graphlink_plugins/code_sandbox/domain.py
+++ b/graphlink_plugins/code_sandbox/domain.py
@@ -344,7 +344,7 @@ class VirtualEnvSandbox:
         if return_code != 0:
             raise RuntimeError(f"Failed to create sandbox environment.\n{output.strip()}")
 
-    def sync_requirements(self, requirements_manifest, should_continue, emit_line=None):
+    def sync_requirements(self, requirements_manifest, should_continue, emit_line=None, allow_source_builds=False):
         normalized = _normalize_requirements(requirements_manifest)
         manifest_hash = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
         previous_hash = self.requirements_hash_file.read_text(encoding="utf-8").strip() if self.requirements_hash_file.exists() else ""
@@ -352,6 +352,19 @@ class VirtualEnvSandbox:
         self.requirements_file.write_text(normalized + ("\n" if normalized else ""), encoding="utf-8")
 
         if manifest_hash == previous_hash:
+            # ADR-005 stage 5.5 review-fix: this pre-existing cache
+            # short-circuit is keyed ONLY on the manifest text - it runs
+            # BEFORE allow_source_builds is ever consulted below, and pip is
+            # not invoked at all on a hit. This means the escalation
+            # checkbox's real guarantee is "governs the first install of
+            # this exact manifest text", not literally "governs every run" -
+            # a later run with an unchecked box can silently reuse an
+            # environment an earlier, explicitly-approved source build
+            # produced. This is NOT a new install-time risk on the cache-hit
+            # path itself (no pip invocation means no build backend can
+            # execute here either way) - it is a disclosure-accuracy point
+            # an adversarial review flagged: the checkbox does not mean
+            # "source builds are re-verified on every run of this node."
             if emit_line:
                 emit_line("[Sandbox] Requirements unchanged. Reusing cached environment.\n")
             return
@@ -364,37 +377,49 @@ class VirtualEnvSandbox:
 
         if emit_line:
             emit_line("[Sandbox] Installing sandbox dependencies...\n")
+        pip_args = [
+            str(self.python_executable),
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+        ]
+        if not allow_source_builds:
+            # ADR-005 stage 5.5: without this, pip resolving a requirement to
+            # a source distribution (no wheel published for this
+            # platform/version, or a private/unindexed package) invokes that
+            # sdist's own PEP 517 build backend - arbitrary Python, not a
+            # data format - to produce a wheel, *during* what looks like an
+            # ordinary dependency install. Verified empirically with a real
+            # hostile sdist (a custom build backend whose build_wheel() hook
+            # has an observable side effect) before this flag was added: a
+            # plain `pip install -r requirements.txt` against it executes the
+            # backend and its side effect fires; with --only-binary :all:,
+            # pip refuses to consider the sdist at all and fails with "No
+            # matching distribution found" - the backend is never invoked.
+            # Also verified this does not regress the ordinary case: a
+            # package that DOES publish a wheel installs exactly as before.
+            #
+            # allow_source_builds=True is ADR-005 stage 5.5's "source-build
+            # escalation" - an explicit, UI-approved opt-in
+            # (CodeExecutionApprovalPanel.tsx's checkbox, threaded through
+            # AgentDispatcher.start_code_sandbox_run) for a genuinely
+            # source-only package, in effect for the FIRST install of a
+            # given manifest text (see the cache short-circuit above this
+            # method's own comment for why a later run with an identical,
+            # already-cached manifest never reaches this branch at all,
+            # regardless of this run's own checkbox value). Nothing here
+            # re-verifies that the caller actually got a real approval for
+            # this - that gate lives one layer up, the same trust boundary
+            # every other call site of this
+            # method already relies on for `requirements_manifest` itself.
+            pip_args += ["--only-binary", ":all:"]
+        # --no-input stays unconditional either way - defense in depth
+        # matching ADR-005's own decision text, this subprocess has no
+        # attached TTY to prompt on regardless of the source-build setting.
+        pip_args += ["--no-input", "-r", str(self.requirements_file)]
         output, return_code = self._run_subprocess(
-            [
-                str(self.python_executable),
-                "-m",
-                "pip",
-                "install",
-                "--disable-pip-version-check",
-                # ADR-005 stage 5.5: without this, pip resolving a
-                # requirement to a source distribution (no wheel published
-                # for this platform/version, or a private/unindexed
-                # package) invokes that sdist's own PEP 517 build backend -
-                # arbitrary Python, not a data format - to produce a wheel,
-                # *during* what looks like an ordinary dependency install.
-                # Verified empirically with a real hostile sdist (a custom
-                # build backend whose build_wheel() hook has an observable
-                # side effect) before this flag was added: a plain
-                # `pip install -r requirements.txt` against it executes the
-                # backend and its side effect fires; with --only-binary
-                # :all:, pip refuses to consider the sdist at all and fails
-                # with "No matching distribution found" - the backend is
-                # never invoked. Also verified this does not regress the
-                # ordinary case: a package that DOES publish a wheel
-                # installs exactly as before. --no-input is defense in
-                # depth matching ADR-005's own decision text - this
-                # subprocess has no attached TTY to prompt on regardless.
-                "--only-binary",
-                ":all:",
-                "--no-input",
-                "-r",
-                str(self.requirements_file),
-            ],
+            pip_args,
             should_continue=should_continue,
             emit_line=emit_line,
             cwd=self.base_dir,

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -271,7 +271,9 @@ _EXPECTED_SCENE_NODE_WIRE_KEYS = sorted([
     "artifactContent", "attachmentKind", "branchStatus", "byteSize",
     "chartAspectLocked", "chartAssetId", "chartAssetVersion", "chartData",
     "chartError", "chartHeight", "chartSourceNodeId", "chartType", "chartWidth",
-    "chatScrollValue", "code", "codeSandboxAnalysis", "codeSandboxApprovalRequirements",
+    "chatScrollValue", "code", "codeSandboxAnalysis",
+    "codeSandboxApprovalAllowSourceBuilds", "codeSandboxApprovalIsRepair",
+    "codeSandboxApprovalRequirements",
     "codeSandboxAwaitingApproval", "codeSandboxCode", "codeSandboxError",
     "codeSandboxOutput", "codeSandboxPrompt", "codeSandboxRequirements", "color",
     "content", "contentParts", "durationSeconds", "filePath", "gitlinkBranch",
@@ -424,6 +426,8 @@ _EXPECTED_NON_OWNING_KIND_WIRE_DEFAULTS = {
     "codeSandboxAnalysis": "",
     "codeSandboxAwaitingApproval": False,
     "codeSandboxApprovalRequirements": "",
+    "codeSandboxApprovalAllowSourceBuilds": False,
+    "codeSandboxApprovalIsRepair": False,
     "codeSandboxError": "",
 }
 

--- a/web_ui/src/app/canvas/CodeExecutionApprovalPanel.test.tsx
+++ b/web_ui/src/app/canvas/CodeExecutionApprovalPanel.test.tsx
@@ -314,6 +314,66 @@ describe("CodeExecutionApprovalPanel", () => {
     expect(screen.queryByText("Packages to be installed")).toBeNull();
   });
 
+  // -- ADR-005 stage 5.5: source-build escalation checkbox --------------------
+
+  it("renders the source-build checkbox for code_sandbox alongside a non-blank Packages block", () => {
+    renderPanel({ kind: "code_sandbox", requirements: "numpy" });
+    expect(
+      screen.getByRole("checkbox", { name: /Allow building packages from source/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the source-build checkbox for code_sandbox when requirements is blank or omitted", () => {
+    renderPanel({ kind: "code_sandbox", requirements: "" });
+    expect(screen.queryByRole("checkbox")).toBeNull();
+    renderPanel({ kind: "code_sandbox", requirements: undefined });
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
+  it("never renders the source-build checkbox for pycoder, even if requirements were somehow supplied", () => {
+    renderPanel({
+      kind: "pycoder",
+      ...({ requirements: "numpy" } as Partial<Parameters<typeof CodeExecutionApprovalPanel>[0]>),
+    });
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
+  it("the checkbox reflects the current allowSourceBuilds prop value", () => {
+    renderPanel({ kind: "code_sandbox", requirements: "numpy", allowSourceBuilds: true });
+    expect(screen.getByRole("checkbox")).toBeChecked();
+  });
+
+  it("defaults to unchecked when allowSourceBuilds is omitted", () => {
+    renderPanel({ kind: "code_sandbox", requirements: "numpy" });
+    expect(screen.getByRole("checkbox")).not.toBeChecked();
+  });
+
+  it("toggling the checkbox calls onToggleAllowSourceBuilds with the new value, immediately - not deferred to Approve", async () => {
+    const user = userEvent.setup();
+    const onToggleAllowSourceBuilds = vi.fn();
+    renderPanel({
+      kind: "code_sandbox",
+      requirements: "numpy",
+      allowSourceBuilds: false,
+      onToggleAllowSourceBuilds,
+    });
+    await user.click(screen.getByRole("checkbox"));
+    expect(onToggleAllowSourceBuilds).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it("the checkbox is disabled while busy, matching Approve/Deny", () => {
+    renderPanel({ kind: "code_sandbox", requirements: "numpy", busy: true });
+    expect(screen.getByRole("checkbox")).toBeDisabled();
+  });
+
+  it("clicking the checkbox does not call onApprove or onDeny", async () => {
+    const user = userEvent.setup();
+    const { onApprove, onDeny } = renderPanel({ kind: "code_sandbox", requirements: "numpy" });
+    await user.click(screen.getByRole("checkbox"));
+    expect(onApprove).not.toHaveBeenCalled();
+    expect(onDeny).not.toHaveBeenCalled();
+  });
+
   // -- code rendering + security ---------------------------------------------
 
   it("renders the pending code verbatim through the markdown pipeline as a syntax-highlighted fenced block", () => {

--- a/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
+++ b/web_ui/src/app/canvas/CodeExecutionApprovalPanel.tsx
@@ -128,6 +128,21 @@ import { NodeMarkdown } from "./NodeMarkdown";
  * Rendered only when non-blank (mirrors showRequirements below) - a
  * missing Provider (e.g. this component's own standalone tests) degrades
  * to simply omitting the paragraph, not a blank/incorrect claim.
+ *
+ * Source-build escalation (ADR-005 stage 5.5): code_sandbox's dependency
+ * install defaults to --only-binary :all: (graphlink_plugins/code_sandbox/
+ * domain.py's own sync_requirements) - a genuinely source-only package
+ * fails that install rather than running its own build backend. The
+ * checkbox below is the "explicit, separately-approved escalation" ADR-005's
+ * own Decision §4 calls for: unchecked by default, and reset server-side to
+ * unchecked every time a NEW gate opens (backend/agents.py's
+ * start_code_sandbox_run) so a prior run's opt-in never silently carries
+ * forward. Rendered only alongside showRequirements (there is nothing to
+ * install, and so nothing this checkbox could affect, when the manifest is
+ * blank) and only for kind="code_sandbox" (pycoder never installs anything).
+ * allowSourceBuilds/onToggleAllowSourceBuilds are optional props, not
+ * required ones, purely so this component's own pycoder-kind call site and
+ * existing tests are not forced to pass values that would never be read.
  */
 
 export type CodeExecutionKind = "pycoder" | "code_sandbox";
@@ -199,6 +214,24 @@ export interface CodeExecutionApprovalPanelProps {
    * before the reviewed code itself ever runs. Ignored entirely for
    * kind="pycoder" (no such concept there). Rendered only when non-blank. */
   requirements?: string;
+  /** code_sandbox ONLY (ADR-005 stage 5.5) - the CURRENT value of the
+   * source-build opt-in for this pending approval, reset server-side to
+   * false every time a new gate opens. Ignored for kind="pycoder". */
+  allowSourceBuilds?: boolean;
+  /** code_sandbox ONLY - fires immediately on toggle (not deferred to
+   * Approve), same posture as onSetRequirements elsewhere in this node's
+   * own view. Ignored for kind="pycoder". */
+  onToggleAllowSourceBuilds?: (allow: boolean) => void;
+  /** code_sandbox ONLY (ADR-005 stage 5.5 review-fix) - True while the
+   * CURRENT pending approval is a repair-loop re-gate rather than the
+   * initial gate. VirtualEnvSandbox.sync_requirements only ever runs once
+   * per run, before the repair loop starts (backend/agents.py's own
+   * start_code_sandbox_run), so the source-build checkbox has no
+   * dependency install left to affect on any repair round - rather than
+   * render an interactive control that silently does nothing, this panel
+   * hides it entirely when isRepairApproval is true. Ignored for
+   * kind="pycoder" (no repair-round concept relevant here either way). */
+  isRepairApproval?: boolean;
   /** Disables both buttons while the caller's own click handler is waiting
    * out the brief window between a click and the next scene snapshot
    * reflecting it - prevents a double-fire (e.g. Approve clicked twice
@@ -217,6 +250,9 @@ export function CodeExecutionApprovalPanel({
   code,
   awaitingApproval,
   requirements,
+  allowSourceBuilds,
+  onToggleAllowSourceBuilds,
+  isRepairApproval,
   busy,
   onApprove,
   onDeny,
@@ -281,6 +317,12 @@ export function CodeExecutionApprovalPanel({
   if (!awaitingApproval) return null;
 
   const showRequirements = kind === "code_sandbox" && !!requirements?.trim();
+  // ADR-005 stage 5.5 review-fix: sync_requirements only ever runs once per
+  // run, before the repair loop starts (backend/agents.py) - a repair
+  // round's checkbox would have no dependency install left to affect, so
+  // it is hidden entirely rather than rendered as an inert control a user
+  // could mistake for a live decision. See isRepairApproval's own doc.
+  const showAllowSourceBuildsCheckbox = showRequirements && !isRepairApproval;
   const resourceLimitsText =
     kind === "code_sandbox"
       ? executionLimits.codeSandboxResourceLimitsText
@@ -317,6 +359,18 @@ export function CodeExecutionApprovalPanel({
               <span className="code-exec-approval-requirements-label">Packages to be installed</span>
               <pre className="code-exec-approval-requirements-list">{requirements}</pre>
             </div>
+          )}
+          {showAllowSourceBuildsCheckbox && (
+            <label className="settings-checkbox-row code-exec-approval-source-builds-row">
+              <input
+                type="checkbox"
+                checked={!!allowSourceBuilds}
+                disabled={busy}
+                onChange={(event) => onToggleAllowSourceBuilds?.(event.target.checked)}
+              />
+              Allow building packages from source if no pre-built version is available
+              (this can run arbitrary code during installation)
+            </label>
           )}
           <div
             className="chat-node-content code-exec-approval-code"

--- a/web_ui/src/app/canvas/CodeSandboxNodeView.test.tsx
+++ b/web_ui/src/app/canvas/CodeSandboxNodeView.test.tsx
@@ -29,6 +29,8 @@ function baseData(overrides: Partial<CodeSandboxFlowNode["data"]> = {}): CodeSan
   return {
     codeSandboxRequirements: "",
     codeSandboxApprovalRequirements: "",
+    codeSandboxApprovalAllowSourceBuilds: false,
+    codeSandboxApprovalIsRepair: false,
     codeSandboxPrompt: "",
     codeSandboxCode: "",
     codeSandboxOutput: "",
@@ -38,6 +40,7 @@ function baseData(overrides: Partial<CodeSandboxFlowNode["data"]> = {}): CodeSan
     isCollapsed: false,
     pendingRequestId: null,
     onSetRequirements: vi.fn(),
+    onToggleAllowSourceBuilds: vi.fn(),
     onRun: vi.fn(),
     onCancel: vi.fn(),
     onApprove: vi.fn(),
@@ -373,6 +376,43 @@ describe("CodeSandboxNodeView", () => {
     expect(packagesList).not.toBeNull();
     expect(packagesList!.textContent).toBe("numpy");
     expect(packagesList!.textContent).not.toContain("requests");
+  });
+
+  // ADR-005 stage 5.5 test-coverage-gap fix: the sibling requirements tests
+  // above prove codeSandboxApprovalRequirements reaches the real DOM at the
+  // NodeView-integration level (not just CodeExecutionApprovalPanel.test.tsx's
+  // own panel-unit level) - the source-build checkbox's own wiring
+  // (codeSandboxApprovalAllowSourceBuilds -> allowSourceBuilds,
+  // onToggleAllowSourceBuilds -> the real checkbox's onChange) had no
+  // equivalent test, so a broken prop pass-through in this exact file
+  // would have shipped with nothing failing.
+  it("the approval panel's source-build checkbox reflects codeSandboxApprovalAllowSourceBuilds and toggling it calls onToggleAllowSourceBuilds", async () => {
+    const user = userEvent.setup();
+    const data = renderCodeSandboxNode({
+      codeSandboxAwaitingApproval: true,
+      codeSandboxCode: "print(1)",
+      codeSandboxApprovalRequirements: "numpy",
+      codeSandboxApprovalAllowSourceBuilds: true,
+    });
+    const checkbox = document.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.checked).toBe(true);
+
+    await user.click(checkbox);
+    expect(data.onToggleAllowSourceBuilds).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it("hides the source-build checkbox at the real NodeView level when codeSandboxApprovalIsRepair is true", () => {
+    renderCodeSandboxNode({
+      codeSandboxAwaitingApproval: true,
+      codeSandboxCode: "print(1)",
+      codeSandboxApprovalRequirements: "numpy",
+      codeSandboxApprovalIsRepair: true,
+    });
+    expect(document.querySelector('input[type="checkbox"]')).toBeNull();
+    // The requirements block itself must still render on a repair round -
+    // only the (now-inert) checkbox is hidden.
+    expect(screen.getByText("Packages to be installed")).toBeInTheDocument();
   });
 
   it("FIX C: the approval panel also discloses that repaired code needs its own approval", () => {

--- a/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
@@ -57,6 +57,8 @@ import { NodeMenu } from "./NodeMenu";
 export interface CodeSandboxNodeData extends Record<string, unknown> {
   codeSandboxRequirements: string;
   codeSandboxApprovalRequirements: string;
+  codeSandboxApprovalAllowSourceBuilds: boolean;
+  codeSandboxApprovalIsRepair: boolean;
   codeSandboxPrompt: string;
   codeSandboxCode: string;
   codeSandboxOutput: string;
@@ -66,6 +68,7 @@ export interface CodeSandboxNodeData extends Record<string, unknown> {
   isCollapsed: boolean;
   pendingRequestId: string | null;
   onSetRequirements: (requirementsText: string) => void;
+  onToggleAllowSourceBuilds: (allow: boolean) => void;
   onRun: (inputText: string) => void;
   onCancel: () => void;
   onApprove: () => void;
@@ -339,6 +342,9 @@ export function CodeSandboxNodeView({ id, data, selected }: NodeProps<CodeSandbo
           // code_sandbox_awaiting_approval flips true; see
           // AgentDispatcher.start_code_sandbox_run).
           requirements={data.codeSandboxApprovalRequirements}
+          allowSourceBuilds={data.codeSandboxApprovalAllowSourceBuilds}
+          onToggleAllowSourceBuilds={data.onToggleAllowSourceBuilds}
+          isRepairApproval={data.codeSandboxApprovalIsRepair}
           busy={approvalBusy}
           onApprove={handleApprove}
           onDeny={handleDeny}

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -83,6 +83,8 @@ function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
     pycoderError: "",
     codeSandboxRequirements: "",
     codeSandboxApprovalRequirements: "",
+    codeSandboxApprovalAllowSourceBuilds: false,
+    codeSandboxApprovalIsRepair: false,
     codeSandboxPrompt: "",
     codeSandboxCode: "",
     codeSandboxOutput: "",
@@ -993,6 +995,37 @@ describe("toFlowNodes (R5.4 code_sandbox node)", () => {
     expect(setReqSpy).toHaveBeenCalledWith("cs-1", "numpy==1.24");
     data.onRun("plot a sine wave");
     expect(runSpy).toHaveBeenCalledWith("cs-1", "plot a sine wave");
+  });
+
+  it("onToggleAllowSourceBuilds resolves to this node's id, not a different one in a multi-node scene", () => {
+    // ADR-005 stage 5.5 test-coverage-gap fix: this closure is built inside
+    // toFlowNodes's per-node loop - the exact shape of bug that would ship
+    // silently without this test is accidentally capturing the wrong
+    // node's id. Two code_sandbox nodes proves the right one is threaded,
+    // not just "some" id.
+    const scene = baseScene({
+      nodes: [
+        baseNode({ id: "cs-1", kind: "code_sandbox" }),
+        baseNode({ id: "cs-2", kind: "code_sandbox" }),
+      ],
+      edges: [],
+    });
+    const store = makeStore();
+    const toggleSpy = vi.spyOn(store, "setCodeSandboxAllowSourceBuilds");
+
+    const flowNodes = toFlowNodes(scene, store);
+    const cs1Data = flowNodes.find((n) => n.id === "cs-1")!.data as unknown as {
+      onToggleAllowSourceBuilds: (allow: boolean) => void;
+    };
+    const cs2Data = flowNodes.find((n) => n.id === "cs-2")!.data as unknown as {
+      onToggleAllowSourceBuilds: (allow: boolean) => void;
+    };
+
+    cs1Data.onToggleAllowSourceBuilds(true);
+    expect(toggleSpy).toHaveBeenCalledExactlyOnceWith("cs-1", true);
+    cs2Data.onToggleAllowSourceBuilds(false);
+    expect(toggleSpy).toHaveBeenCalledWith("cs-2", false);
+    expect(toggleSpy).toHaveBeenCalledTimes(2);
   });
 
   it("onCancel fires cancelCodeSandboxRequest with pendingRequestId when set, and is a no-op otherwise", () => {

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -983,6 +983,8 @@ export function toFlowNodes(
         data: {
           codeSandboxRequirements: n.codeSandboxRequirements,
           codeSandboxApprovalRequirements: n.codeSandboxApprovalRequirements,
+          codeSandboxApprovalAllowSourceBuilds: n.codeSandboxApprovalAllowSourceBuilds,
+          codeSandboxApprovalIsRepair: n.codeSandboxApprovalIsRepair,
           codeSandboxPrompt: n.codeSandboxPrompt,
           codeSandboxCode: n.codeSandboxCode,
           codeSandboxOutput: n.codeSandboxOutput,
@@ -995,6 +997,8 @@ export function toFlowNodes(
           onDelete: () => store.removeNodes([n.id]),
           onSetRequirements: (requirementsText: string) =>
             store.setCodeSandboxRequirements(n.id, requirementsText),
+          onToggleAllowSourceBuilds: (allow: boolean) =>
+            store.setCodeSandboxAllowSourceBuilds(n.id, allow),
           onRun: (inputText: string) => store.runCodeSandbox(n.id, inputText),
           onCancel: () => {
             if (n.pendingRequestId) store.cancelCodeSandboxRequest(n.pendingRequestId);

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -85,6 +85,8 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         pycoderError: "",
         codeSandboxRequirements: "",
         codeSandboxApprovalRequirements: "",
+        codeSandboxApprovalAllowSourceBuilds: false,
+        codeSandboxApprovalIsRepair: false,
         codeSandboxPrompt: "",
         codeSandboxCode: "",
         codeSandboxOutput: "",
@@ -521,6 +523,22 @@ describe("SceneStore", () => {
         topic: "scene",
         intent: "setCodeSandboxRequirements",
         args: ["n1", "numpy\npandas==2.2.0"],
+      },
+    ]);
+  });
+
+  it("setCodeSandboxAllowSourceBuilds sends the scene-topic setCodeSandboxAllowSourceBuilds intent with [nodeId, allow]", () => {
+    // ADR-005 stage 5.5 test-coverage-gap fix: the sibling requirements
+    // field above already had this parity test; the source-build checkbox
+    // did not, so a wrong intent name/argument order would ship silently.
+    const { transport, intents } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.setCodeSandboxAllowSourceBuilds("n1", true);
+    expect(intents).toEqual([
+      {
+        topic: "scene",
+        intent: "setCodeSandboxAllowSourceBuilds",
+        args: ["n1", true],
       },
     ]);
   });

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -527,6 +527,13 @@ export class SceneStore {
     this.transport.intent("scene", "setCodeSandboxRequirements", [nodeId, requirementsText]);
   }
 
+  // ADR-005 stage 5.5: the approval panel's own source-build opt-in
+  // checkbox - fires immediately on toggle, same posture as
+  // setCodeSandboxRequirements above, not deferred to Approve.
+  setCodeSandboxAllowSourceBuilds(nodeId: string, allow: boolean): void {
+    this.transport.intent("scene", "setCodeSandboxAllowSourceBuilds", [nodeId, allow]);
+  }
+
   runCodeSandbox(nodeId: string, inputText: string): void {
     this.transport.intent("scene", "runCodeSandbox", [nodeId, inputText]);
   }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -5240,6 +5240,23 @@ mark.document-view-search-match-current {
   border-radius: 6px;
 }
 
+/* ADR-005 stage 5.5: the source-build escalation checkbox - reuses
+   .settings-checkbox-row's own layout/hover treatment (SettingsDialog.tsx)
+   for visual consistency with every other checkbox in the app, scaled down
+   to this dialog's own smaller 11px type and given margin-bottom to match
+   .code-exec-approval-requirements's own spacing rhythm above it. */
+.code-exec-approval-source-builds-row {
+  margin: 0 0 12px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--gl-surface-text-primary);
+}
+
+.code-exec-approval-source-builds-row:has(input:disabled) {
+  opacity: 0.45;
+  cursor: default;
+}
+
 .code-exec-approval-code {
   max-height: 320px;
   overflow: auto;

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -65,6 +65,12 @@
           "codeSandboxAnalysis": {
             "type": "string"
           },
+          "codeSandboxApprovalAllowSourceBuilds": {
+            "type": "boolean"
+          },
+          "codeSandboxApprovalIsRepair": {
+            "type": "boolean"
+          },
           "codeSandboxApprovalRequirements": {
             "type": "string"
           },
@@ -460,6 +466,8 @@
           "codeSandboxAnalysis",
           "codeSandboxAwaitingApproval",
           "codeSandboxApprovalRequirements",
+          "codeSandboxApprovalAllowSourceBuilds",
+          "codeSandboxApprovalIsRepair",
           "codeSandboxError"
         ],
         "type": "object"

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -61,6 +61,8 @@ export interface SceneNodeRow {
   codeSandboxAnalysis: string;
   codeSandboxAwaitingApproval: boolean;
   codeSandboxApprovalRequirements: string;
+  codeSandboxApprovalAllowSourceBuilds: boolean;
+  codeSandboxApprovalIsRepair: boolean;
   codeSandboxError: string;
 }
 
@@ -447,6 +449,16 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["codeSandboxApprovalRequirements"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxApprovalRequirements: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.codeSandboxApprovalRequirements` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["codeSandboxApprovalAllowSourceBuilds"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxApprovalAllowSourceBuilds: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.codeSandboxApprovalAllowSourceBuilds` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["codeSandboxApprovalIsRepair"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxApprovalIsRepair: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.codeSandboxApprovalIsRepair` + ": expected boolean"); }
   }
   {
     const fieldValue = value["codeSandboxError"];


### PR DESCRIPTION
## Problem

The Virtual Environment Runner node's dependency install defaults to `pip install --only-binary :all:`, blocking a hostile sdist's PEP 517 build backend from executing arbitrary code during install. That default is correct, but it also means a genuinely source-only package (no wheel published) can never install at all — there was no escape hatch.

## Change

Adds an explicit, per-run, UI-approved checkbox to the approval dialog: "Allow building packages from source if no pre-built version is available (this can run arbitrary code during installation)." Checking it and approving lets that one run's install omit `--only-binary :all:`.

Threaded end to end: `CodeSandboxState.code_sandbox_approval_allow_source_builds` → a new `setCodeSandboxAllowSourceBuilds` WS intent → `SceneNodeRow` wire field → `sceneStore.ts` → `SceneCanvas.tsx` → `CodeSandboxNodeView.tsx` → the panel.

## Review

A 4-lens adversarial review (security-correctness, wiring-integration, UX-disclosure-honesty, test-coverage-adequacy) found 11 confirmed issues, all fixed before this PR:

- **HIGH** — a real cross-connection race: the checkbox's value was re-read from live state right after the approval future resolved, but `future.set_result()` only schedules the waiting coroutine's resumption rather than running it inline, so a second WS connection could change the value in that gap. Fixed by snapshotting the value atomically inside `_resolve_approval`'s own synchronous stretch (`RunHandle.approval_snapshot`), which cannot be interleaved with anything else.
- **HIGH** — the existing dependency-install disclosure text unconditionally said installs "will fail rather than run build code," directly contradicted by the new checkbox in the same dialog. Reworded to describe the default accurately without overclaiming.
- **4 MEDIUM** — the repair loop never reset the checkbox's backing state (it could render checked with no user action that round); the checkbox was still interactive-but-inert on repair rounds; the sceneStore→SceneCanvas→CodeSandboxNodeView wiring chain had no tests; the WS-intent→scene_payload round trip had no test.
- **5 LOW** — a stale docstring claim, an imprecise "per-run" framing given pip's own install cache, a missing positive-path install test, a missing check-then-deny test — all fixed.

## Test plan

- [x] Full backend suite green (`pytest -q`): 1558 passed, 14 skipped
- [x] Full frontend check green (`npm run check`): schema/typecheck/lint/298 tests/build
- [x] Every review fix mutation-verified (reverted → confirmed the intended test fails → restored → confirmed a clean diff)
- [x] Browser-verified the real app loads cleanly with the new wire fields, zero console errors