### PR TITLE
ADR-003 stage 3.4: node-scoped patch protocol for the scene topic

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -298,7 +298,12 @@ def register_canvas(
     # protocol (a 500-node scene snapshot is ~1.6 MB; every other topic's
     # whole payload is smaller than the bookkeeping a delta would cost) -
     # see SessionBus.register_topic's own docstring.
-    bus.register_topic("scene", document.scene_payload, patch_builder=document.take_dirty_patch_ops)
+    bus.register_topic(
+        "scene",
+        document.scene_payload,
+        patch_builder=document.take_dirty_patch_ops,
+        baseline_builder=document.published_scene_payload,
+    )
     bus.register_topic("grid-control", document.grid_payload)
     # Static preset topics, field-for-field the DragSpeedStatePayload /
     # FontControlStatePayload shapes so the generated validators apply

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -294,7 +294,11 @@ def register_canvas(
 
     document = SceneDocument()
 
-    bus.register_topic("scene", document.scene_payload)
+    # ADR-003 stage 3.4: the ONE topic large enough to be worth a delta
+    # protocol (a 500-node scene snapshot is ~1.6 MB; every other topic's
+    # whole payload is smaller than the bookkeeping a delta would cost) -
+    # see SessionBus.register_topic's own docstring.
+    bus.register_topic("scene", document.scene_payload, patch_builder=document.take_dirty_patch_ops)
     bus.register_topic("grid-control", document.grid_payload)
     # Static preset topics, field-for-field the DragSpeedStatePayload /
     # FontControlStatePayload shapes so the generated validators apply

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -201,6 +201,96 @@ class SceneDocument(BranchOps, GroupOps):
     # current chat - a predicate the frontend cannot evaluate without it.
     current_chat_id: int | None = None
     _counter: itertools.count = field(default_factory=itertools.count, repr=False)
+    # ADR-003 stage 3.4: the last wire state actually published, kept so
+    # take_dirty_patch_ops below can diff against it. None until the first
+    # publish (there is nothing to diff a first snapshot against).
+    _published_nodes: dict[str, dict[str, Any]] | None = field(default=None, repr=False, compare=False)
+    _published_edges: dict[str, dict[str, Any]] | None = field(default=None, repr=False, compare=False)
+    _published_pins: list[dict[str, Any]] | None = field(default=None, repr=False, compare=False)
+    _published_view: dict[str, Any] | None = field(default=None, repr=False, compare=False)
+    _published_meta: dict[str, Any] | None = field(default=None, repr=False, compare=False)
+
+    # -- ADR-003 stage 3.4: the scene topic's patch protocol ---------------
+
+    def _view_wire(self) -> dict[str, Any]:
+        return {"zoomFactor": self.zoom_factor, "scrollX": self.scroll_x, "scrollY": self.scroll_y}
+
+    def take_dirty_patch_ops(self) -> list[dict[str, Any]] | None:
+        """The scene topic's patch_builder (wired in backend/canvas.py,
+        SessionBus's patch-aware sibling to the full-snapshot `builder`
+        callable - see events.py's own _Topic docstring). Returns the ops
+        that carry this document from its last-published wire state to its
+        current one, or None meaning "send a full snapshot instead".
+
+        MECHANISM NOTE - this deliberately diverges from the mechanism
+        ADR-003's own Decision text sketches ("server bookkeeping to a
+        dirty-id set" fed by the mutation sites). That was implemented
+        first and abandoned for a real, empirically-reproduced
+        silent-data-loss bug, not a taste preference. A dirty-id set is
+        only safe if EVERY mutator marks; with ~60 mutators across this
+        file, groups.py and branches.py reached from ~146 publish sites,
+        any partial rollout breaks catastrophically rather than gracefully:
+        an UNinstrumented mutation that publishes while some EARLIER
+        instrumented mutation's marks are still pending emits a patch
+        describing only the stale earlier change, and the real one never
+        reaches the client at all. Reproduced against a real intent
+        (setCodeSandboxAllowSourceBuilds, uninstrumented, publishing after
+        an instrumented connect() during node setup): the patch carried
+        only the setup edge and the actual flag change vanished.
+        "Instrument everything, perfectly, forever" is not a property a
+        test can enforce, so the whole-node DIFF below is used instead - it
+        is correct by construction for every mutator, present and future,
+        instrumented or not, and needs no discipline at any mutation site.
+        The granularity the ADR actually specifies is unchanged: whole-node
+        ops, never field-level diffing, no CRDT.
+
+        The cost this trades away is real but small in context: building
+        every node's wire dict on each publish. That is exactly what the
+        pre-3.4 full-snapshot path ALREADY did on every publish, so it adds
+        no work relative to today - it only changes what gets SENT, which
+        is where this stage's own exit criterion (bytes on the wire) lives.
+
+        None (send a full snapshot) is returned for the first publish, and
+        whenever the pins list changed - pins have no op in the ADR's own
+        op set, so a pin mutation is honestly outside what a patch can
+        express and falls back rather than being silently dropped."""
+        nodes = {node_id: self._node_wire(n) for node_id, n in self.nodes.items()}
+        edges = {edge_id: self._edge_wire(e) for edge_id, e in self.edges.items()}
+        pins = self._pins_wire()
+        view = self._view_wire()
+        meta = self._meta_wire()
+        previous_nodes = self._published_nodes
+        previous_edges = self._published_edges
+        previous_view = self._published_view
+        previous_meta = self._published_meta
+        pins_changed = pins != self._published_pins
+        # Record BEFORE any early return: whichever branch the caller takes
+        # (patch or snapshot), what it sends reflects exactly this state.
+        self._published_nodes = nodes
+        self._published_edges = edges
+        self._published_pins = pins
+        self._published_view = view
+        self._published_meta = meta
+        if previous_nodes is None or previous_edges is None or pins_changed:
+            return None
+        ops: list[dict[str, Any]] = []
+        for node_id, wire in nodes.items():
+            if previous_nodes.get(node_id) != wire:
+                ops.append({"op": "upsertNode", "node": wire})
+        removed_node_ids = sorted(set(previous_nodes) - set(nodes))
+        if removed_node_ids:
+            ops.append({"op": "removeNodes", "ids": removed_node_ids})
+        for edge_id, wire in edges.items():
+            if previous_edges.get(edge_id) != wire:
+                ops.append({"op": "upsertEdge", "edge": wire})
+        removed_edge_ids = sorted(set(previous_edges) - set(edges))
+        if removed_edge_ids:
+            ops.append({"op": "removeEdges", "ids": removed_edge_ids})
+        if view != previous_view:
+            ops.append({"op": "setView", "view": view})
+        if meta != previous_meta:
+            ops.append({"op": "setMeta", "meta": meta})
+        return ops
 
     # -- nodes -------------------------------------------------------------
 
@@ -1746,222 +1836,232 @@ class SceneDocument(BranchOps, GroupOps):
 
     # -- snapshots ---------------------------------------------------------
 
-    def scene_payload(self) -> dict[str, Any]:
+    def _node_wire(self, n: SceneNode) -> dict[str, Any]:
+        """The per-node wire shape - ADR-003 stage 3.4 factored this out of
+        scene_payload() verbatim (byte-identical output) so both the full
+        snapshot AND take_dirty_patch_ops's upsertNode ops build a node's
+        payload from exactly ONE place, rather than a second copy drifting
+        out of sync with this one field by field."""
         return {
-            "nodes": [
-                {
-                    "id": n.id,
-                    "x": n.x,
-                    "y": n.y,
-                    "title": n.title,
-                    "kind": n.kind,
-                    "content": n.content,
-                    "isUser": n.state.is_user if isinstance(n.state, ChatState) else False,
-                    "isCollapsed": n.is_collapsed,
-                    "code": n.state.code if isinstance(n.state, CodeState) else "",
-                    "language": n.state.language if isinstance(n.state, CodeState) else "",
-                    "attachmentKind": n.state.attachment_kind if isinstance(n.state, DocumentState) else "",
-                    "filePath": n.state.file_path if isinstance(n.state, DocumentState) else "",
-                    "mimeType": n.state.mime_type if isinstance(n.state, DocumentState) else "",
-                    "durationSeconds": n.state.duration_seconds if isinstance(n.state, DocumentState) else None,
-                    "byteSize": n.state.byte_size if isinstance(n.state, DocumentState) else None,
-                    "previewLabel": n.state.preview_label if isinstance(n.state, DocumentState) else "",
-                    "isDocked": n.is_docked,
-                    "imageAssetId": n.state.image_asset_id if isinstance(n.state, ImageState) else "",
-                    "history": [
-                        {"role": m["role"], "content": m["content"]} for m in n.history
-                    ],
-                    "pendingRequestId": n.pending_request_id,
-                    # ADR-002 Workstream 1 ("Synthesize Branches") - see
-                    # ChatState's own comment, backend/domain/node_states.py.
-                    "provider": n.state.provider if isinstance(n.state, ChatState) else None,
-                    "model": n.state.model if isinstance(n.state, ChatState) else None,
-                    "isBranchSynthesis": n.state.is_branch_synthesis if isinstance(n.state, ChatState) else False,
-                    "synthesisInstructions": (
-                        n.state.synthesis_instructions if isinstance(n.state, ChatState) else ""
-                    ),
-                    # ADR-002 Workstream 1 ("Branch status and lifecycle") -
-                    # see ChatState's own comment/SceneDocument.
-                    # final_deliverable_node_id's own comment. "active" (not
-                    # "") is the correct non-chat fallback - it is
-                    # branch_status's own real pre-migration default, not an
-                    # empty placeholder.
-                    "branchStatus": n.state.branch_status if isinstance(n.state, ChatState) else "active",
-                    "isFinalDeliverable": n.id == self.final_deliverable_node_id,
-                    "researchStage": n.state.research_stage if isinstance(n.state, WebResearchState) else "",
-                    "researchCompleted": n.state.research_completed if isinstance(n.state, WebResearchState) else 0,
-                    "researchTotal": n.state.research_total if isinstance(n.state, WebResearchState) else 0,
-                    "researchActiveSourceId": (
-                        n.state.research_active_source_id if isinstance(n.state, WebResearchState) else None
-                    ),
-                    "researchError": n.state.research_error if isinstance(n.state, WebResearchState) else "",
-                    "researchResult": n.state.research_result if isinstance(n.state, WebResearchState) else None,
-                    "artifactContent": n.state.artifact_content if isinstance(n.state, ArtifactState) else "",
-                    "gitlinkRepo": n.state.gitlink_repo if isinstance(n.state, GitlinkState) else "",
-                    "gitlinkBranch": n.state.gitlink_branch if isinstance(n.state, GitlinkState) else "",
-                    "gitlinkScopeMode": (
-                        n.state.gitlink_scope_mode if isinstance(n.state, GitlinkState) else "selected"
-                    ),
-                    "gitlinkLocalRoot": n.state.gitlink_local_root if isinstance(n.state, GitlinkState) else "",
-                    "gitlinkRepoFilePaths": (
-                        list(n.state.gitlink_repo_file_paths) if isinstance(n.state, GitlinkState) else []
-                    ),
-                    "gitlinkSelectedPaths": (
-                        list(n.state.gitlink_selected_paths) if isinstance(n.state, GitlinkState) else []
-                    ),
-                    "gitlinkTaskPrompt": n.state.gitlink_task_prompt if isinstance(n.state, GitlinkState) else "",
-                    # gitlinkContextXml is DELIBERATELY OMITTED - see
-                    # GitlinkState's own comment. Served on demand via the
-                    # fetchGitlinkContext intent instead.
-                    "gitlinkContextStats": (
-                        dict(n.state.gitlink_context_stats) if isinstance(n.state, GitlinkState) else {}
-                    ),
-                    "gitlinkContextSummary": (
-                        n.state.gitlink_context_summary if isinstance(n.state, GitlinkState) else ""
-                    ),
-                    # R5.3 post-review FIX 6: UNLIKE gitlinkContextXml (and
-                    # unlike gitlink_change_local_root, never on the wire at
-                    # all), this genuinely needs to be here - see
-                    # GitlinkState's own comment for why gitlinkContextSummary
-                    # alone cannot be trusted as a lazy-fetch-once cache key.
-                    "gitlinkContextVersion": (
-                        n.state.gitlink_context_version if isinstance(n.state, GitlinkState) else 0
-                    ),
-                    "gitlinkProposalMarkdown": (
-                        n.state.gitlink_proposal_markdown if isinstance(n.state, GitlinkState) else ""
-                    ),
-                    "gitlinkPendingChanges": (
-                        [dict(c) for c in n.state.gitlink_pending_changes] if isinstance(n.state, GitlinkState) else []
-                    ),
-                    "gitlinkPreviewText": n.state.gitlink_preview_text if isinstance(n.state, GitlinkState) else "",
-                    "gitlinkChangeFingerprint": (
-                        n.state.gitlink_change_fingerprint if isinstance(n.state, GitlinkState) else None
-                    ),
-                    "gitlinkChangeState": (
-                        n.state.gitlink_change_state if isinstance(n.state, GitlinkState) else "draft"
-                    ),
-                    "gitlinkError": n.state.gitlink_error if isinstance(n.state, GitlinkState) else "",
-                    "pycoderMode": n.state.pycoder_mode if isinstance(n.state, PycoderState) else "ai_driven",
-                    "pycoderPrompt": n.state.pycoder_prompt if isinstance(n.state, PycoderState) else "",
-                    "pycoderCode": n.state.pycoder_code if isinstance(n.state, PycoderState) else "",
-                    "pycoderOutput": n.state.pycoder_output if isinstance(n.state, PycoderState) else "",
-                    "pycoderAnalysis": n.state.pycoder_analysis if isinstance(n.state, PycoderState) else "",
-                    "pycoderLastRunFailed": (
-                        n.state.pycoder_last_run_failed if isinstance(n.state, PycoderState) else False
-                    ),
-                    "pycoderAwaitingApproval": (
-                        n.state.pycoder_awaiting_approval if isinstance(n.state, PycoderState) else False
-                    ),
-                    "pycoderError": n.state.pycoder_error if isinstance(n.state, PycoderState) else "",
-                    # codeSandboxSandboxId is DELIBERATELY OMITTED - see
-                    # CodeSandboxState's own comment (pure internal
-                    # directory-naming key, mirrors gitlink_imported_root's
-                    # own "server-side bookkeeping only" precedent).
-                    "codeSandboxRequirements": (
-                        n.state.code_sandbox_requirements if isinstance(n.state, CodeSandboxState) else ""
-                    ),
-                    "codeSandboxPrompt": (
-                        n.state.code_sandbox_prompt if isinstance(n.state, CodeSandboxState) else ""
-                    ),
-                    "codeSandboxCode": n.state.code_sandbox_code if isinstance(n.state, CodeSandboxState) else "",
-                    "codeSandboxOutput": (
-                        n.state.code_sandbox_output if isinstance(n.state, CodeSandboxState) else ""
-                    ),
-                    "codeSandboxAnalysis": (
-                        n.state.code_sandbox_analysis if isinstance(n.state, CodeSandboxState) else ""
-                    ),
-                    "codeSandboxAwaitingApproval": (
-                        n.state.code_sandbox_awaiting_approval if isinstance(n.state, CodeSandboxState) else False
-                    ),
-                    # R5.4 CODESANDBOX FIX: the frozen-at-approval-time
-                    # snapshot, deliberately distinct from
-                    # codeSandboxRequirements above (that one is the user's
-                    # still-live, still-editable draft for the NEXT run) -
-                    # see CodeSandboxState's own comment.
-                    "codeSandboxApprovalRequirements": (
-                        n.state.code_sandbox_approval_requirements if isinstance(n.state, CodeSandboxState) else ""
-                    ),
-                    # ADR-005 stage 5.5: the user's live source-build opt-in
-                    # for the CURRENT pending approval - see CodeSandboxState.
-                    # code_sandbox_approval_allow_source_builds's own comment.
-                    "codeSandboxApprovalAllowSourceBuilds": (
-                        n.state.code_sandbox_approval_allow_source_builds
-                        if isinstance(n.state, CodeSandboxState)
-                        else False
-                    ),
-                    # ADR-005 stage 5.5 review-fix: True only during a
-                    # repair-loop re-gate - see CodeSandboxState.
-                    # code_sandbox_approval_is_repair's own comment.
-                    "codeSandboxApprovalIsRepair": (
-                        n.state.code_sandbox_approval_is_repair
-                        if isinstance(n.state, CodeSandboxState)
-                        else False
-                    ),
-                    "codeSandboxError": n.state.code_sandbox_error if isinstance(n.state, CodeSandboxState) else "",
-                    # R6.1: Notes/Frames/Containers. groupManualWidth/Height
-                    # are DELIBERATELY OMITTED, same "server-side bookkeeping
-                    # only" posture as codeSandboxSandboxId/gitlinkImportedRoot
-                    # above - see those fields' own comments on
-                    # CodeSandboxState/GitlinkState.
-                    "color": n.color,
-                    "headerColor": n.header_color,
-                    "isSystemPrompt": n.state.is_system_prompt if isinstance(n.state, NoteState) else False,
-                    "isSummaryNote": n.state.is_summary_note if isinstance(n.state, NoteState) else False,
-                    # ADR-002 Workstream 1 ("Compare Branches") - see
-                    # NoteState's own comment, backend/domain/node_states.py.
-                    "isBranchComparison": n.state.is_branch_comparison if isinstance(n.state, NoteState) else False,
-                    "itemIds": list(n.item_ids),
-                    "isLocked": n.state.is_locked if isinstance(n.state, FrameState) else True,
-                    "groupWidth": n.state.group_width if isinstance(n.state, (FrameState, ContainerState)) else None,
-                    "groupHeight": (
-                        n.state.group_height if isinstance(n.state, (FrameState, ContainerState)) else None
-                    ),
-                    # R6.2: Chart node.
-                    "chartType": n.state.chart_type if isinstance(n.state, ChartState) else "",
-                    "chartData": dict(n.state.chart_data) if isinstance(n.state, ChartState) else {},
-                    "chartError": n.state.chart_error if isinstance(n.state, ChartState) else "",
-                    "chartAssetId": n.state.chart_asset_id if isinstance(n.state, ChartState) else "",
-                    "chartAssetVersion": n.state.chart_asset_version if isinstance(n.state, ChartState) else 0,
-                    "chartWidth": n.state.chart_width if isinstance(n.state, ChartState) else 680.0,
-                    "chartHeight": n.state.chart_height if isinstance(n.state, ChartState) else 500.0,
-                    "chartAspectLocked": n.state.chart_aspect_locked if isinstance(n.state, ChartState) else True,
-                    "chartSourceNodeId": n.state.chart_source_node_id if isinstance(n.state, ChartState) else "",
-                    # R6.3: HTML splitter + chat scroll gaps.
-                    "htmlSplitterState": n.state.html_splitter_state if isinstance(n.state, HtmlState) else None,
-                    "chatScrollValue": n.state.chat_scroll_value if isinstance(n.state, ChatState) else 0.0,
-                    # R6.3: null (not []) when content_parts is None - "no
-                    # multimodal content" must stay distinguishable from
-                    # "multimodal content that happens to be empty". Any
-                    # part carrying raw bytes under "data" gets that key
-                    # base64-encoded for the wire via content_codec's own
-                    # encode_image_bytes - the WIRE shape this produces
-                    # matches content_codec.process_content_for_serialization's
-                    # own output shape exactly, while n.content_parts itself
-                    # (in memory) keeps holding real bytes, per the field's
-                    # own contract.
-                    "contentParts": _content_parts_wire(n.state.content_parts if isinstance(n.state, ChatState) else None),
-                }
-                for n in self.nodes.values()
+            "id": n.id,
+            "x": n.x,
+            "y": n.y,
+            "title": n.title,
+            "kind": n.kind,
+            "content": n.content,
+            "isUser": n.state.is_user if isinstance(n.state, ChatState) else False,
+            "isCollapsed": n.is_collapsed,
+            "code": n.state.code if isinstance(n.state, CodeState) else "",
+            "language": n.state.language if isinstance(n.state, CodeState) else "",
+            "attachmentKind": n.state.attachment_kind if isinstance(n.state, DocumentState) else "",
+            "filePath": n.state.file_path if isinstance(n.state, DocumentState) else "",
+            "mimeType": n.state.mime_type if isinstance(n.state, DocumentState) else "",
+            "durationSeconds": n.state.duration_seconds if isinstance(n.state, DocumentState) else None,
+            "byteSize": n.state.byte_size if isinstance(n.state, DocumentState) else None,
+            "previewLabel": n.state.preview_label if isinstance(n.state, DocumentState) else "",
+            "isDocked": n.is_docked,
+            "imageAssetId": n.state.image_asset_id if isinstance(n.state, ImageState) else "",
+            "history": [
+                {"role": m["role"], "content": m["content"]} for m in n.history
             ],
-            "edges": [
-                {"id": e.id, "source": e.source, "target": e.target}
-                for e in self.edges.values()
-            ],
-            "pins": [
-                {
-                    "id": p.pin_id,
-                    "title": p.title,
-                    "note": p.note,
-                    "x": p.position[0],
-                    "y": p.position[1],
-                    # R6.3: NavigationPinRecord already carries these three -
-                    # they just weren't exposed on the wire until now.
-                    "anchorItemId": p.anchor_item_id,
-                    "sortOrder": p.sort_order,
-                    "createdAt": p.created_at,
-                }
-                for p in self.pins.records
-            ],
+            "pendingRequestId": n.pending_request_id,
+            # ADR-002 Workstream 1 ("Synthesize Branches") - see
+            # ChatState's own comment, backend/domain/node_states.py.
+            "provider": n.state.provider if isinstance(n.state, ChatState) else None,
+            "model": n.state.model if isinstance(n.state, ChatState) else None,
+            "isBranchSynthesis": n.state.is_branch_synthesis if isinstance(n.state, ChatState) else False,
+            "synthesisInstructions": (
+                n.state.synthesis_instructions if isinstance(n.state, ChatState) else ""
+            ),
+            # ADR-002 Workstream 1 ("Branch status and lifecycle") -
+            # see ChatState's own comment/SceneDocument.
+            # final_deliverable_node_id's own comment. "active" (not
+            # "") is the correct non-chat fallback - it is
+            # branch_status's own real pre-migration default, not an
+            # empty placeholder.
+            "branchStatus": n.state.branch_status if isinstance(n.state, ChatState) else "active",
+            "isFinalDeliverable": n.id == self.final_deliverable_node_id,
+            "researchStage": n.state.research_stage if isinstance(n.state, WebResearchState) else "",
+            "researchCompleted": n.state.research_completed if isinstance(n.state, WebResearchState) else 0,
+            "researchTotal": n.state.research_total if isinstance(n.state, WebResearchState) else 0,
+            "researchActiveSourceId": (
+                n.state.research_active_source_id if isinstance(n.state, WebResearchState) else None
+            ),
+            "researchError": n.state.research_error if isinstance(n.state, WebResearchState) else "",
+            "researchResult": n.state.research_result if isinstance(n.state, WebResearchState) else None,
+            "artifactContent": n.state.artifact_content if isinstance(n.state, ArtifactState) else "",
+            "gitlinkRepo": n.state.gitlink_repo if isinstance(n.state, GitlinkState) else "",
+            "gitlinkBranch": n.state.gitlink_branch if isinstance(n.state, GitlinkState) else "",
+            "gitlinkScopeMode": (
+                n.state.gitlink_scope_mode if isinstance(n.state, GitlinkState) else "selected"
+            ),
+            "gitlinkLocalRoot": n.state.gitlink_local_root if isinstance(n.state, GitlinkState) else "",
+            "gitlinkRepoFilePaths": (
+                list(n.state.gitlink_repo_file_paths) if isinstance(n.state, GitlinkState) else []
+            ),
+            "gitlinkSelectedPaths": (
+                list(n.state.gitlink_selected_paths) if isinstance(n.state, GitlinkState) else []
+            ),
+            "gitlinkTaskPrompt": n.state.gitlink_task_prompt if isinstance(n.state, GitlinkState) else "",
+            # gitlinkContextXml is DELIBERATELY OMITTED - see
+            # GitlinkState's own comment. Served on demand via the
+            # fetchGitlinkContext intent instead.
+            "gitlinkContextStats": (
+                dict(n.state.gitlink_context_stats) if isinstance(n.state, GitlinkState) else {}
+            ),
+            "gitlinkContextSummary": (
+                n.state.gitlink_context_summary if isinstance(n.state, GitlinkState) else ""
+            ),
+            # R5.3 post-review FIX 6: UNLIKE gitlinkContextXml (and
+            # unlike gitlink_change_local_root, never on the wire at
+            # all), this genuinely needs to be here - see
+            # GitlinkState's own comment for why gitlinkContextSummary
+            # alone cannot be trusted as a lazy-fetch-once cache key.
+            "gitlinkContextVersion": (
+                n.state.gitlink_context_version if isinstance(n.state, GitlinkState) else 0
+            ),
+            "gitlinkProposalMarkdown": (
+                n.state.gitlink_proposal_markdown if isinstance(n.state, GitlinkState) else ""
+            ),
+            "gitlinkPendingChanges": (
+                [dict(c) for c in n.state.gitlink_pending_changes] if isinstance(n.state, GitlinkState) else []
+            ),
+            "gitlinkPreviewText": n.state.gitlink_preview_text if isinstance(n.state, GitlinkState) else "",
+            "gitlinkChangeFingerprint": (
+                n.state.gitlink_change_fingerprint if isinstance(n.state, GitlinkState) else None
+            ),
+            "gitlinkChangeState": (
+                n.state.gitlink_change_state if isinstance(n.state, GitlinkState) else "draft"
+            ),
+            "gitlinkError": n.state.gitlink_error if isinstance(n.state, GitlinkState) else "",
+            "pycoderMode": n.state.pycoder_mode if isinstance(n.state, PycoderState) else "ai_driven",
+            "pycoderPrompt": n.state.pycoder_prompt if isinstance(n.state, PycoderState) else "",
+            "pycoderCode": n.state.pycoder_code if isinstance(n.state, PycoderState) else "",
+            "pycoderOutput": n.state.pycoder_output if isinstance(n.state, PycoderState) else "",
+            "pycoderAnalysis": n.state.pycoder_analysis if isinstance(n.state, PycoderState) else "",
+            "pycoderLastRunFailed": (
+                n.state.pycoder_last_run_failed if isinstance(n.state, PycoderState) else False
+            ),
+            "pycoderAwaitingApproval": (
+                n.state.pycoder_awaiting_approval if isinstance(n.state, PycoderState) else False
+            ),
+            "pycoderError": n.state.pycoder_error if isinstance(n.state, PycoderState) else "",
+            # codeSandboxSandboxId is DELIBERATELY OMITTED - see
+            # CodeSandboxState's own comment (pure internal
+            # directory-naming key, mirrors gitlink_imported_root's
+            # own "server-side bookkeeping only" precedent).
+            "codeSandboxRequirements": (
+                n.state.code_sandbox_requirements if isinstance(n.state, CodeSandboxState) else ""
+            ),
+            "codeSandboxPrompt": (
+                n.state.code_sandbox_prompt if isinstance(n.state, CodeSandboxState) else ""
+            ),
+            "codeSandboxCode": n.state.code_sandbox_code if isinstance(n.state, CodeSandboxState) else "",
+            "codeSandboxOutput": (
+                n.state.code_sandbox_output if isinstance(n.state, CodeSandboxState) else ""
+            ),
+            "codeSandboxAnalysis": (
+                n.state.code_sandbox_analysis if isinstance(n.state, CodeSandboxState) else ""
+            ),
+            "codeSandboxAwaitingApproval": (
+                n.state.code_sandbox_awaiting_approval if isinstance(n.state, CodeSandboxState) else False
+            ),
+            # R5.4 CODESANDBOX FIX: the frozen-at-approval-time
+            # snapshot, deliberately distinct from
+            # codeSandboxRequirements above (that one is the user's
+            # still-live, still-editable draft for the NEXT run) -
+            # see CodeSandboxState's own comment.
+            "codeSandboxApprovalRequirements": (
+                n.state.code_sandbox_approval_requirements if isinstance(n.state, CodeSandboxState) else ""
+            ),
+            # ADR-005 stage 5.5: the user's live source-build opt-in
+            # for the CURRENT pending approval - see CodeSandboxState.
+            # code_sandbox_approval_allow_source_builds's own comment.
+            "codeSandboxApprovalAllowSourceBuilds": (
+                n.state.code_sandbox_approval_allow_source_builds
+                if isinstance(n.state, CodeSandboxState)
+                else False
+            ),
+            # ADR-005 stage 5.5 review-fix: True only during a
+            # repair-loop re-gate - see CodeSandboxState.
+            # code_sandbox_approval_is_repair's own comment.
+            "codeSandboxApprovalIsRepair": (
+                n.state.code_sandbox_approval_is_repair
+                if isinstance(n.state, CodeSandboxState)
+                else False
+            ),
+            "codeSandboxError": n.state.code_sandbox_error if isinstance(n.state, CodeSandboxState) else "",
+            # R6.1: Notes/Frames/Containers. groupManualWidth/Height
+            # are DELIBERATELY OMITTED, same "server-side bookkeeping
+            # only" posture as codeSandboxSandboxId/gitlinkImportedRoot
+            # above - see those fields' own comments on
+            # CodeSandboxState/GitlinkState.
+            "color": n.color,
+            "headerColor": n.header_color,
+            "isSystemPrompt": n.state.is_system_prompt if isinstance(n.state, NoteState) else False,
+            "isSummaryNote": n.state.is_summary_note if isinstance(n.state, NoteState) else False,
+            # ADR-002 Workstream 1 ("Compare Branches") - see
+            # NoteState's own comment, backend/domain/node_states.py.
+            "isBranchComparison": n.state.is_branch_comparison if isinstance(n.state, NoteState) else False,
+            "itemIds": list(n.item_ids),
+            "isLocked": n.state.is_locked if isinstance(n.state, FrameState) else True,
+            "groupWidth": n.state.group_width if isinstance(n.state, (FrameState, ContainerState)) else None,
+            "groupHeight": (
+                n.state.group_height if isinstance(n.state, (FrameState, ContainerState)) else None
+            ),
+            # R6.2: Chart node.
+            "chartType": n.state.chart_type if isinstance(n.state, ChartState) else "",
+            "chartData": dict(n.state.chart_data) if isinstance(n.state, ChartState) else {},
+            "chartError": n.state.chart_error if isinstance(n.state, ChartState) else "",
+            "chartAssetId": n.state.chart_asset_id if isinstance(n.state, ChartState) else "",
+            "chartAssetVersion": n.state.chart_asset_version if isinstance(n.state, ChartState) else 0,
+            "chartWidth": n.state.chart_width if isinstance(n.state, ChartState) else 680.0,
+            "chartHeight": n.state.chart_height if isinstance(n.state, ChartState) else 500.0,
+            "chartAspectLocked": n.state.chart_aspect_locked if isinstance(n.state, ChartState) else True,
+            "chartSourceNodeId": n.state.chart_source_node_id if isinstance(n.state, ChartState) else "",
+            # R6.3: HTML splitter + chat scroll gaps.
+            "htmlSplitterState": n.state.html_splitter_state if isinstance(n.state, HtmlState) else None,
+            "chatScrollValue": n.state.chat_scroll_value if isinstance(n.state, ChatState) else 0.0,
+            # R6.3: null (not []) when content_parts is None - "no
+            # multimodal content" must stay distinguishable from
+            # "multimodal content that happens to be empty". Any
+            # part carrying raw bytes under "data" gets that key
+            # base64-encoded for the wire via content_codec's own
+            # encode_image_bytes - the WIRE shape this produces
+            # matches content_codec.process_content_for_serialization's
+            # own output shape exactly, while n.content_parts itself
+            # (in memory) keeps holding real bytes, per the field's
+            # own contract.
+            "contentParts": _content_parts_wire(n.state.content_parts if isinstance(n.state, ChatState) else None),
+        }
+
+    def _edge_wire(self, e: SceneEdge) -> dict[str, Any]:
+        return {"id": e.id, "source": e.source, "target": e.target}
+
+    def _pins_wire(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": p.pin_id,
+                "title": p.title,
+                "note": p.note,
+                "x": p.position[0],
+                "y": p.position[1],
+                # R6.3: NavigationPinRecord already carries these three -
+                # they just weren't exposed on the wire until now.
+                "anchorItemId": p.anchor_item_id,
+                "sortOrder": p.sort_order,
+                "createdAt": p.created_at,
+            }
+            for p in self.pins.records
+        ]
+
+    def _meta_wire(self) -> dict[str, Any]:
+        """The document-level "meta" fields (everything on the wire that
+        isn't a node/edge/pin/view-position) - ADR-003 stage 3.4's setMeta
+        patch op carries this SAME whole blob (not a partial diff), matching
+        the "whole item, not field-level" granularity every other op already
+        uses (see the ADR's own Decision text)."""
+        return {
             "snapToGrid": self.snap_to_grid,
             "fadeConnectionsEnabled": self.fade_connections_enabled,
             "orthogonalRouting": self.orthogonal_routing,
@@ -1974,12 +2074,18 @@ class SceneDocument(BranchOps, GroupOps):
             "fontFamily": self.font_family,
             "fontSizePt": self.font_size_pt,
             "fontColor": self.font_color,
-            # R6.3: canvas view state + the real, live-growing session token
-            # count - see these fields' own comments on SceneDocument.
-            "zoomFactor": self.zoom_factor,
-            "scrollX": self.scroll_x,
-            "scrollY": self.scroll_y,
             "totalSessionTokens": self.total_session_tokens,
+        }
+
+    def scene_payload(self) -> dict[str, Any]:
+        return {
+            "nodes": [self._node_wire(n) for n in self.nodes.values()],
+            "edges": [self._edge_wire(e) for e in self.edges.values()],
+            "pins": self._pins_wire(),
+            **self._meta_wire(),
+            # R6.3: canvas view state - see these fields' own comments on
+            # SceneDocument.
+            **self._view_wire(),
         }
 
     def grid_payload(self) -> dict[str, Any]:

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -215,6 +215,44 @@ class SceneDocument(BranchOps, GroupOps):
     def _view_wire(self) -> dict[str, Any]:
         return {"zoomFactor": self.zoom_factor, "scrollX": self.scroll_x, "scrollY": self.scroll_y}
 
+    def published_scene_payload(self) -> dict[str, Any] | None:
+        """The wire state as of the LAST publish - what every already-connected
+        client currently holds - or None before the first publish.
+
+        REVIEW-FIX, closing a real permanent-divergence bug. A subscribing
+        connection used to be served the LIVE document stamped with the
+        last-published revision, which are two different states whenever the
+        document was mutated between publishes (routine: several intent
+        handlers await another topic's publish in between, and agents.py sets
+        then clears pending_request_id around an await). The patch protocol's
+        whole correctness argument rests on "revision R means you hold the
+        state as of publish R" - hand a client something NEWER than R and its
+        baseRevision still chains perfectly forever while the diff, which is
+        computed against the published baseline, never emits the op that
+        would fix the difference.
+
+        Reproduced: publish (baseline={n0}); add n1 WITHOUT publishing; a
+        second window subscribes and receives n0+n1 stamped revision 1;
+        delete n1 and move n0; publish. The diff never saw n1, so it emits
+        only upsertNode(n0) - no removeNodes - and baseRevision 1 matches, so
+        the client applies it happily and shows the deleted node for the rest
+        of the session with nothing able to detect it.
+
+        Serving the published baseline instead makes the subscriber exactly
+        as up to date as everyone else, and the very next patch carries the
+        intervening changes to all of them identically. Whole-node ops are
+        absolute assignments, so there is no ordering hazard in that catch-up.
+        """
+        if self._published_nodes is None or self._published_edges is None:
+            return None
+        return {
+            "nodes": list(self._published_nodes.values()),
+            "edges": list(self._published_edges.values()),
+            "pins": list(self._published_pins or []),
+            **(self._published_meta or {}),
+            **(self._published_view or {}),
+        }
+
     def take_dirty_patch_ops(self) -> list[dict[str, Any]] | None:
         """The scene topic's patch_builder (wired in backend/canvas.py,
         SessionBus's patch-aware sibling to the full-snapshot `builder`
@@ -342,6 +380,20 @@ class SceneDocument(BranchOps, GroupOps):
         self.scroll_y = 0.0
         self.total_session_tokens = 0
         self.current_chat_id = None
+        # ADR-003 stage 3.4 review-fix: drop the patch baseline too. Loading a
+        # chat replaces the entire document, so diffing the new scene against
+        # the OLD one produced a patch no smaller than the snapshot it
+        # replaced - measured at 1,666,170 bytes vs 1,677,403 for a
+        # 500-node-to-500-node reload (500 upsertNode ops plus removeNodes
+        # and removeEdges listing every old id). Correct output, zero
+        # benefit, on the single most bandwidth-heavy operation in the app.
+        # Clearing the baseline makes the next publish a plain full snapshot,
+        # which is both smaller and what a wholesale replacement actually is.
+        self._published_nodes = None
+        self._published_edges = None
+        self._published_pins = None
+        self._published_view = None
+        self._published_meta = None
 
     def add_chat_node(
         self,

--- a/backend/events.py
+++ b/backend/events.py
@@ -88,6 +88,11 @@ StateBuilder = Callable[[], dict[str, Any]]
 # and backend/domain/graph.py's take_dirty_patch_ops for the one real
 # implementation.
 PatchBuilder = Callable[[], list[dict[str, Any]] | None]
+# ADR-003 stage 3.4 review-fix: a topic's "what did I last publish" source.
+# send_snapshot serves THIS rather than live state, so a subscribing
+# connection lands exactly where every existing one already is - see
+# SessionBus.send_snapshot and SceneDocument.published_scene_payload.
+BaselineBuilder = Callable[[], dict[str, Any] | None]
 IntentHandler = Callable[..., Any | Awaitable[Any]]
 
 # The one session id every real window uses (confirmed by grep:
@@ -181,7 +186,10 @@ class _IntentRegistration:
 
 
 class _Topic:
-    __slots__ = ("name", "builder", "patch_builder", "schema_version", "min_compatible", "revision")
+    __slots__ = (
+        "name", "builder", "patch_builder", "baseline_builder",
+        "schema_version", "min_compatible", "revision",
+    )
 
     def __init__(
         self,
@@ -190,13 +198,33 @@ class _Topic:
         schema_version: int,
         min_compatible: int,
         patch_builder: PatchBuilder | None = None,
+        baseline_builder: BaselineBuilder | None = None,
     ):
         self.name = name
         self.builder = builder
         self.patch_builder = patch_builder
+        self.baseline_builder = baseline_builder
         self.schema_version = schema_version
         self.min_compatible = min_compatible
         self.revision = 0
+
+    def _stamp(self, payload: dict[str, Any]) -> dict[str, Any]:
+        payload["schemaVersion"] = self.schema_version
+        payload["minCompatibleSchemaVersion"] = self.min_compatible
+        payload["revision"] = self.revision
+        return payload
+
+    def baseline_snapshot(self) -> dict[str, Any] | None:
+        """The state as of the last publish, stamped at the current revision -
+        what send_snapshot serves so a new subscriber lands exactly where
+        every existing connection already is. None when the topic has no
+        baseline source, or has not published yet; the caller falls back to
+        the live builder, which is correct in both cases (nothing has been
+        published, so nothing can be behind)."""
+        if self.baseline_builder is None:
+            return None
+        payload = self.baseline_builder()
+        return None if payload is None else self._stamp(dict(payload))
 
     def snapshot(self) -> dict[str, Any]:
         """Build the current full-state payload, stamped at the CURRENT
@@ -215,11 +243,7 @@ class _Topic:
         a phantom gap and forced every other client into a needless
         re-snapshot. Advancing the revision is now the exclusive job of
         bump_revision() below, called only on a real broadcast."""
-        payload = dict(self.builder())
-        payload["schemaVersion"] = self.schema_version
-        payload["minCompatibleSchemaVersion"] = self.min_compatible
-        payload["revision"] = self.revision
-        return payload
+        return self._stamp(dict(self.builder()))
 
     def bump_revision(self) -> int:
         """Advance to the next revision - called ONLY from publish(), i.e.
@@ -258,6 +282,7 @@ class SessionBus:
         schema_version: int = 1,
         min_compatible: int = 1,
         patch_builder: PatchBuilder | None = None,
+        baseline_builder: BaselineBuilder | None = None,
     ) -> None:
         """`patch_builder`, when given, opts this topic into ADR-003 stage
         3.4's delta protocol: publish() asks it for the ops accumulated
@@ -267,9 +292,21 @@ class SessionBus:
         deliberate, permanent answer for the 11 small topics whose whole
         payload is smaller than the bookkeeping a delta would need - only
         the scene topic is large enough to be worth it (see the ADR's own
-        Decision text)."""
+        Decision text).
+
+        `baseline_builder` must accompany `patch_builder` - it supplies the
+        last-published state send_snapshot serves, without which a
+        subscriber can be handed state newer than the revision stamped on it
+        and diverge permanently. Asserted rather than merely documented,
+        because that failure is completely silent."""
         assert name not in self._topics, f"topic {name!r} registered twice"
-        self._topics[name] = _Topic(name, builder, schema_version, min_compatible, patch_builder)
+        assert patch_builder is None or baseline_builder is not None, (
+            f"topic {name!r}: a patch_builder needs a baseline_builder, or "
+            f"send_snapshot serves live state stamped with a stale revision"
+        )
+        self._topics[name] = _Topic(
+            name, builder, schema_version, min_compatible, patch_builder, baseline_builder
+        )
 
     def register_intent(
         self,
@@ -371,15 +408,30 @@ class SessionBus:
             await self._broadcast({
                 "kind": "patch",
                 "topic": topic,
+                # Review-fix: patches carry the version envelope too. Without
+                # it, this module's own stated contract ("a reader must
+                # refuse a payload older than its stated minimum") had no
+                # field to act on for the majority of scene messages - so
+                # bumping the scene topic for a breaking change would leave
+                # an already-snapshotted old client applying new-shaped node
+                # payloads forever with nothing to refuse on.
+                "schemaVersion": t.schema_version,
+                "minCompatibleSchemaVersion": t.min_compatible,
                 "revision": revision,
                 "baseRevision": base_revision,
                 "ops": ops,
             })
-            # The caller's return value must still be real current state,
-            # not the delta - building it here costs one extra builder run
-            # on a path that just avoided sending one, and every existing
-            # caller/test predates the patch protocol entirely.
-            return t.snapshot()
+            # Review-fix: this used to `return t.snapshot()`, rebuilding
+            # every node's wire dict a SECOND time purely to produce a return
+            # value - measured at 2x the pre-3.4 per-publish CPU on the
+            # 500-node workload (7.0 ms diff + 6.4 ms discarded rebuild vs
+            # 6.4 ms before), on the event loop, across ~146 publish sites.
+            # The stage's own commit message claimed CPU was unchanged; it
+            # was not. The baseline the diff just recorded IS the state
+            # every client now holds, so returning it is both free and more
+            # accurate than a fresh live build (which could already include
+            # a later mutation nobody has been sent).
+            return t.baseline_snapshot() or t.snapshot()
         t.bump_revision()
         snapshot = t.snapshot()
         await self._broadcast({"kind": "state", "topic": topic, "payload": snapshot})
@@ -404,13 +456,22 @@ class SessionBus:
         _Topic.snapshot's own docstring): this reaches exactly one
         connection and is invisible to every other, so advancing the shared
         counter here would manufacture a phantom gap in the patch
-        protocol's baseRevision chain for everyone else. The receiving
-        connection is now, correctly, exactly in sync at the current
-        revision."""
+        protocol's baseRevision chain for everyone else.
+
+        REVIEW-FIX: serves the LAST PUBLISHED state, not the live document,
+        whenever the topic can supply one. Those differ whenever the
+        document was mutated since the last publish, and handing a new
+        subscriber state NEWER than the revision stamped on it caused
+        permanent, undetectable divergence - see
+        SceneDocument.published_scene_payload for the full mechanism and a
+        reproduction. Falling back to the live builder is correct for a
+        topic with no baseline (every non-scene topic, all full-snapshot)
+        and for one that has not published yet (nothing can be behind)."""
         t = self._topics.get(topic)
         if t is None:
             raise UnknownTopicError(topic)
-        await conn.send_json({"kind": "state", "topic": topic, "payload": t.snapshot()})
+        payload = t.baseline_snapshot() or t.snapshot()
+        await conn.send_json({"kind": "state", "topic": topic, "payload": payload})
 
     async def publish_stream(
         self,

--- a/backend/events.py
+++ b/backend/events.py
@@ -81,6 +81,13 @@ from graphlink_wire_schema import validate_payload
 logger = logging.getLogger(__name__)
 
 StateBuilder = Callable[[], dict[str, Any]]
+# ADR-003 stage 3.4: a topic's optional delta source. Returns the ops
+# accumulated since its own last call, or None meaning "no dirty state
+# recorded - send a full snapshot instead". See SessionBus.publish()'s own
+# docstring for why None must never be conflated with an empty ops list,
+# and backend/domain/graph.py's take_dirty_patch_ops for the one real
+# implementation.
+PatchBuilder = Callable[[], list[dict[str, Any]] | None]
 IntentHandler = Callable[..., Any | Awaitable[Any]]
 
 # The one session id every real window uses (confirmed by grep:
@@ -174,22 +181,53 @@ class _IntentRegistration:
 
 
 class _Topic:
-    __slots__ = ("name", "builder", "schema_version", "min_compatible", "revision")
+    __slots__ = ("name", "builder", "patch_builder", "schema_version", "min_compatible", "revision")
 
-    def __init__(self, name: str, builder: StateBuilder, schema_version: int, min_compatible: int):
+    def __init__(
+        self,
+        name: str,
+        builder: StateBuilder,
+        schema_version: int,
+        min_compatible: int,
+        patch_builder: PatchBuilder | None = None,
+    ):
         self.name = name
         self.builder = builder
+        self.patch_builder = patch_builder
         self.schema_version = schema_version
         self.min_compatible = min_compatible
         self.revision = 0
 
     def snapshot(self) -> dict[str, Any]:
-        self.revision += 1
+        """Build the current full-state payload, stamped at the CURRENT
+        revision - it does NOT advance it.
+
+        ADR-003 stage 3.4 fixed a real bug here: this method used to do
+        `self.revision += 1` itself, and it is called from BOTH publish()
+        (a real broadcast every attached connection sees) AND
+        send_snapshot() (one connection's private subscribe handshake,
+        never broadcast). So a second window merely subscribing silently
+        advanced the number every OTHER connection was tracking, with no
+        corresponding message ever sent to them. Harmless while `revision`
+        was a decorative envelope field nobody compared; actively wrong now
+        that it is the baseRevision the patch protocol uses to decide "did
+        I miss a message?" - an unrelated subscribe would have manufactured
+        a phantom gap and forced every other client into a needless
+        re-snapshot. Advancing the revision is now the exclusive job of
+        bump_revision() below, called only on a real broadcast."""
         payload = dict(self.builder())
         payload["schemaVersion"] = self.schema_version
         payload["minCompatibleSchemaVersion"] = self.min_compatible
         payload["revision"] = self.revision
         return payload
+
+    def bump_revision(self) -> int:
+        """Advance to the next revision - called ONLY from publish(), i.e.
+        exactly once per real broadcast, so `revision` means "how many
+        state-changing messages every connection has been sent" rather than
+        the pre-3.4 "how many times the builder happened to run"."""
+        self.revision += 1
+        return self.revision
 
 
 class SessionBus:
@@ -219,9 +257,19 @@ class SessionBus:
         *,
         schema_version: int = 1,
         min_compatible: int = 1,
+        patch_builder: PatchBuilder | None = None,
     ) -> None:
+        """`patch_builder`, when given, opts this topic into ADR-003 stage
+        3.4's delta protocol: publish() asks it for the ops accumulated
+        since the last publish and, when it returns a non-empty list, sends
+        a `kind: "patch"` message instead of a full snapshot. Omitting it
+        (the default) keeps the topic full-snapshot-only, which is the
+        deliberate, permanent answer for the 11 small topics whose whole
+        payload is smaller than the bookkeeping a delta would need - only
+        the scene topic is large enough to be worth it (see the ADR's own
+        Decision text)."""
         assert name not in self._topics, f"topic {name!r} registered twice"
-        self._topics[name] = _Topic(name, builder, schema_version, min_compatible)
+        self._topics[name] = _Topic(name, builder, schema_version, min_compatible, patch_builder)
 
     def register_intent(
         self,
@@ -295,27 +343,70 @@ class SessionBus:
     # -- state flow --------------------------------------------------------
 
     async def publish(self, topic: str) -> dict[str, Any]:
-        """Build a fresh snapshot for `topic` and broadcast it to every
-        attached connection. Returns the snapshot (tests + send-current-state
-        on subscribe both want it)."""
+        """Broadcast `topic`'s current state to every attached connection -
+        as an ADR-003 stage 3.4 `kind: "patch"` delta when the topic has a
+        patch_builder that reports real changes, else as the full
+        `kind: "state"` snapshot. Returns the snapshot either way (tests +
+        callers that want the resulting state both rely on this, and it is
+        cheap: the scene builder runs regardless for the fallback decision
+        only when no patch was available).
+
+        The patch/snapshot decision is deliberately fail-safe in one
+        direction: ANY doubt sends the full snapshot. A patch_builder that
+        returns None ("nothing marked dirty") means the mutation ran
+        through a mutator that does not participate in dirty-tracking yet,
+        which is indistinguishable here from "genuinely nothing changed" -
+        and the full snapshot is correct for both. An EMPTY ops list is
+        treated identically rather than being sent as a real patch: a patch
+        carrying no ops tells the client "your baseRevision is now stale"
+        while giving it nothing to apply, which is strictly worse than
+        either sending real state or staying silent."""
         t = self._topics.get(topic)
         if t is None:
             raise UnknownTopicError(topic)
+        ops = t.patch_builder() if t.patch_builder is not None else None
+        if ops:
+            base_revision = t.revision
+            revision = t.bump_revision()
+            await self._broadcast({
+                "kind": "patch",
+                "topic": topic,
+                "revision": revision,
+                "baseRevision": base_revision,
+                "ops": ops,
+            })
+            # The caller's return value must still be real current state,
+            # not the delta - building it here costs one extra builder run
+            # on a path that just avoided sending one, and every existing
+            # caller/test predates the patch protocol entirely.
+            return t.snapshot()
+        t.bump_revision()
         snapshot = t.snapshot()
-        message = {"kind": "state", "topic": topic, "payload": snapshot}
-        # Snapshot the set: a failed send detaches the connection mid-loop.
+        await self._broadcast({"kind": "state", "topic": topic, "payload": snapshot})
+        return snapshot
+
+    async def _broadcast(self, message: dict[str, Any]) -> None:
+        """Send one message to every attached connection, detaching any that
+        fails. Snapshot the set first: a failed send detaches mid-loop, and a
+        dead socket must never poison the broadcast for the rest."""
         for conn in list(self._connections):
             try:
                 await conn.send_json(message)
             except Exception:
-                # A dead socket must never poison the broadcast for the rest.
                 logger.warning("dropping dead connection on session %s", self.session_id)
                 self.detach(conn)
-        return snapshot
 
     async def send_snapshot(self, topic: str, conn: Connection) -> None:
         """Send the current state of one topic to one connection (the
-        subscribe handshake - the successor of loadFinished -> publish())."""
+        subscribe handshake - the successor of loadFinished -> publish()).
+
+        Deliberately does NOT advance the topic's revision (see
+        _Topic.snapshot's own docstring): this reaches exactly one
+        connection and is invisible to every other, so advancing the shared
+        counter here would manufacture a phantom gap in the patch
+        protocol's baseRevision chain for everyone else. The receiving
+        connection is now, correctly, exactly in sync at the current
+        revision."""
         t = self._topics.get(topic)
         if t is None:
             raise UnknownTopicError(topic)
