### PR TITLE
ADR-003 stage 3.5: version negotiation + BridgeErrorState wiring

### DIFF
--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -303,6 +303,16 @@ def register_canvas(
         document.scene_payload,
         patch_builder=document.take_dirty_patch_ops,
         baseline_builder=document.published_scene_payload,
+        # ADR-003 stage 3.5: the patch protocol (stage 3.4) is a real breaking
+        # change for a reader that predates it - kind:"patch" previously hit
+        # the transport's unknown-kind fallback and was silently dropped, so
+        # a stale (not-yet-rebuilt) frontend bundle would keep subscribing
+        # successfully and then simply never update again. schema_version=2
+        # marks that; min_compatible=2 is what actually enforces it - it
+        # tells a v1 reader it is too old, rather than leaving the version
+        # number purely decorative (see WsTransport.onVersionRejection).
+        schema_version=2,
+        min_compatible=2,
     )
     bus.register_topic("grid-control", document.grid_payload)
     # Static preset topics, field-for-field the DragSpeedStatePayload /

--- a/backend/events.py
+++ b/backend/events.py
@@ -5,11 +5,17 @@ Wire semantics are inherited from the IslandBridge/QWebChannel layer this
 replaces, because they were already the right shape and the frontend's
 generated validators depend on them:
 
-- Server -> client: full-state snapshots only, never diffs. Every snapshot
-  carries schemaVersion / minCompatibleSchemaVersion / revision, stamped
-  here exactly as IslandBridge.publish() stamped them (a reader may accept a
-  NEWER payload than it understands - additive-only guarantee - but must
-  refuse one older than its stated minimum).
+- Server -> client: versioned state. Most topics send full-state snapshots
+  only (`kind: "state"`); the scene topic additionally emits `kind: "patch"`
+  node-scoped deltas when a smaller delta is available (ADR-003 stage 3.4),
+  with `baseRevision` letting a client detect a gap and fall back to a fresh
+  snapshot. Every message - snapshot or patch - carries schemaVersion /
+  minCompatibleSchemaVersion / revision, stamped here exactly as
+  IslandBridge.publish() stamped them (a reader may accept a NEWER payload
+  than it understands - additive-only guarantee - but must refuse one
+  older than its stated minimum; ADR-003 stage 3.5 is what actually wires a
+  client-side reader to enforce that refusal instead of leaving the fields
+  decorative).
 - Client -> server: named intents ("setGridSize", "ready", ...) addressed to
   a topic, with positional JSON args - the successor of @Slot methods.
 

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -118,6 +118,29 @@ def test_subscribe_delivers_system_snapshot_with_envelope():
         assert payload["revision"] == 0
 
 
