### PR TITLE
Code-review fix: send_snapshot must not bypass the buffered writer queue

### DIFF
--- a/backend/events.py
+++ b/backend/events.py
@@ -310,6 +310,55 @@ class _BufferedConnection:
             self.dropped += 1
             return False
 
+    def offer_superseding(self, message: dict[str, Any], topic: str) -> None:
+        """Enqueue a full snapshot, first PURGING every queued state/patch
+        frame for the same topic - and, unlike offer(), guaranteed to succeed.
+
+        CODE-REVIEW FIX. send_snapshot used to send directly on the socket,
+        bypassing this queue, which caused two real problems for a buffered
+        connection once a backlog existed: (1) the snapshot OVERTOOK queued
+        older patches, which then arrived after it with baseRevision below
+        the client's new revision - each refused, each refusal triggering yet
+        another resync; (2) the obvious fix, routing it through offer(),
+        creates a WORSE bug - a full queue silently drops the resync snapshot,
+        and the client's sceneResyncPending flag is only ever cleared by a
+        snapshot arriving, so it never asks again: wedged until reconnect.
+
+        Purging is correct because a snapshot strictly supersedes every
+        queued frame of its own topic: the snapshot carries the topic's
+        current revision R, every queued state/patch was enqueued at some
+        revision <= R, and a patch published AFTER this call lands behind the
+        snapshot with baseRevision R - chaining perfectly. Stream frames and
+        other topics' frames are NOT superseded and are kept, order
+        preserved. Everything here is synchronous (no awaits), so the
+        purge-and-requeue cannot interleave with the writer task's get() in a
+        way that reorders the kept frames.
+
+        The final drop-oldest loop covers the pathological remainder (a queue
+        still full of stream/other-topic frames): the snapshot's delivery
+        guarantee outranks a stale stream delta's."""
+        kept: list[dict[str, Any]] = []
+        while True:
+            try:
+                queued = self.queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if queued.get("topic") == topic and queued.get("kind") in ("state", "patch"):
+                continue  # strictly older state for this topic - superseded
+            kept.append(queued)
+        for item in kept:
+            self.queue.put_nowait(item)  # capacity is guaranteed: only removals so far
+        while True:
+            try:
+                self.queue.put_nowait(message)
+                return
+            except asyncio.QueueFull:
+                try:
+                    self.queue.get_nowait()
+                    self.dropped += 1
+                except asyncio.QueueEmpty:  # pragma: no cover - unreachable
+                    return
+
 
 class SessionBus:
     """Topics + connections + intent handlers for ONE session."""
@@ -664,7 +713,21 @@ class SessionBus:
         if t is None:
             raise UnknownTopicError(topic)
         payload = t.baseline_snapshot() or t.snapshot()
