### PR TITLE
ADR-006 stage 6.2: non-blocking dispatch + immediate-release cancel

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -516,22 +516,24 @@ class AgentDispatcher:
         handle = self._runs.get(request_id)
         if handle is None or handle.kind != "pycoder":
             return False
-        handle.cancel_event.set()
+        # ADR-006 stage 6.2: the approval future is resolved BEFORE routing
+        # through RunRegistry.cancel(), because cancel() now pops the handle
+        # (release-on-cancel) and the future lives on it. cancel() then sets
+        # the cancel_event and frees the slot immediately.
         future = handle.approval_future
         if future is not None and not future.done():
             future.set_result(False)
-        return True
+        return self._runs.cancel(request_id, kind="pycoder")
 
     def cancel_code_sandbox(self, request_id: str) -> bool:
         """Mirrors cancel_pycoder exactly (same shape, same reasoning)."""
         handle = self._runs.get(request_id)
         if handle is None or handle.kind != "code_sandbox":
             return False
-        handle.cancel_event.set()
         future = handle.approval_future
         if future is not None and not future.done():
             future.set_result(False)
-        return True
+        return self._runs.cancel(request_id, kind="code_sandbox")
 
     def _resolve_approval(self, request_id: str, approved: bool) -> bool:
         """The shared approve/deny primitive backing approve_code_execution/
@@ -704,8 +706,14 @@ class AgentDispatcher:
         finished - this is a direct, cheap check of the same registry
         cancel_all() itself walks (self._runs, one claimed RunHandle per
         in-flight request across every kind), not a second bookkeeping
-        mechanism that could drift from it."""
-        return bool(self._runs.values())
+        mechanism that could drift from it.
+
+        ADR-006 stage 6.2: release-on-cancel empties the claimed-handle map
+        the instant cancel_all() fires, but the cancelled workers' tasks are
+        still unwinding against this session's objects - has_any_live_work()
+        counts those orphaned tasks too, so eviction still waits for the
+        real work to actually end, exactly as it did before."""
+        return self._runs.has_any_live_work()
 
     def cancel_web_research(self, request_id: str) -> bool:
         """kind="web_research": ADR-002 stage 2.4e - the first surface to
@@ -772,6 +780,18 @@ class AgentDispatcher:
         every other caller (including start_conversation_reply) omits them,
         which simply falls back to persona()'s existing resolution, byte-
         identical to this method's pre-R6.1 behavior."""
+        async def _finalize() -> None:
+            # ADR-006 stage 6.2: the user-visible end transition, run by
+            # RunRegistry.cancel() the moment a cancel lands (slot freed +
+            # composer back to idle immediately), OR by _run's own finally on
+            # a normal completion - never both (release() returning True is
+            # the arbiter; see RunHandle.finalize). Defined up here, above the
+            # busy check, so the check-to-claim stretch below stays free of
+            # statements containing awaits - test_dispatch_claim_ordering's
+            # AST gate scans that stretch recursively.
+            on_end()
+            await bus.publish(state_topic)
+
         if self._runs.is_busy("chat"):
             # Single-request-per-session guard: never start a second
             # concurrent request while one is already in flight.
@@ -794,7 +814,9 @@ class AgentDispatcher:
         # above and this claim - see backend/run_lifecycle.py's own
         # docstring for why that ordering is load-bearing, not incidental.
         cancel_event = threading.Event()
-        handle = self._runs.claim("chat", node_id=node_id, cancel_event=cancel_event)
+        handle = self._runs.claim(
+            "chat", node_id=node_id, cancel_event=cancel_event, finalize=_finalize
+        )
         request_id = handle.request_id
 
         async def _run():
@@ -943,12 +965,17 @@ class AgentDispatcher:
                 notifications_state.show(f"AI response failed: {exc}", "error")
                 await bus.publish("notification")
             finally:
-                # Unconditional on every exit path (success, timeout, cancel,
-                # other error) so the caller's state always returns to a
-                # usable idle state.
-                self._runs.release(request_id)
-                on_end()
-                await bus.publish(state_topic)
+                # ADR-006 stage 6.2: gated on release() actually popping the
+                # handle. On a normal completion it does, and the end
+                # transition runs here as before. After a CANCEL, release()
+                # returns False (cancel already popped the handle and ran
+                # _finalize itself) - re-running on_end here would be at best
+                # redundant and at worst would clobber a NEWER run's
+                # "generating" state, since the slot was freed the moment the
+                # cancel landed and a new claim may already be active.
+                if self._runs.release(request_id):
+                    on_end()
+                    await bus.publish(state_topic)
 
         # NOT awaited here - start_chat_reply/start_conversation_reply return
         # immediately after scheduling the task. This is load-bearing: the WS
@@ -1059,12 +1086,14 @@ class AgentDispatcher:
         comment in __init__ for why this must stay independent rather than
         reusing the existing single-slot guard.
 
-        No cancel_event/on_cancel is passed to claim() - api_provider.
-        generate_image has no cancellation_event parameter at all and its
-        body has no checkpoint to insert one at (it is one blocking network
-        POST), and legacy itself has zero real cancel affordance for image
-        generation either (ImageGenerationWorkerThread.stop() exists but is
-        never called from any UI path). The WATCHDOG_TIMEOUT_SECONDS
+        ADR-006 stage 6.2: claim() now passes a cancel_event -
+        api_provider.generate_image still has no cancellation_event
+        parameter and no mid-call checkpoint (it is one blocking network
+        POST), so the event's effect is post-return suppression plus
+        immediate slot release on cancel/disconnect; it cannot shorten the
+        POST itself. (Legacy had zero cancel affordance here at all -
+        ImageGenerationWorkerThread.stop() existed but was never called
+        from any UI path.) The WATCHDOG_TIMEOUT_SECONDS
         ceiling IS still applied here even though legacy has none for image
         generation - a deliberate, explicitly-flagged improvement (leaving
         this as the only dispatch surface with no ceiling against a hung
@@ -1092,7 +1121,14 @@ class AgentDispatcher:
         # Claimed SYNCHRONOUSLY, with no `await` between the is_busy() check
         # above and this claim - same load-bearing ordering _dispatch's own
         # claim relies on, see backend/run_lifecycle.py's own docstring.
-        handle = self._runs.claim("image")
+        # ADR-006 stage 6.2: image gains a cancel_event. generate_image
+        # still has no mid-call checkpoint (one blocking POST - the
+        # docstring above remains true), so cancellation is post-return
+        # suppression, the same shape artifact already uses: cancel frees
+        # the slot immediately (RunRegistry.cancel), and when the POST
+        # eventually returns, the result is discarded instead of applied.
+        cancel_event = threading.Event()
+        handle = self._runs.claim("image", cancel_event=cancel_event)
         request_id = handle.request_id
 
         async def _run():
@@ -1101,6 +1137,8 @@ class AgentDispatcher:
                     asyncio.to_thread(api_provider.generate_image, prompt),
                     timeout=WATCHDOG_TIMEOUT_SECONDS,
                 )
+                if cancel_event.is_set():
+                    return
                 if inspect.iscoroutinefunction(on_reply):
                     await on_reply(image_bytes)
                 else:
@@ -1110,6 +1148,8 @@ class AgentDispatcher:
                 # already publishes "scene" after mutating the document, so a
                 # second unconditional publish here would be redundant.
             except asyncio.TimeoutError:
+                if cancel_event.is_set():
+                    return  # cancelled runs end quietly, not with a timeout toast
                 notifications_state.show(
                     "Image generation stopped responding before the request "
                     "completed. Please try again.",
@@ -1718,7 +1758,15 @@ class AgentDispatcher:
             await bus.publish("notification")
             return
 
-        handle = self._runs.claim("gitlink_apply", node_id=node_id)
+        # ADR-006 stage 6.2: gitlink_apply gains a cancel_event, checked at
+        # the worker's ENTRY only (below, before any file is written) - once
+        # writing begins the apply deliberately runs to completion, because
+        # stopping between file writes would leave the working tree in a
+        # half-applied state the UI has no way to represent. So cancel (and
+        # session-disconnect cancel_all) covers the queued-but-not-started
+        # window and frees the slot immediately; a mid-write apply finishes.
+        cancel_event = threading.Event()
+        handle = self._runs.claim("gitlink_apply", node_id=node_id, cancel_event=cancel_event)
         request_id = handle.request_id
         node.pending_request_id = request_id
 
@@ -1799,6 +1847,12 @@ class AgentDispatcher:
 
         async def _run():
             try:
+                if cancel_event.is_set():
+                    # Cancelled before any file was written (see the claim's
+                    # own comment) - report it on the node rather than leaving
+                    # "applying" stuck.
+                    on_failure("Apply cancelled before any files were written.")
+                    return
                 written_files = await asyncio.wait_for(
                     asyncio.to_thread(_call_gitlink_apply, local_root_path, changes_snapshot),
                     timeout=GITLINK_APPLY_TIMEOUT_SECONDS,

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -1288,6 +1288,16 @@ class AgentDispatcher:
                     ),
                     timeout=WEB_RESEARCH_WATCHDOG_TIMEOUT_SECONDS,
                 )
+                if self._runs.get(request_id) is None:
+                    # 6.2 review fix: a cancel popped this handle while the
+                    # blocking call was finishing - the same discriminator
+                    # _guarded_progress already uses for progress events, now
+                    # applied to the TERMINAL callbacks too. Without it, a
+                    # cancelled run's late result (or its RequestCancelled
+                    # below) writes stale stage/result state onto a node a
+                    # replacement run may already own, since release-on-cancel
+                    # freed the "web_research" slot the instant cancel landed.
+                    return
                 await _invoke(on_success, result)
                 await bus.publish("scene")
             except asyncio.TimeoutError:
@@ -1296,29 +1306,37 @@ class AgentDispatcher:
                     "Web research stopped responding before the request completed. "
                     "Please try again."
                 )
-                await _invoke(on_failure, ResearchFailure(message, code="watchdog_timeout"))
+                if self._runs.get(request_id) is not None:
+                    await _invoke(on_failure, ResearchFailure(message, code="watchdog_timeout"))
                 notifications_state.show(message, "error")
                 await bus.publish("notification")
                 await bus.publish("scene")
             except RequestCancelled as exc:
-                await _invoke(on_failure, exc)
+                if self._runs.get(request_id) is not None:
+                    await _invoke(on_failure, exc)
                 notifications_state.show("Web research cancelled.", "info")
                 await bus.publish("notification")
                 await bus.publish("scene")
             except ResearchFailure as exc:
-                await _invoke(on_failure, exc)
+                if self._runs.get(request_id) is not None:
+                    await _invoke(on_failure, exc)
                 notifications_state.show(f"Web research failed: {exc}", "error")
                 await bus.publish("notification")
                 await bus.publish("scene")
             except Exception as exc:
                 logger.exception("web research dispatch failed")
-                await _invoke(on_failure, exc)
+                if self._runs.get(request_id) is not None:
+                    await _invoke(on_failure, exc)
                 notifications_state.show(f"Web research failed: {exc}", "error")
                 await bus.publish("notification")
                 await bus.publish("scene")
             finally:
                 self._runs.release(request_id)