+def test_scene_subscribe_snapshot_is_pinned_at_schema_version_2():
+    # ADR-003 stage 3.5: canvas.py's real register_topic("scene", ...) call -
+    # not some test harness's own bus wiring (test_scene_patch_protocol.py's
+    # make_scene_bus deliberately stays at the default 1/1, since it tests
+    # the patch-protocol MACHINERY generically, decoupled from what any one
+    # topic sets it to) - is what the frontend's WsTransport actually talks
+    # to. This is what would have silently drifted back to schemaVersion 1
+    # with no test noticing, defeating stage 3.5's whole point: the patch
+    # protocol (kind:"patch") is a real breaking change for a reader that
+    # predates it, and min_compatible=2 is what lets WsTransport.
+    # onVersionRejection ever actually fire for a stale frontend build - see
+    # backend/canvas.py's own comment on the registration.
+    client = make_client()
+    with client.websocket_connect("/ws?session=default") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["scene"]})
+        message = ws.receive_json()
+        assert message["kind"] == "state"
+        assert message["topic"] == "scene"
+        payload = message["payload"]
+        assert payload["schemaVersion"] == 2
+        assert payload["minCompatibleSchemaVersion"] == 2
+
+
 def test_subscribe_without_topics_sends_every_registered_topic():
     client = make_client()
     with client.websocket_connect("/ws") as ws:

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -1,3 +1,5 @@
+import { ReactFlowProvider } from "@xyflow/react";
+import { act, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
   applyGroupDragDelta,
@@ -8,6 +10,7 @@ import {
   handleSelectionChange,
   isOrthogonalEligible,
   makeDebouncedViewportReport,
+  SceneCanvas,
   toFlowEdges,
   toFlowNodes,
   withPreservedSelection,
@@ -16,6 +19,7 @@ import {
 import type { ConversationMessage } from "./ConversationNodeView";
 import { SceneStore, initialSceneState } from "./sceneStore";
 import type { WsTransport } from "../../lib/ws/transport";
+import type { BridgeRejection } from "../../lib/bridge-core/islandState";
 import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
 
 // toFlowNodes is exported standalone specifically so this doesn't need a
@@ -2590,5 +2594,135 @@ describe("toFlowNodes (R8a Hide Other Branches wiring)", () => {
       data.onToggleBranchFocus();
     }
     expect(calls).toEqual(["A", "B", "X", "Y", "Z", "W"]);
+  });
+});
+
+// ADR-003 stage 3.5: the exported <SceneCanvas> wrapper - not <CanvasInner> -
+// is where the version-rejection gate lives (see SceneCanvas.tsx's own
+// comment on it), so this is the first test in this file to actually
+// render a component rather than exercise a pure exported function. Kept
+// to exactly that one behavior (rejected -> the error, not rejected -> the
+// error is absent) rather than also re-proving CanvasInner's own rendering,
+// which the rest of this file already covers indirectly through
+// toFlowNodes/toFlowEdges.
+describe("SceneCanvas version-rejection gate (ADR-003 stage 3.5)", () => {
+  type VersionRejectionListener = (rejection: BridgeRejection | null) => void;
+
+  type StateListener = (payload: Record<string, unknown>) => void;
+
+  function makeStoreWithVersionControl() {
+    const versionRejectionListeners = new Map<string, VersionRejectionListener>();
+    const stateListeners = new Map<string, StateListener>();
+    const transport = {
+      subscribe: vi.fn((topic: string, listener: StateListener) => {
+        stateListeners.set(topic, listener);
+        return () => stateListeners.delete(topic);
+      }),
+      intent: vi.fn(),
+      fireIntent: vi.fn(),
+      subscribePatch: vi.fn(),
+      onVersionRejection: vi.fn((topic: string, listener: VersionRejectionListener) => {
+        versionRejectionListeners.set(topic, listener);
+        listener(null);
+        return () => versionRejectionListeners.delete(topic);
+      }),
+      // ADR-003 stage 3.5 review-fix: connect() calls this unconditionally.
+      setTopicBlocked: vi.fn(),
+    } as unknown as WsTransport;
+    const store = new SceneStore(transport);
+    store.connect();
+    return { store, versionRejectionListeners, stateListeners };
+  }
+
+  it("renders BridgeErrorState, with the server's own reason, instead of the canvas when the scene topic is rejected", () => {
+    const { store, versionRejectionListeners } = makeStoreWithVersionControl();
+    versionRejectionListeners.get("scene")!({
+      kind: "version",
+      reason: "The desktop app requires an interface of at least schema version 2.",
+      details: [],
+    });
+
+    render(
+      <ReactFlowProvider>
+        <SceneCanvas store={store} onOpenDocumentView={() => {}} />
+      </ReactFlowProvider>,
+    );
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Canvas unavailable");
+    expect(alert).toHaveTextContent("The desktop app requires an interface of at least schema version 2.");
+    // The version-specific hint, not the generic bug one - see
+    // BridgeErrorState.tsx's own kind-branch.
+    expect(alert).toHaveTextContent("Rebuilding the app's interface assets usually resolves this.");
+  });
+
+  it("renders no alert when the scene topic has not been rejected", () => {
+    const { store } = makeStoreWithVersionControl();
+
+    render(
+      <ReactFlowProvider>
+        <SceneCanvas store={store} onOpenDocumentView={() => {}} />
+      </ReactFlowProvider>,
+    );
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("a real recovering snapshot clears the error and the canvas takes over", () => {
+    // Review-fix: recovery is proven with a REAL scene snapshot landing
+    // (the store's own bind("scene", ...) callback, which is what actually
+    // confirms the client is caught up), not by firing the raw
+    // version-rejection callback alone. The wire-level rejection clearing
+    // by itself is deliberately NOT enough to unblock the canvas any more
+    // - see the next test for exactly why.
+    const { store, versionRejectionListeners, stateListeners } = makeStoreWithVersionControl();
+    versionRejectionListeners.get("scene")!({ kind: "version", reason: "too old", details: [] });
+
+    render(
+      <ReactFlowProvider>
+        <SceneCanvas store={store} onOpenDocumentView={() => {}} />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    // The store's emit() fires synchronously from a plain callback, outside
+    // any React event handler - act() is what makes React flush the
+    // resulting re-render before the assertion below reads the DOM.
+    act(() => {
+      versionRejectionListeners.get("scene")!(null);
+      stateListeners.get("scene")!(baseScene() as unknown as Record<string, unknown>);
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("review-fix: the blocking error stays up through the recovery window - clearing the wire-level rejection ALONE does not unblock the canvas", () => {
+    // This is the exact race a 4-lens adversarial review found: WsTransport
+    // clears the version rejection the instant a COMPATIBLE frame arrives,
+    // synchronously and BEFORE dispatching that frame to any listener - so
+    // if the canvas gated on the raw rejection signal alone, it would
+    // briefly mount against whatever stale `scene` data the store was
+    // still holding from before the outage, for the one tick between the
+    // rejection clearing and the store actually catching up. Proven here
+    // by clearing ONLY the rejection (never delivering a snapshot/patch
+    // that would let the store confirm it's caught up) and asserting the
+    // error is still shown, not silently swapped for a stale canvas.
+    const { store, versionRejectionListeners } = makeStoreWithVersionControl();
+    versionRejectionListeners.get("scene")!({ kind: "version", reason: "too old", details: [] });
+
+    render(
+      <ReactFlowProvider>
+        <SceneCanvas store={store} onOpenDocumentView={() => {}} />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    act(() => {
+      versionRejectionListeners.get("scene")!(null);
+    });
+
+    // Still blocked - recovering, not yet confirmed caught up. If this
+    // were null, CanvasInner would have just mounted against stale data.
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(store.getSceneBlockingRejection()).not.toBeNull();
   });
 });

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -20,6 +20,7 @@ import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
 import type { StreamListener } from "../../lib/ws/transport";
+import { BridgeErrorState } from "../../lib/ui/BridgeErrorState";
 import { ArtifactNodeView, type ArtifactFlowNode } from "./ArtifactNodeView";
 import { ChartNodeView, type ChartFlowNode } from "./ChartNodeView";
 import { ChatNodeView, type ChatFlowNode } from "./ChatNodeView";
@@ -1758,5 +1759,26 @@ export function SceneCanvas({
   store: SceneStore;
   onOpenDocumentView: (markdown: string, sourceLabel: string) => void;
 }) {
+  // ADR-003 stage 3.5: renders BridgeErrorState INSTEAD of the canvas - not
+  // alongside it - the moment the scene topic's schema version is rejected.
+  // CanvasInner is not mounted at all in that case: its hooks (toFlowNodes,
+  // the drag/selection state, React Flow itself) all assume `scene` is
+  // current, and per BridgeErrorState's own doc, a rejected payload makes
+  // whatever the store is still holding stale by definition the instant this
+  // fires (WsTransport withholds the frame; the store simply stops updating
+  // - see SceneStore.getSceneVersionRejection's own comment).
+  // Review-fix: getSceneBlockingRejection, not getSceneVersionRejection -
+  // the latter clears the instant a compatible frame arrives at the wire
+  // level, which for a patch (the normal steady-state path) is BEFORE this
+  // store has confirmed the patch actually applies. Gating on the raw
+  // signal let CanvasInner flash the stale pre-outage scene for one tick
+  // during recovery - see sceneStore.ts's own comment on
+  // sceneVersionRecovering for the full mechanism.
+  const versionRejection = useSyncExternalStore(store.subscribe, store.getSceneBlockingRejection);
+  if (versionRejection) {
+    return (
+      <BridgeErrorState title="Canvas unavailable" rejection={versionRejection} className="scene-bridge-error" />
+    );
+  }
   return <CanvasInner store={store} onOpenDocumentView={onOpenDocumentView} />;
 }

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, it, vi } from "vitest";
 import { SceneStore, initialSceneState, scaleDragPosition } from "./sceneStore";
 import type { ScenePatch, WsTransport } from "../../lib/ws/transport";
+import type { BridgeRejection } from "../../lib/bridge-core/islandState";
 
 type StateListener = (payload: Record<string, unknown>) => void;
 type PatchListener = (patch: ScenePatch) => void;
+type VersionRejectionListener = (rejection: BridgeRejection | null) => void;
 
 function makeFakeTransport() {
   const listeners = new Map<string, StateListener>();
   const patchListeners = new Map<string, PatchListener>();
+  // ADR-003 stage 3.5: mirrors the real WsTransport's own map - kept
+  // separate so a test can fire a rejection independently of the
+  // state/patch listeners above, exactly like patchListeners already does
+  // relative to listeners.
+  const versionRejectionListeners = new Map<string, VersionRejectionListener>();
+  const blockedTopics = new Set<string>();
   const resubscribes: string[] = [];
   const intents: Array<{ topic: string; intent: string; args: unknown[] }> = [];
   const requests: Array<{ topic: string; intent: string; args: unknown[] }> = [];
@@ -50,11 +58,28 @@ function makeFakeTransport() {
     resubscribe: vi.fn((topic: string) => {
       resubscribes.push(topic);
     }),
+    // ADR-003 stage 3.5: matches the real transport's contract - fires
+    // immediately with the current (here, always-starts-null) state on
+    // subscribe, same as subscribe()'s own StateListener does not but
+    // onStatus already does; see WsTransport.onVersionRejection's own doc.
+    onVersionRejection: vi.fn((topic: string, listener: VersionRejectionListener) => {
+      versionRejectionListeners.set(topic, listener);
+      listener(null);
+      return () => versionRejectionListeners.delete(topic);
+    }),
+    // ADR-003 stage 3.5 review-fix: connect() calls this unconditionally
+    // (updateSceneBlockedState) - recorded so a test can assert on it.
+    setTopicBlocked: vi.fn((topic: string, blocked: boolean) => {
+      if (blocked) blockedTopics.add(topic);
+      else blockedTopics.delete(topic);
+    }),
   } as unknown as WsTransport;
   return {
     transport,
     listeners,
     patchListeners,
+    versionRejectionListeners,
+    blockedTopics,
     resubscribes,
     intents,
     requests,
@@ -65,8 +90,15 @@ function makeFakeTransport() {
 
 function validScenePayload(overrides: Record<string, unknown> = {}) {
   return {
-    schemaVersion: 1,
-    minCompatibleSchemaVersion: 1,
+    // ADR-003 stage 3.5: matches the real backend registration
+    // (backend/canvas.py's register_topic("scene", ..., schema_version=2,
+    // min_compatible=2)) - this file's fake transport bypasses
+    // WsTransport.handleMessage entirely (see makeFakeTransport above), so
+    // nothing here actually enforces version compatibility, but keeping the
+    // fixture honest matters for anyone reading it as "what scene actually
+    // looks like on the wire".
+    schemaVersion: 2,
+    minCompatibleSchemaVersion: 2,
     revision: 3,
     nodes: [
       {
@@ -569,6 +601,32 @@ describe("SceneStore", () => {
       listeners.get("scene")!(validScenePayload({ revision: 9 }));
       expect(store.getScene().revision).toBe(9);
 
+      patch({ revision: 30, baseRevision: 29, ops: [] });
+      expect(resubscribes).toEqual(["scene", "scene"]);
+    });
+
+    // ADR-003 stage 3.5 review-fix (HIGH): a 4-lens adversarial review found
+    // that a resync whose OWN answer fails schema-version negotiation wedges
+    // gap-recovery shut permanently, since sceneResyncPending was only ever
+    // cleared by the scene bind() callback above - which a version-rejected
+    // frame never reaches (WsTransport withholds it before dispatch). Fixed
+    // by also clearing the flag the moment a rejection fires: any resync
+    // answer in flight is never coming through the normal channel anyway.
+    it("review-fix: a resync whose answer gets version-rejected does not wedge LATER gap recovery shut", () => {
+      const { patchListeners, versionRejectionListeners, resubscribes } = connectedStoreAtRevision3();
+      const patch = patchListeners.get("scene")!;
+
+      patch({ revision: 9, baseRevision: 8, ops: [] });
+      expect(resubscribes).toEqual(["scene"]);
+
+      // The resync's own answering snapshot is withheld for failing
+      // version negotiation - never delivered to the scene bind callback,
+      // simulating exactly what WsTransport.handleMessage does.
+      versionRejectionListeners.get("scene")!({ kind: "version", reason: "too old", details: [] });
+
+      // A second, unrelated gap arrives later. Without the fix,
+      // sceneResyncPending is still true from the first gap and this
+      // silently no-ops - resubscribes would stay ["scene"].
       patch({ revision: 30, baseRevision: 29, ops: [] });
       expect(resubscribes).toEqual(["scene", "scene"]);
     });
@@ -1438,6 +1496,62 @@ describe("SceneStore", () => {
     expect(listeners.size).toBe(4);
     store.dispose();
     expect(listeners.size).toBe(0);
+  });
+
+  // ADR-003 stage 3.5: the store's own responsibility is narrower than the
+  // transport's - it does not run checkSchemaCompatibility itself (that's
+  // transport.test.ts's job, and this file's fake transport bypasses it
+  // entirely - see makeFakeTransport's own comment). What belongs here is
+  // proving the store correctly WIRES to transport.onVersionRejection and
+  // exposes what it receives to React via getSceneVersionRejection.
+  describe("scene version rejection (ADR-003 stage 3.5)", () => {
+    it("starts with no rejection", () => {
+      const { transport } = makeFakeTransport();
+      const store = new SceneStore(transport);
+      store.connect();
+      expect(store.getSceneVersionRejection()).toBeNull();
+    });
+
+    it("subscribes to the transport's onVersionRejection for the scene topic specifically", () => {
+      const { transport, versionRejectionListeners } = makeFakeTransport();
+      const store = new SceneStore(transport);
+      store.connect();
+      expect(versionRejectionListeners.has("scene")).toBe(true);
+    });
+
+    it("reflects a rejection fired by the transport and notifies subscribers", () => {
+      const { transport, versionRejectionListeners } = makeFakeTransport();
+      const store = new SceneStore(transport);
+      const emits: number[] = [];
+      store.connect();
+      store.subscribe(() => emits.push(1));
+
+      const rejection = { kind: "version" as const, reason: "too old", details: [] };
+      versionRejectionListeners.get("scene")!(rejection);
+
+      expect(store.getSceneVersionRejection()).toEqual(rejection);
+      expect(emits).toHaveLength(1);
+    });
+
+    it("clears the rejection when the transport later reports null", () => {
+      const { transport, versionRejectionListeners } = makeFakeTransport();
+      const store = new SceneStore(transport);
+      store.connect();
+      versionRejectionListeners.get("scene")!({ kind: "version", reason: "too old", details: [] });
+      expect(store.getSceneVersionRejection()).not.toBeNull();
+
+      versionRejectionListeners.get("scene")!(null);
+      expect(store.getSceneVersionRejection()).toBeNull();
+    });
+
+    it("dispose() unsubscribes the version-rejection listener too", () => {
+      const { transport, versionRejectionListeners } = makeFakeTransport();
+      const store = new SceneStore(transport);
+      store.connect();
+      expect(versionRejectionListeners.has("scene")).toBe(true);
+      store.dispose();
+      expect(versionRejectionListeners.has("scene")).toBe(false);
+    });
   });
 });
 

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -22,6 +22,7 @@ import type { GridControlState } from "../../lib/bridge-core/generated/grid-cont
 import type { DragSpeedState } from "../../lib/bridge-core/generated/drag-speed-state";
 import type { FontControlState } from "../../lib/bridge-core/generated/font-control-state";
 import type { ScenePatch, StreamListener, WsTransport } from "../../lib/ws/transport";
+import type { BridgeRejection } from "../../lib/bridge-core/islandState";
 
 // ADR-003 stage 3.1 review-fix: matches composerStore's own
 // NATIVE_DIALOG_TIMEOUT_MS - pickGitlinkLocalRoot opens a native OS folder
@@ -160,6 +161,25 @@ export class SceneStore {
   // per patch - see requestSceneResync for the measured failure this
   // prevents.
   private sceneResyncPending = false;
+  // ADR-003 stage 3.5: non-null while the transport has withheld the scene
+  // topic's LAST WIRE FRAME for failing schema-version negotiation - see
+  // WsTransport.onVersionRejection. `scene` above simply stops being
+  // updated while this is non-null (see connect() below), so it is correct
+  // but stale by definition the moment this becomes non-null.
+  //
+  // Review-fix: this alone is NOT the store's full "safe to act on scene
+  // data" signal - see sceneVersionRecovering below and
+  // getSceneBlockingRejection, which is what SceneCanvas.tsx actually
+  // gates on. A 4-lens adversarial review additionally found that ONLY
+  // SceneCanvas checked any form of this signal: every sibling chrome
+  // surface (ViewPopover, Composer, PinOverlay, the command palette) read
+  // `scene` directly and fired real mutating intents completely
+  // unguarded. That gap is closed at the transport layer instead
+  // (WsTransport.setTopicBlocked, kept in sync by updateSceneBlockedState
+  // below) precisely because "never read `scene` without checking this
+  // first" is not enforceable per-reader - a transport-level send-side
+  // gate is.
+  private sceneVersionRejection: BridgeRejection | null = null;
 
   constructor(private readonly transport: WsTransport) {}
 
@@ -301,6 +321,12 @@ export class SceneStore {
       return false;
     }
     this.scene = candidate;
+    // Review-fix: a successfully-applied patch is proof this client is
+    // caught up, same as a fresh snapshot landing - see
+    // sceneVersionRecovering's own doc for the recovery-edge race this
+    // closes.
+    this.sceneVersionRecovering = false;
+    this.updateSceneBlockedState();
     this.emit();
     return true;
   }
@@ -312,6 +338,9 @@ export class SceneStore {
         // ADR-003 stage 3.4 review-fix: the snapshot that closes an
         // outstanding resync request - see requestSceneResync below.
         this.sceneResyncPending = false;
+        // Review-fix: a full snapshot is also proof of being caught up.
+        this.sceneVersionRecovering = false;
+        this.updateSceneBlockedState();
       }),
       this.bind<GridControlState>("grid-control", (v) => (this.grid = v)),
       this.bind<DragSpeedState>("drag-speed", (v) => (this.dragConfig = v)),
@@ -322,7 +351,75 @@ export class SceneStore {
       this.transport.subscribePatch("scene", (patch) => {
         if (!this.applyScenePatch(patch)) this.requestSceneResync();
       }),
+      // ADR-003 stage 3.5: fires immediately with the current (usually null)
+      // state on subscribe, then again on every change - see
+      // onVersionRejection's own doc for why that matters for a component
+      // mounting after the first frame already arrived.
+      //
+      // Review-fix (2 findings from a 4-lens adversarial review, fixed
+      // together since they share the same root cause):
+      //
+      // HIGH: sceneResyncPending is cleared only by the scene bind above,
+      // which a version-rejected frame never reaches (checkVersionAndMaybeReject
+      // withholds it before dispatch) - so a resync whose own answer gets
+      // version-rejected wedges gap-recovery shut for the rest of the
+      // connection: requestSceneResync's `if (this.sceneResyncPending)
+      // return` guard silently no-ops for every LATER, unrelated gap too,
+      // with no timeout or fallback except a full transport reconnect.
+      // Fixed by clearing it here the moment a rejection fires: the
+      // resync's answer (if one was in flight) is never coming through the
+      // normal channel, so there is nothing left to wait for.
+      //
+      // MEDIUM: clearing sceneVersionRejection the instant a COMPATIBLE
+      // frame arrives is correct for a snapshot (SceneCanvas can safely
+      // unblock immediately - the bind above just replaced `scene`
+      // wholesale) but wrong for a patch: WsTransport clears the rejection
+      // synchronously in handleMessage BEFORE dispatching the patch to
+      // this store's own patchListener, so SceneCanvas can unblock and
+      // mount CanvasInner against the OLD, frozen-during-the-outage
+      // `scene` object for one tick, before applyScenePatch (a few lines
+      // below) even runs to discover the patch doesn't apply (its
+      // baseRevision reflects everything that happened server-side during
+      // the outage) and request a resync - transiently reproducing the
+      // exact "stale canvas" failure mode this whole stage exists to
+      // prevent, on the recovery edge instead of the entry edge. Fixed by
+      // sceneVersionRecovering: set true here whenever a rejection fires,
+      // cleared only once a frame is actually confirmed applied (the scene
+      // bind above, or applyScenePatch's own success path) - SceneCanvas
+      // gates on getSceneBlockingRejection(), which stays non-null across
+      // that whole window, not on the raw wire-level rejection alone.
+      this.transport.onVersionRejection("scene", (rejection) => {
+        this.sceneVersionRejection = rejection;
+        if (rejection !== null) {
+          this.sceneVersionRecovering = true;
+          this.sceneResyncPending = false;
+        }
+        this.updateSceneBlockedState();
+        this.emit();
+      }),
     );
+  }
+
+  /** ADR-003 stage 3.5 review-fix: true from the moment a rejection fires
+   * until a frame is CONFIRMED applied (not merely until the wire-level
+   * check passes) - see onVersionRejection's own doc above for the
+   * recovery-edge race this closes. */
+  private sceneVersionRecovering = false;
+
+  private isSceneBlocked(): boolean {
+    return this.sceneVersionRejection !== null || this.sceneVersionRecovering;
+  }
+
+  /** ADR-003 stage 3.5 review-fix: keeps the transport's topic-block gate
+   * (WsTransport.setTopicBlocked) in sync with this store's own combined
+   * blocked signal, so every scene-mutating call site - not just the
+   * canvas viewport - refuses to send while this client cannot currently
+   * trust the scene topic's data. A 4-lens adversarial review found this
+   * gap: only SceneCanvas checked getSceneVersionRejection; ViewPopover,
+   * Composer, PinOverlay, and the command palette all kept firing real
+   * scene-topic intents completely unguarded. */
+  private updateSceneBlockedState(): void {
+    this.transport.setTopicBlocked("scene", this.isSceneBlocked());
   }
 
   /** ADR-003 stage 3.4: recover from a detected patch gap by asking for a
@@ -373,6 +470,33 @@ export class SceneStore {
   };
 
   getScene = (): SceneState => this.scene;
+  /** Raw wire-level signal: was the LAST frame received for the scene topic
+   * incompatible? Kept for direct inspection/tests; SceneCanvas.tsx itself
+   * gates on getSceneBlockingRejection below, not this. */
+  getSceneVersionRejection = (): BridgeRejection | null => this.sceneVersionRejection;
+  // ADR-003 stage 3.5 review-fix: a single stable instance, not allocated
+  // fresh inside the getter below - useSyncExternalStore compares
+  // successive getSnapshot() results with Object.is, so a fresh object
+  // literal on every call reads as "changed" on every render and drives
+  // React into "Maximum update depth exceeded" (caught by this stage's own
+  // SceneCanvas.test.tsx recovery test, not by inspection).
+  private static readonly RECOVERING_REJECTION: BridgeRejection = {
+    kind: "version",
+    reason: "Recovering the canvas after a version mismatch…",
+    details: [],
+  };
+
+  /** ADR-003 stage 3.5 review-fix: what SceneCanvas.tsx actually renders
+   * BridgeErrorState from. Combines the raw wire-level rejection with the
+   * brief post-recovery window (sceneVersionRecovering) where a compatible
+   * frame has arrived but scene data has not yet been confirmed caught up
+   * - see connect()'s onVersionRejection callback for the race this
+   * closes. */
+  getSceneBlockingRejection = (): BridgeRejection | null => {
+    if (this.sceneVersionRejection) return this.sceneVersionRejection;
+    if (this.sceneVersionRecovering) return SceneStore.RECOVERING_REJECTION;
+    return null;
+  };
   getGrid = (): GridControlState => this.grid;
   getDragConfig = (): DragSpeedState => this.dragConfig;
   getFontConfig = (): FontControlState => this.fontConfig;

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -83,6 +83,53 @@ body,
   color: var(--gl-surface-text-primary);
 }
 
+/* ADR-003 stage 3.5: BridgeErrorState.tsx, first live wiring. Fills the
+   canvas region it replaces (SceneCanvas.tsx renders this INSTEAD of
+   CanvasInner, never alongside it) rather than floating as a small toast -
+   a version-skew rejection means every canvas control behind it would be
+   acting on state the desktop app no longer agrees with, so the whole
+   surface reads as unavailable, not just annotated. Palette matches
+   .notification-banner/.notification-error, the app's one other "something
+   is wrong" precedent, rather than inventing a second one. */
+.scene-bridge-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  height: 100%;
+  padding: 32px;
+  text-align: center;
+  background-color: var(--gl-surface-window);
+  border-top: 2px solid var(--gl-semantic-status-error, var(--gl-surface-border));
+}
+
+.bridge-error-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--gl-surface-text-bright);
+}
+
+.bridge-error-reason {
+  max-width: 480px;
+  font-size: 13px;
+  color: var(--gl-surface-text-primary);
+}
+
+.bridge-error-details {
+  max-width: 480px;
+  margin: 0;
+  padding-left: 20px;
+  font-size: 12px;
+  color: var(--gl-surface-text-secondary);
+  text-align: left;
+}
+
+.bridge-error-hint {
+  font-size: 12px;
+  color: var(--gl-surface-text-muted);
+}
+
 .app-canvas-region {
   position: relative;
   flex: 1;

--- a/web_ui/src/lib/bridge-core/schemaVersion.ts
+++ b/web_ui/src/lib/bridge-core/schemaVersion.ts
@@ -27,8 +27,15 @@
  * validator, which is exactly what "additive fields allowed" means.
  */
 
-/** The payload version this build of the island reads. */
-export const READER_SCHEMA_VERSION = 1;
+/** The payload version this build of the island reads.
+ *
+ * ADR-003 stage 3.5: bumped to 2 alongside the backend's `scene` topic
+ * (backend/canvas.py's `register_topic("scene", ..., schema_version=2,
+ * min_compatible=2)`) - this build understands the stage 3.4 patch
+ * protocol (`kind:"patch"` frames), which an older reader does not. Every
+ * other topic stays at server-side schema_version=1 and is unaffected: a
+ * sender's version floor of 1 is satisfied by any reader version >= 1. */
+export const READER_SCHEMA_VERSION = 2;
 
 /** The oldest payload version this build can still read correctly. */
 export const READER_MIN_COMPATIBLE_SCHEMA_VERSION = 1;

--- a/web_ui/src/lib/ui/BridgeErrorState.tsx
+++ b/web_ui/src/lib/ui/BridgeErrorState.tsx
@@ -19,6 +19,18 @@ import type { BridgeRejection } from "../bridge-core/islandState";
  * remain deferred: none of them yet have two independent real
  * implementations to generalize a correct shape from.
  *
+ * Historical note (a 4-lens adversarial review of ADR-003 stage 3.5 found
+ * this paragraph had gone stale and asked for it to be corrected rather
+ * than left implying current-day precedent that isn't there to check): the
+ * 4 islands above existed in the pre-consolidation islands architecture
+ * (deleted in commit 5b0b764, itself superseded two days later by the
+ * chrome-consolidation rewrite in 5434b40, which did not carry this
+ * wiring forward). None of today's Composer.tsx/TokenCounter.tsx/
+ * NotificationBanner.tsx/CommandPalette.tsx render this component. The
+ * scene topic (SceneCanvas.tsx, ADR-003 stage 3.5) is this component's
+ * first REAL live usage - the reference to copy from if wiring one of
+ * those 4 (or a future 5th) island up to this for real.
+ *
  * className is intentionally still owned by the calling island, not baked
  * in here - each island's own background/border/width for its error surface
  * legitimately differs (token-counter is a fixed-width HUD panel; the

--- a/web_ui/src/lib/ws/transport.storeIntegration.test.ts
+++ b/web_ui/src/lib/ws/transport.storeIntegration.test.ts
@@ -113,3 +113,99 @@ describe("real WsTransport wired to a real store (end-to-end fireIntent -> showE
     );
   });
 });
+
+// ADR-003 stage 3.5 review-fix: a 4-lens adversarial review found this exact
+// class of gap again - every layer's OWN test (transport.test.ts,
+// sceneStore.test.ts, SceneCanvas.test.tsx) mocks the boundary immediately
+// below the code it exercises, so nothing proved the real WsTransport ->
+// real SceneStore wiring (the topic-key match, the field shapes) actually
+// works end to end. sceneStore.test.ts's own makeFakeTransport explicitly
+// bypasses WsTransport.handleMessage/checkSchemaCompatibility entirely -
+// this file's whole reason to exist, per its own header doc above, is
+// closing exactly this gap for fireIntent/showError; it was not extended to
+// cover version rejection when that stage landed.
+describe("real WsTransport wired to a real SceneStore (end-to-end version rejection)", () => {
+  it("an incompatible scene frame reaches SceneStore.getSceneBlockingRejection() through the REAL transport pipeline", () => {
+    const { transport, socket } = connectRealTransport();
+    const store = new SceneStore(transport);
+    store.connect();
+    expect(store.getSceneBlockingRejection()).toBeNull();
+
+    socket.receive({
+      kind: "state",
+      topic: "scene",
+      payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [], edges: [], pins: [] },
+    });
+
+    const rejection = store.getSceneBlockingRejection();
+    expect(rejection).toMatchObject({ kind: "version" });
+    expect(rejection!.reason).toContain("99");
+    // And the incompatible payload never reached `scene` itself.
+    expect(store.getScene().nodes).toEqual([]);
+  });
+
+  it("a subsequent compatible snapshot clears it, through the REAL transport pipeline", () => {
+    const { transport, socket } = connectRealTransport();
+    const store = new SceneStore(transport);
+    store.connect();
+
+    socket.receive({
+      kind: "state",
+      topic: "scene",
+      payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [], edges: [], pins: [] },
+    });
+    expect(store.getSceneBlockingRejection()).not.toBeNull();
+
+    socket.receive({
+      kind: "state",
+      topic: "scene",
+      payload: {
+        schemaVersion: 2,
+        minCompatibleSchemaVersion: 2,
+        revision: 1,
+        nodes: [],
+        edges: [],
+        pins: [],
+        snapToGrid: false,
+        fadeConnectionsEnabled: false,
+        orthogonalRouting: false,
+        smartGuides: false,
+        hasSavedChat: false,
+        dragFactor: 1,
+        fontFamily: "Segoe UI",
+        fontSizePt: 9,
+        fontColor: "#F0F0F0",
+      },
+    });
+    expect(store.getSceneBlockingRejection()).toBeNull();
+  });
+
+  it("a real mutating intent is blocked and surfaced via showError while the scene topic is version-rejected", async () => {
+    const { transport, socket } = connectRealTransport();
+    const store = new SceneStore(transport);
+    store.connect();
+
+    socket.receive({
+      kind: "state",
+      topic: "scene",
+      payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [], edges: [], pins: [] },
+    });
+
+    store.addNode(0, 0, "hello");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The addNode intent itself never reached the wire...
+    expect(socket.sent.map((raw) => JSON.parse(raw))).not.toContainEqual(
+      expect.objectContaining({ topic: "scene", intent: "addNode" }),
+    );
+    // ...and a visible error was surfaced instead of silent loss - closing
+    // the exact gap the review found: only the canvas viewport was blocked,
+    // while every sibling call site (ViewPopover, Composer, PinOverlay, the
+    // command palette - all of which ultimately call the same store methods
+    // exercised here) kept firing real intents completely unguarded.
+    expect(socket.sent.map((raw) => JSON.parse(raw))).toContainEqual(
+      expect.objectContaining({ topic: "notification", intent: "showError" }),
+    );
+  });
+});

--- a/web_ui/src/lib/ws/transport.test.ts
+++ b/web_ui/src/lib/ws/transport.test.ts
@@ -1,5 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { WsRequestError, WsTimeoutError, WsTransport, WsUnavailableError } from "./transport";
+import { WsRequestError, WsTimeoutError, WsTopicBlockedError, WsTransport, WsUnavailableError } from "./transport";
+import { READER_SCHEMA_VERSION } from "../bridge-core/schemaVersion";
+
+// ADR-003 stage 3.5: every real `kind:"state"`/`kind:"patch"` frame carries
+// a schemaVersion (backend/events.py's _Topic._stamp/`_publish_now` stamp it
+// unconditionally, for every topic, not just scene - see
+// test_event_bus.py's own assertion on a generic test topic). Fixtures below
+// that predate this stage used bare payloads because nothing checked the
+// field yet; they now use the reader's OWN current version rather than a
+// hardcoded number, so a future version bump does not silently make them
+// start failing for a reason unrelated to what each test actually verifies.
 
 class FakeSocket {
   static instances: FakeSocket[] = [];
@@ -63,8 +73,12 @@ describe("WsTransport", () => {
     socket.open();
     expect(socket.lastSent()).toEqual({ kind: "subscribe", topics: ["system"] });
 
-    socket.receive({ kind: "state", topic: "system", payload: { app: "graphlink", revision: 1 } });
-    expect(seen).toEqual([{ app: "graphlink", revision: 1 }]);
+    socket.receive({
+      kind: "state",
+      topic: "system",
+      payload: { schemaVersion: READER_SCHEMA_VERSION, app: "graphlink", revision: 1 },
+    });
+    expect(seen).toEqual([{ schemaVersion: READER_SCHEMA_VERSION, app: "graphlink", revision: 1 }]);
   });
 
   it("subscribing a NEW topic while open sends subscribe immediately", () => {
@@ -85,7 +99,7 @@ describe("WsTransport", () => {
     t.connect();
     const socket = FakeSocket.instances[0];
     socket.open();
-    socket.receive({ kind: "state", topic: "a", payload: { x: 1 } });
+    socket.receive({ kind: "state", topic: "a", payload: { schemaVersion: READER_SCHEMA_VERSION, x: 1 } });
     expect(a).toHaveLength(1);
     expect(b).toHaveLength(0);
   });
@@ -414,6 +428,7 @@ describe("WsTransport", () => {
     socket.receive({
       kind: "patch",
       topic: "scene",
+      schemaVersion: READER_SCHEMA_VERSION,
       revision: 7,
       baseRevision: 6,
       ops: [{ op: "removeNodes", ids: ["n0"] }],
@@ -433,7 +448,14 @@ describe("WsTransport", () => {
     const snapshots: unknown[] = [];
     t.subscribe("scene", (payload) => snapshots.push(payload));
 
-    socket.receive({ kind: "patch", topic: "scene", revision: 2, baseRevision: 1, ops: [] });
+    socket.receive({
+      kind: "patch",
+      topic: "scene",
+      schemaVersion: READER_SCHEMA_VERSION,
+      revision: 2,
+      baseRevision: 1,
+      ops: [],
+    });
 
     expect(snapshots).toEqual([]);
   });
@@ -445,7 +467,14 @@ describe("WsTransport", () => {
     const socket = FakeSocket.instances[0];
     socket.open();
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-    socket.receive({ kind: "patch", topic: "grid-control", revision: 2, baseRevision: 1, ops: [] });
+    socket.receive({
+      kind: "patch",
+      topic: "grid-control",
+      schemaVersion: READER_SCHEMA_VERSION,
+      revision: 2,
+      baseRevision: 1,
+      ops: [],
+    });
     expect(consoleError).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
@@ -458,7 +487,14 @@ describe("WsTransport", () => {
     const seen: unknown[] = [];
     const off = t.subscribePatch("scene", (patch) => seen.push(patch));
     off();
-    socket.receive({ kind: "patch", topic: "scene", revision: 2, baseRevision: 1, ops: [] });
+    socket.receive({
+      kind: "patch",
+      topic: "scene",
+      schemaVersion: READER_SCHEMA_VERSION,
+      revision: 2,
+      baseRevision: 1,
+      ops: [],
+    });
     expect(seen).toEqual([]);
   });
 
@@ -564,5 +600,352 @@ describe("WsTransport", () => {
     socket.open();
     socket.close();
     expect(statuses).toEqual(["closed", "connecting", "open", "closed"]);
+  });
+
+  // ADR-003 stage 3.5: version negotiation moved here from the dead
+  // bridge-core/islandState.ts path. A `minCompatibleSchemaVersion` set
+  // absurdly high (rather than hand-computing "one more than the current
+  // reader") is deliberate - it stays correct across any future reader
+  // version bump instead of silently under-testing the boundary again the
+  // way transport.test.ts's own pre-3.5 fixtures under-tested this exact
+  // gap by omitting the field entirely.
+  describe("schema-version negotiation (ADR-003 stage 3.5)", () => {
+    it("withholds an incompatible state frame from the topic's snapshot listener", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      const seen: unknown[] = [];
+      t.subscribe("scene", (p) => seen.push(p));
+
+      socket.receive({
+        kind: "state",
+        topic: "scene",
+        payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [] },
+      });
+
+      expect(seen).toEqual([]);
+    });
+
+    it("withholds an incompatible patch frame from the topic's patch listener", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      const seen: unknown[] = [];
+      t.subscribePatch("scene", (p) => seen.push(p));
+
+      socket.receive({
+        kind: "patch",
+        topic: "scene",
+        schemaVersion: 2,
+        minCompatibleSchemaVersion: 99,
+        revision: 2,
+        baseRevision: 1,
+        ops: [],
+      });
+
+      expect(seen).toEqual([]);
+    });
+
+    it("publishes the rejection through onVersionRejection, with a human-readable reason", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      const seen: (unknown | null)[] = [];
+      t.onVersionRejection("scene", (r) => seen.push(r));
+
+      socket.receive({
+        kind: "state",
+        topic: "scene",
+        payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [] },
+      });
+
+      // First call is the immediate "no rejection yet" delivery on subscribe.
+      expect(seen).toHaveLength(2);
+      expect(seen[0]).toBeNull();
+      expect(seen[1]).toMatchObject({ kind: "version" });
+      expect((seen[1] as { reason: string }).reason).toContain("99");
+    });
+
+    it("onVersionRejection delivers the CURRENT state immediately on subscribe, matching onStatus's contract", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      socket.receive({
+        kind: "state",
+        topic: "scene",
+        payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [] },
+      });
+
+      // Subscribing AFTER the rejection already happened must not require a
+      // second incompatible frame to find out about it.
+      const seen: (unknown | null)[] = [];
+      t.onVersionRejection("scene", (r) => seen.push(r));
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toMatchObject({ kind: "version" });
+    });
+
+    it("a subsequent compatible frame clears the rejection and resumes normal dispatch", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      const rejections: (unknown | null)[] = [];
+      const snapshots: unknown[] = [];
+      t.onVersionRejection("scene", (r) => rejections.push(r));
+      t.subscribe("scene", (p) => snapshots.push(p));
+
+      socket.receive({
+        kind: "state",
+        topic: "scene",
+        payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [] },
+      });
+      expect(snapshots).toEqual([]);
+
+      socket.receive({
+        kind: "state",
+        topic: "scene",
+        payload: { schemaVersion: 2, minCompatibleSchemaVersion: 2, nodes: [] },
+      });
+
+      expect(rejections.at(-1)).toBeNull();
+      expect(snapshots).toEqual([{ schemaVersion: 2, minCompatibleSchemaVersion: 2, nodes: [] }]);
+    });
+
+    it("does not re-fire the rejection listener for repeated frames with the identical reason", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      const seen: (unknown | null)[] = [];
+      t.onVersionRejection("scene", (r) => seen.push(r));
+
+      const badFrame = {
+        kind: "state" as const,
+        topic: "scene",
+        payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [] },
+      };
+      socket.receive(badFrame);
+      socket.receive(badFrame);
+      socket.receive(badFrame);
+
+      // The immediate null delivery on subscribe, plus exactly ONE rejection.
+      expect(seen).toHaveLength(2);
+    });
+
+    it("rejection on one topic does not affect a different topic's listener", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      const sceneRejections: (unknown | null)[] = [];
+      const gridSeen: unknown[] = [];
+      t.onVersionRejection("scene", (r) => sceneRejections.push(r));
+      t.subscribe("grid-control", (p) => gridSeen.push(p));
+
+      socket.receive({
+        kind: "state",
+        topic: "scene",
+        payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [] },
+      });
+      socket.receive({
+        kind: "state",
+        topic: "grid-control",
+        payload: { schemaVersion: READER_SCHEMA_VERSION, snapToGrid: false },
+      });
+
+      expect(sceneRejections.at(-1)).toMatchObject({ kind: "version" });
+      expect(gridSeen).toEqual([{ schemaVersion: READER_SCHEMA_VERSION, snapToGrid: false }]);
+    });
+
+    // Review-fix (test-coverage gap): the test above only pairs one
+    // REJECTED topic with one COMPATIBLE topic - nothing proved two
+    // DIFFERENT topics could be simultaneously rejected, each keeping its
+    // own distinct reason and clearing independently. The dedup/rejection
+    // state is correctly per-topic by construction (keyed Maps), but
+    // nothing would have caught a future refactor that accidentally
+    // hoisted any of it onto a shared field.
+    it("review-fix: two topics can be simultaneously rejected with independent reasons, and clear independently", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      const sceneRejections: (unknown | null)[] = [];
+      const gridRejections: (unknown | null)[] = [];
+      t.onVersionRejection("scene", (r) => sceneRejections.push(r));
+      t.onVersionRejection("grid-control", (r) => gridRejections.push(r));
+
+      socket.receive({
+        kind: "state",
+        topic: "scene",
+        payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [] },
+      });
+      socket.receive({
+        kind: "state",
+        topic: "grid-control",
+        payload: { schemaVersion: 1, minCompatibleSchemaVersion: 50, snapToGrid: false },
+      });
+
+      expect(sceneRejections.at(-1)).toMatchObject({ kind: "version" });
+      expect(gridRejections.at(-1)).toMatchObject({ kind: "version" });
+      expect((sceneRejections.at(-1) as { reason: string }).reason).toContain("99");
+      expect((gridRejections.at(-1) as { reason: string }).reason).toContain("50");
+      expect(sceneRejections.at(-1)).not.toEqual(gridRejections.at(-1));
+
+      // Re-sending scene's identical bad frame must not re-fire scene NOR
+      // touch grid-control's independent rejection.
+      socket.receive({
+        kind: "state",
+        topic: "scene",
+        payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [] },
+      });
+      expect(sceneRejections).toHaveLength(2); // immediate-null + the one rejection
+      expect(gridRejections).toHaveLength(2);
+
+      // Clearing scene must not clear grid-control.
+      socket.receive({
+        kind: "state",
+        topic: "scene",
+        payload: { schemaVersion: 2, minCompatibleSchemaVersion: 2, nodes: [] },
+      });
+      expect(sceneRejections.at(-1)).toBeNull();
+      expect(gridRejections.at(-1)).toMatchObject({ kind: "version" });
+    });
+  });
+
+  // ADR-003 stage 3.5 review-fix: closes a real gap a 4-lens adversarial
+  // review found - only SceneCanvas checked any form of version-rejection
+  // signal; every OTHER scene-mutating call site (ViewPopover, Composer,
+  // PinOverlay, the command palette - all ~84 of sceneStore.ts's own
+  // fireIntent call sites) fired real intents completely unguarded while
+  // the client had just declared it could not trust the topic's data.
+  // setTopicBlocked is the single choke point that closes all of them at
+  // once, since every one of those call sites already funnels through
+  // request()/intent().
+  describe("setTopicBlocked (ADR-003 stage 3.5 review-fix)", () => {
+    it("request() (and so fireIntent()) rejects with WsTopicBlockedError for a blocked topic", async () => {
+      const t = makeTransport();
+      t.connect();
+      FakeSocket.instances[0].open();
+      t.setTopicBlocked("scene", true);
+
+      await expect(t.request("scene", "addNode", [0, 0, "x"])).rejects.toBeInstanceOf(WsTopicBlockedError);
+    });
+
+    it("fireIntent() surfaces a blocked-topic rejection via showError - NOT swallowed like WsUnavailableError", async () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      t.setTopicBlocked("scene", true);
+
+      t.fireIntent("scene", "addNode", [0, 0, "x"]);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(socket.sent.map((raw) => JSON.parse(raw))).toContainEqual(
+        expect.objectContaining({ topic: "notification", intent: "showError" }),
+      );
+      // And the blocked intent itself was never actually sent.
+      expect(socket.sent.map((raw) => JSON.parse(raw))).not.toContainEqual(
+        expect.objectContaining({ topic: "scene", intent: "addNode" }),
+      );
+    });
+
+    it("intent() silently no-ops for a blocked topic, same posture as not-connected", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      t.setTopicBlocked("scene", true);
+
+      t.intent("scene", "setSnapToGrid", [true]);
+      expect(socket.sent).toHaveLength(0);
+    });
+
+    it("unblocking resumes normal send behavior", async () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      t.setTopicBlocked("scene", true);
+      t.setTopicBlocked("scene", false);
+
+      const p = t.request("scene", "addNode", [0, 0, "x"]);
+      const sent = socket.lastSent();
+      expect(sent).toMatchObject({ topic: "scene", intent: "addNode" });
+      socket.receive({ kind: "result", id: sent.id, value: null });
+      await expect(p).resolves.toBeNull();
+    });
+
+    it("blocking one topic does not affect a different topic's request()/intent()", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      t.setTopicBlocked("scene", true);
+
+      t.intent("notification", "showInfo", ["still works"]);
+      expect(socket.lastSent()).toEqual({
+        kind: "intent",
+        topic: "notification",
+        intent: "showInfo",
+        args: ["still works"],
+      });
+    });
+  });
+
+  // Review-fix (LOW, defensive): versionRejections had no cleanup path when
+  // a topic's listeners all unsubscribe, unlike every sibling registry in
+  // this file. Not a live bug (the app's one real subscriber never
+  // unsubscribes), but a genuine asymmetry - a short-lived subscriber that
+  // unsubscribed from a rejected topic and later resubscribed would
+  // otherwise see the transport immediately replay the stale prior
+  // rejection instead of starting clean.
+  it("review-fix: forgets a topic's cached rejection once every listener of every kind has unsubscribed", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+
+    const off = t.onVersionRejection("scene", () => {});
+    socket.receive({
+      kind: "state",
+      topic: "scene",
+      payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [] },
+    });
+    off();
+
+    // A brand-new subscriber must see a clean "no rejection yet" state, not
+    // the stale one left behind by the unsubscribed listener above.
+    const seen: (unknown | null)[] = [];
+    t.onVersionRejection("scene", (r) => seen.push(r));
+    expect(seen).toEqual([null]);
+  });
+
+  it("review-fix: does NOT forget the cached rejection while a state/patch listener is still attached", () => {
+    // The cleanup must be keyed off ALL three per-topic registries, not
+    // versionRejectionListeners alone - a topic can have a live snapshot
+    // listener with no rejection listener attached.
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+
+    t.subscribe("scene", () => {}); // stays attached
+    const offRejection = t.onVersionRejection("scene", () => {});
+    socket.receive({
+      kind: "state",
+      topic: "scene",
+      payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, nodes: [] },
+    });
+    offRejection();
+
+    const seen: (unknown | null)[] = [];
+    t.onVersionRejection("scene", (r) => seen.push(r));
+    expect(seen).toEqual([{ kind: "version", reason: expect.any(String), details: [] }]);
   });
 });

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -39,9 +39,19 @@
  * "swallow only what I explicitly know is already visible elsewhere",
  * closing the gap a future new rejection reason could otherwise silently
  * fall into again.
