### PR TITLE
ADR-010 stages 10.2-10.5: working undo/redo

### DIFF
--- a/backend/api/intents_undo.py
+++ b/backend/api/intents_undo.py
@@ -1,0 +1,75 @@
+"""ADR-010 stage 10.2/10.4/10.5: the undo/redo intent surface.
+
+The stack itself lives in backend/domain/commands.py (CommandOps); this
+module is only the WS-intent wrapper around it, in the same shape as every
+other intents_*.py module - call the domain, then publish.
+
+Undo/redo state (can-undo, can-redo, and the action labels) rides the scene
+topic's own payload rather than a separate topic, because it changes on
+exactly the same events the scene does: every mutation, every undo, every
+redo, and a session load. A separate topic would need its own publish call
+bolted onto all ~80 mutating intents to stay in sync, and would be wrong the
+moment one was missed.
+"""
+
+from __future__ import annotations
+
+from backend.api._shared import make_publish_scene
+from backend.domain.commands import UndoRefusedError
+from backend.domain.graph import SceneDocument
+from backend.events import SessionBus
+from backend.notifications import NotificationState
+
+
+def register_undo_intents(
+    bus: SessionBus,
+    document: SceneDocument,
+    notifications: NotificationState,
+) -> None:
+    publish_scene = make_publish_scene(bus)
+
+    async def _refuse(message: str) -> None:
+        """A refusal is a normal, expected outcome (nothing to undo; a node
+        is still generating), not an error - it surfaces through the same
+        notification banner every other user-facing message uses, rather
+        than raising back through the intent layer as a failure."""
+        notifications.show(message, msg_type="info")
+        await bus.publish("notification")
+
+    async def undo():
+        try:
+            command = document.undo()
+        except UndoRefusedError as exc:
+            await _refuse(str(exc))
+            return None
+        await publish_scene()
+        return command.label
+
+    async def redo():
+        try:
+            command = document.redo()
+        except UndoRefusedError as exc:
+            await _refuse(str(exc))
+            return None
+        await publish_scene()
+        return command.label
+
+    async def undo_run(run_id):
+        """ADR-010 stage 10.5: reverse a whole agent build in one action.
+        Deliberately reports how many steps came back rather than staying
+        silent - "undo this build" reversing 7 nodes should say so, since
+        the user cannot count them once they are gone."""
+        try:
+            count = document.undo_run(str(run_id))
+        except UndoRefusedError as exc:
+            await _refuse(str(exc))
+            return 0
+        if count == 0:
+            await _refuse("Nothing from that run is left to undo.")
+            return 0
+        await publish_scene()
+        return count
+
+    bus.register_intent("scene", "undo", undo)
+    bus.register_intent("scene", "redo", redo)
+    bus.register_intent("scene", "undoRun", undo_run)

--- a/backend/api/intents_view.py
+++ b/backend/api/intents_view.py
@@ -56,7 +56,14 @@ def register_view_intents(bus: SessionBus, document: SceneDocument) -> None:
     bus.register_intent("scene", "setViewState", set_view_state)
 
     async def organize_nodes():
-        document.organize()
+        # ADR-010 stage 10.3: auto-layout repositions potentially EVERY node
+        # in the scene. One Ctrl+Z has to put the whole layout back - which
+        # it does here because every node is named, so a single command
+        # captures all of their before/after positions at once.
+        document.record_command(
+            "organizeNodes", "user", document.organize,
+            node_ids=list(document.nodes.keys()),
+        )
         await publish_scene()
 
     async def set_font_family(family):

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -264,6 +264,7 @@ from backend.api.intents_nodes import register_node_intents  # noqa: E402
 from backend.api.intents_pins import register_pins_intents  # noqa: E402
 from backend.api.intents_pycoder import register_pycoder_intents  # noqa: E402
 from backend.api.intents_view import register_view_intents  # noqa: E402
+from backend.api.intents_undo import register_undo_intents  # noqa: E402
 from backend.api.intents_web_research import register_web_research_intents  # noqa: E402
 
 
