### PR TITLE
ADR-006 stage 6.1: Provider protocol + FakeProvider; Ollama ported

### DIFF
--- a/api_provider.py
+++ b/api_provider.py
@@ -2134,64 +2134,25 @@ def chat(task: str, messages: list, **kwargs) -> dict:
                 if not model:
                     raise ValueError(f"No Ollama model configured for task: {task}")
 
-                _assert_ollama_audio_support(model, messages)
-                ollama_messages = _prepare_ollama_messages(messages)
+                # ADR-006 stage 6.1: the Ollama branch routes through the
+                # Provider seam. OllamaProvider.complete() is a faithful port
+                # of the ~65-line block that used to live inline here (prep,
+                # think kwarg, 3-attempt reasoning retry, <think> composition)
+                # - see backend/providers/ollama_provider.py's module doc for
+                # the preserved-invariant inventory. Imported lazily: the
+                # providers package imports this module's helpers at its own
+                # top level, so a module-level import here would be circular.
+                from backend.providers.base import CancelToken, ChatRequest
+                from backend.providers.ollama_provider import OllamaProvider
 
-                ollama_kwargs = kwargs.copy()
-                if task == config.TASK_CHAT:
-                    think_value = ollama_think_kwarg(model, state.ollama_reasoning_level)
-                    if think_value is not None:
-                        ollama_kwargs["think"] = think_value
-                    if _is_ollama_bool_reasoning_model(model) and state.ollama_reasoning_level != "off":
-                        ollama_messages = _append_system_hint(
-                            ollama_messages, reasoning_budget_hint(state.ollama_reasoning_level)
-                        )
-
-                # Reasoning-capable local models occasionally exhaust their own
-                # "thinking" budget before writing a final answer - often just sampling
-                # variance, not a persistent problem - so retry the identical request a
-                # couple of times before surfacing it to the user (see
-                # ReasoningWithoutAnswerError). A short backoff between attempts gives a
-                # transient/momentary cause (e.g. local resource contention) a chance to
-                # clear instead of immediately re-sending the identical request.
-                max_attempts = 3
-                last_reasoning_error = None
-                full_response_content = None
-                for attempt in range(max_attempts):
-                    if attempt > 0:
-                        _raise_if_cancelled(cancel_event)
-                        time.sleep(_OLLAMA_REASONING_RETRY_BACKOFF_SECONDS)
-                        _raise_if_cancelled(cancel_event)
-
-                    response = ollama.chat(model=model, messages=ollama_messages, **ollama_kwargs)
-                    _raise_if_cancelled(cancel_event)
-
-                    raw_response_content = response["message"].get("content", "")
-                    embedded_reasoning, visible_response_content = split_reasoning_and_content(raw_response_content)
-                    reasoning_parts: list[str] = []
-                    reasoning_seen: set[str] = set()
-                    _append_unique_text_segment(reasoning_parts, response["message"].get("thinking"), reasoning_seen)
-                    _append_unique_text_segment(reasoning_parts, embedded_reasoning, reasoning_seen)
-
-                    try:
-                        full_response_content = _compose_reasoned_response(
-                            visible_response_content,
-                            "\n\n".join(reasoning_parts).strip(),
-                            "Ollama",
-                        )
-                        break
-                    except ReasoningWithoutAnswerError as exc:
-                        last_reasoning_error = exc
-                        continue
-                else:
-                    raise RuntimeError(
-                        f"Ollama returned reasoning but no final answer after {max_attempts} attempts. "
-                        "Retry in Quick mode or choose a different chat format/model."
-                    ) from last_reasoning_error
-
+                provider = OllamaProvider(model=model, reasoning_level=state.ollama_reasoning_level)
+                content = provider.complete(
+                    ChatRequest(task=task, messages=messages, extra_kwargs=kwargs),
+                    CancelToken(cancel_event),
+                )
                 return {
                     "message": {
-                        "content": full_response_content,
+                        "content": content,
                         "role": "assistant",
                     }
                 }
