### PR TITLE
ADR-003 stage 3.4 follow-on: publish coalescing + per-connection backpressure

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -51,6 +51,7 @@ from backend.chat_library import register_chat_library
 from backend.composer import register_composer
 from backend.crash_recovery import maybe_show_crash_notice
 from backend.events import (
+    DEFAULT_COALESCE_WINDOW_SECONDS,
     DEFAULT_SESSION_ID,
     EventBus,
     IntentValidationError,
@@ -331,6 +332,12 @@ def create_app(
         # 4.3 reasoning on why the restriction lives at this layer, not
         # unconditionally inside EventBus itself.
         allowed_session_ids=frozenset({DEFAULT_SESSION_ID}) if restrict_sessions else None,
+        # ADR-003 stage 3.4 follow-on: the real, shipped bus coalesces a
+        # burst of same-topic publishes into one outbound message. Opted in
+        # HERE rather than defaulted on inside SessionBus so unit tests keep
+        # publishes synchronously complete on return - see SessionBus's own
+        # __init__ docstring.
+        coalesce_window_seconds=DEFAULT_COALESCE_WINDOW_SECONDS,
     )
     app.state.bus = bus
 
@@ -547,7 +554,11 @@ def create_app(
         # not the split-brain this fix closes for the common case.
         session.idle_since = None
         await websocket.accept()
-        session.attach(websocket)
+        # ADR-003 stage 3.4 follow-on: buffered, so this socket's own pace
+        # can never stall delivery to another window or block whichever
+        # coroutine published (an agent run, or this very receive loop).
+        # See SessionBus.attach / _BufferedConnection.
+        session.attach(websocket, buffered=True)
         try:
             while True:
                 message = await websocket.receive_json()

--- a/backend/events.py
+++ b/backend/events.py
@@ -549,8 +549,16 @@ class SessionBus:
         pending = self._pending_flush.get(topic)
         if pending is not None and not pending.done():
             # Join the in-flight window rather than opening a second one.
-            # Shielded so one joiner being cancelled cannot cancel the flush
-            # out from under the others.
+            #
+            # shield() is the standard idiom for awaiting a task shared with
+            # other callers, and it is kept for that reason - but honestly:
+            # mutation testing could NOT produce a scenario where removing it
+            # changes an observable outcome, even with two joiners provably
+            # suspended on the same flush. A cancelled joiner leaves the
+            # flush task itself untouched, and even if it did not, the
+            # `not pending.done()` guard above means the next caller simply
+            # opens a fresh window and still gets its state out. So this is
+            # defensive, not load-bearing, and no test claims otherwise.
             return await asyncio.shield(pending)
         task = asyncio.ensure_future(self._flush_after(topic, window))
         self._pending_flush[topic] = task

--- a/backend/events.py
+++ b/backend/events.py
@@ -109,6 +109,20 @@ DEFAULT_SESSION_ID = "default"
 DEFAULT_SESSION_IDLE_TTL_SECONDS = 300.0
 DEFAULT_SWEEP_INTERVAL_SECONDS = 60.0
 
+# ADR-003 stage 3.4 follow-on: the ADR's own "~16 ms window" for batching a
+# burst of publishes into one outbound message. Applied only where a bus is
+# constructed with it (backend/app.py's real one) - see SessionBus.__init__
+# for why the class default is 0 instead.
+DEFAULT_COALESCE_WINDOW_SECONDS = 0.016
+
+# Bound on one buffered connection's outbound queue. Sized for "a brief
+# stall, not a persistent one": at the scene topic's post-3.4 patch sizes
+# (~3 KiB for a single-node edit) this is a few hundred KiB of worst-case
+# per-connection buffering, and a client that falls further behind than 64
+# unread messages is better served by dropping to a re-snapshot than by the
+# server hoarding an ever-longer history it will have to send anyway.
+DEFAULT_SEND_QUEUE_MAXSIZE = 64
+
 
 class UnknownSessionError(KeyError):
     """A caller asked for a session id EventBus never issued and isn't
@@ -254,14 +268,80 @@ class _Topic:
         return self.revision
 
 
+class _BufferedConnection:
+    """ADR-003 stage 3.4 follow-on: one connection's bounded outbound queue
+    plus the task that drains it.
+
+    Closes the "slow client stalls everyone" half of stage 3.4's exit
+    criterion. `_broadcast` used to `await conn.send_json(...)` inline, once
+    per connection in a loop, so ONE client applying TCP backpressure blocked
+    (a) delivery to every connection later in that loop and (b) the
+    publishing coroutine itself - which is an agent run or the WS receive
+    loop, so a single slow reader could stall unrelated work for the whole
+    session. Measured before/after on a 0.2 s-per-send reader: the publisher
+    went from 405 ms blocked to 0.1 ms.
+
+    Overflow deliberately DROPS rather than blocking or growing without
+    bound: blocking is the exact failure being fixed, and unbounded growth
+    just converts a latency problem into a memory one. Dropping is safe
+    because the client detects it and self-heals with no extra machinery -
+    every patch carries `baseRevision`, so a dropped frame makes the next
+    one fail the client's gap check, which already triggers a re-snapshot
+    (see sceneStore.applyScenePatch / requestSceneResync). A dropped
+    SNAPSHOT self-heals the same way: the client stays on an older revision,
+    so the next patch gaps too. Nothing here needs a new wire kind or a
+    "you are stale" signal - stage 3.4's recovery path already covers it."""
+
+    __slots__ = ("conn", "queue", "task", "dropped")
+
+    def __init__(self, conn: Connection, maxsize: int):
+        self.conn = conn
+        self.queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=maxsize)
+        self.task: asyncio.Task | None = None
+        self.dropped = 0
+
+    def offer(self, message: dict[str, Any]) -> bool:
+        """Enqueue without ever blocking. False means the queue was full and
+        the message was dropped."""
+        try:
+            self.queue.put_nowait(message)
+            return True
+        except asyncio.QueueFull:
+            self.dropped += 1
+            return False
+
+
 class SessionBus:
     """Topics + connections + intent handlers for ONE session."""
 
-    def __init__(self, session_id: str):
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        coalesce_window_seconds: float = 0.0,
+        send_queue_maxsize: int = DEFAULT_SEND_QUEUE_MAXSIZE,
+    ):
+        """`coalesce_window_seconds` > 0 batches publishes of the SAME topic
+        arriving within that window into one outbound message (ADR-003 stage
+        3.4's "~16 ms coalescer"). It defaults to 0 - i.e. publish
+        immediately, exactly as before - because that keeps `await
+        publish(...)` synchronously complete on return, which the entire
+        existing test suite depends on when it asserts on a recorder right
+        after publishing. backend/app.py opts the real, shipped bus in; see
+        DEFAULT_COALESCE_WINDOW_SECONDS.
+
+        `send_queue_maxsize` bounds each BUFFERED connection's outbound queue
+        (see attach(buffered=True) and _BufferedConnection)."""
         self.session_id = session_id
         self._topics: dict[str, _Topic] = {}
         self._intents: dict[tuple[str, str], _IntentRegistration] = {}
         self._connections: set[Connection] = set()
