### PR TITLE
ADR-003 stage 3.1: intent ids, structured errors, notification surfacing

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -633,15 +633,33 @@ async def _handle_message(session: SessionBus, websocket: WebSocket, message: di
         args = message.get("args") or []
         try:
             result = await session.dispatch_intent(topic, intent, args)
-        except (UnknownTopicError, UnknownIntentError) as exc:
-            await websocket.send_json({"kind": "error", "id": msg_id, "error": str(exc)})
+        except UnknownTopicError as exc:
+            # ADR-003 stage 3.1 review-fix: UnknownTopicError/UnknownIntentError
+            # both subclass KeyError, whose __str__ wraps a single-arg message
+            # in repr() (e.g. "'scene'" with literal quotes) - this error text
+            # now reaches end users via fireIntent()'s notification banner, not
+            # just a developer console, so exc.args[0] is used directly instead
+            # of str(exc) to avoid that raw repr artifact leaking through.
+            await websocket.send_json(
+                {"kind": "error", "id": msg_id, "error": f"Unknown topic: {exc.args[0]}."}
+            )
+            return
+        except UnknownIntentError as exc:
+            await websocket.send_json(
+                {"kind": "error", "id": msg_id, "error": f"Unknown intent: {exc.args[0]}."}
+            )
             return
         except Exception:
             # Handler bugs surface as errors to the caller, never as a dropped
-            # socket - and always land in the log.
+            # socket - and always land in the log (full topic/intent/traceback
+            # detail is here, not repeated in the user-facing message below).
             logger.exception("intent %s/%s failed", topic, intent)
             await websocket.send_json(
-                {"kind": "error", "id": msg_id, "error": f"intent failed: {topic}/{intent}"}
+                {
+                    "kind": "error",
+                    "id": msg_id,
+                    "error": "Something went wrong while handling this request.",
+                }
             )
             return
         if msg_id is not None:

--- a/backend/notifications.py
+++ b/backend/notifications.py
@@ -69,6 +69,19 @@ def register_notifications(bus: SessionBus, settings_manager: "SettingsManager |
         state.show(str(message), "info")
         await bus.publish("notification")
 
+    async def show_error(message: str):
+        # ADR-003 stage 3.1: the same fixed-severity pattern as show_info
+        # above, for the WsTransport-detected class of failure a WS-level
+        # intent request can fail with (a structured {"kind":"error"} reply -
+        # unknown topic/intent, or an unhandled exception inside a handler).
+        # Deliberately a SECOND narrow, fixed-severity entry point rather
+        # than widening show_info to accept a caller-supplied msg_type - see
+        # that function's own reasoning for why an arbitrary wire-supplied
+        # severity is not trusted here either.
+        state.show(str(message), "error")
+        await bus.publish("notification")
+
     bus.register_intent("notification", "dismiss", dismiss)
     bus.register_intent("notification", "showInfo", show_info)
+    bus.register_intent("notification", "showError", show_error)
     return state

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -134,14 +134,57 @@ def test_unknown_intent_and_topic_return_error_not_disconnect():
         message = ws.receive_json()
         assert message["kind"] == "error"
         assert message["id"] == 2
+        # ADR-003 stage 3.1 review-fix: UnknownIntentError subclasses KeyError,
+        # whose __str__ wraps a single-arg message in repr() (literal quotes) -
+        # this text now reaches end users via fireIntent()'s notification
+        # banner, so it must be the clean sentence, not that raw repr artifact.
+        assert message["error"] == "Unknown intent: system/nope."
 
         ws.send_json({"kind": "intent", "topic": "nope", "intent": "x", "args": [], "id": 3})
         message = ws.receive_json()
         assert message["kind"] == "error"
+        assert message["error"] == "Unknown topic: nope."
 
         # Socket must still be usable after errors.
         ws.send_json({"kind": "intent", "topic": "system", "intent": "ping", "args": [], "id": 4})
         assert ws.receive_json()["kind"] == "result"
+
+
+def test_showerror_intent_round_trips_through_the_real_app_and_updates_the_notification_snapshot():
+    # ADR-003 stage 3.1 review-fix (finding K): every other showError test
+    # dispatches straight into a bare EventBus (backend/tests/test_backend_
+    # composer.py), bypassing this real app.py handler entirely - this is the
+    # one test that drives the actual WS frame a browser's WsTransport sends
+    # through the real create_app() wiring end to end: a genuine {"kind":
+    # "intent","topic":"notification","intent":"showError",...} frame in,
+    # a proper {"kind":"result"} reply, and a subsequent notification
+    # snapshot reflecting the error - the same round trip fireIntent()'s own
+    # error-surfacing path in transport.ts relies on in production.
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json(
+            {
+                "kind": "intent",
+                "topic": "notification",
+                "intent": "showError",
+                "args": ["Something went wrong."],
+                "id": 5,
+            }
+        )
+        # bus.publish() broadcasts to every ATTACHED connection unconditionally
+        # (backend/events.py's SessionContext.attach/publish - no client-side
+        # "subscribe" message is required), and the handler awaits that
+        # publish before returning - so the resulting state snapshot arrives
+        # on the wire BEFORE the intent's own {"kind":"result"} reply.
+        snapshot = ws.receive_json()
+        assert snapshot["kind"] == "state"
+        assert snapshot["topic"] == "notification"
+        assert snapshot["payload"]["visible"] is True
+        assert snapshot["payload"]["message"] == "Something went wrong."
+        assert snapshot["payload"]["msgType"] == "error"
+
+        message = ws.receive_json()
+        assert message == {"kind": "result", "id": 5, "value": None}
 
 
 def test_unknown_message_kind_returns_error():

--- a/backend/tests/test_backend_composer.py
+++ b/backend/tests/test_backend_composer.py
@@ -399,6 +399,26 @@ def test_notification_show_info_intent_publishes_a_fixed_info_type():
     asyncio.run(run())
 
 
+def test_notification_show_error_intent_publishes_a_fixed_error_type():
+    # ADR-003 stage 3.1: WsTransport.fireIntent()'s own error-recovery path
+    # (web_ui/src/lib/ws/transport.ts) calls this when a request() rejects
+    # with a genuine server-side {"kind":"error"} reply - fixed to msg_type
+    # "error" regardless of what the frontend passes, same posture as
+    # showInfo above (see notifications.py's own comment for why an
+    # arbitrary wire-supplied severity is not trusted for either).
+    async def run():
+        bus, _, _, notifications, recorder = make_bus()
+        await bus.dispatch_intent("notification", "showError", ["unknown intent: scene/bogus"])
+        assert notifications.payload() == {
+            "visible": True,
+            "message": "unknown intent: scene/bogus",
+            "msgType": "error",
+        }
+        assert recorder.topics_seen().count("notification") == 1
+
+    asyncio.run(run())
+
+
 # -- R7.5d follow-up: the composer must DISPLAY the same persisted reasoning
 # level it writes. The first R7.5d pass wired only the write half, leaving the
 # composer's own private reasoning_level as the display source - and since

--- a/web_ui/src/app/canvas/GitlinkNodeView.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.tsx
@@ -273,6 +273,11 @@ export function GitlinkNodeView({ id, data, selected }: NodeProps<GitlinkFlowNod
   // actual fetch RESULT (fetchedContextXml) needs to be React state, since
   // that is the one value this component renders.
   const [fetchedContextXml, setFetchedContextXml] = useState<string | null>(null);
+  // ADR-003 stage 3.1 review-fix: onFetchContext() previously had no .catch()
+  // at all, so a rejection left this tab stuck on "Loading context…" forever
+  // with no visible error and no way to retry - matching listRepos()'s own
+  // repoOptionsError pattern above.
+  const [contextFetchError, setContextFetchError] = useState<string | null>(null);
   // R5.3 post-review FIX 6: keyed on data.gitlinkContextVersion (a monotonic
   // per-node counter, defaulting to 0, bumped by the backend on every
   // successful Build Context call) rather than data.gitlinkContextSummary -
@@ -294,20 +299,31 @@ export function GitlinkNodeView({ id, data, selected }: NodeProps<GitlinkFlowNod
   // happens when a fetch RESOLVES, regardless of resolution order.
   const contextFetchSeqRef = useRef(0);
 
+  function runContextFetch() {
+    setFetchedContextXml(null);
+    setContextFetchError(null);
+    const seq = ++contextFetchSeqRef.current;
+    data
+      .onFetchContext()
+      .then((xml) => {
+        // A newer fetch has since been kicked off - this result is stale,
+        // discard it silently rather than overwriting the newer content.
+        if (contextFetchSeqRef.current !== seq) return;
+        setFetchedContextXml(xml);
+      })
+      .catch(() => {
+        if (contextFetchSeqRef.current !== seq) return;
+        setContextFetchError("Could not load context.");
+      });
+  }
+
   useEffect(() => {
     if (activeTab !== "context") return;
     if (!data.gitlinkContextSummary) return;
     const version = data.gitlinkContextVersion ?? 0;
     if (fetchedForVersionRef.current === version) return;
     fetchedForVersionRef.current = version;
-    setFetchedContextXml(null);
-    const seq = ++contextFetchSeqRef.current;
-    data.onFetchContext().then((xml) => {
-      // A newer fetch has since been kicked off - this result is stale,
-      // discard it silently rather than overwriting the newer content.
-      if (contextFetchSeqRef.current !== seq) return;
-      setFetchedContextXml(xml);
-    });
+    runContextFetch();
     // data.onFetchContext is a fresh closure every render (see SceneCanvas's
     // toFlowNodes) - depending on it would refetch on every unrelated
     // re-render, so it is deliberately omitted; fetchedForVersionRef is the
@@ -545,9 +561,18 @@ export function GitlinkNodeView({ id, data, selected }: NodeProps<GitlinkFlowNod
               {data.gitlinkContextSummary ? (
                 <>
                   <p className="gitlink-node-context-summary">{data.gitlinkContextSummary}</p>
-                  {/* Machine-generated XML, rendered as plain preformatted text -
-                      never run through the markdown pipeline. */}
-                  <pre className="gitlink-node-context-xml">{fetchedContextXml ?? "Loading context…"}</pre>
+                  {contextFetchError ? (
+                    <>
+                      <p className="gitlink-node-banner-error">{contextFetchError}</p>
+                      <button type="button" onClick={runContextFetch}>
+                        Retry
+                      </button>
+                    </>
+                  ) : (
+                    // Machine-generated XML, rendered as plain preformatted
+                    // text - never run through the markdown pipeline.
+                    <pre className="gitlink-node-context-xml">{fetchedContextXml ?? "Loading context…"}</pre>
+                  )}
                 </>
               ) : (
                 <p className="gitlink-node-empty">No context built yet.</p>

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -24,7 +24,10 @@ import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/s
 // export.
 
 function makeStore(): SceneStore {
-  const transport = { subscribe: vi.fn(), intent: vi.fn() } as unknown as WsTransport;
+  // ADR-003 stage 3.1: fireIntent is the transport method SceneStore's own
+  // mutating intent call sites actually use now - see sceneStore.ts's own
+  // module doc.
+  const transport = { subscribe: vi.fn(), intent: vi.fn(), fireIntent: vi.fn() } as unknown as WsTransport;
   return new SceneStore(transport);
 }
 

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -26,6 +26,15 @@ function makeFakeTransport() {
     intent: vi.fn((topic: string, intent: string, args: unknown[] = []) => {
       intents.push({ topic, intent, args });
     }),
+    // ADR-003 stage 3.1: SceneStore's own mutating intent call sites now go
+    // through fireIntent, not the bare intent() above - recorded into the
+    // SAME `intents` array (real WsTransport.fireIntent's own id-tracking/
+    // error-recovery path is exercised by transport.test.ts, not re-tested
+    // at every one of this file's call sites) so none of this file's many
+    // existing `expect(intents).toEqual([...])` assertions needed to change.
+    fireIntent: vi.fn((topic: string, intent: string, args: unknown[] = []) => {
+      intents.push({ topic, intent, args });
+    }),
     request: requestImpl,
   } as unknown as WsTransport;
   return { transport, listeners, intents, requests, requestImpl, requestResults };

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -6,6 +6,14 @@
  * Deliberately framework-free (plain listeners, no React import) so the
  * store logic is unit-testable without rendering; React consumes it through
  * useSyncExternalStore in SceneCanvas.
+ *
+ * ADR-003 stage 3.1: every mutating intent call site below goes through
+ * transport.fireIntent() (id-tracked, surfaces a genuine server-side
+ * rejection via the notification banner), not the old fire-and-forget
+ * transport.intent() - see transport.ts's own module doc for the mechanism.
+ * fetchGitlinkRepositories/fetchGitlinkContext are the two pre-existing
+ * exceptions, using transport.request() directly since their callers need
+ * the actual return value, not just a fire-and-track.
  */
 
 import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
@@ -14,6 +22,11 @@ import type { GridControlState } from "../../lib/bridge-core/generated/grid-cont
 import type { DragSpeedState } from "../../lib/bridge-core/generated/drag-speed-state";
 import type { FontControlState } from "../../lib/bridge-core/generated/font-control-state";
 import type { StreamListener, WsTransport } from "../../lib/ws/transport";
+
+// ADR-003 stage 3.1 review-fix: matches composerStore's own
+// NATIVE_DIALOG_TIMEOUT_MS - pickGitlinkLocalRoot opens a native OS folder
+// dialog server-side and waits on the user, not the network.
+const NATIVE_DIALOG_TIMEOUT_MS = 5 * 60_000;
 
 export const initialSceneState: SceneState = {
   schemaVersion: 1,
@@ -188,7 +201,7 @@ export class SceneStore {
   // -- intents (backend/canvas.py's registered surface, 1:1) ---------------
 
   addNode(x: number, y: number, title = ""): void {
-    this.transport.intent("scene", "addNode", [x, y, title]);
+    this.transport.fireIntent("scene", "addNode", [x, y, title]);
   }
 
   // R3.1: real chat nodes - createChatNode/deleteChatNode/setChatCollapsed
@@ -197,11 +210,11 @@ export class SceneStore {
   addChatNode(x: number, y: number, content: string, isUser: boolean, parentId?: string): void {
     const args: unknown[] = [x, y, content, isUser];
     if (parentId !== undefined) args.push(parentId);
-    this.transport.intent("scene", "addChatNode", args);
+    this.transport.fireIntent("scene", "addChatNode", args);
   }
 
   deleteChatNode(id: string): void {
-    this.transport.intent("scene", "deleteChatNode", [id]);
+    this.transport.fireIntent("scene", "deleteChatNode", [id]);
   }
 
   // R3.5: real code nodes - deletion has no dedicated intent (code nodes are
@@ -210,11 +223,11 @@ export class SceneStore {
   addCodeNode(x: number, y: number, code: string, language: string, parentId?: string): void {
     const args: unknown[] = [x, y, code, language];
     if (parentId !== undefined) args.push(parentId);
-    this.transport.intent("scene", "addCodeNode", args);
+    this.transport.fireIntent("scene", "addCodeNode", args);
   }
 
   setChatCollapsed(id: string, collapsed: boolean): void {
-    this.transport.intent("scene", "setChatCollapsed", [id, collapsed]);
+    this.transport.fireIntent("scene", "setChatCollapsed", [id, collapsed]);
   }
 
   // R7.5e: legacy's "Collapse All Nodes"/"Expand All Nodes" (graphlink_
@@ -224,11 +237,11 @@ export class SceneStore {
   // scene intent (organizeNodes, ...): the new is_collapsed values arrive
   // through the next scene snapshot, nothing synchronous needed here.
   collapseAllNodes(): void {
-    this.transport.intent("scene", "collapseAllNodes", []);
+    this.transport.fireIntent("scene", "collapseAllNodes", []);
   }
 
   expandAllNodes(): void {
-    this.transport.intent("scene", "expandAllNodes", []);
+    this.transport.fireIntent("scene", "expandAllNodes", []);
   }
 
   // R3.9/R3.10: real document nodes (attachments). Unlike chat/code,
@@ -268,7 +281,7 @@ export class SceneStore {
       byteSize = null,
       previewLabel = "",
     } = options;
-    this.transport.intent("scene", "addDocumentNode", [
+    this.transport.fireIntent("scene", "addDocumentNode", [
       x,
       y,
       title,
@@ -291,7 +304,7 @@ export class SceneStore {
   // ThinkingNodeView's "Dock to Parent Node" and ChatNodeView's per-child
   // "Reveal Docked Items" undock action.
   addThinkingNode(x: number, y: number, thinkingText: string, parentId: string): void {
-    this.transport.intent("scene", "addThinkingNode", [x, y, thinkingText, parentId]);
+    this.transport.fireIntent("scene", "addThinkingNode", [x, y, thinkingText, parentId]);
   }
 
   // R3.17/R3.18: real HTML view nodes. Same posture as addThinkingNode/
@@ -300,7 +313,7 @@ export class SceneStore {
   // agent/plugin layer). The html source string rides the same `content`
   // field every other node kind's text lives in - no new wire field.
   addHtmlNode(x: number, y: number, htmlContent: string, parentId: string): void {
-    this.transport.intent("scene", "addHtmlNode", [x, y, htmlContent, parentId]);
+    this.transport.fireIntent("scene", "addHtmlNode", [x, y, htmlContent, parentId]);
   }
 
   // R3.21/R3.22: real image nodes. Same posture as addThinkingNode/
@@ -319,7 +332,7 @@ export class SceneStore {
     parentId: string,
     mimeType = "image/png",
   ): void {
-    this.transport.intent("scene", "addImageNode", [x, y, imageBytesBase64, prompt, parentId, mimeType]);
+    this.transport.fireIntent("scene", "addImageNode", [x, y, imageBytesBase64, prompt, parentId, mimeType]);
   }
 
   // R3.25/R3.26: real conversation nodes - the only R3 kind shaped like a
@@ -333,7 +346,7 @@ export class SceneStore {
   // rather than inventing a setConversationCollapsed the backend doesn't
   // register.
   addConversationNode(x: number, y: number, parentId: string): void {
-    this.transport.intent("scene", "addConversationNode", [x, y, parentId]);
+    this.transport.fireIntent("scene", "addConversationNode", [x, y, parentId]);
   }
 
   // sendConversationMessage appends a real user message AND triggers the
@@ -342,18 +355,18 @@ export class SceneStore {
   // own sendMessage already flows through - nothing new to wire on the
   // frontend for that half of it.
   sendConversationMessage(id: string, text: string): void {
-    this.transport.intent("scene", "sendConversationMessage", [id, text]);
+    this.transport.fireIntent("scene", "sendConversationMessage", [id, text]);
   }
 
   // No live caller yet this increment (same posture as addThinkingNode when
   // it first landed) - exists so the intent shape is testable now. Will
   // back the real agent reply once R4's agent layer can call it.
   appendConversationAssistantMessage(id: string, text: string): void {
-    this.transport.intent("scene", "appendConversationAssistantMessage", [id, text]);
+    this.transport.fireIntent("scene", "appendConversationAssistantMessage", [id, text]);
   }
 
   deleteConversationMessage(id: string, messageIndex: number): void {
-    this.transport.intent("scene", "deleteConversationMessage", [id, messageIndex]);
+    this.transport.fireIntent("scene", "deleteConversationMessage", [id, messageIndex]);
   }
 
   // R4.3: real per-node Cancel for a conversation node's own in-flight reply.
@@ -363,25 +376,25 @@ export class SceneStore {
   // two topics sharing one action name, so this is named distinctly
   // (cancelConversationRequest) to avoid implying otherwise.
   cancelConversationRequest(requestId: string): void {
-    this.transport.intent("scene", "cancelChatRequest", [requestId]);
+    this.transport.fireIntent("scene", "cancelChatRequest", [requestId]);
   }
 
   setNodeDocked(id: string, docked: boolean): void {
-    this.transport.intent("scene", "setNodeDocked", [id, docked]);
+    this.transport.fireIntent("scene", "setNodeDocked", [id, docked]);
   }
 
   // R4.3c: real Regenerate Response, for both ChatNodeView's own menu and
   // CodeNodeView's menu (which resolves to its parent chat node's id before
   // calling this - see toFlowNodes below; the backend never kind-sniffs).
   regenerateResponse(chatNodeId: string): void {
-    this.transport.intent("scene", "regenerateResponse", [chatNodeId]);
+    this.transport.fireIntent("scene", "regenerateResponse", [chatNodeId]);
   }
 
   // R4.4a: real "Generate Image from Text", for ChatNodeView's own menu -
   // resolves purely from the ChatNode's id (backend reads its own .content
   // as the prompt, mirroring legacy's node.text).
   generateImage(chatNodeId: string): void {
-    this.transport.intent("scene", "generateImage", [chatNodeId]);
+    this.transport.fireIntent("scene", "generateImage", [chatNodeId]);
   }
 
   // R4.4a: real "Regenerate Image", for ImageNodeView's own menu - resolves
@@ -390,7 +403,7 @@ export class SceneStore {
   // backend/canvas.py's resolve_regenerate_image docstring for why this is a
   // deliberate improvement over legacy's parent-.text reuse).
   regenerateImage(imageNodeId: string): void {
-    this.transport.intent("scene", "regenerateImage", [imageNodeId]);
+    this.transport.fireIntent("scene", "regenerateImage", [imageNodeId]);
   }
 
   // R5.1: real Web Research plugin - runWebResearch starts (or restarts) a
@@ -399,11 +412,11 @@ export class SceneStore {
   // requestId-not-nodeId shape cancelConversationRequest above already
   // established for the conversation node's own per-node cancel.
   runWebResearch(nodeId: string, query: string): void {
-    this.transport.intent("scene", "runWebResearch", [nodeId, query]);
+    this.transport.fireIntent("scene", "runWebResearch", [nodeId, query]);
   }
 
   cancelWebResearchRequest(requestId: string): void {
-    this.transport.intent("scene", "cancelWebResearchRequest", [requestId]);
+    this.transport.fireIntent("scene", "cancelWebResearchRequest", [requestId]);
   }
 
   // R5.2: real Artifact/Drafter plugin - sendArtifactMessage appends a real
@@ -413,11 +426,11 @@ export class SceneStore {
   // cancelConversationRequest/cancelWebResearchRequest above already
   // established for their own per-node cancel.
   sendArtifactMessage(nodeId: string, text: string): void {
-    this.transport.intent("scene", "sendArtifactMessage", [nodeId, text]);
+    this.transport.fireIntent("scene", "sendArtifactMessage", [nodeId, text]);
   }
 
   cancelArtifactRequest(requestId: string): void {
-    this.transport.intent("scene", "cancelArtifactRequest", [requestId]);
+    this.transport.fireIntent("scene", "cancelArtifactRequest", [requestId]);
   }
 
   // R5.3: real Gitlink plugin - nine intents backing the three-tab
@@ -425,24 +438,24 @@ export class SceneStore {
   // the full per-tab breakdown). fetchGitlinkRepositories/fetchGitlinkContext
   // are the only two of the nine that need a REPLY (a repo name list / the
   // lazily-fetched context XML body) rather than a fire-and-forget push
-  // through the next scene snapshot - transport.intent() is declared
-  // `: void` (confirmed by reading transport.ts: it is fire-and-forget,
-  // dropped silently pre-connect, no return value at all), so it cannot be
-  // what "returns a Promise" means here. transport.request() is the real
-  // request/response primitive for that (the same one transport.test.ts's
-  // own "system"/"ping" round-trip exercises) - these two ride that instead.
-  // Every other Gitlink method below stays on the ordinary intent() path,
-  // exactly like every other scene intent above.
+  // through the next scene snapshot - transport.fireIntent()/intent() are
+  // both declared `: void` (confirmed by reading transport.ts: neither
+  // returns a value), so neither can be what "returns a Promise" means here.
+  // transport.request() is the real request/response primitive for that (the
+  // same one transport.test.ts's own "system"/"ping" round-trip exercises) -
+  // these two ride that instead. Every other Gitlink method below stays on
+  // the ordinary fireIntent() path (ADR-003 stage 3.1), exactly like every
+  // other scene intent above.
   fetchGitlinkRepositories(nodeId: string): Promise<string[]> {
     return this.transport.request("scene", "fetchGitlinkRepositories", [nodeId]) as Promise<string[]>;
   }
 
   loadGitlinkRepoTree(nodeId: string, repo: string, branch: string): void {
-    this.transport.intent("scene", "loadGitlinkRepoTree", [nodeId, repo, branch]);
+    this.transport.fireIntent("scene", "loadGitlinkRepoTree", [nodeId, repo, branch]);
   }
 
   setGitlinkLocalRoot(nodeId: string, localRoot: string): void {
-    this.transport.intent("scene", "setGitlinkLocalRoot", [nodeId, localRoot]);
+    this.transport.fireIntent("scene", "setGitlinkLocalRoot", [nodeId, localRoot]);
   }
 
   // Opens the real native OS folder picker (backend/native_dialogs.py, the
@@ -451,11 +464,14 @@ export class SceneStore {
   // setGitlinkLocalRoot above - fire-and-forget, the new value arrives back
   // through the next scene snapshot rather than a direct reply.
   pickGitlinkLocalRoot(nodeId: string): void {
-    this.transport.intent("scene", "pickGitlinkLocalRoot", [nodeId]);
+    // ADR-003 stage 3.1 review-fix: opens a native OS folder dialog
+    // server-side and waits on the user, not the network - see
+    // NATIVE_DIALOG_TIMEOUT_MS's own doc.
+    this.transport.fireIntent("scene", "pickGitlinkLocalRoot", [nodeId], NATIVE_DIALOG_TIMEOUT_MS);
   }
 
   importGitlinkSnapshot(nodeId: string, repo: string, branch: string): void {
-    this.transport.intent("scene", "importGitlinkSnapshot", [nodeId, repo, branch]);
+    this.transport.fireIntent("scene", "importGitlinkSnapshot", [nodeId, repo, branch]);
   }
 
   // scopeMode/selectedPaths are never independently mirrored server-side via
@@ -463,7 +479,7 @@ export class SceneStore {
   // only ever travel as parameters of this one call, read from local
   // component state at the moment Build Context is clicked.
   buildGitlinkContext(nodeId: string, scopeMode: string, selectedPaths: string[]): void {
-    this.transport.intent("scene", "buildGitlinkContext", [nodeId, scopeMode, selectedPaths]);
+    this.transport.fireIntent("scene", "buildGitlinkContext", [nodeId, scopeMode, selectedPaths]);
   }
 
   fetchGitlinkContext(nodeId: string): Promise<string> {
@@ -471,14 +487,14 @@ export class SceneStore {
   }
 
   runGitlinkChangeSet(nodeId: string, taskPrompt: string): void {
-    this.transport.intent("scene", "runGitlinkChangeSet", [nodeId, taskPrompt]);
+    this.transport.fireIntent("scene", "runGitlinkChangeSet", [nodeId, taskPrompt]);
   }
 
   // Same requestId-not-nodeId shape cancelConversationRequest/
   // cancelWebResearchRequest/cancelArtifactRequest above already established
   // for their own per-node cancel.
   cancelGitlinkRequest(requestId: string): void {
-    this.transport.intent("scene", "cancelGitlinkRequest", [requestId]);
+    this.transport.fireIntent("scene", "cancelGitlinkRequest", [requestId]);
   }
 
   // fingerprint is passed through verbatim - the caller (GitlinkNodeView's
@@ -486,7 +502,7 @@ export class SceneStore {
   // gitlinkChangeFingerprint, never anything computed client-side; this
   // store method has no opinion on that, it just forwards the argument.
   applyGitlinkChanges(nodeId: string, fingerprint: string): void {
-    this.transport.intent("scene", "applyGitlinkChanges", [nodeId, fingerprint]);
+    this.transport.fireIntent("scene", "applyGitlinkChanges", [nodeId, fingerprint]);
   }
 
   // R5.4: Py-Coder node - setPyCoderMode/runPyCoder/cancelPyCoderRequest
@@ -496,7 +512,7 @@ export class SceneStore {
   // only validator of that value; this store has no opinion on it, same
   // posture as applyGitlinkChanges's fingerprint passthrough above.
   setPyCoderMode(nodeId: string, mode: string): void {
-    this.transport.intent("scene", "setPyCoderMode", [nodeId, mode]);
+    this.transport.fireIntent("scene", "setPyCoderMode", [nodeId, mode]);
   }
 
   // inputText's meaning (a natural-language prompt vs hand-typed code) is
@@ -505,14 +521,14 @@ export class SceneStore {
   // backend/canvas.py's own start_pycoder_run docstring ("stores input_text
   // into the field the CURRENT mode actually reads at dispatch time").
   runPyCoder(nodeId: string, inputText: string): void {
-    this.transport.intent("scene", "runPyCoder", [nodeId, inputText]);
+    this.transport.fireIntent("scene", "runPyCoder", [nodeId, inputText]);
   }
 
   // Same requestId-not-nodeId shape cancelConversationRequest/
   // cancelWebResearchRequest/cancelArtifactRequest/cancelGitlinkRequest above
   // already established for their own per-node cancel.
   cancelPyCoderRequest(requestId: string): void {
-    this.transport.intent("scene", "cancelPyCoderRequest", [requestId]);
+    this.transport.fireIntent("scene", "cancelPyCoderRequest", [requestId]);
   }
 
   // R5.4: Execution Sandbox node - same three-intent shape as Py-Coder above
@@ -524,22 +540,22 @@ export class SceneStore {
   // WS-intent layer - CodeSandboxNodeView is the one that decides whether
   // that's currently sensible to allow (see its own Run-enablement comment).
   setCodeSandboxRequirements(nodeId: string, requirementsText: string): void {
-    this.transport.intent("scene", "setCodeSandboxRequirements", [nodeId, requirementsText]);
+    this.transport.fireIntent("scene", "setCodeSandboxRequirements", [nodeId, requirementsText]);
   }
 
   // ADR-005 stage 5.5: the approval panel's own source-build opt-in
   // checkbox - fires immediately on toggle, same posture as
   // setCodeSandboxRequirements above, not deferred to Approve.
   setCodeSandboxAllowSourceBuilds(nodeId: string, allow: boolean): void {
-    this.transport.intent("scene", "setCodeSandboxAllowSourceBuilds", [nodeId, allow]);
+    this.transport.fireIntent("scene", "setCodeSandboxAllowSourceBuilds", [nodeId, allow]);
   }
 
   runCodeSandbox(nodeId: string, inputText: string): void {
-    this.transport.intent("scene", "runCodeSandbox", [nodeId, inputText]);
+    this.transport.fireIntent("scene", "runCodeSandbox", [nodeId, inputText]);
   }
 
   cancelCodeSandboxRequest(requestId: string): void {
-    this.transport.intent("scene", "cancelCodeSandboxRequest", [requestId]);
+    this.transport.fireIntent("scene", "cancelCodeSandboxRequest", [requestId]);
   }
 
   // R5.4: the shared human-approval gate - ONE request_id namespace across
@@ -554,11 +570,11 @@ export class SceneStore {
   // pendingRequestId the scene snapshot says is in flight for that node,
   // never anything UI-supplied.
   approveCodeExecution(requestId: string): void {
-    this.transport.intent("scene", "approveCodeExecution", [requestId]);
+    this.transport.fireIntent("scene", "approveCodeExecution", [requestId]);
   }
 
   denyCodeExecution(requestId: string): void {
-    this.transport.intent("scene", "denyCodeExecution", [requestId]);
+    this.transport.fireIntent("scene", "denyCodeExecution", [requestId]);
   }
 
   // R5.4: NOT one of the 8 registered WS intents above - a thin passthrough
@@ -596,19 +612,19 @@ export class SceneStore {
   sendMessage(text: string): void {
     const synthesizeNodeIds = this.synthesizeTargetNodeIds;
     if (synthesizeNodeIds !== null) {
-      this.transport.intent("scene", "synthesizeBranches", [synthesizeNodeIds, text]);
+      this.transport.fireIntent("scene", "synthesizeBranches", [synthesizeNodeIds, text]);
       this.setSynthesizeTargetNodeIds(null);
       return;
     }
     const branchFromNodeId = this.replyTargetNodeId;
     const args: unknown[] = [text];
     if (branchFromNodeId !== null) args.push(branchFromNodeId);
-    this.transport.intent("scene", "sendMessage", args);
+    this.transport.fireIntent("scene", "sendMessage", args);
     if (branchFromNodeId !== null) this.setReplyTargetNodeId(null);
   }
 
   moveNode(id: string, x: number, y: number): void {
-    this.transport.intent("scene", "moveNode", [id, x, y]);
+    this.transport.fireIntent("scene", "moveNode", [id, x, y]);
   }
 
   // R6.1 follow-up: a group drag's commit (the group's own node PLUS every
@@ -620,7 +636,7 @@ export class SceneStore {
   // grow a box (rather than staying frozen, the bug the growth logic
   // itself was fixing).
   moveNodes(positions: Array<{ id: string; x: number; y: number }>): void {
-    this.transport.intent(
+    this.transport.fireIntent(
       "scene",
       "moveNodes",
       [positions.map((p) => [p.id, p.x, p.y])],
@@ -628,55 +644,55 @@ export class SceneStore {
   }
 
   removeNodes(ids: string[]): void {
-    if (ids.length > 0) this.transport.intent("scene", "removeNodes", [ids]);
+    if (ids.length > 0) this.transport.fireIntent("scene", "removeNodes", [ids]);
   }
 
   connectNodes(source: string, target: string): void {
-    this.transport.intent("scene", "connectNodes", [source, target]);
+    this.transport.fireIntent("scene", "connectNodes", [source, target]);
   }
 
   removeEdges(ids: string[]): void {
-    if (ids.length > 0) this.transport.intent("scene", "removeEdges", [ids]);
+    if (ids.length > 0) this.transport.fireIntent("scene", "removeEdges", [ids]);
   }
 
   addPin(title: string, x: number, y: number, note = ""): void {
-    this.transport.intent("scene", "addPin", [title, x, y, note]);
+    this.transport.fireIntent("scene", "addPin", [title, x, y, note]);
   }
 
   updatePin(id: string, title: string, note: string): void {
-    this.transport.intent("scene", "updatePin", [id, title, note]);
+    this.transport.fireIntent("scene", "updatePin", [id, title, note]);
   }
 
   removePin(id: string): void {
-    this.transport.intent("scene", "removePin", [id]);
+    this.transport.fireIntent("scene", "removePin", [id]);
   }
 
   setSnapToGrid(enabled: boolean): void {
-    this.transport.intent("scene", "setSnapToGrid", [enabled]);
+    this.transport.fireIntent("scene", "setSnapToGrid", [enabled]);
   }
 
   // R7.5b-1: same bare-bool/"scene"-topic shape as setSnapToGrid above.
   setFadeConnections(enabled: boolean): void {
-    this.transport.intent("scene", "setFadeConnections", [enabled]);
+    this.transport.fireIntent("scene", "setFadeConnections", [enabled]);
   }
 
   // R7.5b-2: same shape again - intent name matches the legacy
   // GridControlBridge's own setOrthogonalConnections Slot name 1:1.
   setOrthogonalConnections(enabled: boolean): void {
-    this.transport.intent("scene", "setOrthogonalConnections", [enabled]);
+    this.transport.fireIntent("scene", "setOrthogonalConnections", [enabled]);
   }
 
   // R7.5b-3: the fourth and final legacy grid-control toggle.
   setSmartGuides(enabled: boolean): void {
-    this.transport.intent("scene", "setSmartGuides", [enabled]);
+    this.transport.fireIntent("scene", "setSmartGuides", [enabled]);
   }
 
   setDragFactor(factor: number): void {
-    this.transport.intent("scene", "setDragFactor", [factor]);
+    this.transport.fireIntent("scene", "setDragFactor", [factor]);
   }
 
   organizeNodes(): void {
-    this.transport.intent("scene", "organizeNodes", []);
+    this.transport.fireIntent("scene", "organizeNodes", []);
   }
 
   // R6.5: session save - targets "app-chat-library", not "scene", since
@@ -688,7 +704,7 @@ export class SceneStore {
   // (see this file's own "grid-control" calls just below for the same
   // precedent: not every method here targets "scene").
   saveChat(): void {
-    this.transport.intent("app-chat-library", "saveChat", []);
+    this.transport.fireIntent("app-chat-library", "saveChat", []);
   }
 
   // R7.5a: command-palette's "New Chat" - same "app-chat-library", not
@@ -696,7 +712,7 @@ export class SceneStore {
   // exists and is wired from the chat-library dialog, this just gives the
   // command palette a second entry point to the same real intent.
   newChat(): void {
-    this.transport.intent("app-chat-library", "newChat", []);
+    this.transport.fireIntent("app-chat-library", "newChat", []);
   }
 
   // -- R6.1: Notes/Frames/Containers ----------------------------------------
@@ -714,19 +730,19 @@ export class SceneStore {
 
   addNote(x: number, y: number, options: { isSystemPrompt?: boolean; isSummaryNote?: boolean } = {}): void {
     const { isSystemPrompt = false, isSummaryNote = false } = options;
-    this.transport.intent("scene", "addNote", [x, y, isSystemPrompt, isSummaryNote]);
+    this.transport.fireIntent("scene", "addNote", [x, y, isSystemPrompt, isSummaryNote]);
   }
 
   setNoteContent(nodeId: string, content: string): void {
-    this.transport.intent("scene", "setNoteContent", [nodeId, content]);
+    this.transport.fireIntent("scene", "setNoteContent", [nodeId, content]);
   }
 
   createFrame(itemIds: string[]): void {
-    this.transport.intent("scene", "createFrame", [itemIds]);
+    this.transport.fireIntent("scene", "createFrame", [itemIds]);
   }
 
   createContainer(itemIds: string[]): void {
-    this.transport.intent("scene", "createContainer", [itemIds]);
+    this.transport.fireIntent("scene", "createContainer", [itemIds]);
   }
 
   // ADR-002 Workstream 1 ("Compare Branches") - same fire-and-forget shape
@@ -735,7 +751,7 @@ export class SceneStore {
   // backend validates/does the work, and the resulting note arrives
   // through the next scene snapshot like any other mutation.
   compareBranches(nodeIds: string[]): void {
-    this.transport.intent("scene", "compareBranches", [nodeIds]);
+    this.transport.fireIntent("scene", "compareBranches", [nodeIds]);
   }
 
   // ADR-002 Workstream 1 ("Branch status and lifecycle") - three plain
@@ -743,22 +759,22 @@ export class SceneStore {
   // below: the backend validates/does the work, and the new value arrives
   // through the next scene snapshot like any other mutation.
   setBranchStatus(nodeId: string, status: string): void {
-    this.transport.intent("scene", "setBranchStatus", [nodeId, status]);
+    this.transport.fireIntent("scene", "setBranchStatus", [nodeId, status]);
   }
 
   setFinalDeliverable(nodeId: string, isFinal: boolean): void {
-    this.transport.intent("scene", "setFinalDeliverable", [nodeId, isFinal]);
+    this.transport.fireIntent("scene", "setFinalDeliverable", [nodeId, isFinal]);
   }
 
   collapseBranch(nodeId: string, collapsed: boolean): void {
-    this.transport.intent("scene", "collapseBranch", [nodeId, collapsed]);
+    this.transport.fireIntent("scene", "collapseBranch", [nodeId, collapsed]);
   }
 
   // Shared setter for frame/container header-note/title text (backend/
   // canvas.py's set_group_label) - reused verbatim for both kinds, same
   // posture as setGroupColor below.
   setGroupLabel(nodeId: string, text: string): void {
-    this.transport.intent("scene", "setGroupLabel", [nodeId, text]);
+    this.transport.fireIntent("scene", "setGroupLabel", [nodeId, text]);
   }
 
   // Shared color setter for note/frame/container kinds. Either argument may
@@ -766,27 +782,27 @@ export class SceneStore {
   // (GroupColorPicker's "Reset to Default" item) passes (null, null) for a
   // full reset, or one real hex + null for a single-half set.
   setGroupColor(nodeId: string, color: string | null, headerColor: string | null): void {
-    this.transport.intent("scene", "setGroupColor", [nodeId, color, headerColor]);
+    this.transport.fireIntent("scene", "setGroupColor", [nodeId, color, headerColor]);
   }
 
   toggleFrameLock(nodeId: string): void {
-    this.transport.intent("scene", "toggleFrameLock", [nodeId]);
+    this.transport.fireIntent("scene", "toggleFrameLock", [nodeId]);
   }
 
   toggleGroupCollapsed(nodeId: string): void {
-    this.transport.intent("scene", "toggleGroupCollapsed", [nodeId]);
+    this.transport.fireIntent("scene", "toggleGroupCollapsed", [nodeId]);
   }
 
   resizeFrame(nodeId: string, width: number, height: number): void {
-    this.transport.intent("scene", "resizeFrame", [nodeId, width, height]);
+    this.transport.fireIntent("scene", "resizeFrame", [nodeId, width, height]);
   }
 
   fitFrameToContent(nodeId: string): void {
-    this.transport.intent("scene", "fitFrameToContent", [nodeId]);
+    this.transport.fireIntent("scene", "fitFrameToContent", [nodeId]);
   }
 
   ungroup(nodeId: string): void {
-    this.transport.intent("scene", "ungroup", [nodeId]);
+    this.transport.fireIntent("scene", "ungroup", [nodeId]);
   }
 
   // -- R6.2: Chart node -----------------------------------------------------
@@ -802,7 +818,7 @@ export class SceneStore {
   // forgets, same as its own onGenerateImage).
 
   generateChart(parentNodeId: string, chartType: string): void {
-    this.transport.intent("scene", "generateChart", [parentNodeId, chartType]);
+    this.transport.fireIntent("scene", "generateChart", [parentNodeId, chartType]);
   }
 
   // R8a: the Key Takeaway / Explainer Note agents, restored from the deleted
@@ -812,19 +828,19 @@ export class SceneStore {
   // generateImage - and the resulting note arrives on the next scene
   // snapshot, so neither needs the new node id back here.
   generateKeyTakeaway(sourceNodeId: string): void {
-    this.transport.intent("scene", "generateKeyTakeaway", [sourceNodeId]);
+    this.transport.fireIntent("scene", "generateKeyTakeaway", [sourceNodeId]);
   }
 
   generateExplainerNote(sourceNodeId: string): void {
-    this.transport.intent("scene", "generateExplainerNote", [sourceNodeId]);
+    this.transport.fireIntent("scene", "generateExplainerNote", [sourceNodeId]);
   }
 
   resizeChart(nodeId: string, width: number, height: number): void {
-    this.transport.intent("scene", "resizeChart", [nodeId, width, height]);
+    this.transport.fireIntent("scene", "resizeChart", [nodeId, width, height]);
   }
 
   toggleChartAspectLock(nodeId: string): void {
-    this.transport.intent("scene", "toggleChartAspectLock", [nodeId]);
+    this.transport.fireIntent("scene", "toggleChartAspectLock", [nodeId]);
   }
 
   // -- R6.3: Scene-level serialization gaps ---------------------------------
@@ -843,45 +859,45 @@ export class SceneStore {
   // through it at all.
 
   setViewState(zoomFactor: number, scrollX: number, scrollY: number): void {
-    this.transport.intent("scene", "setViewState", [zoomFactor, scrollX, scrollY]);
+    this.transport.fireIntent("scene", "setViewState", [zoomFactor, scrollX, scrollY]);
   }
 
   setHtmlSplitterState(nodeId: string, value: number): void {
-    this.transport.intent("scene", "setHtmlSplitterState", [nodeId, value]);
+    this.transport.fireIntent("scene", "setHtmlSplitterState", [nodeId, value]);
   }
 
   setChatScrollValue(nodeId: string, value: number): void {
-    this.transport.intent("scene", "setChatScrollValue", [nodeId, value]);
+    this.transport.fireIntent("scene", "setChatScrollValue", [nodeId, value]);
   }
 
   // Grid intents ride the grid-control topic; font intents ride scene - both
   // keep the legacy bridges' @Slot names 1:1 (backend/canvas.py contract).
   setGridSize(size: number): void {
-    this.transport.intent("grid-control", "setGridSize", [size]);
+    this.transport.fireIntent("grid-control", "setGridSize", [size]);
   }
 
   setGridOpacityPercent(percent: number): void {
-    this.transport.intent("grid-control", "setGridOpacityPercent", [percent]);
+    this.transport.fireIntent("grid-control", "setGridOpacityPercent", [percent]);
   }
 
   setGridStyle(style: string): void {
-    this.transport.intent("grid-control", "setGridStyle", [style]);
+    this.transport.fireIntent("grid-control", "setGridStyle", [style]);
   }
 
   setGridColor(hex: string): void {
-    this.transport.intent("grid-control", "setGridColor", [hex]);
+    this.transport.fireIntent("grid-control", "setGridColor", [hex]);
   }
 
   setFontFamily(family: string): void {
-    this.transport.intent("scene", "setFontFamily", [family]);
+    this.transport.fireIntent("scene", "setFontFamily", [family]);
   }
 
   setFontSize(sizePt: number): void {
-    this.transport.intent("scene", "setFontSize", [sizePt]);
+    this.transport.fireIntent("scene", "setFontSize", [sizePt]);
   }
 
   setFontColor(hex: string): void {
-    this.transport.intent("scene", "setFontColor", [hex]);
+    this.transport.fireIntent("scene", "setFontColor", [hex]);
   }
 
   // Rides the notification topic, not scene - same "this store already
@@ -893,7 +909,7 @@ export class SceneStore {
   // backend/notifications.py's showInfo intent for why this exists instead
   // of a second, parallel client-local notification UI.
   showInfoNotification(message: string): void {
-    this.transport.intent("notification", "showInfo", [message]);
+    this.transport.fireIntent("notification", "showInfo", [message]);
   }
 }
 

--- a/web_ui/src/app/chrome/AppBar.test.tsx
+++ b/web_ui/src/app/chrome/AppBar.test.tsx
@@ -20,7 +20,10 @@ import type { WsTransport } from "../../lib/ws/transport";
 // CSS wiring in a way no visual glance at one window size would catch.
 
 function makeStore(): SceneStore {
-  const transport = { subscribe: vi.fn(), intent: vi.fn() } as unknown as WsTransport;
+  // ADR-003 stage 3.1: fireIntent is the transport method SceneStore's own
+  // mutating intent call sites actually use now - see sceneStore.ts's own
+  // module doc.
+  const transport = { subscribe: vi.fn(), intent: vi.fn(), fireIntent: vi.fn() } as unknown as WsTransport;
   return new SceneStore(transport);
 }
 

--- a/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
@@ -57,6 +57,11 @@ function makeTransport() {
     intent: (topic: string, intent: string, args: unknown[]) => {
       intents.push([topic, intent, args]);
     },
+    // ADR-003 stage 3.1: ChatLibraryDialog's own mutating call sites now go
+    // through fireIntent, not the bare intent() above.
+    fireIntent: (topic: string, intent: string, args: unknown[] = []) => {
+      intents.push([topic, intent, args]);
+    },
   } as unknown as WsTransport;
   return {
     transport,

--- a/web_ui/src/app/chrome/ChatLibraryDialog.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.tsx
@@ -178,12 +178,12 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
   const groups = useMemo(() => groupRows(filtered), [filtered]);
 
   function loadChat(id: number) {
-    transport.intent("app-chat-library", "loadChat", [id]);
+    transport.fireIntent("app-chat-library", "loadChat", [id]);
     overlays.close();
   }
 
   function newChat() {
-    transport.intent("app-chat-library", "newChat", []);
+    transport.fireIntent("app-chat-library", "newChat", []);
     overlays.close();
   }
 
@@ -197,7 +197,7 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
   function commitRename() {
     const title = renameDraft.trim();
     if (renamingId === null || !title) return;
-    transport.intent("app-chat-library", "renameChat", [renamingId, title]);
+    transport.fireIntent("app-chat-library", "renameChat", [renamingId, title]);
     setRenamingId(null);
     lastTriggerRef.current?.focus();
   }
@@ -225,7 +225,7 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
 
   function confirmDelete() {
     if (confirmingDeleteId === null) return;
-    transport.intent("app-chat-library", "deleteChat", [confirmingDeleteId]);
+    transport.fireIntent("app-chat-library", "deleteChat", [confirmingDeleteId]);
     setConfirmingDeleteId(null);
   }
 

--- a/web_ui/src/app/chrome/PluginPicker.test.tsx
+++ b/web_ui/src/app/chrome/PluginPicker.test.tsx
@@ -40,6 +40,11 @@ function makeTransport() {
     intent: (topic: string, intent: string, args: unknown[]) => {
       intents.push([topic, intent, args]);
     },
+    // ADR-003 stage 3.1: PluginPicker's own executePlugin call site now goes
+    // through fireIntent, not the bare intent() above.
+    fireIntent: (topic: string, intent: string, args: unknown[] = []) => {
+      intents.push([topic, intent, args]);
+    },
   } as unknown as WsTransport;
   return {
     transport,
@@ -57,7 +62,7 @@ function OpenPluginsButton() {
   );
 }
 
-function setup(store: SceneStore = new SceneStore({ subscribe: vi.fn(), intent: vi.fn() } as unknown as WsTransport)) {
+function setup(store: SceneStore = new SceneStore({ subscribe: vi.fn(), intent: vi.fn(), fireIntent: vi.fn() } as unknown as WsTransport)) {
   const user = userEvent.setup();
   const fake = makeTransport();
   render(
@@ -96,7 +101,7 @@ describe("PluginPicker", () => {
   });
 
   it("selecting a plugin fires executePlugin with the currently-selected node id", async () => {
-    const store = new SceneStore({ subscribe: vi.fn(), intent: vi.fn() } as unknown as WsTransport);
+    const store = new SceneStore({ subscribe: vi.fn(), intent: vi.fn(), fireIntent: vi.fn() } as unknown as WsTransport);
     store.setSelectedNodeId("node-42");
     const { user, intents } = setup(store);
     await user.click(screen.getByText("open plugins"));
@@ -106,7 +111,7 @@ describe("PluginPicker", () => {
   });
 
   it("every plugin's click sends the selected node id, not just Web Research's", async () => {
-    const store = new SceneStore({ subscribe: vi.fn(), intent: vi.fn() } as unknown as WsTransport);
+    const store = new SceneStore({ subscribe: vi.fn(), intent: vi.fn(), fireIntent: vi.fn() } as unknown as WsTransport);
     store.setSelectedNodeId("node-7");
     const { user, intents } = setup(store);
     await user.click(screen.getByText("open plugins"));

--- a/web_ui/src/app/chrome/PluginPicker.tsx
+++ b/web_ui/src/app/chrome/PluginPicker.tsx
@@ -86,7 +86,7 @@ export function PluginPicker({ transport, store }: { transport: WsTransport; sto
                     type="button"
                     className="plugin-picker-row"
                     onClick={() => {
-                      transport.intent("app-plugins", "executePlugin", [
+                      transport.fireIntent("app-plugins", "executePlugin", [
                         plugin.name,
                         store.getSelectedNodeId(),
                       ]);

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -67,6 +67,11 @@ function makeTransport() {
     intent: (topic: string, intent: string, args: unknown[]) => {
       intents.push([topic, intent, args]);
     },
+    // ADR-003 stage 3.1: SettingsDialog's own mutating call sites now go
+    // through fireIntent, not the bare intent() above.
+    fireIntent: (topic: string, intent: string, args: unknown[] = []) => {
+      intents.push([topic, intent, args]);
+    },
   } as unknown as WsTransport;
   return {
     transport,

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -160,7 +160,7 @@ function GeneralPage({
         <input
           type="checkbox"
           checked={state.showTokenCounter}
-          onChange={(event) => transport.intent("app-settings", "setShowTokenCounter", [event.target.checked])}
+          onChange={(event) => transport.fireIntent("app-settings", "setShowTokenCounter", [event.target.checked])}
         />
         Show Token Counter Overlay
       </label>
@@ -169,7 +169,7 @@ function GeneralPage({
         <input
           type="checkbox"
           checked={state.enableSystemPrompt}
-          onChange={(event) => transport.intent("app-settings", "setEnableSystemPrompt", [event.target.checked])}
+          onChange={(event) => transport.fireIntent("app-settings", "setEnableSystemPrompt", [event.target.checked])}
         />
         Enable Assistant System Prompt
       </label>
@@ -182,7 +182,7 @@ function GeneralPage({
               type="checkbox"
               checked={state.notificationPreferences[type] ?? true}
               onChange={(event) =>
-                transport.intent("app-settings", "setNotificationPreference", [type, event.target.checked])
+                transport.fireIntent("app-settings", "setNotificationPreference", [type, event.target.checked])
               }
             />
             {NOTIFICATION_TYPE_LABELS[type]}
@@ -230,7 +230,7 @@ function IntegrationsPage({
           type="button"
           className="settings-button"
           onClick={() => {
-            transport.intent("app-settings", "clearGithubToken", []);
+            transport.fireIntent("app-settings", "clearGithubToken", []);
             setDraftToken("");
           }}
         >
@@ -241,7 +241,7 @@ function IntegrationsPage({
           className="settings-button settings-button-primary"
           disabled={draftToken.trim().length === 0}
           onClick={() => {
-            transport.intent("app-settings", "setGithubToken", [draftToken]);
+            transport.fireIntent("app-settings", "setGithubToken", [draftToken]);
             setDraftToken("");
           }}
         >
@@ -310,7 +310,7 @@ function ApiProviderPage({
           ariaLabel="API Provider"
           value={viewingProvider}
           options={API_PROVIDERS.map((provider) => ({ id: provider, label: provider }))}
-          onChange={(id) => transport.intent("app-settings", "setViewingApiProvider", [id])}
+          onChange={(id) => transport.fireIntent("app-settings", "setViewingApiProvider", [id])}
         />
       </div>
 
@@ -372,7 +372,7 @@ function ApiProviderPage({
               className="settings-button"
               disabled={state.apiCatalogStatus === "loading"}
               onClick={() =>
-                transport.intent("app-settings", "loadApiModels", [viewingProvider, draftApiKey, draftBaseUrl])
+                transport.fireIntent("app-settings", "loadApiModels", [viewingProvider, draftApiKey, draftBaseUrl])
               }
             >
               {state.apiCatalogStatus === "loading" ? "Loading catalog…" : "Load Available Models"}
@@ -429,7 +429,7 @@ function ApiProviderPage({
               type="button"
               className="settings-button settings-button-primary"
               onClick={() => {
-                transport.intent("app-settings", "resetApiSettings", []);
+                transport.fireIntent("app-settings", "resetApiSettings", []);
                 // Reset must clear the local drafts too, not just the key:
                 // the resync block only fires on a viewingProvider change,
                 // which Reset doesn't cause, so stale draftBaseUrl/
@@ -457,7 +457,7 @@ function ApiProviderPage({
             requiredTasks.some(({ task }) => !(draftModels[task] ?? "").trim())
           }
           onClick={() => {
-            transport.intent("app-settings", "saveApiConfiguration", [
+            transport.fireIntent("app-settings", "saveApiConfiguration", [
               viewingProvider,
               draftBaseUrl,
               draftApiKey,
@@ -514,7 +514,7 @@ function OllamaTaskField({
           onChange={(nextMode) => {
             setUiMode(nextMode);
             if (nextMode !== "explicit") {
-              transport.intent("app-settings", "setOllamaModelAssignment", [task, nextMode]);
+              transport.fireIntent("app-settings", "setOllamaModelAssignment", [task, nextMode]);
             }
           }}
         />
@@ -527,7 +527,7 @@ function OllamaTaskField({
             className="settings-select"
             list={OLLAMA_MODELS_DATALIST_ID}
             value={isSpecial ? "" : value}
-            onChange={(event) => transport.intent("app-settings", "setOllamaModelAssignment", [task, event.target.value])}
+            onChange={(event) => transport.fireIntent("app-settings", "setOllamaModelAssignment", [task, event.target.value])}
           />
         </label>
       )}
@@ -548,7 +548,7 @@ function OllamaPage({ state, transport }: { state: AppSettingsState; transport: 
               type="radio"
               name="ollama-reasoning-level"
               checked={state.ollamaReasoningLevel === option.id}
-              onChange={() => transport.intent("app-settings", "setOllamaReasoningLevel", [option.id])}
+              onChange={() => transport.fireIntent("app-settings", "setOllamaReasoningLevel", [option.id])}
             />
             {option.label}
           </label>
@@ -564,7 +564,7 @@ function OllamaPage({ state, transport }: { state: AppSettingsState; transport: 
           type="button"
           className="settings-button"
           disabled={state.ollamaScanStatus === "running"}
-          onClick={() => transport.intent("app-settings", "scanOllamaSystem", [])}
+          onClick={() => transport.fireIntent("app-settings", "scanOllamaSystem", [])}
         >
           {state.ollamaScanStatus === "running" ? "Scanning..." : "System Scan"}
         </button>
@@ -572,7 +572,7 @@ function OllamaPage({ state, transport }: { state: AppSettingsState; transport: 
           type="button"
           className="settings-button"
           disabled={state.ollamaScanStatus === "running"}
-          onClick={() => transport.intent("app-settings", "pickOllamaScanFolder", [])}
+          onClick={() => transport.fireIntent("app-settings", "pickOllamaScanFolder", [])}
         >
           Scan Folder...
         </button>
@@ -613,7 +613,7 @@ function OllamaPage({ state, transport }: { state: AppSettingsState; transport: 
           type="button"
           className="settings-button settings-button-primary"
           disabled={draftPullModel.trim().length === 0 || state.ollamaPullStatus === "running"}
-          onClick={() => transport.intent("app-settings", "pullOllamaModel", [draftPullModel])}
+          onClick={() => transport.fireIntent("app-settings", "pullOllamaModel", [draftPullModel])}
         >
           {state.ollamaPullStatus === "running" ? "Validating..." : "Validate and Pull Model"}
         </button>
@@ -727,7 +727,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
               type="radio"
               name="llama-cpp-reasoning-level"
               checked={state.llamaCppReasoningLevel === option.id}
-              onChange={() => transport.intent("app-settings", "setLlamaCppReasoningLevel", [option.id])}
+              onChange={() => transport.fireIntent("app-settings", "setLlamaCppReasoningLevel", [option.id])}
             />
             {option.label}
           </label>
@@ -743,7 +743,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
           type="button"
           className="settings-button"
           disabled={state.llamaCppScanStatus === "running"}
-          onClick={() => transport.intent("app-settings", "scanLlamaCppSystem", [])}
+          onClick={() => transport.fireIntent("app-settings", "scanLlamaCppSystem", [])}
         >
           {state.llamaCppScanStatus === "running" ? "Scanning..." : "System Scan"}
         </button>
@@ -751,7 +751,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
           type="button"
           className="settings-button"
           disabled={state.llamaCppScanStatus === "running"}
-          onClick={() => transport.intent("app-settings", "pickLlamaCppScanFolder", [])}
+          onClick={() => transport.fireIntent("app-settings", "pickLlamaCppScanFolder", [])}
         >
           Scan Folder...
         </button>
@@ -774,7 +774,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
               { id: "", label: "Select a scanned model..." },
               ...state.llamaCppScannedModels.map((path) => ({ id: path, label: basename(path) })),
             ]}
-            onChange={(path) => transport.intent("app-settings", "setLlamaCppChatModelPath", [path])}
+            onChange={(path) => transport.fireIntent("app-settings", "setLlamaCppChatModelPath", [path])}
           />
         </div>
       )}
@@ -785,7 +785,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
         <button
           type="button"
           className="settings-button"
-          onClick={() => transport.intent("app-settings", "pickLlamaCppChatModelFile", [])}
+          onClick={() => transport.fireIntent("app-settings", "pickLlamaCppChatModelFile", [])}
         >
           Browse...
         </button>
@@ -801,7 +801,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
               { id: "", label: "Select a scanned model..." },
               ...state.llamaCppScannedModels.map((path) => ({ id: path, label: basename(path) })),
             ]}
-            onChange={(path) => transport.intent("app-settings", "setLlamaCppTitleModelPath", [path])}
+            onChange={(path) => transport.fireIntent("app-settings", "setLlamaCppTitleModelPath", [path])}
           />
         </div>
       )}
@@ -812,7 +812,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
         <button
           type="button"
           className="settings-button"
-          onClick={() => transport.intent("app-settings", "pickLlamaCppTitleModelFile", [])}
+          onClick={() => transport.fireIntent("app-settings", "pickLlamaCppTitleModelFile", [])}
         >
           Browse...
         </button>
@@ -827,7 +827,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
           value={draftChatFormat}
           onChange={(event) => {
             setDraftChatFormat(event.target.value);
-            transport.intent("app-settings", "setLlamaCppChatFormat", [event.target.value]);
+            transport.fireIntent("app-settings", "setLlamaCppChatFormat", [event.target.value]);
           }}
         />
       </label>
@@ -838,14 +838,14 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
         min={256}
         max={131072}
         step={256}
-        onCommit={(n) => transport.intent("app-settings", "setLlamaCppNCtx", [n])}
+        onCommit={(n) => transport.fireIntent("app-settings", "setLlamaCppNCtx", [n])}
       />
       <LlamaCppNumberField
         label="GPU Layers"
         value={state.llamaCppNGpuLayers}
         min={-1}
         max={9999}
-        onCommit={(n) => transport.intent("app-settings", "setLlamaCppNGpuLayers", [n])}
+        onCommit={(n) => transport.fireIntent("app-settings", "setLlamaCppNGpuLayers", [n])}
       />
       <LlamaCppNumberField
         label="CPU Threads"
@@ -853,7 +853,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
         min={0}
         max={256}
         placeholder="0 = Auto"
-        onCommit={(n) => transport.intent("app-settings", "setLlamaCppNThreads", [n])}
+        onCommit={(n) => transport.fireIntent("app-settings", "setLlamaCppNThreads", [n])}
       />
 
       {state.llamaCppNotice && (
@@ -866,7 +866,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
         <button
           type="button"
           className="settings-button settings-button-primary"
-          onClick={() => transport.intent("app-settings", "saveLlamaCppSettings", [])}
+          onClick={() => transport.fireIntent("app-settings", "saveLlamaCppSettings", [])}
         >
           Save Settings
         </button>
@@ -917,7 +917,7 @@ export function SettingsDialog({ transport }: { transport: WsTransport }) {
               type="button"
               className={"settings-rail-button" + (section === activeSection ? " active" : "")}
               aria-current={section === activeSection ? "page" : undefined}
-              onClick={() => transport.intent("app-settings", "setActiveSection", [sectionKey(section)])}
+              onClick={() => transport.fireIntent("app-settings", "setActiveSection", [sectionKey(section)])}
             >
               {section}
             </button>

--- a/web_ui/src/app/chrome/composerStore.test.ts
+++ b/web_ui/src/app/chrome/composerStore.test.ts
@@ -26,6 +26,15 @@ function makeFakeTransport() {
     intent: vi.fn((topic: string, intent: string, args: unknown[] = []) => {
       intents.push({ topic, intent, args });
     }),
+    // ADR-003 stage 3.1: ComposerStore's own mutating intent call sites now
+    // go through fireIntent, not the bare intent() above - recorded into the
+    // SAME `intents` array (real WsTransport.fireIntent's own error-recovery
+    // path is exercised by transport.test.ts, not re-tested at every call
+    // site) so this file's existing assertions don't need to distinguish
+    // the two.
+    fireIntent: vi.fn((topic: string, intent: string, args: unknown[] = []) => {
+      intents.push({ topic, intent, args });
+    }),
     subscribeStream,
   } as unknown as WsTransport;
   return { transport, listeners, intents, subscribeStream, streamListeners, streamUnsubFns };

--- a/web_ui/src/app/chrome/composerStore.ts
+++ b/web_ui/src/app/chrome/composerStore.ts
@@ -11,6 +11,11 @@ import type { TokenCounterState } from "../../lib/bridge-core/generated/token-co
 import type { NotificationState } from "../../lib/bridge-core/generated/notification-state";
 import type { WsTransport } from "../../lib/ws/transport";
 
+// ADR-003 stage 3.1 review-fix: a native OS file dialog waits on the user,
+// not the network - long enough that a person genuinely browsing for a file
+// never trips the transport's ordinary request-timeout error path.
+const NATIVE_DIALOG_TIMEOUT_MS = 5 * 60_000;
+
 export const initialComposerState: AppComposerState = {
   schemaVersion: 1,
   minCompatibleSchemaVersion: 1,
@@ -138,36 +143,39 @@ export class ComposerStore {
   // -- intents (backend/composer.py + notifications.py, 1:1) --------------
 
   updateDraft(text: string): void {
-    this.transport.intent("app-composer", "updateDraft", [text]);
+    this.transport.fireIntent("app-composer", "updateDraft", [text]);
   }
 
   selectModel(modelId: string): void {
     // R8a: writes the chat-task model assignment. The backend routes this
     // through the same helper the Settings > Ollama page uses, so the two
     // surfaces cannot report different models.
-    this.transport.intent("app-composer", "selectModel", [modelId]);
+    this.transport.fireIntent("app-composer", "selectModel", [modelId]);
   }
 
   setReasoningLevel(level: string): void {
-    this.transport.intent("app-composer", "setReasoningLevel", [level]);
+    this.transport.fireIntent("app-composer", "setReasoningLevel", [level]);
   }
 
   attachFile(): void {
     // R8a: opens a NATIVE file dialog server-side (backend/native_dialogs.py,
     // same mechanism as Settings > Llama.cpp's GGUF picker) - there is no
     // browser-side file to pass, staging happens entirely on the backend.
-    this.transport.intent("app-composer", "attachFile", []);
+    // ADR-003 stage 3.1 review-fix: the backend handler blocks on the user's
+    // own pace in a native OS dialog, not on the network - the transport's
+    // ordinary 10s default would report an ordinary slow picker as a failure.
+    this.transport.fireIntent("app-composer", "attachFile", [], NATIVE_DIALOG_TIMEOUT_MS);
   }
 
   removeAttachment(attachmentId: string): void {
-    this.transport.intent("app-composer", "removeAttachment", [attachmentId]);
+    this.transport.fireIntent("app-composer", "removeAttachment", [attachmentId]);
   }
 
   cancelChatRequest(requestId: string): void {
-    this.transport.intent("app-composer", "cancelChatRequest", [requestId]);
+    this.transport.fireIntent("app-composer", "cancelChatRequest", [requestId]);
   }
 
   dismissNotification(): void {
-    this.transport.intent("notification", "dismiss", []);
+    this.transport.fireIntent("notification", "dismiss", []);
   }
 }

--- a/web_ui/src/lib/ws/transport.storeIntegration.test.ts
+++ b/web_ui/src/lib/ws/transport.storeIntegration.test.ts
@@ -1,0 +1,115 @@
+/**
+ * ADR-003 stage 3.1 review-fix (findings I/J): every other store test wires
+ * SceneStore/ComposerStore to a stub transport object whose own `fireIntent`
+ * mock is a synchronous push into a recorded-calls array - real, but it never
+ * actually exercises WsTransport.fireIntent()'s own id-tracking/error-catch
+ * machinery (that lives entirely in transport.test.ts, in isolation from any
+ * store). This file closes that gap: a REAL WsTransport (the same FakeSocket
+ * harness transport.test.ts uses) wired to a REAL store instance, driving one
+ * representative mutating call through the full store -> transport -> wire
+ * -> server-error-reply -> notification/showError chain end to end.
+ */
+import { describe, expect, it } from "vitest";
+import { WsTransport } from "./transport";
+import { SceneStore } from "../../app/canvas/sceneStore";
+import { ComposerStore } from "../../app/chrome/composerStore";
+
+class FakeSocket {
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+
+  constructor(public url: string) {}
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.onclose?.();
+  }
+
+  open() {
+    this.onopen?.();
+  }
+
+  receive(message: unknown) {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
+
+  lastSent(): Record<string, unknown> {
+    return JSON.parse(this.sent[this.sent.length - 1]);
+  }
+}
+
+function connectRealTransport() {
+  let socket: FakeSocket | null = null;
+  const transport = new WsTransport("ws://test/ws", {
+    webSocketFactory: (url) => {
+      socket = new FakeSocket(url);
+      return socket;
+    },
+  });
+  transport.connect();
+  socket!.open();
+  return { transport, socket: socket! };
+}
+
+describe("real WsTransport wired to a real store (end-to-end fireIntent -> showError)", () => {
+  it("SceneStore.collapseAllNodes: a real {kind:error} reply produces a real notification/showError intent on the wire", async () => {
+    const { transport, socket } = connectRealTransport();
+    const store = new SceneStore(transport);
+
+    store.collapseAllNodes();
+    const sent = socket.lastSent();
+    expect(sent).toMatchObject({ kind: "intent", topic: "scene", intent: "collapseAllNodes", args: [] });
+
+    socket.receive({ kind: "error", id: sent.id, error: "collapse failed" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(socket.lastSent()).toEqual({
+      kind: "intent",
+      topic: "notification",
+      intent: "showError",
+      args: ["collapse failed"],
+    });
+  });
+
+  it("ComposerStore.selectModel: a real {kind:error} reply produces a real notification/showError intent on the wire", async () => {
+    const { transport, socket } = connectRealTransport();
+    const store = new ComposerStore(transport);
+
+    store.selectModel("llama3");
+    const sent = socket.lastSent();
+    expect(sent).toMatchObject({ kind: "intent", topic: "app-composer", intent: "selectModel", args: ["llama3"] });
+
+    socket.receive({ kind: "error", id: sent.id, error: "unknown model" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(socket.lastSent()).toEqual({
+      kind: "intent",
+      topic: "notification",
+      intent: "showError",
+      args: ["unknown model"],
+    });
+  });
+
+  it("a successful reply does NOT produce a notification/showError intent", async () => {
+    const { transport, socket } = connectRealTransport();
+    const store = new SceneStore(transport);
+
+    store.collapseAllNodes();
+    const sent = socket.lastSent();
+    socket.receive({ kind: "result", id: sent.id, value: null });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(socket.sent.map((raw) => JSON.parse(raw))).not.toContainEqual(
+      expect.objectContaining({ intent: "showError" }),
+    );
+  });
+});

--- a/web_ui/src/lib/ws/transport.test.ts
+++ b/web_ui/src/lib/ws/transport.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { WsTransport } from "./transport";
+import { WsRequestError, WsTimeoutError, WsTransport, WsUnavailableError } from "./transport";
 
 class FakeSocket {
   static instances: FakeSocket[] = [];
@@ -117,6 +117,211 @@ describe("WsTransport", () => {
     const second = socket.lastSent();
     socket.receive({ kind: "error", id: second.id, error: "unknown intent" });
     await expect(bad).rejects.toThrow("unknown intent");
+  });
+
+  // ADR-003 stage 3.1
+  it("request() rejects with a WsRequestError specifically on a real {kind:error} server reply", async () => {
+    // Distinguishes a genuine server-side rejection from a transport-level
+    // one (not connected/closed/disposed/timeout, all still plain Error) -
+    // fireIntent() below relies on this to decide when to surface a
+    // notification and when to swallow silently.
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const p = t.request("system", "nope", []);
+    const sent = socket.lastSent();
+    socket.receive({ kind: "error", id: sent.id, error: "unknown intent" });
+    await expect(p).rejects.toBeInstanceOf(WsRequestError);
+  });
+
+  it("request() rejects with WsUnavailableError, NOT WsRequestError, when never connected", async () => {
+    const t = makeTransport();
+    await expect(t.request("system", "ping", [])).rejects.toBeInstanceOf(WsUnavailableError);
+  });
+
+  describe("fireIntent()", () => {
+    it("sends the intent id-tracked, like request(), not fire-and-forget like intent()", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      t.fireIntent("scene", "setPyCoderMode", ["n1", "manual"]);
+      const sent = socket.lastSent();
+      expect(sent).toEqual({ kind: "intent", topic: "scene", intent: "setPyCoderMode", args: ["n1", "manual"], id: sent.id });
+      expect(sent.id).toBeDefined();
+    });
+
+    it("on a real server error reply, fires notification/showError with the error message", async () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      t.fireIntent("scene", "nope", []);
+      const sent = socket.lastSent();
+      socket.receive({ kind: "error", id: sent.id, error: "unknown intent: scene/nope" });
+      // The rejection is handled asynchronously (a .catch callback) - flush
+      // the microtask queue before asserting the follow-up intent fired.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(socket.lastSent()).toEqual({
+        kind: "intent",
+        topic: "notification",
+        intent: "showError",
+        args: ["unknown intent: scene/nope"],
+      });
+    });
+
+    it("on success, does NOT fire notification/showError", async () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      t.fireIntent("scene", "setPyCoderMode", ["n1", "manual"]);
+      const sent = socket.lastSent();
+      socket.receive({ kind: "result", id: sent.id, value: null });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(socket.sent.map((raw) => JSON.parse(raw))).not.toContainEqual(
+        expect.objectContaining({ intent: "showError" }),
+      );
+    });
+
+    it("swallows a transport-level failure (not connected) silently, matching intent()'s own pre-migration behavior", async () => {
+      // No .connect() at all - request() rejects synchronously with a
+      // WsUnavailableError("not connected"), the ONE class fireIntent's
+      // review-fixed catch still swallows, so it must not attempt a
+      // showError round trip that could not reach the server anyway.
+      const t = makeTransport();
+      expect(() => t.fireIntent("scene", "setPyCoderMode", ["n1", "manual"])).not.toThrow();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(FakeSocket.instances).toHaveLength(0);
+    });
+
+    it("review-fix: surfaces a request timeout even though the connection stays open the whole time", async () => {
+      // The original version of this stage swallowed EVERY non-WsRequestError
+      // rejection, including a timeout - but a timeout with the connection
+      // still "open" the whole time (never closed here) is a real forced
+      // failure this stage's own exit criterion covers, not a
+      // connection-status condition the indicator already communicates. A
+      // WsTimeoutError is deliberately NOT a WsUnavailableError, so it must
+      // now surface via showError rather than being silently dropped.
+      const t = makeTransport({ requestTimeoutMs: 100 });
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      t.fireIntent("scene", "setPyCoderMode", ["n1", "manual"]);
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(t.getStatus()).toBe("open");
+      expect(socket.sent.map((raw) => JSON.parse(raw))).toContainEqual({
+        kind: "intent",
+        topic: "notification",
+        intent: "showError",
+        args: ["request timed out: scene/setPyCoderMode"],
+      });
+    });
+
+    it("passes a per-call timeoutMs through to request(), overriding the transport-wide default", async () => {
+      // The transport-wide default here is 100ms; a call site passing its
+      // own much longer override must not time out within that window - the
+      // exact scenario NATIVE_DIALOG_TIMEOUT_MS-style call sites need.
+      const t = makeTransport({ requestTimeoutMs: 100 });
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      t.fireIntent("scene", "pickGitlinkLocalRoot", ["n1"], 5_000);
+      vi.advanceTimersByTime(150);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(socket.sent.map((raw) => JSON.parse(raw))).not.toContainEqual(
+        expect.objectContaining({ intent: "showError" }),
+      );
+    });
+
+    it("review-fix: dedups an identical consecutive showError message within the dedupe window", async () => {
+      // A rapid-fire call site (e.g. a text field committing on every
+      // keystroke) failing with the SAME message repeatedly must not flood
+      // the single-slot notification banner with a fresh showError on every
+      // attempt while the underlying problem persists.
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+
+      t.fireIntent("app-composer", "updateDraft", ["d1", "hello"]);
+      socket.receive({ kind: "error", id: socket.lastSent().id, error: "boom" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      t.fireIntent("app-composer", "updateDraft", ["d1", "hello2"]);
+      socket.receive({ kind: "error", id: socket.lastSent().id, error: "boom" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const showErrors = socket.sent
+        .map((raw) => JSON.parse(raw))
+        .filter((m) => m.intent === "showError");
+      expect(showErrors).toHaveLength(1);
+    });
+
+    it("review-fix: does NOT dedup a DIFFERENT message that arrives within the same window", async () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+
+      t.fireIntent("app-composer", "updateDraft", ["d1", "hello"]);
+      socket.receive({ kind: "error", id: socket.lastSent().id, error: "boom one" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      t.fireIntent("app-composer", "updateDraft", ["d1", "hello2"]);
+      socket.receive({ kind: "error", id: socket.lastSent().id, error: "boom two" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const showErrors = socket.sent
+        .map((raw) => JSON.parse(raw))
+        .filter((m) => m.intent === "showError");
+      expect(showErrors).toHaveLength(2);
+    });
+
+    it("review-fix: re-fires the identical message once the dedupe window has passed", async () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+
+      t.fireIntent("app-composer", "updateDraft", ["d1", "hello"]);
+      socket.receive({ kind: "error", id: socket.lastSent().id, error: "boom" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      vi.advanceTimersByTime(3_100);
+
+      t.fireIntent("app-composer", "updateDraft", ["d1", "hello2"]);
+      socket.receive({ kind: "error", id: socket.lastSent().id, error: "boom" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const showErrors = socket.sent
+        .map((raw) => JSON.parse(raw))
+        .filter((m) => m.intent === "showError");
+      expect(showErrors).toHaveLength(2);
+    });
+  });
+
+  it("request() rejects with a WsTimeoutError specifically when the server never answers in time", async () => {
+    const t = makeTransport({ requestTimeoutMs: 100 });
+    t.connect();
+    FakeSocket.instances[0].open();
+    const p = t.request("system", "ping", []);
+    const assertion = expect(p).rejects.toBeInstanceOf(WsTimeoutError);
+    vi.advanceTimersByTime(150);
+    await assertion;
   });
 
   it("request() times out if the server never answers", async () => {

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -18,11 +18,56 @@
  * Reconnect: exponential-ish backoff, capped; every subscribed topic is
  * re-subscribed automatically on reopen so a backend restart re-hydrates
  * the UI without any component doing anything.
+ *
+ * ADR-003 stage 3.1: fireIntent() is the new default a store's own mutating
+ * intent call sites use in place of the old bare intent() - internally
+ * id-tracked, and a real failure (WsRequestError or WsTimeoutError) is
+ * surfaced via the existing notification banner instead of silently lost.
+ * intent() itself still exists for the rare genuinely-fire-and-forget case
+ * (e.g. surfacing an error THROUGH the notification system itself, which
+ * must not recurse back into fireIntent's own error handling).
+ *
+ * Review-fix (a 4-lens adversarial review of the first version of this
+ * stage): the original design swallowed EVERY non-WsRequestError rejection,
+ * including a client-side timeout - but a timeout with the connection still
+ * "open" the whole time is a real forced failure this stage's own exit
+ * criterion ("error visible in UI for a forced failure") covers, not a
+ * connection-status condition the existing indicator already communicates.
+ * fireIntent() now surfaces everything EXCEPT WsUnavailableError (the three
+ * genuinely connection-level rejection reasons: not connected/closed/
+ * disposed) - inverted from "surface only what I explicitly recognize" to
+ * "swallow only what I explicitly know is already visible elsewhere",
+ * closing the gap a future new rejection reason could otherwise silently
+ * fall into again.
  */
 
 import { withAuthToken } from "../auth/token";
 
 export type ConnectionStatus = "connecting" | "open" | "closed";
+
+/** ADR-003 stage 3.1: raised ONLY when the server actually replied with a
+ * structured {"kind":"error"} frame (unknown topic/intent, or an unhandled
+ * exception inside a handler) - i.e. the connection genuinely round-tripped
+ * and the server itself rejected the request. */
+export class WsRequestError extends Error {}
+
+/** ADR-003 stage 3.1 review-fix: raised when a request() times out waiting
+ * for a reply - distinct from WsRequestError (the server never actually
+ * answered either way) and from WsUnavailableError (the connection was, as
+ * far as this client can tell, genuinely open the whole time - a timeout is
+ * NOT a connection-status condition, so it must not be swallowed the way
+ * WsUnavailableError is). */
+export class WsTimeoutError extends Error {}
+
+/** ADR-003 stage 3.1 review-fix: raised for the three rejection reasons that
+ * genuinely correlate with the connection-status indicator already showing
+ * the user something is wrong (never connected, closed mid-request, or this
+ * transport instance was disposed) - the ONLY rejection reason fireIntent()
+ * swallows silently. Real disconnect UX (queue-while-reconnecting or a
+ * visible "paused" state) is ADR-003 stage 3.6, not this one; until then,
+ * silently dropping THESE specific three matches `intent()`'s own
+ * pre-migration fire-and-forget behavior exactly. */
+export class WsUnavailableError extends Error {}
 
 export type StateListener = (payload: Record<string, unknown>) => void;
 export type StatusListener = (status: ConnectionStatus) => void;
@@ -125,7 +170,7 @@ export class WsTransport {
       if (this.socket !== socket) return;
       this.socket = null;
       this.setStatus("closed");
-      this.failAllPending(new Error("connection closed"));
+      this.failAllPending(new WsUnavailableError("connection closed"));
       if (!this.disposed) this.scheduleReconnect();
     };
   }
@@ -133,7 +178,7 @@ export class WsTransport {
   dispose(): void {
     this.disposed = true;
     if (this.reconnectTimer !== null) clearTimeout(this.reconnectTimer);
-    this.failAllPending(new Error("transport disposed"));
+    this.failAllPending(new WsUnavailableError("transport disposed"));
     this.socket?.close();
     this.socket = null;
   }
@@ -193,21 +238,79 @@ export class WsTransport {
     this.socket.send(JSON.stringify({ kind: "intent", topic, intent, args }));
   }
 
-  /** Intent with a reply (result or error), for request/response flows. */
-  request(topic: string, intent: string, args: unknown[] = []): Promise<unknown> {
+  /** Intent with a reply (result or error), for request/response flows.
+   * `timeoutMs` overrides the transport-wide default for this one call -
+   * see fireIntent()'s own doc for why a genuinely user-paced backend
+   * operation (a native OS file/folder picker, say) needs a much longer
+   * window than the default 10s. */
+  request(topic: string, intent: string, args: unknown[] = [], timeoutMs?: number): Promise<unknown> {
     if (this.status !== "open" || !this.socket) {
-      return Promise.reject(new Error("not connected"));
+      return Promise.reject(new WsUnavailableError("not connected"));
     }
     const id = this.nextId++;
     const socket = this.socket;
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`request timed out: ${topic}/${intent}`));
-      }, this.requestTimeout);
+        reject(new WsTimeoutError(`request timed out: ${topic}/${intent}`));
+      }, timeoutMs ?? this.requestTimeout);
       this.pending.set(id, { resolve, reject, timer });
       socket.send(JSON.stringify({ kind: "intent", topic, intent, args, id }));
     });
+  }
+
+  /** ADR-003 stage 3.1: the new default for a store's own "fire this
+   * mutating intent" call sites - replaces the old bare `intent()` (which
+   * silently dropped a real server-side rejection with nothing but a
+   * console.error). Internally still id-tracked via request(), so a real
+   * failure (a genuine {"kind":"error"} reply, or a client-side timeout -
+   * anything except the three connection-level WsUnavailableError reasons,
+   * see that class's own doc) is surfaced to the user through the existing
+   * server-authoritative notification banner - reusing that channel rather
+   * than introducing a second, parallel client-local notification UI (see
+   * notifications.py's own module doc for why that split was rejected).
+   *
+   * `timeoutMs` overrides the default 10s window for this one call - pass
+   * a much longer value for an intent whose backend handler genuinely waits
+   * on the USER, not the network (a native OS file/folder picker, say);
+   * otherwise an ordinary slow user pace looks identical to a hung backend
+   * and gets reported as a spurious failure.
+   *
+   * Review-fix: a naive per-message de-dup (skip re-firing the IDENTICAL
+   * topic/intent/message combination within a short window) guards against
+   * a rapid-fire call site (e.g. a text field committing on every keystroke)
+   * flooding the single-slot notification banner with the same message on
+   * every failed attempt while a backend problem persists - see
+   * lastShowError's own doc for what this does and, just as importantly,
+   * does NOT fix (two DIFFERENT concurrent failures can still race each
+   * other for the one visible banner; that deeper limitation is accepted,
+   * documented residual risk, not something a per-message de-dup can close). */
+  fireIntent(topic: string, intent: string, args: unknown[] = [], timeoutMs?: number): void {
+    this.request(topic, intent, args, timeoutMs).catch((err) => {
+      if (err instanceof WsUnavailableError) return;
+      this.showErrorDeduped(String(err.message));
+    });
+  }
+
+  /** ADR-003 stage 3.1 review-fix: the last showError message this transport
+   * fired and when, so an identical message re-failing on every keystroke
+   * of some rapid-fire call site doesn't re-publish the notification banner
+   * on every single attempt. Keyed on the message text alone (not
+   * topic/intent) - two DIFFERENT intents that happen to produce the exact
+   * same backend error text within the window are rare enough, and
+   * indistinguishable enough to the user reading the banner, that treating
+   * them as "the same ongoing problem" is the more honest read anyway. */
+  private lastShowError: { message: string; at: number } | null = null;
+  private static readonly SHOW_ERROR_DEDUPE_MS = 3_000;
+
+  private showErrorDeduped(message: string): void {
+    const now = Date.now();
+    const last = this.lastShowError;
+    if (last && last.message === message && now - last.at < WsTransport.SHOW_ERROR_DEDUPE_MS) {
+      return;
+    }
+    this.lastShowError = { message, at: now };
+    this.intent("notification", "showError", [message]);
   }
 
   // -- internals ---------------------------------------------------------
@@ -236,7 +339,7 @@ export class WsTransport {
         this.pending.delete(id);
         clearTimeout(entry.timer);
         if (kind === "result") entry.resolve(message.value);
-        else entry.reject(new Error(String(message.error)));
+        else entry.reject(new WsRequestError(String(message.error)));
       } else if (kind === "error") {
         console.error("[ws] server error:", message.error);
       }


### PR DESCRIPTION
## Problem

Store intent call sites used the transport's fire-and-forget `intent()`, which sends no id and silently drops any server-side rejection (unknown topic/intent, unhandled handler exception). A user gets zero feedback for a real, forced failure - it just looks like nothing happened.

## Change

- `WsTransport.fireIntent(topic, intent, args, timeoutMs?)` is the new default for a store's mutating call sites, replacing bare `intent()`. It's id-tracked via `request()`, so a real failure surfaces through the existing server-authoritative notification banner instead of being dropped.
- Three typed error classes on `WsTransport`: `WsRequestError` (a genuine server `{"kind":"error"}` reply), `WsTimeoutError` (client-side request timeout), `WsUnavailableError` (not connected / closed mid-request / transport disposed). `fireIntent` surfaces everything except `WsUnavailableError` - closing a gap where the original opt-in design silently swallowed a real timeout.
- A per-call `timeoutMs` override gives `attachFile`/`pickGitlinkLocalRoot` (both native OS dialogs) a 5-minute window instead of the 10s default, since they wait on the user, not the network.
- A 3-second de-dupe guard stops a rapid-fire call site (e.g. a text field committing on every keystroke) from flooding the single-slot notification banner with the same failure repeatedly.
- All 99 fire-and-forget call sites across the app converted, including 33 in `SettingsDialog.tsx`/`ChatLibraryDialog.tsx`/`PluginPicker.tsx` that bypass the store layer and were missed by the first mechanical sweep.
- `UnknownTopicError`/`UnknownIntentError` subclass `KeyError`, whose `__str__` wraps a single-arg message in `repr()` - `app.py` now builds a clean message instead of leaking that raw quoted artifact into the user-facing banner.
- `GitlinkNodeView`'s Context tab gained a `.catch()` + Retry button; a rejected context fetch previously left the tab stuck on "Loading context…" forever with no way out.

## Test plan

- [x] Backend: `pytest -q` from repo root - 1560 passed, 14 skipped, 0 failed
- [x] Frontend: `npm run check` (schema, typecheck, lint, test, build) - clean; 1175 tests passed
- [x] 4-lens adversarial review: 14 confirmed findings, 0 refuted, all fixed
- [x] Mutation-tested the timeout-surfacing redesign and the de-dupe guard (each fix reverted, confirmed the exact intended test fails, restored)
- [x] New real end-to-end coverage: `transport.storeIntegration.test.ts` (a real `WsTransport` wired to a real `SceneStore`/`ComposerStore`, not a synchronous stub) and a real `create_app()`+`TestClient` WS round trip for `showError` in `test_app_ws.py`