@@ -2448,76 +2409,30 @@ def chat_stream(task: str, messages: list, on_chunk: Callable[[str, bool], None]
         model = config.OLLAMA_MODELS.get(task)
         if not model:
             raise ValueError(f"No Ollama model configured for task: {task}")
-        _assert_ollama_audio_support(model, messages)
-        ollama_messages = _prepare_ollama_messages(messages)
 
-        ollama_kwargs = {k: v for k, v in kwargs.items() if k != "cancellation_event"}
-        if task == config.TASK_CHAT:
-            think_value = ollama_think_kwarg(model, state.ollama_reasoning_level)
-            if think_value is not None:
-                ollama_kwargs["think"] = think_value
-            if _is_ollama_bool_reasoning_model(model) and state.ollama_reasoning_level != "off":
-                ollama_messages = _append_system_hint(
-                    ollama_messages, reasoning_budget_hint(state.ollama_reasoning_level)
-                )
+        # ADR-006 stage 6.1: the streaming Ollama branch routes through the
+        # Provider seam (see chat()'s twin comment). The provider yields typed
+        # events; this adapter maps them onto the on_chunk(delta, reset)
+        # contract EXACTLY as before: "text" deltas forward incrementally,
+        # "reset" becomes on_chunk("", True), "reasoning" deltas are NOT
+        # forwarded (thinking never reached on_chunk here - it only surfaces
+        # in the final <think> block), and "done" carries the composed full
+        # text this function returns.
+        from backend.providers.base import CancelToken, ChatRequest
+        from backend.providers.ollama_provider import OllamaProvider
 
-        # Same 3-attempt reasoning-retry loop as chat() (see ReasoningWithoutAnswerError):
-        # each attempt streams live, and if an attempt is discarded, the caller is told via
-        # one on_chunk("", True) reset event before the next attempt's deltas start
-        # arriving.
-        max_attempts = 3
-        last_reasoning_error = None
+        provider = OllamaProvider(model=model, reasoning_level=state.ollama_reasoning_level)
         full_response_content = None
-        for attempt in range(max_attempts):
-            if attempt > 0:
-                _raise_if_cancelled(cancel_event)
-                time.sleep(_OLLAMA_REASONING_RETRY_BACKOFF_SECONDS)
-                _raise_if_cancelled(cancel_event)
+        for event in provider.stream(
+            ChatRequest(task=task, messages=messages, extra_kwargs=kwargs),
+            CancelToken(cancel_event),
+        ):
+            if event.type == "text":
+                on_chunk(event.text, False)
+            elif event.type == "reset":
                 on_chunk("", True)  # tell the caller: discard the last attempt's partial text
-
-            content_parts: list[str] = []
-            thinking_parts: list[str] = []
-            stream = ollama.chat(model=model, messages=ollama_messages, stream=True, **ollama_kwargs)
-            try:
-                for part in stream:
-                    if cancel_event is not None and cancel_event.is_set():
-                        stream.close()  # unwinds ollama/_client.py's `with self._client.stream(...)`
-                    _raise_if_cancelled(cancel_event)  # raises RequestCancelledError if just closed above
-
-                    delta_content = part["message"].get("content") or ""
-                    if delta_content:
-                        content_parts.append(delta_content)
-                        on_chunk(delta_content, False)
-                    delta_thinking = part["message"].get("thinking") or ""
-                    if delta_thinking:
-                        thinking_parts.append(delta_thinking)  # never forwarded to on_chunk
-                    if part.get("done"):
-                        break
-            finally:
-                stream.close()  # idempotent on an already-exhausted generator
-
-            raw_response_content = "".join(content_parts)
-            embedded_reasoning, visible_response_content = split_reasoning_and_content(raw_response_content)
-            reasoning_parts: list[str] = []
-            reasoning_seen: set[str] = set()
-            _append_unique_text_segment(reasoning_parts, "".join(thinking_parts), reasoning_seen)
-            _append_unique_text_segment(reasoning_parts, embedded_reasoning, reasoning_seen)
-
-            try:
-                full_response_content = _compose_reasoned_response(
-                    visible_response_content,
-                    "\n\n".join(reasoning_parts).strip(),
-                    "Ollama",
-                )
-                break
-            except ReasoningWithoutAnswerError as exc:
-                last_reasoning_error = exc
-                continue
-        else:
-            raise RuntimeError(
-                f"Ollama returned reasoning but no final answer after {max_attempts} attempts. "
-                "Retry in Quick mode or choose a different chat format/model."
-            ) from last_reasoning_error
+            elif event.type == "done":
+                full_response_content = event.text
 
         return {
             "message": {

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -1,0 +1,29 @@
+"""ADR-006: the provider abstraction package.
+
+Stage 6.1 introduces the seam: a `Provider` protocol (base.py), a
+`FakeProvider` that makes the streaming path testable without a network
+(fake.py), and `OllamaProvider` as the first real port (ollama_provider.py).
+api_provider.py's chat()/chat_stream() Ollama branches route through it;
+the other four providers still live in api_provider's if/elif surface until
+stages 6.3+ port them one by one.
+"""
+
+from backend.providers.base import (
+    CancelToken,
+    ChatRequest,
+    Provider,
+    ProviderCapabilities,
+    ProviderEvent,
+)
+from backend.providers.fake import FakeProvider
+from backend.providers.ollama_provider import OllamaProvider
+
+__all__ = [
+    "CancelToken",
+    "ChatRequest",
+    "FakeProvider",
+    "OllamaProvider",
+    "Provider",
+    "ProviderCapabilities",
+    "ProviderEvent",
+]

--- a/backend/providers/base.py
+++ b/backend/providers/base.py
@@ -66,11 +66,18 @@ class ChatRequest:
     per-provider `prepare_messages` responsibility ADR-006 §1 assigns.
     `extra_kwargs` is the passthrough surface today's chat(**kwargs) callers
     rely on (e.g. the chart agent's format hints); it shrinks as stages
-    6.3-6.8 give its remaining uses first-class fields."""
+    6.3-6.8 give its remaining uses first-class fields.
+
+    Deliberately NO reasoning_level field: the level is provider
+    configuration (each provider is constructed with it, from the caller's
+    own settings snapshot), not per-request data - a field here would be a
+    second source of truth that a provider could silently ignore
+    (adversarial-review finding on the first draft, which carried exactly
+    that dead field). Stage 6.5's per-session ProviderRuntime owns where the
+    level ultimately lives."""
 
     task: str
     messages: list
-    reasoning_level: str = "off"
     extra_kwargs: Mapping[str, Any] = field(default_factory=dict)
 
 
@@ -121,5 +128,14 @@ class Provider(Protocol):
         """Yield ProviderEvents for one completion, ending with exactly one
         "done" event carrying the full final text. Raise (never swallow) on
         failure; exception translation to user-facing messages stays with the
-        caller until the stage that moves it in here."""
+        caller until the stage that moves it in here.
+
+        LAZY-GENERATOR CONTRACT (adversarial-review finding, pinned here so
+        stage 6.2 designs against it, not around it): implementations are
+        generator functions, so NOTHING in the body - including entry cancel
+        checks and request prep/validation - runs at call time; it runs on
+        the first next(). Callers must therefore consume the iterator inside
+        whatever try/except owns error translation (both api_provider call
+        sites do), and must never treat a successful stream() CALL as "the
+        request validated"."""
         ...

--- a/backend/providers/base.py
+++ b/backend/providers/base.py
@@ -1,0 +1,125 @@
+"""ADR-006 stage 6.1: the Provider protocol - the seam that replaces
+api_provider.py's ~30-site if/elif dispatch surface, one provider at a time.
+
+Deliberate staging (per ADR-006's own stage table, recorded here so the gap
+between this file and the ADR's §1 sketch reads as a plan, not a drift):
+
+- The ADR's target protocol is async-native (`async def stream(...) ->
+  AsyncIterator[ProviderEvent]`). THIS stage's protocol is a plain sync
+  iterator, because today every provider call runs inside a worker thread
+  (`asyncio.to_thread` in backend/agents.py) against sync SDKs - an async
+  protocol here would mean nesting a private event loop inside each worker
+  thread for zero behavioral gain. Stage 6.2 (non-blocking dispatch) and 6.3
+  (async SDK ports) flip this async-native; the EVENT vocabulary below is
+  already the ADR's, so that flip changes the iteration keyword, not the
+  data model.
+- `usage` events (6.8) and `tool_call` events (ADR-007) are named in the
+  ADR's event union but deliberately absent from EVENT_TYPES until the stage
+  that makes them real - an event type nothing can emit yet would just be an
+  untestable claim.
+- Cancellation rides the same `threading.Event` the whole run pipeline
+  already uses (RunLifecycle claims one per run); `CancelToken` wraps it so
+  the protocol owns the NAME while stage 6.2 swaps the mechanism underneath
+  without touching provider implementations. The cancellation ERROR remains
+  api_provider.RequestCancelledError for now - every consumer
+  (backend/agents.py's dispatch, the WS error path) catches that exact type,
+  and moving the class is a rename-across-the-codebase that belongs to the
+  stage that owns dispatch (6.2), not the one introducing the seam.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Iterator, Literal, Mapping, Protocol, runtime_checkable
+
+EVENT_TYPES = ("text", "reasoning", "reset", "done")
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    """What a provider (with its configured model) can actually do - the
+    single source of truth orchestration and UI consult instead of
+    provider-type string checks (ADR-006 §1). Complements - does not replace -
+    graphlink_model_catalog.ModelDescriptor: the descriptor describes a MODEL
+    in a catalog; this describes the live provider+model pair a request will
+    actually hit."""
+
+    streaming: bool = False
+    reasoning: bool = False
+    vision: bool = False
+    audio: bool = False
+    image_generation: bool = False
+    # ADR-007 / 6.8 - declared now so capability consumers have a stable
+    # shape, but nothing sets them True until the stage that implements them.
+    tools: bool = False
+    structured_output: bool = False
+
+
+@dataclass(frozen=True)
+class ChatRequest:
+    """One chat completion request, provider-agnostic.
+
+    `messages` uses the app's existing wire shape untouched ([{"role": ...,
+    "content": str | [part-dict]}], with "image_bytes"/"audio_file" parts) -
+    each provider owns converting that to its SDK's format, exactly the
+    per-provider `prepare_messages` responsibility ADR-006 §1 assigns.
+    `extra_kwargs` is the passthrough surface today's chat(**kwargs) callers
+    rely on (e.g. the chart agent's format hints); it shrinks as stages
+    6.3-6.8 give its remaining uses first-class fields."""
+
+    task: str
+    messages: list
+    reasoning_level: str = "off"
+    extra_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProviderEvent:
+    """One streaming event. Types:
+
+    - "text":      an incremental visible-content delta (never cumulative).
+    - "reasoning": an incremental thinking delta - surfaced as its own channel
+                   here even though today's UI never displays it (chat_stream's
+                   on_chunk contract deliberately drops these; a future stage
+                   can render them without touching providers).
+    - "reset":     discard everything accumulated so far (a provider-internal
+                   retry discarded the prior attempt's partial output).
+    - "done":      terminal; `text` carries the COMPLETE final content (for
+                   Ollama that is the composed "<think>...</think>\\n{answer}"
+                   shape downstream response parsing depends on).
+    """
+
+    type: Literal["text", "reasoning", "reset", "done"]
+    text: str = ""
+
+
+class CancelToken:
+    """Cooperative cancellation handle passed into every provider call.
+
+    Wraps the run's existing threading.Event (or None for uncancellable
+    callers) so providers depend on this protocol type, never on the event
+    directly - stage 6.2 changes what is underneath, not the provider code."""
+
+    __slots__ = ("event",)
+
+    def __init__(self, event: threading.Event | None = None):
+        self.event = event
+
+    def is_set(self) -> bool:
+        return self.event is not None and self.event.is_set()
+
+
+@runtime_checkable
+class Provider(Protocol):
+    """The seam. One concrete class per provider; adding a 6th provider is
+    one new class implementing this, not 15 edits across api_provider.py."""
+
+    capabilities: ProviderCapabilities
+
+    def stream(self, request: ChatRequest, cancel: CancelToken) -> Iterator[ProviderEvent]:
+        """Yield ProviderEvents for one completion, ending with exactly one
+        "done" event carrying the full final text. Raise (never swallow) on
+        failure; exception translation to user-facing messages stays with the
+        caller until the stage that moves it in here."""
+        ...

--- a/backend/providers/fake.py
+++ b/backend/providers/fake.py
@@ -1,0 +1,60 @@
+"""ADR-006 stage 6.1: FakeProvider - the protocol-conforming test double.
+
+This is what finally makes the real streaming path testable: instead of
+monkeypatching api_provider.chat_stream wholesale (the suite-wide conftest
+stub, which replaces the entire streaming machinery with one synthetic
+chunk), a test installs a FakeProvider at the provider seam and the REAL
+event-consumption code runs against scripted events.
+"""
+
+from __future__ import annotations
+
+from backend.providers.base import (
+    CancelToken,
+    ChatRequest,
+    ProviderCapabilities,
+    ProviderEvent,
+)
+
+
+class FakeProvider:
+    """Yields a scripted event sequence and records every request.
+
+    `events` is yielded verbatim, ending with a synthesized "done" (carrying
+    the concatenation of the scripted text deltas) unless the script already
+    ends with one - so simple tests can script just the deltas. `error`, when
+    set, is raised after the scripted events instead of the "done" - the
+    mid-stream-failure case. Cancellation is honored between events, matching
+    the real providers' between-chunk cooperative checks."""
+
+    def __init__(
+        self,
+        events: list[ProviderEvent] | None = None,
+        *,
+        capabilities: ProviderCapabilities | None = None,
+        error: Exception | None = None,
+    ):
+        self.events = list(events or [])
+        self.capabilities = capabilities or ProviderCapabilities(streaming=True)
+        self.error = error
+        self.requests: list[ChatRequest] = []
+        self.cancelled_after: int | None = None
+
+    def stream(self, request: ChatRequest, cancel: CancelToken):
+        self.requests.append(request)
+        emitted_done = False
+        for index, event in enumerate(self.events):
+            if cancel.is_set():
+                self.cancelled_after = index
+                # Mirrors the real providers: cooperative cancellation raises
+                # the app's one cancellation sentinel, translated nowhere.
+                from api_provider import RequestCancelledError
+
+                raise RequestCancelledError("cancelled")
+            emitted_done = event.type == "done"
+            yield event
+        if self.error is not None:
+            raise self.error
+        if not emitted_done:
+            full = "".join(e.text for e in self.events if e.type == "text")
+            yield ProviderEvent("done", full)

--- a/backend/providers/ollama_provider.py
+++ b/backend/providers/ollama_provider.py
@@ -1,0 +1,201 @@
+"""ADR-006 stage 6.1: OllamaProvider - the first real port onto the Provider
+protocol.
+
+This is a FAITHFUL PORT of api_provider.py's twin Ollama branches (chat()'s
+and chat_stream()'s), deduplicating the two ~70-line blocks into one class
+while preserving every documented invariant of that code:
+
+- message prep flattens images AND audio bytes into ollama's `images` field
+  (_prepare_ollama_messages - Gemma 4 audio rides the multimodal field);
+- the audio capability gate runs before any network call;
+- the `think` kwarg and the reasoning-budget system hint apply ONLY when
+  task == TASK_CHAT, with the per-family string-vs-bool mapping
+  (ollama_think_kwarg) unchanged;
+- the 3-attempt ReasoningWithoutAnswerError retry loop, with the same backoff
+  constant, cancel checks on BOTH sides of the sleep, and (streaming only) a
+  "reset" event before a discarded attempt's replacement deltas start;
+- `thinking` deltas are a separate event channel, never mixed into "text";
+- the final text is composed as "<think>...</think>\\n{answer}" via
+  _compose_reasoned_response - backend/response_parsing.py depends on that
+  exact shape - with the native `thinking` field and embedded <think> text
+  deduplicated (_append_unique_text_segment);
+- mid-stream cancellation closes the live HTTP stream (stream.close()
+  unwinds the ollama client's context manager) then raises
+  RequestCancelledError, which must escape untranslated;
+- "reasoning but no answer after 3 attempts" and "genuinely empty response"
+  remain DISTINCT failures with their exact existing messages.
+
+The helpers are imported from api_provider rather than duplicated: they are
+provider-agnostic text utilities plus Ollama-specific prep that api_provider
+still needs for capability probing; they migrate into this package when the
+last consumer outside it does (stage 6.3+). Exception TRANSLATION stays in
+api_provider._translate_chat_exception at the call sites - this class raises
+raw errors, per the protocol's documented contract.
+
+`complete()` is a transitional extra beyond the protocol: chat()'s Ollama
+branch is non-streaming today (one blocking ollama.chat call), and switching
+it to streamed consumption would change network behavior in a stage whose
+job is the seam, not the semantics. Stage 6.4 (universal streaming) deletes
+it.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Iterator
+
+import ollama
+
+import graphlink_task_config as config
+from api_provider import (
+    _OLLAMA_REASONING_RETRY_BACKOFF_SECONDS,
+    ReasoningWithoutAnswerError,
+    _append_system_hint,
+    _append_unique_text_segment,
+    _assert_ollama_audio_support,
+    _compose_reasoned_response,
+    _is_ollama_bool_reasoning_model,
+    _prepare_ollama_messages,
+    _raise_if_cancelled,
+    ollama_think_kwarg,
+    reasoning_budget_hint,
+    split_reasoning_and_content,
+)
+from backend.providers.base import (
+    CancelToken,
+    ChatRequest,
+    ProviderCapabilities,
+    ProviderEvent,
+)
+
+_MAX_REASONING_ATTEMPTS = 3
+
+
+class OllamaProvider:
+    """One configured (model, reasoning_level) pair. Stateless beyond its
+    construction arguments - the caller captures both from its own provider
+    snapshot, so a mid-request settings change can't half-apply here any more
+    than it could in the branch this ports."""
+
+    def __init__(self, *, model: str, reasoning_level: str = "off"):
+        self.model_id = model
+        self.reasoning_level = reasoning_level
+        # Derived WITHOUT a network round-trip: reasoning support here means
+        # "this family takes a think kwarg" (a pure string-family check, the
+        # same one the request path applies). The richer probed capabilities
+        # (vision/audio via ollama.show) stay behind api_provider's cached
+        # audio gate for now - eagerly probing at construction would add a
+        # network call to every request that today has none.
+        self.capabilities = ProviderCapabilities(
+            streaming=True,
+            reasoning=ollama_think_kwarg(model, "high") is not None,
+        )
+
+    # -- shared request prep --------------------------------------------------
+
+    def _prepared(self, request: ChatRequest) -> tuple[list, dict]:
+        _assert_ollama_audio_support(self.model_id, request.messages)
+        messages = _prepare_ollama_messages(request.messages)
+        kwargs = {k: v for k, v in request.extra_kwargs.items() if k != "cancellation_event"}
+        if request.task == config.TASK_CHAT:
+            think_value = ollama_think_kwarg(self.model_id, self.reasoning_level)
+            if think_value is not None:
+                kwargs["think"] = think_value
+            if _is_ollama_bool_reasoning_model(self.model_id) and self.reasoning_level != "off":
+                messages = _append_system_hint(
+                    messages, reasoning_budget_hint(self.reasoning_level)
+                )
+        return messages, kwargs
+
+    @staticmethod
+    def _compose(raw_content: str, thinking: str) -> str:
+        """The shared tail of both branches: split embedded reasoning out of
+        the raw content, merge it with the native thinking channel without
+        duplication, and re-wrap. Raises ReasoningWithoutAnswerError for the
+        retryable reasoning-only case, RuntimeError for genuinely empty."""
+        embedded_reasoning, visible_content = split_reasoning_and_content(raw_content)
+        reasoning_parts: list[str] = []
+        reasoning_seen: set[str] = set()
+        _append_unique_text_segment(reasoning_parts, thinking, reasoning_seen)
+        _append_unique_text_segment(reasoning_parts, embedded_reasoning, reasoning_seen)
+        return _compose_reasoned_response(
+            visible_content, "\n\n".join(reasoning_parts).strip(), "Ollama"
+        )
+
+    @staticmethod
+    def _exhausted_retries_error() -> RuntimeError:
+        return RuntimeError(
+            f"Ollama returned reasoning but no final answer after {_MAX_REASONING_ATTEMPTS} attempts. "
+            "Retry in Quick mode or choose a different chat format/model."
+        )
+
+    # -- the protocol ---------------------------------------------------------
+
+    def stream(self, request: ChatRequest, cancel: CancelToken) -> Iterator[ProviderEvent]:
+        _raise_if_cancelled(cancel.event)
+        messages, kwargs = self._prepared(request)
+
+        last_reasoning_error: ReasoningWithoutAnswerError | None = None
+        for attempt in range(_MAX_REASONING_ATTEMPTS):
+            if attempt > 0:
+                _raise_if_cancelled(cancel.event)
+                time.sleep(_OLLAMA_REASONING_RETRY_BACKOFF_SECONDS)
+                _raise_if_cancelled(cancel.event)
+                yield ProviderEvent("reset")
+
+            content_parts: list[str] = []
+            thinking_parts: list[str] = []
+            stream = ollama.chat(model=self.model_id, messages=messages, stream=True, **kwargs)
+            try:
+                for part in stream:
+                    if cancel.is_set():
+                        stream.close()  # unwinds ollama/_client.py's `with self._client.stream(...)`
+                    _raise_if_cancelled(cancel.event)  # raises if just closed above
+
+                    delta_content = part["message"].get("content") or ""
+                    if delta_content:
+                        content_parts.append(delta_content)
+                        yield ProviderEvent("text", delta_content)
+                    delta_thinking = part["message"].get("thinking") or ""
+                    if delta_thinking:
+                        thinking_parts.append(delta_thinking)
+                        yield ProviderEvent("reasoning", delta_thinking)
+                    if part.get("done"):
+                        break
+            finally:
+                stream.close()  # idempotent on an already-exhausted generator
+
+            try:
+                final = self._compose("".join(content_parts), "".join(thinking_parts))
+            except ReasoningWithoutAnswerError as exc:
+                last_reasoning_error = exc
+                continue
+            yield ProviderEvent("done", final)
+            return
+        raise self._exhausted_retries_error() from last_reasoning_error
+
+    # -- transitional non-streaming path (dies in stage 6.4) ------------------
+
+    def complete(self, request: ChatRequest, cancel: CancelToken) -> str:
+        _raise_if_cancelled(cancel.event)
+        messages, kwargs = self._prepared(request)
+
+        last_reasoning_error: ReasoningWithoutAnswerError | None = None
+        for attempt in range(_MAX_REASONING_ATTEMPTS):
+            if attempt > 0:
+                _raise_if_cancelled(cancel.event)
+                time.sleep(_OLLAMA_REASONING_RETRY_BACKOFF_SECONDS)
+                _raise_if_cancelled(cancel.event)
+
+            response = ollama.chat(model=self.model_id, messages=messages, **kwargs)
+            _raise_if_cancelled(cancel.event)
+
+            try:
+                return self._compose(
+                    response["message"].get("content", ""),
+                    response["message"].get("thinking") or "",
+                )
+            except ReasoningWithoutAnswerError as exc:
+                last_reasoning_error = exc
+                continue
+        raise self._exhausted_retries_error() from last_reasoning_error

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -202,6 +202,9 @@ def test_reasoning_without_answer_retries_with_a_reset_event(ollama_chat, no_bac
     types = [e.type for e in events]
     assert types == ["reasoning", "reset", "text", "done"]
     assert events[-1].text.endswith("Real answer.")
+    # Review finding: endswith alone would let attempt 1's discarded output
+    # leak into the final text unnoticed - assert the discard actually held.
+    assert "only thoughts" not in events[-1].text
     assert len(ollama_chat.calls) == 2
 
 
@@ -248,6 +251,91 @@ def test_cancellation_mid_stream_closes_the_live_stream_and_raises(ollama_chat):
     with pytest.raises(api_provider.RequestCancelledError):
         list(stream)
     assert live.close_calls >= 1  # the live HTTP stream was actively closed
+
+
+def test_bool_reasoning_models_get_the_budget_hint_prepended_as_a_system_message(ollama_chat):
+    """Review finding: this invariant was claimed in the module doc but never
+    asserted. qwen3 at a non-off level must get reasoning_budget_hint()'s text
+    prepended as a leading system message; gpt-oss (string-think family) must
+    NOT - it steers via the think kwarg alone."""
+    ollama_chat.streams = [
+        FakeOllamaStream([_part(content="a", done=True)]),
+        FakeOllamaStream([_part(content="b", done=True)]),
+    ]
+
+    list(OllamaProvider(model="qwen3:8b", reasoning_level="high").stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "x"}]),
+        CancelToken(),
+    ))
+    sent = ollama_chat.calls[0]["messages"]
+    assert sent[0]["role"] == "system"
+    assert api_provider.reasoning_budget_hint("high") in sent[0]["content"]
+    assert ollama_chat.calls[0]["think"] is True  # bool family
+
+    list(OllamaProvider(model="gpt-oss:20b", reasoning_level="high").stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "x"}]),
+        CancelToken(),
+    ))
+    sent = ollama_chat.calls[1]["messages"]
+    assert all(m["role"] != "system" for m in sent)  # no hint for the string family
+
+
+def test_extra_kwargs_pass_through_and_cancellation_event_is_stripped(ollama_chat):
+    """Review finding: the passthrough surface (e.g. the chart agent's format
+    kwarg) and the cancellation_event strip were untested in BOTH paths."""
+    ollama_chat.streams = [FakeOllamaStream([_part(content="a", done=True)])]
+    ollama_chat.responses = [{"message": {"content": "b"}}]
+    provider = OllamaProvider(model="llava:13b")
+    sentinel_event = threading.Event()
+    request = ChatRequest(
+        task=config.TASK_TITLE,
+        messages=[{"role": "user", "content": "x"}],
+        extra_kwargs={"format": "json", "cancellation_event": sentinel_event},
+    )
+
+    list(provider.stream(request, CancelToken()))
+    provider.complete(request, CancelToken())
+
+    for call in ollama_chat.calls:
+        assert call["format"] == "json"
+        assert "cancellation_event" not in call
+
+
+def test_image_bytes_parts_flow_into_ollamas_images_field(ollama_chat):
+    """Review finding: the media-flattening invariant (image/audio parts land
+    in ollama's `images` field via _prepare_ollama_messages) was claimed but
+    never exercised through the provider path."""
+    ollama_chat.streams = [FakeOllamaStream([_part(content="seen", done=True)])]
+    provider = OllamaProvider(model="llava:13b")
+    list(provider.stream(
+        ChatRequest(
+            task=config.TASK_CHAT,
+            messages=[{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this"},
+                    {"type": "image_bytes", "data": b"\x89PNG-fake"},
+                ],
+            }],
+        ),
+        CancelToken(),
+    ))
+    sent = ollama_chat.calls[0]["messages"]
+    assert sent[-1]["images"] == [b"\x89PNG-fake"]
+    assert sent[-1]["content"] == "what is this"
+
+
+def test_complete_honors_cancellation(ollama_chat):
+    """Review finding: only stream()'s cancellation was tested."""
+    cancel_event = threading.Event()
+    cancel_event.set()
+    provider = OllamaProvider(model="llava:13b")
+    with pytest.raises(api_provider.RequestCancelledError):
+        provider.complete(
+            ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "x"}]),
+            CancelToken(cancel_event),
+        )
+    assert ollama_chat.calls == []  # cancelled before any network call
 
 
 def test_think_kwarg_and_hint_apply_only_for_the_chat_task(ollama_chat):