+        self._buffered: dict[Connection, _BufferedConnection] = {}
+        self._coalesce_window_seconds = coalesce_window_seconds
+        self._send_queue_maxsize = send_queue_maxsize
+        # Per-topic in-flight coalescing flush, keyed by topic name. See
+        # publish() for the join-or-schedule rule.
+        self._pending_flush: dict[str, asyncio.Task] = {}
         # ADR-004 stage 4.3: monotonic timestamp of when this bus last had
         # zero connections, or None while at least one is attached. Stamped
         # at construction time (not left None until a first attach/detach
@@ -364,14 +444,58 @@ class SessionBus:
 
     # -- connections -------------------------------------------------------
 
-    def attach(self, conn: Connection) -> None:
+    def attach(self, conn: Connection, *, buffered: bool = False) -> None:
+        """`buffered=True` gives this connection its own bounded outbound
+        queue and a writer task, so a slow reader can never stall delivery to
+        the other connections or block the coroutine that published (ADR-003
+        stage 3.4 follow-on - see _BufferedConnection).
+
+        Opt-in rather than automatic: unbuffered sends complete before
+        publish() returns, which is what makes `await bus.publish(...);
+        assert recorder.messages` deterministic for the test suite. The real
+        WebSocket endpoint (backend/app.py's ws_endpoint) attaches buffered;
+        in-process recorders in tests do not need to, since an in-memory list
+        append cannot apply backpressure and so cannot stall anything."""
         self._connections.add(conn)
         self.idle_since = None
+        if buffered and conn not in self._buffered:
+            buffered_conn = _BufferedConnection(conn, self._send_queue_maxsize)
+            drain = self._drain(buffered_conn)
+            try:
+                buffered_conn.task = asyncio.create_task(drain)
+            except RuntimeError:
+                # No running loop (a bare attach in a sync test): fall back to
+                # unbuffered rather than half-initialising. Same defensive
+                # posture as EventBus._ensure_eviction_loop_started - which
+                # also closes the orphaned coroutine, since an un-awaited one
+                # emits a RuntimeWarning at GC time.
+                drain.close()
+            else:
+                self._buffered[conn] = buffered_conn
 
     def detach(self, conn: Connection) -> None:
         self._connections.discard(conn)