+ *
+ * ADR-003 stage 3.5: schema-version negotiation moved here from the dead
+ * bridge-core/islandState.ts path (built, unit-tested, never wired to
+ * anything live). Every `state`/`patch` frame is checked with the shared
+ * checkSchemaCompatibility() algorithm before being dispatched to any
+ * listener; an incompatible frame is withheld and the topic's rejection is
+ * published through onVersionRejection() instead - see that method and
+ * lib/ui/BridgeErrorState.tsx, the component this is finally wired to.
  */
 
 import { withAuthToken } from "../auth/token";
+import { checkSchemaCompatibility } from "../bridge-core/schemaVersion";
+import type { BridgeRejection } from "../bridge-core/islandState";
 
 export type ConnectionStatus = "connecting" | "open" | "closed";
 
@@ -69,6 +79,23 @@ export class WsTimeoutError extends Error {}
  * pre-migration fire-and-forget behavior exactly. */
 export class WsUnavailableError extends Error {}
 
+/** ADR-003 stage 3.5 review-fix: raised by request() (and so also by
+ * fireIntent(), which wraps it) for a topic currently marked blocked via
+ * setTopicBlocked() - today, exclusively the "scene" topic while its
+ * incoming data has failed schema-version negotiation (see
+ * onVersionRejection). Deliberately NOT a WsUnavailableError: the
+ * connection is genuinely open, and fireIntent's catch surfaces everything
+ * except WsUnavailableError by default specifically so a new rejection
+ * reason is visible unless someone explicitly opts it into the swallowed
+ * set - this is the case where that visibility matters most, since sending
+ * a mutating intent against data the client has just declared it cannot
+ * currently trust is exactly the scenario a 4-lens adversarial review of
+ * this stage found completely unguarded outside the canvas viewport
+ * itself (ViewPopover, Composer, PinOverlay, and the command palette all
+ * kept firing real scene-topic intents while BridgeErrorState blocked only
+ * the canvas). */
+export class WsTopicBlockedError extends Error {}
+
 export type StateListener = (payload: Record<string, unknown>) => void;
 export type StatusListener = (status: ConnectionStatus) => void;
 export type StreamListener = (delta: string, done: boolean, reset: boolean, seq: number) => void;