@@ -375,6 +463,70 @@ def test_chat_and_chat_stream_actually_route_through_the_provider_seam(
     _REAL_CHAT(config.TASK_CHAT, [{"role": "user", "content": "x"}])
 
     assert calls == {"stream": 1, "complete": 1}
+
+
+def test_a_fake_provider_can_substitute_for_ollama_at_the_real_chat_stream_seam(
+    monkeypatch, ollama_mode
+):
+    """Review finding (HIGH): the whole design promises the seam is
+    provider-agnostic, but nothing proved a protocol-conforming double can
+    stand in for OllamaProvider under the REAL chat_stream. Here the seam's
+    provider construction is swapped for a FakeProvider factory and the real
+    adapter runs end to end against it - scripted deltas reach on_chunk, the
+    scripted done becomes the return value, no ollama.chat involved at all."""
+    from backend.providers import ollama_provider as op_module
+
+    fake = FakeProvider([
+        ProviderEvent("text", "from "),
+        ProviderEvent("text", "the "),
+        ProviderEvent("text", "fake"),
+    ])
+
+    class FakeFactory:
+        def __init__(self, **_kwargs):
+            self.capabilities = fake.capabilities
+
+        def stream(self, request, cancel):
+            return fake.stream(request, cancel)
+
+    monkeypatch.setattr(op_module, "OllamaProvider", FakeFactory)
+    monkeypatch.setattr(api_provider, "chat_stream", _REAL_CHAT_STREAM)
+
+    chunks: list[tuple[str, bool]] = []
+    response = api_provider.chat_stream(
+        config.TASK_CHAT,
+        [{"role": "user", "content": "hi"}],
+        lambda delta, reset: chunks.append((delta, reset)),
+    )
+
+    assert chunks == [("from ", False), ("the ", False), ("fake", False)]
+    assert response == {"message": {"content": "from the fake", "role": "assistant"}}
+    assert len(fake.requests) == 1
+
+
+def test_api_provider_never_imports_the_providers_package_at_module_level():
+    """Review finding: the circular-import structure is sound ONLY while
+    api_provider keeps its backend.providers imports function-local (the
+    providers package imports api_provider's helpers at ITS module level).
+    Pin the invariant so a future convenience refactor that hoists the import
+    to the top of api_provider.py fails here instead of at app boot."""
+    import ast
+    from pathlib import Path
+
+    source = (Path(api_provider.__file__)).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    offenders = [
+        node.lineno
+        for node in tree.body  # module level only - function-local imports are the sanctioned form
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        and "backend.providers" in ast.dump(node)
+    ]
+    assert not offenders, (
+        "api_provider.py imports backend.providers at module level (lines "
+        f"{offenders}) - that direction must stay function-local; the providers "
+        "package imports api_provider's helpers at its own module level, so a "
+        "top-level import here is a genuine import cycle."
+    )
 
 
 def test_cancellation_through_the_real_chat_stream_is_the_untranslated_sentinel(

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -1,0 +1,396 @@
+"""ADR-006 stage 6.1: the Provider protocol, FakeProvider, and the Ollama port.
+
+Layer map:
+1. Protocol conformance - both implementations satisfy the runtime-checkable
+   Provider protocol.
+2. FakeProvider semantics - scripted events, synthesized "done", mid-stream
+   error, request recording, cooperative cancellation.
+3. OllamaProvider unit tests against a fake ollama.chat - event ordering,
+   thinking-as-its-own-channel, <think> composition, the 3-attempt
+   reasoning retry with its "reset" event, cancellation closing the live
+   stream, think-kwarg/system-hint gating on TASK_CHAT, and the
+   empty-vs-reasoning-only error distinction.
+4. The stage's EXIT CRITERION - api_provider.chat_stream's REAL machinery
+   (not the suite-wide conftest stub, which this file explicitly restores
+   the real function over) streams multiple incremental deltas end to end
+   through the provider seam, with only the network call faked. Before this
+   stage, that path was untestable without a live Ollama server - the seam
+   is what makes it testable, which is the point of the stage.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+import api_provider
+import graphlink_task_config as config
+from backend.providers import (
+    CancelToken,
+    ChatRequest,
+    FakeProvider,
+    OllamaProvider,
+    Provider,
+    ProviderEvent,
+)
+
+# Captured at import time - module-level code runs at collection, BEFORE the
+# autouse conftest fixture swaps api_provider.chat_stream for its one-chunk
+# stub - so this is the genuine function object, restorable per-test.
+_REAL_CHAT_STREAM = api_provider.chat_stream
+_REAL_CHAT = api_provider.chat
+
+
+# -- fakes --------------------------------------------------------------------
+
+
+class FakeOllamaStream:
+    """Stands in for the generator ollama.chat(stream=True) returns: iterable
+    parts plus the close() the cancellation path calls on the live HTTP
+    stream."""
+
+    def __init__(self, parts):
+        self._iter = iter(parts)
+        self.close_calls = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._iter)
+
+    def close(self):
+        self.close_calls += 1
+
+
+def _part(content="", thinking="", done=False):
+    message = {"content": content}
+    if thinking:
+        message["thinking"] = thinking
+    return {"message": message, "done": done}
+
+
+class FakeOllamaChat:
+    """Callable installed as ollama.chat. Streaming calls pop the next scripted
+    FakeOllamaStream (one per retry attempt); non-streaming calls pop the next
+    scripted response dict. Records every call's kwargs."""
+
+    def __init__(self, streams=None, responses=None):
+        self.streams = list(streams or [])
+        self.responses = list(responses or [])
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        if kwargs.get("stream"):
+            return self.streams.pop(0)
+        return self.responses.pop(0)
+
+
+@pytest.fixture
+def no_backoff(monkeypatch):
+    """The retry loop's 1 s inter-attempt sleep, skipped for test speed."""
+    monkeypatch.setattr(time, "sleep", lambda _s: None)
+
+
+@pytest.fixture
+def ollama_chat(monkeypatch):
+    fake = FakeOllamaChat()
+    import ollama
+
+    monkeypatch.setattr(ollama, "chat", fake)
+    return fake
+
+
+# -- layer 1: protocol conformance -------------------------------------------
+
+
+def test_both_implementations_satisfy_the_provider_protocol():
+    assert isinstance(FakeProvider(), Provider)
+    assert isinstance(OllamaProvider(model="m"), Provider)
+
+
+def test_ollama_capabilities_derive_from_the_think_kwarg_family_without_network():
+    # gpt-oss and qwen3 families take a think kwarg -> reasoning-capable;
+    # an unknown family does not. Pure string checks - no ollama.show probe.
+    assert OllamaProvider(model="gpt-oss:20b").capabilities.reasoning is True
+    assert OllamaProvider(model="qwen3:8b").capabilities.reasoning is True
+    assert OllamaProvider(model="llava:13b").capabilities.reasoning is False
+    assert OllamaProvider(model="llava:13b").capabilities.streaming is True
+
+
+# -- layer 2: FakeProvider ----------------------------------------------------
+
+
+def test_fake_provider_yields_scripted_events_and_synthesizes_done():
+    fake = FakeProvider([ProviderEvent("text", "a"), ProviderEvent("text", "b")])
+    events = list(fake.stream(ChatRequest(task="t", messages=[]), CancelToken()))
+    assert [e.type for e in events] == ["text", "text", "done"]
+    assert events[-1].text == "ab"
+    assert len(fake.requests) == 1
+
+
+def test_fake_provider_raises_its_scripted_error_after_the_events():
+    fake = FakeProvider([ProviderEvent("text", "partial")], error=RuntimeError("boom"))
+    events = []
+    with pytest.raises(RuntimeError, match="boom"):
+        for event in fake.stream(ChatRequest(task="t", messages=[]), CancelToken()):
+            events.append(event)
+    assert [e.type for e in events] == ["text"]  # partial output was delivered first
+
+
+def test_fake_provider_honors_cancellation_between_events():
+    fake = FakeProvider([ProviderEvent("text", "a"), ProviderEvent("text", "b")])
+    event = threading.Event()
+    token = CancelToken(event)
+    stream = fake.stream(ChatRequest(task="t", messages=[]), token)
+    assert next(stream).text == "a"
+    event.set()
+    with pytest.raises(api_provider.RequestCancelledError):
+        next(stream)
+
+
+# -- layer 3: OllamaProvider ---------------------------------------------------
+
+
+def test_stream_yields_incremental_text_events_and_a_composed_done(ollama_chat):
+    ollama_chat.streams = [FakeOllamaStream([
+        _part(content="Hel"),
+        _part(content="lo "),
+        _part(content="world", done=True),
+    ])]
+    provider = OllamaProvider(model="llava:13b")
+    events = list(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]),
+        CancelToken(),
+    ))
+    assert [e.type for e in events] == ["text", "text", "text", "done"]
+    assert [e.text for e in events[:3]] == ["Hel", "lo ", "world"]
+    assert events[-1].text == "Hello world"
+
+
+def test_thinking_deltas_are_their_own_event_channel_and_compose_into_the_think_block(ollama_chat):
+    ollama_chat.streams = [FakeOllamaStream([
+        _part(thinking="pondering..."),
+        _part(content="Answer.", done=True),
+    ])]
+    provider = OllamaProvider(model="qwen3:8b")
+    events = list(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]),
+        CancelToken(),
+    ))
+    assert [e.type for e in events] == ["reasoning", "text", "done"]
+    final = events[-1].text
+    # The exact shape backend/response_parsing.py depends on.
+    assert final.startswith("<think>")
+    assert "pondering..." in final
+    assert final.endswith("Answer.")
+
+
+def test_reasoning_without_answer_retries_with_a_reset_event(ollama_chat, no_backoff):
+    ollama_chat.streams = [
+        FakeOllamaStream([_part(thinking="only thoughts", done=True)]),   # attempt 1: no answer
+        FakeOllamaStream([_part(content="Real answer.", done=True)]),     # attempt 2: succeeds
+    ]
+    provider = OllamaProvider(model="qwen3:8b")
+    events = list(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]),
+        CancelToken(),
+    ))
+    types = [e.type for e in events]
+    assert types == ["reasoning", "reset", "text", "done"]
+    assert events[-1].text.endswith("Real answer.")
+    assert len(ollama_chat.calls) == 2
+
+
+def test_three_reasoning_only_attempts_exhaust_into_the_exact_legacy_error(ollama_chat, no_backoff):
+    ollama_chat.streams = [
+        FakeOllamaStream([_part(thinking="t", done=True)]) for _ in range(3)
+    ]
+    provider = OllamaProvider(model="qwen3:8b")
+    with pytest.raises(RuntimeError, match="reasoning but no final answer after 3 attempts"):
+        list(provider.stream(
+            ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]),
+            CancelToken(),
+        ))
+    assert len(ollama_chat.calls) == 3
+
+
+def test_an_empty_response_is_a_distinct_error_not_a_retry(ollama_chat):
+    ollama_chat.streams = [FakeOllamaStream([_part(done=True)])]
+    provider = OllamaProvider(model="llava:13b")
+    with pytest.raises(RuntimeError, match="empty response"):
+        list(provider.stream(
+            ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]),
+            CancelToken(),
+        ))
+    assert len(ollama_chat.calls) == 1  # no retry - empty is not reasoning-without-answer
+
+
+def test_cancellation_mid_stream_closes_the_live_stream_and_raises(ollama_chat):
+    cancel_event = threading.Event()
+
+    class CancellingStream(FakeOllamaStream):
+        def __next__(self):
+            part = super().__next__()
+            cancel_event.set()  # cancel lands after the first part is delivered
+            return part
+
+    live = CancellingStream([_part(content="par"), _part(content="tial", done=True)])
+    ollama_chat.streams = [live]
+    provider = OllamaProvider(model="llava:13b")
+    stream = provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]),
+        CancelToken(cancel_event),
+    )
+    with pytest.raises(api_provider.RequestCancelledError):
+        list(stream)
+    assert live.close_calls >= 1  # the live HTTP stream was actively closed
+
+
+def test_think_kwarg_and_hint_apply_only_for_the_chat_task(ollama_chat):
+    ollama_chat.streams = [
+        FakeOllamaStream([_part(content="a", done=True)]),
+        FakeOllamaStream([_part(content="b", done=True)]),
+    ]
+    provider = OllamaProvider(model="gpt-oss:20b", reasoning_level="high")
+
+    list(provider.stream(ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "x"}]), CancelToken()))
+    assert ollama_chat.calls[0]["think"] == "high"  # gpt-oss family: string level
+
+    list(provider.stream(ChatRequest(task=config.TASK_TITLE, messages=[{"role": "user", "content": "x"}]), CancelToken()))
+    assert "think" not in ollama_chat.calls[1]  # non-chat tasks never reason
+
+
+def test_complete_returns_the_same_composed_content_as_the_streamed_path(ollama_chat):
+    ollama_chat.responses = [
+        {"message": {"content": "Answer.", "thinking": "pondering..."}}
+    ]
+    provider = OllamaProvider(model="qwen3:8b")
+    content = provider.complete(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]),
+        CancelToken(),
+    )
+    assert content.startswith("<think>")
+    assert "pondering..." in content
+    assert content.endswith("Answer.")
+    assert "stream" not in ollama_chat.calls[0]  # transitional non-streaming call
+
+
+# -- layer 4: the stage exit criterion ----------------------------------------
+
+
+@pytest.fixture
+def ollama_mode(monkeypatch):
+    monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+    monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_OLLAMA)
+    monkeypatch.setattr(api_provider, "OLLAMA_REASONING_LEVEL", "off")
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, "fake-model:1b")
+
+
+def test_the_real_chat_stream_streams_multiple_incremental_deltas_through_the_seam(
+    monkeypatch, ollama_mode, ollama_chat
+):
+    """THE 6.1 EXIT CRITERION: api_provider.chat_stream's real machinery (the
+    conftest stub explicitly swapped back out for the genuine function) routes
+    through OllamaProvider and delivers REAL incremental streaming - multiple
+    deltas in order, not the stub's single synthetic chunk."""
+    monkeypatch.setattr(api_provider, "chat_stream", _REAL_CHAT_STREAM)
+    ollama_chat.streams = [FakeOllamaStream([
+        _part(content="one "),
+        _part(content="two "),
+        _part(content="three", done=True),
+    ])]
+
+    chunks: list[tuple[str, bool]] = []
+    response = api_provider.chat_stream(
+        config.TASK_CHAT,
+        [{"role": "user", "content": "count"}],
+        lambda delta, reset: chunks.append((delta, reset)),
+    )
+
+    assert chunks == [("one ", False), ("two ", False), ("three", False)]
+    assert response == {"message": {"content": "one two three", "role": "assistant"}}
+
+
+def test_the_real_chat_stream_forwards_the_retry_reset_to_on_chunk(
+    monkeypatch, ollama_mode, ollama_chat, no_backoff
+):
+    monkeypatch.setattr(api_provider, "chat_stream", _REAL_CHAT_STREAM)
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, "qwen3:8b")
+    ollama_chat.streams = [
+        FakeOllamaStream([_part(thinking="hmm", done=True)]),
+        FakeOllamaStream([_part(content="Second try.", done=True)]),
+    ]
+
+    chunks: list[tuple[str, bool]] = []
+    response = api_provider.chat_stream(
+        config.TASK_CHAT,
+        [{"role": "user", "content": "hi"}],
+        lambda delta, reset: chunks.append((delta, reset)),
+    )
+
+    # The reset frame tells the caller to discard attempt 1's partial text;
+    # thinking deltas were never forwarded to on_chunk (only the reset was).
+    assert chunks == [("", True), ("Second try.", False)]
+    assert response["message"]["content"].endswith("Second try.")
+
+
+def test_the_real_chat_via_the_seam_matches_the_legacy_return_shape(ollama_mode, ollama_chat):
+    ollama_chat.responses = [{"message": {"content": "Plain answer."}}]
+    response = _REAL_CHAT(config.TASK_CHAT, [{"role": "user", "content": "hi"}])
+    assert response == {"message": {"content": "Plain answer.", "role": "assistant"}}
+
+
+def test_chat_and_chat_stream_actually_route_through_the_provider_seam(
+    monkeypatch, ollama_mode, ollama_chat
+):
+    """Not just behavior parity - the SEAM itself is wired. A faithful inline
+    re-implementation of the Ollama branch would pass every behavioral test in
+    this file while silently abandoning the protocol; this catches that by
+    proving both entry points invoke OllamaProvider."""
+    from backend.providers import ollama_provider as op_module
+
+    calls = {"stream": 0, "complete": 0}
+    real_stream, real_complete = op_module.OllamaProvider.stream, op_module.OllamaProvider.complete
+
+    def counting_stream(self, request, cancel):
+        calls["stream"] += 1
+        return real_stream(self, request, cancel)
+
+    def counting_complete(self, request, cancel):
+        calls["complete"] += 1
+        return real_complete(self, request, cancel)
+
+    monkeypatch.setattr(op_module.OllamaProvider, "stream", counting_stream)
+    monkeypatch.setattr(op_module.OllamaProvider, "complete", counting_complete)
+    monkeypatch.setattr(api_provider, "chat_stream", _REAL_CHAT_STREAM)
+
+    ollama_chat.streams = [FakeOllamaStream([_part(content="s", done=True)])]
+    ollama_chat.responses = [{"message": {"content": "c"}}]
+
+    api_provider.chat_stream(config.TASK_CHAT, [{"role": "user", "content": "x"}], lambda d, r: None)
+    _REAL_CHAT(config.TASK_CHAT, [{"role": "user", "content": "x"}])
+
+    assert calls == {"stream": 1, "complete": 1}
+
+
+def test_cancellation_through_the_real_chat_stream_is_the_untranslated_sentinel(
+    monkeypatch, ollama_mode, ollama_chat
+):
+    """RequestCancelledError must escape _translate_chat_exception untouched -
+    backend/agents.py catches exactly this type to end a run quietly."""
+    monkeypatch.setattr(api_provider, "chat_stream", _REAL_CHAT_STREAM)
+    cancel_event = threading.Event()
+    cancel_event.set()  # cancelled before the first chunk
+    ollama_chat.streams = [FakeOllamaStream([_part(content="never", done=True)])]
+
+    with pytest.raises(api_provider.RequestCancelledError):
+        api_provider.chat_stream(
+            config.TASK_CHAT,
+            [{"role": "user", "content": "hi"}],
+            lambda delta, reset: None,
+            cancellation_event=cancel_event,
+        )