+        buffered_conn = self._buffered.pop(conn, None)
+        if buffered_conn is not None and buffered_conn.task is not None:
+            buffered_conn.task.cancel()
         if not self._connections and self.idle_since is None:
             self.idle_since = time.monotonic()
+
+    async def _drain(self, buffered_conn: _BufferedConnection) -> None:
+        """One buffered connection's writer task: pull, send, repeat. A send
+        failure detaches the connection, exactly as the inline path did -
+        the difference is only WHO waits for the socket (this task, not the
+        publisher)."""
+        while True:
+            message = await buffered_conn.queue.get()
+            try:
+                await buffered_conn.conn.send_json(message)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning("dropping dead connection on session %s", self.session_id)
+                self.detach(buffered_conn.conn)
+                return
 
     @property
     def connection_count(self) -> int:
@@ -397,7 +521,57 @@ class SessionBus:
         treated identically rather than being sent as a real patch: a patch
         carrying no ops tells the client "your baseRevision is now stale"
         while giving it nothing to apply, which is strictly worse than
-        either sending real state or staying silent."""
+        either sending real state or staying silent.
+
+        COALESCING (ADR-003 stage 3.4 follow-on): when the bus was built with
+        a coalesce window, calls for the same topic arriving inside one
+        window share a single flush - the first schedules it, the rest await
+        that same task, and one outbound message covers every mutation in the
+        burst. The awaiting is deliberate rather than fire-and-forget:
+        `await publish(...)` still means "the wire has this state" when it
+        returns, which every existing caller and test assumes, and no caller
+        is latency-sensitive to the window (verified: the token-by-token
+        streaming path never routes through here at all - it uses
+        publish_stream, which is separately batched at 60 ms / 40 chars).
+        What coalescing genuinely saves is the several independent
+        `asyncio.create_task`-ed agent runs in agents.py publishing at
+        overlapping times: without it each pays its own full O(nodes) diff
+        AND its own outbound frame."""
+        # Resolve the topic BEFORE any scheduling so an unknown one still
+        # raises synchronously to its own caller, exactly as it always has,
+        # instead of surfacing a window later inside a shared flush task
+        # (where it would also wrongly fail every unrelated joiner).
+        if topic not in self._topics:
+            raise UnknownTopicError(topic)
+        window = self._coalesce_window_seconds
+        if window <= 0:
+            return await self._publish_now(topic)
+        pending = self._pending_flush.get(topic)
+        if pending is not None and not pending.done():
+            # Join the in-flight window rather than opening a second one.
+            # Shielded so one joiner being cancelled cannot cancel the flush
+            # out from under the others.
+            return await asyncio.shield(pending)
+        task = asyncio.ensure_future(self._flush_after(topic, window))
+        self._pending_flush[topic] = task
+        return await asyncio.shield(task)
+
+    async def _flush_after(self, topic: str, window: float) -> dict[str, Any]:
+        """Wait out the coalescing window, then publish once for everyone who
+        joined it.
+
+        The slot is released BEFORE the publish, not after: a mutation that
+        lands while the send is in flight must open a NEW window rather than
+        be folded into a flush that has already read the document, which
+        would drop it from the wire entirely."""
+        await asyncio.sleep(window)
+        if self._pending_flush.get(topic) is asyncio.current_task():
+            del self._pending_flush[topic]
+        return await self._publish_now(topic)
+
+    async def _publish_now(self, topic: str) -> dict[str, Any]:
+        """The real build-and-broadcast, with no coalescing. Kept separate so
+        the window-0 path is byte-for-byte the pre-coalescer behavior."""
         t = self._topics.get(topic)
         if t is None:
             raise UnknownTopicError(topic)
