### PR TITLE
ADR-003 stage 3.3: close C9 by declaring the 26 real wire fields on SceneNodeRow

### DIFF
--- a/backend/tests/test_wire_schema_validation.py
+++ b/backend/tests/test_wire_schema_validation.py
@@ -23,7 +23,10 @@ top-level tests/ directory.
 
 from __future__ import annotations
 
+import dataclasses
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 from graphlink_wire_schema import validate_payload
@@ -206,3 +209,69 @@ def test_top_level_payload_that_is_not_a_dict_at_all_is_rejected():
     assert validate_payload(["not", "a", "dict"], _Person) == [
         "$: expected object, got list"
     ]
+
+
+# ADR-003 stage 3.3 (C9) review-fix: the design review for ChartDataRow (see
+# contracts/graphlink_scene_payload.py's own module docstring) reasoned that
+# flattening canonicalize_chart_data()'s three disjoint chart-type shapes
+# into one all-optional dataclass validates correctly, but that reasoning was
+# never actually exercised against a REAL SceneNodeRow/ChartDataRow/
+# ChartFlowRow instance - every prior test in this file uses the synthetic
+# _Person fixture. This closes that gap for the two shapes that differ most
+# (bar's flat labels/values vs sankey's nested flows list, the field
+# validate_payload's recursive list[dataclass] branch had never touched
+# through this real production dataclass at all), against the SAME
+# production SceneNodeRow the real backend emits from graph.py's
+# scene_payload().
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "contracts"))
+
+from graphlink_scene_payload import ChartDataRow, ChartFlowRow, SceneNodeRow  # noqa: E402
+
+
+def _chart_node_payload(**overrides) -> dict:
+    overrides.setdefault("kind", "chart")
+    row = SceneNodeRow(id="chart-1", x=0.0, y=0.0, title="Chart", **overrides)
+    return dataclasses.asdict(row)
+
+
+def test_a_real_bar_chart_scene_node_row_validates_with_no_errors():
+    payload = _chart_node_payload(
+        chartType="bar",
+        chartData=ChartDataRow(
+            type="bar", title="Revenue", labels=["Q1", "Q2"], values=[10.0, 20.0], xAxis="Quarter", yAxis="Revenue"
+        ),
+    )
+    assert validate_payload(payload, SceneNodeRow) == []
+
+
+def test_a_real_sankey_chart_scene_node_row_with_populated_flows_validates_with_no_errors():
+    payload = _chart_node_payload(
+        chartType="sankey",
+        chartData=ChartDataRow(
+            type="sankey",
+            title="Flow",
+            flows=[
+                ChartFlowRow(source="A", target="B", value=10.0),
+                ChartFlowRow(source="B", target="C", value=4.5),
+            ],
+        ),
+    )
+    assert validate_payload(payload, SceneNodeRow) == []
+
+
+def test_a_sankey_flow_with_a_wrong_typed_field_is_reported_at_its_own_indexed_nested_path():
+    payload = _chart_node_payload(
+        chartType="sankey",
+        chartData=ChartDataRow(type="sankey", title="Flow", flows=[ChartFlowRow(source="A", target="B", value=10.0)]),
+    )
+    payload["chartData"]["flows"][0]["value"] = "not-a-number"
+    errors = validate_payload(payload, SceneNodeRow)
+    assert errors == ["$.chartData.flows[0].value: expected number, got str"]
+
+
+def test_a_non_chart_node_s_all_optional_default_chart_data_row_still_validates_with_no_errors():
+    # The non-chart-node majority path: chartData is ALWAYS present on the
+    # wire (never omitted - see SceneNodeRow's own field comment) but every
+    # one of its fields is None for a node that was never a chart.
+    payload = _chart_node_payload(kind="chat", chartType="")
+    assert validate_payload(payload, SceneNodeRow) == []

--- a/contracts/graphlink_scene_payload.py
+++ b/contracts/graphlink_scene_payload.py
@@ -83,6 +83,68 @@ UNLIKE `gitlinkContextXml`/the backend-only `gitlink_change_local_root`,
 this one DOES belong on the wire: the frontend's Context-tabs lazy-fetch
 guard needs it to detect a new Build Context result even when
 `gitlinkContextSummary` happens to repeat.
