### PR TITLE
ADR-003 stage 3.2 (partial): server-side intent-arg validation

### DIFF
--- a/GRAPHLINK_REPO_NAVIGATION.md
+++ b/GRAPHLINK_REPO_NAVIGATION.md
@@ -301,8 +301,7 @@ This is the practical lookup map for where code actually lives today.
 
 ### `contracts/` (build-time codegen, not runtime application code)
 
-- `codegen.py` - `GENERATED_ARTIFACTS` (11 entries), `--check`/`--write` CLI, the TS/JSON-Schema generation logic.
-- `payload_schema.py` - JSON Schema generation from Python dataclasses.
+- `codegen.py` - `GENERATED_ARTIFACTS` (11 entries), `--check`/`--write` CLI, the TS/JSON-Schema generation logic. Imports `graphlink_wire_schema.py` (repo root, not here - see below) for schema generation.
 - `graphlink_app_*_payload.py` / `graphlink_*_payload.py` - the 11 payload dataclasses (about, chat_library, composer, plugins, settings, drag_speed, font_control, grid_control, notification, scene, token_counter).
 - `tests/test_generated_artifacts.py` - parametrized over all 11 entries plus the `--check`/`--write` CLI drift tests.
 
@@ -324,6 +323,7 @@ This is the practical lookup map for where code actually lives today.
 - `graphlink_memory.py` - branch/history helpers used by `backend/canvas.py::send_message`.
 - `graphlink_chart_agent.py`, `graphlink_chart_data.py`, `graphlink_chart_rendering.py` - the chart-node pipeline (spec extraction/repair, rendering to PNG).
 - `graphlink_artifact_agent.py`, `graphlink_chat_agent.py` - LLM-facing agent logic `backend/agents.py`/`backend/canvas.py` call into.
