### PR TITLE
ADR-019 stage 19.2: CI counting gates for perf regressions

### DIFF
--- a/backend/tests/perf/test_loop_watchdog.py
+++ b/backend/tests/perf/test_loop_watchdog.py
@@ -44,8 +44,6 @@ import asyncio
 import json
 from pathlib import Path
 
-import pytest
-
 from backend.tests.perf.graph_factory import build_graph
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -114,13 +112,19 @@ def _representative_operations(doc):
     ]
 
 
-@pytest.mark.asyncio
-async def test_no_representative_operation_blocks_the_loop_beyond_the_ci_ceiling():
-    doc = build_graph(node_count=500, content_bytes=1200, chart_count=0, image_count=0, extra_edges=200)
-    runs = []
-    for _ in range(2):
-        runs.append(await _max_stall_ms(_representative_operations(doc)))
-    best = min(runs)
+def test_no_representative_operation_blocks_the_loop_beyond_the_ci_ceiling():
+    # asyncio.run() in a sync test, not @pytest.mark.asyncio - pytest-asyncio
+    # is not one of this repo's dependencies (dev deps are pytest+pytest-env
+    # only, see pyproject.toml), and every other async-touching test here
+    # already uses this same convention (test_event_bus.py et al.).
+    async def _run() -> float:
+        doc = build_graph(node_count=500, content_bytes=1200, chart_count=0, image_count=0, extra_edges=200)
+        runs = []
+        for _ in range(2):
+            runs.append(await _max_stall_ms(_representative_operations(doc)))
+        return min(runs)
+
+    best = asyncio.run(_run())
     assert best <= CI_STALL_CEILING_MS, (
         f"an operation blocked the event loop for {best:.1f} ms across both runs "
         f"(CI ceiling: {CI_STALL_CEILING_MS:.0f} ms; the true ADR-019 budget is 16 ms, "

--- a/backend/tests/perf/test_loop_watchdog.py
+++ b/backend/tests/perf/test_loop_watchdog.py
@@ -1,0 +1,182 @@
+"""ADR-019 stage 19.2: the event-loop blocking watchdog, plus the inline
+chart-render call-site freeze.
+
+The budget (ADR-019 §2): no single operation blocks the event loop > 16 ms.
+Wall-clock timing that tight would flake on shared CI runners, and ADR-019 §4
+explicitly splits enforcement for exactly that reason: CI gets stable,
+generous "class-catcher" checks; the true 16 ms line is stage 19.3's nightly
+wall-clock job. So this file enforces two things CI can hold reliably:
+
+1. THE WATCHDOG (timing, generous ceiling): representative mutations and a
+   full publish build+serialize on a 500-node graph must never block the loop
+   longer than CI_STALL_CEILING_MS. The ceiling is 100 ms - ~7x today's worst
+   measured legitimate cost (13.24 ms publish on `large`, measure_baselines
+   2026-08-02), far below the ~125 ms+ matplotlib-class regression this
+   exists to catch. Each operation is yielded around individually, so the
+   assertion is per-operation, matching the budget's own wording. The batch
+   runs twice and the SMALLER max-stall wins: a one-off GC/scheduler spike
+   hits one run, a real synchronous block hits both.
+
+2. THE CALL-SITE FREEZE (counting, fully stable): render_chart_png - the one
+   known ~125 ms synchronous loop-blocker - is called from EXACTLY the sites
+   listed in _KNOWN_RENDER_CALL_SITES, all three of which are today's
+   documented, deliberately-excluded offenders owned by ADR-013 ("0 ms on the
+   loop" via off-thread render is that ADR's exit criterion). A NEW call site
+   fails this test immediately: you may not add another inline render to the
+   loop - wrap it in asyncio.to_thread or route it through the ADR-013 work.
+   When ADR-013 lands and moves these off-loop, the freeze table shrinks with
+   it - that failure is the reminder to update both this test and the
+   watchdog's chart exclusion.
+
+Known offenders excluded from the watchdog window (all ADR-013's to fix):
+  - SceneDocument.add_chart_node's inline render (backend/domain/graph.py)
+  - SceneDocument's chart re-render on resize/update (same file)
+  - the 3x-DPI export route (backend/assets.py)
+The watchdog's fixture is therefore built with chart_count=0 - not to hide
+the problem (the freeze above pins it visibly) but because a gate that is
+red on day one enforces nothing.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.tests.perf.graph_factory import build_graph
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CI_STALL_CEILING_MS = 100.0
+_SAMPLER_TICK_S = 0.005
+
+
+async def _max_stall_ms(operations) -> float:
+    """Runs each zero-arg callable in `operations` on the loop, yielding
+    between them, while a sampler task measures how late its own ticks fire.
+    Returns the worst single gap (ms) beyond the tick interval - i.e. the
+    longest stretch the loop was blocked by any one operation. Windows timer
+    granularity (~15 ms) inflates every gap equally; the ceiling accounts
+    for it."""
+    loop = asyncio.get_running_loop()
+    gaps: list[float] = []
+    stop = asyncio.Event()
+
+    async def sampler() -> None:
+        last = loop.time()
+        while not stop.is_set():
+            await asyncio.sleep(_SAMPLER_TICK_S)
+            now = loop.time()
+            gaps.append(now - last - _SAMPLER_TICK_S)
+            last = now
+
+    task = asyncio.create_task(sampler())
+    await asyncio.sleep(_SAMPLER_TICK_S * 3)  # sampler settles first
+    for op in operations:
+        op()
+        await asyncio.sleep(0)
+    await asyncio.sleep(_SAMPLER_TICK_S * 3)  # last op's gap gets sampled
+    stop.set()
+    await task
+    return max(gaps, default=0.0) * 1000
+
+
+def _representative_operations(doc):
+    """Today's real mutation + publish surface, minus the known chart
+    offenders (see module docstring). Every callable here runs synchronously
+    on the loop in production - via an async intent handler or the publish
+    path - so each is individually subject to the 16 ms budget."""
+    node_ids = list(doc.nodes.keys())
+    first, second = node_ids[0], node_ids[1]
+
+    def publish_build_and_serialize():
+        json.dumps(doc.scene_payload())
+
+    return [
+        lambda: doc.record_command(
+            "moveNode", "user", lambda: doc.move_node(first, 5000.0, 5000.0),
+            node_ids=[first],
+        ),
+        lambda: doc.record_command(
+            "moveNodes", "user",
+            lambda: doc.move_nodes([(nid, doc.nodes[nid].x + 10.0, doc.nodes[nid].y) for nid in node_ids[:50]]),
+            node_ids=node_ids[:50],
+        ),
+        lambda: doc.record_command(
+            "removeNodes", "user", lambda: doc.remove_nodes([second]), node_ids=[second],
+        ),
+        lambda: doc.undo(),
+        lambda: doc.undo(),
+        publish_build_and_serialize,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_no_representative_operation_blocks_the_loop_beyond_the_ci_ceiling():
+    doc = build_graph(node_count=500, content_bytes=1200, chart_count=0, image_count=0, extra_edges=200)
+    runs = []
+    for _ in range(2):
+        runs.append(await _max_stall_ms(_representative_operations(doc)))
+    best = min(runs)
+    assert best <= CI_STALL_CEILING_MS, (
+        f"an operation blocked the event loop for {best:.1f} ms across both runs "
+        f"(CI ceiling: {CI_STALL_CEILING_MS:.0f} ms; the true ADR-019 budget is 16 ms, "
+        "enforced by stage 19.3's nightly job) - something synchronous and heavy "
+        "(the matplotlib-render class) landed on the loop. Move it off-thread "
+        "(asyncio.to_thread) instead of raising this ceiling."
+    )
+
+
+# -- the call-site freeze -----------------------------------------------------
+
+# module (repo-relative, posix) -> exact number of render_chart_png() calls.
+_KNOWN_RENDER_CALL_SITES = {
+    "backend/domain/graph.py": 2,  # add_chart_node + the resize/update re-render
+    "backend/assets.py": 1,        # the 3x-DPI export route
+}
+
+
+def _count_render_calls(tree: ast.Module) -> int:
+    count = 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else (
+                func.attr if isinstance(func, ast.Attribute) else None
+            )
+            if name == "render_chart_png":
+                count += 1
+    return count
+
+
+def test_inline_chart_render_call_sites_are_frozen():
+    found: dict[str, int] = {}
+    for path in sorted((REPO_ROOT / "backend").rglob("*.py")):
+        if "__pycache__" in path.parts or "tests" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        count = _count_render_calls(tree)
+        if count:
+            found[path.relative_to(REPO_ROOT).as_posix()] = count
+
+    assert found == _KNOWN_RENDER_CALL_SITES, (
+        "the set of render_chart_png() call sites under backend/ changed.\n"
+        f"  expected: {_KNOWN_RENDER_CALL_SITES}\n"
+        f"  found:    {found}\n"
+        "A NEW site means another synchronous ~125 ms matplotlib render landed on "
+        "the event loop - wrap it in asyncio.to_thread or route it through ADR-013's "
+        "off-loop render work instead of adding it here. A REMOVED site most likely "
+        "means ADR-013 landed - shrink this table and the watchdog's chart_count=0 "
+        "exclusion together, deliberately."
+    )
+
+
+def test_the_freeze_scan_finds_the_known_offenders_at_all():
+    # Guards the guard: if the scan's glob or name-matching broke, the freeze
+    # above could pass vacuously against an empty `found`. The two known
+    # offender modules must actually exist and parse.
+    for rel in _KNOWN_RENDER_CALL_SITES:
+        assert (REPO_ROOT / rel).is_file(), f"{rel} vanished - update _KNOWN_RENDER_CALL_SITES"

--- a/web_ui/eslint.config.js
+++ b/web_ui/eslint.config.js
@@ -41,4 +41,13 @@ export default tseslint.config(
       globals: globals.node,
     },
   },
+  {
+    // ADR-019 stage 19.2: build-tooling scripts (check-bundle-size.mjs) run
+    // under Node, not the browser - same globals carve-out the test files
+    // above already get.
+    files: ["scripts/**/*.mjs"],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
 );

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -14,7 +14,8 @@
     "test:watch": "vitest",
     "lint": "eslint .",
     "check:schema": "python ../contracts/codegen.py --check",
-    "check": "npm run check:schema && npm run typecheck && npm run lint && npm run test && npm run build"
+    "check:bundle": "node scripts/check-bundle-size.mjs",
+    "check": "npm run check:schema && npm run typecheck && npm run lint && npm run test && npm run build && npm run check:bundle"
   },
   "dependencies": {
     "@xyflow/react": "^12.11.2",

--- a/web_ui/scripts/check-bundle-size.mjs
+++ b/web_ui/scripts/check-bundle-size.mjs
@@ -1,0 +1,93 @@
+// ADR-019 stage 19.2: the bundle-size CI counting gate.
+//
+// Fails the build when the built JS grows past a ratchet ceiling. This is a
+// REGRESSION ratchet pinned ~5% above today's measured reality (one chunk,
+// 1,255,741 bytes on 2026-08-06), NOT the ADR-019 budget itself - the budget
+// (initial chunk <= 500 KiB, rest lazy-loaded) is ADR-011's code-splitting
+// work. Until that lands, this gate's job is to make sure the number only
+// ever moves DOWN: nobody can add half a megabyte of dependencies without CI
+// saying so.
+//
+// When ADR-011's splitting lands, tighten LARGEST_CHUNK_CEILING_BYTES to the
+// real 500 KiB budget (512_000) as part of that stage - per ADR-019 §4,
+// changing a ceiling is a deliberate, commented amendment, never a quiet edit
+// to make a red build green.
+//
+// Runs after `npm run build` in the `check` chain (see package.json), so CI's
+// existing frontend-checks job enforces it with no workflow changes.
+
+import { readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ASSETS_DIR = join(HERE, "..", "dist", "app", "assets");
+
+// Today's reality: a single 1,255,741-byte chunk. ~5% headroom absorbs
+// ordinary dependency-patch drift; a real regression (a new heavyweight
+// dependency, an accidental double-bundle) blows straight through it.
+const LARGEST_CHUNK_CEILING_BYTES = 1_320_000;
+// Slightly looser than the per-chunk ceiling so future code-splitting can add
+// small lazy chunks without tripping the TOTAL, while still catching the
+// "total payload quietly ballooned" class the per-chunk ceiling alone would
+// miss once there is more than one chunk.
+const TOTAL_JS_CEILING_BYTES = 1_400_000;
+
+let entries;
+try {
+  entries = readdirSync(ASSETS_DIR);
+} catch {
+  console.error(
+    `check-bundle-size: ${ASSETS_DIR} does not exist - run \`npm run build\` first ` +
+      "(the `check` script does this; this gate must never pass vacuously on a missing build).",
+  );
+  process.exit(1);
+}
+
+const chunks = entries
+  .filter((name) => name.endsWith(".js"))
+  .map((name) => ({ name, bytes: statSync(join(ASSETS_DIR, name)).size }))
+  .sort((a, b) => b.bytes - a.bytes);
+
+if (chunks.length === 0) {
+  // Guards the guard: an empty assets dir means the build layout changed out
+  // from under this script - that must fail loud, not pass with zero chunks.
+  console.error(
+    `check-bundle-size: no .js chunks found in ${ASSETS_DIR} - the build output ` +
+      "layout changed; update this script's ASSETS_DIR to match.",
+  );
+  process.exit(1);
+}
+
+const totalBytes = chunks.reduce((sum, c) => sum + c.bytes, 0);
+const failures = [];
+
+if (chunks[0].bytes > LARGEST_CHUNK_CEILING_BYTES) {
+  failures.push(
+    `largest chunk ${chunks[0].name} is ${chunks[0].bytes.toLocaleString()} bytes ` +
+      `(ceiling: ${LARGEST_CHUNK_CEILING_BYTES.toLocaleString()})`,
+  );
+}
+if (totalBytes > TOTAL_JS_CEILING_BYTES) {
+  failures.push(
+    `total JS is ${totalBytes.toLocaleString()} bytes across ${chunks.length} chunk(s) ` +
+      `(ceiling: ${TOTAL_JS_CEILING_BYTES.toLocaleString()})`,
+  );
+}
+
+if (failures.length > 0) {
+  console.error(
+    "check-bundle-size FAILED (ADR-019 stage 19.2 bundle ratchet):\n" +
+      failures.map((f) => `  - ${f}`).join("\n") +
+      "\n\nIf this growth is genuinely intended, raise the ceiling in " +
+      "web_ui/scripts/check-bundle-size.mjs as a deliberate, commented amendment " +
+      "(ADR-019 §4) - never to quietly absorb an accidental dependency.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `check-bundle-size OK: largest chunk ${chunks[0].bytes.toLocaleString()} bytes ` +
+    `(ceiling ${LARGEST_CHUNK_CEILING_BYTES.toLocaleString()}), ` +
+    `total ${totalBytes.toLocaleString()} bytes (ceiling ${TOTAL_JS_CEILING_BYTES.toLocaleString()}).`,
+);

--- a/web_ui/src/app/canvas/renderCountGate.test.tsx
+++ b/web_ui/src/app/canvas/renderCountGate.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * ADR-019 stage 19.2: the re-renders-per-update CI counting gate.
+ *
+ * The budget (ADR-019 §2): a single-node update re-renders exactly 1 node
+ * view. Today's reality (audit finding P-class, confirmed by this gate's own
+ * baseline measurement): every node view re-renders on every update - there
+ * is no React.memo anywhere in the SPA, and a scene snapshot/patch rebuilds
+ * every flow-node object so React Flow's own internal memoization never gets
+ * reference-equal props. Fixing that is ADR-011's memoization stage; this
+ * gate exists so the number can only ever move DOWN in the meantime:
+ *
+ *   1. commits per single-node update are pinned at today's measured 4 (one
+ *      from SceneCanvas's own setState, three from React Flow's internal
+ *      store-sync/measure cascade) - a 5th commit means someone added another
+ *      cascading state update on top;
+ *   2. node-view renders for that update are pinned at today's baseline
+ *      (every chat node, = NODE_COUNT) - growing past it means views render
+ *      more than once per update.
+ *
+ * When ADR-011's memoization lands, tighten RENDERS_PER_UPDATE_CEILING to 1
+ * (and revisit the commit cascade) - per ADR-019 §4 that is a deliberate
+ * amendment tied to that stage, and this comment is the reminder.
+ *
+ * Counting mechanism: ChatNodeView is replaced (vi.mock) with a stub that
+ * increments a counter per render - counting actual component renders, not
+ * Profiler timings, so the assertion is a stable integer, never wall-clock.
+ * The scene updates arrive through the REAL SceneStore listener path (the
+ * same transport-level subscribe callback production uses), not by poking
+ * React state directly - so the gate covers the store->React wiring too.
+ */
+import { Profiler, type ReactNode } from "react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { act, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const chatNodeRenders = { count: 0 };
+
+vi.mock("./ChatNodeView", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./ChatNodeView")>();
+  return {
+    ...original,
+    ChatNodeView: () => {
+      chatNodeRenders.count += 1;
+      return <div data-testid="chat-node-stub" />;
+    },
+  };
+});
+
+import { SceneCanvas } from "./SceneCanvas";
+import { SceneStore, initialSceneState } from "./sceneStore";
+import type { WsTransport } from "../../lib/ws/transport";
+import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
+
+const NODE_COUNT = 10;
+// Today's baseline: every node re-renders on a single-node update (no memo
+// anywhere - see module doc). ADR-011 tightens this to 1.
+const RENDERS_PER_UPDATE_CEILING = NODE_COUNT;
+// Today's measured cascade (see module doc): 1 SceneCanvas commit + 3 React
+// Flow internal store-sync/measure commits. The gate holds this from GROWING.
+const COMMITS_PER_UPDATE_CEILING = 4;
+
+function chatRow(id: string, x: number): SceneNodeRow {
+  // Only the fields toFlowNodes/ChatNodeView actually branch on need real
+  // values; everything else takes the wire default. Kept minimal on purpose -
+  // SceneCanvas.test.tsx's own baseNode() is the exhaustive fixture.
+  return {
+    ...(Object.fromEntries(
+      Object.entries({
+        id, x, y: 0, title: id, kind: "chat", content: "hello", isUser: false,
+        isCollapsed: false, code: "", language: "", attachmentKind: "", filePath: "",
+        mimeType: "", durationSeconds: null, byteSize: null, previewLabel: "",
+        isDocked: false, imageAssetId: "", history: [], pendingRequestId: null,
+        researchStage: "", researchCompleted: 0, researchTotal: 0,
+        researchActiveSourceId: null, researchError: "", researchResult: null,
+        artifactContent: "", gitlinkRepo: "", gitlinkBranch: "",
+        gitlinkScopeMode: "selected", gitlinkLocalRoot: "", gitlinkRepoFilePaths: [],
+        gitlinkSelectedPaths: [], gitlinkTaskPrompt: "", gitlinkContextStats: {},
+        gitlinkContextSummary: "", gitlinkContextVersion: 0,
+        gitlinkProposalMarkdown: "", gitlinkPendingChanges: [], gitlinkPreviewText: "",
+        gitlinkChangeFingerprint: null, gitlinkChangeState: "", gitlinkError: "",
+        pycoderMode: "ai_driven", pycoderPrompt: "", pycoderCode: "",
+        pycoderOutput: "", pycoderAnalysis: "", pycoderLastRunFailed: false,
+        pycoderAwaitingApproval: false, pycoderError: "",
+        codeSandboxRequirements: "", codeSandboxApprovalRequirements: "",
+        codeSandboxApprovalAllowSourceBuilds: false, codeSandboxApprovalIsRepair: false,
+        codeSandboxPrompt: "", codeSandboxCode: "", codeSandboxOutput: "",
+        codeSandboxAnalysis: "", codeSandboxAwaitingApproval: false,
+        codeSandboxError: "", provider: null, model: null, isBranchSynthesis: false,
+        synthesisInstructions: "", branchStatus: "active", isFinalDeliverable: false,
+        color: null, headerColor: null, isSystemPrompt: false, isSummaryNote: false,
+        isBranchComparison: false, itemIds: [], isLocked: true, groupWidth: null,
+        groupHeight: null, chartType: "", chartData: {}, chartError: "",
+        chartAssetId: "", chartAssetVersion: 0, chartWidth: 680.0, chartHeight: 500.0,
+        chartAspectLocked: true, chartSourceNodeId: "", htmlSplitterState: null,
+        chatScrollValue: 0.0,
+      }),
+    ) as unknown as SceneNodeRow),
+  };
+}
+
+function makeScene(movedNodeX: number | null = null): SceneState {
+  const nodes = Array.from({ length: NODE_COUNT }, (_, i) => chatRow(`n${i}`, i * 100));
+  if (movedNodeX !== null) nodes[0] = { ...nodes[0], x: movedNodeX };
+  return { ...initialSceneState, nodes, edges: [] };
+}
+
+type StateListener = (payload: Record<string, unknown>) => void;
+
+function makeWiredStore() {
+  const stateListeners = new Map<string, StateListener>();
+  const transport = {
+    subscribe: vi.fn((topic: string, listener: StateListener) => {
+      stateListeners.set(topic, listener);
+      return () => stateListeners.delete(topic);
+    }),
+    intent: vi.fn(),
+    fireIntent: vi.fn(),
+    subscribePatch: vi.fn(),
+    onVersionRejection: vi.fn((_topic: string, listener: (r: null) => void) => {
+      listener(null);
+      return () => {};
+    }),
+    setTopicBlocked: vi.fn(),
+  } as unknown as WsTransport;
+  const store = new SceneStore(transport);
+  store.connect();
+  return { store, stateListeners };
+}
+
+function mountWithCommitCounter(children: ReactNode) {
+  const commits = { count: 0 };
+  render(
+    <Profiler
+      id="render-count-gate"
+      onRender={() => {
+        commits.count += 1;
+      }}
+    >
+      {children}
+    </Profiler>,
+  );
+  return commits;
+}
+
+describe("re-renders per single-node update (ADR-019 stage 19.2)", () => {
+  it("finds real renders at all (guards the guard)", () => {
+    const { store, stateListeners } = makeWiredStore();
+    mountWithCommitCounter(
+      <ReactFlowProvider>
+        <SceneCanvas store={store} onOpenDocumentView={() => {}} />
+      </ReactFlowProvider>,
+    );
+    act(() => {
+      stateListeners.get("scene")!(makeScene() as unknown as Record<string, unknown>);
+    });
+    // The stub actually rendered once per node on mount - a broken mock or a
+    // React Flow harness change would make the gate below pass vacuously.
+    expect(chatNodeRenders.count).toBeGreaterThanOrEqual(NODE_COUNT);
+  });
+
+  it("a single-node update stays within the pinned commit and render baselines", () => {
+    const { store, stateListeners } = makeWiredStore();
+    const commits = mountWithCommitCounter(
+      <ReactFlowProvider>
+        <SceneCanvas store={store} onOpenDocumentView={() => {}} />
+      </ReactFlowProvider>,
+    );
+    act(() => {
+      stateListeners.get("scene")!(makeScene() as unknown as Record<string, unknown>);
+    });
+
+    chatNodeRenders.count = 0;
+    commits.count = 0;
+    act(() => {
+      stateListeners.get("scene")!(makeScene(9999) as unknown as Record<string, unknown>);
+    });
+
+    expect(commits.count).toBeLessThanOrEqual(COMMITS_PER_UPDATE_CEILING);
+    expect(chatNodeRenders.count).toBeLessThanOrEqual(RENDERS_PER_UPDATE_CEILING);
+    // Baseline honesty: today it IS the ceiling (all nodes re-render). If
+    // this starts failing LOW, memoization landed - tighten the ceiling to 1
+    // per ADR-011 instead of deleting the assertion.
+    expect(chatNodeRenders.count).toBe(NODE_COUNT);
+  });
+});


### PR DESCRIPTION
## Problem

ADR-019's budget table (wire bytes, bundle size, loop blocking, re-renders per update) was a document, not enforcement — a perf regression in any of those dimensions would land silently, which is exactly how the app previously drifted into 1.6 MB-per-edit territory without anyone noticing.

## Change

Four per-PR counting gates, per ADR-019 §4's split (stable counting checks in CI; wall-clock belongs to the 19.3 nightly job). Wire bytes/op was already enforced by ADR-003 stage 3.4's ≤5 KiB patch test, so three are new:

- **Bundle size** — `web_ui/scripts/check-bundle-size.mjs`, wired into `npm run check` after the build. Ratcheted ~5% over today's measured 1,255,741-byte single chunk (largest-chunk and total-JS ceilings). ADR-011's code-splitting later tightens this to the real 500 KiB budget.
- **Loop watchdog** — `backend/tests/perf/test_loop_watchdog.py`. An async sampler measures the longest stretch any representative operation (single/bulk move, delete, undo, publish build+serialize on a 500-node graph) blocks the event loop; 100 ms CI ceiling catches the ~125 ms matplotlib-class regression while staying flake-free on shared runners. Plus an AST freeze pinning `render_chart_png`'s call sites to exactly today's three known offenders (`backend/domain/graph.py` ×2, `backend/assets.py` export — ADR-013's to move off-loop), so no new inline render can land on the loop.
- **Re-renders per update** — `web_ui/src/app/canvas/renderCountGate.test.tsx`. Drives a single-node update through the real SceneStore listener path and pins today's measured reality: 4 commits (1 SceneCanvas + 3 React Flow internal) and all-N node-view re-renders. ADR-011's memoization tightens the render ceiling to 1.

`eslint.config.js` gains a node-globals carve-out for `scripts/`, matching the existing test-file carve-out.

## Test plan

- [x] Each gate verified against a deliberate regression: bundle ceiling breach fails the check chain; a 150 ms synchronous block trips the watchdog (measured 145 ms > 100 ceiling); a new `render_chart_png` call site trips the freeze; a cascading double update trips the commit ceiling (8 > 4)
- [x] `pytest -q` from repo root — 1713 passed, 14 skipped
- [x] `npm run check` (web_ui) — 1346 tests passed, bundle gate green in the chain