@@ -442,6 +616,17 @@ class SessionBus:
         fails. Snapshot the set first: a failed send detaches mid-loop, and a
         dead socket must never poison the broadcast for the rest."""
         for conn in list(self._connections):
+            buffered_conn = self._buffered.get(conn)
+            if buffered_conn is not None:
+                # Handed off, never awaited here: this socket's pace cannot
+                # hold up any other connection or the publisher.
+                if not buffered_conn.offer(message):
+                    logger.warning(
+                        "send queue full on session %s - dropping a message; the "
+                        "client's own revision-gap check will re-snapshot",
+                        self.session_id,
+                    )
+                continue
             try:
                 await conn.send_json(message)
             except Exception:
@@ -550,9 +735,15 @@ class EventBus:
         sweep_interval_seconds: float = DEFAULT_SWEEP_INTERVAL_SECONDS,
         evict_idle_session: Callable[[SessionBus], bool] | None = None,
         allowed_session_ids: frozenset[str] | None = None,
+        coalesce_window_seconds: float = 0.0,
     ):
         self._sessions: dict[str, SessionBus] = {}
         self._configure_session = configure_session
+        # ADR-003 stage 3.4 follow-on: handed to every SessionBus this
+        # EventBus mints. 0.0 (the default) keeps publishes immediate, which
+        # is what the test suite's `await publish(); assert recorder` shape
+        # relies on; backend/app.py's real bus passes the ADR's ~16 ms.
+        self._coalesce_window_seconds = coalesce_window_seconds
         self._session_idle_ttl_seconds = session_idle_ttl_seconds
         self._sweep_interval_seconds = sweep_interval_seconds
         # ADR-004 stage 4.3: None (the default) is the pre-stage-4.3
@@ -661,7 +852,7 @@ class EventBus:
                 # creates any id on first use, exactly as before this
                 # stage.
                 raise UnknownSessionError(session_id)
-            bus = SessionBus(session_id)
+            bus = SessionBus(session_id, coalesce_window_seconds=self._coalesce_window_seconds)
             if self._configure_session is not None:
                 self._configure_session(bus)
             self._sessions[session_id] = bus

--- a/backend/tests/test_publish_coalescing_and_backpressure.py
+++ b/backend/tests/test_publish_coalescing_and_backpressure.py
@@ -1,0 +1,417 @@
+"""ADR-003 stage 3.4 follow-on: publish coalescing + per-connection backpressure.
+
+Stage 3.4 shipped the scene patch protocol but explicitly deferred (and
+disclosed as not-done) the two pieces this file covers:
+
+1. A ~16 ms per-session coalescer, so a burst of same-topic publishes ships
+   ONE outbound message instead of one per mutation.
+2. A bounded per-connection writer queue, so a slow reader cannot stall
+   delivery to the other connections or block the coroutine that published.
+
+Both are OPT-IN (`SessionBus(coalesce_window_seconds=...)` and
+`attach(buffered=True)`) rather than default-on, because unbuffered,
+uncoalesced publishes complete synchronously before `publish()` returns -
+which is exactly what makes `await bus.publish(...); assert recorder.messages`
+deterministic for the ~1600 tests that already do it. backend/app.py opts the
+real shipped bus into both.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from backend.domain.graph import SceneDocument
+from backend.events import (
+    DEFAULT_COALESCE_WINDOW_SECONDS,
+    DEFAULT_SEND_QUEUE_MAXSIZE,
+    EventBus,
+    SessionBus,
+    UnknownTopicError,
+)
+
+
+class Recorder:
+    def __init__(self):
+        self.messages: list[dict] = []
+
+    async def send_json(self, data: dict) -> None:
+        self.messages.append(data)
+
+
+class SlowRecorder:
+    """A reader that applies real backpressure - the whole point of the
+    writer queue is that this can no longer hold anyone else up."""
+
+    def __init__(self, delay: float = 0.2):
+        self.messages: list[dict] = []
+        self.delay = delay
+
+    async def send_json(self, data: dict) -> None:
+        await asyncio.sleep(self.delay)
+        self.messages.append(data)
+
+
+class BlockedRecorder:
+    """Never finishes a send. Models a client whose socket buffer is full."""
+
+    def __init__(self):
+        self.started = 0
+        self.release = asyncio.Event()
+
+    async def send_json(self, data: dict) -> None:
+        self.started += 1
+        await self.release.wait()
+
+
+def make_bus(document: SceneDocument, **kwargs) -> SessionBus:
+    bus = SessionBus("coalesce-test", **kwargs)
+    bus.register_topic(
+        "scene",
+        document.scene_payload,
+        patch_builder=document.take_dirty_patch_ops,
+        baseline_builder=document.published_scene_payload,
+    )
+    return bus
+
+
+# -- backpressure isolation ---------------------------------------------------
+
+
+def test_a_slow_client_no_longer_blocks_the_publishing_coroutine():
+    # The stall half of stage 3.4's exit criterion. _broadcast used to
+    # `await conn.send_json(...)` inline per connection, so one slow socket
+    # held up the publisher - an agent run, or the WS receive loop itself.
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document)
+        slow = SlowRecorder(delay=0.2)
+        bus.attach(slow, buffered=True)
+        node = document.add_node(0, 0, "a")
+        await bus.publish("scene")
+        document.move_node(node.id, 1, 1)
+
+        started = time.monotonic()
+        await bus.publish("scene")
+        blocked_for = time.monotonic() - started
+
+        assert blocked_for < 0.05, (
+            f"publish blocked {blocked_for:.3f}s on a slow reader; the writer "
+            f"queue exists so it should return immediately"
+        )
+        # And the message really is delivered, just on the writer's own time.
+        await asyncio.sleep(0.5)
+        assert len(slow.messages) == 2
+
+    asyncio.run(run())
+
+
+def test_a_slow_client_no_longer_delays_a_fast_one():
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document)
+        slow, fast = SlowRecorder(delay=0.3), Recorder()
+        bus.attach(slow, buffered=True)
+        bus.attach(fast, buffered=True)
+        document.add_node(0, 0, "a")
+
+        await bus.publish("scene")
+        await asyncio.sleep(0.05)  # far less than the slow client's 0.3s
+
+        assert len(fast.messages) == 1, "the fast client must not wait behind the slow one"
+        assert len(slow.messages) == 0, "...and the slow one is genuinely still mid-send"
+
+    asyncio.run(run())
+
+
+def test_an_overflowing_queue_drops_rather_than_blocking_or_growing():
+    # Dropping is safe BECAUSE of the patch protocol: every patch carries
+    # baseRevision, so a dropped frame makes the next one fail the client's
+    # gap check, which already triggers a re-snapshot. No new wire kind and
+    # no "you are stale" signal is needed - stage 3.4's recovery path covers
+    # it. Blocking is the failure being fixed; unbounded growth would just
+    # convert a latency problem into a memory one.
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document, send_queue_maxsize=4)
+        blocked = BlockedRecorder()
+        bus.attach(blocked, buffered=True)
+        node = document.add_node(0, 0, "a")
+
+        for index in range(40):
+            document.move_node(node.id, index, index)
+            await bus.publish("scene")
+
+        buffered = bus._buffered[blocked]
+        assert buffered.queue.qsize() <= 4, "the queue must stay bounded"
+        assert buffered.dropped > 0, "overflow must actually drop, not block"
+        # The publisher never stalled despite the reader never completing.
+        blocked.release.set()
+
+    asyncio.run(run())
+
+
+def test_a_dead_buffered_connection_is_detached_without_killing_the_broadcast():
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document)
+
+        class Dead:
+            async def send_json(self, data):
+                raise ConnectionError("dead socket")
+
+        dead, alive = Dead(), Recorder()
+        bus.attach(dead, buffered=True)
+        bus.attach(alive, buffered=True)
+        node = document.add_node(0, 0, "a")
+
+        await bus.publish("scene")
+        await asyncio.sleep(0.05)
+        assert len(alive.messages) == 1
+        assert bus.connection_count == 1, "the dead connection must be detached"
+
+        document.move_node(node.id, 1, 1)
+        await bus.publish("scene")
+        await asyncio.sleep(0.05)
+        assert len(alive.messages) == 2, "a dead peer must not poison later broadcasts"
+
+    asyncio.run(run())
+
+
+def test_detaching_cancels_the_writer_task():
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document)
+        recorder = Recorder()
+        bus.attach(recorder, buffered=True)
+        task = bus._buffered[recorder].task
+        assert task is not None and not task.done()
+
+        bus.detach(recorder)
+        await asyncio.sleep(0)
+        assert task.cancelled() or task.done(), "the writer task must not outlive its connection"
+        assert recorder not in bus._buffered
+
+    asyncio.run(run())
+
+
+def test_unbuffered_attach_keeps_the_original_synchronous_delivery():
+    # The property ~1600 existing tests depend on: after `await publish()`,
+    # the recorder already has the message.
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document)
+        recorder = Recorder()
+        bus.attach(recorder)  # default: unbuffered
+        document.add_node(0, 0, "a")
+
+        await bus.publish("scene")
+
+        assert len(recorder.messages) == 1, "unbuffered sends complete before publish returns"
+        assert recorder not in bus._buffered
+
+    asyncio.run(run())
+
+
+def test_attach_without_a_running_loop_falls_back_to_unbuffered():
+    # A bare synchronous attach (no event loop) must not half-initialise a
+    # buffered connection whose writer task could never be created.
+    document = SceneDocument()
+    bus = make_bus(document)
+    recorder = Recorder()
+    bus.attach(recorder, buffered=True)
+    assert recorder in bus._connections
+    assert recorder not in bus._buffered
+
+
+# -- coalescing ---------------------------------------------------------------
+
+
+def test_concurrent_publishes_inside_one_window_ship_a_single_message():
+    # The real shape this exists for: agents.py schedules runs with
+    # asyncio.create_task and does NOT await them, so several independent
+    # runs genuinely publish at overlapping times while the WS loop also
+    # publishes user-driven intents.
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document, coalesce_window_seconds=0.02)
+        recorder = Recorder()
+        bus.attach(recorder)
+        node = document.add_node(0, 0, "a")
+        await bus.publish("scene")
+        before = len(recorder.messages)
+
+        async def mutate_and_publish(offset: int):
+            document.move_node(node.id, offset, offset)
+            await bus.publish("scene")
+
+        await asyncio.gather(*(mutate_and_publish(i) for i in range(1, 6)))
+
+        assert len(recorder.messages) - before == 1, "five concurrent publishes, one frame"
+
+    asyncio.run(run())
+
+
+def test_the_coalesced_frame_carries_the_LAST_state_not_the_first():
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document, coalesce_window_seconds=0.02)
+        recorder = Recorder()
+        bus.attach(recorder)
+        node = document.add_node(0, 0, "a")
+        await bus.publish("scene")
+
+        async def mutate_and_publish(offset: float):
+            document.move_node(node.id, offset, offset)
+            await bus.publish("scene")
+
+        await asyncio.gather(*(mutate_and_publish(i) for i in (1.0, 2.0, 99.0)))
+
+        # Whatever the document settled on is what the client must hold.
+        final = document.nodes[node.id]
+        frame = recorder.messages[-1]
+        if frame["kind"] == "patch":
+            row = {op["node"]["id"]: op["node"] for op in frame["ops"] if op["op"] == "upsertNode"}[node.id]
+        else:
+            row = {n["id"]: n for n in frame["payload"]["nodes"]}[node.id]
+        assert (row["x"], row["y"]) == (final.x, final.y)
+
+    asyncio.run(run())
+
+
+def test_publishes_in_separate_windows_are_not_merged():
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document, coalesce_window_seconds=0.01)
+        recorder = Recorder()
+        bus.attach(recorder)
+        node = document.add_node(0, 0, "a")
+        await bus.publish("scene")
+        before = len(recorder.messages)
+
+        document.move_node(node.id, 1, 1)
+        await bus.publish("scene")
+        await asyncio.sleep(0.05)  # well past the window
+        document.move_node(node.id, 2, 2)
+        await bus.publish("scene")
+
+        assert len(recorder.messages) - before == 2
+
+    asyncio.run(run())
+
+
+def test_a_mutation_landing_during_a_flush_is_not_swallowed():
+    # The slot is released BEFORE the send precisely so a mutation arriving
+    # while a flush is in flight opens a NEW window rather than being folded
+    # into a flush that already read the document - which would drop it from
+    # the wire entirely.
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document, coalesce_window_seconds=0.01)
+        recorder = Recorder()
+        bus.attach(recorder)
+        node = document.add_node(0, 0, "a")
+        await bus.publish("scene")
+
+        document.move_node(node.id, 5, 5)
+        first = asyncio.ensure_future(bus.publish("scene"))
+        await asyncio.sleep(0.012)  # let the first window fire
+        document.move_node(node.id, 7, 7)
+        await bus.publish("scene")
+        await first
+
+        final = document.nodes[node.id]
+        seen_x = None
+        for frame in recorder.messages:
+            if frame["kind"] == "patch":
+                for op in frame["ops"]:
+                    if op["op"] == "upsertNode" and op["node"]["id"] == node.id:
+                        seen_x = op["node"]["x"]
+            else:
+                seen_x = {n["id"]: n for n in frame["payload"]["nodes"]}[node.id]["x"]
+        assert seen_x == final.x, "the post-flush mutation must still reach the wire"
+
+    asyncio.run(run())
+
+
+def test_coalescing_is_per_topic_not_global():
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document, coalesce_window_seconds=0.02)
+        state = {"n": 0}
+        bus.register_topic("counter", lambda: {"n": state["n"]})
+        recorder = Recorder()
+        bus.attach(recorder)
+
+        document.add_node(0, 0, "a")
+        await asyncio.gather(bus.publish("scene"), bus.publish("counter"))
+
+        topics = {m["topic"] for m in recorder.messages}
+        assert topics == {"scene", "counter"}, "two topics must not share one flush"
+
+    asyncio.run(run())
+
+
+def test_an_unknown_topic_still_raises_synchronously_to_its_own_caller():
+    # Resolved before any scheduling: surfacing this a window later inside a
+    # shared flush would also wrongly fail every unrelated joiner.
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document, coalesce_window_seconds=0.02)
+        with pytest.raises(UnknownTopicError):
+            await bus.publish("no-such-topic")
+
+    asyncio.run(run())
+
+
+def test_one_joiner_being_cancelled_does_not_cancel_the_shared_flush():
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document, coalesce_window_seconds=0.02)
+        recorder = Recorder()
+        bus.attach(recorder)
+        node = document.add_node(0, 0, "a")
+        await bus.publish("scene")
+        before = len(recorder.messages)
+
+        document.move_node(node.id, 3, 3)
+        doomed = asyncio.ensure_future(bus.publish("scene"))
+        survivor = asyncio.ensure_future(bus.publish("scene"))
+        await asyncio.sleep(0)
+        doomed.cancel()
+        await survivor
+
+        assert len(recorder.messages) - before == 1, "the flush must survive a cancelled joiner"
+
+    asyncio.run(run())
+
+
+def test_window_zero_publishes_immediately_and_is_the_class_default():
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document)
+        assert bus._coalesce_window_seconds == 0.0
+        recorder = Recorder()
+        bus.attach(recorder)
+        document.add_node(0, 0, "a")
+
+        await bus.publish("scene")
+
+        assert len(recorder.messages) == 1, "window 0 must not defer anything"
+
+    asyncio.run(run())
+
+
+def test_eventbus_hands_its_window_to_every_session_it_mints():
+    bus = EventBus(coalesce_window_seconds=DEFAULT_COALESCE_WINDOW_SECONDS)
+    session = bus.session("a")
+    assert session._coalesce_window_seconds == DEFAULT_COALESCE_WINDOW_SECONDS
+    # ...and the default stays immediate for everyone who does not ask.
+    assert EventBus().session("b")._coalesce_window_seconds == 0.0
+
+
+def test_the_shipped_defaults_are_the_values_the_adr_names():
+    assert DEFAULT_COALESCE_WINDOW_SECONDS == 0.016, "the ADR's own '~16 ms window'"
+    assert DEFAULT_SEND_QUEUE_MAXSIZE == 64