-        await conn.send_json({"kind": "state", "topic": topic, "payload": payload})
+        message = {"kind": "state", "topic": topic, "payload": payload}
+        # CODE-REVIEW FIX: a BUFFERED connection's snapshot must go through
+        # its queue, not directly onto the socket - a direct send OVERTAKES
+        # any queued older frames, which then arrive after it with
+        # baseRevision below the client's new revision, each refused, each
+        # refusal triggering yet another resync. offer_superseding (not plain
+        # offer) both purges those now-obsolete frames and guarantees the
+        # snapshot is never itself dropped by a full queue - a dropped resync
+        # snapshot would leave the client's sceneResyncPending flag set
+        # forever with nothing left to clear it. See _BufferedConnection.
+        buffered_conn = self._buffered.get(conn)
+        if buffered_conn is not None:
+            buffered_conn.offer_superseding(message, topic)
+            return
+        await conn.send_json(message)
 
     async def publish_stream(
         self,

--- a/backend/tests/test_publish_coalescing_and_backpressure.py
+++ b/backend/tests/test_publish_coalescing_and_backpressure.py
@@ -226,6 +226,139 @@ def test_attach_without_a_running_loop_falls_back_to_unbuffered():
     assert recorder not in bus._buffered
 
 
+class GatedRecorder:
+    """A reader whose sends block until released - lets a test build up a
+    real backlog in the writer queue, then observe exact delivery order."""
+
+    def __init__(self):
+        self.messages: list[dict] = []
+        self.gate = asyncio.Event()
+
+    async def send_json(self, data: dict) -> None:
+        await self.gate.wait()
+        self.messages.append(data)
+
+
+# -- send_snapshot vs the writer queue (code-review fix) ----------------------
+#
+# send_snapshot used to send DIRECTLY on the socket, bypassing the buffered
+# queue. With a backlog present, the snapshot overtook queued older patches,
+# which then arrived after it with baseRevision below the client's new
+# revision - each refused, each refusal triggering another resync. And the
+# naive fix (plain offer()) is worse: a full queue silently drops the resync
+# snapshot, and the client's sceneResyncPending flag is only cleared by a
+# snapshot arriving, so it never asks again - wedged until reconnect.
+
+
+def test_a_snapshot_never_overtakes_nor_is_followed_by_superseded_patches():
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document)
+        gated = GatedRecorder()
+        bus.attach(gated, buffered=True)
+        node = document.add_node(0, 0, "a")
+
+        await bus.publish("scene")  # writer grabs this, then blocks on the gate
+        await asyncio.sleep(0.01)
+        for index in range(1, 5):   # a real backlog of scene patches
+            document.move_node(node.id, index, index)
+            await bus.publish("scene")
+
+        await bus.send_snapshot("scene", gated)  # must purge + join the queue
+        gated.gate.set()
+        await asyncio.sleep(0.05)
+
+        kinds = [m["kind"] for m in gated.messages]
+        assert kinds[-1] == "state", f"the snapshot must arrive LAST, got {kinds}"
+        assert "patch" not in kinds, (
+            f"superseded patches must be purged, not delivered stale: {kinds}"
+        )
+        # And the snapshot is current: it carries the last-published position.
+        snap = gated.messages[-1]["payload"]
+        assert {n["id"]: n for n in snap["nodes"]}[node.id]["x"] == 4.0
+
+    asyncio.run(run())
+
+
+def test_a_resync_snapshot_is_never_dropped_by_a_full_queue():
+    # The wedge case: sceneResyncPending is only ever cleared client-side by
+    # a snapshot arriving, so dropping the resync snapshot means the client
+    # never asks again - stuck until reconnect.
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document, send_queue_maxsize=3)
+        gated = GatedRecorder()
+        bus.attach(gated, buffered=True)
+        node = document.add_node(0, 0, "a")
+
+        await bus.publish("scene")
+        await asyncio.sleep(0.01)
+        for index in range(1, 8):  # overflow the tiny queue
+            document.move_node(node.id, index, index)
+            await bus.publish("scene")
+        assert bus._buffered[gated].dropped > 0, "precondition: the queue really overflowed"
+
+        await bus.send_snapshot("scene", gated)
+        gated.gate.set()
+        await asyncio.sleep(0.05)
+
+        assert gated.messages[-1]["kind"] == "state", (
+            "the resync snapshot must be delivered even through a full queue"
+        )
+
+    asyncio.run(run())
+
+
+def test_the_purge_keeps_stream_frames_and_other_topics_untouched():
+    # A snapshot supersedes only ITS OWN topic's state/patch frames. Stream
+    # deltas and other topics' frames are unrelated and must survive, in
+    # their original order.
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document)
+        state = {"n": 0}
+        bus.register_topic("counter", lambda: {"n": state["n"]})
+        gated = GatedRecorder()
+        bus.attach(gated, buffered=True)
+        node = document.add_node(0, 0, "a")
+
+        await bus.publish("scene")  # in the writer's hands, gate closed
+        await asyncio.sleep(0.01)
+        document.move_node(node.id, 1, 1)
+        await bus.publish("scene")                       # queued: scene patch (superseded)
+        await bus.publish_stream(
+            topic="scene", request_id="r1", seq=0, delta="hi", done=False
+        )                                                # queued: stream (kept)
+        await bus.publish("counter")                     # queued: other topic (kept)
+
+        await bus.send_snapshot("scene", gated)
+        gated.gate.set()
+        await asyncio.sleep(0.05)
+
+        tail = [(m["kind"], m["topic"]) for m in gated.messages[1:]]
+        assert tail == [("stream", "scene"), ("state", "counter"), ("state", "scene")], tail
+
+    asyncio.run(run())
+
+
+def test_send_snapshot_to_an_unbuffered_connection_is_still_synchronous():
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document)
+        recorder = Recorder()
+        bus.attach(recorder)  # unbuffered
+        document.add_node(0, 0, "a")
+        await bus.publish("scene")
+
+        await bus.send_snapshot("scene", recorder)
+
+        assert recorder.messages[-1]["kind"] == "state", (
+            "unbuffered handshake must complete before send_snapshot returns"
+        )
+
+    asyncio.run(run())
+
+
 # -- coalescing ---------------------------------------------------------------
 
 


### PR DESCRIPTION
## Problem

Found by a line-by-line code review of #283's diff (after tests-only validation was rightly rejected as insufficient). `send_snapshot` sent **directly on the socket**, bypassing the bounded writer queue every real connection now routes broadcasts through. Two real failure modes:

1. **Overtaking.** With a backlog queued, a resync snapshot arrived *before* the older patches still in the queue. Those then landed after it carrying `baseRevision` below the client's new revision — each refused, each refusal triggering yet another resync. Churn introduced by the queue itself: before #283 there was no backlog to overtake.
2. **The naive fix is worse than the bug.** Routing the snapshot through a plain `offer()` means a full queue silently drops it — and the client's `sceneResyncPending` flag is cleared *only* by a snapshot arriving, so it never asks again: wedged until reconnect.

## Change

`_BufferedConnection.offer_superseding`: the snapshot **purges** every queued `state`/`patch` frame of its own topic — all strictly superseded, since they carry revisions ≤ the snapshot's, and a patch published afterward chains onto it with `baseRevision` equal to its revision. Stream frames and other topics' frames are kept in their original order. A drop-oldest fallback guarantees the snapshot itself always fits. Everything is synchronous, so the purge cannot interleave with the writer task.

## Test plan

- [x] 4 new regression tests: no-overtake/no-stale-tail, the full-queue wedge, purge precision (streams + other topics survive in order), unbuffered handshake unchanged
- [x] Mutation-verified both ways: reverting to the direct send **deadlocks** the overtake test (send_snapshot blocks on a gated socket — the exact stall the queue exists to prevent, flagged by pytest's own faulthandler); reverting to plain `offer()` fails 3 tests including the wedge
- [x] Full backend suite: 1647 passed, 14 skipped
- [x] Tree is byte-identical to the reviewed-and-tested branch tip (verified via `git diff --stat` = empty); this PR exists because #283 squash-merged mid-review