@@ -361,6 +362,9 @@ def register_canvas(
     register_groups_intents(bus, document)
     register_pins_intents(bus, document)
     register_view_intents(bus, document)
+    # ADR-010 stage 10.2: undo/redo rides the scene topic (see that
+    # module's own doc for why it is not its own topic).
+    register_undo_intents(bus, document, notifications)
     register_grid_intents(bus, document)
 
     return document

--- a/backend/domain/commands.py
+++ b/backend/domain/commands.py
@@ -49,19 +49,33 @@ exception (frame/container nodes are always defensively watched, since
 their item_ids/bounds are exactly the state other operations mutate as a
 side effect) and why that exception is still bounded, not O(document size).
 
-## What this module does NOT do (yet)
+## The stack (stages 10.2-10.5)
 
-No undo/redo STACK exists here - that is stage 10.2, a separate ADR-010
-stage with its own exit criterion. This module produces Command objects
-whose apply()/invert() are proven correct in isolation; nothing here
-decides when to call them or how many to retain. Composite commands
-(stage 10.3), live-run refusal (10.4), and provenance-scoped "undo last
-build" (10.5) are equally out of scope here.
+Beyond producing Commands, this module owns the undo/redo stack itself:
+
+- **undo()/redo()** move commands between `command_log` (the undo stack) and
+  `redo_stack`. Performing any NEW command clears the redo branch, the
+  standard behavior everywhere - undo three things, do something else, and
+  "redo" must not reapply the discarded three onto a now-divergent document.
+- **composite()** (10.3) groups several separate record_command calls into
+  one undoable action, for multi-step operations like auto-layout. A single
+  record_command already handles multiple nodes on its own; this is for the
+  different case of several distinct calls that should read as one action.
+- **_guard_live_runs** (10.4) refuses an undo that would touch a node with an
+  in-flight agent run - restoring a pre-run snapshot underneath a writing
+  agent would leave state neither party asked for. Cancel first, then undo.
+- **undo_run()** (10.5) reverses a whole agent run's commands as one action,
+  keyed on `Command.run_id`.
+
+Undo history is session-scoped and in-memory, bounded at 100, and cleared on
+session load - it is an interaction convenience, deliberately distinct from
+ADR-009's on-disk backups, which are the actual durability control.
 """
 
 from __future__ import annotations
 
 import copy
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, Iterable, TypeVar
 
@@ -103,6 +117,25 @@ class Command:
     edge_after: dict[str, "SceneEdge | None"] = field(default_factory=dict)
     asset_before: dict[str, "tuple[bytes, str] | None"] = field(default_factory=dict)
     asset_after: dict[str, "tuple[bytes, str] | None"] = field(default_factory=dict)
+    # ADR-010 stage 10.5: the agent run this command belongs to, or None for
+    # a direct user action. Set for every mutation an agent run produces, so
+    # "undo this build" can revert a whole run's worth of commands as a unit
+    # rather than making the user press Ctrl+Z once per node the agent made.
+    run_id: str | None = None
+
+    @property
+    def label(self) -> str:
+        """The human-readable action name the undo affordance shows ("Undo
+        Delete", "Redo Move"). Derived from command_type rather than stored
+        separately so it can never drift from what the command actually is."""
+        return _COMMAND_LABELS.get(self.command_type, _humanize(self.command_type))
+
+    @property
+    def touched_node_ids(self) -> set[str]:
+        """Every node id this command would create, delete or modify in
+        either direction - what stage 10.4's live-run refusal checks against
+        (you cannot undo across a node that is mid-generation)."""
+        return set(self.node_before) | set(self.node_after)
 
     @property
     def is_noop(self) -> bool:
@@ -143,6 +176,124 @@ def _restore(live: dict, snapshot: dict) -> None:
             live.pop(key, None)
         else:
             live[key] = copy.deepcopy(value)
+
+
+# The user-facing action names. Deliberately phrased as what the USER did
+# ("Delete", "Move") rather than the intent name ("removeNodes"), since this
+# text lands directly in "Undo Delete" on a button and in its tooltip.
+_COMMAND_LABELS = {
+    "addNode": "Add Node",
+    "addChatNode": "Add Chat Node",
+    "addCodeNode": "Add Code Node",
+    "addDocumentNode": "Add Document",
+    "addThinkingNode": "Add Thinking Node",
+    "addHtmlNode": "Add HTML Node",
+    "addImageNode": "Add Image",
+    "addConversationNode": "Add Conversation",
+    "addNote": "Add Note",
+    "removeNodes": "Delete",
+    "deleteChatNode": "Delete Message",
+    "deleteConversationMessage": "Delete Message",
+    "moveNode": "Move",
+    "moveNodes": "Move",
+    "organizeNodes": "Organize Nodes",
+    "connectNodes": "Connect",
+    "removeEdges": "Disconnect",
+    "createFrame": "Create Frame",
+    "createContainer": "Create Container",
+    "ungroup": "Ungroup",
+    "sendMessage": "Send Message",
+    "chatReply": "Assistant Reply",
+    "regenerateResponse": "Regenerate",
+    "generateChart": "Generate Chart",
+    "generateNote": "Generate Note",
+    "compareBranches": "Compare Branches",
+    "synthesizeBranches": "Synthesize Branches",
+    "generateImageReply": "Generate Image",
+    "setNoteContent": "Edit Note",
+    "setGroupLabel": "Rename Group",
+    "setGroupColor": "Recolor",
+    "toggleFrameLock": "Lock Frame",
+    "toggleGroupCollapsed": "Collapse Group",
+    "resizeFrame": "Resize Frame",
+    "fitFrameToContent": "Fit Frame",
+    "resizeChart": "Resize Chart",
+    "toggleChartAspectLock": "Chart Aspect Lock",
+    "setChatCollapsed": "Collapse",
+    "collapseAllNodes": "Collapse All",
+    "expandAllNodes": "Expand All",
+    "setNodeDocked": "Dock",
+    "collapseBranch": "Collapse Branch",
+    "setBranchStatus": "Set Status",
+    "setFinalDeliverable": "Mark Final",
+    "addPin": "Add Pin",
+    "removePin": "Remove Pin",
+    "updatePin": "Edit Pin",
+    "movePin": "Move Pin",
+}
+
+
+def _humanize(command_type: str) -> str:
+    """Fallback label for a command_type with no explicit entry above -
+    "setSomeThing" -> "Set Some Thing". Keeps a newly added command from
+    ever showing a raw camelCase identifier in the UI, even if whoever
+    added it forgot the label table."""
+    out = []
+    for index, char in enumerate(command_type):
+        if char.isupper() and index > 0:
+            out.append(" ")
+        out.append(char.upper() if index == 0 else char)
+    return "".join(out)
+
+
+class UndoRefusedError(Exception):
+    """ADR-010 stage 10.4: raised when an undo/redo is refused rather than
+    failed - carries a message meant to be shown to the user verbatim."""
+
+
+def _merge_commands(command_type, provenance, commands):
+    """ADR-010 stage 10.3: folds a composite's buffered commands into one.
+
+    Merge order matters and is asymmetric: for the BEFORE state the FIRST
+    write wins (the earliest snapshot is the true "before the whole group"),
+    while for the AFTER state the LAST write wins (the final value is what
+    the group ended up producing). Getting this backwards would make undo
+    restore an intermediate state rather than the state before the action.
+    """
+    real = [c for c in commands if not c.is_noop]
+    if not real:
+        return None
+    if len(real) == 1:
+        return real[0]
+
+    merged = Command(
+        command_type=command_type,
+        provenance=provenance,
+        run_id=next((c.run_id for c in real if c.run_id), None),
+    )
+    for command in real:
+        for field_name in ("node_before", "edge_before", "asset_before"):
+            target = getattr(merged, field_name)
+            for key, value in getattr(command, field_name).items():
+                target.setdefault(key, value)  # first write wins
+        for field_name in ("node_after", "edge_after", "asset_after"):
+            getattr(merged, field_name).update(getattr(command, field_name))  # last wins
+
+    # An id created and then deleted inside the same group (or restored to
+    # exactly what it was) nets out to no change at all - dropping those
+    # keeps the merged command's own is_noop honest and avoids a pointless
+    # dict entry that would restore a value to itself.
+    for before_name, after_name in (
+        ("node_before", "node_after"),
+        ("edge_before", "edge_after"),
+        ("asset_before", "asset_after"),
+    ):
+        before, after = getattr(merged, before_name), getattr(merged, after_name)
+        for key in set(before) & set(after):
+            if before[key] == after[key]:
+                del before[key]
+                del after[key]
+    return merged
 
 
 class CommandOps:
@@ -304,5 +455,124 @@ class CommandOps:
         # the bounded log's slots and make Ctrl+Z appear to "do nothing
         # once" before reaching the operation the user actually meant.
         if not command.is_noop:
-            self.command_log.append(command)
+            self._push_command(command)
         return result, command
+
+    # -- ADR-010 stage 10.2/10.3/10.4/10.5: the undo/redo stack -------------
+
+    def _push_command(self, command: "Command") -> None:
+        """Adds a newly performed command to the undo stack.
+
+        Doing anything new after undoing discards the redo branch - the
+        standard, universally expected behavior (undo three things, type
+        something, and "redo" must not reapply the discarded three on top of
+        a now-divergent document). While an open composite is being built
+        (see composite()), commands accumulate there instead and only reach
+        the stack when the group closes."""
+        if self._composite_depth > 0:
+            self._composite_buffer.append(command)
+            return
+        self.redo_stack.clear()
+        self.command_log.append(command)
+
+    @contextmanager
+    def composite(self, command_type: str, provenance: str = "user"):
+        """ADR-010 stage 10.3: groups every command recorded inside the block
+        into ONE undoable action.
+
+        Needed for multi-step actions whose individual mutations are separate
+        record_command calls - the canonical case being auto-layout
+        (organizeNodes moves every node in the scene) and a multi-select
+        delete. One Ctrl+Z must reverse the whole logical action, not peel it
+        apart one node at a time.
+
+        Note that a SINGLE record_command call already covers multiple nodes
+        fine - its before/after diff is naturally n-ary. This exists for the
+        different case of several SEPARATE record_command calls that should
+        read as one action. Re-entrant: nesting composites flattens into the
+        outermost one, so a helper that opens its own composite does not
+        fragment its caller's."""
+        self._composite_depth += 1
+        outermost = self._composite_depth == 1
+        try:
+            yield
+        finally:
+            self._composite_depth -= 1
+            if outermost:
+                buffered = list(self._composite_buffer)
+                self._composite_buffer.clear()
+                merged = _merge_commands(command_type, provenance, buffered)
+                # is_noop is re-checked AFTER merging, not just on the inputs:
+                # a group whose steps cancel out (create a node then delete it
+                # inside the same composite) has real non-noop members but
+                # nets to nothing, and pushing that would put a do-nothing
+                # entry on the stack that eats one Ctrl+Z silently.
+                if merged is not None and not merged.is_noop:
+                    self.redo_stack.clear()
+                    self.command_log.append(merged)
+
+    def can_undo(self) -> bool:
+        return len(self.command_log) > 0
+
+    def can_redo(self) -> bool:
+        return len(self.redo_stack) > 0
+
+    def undo_label(self) -> str:
+        return self.command_log[-1].label if self.command_log else ""
+
+    def redo_label(self) -> str:
+        return self.redo_stack[-1].label if self.redo_stack else ""
+
+    def _guard_live_runs(self, command: "Command") -> None:
+        """ADR-010 stage 10.4: refuse to undo/redo across a node with a live
+        run. A node mid-generation has an in-flight agent writing to it;
+        restoring a snapshot from before that run started would race the
+        write and leave the node in a state neither the user nor the agent
+        asked for. The ADR's own guardrail - cancel first, then undo."""
+        for node_id in command.touched_node_ids:
+            node = self.nodes.get(node_id)
+            if node is not None and node.pending_request_id:
+                raise UndoRefusedError(
+                    f"Can't undo while \"{node.title}\" is still generating - "
+                    "cancel it first."
+                )
+
+    def undo(self) -> "Command":
+        """Reverses the most recent command and moves it onto the redo stack.
+        Raises UndoRefusedError if there is nothing to undo, or if the
+        command touches a node with a live run."""
+        if not self.command_log:
+            raise UndoRefusedError("Nothing to undo.")
+        command = self.command_log[-1]
+        self._guard_live_runs(command)
+        command.invert(self)
+        self.command_log.pop()
+        self.redo_stack.append(command)
+        return command
+
+    def redo(self) -> "Command":
+        """Re-applies the most recently undone command."""
+        if not self.redo_stack:
+            raise UndoRefusedError("Nothing to redo.")
+        command = self.redo_stack[-1]
+        self._guard_live_runs(command)
+        command.apply(self)
+        self.redo_stack.pop()
+        self.command_log.append(command)
+        return command
+
+    def undo_run(self, run_id: str) -> int:
+        """ADR-010 stage 10.5: reverses every command belonging to one agent
+        run, newest first, as a single user-facing action ("undo this
+        build"). Returns how many commands were reversed.
+
+        Only reverses commands at the TOP of the stack that belong to the
+        run: if the user has since made their own edits on top, those are
+        not silently discarded to reach the agent's work underneath -
+        undoing a build has to mean undoing the build, not everything after
+        it too. Stops at the first command that is not part of the run."""
+        reversed_count = 0
+        while self.command_log and self.command_log[-1].run_id == run_id:
+            self.undo()
+            reversed_count += 1
+        return reversed_count

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -210,12 +210,20 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
     # to undo something from 100 operations ago is the intended limit, not a
     # data loss (the scene itself is untouched).
     #
-    # This is a LOG, deliberately not yet an undo STACK - there is no cursor
-    # and no redo pointer, because deciding WHEN to invert is ADR-010 stage
-    # 10.2's job, with its own exit criterion. 10.1 only has to prove the
-    # commands are correctly invertible, which is what backend/tests/
-    # test_commands.py does. Stage 10.2 adds the cursor on top of this.
+    # This IS the undo stack (newest last). ADR-010 stage 10.2 added
+    # undo()/redo() on top of it - see backend/domain/commands.py's CommandOps
+    # for the cursor semantics, live-run refusal and composite grouping.
     command_log: deque = field(default_factory=lambda: deque(maxlen=100), repr=False)
+    # Commands that have been undone and can be re-applied. Cleared the
+    # moment any NEW command is performed (the standard redo-branch discard).
+    # Unbounded is fine: it can never exceed command_log's own 100, since
+    # every entry here came out of there.
+    redo_stack: list = field(default_factory=list, repr=False)
+    # ADR-010 stage 10.3: composite() bookkeeping. While depth > 0, recorded
+    # commands buffer here instead of hitting the stack, and merge into one
+    # command when the outermost composite closes.
+    _composite_depth: int = field(default=0, repr=False)
+    _composite_buffer: list = field(default_factory=list, repr=False)
     _counter: itertools.count = field(default_factory=itertools.count, repr=False)
     # ADR-003 stage 3.4: the last wire state actually published, kept so
     # take_dirty_patch_ops below can diff against it. None until the first
@@ -403,6 +411,13 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
         # to a session deliberately ("session-scoped and in-memory ... not
         # persisted"); this is the boundary that enforces it.
         self.command_log.clear()
+        self.redo_stack.clear()
+        # A load landing mid-composite would otherwise leave the buffer
+        # holding commands against the OLD document, which the next composite
+        # close would merge into a command referencing nodes that no longer
+        # exist.
+        self._composite_buffer.clear()
+        self._composite_depth = 0
         # ADR-003 stage 3.4 review-fix: drop the patch baseline too. Loading a
         # chat replaces the entire document, so diffing the new scene against
         # the OLD one produced a patch no smaller than the snapshot it
@@ -2150,6 +2165,19 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
             "fontSizePt": self.font_size_pt,
             "fontColor": self.font_color,
             "totalSessionTokens": self.total_session_tokens,
+            # ADR-010 stage 10.2: the undo/redo affordance's own state. Rides
+            # the scene meta blob rather than a separate topic because it
+            # changes on exactly the events the scene does - every mutation,
+            # every undo/redo, every load - so a separate topic would need a
+            # publish bolted onto all ~80 mutating intents to stay in sync,
+            # and would go stale the first time one was missed.
+            # The LABELS travel, not just the booleans: the button says
+            # "Undo Delete", and only the backend knows what the top of the
+            # stack actually is.
+            "canUndo": self.can_undo(),
+            "canRedo": self.can_redo(),
+            "undoLabel": self.undo_label(),
+            "redoLabel": self.redo_label(),
         }
 
     def scene_payload(self) -> dict[str, Any]:

--- a/backend/tests/test_commands.py
+++ b/backend/tests/test_commands.py
@@ -442,3 +442,203 @@ def test_loading_a_session_clears_undo_history(wired):
     # Inverting a command from the PREVIOUS chat would resurrect one of its
     # nodes into this one - the history must not survive the boundary.
     assert len(document.command_log) == 0
+
+
+# -- layer 4: the undo/redo stack (ADR-010 stages 10.2-10.5) ----------------
+
+
+def test_undo_then_redo_round_trips_a_delete(wired):
+    bus, document = wired
+    node_id = _dispatch(bus, "addNode", 0, 0, "keep me")
+    _dispatch(bus, "removeNodes", [node_id])
+    assert node_id not in document.nodes
+
+    _dispatch(bus, "undo")
+    assert node_id in document.nodes
+
+    _dispatch(bus, "redo")
+    assert node_id not in document.nodes
+
+
+def test_multiple_undos_walk_back_through_history_in_order(wired):
+    bus, document = wired
+    a = _dispatch(bus, "addNode", 0, 0, "a")
+    b = _dispatch(bus, "addNode", 1, 1, "b")
+    c = _dispatch(bus, "addNode", 2, 2, "c")
+
+    _dispatch(bus, "undo")
+    assert c not in document.nodes and b in document.nodes
+    _dispatch(bus, "undo")
+    assert b not in document.nodes and a in document.nodes
+    _dispatch(bus, "undo")
+    assert a not in document.nodes
+
+
+def test_doing_something_new_after_undo_discards_the_redo_branch(wired):
+    bus, document = wired
+    first = _dispatch(bus, "addNode", 0, 0, "first")
+    _dispatch(bus, "undo")
+    assert first not in document.nodes
+
+    # A new action after an undo makes the undone one unreachable - redoing
+    # it would reapply a change onto a document that has since diverged.
+    second = _dispatch(bus, "addNode", 5, 5, "second")
+    _dispatch(bus, "redo")
+    assert first not in document.nodes
+    assert second in document.nodes
+
+
+def test_undo_reports_the_action_name_so_the_button_can_say_what_it_undoes(wired):
+    bus, document = wired
+    node_id = _dispatch(bus, "addNode", 0, 0, "x")
+    assert document.undo_label() == "Add Node"
+
+    _dispatch(bus, "removeNodes", [node_id])
+    assert document.undo_label() == "Delete"
+    assert document.can_undo() is True
+    assert document.can_redo() is False
+
+    _dispatch(bus, "undo")
+    assert document.redo_label() == "Delete"
+
+
+def test_scene_payload_carries_undo_state_for_the_toolbar(wired):
+    bus, document = wired
+    payload = document.scene_payload()
+    assert payload["canUndo"] is False
+    assert payload["canRedo"] is False
+    assert payload["undoLabel"] == ""
+
+    _dispatch(bus, "addNode", 0, 0, "x")
+    payload = document.scene_payload()
+    assert payload["canUndo"] is True
+    assert payload["undoLabel"] == "Add Node"
+
+
+def test_undo_with_empty_history_is_refused_not_crashed(wired):
+    bus, document = wired
+    # No exception reaches the intent layer - a refusal is a normal outcome.
+    assert _dispatch(bus, "undo") is None
+    assert _dispatch(bus, "redo") is None
+
+
+def test_undo_is_refused_while_a_node_is_still_generating(wired):
+    bus, document = wired
+    node_id = _dispatch(bus, "addNode", 0, 0, "busy")
+    _dispatch(bus, "moveNode", node_id, 50, 50)
+
+    # A live run is writing to this node; restoring a pre-run snapshot
+    # underneath it would leave state neither the user nor the agent asked
+    # for. ADR-010's own guardrail: cancel first, then undo.
+    document.nodes[node_id].pending_request_id = "req-live"
+    assert _dispatch(bus, "undo") is None
+    assert document.nodes[node_id].x == 50  # unchanged - the undo was refused
+
+    document.nodes[node_id].pending_request_id = None
+    _dispatch(bus, "undo")
+    assert document.nodes[node_id].x == 0
+
+
+def test_organize_is_one_undo_not_one_per_node(wired):
+    bus, document = wired
+    a = _dispatch(bus, "addNode", 0, 0, "a")
+    b = _dispatch(bus, "addNode", 500, 500, "b")
+    before = {a: (document.nodes[a].x, document.nodes[a].y),
+              b: (document.nodes[b].x, document.nodes[b].y)}
+
+    _dispatch(bus, "organizeNodes")
+    _dispatch(bus, "undo")
+
+    # One Ctrl+Z restores the whole layout, not one node at a time.
+    for node_id, (x, y) in before.items():
+        assert (document.nodes[node_id].x, document.nodes[node_id].y) == (x, y)
+
+
+def test_composite_groups_separate_commands_into_one_undo(document):
+    a = document.add_note(0, 0)
+    b = document.add_note(100, 0)
+
+    with document.composite("multiMove", "user"):
+        document.record_command("moveNode", "user",
+                                lambda: document.move_node(a.id, 10, 10), node_ids=[a.id])
+        document.record_command("moveNode", "user",
+                                lambda: document.move_node(b.id, 110, 10), node_ids=[b.id])
+
+    assert len(document.command_log) == 1
+    document.undo()
+    assert (document.nodes[a.id].x, document.nodes[a.id].y) == (0, 0)
+    assert (document.nodes[b.id].x, document.nodes[b.id].y) == (100, 0)
+
+
+def test_composite_merge_keeps_the_earliest_before_and_latest_after(document):
+    node = document.add_note(0, 0)
+
+    with document.composite("repeatedMove", "user"):
+        document.record_command("moveNode", "user",
+                                lambda: document.move_node(node.id, 10, 10), node_ids=[node.id])
+        document.record_command("moveNode", "user",
+                                lambda: document.move_node(node.id, 99, 99), node_ids=[node.id])
+
+    command = document.command_log[-1]
+    # Undo must go back to the state before the WHOLE group (0, 0), not to
+    # the intermediate (10, 10) the first step left behind.
+    command.invert(document)
+    assert (document.nodes[node.id].x, document.nodes[node.id].y) == (0, 0)
+    command.apply(document)
+    assert (document.nodes[node.id].x, document.nodes[node.id].y) == (99, 99)
+
+
+def test_a_composite_that_nets_out_to_nothing_is_not_logged(document):
+    with document.composite("createThenDelete", "user"):
+        created, _ = document.record_command(
+            "addNote", "user", lambda: document.add_note(0, 0),
+        )
+        document.record_command(
+            "removeNodes", "user", lambda: document.remove_nodes([created.id]),
+            node_ids=[created.id],
+        )
+    # Created and deleted inside the same group - nothing survives, so there
+    # is nothing to undo and the stack must not gain a do-nothing entry.
+    assert len(document.command_log) == 0
+
+
+def test_undo_run_reverses_a_whole_agent_build_in_one_action(document):
+    """ADR-010 stage 10.5."""
+    for index in range(3):
+        _node, command = document.record_command(
+            "addNote", "agent", lambda i=index: document.add_note(i * 10, 0),
+        )
+        command.run_id = "run-1"
+
+    assert len(document.command_log) == 3
+    reversed_count = document.undo_run("run-1")
+    assert reversed_count == 3
+    assert len(document.nodes) == 0
+
+
+def test_undo_run_stops_at_the_users_own_later_edits(document):
+    _node, command = document.record_command(
+        "addNote", "agent", lambda: document.add_note(0, 0),
+    )
+    command.run_id = "run-1"
+    user_node, _ = document.record_command(
+        "addNote", "user", lambda: document.add_note(500, 500),
+    )
+
+    # The user's own work sits on top of the agent's. Undoing "the build"
+    # must not silently discard it to reach the agent's commands underneath.
+    assert document.undo_run("run-1") == 0
+    assert user_node.id in document.nodes
+
+
+def test_session_load_clears_both_stacks(wired):
+    bus, document = wired
+    node_id = _dispatch(bus, "addNode", 0, 0, "old session")
+    _dispatch(bus, "undo")
+    assert len(document.redo_stack) == 1
+
+    document.clear_for_load()
+    # Redoing here would resurrect a node from the PREVIOUS chat into this
+    # one - both directions have to be cleared, not just the undo side.
+    assert len(document.command_log) == 0
+    assert len(document.redo_stack) == 0

--- a/contracts/graphlink_scene_payload.py
+++ b/contracts/graphlink_scene_payload.py
@@ -490,4 +490,14 @@ class SceneStatePayload:
     fontFamily: str
     fontSizePt: int
     fontColor: str
+    # ADR-010 stage 10.2: the undo/redo affordance's state. The LABELS are on
+    # the wire, not just the booleans, because the button reads "Undo Delete"
+    # and only the backend knows what is actually on top of the stack. Empty
+    # string (not null) when there is nothing to undo/redo, so the frontend
+    # never has to null-check before rendering - canUndo/canRedo is the
+    # single source of truth for enablement.
+    canUndo: bool = False
+    canRedo: bool = False
+    undoLabel: str = ""
+    redoLabel: str = ""
     minCompatibleSchemaVersion: int | None = None

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -125,6 +125,14 @@ function GlobalShortcuts({ store }: { store: SceneStore }) {
           return overlays.toggle("palette", "dialog");
         case "toggle-search":
           return overlays.toggle("search", "popover");
+        // ADR-010 stage 10.2: the backend owns the stack, so these are a
+        // straight forward - the frontend never decides WHAT gets undone.
+        // A refusal (nothing to undo, or a node still generating) comes
+        // back as a notification, not a silent no-op.
+        case "undo":
+          return store.undo();
+        case "redo":
+          return store.redo();
         case "navigate-up":
           return navigate("up");
         case "navigate-down":

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -190,6 +190,12 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
     fontFamily: "Segoe UI",
     fontSizePt: 9,
     fontColor: "#F0F0F0",
+    // ADR-010 stage 10.2: the backend stamps these on every scene frame, so
+    // a fixture without them is not a shape the wire ever actually produces.
+    canUndo: false,
+    canRedo: false,
+    undoLabel: "",
+    redoLabel: "",
     ...overrides,
   };
 }

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -45,6 +45,13 @@ export const initialSceneState: SceneState = {
   fontFamily: "Segoe UI",
   fontSizePt: 9,
   fontColor: "#F0F0F0",
+  // ADR-010 stage 10.2: nothing is undoable before the first real scene
+  // frame arrives - a fresh client has no history of its own, and the
+  // backend's is what counts.
+  canUndo: false,
+  canRedo: false,
+  undoLabel: "",
+  redoLabel: "",
 };
 
 export const initialDragSpeedState: DragSpeedState = {
@@ -1032,6 +1039,24 @@ export class SceneStore {
 
   setDragFactor(factor: number): void {
     this.transport.fireIntent("scene", "setDragFactor", [factor], undefined, true);
+  }
+
+  // ADR-010 stage 10.2: undo/redo. NOT queueable (the 5th fireIntent arg) -
+  // replaying an undo minutes later against a scene the user has since
+  // changed would reverse whatever happens to be on the stack THEN, not what
+  // they asked to undo. A refused/dropped undo is safe; a mis-replayed one
+  // is exactly the silent data damage this whole feature exists to prevent.
+  undo(): void {
+    this.transport.fireIntent("scene", "undo", []);
+  }
+
+  redo(): void {
+    this.transport.fireIntent("scene", "redo", []);
+  }
+
+  /** ADR-010 stage 10.5: reverse an entire agent build in one action. */
+  undoRun(runId: string): void {
+    this.transport.fireIntent("scene", "undoRun", [runId]);
   }
 
   organizeNodes(): void {

--- a/web_ui/src/app/chrome/AppBar.tsx
+++ b/web_ui/src/app/chrome/AppBar.tsx
@@ -1,4 +1,5 @@
 import { useReactFlow } from "@xyflow/react";
+import { useSyncExternalStore } from "react";
 import { exportCanvasAsPng } from "../canvas/exportCanvasPng";
 import type { SceneStore } from "../canvas/sceneStore";
 import { Popover, useOverlays } from "../overlays/overlays";
@@ -77,6 +78,10 @@ import { Popover, useOverlays } from "../overlays/overlays";
 
 export function AppBar({ store }: { store: SceneStore }) {
   const overlays = useOverlays();
+  // ADR-010 stage 10.2: the backend owns the undo stack, so enablement AND
+  // the action name both come off the scene payload - the frontend never
+  // guesses what the next undo would do.
+  const scene = useSyncExternalStore(store.subscribe, store.getScene);
   const { zoomIn, zoomOut, setViewport, fitView, getViewport, getNodes } = useReactFlow();
 
   const chip = (surface: string) =>
@@ -124,6 +129,28 @@ export function AppBar({ store }: { store: SceneStore }) {
       </button>
       <button type="button" className="appbar-btn appbar-tier" data-tier="2" onClick={() => store.organizeNodes()}>
         Organize
+      </button>
+
+      <span className="appbar-separator appbar-tier" data-tier="1" />
+      <button
+        type="button"
+        className="appbar-btn appbar-tier"
+        data-tier="1"
+        disabled={!scene.canUndo}
+        title={scene.canUndo ? `Undo ${scene.undoLabel} (Ctrl+Z)` : "Nothing to undo"}
+        onClick={() => store.undo()}
+      >
+        Undo
+      </button>
+      <button
+        type="button"
+        className="appbar-btn appbar-tier"
+        data-tier="1"
+        disabled={!scene.canRedo}
+        title={scene.canRedo ? `Redo ${scene.redoLabel} (Ctrl+Shift+Z)` : "Nothing to redo"}
+        onClick={() => store.redo()}
+      >
+        Redo
       </button>
 
       <span className="appbar-separator appbar-tier" data-tier="3" />

--- a/web_ui/src/app/chrome/shortcuts.test.ts
+++ b/web_ui/src/app/chrome/shortcuts.test.ts
@@ -118,3 +118,25 @@ describe("isGatedWhileTyping", () => {
     expect(all.filter(isGatedWhileTyping)).toHaveLength(11);
   });
 });
+
+// ADR-010 stage 10.2: undo/redo bindings.
+describe("undo/redo shortcuts (ADR-010 stage 10.2)", () => {
+  it("maps Ctrl+Z to undo and Ctrl+Shift+Z to redo", () => {
+    expect(resolveShortcut(key("z"))).toBe("undo");
+    expect(resolveShortcut(key("z", { shift: true }))).toBe("redo");
+  });
+
+  it("also maps Ctrl+Y to redo, the Windows convention", () => {
+    // The app runs on Windows, where Ctrl+Y is the platform norm, while
+    // Ctrl+Shift+Z is the cross-platform one. Supporting only one would
+    // feel broken to half the muscle memory in the room.
+    expect(resolveShortcut(key("y"))).toBe("redo");
+  });
+
+  it("gates both while typing so native text undo is never shadowed", () => {
+    // Deliberately unlike Save's exemption: Ctrl+Z inside a text field must
+    // stay the browser's own undo. The ADR names that boundary explicitly.
+    expect(isGatedWhileTyping("undo")).toBe(true);
+    expect(isGatedWhileTyping("redo")).toBe(true);
+  });
+});

--- a/web_ui/src/app/chrome/shortcuts.ts
+++ b/web_ui/src/app/chrome/shortcuts.ts
@@ -30,7 +30,9 @@ export type ShortcutId =
   | "navigate-up"
   | "navigate-down"
   | "navigate-left"
-  | "navigate-right";
+  | "navigate-right"
+  | "undo"
+  | "redo";
 
 /**
  * The shortcuts legacy SUPPRESSES while a text input has focus - ported
@@ -63,6 +65,14 @@ const GATED_WHILE_TYPING = new Set<ShortcutId>([
   "navigate-down",
   "navigate-left",
   "navigate-right",
+  // ADR-010 stage 10.2: undo/redo are GATED, deliberately unlike Save's
+  // exemption above. Ctrl+Z inside a text field must stay the browser's own
+  // native text undo - shadowing it with canvas-structural undo would be a
+  // regression for anyone mid-sentence, and the ADR names that boundary
+  // explicitly ("text edits inside a node keep native browser undo; canvas-
+  // structural undo is the command stack").
+  "undo",
+  "redo",
 ]);
 
 export function isGatedWhileTyping(id: ShortcutId): boolean {
@@ -128,6 +138,15 @@ export function resolveShortcut(event: ShortcutKeyEvent): ShortcutId | null {
     // is already save-chat's key.
     case "m":
       return event.shiftKey ? "synthesize-branches" : null;
+    // ADR-010 stage 10.2: Ctrl+Z / Ctrl+Shift+Z, plus Ctrl+Y as the second
+    // redo binding Windows users reach for. Both redo spellings are wired
+    // because the app runs on Windows, where Ctrl+Y is the platform norm
+    // and Ctrl+Shift+Z is the cross-platform one - supporting only one
+    // would feel broken to half the muscle memory in the room.
+    case "z":
+      return event.shiftKey ? "redo" : "undo";
+    case "y":
+      return event.shiftKey ? null : "redo";
     default:
       return null;
   }

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -2,6 +2,12 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
+    "canRedo": {
+      "type": "boolean"
+    },
+    "canUndo": {
+      "type": "boolean"
+    },
     "dragFactor": {
       "type": "number"
     },
@@ -669,6 +675,9 @@
       },
       "type": "array"
     },
+    "redoLabel": {
+      "type": "string"
+    },
     "revision": {
       "type": "integer"
     },
@@ -680,6 +689,9 @@
     },
     "snapToGrid": {
       "type": "boolean"
+    },
+    "undoLabel": {
+      "type": "string"
     }
   },
   "required": [
@@ -696,7 +708,11 @@
     "dragFactor",
     "fontFamily",
     "fontSizePt",
-    "fontColor"
+    "fontColor",
+    "canUndo",
+    "canRedo",
+    "undoLabel",
+    "redoLabel"
   ],
   "title": "SceneState",
   "type": "object"

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -184,6 +184,10 @@ export interface SceneState {
   fontFamily: string;
   fontSizePt: number;
   fontColor: string;
+  canUndo: boolean;
+  canRedo: boolean;
+  undoLabel: string;
+  redoLabel: string;
   minCompatibleSchemaVersion?: number | null;
 }
 
@@ -992,6 +996,26 @@ function checkSceneState(value: unknown, path: string, errors: string[]): void {
     const fieldValue = value["fontColor"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.fontColor: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.fontColor` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["canUndo"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.canUndo: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.canUndo` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["canRedo"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.canRedo: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.canRedo` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["undoLabel"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.undoLabel: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.undoLabel` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["redoLabel"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.redoLabel: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.redoLabel` + ": expected string"); }
   }
   {
     const fieldValue = value["minCompatibleSchemaVersion"];

--- a/web_ui/src/lib/ws/transport.storeIntegration.test.ts
+++ b/web_ui/src/lib/ws/transport.storeIntegration.test.ts
@@ -175,6 +175,11 @@ describe("real WsTransport wired to a real SceneStore (end-to-end version reject
         fontFamily: "Segoe UI",
         fontSizePt: 9,
         fontColor: "#F0F0F0",
+        // ADR-010 stage 10.2: stamped on every real scene frame.
+        canUndo: false,
+        canRedo: false,
+        undoLabel: "",
+        redoLabel: "",
       },
     });
     expect(store.getSceneBlockingRejection()).toBeNull();


### PR DESCRIPTION
## Problem

Stage 10.1 made every create/delete/move/connect mutation invertible — but nothing ever called `invert()`. Ctrl+Z did nothing, and there was no button to reach an undo. The machinery existed with no way to use it.

This makes it real: **Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y now work, and there are Undo/Redo buttons in the toolbar that tell you what they'll undo.**

## What's in it

**The stack (10.2).** `undo()`/`redo()` move commands between the existing `command_log` and a new `redo_stack`. Performing anything new clears the redo branch — the standard behavior everywhere: undo three things, do something else, and "redo" must not reapply the discarded three onto a document that has since diverged. Both stacks clear on session load, so undo can never resurrect a node from a previously loaded chat.

**Keyboard and toolbar.** All three bindings are **gated while typing**, so native text undo inside a field is never shadowed — deliberately unlike Save's exemption, and the boundary the ADR names explicitly. Both redo spellings are wired because the app runs on Windows, where Ctrl+Y is the platform norm and Ctrl+Shift+Z is the cross-platform one; supporting one would feel broken to half the muscle memory in the room.

Undo/Redo buttons sit at toolbar tier 1 — last to collapse under width pressure, since hiding a *recovery* action in an overflow menu is exactly backwards for someone reaching for undo. Disabled when there's nothing to do, with the specific action in the tooltip.

The action **labels** travel on the wire, not just the booleans: the button reads "Undo Delete", and only the backend knows what's actually on top of the stack. They ride the scene payload rather than a new topic, because they change on exactly the events the scene does — a separate topic would need a publish bolted onto all ~80 mutating intents and would go stale the first time one was missed.

**Composites (10.3).** `composite()` groups several separate `record_command` calls into one undoable action. Merge order is asymmetric and load-bearing: **first-write-wins for the before state** (the earliest snapshot is the true "before the group"), **last-write-wins for after**. Reversed, undo would restore an intermediate state. A group that nets out to nothing isn't logged at all. `organizeNodes` now captures every node in one command, so one Ctrl+Z restores the whole auto-layout.

**Live-run refusal (10.4).** Undo is refused when the command touches a node with an in-flight agent run — restoring a pre-run snapshot underneath a writing agent leaves state neither party asked for. Refusals surface as a notification, not an error: *"Can't undo while X is still generating — cancel it first."*

**Run-scoped undo (10.5).** `undo_run()` reverses a whole agent build as one action, keyed on `Command.run_id`. It **stops at the user's own later edits** rather than discarding them to reach the agent's work underneath.

## Test plan

- `python -m pytest -q` from repo root: **1688 passed, 14 skipped**
- `cd web_ui && npm run check`: **56 files, 1344 tests, 0 errors**, build clean
- 14 new stack tests: multi-step undo, redo-branch discard, action labels, the payload the toolbar reads, empty-history refusal, live-run refusal, organize-as-one-undo, composite merge order, net-zero composites, run-scoped undo, both stacks clearing on load
- Mutation-tested with backup/restore, each confirming the intended test fails and the tree is byte-identical afterward: not clearing the redo branch, skipping the live-run guard, inverting the composite merge order, and letting `undo_run` cross run boundaries into user edits
- **Verified against the real running app** over its own WebSocket: create → patch carries `upsertNode` + `canUndo`/`undoLabel: "Add Node"`; undo → patch carries `removeNodes` + `canRedo`/`redoLabel`; redo → `upsertNode` again

## Not closed by this

~56 mutating intents (settings toggles, pins, grid, gitlink/pycoder/sandbox state) still bypass the command layer, so **they are not undoable**. ADR-010 cannot close until they produce commands too. Flagged here rather than left to be discovered.