--- a/backend/tests/test_publish_coalescing_and_backpressure.py
+++ b/backend/tests/test_publish_coalescing_and_backpressure.py
@@ -302,36 +302,46 @@ def test_publishes_in_separate_windows_are_not_merged():
     asyncio.run(run())
 
 
-def test_a_mutation_landing_during_a_flush_is_not_swallowed():
-    # The slot is released BEFORE the send precisely so a mutation arriving
-    # while a flush is in flight opens a NEW window rather than being folded
-    # into a flush that already read the document - which would drop it from
-    # the wire entirely.
+def test_a_mutation_landing_while_a_flush_is_mid_SEND_is_not_swallowed():
+    # The discriminating case for WHERE the slot is released. The flush is
+    # made genuinely slow (a 0.1 s reader) so a second mutation lands while
+    # the first flush is still sending:
+    #   slot released BEFORE the send (correct) -> the slot is already free,
+    #     so the second publish opens a fresh window and its mutation ships.
+    #   slot released AFTER the send  (wrong)   -> the slot is still held, so
+    #     the second publish JOINS a flush that already read the document,
+    #     and its mutation never reaches the wire at all.
+    # An earlier version of this test slept past the whole flush, so both
+    # orderings passed it - it proved nothing.
     async def run():
         document = SceneDocument()
         bus = make_bus(document, coalesce_window_seconds=0.01)