@@ -352,14 +443,7 @@ class SessionBus:
             "done": done,
             "reset": reset,
         }
-        # Snapshot the set: a failed send detaches the connection mid-loop -
-        # same defensive shape as publish() above.
-        for conn in list(self._connections):
-            try:
-                await conn.send_json(message)
-            except Exception:
-                logger.warning("dropping dead connection on session %s", self.session_id)
-                self.detach(conn)
+        await self._broadcast(message)
 
     def topic_names(self) -> list[str]:
         return sorted(self._topics)

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -64,6 +64,25 @@ def make_client(tmp_path: Path | None = None, *, restrict_sessions: bool = True)
     return client
 
 
+def scene_nodes_from(message: dict, previous: list[dict] | None = None) -> list[dict]:
+    """ADR-003 stage 3.4: read a scene publish's node rows off EITHER wire
+    shape - the full `kind:"state"` snapshot or a `kind:"patch"` delta, which
+    the scene topic now sends whenever it is the smaller of the two. A patch
+    carries only the nodes that CHANGED, so `previous` supplies the rest;
+    omit it when the caller only cares about the changed ones (the usual case
+    for a test asserting "the intent I just fired produced this node")."""
+    if message["kind"] == "state":
+        return message["payload"]["nodes"]
+    by_id = {n["id"]: n for n in (previous or [])}
+    for op in message["ops"]:
+        if op["op"] == "upsertNode":
+            by_id[op["node"]["id"]] = op["node"]
+        elif op["op"] == "removeNodes":
+            for node_id in op["ids"]:
+                by_id.pop(node_id, None)
+    return list(by_id.values())
+
+
 def test_health_reports_ok_and_version():
     client = make_client()
     response = client.get("/api/health")
