### PR TITLE
Bump h2 4.3.0 -> 4.4.1 for CVE-2026-71554

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -515,10 +515,11 @@ h11==0.16.0 \
     # via
     #   httpcore
     #   uvicorn
-h2==4.3.0 \
-    --hash=sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1 \
-    --hash=sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd
+h2==4.4.1 \
+    --hash=sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6 \
+    --hash=sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516
     # via httpx
+    # bumped 4.3.0 -> 4.4.1 for CVE-2026-71554 (pip-audit gate, 2026-08-07)
 hpack==4.2.0 \
     --hash=sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0 \
     --hash=sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986


### PR DESCRIPTION
## Problem

Main's CI went red at the pip-audit step: a new advisory (CVE-2026-71554) was published against `h2` 4.3.0, a transitive HTTP/2 dependency pulled in via httpx. The security gate is doing exactly what ADR-015 built it to do — no code change caused this, and the test suite on the same run was fully green (1751 passed).

## Change

Bump the `h2` pin to 4.4.1 (the fixed release) with sha256 hashes taken from PyPI's own digests for both the wheel and sdist.

## Test plan

- [x] `pip-audit -r requirements.txt` locally: "No known vulnerabilities found"
- [x] Full backend suite against the installed 4.4.1: 1751 passed, 14 skipped