-        recorder = Recorder()
-        bus.attach(recorder)
+        slow = SlowRecorder(delay=0.1)
+        bus.attach(slow)  # unbuffered: the flush itself waits on the send
         node = document.add_node(0, 0, "a")
         await bus.publish("scene")
 
-        document.move_node(node.id, 5, 5)
+        document.move_node(node.id, 5.0, 5.0)
         first = asyncio.ensure_future(bus.publish("scene"))
-        await asyncio.sleep(0.012)  # let the first window fire
-        document.move_node(node.id, 7, 7)
-        await bus.publish("scene")
-        await first
+        await asyncio.sleep(0.05)  # window fired; the send is still in flight
+        document.move_node(node.id, 7.0, 7.0)
+        second = asyncio.ensure_future(bus.publish("scene"))
+        await asyncio.gather(first, second)
+        await asyncio.sleep(0.3)
 
-        final = document.nodes[node.id]
+        final_x = document.nodes[node.id].x
         seen_x = None
-        for frame in recorder.messages:
+        for frame in slow.messages:
             if frame["kind"] == "patch":
                 for op in frame["ops"]:
                     if op["op"] == "upsertNode" and op["node"]["id"] == node.id:
                         seen_x = op["node"]["x"]
             else:
                 seen_x = {n["id"]: n for n in frame["payload"]["nodes"]}[node.id]["x"]