@@ -86,7 +105,17 @@ def test_subscribe_delivers_system_snapshot_with_envelope():
         assert payload["app"] == "graphlink"
         assert payload["sessionId"] == "default"
         assert payload["schemaVersion"] == 1
-        assert payload["revision"] >= 1
+        # ADR-003 stage 3.4: this used to assert >= 1, which only held
+        # because _Topic.snapshot() itself bumped the revision - so merely
+        # SUBSCRIBING advanced the counter, even though a subscribe reaches
+        # exactly one connection and is invisible to every other. That is a
+        # real bug once `revision` becomes the baseRevision the patch
+        # protocol compares against (an unrelated second window subscribing
+        # would manufacture a phantom gap and force everyone else to
+        # re-snapshot), so bumping now happens only on a real broadcast.
+        # A freshly-subscribed session that has published nothing is
+        # therefore correctly at 0.
+        assert payload["revision"] == 0
 
 
 def test_subscribe_without_topics_sends_every_registered_topic():
@@ -497,14 +526,14 @@ def test_disconnect_auto_denies_any_pending_pycoder_approval(monkeypatch):
         # and the new node's id is read back from that broadcast's own
         # payload rather than from a "result" envelope.
         ws.send_json({"kind": "intent", "topic": "scene", "intent": "addNode", "args": [0, 0, "root"]})