### PR DESCRIPTION
## Problem

The LLM layer has no provider interface: ~30 if/elif sites across `chat`, `chat_stream`, `generate_image`, init, exception translation, and model listing branch on provider-type strings. Adding a provider means editing all of them, and the streaming path was untestable without a live Ollama server — the test suite stubs `chat_stream` wholesale (one synthetic chunk), so the real streaming machinery had zero coverage.

## Change

First stage of the ADR-006 rebuild — the seam, with Ollama as the first port:

- **`backend/providers/base.py`**: a runtime-checkable `Provider` protocol with the target event vocabulary (`text` / `reasoning` / `reset` / `done`), `ProviderCapabilities`, `ChatRequest`, and `CancelToken` wrapping the run pipeline's existing `threading.Event`. Sync iterator by explicit staging — every provider call today runs in a worker thread against sync SDKs; the async-native flip is stages 6.2/6.3's content and changes the iteration keyword, not the data model. The lazy-generator contract is pinned on the protocol docstring.
- **`backend/providers/fake.py`**: `FakeProvider` — scripted events, synthesized `done`, mid-stream error, cooperative cancellation. This is what makes the real streaming path testable.
- **`backend/providers/ollama_provider.py`**: `OllamaProvider`, a faithful port of the twin ~70-line Ollama branches in `chat()`/`chat_stream()`, deduplicated into one class with every documented invariant preserved (think-kwarg family mapping, reasoning-budget hint, 3-attempt reasoning retry with reset events, thinking as its own channel, `<think>` composition, `stream.close()` on cancel, empty-vs-reasoning-only error distinction).
- `api_provider.py`'s two Ollama branches now construct the provider from their snapshot and adapt its events onto the unchanged `on_chunk(delta, reset)` contract. The other four providers stay inline until 6.3. Exception translation stays at the call sites.

## Test plan

- [x] 24 new tests in `backend/tests/test_providers.py`: protocol conformance, FakeProvider semantics, provider unit tests (event ordering, retry/reset, cancellation closing the live stream, think-kwarg + system-hint gating, media flattening, extra-kwargs passthrough), the **stage exit criterion** (the real `chat_stream` machinery streaming multiple incremental deltas with only `ollama.chat` faked — the suite-wide stub explicitly swapped back out), a seam-wiring test proving both entry points invoke the provider, a FakeProvider-substitution test at the real seam, and an AST pin on the import-cycle invariant
- [x] Mutation-tested: dropping the reset frame and misrouting thinking-as-text each caught by exact-sequence assertions
- [x] Adversarial review (3 dimensions, 24 agents, every finding independently verified): behavioral fidelity of the port explicitly confirmed item-by-item against the pre-port implementation; all confirmed gaps were coverage/documentation and are fixed in the second commit
- [x] Full backend suite: 1737 passed, 14 skipped