### PR TITLE
ADR-003 stage 3.6: offline intent queue + reconnecting state

### DIFF
--- a/web_ui/src/app/App.test.tsx
+++ b/web_ui/src/app/App.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * ADR-003 stage 3.6: the connection badge's own text.
+ *
+ * This is the user-visible half of the stage's exit criterion ("visible paused
+ * state") - and until this file existed, nothing in the suite covered the
+ * badge at all, in any status. It was verified once by hand against a real
+ * running app, which proves it worked that day but is not a regression guard.
+ */
+import { describe, expect, it } from "vitest";
+import { connectionBadgeLabel } from "./connectionBadge";
+
+describe("connectionBadgeLabel (ADR-003 stage 3.6)", () => {
+  it("says a session is paused while reconnecting, not just the bare status", () => {
+    // The exact wording matters: the ADR's decision text names this string as
+    // what the badge "gains", and it is the app's only answer to "why didn't
+    // my click do anything" while intents are being queued or refused.
+    expect(connectionBadgeLabel("reconnecting")).toBe("reconnecting — actions paused");
+  });
+
+  it("distinguishes the first-ever connect from a reconnect", () => {
+    // "connecting" is the very first attempt - nothing was ever working, so
+    // there is no in-progress session to report as paused. Collapsing these
+    // two into one label is exactly the pre-3.6 behaviour this stage changed.
+    expect(connectionBadgeLabel("connecting")).toBe("connecting");
+    expect(connectionBadgeLabel("connecting")).not.toBe(connectionBadgeLabel("reconnecting"));
+  });
+
+  it("keeps the established labels for the pre-existing statuses", () => {
+    expect(connectionBadgeLabel("open")).toBe("connected");
+    expect(connectionBadgeLabel("closed")).toBe("closed");
+  });
+});

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -4,6 +4,7 @@ import { TOPIC_VALIDATORS } from "../lib/api-contract/topics";
 import type { AppSettingsState } from "../lib/bridge-core/generated/app-settings-state";
 import { isTextEditable } from "../lib/bridge-core/textFocus";
 import { ConnectionStatus, WsTransport, defaultWsUrl } from "../lib/ws/transport";
+import { connectionBadgeLabel } from "./connectionBadge";
 import { ExecutionLimitsProvider } from "./canvas/ExecutionLimitsContext";
 import { SceneCanvas, measuredNodeSize } from "./canvas/SceneCanvas";
 import { SceneStore } from "./canvas/sceneStore";