-                node.pending_request_id = None
+                # 6.2 review fix: same stale-task guard as artifact/gitlink -
+                # a cancelled run's late unwind must not wipe a replacement
+                # run's in-flight marker on this same node.
+                if node.pending_request_id == request_id:
+                    node.pending_request_id = None
                 await bus.publish("scene")
 
         self._runs.attach_task(handle, asyncio.create_task(_run()))
@@ -1408,12 +1426,26 @@ class AgentDispatcher:
                 )
                 await bus.publish("notification")
             except Exception as exc:
+                if cancel_event.is_set():
+                    # 6.2 review fix: a cancelled run whose provider call then
+                    # errors ends quietly - the user already asked for it to
+                    # stop; an "Artifact generation failed" toast would be
+                    # noise about work they abandoned.
+                    return
                 logger.exception("artifact dispatch failed")
                 notifications_state.show(f"Artifact generation failed: {exc}", "error")
                 await bus.publish("notification")
             finally:
                 self._runs.release(request_id)
-                node.pending_request_id = None
+                # 6.2 review fix (reproduced live): only clear if this task's
+                # OWN request_id is still the one recorded - the same
+                # stale-task guard every gitlink/pycoder/sandbox finally has.
+                # Release-on-cancel frees the "artifact" slot the instant a
+                # cancel lands, so a NEW artifact run can claim and stamp
+                # this same node before this old worker unwinds; the old
+                # unconditional clear wiped the new run's in-flight marker.
+                if node.pending_request_id == request_id:
+                    node.pending_request_id = None
                 await bus.publish("scene")
 
         self._runs.attach_task(handle, asyncio.create_task(_run()))