+- `graphlink_wire_schema.py` - dataclass -> JSON Schema generation + payload validation (ADR-003 stage 3.2). Shared by `contracts/codegen.py` (dev-time TS generation) and `backend/events.py` (runtime intent-arg validation) - lives at the repo root, not inside `contracts/`, specifically so the runtime backend can import it (`contracts/` is excluded from the shipped wheel).
 
 ## Where To Edit When...
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -53,6 +53,7 @@ from backend.crash_recovery import maybe_show_crash_notice
 from backend.events import (
     DEFAULT_SESSION_ID,
     EventBus,
+    IntentValidationError,
     SessionBus,
     UnknownIntentError,
     UnknownSessionError,
@@ -647,6 +648,20 @@ async def _handle_message(session: SessionBus, websocket: WebSocket, message: di
         except UnknownIntentError as exc:
             await websocket.send_json(
                 {"kind": "error", "id": msg_id, "error": f"Unknown intent: {exc.args[0]}."}
+            )
+            return
+        except IntentValidationError as exc:
+            # ADR-003 stage 3.2: a schema-validated intent's args failed
+            # BEFORE dispatch_intent ever called the handler - exc.errors are
+            # already clean, human-readable strings (validate_payload's own
+            # output, not a raw exception repr), so they're joined directly
+            # rather than routed through the generic catch-all below.
+            await websocket.send_json(
+                {
+                    "kind": "error",
+                    "id": msg_id,
+                    "error": f"Invalid arguments: {'; '.join(exc.errors)}.",
+                }
             )
             return
         except Exception:

--- a/backend/events.py
+++ b/backend/events.py
@@ -70,10 +70,13 @@ never-evicted SessionBus for any `?session=<anything>` string).
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import inspect
 import logging
 import time
 from typing import Any, Awaitable, Callable, Protocol
+
+from graphlink_wire_schema import validate_payload
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +116,63 @@ class UnknownIntentError(KeyError):
     """A client sent an intent name the topic does not expose."""
 
 
+class IntentValidationError(Exception):
+    """ADR-003 stage 3.2: an intent's args failed schema validation - raised
+    BEFORE the handler runs (dispatch_intent, below), so a malformed request
+    can never reach - and partially mutate state through - a handler body.
+    See register_intent's own docstring for how a handler opts into this."""
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("; ".join(errors))
+
+
+def _validate_intent_args(args_schema: type, args: Any) -> list[str]:
+    """Adapt validate_payload (dict-shaped, for wire STATE payloads) to the
+    positional-list shape intent args actually arrive in - args_schema's
+    dataclass field order defines the positional mapping. zip() alone would
+    silently drop any args beyond the field count, so the arity ceiling is
+    checked explicitly first; a too-few-args shortfall is left to
+    validate_payload's own existing "missing required field" check (a
+    dataclass field with a default - typically `X | None = None` - is
+    correctly optional there already, with no new logic needed).
+
+    Review-fix: `args` is typed `list[Any]` by dispatch_intent's own
+    signature, but that is a Python-side type hint, not a runtime guarantee -
+    _handle_message (backend/app.py) builds it straight from
+    `message.get("args") or []` with no shape check, so a client sending a
+    JSON OBJECT for "args" reached here unchanged. zip(fields, a_dict) pairs
+    each field with the dict's KEY strings (never its values), so validation
+    could report zero errors while payload held only field-name echoes - and
+    the caller then did `handler(*args)` with that same dict, which unpacks
+    its KEYS as positional args, silently calling the handler with the wrong
+    values entirely rather than the rejection this whole mechanism exists to
+    guarantee. Rejecting outright here closes that gap for every schema at
+    once, not just this one call site.
+
+    Review-fix: validate_payload's per-field errors carry a JSON-Schema-style
+    "$." path prefix (e.g. "$.message: missing required field") - meaningful
+    for a wire-payload schema, but the ADR-003 stage 3.1 review already
+    established that this exact error text reaches the end-user notification
+    banner verbatim (see backend/app.py's IntentValidationError handler), so
+    that implementation-detail prefix is stripped before it ever gets there."""
+    if not isinstance(args, list):
+        return [f"expected a list of arguments, got {type(args).__name__}"]
+    fields = dataclasses.fields(args_schema)
+    if len(args) > len(fields):
+        return [f"expected at most {len(fields)} argument(s), got {len(args)}"]
+    payload = {field.name: value for field, value in zip(fields, args)}
+    return [error.removeprefix("$.") for error in validate_payload(payload, args_schema)]
+
+
+class _IntentRegistration:
+    __slots__ = ("handler", "args_schema")
+
+    def __init__(self, handler: IntentHandler, args_schema: type | None):
+        self.handler = handler
+        self.args_schema = args_schema
+
+
 class _Topic:
     __slots__ = ("name", "builder", "schema_version", "min_compatible", "revision")
 
@@ -138,7 +198,7 @@ class SessionBus:
     def __init__(self, session_id: str):
         self.session_id = session_id
         self._topics: dict[str, _Topic] = {}
-        self._intents: dict[tuple[str, str], IntentHandler] = {}
+        self._intents: dict[tuple[str, str], _IntentRegistration] = {}
         self._connections: set[Connection] = set()
         # ADR-004 stage 4.3: monotonic timestamp of when this bus last had
         # zero connections, or None while at least one is attached. Stamped
@@ -163,10 +223,44 @@ class SessionBus:
         assert name not in self._topics, f"topic {name!r} registered twice"
         self._topics[name] = _Topic(name, builder, schema_version, min_compatible)
 
-    def register_intent(self, topic: str, intent: str, handler: IntentHandler) -> None:
+    def register_intent(
+        self,
+        topic: str,
+        intent: str,
+        handler: IntentHandler,
+        *,
+        args_schema: type | None = None,
+    ) -> None:
+        """`args_schema`, when given, is a dataclass whose FIELD ORDER defines
+        the expected positional args - dispatch_intent validates a real
+        request's args against it before calling `handler` (ADR-003 stage
+        3.2), turning a malformed request into an IntentValidationError
+        instead of `handler(*args)`'s own bare TypeError from inside the
+        handler body (potentially after it has already partially mutated
+        state).
+
+        `None` (the default) covers TWO genuinely different cases - review-
+        fix: an earlier version of this docstring folded both into one
+        "deliberate, legitimate opt-out" claim, which is only true of the
+        first:
+          1. Permanently unschemaable: a variadic handler (`ping(*args)`, an
+             echo passthrough with no fixed arity) or a genuinely zero-arg
+             one (`dismiss()`) has no static shape a fixed-field dataclass
+             could ever describe - `None` here is the final state, not a gap.
+          2. Not yet migrated: the ~130 intents this stage's own "topic-by-
+             topic, scene last" rollout (see doc/adr/ADR-003-wire-protocol-
+             v2.md) hasn't reached yet keep today's pre-3.2 behavior (a bad
+             call still gets caught by app.py's generic exception handler,
+             just without a schema's specific error text or the
+             pre-execution guarantee) - `None` here is temporary, expected to
+             become a real schema in a later increment.
+        """
         key = (topic, intent)
         assert key not in self._intents, f"intent {topic}/{intent} registered twice"
-        self._intents[key] = handler
+        assert args_schema is None or dataclasses.is_dataclass(args_schema), (
+            f"args_schema for {topic}/{intent} must be a dataclass type, got {args_schema!r}"
+        )
+        self._intents[key] = _IntentRegistration(handler, args_schema)
 
     def has_topic(self, name: str) -> bool:
         """True when `name` has a registered builder on this bus.
@@ -273,12 +367,26 @@ class SessionBus:
     async def dispatch_intent(self, topic: str, intent: str, args: list[Any]) -> Any:
         """Run a registered intent handler. Sync and async handlers are both
         supported; sync handlers run in a thread so a slow one cannot stall
-        the event loop (QThread's replacement in miniature)."""
-        handler = self._intents.get((topic, intent))
-        if handler is None:
+        the event loop (QThread's replacement in miniature).
+
+        ADR-003 stage 3.2: when the handler was registered with an
+        args_schema, `args` is validated against it BEFORE the handler is
+        ever called - raises IntentValidationError on a mismatch, so a
+        malformed request cannot reach (and partially mutate state through)
+        the handler body. A registration with no schema (args_schema=None,
+        the default) skips this - see register_intent's own docstring for
+        why that is a legitimate, not merely deferred, choice for some
+        intents."""
+        registration = self._intents.get((topic, intent))
+        if registration is None:
             if topic not in self._topics and not any(t == topic for t, _ in self._intents):
                 raise UnknownTopicError(topic)
             raise UnknownIntentError(f"{topic}/{intent}")
+        if registration.args_schema is not None:
+            errors = _validate_intent_args(registration.args_schema, args)
+            if errors:
+                raise IntentValidationError(errors)
+        handler = registration.handler
         if inspect.iscoroutinefunction(handler):
             return await handler(*args)
         return await asyncio.to_thread(handler, *args)

--- a/backend/notifications.py
+++ b/backend/notifications.py
@@ -21,6 +21,19 @@ MessageType = Literal["info", "success", "warning", "error"]
 
 
 @dataclass
+class ShowMessageArgs:
+    """ADR-003 stage 3.2: args schema for showInfo/showError - both take
+    exactly one required string. dispatch_intent validates a real request's
+    args against this before show_info/show_error ever runs (see
+    backend/events.py's register_intent for the mechanism); a malformed call
+    (missing, wrong-typed, or extra args) is rejected with a structured error
+    instead of silently coercing via show()'s own str(message) - a non-string
+    arg used to become a display string with no complaint."""
+
+    message: str
+
+
+@dataclass
 class NotificationState:
     visible: bool = False
     message: str = ""
@@ -82,6 +95,6 @@ def register_notifications(bus: SessionBus, settings_manager: "SettingsManager |
         await bus.publish("notification")
 
     bus.register_intent("notification", "dismiss", dismiss)
-    bus.register_intent("notification", "showInfo", show_info)
-    bus.register_intent("notification", "showError", show_error)
+    bus.register_intent("notification", "showInfo", show_info, args_schema=ShowMessageArgs)
+    bus.register_intent("notification", "showError", show_error, args_schema=ShowMessageArgs)
     return state

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -27,11 +27,22 @@ silently doing nothing or fabricating node creation.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
+
+
+@dataclass
+class ExecutePluginArgs:
+    """ADR-003 stage 3.2: args schema for executePlugin - mirrors
+    execute_plugin's own signature below exactly (dataclass field order is
+    the positional mapping dispatch_intent validates against)."""
+
+    plugin_name: str
+    parent_node_id: str | None = None
 
 _CATEGORY_META = [
     {
@@ -312,4 +323,4 @@ def register_plugins(
         await bus.publish("notification")
         return None
 
-    bus.register_intent("app-plugins", "executePlugin", execute_plugin)
+    bus.register_intent("app-plugins", "executePlugin", execute_plugin, args_schema=ExecutePluginArgs)

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -3666,7 +3666,7 @@ def test_gitlink_apply_no_changes_payload_in_intent_signature():
 
     register_canvas(bus, notifications, _FakeDispatcher(), composer_document)
 
-    handler = bus._intents[("scene", "applyGitlinkChanges")]
+    handler = bus._intents[("scene", "applyGitlinkChanges")].handler
     signature = inspect.signature(handler)
     assert list(signature.parameters) == ["node_id", "fingerprint"], (
         "applyGitlinkChanges must take ONLY (node_id, fingerprint) - no changes/pending_changes param"

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -150,6 +150,205 @@ def test_unknown_intent_and_topic_return_error_not_disconnect():
         assert ws.receive_json()["kind"] == "result"
 
 
+def test_showinfo_rejects_missing_message_before_running_the_handler():
+    # ADR-003 stage 3.2: notification/showInfo is one of the 3 intents
+    # migrated to args_schema validation in this stage - a malformed call
+    # must be rejected BEFORE show_info() runs, not become a bare
+    # TypeError caught by the generic handler below it.
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json({"kind": "intent", "topic": "notification", "intent": "showInfo", "args": [], "id": 6})
+        message = ws.receive_json()
+        assert message["kind"] == "error"
+        # Review-fix: validate_payload's own error text carries a JSON-
+        # Schema-style "$." path prefix - meaningful internally, but this
+        # exact string reaches the end-user notification banner verbatim
+        # (fireIntent's showError path from ADR-003 stage 3.1), so
+        # _validate_intent_args strips it before app.py ever sends it.
+        assert message["error"] == "Invalid arguments: message: missing required field."
+
+        # The rejected call must not have touched notification state - the
+        # NEXT subscribe should show visible=False, not a banner from a
+        # handler that ran anyway despite the missing arg.
+        ws.send_json({"kind": "subscribe", "topics": ["notification"]})
+        snapshot = ws.receive_json()
+        assert snapshot["payload"]["visible"] is False
+
+
+def test_showinfo_rejects_wrong_typed_message_before_running_the_handler():
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json(
+            {"kind": "intent", "topic": "notification", "intent": "showInfo", "args": [12345], "id": 7}
+        )
+        message = ws.receive_json()
+        assert message["kind"] == "error"
+        assert message["error"] == "Invalid arguments: message: expected string, got int."
+
+
+def test_showinfo_rejects_a_dict_shaped_args_frame_instead_of_silently_corrupting_the_call():
+    # Review-fix (HIGH): the real wire-level version of the attack the
+    # adversarial review demonstrated - a client sends a genuine WS frame
+    # with "args" as a JSON OBJECT rather than an array. Before the fix,
+    # _handle_message's `args = message.get("args") or []` (backend/app.py)
+    # passed this dict straight through, zip(fields, a_dict) paired the
+    # schema's "message" field with the dict's own KEY STRING (never its
+    # value), validation reported zero errors, and show_info(*args) then
+    # unpacked the dict's KEYS as positional args - silently displaying the
+    # literal field name "message" in the notification banner instead of
+    # either the real value or a clean rejection.
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json(
+            {
+                "kind": "intent",
+                "topic": "notification",
+                "intent": "showInfo",
+                "args": {"message": "ATTACKER-CONTROLLED-VALUE"},
+                "id": 9,
+            }
+        )
+        message = ws.receive_json()
+        assert message["kind"] == "error"
+        assert message["error"] == "Invalid arguments: expected a list of arguments, got dict."
+
+        # The rejected call must not have touched notification state at all
+        # - not with the attacker's value, and not with the leaked field name.
+        ws.send_json({"kind": "subscribe", "topics": ["notification"]})
+        snapshot = ws.receive_json()
+        assert snapshot["payload"]["visible"] is False
+
+
+def test_executeplugin_rejects_wrong_arity_before_running_the_handler():
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json(
+            {
+                "kind": "intent",
+                "topic": "app-plugins",
+                "intent": "executePlugin",
+                "args": ["System Prompt", "node-1", "unexpected-extra"],
+                "id": 8,
+            }
+        )
+        message = ws.receive_json()
+        assert message["kind"] == "error"
+        assert message["error"] == "Invalid arguments: expected at most 2 argument(s), got 3."
+
+
+def test_junk_args_never_crash_or_disconnect_any_registered_intent():
+    """ADR-003 stage 3.2 exit criterion, the fuzz half: 'junk args ->
+    structured errors, no tracebacks' - checked empirically against the
+    FULL registered intent surface (133 pairs as of this stage, all 8
+    topics), not just the 3 intents this stage migrated to args_schema.
+    Even an unmigrated handler's own bare TypeError from bad arity is
+    already caught by _handle_message's generic except Exception
+    (backend/app.py) and turned into a clean {"kind":"error"} reply - this
+    proves that property holds for real, rather than being inferred from
+    reading the code.
+
+    The (topic, intent) list is discovered LIVE from the real app
+    (client.app.state.bus, populated by _configure_session - the same
+    function create_app() wires into every real session) rather than a
+    hand-maintained list here, so a future new intent is covered
+    automatically with no risk of this test silently going stale.
+
+    junk_args is deliberately longer (20 elements) than any real handler's
+    param count (addDocumentNode, the largest, takes 10) - this guarantees
+    Python's own arity check rejects EVERY call with a TypeError before the
+    REAL underlying handler's own body runs, regardless of the handler's own
+    parameter types. That is what makes it safe to fire at literally every
+    intent, including native-OS-dialog openers (pickGitlinkLocalRoot,
+    attachFile, the Llama.cpp/Ollama file/folder pickers) and network/
+    subprocess-backed ones: none of THEIR bodies ever execute, so there is
+    no risk of this test popping a real dialog or making a real network
+    call.
+
+    Review-fix: "the real underlying handler" above is a deliberate
+    qualifier, not loose phrasing - app-chat-library's loadChat/saveChat/
+    newChat are registered via chat_library.py's _serialize_mutating_intent,
+    whose own `wrapped(*args, **kwargs)` IS fully variadic (claims/releases
+    a cross-intent mutation guard before calling the real load_chat/
+    save_chat/new_chat). Python's arity check can't reject a call at THAT
+    outer boundary, so `wrapped`'s own body genuinely runs - claiming, then
+    releasing the guard in a `finally` - before the real handler's own
+    TypeError fires one level in. This is not unsafe (the guard is always
+    released again, and this test's single connection sends everything
+    sequentially, so no other call ever observes it mid-claim), but it does
+    mean "no handler body ever executes" is not literally true for these 3
+    intents specifically - only true of the real, wrapped handler.
+
+    The one exception with no wrapper at all is system/ping, a deliberately
+    variadic echo intent (register_intent's own docstring covers why it has
+    no args_schema) - it accepts and echoes back all 20 values, which is a
+    "result" reply, not a crash, and is asserted for accordingly below.
+    """
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        # Force this session to exist and be fully configured before
+        # introspecting its registered intents.
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        ws.receive_json()
+
+        session_bus = client.app.state.bus.session()
+        all_intents = sorted(session_bus._intents.keys())
+        # Sanity guard: if this collapses to a handful of entries, the
+        # introspection path itself broke silently (e.g. an empty/wrong
+        # session) - the test would then "pass" while covering nothing.
+        assert len(all_intents) >= 100, (
+            f"expected the full ~133-intent app surface, only found {len(all_intents)} - "
+            "the live intent discovery may be broken"
+        )
+
+        junk_args = [{"__fuzz__": True}, 12345, None, "??", [1, 2, 3]] * 4  # 20 elements
+        next_id = 1000
+        for topic, intent in all_intents:
+            next_id += 1
+            ws.send_json(
+                {"kind": "intent", "topic": topic, "intent": intent, "args": junk_args, "id": next_id}
+            )
+            message = ws.receive_json()
+            assert message["kind"] in ("error", "result"), (
+                f"{topic}/{intent}: got {message['kind']!r} for junk args - expected error or result, "
+                "never a disconnect or an unrecognized reply kind"
+            )
+            assert message["id"] == next_id, f"{topic}/{intent}: reply id mismatch - socket desynced"
+
+        # The connection must still be fully usable after 130+ consecutive
+        # malformed calls - proves no cumulative state corruption in the
+        # dispatch loop itself, not just per-call resilience.
+        ws.send_json({"kind": "intent", "topic": "system", "intent": "ping", "args": [], "id": 99999})
+        assert ws.receive_json()["kind"] == "result"
+
+
+def test_args_schema_is_scoped_to_exactly_the_3_intents_this_stage_migrated():
+    # ADR-003 stage 3.2 review-fix: the fuzz sweep above proves every intent
+    # replies safely, but it only checks message["kind"], not the error TEXT
+    # - a schema-validation rejection and an unmigrated handler's own generic
+    # TypeError rejection both come back as plain {"kind":"error"}, so that
+    # sweep alone could not catch a FUTURE mutation that accidentally added
+    # (or removed) an args_schema on the wrong intent. This test asserts the
+    # real registry's args_schema is not None set directly against the exact
+    # 3 intents this stage's own PR description claims to have migrated -
+    # silent scope drift on this security/correctness-adjacent mechanism
+    # would fail here even though it wouldn't fail the fuzz sweep.
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        ws.receive_json()
+
+        session_bus = client.app.state.bus.session()
+        validated = {
+            key for key, registration in session_bus._intents.items()
+            if registration.args_schema is not None
+        }
+        assert validated == {
+            ("notification", "showInfo"),
+            ("notification", "showError"),
+            ("app-plugins", "executePlugin"),
+        }
+
+
 def test_showerror_intent_round_trips_through_the_real_app_and_updates_the_notification_snapshot():
     # ADR-003 stage 3.1 review-fix (finding K): every other showError test
     # dispatches straight into a bare EventBus (backend/tests/test_backend_

--- a/backend/tests/test_event_bus.py
+++ b/backend/tests/test_event_bus.py
@@ -2,11 +2,13 @@
 isolation, broadcast resilience, intent dispatch."""
 
 import asyncio
+from dataclasses import dataclass
 
 import pytest
 
 from backend.events import (
     EventBus,
+    IntentValidationError,
     SessionBus,
     UnknownIntentError,
     UnknownTopicError,
@@ -121,3 +123,114 @@ def test_duplicate_registration_is_a_programming_error():
         bus.register_topic("counter", dict)
     with pytest.raises(AssertionError):
         bus.register_intent("counter", "bump", lambda: None)
+
+
+# -- ADR-003 stage 3.2: args_schema validation --------------------------------
+
+
+@dataclass
+class _GreetArgs:
+    name: str
+    greeting: str | None = None
+
+
+def _make_greet_session():
+    """A session with ONE args_schema-validated intent, plus a call-count
+    side channel so a test can prove the handler was or wasn't actually
+    invoked - the exit criterion is "unreachable without prior validation",
+    not just "eventually errors"."""
+    bus = SessionBus("greet-session")
+    calls = []
+
+    def greet(name, greeting=None):
+        calls.append((name, greeting))
+        return f"{greeting or 'Hello'}, {name}!"
+
+    bus.register_intent("app-test", "greet", greet, args_schema=_GreetArgs)
+    return bus, calls
+
+
+def test_args_schema_none_leaves_dispatch_unvalidated_matching_pre_3_2_behavior():
+    # No args_schema passed - the exact call shape every intent had before
+    # this stage; a wrong-arity call still raises, but as the handler's own
+    # bare TypeError (caught later by app.py's generic handler), never
+    # IntentValidationError - dispatch_intent didn't even look at args.
+    bus, _ = make_session()
+    with pytest.raises(TypeError):
+        asyncio.run(bus.dispatch_intent("counter", "bump", []))
+
+
+def test_args_schema_valid_args_call_the_handler_and_return_its_result():
+    bus, calls = _make_greet_session()
+    result = asyncio.run(bus.dispatch_intent("app-test", "greet", ["Ada"]))
+    assert result == "Hello, Ada!"
+    assert calls == [("Ada", None)]
+
+
+def test_args_schema_optional_field_can_also_be_supplied_explicitly():
+    # Review-fix: this test used to be byte-identical to the one above (both
+    # only ever omitted `greeting`), so its name promised dedicated coverage
+    # of the optional field's two valid shapes but only ever exercised one.
+    # The complementary case - `greeting` supplied explicitly, not omitted -
+    # is what actually makes this a distinct test: `X | None` optional in
+    # validate_payload means "not required if absent", not "must be absent".
+    bus, calls = _make_greet_session()
+    result = asyncio.run(bus.dispatch_intent("app-test", "greet", ["Ada", "Hey"]))
+    assert result == "Hey, Ada!"
+    assert calls == [("Ada", "Hey")]
+
+
+def test_args_schema_rejects_missing_required_field_before_calling_the_handler():
+    bus, calls = _make_greet_session()
+    with pytest.raises(IntentValidationError) as exc_info:
+        asyncio.run(bus.dispatch_intent("app-test", "greet", []))
+    assert calls == [], "the handler must never run when validation fails"
+    assert any("missing required field" in e for e in exc_info.value.errors)
+
+
+def test_args_schema_rejects_too_many_args_before_calling_the_handler():
+    bus, calls = _make_greet_session()
+    with pytest.raises(IntentValidationError) as exc_info:
+        asyncio.run(bus.dispatch_intent("app-test", "greet", ["Ada", "Hi", "extra"]))
+    assert calls == [], "the handler must never run when validation fails"
+    assert "expected at most 2 argument(s), got 3" in exc_info.value.errors[0]
+
+
+def test_args_schema_rejects_wrong_type_before_calling_the_handler():
+    bus, calls = _make_greet_session()
+    with pytest.raises(IntentValidationError) as exc_info:
+        asyncio.run(bus.dispatch_intent("app-test", "greet", [12345]))
+    assert calls == [], "the handler must never run when validation fails"
+    assert any("expected string" in e for e in exc_info.value.errors)
+
+
+def test_args_schema_rejects_null_for_a_required_field():
+    bus, calls = _make_greet_session()
+    with pytest.raises(IntentValidationError):
+        asyncio.run(bus.dispatch_intent("app-test", "greet", [None]))
+    assert calls == []
+
+
+def test_intent_validation_error_str_joins_the_errors_readably():
+    bus, _ = _make_greet_session()
+    with pytest.raises(IntentValidationError) as exc_info:
+        asyncio.run(bus.dispatch_intent("app-test", "greet", []))
+    assert str(exc_info.value) == "; ".join(exc_info.value.errors)
+
+
+def test_args_schema_rejects_a_dict_shaped_args_instead_of_silently_corrupting_the_call():
+    # Review-fix (HIGH): _handle_message (backend/app.py) builds args from
+    # `message.get("args") or []` with no shape check - a client sending a
+    # JSON OBJECT for "args" reached zip(fields, a_dict) unchanged, which
+    # pairs each schema field with the dict's KEY STRINGS, never its values.
+    # Validation could then report zero errors while the caller went on to
+    # do handler(*args) with that SAME dict - which unpacks its keys, not
+    # its values, as positional args. Empirically: dispatch_intent("app-
+    # test", "greet", {"name": "ATTACKER-CONTROLLED-VALUE"}) used to call
+    # greet("name") - the literal field name, not the real or even a
+    # rejected value - silently corrupting the call instead of failing it.
+    bus, calls = _make_greet_session()
+    with pytest.raises(IntentValidationError) as exc_info:
+        asyncio.run(bus.dispatch_intent("app-test", "greet", {"name": "ATTACKER-CONTROLLED-VALUE"}))
+    assert calls == [], "the handler must never run on a malformed (non-list) args shape"
+    assert any("expected a list" in e for e in exc_info.value.errors)

--- a/backend/tests/test_wire_schema_validation.py
+++ b/backend/tests/test_wire_schema_validation.py
@@ -1,0 +1,208 @@
+"""ADR-003 stage 3.2 review-fix: dedicated coverage for graphlink_wire_schema.py's
+validate_payload()/_validate_value(), specifically the recursive list[X]/
+dict[str,X]/nested-dataclass/Literal branches.
+
+Before this file, validate_payload had ZERO test coverage anywhere in the
+repo: contracts/tests/test_generated_artifacts.py only exercises
+json_schema_for/SchemaGenerationError (schema GENERATION), never the VALUE
+validator, and the only real caller today - backend/events.py's
+_validate_intent_args, reached from backend/tests/test_event_bus.py's
+args_schema tests - only ever validates flat, single-string dataclasses
+(ShowMessageArgs, ExecutePluginArgs), so even the production call path never
+exercised these branches. That gap becomes load-bearing the moment a future
+intent (very plausibly during the scene topic's own migration, per this
+ADR's own "topic-by-topic, scene last" plan - e.g. moveNodes' positions list,
+or addImageNode's several fields) gets an args_schema with a list/dict/
+nested field.
+
+graphlink_wire_schema.py lives at the repo root (not backend/), matching the
+existing precedent of backend/tests/test_process_env_allowlist.py testing
+the repo-root graphlink_process_env.py from here rather than a separate
+top-level tests/ directory.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from graphlink_wire_schema import validate_payload
+
+
+@dataclass
+class _Address:
+    city: str
+    zip_code: str | None = None
+
+
+@dataclass
+class _Person:
+    name: str
+    age: int
+    role: Literal["admin", "member"]
+    tags: list[str]
+    address: _Address
+    metadata: dict[str, str]
+    nickname: str | None = None
+
+
+def _valid_payload() -> dict:
+    return {
+        "name": "Ada",
+        "age": 30,
+        "role": "admin",
+        "tags": ["a", "b"],
+        "address": {"city": "London", "zip_code": "SW1"},
+        "metadata": {"team": "core"},
+    }
+
+
+def test_a_fully_valid_payload_has_no_errors():
+    assert validate_payload(_valid_payload(), _Person) == []
+
+
+def test_missing_required_field_is_reported_at_its_own_path():
+    payload = _valid_payload()
+    del payload["name"]
+    errors = validate_payload(payload, _Person)
+    assert any("$.name: missing required field" in e for e in errors)
+
+
+def test_null_for_a_required_field_is_rejected():
+    payload = _valid_payload()
+    payload["age"] = None
+    errors = validate_payload(payload, _Person)
+    assert any("$.age" in e and "null is not allowed" in e for e in errors)
+
+
+def test_optional_field_omitted_is_not_an_error():
+    payload = _valid_payload()
+    assert "nickname" not in payload
+    assert validate_payload(payload, _Person) == []
+
+
+def test_optional_field_supplied_is_validated_like_any_other():
+    payload = _valid_payload()
+    payload["nickname"] = 12345
+    errors = validate_payload(payload, _Person)
+    assert any("$.nickname" in e and "expected string" in e for e in errors)
+
+
+def test_wrong_primitive_type_is_rejected_with_the_type_name_not_the_value():
+    payload = _valid_payload()
+    payload["age"] = "thirty"
+    errors = validate_payload(payload, _Person)
+    assert errors == ["$.age: expected integer, got str"]
+
+
+def test_bool_is_not_silently_accepted_as_int_despite_being_a_subclass():
+    payload = _valid_payload()
+    payload["age"] = True
+    errors = validate_payload(payload, _Person)
+    assert any("$.age" in e and "expected integer" in e for e in errors)
+
+
+def test_literal_field_accepts_an_allowed_value():
+    payload = _valid_payload()
+    payload["role"] = "member"
+    assert validate_payload(payload, _Person) == []
+
+
+def test_literal_field_rejects_a_disallowed_value_without_echoing_it_raw():
+    # Review-fix: the Literal branch used to embed the raw submitted value
+    # via !r (an inconsistency with every other branch's type-name-only
+    # messages) - this pins the corrected, consistent shape.
+    payload = _valid_payload()
+    payload["role"] = "superadmin"
+    errors = validate_payload(payload, _Person)
+    assert errors == ["$.role: not one of ['admin', 'member'], got str"]
+    assert not any("superadmin" in e for e in errors)
+
+
+def test_list_field_rejects_a_non_list_value():
+    payload = _valid_payload()
+    payload["tags"] = "not-a-list"
+    errors = validate_payload(payload, _Person)
+    assert errors == ["$.tags: expected array, got str"]
+
+
+def test_list_field_reports_a_wrong_typed_element_at_its_own_indexed_path():
+    payload = _valid_payload()
+    payload["tags"] = ["ok", 42, "also-ok"]
+    errors = validate_payload(payload, _Person)
+    assert errors == ["$.tags[1]: expected string, got int"]
+
+
+def test_dict_field_rejects_a_non_dict_value():
+    payload = _valid_payload()
+    payload["metadata"] = ["not", "a", "dict"]
+    errors = validate_payload(payload, _Person)
+    assert errors == ["$.metadata: expected object, got list"]
+
+
+def test_dict_field_rejects_a_non_string_key():
+    # A real WS frame can never carry a non-string JSON object key, but
+    # validate_payload is also called directly (e.g. ADR-003 stage 3.2's
+    # _validate_intent_args builds its own dict from zip()), so a caller
+    # bypassing JSON entirely can still hand it one - this proves the guard
+    # holds even then, not only for JSON-sourced payloads.
+    payload = _valid_payload()
+    payload["metadata"] = {7: "seven"}
+    errors = validate_payload(payload, _Person)
+    assert any("key 7 is not a string" in e for e in errors)
+
+
+def test_dict_field_reports_a_wrong_typed_value_at_its_own_key_path():
+    payload = _valid_payload()
+    payload["metadata"] = {"team": 123}
+    errors = validate_payload(payload, _Person)
+    assert errors == ["$.metadata.team: expected string, got int"]
+
+
+def test_nested_dataclass_field_rejects_a_non_dict_value():
+    payload = _valid_payload()
+    payload["address"] = "not-an-object"
+    errors = validate_payload(payload, _Person)
+    assert errors == ["$.address: expected object, got str"]
+
+
+def test_nested_dataclass_field_reports_a_missing_inner_field_at_the_nested_path():
+    payload = _valid_payload()
+    del payload["address"]["city"]
+    errors = validate_payload(payload, _Person)
+    assert errors == ["$.address.city: missing required field"]
+
+
+def test_nested_dataclass_optional_inner_field_can_be_omitted():
+    payload = _valid_payload()
+    del payload["address"]["zip_code"]
+    assert validate_payload(payload, _Person) == []
+
+
+def test_nested_dataclass_reports_a_wrong_typed_inner_field():
+    payload = _valid_payload()
+    payload["address"]["city"] = 99
+    errors = validate_payload(payload, _Person)
+    assert errors == ["$.address.city: expected string, got int"]
+
+
+def test_unexpected_field_not_on_the_dataclass_is_reported():
+    payload = _valid_payload()
+    payload["unexpected_extra_field"] = "surprise"
+    errors = validate_payload(payload, _Person)
+    assert any("unexpected field not present in _Person" in e for e in errors)
+
+
+def test_multiple_independent_errors_are_all_reported_not_just_the_first():
+    payload = _valid_payload()
+    payload["age"] = "not a number"
+    payload["role"] = "bogus"
+    payload["tags"] = 5
+    errors = validate_payload(payload, _Person)
+    assert len(errors) == 3
+
+
+def test_top_level_payload_that_is_not_a_dict_at_all_is_rejected():
+    assert validate_payload(["not", "a", "dict"], _Person) == [
+        "$: expected object, got list"
+    ]

--- a/contracts/codegen.py
+++ b/contracts/codegen.py
@@ -32,7 +32,16 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from payload_schema import json_schema_for
+# ADR-003 stage 3.2: json_schema_for's source (formerly contracts/payload_schema.py)
+# moved to the repo root as graphlink_wire_schema.py, so the runtime backend
+# can import the same validator without depending on contracts/ (deliberately
+# excluded from the shipped wheel - see that module's own docstring). This
+# script still runs as a bare `python contracts/codegen.py`, which only adds
+# contracts/ itself (not the repo root) to sys.path, so the repo root is
+# added explicitly rather than relying on cwd or an editable install.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from graphlink_wire_schema import json_schema_for
 
 __all__ = ["schema_json_for", "typescript_for", "GENERATED_ARTIFACTS"]
 

--- a/contracts/graphlink_app_settings_payload.py
+++ b/contracts/graphlink_app_settings_payload.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 
 @dataclass
 class ApiModelDescriptorPayload:
-    """One entry of apiModelCatalog - payload_schema.py has no bare
+    """One entry of apiModelCatalog - graphlink_wire_schema.py has no bare
     `dict` support by design (a future-drift guard), so this mirrors the
     normalized descriptor shape backend/settings.py's load_api_models
     already builds (model_id/provider/capabilities/ready/available) as a

--- a/contracts/graphlink_scene_payload.py
+++ b/contracts/graphlink_scene_payload.py
@@ -132,7 +132,7 @@ class ResearchResultRow:
     citations: list[ResearchCitationRow]
     warnings: list[str]
     # DEVIATION from the R5.1 spec text (which said a bare `dict`): the
-    # codegen's schema generator (payload_schema.py) has a closed,
+    # codegen's schema generator (graphlink_wire_schema.py) has a closed,
     # deliberately-narrow supported-type set that does NOT include a bare
     # `dict` or `dict[str, Any]` (there is no catch-all/`Any` case - see that
     # module's own docstring) - only `dict[str, X]` for X itself in the

--- a/contracts/tests/test_generated_artifacts.py
+++ b/contracts/tests/test_generated_artifacts.py
@@ -30,13 +30,17 @@ from typing import Literal
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
-from codegen import GENERATED_ARTIFACTS, schema_json_for, typescript_for  # noqa: E402
-from payload_schema import SchemaGenerationError, json_schema_for  # noqa: E402
-
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CODEGEN = _REPO_ROOT / "contracts" / "codegen.py"
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# ADR-003 stage 3.2: json_schema_for's source (formerly contracts/payload_schema.py)
+# moved to the repo root as graphlink_wire_schema.py - see that module's own
+# docstring for why.
+sys.path.insert(0, str(_REPO_ROOT))
+
+from codegen import GENERATED_ARTIFACTS, schema_json_for, typescript_for  # noqa: E402
+from graphlink_wire_schema import SchemaGenerationError, json_schema_for  # noqa: E402
 
 
 def _read(path: Path) -> str:

--- a/graphlink_wire_schema.py
+++ b/graphlink_wire_schema.py
@@ -1,6 +1,19 @@
 """Generic dataclass -> JSON Schema generation and payload validation for
 island bridge wire contracts.
 
+ADR-003 stage 3.2: this module used to live at contracts/payload_schema.py,
+reachable only by contracts/codegen.py (a dev-time-only script; pyproject.toml
+deliberately excludes contracts/ from the shipped wheel - it is build-time
+codegen for the frontend contract, not runtime application code). Stage 3.2
+needs the SAME dataclass-driven validate_payload() to check intent args
+in-process, at runtime, inside the shipped backend (backend/events.py's
+dispatch_intent) - a real dependency the wheel must actually ship. Rather than
+duplicate ~150 lines of validation logic into two copies that could drift,
+this module moved to the repo root and joined pyproject.toml's py-modules
+list, exactly like api_provider.py/graphlink_task_config.py already do:
+one canonical implementation, importable both by contracts/codegen.py
+(dev-time, TS codegen) and by backend/ (runtime, intent-arg validation).
+
 WHY HAND-ROLLED RATHER THAN pydantic/dataclasses-json: the payload shapes this
 has to describe are deliberately narrow - strings, ints, bools, string-literal
 enums, lists, nested objects, and one string->string map. That is a small,
@@ -109,7 +122,7 @@ def _schema_for_annotation(annotation: Any, *, path: str) -> dict[str, Any]:
         return json_schema_for(inner, _path=path)
 
     raise SchemaGenerationError(
-        f"{path}: unsupported type {inner!r}. Extend payload_schema.py "
+        f"{path}: unsupported type {inner!r}. Extend graphlink_wire_schema.py "
         "deliberately rather than working around this - an unsupported type here "
         "means the generated schema would not describe the real payload."
     )
@@ -217,9 +230,26 @@ def _validate_value(value: Any, annotation: Any, *, path: str) -> list[str]:
 
     if origin is Literal:
         allowed = list(get_args(inner))
-        return [] if value in allowed else [f"{path}: {value!r} is not one of {allowed!r}"]
+        # Review-fix: every OTHER branch here reports type(value).__name__
+        # only, never the value itself - matching that minimal-disclosure
+        # convention (rather than echoing the raw submitted value back,
+        # which the primitive-type branches above deliberately don't do).
+        return [] if value in allowed else [f"{path}: not one of {allowed!r}, got {type(value).__name__}"]
 
     if origin is list:
+        # ADR-003 stage 3.2 review-fix, accepted risk (not fixed here): cost
+        # is O(len(value)) with no length cap, and the two intent-arg
+        # schemas this stage actually ships (backend/notifications.py's
+        # ShowMessageArgs, backend/plugins.py's ExecutePluginArgs) are both
+        # flat single strings, so this branch is unreachable via any
+        # currently-registered intent - dormant, not exploitable, today.
+        # The scene topic (deliberately migrated LAST, per this ADR's own
+        # stage table) has real list-arg intents already (e.g. moveNodes'
+        # `positions`) - whoever writes ITS args_schema should weigh a
+        # length cap deliberately against real usage (a user multi-selecting
+        # many nodes is a legitimate large list, not just an attack shape)
+        # rather than guessing a number now with no real schema to size it
+        # against.
         if not isinstance(value, list):
             return [f"{path}: expected array, got {type(value).__name__}"]
         (item_type,) = get_args(inner)
@@ -229,6 +259,7 @@ def _validate_value(value: Any, annotation: Any, *, path: str) -> list[str]:
         return errors
 
     if origin is dict:
+        # Same accepted-risk note as the list branch just above.
         if not isinstance(value, dict):
             return [f"{path}: expected object, got {type(value).__name__}"]
         _, value_type = get_args(inner)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ py-modules = [
     "graphlink_task_config",
     "graphlink_token_estimator",
     "graphlink_version",
+    "graphlink_wire_schema",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Problem

`dispatch_intent` calls `handler(*args)` with zero validation of client-supplied args. A malformed request either duck-types through silently or raises a bare `TypeError` from inside the handler body - potentially after it has already partially mutated state.

## Change

- `SessionBus.register_intent()` gains an optional `args_schema=` kwarg: a dataclass whose field order defines the expected positional args. `dispatch_intent` validates real request args against it **before** calling the handler, raising `IntentValidationError` on a mismatch instead of letting the handler's own `TypeError` fire.
- The clean, structured error reaches the user with **zero frontend changes** - it flows through the exact `{"kind":"error"}` → `WsRequestError` → `fireIntent` → `showError` banner path ADR-003 stage 3.1 already built.
- **Packaging fix required to reuse the validator**: `graphlink_wire_schema.py`'s `validate_payload` (previously only used for outbound state payloads) is now needed at runtime by the backend, but `contracts/` is deliberately excluded from the shipped wheel (build-time codegen only). Moved `contracts/payload_schema.py` → repo-root `graphlink_wire_schema.py` and added it to `pyproject.toml`'s `py-modules`, matching `api_provider.py`'s existing precedent. Verified for real: built the wheel locally, confirmed `graphlink_wire_schema.py` is present and `contracts/` is absent inside it, then imported `backend.events, graphlink_wire_schema` from a clean venv with the repo checkout **not** on `sys.path` - the same check CI's build-check job runs.
- Only 3 of 133 registered intents got a real schema in this increment - `notification/showInfo`, `notification/showError`, `app-plugins/executePlugin` - deliberately the smallest topics, to prove the mechanism end-to-end. `scene` (86 intents, 65% of the total) stays deliberately last per this ADR's own "topic-by-topic, scene last" plan and is explicit follow-on work. `system/ping` (variadic echo) and `notification/dismiss` (zero-arg) are permanently exempt by design.
- The fuzz half of the exit criterion ("junk args → structured errors, no tracebacks") is verified empirically across the **full** 133-intent surface regardless of migration status: a WS-level test discovers the live intent registry from the real running app and fires deliberately-oversized junk args at every one of them over one persistent connection.

## Adversarial review

4-lens review (correctness/security/test-coverage/consistency), 11 confirmed findings, 0 refuted, all fixed - including 3 HIGH-severity issues:
- A dict-shaped (rather than array-shaped) `"args"` in the wire frame bypassed validation entirely **and corrupted the actual handler call** (`zip()` paired schema fields with the dict's own key strings, then `handler(*a_dict)` unpacked those keys as positional args). Closed with an `isinstance(args, list)` guard + regression tests (unit and a real WS frame).
- `validate_payload`'s internal JSON-Schema `"$."` path prefix leaked into the same user-facing banner stage 3.1 had just hardened against a different leak on. Stripped before the error reaches `app.py`.
- Zero test coverage anywhere on `validate_payload`'s recursive `list[X]`/`dict[str,X]`/nested-dataclass branches - closed with a new 21-test `backend/tests/test_wire_schema_validation.py`.

Plus several MEDIUM/LOW polish fixes (docstring accuracy, a duplicate test rewritten for real coverage, a registry-scoping regression test, an accepted-risk note on uncapped list/dict validation cost, a stale post-rename error message, a `Literal`-branch message inconsistency, a missing `is_dataclass` assertion).

## Test plan

- [x] Backend: `pytest -q` from repo root - 1596 passed, 14 skipped, 0 failed
- [x] Frontend: `npm run check` - clean (no frontend code changed, but `contracts/codegen.py`'s import path changed, so schema-drift check was re-verified)
- [x] Wheel packaging: built locally, confirmed `graphlink_wire_schema.py` ships and `contracts/` doesn't, imported from a clean venv with the repo checkout off `sys.path`
- [x] 4-lens adversarial review: 11 confirmed findings, 0 refuted, all fixed
- [x] Mutation-tested the 2 HIGH-severity fixes (dict-args guard, "$." stripping) - each reverted, confirmed the exact intended tests fail, restored