+
+ADR-003 stage 3.3 (C9) adds 26 fields backend/domain/graph.py's
+scene_payload() was ALREADY emitting on the real wire - unlike every
+field above, these were never declared here at all. The frontend read
+them through 8 unsafe `n as SceneNodeRow & LocalInterface` casts in
+SceneCanvas.tsx instead (TypeScript would not otherwise let it access a
+field the generated type didn't have), which is exactly what ADR-002's
+audit finding C9 ("~26 wire fields bypass the contract behind 8 `as`
+casts") names. This stage closes the gap the OTHER direction: rather
+than stop emitting these fields (they are real, shipped, load-bearing
+UI state - branch lifecycle badges, synthesis provenance, note/frame/
+container styling and sizing, real chart nodes, the R6.3 splitter/
+scroll-position round-trip), it declares them here so codegen emits a
+real type and a real runtime validator for them, and the unsafe casts
+can be deleted outright rather than merely narrowed.
+
+`chartType`/`chartData`/`chartError`/`chartAssetId`/`chartAssetVersion`/
+`chartWidth`/`chartHeight`/`chartAspectLocked`/`chartSourceNodeId` are
+the R6.2 chart node's real persisted shape - populated for kind=="chart"
+rows, defaulted for every other kind, same additive rule as every field
+above. `chartData` is the one genuinely hard case: graphlink_chart_data.
+py's canonicalize_chart_data() returns one of THREE different shapes
+depending on chart type (bar/line/pie: labels+values+xAxis+yAxis;
+histogram: values+bins+xAxis+yAxis; sankey: flows only) - a real
+discriminated union the schema generator's closed type set has no direct
+way to express (no tagged-union support). ChartDataRow below resolves
+this the same way SceneNodeRow ITSELF already resolves the analogous
+problem one level up (one node kind's fields, present; every other
+kind's fields, absent-and-defaulted): every field across all three chart
+shapes is declared, all of them optional, so a real chart's dict
+(always a subset of these) and a non-chart node's `{}` (all absent) both
+validate cleanly - not a new pattern, the same one this whole file
+already uses at the top level, applied one level deeper.
+
+`color`/`headerColor`/`isSystemPrompt`/`isSummaryNote`/`isBranchComparison`/
+`itemIds`/`isLocked`/`groupWidth`/`groupHeight` are the R6.1 Notes/Frames/
+Containers fields - `color`/`headerColor`/`itemIds` are genuinely generic
+(every node kind carries SceneNode.color/header_color/item_ids as core
+fields, populated whenever the frontend/backend chooses to use them for
+that kind - not gated behind an isinstance(state, ...) check the way the
+kind-specific fields below are), the rest populated for kind in
+("note", "frame", "container") and defaulted for every other kind.
+`groupManualWidth`/`groupManualHeight` are DELIBERATELY NOT among these -
+same "server-side bookkeeping only" posture as `gitlinkImportedRoot`/
+`codeSandboxSandboxId` above.
+
+`provider`/`model`/`isBranchSynthesis`/`synthesisInstructions`/
+`branchStatus`/`isFinalDeliverable` are ADR-002 Workstream 1's branch-
+lifecycle and Synthesize-Branches fields - populated for kind=="chat"
+rows (branchStatus/isFinalDeliverable read for every kind, since a
+non-chat node can still be marked the branch's final deliverable), same
+additive rule.
+
+`htmlSplitterState`/`chatScrollValue` are the R6.3 UI-position round-trip
+fields (Source/Preview splitter position, chat scroll position) -
+populated for kind=="html"/kind=="chat" respectively, defaulted for
+every other kind. `contentParts` is DELIBERATELY NOT one of these 26:
+it is a real wire field (backend/domain/graph.py's _content_parts_wire)
+but SceneCanvas.tsx never reads it today (a backend-only multimodal
+round-trip capability, not a rendered feature) - C9 is specifically
+about fields an unsafe CAST reaches for, and no cast reaches for this
+one, so adding it here would not serve this stage's own exit criterion.
 """
 
 from __future__ import annotations
@@ -161,6 +223,42 @@ class GitlinkPendingChangeRow:
     # default value, so this must be Optional for a delete-only item to
     # validate.
     content: str | None = None
+
+
+@dataclass
+class ChartFlowRow:
+    """One Sankey flow - the shape canonicalize_chart_data() (graphlink_
+    chart_data.py) always builds every item of its "flows" list from, for
+    chart_type=="sankey" specifically."""
+
+    source: str
+    target: str
+    value: float
+
+
+@dataclass
+class ChartDataRow:
+    """ADR-003 stage 3.3: canonicalize_chart_data() returns one of three
+    disjoint shapes depending on chart type - see SceneNodeRow's own module
+    docstring for why every field here is optional rather than this being
+    three separate row types. `type`/`title` are set on every real chart's
+    dict (never independently absent from each other in practice), but the
+    schema generator has no dependent-required-fields concept, so both stay
+    individually optional like every other field here - the same tolerance
+    the file's existing `gitlinkChangeFingerprint`-style fields already
+    accept."""
+
+    type: Literal["bar", "line", "pie", "histogram", "sankey"] | None = None
+    title: str | None = None
+    # bar/line/pie
+    labels: list[str] | None = None
+    values: list[float] | None = None
+    xAxis: str | None = None
+    yAxis: str | None = None
+    # histogram (values above is reused; xAxis/yAxis above too)
+    bins: int | None = None
+    # sankey
+    flows: list[ChartFlowRow] | None = None
 
 
 @dataclass
@@ -304,6 +402,47 @@ class SceneNodeRow:
     # code_sandbox_approval_is_repair for why the frontend needs this.
     codeSandboxApprovalIsRepair: bool = False
     codeSandboxError: str = ""
+    # ADR-003 stage 3.3 (C9): ADR-002 Workstream 1's branch-lifecycle +
+    # Synthesize-Branches fields - see this file's own module docstring.
+    provider: str | None = None
+    model: str | None = None
+    isBranchSynthesis: bool = False
+    synthesisInstructions: str = ""
+    branchStatus: str = "active"
+    isFinalDeliverable: bool = False
+    # R6.1: Notes/Frames/Containers - color/headerColor/itemIds are generic
+    # (SceneNode core fields, any kind), the rest populated for kind in
+    # ("note", "frame", "container") and defaulted for every other kind.
+    # groupManualWidth/groupManualHeight are DELIBERATELY NOT among these -
+    # same "server-side bookkeeping only" posture as gitlinkImportedRoot/
+    # codeSandboxSandboxId above.
+    color: str | None = None
+    headerColor: str | None = None
+    isSystemPrompt: bool = False
+    isSummaryNote: bool = False
+    isBranchComparison: bool = False
+    itemIds: list[str] = field(default_factory=list)
+    isLocked: bool = True
+    groupWidth: float | None = None
+    groupHeight: float | None = None
+    # R6.2: the chart node's real persisted shape - populated for
+    # kind=="chart" rows, defaulted for every other kind. See this file's
+    # own module docstring for why chartData is a ChartDataRow rather than
+    # a scalar or a bare dict.
+    chartType: str = ""
+    chartData: ChartDataRow = field(default_factory=ChartDataRow)
+    chartError: str = ""
+    chartAssetId: str = ""
+    chartAssetVersion: int = 0
+    chartWidth: float = 680.0
+    chartHeight: float = 500.0
+    chartAspectLocked: bool = True
+    chartSourceNodeId: str = ""
+    # R6.3: the Source/Preview splitter position (html) and chat scroll
+    # position (chat) round-trip fields - populated for kind=="html"/
+    # kind=="chat" respectively, defaulted for every other kind.
+    htmlSplitterState: float | None = None
+    chatScrollValue: float = 0.0
 
 
 @dataclass

--- a/web_ui/src/app/canvas/ChartNodeView.tsx
+++ b/web_ui/src/app/canvas/ChartNodeView.tsx
@@ -1,5 +1,6 @@
 import { Handle, NodeResizer, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
 import { useEffect, useRef, useState } from "react";
+import type { ChartDataRow } from "../../lib/bridge-core/generated/scene-state";
 import { withAuthToken } from "../../lib/auth/token";
 import {
   CHART_MAX_HEIGHT,
@@ -63,7 +64,7 @@ import {
 
 export interface ChartNodeData extends Record<string, unknown> {
   chartType: string;
-  chartData: Record<string, unknown>;
+  chartData: ChartDataRow;
   chartError: string;
   chartAssetId: string;
   chartAssetVersion: number;
@@ -142,7 +143,7 @@ export function ChartNodeView({ id, data, selected }: NodeProps<ChartFlowNode>) 
     [],
   );
 
-  const rawTitle = data.chartData?.title;
+  const rawTitle = data.chartData.title;
   const title = typeof rawTitle === "string" && rawTitle.trim() ? rawTitle : "Chart";
 
   return (

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -94,6 +94,33 @@ function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
     codeSandboxAnalysis: "",
     codeSandboxAwaitingApproval: false,
     codeSandboxError: "",
+    // ADR-003 stage 3.3 (C9)
+    provider: null,
+    model: null,
+    isBranchSynthesis: false,
+    synthesisInstructions: "",
+    branchStatus: "active",
+    isFinalDeliverable: false,
+    color: null,
+    headerColor: null,
+    isSystemPrompt: false,
+    isSummaryNote: false,
+    isBranchComparison: false,
+    itemIds: [],
+    isLocked: true,
+    groupWidth: null,
+    groupHeight: null,
+    chartType: "",
+    chartData: {},
+    chartError: "",
+    chartAssetId: "",
+    chartAssetVersion: 0,
+    chartWidth: 680.0,
+    chartHeight: 500.0,
+    chartAspectLocked: true,
+    chartSourceNodeId: "",
+    htmlSplitterState: null,
+    chatScrollValue: 0.0,
     ...overrides,
   };
 }
@@ -1136,39 +1163,16 @@ describe("handleSelectionChange (R5.1 onSelectionChange wiring)", () => {
   });
 });
 
-// R6.1: Notes/Frames/Containers. The generated SceneNodeRow type hasn't been
-// regenerated yet to carry color/headerColor/isSystemPrompt/isSummaryNote/
-// itemIds/isLocked/groupWidth/groupHeight (see SceneCanvas.tsx's own
-// SceneNodeGroupFields comment) - this local helper builds a baseNode() with
-// those extra fields layered on, the test-file equivalent of that same cast.
-interface GroupTestFields {
-  color: string | null;
-  headerColor: string | null;
-  isSystemPrompt: boolean;
-  isSummaryNote: boolean;
-  // ADR-002 Workstream 1 ("Compare Branches") - same "generated type
-  // doesn't carry this yet" situation as every other field here.
-  isBranchComparison: boolean;
-  itemIds: string[];
-  isLocked: boolean;
-  groupWidth: number | null;
-  groupHeight: number | null;
-}
-
-function groupNode(overrides: Partial<SceneNodeRow & GroupTestFields> = {}): SceneNodeRow & GroupTestFields {
+// R6.1: Notes/Frames/Containers. ADR-003 stage 3.3 (C9) put color/
+// headerColor/isSystemPrompt/isSummaryNote/itemIds/isLocked/groupWidth/
+// groupHeight directly on the generated SceneNodeRow type (baseNode()
+// already sets all of them) - this helper only exists now for its
+// convenient per-kind defaults, not to work around a missing field.
+function groupNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
   return {
     ...baseNode(),
-    color: null,
-    headerColor: null,
-    isSystemPrompt: false,
-    isSummaryNote: false,
-    isBranchComparison: false,
-    itemIds: [],
-    isLocked: true,
-    groupWidth: null,
-    groupHeight: null,
     ...overrides,
-  } as SceneNodeRow & GroupTestFields;
+  };
 }
 
 describe("toFlowNodes (R6.1 note node)", () => {
@@ -1222,6 +1226,25 @@ describe("toFlowNodes (R6.1 note node)", () => {
       isBranchComparison: true,
       compareSourceNodeIds: ["chat-1", "chat-2"],
     });
+  });
+
+  // ADR-003 stage 3.3 (C9) review-fix: groupNode()/baseNode() always supply
+  // a real `null` for color/headerColor, so no test above would fail if
+  // SceneCanvas.tsx's `n.color ?? null`/`n.headerColor ?? null`
+  // normalization were deleted - this proves it does something for a note
+  // whose wire payload genuinely omits the field (`undefined`).
+  it("normalizes an absent (undefined) color/headerColor to null, not undefined", () => {
+    const scene = baseScene({
+      nodes: [groupNode({ id: "note-1", kind: "note", color: undefined, headerColor: undefined })],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const noteFlowNode = flowNodes.find((n) => n.id === "note-1");
+    const data = noteFlowNode!.data as { color: string | null; headerColor: string | null };
+    expect(data.color).toBeNull();
+    expect(data.headerColor).toBeNull();
   });
 
   it("onSetContent/onSetColor/onDelete call the right store intents with this node's id", () => {
@@ -1401,26 +1424,33 @@ describe("toFlowNodes (R6.1 frame/container nodes)", () => {
     data.onUngroup();
     expect(spies.ungroup).toHaveBeenCalledWith("frame-1");
   });
+
+  // ADR-003 stage 3.3 (C9) review-fix: same "always-null-anyway" fixture
+  // gap as the note-node block above - this proves SceneCanvas.tsx's
+  // `n.color ?? null`/`n.headerColor ?? null` normalization in the frame/
+  // container branch actually converts an absent (undefined) wire value to
+  // null rather than leaking undefined through to GroupNodeData.
+  it("normalizes an absent (undefined) color/headerColor to null, not undefined", () => {
+    const scene = baseScene({
+      nodes: [groupNode({ id: "frame-1", kind: "frame", color: undefined, headerColor: undefined })],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const frameFlowNode = flowNodes.find((n) => n.id === "frame-1");
+    const data = frameFlowNode!.data as { color: string | null; headerColor: string | null };
+    expect(data.color).toBeNull();
+    expect(data.headerColor).toBeNull();
+  });
 });
 
-// R6.2: Chart node. The generated SceneNodeRow type hasn't been regenerated
-// yet to carry chartType/chartData/chartError/chartAssetId/
-// chartAssetVersion/chartWidth/chartHeight/chartAspectLocked/
-// chartSourceNodeId (see SceneCanvas.tsx's own SceneNodeChartFields
-// comment) - same situation GroupTestFields above solves for R6.1.
-interface ChartTestFields {
-  chartType: string;
-  chartData: Record<string, unknown>;
-  chartError: string;
-  chartAssetId: string;
-  chartAssetVersion: number;
-  chartWidth: number;
-  chartHeight: number;
-  chartAspectLocked: boolean;
-  chartSourceNodeId: string;
-}
-
-function chartNode(overrides: Partial<SceneNodeRow & ChartTestFields> = {}): SceneNodeRow & ChartTestFields {
+// R6.2: Chart node. ADR-003 stage 3.3 (C9) put chartType/chartData/
+// chartError/chartAssetId/chartAssetVersion/chartWidth/chartHeight/
+// chartAspectLocked/chartSourceNodeId directly on the generated
+// SceneNodeRow type - this helper only exists now for its convenient
+// chart-kind defaults, not to work around missing fields.
+function chartNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
   return {
     ...baseNode(),
     kind: "chart",
@@ -1434,7 +1464,7 @@ function chartNode(overrides: Partial<SceneNodeRow & ChartTestFields> = {}): Sce
     chartAspectLocked: true,
     chartSourceNodeId: "chat-1",
     ...overrides,
-  } as SceneNodeRow & ChartTestFields;
+  };
 }
 
 describe("toFlowNodes (R6.2 chart node)", () => {
@@ -1505,22 +1535,17 @@ describe("toFlowNodes (R6.2 chart node)", () => {
   });
 });
 
-// R6.3: Scene-level serialization gaps. Same situation as ChartTestFields
-// above - htmlSplitterState/chatScrollValue aren't in the generated
-// SceneNodeRow type yet (see SceneCanvas.tsx's own SceneNodeR63Fields
-// comment).
-interface R63TestFields {
-  htmlSplitterState: number | null;
-  chatScrollValue: number;
-}
-
-function withR63Fields(node: SceneNodeRow, overrides: Partial<R63TestFields> = {}): SceneNodeRow & R63TestFields {
+// R6.3: Scene-level serialization gaps. ADR-003 stage 3.3 (C9) put
+// htmlSplitterState/chatScrollValue directly on the generated SceneNodeRow
+// type - this helper only exists now to apply overrides on top of a
+// baseNode(), not to work around missing fields.
+function withR63Fields(node: SceneNodeRow, overrides: Partial<Pick<SceneNodeRow, "htmlSplitterState" | "chatScrollValue">> = {}): SceneNodeRow {
   return {
     ...node,
     htmlSplitterState: null,
     chatScrollValue: 0,
     ...overrides,
-  } as SceneNodeRow & R63TestFields;
+  };
 }
 
 describe("toFlowNodes (R6.3 chat node scroll value)", () => {
@@ -1536,7 +1561,7 @@ describe("toFlowNodes (R6.3 chat node scroll value)", () => {
     expect((chatFlowNode!.data as { chatScrollValue: number }).chatScrollValue).toBe(240);
   });
 
-  it("defaults chatScrollValue to 0 when the field is absent (ahead of codegen regenerating SceneNodeRow)", () => {
+  it("defaults chatScrollValue to 0 for an ordinary chat node", () => {
     const scene = baseScene({ nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hi" })], edges: [] });
     const store = makeStore();
 
@@ -1557,25 +1582,15 @@ describe("toFlowNodes (R6.3 chat node scroll value)", () => {
   });
 });
 
-// ADR-002 Workstream 1 ("Synthesize Branches"). Same situation as
-// R63TestFields above - provider/model/isBranchSynthesis/
-// synthesisInstructions aren't in the generated SceneNodeRow type yet (see
-// SceneCanvas.tsx's own SceneNodeSynthesisFields comment). itemIds is
-// already declared elsewhere in this file via GroupTestFields (an
-// UNRELATED note-kind reuse) - re-declared here rather than shared since
-// this helper intersects it independently, for the chat-kind reuse.
-interface SynthesisTestFields {
-  provider: string | null;
-  model: string | null;
-  isBranchSynthesis: boolean;
-  synthesisInstructions: string;
-  itemIds: string[];
-}
-
+// ADR-002 Workstream 1 ("Synthesize Branches"). ADR-003 stage 3.3 (C9) put
+// provider/model/isBranchSynthesis/synthesisInstructions/itemIds directly
+// on the generated SceneNodeRow type - this helper only exists now to
+// apply overrides on top of a baseNode(), not to work around missing
+// fields.
 function withSynthesisFields(
   node: SceneNodeRow,
-  overrides: Partial<SynthesisTestFields> = {},
-): SceneNodeRow & SynthesisTestFields {
+  overrides: Partial<Pick<SceneNodeRow, "provider" | "model" | "isBranchSynthesis" | "synthesisInstructions" | "itemIds">> = {},
+): SceneNodeRow {
   return {
     ...node,
     provider: null,
@@ -1584,7 +1599,7 @@ function withSynthesisFields(
     synthesisInstructions: "",
     itemIds: [],
     ...overrides,
-  } as SceneNodeRow & SynthesisTestFields;
+  };
 }
 
 describe("toFlowNodes (ADR-002 Workstream 1 - Synthesize Branches provenance)", () => {
@@ -1614,7 +1629,16 @@ describe("toFlowNodes (ADR-002 Workstream 1 - Synthesize Branches provenance)", 
     });
   });
 
-  it("defaults to no provenance for an ordinary chat node (the vast majority - field absent, ahead of codegen regenerating SceneNodeRow)", () => {
+  it("defaults to no provenance for an ordinary chat node (the vast majority)", () => {
+    // ADR-003 stage 3.3 review-fix: this used to assert `undefined` for
+    // every one of these fields - an artifact of the test fixture never
+    // having included them at all (pre-C9, provider/model/etc. genuinely
+    // weren't on the generated SceneNodeRow type), not a reflection of the
+    // real backend, which has ALWAYS sent these fields for every node
+    // (scene_payload() defaults them to null/""/false/[] for a non-
+    // synthesis chat node, never omits the key). Now that baseNode()
+    // matches that real shape, the correct expectation is those same real
+    // defaults, not `undefined`.
     const scene = baseScene({
       nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hello" })],
       edges: [],
@@ -1624,34 +1648,52 @@ describe("toFlowNodes (ADR-002 Workstream 1 - Synthesize Branches provenance)", 
     const flowNodes = toFlowNodes(scene, store);
     const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
     expect(chatFlowNode!.data).toMatchObject({
-      provider: undefined,
-      model: undefined,
-      isBranchSynthesis: undefined,
-      synthesisInstructions: undefined,
-      synthesisSourceNodeIds: undefined,
+      provider: null,
+      model: null,
+      isBranchSynthesis: false,
+      synthesisInstructions: "",
+      synthesisSourceNodeIds: [],
     });
+  });
+
+  // ADR-003 stage 3.3 (C9) review-fix: baseNode() always supplies a real
+  // `null` (never `undefined`) for provider/model, so every test above
+  // would pass identically even if SceneCanvas.tsx's `n.provider ?? null`/
+  // `n.model ?? null` normalization were deleted outright - `null ?? null`
+  // and plain `null` produce the same value. This proves the normalization
+  // itself does something: an OPTIONAL wire field genuinely omitted by a
+  // legacy/partial payload (`undefined`, not `null`) must still surface as
+  // `null` in the flow node's data, never leak `undefined` through to
+  // ChatNodeData's required-but-nullable `provider`/`model` props.
+  it("normalizes an absent (undefined) provider/model to null, not undefined", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "chat-1", kind: "chat", content: "Hello", provider: undefined, model: undefined })],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const chatFlowNode = flowNodes.find((n) => n.id === "chat-1");
+    const data = chatFlowNode!.data as { provider: string | null; model: string | null };
+    expect(data.provider).toBeNull();
+    expect(data.model).toBeNull();
   });
 });
 
-// ADR-002 Workstream 1 ("Branch status and lifecycle"). Same situation as
-// SynthesisTestFields above - branchStatus/isFinalDeliverable aren't in the
-// generated SceneNodeRow type yet (see SceneCanvas.tsx's own
-// SceneNodeBranchLifecycleFields comment).
-interface BranchLifecycleTestFields {
-  branchStatus: string;
-  isFinalDeliverable: boolean;
-}
-
+// ADR-002 Workstream 1 ("Branch status and lifecycle"). ADR-003 stage 3.3
+// (C9) put branchStatus/isFinalDeliverable directly on the generated
+// SceneNodeRow type - this helper only exists now to apply overrides on
+// top of a baseNode(), not to work around missing fields.
 function withBranchLifecycleFields(
   node: SceneNodeRow,
-  overrides: Partial<BranchLifecycleTestFields> = {},
-): SceneNodeRow & BranchLifecycleTestFields {
+  overrides: Partial<Pick<SceneNodeRow, "branchStatus" | "isFinalDeliverable">> = {},
+): SceneNodeRow {
   return {
     ...node,
     branchStatus: "active",
     isFinalDeliverable: false,
     ...overrides,
-  } as SceneNodeRow & BranchLifecycleTestFields;
+  };
 }
 
 describe("toFlowNodes (ADR-002 Workstream 1 - Branch status and lifecycle)", () => {
@@ -1716,7 +1758,7 @@ describe("toFlowNodes (ADR-002 Workstream 1 - Branch status and lifecycle)", () 
 });
 
 describe("computeNonAcceptedNodeIds (ADR-002 Workstream 1 - Focus Accepted Paths)", () => {
-  function lifecycleNode(overrides: Partial<SceneNodeRow & BranchLifecycleTestFields> = {}) {
+  function lifecycleNode(overrides: Partial<SceneNodeRow> = {}) {
     return withBranchLifecycleFields(baseNode(overrides), overrides);
   }
 
@@ -1842,7 +1884,7 @@ describe("toFlowNodes (R6.3 html node splitter state)", () => {
     expect((htmlFlowNode!.data as { htmlSplitterState: number | null }).htmlSplitterState).toBe(0.35);
   });
 
-  it("defaults htmlSplitterState to null when the field is absent (ahead of codegen regenerating SceneNodeRow)", () => {
+  it("defaults htmlSplitterState to null for an ordinary html node", () => {
     const scene = baseScene({ nodes: [baseNode({ id: "html-1", kind: "html", content: "<p>hi</p>" })], edges: [] });
     const store = makeStore();
 
@@ -1860,6 +1902,24 @@ describe("toFlowNodes (R6.3 html node splitter state)", () => {
     const data = flowNodes.find((n) => n.id === "html-1")!.data as { onSplitterChange: (value: number) => void };
     data.onSplitterChange(0.6);
     expect(spy).toHaveBeenCalledWith("html-1", 0.6);
+  });
+
+  // ADR-003 stage 3.3 (C9) review-fix: the "defaults ... to null" test above
+  // never actually exercises SceneCanvas.tsx's `n.htmlSplitterState ??
+  // null` normalization - baseNode()'s own default is already `null`, so
+  // that assertion would pass identically with the normalization deleted.
+  // This proves it explicitly for a wire payload that omits the field
+  // (`undefined`) rather than sending an explicit `null`.
+  it("normalizes an absent (undefined) htmlSplitterState to null, not undefined", () => {
+    const scene = baseScene({
+      nodes: [baseNode({ id: "html-1", kind: "html", content: "<p>hi</p>", htmlSplitterState: undefined })],
+      edges: [],
+    });
+    const store = makeStore();
+
+    const flowNodes = toFlowNodes(scene, store);
+    const htmlFlowNode = flowNodes.find((n) => n.id === "html-1");
+    expect((htmlFlowNode!.data as { htmlSplitterState: number | null }).htmlSplitterState).toBeNull();
   });
 });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -18,7 +18,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
-import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
+import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
 import type { StreamListener } from "../../lib/ws/transport";
 import { ArtifactNodeView, type ArtifactFlowNode } from "./ArtifactNodeView";
 import { ChartNodeView, type ChartFlowNode } from "./ChartNodeView";
@@ -44,99 +44,6 @@ import {
 } from "./canvasConstants";
 import { SceneStore, scaleDragPosition } from "./sceneStore";
 import { computeSmartGuideSnap, type GuideLine, type Rect } from "./smartGuides";
-
-// R6.1: Notes/Frames/Containers - the generated SceneNodeRow type (codegen
-// source: backend/canvas.py's scene_payload()) has not been regenerated yet
-// to include these fields (see backend/canvas.py's own R6.1 section for the
-// exact contract this documents - color/headerColor/isSystemPrompt/
-// isSummaryNote/itemIds/isLocked/groupWidth/groupHeight). This local type
-// carries the contract precisely so toFlowNodes below reads real,
-// type-checked field names instead of scattering `as any` - once codegen
-// runs, SceneNodeRow will carry these natively and this cast (and this
-// comment) can be deleted.
-interface SceneNodeGroupFields {
-  color: string | null;
-  headerColor: string | null;
-  isSystemPrompt: boolean;
-  isSummaryNote: boolean;
-  // ADR-002 Workstream 1 ("Compare Branches") - note kind only, same
-  // "generated type doesn't carry this yet" situation as every other
-  // field on this interface. itemIds (already here, for frame/container
-  // membership) doubles as the source branch node ids for a comparison
-  // note - see backend/canvas.py's SceneNode.item_ids comment.
-  isBranchComparison: boolean;
-  itemIds: string[];
-  isLocked: boolean;
-  groupWidth: number | null;
-  groupHeight: number | null;
-}
-type SceneNodeRowWithGroups = SceneNodeRow & SceneNodeGroupFields;
-
-// R6.2: Chart node. Same situation as SceneNodeGroupFields above - the
-// generated SceneNodeRow type hasn't been regenerated yet to carry
-// chartType/chartData/chartError/chartAssetId/chartAssetVersion/chartWidth/
-// chartHeight/chartAspectLocked/chartSourceNodeId (backend/canvas.py's
-// scene_payload() contract for this increment). chartData is left as
-// Record<string, unknown> rather than a fully-typed union - it is already
-// canonicalized server-side (graphlink_chart_data.py's
-// canonicalize_chart_data), and this view only ever reads its own
-// well-known "title" key defensively (see ChartNodeView.tsx).
-interface SceneNodeChartFields {
-  chartType: string;
-  chartData: Record<string, unknown>;
-  chartError: string;
-  chartAssetId: string;
-  chartAssetVersion: number;
-  chartWidth: number;
-  chartHeight: number;
-  chartAspectLocked: boolean;
-  chartSourceNodeId: string;
-}
-type SceneNodeRowWithChart = SceneNodeRow & SceneNodeChartFields;
-
-// R6.3: Scene-level serialization gaps. Same situation as
-// SceneNodeGroupFields/SceneNodeChartFields above - the generated
-// SceneNodeRow type hasn't been regenerated yet to carry
-// htmlSplitterState/chatScrollValue (backend/canvas.py's scene_payload()
-// contract for this increment). contentParts is deliberately absent here -
-// nothing in this increment's frontend scope reads it (see this increment's
-// own report for why: it's a backend-only round-trip capability for OLD
-// multimodal sessions R6.4 may load, not a new frontend feature).
-interface SceneNodeR63Fields {
-  htmlSplitterState: number | null;
-  chatScrollValue: number;
-}
-type SceneNodeRowWithR63 = SceneNodeRow & SceneNodeR63Fields;
-
-// ADR-002 Workstream 1 ("Synthesize Branches"). Same situation as
-// SceneNodeGroupFields/SceneNodeChartFields/SceneNodeR63Fields above - the
-// generated SceneNodeRow type hasn't been regenerated yet to carry
-// provider/model/isBranchSynthesis/synthesisInstructions (backend/canvas.py's
-// scene_payload() contract for this increment). itemIds is declared again
-// here (already present on SceneNodeGroupFields, for the UNRELATED note-kind
-// Compare Branches reuse) rather than shared between the two interfaces -
-// this one is intersected with SceneNodeRow independently, in the chat-kind
-// branch below, so there is no actual overlap at runtime; see
-// SceneNode.item_ids's own comment on backend/canvas.py for the two,
-// deliberately distinct uses of that one generic field.
-interface SceneNodeSynthesisFields {
-  provider: string | null;
-  model: string | null;
-  isBranchSynthesis: boolean;
-  synthesisInstructions: string;
-  itemIds: string[];
-}
-type SceneNodeRowWithSynthesis = SceneNodeRow & SceneNodeSynthesisFields;
-
-// ADR-002 Workstream 1 ("Branch status and lifecycle"). Same situation as
-// SceneNodeSynthesisFields above - the generated SceneNodeRow type hasn't
-// been regenerated yet to carry branchStatus/isFinalDeliverable
-// (backend/canvas.py's scene_payload() contract for this increment).
-interface SceneNodeBranchLifecycleFields {
-  branchStatus: string;
-  isFinalDeliverable: boolean;
-}
-type SceneNodeRowWithBranchLifecycle = SceneNodeRow & SceneNodeBranchLifecycleFields;
 
 /**
  * The React Flow canvas (Qt-removal plan R1) - the QGraphicsScene/ChatView
@@ -412,10 +319,7 @@ export function computeDimmedNodeIds(scene: SceneState, originId: string | null)
  * ancestor being one) is.
  */
 export function computeNonAcceptedNodeIds(scene: SceneState): Set<string> {
-  // branchStatus isn't on the generated SceneNodeRow type yet (see
-  // SceneNodeBranchLifecycleFields' own comment) - cast once here, rather
-  // than at every read site below.
-  const nodesById = new Map(scene.nodes.map((n) => [n.id, n as SceneNodeRowWithBranchLifecycle]));
+  const nodesById = new Map(scene.nodes.map((n) => [n.id, n]));
   const parentOf = new Map<string, string>();
   const childrenOf = new Map<string, string[]>();
   for (const e of scene.edges) {
@@ -525,9 +429,6 @@ export function toFlowNodes(
         const target = nodesById.get(e.target);
         if (target?.isDocked) dockedChildren.push({ id: target.id, label: target.title });
       }
-      const chatR63 = n as SceneNodeRowWithR63;
-      const chatSynthesis = n as SceneNodeRowWithSynthesis;
-      const chatLifecycle = n as SceneNodeRowWithBranchLifecycle;
       flowNodes.push({
         id: n.id,
         type: "chat" as const,
@@ -582,30 +483,26 @@ export function toFlowNodes(
           // state on SceneCanvas itself, not on the store).
           onBranchFromHere: () => store.setReplyTargetNodeId(n.id),
           // ADR-002 Workstream 1 ("Synthesize Branches"): provenance carried
-          // by the result node - see SceneNodeSynthesisFields' own comment.
-          // provider/model are None/absent for every ordinary chat node
-          // (the vast majority), rendered as no badge at all - see
-          // ChatNodeView.tsx's own guard.
-          provider: chatSynthesis.provider,
-          model: chatSynthesis.model,
-          isBranchSynthesis: chatSynthesis.isBranchSynthesis,
-          synthesisInstructions: chatSynthesis.synthesisInstructions,
-          synthesisSourceNodeIds: chatSynthesis.itemIds,
-          // ADR-002 Workstream 1 ("Branch status and lifecycle") - see
-          // SceneNodeBranchLifecycleFields' own comment. Fire-and-forget,
-          // same posture as onBranchFromHere/onGenerateKeyTakeaway above -
-          // the new value arrives through the next scene snapshot.
-          branchStatus: chatLifecycle.branchStatus,
-          isFinalDeliverable: chatLifecycle.isFinalDeliverable,
+          // by the result node. provider/model are None/absent for every
+          // ordinary chat node (the vast majority), rendered as no badge at
+          // all - see ChatNodeView.tsx's own guard.
+          provider: n.provider ?? null,
+          model: n.model ?? null,
+          isBranchSynthesis: n.isBranchSynthesis,
+          synthesisInstructions: n.synthesisInstructions,
+          synthesisSourceNodeIds: n.itemIds,
+          // ADR-002 Workstream 1 ("Branch status and lifecycle"). Fire-and-
+          // forget, same posture as onBranchFromHere/onGenerateKeyTakeaway
+          // above - the new value arrives through the next scene snapshot.
+          branchStatus: n.branchStatus,
+          isFinalDeliverable: n.isFinalDeliverable,
           onSetBranchStatus: (status: string) => store.setBranchStatus(n.id, status),
           onSetFinalDeliverable: (isFinal: boolean) => store.setFinalDeliverable(n.id, isFinal),
           onCollapseBranch: (collapsed: boolean) => store.collapseBranch(n.id, collapsed),
           // R6.3: the node's own scroll position within its content area -
           // read on mount by ChatNodeView (restore) and reported (debounced)
-          // via the new setChatScrollValue intent on every scroll. Defaults
-          // to 0 the same way every other numeric ?? fallback in this file
-          // does, ahead of codegen regenerating SceneNodeRow to carry it.
-          chatScrollValue: chatR63.chatScrollValue ?? 0,
+          // via the setChatScrollValue intent on every scroll.
+          chatScrollValue: n.chatScrollValue,
           onScrollChange: (value: number) => store.setChatScrollValue(n.id, value),
         },
       });
@@ -710,7 +607,6 @@ export function toFlowNodes(
       // entry exists on this node's own header, and ChatNodeView's own
       // dockedChildren/undock badge is kind-agnostic already, so undocking
       // it is still possible from the parent chat node's side).
-      const htmlR63 = n as SceneNodeRowWithR63;
       flowNodes.push({
         id: n.id,
         type: "html" as const,
@@ -723,10 +619,10 @@ export function toFlowNodes(
           // R6.3: the Source/Preview split position - read on mount by
           // HtmlNodeView (restore; null means "no saved value, use the
           // component's own 50/50 default") and reported (debounced) via the
-          // new setHtmlSplitterState intent once a drag settles. See
+          // setHtmlSplitterState intent once a drag settles. See
           // canvasConstants.ts's own HTML_SPLIT_* doc for why this exists
           // now despite being scoped OUT back in R3.17/R3.18.
-          htmlSplitterState: htmlR63.htmlSplitterState ?? null,
+          htmlSplitterState: n.htmlSplitterState ?? null,
           onSplitterChange: (value: number) => store.setHtmlSplitterState(n.id, value),
         },
       });
@@ -1028,22 +924,21 @@ export function toFlowNodes(
       // above) - a note never offers a dock-into-parent action of its own;
       // the generic `if (n.isDocked) continue` guard above still covers it
       // correctly if it were ever docked via a direct WS call.
-      const note = n as SceneNodeRowWithGroups;
       flowNodes.push({
         id: n.id,
         type: "note" as const,
         position: { x: n.x, y: n.y },
         data: {
           content: n.content,
-          color: note.color,
-          headerColor: note.headerColor,
-          isSystemPrompt: note.isSystemPrompt,
-          isSummaryNote: note.isSummaryNote,
+          color: n.color ?? null,
+          headerColor: n.headerColor ?? null,
+          isSystemPrompt: n.isSystemPrompt,
+          isSummaryNote: n.isSummaryNote,
           // ADR-002 Workstream 1: itemIds doubles as the source branch ids
-          // for a Compare Branches result note - see SceneNodeGroupFields'
-          // own comment.
-          isBranchComparison: note.isBranchComparison,
-          compareSourceNodeIds: note.itemIds,
+          // for a Compare Branches result note - see SceneNode.item_ids's
+          // own comment on backend/domain/model.py.
+          isBranchComparison: n.isBranchComparison,
+          compareSourceNodeIds: n.itemIds,
           onSetContent: (content: string) => store.setNoteContent(n.id, content),
           onSetColor: (color: string | null, headerColor: string | null) =>
             store.setGroupColor(n.id, color, headerColor),
@@ -1079,23 +974,22 @@ export function toFlowNodes(
       // which gate the MEMBER-cascade on lock state, not draggability
       // itself; backend/canvas.py's move_node pins a manual position
       // anchor so the drag actually sticks instead of snapping back).
-      const group = n as SceneNodeRowWithGroups;
       flowNodes.push({
         id: n.id,
         type: n.kind as "frame" | "container",
         position: { x: n.x, y: n.y },
-        width: group.groupWidth ?? GROUP_FALLBACK_WIDTH,
-        height: group.groupHeight ?? GROUP_FALLBACK_HEIGHT,
+        width: n.groupWidth ?? GROUP_FALLBACK_WIDTH,
+        height: n.groupHeight ?? GROUP_FALLBACK_HEIGHT,
         zIndex: n.kind === "container" ? -2 : -1,
         draggable: true,
         data: {
           groupKind: n.kind,
           label: n.content,
-          color: group.color,
-          headerColor: group.headerColor,
+          color: n.color ?? null,
+          headerColor: n.headerColor ?? null,
           isCollapsed: n.isCollapsed,
-          isLocked: group.isLocked,
-          itemIds: group.itemIds,
+          isLocked: n.isLocked,
+          itemIds: n.itemIds,
           // R6.1 follow-up: a simplified equivalent of legacy's collapsed-
           // container hover "ghost frame" preview - just member kinds, not
           // a rendered miniature of actual content. Looked up from the
@@ -1103,7 +997,7 @@ export function toFlowNodes(
           // already builds once per call; a stale/dangling item_ids entry
           // (a member deleted out from under a group) is silently skipped,
           // matching _bbox_of_members' own posture on the backend.
-          memberKinds: group.itemIds.map((id) => nodesById.get(id)?.kind).filter((kind): kind is string => !!kind),
+          memberKinds: n.itemIds.map((id) => nodesById.get(id)?.kind).filter((kind): kind is string => !!kind),
           onSetLabel: (text: string) => store.setGroupLabel(n.id, text),
           onToggleCollapsed: () => store.toggleGroupCollapsed(n.id),
           onToggleLock: () => store.toggleFrameLock(n.id),
@@ -1130,23 +1024,22 @@ export function toFlowNodes(
       // exposes them like every other chart field), so they're ALSO
       // duplicated into `data` below rather than living only on the flow
       // node object.
-      const chart = n as SceneNodeRowWithChart;
       flowNodes.push({
         id: n.id,
         type: "chart" as const,
         position: { x: n.x, y: n.y },
-        width: chart.chartWidth,
-        height: chart.chartHeight,
+        width: n.chartWidth,
+        height: n.chartHeight,
         data: {
-          chartType: chart.chartType,
-          chartData: chart.chartData,
-          chartError: chart.chartError,
-          chartAssetId: chart.chartAssetId,
-          chartAssetVersion: chart.chartAssetVersion,
-          chartWidth: chart.chartWidth,
-          chartHeight: chart.chartHeight,
-          chartAspectLocked: chart.chartAspectLocked,
-          chartSourceNodeId: chart.chartSourceNodeId,
+          chartType: n.chartType,
+          chartData: n.chartData,
+          chartError: n.chartError,
+          chartAssetId: n.chartAssetId,
+          chartAssetVersion: n.chartAssetVersion,
+          chartWidth: n.chartWidth,
+          chartHeight: n.chartHeight,
+          chartAspectLocked: n.chartAspectLocked,
+          chartSourceNodeId: n.chartSourceNodeId,
           onToggleAspectLock: () => store.toggleChartAspectLock(n.id),
           onResize: (width: number, height: number) => store.resizeChart(n.id, width, height),
         },

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -102,6 +102,26 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         codeSandboxAnalysis: "",
         codeSandboxAwaitingApproval: false,
         codeSandboxError: "",
+        // ADR-003 stage 3.3 (C9)
+        isBranchSynthesis: false,
+        synthesisInstructions: "",
+        branchStatus: "active",
+        isFinalDeliverable: false,
+        isSystemPrompt: false,
+        isSummaryNote: false,
+        isBranchComparison: false,
+        itemIds: [],
+        isLocked: true,
+        chartType: "",
+        chartData: {},
+        chartError: "",
+        chartAssetId: "",
+        chartAssetVersion: 0,
+        chartWidth: 680.0,
+        chartHeight: 500.0,
+        chartAspectLocked: true,
+        chartSourceNodeId: "",
+        chatScrollValue: 0.0,
       },
     ],
     edges: [],
@@ -131,6 +151,98 @@ describe("SceneStore", () => {
     expect(seen).toHaveBeenCalledTimes(1);
     expect(store.getScene().nodes[0].title).toBe("A");
     expect(store.getScene().dragFactor).toBe(0.5);
+  });
+
+  // ADR-003 stage 3.3 (C9) review-fix: every other test that touches
+  // chartData only ever exercises the ALL-FIELDS-absent default ({}) the
+  // base validScenePayload() node uses - the runtime validator's
+  // checkChartDataRow/checkChartFlowRow (bridge-core/generated/scene-
+  // state.ts) had never been proven against a real POPULATED chart payload,
+  // including the one field shape (sankey's nested `flows` list of
+  // ChartFlowRow objects) no other test anywhere touches at all.
+  it("accepts a real populated sankey chart node's chartData (flows) within a scene snapshot", () => {
+    const { transport, listeners } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.connect();
+    const seen = vi.fn();
+    store.subscribe(seen);
+
+    const base = validScenePayload().nodes[0] as Record<string, unknown>;
+    const chartNode = {
+      ...base,
+      id: "chart-1",
+      kind: "chart",
+      chartType: "sankey",
+      chartData: {
+        type: "sankey",
+        title: "Flow",
+        flows: [
+          { source: "A", target: "B", value: 10 },
+          { source: "B", target: "C", value: 4.5 },
+        ],
+      },
+      chartAssetId: "asset-chart-1",
+      chartAssetVersion: 1,
+    };
+
+    listeners.get("scene")!(validScenePayload({ nodes: [chartNode] }));
+    expect(seen).toHaveBeenCalledTimes(1);
+    expect(store.getScene().nodes[0].chartData).toEqual(chartNode.chartData);
+  });
+
+  it("accepts a real populated bar chart node's chartData (labels/values) within a scene snapshot", () => {
+    const { transport, listeners } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.connect();
+    const seen = vi.fn();
+    store.subscribe(seen);
+
+    const base = validScenePayload().nodes[0] as Record<string, unknown>;
+    const chartNode = {
+      ...base,
+      id: "chart-1",
+      kind: "chart",
+      chartType: "bar",
+      chartData: {
+        type: "bar",
+        title: "Revenue",
+        labels: ["Q1", "Q2"],
+        values: [10, 20],
+        xAxis: "Quarter",
+        yAxis: "Revenue",
+      },
+      chartAssetId: "asset-chart-1",
+      chartAssetVersion: 1,
+    };
+
+    listeners.get("scene")!(validScenePayload({ nodes: [chartNode] }));
+    expect(seen).toHaveBeenCalledTimes(1);
+    expect(store.getScene().nodes[0].chartData).toEqual(chartNode.chartData);
+  });
+
+  it("REJECTS a scene snapshot whose sankey flow has a wrong-typed nested field", () => {
+    const { transport, listeners } = makeFakeTransport();
+    const store = new SceneStore(transport);
+    store.connect();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const base = validScenePayload().nodes[0] as Record<string, unknown>;
+    const chartNode = {
+      ...base,
+      id: "chart-1",
+      kind: "chart",
+      chartType: "sankey",
+      chartData: {
+        type: "sankey",
+        title: "Flow",
+        flows: [{ source: "A", target: "B", value: "not-a-number" }],
+      },
+    };
+
+    listeners.get("scene")!(validScenePayload({ nodes: [chartNode] }));
+    expect(store.getScene()).toEqual(initialSceneState);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 
   it("REJECTS a malformed snapshot and keeps the previous state", () => {

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -56,8 +56,102 @@
           "attachmentKind": {
             "type": "string"
           },
+          "branchStatus": {
+            "type": "string"
+          },
           "byteSize": {
             "type": "integer"
+          },
+          "chartAspectLocked": {
+            "type": "boolean"
+          },
+          "chartAssetId": {
+            "type": "string"
+          },
+          "chartAssetVersion": {
+            "type": "integer"
+          },
+          "chartData": {
+            "additionalProperties": false,
+            "properties": {
+              "bins": {
+                "type": "integer"
+              },
+              "flows": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "source": {
+                      "type": "string"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "source",
+                    "target",
+                    "value"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "labels": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "bar",
+                  "line",
+                  "pie",
+                  "histogram",
+                  "sankey"
+                ],
+                "type": "string"
+              },
+              "values": {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              "xAxis": {
+                "type": "string"
+              },
+              "yAxis": {
+                "type": "string"
+              }
+            },
+            "required": [],
+            "type": "object"
+          },
+          "chartError": {
+            "type": "string"
+          },
+          "chartHeight": {
+            "type": "number"
+          },
+          "chartSourceNodeId": {
+            "type": "string"
+          },
+          "chartType": {
+            "type": "string"
+          },
+          "chartWidth": {
+            "type": "number"
+          },
+          "chatScrollValue": {
+            "type": "number"
           },
           "code": {
             "type": "string"
@@ -90,6 +184,9 @@
             "type": "string"
           },
           "codeSandboxRequirements": {
+            "type": "string"
+          },
+          "color": {
             "type": "string"
           },
           "content": {
@@ -181,6 +278,15 @@
           "gitlinkTaskPrompt": {
             "type": "string"
           },
+          "groupHeight": {
+            "type": "number"
+          },
+          "groupWidth": {
+            "type": "number"
+          },
+          "headerColor": {
+            "type": "string"
+          },
           "history": {
             "items": {
               "additionalProperties": false,
@@ -204,11 +310,20 @@
             },
             "type": "array"
           },
+          "htmlSplitterState": {
+            "type": "number"
+          },
           "id": {
             "type": "string"
           },
           "imageAssetId": {
             "type": "string"
+          },
+          "isBranchComparison": {
+            "type": "boolean"
+          },
+          "isBranchSynthesis": {
+            "type": "boolean"
           },
           "isCollapsed": {
             "type": "boolean"
@@ -216,8 +331,26 @@
           "isDocked": {
             "type": "boolean"
           },
+          "isFinalDeliverable": {
+            "type": "boolean"
+          },
+          "isLocked": {
+            "type": "boolean"
+          },
+          "isSummaryNote": {
+            "type": "boolean"
+          },
+          "isSystemPrompt": {
+            "type": "boolean"
+          },
           "isUser": {
             "type": "boolean"
+          },
+          "itemIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "kind": {
             "type": "string"
@@ -228,10 +361,16 @@
           "mimeType": {
             "type": "string"
           },
+          "model": {
+            "type": "string"
+          },
           "pendingRequestId": {
             "type": "string"
           },
           "previewLabel": {
+            "type": "string"
+          },
+          "provider": {
             "type": "string"
           },
           "pycoderAnalysis": {
@@ -403,6 +542,9 @@
           "researchTotal": {
             "type": "integer"
           },
+          "synthesisInstructions": {
+            "type": "string"
+          },
           "title": {
             "type": "string"
           },
@@ -468,7 +610,26 @@
           "codeSandboxApprovalRequirements",
           "codeSandboxApprovalAllowSourceBuilds",
           "codeSandboxApprovalIsRepair",
-          "codeSandboxError"
+          "codeSandboxError",
+          "isBranchSynthesis",
+          "synthesisInstructions",
+          "branchStatus",
+          "isFinalDeliverable",
+          "isSystemPrompt",
+          "isSummaryNote",
+          "isBranchComparison",
+          "itemIds",
+          "isLocked",
+          "chartType",
+          "chartData",
+          "chartError",
+          "chartAssetId",
+          "chartAssetVersion",
+          "chartWidth",
+          "chartHeight",
+          "chartAspectLocked",
+          "chartSourceNodeId",
+          "chatScrollValue"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -64,6 +64,32 @@ export interface SceneNodeRow {
   codeSandboxApprovalAllowSourceBuilds: boolean;
   codeSandboxApprovalIsRepair: boolean;
   codeSandboxError: string;
+  provider?: string | null;
+  model?: string | null;
+  isBranchSynthesis: boolean;
+  synthesisInstructions: string;
+  branchStatus: string;
+  isFinalDeliverable: boolean;
+  color?: string | null;
+  headerColor?: string | null;
+  isSystemPrompt: boolean;
+  isSummaryNote: boolean;
+  isBranchComparison: boolean;
+  itemIds: string[];
+  isLocked: boolean;
+  groupWidth?: number | null;
+  groupHeight?: number | null;
+  chartType: string;
+  chartData: ChartDataRow;
+  chartError: string;
+  chartAssetId: string;
+  chartAssetVersion: number;
+  chartWidth: number;
+  chartHeight: number;
+  chartAspectLocked: boolean;
+  chartSourceNodeId: string;
+  htmlSplitterState?: number | null;
+  chatScrollValue: number;
 }
 
 export interface ConversationMessageRow {
@@ -110,6 +136,23 @@ export interface GitlinkPendingChangeRow {
   operation: string;
   reason: string;
   content?: string | null;
+}
+
+export interface ChartDataRow {
+  type?: "bar" | "line" | "pie" | "histogram" | "sankey" | null;
+  title?: string | null;
+  labels?: string[] | null;
+  values?: number[] | null;
+  xAxis?: string | null;
+  yAxis?: string | null;
+  bins?: number | null;
+  flows?: ChartFlowRow[] | null;
+}
+
+export interface ChartFlowRow {
+  source: string;
+  target: string;
+  value: number;
 }
 
 export interface SceneEdgeRow {
@@ -465,6 +508,130 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.codeSandboxError: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.codeSandboxError` + ": expected string"); }
   }
+  {
+    const fieldValue = value["provider"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.provider` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["model"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.model` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["isBranchSynthesis"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isBranchSynthesis: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isBranchSynthesis` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["synthesisInstructions"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.synthesisInstructions: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.synthesisInstructions` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["branchStatus"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.branchStatus: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.branchStatus` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["isFinalDeliverable"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isFinalDeliverable: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isFinalDeliverable` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["color"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.color` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["headerColor"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.headerColor` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["isSystemPrompt"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isSystemPrompt: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isSystemPrompt` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["isSummaryNote"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isSummaryNote: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isSummaryNote` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["isBranchComparison"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isBranchComparison: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isBranchComparison` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["itemIds"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.itemIds: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.itemIds` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "string") errors.push(`${path}.itemIds` + `[${i}]` + ": expected string"); }); }
+  }
+  {
+    const fieldValue = value["isLocked"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isLocked: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isLocked` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["groupWidth"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.groupWidth` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["groupHeight"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.groupHeight` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["chartType"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.chartType: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.chartType` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["chartData"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.chartData: missing required field`);
+    else { checkChartDataRow(fieldValue, `${path}.chartData`, errors); }
+  }
+  {
+    const fieldValue = value["chartError"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.chartError: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.chartError` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["chartAssetId"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.chartAssetId: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.chartAssetId` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["chartAssetVersion"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.chartAssetVersion: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.chartAssetVersion` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["chartWidth"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.chartWidth: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.chartWidth` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["chartHeight"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.chartHeight: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.chartHeight` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["chartAspectLocked"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.chartAspectLocked: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.chartAspectLocked` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["chartSourceNodeId"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.chartSourceNodeId: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.chartSourceNodeId` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["htmlSplitterState"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.htmlSplitterState` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["chatScrollValue"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.chatScrollValue: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.chatScrollValue` + ": expected number"); }
+  }
 }
 
 function checkConversationMessageRow(value: unknown, path: string, errors: string[]): void {
@@ -642,6 +809,64 @@ function checkGitlinkPendingChangeRow(value: unknown, path: string, errors: stri
   {
     const fieldValue = value["content"];
     if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.content` + ": expected string"); }
+  }
+}
+
+function checkChartDataRow(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["type"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (!["bar", "line", "pie", "histogram", "sankey"].includes(fieldValue as string)) errors.push(`${path}.type` + `: ${JSON.stringify(fieldValue)} is not one of [` + "bar, line, pie, histogram, sankey" + `]`); }
+  }
+  {
+    const fieldValue = value["title"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.title` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["labels"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (!Array.isArray(fieldValue)) errors.push(`${path}.labels` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "string") errors.push(`${path}.labels` + `[${i}]` + ": expected string"); }); }
+  }
+  {
+    const fieldValue = value["values"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (!Array.isArray(fieldValue)) errors.push(`${path}.values` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "number") errors.push(`${path}.values` + `[${i}]` + ": expected number"); }); }
+  }
+  {
+    const fieldValue = value["xAxis"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.xAxis` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["yAxis"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.yAxis` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["bins"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.bins` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["flows"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (!Array.isArray(fieldValue)) errors.push(`${path}.flows` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { checkChartFlowRow(item, `${path}.flows` + `[${i}]`, errors); }); }
+  }
+}
+
+function checkChartFlowRow(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["source"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.source: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.source` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["target"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.target: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.target` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["value"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.value: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.value` + ": expected number"); }
   }
 }
 

--- a/web_ui/src/lib/bridge-core/wireTypeCastGuard.test.ts
+++ b/web_ui/src/lib/bridge-core/wireTypeCastGuard.test.ts
@@ -1,0 +1,180 @@
+/**
+ * ADR-003 stage 3.3 (C9): repo-hygiene guard for the pattern this stage
+ * eliminated - a local TypeScript interface widening a GENERATED wire type
+ * via intersection (`type XWithY = SceneNodeRow & YFields`) so a component
+ * could read a real field the generated type didn't (yet) declare, cast in
+ * with `n as XWithY`. That was never a type-safety net; it was TypeScript
+ * being told to trust a field really exists on the wire, on the component
+ * author's word alone - exactly backwards from what the generated type +
+ * runtime validator (contracts/codegen.py's whole reason for existing) are
+ * for. The real fix, applied in this stage, is declaring the field on the
+ * SOURCE dataclass so codegen emits it for real; this test is the ratchet
+ * that keeps a future field gap from being "fixed" the cast way again.
+ *
+ * Scoped to intersecting a GENERATED type specifically (derived dynamically
+ * from every `export interface`/`export type` in bridge-core/generated/,
+ * not a hardcoded list - a future new generated topic is covered
+ * automatically) - an ordinary `A & B` intersecting two hand-authored types
+ * is unrelated to this problem and must not be flagged. Generic exports
+ * (e.g. `ValidationResult<T>`, shared boilerplate every generated file
+ * re-exports identically) are excluded from the collected name set - a real
+ * wire ROW type is never generic, and including one would risk flagging
+ * completely unrelated code that merely shares a substring with a
+ * generic helper's name (see the false-positive regression test below).
+ *
+ * KNOWN LIMITATION, not fixed here (same "flagged so it isn't rediscovered
+ * as a surprise" posture as no-raw-colors.test.ts's own documented gap):
+ * this is regex/text matching, not real TypeScript type resolution, so it
+ * can be evaded by one extra level of local aliasing - `type Row =
+ * SceneNodeRow; type Wide = Row & { extra: string };` never puts the
+ * literal substring "SceneNodeRow" next to `&`, so it passes undetected
+ * even though `Wide` is structurally the exact same widened-wire-type shape
+ * this guard exists to catch. Closing that gap for real needs actual TS
+ * type-checker integration (ts-morph or the compiler API), which is
+ * disproportionate machinery for a repo-hygiene ratchet - no such alias
+ * pattern exists anywhere in the codebase today (grepped), so this is a
+ * latent gap in the TOOL's robustness, not a live, currently-undetected
+ * violation.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { globSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_SRC = join(HERE, "..", "..");
+const GENERATED_DIR = join(HERE, "generated");
+
+// Captures an optional generic parameter list (`<T>`) after the name, so
+// generic exports can be filtered out below - a real wire ROW/ENTITY type is
+// never generic; only shared boilerplate helpers are (e.g. ValidationResult).
+const EXPORTED_TYPE_NAME_RE = /^export (?:interface|type) (\w+)(<[^>]*>)?/gm;
+
+function generatedWireTypeNames(): string[] {
+  const names = new Set<string>();
+  for (const file of globSync("*.ts", { cwd: GENERATED_DIR })) {
+    const source = readFileSync(join(GENERATED_DIR, file), "utf-8");
+    for (const match of source.matchAll(EXPORTED_TYPE_NAME_RE)) {
+      const [, name, genericParams] = match;
+      if (genericParams) continue; // e.g. ValidationResult<T> - not a row type
+      names.add(name);
+    }
+  }
+  return [...names];
+}
+
+function findWireTypeWideningCasts(source: string, wireTypeNames: string[]): string[] {
+  const found: string[] = [];
+  for (const name of wireTypeNames) {
+    // A type intersection widening the generated type, EITHER operand
+    // order - `SceneNodeRow & X` and `X & SceneNodeRow` are semantically
+    // identical in TypeScript, so both must be caught; an earlier version
+    // of this scanner only matched the name-then-`&` order and silently
+    // passed the reversed one. Word-boundaried on both sides so e.g.
+    // "SceneNodeRow" doesn't also match a longer identifier that happens to
+    // contain it as a substring.
+    const intersectionRe = new RegExp(`(?:\\b${name}\\s*&|&\\s*${name}\\b)`, "g");
+    for (const match of source.matchAll(intersectionRe)) found.push(match[0].trim());
+    // `as unknown as SceneNodeRow` (or straight to a local alias built from
+    // one) - the other half of the ADR's own wording for this anti-pattern.
+    const unsafeCastRe = new RegExp(`as unknown as \\w*${name}\\w*`, "g");
+    for (const match of source.matchAll(unsafeCastRe)) found.push(match[0].trim());
+  }
+  return found;
+}
+
+describe("no local interface/cast widens a generated wire type (ADR-003 C9 ratchet)", () => {
+  const wireTypeNames = generatedWireTypeNames();
+
+  it("found at least one generated wire type name (sanity check the scanner itself)", () => {
+    expect(wireTypeNames.length).toBeGreaterThan(0);
+    expect(wireTypeNames).toContain("SceneNodeRow");
+  });
+
+  it("excludes generic exports like ValidationResult<T> from the collected name set", () => {
+    // Review-fix: ValidationResult<T> is real, shared boilerplate re-exported
+    // identically by every generated file (confirmed: scene-state.ts and
+    // app-settings-state.ts both declare it) - if it were included, any
+    // future, entirely unrelated `as unknown as SomeValidationResultThing`
+    // anywhere in the app would trip this guard for no real reason.
+    expect(wireTypeNames).not.toContain("ValidationResult");
+  });
+
+  // Scans BOTH app/** (components) and lib/** (transport/store/api-contract
+  // code that also imports generated wire types, e.g. lib/api-contract/
+  // topics.ts) - review-fix: the original version only scanned app/**,
+  // leaving lib/** as a real, unmonitored blind spot for the exact same
+  // anti-pattern. generated/ itself is excluded (it's what defines the
+  // names being searched for, not code that could misuse them), as is any
+  // .test. file (test-only fixtures are covered by a dedicated hygiene pass
+  // in SceneCanvas.test.tsx itself, not this production-code ratchet).
+  const sourceFiles = globSync("{app,lib}/**/*.{ts,tsx}", { cwd: REPO_SRC }).filter(
+    // globSync always returns POSIX-style ("/") relative paths regardless of
+    // platform - a join()-built prefix would use "\" on Windows and never
+    // match, silently defeating this exclusion there.
+    (path) => !path.includes(".test.") && !path.startsWith("lib/bridge-core/generated/"),
+  );
+
+  it("found at least one source file to scan (sanity check the glob itself)", () => {
+    expect(sourceFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(sourceFiles)("%s does not widen a generated wire type", (relPath) => {
+    const source = readFileSync(join(REPO_SRC, relPath), "utf-8");
+    expect(findWireTypeWideningCasts(source, wireTypeNames)).toEqual([]);
+  });
+});
+
+describe("the scanner itself catches a real regression", () => {
+  const wireTypeNames = ["SceneNodeRow"];
+
+  it("flags a local interface intersection widening the wire type (wire type on the left)", () => {
+    const source = 'type SceneNodeRowWithChart = SceneNodeRow & { chartType: string };\nconst chart = n as SceneNodeRowWithChart;';
+    expect(findWireTypeWideningCasts(source, wireTypeNames)).toEqual(["SceneNodeRow &"]);
+  });
+
+  it("flags a local interface intersection widening the wire type (wire type on the right)", () => {
+    // Review-fix: TypeScript intersections are commutative - `X & SceneNodeRow`
+    // is the identical anti-pattern with the operands swapped, and the
+    // original regex (name immediately BEFORE `&` only) silently missed it.
+    const source = 'type Wide = { chartType: string } & SceneNodeRow;\nconst chart = n as Wide;';
+    expect(findWireTypeWideningCasts(source, wireTypeNames)).toEqual(["& SceneNodeRow"]);
+  });
+
+  it("flags a direct `as unknown as` escape hatch onto the wire type", () => {
+    const source = "const n = raw as unknown as SceneNodeRow;";
+    expect(findWireTypeWideningCasts(source, wireTypeNames)).toEqual(["as unknown as SceneNodeRow"]);
+  });
+
+  it("does NOT flag an intersection of two UNRELATED, non-generated types", () => {
+    const source = "type Combined = Foo & Bar;";
+    expect(findWireTypeWideningCasts(source, wireTypeNames)).toEqual([]);
+  });
+
+  it("does NOT flag plain, unwidened use of the generated type", () => {
+    const source = "function f(n: SceneNodeRow) { return n.title; }";
+    expect(findWireTypeWideningCasts(source, wireTypeNames)).toEqual([]);
+  });
+});
+
+describe("generatedWireTypeNames() itself", () => {
+  it("does not collect a generic export's bare name (regression pin for the ValidationResult false-positive gap)", () => {
+    // Direct unit test of the regex/filter logic, independent of the real
+    // generated/ directory's current contents - proves the exclusion holds
+    // even if a future generated file's exact type set changes.
+    const source = [
+      "export interface RealRowType {",
+      "  id: string;",
+      "}",
+      "export type ValidationResult<T> = { ok: true; value: T } | { ok: false; errors: string[] };",
+    ].join("\n");
+    const names = new Set<string>();
+    for (const match of source.matchAll(EXPORTED_TYPE_NAME_RE)) {
+      const [, name, genericParams] = match;
+      if (genericParams) continue;
+      names.add(name);
+    }
+    expect([...names]).toEqual(["RealRowType"]);
+  });
+});


### PR DESCRIPTION
## Problem

`backend/domain/graph.py`'s `scene_payload()` already emitted 26 real wire fields (ADR-002 Workstream 1 branch provenance/lifecycle, R6.1 group fields, R6.2 chart fields, R6.3 splitter/scroll state) that `contracts/graphlink_scene_payload.py`'s `SceneNodeRow` never declared. The frontend worked around the gap with 8 unsafe `n as SceneNodeRow & LocalInterface` casts across 5 local widening interfaces in `SceneCanvas.tsx` — exactly audit finding C9.

## Change

- Declares all 26 fields for real on `SceneNodeRow`, including a new `ChartDataRow`/`ChartFlowRow` pair that flattens `canonicalize_chart_data()`'s three disjoint chart-type shapes (bar/line/pie, histogram, sankey) into one all-optional dataclass — the same flattening pattern `SceneNodeRow` itself already uses one level up, since the schema generator has no tagged-union support.
- Regenerates the schema/TypeScript/runtime validator from the updated dataclass.
- Deletes all 8 unsafe casts and their 5 backing local interfaces in `SceneCanvas.tsx`.
- Adds `wireTypeCastGuard.test.ts`, a CI ratchet that fails on any future local type intersecting (or `as unknown as`-casting to) a generated wire-row type, so this pattern can't silently recur.

Scope is deliberately just the C9 cast-driven schema gap — the per-kind payload restructuring this ADR's own title also names is stage 3.4's scope, not this one.

Two rounds of 4-lens adversarial review (12 confirmed findings, 0 refuted) were fixed in this same PR:
- Guard missed the reversed `X & WireType` intersection operand order.
- Guard's generated-type name collection could false-positive against generic re-exports like `ValidationResult<T>`.
- `chartData.flows`/`labels`/`values` had no test coverage against the real production dataclasses or the real runtime validator.
- The 5 `?? null` optional-to-required-nullable normalizations in `toFlowNodes` were unpinned by any test using a genuinely `undefined` (not already-`null`) wire value.
- 5 dead widening-helper test fixtures in `SceneCanvas.test.tsx` still carried now-false "hasn't been regenerated yet" comments.
- Guard's own scan glob excluded `web_ui/src/lib/**`, a live blind spot for the same anti-pattern in transport/store code.

## Test plan

- [x] Full backend suite: `python -m pytest -q` — 1600 passed, 14 skipped
- [x] Full frontend check: `npm run check` (typecheck, lint, tests, build) — clean
- [x] New backend coverage: real `SceneNodeRow`/`ChartDataRow`/`ChartFlowRow` validated for bar and sankey charts, including a nested `flows[i].value` type-error path
- [x] New frontend coverage: real populated sankey/bar chart payloads accepted through the actual scene-store validator; a malformed nested flow rejected
- [x] `?? null` normalizations pinned against genuinely-`undefined` (not pre-defaulted-`null`) wire values for provider/model, color/headerColor (×2 branches), htmlSplitterState
- [x] Every review-pass fix mutation-tested (reverted, confirmed the intended test fails, restored)