@@ -95,6 +122,13 @@ export interface ScenePatch {
 }
 
 export type PatchListener = (patch: ScenePatch) => void;
+
+/** ADR-003 stage 3.5: `rejection` is non-null while the last `kind:"state"`
+ * or `kind:"patch"` frame for this topic failed schema-version negotiation,
+ * and null once a compatible frame has been seen (including the very first
+ * one, or none yet). Mirrors StatusListener's own "always fires immediately
+ * with the current value on subscribe" contract - see onVersionRejection. */
+export type VersionRejectionListener = (rejection: BridgeRejection | null) => void;
 
 interface WsLike {
   send(data: string): void;
@@ -150,6 +184,18 @@ export class WsTransport {
    * `kind:"state"` frame unchanged, and only patch frames route here, so a
    * consumer that never opts into patches keeps working untouched. */
   private readonly patchListeners = new Map<string, Set<PatchListener>>();
+  /** ADR-003 stage 3.5: keyed by topic, like stateListeners/patchListeners.
+   * A topic absent from this map has never seen an incompatible frame -
+   * getVersionRejection()/onVersionRejection() treat that the same as an
+   * explicit null (compatible). */
+  private readonly versionRejections = new Map<string, BridgeRejection | null>();
+  private readonly versionRejectionListeners = new Map<string, Set<VersionRejectionListener>>();
+  /** ADR-003 stage 3.5 review-fix: topics for which intent()/request() (and
+   * so fireIntent(), which wraps request()) currently refuse to send - see
+   * setTopicBlocked()'s own doc. Generic per-topic gate, not scene-specific
+   * logic baked into the transport: any caller can block/unblock any topic
+   * for any reason. */
+  private readonly blockedTopics = new Set<string>();
   private readonly pending = new Map<
     number,
     { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
@@ -240,6 +286,7 @@ export class WsTransport {
     return () => {
       set.delete(listener);
       if (set.size === 0) this.stateListeners.delete(topic);
+      this.maybeForgetTopic(topic);
     };
   }
 
@@ -272,6 +319,7 @@ export class WsTransport {
     return () => {
       set.delete(listener);
       if (set.size === 0) this.patchListeners.delete(topic);
+      this.maybeForgetTopic(topic);
     };
   }
 
@@ -299,10 +347,76 @@ export class WsTransport {
     return () => this.statusListeners.delete(listener);
   }
 
+  /** ADR-003 stage 3.5: listen for a topic's schema-version compatibility.
+   * Fires immediately with the topic's CURRENT rejection state (null if none
+   * yet), then again on every change - same "deliver current state on
+   * subscribe" contract as onStatus above, so a component mounting after the
+   * first frame already arrived does not have to wait for a second one to
+   * find out it was incompatible. See handleMessage()'s state/patch branches
+   * for where this is actually decided. */
+  onVersionRejection(topic: string, listener: VersionRejectionListener): () => void {
+    let set = this.versionRejectionListeners.get(topic);
+    if (!set) {
+      set = new Set();
+      this.versionRejectionListeners.set(topic, set);
+    }
+    set.add(listener);
+    listener(this.versionRejections.get(topic) ?? null);
+    return () => {
+      set.delete(listener);
+      if (set.size === 0) this.versionRejectionListeners.delete(topic);
+      this.maybeForgetTopic(topic);
+    };
+  }
+
+  /** ADR-003 stage 3.5 review-fix: drops `versionRejections`' cached entry
+   * for `topic` once nothing is listening to it via ANY of the three
+   * per-topic registries - state, patch, or rejection. Keyed off all three
+   * (not just versionRejectionListeners alone) deliberately: a topic can
+   * still have live state/patch listeners with no rejection listener
+   * attached, and forgetting the cache in that case would make the NEXT
+   * onVersionRejection subscriber see a false "compatible" reading instead
+   * of the topic's real last-known status until another frame arrives.
+   * Without this, a short-lived subscriber that unsubscribes from a
+   * rejected topic and later re-subscribes would see the transport replay
+   * the stale prior rejection immediately, rather than starting clean the
+   * way a never-before-seen topic does - harmless today (the app's one
+   * real subscriber, SceneStore, never unsubscribes for its own lifetime)
+   * but an asymmetry with this file's own established per-topic cleanup
+   * convention every other registry already follows. */
+  private maybeForgetTopic(topic: string): void {
+    if (this.stateListeners.has(topic)) return;
+    if (this.patchListeners.has(topic)) return;
+    if (this.versionRejectionListeners.has(topic)) return;
+    this.versionRejections.delete(topic);
+  }
+
+  /** ADR-003 stage 3.5 review-fix: blocks intent()/request() (and so
+   * fireIntent()) for `topic`, so a mutating call site cannot send against
+   * data this client currently cannot trust - e.g. the scene topic during
+   * a version-rejection episode (see onVersionRejection). Closes a real
+   * gap a 4-lens adversarial review found: only the canvas viewport was
+   * gated on scene version-rejection, while every sibling chrome surface
+   * (Composer, ViewPopover, PinOverlay, the command palette) kept firing
+   * real scene-topic intents completely unguarded, directly contradicting
+   * BridgeErrorState's own stated rationale for existing at all.
+   *
+   * A single choke point here - not 84 individual call-site edits in
+   * sceneStore.ts - because every one of those call sites already funnels
+   * through intent()/request(); gating here covers all of them, present
+   * and future, without touching any of them. */
+  setTopicBlocked(topic: string, blocked: boolean): void {
+    if (blocked) this.blockedTopics.add(topic);
+    else this.blockedTopics.delete(topic);
+  }
+
   /** Fire-and-forget intent (the @Slot successor). Silently dropped when the
    * socket is not open - matching the old bridge's pre-connect no-op call()
-   * semantics that every island already codes against. */
+   * semantics that every island already codes against. Also silently
+   * dropped for a blocked topic (see setTopicBlocked), same posture: this
+   * method's whole contract is "no reply, nothing to surface." */
   intent(topic: string, intent: string, args: unknown[] = []): void {
+    if (this.blockedTopics.has(topic)) return;
     if (this.status !== "open" || !this.socket) return;
     this.socket.send(JSON.stringify({ kind: "intent", topic, intent, args }));
   }
@@ -313,6 +427,13 @@ export class WsTransport {
    * operation (a native OS file/folder picker, say) needs a much longer
    * window than the default 10s. */
   request(topic: string, intent: string, args: unknown[] = [], timeoutMs?: number): Promise<unknown> {
+    if (this.blockedTopics.has(topic)) {
+      return Promise.reject(
+        new WsTopicBlockedError(
+          "Can't send changes - the desktop app and this interface currently disagree about the data format.",
+        ),
+      );
+    }
     if (this.status !== "open" || !this.socket) {
       return Promise.reject(new WsUnavailableError("not connected"));
     }
@@ -394,9 +515,19 @@ export class WsTransport {
     }
     const kind = message.kind;
     if (kind === "state") {
-      const listeners = this.stateListeners.get(message.topic as string);
+      const topic = message.topic as string;
+      const payload = message.payload as Record<string, unknown>;
+      // ADR-003 stage 3.5: the version envelope lives INSIDE payload for a
+      // state frame (see _Topic._stamp on the backend) - checked and, on
+      // rejection, dispatched to NOTHING below. A rejected payload is stale
+      // by definition (BridgeErrorState.tsx's own doc), so silently handing
+      // it to a listener would be strictly worse than the pre-3.5 behavior
+      // this stage exists to replace: at least the old frozen-UI failure
+      // mode didn't also risk running shape validation against fields a
+      // breaking version change may have renamed or removed.
+      if (!this.checkVersionAndMaybeReject(topic, payload)) return;
+      const listeners = this.stateListeners.get(topic);
       if (listeners) {
-        const payload = message.payload as Record<string, unknown>;
         for (const listener of [...listeners]) listener(payload);
       }
       return;
@@ -408,7 +539,13 @@ export class WsTransport {
       // into snapshots only (every topic except scene today) is a supported
       // configuration, not an anomaly - same posture as the stream branch
       // below, and deliberately unlike the unknown-kind fallback at the end.
-      const listeners = this.patchListeners.get(message.topic as string);
+      const topic = message.topic as string;
+      // ADR-003 stage 3.5: unlike a state frame, the version envelope is at
+      // the TOP LEVEL of a patch frame, a sibling of ops/revision (see
+      // _publish_now's broadcast dict on the backend) - `message` itself is
+      // what gets checked, not a sub-object.
+      if (!this.checkVersionAndMaybeReject(topic, message)) return;
+      const listeners = this.patchListeners.get(topic);
       if (listeners) {
         const patch: ScenePatch = {
           revision: message.revision as number,
@@ -453,6 +590,36 @@ export class WsTransport {
     if (this.status === status) return;
     this.status = status;
     for (const listener of [...this.statusListeners]) listener(status);
+  }
+
+  /** ADR-003 stage 3.5: runs the shared checkSchemaCompatibility() algorithm
+   * (bridge-core/schemaVersion.ts - the same one BridgeErrorState's now-live
+   * caller uses) against an incoming frame, updates the topic's rejection
+   * state, and returns whether the caller should proceed to dispatch. `on`
+   * is either the state frame's `payload` or the patch frame's `message`
+   * itself - see the two call sites for which. */
+  private checkVersionAndMaybeReject(topic: string, on: unknown): boolean {
+    const verdict = checkSchemaCompatibility(on);
+    if (!verdict.compatible) {
+      this.setVersionRejection(topic, { kind: "version", reason: verdict.reason, details: [] });
+      return false;
+    }
+    this.setVersionRejection(topic, null);
+    return true;
+  }
+
+  private setVersionRejection(topic: string, rejection: BridgeRejection | null): void {
+    const current = this.versionRejections.get(topic) ?? null;
+    // Dedup by reason text, not reference: two independently-constructed
+    // rejections for the same ongoing skew must not re-fire listeners on
+    // every single subsequent frame while it persists.
+    if (current === rejection) return;
+    if (current !== null && rejection !== null && current.reason === rejection.reason) return;
+    this.versionRejections.set(topic, rejection);
+    const listeners = this.versionRejectionListeners.get(topic);
+    if (listeners) {
+      for (const listener of [...listeners]) listener(rejection);
+    }
   }
 
   private scheduleReconnect(): void {


### PR DESCRIPTION
## Problem

The client had no way to detect it was talking to a backend whose wire shape it doesn't understand. The version-check algorithm existed (built earlier, fully unit-tested) but was never wired to anything live — a version-skewed frame just silently froze the UI on stale data, with nothing on screen indicating anything was wrong.

Concretely: the stage 3.4 patch protocol (`kind:"patch"`) is a real breaking change for a reader that predates it. Such a frame used to hit the transport's unknown-kind fallback and get silently dropped — a stale, not-yet-rebuilt frontend bundle would keep subscribing successfully and then simply never update again.

## Change

`WsTransport.handleMessage` now checks every `kind:"state"`/`kind:"patch"` frame against the schema-version envelope before dispatching to any listener. An incompatible frame is withheld; the topic's rejection is published through a new `onVersionRejection` API. The scene topic bumps to `schemaVersion=2, min_compatible=2` (every other topic is unaffected).

`SceneCanvas` renders `BridgeErrorState` — a component built in an earlier increment and never actually imported anywhere — instead of mounting the canvas while scene is rejected, matching that component's own "replace, don't decorate" design.

## Verified against a real running app

Temporarily forced a version-skew condition (`min_compatible=99`) against the actual built frontend and backend, confirmed via the live accessibility tree that the canvas shows:

> **Canvas unavailable** — The desktop app requires an interface of at least schema version 99, but this one is version 2. The bundled interface is out of date.

...while the rest of the app chrome (toolbar, composer, connection badge) kept working normally around it. Reverted, confirmed normal operation resumes.

## A 4-lens adversarial review found 10 confirmed issues — all fixed here, not just logged

- **HIGH** — a resync whose own answering snapshot got version-rejected wedged gap-recovery shut *permanently* for the rest of the connection (nothing else could ever trigger a retry).
- **MEDIUM** — recovering via a compatible *patch* (the normal steady-state path, not a snapshot) cleared the blocking error one tick before the store confirmed the patch actually applied — the canvas could flash stale pre-outage data for a frame.
- **HIGH+MEDIUM** (two lenses independently found the same gap) — only the canvas viewport was gated. Every sibling surface — ViewPopover, Composer, PinOverlay, the command palette — kept firing real mutating intents completely unguarded against data the client had just declared it couldn't trust. Fixed with a single choke point (`WsTransport.setTopicBlocked`, checked inside `request()`/`intent()`) rather than editing ~84 individual call sites in `sceneStore.ts`.
- Two test-coverage gaps: no test exercised a *real* `WsTransport` wired to a *real* `SceneStore` for this path end to end (every layer mocked the boundary immediately below it — the same class of gap stage 3.1 already had to close once for `fireIntent`/`showError`); nothing proved two topics could be independently rejected without cross-contaminating the shared dedup logic.
- Two stale doc comments (one pre-existing, unrelated to this diff) and one defensive `Map` cleanup asymmetry.

**The review-fix pass caught its own bug in flight:** the first version of the recovery-window getter allocated a fresh object on every call, which `useSyncExternalStore` read as "changed" on every render — drove React straight into "Maximum update depth exceeded." Caught immediately by this stage's own new test, not by inspection. Fixed with a single cached instance.

## Test plan

- [x] Full backend suite: `pytest -q` — 1648 passed, 14 skipped
- [x] Full frontend suite: `npm run check` — 1319 passed (54 files), 0 TypeScript errors
- [x] Mutation-tested the core gating logic and every review-fix (revert → confirm the intended test fails → restore)
- [x] Real end-to-end browser verification against a live backend (see above)
- [x] New real `WsTransport`+`SceneStore` integration tests in `transport.storeIntegration.test.ts`