@@ -281,7 +282,7 @@ function App() {
             <span className="app-title">Graphlink</span>
             <AppBar store={sceneStore} />
             <span className={`app-conn app-conn-${status}`} title={`backend ${system.backendVersion ?? ""}`}>
-              {status === "open" ? "connected" : status}
+              {connectionBadgeLabel(status)}
             </span>
           </header>
 

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -565,7 +565,7 @@ export class SceneStore {
   }
 
   setChatCollapsed(id: string, collapsed: boolean): void {
-    this.transport.fireIntent("scene", "setChatCollapsed", [id, collapsed]);
+    this.transport.fireIntent("scene", "setChatCollapsed", [id, collapsed], undefined, true);
   }
 
   // R7.5e: legacy's "Collapse All Nodes"/"Expand All Nodes" (graphlink_
@@ -575,11 +575,11 @@ export class SceneStore {
   // scene intent (organizeNodes, ...): the new is_collapsed values arrive
   // through the next scene snapshot, nothing synchronous needed here.
   collapseAllNodes(): void {
-    this.transport.fireIntent("scene", "collapseAllNodes", []);
+    this.transport.fireIntent("scene", "collapseAllNodes", [], undefined, true);
   }
 
   expandAllNodes(): void {
-    this.transport.fireIntent("scene", "expandAllNodes", []);
+    this.transport.fireIntent("scene", "expandAllNodes", [], undefined, true);
   }
 
   // R3.9/R3.10: real document nodes (attachments). Unlike chat/code,
@@ -718,7 +718,7 @@ export class SceneStore {
   }
 
   setNodeDocked(id: string, docked: boolean): void {
-    this.transport.fireIntent("scene", "setNodeDocked", [id, docked]);
+    this.transport.fireIntent("scene", "setNodeDocked", [id, docked], undefined, true);
   }
 
   // R4.3c: real Regenerate Response, for both ChatNodeView's own menu and
@@ -793,7 +793,7 @@ export class SceneStore {
   }
 
   setGitlinkLocalRoot(nodeId: string, localRoot: string): void {
-    this.transport.fireIntent("scene", "setGitlinkLocalRoot", [nodeId, localRoot]);
+    this.transport.fireIntent("scene", "setGitlinkLocalRoot", [nodeId, localRoot], undefined, true);
   }
 
   // Opens the real native OS folder picker (backend/native_dialogs.py, the
@@ -850,7 +850,7 @@ export class SceneStore {
   // only validator of that value; this store has no opinion on it, same
   // posture as applyGitlinkChanges's fingerprint passthrough above.
   setPyCoderMode(nodeId: string, mode: string): void {
-    this.transport.fireIntent("scene", "setPyCoderMode", [nodeId, mode]);
+    this.transport.fireIntent("scene", "setPyCoderMode", [nodeId, mode], undefined, true);
   }
 
   // inputText's meaning (a natural-language prompt vs hand-typed code) is
@@ -878,7 +878,7 @@ export class SceneStore {
   // WS-intent layer - CodeSandboxNodeView is the one that decides whether
   // that's currently sensible to allow (see its own Run-enablement comment).
   setCodeSandboxRequirements(nodeId: string, requirementsText: string): void {
-    this.transport.fireIntent("scene", "setCodeSandboxRequirements", [nodeId, requirementsText]);
+    this.transport.fireIntent("scene", "setCodeSandboxRequirements", [nodeId, requirementsText], undefined, true);
   }
 
   // ADR-005 stage 5.5: the approval panel's own source-build opt-in
@@ -962,7 +962,7 @@ export class SceneStore {
   }
 
   moveNode(id: string, x: number, y: number): void {
-    this.transport.fireIntent("scene", "moveNode", [id, x, y]);
+    this.transport.fireIntent("scene", "moveNode", [id, x, y], undefined, true);
   }
 
   // R6.1 follow-up: a group drag's commit (the group's own node PLUS every
@@ -974,10 +974,15 @@ export class SceneStore {
   // grow a box (rather than staying frozen, the bug the growth logic
   // itself was fixing).
   moveNodes(positions: Array<{ id: string; x: number; y: number }>): void {
+    // ADR-003 stage 3.6: queueable - a position commit is idempotent
+    // last-write-wins, the ADR's own literal "move" example, and the
+    // exit-criterion scenario (kill the server mid-drag) this stage names.
     this.transport.fireIntent(
       "scene",
       "moveNodes",
       [positions.map((p) => [p.id, p.x, p.y])],
+      undefined,
+      true,
     );
   }
 
@@ -998,7 +1003,7 @@ export class SceneStore {
   }
 
   updatePin(id: string, title: string, note: string): void {
-    this.transport.fireIntent("scene", "updatePin", [id, title, note]);
+    this.transport.fireIntent("scene", "updatePin", [id, title, note], undefined, true);
   }
 
   removePin(id: string): void {
@@ -1006,27 +1011,27 @@ export class SceneStore {
   }
 
   setSnapToGrid(enabled: boolean): void {
-    this.transport.fireIntent("scene", "setSnapToGrid", [enabled]);
+    this.transport.fireIntent("scene", "setSnapToGrid", [enabled], undefined, true);
   }
 
   // R7.5b-1: same bare-bool/"scene"-topic shape as setSnapToGrid above.
   setFadeConnections(enabled: boolean): void {
-    this.transport.fireIntent("scene", "setFadeConnections", [enabled]);
+    this.transport.fireIntent("scene", "setFadeConnections", [enabled], undefined, true);
   }
 
   // R7.5b-2: same shape again - intent name matches the legacy
   // GridControlBridge's own setOrthogonalConnections Slot name 1:1.
   setOrthogonalConnections(enabled: boolean): void {
-    this.transport.fireIntent("scene", "setOrthogonalConnections", [enabled]);
+    this.transport.fireIntent("scene", "setOrthogonalConnections", [enabled], undefined, true);
   }
 
   // R7.5b-3: the fourth and final legacy grid-control toggle.
   setSmartGuides(enabled: boolean): void {
-    this.transport.fireIntent("scene", "setSmartGuides", [enabled]);
+    this.transport.fireIntent("scene", "setSmartGuides", [enabled], undefined, true);
   }
 
   setDragFactor(factor: number): void {
-    this.transport.fireIntent("scene", "setDragFactor", [factor]);
+    this.transport.fireIntent("scene", "setDragFactor", [factor], undefined, true);
   }
 
   organizeNodes(): void {
@@ -1072,7 +1077,7 @@ export class SceneStore {
   }
 
   setNoteContent(nodeId: string, content: string): void {
-    this.transport.fireIntent("scene", "setNoteContent", [nodeId, content]);
+    this.transport.fireIntent("scene", "setNoteContent", [nodeId, content], undefined, true);
   }
 
   createFrame(itemIds: string[]): void {
@@ -1097,22 +1102,22 @@ export class SceneStore {
   // below: the backend validates/does the work, and the new value arrives
   // through the next scene snapshot like any other mutation.
   setBranchStatus(nodeId: string, status: string): void {
-    this.transport.fireIntent("scene", "setBranchStatus", [nodeId, status]);
+    this.transport.fireIntent("scene", "setBranchStatus", [nodeId, status], undefined, true);
   }
 
   setFinalDeliverable(nodeId: string, isFinal: boolean): void {
-    this.transport.fireIntent("scene", "setFinalDeliverable", [nodeId, isFinal]);
+    this.transport.fireIntent("scene", "setFinalDeliverable", [nodeId, isFinal], undefined, true);
   }
 
   collapseBranch(nodeId: string, collapsed: boolean): void {
-    this.transport.fireIntent("scene", "collapseBranch", [nodeId, collapsed]);
+    this.transport.fireIntent("scene", "collapseBranch", [nodeId, collapsed], undefined, true);
   }
 
   // Shared setter for frame/container header-note/title text (backend/
   // canvas.py's set_group_label) - reused verbatim for both kinds, same
   // posture as setGroupColor below.
   setGroupLabel(nodeId: string, text: string): void {
-    this.transport.fireIntent("scene", "setGroupLabel", [nodeId, text]);
+    this.transport.fireIntent("scene", "setGroupLabel", [nodeId, text], undefined, true);
   }
 
   // Shared color setter for note/frame/container kinds. Either argument may
@@ -1120,9 +1125,17 @@ export class SceneStore {
   // (GroupColorPicker's "Reset to Default" item) passes (null, null) for a
   // full reset, or one real hex + null for a single-half set.
   setGroupColor(nodeId: string, color: string | null, headerColor: string | null): void {
-    this.transport.fireIntent("scene", "setGroupColor", [nodeId, color, headerColor]);
+    this.transport.fireIntent("scene", "setGroupColor", [nodeId, color, headerColor], undefined, true);
   }
 
+  // ADR-003 stage 3.6: deliberately NOT queueable, unlike the set*/resize*
+  // neighbours here. The backend handler flips (`is_locked = not is_locked`,
+  // groups.py) rather than setting an explicit value, so it is not
+  // idempotent - and fireIntent re-queues an intent that was genuinely in
+  // flight when the socket died, a case where the server may well have
+  // APPLIED it already and only the reply was lost. Replaying then toggles a
+  // SECOND time and silently reverts the user's action. Same reasoning for
+  // toggleGroupCollapsed and toggleChartAspectLock.
   toggleFrameLock(nodeId: string): void {
     this.transport.fireIntent("scene", "toggleFrameLock", [nodeId]);
   }
@@ -1132,11 +1145,11 @@ export class SceneStore {
   }
 
   resizeFrame(nodeId: string, width: number, height: number): void {
-    this.transport.fireIntent("scene", "resizeFrame", [nodeId, width, height]);
+    this.transport.fireIntent("scene", "resizeFrame", [nodeId, width, height], undefined, true);
   }
 
   fitFrameToContent(nodeId: string): void {
-    this.transport.fireIntent("scene", "fitFrameToContent", [nodeId]);
+    this.transport.fireIntent("scene", "fitFrameToContent", [nodeId], undefined, true);
   }
 
   ungroup(nodeId: string): void {
@@ -1174,9 +1187,10 @@ export class SceneStore {
   }
 
   resizeChart(nodeId: string, width: number, height: number): void {
-    this.transport.fireIntent("scene", "resizeChart", [nodeId, width, height]);
+    this.transport.fireIntent("scene", "resizeChart", [nodeId, width, height], undefined, true);
   }
 
+  // Not queueable - flips rather than sets; see toggleFrameLock's own comment.
   toggleChartAspectLock(nodeId: string): void {
     this.transport.fireIntent("scene", "toggleChartAspectLock", [nodeId]);
   }
@@ -1197,45 +1211,45 @@ export class SceneStore {
   // through it at all.
 
   setViewState(zoomFactor: number, scrollX: number, scrollY: number): void {
-    this.transport.fireIntent("scene", "setViewState", [zoomFactor, scrollX, scrollY]);
+    this.transport.fireIntent("scene", "setViewState", [zoomFactor, scrollX, scrollY], undefined, true);
   }
 
   setHtmlSplitterState(nodeId: string, value: number): void {
-    this.transport.fireIntent("scene", "setHtmlSplitterState", [nodeId, value]);
+    this.transport.fireIntent("scene", "setHtmlSplitterState", [nodeId, value], undefined, true);
   }
 
   setChatScrollValue(nodeId: string, value: number): void {
-    this.transport.fireIntent("scene", "setChatScrollValue", [nodeId, value]);
+    this.transport.fireIntent("scene", "setChatScrollValue", [nodeId, value], undefined, true);
   }
 
   // Grid intents ride the grid-control topic; font intents ride scene - both
   // keep the legacy bridges' @Slot names 1:1 (backend/canvas.py contract).
   setGridSize(size: number): void {
-    this.transport.fireIntent("grid-control", "setGridSize", [size]);
+    this.transport.fireIntent("grid-control", "setGridSize", [size], undefined, true);
   }
 
   setGridOpacityPercent(percent: number): void {
-    this.transport.fireIntent("grid-control", "setGridOpacityPercent", [percent]);
+    this.transport.fireIntent("grid-control", "setGridOpacityPercent", [percent], undefined, true);
   }
 
   setGridStyle(style: string): void {
-    this.transport.fireIntent("grid-control", "setGridStyle", [style]);
+    this.transport.fireIntent("grid-control", "setGridStyle", [style], undefined, true);
   }
 
   setGridColor(hex: string): void {
-    this.transport.fireIntent("grid-control", "setGridColor", [hex]);
+    this.transport.fireIntent("grid-control", "setGridColor", [hex], undefined, true);
   }
 
   setFontFamily(family: string): void {
-    this.transport.fireIntent("scene", "setFontFamily", [family]);
+    this.transport.fireIntent("scene", "setFontFamily", [family], undefined, true);
   }
 
   setFontSize(sizePt: number): void {
-    this.transport.fireIntent("scene", "setFontSize", [sizePt]);
+    this.transport.fireIntent("scene", "setFontSize", [sizePt], undefined, true);
   }
 
   setFontColor(hex: string): void {
-    this.transport.fireIntent("scene", "setFontColor", [hex]);
+    this.transport.fireIntent("scene", "setFontColor", [hex], undefined, true);
   }
 
   // Rides the notification topic, not scene - same "this store already

--- a/web_ui/src/app/chrome/ChatLibraryDialog.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.tsx
@@ -197,7 +197,7 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
   function commitRename() {
     const title = renameDraft.trim();
     if (renamingId === null || !title) return;
-    transport.fireIntent("app-chat-library", "renameChat", [renamingId, title]);
+    transport.fireIntent("app-chat-library", "renameChat", [renamingId, title], undefined, true);
     setRenamingId(null);
     lastTriggerRef.current?.focus();
   }

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -160,7 +160,7 @@ function GeneralPage({
         <input
           type="checkbox"
           checked={state.showTokenCounter}
-          onChange={(event) => transport.fireIntent("app-settings", "setShowTokenCounter", [event.target.checked])}
+          onChange={(event) => transport.fireIntent("app-settings", "setShowTokenCounter", [event.target.checked], undefined, true)}
         />
         Show Token Counter Overlay
       </label>
@@ -169,7 +169,7 @@ function GeneralPage({
         <input
           type="checkbox"
           checked={state.enableSystemPrompt}
-          onChange={(event) => transport.fireIntent("app-settings", "setEnableSystemPrompt", [event.target.checked])}
+          onChange={(event) => transport.fireIntent("app-settings", "setEnableSystemPrompt", [event.target.checked], undefined, true)}
         />
         Enable Assistant System Prompt
       </label>
@@ -182,7 +182,7 @@ function GeneralPage({
               type="checkbox"
               checked={state.notificationPreferences[type] ?? true}
               onChange={(event) =>
-                transport.fireIntent("app-settings", "setNotificationPreference", [type, event.target.checked])
+                transport.fireIntent("app-settings", "setNotificationPreference", [type, event.target.checked], undefined, true)
               }
             />
             {NOTIFICATION_TYPE_LABELS[type]}
@@ -310,7 +310,7 @@ function ApiProviderPage({
           ariaLabel="API Provider"
           value={viewingProvider}
           options={API_PROVIDERS.map((provider) => ({ id: provider, label: provider }))}
-          onChange={(id) => transport.fireIntent("app-settings", "setViewingApiProvider", [id])}
+          onChange={(id) => transport.fireIntent("app-settings", "setViewingApiProvider", [id], undefined, true)}
         />
       </div>
 
@@ -514,7 +514,7 @@ function OllamaTaskField({
           onChange={(nextMode) => {
             setUiMode(nextMode);
             if (nextMode !== "explicit") {
-              transport.fireIntent("app-settings", "setOllamaModelAssignment", [task, nextMode]);
+              transport.fireIntent("app-settings", "setOllamaModelAssignment", [task, nextMode], undefined, true);
             }
           }}
         />
@@ -527,7 +527,7 @@ function OllamaTaskField({
             className="settings-select"
             list={OLLAMA_MODELS_DATALIST_ID}
             value={isSpecial ? "" : value}
-            onChange={(event) => transport.fireIntent("app-settings", "setOllamaModelAssignment", [task, event.target.value])}
+            onChange={(event) => transport.fireIntent("app-settings", "setOllamaModelAssignment", [task, event.target.value], undefined, true)}
           />
         </label>
       )}
@@ -548,7 +548,7 @@ function OllamaPage({ state, transport }: { state: AppSettingsState; transport: 
               type="radio"
               name="ollama-reasoning-level"
               checked={state.ollamaReasoningLevel === option.id}
-              onChange={() => transport.fireIntent("app-settings", "setOllamaReasoningLevel", [option.id])}
+              onChange={() => transport.fireIntent("app-settings", "setOllamaReasoningLevel", [option.id], undefined, true)}
             />
             {option.label}
           </label>
@@ -727,7 +727,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
               type="radio"
               name="llama-cpp-reasoning-level"
               checked={state.llamaCppReasoningLevel === option.id}
-              onChange={() => transport.fireIntent("app-settings", "setLlamaCppReasoningLevel", [option.id])}
+              onChange={() => transport.fireIntent("app-settings", "setLlamaCppReasoningLevel", [option.id], undefined, true)}
             />
             {option.label}
           </label>
@@ -774,7 +774,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
               { id: "", label: "Select a scanned model..." },
               ...state.llamaCppScannedModels.map((path) => ({ id: path, label: basename(path) })),
             ]}
-            onChange={(path) => transport.fireIntent("app-settings", "setLlamaCppChatModelPath", [path])}
+            onChange={(path) => transport.fireIntent("app-settings", "setLlamaCppChatModelPath", [path], undefined, true)}
           />
         </div>
       )}
@@ -801,7 +801,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
               { id: "", label: "Select a scanned model..." },
               ...state.llamaCppScannedModels.map((path) => ({ id: path, label: basename(path) })),
             ]}
-            onChange={(path) => transport.fireIntent("app-settings", "setLlamaCppTitleModelPath", [path])}
+            onChange={(path) => transport.fireIntent("app-settings", "setLlamaCppTitleModelPath", [path], undefined, true)}
           />
         </div>
       )}
@@ -827,7 +827,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
           value={draftChatFormat}
           onChange={(event) => {
             setDraftChatFormat(event.target.value);
-            transport.fireIntent("app-settings", "setLlamaCppChatFormat", [event.target.value]);
+            transport.fireIntent("app-settings", "setLlamaCppChatFormat", [event.target.value], undefined, true);
           }}
         />
       </label>
@@ -838,14 +838,14 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
         min={256}
         max={131072}
         step={256}
-        onCommit={(n) => transport.fireIntent("app-settings", "setLlamaCppNCtx", [n])}
+        onCommit={(n) => transport.fireIntent("app-settings", "setLlamaCppNCtx", [n], undefined, true)}
       />
       <LlamaCppNumberField
         label="GPU Layers"
         value={state.llamaCppNGpuLayers}
         min={-1}
         max={9999}
-        onCommit={(n) => transport.fireIntent("app-settings", "setLlamaCppNGpuLayers", [n])}
+        onCommit={(n) => transport.fireIntent("app-settings", "setLlamaCppNGpuLayers", [n], undefined, true)}
       />
       <LlamaCppNumberField
         label="CPU Threads"
@@ -853,7 +853,7 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
         min={0}
         max={256}
         placeholder="0 = Auto"
-        onCommit={(n) => transport.fireIntent("app-settings", "setLlamaCppNThreads", [n])}
+        onCommit={(n) => transport.fireIntent("app-settings", "setLlamaCppNThreads", [n], undefined, true)}
       />
 
       {state.llamaCppNotice && (
@@ -917,7 +917,7 @@ export function SettingsDialog({ transport }: { transport: WsTransport }) {
               type="button"
               className={"settings-rail-button" + (section === activeSection ? " active" : "")}
               aria-current={section === activeSection ? "page" : undefined}
-              onClick={() => transport.fireIntent("app-settings", "setActiveSection", [sectionKey(section)])}
+              onClick={() => transport.fireIntent("app-settings", "setActiveSection", [sectionKey(section)], undefined, true)}
             >
               {section}
             </button>

--- a/web_ui/src/app/chrome/composerStore.ts
+++ b/web_ui/src/app/chrome/composerStore.ts
@@ -143,18 +143,22 @@ export class ComposerStore {
   // -- intents (backend/composer.py + notifications.py, 1:1) --------------
 
   updateDraft(text: string): void {
-    this.transport.fireIntent("app-composer", "updateDraft", [text]);
+    // ADR-003 stage 3.6: queueable - the single most textbook idempotent
+    // last-write-wins case in the app; a keystroke autosave lost to a
+    // dropped connection is the exact "vanishes silently" gap this stage
+    // exists to close.
+    this.transport.fireIntent("app-composer", "updateDraft", [text], undefined, true);
   }
 
   selectModel(modelId: string): void {
     // R8a: writes the chat-task model assignment. The backend routes this
     // through the same helper the Settings > Ollama page uses, so the two
     // surfaces cannot report different models.
-    this.transport.fireIntent("app-composer", "selectModel", [modelId]);
+    this.transport.fireIntent("app-composer", "selectModel", [modelId], undefined, true);
   }
 
   setReasoningLevel(level: string): void {
-    this.transport.fireIntent("app-composer", "setReasoningLevel", [level]);
+    this.transport.fireIntent("app-composer", "setReasoningLevel", [level], undefined, true);
   }
 
   attachFile(): void {

--- a/web_ui/src/app/connectionBadge.ts
+++ b/web_ui/src/app/connectionBadge.ts
@@ -1,0 +1,28 @@
+/**
+ * The connection badge's user-facing text (rendered by App.tsx's topbar).
+ *
+ * Its own module rather than an export from App.tsx: `react-refresh/
+ * only-export-components` correctly flags a component file that also exports
+ * a plain function, and the rule's own advice is to move it here. Being
+ * separate also means a test can pin these strings without standing up
+ * ReactFlow, the overlay provider and a live WsTransport.
+ */
+import type { ConnectionStatus } from "../lib/ws/transport";
+
+/**
+ * ADR-003 stage 3.6: "reconnecting" gets a real sentence rather than the bare
+ * status word, because it is the badge's own visible answer to "why didn't my
+ * click do anything" - a session WAS in progress, and intents fired right now
+ * are being queued or refused rather than sent (see WsTransport.fireIntent).
+ *
+ * First-ever "connecting" deliberately keeps the bare word: nothing was ever
+ * working yet, so there is nothing paused to report. "closed" likewise stays
+ * bare, and after this stage's review-fix it means what it says - the
+ * transport has given up, no retry is scheduled - rather than being published
+ * for the whole backoff wait between attempts (see transport.ts's onclose).
+ */
+export function connectionBadgeLabel(status: ConnectionStatus): string {
+  if (status === "open") return "connected";
+  if (status === "reconnecting") return "reconnecting — actions paused";
+  return status;
+}

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -83,6 +83,14 @@ body,
   color: var(--gl-surface-text-primary);
 }
 
+/* ADR-003 stage 3.6: a real session existed and is currently paused, not
+   the muted/understated styling app-conn's base rule gives "connecting"
+   (first load, nothing was ever working) - warrants standing out the same
+   way .notification-error already does for "something needs attention". */
+.app-conn-reconnecting {
+  color: var(--gl-semantic-status-error, var(--gl-surface-text-primary));
+}
+
 /* ADR-003 stage 3.5: BridgeErrorState.tsx, first live wiring. Fills the
    canvas region it replaces (SceneCanvas.tsx renders this INSTEAD of
    CanvasInner, never alongside it) rather than floating as a small toast -

--- a/web_ui/src/lib/ws/queueableClassificationGuard.test.ts
+++ b/web_ui/src/lib/ws/queueableClassificationGuard.test.ts
@@ -1,0 +1,94 @@
+/**
+ * ADR-003 stage 3.6: repo-hygiene ratchet for the ONE way the offline intent
+ * queue can silently corrupt user data - marking a NON-IDEMPOTENT intent
+ * `queueable: true`.
+ *
+ * fireIntent's 5th argument opts an intent into being held while the socket is
+ * closed and replayed on reconnect. That is only safe when replaying is
+ * indistinguishable from delivering once: a `set*` intent carries the value it
+ * wants, so applying it twice lands on the same state. A `toggle*` intent does
+ * NOT - the backend handler flips (`node.state.is_locked = not
+ * node.state.is_locked`, backend/domain/groups.py), so a second application
+ * undoes the first.
+ *
+ * That second application is reachable, not theoretical: fireIntent re-queues
+ * an intent that was genuinely IN FLIGHT when the socket died (the
+ * WsUnavailableError branch), and in that window the server may already have
+ * received and applied it - only the reply was lost. The replay then flips the
+ * value back and the user's action silently reverts. This was a real
+ * misclassification caught during stage 3.6's own review of its call sites;
+ * this guard is what stops it being reintroduced.
+ *
+ * KNOWN LIMITATION, stated rather than papered over (same posture as
+ * wireTypeCastGuard.test.ts's own documented gap): this keys off the `toggle`
+ * NAMING CONVENTION, not semantic analysis of the backend handler. An intent
+ * that flips a value without saying "toggle" in its name is equally unsafe and
+ * equally invisible here. The convention holds across every intent in the
+ * codebase today (checked against backend/api/intents_*.py), so this is a
+ * limitation of the tool's reach, not a live undetected violation - but a
+ * reviewer adding a new flip-style intent must still think, and should extend
+ * NON_IDEMPOTENT_PREFIXES below rather than assuming a green test means safe.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync, globSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_SRC = join(HERE, "..", "..", "app");
+
+const NON_IDEMPOTENT_PREFIXES = ["toggle"];
+
+/** Captures one whole fireIntent(...) statement, up to the `)` that is
+ * followed by `;`. Tolerates the multi-line formatting prettier gives the
+ * longer call sites (moveNodes) and nested parens inside the args array
+ * (`positions.map((p) => [...])`), neither of which puts `);` inside itself. */
+const FIRE_INTENT_RE = /fireIntent\(([\s\S]{0,500}?)\)\s*;/g;
+const INTENT_NAME_RE = /"[^"]*"\s*,\s*"([^"]+)"/;
+/** The 5th positional arg. Trailing comma is prettier's, for multi-line calls. */
+const QUEUEABLE_RE = /,\s*true\s*,?\s*$/;
+
+interface CallSite {
+  file: string;
+  intent: string;
+  queueable: boolean;
+}
+
+function collectFireIntentCallSites(): CallSite[] {
+  const files = globSync("**/*.{ts,tsx}", { cwd: APP_SRC })
+    .filter((f) => !f.endsWith(".test.ts") && !f.endsWith(".test.tsx"))
+    .map((f) => join(APP_SRC, f));
+
+  const sites: CallSite[] = [];
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    for (const match of source.matchAll(FIRE_INTENT_RE)) {
+      const args = match[1];
+      const name = INTENT_NAME_RE.exec(args);
+      if (!name) continue;
+      sites.push({ file, intent: name[1], queueable: QUEUEABLE_RE.test(args) });
+    }
+  }
+  return sites;
+}
+
+describe("queueable intent classification (ADR-003 stage 3.6)", () => {
+  // Guards the guard: a regex that silently matched nothing would make every
+  // assertion below vacuously true, which is exactly the false-confidence
+  // failure this stage's review was hunting for.
+  it("finds the real fireIntent call sites at all", () => {
+    const sites = collectFireIntentCallSites();
+    expect(sites.length).toBeGreaterThan(100);
+    expect(sites.some((s) => s.intent === "moveNodes" && s.queueable)).toBe(true);
+    expect(sites.some((s) => s.intent === "sendMessage" && !s.queueable)).toBe(true);
+  });
+
+  it("never marks a non-idempotent toggle* intent queueable", () => {
+    const offenders = collectFireIntentCallSites()
+      .filter((s) => s.queueable)
+      .filter((s) => NON_IDEMPOTENT_PREFIXES.some((p) => s.intent.startsWith(p)))
+      .map((s) => `${s.intent} (${s.file})`);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/web_ui/src/lib/ws/transport.test.ts
+++ b/web_ui/src/lib/ws/transport.test.ts
@@ -355,7 +355,11 @@ describe("WsTransport", () => {
     const first = FakeSocket.instances[0];
     first.open();
     first.close();
-    expect(t.getStatus()).toBe("closed");
+    // ADR-003 stage 3.6 review-fix: this asserted "closed" until a reconnect
+    // was scheduled AND entered. A drop that will be retried is now reported
+    // as "reconnecting" from the moment it happens, so the badge can hold the
+    // paused state across the backoff wait instead of flickering.
+    expect(t.getStatus()).toBe("reconnecting");
 
     vi.advanceTimersByTime(50);
     expect(FakeSocket.instances).toHaveLength(2);
@@ -599,7 +603,12 @@ describe("WsTransport", () => {
     const socket = FakeSocket.instances[0];
     socket.open();
     socket.close();
-    expect(statuses).toEqual(["closed", "connecting", "open", "closed"]);
+    // ADR-003 stage 3.6 review-fix: the final "closed" became "reconnecting".
+    // A drop that WILL be retried is not the same state as a transport that
+    // has given up, and conflating them is what left the badge showing the
+    // bare word "closed" for the whole backoff wait. "closed" is now reserved
+    // for a disposed transport - nothing is coming back.
+    expect(statuses).toEqual(["closed", "connecting", "open", "reconnecting"]);
   });
 
   // ADR-003 stage 3.5: version negotiation moved here from the dead
@@ -947,5 +956,352 @@ describe("WsTransport", () => {
     const seen: (unknown | null)[] = [];
     t.onVersionRejection("scene", (r) => seen.push(r));
     expect(seen).toEqual([{ kind: "version", reason: expect.any(String), details: [] }]);
+  });
+});
+
+// ADR-003 stage 3.6: closes the last "vanishes silently" gap (D5). Every
+// fireIntent call site across the app used to be dropped with nothing but
+// a console.error the instant the socket wasn't open, no exceptions. A
+// `queueable: true` intent is now held and replayed in order on the next
+// reconnect; everything else is counted and surfaced as one summary banner
+// once the connection is actually able to deliver it again (see
+// droppedWhileOffline's own doc in transport.ts for why "surface it
+// immediately" cannot work - the notification banner is itself
+// server-authoritative and needs the very connection that just failed).
+describe("offline intent queue (ADR-003 stage 3.6)", () => {
+  it("a queueable intent fired before the socket ever opens is held, not dropped", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+
+    t.fireIntent("scene", "moveNodes", [[{ id: "n1", x: 1, y: 2 }]], undefined, true);
+    expect(socket.sent).toHaveLength(0);
+
+    socket.open();
+    expect(socket.sent.map((raw) => JSON.parse(raw))).toContainEqual(
+      expect.objectContaining({ topic: "scene", intent: "moveNodes" }),
+    );
+  });
+
+  it("queued intents replay in the order they were fired", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+
+    t.fireIntent("scene", "moveNodes", ["first"], undefined, true);
+    t.fireIntent("app-composer", "updateDraft", ["second"], undefined, true);
+    t.fireIntent("scene", "setViewState", ["third"], undefined, true);
+
+    socket.open();
+    const sent = socket.sent.map((raw) => JSON.parse(raw));
+    expect(sent.map((m) => m.args[0])).toEqual(["first", "second", "third"]);
+  });
+
+  it("replay happens AFTER the resubscribe message, not before", () => {
+    const t = makeTransport();
+    t.subscribe("scene", () => {});
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    t.fireIntent("scene", "moveNodes", [[]], undefined, true);
+
+    socket.open();
+    const sent = socket.sent.map((raw) => JSON.parse(raw));
+    expect(sent[0]).toEqual({ kind: "subscribe", topics: ["scene"] });
+    expect(sent[1]).toMatchObject({ topic: "scene", intent: "moveNodes" });
+  });
+
+  it("a non-queueable intent fired while not open is dropped and reported as one summary banner on reconnect", async () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+
+    t.fireIntent("scene", "sendMessage", ["hello"]); // queueable defaults to false
+    expect(socket.sent).toHaveLength(0);
+
+    socket.open();
+    // The dropped-message intent itself was never queued for replay...
+    expect(socket.sent.map((raw) => JSON.parse(raw))).not.toContainEqual(
+      expect.objectContaining({ intent: "sendMessage" }),
+    );
+    // ...and a visible summary was sent instead, now that the connection
+    // that can actually deliver it exists again.
+    expect(socket.sent.map((raw) => JSON.parse(raw))).toContainEqual({
+      kind: "intent",
+      topic: "notification",
+      intent: "showError",
+      args: ["1 change could not be sent while disconnected."],
+    });
+  });
+
+  it("multiple dropped non-queueable intents are reported as one combined count, not one banner each", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+
+    t.fireIntent("scene", "sendMessage", ["a"]);
+    t.fireIntent("scene", "removeNodes", [["n1"]]);
+    t.fireIntent("scene", "approveCodeExecution", ["r1"]);
+
+    socket.open();
+    const showErrors = socket.sent.map((raw) => JSON.parse(raw)).filter((m) => m.intent === "showError");
+    expect(showErrors).toEqual([
+      { kind: "intent", topic: "notification", intent: "showError", args: ["3 changes could not be sent while disconnected."] },
+    ]);
+  });
+
+  it("a queueable intent that was genuinely in flight and gets cut off by a disconnect is replayed, not lost", async () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+
+    t.fireIntent("scene", "moveNodes", [[{ id: "n1", x: 5, y: 5 }]], undefined, true);
+    expect(socket.sent).toHaveLength(1); // sent normally while open
+
+    // The connection dies before any reply arrives.
+    socket.onclose?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // No error was shown for this one - it's recoverable, not lost.
+    expect(socket.sent.map((raw) => JSON.parse(raw))).not.toContainEqual(
+      expect.objectContaining({ intent: "showError" }),
+    );
+
+    vi.advanceTimersByTime(10_000);
+    const reconnected = FakeSocket.instances[1];
+    reconnected.open();
+
+    expect(reconnected.sent.map((raw) => JSON.parse(raw))).toContainEqual(
+      expect.objectContaining({ topic: "scene", intent: "moveNodes" }),
+    );
+  });
+
+  it("a non-queueable intent that was in flight and gets cut off is counted, not silently lost", async () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+
+    t.fireIntent("scene", "sendMessage", ["hello"]); // queueable defaults to false
+    socket.onclose?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(10_000);
+    const reconnected = FakeSocket.instances[1];
+    reconnected.open();
+
+    expect(reconnected.sent.map((raw) => JSON.parse(raw))).toContainEqual({
+      kind: "intent",
+      topic: "notification",
+      intent: "showError",
+      args: ["1 change could not be sent while disconnected."],
+    });
+  });
+
+  it("the queue is bounded at 50 - the 51st queueable intent is counted as dropped, not queued", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+
+    for (let i = 0; i < 51; i++) {
+      t.fireIntent("scene", "moveNodes", [[{ id: `n${i}`, x: i, y: i }]], undefined, true);
+    }
+
+    socket.open();
+    const sent = socket.sent.map((raw) => JSON.parse(raw));
+    const replayed = sent.filter((m) => m.intent === "moveNodes");
+    expect(replayed).toHaveLength(50);
+    expect(sent).toContainEqual({
+      kind: "intent",
+      topic: "notification",
+      intent: "showError",
+      args: ["1 change could not be sent while disconnected."],
+    });
+  });
+
+  it("status is 'reconnecting', not 'connecting', on every attempt after a real connection was lost", () => {
+    const t = makeTransport();
+    const statuses: string[] = [];
+    t.onStatus((s) => statuses.push(s));
+    t.connect();
+    FakeSocket.instances[0].open(); // first-ever open: "connecting" was correct
+    FakeSocket.instances[0].onclose?.();
+
+    vi.advanceTimersByTime(10_000); // the scheduled retry's connect() fires
+
+    // Review-fix: no "closed" between "open" and "reconnecting". onclose now
+    // publishes the paused state directly - see the next test for why.
+    expect(statuses).toEqual(["closed", "connecting", "open", "reconnecting"]);
+  });
+
+  // The paused state has to cover the whole outage. Publishing "closed" on
+  // disconnect and only entering "reconnecting" when the retry timer fires
+  // meant the badge showed the bare word "closed" for the entire backoff
+  // sleep - which is where all the wall-clock time goes - and flickered
+  // "reconnecting" for the few ms of each attempt against a refused port.
+  // Intents are being queued and counted that entire time, so this is the
+  // half of the exit criterion the user actually sees.
+  it("holds 'reconnecting' for the whole backoff wait, never reverting to 'closed'", () => {
+    const t = makeTransport();
+    const statuses: string[] = [];
+    t.connect();
+    FakeSocket.instances[0].open();
+    t.onStatus((s) => statuses.push(s));
+
+    FakeSocket.instances[0].onclose?.();
+    expect(t.getStatus()).toBe("reconnecting"); // immediately, not after the sleep
+
+    // Right through the backoff sleep and a second FAILED attempt, the user
+    // never sees "closed" again.
+    vi.advanceTimersByTime(400);
+    expect(t.getStatus()).toBe("reconnecting");
+    vi.advanceTimersByTime(200); // retry fires
+    FakeSocket.instances[1].onclose?.();
+    vi.advanceTimersByTime(2_000);
+
+    expect(statuses).not.toContain("closed");
+    expect(t.getStatus()).toBe("reconnecting");
+  });
+
+  // The counterpart to the guard above: a blocked topic is never QUEUED, but
+  // it must still be COUNTED. Letting it fall through to request() produced a
+  // WsTopicBlockedError whose banner intent() then dropped for want of an
+  // open socket - not queued, not counted, no banner ever, which is the exact
+  // D5 bug this stage closes, reintroduced in the one combination the
+  // blocked-topic guard itself created.
+  it("counts a blocked topic's intent dropped while offline instead of losing it silently", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    t.setTopicBlocked("scene", true);
+    socket.onclose?.();
+
+    t.fireIntent("scene", "sendMessage", ["hello"]);
+    t.fireIntent("scene", "moveNodes", [[{ id: "n1", x: 1, y: 2 }]], undefined, true);
+
+    vi.advanceTimersByTime(500);
+    const reconnected = FakeSocket.instances[1];
+    reconnected.open();
+
+    const sent = reconnected.sent.map((raw) => JSON.parse(raw));
+    // Neither was replayed - the topic is still blocked, still untrusted...
+    expect(sent).not.toContainEqual(expect.objectContaining({ intent: "sendMessage" }));
+    expect(sent).not.toContainEqual(expect.objectContaining({ intent: "moveNodes" }));
+    // ...but the user is told both were lost, rather than nothing at all.
+    expect(sent).toContainEqual({
+      kind: "intent",
+      topic: "notification",
+      intent: "showError",
+      args: ["2 changes could not be sent while disconnected."],
+    });
+  });
+
+  it("a genuine server-side rejection on replay still surfaces normally, not silently re-queued", async () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    t.fireIntent("scene", "moveNodes", [[]], undefined, true);
+
+    socket.open();
+    const sent = socket.lastSent();
+    socket.receive({ kind: "error", id: sent.id, error: "unknown node" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(socket.sent.map((raw) => JSON.parse(raw))).toContainEqual({
+      kind: "intent",
+      topic: "notification",
+      intent: "showError",
+      args: ["unknown node"],
+    });
+  });
+
+  // Stage 3.6 x stage 3.5: setTopicBlocked exists because this client cannot
+  // trust the state a blocked topic's args were computed against. Queueing
+  // such an intent would defer exactly that untrusted send to whenever the
+  // block lifts, and would spend the bounded queue's finite slots on intents
+  // certain to be refused - displacing recoverable ones from other topics.
+  // NB: asserting only "the blocked intent never reaches the wire" would be a
+  // FALSE-CONFIDENCE test - request()'s own blockedTopics check already stops
+  // it at replay time, so it passes with or without the guard above (verified
+  // by mutation). The behaviour that genuinely distinguishes them is what
+  // happens when the block LIFTS before the socket returns.
+  it("an intent refused while its topic was blocked is not resurrected once the block lifts", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    t.setTopicBlocked("scene", true);
+
+    t.fireIntent("scene", "moveNodes", [[{ id: "n1", x: 1, y: 2 }]], undefined, true);
+    // A queueable intent on an UNBLOCKED topic still queues normally, so this
+    // also asserts the check is topic-scoped rather than a blanket bypass.
+    t.fireIntent("app-composer", "updateDraft", ["kept"], undefined, true);
+
+    // The version-rejection episode ends before the connection returns. Were
+    // the scene intent sitting in the queue, it would now be replayed for
+    // real - against state this client was explicitly told not to trust.
+    t.setTopicBlocked("scene", false);
+    socket.open();
+
+    const sent = socket.sent.map((raw) => JSON.parse(raw));
+    expect(sent).not.toContainEqual(expect.objectContaining({ intent: "moveNodes" }));
+    expect(sent).toContainEqual(expect.objectContaining({ intent: "updateDraft", args: ["kept"] }));
+  });
+
+  it("a blocked topic's refused intent does not consume an offline-queue slot", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    t.setTopicBlocked("scene", true);
+
+    // 50 blocked-topic intents would fill the whole queue if they were being
+    // enqueued; none of them should be.
+    for (let i = 0; i < 50; i++) {
+      t.fireIntent("scene", "moveNodes", [[{ id: `n${i}`, x: i, y: i }]], undefined, true);
+    }
+    t.fireIntent("app-composer", "updateDraft", ["still room"], undefined, true);
+
+    socket.open();
+    const sent = socket.sent.map((raw) => JSON.parse(raw));
+    expect(sent).toContainEqual(expect.objectContaining({ intent: "updateDraft", args: ["still room"] }));
+  });
+
+  // The summary must NOT go through showErrorDeduped. That de-dup suppresses
+  // an identical message inside a 3s window - and the reconnect backoff's
+  // first retry is 500ms, so two quick outages that each lose one change
+  // produce the identical string well inside the window. Swallowing the
+  // second would under-report real data loss: the user is told one change was
+  // lost when two were. Under-reporting loss is the exact failure this whole
+  // stage exists to remove, so it cannot be reintroduced via the de-dup.
+  it("reports a second outage's losses even though the count message is identical", () => {
+    const t = makeTransport();
+    t.connect();
+    const first = FakeSocket.instances[0];
+    first.open();
+
+    first.onclose?.();
+    t.fireIntent("scene", "sendMessage", ["a"]);
+    vi.advanceTimersByTime(500);
+    const second = FakeSocket.instances[1];
+    second.open();
+    expect(
+      second.sent.map((raw) => JSON.parse(raw)).filter((m) => m.intent === "showError"),
+    ).toEqual([
+      { kind: "intent", topic: "notification", intent: "showError", args: ["1 change could not be sent while disconnected."] },
+    ]);
+
+    second.onclose?.();
+    t.fireIntent("scene", "sendMessage", ["b"]);
+    vi.advanceTimersByTime(500);
+    const third = FakeSocket.instances[2];
+    third.open();
+    expect(
+      third.sent.map((raw) => JSON.parse(raw)).filter((m) => m.intent === "showError"),
+    ).toEqual([
+      { kind: "intent", topic: "notification", intent: "showError", args: ["1 change could not be sent while disconnected."] },
+    ]);
   });
 });

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -47,13 +47,31 @@
  * listener; an incompatible frame is withheld and the topic's rejection is
  * published through onVersionRejection() instead - see that method and
  * lib/ui/BridgeErrorState.tsx, the component this is finally wired to.
+ *
+ * ADR-003 stage 3.6: closes the last "vanishes silently" gap (D5) - an
+ * intent fired while not open used to be dropped with nothing but a
+ * console.error, for every one of the ~130 fireIntent call sites across
+ * the app with no exceptions. fireIntent() now takes a `queueable`
+ * opt-in: an idempotent, last-write-wins intent (a position, a view
+ * setting, a text field - never a create/delete/send/run/approve) is held
+ * in a bounded offline queue and replayed in order on the next reconnect;
+ * everything else surfaces immediately via the notification banner
+ * instead of disappearing. `ConnectionStatus` gained "reconnecting",
+ * distinct from the first-ever "connecting", so the UI can say a session
+ * is paused rather than looking identical to first load.
  */
 
 import { withAuthToken } from "../auth/token";
 import { checkSchemaCompatibility } from "../bridge-core/schemaVersion";
 import type { BridgeRejection } from "../bridge-core/islandState";
 
-export type ConnectionStatus = "connecting" | "open" | "closed";
+/** ADR-003 stage 3.6: "reconnecting" is distinct from "connecting" - the
+ * latter is the very first connection attempt on a fresh transport (nothing
+ * to pause, nothing was ever working), the former is every attempt AFTER a
+ * real connection has been lost (there is a session in progress, and the
+ * app should visibly say so rather than looking identical to first load).
+ * See connect()'s own status-selection logic. */
+export type ConnectionStatus = "connecting" | "open" | "closed" | "reconnecting";
 
 /** ADR-003 stage 3.1: raised ONLY when the server actually replied with a
  * structured {"kind":"error"} frame (unknown topic/intent, or an unhandled
@@ -72,11 +90,16 @@ export class WsTimeoutError extends Error {}
 /** ADR-003 stage 3.1 review-fix: raised for the three rejection reasons that
  * genuinely correlate with the connection-status indicator already showing
  * the user something is wrong (never connected, closed mid-request, or this
- * transport instance was disposed) - the ONLY rejection reason fireIntent()
- * swallows silently. Real disconnect UX (queue-while-reconnecting or a
- * visible "paused" state) is ADR-003 stage 3.6, not this one; until then,
- * silently dropping THESE specific three matches `intent()`'s own
- * pre-migration fire-and-forget behavior exactly. */
+ * transport instance was disposed).
+ *
+ * ADR-003 stage 3.6 update: fireIntent() no longer swallows all three
+ * unconditionally - only the disposed-transport case still does (nothing
+ * left to recover into on real teardown). "Not connected"/"closed
+ * mid-request" are now either queued (a `queueable` call - see that
+ * method's own doc) or counted and surfaced as a summary banner on the
+ * next reconnect (everything else) - "vanishes silently with no
+ * exceptions" was the exact D5 gap this stage exists to close, and this
+ * class's own three reasons were that gap's entire surface. */
 export class WsUnavailableError extends Error {}
 
 /** ADR-003 stage 3.5 review-fix: raised by request() (and so also by
@@ -201,6 +224,26 @@ export class WsTransport {
     { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
   >();
   private nextId = 1;
+  /** ADR-003 stage 3.6: true once this transport has EVER seen a real
+   * `onopen` - what distinguishes "connecting" (first attempt, nothing to
+   * pause) from "reconnecting" (a session was in progress) in connect()'s
+   * status selection below. */
+  private hasEverConnected = false;
+  /** ADR-003 stage 3.6: intents fired with `queueable: true` while not
+   * open are held here instead of being dropped, and replayed in order on
+   * the next successful `onopen` - see fireIntent()'s own doc for exactly
+   * which intents this applies to (a per-call opt-in, not a topic-wide
+   * default) and flushOfflineQueue() for the replay. Bounded per the ADR's
+   * own "~50" - a queue exists to survive a brief drop during a real user
+   * action, not to become an unbounded backlog of everything fired while
+   * offline. */
+  private readonly offlineQueue: Array<{
+    topic: string;
+    intent: string;
+    args: unknown[];
+    timeoutMs?: number;
+  }> = [];
+  private static readonly OFFLINE_QUEUE_MAX = 50;
 
   constructor(url: string, options: WsTransportOptions = {}) {
     this.url = url;
@@ -218,7 +261,9 @@ export class WsTransport {
   connect(): void {
     if (this.socket) return;
     this.disposed = false;
-    this.setStatus("connecting");
+    // ADR-003 stage 3.6: "reconnecting", not "connecting", once a real
+    // session has existed before - see hasEverConnected's own doc.
+    this.setStatus(this.hasEverConnected ? "reconnecting" : "connecting");
     const socket = this.factory(this.url);
     this.socket = socket;
 
@@ -229,6 +274,7 @@ export class WsTransport {
     socket.onopen = () => {
       if (this.socket !== socket) return;
       this.attempts = 0;
+      this.hasEverConnected = true;
       this.setStatus("open");
       // ADR-003 stage 3.4 review-fix: patch topics are re-subscribed too.
       // This list used to come from stateListeners alone, so a consumer that
@@ -241,6 +287,10 @@ export class WsTransport {
       if (topics.length > 0) {
         socket.send(JSON.stringify({ kind: "subscribe", topics }));
       }
+      // ADR-003 stage 3.6: AFTER re-subscribing, so a replayed intent
+      // (e.g. moveNodes) applies against fresh server state rather than
+      // racing the subscribe message.
+      this.flushOfflineQueue();
     };
     socket.onmessage = (event) => {
       if (this.socket !== socket) return;
@@ -252,7 +302,20 @@ export class WsTransport {
     socket.onclose = () => {
       if (this.socket !== socket) return;
       this.socket = null;
-      this.setStatus("closed");
+      // ADR-003 stage 3.6 review-fix: the paused state has to cover the WHOLE
+      // outage, not just an in-flight connect attempt. This used to publish
+      // "closed" here and leave connect() - which only runs after a 500ms-4s
+      // backoff sleep - as the sole publisher of "reconnecting", so the badge
+      // read the bare word "closed" for essentially all the wall-clock time
+      // that intents were being queued and counted, flickering "reconnecting"
+      // for the few ms of each attempt against a refused port. That left this
+      // stage's own "visible paused state" exit criterion undelivered in
+      // practice. "closed" now means what it says: nothing is coming back.
+      if (this.disposed) {
+        this.setStatus("closed");
+      } else {
+        this.setStatus(this.hasEverConnected ? "reconnecting" : "connecting");
+      }
       this.failAllPending(new WsUnavailableError("connection closed"));
       if (!this.disposed) this.scheduleReconnect();
     };
@@ -474,12 +537,157 @@ export class WsTransport {
    * lastShowError's own doc for what this does and, just as importantly,
    * does NOT fix (two DIFFERENT concurrent failures can still race each
    * other for the one visible banner; that deeper limitation is accepted,
-   * documented residual risk, not something a per-message de-dup can close). */
-  fireIntent(topic: string, intent: string, args: unknown[] = [], timeoutMs?: number): void {
+   * documented residual risk, not something a per-message de-dup can close).
+   *
+   * ADR-003 stage 3.6: `queueable` is the new per-call opt-in that decides
+   * what happens while the transport is NOT open - it does nothing while
+   * open, where this call behaves exactly as before. Pass `true` ONLY for
+   * an intent whose effect is idempotent last-write-wins and has no side
+   * effect beyond updating already-existing data (a position, a view
+   * setting, a text field). Idempotence is a HARD requirement, not a
+   * nicety: the WsUnavailableError branch below re-queues an intent that
+   * was genuinely in flight when the socket died, and in that window the
+   * server may already have applied it with only the reply lost - so a
+   * replay is a SECOND application. That rules out every `toggle*` intent,
+   * whose backend handler flips (`x = not x`) rather than setting a value;
+   * replaying one silently reverts the user's action. See
+   * queueableClassificationGuard.test.ts, the ratchet on exactly that
+   * mistake - see also the classification this stage did across
+   * every real call site in the app (sceneStore.ts/composerStore.ts/
+   * SettingsDialog.tsx/ChatLibraryDialog.tsx) for the actual list and the
+   * reasoning behind each one. The default (`false`) is the SAFE choice:
+   * an intent that creates, deletes, sends, runs, or approves something
+   * must never be silently replayed later against scene state the user
+   * has not seen and may have since changed their mind about - instead it
+   * is COUNTED and surfaced as one summary banner the moment the
+   * connection is next able to actually deliver it (see
+   * droppedWhileOffline's own doc for why "surface it immediately" does
+   * not work here). Previously this was the ONE case fireIntent silently
+   * swallowed with no exceptions - "vanish silently" is the exact D5
+   * finding this stage exists to close. The disposed-transport case is the
+   * only one that still keeps the older silent posture (see below). A
+   * BLOCKED topic is refused rather than queued either way, but HOW that
+   * surfaces depends on the socket: while open, through request()'s own
+   * WsTopicBlockedError banner; while not open - where no banner can be
+   * delivered at all - by being counted into the reconnect summary like any
+   * other loss. */
+  fireIntent(topic: string, intent: string, args: unknown[] = [], timeoutMs?: number, queueable = false): void {
+    // ADR-003 stage 3.6 x stage 3.5 interaction: a blocked topic must NEVER
+    // enter the offline queue. Blocking exists precisely because this client
+    // cannot trust the state these args were computed against, so holding
+    // them would defer exactly that untrusted send to whenever the block
+    // lifts - and would spend the bounded queue's finite slots on intents
+    // certain to be refused anyway, displacing recoverable ones from other
+    // topics.
+    //
+    // Review-fix: it must still be COUNTED, though. An earlier version of
+    // this guard let blocked-and-offline fall through to request(), which
+    // rejects with WsTopicBlockedError - not a WsUnavailableError, so the
+    // catch below routed it to a banner that intent() then silently dropped
+    // for want of an open socket. Not queued, not counted, no banner ever:
+    // the exact D5 "vanishes silently" bug this stage exists to close,
+    // reintroduced in the one combination the guard itself created. Blocked
+    // topics are refused, and being refused is reported like any other loss.
+    if (this.status !== "open") {
+      if (queueable && !this.blockedTopics.has(topic)) {
+        this.enqueueOffline(topic, intent, args, timeoutMs);
+      } else {
+        this.droppedWhileOffline += 1;
+      }
+      return;
+    }
     this.request(topic, intent, args, timeoutMs).catch((err) => {
-      if (err instanceof WsUnavailableError) return;
+      // A disposed transport is real teardown (unmount, or StrictMode's
+      // dev-only dispose-then-remount check) - there is nothing left to
+      // recover into.
+      if (this.disposed) return;
+      if (err instanceof WsUnavailableError) {
+        // Was genuinely in flight (status was "open" when sent) and got cut
+        // off mid-request rather than refused up front - same fate as the
+        // not-open case above either way: recoverable data is queued,
+        // everything else is counted for the next reconnect's summary.
+        if (queueable) this.enqueueOffline(topic, intent, args, timeoutMs);
+        else this.droppedWhileOffline += 1;
+        return;
+      }
       this.showErrorDeduped(String(err.message));
     });
+  }
+
+  /** ADR-003 stage 3.6: how many non-queueable intents were refused while
+   * not open, since the last time this was reported. NOT surfaced
+   * immediately as each one happens: the notification banner itself is
+   * server-authoritative (notifications.py's own module doc - reused
+   * deliberately rather than building a second, client-local notification
+   * UI), which means showErrorDeduped()'s own `intent()` call needs a live
+   * connection to deliver anything at all. Trying to show a "not
+   * connected" banner AT THE MOMENT the connection is unavailable cannot
+   * work - it would just silently no-op through the exact same
+   * not-open check, reproducing the bug this stage exists to fix one
+   * layer down. Reported as a single summary count instead, the moment
+   * the connection is next actually able to deliver it - see onopen. */
+  private droppedWhileOffline = 0;
+
+  /** ADR-003 stage 3.6: holds one queueable intent for replay on the next
+   * successful reconnect - see fireIntent()'s own doc for which intents
+   * this applies to, and flushOfflineQueue() for the replay. Bounded: a
+   * queue that grows without limit while offline is itself a form of
+   * silent-loss risk deferred rather than removed (nothing guarantees the
+   * user will ever see all 500 of them applied at once on reconnect) - so
+   * past OFFLINE_QUEUE_MAX this counts the new intent as dropped (see
+   * droppedWhileOffline) rather than silently evicting an older,
+   * already-accepted one: evicting silently would just move the
+   * "vanishes with no signal" failure from the un-queued case onto the
+   * queued one. */
+  private enqueueOffline(topic: string, intent: string, args: unknown[], timeoutMs?: number): void {
+    if (this.offlineQueue.length >= WsTransport.OFFLINE_QUEUE_MAX) {
+      this.droppedWhileOffline += 1;
+      return;
+    }
+    this.offlineQueue.push({ topic, intent, args, timeoutMs });
+  }
+
+  /** ADR-003 stage 3.6: replays every queued intent, in the order they were
+   * fired, through fireIntent() itself (still `queueable: true` - if the
+   * connection drops again mid-flush, an item just re-queues via the exact
+   * same path rather than needing special-cased retry logic here). Drains
+   * the queue FIRST (rather than iterating it in place) so a re-entrant
+   * enqueue during replay - a queued intent whose OWN failure handling
+   * queues it again - can never see or grow the list this loop is
+   * currently walking.
+   *
+   * Reports droppedWhileOffline (if any) AFTER the replay, as one summary
+   * banner - by this point `status` is genuinely "open" (the caller,
+   * onopen, only calls this after setStatus("open")), which is the
+   * earliest moment showErrorDeduped's own send can actually succeed. */
+  private flushOfflineQueue(): void {
+    if (this.offlineQueue.length > 0) {
+      const queued = this.offlineQueue.splice(0, this.offlineQueue.length);
+      for (const item of queued) {
+        this.fireIntent(item.topic, item.intent, item.args, item.timeoutMs, true);
+      }
+    }
+    if (this.droppedWhileOffline > 0) {
+      const n = this.droppedWhileOffline;
+      this.droppedWhileOffline = 0;
+      // Deliberately NOT showErrorDeduped. That de-dup exists to stop one
+      // rapid-fire call site re-publishing the SAME ongoing failure on every
+      // keystroke; this message is different in kind - it is a COUNT of
+      // distinct losses, and it can only fire once per reconnect, so it is
+      // already inherently rate-limited. Routing it through the de-dup would
+      // mean two outages inside the 3s window that each lost one change
+      // report "1 change..." once and swallow the second - under-reporting
+      // real data loss, which is precisely what this stage exists to stop.
+      this.intent(
+        "notification",
+        "showError",
+        [
+          n === 1
+            ? "1 change could not be sent while disconnected."
+            : `${n} changes could not be sent while disconnected.`,
+        ],
+      );
+    }
   }
 
   /** ADR-003 stage 3.1 review-fix: the last showError message this transport


### PR DESCRIPTION
## Problem

Intents fired while the WebSocket was not open were dropped with nothing but a `console.error`. That applied to every one of the ~130 `fireIntent` call sites in the app — `fireIntent`'s catch swallowed `WsUnavailableError` by design, with a comment deferring real disconnect UX to a later stage. Drag a node, type a message, or flip a setting while the backend is restarting and the change was simply gone, with no indication anything had happened.

The connection badge showed the bare status word, so a paused session looked identical to first load.

## Change

`fireIntent` gains a per-call-site `queueable` flag (default `false`). While the transport is not open:

- **queueable** → held in a bounded queue (50) and replayed in order on reconnect
- **anything else** → counted, and surfaced as a single summary banner once a connection exists to deliver it

The same fork handles a request that was genuinely in flight when the socket died. Replay runs *after* the resubscribe message so it applies against fresh server state, and drains the queue before walking it so a re-entrant enqueue cannot grow the list under the loop.

The counter exists because `showErrorDeduped` publishes through `intent("notification", "showError", ...)`, which itself requires an open socket — surfacing "not connected" at the moment the connection is gone would no-op through the identical check. The summary deliberately bypasses the 3s de-dup: the reconnect backoff starts at 500ms, so two quick outages produce the same string and the second would be swallowed, under-reporting how much was actually lost.

`ConnectionStatus` gains `"reconnecting"`, distinct from the first-ever `"connecting"`, and `onclose` publishes it directly rather than `"closed"` — the paused state has to cover the whole backoff wait, not just the few milliseconds of an in-flight connect attempt. `"closed"` now means the transport has given up.

### Classification

~55 call sites are marked queueable: positions, view/grid/font settings, text fields, preference toggles. Everything that creates, deletes, sends, runs, approves, cancels, opens a native dialog, switches session/context or touches credentials keeps the safe default — including `setCodeSandboxAllowSourceBuilds`, which is security-sensitive and must never be replayed.

`toggle*` intents are excluded on purpose. Their handlers flip (`x = not x`) rather than set, so they are not idempotent: `fireIntent` re-queues an intent that was in flight when the socket died, and in that window the server may already have applied it with only the reply lost — replaying then toggles a second time and silently reverts the user's action. `queueableClassificationGuard.test.ts` scans every real call site and fails on any `toggle*` marked queueable.

A version-blocked topic (stage 3.5) is never queued — its args were computed against state this client was explicitly told not to trust — but is still counted, so being refused is reported rather than vanishing.

## Test plan

- `python -m pytest -q` from repo root: **1648 passed, 14 skipped**
- `cd web_ui && npm run check`: **56 files, 1341 tests, 0 errors**, build clean
- Mutation-tested with backup/restore, each confirming the intended test fails and the tree is byte-identical afterward: bypassing the queueable fork, removing the 50-item bound, reordering flush before subscribe, removing the blocked-topic guard, dropping the blocked-topic count, routing the summary back through the de-dup, reverting `onclose` to `"closed"`, and reintroducing a `toggle*` misclassification.
- Live browser check against a real killed and restarted backend: the badge holds "reconnecting — actions paused" across the outage and returns to "connected" automatically with no reload.

The literal kill-server-mid-drag gesture could not be driven in this environment — React Flow's drag geometry needs a genuinely compositing pane, and synthetic pointer events leave the node transform unchanged. The queue path `moveNodes` depends on is topic- and intent-agnostic and is covered at the real-`WsTransport` level (queued, replayed in order, survives a mid-flight cutoff).