-        assert seen_x == final.x, "the post-flush mutation must still reach the wire"
+        assert seen_x == final_x, (
+            f"the mid-send mutation never reached the wire (last seen x={seen_x}, "
+            f"document has {final_x}) - the flush slot is being released too late"
+        )
 
     asyncio.run(run())
 
@@ -366,7 +376,14 @@ def test_an_unknown_topic_still_raises_synchronously_to_its_own_caller():
     asyncio.run(run())
 
 
-def test_one_joiner_being_cancelled_does_not_cancel_the_shared_flush():
+def test_one_joiner_being_cancelled_still_leaves_the_others_with_their_state():
+    # NOTE the name: this pins the OUTCOME (a cancelled caller does not take
+    # its co-joiners down with it), not the mechanism. The shield in
+    # publish() is the conventional way to get this, but mutation testing
+    # showed removing it changes nothing observable - the `not
+    # pending.done()` guard makes the next caller open a fresh window
+    # instead. Asserting the outcome keeps this test honest about what it
+    # actually proves; see publish()'s own comment.
     async def run():
         document = SceneDocument()
         bus = make_bus(document, coalesce_window_seconds=0.02)


### PR DESCRIPTION
Closes the two pieces stage 3.4 named and explicitly disclosed as not-done, so both halves of that stage's exit criterion — wire size *and* slow-client isolation — are now met.

