### PR TITLE
ADR-010 stage 10.1: invertible command layer for scene mutations

### DIFF
--- a/backend/api/intents_branches.py
+++ b/backend/api/intents_branches.py
@@ -71,16 +71,28 @@ def register_branches_intents(
                 # Deleted mid-flight - silent no-op, same posture as
                 # _dispatch_image's own liveness check.
                 return
-            note = document.add_note(source.x + x_offset, source.y + y_offset)
-            document.set_note_content(note.id, text)
-            # Legacy tinted these notes "Mid Gray" with an info-coloured
-            # header. Both values come from the frontend's own palette
-            # (GroupColorPicker's GROUP_MONO_COLORS/GROUP_NAMED_COLORS) since
-            # the backend stores hex and never resolves a colour name. The
-            # legacy note width of 400 is NOT ported: note width is not a
-            # modeled field here (it is CSS-driven), so there is nothing to
-            # set it on.
-            document.set_group_color(note.id, NOTE_AGENT_BODY_COLOR, NOTE_AGENT_HEADER_COLOR)
+            # ADR-010 stage 10.1: the note plus its content and colouring are
+            # ONE command - the three calls together are a single logical
+            # "the agent produced this note", so one undo removes all of it
+            # rather than peeling off the colour, then the text, then the
+            # node. Agent provenance, per stage 10.5's eventual "undo this
+            # build".
+            def _create_agent_note():
+                created = document.add_note(source.x + x_offset, source.y + y_offset)
+                document.set_note_content(created.id, text)
+                # Legacy tinted these notes "Mid Gray" with an info-coloured
+                # header. Both values come from the frontend's own palette
+                # (GroupColorPicker's GROUP_MONO_COLORS/GROUP_NAMED_COLORS)
+                # since the backend stores hex and never resolves a colour
+                # name. The legacy note width of 400 is NOT ported: note
+                # width is not a modeled field here (it is CSS-driven), so
+                # there is nothing to set it on.
+                document.set_group_color(created.id, NOTE_AGENT_BODY_COLOR, NOTE_AGENT_HEADER_COLOR)
+                return created
+
+            note, _command = document.record_command(
+                "generateNote", "agent", _create_agent_note,
+            )
             result_holder["node_id"] = note.id
             await bus.publish("scene")
 
@@ -157,10 +169,18 @@ def register_branches_intents(
                 # A source was deleted mid-flight - same liveness posture as
                 # _generate_note_from_node's own on_success guard.
                 return
-            note = document.add_note(avg_x + NOTE_AGENT_X_OFFSET, max_y)
-            document.set_note_content(note.id, text)
-            document.set_group_color(note.id, NOTE_AGENT_BODY_COLOR, NOTE_AGENT_HEADER_COLOR)
-            document.mark_branch_comparison_note(note.id, ids)
+            # One command for the whole comparison note - see
+            # _generate_note_from_node's own equivalent block above.
+            def _create_comparison_note():
+                created = document.add_note(avg_x + NOTE_AGENT_X_OFFSET, max_y)
+                document.set_note_content(created.id, text)
+                document.set_group_color(created.id, NOTE_AGENT_BODY_COLOR, NOTE_AGENT_HEADER_COLOR)
+                document.mark_branch_comparison_note(created.id, ids)
+                return created
+
+            note, _command = document.record_command(
+                "compareBranches", "agent", _create_comparison_note, node_ids=ids,
+            )
             result_holder["node_id"] = note.id
             await bus.publish("scene")
 
@@ -236,11 +256,24 @@ def register_branches_intents(
                 # A source was deleted mid-flight - same liveness posture as
                 # compare_branches's own on_success guard.
                 return
-            node = document.add_chat_node(
-                avg_x, max_y + MESSAGE_VERTICAL_SPACING, text, False, parent_id=parent.id,
-            )
-            document.mark_branch_synthesis(
-                node.id, ids, clean_instructions, route.get("provider"), route.get("modelLabel"),
+            # The synthesis node plus its synthesis metadata as one command.
+            # last_chat_node_id is deliberately set OUTSIDE it: that is
+            # document-level cursor state, not node state, so it is not
+            # something record_command's node/edge diff captures - restoring
+            # it correctly on undo is part of stage 10.2's stack work, where
+            # the cursor semantics actually live.
+            def _create_synthesis_node():
+                created = document.add_chat_node(
+                    avg_x, max_y + MESSAGE_VERTICAL_SPACING, text, False, parent_id=parent.id,
+                )
+                document.mark_branch_synthesis(
+                    created.id, ids, clean_instructions, route.get("provider"), route.get("modelLabel"),
+                )
+                return created
+
+            node, _command = document.record_command(
+                "synthesizeBranches", "agent", _create_synthesis_node,
+                node_ids=[parent.id, *ids],
             )
             document.last_chat_node_id = node.id
             result_holder["node_id"] = node.id

--- a/backend/api/intents_chart.py
+++ b/backend/api/intents_chart.py
@@ -81,13 +81,23 @@ def register_chart_intents(
                 # fallback chain.
                 chart_data = _placeholder_chart_data(normalized_chart_type)
                 chart_error = f"The generated chart data could not be validated: {exc}"
-            node = document.add_chart_node(
-                parent.x + MESSAGE_VERTICAL_SPACING,
-                parent.y,
-                parent_node_id,
-                normalized_chart_type,
-                chart_data,
-                chart_error=chart_error,
+            # ADR-010 stage 10.1: agent provenance - this node is produced by
+            # a model generation, not a direct user action (stage 10.5's
+            # "undo this build" is what will consume that distinction).
+            # add_chart_node also mints chart asset bytes into image_assets;
+            # record_command captures those alongside the node, so undoing a
+            # generated chart does not strand its PNG.
+            node, _command = document.record_command(
+                "generateChart", "agent",
+                lambda: document.add_chart_node(
+                    parent.x + MESSAGE_VERTICAL_SPACING,
+                    parent.y,
+                    parent_node_id,
+                    normalized_chart_type,
+                    chart_data,
+                    chart_error=chart_error,
+                ),
+                node_ids=[parent_node_id],
             )
             result_holder["node_id"] = node.id
             await bus.publish("scene")

--- a/backend/api/intents_chat.py
+++ b/backend/api/intents_chat.py
@@ -46,6 +46,75 @@ from backend.response_parsing import (
 from backend.token_counter import TokenCounterState
 
 
+# ADR-010 stage 10.1: these two live at module level rather than as closures
+# inside register_chat_intents for the reason ADR-002 stage 2.7 established -
+# tests/test_register_function_length.py caps every register* function at 300
+# lines, and wrapping both reply paths in record_command pushed this one over.
+# They take `document` explicitly instead of capturing it, exactly like the
+# intents_*.py split itself did.
+#
+# NOTE: the calls below MUST use the `document.` prefix. Before ADR-002 stage
+# 2.6, a bare `add_code_node(...)`/`add_thinking_node(...)` would have silently
+# resolved to register_canvas's own same-scope async WS-intent wrapper closures
+# of the same name instead of raising NameError - producing an unawaited
+# coroutine that never ran and never errored, so no node would be created and
+# nothing would look wrong until the scene state was actually inspected. At
+# module level here that hazard is structurally gone, but the prefix is kept
+# because correctness should not depend on which failure mode happens to be
+# true today.
+def _build_reply_nodes(document, parent_node, placeholder_text, parsed_parts):
+    """Creates the assistant's reply node plus every thinking/code child the
+    parsed reply calls for, returning the reply node. Wrapped by ONE
+    record_command at each call site, so a single undo reverses the whole
+    reply rather than peeling off one child per Ctrl+Z."""
+    ax, ay = parent_node.x, parent_node.y + MESSAGE_VERTICAL_SPACING
+    ai = document.add_chat_node(ax, ay, placeholder_text, False, parent_id=parent_node.id)
+    for part in parsed_parts:
+        if part["type"] == "thinking":
+            document.add_thinking_node(
+                ax - MESSAGE_VERTICAL_SPACING, ay + MESSAGE_VERTICAL_SPACING,
+                part["content"], parent_id=ai.id,
+            )
+        elif part["type"] == "code":
+            document.add_code_node(
+                ax + MESSAGE_VERTICAL_SPACING, ay + MESSAGE_VERTICAL_SPACING,
+                part["content"], part["language"], parent_id=ai.id,
+            )
+    return ai
+
+
+def _regenerate_in_place(document, node_to_regenerate, reply_text):
+    """Regenerate's teardown/parse/mutate sequence, in the exact legacy step
+    order: tear down the old content children FIRST (unconditionally, even if
+    the new reply parses to nothing), then replace the node's own content,
+    then rebuild children from the new parse."""
+    document.remove_associated_content_children(node_to_regenerate.id)
+
+    parsed_parts = parse_response(reply_text)
+    text_parts = [p["content"] for p in parsed_parts if p["type"] == "text"]
+    text_content = "\n\n".join(text_parts)
+
+    # THE SIMPLE 1-WAY TERNARY - NOT send_message's 3-way priority chain.
+    # PLACEHOLDER_ASSISTANT_REASONING is NEVER touched by this path. Exact
+    # match to legacy line 561:
+    # `text_content if text_content else "[Generated Content]"`.
+    placeholder_text = text_content if text_content else PLACEHOLDER_GENERATED_CONTENT
+    document.update_chat_node_content(node_to_regenerate.id, placeholder_text)
+
+    bx, by = node_to_regenerate.x, node_to_regenerate.y
+    for part in parsed_parts:
+        if part["type"] == "thinking":
+            document.add_thinking_node(
+                bx - MESSAGE_VERTICAL_SPACING, by + MESSAGE_VERTICAL_SPACING,
+                part["content"], parent_id=node_to_regenerate.id,
+            )
+        elif part["type"] == "code":
+            document.add_code_node(
+                bx + MESSAGE_VERTICAL_SPACING, by + MESSAGE_VERTICAL_SPACING,
+                part["content"], part["language"], parent_id=node_to_regenerate.id,
+            )
+
+
 def register_chat_intents(
     bus: SessionBus,
     document: SceneDocument,
@@ -87,7 +156,17 @@ def register_chat_intents(
         media_parts = [item.content_part for item in staged if item.content_part is not None]
         content_parts = [{"type": "text", "text": full_text}, *media_parts] if media_parts else None
 
-        node = document.send_message(full_text, content_parts=content_parts, branch_from_node_id=branch_from_node_id)
+        # ADR-010 stage 10.1: a hidden create - send_message internally calls
+        # add_chat_node and updates last_chat_node_id, so it is a real node
+        # creation despite not being named add*. branch_from_node_id is
+        # watched because the new node connects to it.
+        node, _command = document.record_command(
+            "sendMessage", "user",
+            lambda: document.send_message(
+                full_text, content_parts=content_parts, branch_from_node_id=branch_from_node_id,
+            ),
+            node_ids=[branch_from_node_id] if branch_from_node_id else (),
+        )
         if staged:
             # The staged list is now empty (popped above) - republish so the
             # composer's attachment chips clear the instant Send fires,
@@ -166,34 +245,29 @@ def register_chat_intents(
                     # structural parity rather than optimized away.
                     placeholder_text = PLACEHOLDER_EMPTY_RESPONSE
 
-            ax, ay = node.x, node.y + MESSAGE_VERTICAL_SPACING
-            ai_node = document.add_chat_node(ax, ay, placeholder_text, False, parent_id=node.id)
+            # ADR-010 stage 10.1: reply node + children as ONE command (see
+            # _build_reply_nodes). "agent" provenance, not "user" - stage 10.5
+            # ("undo this build") is what consumes that distinction.
+            ai_node, _command = document.record_command(
+                "chatReply", "agent",
+                lambda: _build_reply_nodes(document, node, placeholder_text, parsed_parts),
+                node_ids=[node.id],
+            )
 
-            # NOTE: these two calls MUST use the `document.` prefix. Before
-            # ADR-002 stage 2.6, a bare `add_code_node(...)`/
-            # `add_thinking_node(...)` here would have silently resolved to
-            # register_canvas's own same-scope async WS-intent wrapper
-            # closures of the same name instead of raising a NameError -
-            # producing an unawaited coroutine that never ran and never
-            # errored, so no node would be created and nothing would look
-            # wrong until the scene state was actually inspected. Those
-            # wrapper closures now live in backend/api/intents_nodes.py, a
-            # different module - a bare call here would raise NameError
+            # NOTE: the calls inside _create_reply_nodes above MUST use the
+            # `document.` prefix. Before ADR-002 stage 2.6, a bare
+            # `add_code_node(...)`/`add_thinking_node(...)` here would have
+            # silently resolved to register_canvas's own same-scope async
+            # WS-intent wrapper closures of the same name instead of raising
+            # a NameError - producing an unawaited coroutine that never ran
+            # and never errored, so no node would be created and nothing
+            # would look wrong until the scene state was actually inspected.
+            # Those wrapper closures now live in backend/api/intents_nodes.py,
+            # a different module - a bare call here would raise NameError
             # immediately instead, a strictly SAFER failure mode than the
             # original silent one. The `document.` prefix requirement is
             # kept regardless, since correctness should not depend on which
             # of the two failure modes happens to be true today.
-            for part in parsed_parts:
-                if part["type"] == "thinking":
-                    document.add_thinking_node(
-                        ax - MESSAGE_VERTICAL_SPACING, ay + MESSAGE_VERTICAL_SPACING,
-                        part["content"], parent_id=ai_node.id,
-                    )
-                elif part["type"] == "code":
-                    document.add_code_node(
-                        ax + MESSAGE_VERTICAL_SPACING, ay + MESSAGE_VERTICAL_SPACING,
-                        part["content"], part["language"], parent_id=ai_node.id,
-                    )
 
             # Always the real chat node's id, never a code/thinking child's -
             # add_code_node/add_thinking_node are documented above (see their
@@ -276,35 +350,28 @@ def register_chat_intents(
             # the new reply has no code/thinking parts at all - this is why
             # document/image children are deleted but never recreated
             # (parse_response structurally only emits thinking/text/code).
-            document.remove_associated_content_children(node_to_regenerate.id)
-
-            parsed_parts = parse_response(reply_text)
-            text_parts = [p["content"] for p in parsed_parts if p["type"] == "text"]
-            text_content = "\n\n".join(text_parts)
-
-            # THE SIMPLE 1-WAY TERNARY - NOT send_message's 3-way priority
-            # chain. PLACEHOLDER_ASSISTANT_REASONING is NEVER touched by this
-            # path. Exact match to legacy line 561:
-            # `text_content if text_content else "[Generated Content]"`.
-            placeholder_text = text_content if text_content else PLACEHOLDER_GENERATED_CONTENT
-            document.update_chat_node_content(node_to_regenerate.id, placeholder_text)
-
-            # NOTE: `document.` prefix is REQUIRED - see send_message's own
-            # identical _on_reply comment earlier in this same file for the
-            # full history of this hazard and why the prefix requirement is
-            # kept regardless of which failure mode a bare call would hit.
-            bx, by = node_to_regenerate.x, node_to_regenerate.y
-            for part in parsed_parts:
-                if part["type"] == "thinking":
-                    document.add_thinking_node(
-                        bx - MESSAGE_VERTICAL_SPACING, by + MESSAGE_VERTICAL_SPACING,
-                        part["content"], parent_id=node_to_regenerate.id,
-                    )
-                elif part["type"] == "code":
-                    document.add_code_node(
-                        bx + MESSAGE_VERTICAL_SPACING, by + MESSAGE_VERTICAL_SPACING,
-                        part["content"], part["language"], parent_id=node_to_regenerate.id,
-                    )
+            # ADR-010 stage 10.1: regenerate is delete-then-recreate, and one
+            # Ctrl+Z has to reverse the WHOLE thing - the torn-down children,
+            # the replaced content, and the newly parsed children - so it is
+            # one command, not three. The pre-existing children have to be
+            # named explicitly: remove_associated_content_children deletes
+            # nodes that are not this command's own target, which
+            # record_command would otherwise refuse to lose silently (by
+            # design - see its AssertionError).
+            #
+            # The teardown/parse/mutate ORDER is unchanged from the legacy
+            # step order documented just above - see _regenerate_in_place at
+            # module level; wrapping it moves no step relative to any other.
+            existing_children = [
+                edge.target
+                for edge in document.edges.values()
+                if edge.source == node_to_regenerate.id
+            ]
+            document.record_command(
+                "regenerateResponse", "agent",
+                lambda: _regenerate_in_place(document, node_to_regenerate, reply_text),
+                node_ids=[node_to_regenerate.id, *existing_children],
+            )
 
             # last_chat_node_id: DELIBERATELY untouched. See §5.
 

--- a/backend/api/intents_chat_image.py
+++ b/backend/api/intents_chat_image.py
@@ -38,7 +38,16 @@ def register_chat_image_intents(
                 # regenerate_response's own liveness check (backend/api/
                 # intents_chat.py, ADR-002 stage 2.6).
                 return
-            document.add_generated_image_reply(parent_chat_node_id, prompt, image_bytes)
+            # ADR-010 stage 10.1: a create despite the name - this mints a
+            # real image node AND its asset bytes into image_assets, both of
+            # which record_command captures (the asset half matters: undoing
+            # a generated image must not strand its PNG in the asset store).
+            # Agent provenance, like every other model-produced node.
+            document.record_command(
+                "generateImageReply", "agent",
+                lambda: document.add_generated_image_reply(parent_chat_node_id, prompt, image_bytes),
+                node_ids=[parent_chat_node_id],
+            )
             await bus.publish("scene")
 
         await agent_dispatcher.start_image_reply(

--- a/backend/api/intents_conversation.py
+++ b/backend/api/intents_conversation.py
@@ -67,7 +67,15 @@ def register_conversation_intents(
         return node.id
 
     async def delete_conversation_message(node_id, message_index):
-        document.delete_conversation_message(node_id, message_index)
+        # A delete at sub-node granularity: one message inside a
+        # ConversationNode's history list, not a SceneNode. node_ids is
+        # required because the node itself survives - the id never leaves
+        # self.nodes, so only the in-place before/after diff catches this.
+        document.record_command(
+            "deleteConversationMessage", "user",
+            lambda: document.delete_conversation_message(node_id, message_index),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def set_node_docked(node_id, docked):
@@ -75,7 +83,23 @@ def register_conversation_intents(
         await publish_scene()
 
     async def delete_chat_node(node_id):
-        document.delete_chat_node(node_id)
+        # The SECOND, structurally different delete path (the first being
+        # remove_nodes): this REPARENTS the deleted node's children onto its
+        # own parent rather than cascade-deleting them, so undoing it has to
+        # restore both the node AND every child's original parent edge. The
+        # children are named explicitly for that reason - they are mutated
+        # (re-parented), not deleted, so the id-set diff alone would miss
+        # them. Their new edges are auto-discovered from the ids named here.
+        children = [
+            edge.target for edge in document.edges.values() if edge.source == node_id
+        ]
+        parents = [
+            edge.source for edge in document.edges.values() if edge.target == node_id
+        ]
+        document.record_command(
+            "deleteChatNode", "user", lambda: document.delete_chat_node(node_id),
+            node_ids=[node_id, *children, *parents],
+        )
         await publish_scene()
 
     async def set_chat_collapsed(node_id, collapsed):

--- a/backend/api/intents_groups.py
+++ b/backend/api/intents_groups.py
@@ -16,9 +16,19 @@ from backend.events import SessionBus
 def register_groups_intents(bus: SessionBus, document: SceneDocument) -> None:
     publish_scene = make_publish_scene(bus)
 
+    # ADR-010 stage 10.1: the create/delete-shaped intents here are wrapped
+    # in record_command (see backend/domain/commands.py). The pure setters
+    # below (setNoteContent, setGroupLabel, toggle*, resize*) are NOT - they
+    # are stage 10.1's explicit scope boundary, which covers create/delete/
+    # move/connect. Every one of them still needs a command before ADR-010
+    # can close, per that ADR's own Consequences section ("Every new
+    # mutating intent ... must produce a command").
     async def add_note(x, y, is_system_prompt=False, is_summary_note=False):
-        node = document.add_note(
-            x, y, is_system_prompt=is_system_prompt, is_summary_note=is_summary_note,
+        node, _command = document.record_command(
+            "addNote", "user",
+            lambda: document.add_note(
+                x, y, is_system_prompt=is_system_prompt, is_summary_note=is_summary_note,
+            ),
         )
         await publish_scene()
         return node.id
@@ -28,12 +38,24 @@ def register_groups_intents(bus: SessionBus, document: SceneDocument) -> None:
         await publish_scene()
 
     async def create_frame(item_ids):
-        node = document.create_frame(list(item_ids))
+        ids = list(item_ids)
+        # The members are named so their own detach-from-a-previous-group
+        # mutation is captured too - create_frame does not only create the
+        # frame node, it also rewrites each member's existing membership
+        # (see _detach_from_existing_group).
+        node, _command = document.record_command(
+            "createFrame", "user", lambda: document.create_frame(ids),
+            node_ids=ids,
+        )
         await publish_scene()
         return node.id
 
     async def create_container(item_ids):
-        node = document.create_container(list(item_ids))
+        ids = list(item_ids)
+        node, _command = document.record_command(
+            "createContainer", "user", lambda: document.create_container(ids),
+            node_ids=ids,
+        )
         await publish_scene()
         return node.id
 
@@ -62,7 +84,12 @@ def register_groups_intents(bus: SessionBus, document: SceneDocument) -> None:
         await publish_scene()
 
     async def ungroup(node_id):
-        document.ungroup(node_id)
+        # A delete, structurally: the group wrapper node is removed while
+        # its members are released rather than cascade-deleted.
+        document.record_command(
+            "ungroup", "user", lambda: document.ungroup(node_id),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     bus.register_intent("scene", "addNote", add_note)

--- a/backend/api/intents_nodes.py
+++ b/backend/api/intents_nodes.py
@@ -25,18 +25,36 @@ def register_node_intents(
 ) -> None:
     publish_scene = make_publish_scene(bus)
 
+    # ADR-010 stage 10.1: every mutation below is wrapped in
+    # document.record_command(...), which runs the SAME domain call it always
+    # did and additionally captures the Command that inverts it (see
+    # backend/domain/commands.py). `node_ids`/`edge_ids` name what the caller
+    # already knows is being touched, so a mutation that modifies an existing
+    # object IN PLACE (a move) is captured as well as one that creates or
+    # deletes - a create needs no hint, since a brand-new id is caught by the
+    # id-set diff on its own.
     async def add_node(x, y, title=""):
-        node = document.add_node(x, y, title)
+        node, _command = document.record_command(
+            "addNode", "user", lambda: document.add_node(x, y, title),
+        )
         await publish_scene()
         return node.id
 
     async def add_chat_node(x, y, content, is_user, parent_id=None):
-        node = document.add_chat_node(x, y, content, is_user, parent_id)
+        node, _command = document.record_command(
+            "addChatNode", "user",
+            lambda: document.add_chat_node(x, y, content, is_user, parent_id),
+            node_ids=[parent_id] if parent_id else (),
+        )
         await publish_scene()
         return node.id
 
     async def add_code_node(x, y, code, language, parent_id=None):
-        node = document.add_code_node(x, y, code, language, parent_id)
+        node, _command = document.record_command(
+            "addCodeNode", "user",
+            lambda: document.add_code_node(x, y, code, language, parent_id),
+            node_ids=[parent_id] if parent_id else (),
+        )
         await publish_scene()
         return node.id
 
@@ -53,29 +71,41 @@ def register_node_intents(
         byte_size=None,
         preview_label="",
     ):
-        node = document.add_document_node(
-            x,
-            y,
-            title,
-            content,
-            attachment_kind,
-            parent_id,
-            file_path=file_path,
-            mime_type=mime_type,
-            duration_seconds=duration_seconds,
-            byte_size=byte_size,
-            preview_label=preview_label,
+        node, _command = document.record_command(
+            "addDocumentNode", "user",
+            lambda: document.add_document_node(
+                x,
+                y,
+                title,
+                content,
+                attachment_kind,
+                parent_id,
+                file_path=file_path,
+                mime_type=mime_type,
+                duration_seconds=duration_seconds,
+                byte_size=byte_size,
+                preview_label=preview_label,
+            ),
+            node_ids=[parent_id],
         )
         await publish_scene()
         return node.id
 
     async def add_thinking_node(x, y, thinking_text, parent_id):
-        node = document.add_thinking_node(x, y, thinking_text, parent_id)
+        node, _command = document.record_command(
+            "addThinkingNode", "user",
+            lambda: document.add_thinking_node(x, y, thinking_text, parent_id),
+            node_ids=[parent_id],
+        )
         await publish_scene()
         return node.id
 
     async def add_html_node(x, y, html_content, parent_id):
-        node = document.add_html_node(x, y, html_content, parent_id)
+        node, _command = document.record_command(
+            "addHtmlNode", "user",
+            lambda: document.add_html_node(x, y, html_content, parent_id),
+            node_ids=[parent_id],
+        )
         await publish_scene()
         return node.id
 
@@ -89,24 +119,45 @@ def register_node_intents(
         # before it ever reaches SceneDocument (which only ever deals in real
         # bytes, same as the HTTP asset route on the read side).
         image_bytes = base64.b64decode(image_bytes_base64)
-        node = document.add_image_node(x, y, image_bytes, prompt, parent_id, mime_type=mime_type)
+        node, _command = document.record_command(
+            "addImageNode", "user",
+            lambda: document.add_image_node(x, y, image_bytes, prompt, parent_id, mime_type=mime_type),
+            node_ids=[parent_id],
+        )
         await publish_scene()
         return node.id
 
     async def add_conversation_node(x, y, parent_id):
-        node = document.add_conversation_node(x, y, parent_id)
+        node, _command = document.record_command(
+            "addConversationNode", "user",
+            lambda: document.add_conversation_node(x, y, parent_id),
+            node_ids=[parent_id],
+        )
         await publish_scene()
         return node.id
 
     async def move_node(node_id, x, y):
-        document.move_node(node_id, x, y)
+        # node_ids is REQUIRED here, unlike a create: a move mutates an
+        # existing object in place, so its id never enters or leaves
+        # self.nodes and the id-set diff alone would see nothing.
+        document.record_command(
+            "moveNode", "user", lambda: document.move_node(node_id, x, y),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def move_nodes(positions):
         # positions: a JSON array of [node_id, x, y] triples - see
         # SceneDocument.move_nodes's own docstring for why a group drag's
         # commit uses this batched intent instead of N calls to moveNode.
-        document.move_nodes([(p[0], p[1], p[2]) for p in positions])
+        triples = [(p[0], p[1], p[2]) for p in positions]
+        # One command for the whole group drag, not N - a single Ctrl+Z must
+        # put every dragged node back, which is also why this stays one
+        # record_command call rather than a loop.
+        document.record_command(
+            "moveNodes", "user", lambda: document.move_nodes(triples),
+            node_ids=[t[0] for t in triples],
+        )
         await publish_scene()
 
     async def remove_nodes(node_ids):
@@ -162,7 +213,18 @@ def register_node_intents(
             and document.nodes[node_id].kind in ("pycoder", "code_sandbox")
             and document.nodes[node_id].pending_request_id
         ]
-        document.remove_nodes(ids)
+        # ADR-010 stage 10.1: the delete itself is recorded. Only the
+        # DOCUMENT half is invertible - the subprocess teardown and
+        # scratch-dir removal below are deliberately outside the command,
+        # since killing a REPL and rmtree-ing a venv are not reversible by
+        # restoring a dict entry. Undoing a pycoder/code_sandbox delete
+        # therefore restores the node and its state but NOT a live REPL,
+        # which is the honest boundary; stage 10.4's live-run refusal is
+        # where that interaction gets a real policy.
+        document.record_command(
+            "removeNodes", "user", lambda: document.remove_nodes(ids),
+            node_ids=ids,
+        )
         for kind, request_id in code_exec_cancels:
             # cancel_pycoder/cancel_code_sandbox resolve any pending
             # approval_future with False (exactly like a manual Cancel/Deny)
@@ -202,12 +264,26 @@ def register_node_intents(
         await publish_scene()
 
     async def connect_nodes(source, target):
-        edge = document.connect(source, target)
+        # connect() is idempotent - if the edge already exists it returns
+        # that one and creates nothing, which record_command sees as a
+        # genuine no-op and correctly declines to log (inverting it would
+        # otherwise delete a pre-existing edge the user never created).
+        edge, _command = document.record_command(
+            "connectNodes", "user", lambda: document.connect(source, target),
+            node_ids=[source, target],
+        )
         await publish_scene()
         return edge.id
 
     async def remove_edges(edge_ids):
-        document.remove_edges(list(edge_ids))
+        ids = list(edge_ids)
+        # edge_ids is required here for the same reason move needs node_ids:
+        # the edges' endpoint nodes are NOT being deleted, so there is no
+        # node to auto-discover these edges from.
+        document.record_command(
+            "removeEdges", "user", lambda: document.remove_edges(ids),
+            edge_ids=ids,
+        )
         await publish_scene()
 
     bus.register_intent("scene", "addNode", add_node)

--- a/backend/domain/commands.py
+++ b/backend/domain/commands.py
@@ -1,0 +1,308 @@
+"""CommandOps - ADR-010 stage 10.1: the command layer, undo/redo's foundation.
+
+A MIXIN, not a standalone class, following the exact composition pattern
+BranchOps/GroupOps already established: methods operate on the composing
+dataclass's own state (self.nodes/self.edges/self.image_assets), composed
+exactly once by domain/graph.py's `class SceneDocument(BranchOps, GroupOps,
+CommandOps)`.
+
+## Why a scoped before/after diff, not hand-authored inverses
+
+The ADR's own text ("invert a delete = re-add those nodes+edges; invert a
+move = restore prior positions") reads as if each mutation type needs its
+own bespoke inverse. Recon into the ACTUAL domain model (done before writing
+this file, not assumed) found three traps that make hand-authoring wrong in
+practice, not just tedious:
+
+- Node/edge ids come from one shared monotonic counter that never reuses
+  values (SceneDocument._counter). A hand-authored "invert a delete by
+  calling add_chat_node again" gets a NEW id - every reference to the old
+  one (edges, frame/container item_ids, last_chat_node_id, pins) would need
+  remapping. See node_states.py's PycoderState.pycoder_repl_id for the
+  documented precedent of a REAL bug this exact instability already caused
+  once (session reload silently swapping which on-disk REPL directory a
+  node resolved to).
+- remove_nodes() cascades silently: it evicts image/chart asset bytes from
+  image_assets with no return value, and calls _detach_node_from_membership
+  (groups.py), which can itself delete a SECOND node (an emptied frame/
+  container) never named in the caller's node_ids list and never reported
+  back.
+- connect() is idempotent - it returns the pre-existing edge if
+  source->target already exists. Inverting "connect" by deleting whatever
+  edge it returned is wrong whenever no new edge was actually minted.
+
+A snapshot-and-restore Command sidesteps all three by construction: undoing
+a delete restores the SAME node object under its SAME id (no counter
+involved, no remapping needed); a cascade-deleted frame is caught by the
+generic before/after id-set diff below rather than needing to be
+specifically anticipated; connect()'s idempotence is invisible to the diff
+when it doesn't change anything, so a no-op connect naturally produces an
+empty command.
+
+This is NOT the "snapshot deque" the ADR's own Alternatives section
+rejects. That alternative serializes the WHOLE document per op (megabytes
+at 500 nodes). This snapshots only the ids a command actually touches -
+O(command size), not O(document size) - the same complexity class the
+ADR's chosen design already commits to elsewhere ("undo cost is O(change),
+not O(graph)"). See record_command's own doc for the one deliberate
+exception (frame/container nodes are always defensively watched, since
+their item_ids/bounds are exactly the state other operations mutate as a
+side effect) and why that exception is still bounded, not O(document size).
+
+## What this module does NOT do (yet)
+
+No undo/redo STACK exists here - that is stage 10.2, a separate ADR-010
+stage with its own exit criterion. This module produces Command objects
+whose apply()/invert() are proven correct in isolation; nothing here
+decides when to call them or how many to retain. Composite commands
+(stage 10.3), live-run refusal (10.4), and provenance-scoped "undo last
+build" (10.5) are equally out of scope here.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable, Iterable, TypeVar
+
+if TYPE_CHECKING:
+    from backend.domain.model import SceneEdge, SceneNode
+
+T = TypeVar("T")
+
+# Asset bytes (image/chart PNGs) are the one thing in this module that IS
+# genuinely expensive to snapshot - a multi-megabyte image is not "O(command
+# size)" in the same cheap sense a node/edge dataclass copy is. Deliberately
+# keyed as tuple[bytes, str] (raw bytes + mime type) to match
+# SceneDocument.image_assets' own value shape exactly, so _restore below can
+# write it straight back with no repacking.
+_AssetSnapshot = "tuple[bytes, str]"
+
+
+@dataclass
+class Command:
+    """A single invertible mutation, already applied by the time this
+    object exists. `*_before`/`*_after` are keyed by id; a value of None
+    means "this id did not exist" (so `invert()` deletes it / `apply()`
+    creates it) rather than "no change" - an id with no real change at all
+    is simply absent from the dict, keeping empty commands (e.g. an
+    idempotent connect() that created nothing) cheap and easy to detect via
+    `is_noop`.
+
+    provenance: "user" for a direct user-initiated intent, or
+    f"agent:{run_id}" for an agent-driven mutation - carried now so stage
+    10.5's "undo last build" has something to key on later; unused by
+    apply()/invert() themselves.
+    """
+
+    command_type: str
+    provenance: str
+    node_before: dict[str, "SceneNode | None"] = field(default_factory=dict)
+    node_after: dict[str, "SceneNode | None"] = field(default_factory=dict)
+    edge_before: dict[str, "SceneEdge | None"] = field(default_factory=dict)
+    edge_after: dict[str, "SceneEdge | None"] = field(default_factory=dict)
+    asset_before: dict[str, "tuple[bytes, str] | None"] = field(default_factory=dict)
+    asset_after: dict[str, "tuple[bytes, str] | None"] = field(default_factory=dict)
+
+    @property
+    def is_noop(self) -> bool:
+        """True when the mutator this command wrapped touched nothing that
+        survived the diff (id.e. every explicitly/defensively watched id
+        came out byte-identical to how it went in) - the idempotent-
+        connect() case is the motivating example, but any accidental no-op
+        call hits this the same way."""
+        return not (
+            self.node_before or self.node_after or self.edge_before or self.edge_after
+        )
+
+    def invert(self, document: object) -> None:
+        """Restores document state to exactly how it was before this
+        command's mutator ran. Goes through the *_before snapshots only -
+        never re-invokes the original domain method, which is the whole
+        point (re-invoking move_node with old coordinates would work, but
+        re-invoking add_chat_node to "undo a delete" would mint a new id;
+        restoring the captured object under its original id sidesteps that
+        entirely)."""
+        _restore(document.nodes, self.node_before)
+        _restore(document.edges, self.edge_before)
+        _restore(document.image_assets, self.asset_before)
+
+    def apply(self, document: object) -> None:
+        """The mirror of invert() - restores to the *_after state. Not
+        needed for a first-time forward mutation (that already happened
+        for real before this Command was constructed); this exists for
+        REDO, applying a previously-inverted command a second time."""
+        _restore(document.nodes, self.node_after)
+        _restore(document.edges, self.edge_after)
+        _restore(document.image_assets, self.asset_after)
+
+
+def _restore(live: dict, snapshot: dict) -> None:
+    for key, value in snapshot.items():
+        if value is None:
+            live.pop(key, None)
+        else:
+            live[key] = copy.deepcopy(value)
+
+
+class CommandOps:
+    def record_command(
+        self,
+        command_type: str,
+        provenance: str,
+        mutator: Callable[[], T],
+        *,
+        node_ids: Iterable[str] = (),
+        edge_ids: Iterable[str] = (),
+    ) -> "tuple[T, Command]":
+        """Runs `mutator` (a zero-arg closure wrapping exactly one call into
+        an existing SceneDocument mutator, e.g. `lambda:
+        self.remove_nodes(ids)`) and returns `(mutator's return value,
+        the Command that inverts it)`.
+
+        `node_ids`/`edge_ids` are the ids the CALLER already knows the
+        mutator targets (a create's parent-connect target, a delete's
+        victim ids, a move's moved ids, connect's two endpoints) - used to
+        take a defensive BEFORE snapshot of anything that might be mutated
+        in place rather than created/deleted (move_node mutates x/y on the
+        SAME object; a naive before/after id-set diff alone would miss
+        that, since the id never leaves self.nodes).
+
+        Every frame/container-kind node is ALSO always defensively
+        snapshotted, regardless of node_ids - not because most commands
+        touch them, but because they are the one kind of node whose state
+        (item_ids, bounds, group_manual_x/y) other operations mutate as a
+        documented SIDE EFFECT (_detach_node_from_membership's cascade-
+        delete-when-emptied, move_node's bounds recompute on an enclosing
+        frame) without that frame ever appearing in the caller's own
+        node_ids. This is bounded by frame/container COUNT, not total node
+        count - cheap even at 500 nodes, since a scene has far fewer group
+        nodes than leaf nodes in practice, and is correct by construction
+        for every group side effect discovered during this stage's own
+        recon, not just the one the recon happened to name.
+
+        Asset bytes (image_assets) are snapshotted only for explicitly
+        named node_ids that currently carry an image_asset_id/
+        chart_asset_id - deliberately NOT defensive like the frame case,
+        since asset bytes are the one genuinely expensive thing here and
+        only a node's OWN delete evicts its OWN asset (see
+        remove_nodes' - never a side effect of some other node's edit).
+
+        Raises AssertionError if a node/edge disappears during `mutator()`
+        that was not in the watched set - a Command silently missing a
+        deletion IS the exact "vanishes without a trace" failure this
+        stage exists to prevent, so this fails loud rather than shipping a
+        Command whose invert() would be wrong.
+
+        Edge discovery is automatic, not the caller's job: remove_nodes()
+        deletes EVERY edge touching any of its target ids (both directions,
+        including a parent-connect edge created as a side effect of the
+        node's own creation, e.g. add_image_node's unconditional connect())
+        - requiring the caller to enumerate those by hand is exactly the
+        kind of easy-to-forget bookkeeping this layer exists to remove.
+        `edge_ids` remains for the cases with no node on one/either end of
+        the relevant edges to discover from (connect's freshly-minted edge
+        is caught by the id-set diff below either way; removeEdges' targets
+        have no other discovery path since the node(s) they touch are not
+        being deleted)."""
+        watch_node_ids = set(node_ids) | {
+            n.id for n in self.nodes.values() if n.kind in ("frame", "container")
+        }
+        watch_edge_ids = set(edge_ids) | {
+            e.id for e in self.edges.values() if e.source in watch_node_ids or e.target in watch_node_ids
+        }
+
+        node_snapshot_before = {
+            nid: copy.deepcopy(self.nodes[nid]) for nid in watch_node_ids if nid in self.nodes
+        }
+        edge_snapshot_before = {
+            eid: copy.deepcopy(self.edges[eid]) for eid in watch_edge_ids if eid in self.edges
+        }
+        asset_snapshot_before: dict[str, tuple[bytes, str]] = {}
+        for nid in set(node_ids):
+            node = self.nodes.get(nid)
+            if node is None or node.state is None:
+                continue
+            for attr in ("image_asset_id", "chart_asset_id"):
+                asset_id = getattr(node.state, attr, None)
+                if asset_id and asset_id in self.image_assets:
+                    asset_snapshot_before[asset_id] = self.image_assets[asset_id]
+
+        node_ids_before = set(self.nodes.keys())
+        edge_ids_before = set(self.edges.keys())
+        asset_ids_before = set(self.image_assets.keys())
+
+        result = mutator()
+
+        node_ids_after = set(self.nodes.keys())
+        edge_ids_after = set(self.edges.keys())
+        asset_ids_after = set(self.image_assets.keys())
+
+        node_before_out: dict[str, "SceneNode | None"] = {}
+        node_after_out: dict[str, "SceneNode | None"] = {}
+        for nid in node_ids_after - node_ids_before:
+            node_before_out[nid] = None
+            node_after_out[nid] = copy.deepcopy(self.nodes[nid])
+        for nid in node_ids_before - node_ids_after:
+            if nid not in node_snapshot_before:
+                raise AssertionError(
+                    f"command {command_type!r} deleted node {nid!r} with no defensive "
+                    "snapshot taken - extend record_command's watch set (node_ids or "
+                    "the frame/container defensive set) rather than let this Command "
+                    "silently lose it"
+                )
+            node_before_out[nid] = node_snapshot_before[nid]
+            node_after_out[nid] = None
+        for nid in watch_node_ids & node_ids_before & node_ids_after:
+            before = node_snapshot_before.get(nid)
+            after = self.nodes.get(nid)
+            if before is not None and after is not None and before != after:
+                node_before_out[nid] = before
+                node_after_out[nid] = copy.deepcopy(after)
+
+        edge_before_out: dict[str, "SceneEdge | None"] = {}
+        edge_after_out: dict[str, "SceneEdge | None"] = {}
+        for eid in edge_ids_after - edge_ids_before:
+            edge_before_out[eid] = None
+            edge_after_out[eid] = copy.deepcopy(self.edges[eid])
+        for eid in edge_ids_before - edge_ids_after:
+            if eid not in edge_snapshot_before:
+                raise AssertionError(
+                    f"command {command_type!r} deleted edge {eid!r} with no defensive "
+                    "snapshot taken - pass its id via edge_ids"
+                )
+            edge_before_out[eid] = edge_snapshot_before[eid]
+            edge_after_out[eid] = None
+
+        asset_before_out: dict[str, "tuple[bytes, str] | None"] = {}
+        asset_after_out: dict[str, "tuple[bytes, str] | None"] = {}
+        for aid in asset_ids_after - asset_ids_before:
+            asset_before_out[aid] = None
+            asset_after_out[aid] = self.image_assets[aid]
+        for aid in asset_ids_before - asset_ids_after:
+            if aid not in asset_snapshot_before:
+                raise AssertionError(
+                    f"command {command_type!r} evicted asset {aid!r} with no defensive "
+                    "snapshot taken - its owning node must be in node_ids"
+                )
+            asset_before_out[aid] = asset_snapshot_before[aid]
+            asset_after_out[aid] = None
+
+        command = Command(
+            command_type=command_type,
+            provenance=provenance,
+            node_before=node_before_out,
+            node_after=node_after_out,
+            edge_before=edge_before_out,
+            edge_after=edge_after_out,
+            asset_before=asset_before_out,
+            asset_after=asset_after_out,
+        )
+        # A no-op command (an idempotent connect() that created nothing, a
+        # setter called with the value it already had) is never logged -
+        # undoing it would do nothing, so it would only ever consume one of
+        # the bounded log's slots and make Ctrl+Z appear to "do nothing
+        # once" before reaching the operation the user actually meant.
+        if not command.is_noop:
+            self.command_log.append(command)
+        return result, command

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -33,6 +33,7 @@ would silently no-op; patch `backend.domain.graph.<name>` instead.
 
 from __future__ import annotations
 
+from collections import deque
 import itertools
 import math
 import uuid
@@ -50,6 +51,7 @@ from graphlink_navigation_pins import NavigationPinStore
 from graphlink_token_estimator import TokenEstimator
 
 from backend.domain.branches import BranchOps
+from backend.domain.commands import CommandOps
 from backend.domain.content_codec import _content_codec
 from backend.domain.groups import GroupOps
 from backend.domain.model import (
@@ -110,7 +112,7 @@ def _estimate_tokens(text: str) -> int:
 
 
 @dataclass
-class SceneDocument(BranchOps, GroupOps):
+class SceneDocument(BranchOps, GroupOps, CommandOps):
     """The canvas document for one session. Plain data + invariants; the
     R6 serializer will read/write exactly this shape."""
 
@@ -200,6 +202,20 @@ class SceneDocument(BranchOps, GroupOps):
     # New Chat confirm skips only when the canvas is empty AND there is no
     # current chat - a predicate the frontend cannot evaluate without it.
     current_chat_id: int | None = None
+    # ADR-010 stage 10.1: every invertible mutation this session has
+    # recorded, oldest first. Bounded per the ADR's own durability boundary
+    # ("session-scoped and in-memory (bounded, e.g. 100 composite commands),
+    # not persisted") - a deque's maxlen drops the oldest silently, which is
+    # the correct behavior for undo history specifically: losing the ability
+    # to undo something from 100 operations ago is the intended limit, not a
+    # data loss (the scene itself is untouched).
+    #
+    # This is a LOG, deliberately not yet an undo STACK - there is no cursor
+    # and no redo pointer, because deciding WHEN to invert is ADR-010 stage
+    # 10.2's job, with its own exit criterion. 10.1 only has to prove the
+    # commands are correctly invertible, which is what backend/tests/
+    # test_commands.py does. Stage 10.2 adds the cursor on top of this.
+    command_log: deque = field(default_factory=lambda: deque(maxlen=100), repr=False)
     _counter: itertools.count = field(default_factory=itertools.count, repr=False)
     # ADR-003 stage 3.4: the last wire state actually published, kept so
     # take_dirty_patch_ops below can diff against it. None until the first
@@ -380,6 +396,13 @@ class SceneDocument(BranchOps, GroupOps):
         self.scroll_y = 0.0
         self.total_session_tokens = 0
         self.current_chat_id = None
+        # ADR-010 stage 10.1: undo history does NOT survive a session load.
+        # Every command in it references node/edge ids from the document
+        # being replaced, so inverting one afterward would resurrect a node
+        # from the PREVIOUS chat into this one. The ADR scopes undo history
+        # to a session deliberately ("session-scoped and in-memory ... not
+        # persisted"); this is the boundary that enforces it.
+        self.command_log.clear()
         # ADR-003 stage 3.4 review-fix: drop the patch baseline too. Loading a
         # chat replaces the entire document, so diffing the new scene against
         # the OLD one produced a patch no smaller than the snapshot it

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -151,8 +151,12 @@ def register_plugins(
                 await bus.publish("notification")
                 return None
             parent = canvas_document.nodes[parent_node_id]
-            node = canvas_document.add_web_research_node(
-                parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            node, _command = canvas_document.record_command(
+                "pluginWebResearch", "user",
+                lambda: canvas_document.add_web_research_node(
+                    parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+                ),
+                node_ids=[parent_node_id],
             )
             await bus.publish("scene")
             return node.id
@@ -173,8 +177,12 @@ def register_plugins(
                 await bus.publish("notification")
                 return None
             parent = canvas_document.nodes[parent_node_id]
-            node = canvas_document.add_gitlink_node(
-                parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            node, _command = canvas_document.record_command(
+                "pluginGitlink", "user",
+                lambda: canvas_document.add_gitlink_node(
+                    parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+                ),
+                node_ids=[parent_node_id],
             )
             await bus.publish("scene")
             return node.id
@@ -194,8 +202,12 @@ def register_plugins(
                 await bus.publish("notification")
                 return None
             parent = canvas_document.nodes[parent_node_id]
-            node = canvas_document.add_pycoder_node(
-                parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            node, _command = canvas_document.record_command(
+                "pluginPyCoder", "user",
+                lambda: canvas_document.add_pycoder_node(
+                    parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+                ),
+                node_ids=[parent_node_id],
             )
             await bus.publish("scene")
             return node.id
@@ -211,8 +223,12 @@ def register_plugins(
                 await bus.publish("notification")
                 return None
             parent = canvas_document.nodes[parent_node_id]
-            node = canvas_document.add_code_sandbox_node(
-                parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            node, _command = canvas_document.record_command(
+                "pluginCodeSandbox", "user",
+                lambda: canvas_document.add_code_sandbox_node(
+                    parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+                ),
+                node_ids=[parent_node_id],
             )
             await bus.publish("scene")
             return node.id
@@ -231,8 +247,12 @@ def register_plugins(
                 await bus.publish("notification")
                 return None
             parent = canvas_document.nodes[parent_node_id]
-            node = canvas_document.add_artifact_node(
-                parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            node, _command = canvas_document.record_command(
+                "pluginArtifact", "user",
+                lambda: canvas_document.add_artifact_node(
+                    parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+                ),
+                node_ids=[parent_node_id],
             )
             await bus.publish("scene")
             return node.id
@@ -277,8 +297,18 @@ def register_plugins(
             if existing is not None:
                 await bus.publish("scene")
                 return existing.id
-            note = canvas_document.add_note(root.x, root.y - 150, is_system_prompt=True)
-            canvas_document.connect(note.id, root.id)
+            # The only plugin branch that creates AND connects - both are
+            # captured by one command, so undoing it removes the note and
+            # its edge together rather than leaving a dangling edge.
+            def _create_system_prompt_note():
+                created = canvas_document.add_note(root.x, root.y - 150, is_system_prompt=True)
+                canvas_document.connect(created.id, root.id)
+                return created
+
+            note, _command = canvas_document.record_command(
+                "pluginSystemPrompt", "user", _create_system_prompt_note,
+                node_ids=[root.id],
+            )
             await bus.publish("scene")
             return note.id
 
@@ -296,7 +326,11 @@ def register_plugins(
                 await bus.publish("notification")
                 return None
             parent = canvas_document.nodes[parent_node_id]
-            node = canvas_document.add_conversation_node(parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id)
+            node, _command = canvas_document.record_command(
+                "pluginConversationNode", "user",
+                lambda: canvas_document.add_conversation_node(parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id),
+                node_ids=[parent_node_id],
+            )
             await bus.publish("scene")
             return node.id
 
@@ -315,7 +349,11 @@ def register_plugins(
                 await bus.publish("notification")
                 return None
             parent = canvas_document.nodes[parent_node_id]
-            node = canvas_document.add_html_node(parent.x, parent.y + MESSAGE_VERTICAL_SPACING, "", parent_node_id)
+            node, _command = canvas_document.record_command(
+                "pluginHtmlRenderer", "user",
+                lambda: canvas_document.add_html_node(parent.x, parent.y + MESSAGE_VERTICAL_SPACING, "", parent_node_id),
+                node_ids=[parent_node_id],
+            )
             await bus.publish("scene")
             return node.id
 

--- a/backend/tests/test_commands.py
+++ b/backend/tests/test_commands.py
@@ -1,0 +1,444 @@
+"""ADR-010 stage 10.1: the command layer (backend/domain/commands.py).
+
+Two layers of test here, deliberately kept separate:
+
+1. Command.apply()/invert() proven against SYNTHETIC before/after state -
+   no SceneDocument involved, just the restore mechanism itself.
+2. CommandOps.record_command() proven against a REAL SceneDocument for
+   every hard case commands.py's own module doc names: id-stable delete
+   recreation, remove_nodes' silent asset eviction, remove_nodes' cascade-
+   delete of an emptied frame, connect()'s idempotence, and move_node's
+   hidden frame group_manual_x/y side effect.
+"""
+
+import copy
+
+import pytest
+
+from backend.domain.commands import Command
+from backend.domain.graph import SceneDocument
+from backend.domain.model import SceneEdge, SceneNode
+
+
+# -- layer 1: Command.apply()/invert() against synthetic state --------------
+
+
+def test_invert_restores_a_deleted_node_under_its_original_object():
+    node = SceneNode(id="n1", x=1.0, y=2.0, title="t", kind="note")
+    document = SceneDocument()
+    command = Command(
+        command_type="test",
+        provenance="user",
+        node_before={"n1": node},
+        node_after={"n1": None},
+    )
+    command.invert(document)
+    assert document.nodes["n1"] == node
+    assert document.nodes["n1"] is not node  # deep copy, not the same object
+
+
+def test_invert_removes_a_created_node():
+    document = SceneDocument()
+    document.nodes["n1"] = SceneNode(id="n1", x=0, y=0, title="t", kind="note")
+    command = Command(
+        command_type="test",
+        provenance="user",
+        node_before={"n1": None},
+        node_after={"n1": document.nodes["n1"]},
+    )
+    command.invert(document)
+    assert "n1" not in document.nodes
+
+
+def test_apply_is_the_mirror_of_invert_for_redo():
+    document = SceneDocument()
+    before = SceneNode(id="n1", x=1.0, y=1.0, title="t", kind="note")
+    after = SceneNode(id="n1", x=5.0, y=5.0, title="t", kind="note")
+    command = Command(
+        command_type="move", provenance="user",
+        node_before={"n1": before}, node_after={"n1": after},
+    )
+    document.nodes["n1"] = copy.deepcopy(before)
+    command.apply(document)
+    assert document.nodes["n1"].x == 5.0
+    command.invert(document)
+    assert document.nodes["n1"].x == 1.0
+
+
+def test_is_noop_true_for_an_empty_command():
+    assert Command(command_type="test", provenance="user").is_noop
+
+
+def test_is_noop_false_when_anything_changed():
+    command = Command(
+        command_type="test", provenance="user", node_after={"n1": None},
+    )
+    assert not command.is_noop
+
+
+def test_invert_restores_evicted_asset_bytes():
+    document = SceneDocument()
+    command = Command(
+        command_type="test",
+        provenance="user",
+        asset_before={"img1": (b"\x89PNG...", "image/png")},
+        asset_after={"img1": None},
+    )
+    command.invert(document)
+    assert document.image_assets["img1"] == (b"\x89PNG...", "image/png")
+
+
+# -- layer 2: record_command() against a real SceneDocument -----------------
+
+
+@pytest.fixture
+def document():
+    return SceneDocument()
+
+
+def test_create_is_invertible_and_id_is_never_reused_by_a_later_create(document):
+    _node, command = document.record_command(
+        "createNote", "user", lambda: document.add_note(0, 0),
+    )
+    node_id = next(iter(command.node_after))
+    assert node_id in document.nodes
+
+    command.invert(document)
+    assert node_id not in document.nodes
+
+    # A later, unrelated create must not reuse the undone node's old id -
+    # the counter never rewinds, so this also pins that record_command
+    # itself does nothing to the counter.
+    other = document.add_note(10, 10)
+    assert other.id != node_id
+
+
+def test_delete_restores_the_node_under_its_original_id_no_remap_needed(document):
+    node = document.add_note(0, 0)
+    original_id = node.id
+
+    _result, command = document.record_command(
+        "deleteNodes", "user", lambda: document.remove_nodes([original_id]),
+        node_ids=[original_id],
+    )
+    assert original_id not in document.nodes
+
+    command.invert(document)
+    # Same id, no remapping - the whole point of snapshot/restore over
+    # re-invoking add_note to recreate it.
+    assert original_id in document.nodes
+    assert document.nodes[original_id].id == original_id
+
+
+def test_delete_restores_edges_touching_the_deleted_node(document):
+    parent = document.add_note(0, 0)
+    child = document.add_chat_node(50, 0, "hi", is_user=True, parent_id=parent.id)
+    edge_id = next(iter(document.edges))
+
+    _result, command = document.record_command(
+        "deleteNodes", "user", lambda: document.remove_nodes([child.id]),
+        node_ids=[child.id], edge_ids=[edge_id],
+    )
+    assert edge_id not in document.edges
+
+    command.invert(document)
+    assert edge_id in document.edges
+    assert document.edges[edge_id].source == parent.id
+    assert document.edges[edge_id].target == child.id
+
+
+def test_delete_restores_asset_bytes_remove_nodes_would_otherwise_discard(document):
+    node = document.add_image_node(0, 0, b"\x89PNG-fake", "a cat",
+                                    parent_id=document.add_note(0, 0).id)
+    asset_id = node.state.image_asset_id
+    assert asset_id in document.image_assets
+
+    _result, command = document.record_command(
+        "deleteNodes", "user", lambda: document.remove_nodes([node.id]),
+        node_ids=[node.id],
+    )
+    assert asset_id not in document.image_assets  # remove_nodes evicted it for real
+
+    command.invert(document)
+    assert asset_id in document.image_assets
+    assert document.image_assets[asset_id] == (b"\x89PNG-fake", "image/png")
+
+
+def test_delete_that_empties_a_frame_restores_the_cascade_deleted_frame_too(document):
+    member = document.add_chat_node(0, 0, "hi", is_user=True)
+    frame = document.create_frame([member.id])
+    frame_id = frame.id
+    assert frame_id in document.nodes
+
+    _result, command = document.record_command(
+        "deleteNodes", "user", lambda: document.remove_nodes([member.id]),
+        node_ids=[member.id],
+    )
+    # The frame was the member's only member - remove_nodes' own
+    # _detach_node_from_membership cascade-deletes it, unrequested.
+    assert frame_id not in document.nodes
+
+    command.invert(document)
+    # Both the explicit target AND the cascade-deleted frame come back -
+    # this is the case a naive "snapshot only the caller's explicit ids"
+    # design would have silently lost.
+    assert member.id in document.nodes
+    assert frame_id in document.nodes
+    assert document.nodes[frame_id].item_ids == [member.id]
+
+
+def test_delete_that_shrinks_a_frame_without_emptying_it_restores_membership(document):
+    a = document.add_chat_node(0, 0, "a", is_user=True)
+    b = document.add_chat_node(100, 0, "b", is_user=True)
+    frame = document.create_frame([a.id, b.id])
+    frame_id = frame.id
+
+    _result, command = document.record_command(
+        "deleteNodes", "user", lambda: document.remove_nodes([a.id]),
+        node_ids=[a.id],
+    )
+    assert document.nodes[frame_id].item_ids == [b.id]
+
+    command.invert(document)
+    assert a.id in document.nodes
+    # Frame survived the forward op (still had b.id); its item_ids must be
+    # restored to include a.id again, not left at the shrunk [b.id].
+    assert set(document.nodes[frame_id].item_ids) == {a.id, b.id}
+
+
+def test_move_restores_position_and_the_hidden_frame_pinning_side_effect(document):
+    member = document.add_chat_node(0, 0, "hi", is_user=True)
+    frame = document.create_frame([member.id])
+    frame_id = frame.id
+    was_auto_fit = document.nodes[frame_id].state.group_manual_x is None
+    assert was_auto_fit  # precondition: frame starts in auto-fit mode
+    # create_frame computes the frame's initial position from a padded bbox
+    # of its members, not (0, 0) - capture the REAL starting position rather
+    # than assume one.
+    original_x, original_y = document.nodes[frame_id].x, document.nodes[frame_id].y
+
+    _result, command = document.record_command(
+        "moveNode", "user", lambda: document.move_node(frame_id, 500.0, 500.0),
+        node_ids=[frame_id],
+    )
+    # move_node's own documented side effect: moving a frame pins it out of
+    # auto-fit, regardless of whether it was auto-fit before.
+    assert document.nodes[frame_id].state.group_manual_x is not None
+
+    command.invert(document)
+    # A naive invert that only restored x/y (not the whole node) would
+    # leave group_manual_x/y set here, silently converting an auto-fit
+    # frame into a manually-pinned one - this pins that snapshot/restore
+    # of the WHOLE object avoids that.
+    assert document.nodes[frame_id].state.group_manual_x is None
+    assert document.nodes[frame_id].x == original_x
+    assert document.nodes[frame_id].y == original_y
+
+
+def test_connect_is_invertible(document):
+    a = document.add_note(0, 0)
+    b = document.add_note(100, 0)
+
+    _edge, command = document.record_command(
+        "connectNodes", "user", lambda: document.connect(a.id, b.id),
+        node_ids=[a.id, b.id],
+    )
+    edge_id = next(iter(command.edge_after))
+    assert edge_id in document.edges
+
+    command.invert(document)
+    assert edge_id not in document.edges
+
+
+def test_idempotent_connect_produces_a_noop_command(document):
+    a = document.add_note(0, 0)
+    b = document.add_note(100, 0)
+    document.connect(a.id, b.id)
+    existing_edge_id = next(iter(document.edges))
+
+    _edge, command = document.record_command(
+        "connectNodes", "user", lambda: document.connect(a.id, b.id),
+        node_ids=[a.id, b.id],
+    )
+    # connect() returned the pre-existing edge - nothing was created, so
+    # inverting must be a true no-op, not "delete the edge it returned."
+    assert command.is_noop
+
+    command.invert(document)
+    assert existing_edge_id in document.edges
+
+
+def test_remove_edges_is_invertible_under_the_original_edge_id(document):
+    a = document.add_note(0, 0)
+    b = document.add_note(100, 0)
+    edge = document.connect(a.id, b.id)
+
+    _result, command = document.record_command(
+        "removeEdges", "user", lambda: document.remove_edges([edge.id]),
+        edge_ids=[edge.id],
+    )
+    assert edge.id not in document.edges
+
+    command.invert(document)
+    assert edge.id in document.edges
+    assert document.edges[edge.id] == edge
+
+
+def test_unanticipated_deletion_raises_instead_of_silently_losing_it(document):
+    node = document.add_note(0, 0)
+    with pytest.raises(AssertionError, match="no defensive snapshot"):
+        # node_ids deliberately omitted - record_command has no way to know
+        # this node is about to be deleted, and must fail loud rather than
+        # produce a Command whose invert() can't restore it.
+        document.record_command(
+            "deleteNodes", "user", lambda: document.remove_nodes([node.id]),
+        )
+
+
+# -- layer 3: end-to-end through the REAL wired intent surface --------------
+#
+# Layers 1-2 above prove the mechanism in isolation. These prove the actual
+# migration landed: that dispatching a real WS intent through the real
+# register_canvas wiring produces a logged, correctly-inverting command. A
+# call site that was MISSED by the migration fails here and only here - the
+# domain-level tests above would still pass, since they call record_command
+# directly rather than going through the intent.
+
+
+@pytest.fixture
+def wired():
+    """The real bus + document + intent registrations, same construction
+    backend/app.py itself uses."""
+    from backend.tests.test_canvas import make_bus_with_dispatcher
+
+    bus, document, _recorder, _dispatcher = make_bus_with_dispatcher()
+    return bus, document
+
+
+def _dispatch(bus, intent, *args, topic="scene"):
+    import asyncio
+
+    return asyncio.run(bus.dispatch_intent(topic, intent, list(args)))
+
+
+def test_addnode_intent_logs_an_invertible_command(wired):
+    bus, document = wired
+    node_id = _dispatch(bus, "addNode", 10, 20, "hello")
+
+    assert len(document.command_log) == 1
+    command = document.command_log[-1]
+    assert command.command_type == "addNode"
+    assert command.provenance == "user"
+
+    command.invert(document)
+    assert node_id not in document.nodes
+
+
+def test_removenodes_intent_logs_a_command_that_restores_the_node(wired):
+    bus, document = wired
+    node_id = _dispatch(bus, "addNode", 10, 20, "hello")
+    document.command_log.clear()
+
+    _dispatch(bus, "removeNodes", [node_id])
+    assert node_id not in document.nodes
+
+    assert len(document.command_log) == 1
+    assert document.command_log[-1].command_type == "removeNodes"
+    document.command_log[-1].invert(document)
+    assert node_id in document.nodes
+    assert document.nodes[node_id].title == "hello"
+
+
+def test_movenode_intent_logs_a_command_that_restores_the_position(wired):
+    bus, document = wired
+    node_id = _dispatch(bus, "addNode", 10, 20, "hello")
+    document.command_log.clear()
+
+    _dispatch(bus, "moveNode", node_id, 500, 600)
+    assert document.nodes[node_id].x == 500
+
+    document.command_log[-1].invert(document)
+    assert document.nodes[node_id].x == 10
+    assert document.nodes[node_id].y == 20
+
+
+def test_movenodes_group_drag_is_ONE_command_not_one_per_node(wired):
+    bus, document = wired
+    a = _dispatch(bus, "addNode", 0, 0, "a")
+    b = _dispatch(bus, "addNode", 100, 0, "b")
+    document.command_log.clear()
+
+    _dispatch(bus, "moveNodes", [[a, 50, 50], [b, 150, 50]])
+    # One Ctrl+Z must put the whole group drag back, so the intent must
+    # produce exactly one command regardless of how many nodes moved.
+    assert len(document.command_log) == 1
+
+    document.command_log[-1].invert(document)
+    assert (document.nodes[a].x, document.nodes[a].y) == (0, 0)
+    assert (document.nodes[b].x, document.nodes[b].y) == (100, 0)
+
+
+def test_connectnodes_intent_is_invertible_and_idempotent_repeat_logs_nothing(wired):
+    bus, document = wired
+    a = _dispatch(bus, "addNode", 0, 0, "a")
+    b = _dispatch(bus, "addNode", 100, 0, "b")
+    document.command_log.clear()
+
+    edge_id = _dispatch(bus, "connectNodes", a, b)
+    assert len(document.command_log) == 1
+
+    # Re-connecting the same pair creates nothing (connect is idempotent),
+    # so it must not add a command that would delete the existing edge.
+    _dispatch(bus, "connectNodes", a, b)
+    assert len(document.command_log) == 1
+
+    document.command_log[-1].invert(document)
+    assert edge_id not in document.edges
+
+
+def test_removeedges_intent_is_invertible(wired):
+    bus, document = wired
+    a = _dispatch(bus, "addNode", 0, 0, "a")
+    b = _dispatch(bus, "addNode", 100, 0, "b")
+    edge_id = _dispatch(bus, "connectNodes", a, b)
+    document.command_log.clear()
+
+    _dispatch(bus, "removeEdges", [edge_id])
+    assert edge_id not in document.edges
+
+    document.command_log[-1].invert(document)
+    assert edge_id in document.edges
+
+
+def test_addnote_and_createframe_intents_are_invertible(wired):
+    bus, document = wired
+    member = _dispatch(bus, "addChatNode", 0, 0, "hi", True, None)
+    document.command_log.clear()
+
+    frame_id = _dispatch(bus, "createFrame", [member])
+    assert frame_id in document.nodes
+
+    document.command_log[-1].invert(document)
+    assert frame_id not in document.nodes
+
+
+def test_the_command_log_is_bounded_and_drops_oldest_not_newest(wired):
+    bus, document = wired
+    for i in range(120):
+        _dispatch(bus, "addNode", i, i, f"n{i}")
+
+    # maxlen=100 per the ADR's own "bounded, e.g. 100" durability boundary.
+    assert len(document.command_log) == 100
+    # The newest survive; the oldest are the ones dropped.
+    assert document.command_log[-1].command_type == "addNode"
+
+
+def test_loading_a_session_clears_undo_history(wired):
+    bus, document = wired
+    _dispatch(bus, "addNode", 0, 0, "from the old session")
+    assert len(document.command_log) > 0
+
+    document.clear_for_load()
+    # Inverting a command from the PREVIOUS chat would resurrect one of its
+    # nodes into this one - the history must not survive the boundary.
+    assert len(document.command_log) == 0


### PR DESCRIPTION
## Problem

There is no undo/redo anywhere in the app (grep-verified). Delete a node, delete a branch, move a group, ungroup, regenerate a response — all irreversible, and Delete/Backspace are wired with no confirmation. For a canvas where a node is a chat turn or an agent-built step, that's a trust problem, and it blocks the agentic build work that has to be reversible to be safe.

This lands the foundation: every create/delete/move/connect mutation now produces a `Command` that can invert itself.

## Two corrections to the ADR's framing

Reconnaissance came first, and the ADR's own text didn't survive contact with the code:

1. **ADR-010 says the service layer "already becomes the single mutation entry point in ADR-002".** It doesn't. Every intent handler calls `document.<method>()` directly, then `publish_scene()`. `RunLifecycle` is a concurrency guard for agent dispatch, unrelated to document mutation. There was no seam to hook into — this creates one.

2. **"create/delete/move/connect" is 4 intents by name and ~25 call sites in fact.** 9 `add*` intents; 5 creates hidden inside `sendMessage` / `synthesizeBranches` / `generateChart` / `compareBranches`; 8 more inside `plugins.py`'s `executePlugin` (on the `app-plugins` topic, not `scene` — invisible to an `intents_*.py`-only search); two structurally different delete paths (`remove_nodes` cascades, `delete_chat_node` reparents); and a sub-node-granularity message delete. All are migrated here. Reading the exit criterion as just the 4 named intents would have repeated the mis-scoping ADR-002 stage 2.6 already hit once.

## Approach

Commands capture a **scoped before/after snapshot** rather than a hand-authored inverse per mutation type. Hand-authoring loses to three real traps, not just tedium:

- Node ids come from a monotonic counter with no reinsert-under-old-id path, so undo-recreate would mint a new id and need every edge, frame membership, and cursor referencing the old one remapped. (`PycoderState.pycoder_repl_id` exists because this exact id instability already caused a real bug once.)
- `remove_nodes` silently evicts image/chart asset bytes and can **cascade-delete an emptied frame** that was never in the caller's id list.
- `connect()` is idempotent — deleting whatever edge it returned is wrong when it created nothing.

Snapshot/restore is correct for all three by construction. This is **not** the whole-document snapshot deque the ADR rejects: it captures only the ids a command touches, plus every frame/container node defensively (those are what other operations mutate as a side effect). A deletion with no defensive snapshot **raises** rather than producing a `Command` whose `invert()` would silently lose data.

Commands land in a bounded (100) per-session log, cleared on session load so undo can never resurrect a node from a previously loaded chat. This is a **log, not yet a stack** — no cursor, no redo pointer. Deciding when to invert is stage 10.2.

## Explicitly not in scope

~56 remaining mutating intents (settings toggles, group/frame setters, gitlink/pycoder/sandbox state, pins, grid) still mutate directly. ADR-010 cannot close until they produce commands too — flagged here rather than left to be discovered later.

Undoing a pycoder/code_sandbox delete restores the node but **not** a live REPL: subprocess teardown and scratch-dir removal are deliberately outside the command, since killing a process isn't reversible by restoring a dict entry. Stage 10.4's live-run refusal is where that gets a real policy.

## Test plan

- `python -m pytest -q` from repo root: **1674 passed, 14 skipped**
- 26 new tests in three deliberate layers: the restore mechanism against synthetic state; `record_command` against a real `SceneDocument` for every hard case above; and **end-to-end through the real `register_canvas` intent wiring** — a call site missed by the migration fails only in that third layer
- Mutation-tested with backup/restore, each confirming the intended test fails and the tree is byte-identical afterward: removing automatic edge discovery, removing the frame/container defensive watch, removing the asset snapshot, reverting `removeNodes` to a bare domain call, and splitting a group drag into one command per node
- `tests/test_register_function_length.py`'s 300-line cap caught `register_chat_intents` growing to 350 — the two reply paths were extracted to module level rather than raising the cap
