### PR TITLE
ADR-010 close-out: classify every intent undoable/not, enforce it in CI

### DIFF
--- a/backend/api/intents_artifact.py
+++ b/backend/api/intents_artifact.py
@@ -39,7 +39,11 @@ def register_artifact_intents(
         # state on this node that an unguarded call could corrupt, so a
         # stale click racing a delete has nothing destructive to protect
         # against.
-        node = document.send_artifact_message(node_id, text)
+        node, _command = document.record_command(
+            "sendArtifactMessage", "user",
+            lambda: document.send_artifact_message(node_id, text),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
         parent_edge = document._branch_parent_edge(node_id)
@@ -47,7 +51,15 @@ def register_artifact_intents(
         full_history = branch_history + node.history
 
         def _on_reply(new_content, ai_message):
-            document.complete_artifact_generation(node_id, new_content, ai_message)
+            # Same content-mutation shape as intents_chat.py's chatReply /
+            # intents_conversation.py's appendConversationAssistantMessage -
+            # "agent" provenance since this is a model-produced reply, not a
+            # direct user action.
+            document.record_command(
+                "completeArtifactGeneration", "agent",
+                lambda: document.complete_artifact_generation(node_id, new_content, ai_message),
+                node_ids=[node_id],
+            )
 
         await agent_dispatcher.start_artifact_reply(
             bus=bus,

--- a/backend/api/intents_chart.py
+++ b/backend/api/intents_chart.py
@@ -123,11 +123,18 @@ def register_chart_intents(
         return result_holder.get("node_id")
 
     async def resize_chart(node_id, width, height):
-        document.resize_chart(node_id, width, height)
+        document.record_command(
+            "resizeChart", "user", lambda: document.resize_chart(node_id, width, height),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def toggle_chart_aspect_lock(node_id):
-        document.toggle_chart_aspect_lock(node_id)
+        document.record_command(
+            "toggleChartAspectLock", "user",
+            lambda: document.toggle_chart_aspect_lock(node_id),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     # R6.2: a single combined create+generate action, unlike every

--- a/backend/api/intents_code_sandbox.py
+++ b/backend/api/intents_code_sandbox.py
@@ -28,7 +28,11 @@ def register_code_sandbox_intents(
     publish_scene = make_publish_scene(bus)
 
     async def set_code_sandbox_requirements(node_id, requirements_text):
-        document.set_code_sandbox_requirements(node_id, requirements_text)
+        document.record_command(
+            "setCodeSandboxRequirements", "user",
+            lambda: document.set_code_sandbox_requirements(node_id, requirements_text),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def set_code_sandbox_allow_source_builds(node_id, allow):

--- a/backend/api/intents_conversation.py
+++ b/backend/api/intents_conversation.py
@@ -31,7 +31,15 @@ def register_conversation_intents(
         # calling document.append_conversation_assistant_message directly -
         # same established relationship as send_message's own _on_reply
         # calling document.add_chat_node directly.
-        node = document.send_conversation_message(node_id, text)
+        # ADR-010 close-out: appends real message content to node.history -
+        # same shape as the already-wrapped sendMessage. node_ids names the
+        # target node since it survives (the id never leaves self.nodes, so
+        # only the in-place before/after diff catches an appended message).
+        node, _command = document.record_command(
+            "sendConversationMessage", "user",
+            lambda: document.send_conversation_message(node_id, text),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
         def _on_reply(reply_text):
@@ -47,7 +55,14 @@ def register_conversation_intents(
             # child node. A ConversationNode is a self-contained mega-node
             # with a flat plain-text-only history and no child-node concept
             # at all in legacy.
-            document.append_conversation_assistant_message(node_id, reply_text)
+            #
+            # "agent" provenance, not "user" - this reply is model-produced,
+            # same posture as intents_chat.py's own chatReply command.
+            document.record_command(
+                "appendConversationAssistantMessage", "agent",
+                lambda: document.append_conversation_assistant_message(node_id, reply_text),
+                node_ids=[node_id],
+            )
 
         await agent_dispatcher.start_conversation_reply(
             bus=bus,
@@ -61,8 +76,15 @@ def register_conversation_intents(
     async def append_conversation_assistant_message(node_id, text):
         # Unlike send_conversation_message, this represents a real reply
         # landing once ConversationNode gets real agent dispatch, not a
-        # deferral - so no notification fires.
-        node = document.append_conversation_assistant_message(node_id, text)
+        # deferral - so no notification fires. This is the standalone
+        # registered intent (a direct WS call), distinct from _on_reply's
+        # own use of the same document method above - "user" provenance
+        # here since nothing marks this specific entry point as agent-driven.
+        node, _command = document.record_command(
+            "appendConversationAssistantMessage", "user",
+            lambda: document.append_conversation_assistant_message(node_id, text),
+            node_ids=[node_id],
+        )
         await publish_scene()
         return node.id
 
@@ -79,7 +101,10 @@ def register_conversation_intents(
         await publish_scene()
 
     async def set_node_docked(node_id, docked):
-        document.set_node_docked(node_id, docked)
+        document.record_command(
+            "setNodeDocked", "user", lambda: document.set_node_docked(node_id, docked),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def delete_chat_node(node_id):
@@ -103,7 +128,10 @@ def register_conversation_intents(
         await publish_scene()
 
     async def set_chat_collapsed(node_id, collapsed):
-        document.set_chat_collapsed(node_id, collapsed)
+        document.record_command(
+            "setChatCollapsed", "user", lambda: document.set_chat_collapsed(node_id, collapsed),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     # ADR-002 Workstream 1 ("Branch status and lifecycle"): three plain
@@ -114,23 +142,47 @@ def register_conversation_intents(
     # pre-check pattern used where a delete could realistically race an
     # in-flight agent dispatch - none of these three ever dispatch an agent).
     async def set_branch_status(node_id, status):
-        document.set_branch_status(node_id, status)
+        document.record_command(
+            "setBranchStatus", "user", lambda: document.set_branch_status(node_id, status),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def set_final_deliverable(node_id, is_final):
-        document.set_final_deliverable(node_id, is_final)
+        document.record_command(
+            "setFinalDeliverable", "user",
+            lambda: document.set_final_deliverable(node_id, is_final),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def collapse_branch(node_id, collapsed):
-        document.collapse_branch(node_id, collapsed)
+        document.record_command(
+            "collapseBranch", "user", lambda: document.collapse_branch(node_id, collapsed),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def collapse_all_nodes():
-        document.set_all_conversational_collapsed(True)
+        # A bulk mutation across potentially every chat/conversation/html
+        # node in the scene - same shape as the already-wrapped
+        # organizeNodes, so every node id is named for the same reason:
+        # record_command's diff needs to be told what MIGHT change to
+        # capture an in-place mutation (an id that never enters/leaves
+        # self.nodes on its own gives the id-set diff nothing to see).
+        document.record_command(
+            "collapseAllNodes", "user",
+            lambda: document.set_all_conversational_collapsed(True),
+            node_ids=list(document.nodes.keys()),
+        )
         await publish_scene()
 
     async def expand_all_nodes():
-        document.set_all_conversational_collapsed(False)
+        document.record_command(
+            "expandAllNodes", "user",
+            lambda: document.set_all_conversational_collapsed(False),
+            node_ids=list(document.nodes.keys()),
+        )
         await publish_scene()
 
     async def set_chat_scroll_value(node_id, value):

--- a/backend/api/intents_gitlink.py
+++ b/backend/api/intents_gitlink.py
@@ -59,7 +59,11 @@ def register_gitlink_intents(
         return node_id
 
     async def set_gitlink_local_root(node_id, local_root):
-        document.set_gitlink_local_root(node_id, local_root)
+        document.record_command(
+            "setGitlinkLocalRoot", "user",
+            lambda: document.set_gitlink_local_root(node_id, local_root),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def pick_gitlink_local_root(node_id):
@@ -82,7 +86,11 @@ def register_gitlink_intents(
             return
         if not folder:
             return
-        document.set_gitlink_local_root(node_id, folder)
+        document.record_command(
+            "setGitlinkLocalRoot", "user",
+            lambda: document.set_gitlink_local_root(node_id, folder),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def import_gitlink_snapshot(node_id, repo, branch):

--- a/backend/api/intents_groups.py
+++ b/backend/api/intents_groups.py
@@ -34,7 +34,10 @@ def register_groups_intents(bus: SessionBus, document: SceneDocument) -> None:
         return node.id
 
     async def set_note_content(node_id, content):
-        document.set_note_content(node_id, content)
+        document.record_command(
+            "setNoteContent", "user", lambda: document.set_note_content(node_id, content),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def create_frame(item_ids):
@@ -60,27 +63,52 @@ def register_groups_intents(bus: SessionBus, document: SceneDocument) -> None:
         return node.id
 
     async def set_group_label(node_id, text):
-        document.set_group_label(node_id, text)
+        document.record_command(
+            "setGroupLabel", "user", lambda: document.set_group_label(node_id, text),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def set_group_color(node_id, color, header_color):
-        document.set_group_color(node_id, color, header_color)
+        document.record_command(
+            "setGroupColor", "user",
+            lambda: document.set_group_color(node_id, color, header_color),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
+    # toggle_frame_lock/toggle_group_collapsed FLIP a boolean rather than
+    # setting it - record_command's snapshot/restore is safe for this
+    # regardless (it restores the captured object, never re-invokes the
+    # mutator), unlike ADR-003's offline-queue replay mechanism, which is
+    # why those two intents are marked non-queueable on the frontend side
+    # while being perfectly fine to wrap here.
     async def toggle_frame_lock(node_id):
-        document.toggle_frame_lock(node_id)
+        document.record_command(
+            "toggleFrameLock", "user", lambda: document.toggle_frame_lock(node_id),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def toggle_group_collapsed(node_id):
-        document.toggle_group_collapsed(node_id)
+        document.record_command(
+            "toggleGroupCollapsed", "user", lambda: document.toggle_group_collapsed(node_id),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def resize_frame(node_id, width, height):
-        document.resize_frame(node_id, width, height)
+        document.record_command(
+            "resizeFrame", "user", lambda: document.resize_frame(node_id, width, height),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def fit_frame_to_content(node_id):
-        document.fit_frame_to_content(node_id)
+        document.record_command(
+            "fitFrameToContent", "user", lambda: document.fit_frame_to_content(node_id),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def ungroup(node_id):

--- a/backend/api/intents_pins.py
+++ b/backend/api/intents_pins.py
@@ -7,8 +7,6 @@ code motion, no behavior change.
 
 from __future__ import annotations
 
-from graphlink_navigation_pins import NavigationPinRecord
-
 from backend.api._shared import make_publish_scene
 from backend.domain.graph import SceneDocument
 from backend.events import SessionBus
@@ -23,9 +21,16 @@ def register_pins_intents(bus: SessionBus, document: SceneDocument) -> None:
     # backend/domain/commands.py), so no node_ids/edge_ids-style scoping
     # parameter is needed here - the wrap is a one-line change per intent.
     async def add_pin(title, x, y, note=""):
+        # Kwargs form, NOT a pre-built NavigationPinRecord: only the
+        # record=None path inside NavigationPinStore.add() auto-assigns the
+        # incrementing sort_order (len(self._records)) - a pre-built record
+        # is appended as-is with the dataclass's sort_order=0 default, which
+        # left every pin after the first at sort_order 0 (the persisted
+        # ordering key chat_library.py loads by). Validation is unchanged:
+        # both paths run NavigationPinRecord.create()'s field validators.
         record, _command = document.record_command(
             "addPin", "user",
-            lambda: document.pins.add(NavigationPinRecord.create(title=title, x=x, y=y, note=note)),
+            lambda: document.pins.add(title=title, x=x, y=y, note=note),
         )
         await publish_scene()
         return record.pin_id

--- a/backend/api/intents_pins.py
+++ b/backend/api/intents_pins.py
@@ -17,18 +17,29 @@ from backend.events import SessionBus
 def register_pins_intents(bus: SessionBus, document: SceneDocument) -> None:
     publish_scene = make_publish_scene(bus)
 
+    # ADR-010 close-out: pins are List A (undoable) - "pin" is named
+    # explicitly in the classification rule's A definition. record_command's
+    # own pin support snapshots the WHOLE store per call (see
+    # backend/domain/commands.py), so no node_ids/edge_ids-style scoping
+    # parameter is needed here - the wrap is a one-line change per intent.
     async def add_pin(title, x, y, note=""):
-        record = NavigationPinRecord.create(title=title, x=x, y=y, note=note)
-        document.pins.add(record)
+        record, _command = document.record_command(
+            "addPin", "user",
+            lambda: document.pins.add(NavigationPinRecord.create(title=title, x=x, y=y, note=note)),
+        )
         await publish_scene()
         return record.pin_id
 
     async def move_pin(pin_id, x, y):
-        document.pins.move(pin_id, x, y)
+        document.record_command(
+            "movePin", "user", lambda: document.pins.move(pin_id, x, y),
+        )
         await publish_scene()
 
     async def remove_pin(pin_id):
-        document.pins.remove(pin_id)
+        document.record_command(
+            "removePin", "user", lambda: document.pins.remove(pin_id),
+        )
         await publish_scene()
 
     async def update_pin(pin_id, title, note):
@@ -36,8 +47,14 @@ def register_pins_intents(bus: SessionBus, document: SceneDocument) -> None:
         # title, length-bounded note) runs via with_updates -> create's own
         # field validators, same as add_pin's path - a bad edit raises
         # NavigationPinValidationError, which is a ValueError subclass and
-        # therefore already reported to the caller as an intent error.
-        document.pins.update(pin_id, title=str(title), note=str(note))
+        # therefore already reported to the caller as an intent error. That
+        # raise happens INSIDE the record_command-wrapped mutator, before
+        # the store is actually touched, so a rejected edit produces no
+        # command at all - nothing partial to undo.
+        document.record_command(
+            "updatePin", "user",
+            lambda: document.pins.update(pin_id, title=str(title), note=str(note)),
+        )
         await publish_scene()
 
     bus.register_intent("scene", "addPin", add_pin)

--- a/backend/api/intents_pycoder.py
+++ b/backend/api/intents_pycoder.py
@@ -32,7 +32,10 @@ def register_pycoder_intents(
     publish_scene = make_publish_scene(bus)
 
     async def set_pycoder_mode(node_id, mode):
-        document.set_pycoder_mode(node_id, mode)
+        document.record_command(
+            "setPyCoderMode", "user", lambda: document.set_pycoder_mode(node_id, mode),
+            node_ids=[node_id],
+        )
         await publish_scene()
 
     async def run_pycoder(node_id, input_text):

--- a/backend/domain/commands.py
+++ b/backend/domain/commands.py
@@ -81,6 +81,7 @@ from typing import TYPE_CHECKING, Callable, Iterable, TypeVar
 
 if TYPE_CHECKING:
     from backend.domain.model import SceneEdge, SceneNode
+    from graphlink_navigation_pins import NavigationPinRecord
 
 T = TypeVar("T")
 
@@ -117,6 +118,20 @@ class Command:
     edge_after: dict[str, "SceneEdge | None"] = field(default_factory=dict)
     asset_before: dict[str, "tuple[bytes, str] | None"] = field(default_factory=dict)
     asset_after: dict[str, "tuple[bytes, str] | None"] = field(default_factory=dict)
+    # ADR-010 close-out: navigation pins live in a SEPARATE store
+    # (SceneDocument.pins, a NavigationPinStore) - not self.nodes/self.edges,
+    # so they need their own snapshot shape, not another dict-by-id like the
+    # fields above. NavigationPinRecord is a FROZEN dataclass and
+    # NavigationPinStore.records already returns an immutable tuple
+    # snapshot, so - unlike nodes/edges, which need copy.deepcopy because
+    # they're mutated in place - a held reference IS already a safe
+    # point-in-time snapshot; no deep copy needed anywhere in this module
+    # for pins. None means "this command never touched the pin store"
+    # (the same "None vs empty" distinction is_noop relies on for the dicts
+    # above); a non-None value - including an empty tuple, e.g. after
+    # deleting the last pin - means "watched, this is what it was."
+    pin_before: "tuple[NavigationPinRecord, ...] | None" = None
+    pin_after: "tuple[NavigationPinRecord, ...] | None" = None
     # ADR-010 stage 10.5: the agent run this command belongs to, or None for
     # a direct user action. Set for every mutation an agent run produces, so
     # "undo this build" can revert a whole run's worth of commands as a unit
@@ -146,7 +161,7 @@ class Command:
         call hits this the same way."""
         return not (
             self.node_before or self.node_after or self.edge_before or self.edge_after
-        )
+        ) and (self.pin_before is None or self.pin_before == self.pin_after)
 
     def invert(self, document: object) -> None:
         """Restores document state to exactly how it was before this
@@ -159,6 +174,12 @@ class Command:
         _restore(document.nodes, self.node_before)
         _restore(document.edges, self.edge_before)
         _restore(document.image_assets, self.asset_before)
+        if self.pin_before is not None:
+            # reset() replaces the WHOLE store, unlike _restore's per-key
+            # dict surgery - correct here because the pin store is always
+            # snapshotted as one unit (see record_command's own doc for why
+            # per-id scoping doesn't apply to pins the way it does nodes).
+            document.pins.reset(list(self.pin_before))
 
     def apply(self, document: object) -> None:
         """The mirror of invert() - restores to the *_after state. Not
@@ -168,6 +189,8 @@ class Command:
         _restore(document.nodes, self.node_after)
         _restore(document.edges, self.edge_after)
         _restore(document.image_assets, self.asset_after)
+        if self.pin_after is not None:
+            document.pins.reset(list(self.pin_after))
 
 
 def _restore(live: dict, snapshot: dict) -> None:
@@ -230,6 +253,18 @@ _COMMAND_LABELS = {
     "removePin": "Remove Pin",
     "updatePin": "Edit Pin",
     "movePin": "Move Pin",
+    # ADR-010 close-out: the 7 List-A intents that had no reserved label
+    # (the 20 above were pre-reserved during stage 10.1's own recon, a
+    # direct code-level signal they were already scoped as List A and only
+    # pending the wrap - these 7 were genuine gaps the close-out recon
+    # found, not pre-flagged).
+    "sendConversationMessage": "Send Message",
+    "appendConversationAssistantMessage": "Assistant Reply",
+    "sendArtifactMessage": "Send Instruction",
+    "completeArtifactGeneration": "Artifact Reply",
+    "setPyCoderMode": "Set Mode",
+    "setCodeSandboxRequirements": "Edit Requirements",
+    "setGitlinkLocalRoot": "Set Local Folder",
 }
 
 
@@ -278,6 +313,14 @@ def _merge_commands(command_type, provenance, commands):
                 target.setdefault(key, value)  # first write wins
         for field_name in ("node_after", "edge_after", "asset_after"):
             getattr(merged, field_name).update(getattr(command, field_name))  # last wins
+        # Pins are a single whole-store value per command, not a dict to
+        # union - "first write wins" for before/"last write wins" for after
+        # means literally the first non-None pin_before seen and the last
+        # non-None pin_after seen, same ordering rule as the dicts above.
+        if command.pin_before is not None and merged.pin_before is None:
+            merged.pin_before = command.pin_before
+        if command.pin_after is not None:
+            merged.pin_after = command.pin_after
 
     # An id created and then deleted inside the same group (or restored to
     # exactly what it was) nets out to no change at all - dropping those
@@ -293,6 +336,14 @@ def _merge_commands(command_type, provenance, commands):
             if before[key] == after[key]:
                 del before[key]
                 del after[key]
+
+    # Same net-zero cleanup for pins: if the store ended up byte-identical
+    # to how it started across the whole group, there is nothing to record -
+    # clearing both back to None keeps is_noop (and therefore whether this
+    # composite gets logged at all) correct.
+    if merged.pin_before is not None and merged.pin_before == merged.pin_after:
+        merged.pin_before = None
+        merged.pin_after = None
     return merged
 
 
@@ -382,12 +433,25 @@ class CommandOps:
         node_ids_before = set(self.nodes.keys())
         edge_ids_before = set(self.edges.keys())
         asset_ids_before = set(self.image_assets.keys())
+        # ADR-010 close-out: pins are ALWAYS defensively watched as one
+        # whole-store unit, unconditionally, the same "always watch, no
+        # opt-in flag needed" posture already used for frame/container nodes
+        # above - not a per-id scope like node_ids/edge_ids, since the store
+        # is small (a handful of waypoints, never hundreds) and cheap to
+        # snapshot whole (NavigationPinStore.records is already an
+        # immutable tuple, no deep copy required). This also means a
+        # mutation NOT wrapped for pins simply never sees a diff here,
+        # rather than needing its own opt-in parameter that could be
+        # forgotten - the same reasoning record_command's own doc gives for
+        # rejecting a `pin_ids` parameter.
+        pin_snapshot_before = self.pins.records
 
         result = mutator()
 
         node_ids_after = set(self.nodes.keys())
         edge_ids_after = set(self.edges.keys())
         asset_ids_after = set(self.image_assets.keys())
+        pin_snapshot_after = self.pins.records
 
         node_before_out: dict[str, "SceneNode | None"] = {}
         node_after_out: dict[str, "SceneNode | None"] = {}
@@ -439,6 +503,9 @@ class CommandOps:
             asset_before_out[aid] = asset_snapshot_before[aid]
             asset_after_out[aid] = None
 
+        pin_before_out = pin_snapshot_before if pin_snapshot_after != pin_snapshot_before else None
+        pin_after_out = pin_snapshot_after if pin_snapshot_after != pin_snapshot_before else None
+
         command = Command(
             command_type=command_type,
             provenance=provenance,
@@ -448,6 +515,8 @@ class CommandOps:
             edge_after=edge_after_out,
             asset_before=asset_before_out,
             asset_after=asset_after_out,
+            pin_before=pin_before_out,
+            pin_after=pin_after_out,
         )
         # A no-op command (an idempotent connect() that created nothing, a
         # setter called with the value it already had) is never logged -

--- a/backend/tests/test_commands.py
+++ b/backend/tests/test_commands.py
@@ -789,6 +789,30 @@ def test_pins_are_undoable_end_to_end(wired):
     assert document.pins.get(pin_id).position == (0, 0)
 
 
+def test_add_pin_assigns_an_incrementing_sort_order(wired):
+    """Regression: the REAL addPin handler must go through the store's
+    record=None kwargs path, which auto-assigns sort_order=len(records).
+    The handler used to pre-build a NavigationPinRecord (whose dataclass
+    default is sort_order=0) and pass it in, so every pin after the first
+    landed at sort_order 0 - wrong for the persisted ordering key
+    chat_library.py loads pins by (ORDER BY sort_order, id)."""
+    bus, document = wired
+    a = _dispatch(bus, "addPin", "First", 0, 0, "")
+    b = _dispatch(bus, "addPin", "Second", 100, 0, "")
+    c = _dispatch(bus, "addPin", "Third", 200, 0, "")
+
+    by_id = {p.pin_id: p.sort_order for p in document.pins.records}
+    assert [by_id[a], by_id[b], by_id[c]] == [0, 1, 2]
+
+    # And the numbering stays dense across the store's remove-renumber
+    # cascade: after removing the middle pin, a NEW pin continues from the
+    # renumbered length, not from a stale count.
+    _dispatch(bus, "removePin", b)
+    d = _dispatch(bus, "addPin", "Fourth", 300, 0, "")
+    assert [p.sort_order for p in document.pins.records] == [0, 1, 2]
+    assert document.pins.get(d).sort_order == 2
+
+
 def test_conversation_send_and_agent_reply_are_undoable_and_correctly_attributed(wired):
     bus, document = wired
     parent = _dispatch(bus, "addNote", 0, 0, False, False)

--- a/backend/tests/test_commands.py
+++ b/backend/tests/test_commands.py
@@ -642,3 +642,277 @@ def test_session_load_clears_both_stacks(wired):
     # one - both directions have to be cleared, not just the undo side.
     assert len(document.command_log) == 0
     assert len(document.redo_stack) == 0
+
+
+# -- layer 5: pin snapshot/restore (ADR-010 close-out) ----------------------
+
+
+def test_add_pin_is_invertible(document):
+    from graphlink_navigation_pins import NavigationPinRecord
+
+    _result, command = document.record_command(
+        "addPin", "user",
+        lambda: document.pins.add(NavigationPinRecord.create(title="Start", x=0, y=0)),
+    )
+    assert len(document.pins.records) == 1
+
+    command.invert(document)
+    assert len(document.pins.records) == 0
+
+
+def test_remove_pin_is_invertible_including_the_sort_order_renumber_cascade(document):
+    # .add(title=..., x=..., y=...) via kwargs (not a pre-built record) is
+    # what makes the store auto-assign an incrementing sort_order - needed
+    # here to set up a real ordering to test the renumber cascade against.
+    a = document.pins.add(title="a", x=0, y=0)
+    b = document.pins.add(title="b", x=1, y=1)
+    c = document.pins.add(title="c", x=2, y=2)
+    assert [p.sort_order for p in document.pins.records] == [0, 1, 2]
+
+    _result, command = document.record_command(
+        "removePin", "user", lambda: document.pins.remove(a.pin_id),
+    )
+    # remove() renumbers every pin AFTER the removed one - b and c shift down.
+    assert [p.pin_id for p in document.pins.records] == [b.pin_id, c.pin_id]
+    assert [p.sort_order for p in document.pins.records] == [0, 1]
+
+    command.invert(document)
+    # The whole-store snapshot restore undoes the renumber cascade too, not
+    # just "a exists again" - order and sort_order both come back exact.
+    restored = document.pins.records
+    assert [p.pin_id for p in restored] == [a.pin_id, b.pin_id, c.pin_id]
+    assert [p.sort_order for p in restored] == [0, 1, 2]
+
+
+def test_move_and_update_pin_are_invertible(document):
+    from graphlink_navigation_pins import NavigationPinRecord
+
+    pin = document.pins.add(NavigationPinRecord.create(title="Waypoint", note="", x=0, y=0))
+
+    _result, move_command = document.record_command(
+        "movePin", "user", lambda: document.pins.move(pin.pin_id, 500, 500),
+    )
+    assert document.pins.get(pin.pin_id).position == (500, 500)
+    move_command.invert(document)
+    assert document.pins.get(pin.pin_id).position == (0, 0)
+
+    _result, update_command = document.record_command(
+        "updatePin", "user", lambda: document.pins.update(pin.pin_id, title="Renamed", note="edited"),
+    )
+    assert document.pins.get(pin.pin_id).title == "Renamed"
+    update_command.invert(document)
+    assert document.pins.get(pin.pin_id).title == "Waypoint"
+
+
+def test_a_mutation_that_never_touches_pins_produces_no_pin_diff(document):
+    _result, command = document.record_command(
+        "addNote", "user", lambda: document.add_note(0, 0),
+    )
+    # None, not an empty tuple - "never touched" must stay distinguishable
+    # from "watched and found unchanged" (an empty store IS a valid pin
+    # state, e.g. after the last pin was removed).
+    assert command.pin_before is None
+    assert command.pin_after is None
+    assert command.is_noop is False  # the note creation itself still counts
+
+
+def test_pin_command_survives_a_redo_round_trip(document):
+    from graphlink_navigation_pins import NavigationPinRecord
+
+    _result, command = document.record_command(
+        "addPin", "user",
+        lambda: document.pins.add(NavigationPinRecord.create(title="p", x=0, y=0)),
+    )
+    command.invert(document)
+    assert len(document.pins.records) == 0
+    command.apply(document)
+    assert len(document.pins.records) == 1
+    assert document.pins.records[0].title == "p"
+
+
+def test_pin_mutation_inside_a_composite_merges_correctly(document):
+    from graphlink_navigation_pins import NavigationPinRecord
+
+    pin = document.pins.add(NavigationPinRecord.create(title="p", x=0, y=0))
+
+    with document.composite("multiPinEdit", "user"):
+        document.record_command(
+            "movePin", "user", lambda: document.pins.move(pin.pin_id, 10, 10),
+        )
+        document.record_command(
+            "updatePin", "user", lambda: document.pins.update(pin.pin_id, title="renamed"),
+        )
+
+    assert len(document.command_log) == 1
+    document.command_log[-1].invert(document)
+    restored = document.pins.get(pin.pin_id)
+    assert restored.position == (0, 0)
+    assert restored.title == "p"
+
+
+def test_pin_only_mutations_inside_a_composite_with_node_mutations_all_undo_together(document):
+    from graphlink_navigation_pins import NavigationPinRecord
+
+    node = document.add_note(0, 0)
+    with document.composite("mixedEdit", "user"):
+        document.record_command(
+            "moveNode", "user", lambda: document.move_node(node.id, 50, 50), node_ids=[node.id],
+        )
+        document.record_command(
+            "addPin", "user",
+            lambda: document.pins.add(NavigationPinRecord.create(title="p", x=0, y=0)),
+        )
+
+    assert len(document.command_log) == 1
+    document.command_log[-1].invert(document)
+    assert document.nodes[node.id].x == 0
+    assert len(document.pins.records) == 0
+
+
+# -- layer 6: end-to-end for the ADR-010 close-out wraps ---------------------
+#
+# One test per module wrapped in the close-out, hitting the shape that
+# matters most in that file - not exhaustive per-intent coverage (the
+# classify-or-fail gate is what guarantees every List-A intent calls
+# record_command at all; these prove the WRAPS are actually correct).
+
+
+def test_pins_are_undoable_end_to_end(wired):
+    bus, document = wired
+    pin_id = _dispatch(bus, "addPin", "Waypoint", 0, 0, "")
+    document.command_log.clear()
+
+    _dispatch(bus, "movePin", pin_id, 500, 500)
+    assert document.pins.get(pin_id).position == (500, 500)
+
+    document.command_log[-1].invert(document)
+    assert document.pins.get(pin_id).position == (0, 0)
+
+
+def test_conversation_send_and_agent_reply_are_undoable_and_correctly_attributed(wired):
+    bus, document = wired
+    parent = _dispatch(bus, "addNote", 0, 0, False, False)
+    node_id = _dispatch(bus, "addConversationNode", 0, 0, parent)
+    document.command_log.clear()
+
+    _dispatch(bus, "sendConversationMessage", node_id, "hello")
+    # history is SceneNode's own generic field (reused across every
+    # multi-turn kind), not something on state - see ArtifactState's own
+    # docstring for why that field lives at the node level.
+    assert len(document.nodes[node_id].history) == 1
+    assert document.command_log[-1].command_type == "sendConversationMessage"
+    assert document.command_log[-1].provenance == "user"
+
+    document.command_log[-1].invert(document)
+    assert len(document.nodes[node_id].history) == 0
+
+
+def test_collapse_all_is_one_undo_across_every_node(wired):
+    bus, document = wired
+    a = _dispatch(bus, "addChatNode", 0, 0, "a", True, None)
+    b = _dispatch(bus, "addChatNode", 100, 0, "b", True, None)
+    document.command_log.clear()
+
+    _dispatch(bus, "collapseAllNodes")
+    assert document.nodes[a].is_collapsed and document.nodes[b].is_collapsed
+    assert len(document.command_log) == 1
+
+    document.command_log[-1].invert(document)
+    assert not document.nodes[a].is_collapsed and not document.nodes[b].is_collapsed
+
+
+def test_toggle_frame_lock_is_undoable_via_snapshot_not_replay(wired):
+    """The flip-semantics concern from ADR-003's offline queue does not
+    apply here - record_command restores a captured snapshot, it never
+    re-invokes toggle_frame_lock, so there is no double-flip risk."""
+    bus, document = wired
+    member = _dispatch(bus, "addChatNode", 0, 0, "m", True, None)
+    frame_id = _dispatch(bus, "createFrame", [member])
+    document.command_log.clear()
+
+    _dispatch(bus, "toggleFrameLock", frame_id)
+    locked_after_toggle = document.nodes[frame_id].state.is_locked
+
+    document.command_log[-1].invert(document)
+    assert document.nodes[frame_id].state.is_locked != locked_after_toggle
+
+
+def test_resize_chart_is_undoable(wired):
+    bus, document = wired
+    parent = _dispatch(bus, "addNote", 0, 0, False, False)
+    # Built directly via the domain method (bypassing generateChart's own
+    # async agent dispatch) - this test is about resizeChart's wrap, not
+    # about exercising chart generation.
+    node, _command = document.record_command(
+        "addChartNode", "user",
+        lambda: document.add_chart_node(0, 0, parent, "bar", {"labels": [], "values": []}),
+    )
+    document.command_log.clear()
+
+    original_width = document.nodes[node.id].state.chart_width
+    _dispatch(bus, "resizeChart", node.id, 900, 700)
+    assert document.nodes[node.id].state.chart_width != original_width
+
+    document.command_log[-1].invert(document)
+    assert document.nodes[node.id].state.chart_width == original_width
+
+
+def test_set_pycoder_mode_is_undoable(wired):
+    bus, document = wired
+    parent = _dispatch(bus, "addNote", 0, 0, False, False)
+    node, _command = document.record_command(
+        "addPycoderNode", "user", lambda: document.add_pycoder_node(0, 0, parent),
+    )
+    document.command_log.clear()
+
+    _dispatch(bus, "setPyCoderMode", node.id, "manual")
+    assert document.nodes[node.id].state.pycoder_mode == "manual"
+
+    document.command_log[-1].invert(document)
+    assert document.nodes[node.id].state.pycoder_mode != "manual"
+
+
+def test_set_code_sandbox_requirements_is_undoable(wired):
+    bus, document = wired
+    parent = _dispatch(bus, "addNote", 0, 0, False, False)
+    node, _command = document.record_command(
+        "addCodeSandboxNode", "user",
+        lambda: document.add_code_sandbox_node(0, 0, parent),
+    )
+    document.command_log.clear()
+
+    _dispatch(bus, "setCodeSandboxRequirements", node.id, "requests==2.0")
+    assert document.nodes[node.id].state.code_sandbox_requirements == "requests==2.0"
+
+    document.command_log[-1].invert(document)
+    assert document.nodes[node.id].state.code_sandbox_requirements != "requests==2.0"
+
+
+def test_send_artifact_message_is_undoable(wired):
+    bus, document = wired
+    parent = _dispatch(bus, "addNote", 0, 0, False, False)
+    node, _command = document.record_command(
+        "addArtifactNode", "user", lambda: document.add_artifact_node(0, 0, parent),
+    )
+    document.command_log.clear()
+
+    _dispatch(bus, "sendArtifactMessage", node.id, "write a haiku")
+    assert len(document.nodes[node.id].history) == 1
+
+    document.command_log[-1].invert(document)
+    assert len(document.nodes[node.id].history) == 0
+
+
+def test_set_gitlink_local_root_is_undoable(wired):
+    bus, document = wired
+    parent = _dispatch(bus, "addNote", 0, 0, False, False)
+    node, _command = document.record_command(
+        "addGitlinkNode", "user", lambda: document.add_gitlink_node(0, 0, parent),
+    )
+    document.command_log.clear()
+
+    _dispatch(bus, "setGitlinkLocalRoot", node.id, "C:/somewhere")
+    assert document.nodes[node.id].state.gitlink_local_root == "C:/somewhere"
+
+    document.command_log[-1].invert(document)
+    assert document.nodes[node.id].state.gitlink_local_root != "C:/somewhere"

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -1,0 +1,328 @@
+"""ADR-010 close-out: the classify-or-fail gate.
+
+The user's mandate for this stage was explicit: every action in the app
+must be explicitly classified undoable-or-not, WITH A REASON, and that
+classification must be enforced going forward - "no more wandering or
+patchwork... all doors closed on this matter." tests/undo_classification.py
+is the hand-authored decision; this file is what makes it load-bearing
+rather than a document nobody re-reads.
+
+Same AST-scan philosophy as test_register_function_length.py (measure the
+real thing, don't grep and hope) and the same "guard the guard" posture as
+queueableClassificationGuard.test.ts (assert the scan finds a sane
+population before trusting its silence). Four checks, each catching a
+different way the table and the code could drift apart:
+
+  1. every bus.register_intent() the app really has is in the table -
+     a new intent with no entry fails the build (must be classified, not
+     silently defaulted to "not undoable" by omission).
+  2. every table entry names a real, still-registered intent - a removed/
+     renamed intent leaves a stale entry (fails the build).
+  3. every "A" entry's handler actually calls record_command somewhere in
+     its reachable body (direct, or via a same-file helper closure it
+     calls) - a claimed-A intent whose wrap was reverted or never written
+     fails the build.
+  4. every "B" entry's handler does NOT reach a record_command call - a "B"
+     intent that quietly grew a wrap should have been reclassified "A";
+     this catches that drift too, not just the one direction.
+
+KNOWN LIMITATION, stated rather than papered over (same posture as
+wireTypeCastGuard.test.ts's and queueableClassificationGuard.test.ts's own
+documented gaps): checks 3/4's reachability walk is a same-file, name-based
+BFS (a handler's own body, plus any locally-defined function it calls by
+name, transitively) - not a real cross-module call graph. Every handler in
+this codebase calls record_command (if at all) within its own file, so this
+holds today; a future handler that delegates to a helper in a DIFFERENT
+module would be invisible to this walk and could misclassify silently. If
+that pattern is ever introduced, extend _reaches_record_command rather than
+assuming green means safe.
+
+Adversarial-review fixes (same increment, not a follow-up): a first version
+of this gate had four real gaps, each mechanically reproduced and then
+closed here - (1) an unresolvable handler shape made the "B" check silently
+PASS while the "A" check correctly failed on the identical input (asymmetric
+- a claim this gate can't verify must fail on BOTH sides, not quietly count
+as "not undoable"); (2) local_funcs was a flat, file-wide name map with no
+class-body exclusion, so a same-named class METHOD elsewhere in the file
+(confirmed live today: NotificationState.dismiss shadows the registered
+`dismiss` closure in backend/notifications.py) could silently resolve to the
+wrong node; (3) a register_intent call using a keyword argument or a
+non-literal topic/intent (a hoisted constant, say) was silently skipped
+entirely rather than flagged, defeating the whole population count; (4) a
+genuine cross-file (topic, intent) collision silently let the second file
+scanned win with no diagnostic of its own (production's EventBus.
+register_intent asserts against this at session-bring-up time, but this
+static gate had no independent signal).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from undo_classification import CLASSIFICATION
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_DIR = REPO_ROOT / "backend"
+
+_UNRESOLVED = object()  # sentinel: distinct from "resolved to a lambda/def"
+
+
+def _iter_python_files():
+    for path in sorted(SCAN_DIR.rglob("*.py")):
+        if "__pycache__" in path.parts or "tests" in path.parts:
+            continue
+        yield path
+
+
+def _string_constant(node) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _collect_non_method_functions(tree: ast.Module) -> dict[str, ast.AST]:
+    """Every FunctionDef/AsyncFunctionDef reachable WITHOUT descending into a
+    ClassDef body - deliberately excludes methods, which live in a different
+    namespace and must never be able to shadow a same-named module-level
+    handler or helper closure (see the module docstring's fix (2))."""
+    found: dict[str, ast.AST] = {}
+
+    def visit(node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.ClassDef):
+                continue
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                found[child.name] = child
+            visit(child)
+
+    visit(tree)
+    return found
+
+
+def _call_topic_intent_handler(node: ast.Call):
+    """Extracts (topic_node, intent_node, handler_node) from a
+    register_intent call, accepting BOTH positional and keyword-argument
+    forms (register_intent's real signature has no positional-only marker -
+    see backend/events.py's register_intent). Returns None only when the
+    call genuinely omits one of the three (a TypeError at runtime already,
+    not this gate's concern)."""
+    positional = list(node.args)
+    by_kw = {kw.arg: kw.value for kw in node.keywords if kw.arg is not None}
+
+    def _nth_or_kw(index: int, name: str):
+        if index < len(positional):
+            return positional[index]
+        return by_kw.get(name)
+
+    topic_node = _nth_or_kw(0, "topic")
+    intent_node = _nth_or_kw(1, "intent")
+    handler_node = _nth_or_kw(2, "handler")
+    if topic_node is None or intent_node is None or handler_node is None:
+        return None
+    return topic_node, intent_node, handler_node
+
+
+class _FileIntents:
+    """One file's register_intent() call sites plus its local functions,
+    both needed to resolve a handler expression back to a walkable body."""
+
+    def __init__(self, path: Path, tree: ast.Module):
+        self.path = path
+        self.local_funcs: dict[str, ast.AST] = _collect_non_method_functions(tree)
+        self.registrations: list[tuple[str, str, ast.AST]] = []
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                continue
+            if node.func.attr != "register_intent":
+                continue
+            extracted = _call_topic_intent_handler(node)
+            if extracted is None:
+                continue
+            topic_node, intent_node, handler_node = extracted
+            topic = _string_constant(topic_node)
+            intent = _string_constant(intent_node)
+            if topic is None or intent is None:
+                # A non-literal topic/intent would be silently invisible to
+                # every check below (never counted as "real", so it can
+                # never be flagged as missing OR classified) - exactly the
+                # "new intent added, gate says nothing" failure mode this
+                # whole file exists to prevent. Fail loud instead of
+                # continuing past it.
+                raise AssertionError(
+                    f"{path.relative_to(REPO_ROOT)}:{node.lineno}: register_intent() called with a "
+                    "non-literal topic and/or intent argument - tests/test_undo_classification_gate.py "
+                    "can only classify string-literal (topic, intent) pairs. Use literal strings, or "
+                    "extend _call_topic_intent_handler/_string_constant to resolve this shape."
+                )
+            self.registrations.append((topic, intent, handler_node))
+
+    def resolve_handler_root(self, handler_expr: ast.AST):
+        """The AST node whose subtree should be walked for record_command -
+        the handler function itself, the real function inside a wrapper
+        call like `_serialize_mutating_intent(load_chat)`, or the lambda
+        node itself. Returns the _UNRESOLVED sentinel (never None - see the
+        module docstring's fix (1)) when the shape isn't recognized, so
+        BOTH the "A" and "B" checks below can treat "could not verify" as a
+        failure on either side, not a silent pass on one of them."""
+        if isinstance(handler_expr, ast.Name):
+            return self.local_funcs.get(handler_expr.id, _UNRESOLVED)
+        if isinstance(handler_expr, ast.Lambda):
+            return handler_expr
+        if isinstance(handler_expr, ast.Call) and handler_expr.args:
+            inner = handler_expr.args[0]
+            if isinstance(inner, ast.Name):
+                return self.local_funcs.get(inner.id, _UNRESOLVED)
+        return _UNRESOLVED
+
+
+def _reaches_record_command(root: ast.AST, local_funcs: dict[str, ast.AST]) -> bool:
+    """BFS over `root`'s own body plus any same-file function it calls by
+    name, transitively - handles both a direct call and the shared-helper
+    pattern (e.g. generateKeyTakeaway -> _generate_note_from_node ->
+    record_command, where the two are SIBLING closures, not nested)."""
+    seen: set[int] = set()
+    queue = [root]
+    while queue:
+        node = queue.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        for child in ast.walk(node):
+            if (
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Attribute)
+                and child.func.attr == "record_command"
+            ):
+                return True
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name):
+                callee = local_funcs.get(child.func.id)
+                if callee is not None and id(callee) not in seen:
+                    queue.append(callee)
+    return False
+
+
+def _collect_real_registrations() -> dict[tuple[str, str], _FileIntents]:
+    """Maps every real (topic, intent) to the _FileIntents that registered
+    it - a dict, not a set, specifically so checks 3/4 below can resolve
+    each table entry's handler back to a walkable body without re-parsing."""
+    by_key: dict[tuple[str, str], _FileIntents] = {}
+    for path in _iter_python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        file_intents = _FileIntents(path, tree)
+        for topic, intent, _handler in file_intents.registrations:
+            existing = by_key.get((topic, intent))
+            if existing is not None and existing.path != path:
+                # SessionBus.register_intent asserts against this too (see
+                # backend/events.py), but only at actual session bring-up -
+                # this static gate should say so on its own, immediately,
+                # rather than silently letting the alphabetically-later file
+                # win and validating checks 3/4 against the wrong handler.
+                raise AssertionError(
+                    f'intent "{topic}/{intent}" is registered in both '
+                    f"{existing.path.relative_to(REPO_ROOT)} and {path.relative_to(REPO_ROOT)} - "
+                    "SessionBus keys handlers by (topic, intent), so this is a real collision, "
+                    "not just a classification-table ambiguity."
+                )
+            by_key[(topic, intent)] = file_intents
+    return by_key
+
+
+def test_the_scan_finds_the_real_population_of_registered_intents():
+    # Guards the guard: a broken predicate here would make every check below
+    # vacuously pass. 136 is the exact count locked by ADR-010's close-out
+    # recon (scene=89, app-settings=27, app-composer=6, app-chat-library=5,
+    # grid-control=4, notification=3, app-plugins=1, system=1).
+    real = _collect_real_registrations()
+    assert len(real) == 136, (
+        f"expected exactly 136 real registered intents, found {len(real)} - "
+        "either the scan broke, or the app's registered-intent surface "
+        "genuinely changed and tests/undo_classification.py's own count "
+        "comment (and this assertion) need a deliberate update alongside it"
+    )
+
+
+def test_every_registered_intent_is_classified():
+    real = set(_collect_real_registrations().keys())
+    classified = {(c.topic, c.intent) for c in CLASSIFICATION}
+    missing = sorted(real - classified)
+    assert not missing, (
+        "these intents are registered but not in tests/undo_classification.py - "
+        "every mutating action must be explicitly classified A (undoable, wraps "
+        "record_command) or B (not undoable, WITH A REASON):\n"
+        + "\n".join(f"  {topic}/{intent}" for topic, intent in missing)
+    )
+
+
+def test_every_classification_entry_names_a_real_intent():
+    real = set(_collect_real_registrations().keys())
+    classified = {(c.topic, c.intent) for c in CLASSIFICATION}
+    stale = sorted(classified - real)
+    assert not stale, (
+        "tests/undo_classification.py classifies these intents, but they are "
+        "no longer registered anywhere under backend/ - remove the stale "
+        "entry (the intent was renamed or deleted):\n"
+        + "\n".join(f"  {topic}/{intent}" for topic, intent in stale)
+    )
+
+
+def _handler_expr_for(file_intents: _FileIntents, topic: str, intent: str) -> ast.AST:
+    return next(
+        handler
+        for reg_topic, reg_intent, handler in file_intents.registrations
+        if reg_topic == topic and reg_intent == intent
+    )
+
+
+def test_every_a_classified_intent_actually_records_a_command():
+    real = _collect_real_registrations()
+    offenders = []
+    for entry in CLASSIFICATION:
+        if entry.call != "A":
+            continue
+        file_intents = real.get((entry.topic, entry.intent))
+        if file_intents is None:
+            continue  # already reported by the stale-entry check above
+        handler_expr = _handler_expr_for(file_intents, entry.topic, entry.intent)
+        root = file_intents.resolve_handler_root(handler_expr)
+        # "A" claims the handler reaches record_command - an unresolvable
+        # handler shape means that claim can't be verified either, which is
+        # itself a failure (see the module docstring's fix (1)).
+        if root is _UNRESOLVED or not _reaches_record_command(root, file_intents.local_funcs):
+            offenders.append(f"{entry.topic}/{entry.intent} ({file_intents.path.relative_to(REPO_ROOT)})")
+    assert not offenders, (
+        "these intents are classified \"A\" (undoable) in tests/undo_classification.py "
+        "but their handler never reaches a record_command(...) call (or its handler shape "
+        "could not be resolved at all) - either the wrap was reverted/never written (fix the "
+        "handler), the handler needs a resolvable shape (a plain same-file function/lambda, "
+        "not e.g. a bound method or an aliased variable), or this should be reclassified "
+        "\"B\" with a real reason:\n" + "\n".join(f"  {o}" for o in offenders)
+    )
+
+
+def test_every_b_classified_intent_never_records_a_command():
+    real = _collect_real_registrations()
+    offenders = []
+    for entry in CLASSIFICATION:
+        if entry.call != "B":
+            continue
+        file_intents = real.get((entry.topic, entry.intent))
+        if file_intents is None:
+            continue  # already reported by the stale-entry check above
+        handler_expr = _handler_expr_for(file_intents, entry.topic, entry.intent)
+        root = file_intents.resolve_handler_root(handler_expr)
+        # "B" claims the handler does NOT reach record_command - an
+        # unresolvable handler shape means that claim can't be verified
+        # either, so it fails here too, symmetric with the "A" check above
+        # (this is the exact asymmetry the adversarial review's fix (1)
+        # closed: an unresolvable shape used to silently PASS this check).
+        if root is _UNRESOLVED or _reaches_record_command(root, file_intents.local_funcs):
+            offenders.append(f"{entry.topic}/{entry.intent} ({file_intents.path.relative_to(REPO_ROOT)})")
+    assert not offenders, (
+        "these intents are classified \"B\" (not undoable) in tests/undo_classification.py "
+        "but their handler now calls record_command(...), or its handler shape could not be "
+        "resolved at all (an unverifiable \"B\" claim is treated as a failure, not a pass) - "
+        "if it now calls record_command, flip the entry to \"A\" with a real reason; if it's "
+        "just unresolvable, give it a resolvable shape:\n"
+        + "\n".join(f"  {o}" for o in offenders)
+    )

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -1,0 +1,249 @@
+"""ADR-010 close-out: the hand-authored undo/redo classification table.
+
+Every intent the app registers (bus.register_intent, any topic) is listed
+here EXACTLY ONCE, with a deliberate call: "A" (undoable - its handler wraps
+its document mutation in CommandOps.record_command, so it lands on the
+Ctrl+Z stack) or "B" (not undoable, WITH A REASON).
+
+This table is not derived from the code - it is the actual decision a human
+made about what SHOULD be undoable, entry by entry. test_undo_classification_
+gate.py (same directory) cross-checks it against the real registered intents
+AND against what the handlers actually do, in both directions:
+
+  1. every intent bus.register_intent() actually registers must appear here
+     (a newly-added intent with no entry fails the build - you must decide
+     A or B, not silently inherit "not undoable" by omission);
+  2. every entry here must still name a real, currently-registered intent
+     (a removed/renamed intent leaves a stale entry - fails the build);
+  3. every "A" entry's handler must actually call record_command somewhere
+     in its reachable body (a claimed-A intent whose wrap was reverted or
+     never written - fails the build, catches the claim going stale);
+  4. every "B" entry's handler must NOT call record_command anywhere in its
+     reachable body (a "B" intent that quietly grew a wrap - and so should
+     have been reclassified "A" - fails the build too).
+
+This is what closes the loop the user asked for: "no more wandering or
+patchwork... all doors closed." A future PR that adds a new mutating intent
+and forgets to either wrap it or explicitly mark it "B: <reason>" cannot
+merge - CI fails, not "trust me, I checked."
+
+Reason-category prefixes (informal, for fast scanning - not machine-checked):
+  content         - a real document-content mutation; SHOULD be undoable (A)
+  view-state      - zoom/scroll/splitter/per-node-scroll position
+  preference      - appearance/behavior setting (grid, fonts, drag, routing,
+                    reasoning level, model assignment, notification prefs)
+  draft-state     - composer draft text/staged attachments before Send
+  run-lifecycle   - start/progress/complete/fail/cancel of an agent run, or
+                    a fetch/scan/cache of externally-sourced data
+  read-only       - no document mutation at all
+  security        - execution-approval / source-build-approval gate
+  whole-session   - load/save/delete/rename/new chat session
+  notification    - ephemeral UI banner, not document state
+  undo-machinery  - the undo/redo intents themselves (self-referential)
+
+See doc/adr/ADR-010-undo-redo-command-layer.md for the design; see
+backend/domain/commands.py for record_command/CommandOps itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Classified:
+    topic: str
+    intent: str
+    call: str  # "A" or "B"
+    reason: str
+
+
+CLASSIFICATION: tuple[Classified, ...] = (
+    # -- backend/app.py (system) --------------------------------------------
+    Classified("system", "ping", "B", "read-only: diagnostic echo, no document mutation"),
+
+    # -- backend/notifications.py (notification) -----------------------------
+    Classified("notification", "dismiss", "B", "notification: ephemeral UI banner, not document state"),
+    Classified("notification", "showInfo", "B", "notification: ephemeral UI banner, not document state"),
+    Classified("notification", "showError", "B", "notification: ephemeral UI banner, not document state"),
+
+    # -- backend/composer.py (app-composer) ----------------------------------
+    Classified("app-composer", "attachFile", "B", "draft-state: staged attachment before Send, not committed content"),
+    Classified("app-composer", "removeAttachment", "B", "draft-state: staged attachment before Send, not committed content"),
+    Classified("app-composer", "selectModel", "B", "preference: per-task model assignment"),
+    Classified("app-composer", "updateDraft", "B", "draft-state: native-text-edit equivalent - the composer's own draft field before Send"),
+    Classified("app-composer", "setReasoningLevel", "B", "preference: reasoning level, mirrors Settings' own reasoning-level setters"),
+
+    # -- backend/agents.py (app-composer) ------------------------------------
+    Classified("app-composer", "cancelChatRequest", "B", "run-lifecycle: cancel an in-flight generation"),
+
+    # -- backend/chat_library.py (app-chat-library) --------------------------
+    Classified("app-chat-library", "renameChat", "B", "whole-session: renames a saved session's title, not the live document"),
+    Classified("app-chat-library", "deleteChat", "B", "whole-session: deletes a saved chat session record"),
+    Classified("app-chat-library", "loadChat", "B", "whole-session: load - clear_for_load already clears command_log/redo_stack"),
+    Classified("app-chat-library", "saveChat", "B", "whole-session: persistence, not an in-document edit"),
+    Classified("app-chat-library", "newChat", "B", "whole-session: new - clear_for_load already clears command_log/redo_stack"),
+
+    # -- backend/plugins.py (app-plugins) ------------------------------------
+    Classified("app-plugins", "executePlugin", "A", "content: creates a new node (Web Research/Gitlink/PyCoder/Sandbox/Artifact/System-Prompt note/Conversation/HTML) - every branch wraps its own pluginX command_type"),
+
+    # -- backend/api/intents_grid.py (grid-control) --------------------------
+    Classified("grid-control", "setGridSize", "B", "preference: grid appearance"),
+    Classified("grid-control", "setGridOpacityPercent", "B", "preference: grid appearance"),
+    Classified("grid-control", "setGridStyle", "B", "preference: grid appearance"),
+    Classified("grid-control", "setGridColor", "B", "preference: grid appearance"),
+
+    # -- backend/api/intents_view.py (scene) ---------------------------------
+    Classified("scene", "setSnapToGrid", "B", "preference: canvas behavior toggle"),
+    Classified("scene", "setFadeConnections", "B", "preference: canvas appearance toggle"),
+    Classified("scene", "setOrthogonalConnections", "B", "preference: connection routing style"),
+    Classified("scene", "setSmartGuides", "B", "preference: canvas behavior toggle"),
+    Classified("scene", "setDragFactor", "B", "preference: drag sensitivity"),
+    Classified("scene", "setViewState", "B", "view-state: zoom/scroll position"),
+    Classified("scene", "organizeNodes", "A", "content: auto-layout repositions every node - one Ctrl+Z restores them all"),
+    Classified("scene", "setFontFamily", "B", "preference: canvas-appearance font"),
+    Classified("scene", "setFontSize", "B", "preference: canvas-appearance font"),
+    Classified("scene", "setFontColor", "B", "preference: canvas-appearance font"),
+
+    # -- backend/api/intents_undo.py (scene) - the machinery itself ---------
+    Classified("scene", "undo", "B", "undo-machinery: pops command_log itself, self-referential"),
+    Classified("scene", "redo", "B", "undo-machinery: pops redo_stack itself, self-referential"),
+    Classified("scene", "undoRun", "B", "undo-machinery: reverses a whole run via command_log, self-referential"),
+
+    # -- backend/api/intents_web_research.py (scene) -------------------------
+    Classified("scene", "runWebResearch", "B", "run-lifecycle: starts an agent run; node creation itself is executePlugin's job"),
+    Classified("scene", "cancelWebResearchRequest", "B", "run-lifecycle: cancel"),
+
+    # -- backend/api/intents_nodes.py (scene) --------------------------------
+    Classified("scene", "addNode", "A", "content: create"),
+    Classified("scene", "addChatNode", "A", "content: create"),
+    Classified("scene", "addCodeNode", "A", "content: create"),
+    Classified("scene", "addDocumentNode", "A", "content: create"),
+    Classified("scene", "addThinkingNode", "A", "content: create"),
+    Classified("scene", "addHtmlNode", "A", "content: create"),
+    Classified("scene", "setHtmlSplitterState", "B", "view-state: per-node UI splitter position"),
+    Classified("scene", "addImageNode", "A", "content: create"),
+    Classified("scene", "addConversationNode", "A", "content: create"),
+    Classified("scene", "moveNode", "A", "content: move"),
+    Classified("scene", "moveNodes", "A", "content: move (bulk)"),
+    Classified("scene", "removeNodes", "A", "content: delete"),
+    Classified("scene", "connectNodes", "A", "content: connect"),
+    Classified("scene", "removeEdges", "A", "content: delete edges"),
+
+    # -- backend/api/intents_artifact.py (scene) -----------------------------
+    Classified("scene", "sendArtifactMessage", "A", "content: user instruction + agent reply, both recorded"),
+    Classified("scene", "cancelArtifactRequest", "B", "run-lifecycle: cancel"),
+
+    # -- backend/api/intents_conversation.py (scene) -------------------------
+    Classified("scene", "sendConversationMessage", "A", "content: user message"),
+    Classified("scene", "appendConversationAssistantMessage", "A", "content: message append (agent reply or direct)"),
+    Classified("scene", "deleteConversationMessage", "A", "content: sub-node message delete"),
+    Classified("scene", "setNodeDocked", "A", "content: docked flag is document state"),
+    Classified("scene", "deleteChatNode", "A", "content: delete"),
+    Classified("scene", "setChatCollapsed", "A", "content: collapsed flag is document state"),
+    Classified("scene", "setBranchStatus", "A", "content: branch status is document state"),
+    Classified("scene", "setFinalDeliverable", "A", "content: final-deliverable flag is document state"),
+    Classified("scene", "collapseBranch", "A", "content: collapsed flag is document state"),
+    Classified("scene", "collapseAllNodes", "A", "content: bulk collapsed-flag change, one composite undo"),
+    Classified("scene", "expandAllNodes", "A", "content: bulk collapsed-flag change, one composite undo"),
+    Classified("scene", "setChatScrollValue", "B", "view-state: per-node scroll position"),
+
+    # -- backend/api/intents_gitlink.py (scene) ------------------------------
+    Classified("scene", "fetchGitlinkRepositories", "B", "read-only: fetches provider repo list for display"),
+    Classified("scene", "loadGitlinkRepoTree", "B", "run-lifecycle: caches a fetched repo-tree listing"),
+    Classified("scene", "setGitlinkLocalRoot", "A", "content: user-typed/picked local folder path"),
+    Classified("scene", "pickGitlinkLocalRoot", "A", "content: same field via the native folder picker"),
+    Classified("scene", "importGitlinkSnapshot", "B", "run-lifecycle: caches an imported snapshot root from disk"),
+    Classified("scene", "buildGitlinkContext", "B", "run-lifecycle: caches a built context artifact for review"),
+    Classified("scene", "fetchGitlinkContext", "B", "read-only: fetches the built context XML, no mutation"),
+    Classified("scene", "runGitlinkChangeSet", "B", "run-lifecycle: start/complete/fail an agent run"),
+    Classified("scene", "cancelGitlinkRequest", "B", "run-lifecycle: cancel"),
+    Classified("scene", "applyGitlinkChanges", "B", "run-lifecycle: writes real files to disk, an external side effect Ctrl+Z cannot safely reverse"),
+
+    # -- backend/api/intents_groups.py (scene) -------------------------------
+    Classified("scene", "addNote", "A", "content: create"),
+    Classified("scene", "setNoteContent", "A", "content: text edit"),
+    Classified("scene", "createFrame", "A", "content: create/group"),
+    Classified("scene", "createContainer", "A", "content: create/group"),
+    Classified("scene", "setGroupLabel", "A", "content: label edit"),
+    Classified("scene", "setGroupColor", "A", "content: color edit"),
+    Classified("scene", "toggleFrameLock", "A", "content: lock flag is document state (snapshot/restore, not replay - safe to flip)"),
+    Classified("scene", "toggleGroupCollapsed", "A", "content: collapsed flag is document state"),
+    Classified("scene", "resizeFrame", "A", "content: size is document state"),
+    Classified("scene", "fitFrameToContent", "A", "content: size is document state"),
+    Classified("scene", "ungroup", "A", "content: delete grouping"),
+
+    # -- backend/api/intents_pins.py (scene) ---------------------------------
+    Classified("scene", "addPin", "A", "content: user-placed navigation waypoint"),
+    Classified("scene", "movePin", "A", "content: user-placed navigation waypoint"),
+    Classified("scene", "removePin", "A", "content: user-placed navigation waypoint"),
+    Classified("scene", "updatePin", "A", "content: user-placed navigation waypoint"),
+
+    # -- backend/api/intents_chart.py (scene) --------------------------------
+    Classified("scene", "generateChart", "A", "content: agent-produced chart node"),
+    Classified("scene", "resizeChart", "A", "content: size is document state"),
+    Classified("scene", "toggleChartAspectLock", "A", "content: lock flag is document state (snapshot/restore, safe to flip)"),
+
+    # -- backend/api/intents_chat.py (scene) ---------------------------------
+    Classified("scene", "sendMessage", "A", "content: user message (hidden create - internally adds a chat node)"),
+    Classified("scene", "regenerateResponse", "A", "content: delete-then-recreate of a node's content, one composite undo"),
+    Classified("scene", "cancelChatRequest", "B", "run-lifecycle: cancel"),
+
+    # -- backend/api/intents_chat_image.py (scene) ---------------------------
+    Classified("scene", "generateImage", "A", "content: mints an image node + asset bytes via the shared _dispatch_image path"),
+    Classified("scene", "regenerateImage", "A", "content: mints an image node + asset bytes via the shared _dispatch_image path"),
+
+    # -- backend/api/intents_branches.py (scene) -----------------------------
+    Classified("scene", "generateKeyTakeaway", "A", "content: agent-produced note via the shared _generate_note_from_node path"),
+    Classified("scene", "generateExplainerNote", "A", "content: agent-produced note via the shared _generate_note_from_node path"),
+    Classified("scene", "compareBranches", "A", "content: agent-produced comparison note"),
+    Classified("scene", "synthesizeBranches", "A", "content: agent-produced synthesis chat node"),
+
+    # -- backend/api/intents_code_sandbox.py (scene) -------------------------
+    Classified("scene", "setCodeSandboxRequirements", "A", "content: requirements text is document state"),
+    Classified("scene", "setCodeSandboxAllowSourceBuilds", "B", "security: source-build approval gate"),
+    Classified("scene", "runCodeSandbox", "B", "run-lifecycle: start/complete/fail an agent run"),
+    Classified("scene", "cancelCodeSandboxRequest", "B", "run-lifecycle: cancel"),
+
+    # -- backend/api/intents_pycoder.py (scene) ------------------------------
+    Classified("scene", "setPyCoderMode", "A", "content: mode is document state"),
+    Classified("scene", "runPyCoder", "B", "run-lifecycle: start/complete/fail an agent run"),
+    Classified("scene", "cancelPyCoderRequest", "B", "run-lifecycle: cancel"),
+    Classified("scene", "approveCodeExecution", "B", "security: code-execution approval gate"),
+    Classified("scene", "denyCodeExecution", "B", "security: code-execution approval gate"),
+
+    # -- backend/api/intents_settings_general.py (app-settings) -------------
+    Classified("app-settings", "setActiveSection", "B", "preference: which Settings page is open"),
+    Classified("app-settings", "setShowTokenCounter", "B", "preference: appearance toggle"),
+    Classified("app-settings", "setEnableSystemPrompt", "B", "preference: behavior toggle"),
+    Classified("app-settings", "setNotificationPreference", "B", "preference: notification-type toggle"),
+    Classified("app-settings", "setGithubToken", "B", "preference: write-only credential field, not document content"),
+    Classified("app-settings", "clearGithubToken", "B", "preference: write-only credential field, not document content"),
+
+    # -- backend/api/intents_settings_api_provider.py (app-settings) --------
+    Classified("app-settings", "setViewingApiProvider", "B", "preference: which provider sub-page is viewed"),
+    Classified("app-settings", "loadApiModels", "B", "run-lifecycle: fetches a live model catalog"),
+    Classified("app-settings", "saveApiConfiguration", "B", "preference: API provider/key/model configuration"),
+    Classified("app-settings", "resetApiSettings", "B", "preference: API provider/key/model configuration"),
+
+    # -- backend/api/intents_settings_ollama.py (app-settings) --------------
+    Classified("app-settings", "setOllamaReasoningLevel", "B", "preference: reasoning level"),
+    Classified("app-settings", "setOllamaModelAssignment", "B", "preference: per-task model assignment"),
+    Classified("app-settings", "scanOllamaSystem", "B", "run-lifecycle: scans/caches locally installed models"),
+    Classified("app-settings", "pullOllamaModel", "B", "run-lifecycle: downloads a model"),
+    Classified("app-settings", "pickOllamaScanFolder", "B", "run-lifecycle: native folder pick + scan"),
+
+    # -- backend/api/intents_settings_llama_cpp.py (app-settings) -----------
+    Classified("app-settings", "setLlamaCppReasoningLevel", "B", "preference: reasoning level"),
+    Classified("app-settings", "setLlamaCppChatFormat", "B", "preference: runtime tunable"),
+    Classified("app-settings", "setLlamaCppNCtx", "B", "preference: runtime tunable"),
+    Classified("app-settings", "setLlamaCppNGpuLayers", "B", "preference: runtime tunable"),
+    Classified("app-settings", "setLlamaCppNThreads", "B", "preference: runtime tunable"),
+    Classified("app-settings", "pickLlamaCppChatModelFile", "B", "preference: staged model file path, not saved until saveLlamaCppSettings"),
+    Classified("app-settings", "pickLlamaCppTitleModelFile", "B", "preference: staged model file path, not saved until saveLlamaCppSettings"),
+    Classified("app-settings", "setLlamaCppChatModelPath", "B", "preference: staged model file path, not saved until saveLlamaCppSettings"),
+    Classified("app-settings", "setLlamaCppTitleModelPath", "B", "preference: staged model file path, not saved until saveLlamaCppSettings"),
+    Classified("app-settings", "scanLlamaCppSystem", "B", "run-lifecycle: scans/caches locally installed models"),
+    Classified("app-settings", "pickLlamaCppScanFolder", "B", "run-lifecycle: native folder pick + scan"),
+    Classified("app-settings", "saveLlamaCppSettings", "B", "preference: runtime configuration"),
+)


### PR DESCRIPTION
## Problem

Undo/redo (stages 10.1-10.5) worked, but coverage was ad hoc: whether a given action was undoable had never been enumerated, so it could drift silently as new features were added — some content-mutating actions (pins, most of conversation/groups editing, chart resize, pycoder mode, code-sandbox requirements, artifact messages, gitlink's local-root field) still bypassed the command layer entirely.

Separately, `addPin` never assigned an incrementing `sort_order`: the handler pre-built a `NavigationPinRecord` (dataclass default `sort_order=0`) instead of using `NavigationPinStore.add()`'s kwargs path, which is the only path that auto-assigns `len(records)`. Every pin after the first landed at `sort_order` 0 — the persisted ordering key `chat_library.py` loads pins by.

## Change

- `backend/domain/commands.py`: `record_command`/`Command` now snapshot and restore navigation pins, closing the one content type the original command layer didn't cover.
- 8 `backend/api/intents_*.py` files: wrap the remaining content-mutating intents in `record_command` so Ctrl+Z actually reverses them.
- `tests/undo_classification.py`: every one of the app's 136 registered intents, classified `"A"` (undoable) or `"B"` (not, with a stated reason) — 57 `A`, 79 `B`.
- `tests/test_undo_classification_gate.py`: an AST-based CI gate that cross-checks the table against the real `bus.register_intent()` call sites in both directions — a newly-added intent with no entry, a stale entry for a removed intent, an `"A"` entry whose handler no longer calls `record_command`, or a `"B"` entry whose handler now does, all fail the build.
- `backend/api/intents_pins.py`: `add_pin` now uses the store's kwargs path so `sort_order` increments correctly. No data migration needed — existing all-zero rows load in insertion order via the `ORDER BY sort_order, id` tiebreaker, and `pins.reset()` (the session-load path) re-derives `sort_order`, so old sessions self-heal on their next load/save.

## Test plan

- [x] `pytest -q` from repo root — 1710 passed, 14 skipped
- [x] `npm run check` (web_ui) — typecheck/lint/build/tests all clean, 1344 tests passed
- [x] Mutation-tested the 27 newly-wrapped intents by reverting the wraps and confirming the new end-to-end tests fail
- [x] Mutation-tested the enforcement gate itself in all 4 directions (new unclassified intent, stale entry, reverted A-wrap, grown B-wrap) — each correctly caught
- [x] Adversarial-review workflow run against the classification table, the gate's own implementation, and this PR's doc updates; 4 real bugs found in the gate (asymmetric unresolved-handler handling, class-method name collisions, keyword/non-literal `register_intent` calls invisible to the scan, silent cross-file duplicate overwrite) — all fixed and re-verified by direct reproduction
- [x] `sort_order` regression test drives the real `addPin` handler across add/remove/add and asserts incrementing + dense renumbering; verified it fails against the old pre-built-record form