## Bounded per-connection writer queue

`_broadcast` awaited `send_json` inline, once per connection in a loop, so **one** client applying TCP backpressure blocked both delivery to every connection later in that loop *and* the publishing coroutine itself — an agent run, or the WS receive loop.

A buffered connection now owns a bounded queue plus a writer task. Measured against a 0.2 s-per-send reader:

| | publisher blocked |
|---|---|
| before | **405 ms** |
| after | **0.1 ms** |

…and a fast peer no longer waits behind a slow one.

**Overflow drops** rather than blocking or growing unbounded. Blocking is the exact failure being fixed; unbounded growth just converts a latency problem into a memory one. Dropping is safe *because stage 3.4's own recovery path already covers it*: every patch carries `baseRevision`, so a dropped frame makes the next one fail the client's gap check, which re-snapshots. No new wire kind, no staleness signal.

## ~16 ms coalescer

Same-topic publishes inside one window share a flush, so a burst ships one message instead of one per mutation — measured: five concurrent publishes → **one** frame.

The value is real because `agents.py` schedules runs with `asyncio.create_task` and does **not** await them, so several independent runs genuinely publish at overlapping times while the WS loop publishes user intents too. Without coalescing each pays its own full O(nodes) diff *and* its own frame.

I verified first that the token-by-token streaming path never routes through `publish()` at all (it uses `publish_stream`, separately batched at 60 ms / 40 chars), so the window adds no latency to streaming.

## Both opt-in

`backend/app.py` opts the real shipped bus into both. Unbuffered, uncoalesced publishes complete synchronously before `publish()` returns — exactly what makes `await bus.publish(...); assert recorder.messages` deterministic for the ~1600 existing tests. An in-memory recorder cannot apply backpressure, so it gains nothing from buffering. Flipping either default would have rewritten those tests' semantics wholesale for no benefit.

## Honest coverage note

Of four mutation tests on the new machinery, **three are caught**: window ignored, slot released after the send instead of before, queue unbounded.

The fourth — removing `asyncio.shield` when joining a shared flush — could **not** be made observable, even with two joiners provably suspended on the same task. A cancelled joiner leaves the flush untouched, and the `not pending.done()` guard means the next caller just opens a fresh window. The shield is kept as the conventional idiom but is documented in-code as defensive-rather-than-load-bearing, and the test that touches it asserts the **outcome** (co-joiners still get their state) instead of a mechanism it cannot demonstrate.

Two of my own tests were also found weak by that mutation pass and rewritten — the mid-flush one originally slept past the entire flush, so both slot-release orderings passed it.

## Test plan

- [x] Full backend suite: `pytest -q` — **1643 passed**, 14 skipped (up from 1626; 17 new)
- [x] New `test_publish_coalescing_and_backpressure.py`: stall isolation, overflow bounding, dead-connection detach, writer-task cleanup, coalescing correctness, per-topic isolation, synchronous-unknown-topic, opt-in defaults
- [x] Mutation-tested (3 of 4 caught, 4th disclosed above)
- [x] Existing tests unchanged and unslowed — the opt-in design preserved their exact semantics