-        scene_after_add = ws.receive_json()["payload"]
-        parent_id = scene_after_add["nodes"][0]["id"]
+        nodes_after_add = scene_nodes_from(ws.receive_json())
+        parent_id = nodes_after_add[0]["id"]
 
         ws.send_json(
             {"kind": "intent", "topic": "app-plugins", "intent": "executePlugin", "args": ["Py-Coder", parent_id]}
         )
-        scene_after_plugin = ws.receive_json()["payload"]
-        node_id = next(n["id"] for n in scene_after_plugin["nodes"] if n["kind"] == "pycoder")
+        nodes_after_plugin = scene_nodes_from(ws.receive_json(), nodes_after_add)
+        node_id = next(n["id"] for n in nodes_after_plugin if n["kind"] == "pycoder")
 
         ws.send_json(
             {"kind": "intent", "topic": "scene", "intent": "runPyCoder", "args": [node_id, "add 1"]}

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -2060,7 +2060,14 @@ class Recorder:
         self.messages.append(data)
 
     def topics_seen(self):
-        return [m["topic"] for m in self.messages if m["kind"] == "state"]
+        # ADR-003 stage 3.4: "state" AND "patch" both mean "this topic
+        # published its new state to the client" - the scene topic now
+        # sends whichever is smaller (see SessionBus.publish). Every
+        # existing caller of this helper is asserting that a publish
+        # HAPPENED, not that it took the full-snapshot form specifically,
+        # so counting only "state" here would silently under-report a real
+        # publish rather than test anything meaningful about it.
+        return [m["topic"] for m in self.messages if m["kind"] in ("state", "patch")]
 
 
 class _FakeSettingsManager:

--- a/backend/tests/test_scene_patch_protocol.py
+++ b/backend/tests/test_scene_patch_protocol.py
@@ -53,7 +53,12 @@ class Recorder:
 
 def make_scene_bus(document: SceneDocument) -> SessionBus:
     bus = SessionBus("patch-test")
-    bus.register_topic("scene", document.scene_payload, patch_builder=document.take_dirty_patch_ops)
+    bus.register_topic(
+        "scene",
+        document.scene_payload,
+        patch_builder=document.take_dirty_patch_ops,
+        baseline_builder=document.published_scene_payload,
+    )
     return bus
 
 
@@ -317,6 +322,172 @@ def test_a_subscribing_connection_receives_state_at_the_current_revision():
         # revision the next patch will name as its baseRevision.
         assert late.messages[0]["kind"] == "state"
         assert revision_of(late.messages[0]) == 2
+
+    asyncio.run(run())
+
+
+# -- review-fix: subscribers must land on the PUBLISHED baseline --------------
+#
+# The protocol's correctness rests on "revision R means you hold the state as
+# of publish R". send_snapshot used to serve the LIVE document stamped with
+# the last-published revision, and those differ whenever the document is
+# mutated between publishes - which is routine (several intent handlers await
+# another topic's publish in between; agents.py sets then clears
+# pending_request_id around an await). Hand a client something NEWER than R
+# and its baseRevision chains perfectly forever while the diff, computed
+# against the published baseline, never emits the op that would reconcile it.
+
+
+def test_a_late_subscriber_never_keeps_a_node_the_diff_baseline_never_saw():
+    # The "ghost node" case: created after the last publish, delivered to a
+    # new subscriber by the handshake, then deleted. The diff never saw it,
+    # so it emits no removeNodes - and the client would have shown a deleted
+    # node for the rest of the session with nothing able to detect it.
+    async def run():
+        document = SceneDocument()
+        bus = make_scene_bus(document)
+        first = Recorder()
+        bus.attach(first)
+        keep = document.add_node(0, 0, "keep")
+        await bus.publish("scene")
+
+        ghost = document.add_node(50, 0, "ghost")  # mutated, NOT published
+        late = Recorder()
+        bus.attach(late)
+        await bus.send_snapshot("scene", late)
+        late_nodes = {n["id"] for n in late.messages[0]["payload"]["nodes"]}
+        assert ghost.id not in late_nodes, "the handshake must serve the published baseline"
+
+        document.remove_nodes([ghost.id])
+        document.move_node(keep.id, 9, 9)  # unrelated change keeps ops non-empty
+        await bus.publish("scene")
+
+        for op in late.messages[1]["ops"]:
+            if op["op"] == "upsertNode":
+                late_nodes.add(op["node"]["id"])
+            elif op["op"] == "removeNodes":
+                late_nodes -= set(op["ids"])
+        assert late_nodes == set(document.nodes)
+
+    asyncio.run(run())
+
+
+def test_a_value_mutated_and_reverted_between_publishes_never_leaks_to_a_late_subscriber():
+    # The complementary case, and the nastier one: no op is EVER emitted for
+    # a node whose value returns to its published state, so a subscriber
+    # handed the transient value keeps it permanently.
+    async def run():
+        document = SceneDocument()
+        bus = make_scene_bus(document)
+        bus.attach(Recorder())
+        node = document.add_node(0, 0, "n")
+        await bus.publish("scene")
+
+        document.move_node(node.id, 999.0, 999.0)  # transient, unpublished
+        late = Recorder()
+        bus.attach(late)
+        await bus.send_snapshot("scene", late)
+        seen_x = {n["id"]: n for n in late.messages[0]["payload"]["nodes"]}[node.id]["x"]
+        assert seen_x == 0.0, "the handshake must not expose an unpublished value"
+
+        document.move_node(node.id, 0.0, 0.0)  # reverted
+        document.add_node(1, 1, "unrelated")   # keeps ops non-empty
+        await bus.publish("scene")
+
+        for op in late.messages[1]["ops"]:
+            if op["op"] == "upsertNode" and op["node"]["id"] == node.id:
+                seen_x = op["node"]["x"]
+        assert seen_x == document.nodes[node.id].x
+
+    asyncio.run(run())
+
+
+def test_registering_a_patch_builder_without_a_baseline_builder_is_a_programming_error():
+    # The pairing is load-bearing and its failure is completely silent, so
+    # it is asserted rather than merely documented.
+    document = SceneDocument()
+    bus = SessionBus("no-baseline")
+    with pytest.raises(AssertionError):
+        bus.register_topic("scene", document.scene_payload, patch_builder=document.take_dirty_patch_ops)
+
+
+def test_a_patch_publish_builds_every_node_payload_exactly_once():
+    # publish() used to call take_dirty_patch_ops() (which builds every node
+    # wire) and THEN t.snapshot() (which builds them all again) purely for a
+    # return value no production caller reads - 2x the pre-3.4 per-publish
+    # CPU on the event loop, across ~146 publish sites, on the exact hot path
+    # this stage exists to make cheaper.
+    async def run():
+        document = SceneDocument()
+        for index in range(20):
+            document.add_node(index, 0, f"n{index}")
+        bus = make_scene_bus(document)
+        bus.attach(Recorder())
+        await bus.publish("scene")
+
+        built = 0
+        original = SceneDocument._node_wire
+
+        def counting(self, node):
+            nonlocal built
+            built += 1
+            return original(self, node)
+
+        document.move_node(next(iter(document.nodes)), 5, 5)
+        SceneDocument._node_wire = counting
+        try:
+            await bus.publish("scene")
+        finally:
+            SceneDocument._node_wire = original
+
+        assert built == len(document.nodes), (
+            f"expected one wire build per node, got {built} for {len(document.nodes)} nodes"
+        )
+
+    asyncio.run(run())
+
+
+def test_loading_a_chat_resets_the_baseline_so_the_next_publish_is_a_snapshot():
+    # clear_for_load replaces the whole document. Diffing the new scene
+    # against the OLD one produced a patch no smaller than the snapshot it
+    # replaced (500 upsertNode ops plus removeNodes/removeEdges listing every
+    # old id) on the most bandwidth-heavy operation in the app.
+    async def run():
+        document = SceneDocument()
+        bus = make_scene_bus(document)
+        recorder = Recorder()
+        bus.attach(recorder)
+        document.add_node(0, 0, "before")
+        await bus.publish("scene")
+
+        document.clear_for_load()
+        document.add_node(0, 0, "after")
+        await bus.publish("scene")
+
+        assert recorder.messages[-1]["kind"] == "state", "a wholesale replacement must send a snapshot"
+
+    asyncio.run(run())
+
+
+def test_a_patch_frame_carries_the_version_envelope():
+    # The module's own contract is that a reader must be able to refuse a
+    # payload older than its stated minimum. Without these fields on patches,
+    # a future breaking scene-schema bump would leave an already-snapshotted
+    # old client applying new-shaped nodes forever with nothing to refuse on.
+    async def run():
+        document = SceneDocument()
+        node = document.add_node(0, 0, "a")
+        bus = make_scene_bus(document)
+        recorder = Recorder()
+        bus.attach(recorder)
+        await bus.publish("scene")
+        document.move_node(node.id, 1, 1)
+        await bus.publish("scene")
+
+        patch = recorder.messages[1]
+        assert patch["kind"] == "patch"
+        assert patch["schemaVersion"] == 1
+        assert patch["minCompatibleSchemaVersion"] == 1
 
     asyncio.run(run())
 

--- a/backend/tests/test_scene_patch_protocol.py
+++ b/backend/tests/test_scene_patch_protocol.py
@@ -1,0 +1,413 @@
+"""ADR-003 stage 3.4: the scene topic's patch protocol.
+
+Covers the three pieces that together make a delta safe to send:
+
+1. SceneDocument.take_dirty_patch_ops - what changed since the last publish,
+   as whole-node/edge ops (backend/domain/graph.py).
+2. SessionBus.publish's patch-vs-snapshot decision, and the revision
+   semantics baseRevision depends on (backend/events.py).
+3. The stage's own numeric exit criterion: a single node edit on a 500-node
+   graph must cost <= 5 KiB on the wire.
+
+The exit criterion is asserted as BYTES, not wall-clock. ADR-003's own
+"Measured targets" line cites "the perf harness from ADR-015", but ADR-015
+(quality gates and CI) contains no perf harness at all - ADR-019
+(performance budgets) is the ADR that actually owns that concept, and says
+so explicitly ("Three ADRs (003, 011, 015) already promise 'budgets' and a
+'perf harness' that do not exist"). ADR-019 also rejects wall-clock timing
+as a per-PR CI gate outright (shared-runner flakiness), reserving it for
+nightly runs and gating CI on counting/size assertions instead. A byte-size
+assertion is therefore both what this stage's exit criterion literally asks
+for AND the only half of it that belongs in per-PR CI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from backend.domain.graph import SceneDocument
+from backend.events import SessionBus
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "perf"))
+
+from graph_factory import LARGE  # noqa: E402
+
+# ADR-003 stage 3.4's own stated exit criterion.
+SINGLE_EDIT_WIRE_BUDGET_BYTES = 5 * 1024
+
+
+class Recorder:
+    """A connection that just records what it was sent."""
+
+    def __init__(self):
+        self.messages: list[dict] = []
+
+    async def send_json(self, data: dict) -> None:
+        self.messages.append(data)
+
+
+def make_scene_bus(document: SceneDocument) -> SessionBus:
+    bus = SessionBus("patch-test")
+    bus.register_topic("scene", document.scene_payload, patch_builder=document.take_dirty_patch_ops)
+    return bus
+
+
+def ops_of(message_or_ops: dict | list) -> list[str]:
+    """The op names in either a whole patch MESSAGE or a bare ops list -
+    take_dirty_patch_ops returns the latter, SessionBus wraps it in the
+    former, and both are asserted on below."""
+    ops = message_or_ops["ops"] if isinstance(message_or_ops, dict) else message_or_ops
+    return [op["op"] for op in ops]
+
+
+def revision_of(message: dict) -> int:
+    """A scene publish carries its revision in a different place depending on
+    which form it took - inside the envelope for a snapshot, at the top level
+    for a patch."""
+    return message["payload"]["revision"] if message["kind"] == "state" else message["revision"]
+
+
+# -- take_dirty_patch_ops -----------------------------------------------------
+
+
+def test_the_first_call_returns_none_so_the_caller_sends_a_full_snapshot():
+    document = SceneDocument()
+    document.add_node(0, 0, "a")
+    assert document.take_dirty_patch_ops() is None
+
+
+def test_no_change_since_the_last_publish_yields_no_ops():
+    document = SceneDocument()
+    document.add_node(0, 0, "a")
+    document.take_dirty_patch_ops()
+    assert document.take_dirty_patch_ops() == []
+
+
+def test_a_moved_node_yields_exactly_one_upsert_carrying_its_new_position():
+    document = SceneDocument()
+    node = document.add_node(0, 0, "a")
+    document.add_node(500, 500, "b")
+    document.take_dirty_patch_ops()
+
+    document.move_node(node.id, 42.0, 99.0)
+    ops = document.take_dirty_patch_ops()
+
+    assert ops_of(ops) == ["upsertNode"]
+    assert ops[0]["node"]["id"] == node.id
+    assert (ops[0]["node"]["x"], ops[0]["node"]["y"]) == (42.0, 99.0)
+
+
+def test_a_removed_node_and_its_cascaded_edges_are_both_reported():
+    # The client does not re-derive edge validity from a node removal, so the
+    # cascade (edges die with either endpoint) has to be on the wire too.
+    document = SceneDocument()
+    a = document.add_node(0, 0, "a")
+    b = document.add_node(100, 0, "b")
+    edge = document.connect(a.id, b.id)
+    document.take_dirty_patch_ops()
+
+    document.remove_nodes([a.id])
+    ops = document.take_dirty_patch_ops()
+
+    assert ops_of(ops) == ["removeNodes", "removeEdges"]
+    assert ops[0]["ids"] == [a.id]
+    assert ops[1]["ids"] == [edge.id]
+
+
+def test_a_frame_that_silently_refits_when_a_member_moves_is_reported_too():
+    # The case a "mutators report their own changed ids" design misses:
+    # move_node's caller knows only the node it asked to move, while
+    # _recompute_group_bounds mutates the ENCLOSING frame as a side effect.
+    # Diffing catches it with no per-mutator instrumentation at all.
+    document = SceneDocument()
+    a = document.add_node(0, 0, "a")
+    b = document.add_node(100, 0, "b")
+    frame = document.create_frame([a.id, b.id])
+    document.take_dirty_patch_ops()
+
+    document.move_node(a.id, 900.0, 900.0)
+    upserted = {op["node"]["id"] for op in document.take_dirty_patch_ops() if op["op"] == "upsertNode"}
+
+    assert a.id in upserted
+    assert frame.id in upserted, "the frame re-fits as a side effect and must be on the wire"
+
+
+def test_a_mutator_that_does_no_dirty_bookkeeping_of_its_own_is_still_reported():
+    # Regression pin for a real silent-data-loss bug this stage hit and
+    # abandoned an earlier mechanism over: with a mutation-site-fed dirty-id
+    # set, an UNinstrumented mutation publishing while an earlier
+    # instrumented one's marks were pending emitted a patch describing only
+    # the stale earlier change - the real one never reached the client.
+    # set_code_sandbox_allow_source_builds is exactly such a mutator (it does
+    # no bookkeeping whatsoever), and connect() ran during its node setup.
+    document = SceneDocument()
+    parent = document.add_node(0, 0, "parent")
+    node = document.add_code_sandbox_node(0, 0, parent.id)
+    document.take_dirty_patch_ops()
+
+    document.set_code_sandbox_allow_source_builds(node.id, True)
+    ops = document.take_dirty_patch_ops()
+
+    assert ops_of(ops) == ["upsertNode"]
+    assert ops[0]["node"]["codeSandboxApprovalAllowSourceBuilds"] is True
+
+
+def test_view_and_meta_changes_get_their_own_ops():
+    document = SceneDocument()
+    document.add_node(0, 0, "a")
+    document.take_dirty_patch_ops()
+
+    document.set_view_state(2.0, 10.0, 20.0)
+    document.set_drag_factor(0.5)
+    ops = document.take_dirty_patch_ops()
+
+    assert ops_of(ops) == ["setView", "setMeta"]
+    assert ops[0]["view"] == {"zoomFactor": 2.0, "scrollX": 10.0, "scrollY": 20.0}
+    assert ops[1]["meta"]["dragFactor"] == 0.5
+
+
+def test_a_pin_change_falls_back_to_a_full_snapshot():
+    # Pins have no op in the ADR's own op set, so a pin mutation is honestly
+    # outside what a patch can express - falling back beats silently
+    # dropping it.
+    document = SceneDocument()
+    document.add_node(0, 0, "a")
+    document.take_dirty_patch_ops()
+
+    document.pins.add(title="Pin", note="", x=0.0, y=0.0)
+    assert document.take_dirty_patch_ops() is None
+
+
+def test_every_node_field_change_is_detected_not_just_position():
+    document = SceneDocument()
+    node = document.add_chat_node(0, 0, "hello", is_user=True)
+    document.take_dirty_patch_ops()
+
+    document.update_chat_node_content(node.id, "changed")
+    ops = document.take_dirty_patch_ops()
+
+    assert ops_of(ops) == ["upsertNode"]
+    assert ops[0]["node"]["content"] == "changed"
+
+
+# -- SessionBus publish/revision ----------------------------------------------
+
+
+def test_publish_sends_a_patch_once_a_baseline_exists():
+    async def run():
+        document = SceneDocument()
+        node = document.add_node(0, 0, "a")
+        bus = make_scene_bus(document)
+        recorder = Recorder()
+        bus.attach(recorder)
+
+        await bus.publish("scene")  # first publish: full snapshot
+        assert recorder.messages[0]["kind"] == "state"
+
+        document.move_node(node.id, 5.0, 6.0)
+        await bus.publish("scene")
+
+        patch = recorder.messages[1]
+        assert patch["kind"] == "patch"
+        assert patch["topic"] == "scene"
+        assert ops_of(patch) == ["upsertNode"]
+
+    asyncio.run(run())
+
+
+def test_a_patch_chains_baserevision_to_the_previous_revision():
+    async def run():
+        document = SceneDocument()
+        node = document.add_node(0, 0, "a")
+        bus = make_scene_bus(document)
+        recorder = Recorder()
+        bus.attach(recorder)
+
+        await bus.publish("scene")
+        first_revision = revision_of(recorder.messages[0])
+
+        document.move_node(node.id, 1.0, 1.0)
+        await bus.publish("scene")
+        patch = recorder.messages[1]
+
+        assert patch["baseRevision"] == first_revision
+        assert patch["revision"] == first_revision + 1
+
+    asyncio.run(run())
+
+
+def test_publish_falls_back_to_a_snapshot_when_nothing_changed():
+    async def run():
+        document = SceneDocument()
+        document.add_node(0, 0, "a")
+        bus = make_scene_bus(document)
+        recorder = Recorder()
+        bus.attach(recorder)
+
+        await bus.publish("scene")
+        await bus.publish("scene")
+
+        assert [m["kind"] for m in recorder.messages] == ["state", "state"]
+
+    asyncio.run(run())
+
+
+def test_a_topic_with_no_patch_builder_always_sends_snapshots():
+    async def run():
+        bus = SessionBus("no-patch")
+        state = {"n": 0}
+        bus.register_topic("counter", lambda: {"n": state["n"]})
+        recorder = Recorder()
+        bus.attach(recorder)
+
+        await bus.publish("counter")
+        state["n"] = 1
+        await bus.publish("counter")
+
+        assert [m["kind"] for m in recorder.messages] == ["state", "state"]
+
+    asyncio.run(run())
+
+
+def test_send_snapshot_does_not_advance_the_revision():
+    # The bug this stage fixed: _Topic.snapshot() used to bump the revision
+    # itself, so a second window merely SUBSCRIBING advanced the counter
+    # every other connection tracks - manufacturing a phantom baseRevision
+    # gap and forcing needless re-snapshots for everyone.
+    async def run():
+        document = SceneDocument()
+        bus = make_scene_bus(document)
+        broadcast_recorder = Recorder()
+        bus.attach(broadcast_recorder)
+        await bus.publish("scene")
+        revision_before = revision_of(broadcast_recorder.messages[0])
+
+        subscriber = Recorder()
+        await bus.send_snapshot("scene", subscriber)
+        await bus.send_snapshot("scene", subscriber)
+
+        assert revision_of(subscriber.messages[0]) == revision_before
+        # ...and the next real broadcast still chains off that same number.
+        document.add_node(0, 0, "a")
+        await bus.publish("scene")
+        assert revision_of(broadcast_recorder.messages[-1]) == revision_before + 1
+
+    asyncio.run(run())
+
+
+def test_a_subscribing_connection_receives_state_at_the_current_revision():
+    async def run():
+        document = SceneDocument()
+        bus = make_scene_bus(document)
+        first = Recorder()
+        bus.attach(first)
+        await bus.publish("scene")
+        document.add_node(0, 0, "a")
+        await bus.publish("scene")
+
+        late = Recorder()
+        await bus.send_snapshot("scene", late)
+
+        # Exactly in sync: the late joiner's snapshot carries the same
+        # revision the next patch will name as its baseRevision.
+        assert late.messages[0]["kind"] == "state"
+        assert revision_of(late.messages[0]) == 2
+
+    asyncio.run(run())
+
+
+# -- the stage's numeric exit criterion ---------------------------------------
+
+
+def test_a_single_node_edit_on_a_500_node_graph_fits_the_wire_budget():
+    document = LARGE.build()
+    assert len(document.nodes) == 500, "ADR-019's LARGE workload is the 500-node reference"
+    document.take_dirty_patch_ops()  # establish the baseline
+
+    node_id = next(iter(document.nodes))
+    document.move_node(node_id, 42.0, 99.0)
+    ops = document.take_dirty_patch_ops()
+    patch_bytes = len(
+        json.dumps(
+            {"kind": "patch", "topic": "scene", "revision": 2, "baseRevision": 1, "ops": ops}
+        ).encode("utf-8")
+    )
+
+    assert patch_bytes <= SINGLE_EDIT_WIRE_BUDGET_BYTES, (
+        f"a single-node edit costs {patch_bytes} bytes, over the "
+        f"{SINGLE_EDIT_WIRE_BUDGET_BYTES}-byte budget ADR-003 stage 3.4 sets"
+    )
+
+
+def test_the_patch_is_dramatically_smaller_than_the_snapshot_it_replaces():
+    # Guards the actual POINT of the stage, independent of the absolute
+    # budget above: if a future change quietly made publish() fall back to
+    # snapshots for ordinary edits, the byte assertion alone would still
+    # pass on a small fixture while the real win silently disappeared.
+    document = LARGE.build()
+    snapshot_bytes = len(json.dumps(document.scene_payload()).encode("utf-8"))
+    document.take_dirty_patch_ops()
+
+    document.move_node(next(iter(document.nodes)), 1.0, 2.0)
+    patch_bytes = len(json.dumps(document.take_dirty_patch_ops()).encode("utf-8"))
+
+    assert patch_bytes * 100 < snapshot_bytes, (
+        f"expected a 100x+ reduction; got {snapshot_bytes} -> {patch_bytes}"
+    )
+
+
+# -- slow-client isolation ----------------------------------------------------
+
+
+def test_one_dead_connection_never_blocks_delivery_to_the_others():
+    # The stall half of the exit criterion, at the level this stage actually
+    # changes: publish() must reach every healthy connection even when one
+    # fails outright, and must drop the bad one rather than retry it forever.
+    async def run():
+        document = SceneDocument()
+        node = document.add_node(0, 0, "a")
+        bus = make_scene_bus(document)
+
+        class Dead:
+            async def send_json(self, data):
+                raise ConnectionError("dead socket")
+
+        healthy = Recorder()
+        bus.attach(Dead())
+        bus.attach(healthy)
+
+        await bus.publish("scene")
+        document.move_node(node.id, 1.0, 1.0)
+        await bus.publish("scene")
+
+        assert len(healthy.messages) == 2
+        assert healthy.messages[1]["kind"] == "patch"
+        assert bus.connection_count == 1, "the dead connection must be detached"
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("connection_count", [1, 3])
+def test_every_attached_connection_receives_the_same_patch(connection_count):
+    async def run():
+        document = SceneDocument()
+        node = document.add_node(0, 0, "a")
+        bus = make_scene_bus(document)
+        recorders = [Recorder() for _ in range(connection_count)]
+        for recorder in recorders:
+            bus.attach(recorder)
+
+        await bus.publish("scene")
+        document.move_node(node.id, 7.0, 8.0)
+        await bus.publish("scene")
+
+        patches = [r.messages[1] for r in recorders]
+        assert all(p["kind"] == "patch" for p in patches)
+        assert all(p == patches[0] for p in patches)
+
+    asyncio.run(run())

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import { SceneStore, initialSceneState, scaleDragPosition } from "./sceneStore";
-import type { WsTransport } from "../../lib/ws/transport";
+import type { ScenePatch, WsTransport } from "../../lib/ws/transport";
 
 type StateListener = (payload: Record<string, unknown>) => void;
+type PatchListener = (patch: ScenePatch) => void;
 
 function makeFakeTransport() {
   const listeners = new Map<string, StateListener>();
+  const patchListeners = new Map<string, PatchListener>();
+  const resubscribes: string[] = [];
   const intents: Array<{ topic: string; intent: string; args: unknown[] }> = [];
   const requests: Array<{ topic: string; intent: string; args: unknown[] }> = [];
   // A queue rather than mockResolvedValueOnce: the latter REPLACES the
@@ -36,8 +39,28 @@ function makeFakeTransport() {
       intents.push({ topic, intent, args });
     }),
     request: requestImpl,
+    // ADR-003 stage 3.4: the scene topic's delta channel. Kept in its own
+    // map (mirroring the real WsTransport's own parallel registry) so a
+    // test can drive patches and snapshots independently, which is exactly
+    // what the baseRevision-gap cases below need.
+    subscribePatch: vi.fn((topic: string, listener: PatchListener) => {
+      patchListeners.set(topic, listener);
+      return () => patchListeners.delete(topic);
+    }),
+    resubscribe: vi.fn((topic: string) => {
+      resubscribes.push(topic);
+    }),
   } as unknown as WsTransport;
-  return { transport, listeners, intents, requests, requestImpl, requestResults };
+  return {
+    transport,
+    listeners,
+    patchListeners,
+    resubscribes,
+    intents,
+    requests,
+    requestImpl,
+    requestResults,
+  };
 }
 
 function validScenePayload(overrides: Record<string, unknown> = {}) {
@@ -255,6 +278,193 @@ describe("SceneStore", () => {
     expect(store.getScene()).toEqual(initialSceneState);
     expect(consoleError).toHaveBeenCalled();
     consoleError.mockRestore();
+  });
+
+  // ADR-003 stage 3.4: the scene patch protocol. The store now receives
+  // `kind:"patch"` deltas (upsertNode/removeNodes/upsertEdge/removeEdges/
+  // setView/setMeta) applied ON TOP of the current scene, instead of a full
+  // snapshot on every backend mutation - see SceneStore.applyScenePatch.
+  describe("scene patch application (ADR-003 stage 3.4)", () => {
+    function connectedStoreAtRevision3() {
+      const fake = makeFakeTransport();
+      const store = new SceneStore(fake.transport);
+      store.connect();
+      // validScenePayload() is revision 3 - every patch below must therefore
+      // arrive with baseRevision 3 to be accepted.
+      fake.listeners.get("scene")!(validScenePayload());
+      return { ...fake, store };
+    }
+
+    it("applies an upsertNode op onto the existing scene without replacing it wholesale", () => {
+      const { store, patchListeners } = connectedStoreAtRevision3();
+      const existing = store.getScene().nodes[0];
+
+      patchListeners.get("scene")!({
+        revision: 4,
+        baseRevision: 3,
+        ops: [{ op: "upsertNode", node: { ...existing, title: "renamed" } }],
+      });
+
+      expect(store.getScene().nodes).toHaveLength(1);
+      expect(store.getScene().nodes[0].title).toBe("renamed");
+      expect(store.getScene().revision).toBe(4);
+    });
+
+    it("adds a node it has never seen, and removes one via removeNodes", () => {
+      const { store, patchListeners } = connectedStoreAtRevision3();
+      const existing = store.getScene().nodes[0];
+
+      patchListeners.get("scene")!({
+        revision: 4,
+        baseRevision: 3,
+        ops: [{ op: "upsertNode", node: { ...existing, id: "n1", title: "second" } }],
+      });
+      expect(store.getScene().nodes.map((n) => n.id)).toEqual(["n0", "n1"]);
+
+      patchListeners.get("scene")!({
+        revision: 5,
+        baseRevision: 4,
+        ops: [{ op: "removeNodes", ids: ["n0"] }],
+      });
+      expect(store.getScene().nodes.map((n) => n.id)).toEqual(["n1"]);
+    });
+
+    it("preserves the object identity of nodes the patch did not touch", () => {
+      // The property ADR-011 stage 11.1's React.memo work depends on: a
+      // patch that changes one node must not mint new objects for the rest.
+      // Nothing in the app exploits this yet (toFlowNodes still rebuilds
+      // everything, and there is no React.memo anywhere), so without this
+      // test the property could silently regress before 11.1 arrives to
+      // depend on it.
+      const { store, patchListeners } = connectedStoreAtRevision3();
+      const first = store.getScene().nodes[0];
+      patchListeners.get("scene")!({
+        revision: 4,
+        baseRevision: 3,
+        ops: [{ op: "upsertNode", node: { ...first, id: "n1", title: "second" } }],
+      });
+      const untouched = store.getScene().nodes[0];
+
+      patchListeners.get("scene")!({
+        revision: 5,
+        baseRevision: 4,
+        ops: [{ op: "upsertNode", node: { ...untouched, id: "n1", title: "changed again" } }],
+      });
+
+      expect(store.getScene().nodes[0]).toBe(untouched);
+    });
+
+    it("applies setView and setMeta ops onto the scene's own fields", () => {
+      const { store, patchListeners } = connectedStoreAtRevision3();
+
+      patchListeners.get("scene")!({
+        revision: 4,
+        baseRevision: 3,
+        ops: [
+          { op: "setView", view: { zoomFactor: 2, scrollX: 10, scrollY: 20 } },
+          { op: "setMeta", meta: { dragFactor: 0.25, fontFamily: "Consolas" } },
+        ],
+      });
+
+      const scene = store.getScene() as unknown as Record<string, unknown>;
+      expect(scene.zoomFactor).toBe(2);
+      expect(scene.scrollX).toBe(10);
+      expect(store.getScene().dragFactor).toBe(0.25);
+      expect(store.getScene().fontFamily).toBe("Consolas");
+    });
+
+    it("upserts and removes edges", () => {
+      const { store, patchListeners } = connectedStoreAtRevision3();
+
+      patchListeners.get("scene")!({
+        revision: 4,
+        baseRevision: 3,
+        ops: [{ op: "upsertEdge", edge: { id: "e1", source: "n0", target: "n0" } }],
+      });
+      expect(store.getScene().edges.map((e) => e.id)).toEqual(["e1"]);
+
+      patchListeners.get("scene")!({
+        revision: 5,
+        baseRevision: 4,
+        ops: [{ op: "removeEdges", ids: ["e1"] }],
+      });
+      expect(store.getScene().edges).toEqual([]);
+    });
+
+    it("REFUSES a patch whose baseRevision does not match, and asks for a fresh snapshot", () => {
+      // The self-healing half of the protocol: a gap means a frame was
+      // missed, and the missing ops are the only thing that could close it,
+      // so applying this one would produce a scene that never existed
+      // server-side. Re-snapshot instead of guessing.
+      const { store, patchListeners, resubscribes } = connectedStoreAtRevision3();
+      const before = store.getScene();
+
+      patchListeners.get("scene")!({
+        revision: 9,
+        baseRevision: 8, // client is at 3 - a real gap
+        ops: [{ op: "removeNodes", ids: ["n0"] }],
+      });
+
+      expect(store.getScene()).toBe(before);
+      expect(resubscribes).toEqual(["scene"]);
+    });
+
+    it("REFUSES a patch carrying an unknown op kind rather than applying the ops around it", () => {
+      const { store, patchListeners, resubscribes } = connectedStoreAtRevision3();
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const before = store.getScene();
+
+      patchListeners.get("scene")!({
+        revision: 4,
+        baseRevision: 3,
+        ops: [{ op: "reticulateSplines", whatever: true }],
+      });
+
+      expect(store.getScene()).toBe(before);
+      expect(resubscribes).toEqual(["scene"]);
+      expect(consoleError).toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
+
+    it("notifies subscribers exactly once per applied patch", () => {
+      const { store, patchListeners } = connectedStoreAtRevision3();
+      const seen = vi.fn();
+      store.subscribe(seen);
+
+      patchListeners.get("scene")!({
+        revision: 4,
+        baseRevision: 3,
+        ops: [{ op: "setMeta", meta: { dragFactor: 0.75 } }],
+      });
+
+      expect(seen).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not notify subscribers when a patch is refused", () => {
+      const { store, patchListeners } = connectedStoreAtRevision3();
+      const seen = vi.fn();
+      store.subscribe(seen);
+
+      patchListeners.get("scene")!({ revision: 9, baseRevision: 8, ops: [] });
+
+      expect(seen).not.toHaveBeenCalled();
+    });
+
+    it("accepts a later snapshot after a refused patch, resyncing the client", () => {
+      const { store, patchListeners, listeners } = connectedStoreAtRevision3();
+      patchListeners.get("scene")!({ revision: 9, baseRevision: 8, ops: [] });
+
+      listeners.get("scene")!(validScenePayload({ revision: 9 }));
+
+      expect(store.getScene().revision).toBe(9);
+      // ...and a patch built on THAT revision now applies cleanly.
+      patchListeners.get("scene")!({
+        revision: 10,
+        baseRevision: 9,
+        ops: [{ op: "setMeta", meta: { dragFactor: 0.5 } }],
+      });
+      expect(store.getScene().dragFactor).toBe(0.5);
+    });
   });
 
   it("routes grid snapshots through the grid validator", () => {

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -450,6 +450,129 @@ describe("SceneStore", () => {
       expect(seen).not.toHaveBeenCalled();
     });
 
+    // Review-fix: ops used to be applied from bare TS casts with no runtime
+    // check. That was strictly WORSE than the snapshot path it replaced: a
+    // malformed op that does not throw still advanced `revision`, so every
+    // later patch's baseRevision matched and the gap detector could never
+    // notice - permanent divergence with nothing able to detect it. The
+    // result is now validated and the whole patch discarded if it fails.
+    it("REFUSES a patch whose removeNodes ids are not an array (silently removed nothing before)", () => {
+      const { store, patchListeners, resubscribes } = connectedStoreAtRevision3();
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const before = store.getScene();
+
+      // `new Set(null)` is an EMPTY set - this removed nothing, returned
+      // true, and advanced the revision, so the client kept showing a node
+      // the server had deleted, undetectably, until a reconnect.
+      patchListeners.get("scene")!({
+        revision: 4,
+        baseRevision: 3,
+        ops: [{ op: "removeNodes", ids: null }],
+      });
+
+      expect(store.getScene()).toBe(before);
+      expect(store.getScene().revision).toBe(3);
+      expect(resubscribes).toEqual(["scene"]);
+      consoleError.mockRestore();
+    });
+
+    it("REFUSES a patch whose upsertNode carries a wrong-typed field", () => {
+      // A string `x` reached React Flow's `position: {x, y}` and turned the
+      // canvas transform into NaN. The generated validator has always
+      // rejected this on the snapshot path.
+      const { store, patchListeners, resubscribes } = connectedStoreAtRevision3();
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const existing = store.getScene().nodes[0];
+
+      patchListeners.get("scene")!({
+        revision: 4,
+        baseRevision: 3,
+        ops: [{ op: "upsertNode", node: { ...existing, x: "not-a-number" } }],
+      });
+
+      expect(store.getScene().revision).toBe(3);
+      expect(resubscribes).toEqual(["scene"]);
+      consoleError.mockRestore();
+    });
+
+    it("REFUSES a patch whose op body THROWS rather than merely being wrong", () => {
+      // `new Set(7)` is a TypeError. The exception used to escape through the
+      // listener fan-out to socket.onmessage, so the `if (!applyScenePatch)`
+      // resync never ran - the "refuse whole and self-heal" contract silently
+      // did not hold for this input class.
+      const { store, patchListeners, resubscribes } = connectedStoreAtRevision3();
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      expect(() =>
+        patchListeners.get("scene")!({
+          revision: 4,
+          baseRevision: 3,
+          ops: [{ op: "removeNodes", ids: 7 }],
+        }),
+      ).not.toThrow();
+
+      expect(store.getScene().revision).toBe(3);
+      expect(resubscribes).toEqual(["scene"]);
+      consoleError.mockRestore();
+    });
+
+    it("does not let a setMeta op blank structural fields like pins", () => {
+      // The op bodies are spread in blindly, so `nodes`/`edges`/`revision`
+      // were protected only by key order and `pins` not at all - a
+      // `{"pins": null}` would crash PinOverlay's scene.pins.filter() on
+      // every render. No backend key does this today; the guard is
+      // structural rather than one field name away from being needed.
+      const { store, patchListeners } = connectedStoreAtRevision3();
+      const pinsBefore = store.getScene().pins;
+
+      patchListeners.get("scene")!({
+        revision: 4,
+        baseRevision: 3,
+        ops: [{ op: "setMeta", meta: { pins: null, nodes: null, revision: 999, dragFactor: 0.3 } }],
+      });
+
+      expect(store.getScene().pins).toBe(pinsBefore);
+      expect(store.getScene().nodes).toHaveLength(1);
+      expect(store.getScene().revision).toBe(4);
+      expect(store.getScene().dragFactor).toBe(0.3);
+    });
+
+    it("asks for ONE resync per gap, not one per refused patch", () => {
+      // Review-fix, measured against a real backend: without this guard a
+      // single dropped frame during a burst of mutations made things far
+      // WORSE than the full snapshots this stage replaced. The client
+      // refuses every subsequent patch until its snapshot lands, and each
+      // refusal fired another resync answered with another FULL snapshot -
+      // 14 requests and 14 snapshots from one dropped frame in a
+      // 15-mutation burst (~22 MB at the 500-node workload).
+      const { store, patchListeners, resubscribes } = connectedStoreAtRevision3();
+      const patch = patchListeners.get("scene")!;
+
+      // A burst arriving while the client sits at revision 3 with a gap.
+      for (let revision = 10; revision < 20; revision++) {
+        patch({ revision, baseRevision: revision - 1, ops: [] });
+      }
+
+      expect(resubscribes).toEqual(["scene"]);
+      expect(store.getScene().revision).toBe(3);
+    });
+
+    it("re-arms the resync request once the recovering snapshot lands", () => {
+      // The flag must not wedge recovery permanently shut: after the
+      // snapshot closes one gap, a LATER gap must be able to ask again.
+      const { store, patchListeners, listeners, resubscribes } = connectedStoreAtRevision3();
+      const patch = patchListeners.get("scene")!;
+
+      patch({ revision: 9, baseRevision: 8, ops: [] });
+      expect(resubscribes).toEqual(["scene"]);
+
+      listeners.get("scene")!(validScenePayload({ revision: 9 }));
+      expect(store.getScene().revision).toBe(9);
+
+      patch({ revision: 30, baseRevision: 29, ops: [] });
+      expect(resubscribes).toEqual(["scene", "scene"]);
+    });
+
     it("accepts a later snapshot after a refused patch, resyncing the client", () => {
       const { store, patchListeners, listeners } = connectedStoreAtRevision3();
       patchListeners.get("scene")!({ revision: 9, baseRevision: 8, ops: [] });

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -17,11 +17,11 @@
  */
 
 import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
-import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
+import type { SceneEdgeRow, SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
 import type { GridControlState } from "../../lib/bridge-core/generated/grid-control-state";
 import type { DragSpeedState } from "../../lib/bridge-core/generated/drag-speed-state";
 import type { FontControlState } from "../../lib/bridge-core/generated/font-control-state";
-import type { StreamListener, WsTransport } from "../../lib/ws/transport";
+import type { ScenePatch, StreamListener, WsTransport } from "../../lib/ws/transport";
 
 // ADR-003 stage 3.1 review-fix: matches composerStore's own
 // NATIVE_DIALOG_TIMEOUT_MS - pickGitlinkLocalRoot opens a native OS folder
@@ -139,13 +139,109 @@ export class SceneStore {
     });
   }
 
+  /** ADR-003 stage 3.4: apply one `kind:"patch"` frame's ops on top of the
+   * current scene, in place of a full snapshot.
+   *
+   * Returns false when the patch cannot be safely applied, which happens in
+   * exactly one case: its baseRevision does not match the revision this
+   * client is actually at, meaning a frame was missed and applying this one
+   * would silently produce a scene that never existed on the server. There
+   * is no partial/best-effort application - a gap is unrecoverable locally
+   * by construction (the missing ops are the only thing that could close
+   * it), so the caller re-snapshots instead. That self-healing fallback is
+   * why the protocol needs no divergence debugging: any doubt resolves to
+   * "ask for the truth again".
+   *
+   * Untouched nodes keep their EXACT existing object references (only
+   * changed/added ones are new objects). Nothing in the app benefits from
+   * that today - SceneCanvas.tsx's toFlowNodes still rebuilds every flow
+   * node on every scene change, and the SPA has no React.memo anywhere -
+   * but it is the property ADR-011 stage 11.1's memoization depends on, and
+   * preserving it here costs nothing while retrofitting it later would mean
+   * revisiting this code. */
+  private applyScenePatch(patch: ScenePatch): boolean {
+    if (patch.baseRevision !== this.scene.revision) return false;
+    let nodes = this.scene.nodes;
+    let edges = this.scene.edges;
+    let meta: Record<string, unknown> = {};
+    for (const op of patch.ops) {
+      switch (op.op) {
+        case "upsertNode": {
+          const node = op.node as SceneNodeRow;
+          const index = nodes.findIndex((n) => n.id === node.id);
+          nodes = index === -1 ? [...nodes, node] : nodes.map((n, i) => (i === index ? node : n));
+          break;
+        }
+        case "removeNodes": {
+          const ids = new Set(op.ids as string[]);
+          nodes = nodes.filter((n) => !ids.has(n.id));
+          break;
+        }
+        case "upsertEdge": {
+          const edge = op.edge as SceneEdgeRow;
+          const index = edges.findIndex((e) => e.id === edge.id);
+          edges = index === -1 ? [...edges, edge] : edges.map((e, i) => (i === index ? edge : e));
+          break;
+        }
+        case "removeEdges": {
+          const ids = new Set(op.ids as string[]);
+          edges = edges.filter((e) => !ids.has(e.id));
+          break;
+        }
+        case "setView":
+          meta = { ...meta, ...(op.view as Record<string, unknown>) };
+          break;
+        case "setMeta":
+          meta = { ...meta, ...(op.meta as Record<string, unknown>) };
+          break;
+        default:
+          // An op kind this client does not know is a real protocol gap, not
+          // a routine occurrence - refuse the whole patch and re-snapshot
+          // rather than applying the ops around it and silently ending up
+          // with a scene missing whatever that op carried.
+          console.error("[scene] unknown patch op, re-snapshotting:", op.op);
+          return false;
+      }
+    }
+    this.scene = { ...this.scene, ...meta, nodes, edges, revision: patch.revision };
+    this.emit();
+    return true;
+  }
+
   connect(): void {
     this.unsubscribers.push(
       this.bind<SceneState>("scene", (v) => (this.scene = v)),
       this.bind<GridControlState>("grid-control", (v) => (this.grid = v)),
       this.bind<DragSpeedState>("drag-speed", (v) => (this.dragConfig = v)),
       this.bind<FontControlState>("font-control", (v) => (this.fontConfig = v)),
+      // ADR-003 stage 3.4: patches ride the SAME server-side subscription
+      // the snapshot bind above established, so this adds a listener, not a
+      // second subscribe. Snapshots remain the reconnect/resync answer.
+      this.transport.subscribePatch("scene", (patch) => {
+        if (!this.applyScenePatch(patch)) this.requestSceneResync();
+      }),
     );
+  }
+
+  /** ADR-003 stage 3.4: recover from a detected patch gap by asking for a
+   * fresh full snapshot.
+   *
+   * Re-uses the EXISTING `subscribe` message rather than adding a resync
+   * intent: its server-side handler (app.py's _handle_message) already does
+   * exactly and only what a resync needs - send this topic's current
+   * snapshot to THIS connection, without advancing the shared revision or
+   * disturbing any other connection. A new intent would have had to
+   * re-derive that from scratch, and intents cannot address the requesting
+   * connection anyway (dispatch_intent has no connection handle), so it
+   * would have had to broadcast to everyone instead.
+   *
+   * Deliberately fire-and-forget: a resync is this client's own recovery
+   * bookkeeping, not a user action, so a transient failure must not raise
+   * an error banner at someone who did nothing wrong - and it is
+   * self-correcting anyway, since the next patch detects the same
+   * still-unclosed gap and asks again. */
+  private requestSceneResync(): void {
+    this.transport.resubscribe("scene");
   }
 
   dispose(): void {

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -80,6 +80,37 @@ export const initialGridState: GridControlState = {
 
 type Listener = () => void;
 
+/** ADR-003 stage 3.4 review-fix: op-BODY shape guards.
+ *
+ * Validating the resulting scene (see applyScenePatch) catches an op that
+ * corrupts a VALUE, but not one that silently does nothing: `new Set(null)`
+ * is an empty set, so `{"op":"removeNodes","ids":null}` removes nothing and
+ * leaves a perfectly valid scene behind - while still advancing the
+ * revision, which is what makes the divergence permanently undetectable.
+ * The two checks are complementary and both are needed. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** A node/edge row body: an object carrying at least a string `id`, which is
+ * the field every op is keyed on. Field-level types are deliberately NOT
+ * checked here - they are the job of the scene validator that runs over the
+ * result (see applyScenePatch), and duplicating them would mean
+ * hand-maintaining a second copy of the generated schema.
+ *
+ * A real type predicate rather than a bare boolean, specifically so callers
+ * narrow instead of casting: `op.node as unknown as SceneNodeRow` is the
+ * exact wire-type-widening cast stage 3.3's own CI ratchet
+ * (wireTypeCastGuard.test.ts) exists to forbid, and it correctly caught
+ * this file when the checks were first written that way. */
+function isWireRow<T extends { id: string }>(value: unknown): value is T {
+  return isPlainObject(value) && typeof value.id === "string";
+}
+
+function isIdList(value: unknown): boolean {
+  return Array.isArray(value) && value.every((id) => typeof id === "string");
+}
+
 export class SceneStore {
   private scene: SceneState = initialSceneState;
   private grid: GridControlState = initialGridState;
@@ -124,6 +155,11 @@ export class SceneStore {
   // the same reason selectedNodeId/replyTargetNodeId already live on this
   // store rather than in whichever single component happens to set them.
   private focusAcceptedPaths = false;
+  // ADR-003 stage 3.4 review-fix: true while a scene resync request is
+  // outstanding, so a burst of refused patches asks once rather than once
+  // per patch - see requestSceneResync for the measured failure this
+  // prevents.
+  private sceneResyncPending = false;
 
   constructor(private readonly transport: WsTransport) {}
 
@@ -142,75 +178,141 @@ export class SceneStore {
   /** ADR-003 stage 3.4: apply one `kind:"patch"` frame's ops on top of the
    * current scene, in place of a full snapshot.
    *
-   * Returns false when the patch cannot be safely applied, which happens in
-   * exactly one case: its baseRevision does not match the revision this
-   * client is actually at, meaning a frame was missed and applying this one
-   * would silently produce a scene that never existed on the server. There
-   * is no partial/best-effort application - a gap is unrecoverable locally
-   * by construction (the missing ops are the only thing that could close
-   * it), so the caller re-snapshots instead. That self-healing fallback is
-   * why the protocol needs no divergence debugging: any doubt resolves to
-   * "ask for the truth again".
+   * Returns false when the patch cannot be safely applied - the caller then
+   * re-snapshots. There is no partial/best-effort application: the result is
+   * either committed whole or discarded whole, so the store can never hold a
+   * scene that never existed server-side. Three things cause a refusal:
+   *
+   * 1. baseRevision does not match the revision this client is at - a frame
+   *    was missed, and the missing ops are by construction the only thing
+   *    that could close the gap, so only a fresh snapshot can.
+   * 2. An op kind this client does not understand - a real protocol gap.
+   * 3. The RESULT fails the generated scene validator (review-fix, below).
+   *
+   * REVIEW-FIX - the result is validated before it is committed. Ops used to
+   * be applied straight from bare TypeScript casts with no runtime check,
+   * which was not merely "unvalidated data can enter the store" but
+   * something strictly worse than the pre-3.4 behavior it replaced: a
+   * malformed op that does not happen to throw would ALSO advance
+   * `revision`, so every later patch's baseRevision matched and the gap
+   * detector could never notice. `{"op":"removeNodes","ids":null}` is the
+   * sharp case - `new Set(null)` is an empty set, so it removes nothing,
+   * returns true, and the client shows a node the server deleted with no
+   * mechanism able to detect it, permanently, until a reconnect. A snapshot
+   * carrying the same corruption was always caught loudly by this same
+   * validator and dropped whole. Validating the result restores exactly that
+   * property, and costs what the snapshot path already cost per publish (one
+   * validateSceneState over the scene) - this stage's win is bytes on the
+   * wire, which is untouched by it.
    *
    * Untouched nodes keep their EXACT existing object references (only
-   * changed/added ones are new objects). Nothing in the app benefits from
+   * changed/added ones are new objects), and a meta-only patch leaves the
+   * `nodes` ARRAY itself identical too. Nothing in the app benefits from
    * that today - SceneCanvas.tsx's toFlowNodes still rebuilds every flow
    * node on every scene change, and the SPA has no React.memo anywhere -
    * but it is the property ADR-011 stage 11.1's memoization depends on, and
    * preserving it here costs nothing while retrofitting it later would mean
    * revisiting this code. */
+  /** Log why a patch was rejected and refuse it whole. Always returns false
+   * so an op case can `return this.refusePatch(...)` in one line. */
+  private refusePatch(reason: string, op: unknown): boolean {
+    console.error("[scene] malformed patch op, re-snapshotting:", reason, op);
+    return false;
+  }
+
   private applyScenePatch(patch: ScenePatch): boolean {
     if (patch.baseRevision !== this.scene.revision) return false;
     let nodes = this.scene.nodes;
     let edges = this.scene.edges;
     let meta: Record<string, unknown> = {};
-    for (const op of patch.ops) {
-      switch (op.op) {
-        case "upsertNode": {
-          const node = op.node as SceneNodeRow;
-          const index = nodes.findIndex((n) => n.id === node.id);
-          nodes = index === -1 ? [...nodes, node] : nodes.map((n, i) => (i === index ? node : n));
-          break;
+    try {
+      for (const op of patch.ops) {
+        switch (op.op) {
+          case "upsertNode": {
+            if (!isWireRow<SceneNodeRow>(op.node)) return this.refusePatch("upsertNode.node is not a row", op);
+            const node = op.node;
+            const index = nodes.findIndex((n) => n.id === node.id);
+            nodes = index === -1 ? [...nodes, node] : nodes.map((n, i) => (i === index ? node : n));
+            break;
+          }
+          case "removeNodes": {
+            if (!isIdList(op.ids)) return this.refusePatch("removeNodes.ids is not a string[]", op);
+            const ids = new Set(op.ids as string[]);
+            nodes = nodes.filter((n) => !ids.has(n.id));
+            break;
+          }
+          case "upsertEdge": {
+            if (!isWireRow<SceneEdgeRow>(op.edge)) return this.refusePatch("upsertEdge.edge is not a row", op);
+            const edge = op.edge;
+            const index = edges.findIndex((e) => e.id === edge.id);
+            edges = index === -1 ? [...edges, edge] : edges.map((e, i) => (i === index ? edge : e));
+            break;
+          }
+          case "removeEdges": {
+            if (!isIdList(op.ids)) return this.refusePatch("removeEdges.ids is not a string[]", op);
+            const ids = new Set(op.ids as string[]);
+            edges = edges.filter((e) => !ids.has(e.id));
+            break;
+          }
+          case "setView":
+            if (!isPlainObject(op.view)) return this.refusePatch("setView.view is not an object", op);
+            meta = { ...meta, ...(op.view as Record<string, unknown>) };
+            break;
+          case "setMeta":
+            if (!isPlainObject(op.meta)) return this.refusePatch("setMeta.meta is not an object", op);
+            meta = { ...meta, ...(op.meta as Record<string, unknown>) };
+            break;
+          default:
+            console.error("[scene] unknown patch op, re-snapshotting:", op.op);
+            return false;
         }
-        case "removeNodes": {
-          const ids = new Set(op.ids as string[]);
-          nodes = nodes.filter((n) => !ids.has(n.id));
-          break;
-        }
-        case "upsertEdge": {
-          const edge = op.edge as SceneEdgeRow;
-          const index = edges.findIndex((e) => e.id === edge.id);
-          edges = index === -1 ? [...edges, edge] : edges.map((e, i) => (i === index ? edge : e));
-          break;
-        }
-        case "removeEdges": {
-          const ids = new Set(op.ids as string[]);
-          edges = edges.filter((e) => !ids.has(e.id));
-          break;
-        }
-        case "setView":
-          meta = { ...meta, ...(op.view as Record<string, unknown>) };
-          break;
-        case "setMeta":
-          meta = { ...meta, ...(op.meta as Record<string, unknown>) };
-          break;
-        default:
-          // An op kind this client does not know is a real protocol gap, not
-          // a routine occurrence - refuse the whole patch and re-snapshot
-          // rather than applying the ops around it and silently ending up
-          // with a scene missing whatever that op carried.
-          console.error("[scene] unknown patch op, re-snapshotting:", op.op);
-          return false;
       }
+    } catch (error) {
+      // Review-fix: a malformed op body can THROW rather than merely produce
+      // wrong data (`new Set(7)` is "number 7 is not iterable"; a null
+      // `op.node` dereferences). Without this the exception escaped through
+      // the listener fan-out to socket.onmessage, so the `if
+      // (!applyScenePatch(...))` resync never ran and any sibling listener
+      // was skipped - the exact "refuse whole and self-heal" contract this
+      // method advertises, silently not holding.
+      console.error("[scene] patch op threw, re-snapshotting:", error);
+      return false;
     }
-    this.scene = { ...this.scene, ...meta, nodes, edges, revision: patch.revision };
+    // Review-fix: `nodes`/`edges`/`revision` are listed after `...meta` so a
+    // meta key can never overwrite them, and `pins`/`schemaVersion`/
+    // `minCompatibleSchemaVersion` are restated for the same reason - a
+    // `setMeta` carrying `{"pins": null}` would otherwise blank the pin list
+    // and crash PinOverlay's `scene.pins.filter(...)` on every render. The
+    // backend sends no such key today; this makes the guard structural
+    // rather than one backend field name away from being needed.
+    const candidate: SceneState = {
+      ...this.scene,
+      ...meta,
+      nodes,
+      edges,
+      pins: this.scene.pins,
+      schemaVersion: this.scene.schemaVersion,
+      minCompatibleSchemaVersion: this.scene.minCompatibleSchemaVersion,
+      revision: patch.revision,
+    };
+    const validated = TOPIC_VALIDATORS["scene"](candidate as unknown as Record<string, unknown>);
+    if (!validated.ok) {
+      console.error("[scene] patch produced an invalid scene, re-snapshotting:", validated.errors);
+      return false;
+    }
+    this.scene = candidate;
     this.emit();
     return true;
   }
 
   connect(): void {
     this.unsubscribers.push(
-      this.bind<SceneState>("scene", (v) => (this.scene = v)),
+      this.bind<SceneState>("scene", (v) => {
+        this.scene = v;
+        // ADR-003 stage 3.4 review-fix: the snapshot that closes an
+        // outstanding resync request - see requestSceneResync below.
+        this.sceneResyncPending = false;
+      }),
       this.bind<GridControlState>("grid-control", (v) => (this.grid = v)),
       this.bind<DragSpeedState>("drag-speed", (v) => (this.dragConfig = v)),
       this.bind<FontControlState>("font-control", (v) => (this.fontConfig = v)),
@@ -237,10 +339,26 @@ export class SceneStore {
    *
    * Deliberately fire-and-forget: a resync is this client's own recovery
    * bookkeeping, not a user action, so a transient failure must not raise
-   * an error banner at someone who did nothing wrong - and it is
-   * self-correcting anyway, since the next patch detects the same
-   * still-unclosed gap and asks again. */
+   * an error banner at someone who did nothing wrong.
+   *
+   * REVIEW-FIX (measured against a real backend): at most ONE request is in
+   * flight at a time. Without that guard a single dropped frame during a
+   * burst of mutations was catastrophic rather than self-healing - the
+   * client refuses EVERY subsequent patch until its snapshot arrives, and
+   * each refusal fired another resync, each answered with another FULL
+   * snapshot. Measured: one dropped frame inside a 15-mutation burst
+   * produced 14 resync requests and 14 full snapshots (602 KiB on a small
+   * scene; ~22 MB at the 500-node workload) - dramatically WORSE than the
+   * full-snapshot protocol this stage replaced, turning a momentary blip
+   * into a self-inflicted flood. Suppressing duplicates makes it one
+   * request and one snapshot. The flag is cleared by the scene snapshot
+   * bind in connect() above, i.e. by the very frame that closes the gap, so
+   * a resync that never arrives (connection died) cannot wedge recovery
+   * permanently shut: reconnecting re-subscribes every topic from scratch
+   * and delivers a fresh snapshot through that same bind. */
   private requestSceneResync(): void {
+    if (this.sceneResyncPending) return;
+    this.sceneResyncPending = true;
     this.transport.resubscribe("scene");
   }
 

--- a/web_ui/src/lib/bridge-core/wireTypeCastGuard.test.ts
+++ b/web_ui/src/lib/bridge-core/wireTypeCastGuard.test.ts
@@ -64,7 +64,25 @@ function generatedWireTypeNames(): string[] {
   return [...names];
 }
 
-function findWireTypeWideningCasts(source: string, wireTypeNames: string[]): string[] {
+/** ADR-003 stage 3.4 review-fix: strip comments before scanning.
+ *
+ * This is a text scanner, so it could not tell a real cast from one QUOTED
+ * IN A COMMENT - and it fired on exactly that: a doc comment explaining why
+ * `op.node as unknown as SceneNodeRow` is forbidden was itself reported as a
+ * violation. That made the anti-pattern undocumentable in the codebase it
+ * governs, which is the wrong incentive: the clearest way to stop someone
+ * reintroducing a pattern is to name it precisely at the site that avoids
+ * it. Deliberately simple regex stripping, consistent with this file's
+ * already-documented "regex, not a TS parser" posture - it can be confused
+ * by a comment-like sequence inside a string literal, which would only ever
+ * cause a MISSED detection in code no part of this repo writes, never a
+ * false alarm. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+function findWireTypeWideningCasts(rawSource: string, wireTypeNames: string[]): string[] {
+  const source = stripComments(rawSource);
   const found: string[] = [];
   for (const name of wireTypeNames) {
     // A type intersection widening the generated type, EITHER operand
@@ -155,6 +173,24 @@ describe("the scanner itself catches a real regression", () => {
   it("does NOT flag plain, unwidened use of the generated type", () => {
     const source = "function f(n: SceneNodeRow) { return n.title; }";
     expect(findWireTypeWideningCasts(source, wireTypeNames)).toEqual([]);
+  });
+
+  it("does NOT flag the anti-pattern QUOTED IN A COMMENT explaining why it is forbidden", () => {
+    // Review-fix: this scanner fired on a doc comment that named the exact
+    // cast it forbids, making the pattern undocumentable in the codebase it
+    // governs - precisely backwards, since naming it at the site that
+    // avoids it is the clearest way to stop someone reintroducing it.
+    const lineComment = "// never write `op.node as unknown as SceneNodeRow` here\nconst x = 1;";
+    const blockComment = "/* forbidden: type Wide = SceneNodeRow & { extra: string } */\nconst y = 2;";
+    expect(findWireTypeWideningCasts(lineComment, wireTypeNames)).toEqual([]);
+    expect(findWireTypeWideningCasts(blockComment, wireTypeNames)).toEqual([]);
+  });
+
+  it("STILL flags a real cast that merely sits next to a comment", () => {
+    // The complementary half - stripping comments must not create a blind
+    // spot for code on the same line or the next one.
+    const source = "// a note about types\nconst n = raw as unknown as SceneNodeRow;";
+    expect(findWireTypeWideningCasts(source, wireTypeNames)).toEqual(["as unknown as SceneNodeRow"]);
   });
 });
 

--- a/web_ui/src/lib/ws/transport.test.ts
+++ b/web_ui/src/lib/ws/transport.test.ts
@@ -399,6 +399,109 @@ describe("WsTransport", () => {
     consoleError.mockRestore();
   });
 
+  // ADR-003 stage 3.4 review-fix: the patch branch, subscribePatch and
+  // resubscribe shipped with ZERO tests at this level - sceneStore.test.ts
+  // drives a hand-written fake that REIMPLEMENTS this routing rather than
+  // exercising it, so a routing bug here would have been invisible.
+  it("subscribePatch: routes a kind:'patch' frame to that topic's patch listener", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const seen: unknown[] = [];
+    t.subscribePatch("scene", (patch) => seen.push(patch));
+
+    socket.receive({
+      kind: "patch",
+      topic: "scene",
+      revision: 7,
+      baseRevision: 6,
+      ops: [{ op: "removeNodes", ids: ["n0"] }],
+    });
+
+    expect(seen).toEqual([{ revision: 7, baseRevision: 6, ops: [{ op: "removeNodes", ids: ["n0"] }] }]);
+  });
+
+  it("subscribePatch: a patch frame never reaches the topic's SNAPSHOT listener", () => {
+    // The two registries are parallel and must stay disjoint - a patch
+    // delivered as though it were a snapshot would hit the generated
+    // validator with an envelope it cannot understand.
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const snapshots: unknown[] = [];
+    t.subscribe("scene", (payload) => snapshots.push(payload));
+
+    socket.receive({ kind: "patch", topic: "scene", revision: 2, baseRevision: 1, ops: [] });
+
+    expect(snapshots).toEqual([]);
+  });
+
+  it("subscribePatch: a patch for a topic with no patch listener is dropped silently, not logged", () => {
+    // Routine, not anomalous: every topic except scene is snapshot-only.
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    socket.receive({ kind: "patch", topic: "grid-control", revision: 2, baseRevision: 1, ops: [] });
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("subscribePatch: unsubscribing stops delivery", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const seen: unknown[] = [];
+    const off = t.subscribePatch("scene", (patch) => seen.push(patch));
+    off();
+    socket.receive({ kind: "patch", topic: "scene", revision: 2, baseRevision: 1, ops: [] });
+    expect(seen).toEqual([]);
+  });
+
+  it("a patch topic is re-subscribed on reconnect even with no snapshot listener", () => {
+    // Review-fix: the reconnect topic list came from stateListeners alone,
+    // so a patch-only consumer was never subscribed server-side at all and
+    // never re-subscribed - it silently received nothing forever.
+    const t = makeTransport();
+    t.connect();
+    FakeSocket.instances[0].open();
+    t.subscribePatch("scene", () => {});
+
+    FakeSocket.instances[0].onclose?.();
+    vi.advanceTimersByTime(10_000);
+    const reconnected = FakeSocket.instances[1];
+    reconnected.open();
+
+    expect(reconnected.lastSent()).toEqual({ kind: "subscribe", topics: ["scene"] });
+  });
+
+  it("resubscribe() re-requests a snapshot for an already-subscribed topic", () => {
+    // subscribe() sends its message only for a topic's FIRST listener, so
+    // this is the only way an already-subscribed topic can ask for fresh
+    // state - the scene store's gap recovery depends on it.
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    t.subscribe("scene", () => {});
+
+    t.resubscribe("scene");
+
+    expect(socket.lastSent()).toEqual({ kind: "subscribe", topics: ["scene"] });
+  });
+
+  it("resubscribe() is a no-op while the socket is not open", () => {
+    const t = makeTransport();
+    t.connect();
+    // never opened - lastSent() parses JSON, so assert on the raw list.
+    expect(() => t.resubscribe("scene")).not.toThrow();
+    expect(FakeSocket.instances[0].sent).toEqual([]);
+  });
+
   it("subscribeStream: a stream frame with no matching requestId subscriber is silently dropped", () => {
     const t = makeTransport();
     t.connect();

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -74,10 +74,14 @@ export type StatusListener = (status: ConnectionStatus) => void;
 export type StreamListener = (delta: string, done: boolean, reset: boolean, seq: number) => void;
 
 /** ADR-003 stage 3.4: one node-scoped delta from a `kind:"patch"` frame.
- * Deliberately typed loosely here (`Record<string, unknown>` for the node/
- * edge bodies) - the transport's job is routing, not validating; the store
- * runs the real generated validator on the result of applying these, which
- * is what actually guarantees the shape. */
+ * Deliberately typed loosely (`Record<string, unknown>` for the node/edge
+ * bodies) - the transport's job is routing, not validating. Nothing here
+ * checks the shape, so a consumer MUST validate before trusting it;
+ * SceneStore.applyScenePatch does that by running the generated scene
+ * validator over the RESULT of applying a patch and discarding the whole
+ * patch if it fails. (An earlier version of this comment asserted that
+ * validation as though it were already happening - it was not, which is
+ * exactly how unvalidated ops reached the store.) */
 export type ScenePatchOp = Record<string, unknown> & { op: string };
 
 /** ADR-003 stage 3.4: a patch frame's contents, handed to a patch listener.
@@ -180,7 +184,14 @@ export class WsTransport {
       if (this.socket !== socket) return;
       this.attempts = 0;
       this.setStatus("open");
-      const topics = [...this.stateListeners.keys()];
+      // ADR-003 stage 3.4 review-fix: patch topics are re-subscribed too.
+      // This list used to come from stateListeners alone, so a consumer that
+      // registered ONLY a patch listener - which subscribePatch's own doc
+      // presents as a supported shape - was never subscribed server-side at
+      // all and never re-subscribed on reconnect, silently receiving
+      // nothing. The scene store happens to call both, but that made the
+      // pairing a load-bearing invariant with nothing enforcing it.
+      const topics = [...new Set([...this.stateListeners.keys(), ...this.patchListeners.keys()])];
       if (topics.length > 0) {
         socket.send(JSON.stringify({ kind: "subscribe", topics }));
       }

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -73,6 +73,25 @@ export type StateListener = (payload: Record<string, unknown>) => void;
 export type StatusListener = (status: ConnectionStatus) => void;
 export type StreamListener = (delta: string, done: boolean, reset: boolean, seq: number) => void;
 
+/** ADR-003 stage 3.4: one node-scoped delta from a `kind:"patch"` frame.
+ * Deliberately typed loosely here (`Record<string, unknown>` for the node/
+ * edge bodies) - the transport's job is routing, not validating; the store
+ * runs the real generated validator on the result of applying these, which
+ * is what actually guarantees the shape. */
+export type ScenePatchOp = Record<string, unknown> & { op: string };
+
+/** ADR-003 stage 3.4: a patch frame's contents, handed to a patch listener.
+ * `baseRevision` is the revision the server believes this client is at; a
+ * client whose own revision differs has missed a frame and must re-snapshot
+ * rather than apply this out of order. */
+export interface ScenePatch {
+  revision: number;
+  baseRevision: number;
+  ops: ScenePatchOp[];
+}
+
+export type PatchListener = (patch: ScenePatch) => void;
+
 interface WsLike {
   send(data: string): void;
   close(): void;
@@ -120,6 +139,13 @@ export class WsTransport {
   /** Keyed by requestId - stream deltas are addressed to a specific in-flight
    * request, not a topic. See handleMessage()'s "stream" branch. */
   private readonly streamListeners = new Map<string, Set<StreamListener>>();
+  /** ADR-003 stage 3.4: keyed by topic, like stateListeners, but a separate
+   * Map rather than a widened StateListener signature - mirroring how
+   * streamListeners is already its own parallel registry. A topic can have
+   * both (the scene topic does): its snapshot listener still receives every
+   * `kind:"state"` frame unchanged, and only patch frames route here, so a
+   * consumer that never opts into patches keeps working untouched. */
+  private readonly patchListeners = new Map<string, Set<PatchListener>>();
   private readonly pending = new Map<
     number,
     { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
@@ -203,6 +229,38 @@ export class WsTransport {
     return () => {
       set.delete(listener);
       if (set.size === 0) this.stateListeners.delete(topic);
+    };
+  }
+
+  /** ADR-003 stage 3.4: re-request a topic's current full snapshot.
+   *
+   * `subscribe()` above sends its subscribe message only for a topic's FIRST
+   * listener (the isNewTopic guard), so an already-subscribed topic has no
+   * way to ask for fresh state through it - this is that missing half, used
+   * by the scene store to self-heal after a detected patch gap. Silently
+   * no-ops while the socket is not open, matching intent()'s own
+   * pre-connect behavior: reconnecting re-subscribes every topic from
+   * scratch anyway, which resolves the gap by itself. */
+  resubscribe(topic: string): void {
+    if (this.status !== "open" || !this.socket) return;
+    this.socket.send(JSON.stringify({ kind: "subscribe", topics: [topic] }));
+  }
+
+  /** ADR-003 stage 3.4: listen for a topic's `kind:"patch"` deltas. Sends no
+   * subscribe message of its own - patches arrive on the SAME server-side
+   * topic subscription `subscribe()` already established, so a consumer that
+   * wants both calls both (the scene store does: snapshots are still the
+   * reconnect/resync answer, patches are the steady-state path). */
+  subscribePatch(topic: string, listener: PatchListener): () => void {
+    let set = this.patchListeners.get(topic);
+    if (!set) {
+      set = new Set();
+      this.patchListeners.set(topic, set);
+    }
+    set.add(listener);
+    return () => {
+      set.delete(listener);
+      if (set.size === 0) this.patchListeners.delete(topic);
     };
   }
 
@@ -329,6 +387,24 @@ export class WsTransport {
       if (listeners) {
         const payload = message.payload as Record<string, unknown>;
         for (const listener of [...listeners]) listener(payload);
+      }
+      return;
+    }
+    if (kind === "patch") {
+      // ADR-003 stage 3.4. A patch frame for a topic with no patch
+      // subscriber is dropped SILENTLY rather than logged: the server sends
+      // patches to every connection on the topic, and a consumer opting
+      // into snapshots only (every topic except scene today) is a supported
+      // configuration, not an anomaly - same posture as the stream branch
+      // below, and deliberately unlike the unknown-kind fallback at the end.
+      const listeners = this.patchListeners.get(message.topic as string);
+      if (listeners) {
+        const patch: ScenePatch = {
+          revision: message.revision as number,
+          baseRevision: message.baseRevision as number,
+          ops: (message.ops as ScenePatchOp[]) ?? [],
+        };
+        for (const listener of [...listeners]) listener(patch);
       }
       return;
     }


### PR DESCRIPTION
## Problem

The scene topic published a full snapshot on every mutation — **1.6 MB at 500 nodes**, across ~146 publish sites. Every node was re-serialized and re-sent whether or not it changed.

## Change

The scene topic now sends `{"kind":"patch","topic":"scene","revision":N,"baseRevision":N-1,"ops":[…]}` whenever a delta is available, falling back to the full `kind:"state"` snapshot otherwise.

**Measured against the stage's own exit criterion:** a single node edit on the 500-node reference workload drops from **1638 KiB → 3.34 KiB, a 490× reduction**, under the 5 KiB budget. Pinned by a CI byte-size test.

### Mechanism deviates from the ADR, deliberately

The ADR specifies "server bookkeeping to a dirty-id set" fed by the mutation sites. That was built first and abandoned after it produced reproducible silent data loss.

A dirty-id set is only safe if *every* mutator marks. With ~60 mutators across `domain/graph.py`/`groups.py`/`branches.py` reached from ~146 publish sites, partial rollout fails catastrophically rather than gracefully: an **un**instrumented mutation that publishes while an earlier instrumented one's marks are still pending emits a patch describing only the stale earlier change — the real one never reaches the client. Reproduced against a real intent (`setCodeSandboxAllowSourceBuilds`, publishing after an instrumented `connect()` during node setup): the patch carried only the setup edge and the flag change vanished.

Since "instrument everything, perfectly, forever" is not a property a test can enforce, the mechanism is a **whole-node diff** against the last published wire state — correct by construction for every mutator, present and future, with no discipline required at any mutation site. The granularity the ADR actually specifies is unchanged (whole-node ops, no field-level diffing, no CRDT), and CPU cost is unchanged too: the pre-3.4 snapshot path already built every node's wire dict on every publish, so this only changes what gets **sent**.

Pin mutations have no op in the ADR's op set and honestly fall back to a full snapshot rather than being silently dropped.

### A real pre-existing bug, fixed en route

`_Topic.snapshot()` incremented `revision` itself, and is called by **both** `publish()` (a real broadcast) **and** `send_snapshot()` (one connection's private subscribe handshake). So a second window merely *subscribing* advanced the counter every other connection tracks, with no message ever sent to them. Harmless while `revision` was a decorative envelope field nobody compared; actively wrong now that it is the `baseRevision` the patch protocol compares against — an unrelated subscribe would manufacture a phantom gap and force every other client into a needless re-snapshot. Bumping is now exclusively `publish()`'s job.

### Frontend

- `WsTransport` gained a `kind:"patch"` branch — such a frame previously hit the unknown-kind `console.error` and was dropped entirely — plus a `subscribePatch` registry parallel to the existing `streamListeners`.
- `SceneStore.applyScenePatch` applies ops onto the live scene, **preserving object identity for untouched nodes** (the property ADR-011 stage 11.1's `React.memo` work will depend on; nothing exploits it yet, so it's pinned by a dedicated test rather than left to regress silently).
- A patch with a mismatched `baseRevision` or an unknown op kind is refused **whole** — never partially applied — and self-heals by re-requesting a snapshot through the existing `subscribe` message.

## Not done here

The ~16 ms coalescer and the bounded per-connection writer queue this stage also names. `SessionBus.publish` is still a synchronous per-connection send loop, so a genuinely slow (as opposed to dead) client can still stall its siblings. **Stage 3.4 is therefore partially complete**, tracked as follow-on work.

## Test plan

- [x] Full backend suite: `pytest -q` — 1620 passed, 14 skipped (up from 1600; 20 new)
- [x] Full frontend check: `npm run check` (typecheck, lint, tests, build) — clean
- [x] New `test_scene_patch_protocol.py`: op generation, revision semantics, patch-vs-snapshot decision, the 500-node byte budget, and the reduction ratio itself
- [x] New `sceneStore.test.ts` suite: op application, baseRevision-gap refusal + resync, unknown-op refusal, referential identity
- [x] Regression pin for the silent-data-loss bug that killed the first mechanism
- [x] Mutation-tested: empty-ops fail-safe, revision-bump fix, baseRevision gate, referential identity — each reverted, confirmed the exact intended test fails, restored