--- a/backend/api/intents_chart.py
+++ b/backend/api/intents_chart.py
@@ -66,6 +66,17 @@ def register_chart_intents(
         result_holder: dict[str, str] = {}
 
         async def _on_success(result):
+            if parent_node_id not in document.nodes:
+                # 6.2 review fix: parent deleted mid-generation - silent
+                # no-op, the same liveness posture every other agent-produced
+                # surface already takes (_generate_note_from_node,
+                # compare_branches, synthesize_branches, _dispatch_image).
+                # Newly reachable from a SINGLE connection now that the
+                # generation no longer blocks the WS read loop: the user can
+                # freely delete the parent while the chart generates, and
+                # add_chart_node would raise SceneError into a spurious
+                # "Chart generation failed" toast.
+                return
             try:
                 chart_data = canonicalize_chart_data(result, normalized_chart_type)
                 chart_error = ""

--- a/backend/run_lifecycle.py
+++ b/backend/run_lifecycle.py
@@ -296,9 +296,36 @@ class RunRegistry:
             # Popping here + scheduling the handle's finalize makes cancel
             # latency independent of worker-thread latency; the worker's own
             # late finally sees release() -> False and skips its tail.
-            self._pop(request_id)
-            self._schedule_finalize(handle)
+            self._finish_cancel(request_id, handle)
         return fired
+
+    def _finish_cancel(self, request_id: str, handle: RunHandle) -> None:
+        """Pop + finalize, ALWAYS executed on the registry's event loop.
+
+        6.2 review fix (thread affinity): cancelChatRequest's sync handler
+        runs via asyncio.to_thread, so cancel() can arrive on a worker
+        thread - but _pop mutates the handles dict (raced by the loop
+        thread's is_busy/values iteration), calls Task.add_done_callback
+        (not thread-safe on a running task), and may resolve an approval
+        future (loop-affine). The cancel EVENT was already set inline above
+        (threading.Event.set is thread-safe, so the worker observes the
+        cancel with zero added latency); only the bookkeeping is marshalled
+        here, landing microseconds later - still far inside the 2 s budget."""
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if handle.loop is not None and running is not handle.loop:
+            if not handle.loop.is_closed():
+                handle.loop.call_soon_threadsafe(self._finish_cancel, request_id, handle)
+            return
+        # Gated on the pop actually succeeding: in the marshalled case the
+        # worker may have completed NORMALLY in the gap before this callback
+        # ran - its finally already popped the handle and ran the end
+        # transition, and running finalize again here would be the exact
+        # double-transition this design exists to prevent.
+        if self._pop(request_id) is not None:
+            self._schedule_finalize(handle)
 
     def cancel_all(self) -> None:
         """Fires every handle's cancel mechanism, releasing each fired
@@ -315,8 +342,7 @@ class RunRegistry:
                 handle.on_cancel()
                 fired = True
             if fired:
-                self._pop(handle.request_id)
-                self._schedule_finalize(handle)
+                self._finish_cancel(handle.request_id, handle)
 
     def has_any_live_work(self) -> bool:
         """Claimed handles OR cancelled-but-still-unwinding orphan tasks -
@@ -411,6 +437,16 @@ async def run_single_shot(
     # cancel_event (new - these kinds were previously uncancellable and
     # silently skipped by cancel_all) suppresses the result callbacks when
     # a cancel or session disconnect lands mid-generation.
+    #
+    # DELIBERATE BEHAVIOR CHANGE, decided rather than drifted into (6.2
+    # adversarial review surfaced it): pre-6.2, a last-connection drop left
+    # these four generations running because cancel_all skipped them, so a
+    # reconnecting client found the finished node. Now a disconnect cancels
+    # them like every OTHER kind (chat has always discarded on disconnect),
+    # trading that accidental resilience for the uniform "disconnect cancels
+    # everything" contract the eviction/cancel machinery is built on. If
+    # blip-survival ever becomes a requirement, it belongs to a
+    # reconnect-grace design for ALL kinds, not a silent carve-out for four.
     cancel_event = threading.Event()
     handle = registry.claim(kind, node_id=node_id, cancel_event=cancel_event)
 

--- a/backend/run_lifecycle.py
+++ b/backend/run_lifecycle.py
@@ -57,13 +57,14 @@ cancel_event (threading.Event, the majority shape) or RunHandle.
 on_cancel (a generic callable, for kinds like web_research whose own
 cancellation primitive is not a threading.Event) - which callers other
 than the run itself trip and the run's own code observes at its next
-checkpoint. cancel_all() below preserves this exactly: it walks every
-claimed handle and fires whichever of the two mechanisms is present,
-silently no-oping on kinds (like chart/note/branch_comparison/branch_
-synthesis) that have neither - the same honestly-documented "this kind
-cannot be cancelled" limitation those already had before their own
-migration, just visible in one place now instead of being invisible to
-cancel_all() entirely.
+checkpoint. cancel_all() below fires whichever of the two mechanisms is present on
+each claimed handle. As of ADR-006 stage 6.2 every kind carries one (the
+formerly-uncancellable chart/note/branch_comparison/branch_synthesis now
+get a cancel_event from run_single_shot itself; image and gitlink_apply
+from their own dispatch surfaces), cancel releases the slot IMMEDIATELY
+instead of waiting for the worker thread to observe it (see
+RunRegistry.cancel/release), and run_single_shot schedules its work off
+the WS read loop instead of being awaited on it.
 """
 
 from __future__ import annotations
@@ -152,6 +153,20 @@ class RunHandle:
     approval_snapshot_fn: Callable[[], Any] | None = None
     approval_snapshot: Any = None
     task: asyncio.Task | None = None
+    # ADR-006 stage 6.2: the surface's user-visible end transition (its
+    # on_end() + state-topic publish), as an async zero-arg closure. On a
+    # NORMAL completion the surface's own `finally` runs it - gated on
+    # release() returning True. On CANCEL, RunRegistry.cancel() pops the
+    # handle immediately (freeing the slot) and schedules THIS instead, so
+    # the UI returns to idle the moment the user cancels rather than when
+    # the worker thread eventually dies - and the worker's late `finally`
+    # sees release() -> False and skips the transition, which is what stops
+    # a stale run's teardown from clobbering a NEWER run's "generating"
+    # state (the slot is free, so a new claim may already exist).
+    finalize: Callable[[], Any] | None = None
+    # Captured at claim() time so cancel() can schedule `finalize` from any
+    # thread (cancelChatRequest's sync handler runs via asyncio.to_thread).
+    loop: asyncio.AbstractEventLoop | None = None
 
 
 class RunRegistry:
@@ -160,6 +175,14 @@ class RunRegistry:
 
     def __init__(self) -> None:
         self._handles: dict[str, RunHandle] = {}
+        # ADR-006 stage 6.2: tasks whose handle was popped by cancel() while
+        # the task still runs. Held ONLY as an anti-GC reference (the event
+        # loop keeps just a weak ref to scheduled tasks - the same reason
+        # RunHandle.task exists) and to keep has-in-flight semantics honest:
+        # a cancelled-but-still-unwinding worker is still real work against
+        # this session's objects, so session eviction must keep waiting for
+        # it (see values_or_orphans / backend/agents.py has_in_flight_runs).
+        self._orphaned_tasks: set[asyncio.Task] = set()
 
     def is_busy(self, kind: str) -> bool:
         return any(handle.kind == kind for handle in self._handles.values())
@@ -173,10 +196,18 @@ class RunRegistry:
         on_cancel: Callable[[], None] | None = None,
         approval_future: asyncio.Future | None = None,
         approval_snapshot_fn: Callable[[], Any] | None = None,
+        finalize: Callable[[], Any] | None = None,
     ) -> RunHandle:
         """Synchronous by design - see this module's own docstring for
         why callers must call this in the same synchronous stretch as
         their own is_busy() pre-check."""
+        try:
+            loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
+        except RuntimeError:
+            # Direct registry use outside a loop (unit tests) - cancel()
+            # then simply cannot schedule finalize, which such tests never
+            # pass anyway.
+            loop = None
         handle = RunHandle(
             kind=kind,
             request_id=uuid.uuid4().hex,
@@ -185,6 +216,8 @@ class RunRegistry:
             on_cancel=on_cancel,
             approval_future=approval_future,
             approval_snapshot_fn=approval_snapshot_fn,
+            finalize=finalize,
+            loop=loop,
         )
         self._handles[handle.request_id] = handle
         return handle
@@ -192,8 +225,39 @@ class RunRegistry:
     def attach_task(self, handle: RunHandle, task: asyncio.Task) -> None:
         handle.task = task
 
-    def release(self, request_id: str) -> None:
-        self._handles.pop(request_id, None)
+    def _pop(self, request_id: str) -> RunHandle | None:
+        handle = self._handles.pop(request_id, None)
+        if handle is not None and handle.task is not None and not handle.task.done():
+            self._orphaned_tasks.add(handle.task)
+            handle.task.add_done_callback(self._orphaned_tasks.discard)
+        if handle is not None:
+            # A popped handle is unreachable to cancel_all_pending_approvals
+            # (it walks _handles), so an unresolved approval future MUST be
+            # auto-denied here or the run's parked `await approval_future`
+            # waits forever - the disconnect path calls cancel_all() BEFORE
+            # cancel_all_pending_approvals() (backend/app.py), and before
+            # release-on-cancel that ordering was harmless because cancel
+            # never popped. Denial (False), never approval: popping means the
+            # run was cancelled or torn down, and cancel-means-deny is the
+            # semantic cancel_pycoder/cancel_code_sandbox already had.
+            future = handle.approval_future
+            if future is not None and not future.done():
+                future.set_result(False)
+        return handle
+
+    def release(self, request_id: str) -> bool:
+        """Returns True if this call actually popped the handle - False when
+        cancel() already released it. ADR-006 stage 6.2: every surface's
+        `finally` gates its on_end/state-publish tail on this bool, so a
+        cancelled run's late teardown never re-runs the end transition that
+        cancel() already performed (and never clobbers a newer run's state -
+        see RunHandle.finalize)."""
+        return self._pop(request_id) is not None
+
+    def _schedule_finalize(self, handle: RunHandle) -> None:
+        if handle.finalize is None or handle.loop is None or handle.loop.is_closed():
+            return
+        asyncio.run_coroutine_threadsafe(handle.finalize(), handle.loop)
 
     def get(self, request_id: str) -> RunHandle | None:
         return self._handles.get(request_id)
@@ -222,18 +286,47 @@ class RunRegistry:
         if handle.on_cancel is not None:
             handle.on_cancel()
             fired = True
+        if fired:
+            # ADR-006 stage 6.2: cancel frees the slot IMMEDIATELY. Before
+            # this, release() lived only in the run's `finally`, downstream
+            # of an uninterruptible asyncio.to_thread - so is_busy stayed
+            # True (and the UI stayed "generating") for however long the
+            # worker took to actually observe the cancel, up to the full
+            # watchdog timeout for surfaces that only check post-return.
+            # Popping here + scheduling the handle's finalize makes cancel
+            # latency independent of worker-thread latency; the worker's own
+            # late finally sees release() -> False and skips its tail.
+            self._pop(request_id)
+            self._schedule_finalize(handle)
         return fired
 
     def cancel_all(self) -> None:
-        """See this module's own docstring for why kinds with neither
-        cancel_event nor on_cancel (chart, note, branch_comparison,
-        branch_synthesis) are silently skipped rather than treated as an
-        error."""
-        for handle in self._handles.values():
+        """Fires every handle's cancel mechanism, releasing each fired
+        handle immediately (same semantics as cancel() above). As of
+        ADR-006 stage 6.2 every kind carries a mechanism, so nothing is
+        skipped any more - the pre-6.2 "chart/note/branch_* are silently
+        skipped" limitation is closed."""
+        for handle in list(self._handles.values()):
+            fired = False
             if handle.cancel_event is not None:
                 handle.cancel_event.set()
+                fired = True
             if handle.on_cancel is not None:
                 handle.on_cancel()
+                fired = True
+            if fired:
+                self._pop(handle.request_id)
+                self._schedule_finalize(handle)
+
+    def has_any_live_work(self) -> bool:
+        """Claimed handles OR cancelled-but-still-unwinding orphan tasks -
+        the honest "is anything still running against this session"
+        predicate session eviction consults (ADR-004 stage 4.3 veto).
+        Release-on-cancel empties _handles instantly, but the worker
+        threads those runs hold are still alive until they observe the
+        cancel; evicting the session out from under them would orphan real
+        in-flight work mid-write."""
+        return bool(self._handles) or bool(self._orphaned_tasks)
 
     def cancel_all_pending_approvals(self, kinds: tuple[str, ...]) -> None:
         """Auto-denies every still-undone approval_future among handles
@@ -277,10 +370,11 @@ async def run_single_shot(
     log_exception: Callable[[BaseException], None],
     validate_notify: Callable[[str], str] | None = None,
 ) -> None:
-    """Shared skeleton for a "directly-awaited, single combined
-    create+generate action" dispatch surface - start_chart_generation and
-    start_note_generation today; see this module's own docstring for why
-    chat/conversation cannot share this same function.
+    """Shared skeleton for a "single combined create+generate action"
+    dispatch surface - chart/note/branch-comparison/branch-synthesis.
+    Fire-and-forget as of ADR-006 stage 6.2 (claim synchronously, schedule
+    the generation, return immediately) - see the inline comment at the
+    claim below for why the old directly-awaited shape had to go.
 
     `call`: zero-arg callable, run inside asyncio.to_thread. `validate`:
     inspects a SUCCESSFUL `call` result and returns a human-readable
@@ -302,26 +396,52 @@ async def run_single_shot(
         await bus.publish("notification")
         return
 
-    handle = registry.claim(kind, node_id=node_id)
-    try:
-        result = await asyncio.wait_for(asyncio.to_thread(call), timeout=timeout)
-        message = validate(result)
-        if message is not None:
-            await _invoke(on_failure, message)
-            notify_message = validate_notify(message) if validate_notify else message
-            notifications_state.show(notify_message, "error")
+    # ADR-006 stage 6.2: claimed synchronously (unchanged), but the actual
+    # generation now runs in a SCHEDULED task instead of being awaited here.
+    # These four surfaces used to be the app's worst read-loop blockers: the
+    # WS receive loop (backend/app.py) awaits each intent handler inline, so
+    # a chart/note/comparison/synthesis generation held the ENTIRE socket -
+    # no further frame, including a cancel, was even read - for up to the
+    # 420 s watchdog. The old justification was a return-value contract
+    # ("the caller needs the new node id back in the same round trip"), but
+    # every frontend call site fires these intents fire-and-forget and
+    # discards the result (sceneStore.ts fireIntent sites) - the node
+    # arrives via the scene publish inside on_success, exactly like every
+    # other fire-and-forget surface. So this returns immediately; the
+    # cancel_event (new - these kinds were previously uncancellable and
+    # silently skipped by cancel_all) suppresses the result callbacks when
+    # a cancel or session disconnect lands mid-generation.
+    cancel_event = threading.Event()
+    handle = registry.claim(kind, node_id=node_id, cancel_event=cancel_event)
+
+    async def _task() -> None:
+        try:
+            result = await asyncio.wait_for(asyncio.to_thread(call), timeout=timeout)
+            if cancel_event.is_set():
+                return
+            message = validate(result)
+            if message is not None:
+                await _invoke(on_failure, message)
+                notify_message = validate_notify(message) if validate_notify else message
+                notifications_state.show(notify_message, "error")
+                await bus.publish("notification")
+            else:
+                await _invoke(on_success, result)
+        except asyncio.TimeoutError:
+            if cancel_event.is_set():
+                return
+            await _invoke(on_failure, timeout_message)
+            notifications_state.show(timeout_message, "error")
             await bus.publish("notification")
-        else:
-            await _invoke(on_success, result)
-    except asyncio.TimeoutError:
-        await _invoke(on_failure, timeout_message)
-        notifications_state.show(timeout_message, "error")
-        await bus.publish("notification")
-    except Exception as exc:
-        log_exception(exc)
-        message = f"{exception_prefix}: {exc}"
-        await _invoke(on_failure, message)
-        notifications_state.show(message, "error")
-        await bus.publish("notification")
-    finally:
-        registry.release(handle.request_id)
+        except Exception as exc:
+            if cancel_event.is_set():
+                return
+            log_exception(exc)
+            message = f"{exception_prefix}: {exc}"
+            await _invoke(on_failure, message)
+            notifications_state.show(message, "error")
+            await bus.publish("notification")
+        finally:
+            registry.release(handle.request_id)
+
+    registry.attach_task(handle, asyncio.create_task(_task()))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -99,6 +99,24 @@ def web_research_slots(dispatcher):
     return _run_slots(dispatcher, "web_research")
 
 
+async def drain_runs(dispatcher, kind=None):
+    """ADR-006 stage 6.2 fire-and-forget test adapter: run_single_shot's
+    surfaces (chart/note/branch_comparison/branch_synthesis) now claim
+    their slot synchronously and SCHEDULE the generation as an asyncio
+    task, returning BEFORE it runs - so a test that awaits start_* must
+    drain the scheduled task(s) before asserting on callbacks/
+    notifications/slot state (and before the test's event loop closes).
+    Filters to one kind when given; a directly-seeded handle with no task
+    (registry.claim() in busy-guard tests) is skipped either way."""
+    tasks = [
+        handle.task
+        for handle in list(dispatcher._runs.values())
+        if handle.task is not None and (kind is None or handle.kind == kind)
+    ]
+    for task in tasks:
+        await task
+
+
 def busy_count(dispatcher, kind):
     """ADR-002 stage 2.3 test adapter: the count-based equivalent of the
     old dict-of-sentinels' len()/truthiness checks for a "directly-

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -36,6 +36,7 @@ from backend.tests.conftest import (
     busy_count,
     chat_slots,
     code_sandbox_slots,
+    drain_runs,
     gitlink_apply_slots,
     gitlink_run_slots,
     image_slots,
@@ -2499,10 +2500,16 @@ def test_cancel_artifact_drops_the_result_and_never_calls_on_reply_even_on_a_lat
         await asyncio.to_thread(started.wait, 5)
 
         request_id = next(iter(artifact_slots(dispatcher).keys()))
+        # ADR-006 stage 6.2 fire-and-forget: cancel now pops the handle
+        # immediately (release-on-cancel), so grab the still-running worker
+        # task BEFORE cancelling - it is unreachable via the slots after.
+        entry = next(iter(artifact_slots(dispatcher).values()))
         assert dispatcher.cancel_artifact(request_id) is True
+        # Release-on-cancel: the slot is freed the moment cancel returns,
+        # not when the worker thread eventually observes the event.
+        assert artifact_slots(dispatcher) == {}
 
         release.set()
-        entry = next(iter(artifact_slots(dispatcher).values()))
         await entry["task"]
 
         assert replies == [], "on_reply must never be called once the request is cancelled"
@@ -5844,11 +5851,6 @@ def test_start_chart_generation_calls_on_success_with_the_parsed_result_then_cle
         successes = []
         failures = []
 
-        # Directly awaited (NOT scheduled via asyncio.create_task) - see
-        # start_chart_generation's own docstring for why: unlike every other
-        # independent slot, there is no background task to wait on
-        # separately, the whole thing (including on_success) has already
-        # completed by the time this await returns.
         await dispatcher.start_chart_generation(
             bus=bus,
             notifications_state=notifications,
@@ -5858,6 +5860,10 @@ def test_start_chart_generation_calls_on_success_with_the_parsed_result_then_cle
             on_success=lambda result: successes.append(result),
             on_failure=lambda message: failures.append(message),
         )
+        # ADR-006 stage 6.2 fire-and-forget: the awaited call above only
+        # claims the slot and schedules the generation - drain the scheduled
+        # task so on_success and the release have landed before asserting.
+        await drain_runs(dispatcher, "chart")
 
         assert successes == [{"type": "bar", "title": "T", "labels": ["A", "B"], "values": [1, 2]}]
         assert failures == []
@@ -5882,23 +5888,23 @@ def test_start_chart_generation_second_call_while_in_flight_is_rejected(monkeypa
         bus, notifications, dispatcher = _make_chart_env()
         successes = []
 
-        # Unlike the fire-and-forget slots' own equivalent test,
-        # start_chart_generation is directly awaited by ITS caller (see its
-        # own docstring) - so testing the busy guard requires the TEST
-        # itself to schedule the first call as a background task, mirroring
-        # what backend/canvas.py's generateChart WS wrapper's own caller
-        # (the WS read loop) effectively does across two overlapping
-        # connections to the same session.
-        first_call_task = asyncio.create_task(
-            dispatcher.start_chart_generation(
-                bus=bus,
-                notifications_state=notifications,
-                node_id="n1",
-                chart_type="bar",
-                source_text="text one",
-                on_success=lambda result: successes.append(result),
-                on_failure=lambda message: None,
-            )
+        # ADR-006 stage 6.2 fire-and-forget: start_chart_generation now
+        # claims the slot synchronously and schedules the generation itself,
+        # returning before it runs - the first call stays in flight on its
+        # own, no wrapper task needed to race a second call against it.
+        await dispatcher.start_chart_generation(
+            bus=bus,
+            notifications_state=notifications,
+            node_id="n1",
+            chart_type="bar",
+            source_text="text one",
+            on_success=lambda result: successes.append(result),
+            on_failure=lambda message: None,
+        )
+        # Grab the scheduled worker task now, while the slot still holds it,
+        # so it can be drained at the end.
+        first_call_task = next(
+            handle.task for handle in dispatcher._runs.values() if handle.kind == "chart"
         )
         await asyncio.to_thread(started.wait, 5)
 
@@ -5951,6 +5957,9 @@ def test_start_chart_generation_top_level_error_key_calls_on_failure_and_shows_n
             on_success=lambda result: successes.append(result),
             on_failure=lambda message: failures.append(message),
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain the scheduled task so the
+        # failure path has run before asserting.
+        await drain_runs(dispatcher, "chart")
 
         assert successes == [], "on_success must never be called on a top-level error-key response"
         assert failures == ["Could not find sufficient data to generate a bar chart."]
@@ -5987,6 +5996,9 @@ def test_start_chart_generation_timeout_fires_the_exact_message_and_clears_the_s
             on_success=lambda result: successes.append(result),
             on_failure=lambda message: failures.append(message),
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain the scheduled task so the
+        # timeout path has run before asserting.
+        await drain_runs(dispatcher, "chart")
 
         assert successes == []
         assert len(failures) == 1 and "stopped responding" in failures[0]
@@ -6036,17 +6048,13 @@ def test_chart_request_and_chat_request_run_concurrently_both_busy(monkeypatch):
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=chat_replies.append,
         )
-        # start_chart_generation is directly awaited by ITS caller (unlike
-        # chat's fire-and-forget shape) - the test itself schedules it as a
-        # background task to race it against the still-in-flight chat
-        # request, mirroring test_start_chart_generation_second_call_
-        # while_in_flight_is_rejected's own approach above.
-        chart_task = asyncio.create_task(
-            dispatcher.start_chart_generation(
-                bus=bus, notifications_state=notifications, node_id="n1",
-                chart_type="bar", source_text="text", on_success=chart_successes.append,
-                on_failure=lambda message: None,
-            )
+        # ADR-006 stage 6.2 fire-and-forget: start_chart_generation now
+        # schedules its own background task and returns immediately, the
+        # same shape as chat - no wrapper task needed to race the two.
+        await dispatcher.start_chart_generation(
+            bus=bus, notifications_state=notifications, node_id="n1",
+            chart_type="bar", source_text="text", on_success=chart_successes.append,
+            on_failure=lambda message: None,
         )
 
         await asyncio.to_thread(chat_started.wait, 5)
@@ -6062,7 +6070,9 @@ def test_chart_request_and_chat_request_run_concurrently_both_busy(monkeypatch):
         chat_entry = next(iter(chat_slots(dispatcher).values()))
         await chat_entry["task"]
         chart_release.set()
-        await chart_task
+        # ADR-006 stage 6.2 fire-and-forget: drain chart's scheduled task
+        # before asserting its side effects.
+        await drain_runs(dispatcher, "chart")
 
         assert chat_replies == ["chat reply"]
         assert chart_successes == [{"type": "bar", "title": "T", "labels": ["A"], "values": [1]}]
@@ -6101,6 +6111,9 @@ def test_start_note_generation_takeaway_calls_on_success_then_clears_the_slot(mo
             note_kind="takeaway", source_text="the source node's text",
             on_success=successes.append, on_failure=failures.append,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain the scheduled task so
+        # on_success and the release have landed before asserting.
+        await drain_runs(dispatcher, "note")
         assert successes == ["Key Takeaway\n\nMain Points:\n• from the source node's text"]
         assert failures == []
         assert busy_count(dispatcher, "note") == 0
@@ -6123,6 +6136,8 @@ def test_start_note_generation_explainer_uses_the_explainer_agent(monkeypatch):
             note_kind="explainer", source_text="x",
             on_success=got.append, on_failure=lambda m: None,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain before asserting.
+        await drain_runs(dispatcher, "note")
         assert got == ["EXPLAINER"]
 
     asyncio.run(run())
@@ -6162,6 +6177,9 @@ def test_start_note_generation_empty_response_fails_instead_of_creating_a_blank_
             note_kind="takeaway", source_text="x",
             on_success=successes.append, on_failure=failures.append,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain so the validate-failure
+        # path has run before asserting.
+        await drain_runs(dispatcher, "note")
         assert successes == [], "an empty agent response must not become a note"
         assert len(failures) == 1
         assert notifications.msg_type == "error"
@@ -6184,6 +6202,9 @@ def test_start_note_generation_agent_exception_surfaces_and_clears_the_slot(monk
             note_kind="takeaway", source_text="x",
             on_success=successes.append, on_failure=failures.append,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain so the exception path has
+        # run before asserting.
+        await drain_runs(dispatcher, "note")
         assert successes == []
         assert "model exploded" in failures[0]
         assert notifications.msg_type == "error"
@@ -6228,15 +6249,13 @@ def test_note_request_and_chat_request_run_concurrently_both_busy(monkeypatch):
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=chat_replies.append,
         )
-        # start_note_generation is directly awaited by ITS caller (same
-        # shape as chart) - schedule it as a background task to race it
-        # against the still-in-flight chat request.
-        note_task = asyncio.create_task(
-            dispatcher.start_note_generation(
-                bus=bus, notifications_state=notifications, node_id="n1",
-                note_kind="takeaway", source_text="x", on_success=note_successes.append,
-                on_failure=lambda message: None,
-            )
+        # ADR-006 stage 6.2 fire-and-forget: start_note_generation now
+        # schedules its own background task and returns immediately, the
+        # same shape as chat - no wrapper task needed to race the two.
+        await dispatcher.start_note_generation(
+            bus=bus, notifications_state=notifications, node_id="n1",
+            note_kind="takeaway", source_text="x", on_success=note_successes.append,
+            on_failure=lambda message: None,
         )
 
         await asyncio.to_thread(chat_started.wait, 5)
@@ -6252,7 +6271,9 @@ def test_note_request_and_chat_request_run_concurrently_both_busy(monkeypatch):
         chat_entry = next(iter(chat_slots(dispatcher).values()))
         await chat_entry["task"]
         note_release.set()
-        await note_task
+        # ADR-006 stage 6.2 fire-and-forget: drain note's scheduled task
+        # before asserting its side effects.
+        await drain_runs(dispatcher, "note")
 
         assert chat_replies == ["chat reply"]
         assert note_successes == ["Key Takeaway\n\nMain Points:\n• done"]
@@ -6282,6 +6303,9 @@ def test_start_branch_comparison_calls_on_success_then_clears_the_slot(monkeypat
             source_text="=== Branch 1 ===\n...",
             on_success=successes.append, on_failure=failures.append,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain the scheduled task so
+        # on_success and the release have landed before asserting.
+        await drain_runs(dispatcher, "branch_comparison")
         assert successes == ["Branch Comparison\n\nAgreements:\n• from === Branch 1 ===\n..."]
         assert failures == []
         assert busy_count(dispatcher, "branch_comparison") == 0
@@ -6325,6 +6349,9 @@ def test_start_branch_comparison_does_not_share_a_busy_slot_with_note_generation
             bus=bus, notifications_state=notifications, source_text="x",
             on_success=successes.append, on_failure=lambda m: None,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain before asserting (the
+        # seeded "note" claim has no task, so only the comparison drains).
+        await drain_runs(dispatcher, "branch_comparison")
         assert successes == ["Branch Comparison"], "an in-flight note generation must not block this"
 
     asyncio.run(run())
@@ -6340,6 +6367,9 @@ def test_start_branch_comparison_empty_response_fails_instead_of_creating_a_blan
             bus=bus, notifications_state=notifications, source_text="x",
             on_success=successes.append, on_failure=failures.append,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain so the validate-failure
+        # path has run before asserting.
+        await drain_runs(dispatcher, "branch_comparison")
         assert successes == [], "an empty agent response must not become a note"
         assert len(failures) == 1
         assert notifications.msg_type == "error"
@@ -6361,6 +6391,9 @@ def test_start_branch_comparison_agent_exception_surfaces_and_clears_the_slot(mo
             bus=bus, notifications_state=notifications, source_text="x",
             on_success=successes.append, on_failure=failures.append,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain so the exception path has
+        # run before asserting.
+        await drain_runs(dispatcher, "branch_comparison")
         assert successes == []
         assert "model exploded" in failures[0]
         assert notifications.msg_type == "error"
@@ -6391,6 +6424,9 @@ def test_start_branch_synthesis_calls_on_success_then_clears_the_slot(monkeypatc
             source_text="=== Branch 1 ===\n...", instructions="merge them",
             on_success=successes.append, on_failure=failures.append,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain the scheduled task so
+        # on_success and the release have landed before asserting.
+        await drain_runs(dispatcher, "branch_synthesis")
         assert successes == ["Combined from === Branch 1 ===\n... per 'merge them'"]
         assert failures == []
         assert busy_count(dispatcher, "branch_synthesis") == 0
@@ -6437,6 +6473,10 @@ def test_start_branch_synthesis_does_not_share_a_busy_slot_with_branch_compariso
             bus=bus, notifications_state=notifications, source_text="x", instructions="y",
             on_success=successes.append, on_failure=lambda m: None,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain before asserting (the
+        # seeded "branch_comparison" claim has no task, so only the
+        # synthesis drains).
+        await drain_runs(dispatcher, "branch_synthesis")
         assert successes == ["Combined answer."], "an in-flight branch comparison must not block this"
 
     asyncio.run(run())
@@ -6452,6 +6492,9 @@ def test_start_branch_synthesis_empty_response_fails_instead_of_creating_a_blank
             bus=bus, notifications_state=notifications, source_text="x", instructions="y",
             on_success=successes.append, on_failure=failures.append,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain so the validate-failure
+        # path has run before asserting.
+        await drain_runs(dispatcher, "branch_synthesis")
         assert successes == [], "an empty agent response must not become a node"
         assert len(failures) == 1
         assert notifications.msg_type == "error"
@@ -6473,6 +6516,9 @@ def test_start_branch_synthesis_agent_exception_surfaces_and_clears_the_slot(mon
             bus=bus, notifications_state=notifications, source_text="x", instructions="y",
             on_success=successes.append, on_failure=failures.append,
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain so the exception path has
+        # run before asserting.
+        await drain_runs(dispatcher, "branch_synthesis")
         assert successes == []
         assert "model exploded" in failures[0]
         assert notifications.msg_type == "error"
@@ -6518,14 +6564,12 @@ def test_branch_comparison_request_and_chat_request_run_concurrently_both_busy(m
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=chat_replies.append,
         )
-        # start_branch_comparison is directly awaited by ITS caller (same
-        # shape as chart/note) - schedule it as a background task to race
-        # it against the still-in-flight chat request.
-        comparison_task = asyncio.create_task(
-            dispatcher.start_branch_comparison(
-                bus=bus, notifications_state=notifications, source_text="x",
-                on_success=comparison_successes.append, on_failure=lambda message: None,
-            )
+        # ADR-006 stage 6.2 fire-and-forget: start_branch_comparison now
+        # schedules its own background task and returns immediately, the
+        # same shape as chat - no wrapper task needed to race the two.
+        await dispatcher.start_branch_comparison(
+            bus=bus, notifications_state=notifications, source_text="x",
+            on_success=comparison_successes.append, on_failure=lambda message: None,
         )
 
         await asyncio.to_thread(chat_started.wait, 5)
@@ -6541,7 +6585,9 @@ def test_branch_comparison_request_and_chat_request_run_concurrently_both_busy(m
         chat_entry = next(iter(chat_slots(dispatcher).values()))
         await chat_entry["task"]
         comparison_release.set()
-        await comparison_task
+        # ADR-006 stage 6.2 fire-and-forget: drain the comparison's
+        # scheduled task before asserting its side effects.
+        await drain_runs(dispatcher, "branch_comparison")
 
         assert chat_replies == ["chat reply"]
         assert comparison_successes == ["Branch Comparison\n\nAgreements:\n• done"]
@@ -6583,11 +6629,12 @@ def test_branch_synthesis_request_and_chat_request_run_concurrently_both_busy(mo
             conversation_history=[{"role": "user", "content": "hi"}],
             on_reply=chat_replies.append,
         )
-        synthesis_task = asyncio.create_task(
-            dispatcher.start_branch_synthesis(
-                bus=bus, notifications_state=notifications, source_text="x", instructions="y",
-                on_success=synthesis_successes.append, on_failure=lambda message: None,
-            )
+        # ADR-006 stage 6.2 fire-and-forget: start_branch_synthesis now
+        # schedules its own background task and returns immediately, the
+        # same shape as chat - no wrapper task needed to race the two.
+        await dispatcher.start_branch_synthesis(
+            bus=bus, notifications_state=notifications, source_text="x", instructions="y",
+            on_success=synthesis_successes.append, on_failure=lambda message: None,
         )
 
         await asyncio.to_thread(chat_started.wait, 5)
@@ -6601,7 +6648,9 @@ def test_branch_synthesis_request_and_chat_request_run_concurrently_both_busy(mo
         chat_entry = next(iter(chat_slots(dispatcher).values()))
         await chat_entry["task"]
         synthesis_release.set()
-        await synthesis_task
+        # ADR-006 stage 6.2 fire-and-forget: drain the synthesis's scheduled
+        # task before asserting its side effects.
+        await drain_runs(dispatcher, "branch_synthesis")
 
         assert chat_replies == ["chat reply"]
         assert synthesis_successes == ["Combined answer."]

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -6656,3 +6656,237 @@ def test_branch_synthesis_request_and_chat_request_run_concurrently_both_busy(mo
         assert synthesis_successes == ["Combined answer."]
 
     asyncio.run(run())
+
+
+# -- ADR-006 stage 6.2 review fixes: release-on-cancel at the dispatcher level -
+
+
+def test_cancelled_runs_late_teardown_never_clobbers_a_new_runs_claimed_slot(monkeypatch):
+    """ADR-006 stage 6.2 review fix (NEW-RUN-CLOBBER): release-on-cancel
+    frees the chat slot the instant a cancel lands, so a NEW chat run can
+    claim it while the cancelled worker is still unwinding. That stale
+    worker's late finally must neither pop the new run's handle nor re-run
+    run 1's end transition (cancel() already ran it via finalize) - the
+    gated `if release(): on_end()` tail is exactly what this pins, through
+    _dispatch's own on_begin/on_end callbacks."""
+    started1, release1 = threading.Event(), threading.Event()
+    started2, release2 = threading.Event(), threading.Event()
+    calls = []
+
+    def sequential_blocking_chat(task, messages, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            started1.set()
+            release1.wait(5)
+            # Run 1 was cancelled mid-flight - the real driver observes the
+            # cancel event and raises, same shape as the mid-flight-cancel
+            # test above.
+            raise api_provider.RequestCancelledError("Request cancelled.")
+        started2.set()
+        release2.wait(5)
+        return {"message": {"content": "second reply"}}
+
+    _configure_fake_ollama(monkeypatch, sequential_blocking_chat)
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        begins1, ends1 = [], []
+        begins2, ends2 = [], []
+
+        await dispatcher._dispatch(
+            bus=bus,
+            notifications_state=notifications,
+            conversation_history=[{"role": "user", "content": "first"}],
+            on_reply=lambda text: None,
+            on_begin=begins1.append,
+            on_end=lambda: ends1.append(1),
+            state_topic="app-composer",
+        )
+        await asyncio.to_thread(started1.wait, 5)
+        request_id1, entry1 = next(iter(chat_slots(dispatcher).items()))
+
+        # Cancel run 1 - release-on-cancel: the slot frees IMMEDIATELY,
+        # while the worker is still held open.
+        assert dispatcher.cancel(request_id1) is True
+        assert chat_slots(dispatcher) == {}
+
+        # cancel() schedules run 1's finalize (its on_end + publish) - it
+        # must land exactly once, promptly, without waiting for the worker.
+        deadline = asyncio.get_running_loop().time() + 2
+        while len(ends1) < 1 and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+        assert ends1 == [1], "cancel must run run 1's end transition exactly once"
+
+        # Run 2 claims the freed slot while run 1's worker is STILL running.
+        await dispatcher._dispatch(
+            bus=bus,
+            notifications_state=notifications,
+            conversation_history=[{"role": "user", "content": "second"}],
+            on_reply=lambda text: None,
+            on_begin=begins2.append,
+            on_end=lambda: ends2.append(1),
+            state_topic="app-composer",
+        )
+        await asyncio.to_thread(started2.wait, 5)
+        request_id2 = next(iter(chat_slots(dispatcher).keys()))
+        assert request_id2 != request_id1
+
+        # NOW let run 1's stale worker unwind fully...
+        release1.set()
+        await entry1["task"]
+
+        # ...and run 2's claim must be completely undisturbed by it.
+        assert len(chat_slots(dispatcher)) == 1, "run 1's late teardown must not free run 2's slot"
+        assert next(iter(chat_slots(dispatcher).keys())) == request_id2, (
+            "run 2's handle must still be the claimed one after run 1's stale finally"
+        )
+        assert ends1 == [1], "run 1's end transition must NOT fire a second time from the stale finally"
+        assert ends2 == [], "run 2 is still in flight - its end transition must not have fired"
+        assert begins1 == [request_id1] and begins2 == [request_id2]
+
+        release2.set()
+        entry2 = next(iter(chat_slots(dispatcher).values()))
+        await entry2["task"]
+        assert chat_slots(dispatcher) == {}
+        assert ends2 == [1]
+
+    asyncio.run(run())
+
+
+def test_cancel_all_now_cancels_a_chart_generation_and_frees_its_slot_immediately(monkeypatch):
+    """ADR-006 stage 6.2 review fix: runtime proof that a formerly-
+    uncancellable kind (chart - pre-6.2 cancel_all silently skipped it)
+    really cancels now: the slot frees the instant cancel_all() fires, the
+    late result is suppressed (on_success never called), and no error
+    notification is shown for work the user abandoned."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_get_response(self, text, chart_type):
+        started.set()
+        release.wait(5)
+        return '{"type": "bar", "title": "T", "labels": ["A"], "values": [1]}'
+
+    monkeypatch.setattr(agents_module.ChartDataAgent, "get_response", blocking_get_response)
+
+    async def run():
+        bus, notifications, dispatcher = _make_chart_env()
+        successes = []
+        failures = []
+
+        await dispatcher.start_chart_generation(
+            bus=bus,
+            notifications_state=notifications,
+            node_id="n1",
+            chart_type="bar",
+            source_text="text",
+            on_success=lambda result: successes.append(result),
+            on_failure=lambda message: failures.append(message),
+        )
+        # Grab the scheduled worker task now - after cancel_all it is only
+        # reachable as an orphan, no longer via the slots.
+        worker_task = next(
+            handle.task for handle in dispatcher._runs.values() if handle.kind == "chart"
+        )
+        await asyncio.to_thread(started.wait, 5)
+        assert busy_count(dispatcher, "chart") == 1
+
+        dispatcher.cancel_all()
+
+        # Release-on-cancel: the slot is free the moment cancel_all returns,
+        # while the worker is still held open...
+        assert busy_count(dispatcher, "chart") == 0
+        assert not release.is_set()
+        # ...but the unwinding worker still counts as live work (eviction veto).
+        assert dispatcher.has_in_flight_runs() is True
+
+        release.set()
+        await worker_task
+        deadline = asyncio.get_running_loop().time() + 2
+        while dispatcher.has_in_flight_runs() and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+        assert dispatcher.has_in_flight_runs() is False
+
+        assert successes == [], "a cancelled chart's late result must be suppressed"
+        assert failures == []
+        assert notifications.visible is False, (
+            "no error notification for work the user already abandoned"
+        )
+
+    asyncio.run(run())
+
+
+def test_stale_artifact_teardown_never_clears_a_newer_runs_pending_request_id(monkeypatch):
+    """ADR-006 stage 6.2 review fix (pins start_artifact_reply's finally):
+    release-on-cancel frees the artifact slot instantly, so a NEW artifact
+    run can claim and stamp the SAME node before the cancelled worker
+    unwinds. The old unconditional `node.pending_request_id = None` in the
+    stale worker's finally wiped the new run's in-flight marker - the fix
+    only clears it when it still equals the stale run's own request_id."""
+    started1, release1 = threading.Event(), threading.Event()
+    started2, release2 = threading.Event(), threading.Event()
+    calls = []
+
+    def sequential_blocking_get_response(self, current_artifact, history):
+        calls.append(1)
+        if len(calls) == 1:
+            started1.set()
+            release1.wait(5)
+            return "first document", "first message"
+        started2.set()
+        release2.wait(5)
+        return "second document", "second message"
+
+    monkeypatch.setattr(
+        agents_module.ArtifactAgent, "get_response", sequential_blocking_get_response
+    )
+
+    async def run():
+        bus, notifications, dispatcher = _make_artifact_env()
+        node = _make_node()
+        replies = []
+
+        await dispatcher.start_artifact_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            current_artifact="doc",
+            history=[],
+            on_reply=lambda new_content, ai_message: replies.append((new_content, ai_message)),
+        )
+        await asyncio.to_thread(started1.wait, 5)
+        request_id1, entry1 = next(iter(artifact_slots(dispatcher).items()))
+        assert node.pending_request_id == request_id1
+
+        assert dispatcher.cancel_artifact(request_id1) is True
+        assert artifact_slots(dispatcher) == {}, "release-on-cancel frees the slot immediately"
+
+        # Run 2 on the SAME node, while run 1's worker is still held open.
+        await dispatcher.start_artifact_reply(
+            bus=bus,
+            notifications_state=notifications,
+            node=node,
+            current_artifact="doc",
+            history=[],
+            on_reply=lambda new_content, ai_message: replies.append((new_content, ai_message)),
+        )
+        await asyncio.to_thread(started2.wait, 5)
+        request_id2, entry2 = next(iter(artifact_slots(dispatcher).items()))
+        assert node.pending_request_id == request_id2
+
+        # Run 1's stale worker unwinds fully - its finally must NOT clear
+        # run 2's in-flight marker.
+        release1.set()
+        await entry1["task"]
+        assert node.pending_request_id == request_id2, (
+            "the stale run's teardown wiped the newer run's pending_request_id"
+        )
+        assert replies == [], "the cancelled run's result must have been dropped"
+
+        release2.set()
+        await entry2["task"]
+        assert replies == [("second document", "second message")]
+        assert node.pending_request_id is None
+        assert artifact_slots(dispatcher) == {}
+
+    asyncio.run(run())

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -40,6 +40,7 @@ from backend.notifications import NotificationState
 from backend.tests.conftest import (
     chat_slots,
     code_sandbox_slots,
+    drain_runs,
     gitlink_run_slots,
     image_slots,
     pycoder_slots,
@@ -7227,14 +7228,20 @@ def test_generate_key_takeaway_creates_a_tinted_note_beside_the_source_node(monk
     )
 
     async def run():
-        bus, document, recorder, _ = make_bus_with_dispatcher()
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
         chat = document.add_chat_node(100, 200, "a long assistant answer", False)
         scene_publishes_before = recorder.topics_seen().count("scene")
+        ids_before = set(document.nodes)
 
-        note_id = await bus.dispatch_intent("scene", "generateKeyTakeaway", [chat.id])
+        # ADR-006 stage 6.2 fire-and-forget: the intent returns before the
+        # generation runs (and no longer returns the note id) - drain the
+        # scheduled task, then find the note as the one new node.
+        await bus.dispatch_intent("scene", "generateKeyTakeaway", [chat.id])
+        await drain_runs(dispatcher, "note")
 
-        assert note_id is not None
-        note = document.nodes[note_id]
+        new_ids = set(document.nodes) - ids_before
+        assert len(new_ids) == 1, "exactly one note must have been created"
+        note = document.nodes[new_ids.pop()]
         assert note.kind == "note"
         assert note.content == "Key Takeaway\n\nMain Points:\n• it works"
         # Offset to the RIGHT of the source, clearing the chat node's width.
@@ -7252,13 +7259,27 @@ def test_generate_explainer_note_staggers_below_a_takeaway_from_the_same_node(mo
     monkeypatch.setattr(agents_module.ExplainerAgent, "get_response", lambda self, text: "EXPLAINER")
 
     async def run():
-        bus, document, _, _ = make_bus_with_dispatcher()
+        bus, document, _, dispatcher = make_bus_with_dispatcher()
         chat = document.add_chat_node(0, 0, "source text", False)
 
-        takeaway_id = await bus.dispatch_intent("scene", "generateKeyTakeaway", [chat.id])
-        explainer_id = await bus.dispatch_intent("scene", "generateExplainerNote", [chat.id])
+        # ADR-006 stage 6.2 fire-and-forget: each intent returns before its
+        # generation runs (and no longer returns the note id) - drain after
+        # EACH dispatch (both share the "note" slot, so the second would be
+        # bounced as busy without the first drain) and diff the node set to
+        # find each created note.
+        ids_before = set(document.nodes)
+        await bus.dispatch_intent("scene", "generateKeyTakeaway", [chat.id])
+        await drain_runs(dispatcher, "note")
+        takeaway_ids = set(document.nodes) - ids_before
+        assert len(takeaway_ids) == 1
 
-        takeaway, explainer = document.nodes[takeaway_id], document.nodes[explainer_id]
+        ids_before = set(document.nodes)
+        await bus.dispatch_intent("scene", "generateExplainerNote", [chat.id])
+        await drain_runs(dispatcher, "note")
+        explainer_ids = set(document.nodes) - ids_before
+        assert len(explainer_ids) == 1
+
+        takeaway, explainer = document.nodes[takeaway_ids.pop()], document.nodes[explainer_ids.pop()]
         assert takeaway.content == "TAKEAWAY"
         assert explainer.content == "EXPLAINER"
         assert takeaway.x == explainer.x
@@ -7324,11 +7345,14 @@ def test_generate_key_takeaway_sends_the_nodes_own_text_not_the_branch_history(m
     )
 
     async def run():
-        bus, document, _, _ = make_bus_with_dispatcher()
+        bus, document, _, dispatcher = make_bus_with_dispatcher()
         parent = document.add_chat_node(0, 0, "the parent question", True)
         child = document.add_chat_node(0, 160, "the child answer", False, parent_id=parent.id)
 
         await bus.dispatch_intent("scene", "generateKeyTakeaway", [child.id])
+        # ADR-006 stage 6.2 fire-and-forget: drain the scheduled generation
+        # so the agent has actually been called before asserting.
+        await drain_runs(dispatcher, "note")
 
         assert seen == ["the child answer"]
         assert "the parent question" not in seen[0]
@@ -7396,16 +7420,22 @@ def test_compare_branches_creates_a_note_linked_to_all_sources(monkeypatch):
     )
 
     async def run():
-        bus, document, recorder, _ = make_bus_with_dispatcher()
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
         root = document.add_chat_node(0, 0, "root question", True)
         first = document.add_chat_node(0, 160, "first answer", False, parent_id=root.id)
         second = document.add_chat_node(460, 160, "second answer", False, parent_id=root.id)
         scene_publishes_before = recorder.topics_seen().count("scene")
+        ids_before = set(document.nodes)
 
-        note_id = await bus.dispatch_intent("scene", "compareBranches", [[first.id, second.id]])
+        # ADR-006 stage 6.2 fire-and-forget: the intent returns before the
+        # generation runs (and no longer returns the note id) - drain the
+        # scheduled task, then find the note as the one new node.
+        await bus.dispatch_intent("scene", "compareBranches", [[first.id, second.id]])
+        await drain_runs(dispatcher, "branch_comparison")
 
-        assert note_id is not None
-        note = document.nodes[note_id]
+        new_ids = set(document.nodes) - ids_before
+        assert len(new_ids) == 1, "exactly one note must have been created"
+        note = document.nodes[new_ids.pop()]
         assert note.kind == "note"
         assert note.content == "Branch Comparison\n\nAgreements:\n• both agree"
         assert note.state.is_branch_comparison is True
@@ -7433,12 +7463,15 @@ def test_compare_branches_sends_each_branchs_own_full_history_not_just_its_own_c
     )
 
     async def run():
-        bus, document, _, _ = make_bus_with_dispatcher()
+        bus, document, _, dispatcher = make_bus_with_dispatcher()
         root = document.add_chat_node(0, 0, "shared root question", True)
         first = document.add_chat_node(0, 160, "first branch reply", False, parent_id=root.id)
         second = document.add_chat_node(460, 160, "second branch reply", False, parent_id=root.id)
 
         await bus.dispatch_intent("scene", "compareBranches", [[first.id, second.id]])
+        # ADR-006 stage 6.2 fire-and-forget: drain the scheduled generation
+        # so the agent has actually been called before asserting.
+        await drain_runs(dispatcher, "branch_comparison")
 
         assert len(seen) == 1
         formatted = seen[0]
@@ -7533,18 +7566,24 @@ def test_synthesize_branches_creates_a_chat_node_continuing_from_the_first_sourc
     )
 
     async def run():
-        bus, document, recorder, _ = make_bus_with_dispatcher()
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
         root = document.add_chat_node(0, 0, "root question", True)
         first = document.add_chat_node(0, 160, "first answer", False, parent_id=root.id)
         second = document.add_chat_node(460, 160, "second answer", False, parent_id=root.id)
         scene_publishes_before = recorder.topics_seen().count("scene")
+        ids_before = set(document.nodes)
 
-        node_id = await bus.dispatch_intent(
+        # ADR-006 stage 6.2 fire-and-forget: the intent returns before the
+        # generation runs (and no longer returns the node id) - drain the
+        # scheduled task, then find the result as the one new node.
+        await bus.dispatch_intent(
             "scene", "synthesizeBranches", [[first.id, second.id], "merge the best of both"],
         )
+        await drain_runs(dispatcher, "branch_synthesis")
 
-        assert node_id is not None
-        node = document.nodes[node_id]
+        new_ids = set(document.nodes) - ids_before
+        assert len(new_ids) == 1, "exactly one chat node must have been created"
+        node = document.nodes[new_ids.pop()]
         assert node.kind == "chat"
         assert node.state.is_user is False
         assert node.content == "Combined answer drawing on both branches."
@@ -7572,16 +7611,20 @@ def test_synthesize_branches_stamps_provider_and_model_from_the_composer_route(m
     )
 
     async def run():
-        bus, document, _, _ = make_bus_with_dispatcher()
+        bus, document, _, dispatcher = make_bus_with_dispatcher()
         root = document.add_chat_node(0, 0, "root question", True)
         first = document.add_chat_node(0, 160, "first answer", False, parent_id=root.id)
         second = document.add_chat_node(460, 160, "second answer", False, parent_id=root.id)
 
-        node_id = await bus.dispatch_intent(
+        # ADR-006 stage 6.2 fire-and-forget: the intent no longer returns
+        # the node id - drain the scheduled task, then read the result via
+        # last_chat_node_id (set by the synthesis's own on_success).
+        await bus.dispatch_intent(
             "scene", "synthesizeBranches", [[first.id, second.id], "merge them"],
         )
+        await drain_runs(dispatcher, "branch_synthesis")
 
-        node = document.nodes[node_id]
+        node = document.nodes[document.last_chat_node_id]
         # ComposerDocument() in make_bus_with_dispatcher has no route_reader
         # wired - route()'s own honest "no settings manager wired" fallback
         # (see backend/composer.py) reports Ollama (Local) with an empty
@@ -7600,7 +7643,7 @@ def test_synthesize_branches_sends_each_branchs_own_full_history_and_the_instruc
     )
 
     async def run():
-        bus, document, _, _ = make_bus_with_dispatcher()
+        bus, document, _, dispatcher = make_bus_with_dispatcher()
         root = document.add_chat_node(0, 0, "shared root question", True)
         first = document.add_chat_node(0, 160, "first branch reply", False, parent_id=root.id)
         second = document.add_chat_node(460, 160, "second branch reply", False, parent_id=root.id)
@@ -7608,6 +7651,9 @@ def test_synthesize_branches_sends_each_branchs_own_full_history_and_the_instruc
         await bus.dispatch_intent(
             "scene", "synthesizeBranches", [[first.id, second.id], "pick the simpler one"],
         )
+        # ADR-006 stage 6.2 fire-and-forget: drain the scheduled generation
+        # so the agent has actually been called before asserting.
+        await drain_runs(dispatcher, "branch_synthesis")
 
         assert len(seen) == 1
         formatted, instructions = seen[0]

--- a/backend/tests/test_nonblocking_dispatch.py
+++ b/backend/tests/test_nonblocking_dispatch.py
@@ -1,0 +1,201 @@
+"""ADR-006 stage 6.2 exit criteria, each pinned as a test:
+
+1. the 7-minute-freeze class is gone - a chart generation (formerly awaited
+   inline by the WS read loop for up to the 420 s watchdog) no longer blocks
+   the socket: a ping sent DURING a held generation round-trips immediately;
+2. cancel frees the slot immediately (well under the 2 s budget) - the slot
+   empties the moment the cancel intent lands, not when the worker thread
+   eventually observes it;
+3. cancel_all covers every run kind - statically, every claim() call site
+   passes a cancellation mechanism, so the pre-6.2 "chart/note/branch_*/
+   image/gitlink_apply are silently skipped" gap cannot re-open unnoticed.
+
+The WS-level tests drive the REAL ASGI app end to end (the same harness
+test_app_ws.py established), with only the provider network call faked.
+"""
+
+from __future__ import annotations
+
+import ast
+import threading
+import time
+from pathlib import Path
+
+import api_provider
+import graphlink_task_config as config
+from backend.app import get_session_context
+from backend.tests.conftest import chat_slots
+from backend.tests.test_app_ws import make_client
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _recv_until(ws, predicate, max_frames=50):
+    for _ in range(max_frames):
+        frame = ws.receive_json()
+        if predicate(frame):
+            return frame
+    raise AssertionError(f"no matching frame within {max_frames} frames")
+
+
+def test_a_held_chart_generation_no_longer_blocks_the_ws_read_loop(monkeypatch):
+    """EXIT CRITERION (the C2 freeze class): before 6.2, generateChart was
+    awaited inline at app.py's receive loop - THIS exact sequence (hold the
+    generation open, then ping on the same socket) would deadlock until the
+    watchdog. Now the ping round-trips while the generation is still held."""
+    started, release = threading.Event(), threading.Event()
+
+    def fake_chat(task, messages, **kwargs):
+        started.set()
+        assert release.wait(10), "test never released the held chart call"
+        return {"message": {"content": '{"type": "bar", "title": "T", "labels": ["A"], "values": [1.0]}'}}
+
+    client = make_client()
+    monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+    monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_OLLAMA)
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, "test-model")
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHART, "test-model")
+    monkeypatch.setattr(api_provider, "chat", fake_chat)
+
+    with client.websocket_connect("/ws?session=default") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["scene"]})
+        ws.receive_json()  # initial scene snapshot
+
+        session = client.app.state.bus.session("default")
+        context = get_session_context(session)
+        # The chart's source node, created directly on the document - node
+        # creation is not what this test is about.
+        node = context.canvas_document.add_chat_node(0, 0, "some data: 1, 2, 3", False, parent_id=None)
+
+        ws.send_json({"kind": "intent", "topic": "scene", "intent": "generateChart", "args": [node.id, "bar"]})
+
+        deadline = time.monotonic() + 5
+        while not started.is_set() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert started.is_set(), "chart generation never started"
+        assert context.agent_dispatcher._runs.is_busy("chart")
+
+        # The exit criterion itself: with the generation STILL HELD, a ping on
+        # the same socket must round-trip. Pre-6.2 this receive would hang
+        # until the 420 s watchdog fired.
+        t0 = time.monotonic()
+        # The WS protocol only sends a {"kind": "result"} frame back when the
+        # intent message carries an "id", and the payload field is "value"
+        # (backend/app.py's intent branch) - without both, this receive would
+        # wait forever regardless of whether the read loop is alive.
+        ws.send_json({
+            "kind": "intent", "topic": "system", "intent": "ping",
+            "args": ["loop-alive"], "id": "ping-loop-alive",
+        })
+        frame = _recv_until(
+            ws, lambda f: f.get("kind") == "result" and "loop-alive" in str(f.get("value", ""))
+        )
+        assert time.monotonic() - t0 < 5
+        assert frame["kind"] == "result"
+
+        release.set()
+        deadline = time.monotonic() + 5
+        while context.agent_dispatcher.has_in_flight_runs() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert not context.agent_dispatcher.has_in_flight_runs()
+
+
+def test_cancel_frees_the_chat_slot_immediately_not_when_the_worker_returns(monkeypatch):
+    """EXIT CRITERION (cancel frees slot < 2 s): the slot empties the moment
+    cancelChatRequest lands. The fake worker deliberately IGNORES the cancel
+    event for a while (simulating a provider blocked in a network call, the
+    exact case where the old release-in-finally kept the slot busy) - the
+    slot must be free while the worker is still running."""
+    started, release = threading.Event(), threading.Event()
+
+    def fake_chat(task, messages, cancellation_event=None, **kwargs):
+        started.set()
+        assert release.wait(10), "test never released the held chat call"
+        raise api_provider.RequestCancelledError("cancelled")
+
+    client = make_client()
+    monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+    monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_OLLAMA)
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, "test-model")
+    monkeypatch.setattr(api_provider, "chat", fake_chat)
+
+    with client.websocket_connect("/ws?session=default") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["scene"]})
+        ws.receive_json()
+        ws.send_json({"kind": "intent", "topic": "scene", "intent": "sendMessage", "args": ["hello"]})
+        ws.receive_json()  # scene republish after the user node is created
+
+        deadline = time.monotonic() + 5
+        while not started.is_set() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert started.is_set()
+
+        session = client.app.state.bus.session("default")
+        dispatcher = get_session_context(session).agent_dispatcher
+        in_flight = list(chat_slots(dispatcher).values())
+        assert len(in_flight) == 1
+        request_id = next(iter(chat_slots(dispatcher).keys()))
+
+        ws.send_json({"kind": "intent", "topic": "scene", "intent": "cancelChatRequest", "args": [request_id]})
+
+        # The budget is 2 s; the slot should actually free within
+        # milliseconds of the cancel intent being dispatched - and crucially
+        # while the worker is STILL held open (release has not been set).
+        deadline = time.monotonic() + 2
+        while chat_slots(dispatcher) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert not chat_slots(dispatcher), "cancel did not free the slot within the 2 s budget"
+        assert not release.is_set()  # the worker really is still running
+        # ...but the cancelled work is still tracked as live until it ends
+        # (session eviction must keep waiting for it - see has_any_live_work).
+        assert dispatcher.has_in_flight_runs()
+
+        release.set()
+        deadline = time.monotonic() + 5
+        while dispatcher.has_in_flight_runs() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert not dispatcher.has_in_flight_runs()
+
+
+def test_every_claim_site_passes_a_cancellation_mechanism():
+    """EXIT CRITERION (cancel_all covers all runs), enforced statically the
+    same way test_dispatch_claim_ordering pins its own invariant: every
+    registry claim() call under backend/ must pass cancel_event= or
+    on_cancel=. Before 6.2, six kinds (chart, note, branch_comparison,
+    branch_synthesis, image, gitlink_apply) passed neither and were silently
+    skipped by cancel_all() - a new kind reintroducing that gap fails here."""
+    offenders = []
+    for rel in ("backend/agents.py", "backend/run_lifecycle.py"):
+        tree = ast.parse((REPO_ROOT / rel).read_text(encoding="utf-8"), filename=rel)
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "claim"
+            ):
+                continue
+            keywords = {kw.arg for kw in node.keywords}
+            if "cancel_event" not in keywords and "on_cancel" not in keywords:
+                offenders.append(f"{rel}:{node.lineno}")
+    assert not offenders, (
+        "these claim() call sites pass neither cancel_event= nor on_cancel= - "
+        "the run kind they create would be invisible to cancel()/cancel_all(), "
+        "reopening the pre-6.2 uncancellable-kind gap:\n"
+        + "\n".join(f"  {o}" for o in offenders)
+    )
+
+
+def test_the_claim_scan_finds_the_real_population():
+    # Guards the guard: the scan above must actually see the known claim
+    # sites (9 as of stage 6.2), not silently match nothing.
+    count = 0
+    for rel in ("backend/agents.py", "backend/run_lifecycle.py"):
+        tree = ast.parse((REPO_ROOT / rel).read_text(encoding="utf-8"), filename=rel)
+        count += sum(
+            1
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "claim"
+        )
+    assert count >= 9, f"expected at least 9 claim() call sites, found {count}"

--- a/backend/tests/test_run_lifecycle.py
+++ b/backend/tests/test_run_lifecycle.py
@@ -96,8 +96,10 @@ def test_cancel_returns_false_for_an_unknown_request_id():
 
 
 def test_cancel_returns_false_for_a_handle_with_no_cancel_event():
-    # chart/note's own shape - no cancellation checkpoint of their own,
-    # see backend/run_lifecycle.py's own docstring.
+    # A handle carrying neither mechanism cannot be cancelled. ADR-006
+    # stage 6.2 note: no production kind claims this shape any more (even
+    # chart/note now get a cancel_event from run_single_shot) - this pins
+    # the registry-level contract for a mechanism-less handle itself.
     registry = RunRegistry()
     handle = registry.claim("chart")
     assert registry.cancel(handle.request_id) is False
@@ -106,13 +108,22 @@ def test_cancel_returns_false_for_a_handle_with_no_cancel_event():
 def test_cancel_all_trips_every_cancel_event_and_skips_handles_without_one():
     registry = RunRegistry()
     chat_cancel = threading.Event()
-    registry.claim("chat", cancel_event=chat_cancel)
+    chat_handle = registry.claim("chat", cancel_event=chat_cancel)
     chart_handle = registry.claim("chart")  # no cancel_event
 
     registry.cancel_all()  # must not raise on the cancel_event-less handle
 
     assert chat_cancel.is_set()
-    assert registry.get(chart_handle.request_id) is not None, "cancel_all() must not release anything"
+    # ADR-006 stage 6.2 (release-on-cancel): a fired handle is popped
+    # IMMEDIATELY - the pre-6.2 "cancel_all() must not release anything"
+    # assertion here is now the opposite of the contract for any handle
+    # that carries a mechanism. Only a mechanism-less handle survives.
+    assert registry.get(chat_handle.request_id) is None, (
+        "cancel_all() must release a fired handle immediately (release-on-cancel)"
+    )
+    assert registry.get(chart_handle.request_id) is not None, (
+        "cancel_all() must not release a handle it could not fire"
+    )
 
 
 def test_cancel_all_on_an_empty_registry_is_a_safe_noop():
@@ -202,16 +213,24 @@ def test_cancel_with_mismatched_kind_is_rejected_and_does_not_trip_the_event():
 def test_cancel_all_fires_on_cancel_for_every_handle_that_has_one():
     registry = RunRegistry()
     chat_cancel = threading.Event()
-    registry.claim("chat", cancel_event=chat_cancel)
+    chat_handle = registry.claim("chat", cancel_event=chat_cancel)
     web_fired = []
-    registry.claim("web_research", on_cancel=lambda: web_fired.append(True))
+    web_handle = registry.claim("web_research", on_cancel=lambda: web_fired.append(True))
     chart_handle = registry.claim("chart")  # neither mechanism
 
     registry.cancel_all()
 
     assert chat_cancel.is_set()
     assert web_fired == [True]
-    assert registry.get(chart_handle.request_id) is not None, "cancel_all() must not release anything"
+    # ADR-006 stage 6.2 (release-on-cancel): both fired handles - whichever
+    # mechanism they carry - are popped immediately; the stale "must not
+    # release anything" assertion only ever passed vacuously here because
+    # the surviving handle carried no mechanism at all.
+    assert registry.get(chat_handle.request_id) is None
+    assert registry.get(web_handle.request_id) is None
+    assert registry.get(chart_handle.request_id) is not None, (
+        "cancel_all() must not release a handle it could not fire"
+    )
 
 
 def test_cancel_all_pending_approvals_resolves_only_listed_kinds_with_false():
@@ -270,5 +289,197 @@ def test_approval_future_can_be_replaced_in_place_on_the_same_handle():
         handle.approval_future = second
 
         assert registry.get(handle.request_id).approval_future is second
+
+    asyncio.run(run())
+
+
+# -- ADR-006 stage 6.2: release-on-cancel / finalize / orphan tracking --------
+
+
+def test_cancel_pops_the_handle_immediately_and_clears_is_busy():
+    """ADR-006 stage 6.2 review fix: cancel() now releases the slot the
+    moment it fires (release-on-cancel), instead of leaving release() to
+    the worker's own finally - while a handle with NO mechanism must stay
+    claimed (cancel returns False and pops nothing)."""
+    registry = RunRegistry()
+    cancel_event = threading.Event()
+    handle = registry.claim("chat", cancel_event=cancel_event)
+    assert registry.cancel(handle.request_id) is True
+    assert cancel_event.is_set()
+    assert registry.get(handle.request_id) is None, "cancel must pop the handle immediately"
+    assert registry.is_busy("chat") is False
+
+    bare = registry.claim("chart")  # no mechanism - cannot be cancelled
+    assert registry.cancel(bare.request_id) is False
+    assert registry.get(bare.request_id) is bare, "an unfired handle must not be popped"
+    assert registry.is_busy("chart") is True
+
+
+def test_cancel_auto_denies_an_unresolved_approval_future():
+    """ADR-006 stage 6.2 review fix: a popped handle is unreachable to
+    cancel_all_pending_approvals (it walks _handles), so _pop itself must
+    auto-deny (False) an unresolved approval future or the run's parked
+    `await approval_future` waits forever."""
+    async def run():
+        registry = RunRegistry()
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        handle = registry.claim(
+            "pycoder", cancel_event=threading.Event(), approval_future=future
+        )
+        assert registry.cancel(handle.request_id) is True
+        assert future.done() and future.result() is False, "cancel must auto-deny, never approve"
+
+    asyncio.run(run())
+
+
+def test_cancel_never_clobbers_an_already_resolved_approval_future():
+    """ADR-006 stage 6.2 review fix: an approval resolved a moment before
+    the cancel lands must survive untouched - set_result on a done future
+    would raise InvalidStateError."""
+    async def run():
+        registry = RunRegistry()
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        future.set_result(True)  # a human approved it just before the cancel
+        handle = registry.claim(
+            "pycoder", cancel_event=threading.Event(), approval_future=future
+        )
+        assert registry.cancel(handle.request_id) is True  # must not raise InvalidStateError
+        assert future.result() is True, "an already-resolved future must never be clobbered"
+
+    asyncio.run(run())
+
+
+def test_finalize_runs_exactly_once_on_cancel_and_the_stale_release_returns_false():
+    """ADR-006 stage 6.2 review fix: on cancel, the handle's finalize (the
+    surface's end transition) is scheduled exactly once by cancel() itself;
+    the worker's late release() then returns False, so the gated tail
+    pattern (`if registry.release(...): on_end()`) skips - never a second
+    end transition."""
+    async def run():
+        registry = RunRegistry()
+        counter = []
+
+        async def finalize():
+            counter.append(1)
+
+        handle = registry.claim(
+            "chat", cancel_event=threading.Event(), finalize=finalize
+        )
+        assert registry.cancel(handle.request_id) is True
+
+        # Drain the finalize coroutine cancel() scheduled onto this loop.
+        deadline = asyncio.get_running_loop().time() + 2
+        while not counter and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+        assert counter == [1], "finalize must run exactly once on cancel"
+
+        # The worker's own finally now runs release() - it must report False
+        # (cancel already popped), which is exactly what gates the tail skip.
+        assert registry.release(handle.request_id) is False
+
+        # And nothing schedules finalize a second time.
+        await asyncio.sleep(0.05)
+        assert counter == [1]
+
+    asyncio.run(run())
+
+
+def test_finalize_is_not_run_on_a_normal_release():
+    """ADR-006 stage 6.2 review fix: on a NORMAL completion the surface's
+    own finally owns the end transition (gated on release() -> True);
+    the registry must never fire finalize itself then."""
+    async def run():
+        registry = RunRegistry()
+        counter = []
+
+        async def finalize():
+            counter.append(1)
+
+        handle = registry.claim(
+            "chat", cancel_event=threading.Event(), finalize=finalize
+        )
+        assert registry.release(handle.request_id) is True
+        await asyncio.sleep(0.05)  # give any (wrongly) scheduled finalize a chance to run
+        assert counter == [], "finalize must never fire on a normal release"
+
+    asyncio.run(run())
+
+
+def test_cancel_from_a_worker_thread_sets_the_event_inline_and_marshals_the_pop_to_the_loop():
+    """ADR-006 stage 6.2 review fix (thread affinity - pins _finish_cancel):
+    cancelChatRequest's sync handler runs via asyncio.to_thread, so cancel()
+    can arrive on a worker thread. The cancel EVENT must be set inline on
+    that thread (zero added latency for the worker to observe it); the pop +
+    finalize bookkeeping is marshalled onto the handle's loop and lands
+    shortly after, exactly once."""
+    async def run():
+        registry = RunRegistry()
+        cancel_event = threading.Event()
+        counter = []
+
+        async def finalize():
+            counter.append(1)
+
+        handle = registry.claim("chat", cancel_event=cancel_event, finalize=finalize)
+
+        observed = {}
+
+        def worker():
+            observed["returned"] = registry.cancel(handle.request_id)
+            # Checked ON the worker thread, before the loop had any chance
+            # to run the marshalled bookkeeping.
+            observed["event_set_inline"] = cancel_event.is_set()
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        await asyncio.to_thread(thread.join, 5)
+        assert observed["returned"] is True
+        assert observed["event_set_inline"] is True
+
+        # The pop lands on the loop shortly after (call_soon_threadsafe).
+        deadline = asyncio.get_running_loop().time() + 2
+        while registry.get(handle.request_id) is not None and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+        assert registry.get(handle.request_id) is None, "the marshalled pop never landed on the loop"
+        assert registry.is_busy("chat") is False
+
+        deadline = asyncio.get_running_loop().time() + 2
+        while not counter and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+        await asyncio.sleep(0.05)  # settle: prove no second finalize follows
+        assert counter == [1], "finalize must run exactly once for a worker-thread cancel"
+
+    asyncio.run(run())
+
+
+def test_has_any_live_work_counts_a_popped_but_unfinished_orphan_task():
+    """ADR-006 stage 6.2 review fix: release-on-cancel empties _handles
+    instantly, but the cancelled worker is still real in-flight work -
+    has_any_live_work() must stay True until the orphaned task actually
+    completes (session eviction consults exactly this)."""
+    async def run():
+        registry = RunRegistry()
+        gate = asyncio.Event()
+
+        async def held_worker():
+            await gate.wait()
+
+        handle = registry.claim("chat", cancel_event=threading.Event())
+        registry.attach_task(handle, asyncio.create_task(held_worker()))
+        await asyncio.sleep(0)  # let the task start
+
+        assert registry.cancel(handle.request_id) is True
+        assert registry.is_busy("chat") is False, "the slot itself frees immediately"
+        assert registry.has_any_live_work() is True, (
+            "a popped-but-unfinished task is still live work"
+        )
+
+        gate.set()
+        deadline = asyncio.get_running_loop().time() + 2
+        while registry.has_any_live_work() and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+        assert registry.has_any_live_work() is False
 
     asyncio.run(run())


### PR DESCRIPTION
## Problem

Two of the audit's worst findings lived here. C2: four intent surfaces (chart, note, branch comparison, branch synthesis) were awaited **inline by the WebSocket receive loop** — one generation blocked the entire socket for up to the 420-second watchdog, including the cancel frame itself. C3: cancelling any run only *signaled* the worker; the slot (and the UI's "generating" state) stayed occupied until the worker thread actually returned — up to the full remaining network call. Six run kinds (chart, note, comparison, synthesis, image, gitlink-apply) had no cancel mechanism at all, silently skipped by `cancel_all()` on disconnect.

## Change

- **`run_single_shot` is fire-and-forget**: claim synchronously, schedule the generation, return. The old inline-await justification was a return-value contract (the new node id), but every frontend call site fires these intents and discards the result — the node arrives via the scene publish. The four Gitlink read-only helpers remain inline by explicit decision (their results ARE consumed; documented in the ADR).
- **Release-on-cancel**: `RunRegistry.cancel()/cancel_all()` pop the handle immediately; a new per-handle `finalize` closure runs the user-visible end transition right away; the worker's late `finally` — gated on `release()` returning `True` — skips it, so a stale run's teardown can never clobber a newer run that claimed the freed slot. Cancel bookkeeping is loop-affine (`_finish_cancel` marshals off worker threads; the cancel *event* still fires inline with zero latency). Orphaned tasks stay referenced and count as live work, so the session-eviction veto is unchanged. Popped handles auto-deny unresolved approval futures — without this, the disconnect path's `cancel_all` → `cancel_all_pending_approvals` ordering would leave a parked approval waiting forever.
- **Every run kind is now cancellable**: the four single-shot kinds get a cancel_event from `run_single_shot`; image and gitlink-apply get their own (post-return suppression; apply checks at entry only — once file writes begin it deliberately runs to completion). Enforced by an AST gate over every `claim()` site.
- **Adversarial-review fixes (second commit, all findings independently verified with live reproductions)**: artifact + web-research stale-teardown guards (a cancelled run's late unwind wiped a replacement run's in-flight marker); web-research terminal callbacks gated on the handle still being registered; chart's deleted-parent liveness guard (newly reachable from a single connection); the disconnect-discards-results behavior change documented as a decision.

## Test plan

- [x] Exit criteria pinned in `backend/tests/test_nonblocking_dispatch.py`: a ping round-trips on the same socket while a chart generation is held open (the pre-6.2 deadlock sequence); cancel empties the chat slot within the 2 s budget while the worker is still running; every `claim()` site passes a cancel mechanism (AST gate)
- [x] Review-gap tests: new-run-clobber protection, finalize-exactly-once (same-loop and worker-thread cancel paths), approval auto-deny without clobbering resolved futures, runtime `cancel_all` of a chart generation with result suppression, artifact stale-teardown regression
- [x] Stale `test_run_lifecycle.py` assertions ("cancel_all must not release") updated to the new semantics
- [x] ~29 existing tests updated for fire-and-forget with assertions strengthened, never weakened
- [x] Full backend suite: 1751 passed, 14 skipped