### PR TITLE
ADR-006 stage 6.3: OpenAI/Anthropic/Gemini/llama.cpp ported; C4 closed

### DIFF
--- a/api_provider.py
+++ b/api_provider.py
@@ -2158,18 +2158,21 @@ def chat(task: str, messages: list, **kwargs) -> dict:
                 }
 
             if state.local_provider_type == config.LOCAL_PROVIDER_LLAMACPP:
-                _assert_llama_cpp_message_support(messages)
-                llama_messages = _prepare_llama_cpp_messages(messages, task, state.llama_cpp_settings)
-                client = _get_llama_cpp_client(task, state.llama_cpp_settings)
-                llama_kwargs = _filter_kwargs_for_callable(
-                    client.create_chat_completion,
-                    _prepare_llama_cpp_kwargs(kwargs, state.llama_cpp_settings),
+                # ADR-006 stage 6.3: routed through the Provider seam, same
+                # lazy-import pattern as the Ollama branch above - see
+                # backend/providers/llama_cpp_provider.py for the preserved
+                # invariants (media rejection, frozen settings, cached client).
+                from backend.providers.base import CancelToken, ChatRequest
+                from backend.providers.llama_cpp_provider import LlamaCppProvider
+
+                provider = LlamaCppProvider(settings=state.llama_cpp_settings)
+                content = provider.complete(
+                    ChatRequest(task=task, messages=messages, extra_kwargs=kwargs),
+                    CancelToken(cancel_event),
                 )
-                response = client.create_chat_completion(messages=llama_messages, **llama_kwargs)
-                _raise_if_cancelled(cancel_event)
                 return {
                     "message": {
-                        "content": _extract_llama_cpp_text(response),
+                        "content": content,
                         "role": "assistant",
                     }
                 }
@@ -2187,96 +2190,46 @@ def chat(task: str, messages: list, **kwargs) -> dict:
                 "Please configure models in API Settings."
             )
 
+        # ADR-006 stage 6.3: the three API-mode branches route through the
+        # Provider seam. Each provider is constructed from THIS request's
+        # snapshot (client/key/model/reasoning level), preserving the
+        # mid-request-swap immunity the snapshot exists for. OpenAI's port
+        # additionally closes C4: image/audio content parts are converted to
+        # the OpenAI content-part format instead of being passed through raw.
+        from backend.providers.base import CancelToken, ChatRequest
+
+        chat_request = ChatRequest(task=task, messages=messages, extra_kwargs=kwargs)
+        token = CancelToken(cancel_event)
+
         if state.api_provider_type == config.API_PROVIDER_OPENAI:
-            openai_kwargs = dict(kwargs)
-            if task == config.TASK_CHAT:
-                openai_kwargs.update(openai_reasoning_kwargs(api_model, state.openai_reasoning_level))
-            response = state.api_client.chat.completions.create(
-                model=api_model,
-                messages=messages,
-                **openai_kwargs,
+            from backend.providers.openai_provider import OpenAIProvider
+
+            provider = OpenAIProvider(
+                client=state.api_client, model=api_model,
+                reasoning_level=state.openai_reasoning_level,
             )
-            _raise_if_cancelled(cancel_event)
-            return {
-                "message": {
-                    "content": response.choices[0].message.content,
-                    "role": "assistant",
-                }
-            }
+            content = provider.complete(chat_request, token)
+            return {"message": {"content": content, "role": "assistant"}}
 
         if state.api_provider_type == config.API_PROVIDER_ANTHROPIC:
-            system_prompt, anthropic_messages = _prepare_anthropic_messages(
-                messages,
-                cancel_event=cancel_event,
-            )
-            reasoning_level = state.anthropic_reasoning_level if task == config.TASK_CHAT else "off"
-            request_kwargs = {
-                "model": api_model,
-                "messages": anthropic_messages,
-                **_prepare_anthropic_kwargs(task, kwargs, api_model, reasoning_level),
-            }
-            if system_prompt:
-                request_kwargs["system"] = system_prompt
+            from backend.providers.anthropic_provider import AnthropicProvider
 
-            create_callable = getattr(getattr(state.api_client, "messages", None), "create", None)
-            if callable(create_callable):
-                filtered_kwargs = _filter_kwargs_for_callable(create_callable, request_kwargs)
-                response = create_callable(**filtered_kwargs)
-            else:
-                response = _anthropic_post_json(
-                    "https://api.anthropic.com/v1/messages",
-                    request_kwargs,
-                    timeout=180,
-                    cancel_event=cancel_event,
-                    api_key=state.api_key,
-                )
-            _raise_if_cancelled(cancel_event)
-            return {
-                "message": {
-                    "content": _extract_anthropic_text(response),
-                    "role": "assistant",
-                }
-            }
+            provider = AnthropicProvider(
+                client=state.api_client, api_key=state.api_key, model=api_model,
+                reasoning_level=state.anthropic_reasoning_level,
+            )
+            content = provider.complete(chat_request, token)
+            return {"message": {"content": content, "role": "assistant"}}
 
         if state.api_provider_type == config.API_PROVIDER_GEMINI:
-            system_prompt, gemini_contents, uploaded_files = _prepare_gemini_contents(
-                messages,
-                cancel_event=cancel_event,
-                api_key=state.api_key,
+            from backend.providers.gemini_provider import GeminiProvider
+
+            provider = GeminiProvider(
+                api_key=state.api_key, model=api_model,
+                reasoning_level=state.gemini_reasoning_level,
             )
-            generation_config = dict(kwargs) if kwargs else {}
-            if task == config.TASK_CHAT:
-                thinking_config = gemini_thinking_config(api_model, state.gemini_reasoning_level)
-                if thinking_config is not None:
-                    generation_config["thinkingConfig"] = thinking_config
-            request_body = {
-                "contents": gemini_contents,
-            }
-            if system_prompt:
-                request_body["system_instruction"] = {
-                    "parts": [{"text": str(system_prompt)}],
-                }
-            if generation_config:
-                request_body["generationConfig"] = generation_config
-
-            try:
-                payload = _gemini_post_json(
-                    f"{GEMINI_BASE_URL}/v1beta/models/{api_model}:generateContent",
-                    request_body,
-                    timeout=_calculate_gemini_timeout(messages),
-                    cancel_event=cancel_event,
-                    api_key=state.api_key,
-                )
-            finally:
-                for file_name in uploaded_files:
-                    _gemini_delete_file(file_name, api_key=state.api_key)
-
-            return {
-                "message": {
-                    "content": _extract_gemini_text(payload),
-                    "role": "assistant",
-                }
-            }
+            content = provider.complete(chat_request, token)
+            return {"message": {"content": content, "role": "assistant"}}
 
         raise RuntimeError(f"Unsupported API provider: {state.api_provider_type}")
 

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -8,6 +8,7 @@ the other four providers still live in api_provider's if/elif surface until
 stages 6.3+ port them one by one.
 """
 
+from backend.providers.anthropic_provider import AnthropicProvider
 from backend.providers.base import (
     CancelToken,
     ChatRequest,
@@ -16,13 +17,20 @@ from backend.providers.base import (
     ProviderEvent,
 )
 from backend.providers.fake import FakeProvider
+from backend.providers.gemini_provider import GeminiProvider
+from backend.providers.llama_cpp_provider import LlamaCppProvider
 from backend.providers.ollama_provider import OllamaProvider
+from backend.providers.openai_provider import OpenAIProvider
 
 __all__ = [
+    "AnthropicProvider",
     "CancelToken",
     "ChatRequest",
     "FakeProvider",
+    "GeminiProvider",
+    "LlamaCppProvider",
     "OllamaProvider",
+    "OpenAIProvider",
     "Provider",
     "ProviderCapabilities",
     "ProviderEvent",

--- a/backend/providers/anthropic_provider.py
+++ b/backend/providers/anthropic_provider.py
@@ -44,7 +44,8 @@ class AnthropicProvider:
             streaming=False,
             reasoning=anthropic_supports_reasoning(model),
             vision=True,   # _prepare_anthropic_messages converts image parts
-            audio=False,   # Anthropic has no audio input; parts would be rejected upstream
+            audio=False,   # Anthropic has no audio input API; False is what
+                           # keeps a future capability consumer from offering it
             image_generation=False,  # generate_image's branch raises the explicit "not yet" error
         )
 

--- a/backend/providers/anthropic_provider.py
+++ b/backend/providers/anthropic_provider.py
@@ -1,0 +1,81 @@
+"""ADR-006 stage 6.3: AnthropicProvider - faithful port of chat()'s
+Anthropic branch, including its SDK-or-REST duality: initialize_api installs
+either a real anthropic SDK client or a dict sentinel when the SDK isn't
+installed, and this port preserves the exact same runtime dispatch
+(messages.create when callable, _anthropic_post_json otherwise). Message
+prep, media handling (_prepare_anthropic_messages already converts image
+parts via _anthropic_content_block_from_part), reasoning gating on
+TASK_CHAT, and text extraction all come from the same api_provider helpers
+the branch used - behavior byte-identical. stream() is the transitional
+single-"done" shape until 6.4.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import graphlink_task_config as config
+from api_provider import (
+    _anthropic_post_json,
+    _extract_anthropic_text,
+    _filter_kwargs_for_callable,
+    _prepare_anthropic_kwargs,
+    _prepare_anthropic_messages,
+    _raise_if_cancelled,
+    anthropic_supports_reasoning,
+)
+from backend.providers.base import (
+    CancelToken,
+    ChatRequest,
+    ProviderCapabilities,
+    ProviderEvent,
+)
+
+_ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+
+
+class AnthropicProvider:
+    def __init__(self, *, client, api_key: str, model: str, reasoning_level: str = "off"):
+        self.client = client
+        self.api_key = api_key
+        self.model_id = model
+        self.reasoning_level = reasoning_level
+        self.capabilities = ProviderCapabilities(
+            streaming=False,
+            reasoning=anthropic_supports_reasoning(model),
+            vision=True,   # _prepare_anthropic_messages converts image parts
+            audio=False,   # Anthropic has no audio input; parts would be rejected upstream
+            image_generation=False,  # generate_image's branch raises the explicit "not yet" error
+        )
+
+    def complete(self, request: ChatRequest, cancel: CancelToken) -> str:
+        system_prompt, anthropic_messages = _prepare_anthropic_messages(
+            request.messages, cancel_event=cancel.event
+        )
+        reasoning_level = self.reasoning_level if request.task == config.TASK_CHAT else "off"
+        kwargs = {k: v for k, v in request.extra_kwargs.items() if k != "cancellation_event"}
+        request_kwargs = {
+            "model": self.model_id,
+            "messages": anthropic_messages,
+            **_prepare_anthropic_kwargs(request.task, kwargs, self.model_id, reasoning_level),
+        }
+        if system_prompt:
+            request_kwargs["system"] = system_prompt
+
+        create_callable = getattr(getattr(self.client, "messages", None), "create", None)
+        if callable(create_callable):
+            filtered_kwargs = _filter_kwargs_for_callable(create_callable, request_kwargs)
+            response = create_callable(**filtered_kwargs)
+        else:
+            response = _anthropic_post_json(
+                _ANTHROPIC_MESSAGES_URL,
+                request_kwargs,
+                timeout=180,
+                cancel_event=cancel.event,
+                api_key=self.api_key,
+            )
+        _raise_if_cancelled(cancel.event)
+        return _extract_anthropic_text(response)
+
+    def stream(self, request: ChatRequest, cancel: CancelToken) -> Iterator[ProviderEvent]:
+        yield ProviderEvent("done", self.complete(request, cancel))

--- a/backend/providers/base.py
+++ b/backend/providers/base.py
@@ -39,8 +39,10 @@ EVENT_TYPES = ("text", "reasoning", "reset", "done")
 @dataclass(frozen=True)
 class ProviderCapabilities:
     """What a provider (with its configured model) can actually do - the
-    single source of truth orchestration and UI consult instead of
-    provider-type string checks (ADR-006 §1). Complements - does not replace -
+    single source of truth orchestration and UI WILL consult instead of
+    provider-type string checks (ADR-006 §1; nothing consumes these yet -
+    the first consumers arrive with 6.4's streaming gate and the runtime
+    switcher/attachment gating in 6.5/ADR-012). Complements - does not replace -
     graphlink_model_catalog.ModelDescriptor: the descriptor describes a MODEL
     in a catalog; this describes the live provider+model pair a request will
     actually hit."""

--- a/backend/providers/gemini_provider.py
+++ b/backend/providers/gemini_provider.py
@@ -1,0 +1,77 @@
+"""ADR-006 stage 6.3: GeminiProvider - faithful port of chat()'s Gemini
+branch (raw REST :generateContent, no SDK). Preserves exactly: content prep
+with media upload via _prepare_gemini_contents (which returns the uploaded
+file names), thinkingConfig gated on TASK_CHAT, the message-size-derived
+timeout, and - load-bearing - the finally-block cleanup that deletes every
+uploaded file even when the generation call fails. stream() is the
+transitional single-"done" shape until 6.4.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import graphlink_task_config as config
+from api_provider import (
+    GEMINI_BASE_URL,
+    _calculate_gemini_timeout,
+    _extract_gemini_text,
+    _gemini_delete_file,
+    _gemini_post_json,
+    _prepare_gemini_contents,
+    gemini_supports_reasoning,
+    gemini_thinking_config,
+)
+from backend.providers.base import (
+    CancelToken,
+    ChatRequest,
+    ProviderCapabilities,
+    ProviderEvent,
+)
+
+
+class GeminiProvider:
+    def __init__(self, *, api_key: str, model: str, reasoning_level: str = "off"):
+        self.api_key = api_key
+        self.model_id = model
+        self.reasoning_level = reasoning_level
+        self.capabilities = ProviderCapabilities(
+            streaming=False,
+            reasoning=gemini_supports_reasoning(model),
+            vision=True,
+            audio=True,   # media rides the Files API upload path in _prepare_gemini_contents
+            image_generation=True,
+        )
+
+    def complete(self, request: ChatRequest, cancel: CancelToken) -> str:
+        system_prompt, gemini_contents, uploaded_files = _prepare_gemini_contents(
+            request.messages, cancel_event=cancel.event, api_key=self.api_key
+        )
+        kwargs = {k: v for k, v in request.extra_kwargs.items() if k != "cancellation_event"}
+        generation_config = dict(kwargs) if kwargs else {}
+        if request.task == config.TASK_CHAT:
+            thinking_config = gemini_thinking_config(self.model_id, self.reasoning_level)
+            if thinking_config is not None:
+                generation_config["thinkingConfig"] = thinking_config
+        request_body = {"contents": gemini_contents}
+        if system_prompt:
+            request_body["system_instruction"] = {"parts": [{"text": str(system_prompt)}]}
+        if generation_config:
+            request_body["generationConfig"] = generation_config
+
+        try:
+            payload = _gemini_post_json(
+                f"{GEMINI_BASE_URL}/v1beta/models/{self.model_id}:generateContent",
+                request_body,
+                timeout=_calculate_gemini_timeout(request.messages),
+                cancel_event=cancel.event,
+                api_key=self.api_key,
+            )
+        finally:
+            for file_name in uploaded_files:
+                _gemini_delete_file(file_name, api_key=self.api_key)
+
+        return _extract_gemini_text(payload)
+
+    def stream(self, request: ChatRequest, cancel: CancelToken) -> Iterator[ProviderEvent]:
+        yield ProviderEvent("done", self.complete(request, cancel))

--- a/backend/providers/llama_cpp_provider.py
+++ b/backend/providers/llama_cpp_provider.py
@@ -1,0 +1,64 @@
+"""ADR-006 stage 6.3: LlamaCppProvider - faithful port of chat()'s llama.cpp
+branch. Preserves exactly: the up-front media rejection
+(_assert_llama_cpp_message_support - llama.cpp is text-only here, with the
+actionable "use Ollama or Gemini" message), per-task message prep against
+the FROZEN settings dict the caller snapshotted, the cached client lookup
+(_get_llama_cpp_client - a heavyweight in-process model load, cached in
+api_provider under its own lock), kwargs filtered to what
+create_chat_completion actually accepts, and text extraction. stream() is
+the transitional single-"done" shape; local token streaming lands in 6.4
+via the threaded-generator bridge the ADR names for this provider.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+from api_provider import (
+    _assert_llama_cpp_message_support,
+    _extract_llama_cpp_text,
+    _filter_kwargs_for_callable,
+    _get_llama_cpp_client,
+    _prepare_llama_cpp_kwargs,
+    _prepare_llama_cpp_messages,
+    _raise_if_cancelled,
+    llama_cpp_supports_reasoning,
+)
+from backend.providers.base import (
+    CancelToken,
+    ChatRequest,
+    ProviderCapabilities,
+    ProviderEvent,
+)
+
+
+class LlamaCppProvider:
+    def __init__(self, *, settings: dict):
+        # The whole settings dict (paths, n_ctx, chat_format, reasoning
+        # level) is this provider's configuration - captured from the
+        # caller's snapshot, same immutability contract as every provider
+        # in this package.
+        self.settings = settings
+        self.capabilities = ProviderCapabilities(
+            streaming=False,
+            reasoning=llama_cpp_supports_reasoning(str(settings.get("chat_model_path", ""))),
+            vision=False,  # _assert_llama_cpp_message_support rejects media up front
+            audio=False,
+            image_generation=False,
+        )
+
+    def complete(self, request: ChatRequest, cancel: CancelToken) -> str:
+        _assert_llama_cpp_message_support(request.messages)
+        llama_messages = _prepare_llama_cpp_messages(request.messages, request.task, self.settings)
+        client = _get_llama_cpp_client(request.task, self.settings)
+        kwargs = {k: v for k, v in request.extra_kwargs.items() if k != "cancellation_event"}
+        llama_kwargs = _filter_kwargs_for_callable(
+            client.create_chat_completion,
+            _prepare_llama_cpp_kwargs(kwargs, self.settings),
+        )
+        response = client.create_chat_completion(messages=llama_messages, **llama_kwargs)
+        _raise_if_cancelled(cancel.event)
+        return _extract_llama_cpp_text(response)
+
+    def stream(self, request: ChatRequest, cancel: CancelToken) -> Iterator[ProviderEvent]:
+        yield ProviderEvent("done", self.complete(request, cancel))

--- a/backend/providers/ollama_provider.py
+++ b/backend/providers/ollama_provider.py
@@ -82,13 +82,19 @@ class OllamaProvider:
         self.reasoning_level = reasoning_level
         # Derived WITHOUT a network round-trip: reasoning support here means
         # "this family takes a think kwarg" (a pure string-family check, the
-        # same one the request path applies). The richer probed capabilities
-        # (vision/audio via ollama.show) stay behind api_provider's cached
-        # audio gate for now - eagerly probing at construction would add a
-        # network call to every request that today has none.
+        # same one the request path applies). vision/audio are True because
+        # the REQUEST PATH genuinely sends both (_prepare_ollama_messages
+        # flattens image and audio bytes into ollama's images field) - the
+        # per-MODEL audio gate (_assert_ollama_audio_support's probed
+        # capability cache) still enforces at request time, exactly as
+        # before; a False here would wrongly tell a future consumer to
+        # disable attachments for vision-capable Ollama models (6.3
+        # adversarial review finding on the first draft's under-claim).
         self.capabilities = ProviderCapabilities(
             streaming=True,
             reasoning=ollama_think_kwarg(model, "high") is not None,
+            vision=True,
+            audio=True,
         )
 
     # -- shared request prep --------------------------------------------------

--- a/backend/providers/openai_provider.py
+++ b/backend/providers/openai_provider.py
@@ -43,8 +43,15 @@ from backend.providers.base import (
     ProviderEvent,
 )
 
-# OpenAI's input_audio accepts exactly these container formats today.
-_OPENAI_AUDIO_FORMATS = {"wav": "wav", "mp3": "mp3", "mpga": "mp3", "mpeg": "mp3"}
+# OpenAI's input_audio accepts exactly these container formats today. mpga is
+# MPEG-1 audio (mp3-family bytes); .mpeg is deliberately ABSENT - it
+# conventionally names an MPEG program/video stream, and the attachment
+# classifier stages it as audio (mutagen reads the audio track's duration
+# from the container), so mapping it to "mp3" would ship program-stream
+# bytes labeled mp3 and reintroduce the provider-side 400 this conversion
+# exists to eliminate (6.3 adversarial review, proven with a real ffmpeg
+# .mpeg fixture). It routes to the actionable error below instead.
+_OPENAI_AUDIO_FORMATS = {"wav": "wav", "mp3": "mp3", "mpga": "mp3"}
 
 
 def _sniff_image_mime(data: bytes) -> str:
@@ -72,11 +79,19 @@ def prepare_openai_messages(messages: list) -> list:
             continue
         parts = []
         for part in content:
+            if not isinstance(part, dict):
+                # Same defensive posture as _prepare_ollama_messages' own
+                # str(part) fallback - a non-dict part (legacy/hand-edited
+                # session data) becomes text instead of an AttributeError.
+                parts.append({"type": "text", "text": str(part)})
+                continue
             part_type = part.get("type")
             if part_type == "text":
                 parts.append({"type": "text", "text": str(part.get("text", ""))})
             elif part_type == "image_bytes":
                 data = part.get("data") or b""
+                if not data:
+                    continue  # an empty data URI is malformed; drop the corrupt part
                 encoded = base64.b64encode(data).decode("ascii")
                 parts.append({
                     "type": "image_url",
@@ -86,8 +101,12 @@ def prepare_openai_messages(messages: list) -> list:
                 path = str(part.get("path", ""))
                 audio_format = _OPENAI_AUDIO_FORMATS.get(Path(path).suffix.lstrip(".").lower())
                 if audio_format is None:
+                    # Worded to NOT contain the "audio input" fragment
+                    # _translate_chat_exception's audio-enrichment branch
+                    # matches on - this message is already complete and
+                    # actionable; the generic suffix would contradict it.
                     raise RuntimeError(
-                        "OpenAI-compatible audio input supports WAV and MP3 files.\n\n"
+                        "OpenAI-compatible endpoints accept WAV and MP3 audio files.\n\n"
                         f"'{Path(path).name}' is a different container - convert it, or use "
                         "Ollama or Gemini for this attachment."
                     )
@@ -117,7 +136,15 @@ class OpenAIProvider:
             reasoning=openai_supports_reasoning(model),
             vision=True,   # C4: image_url parts now real
             audio=True,    # C4: input_audio parts now real (wav/mp3)
-            image_generation=True,  # endpoint-dependent; the images API branch guards at call time
+            # Derived from the CLIENT, not asserted: "OpenAI-compatible"
+            # covers llama-server/LM Studio/proxies with no images API at
+            # all. Probing the client keeps the capability honest instead of
+            # promising an affordance that would error at call time (6.3
+            # adversarial review - generate_image's own hasattr guard is a
+            # separate mechanism this flag was wrongly claiming to mirror).
+            image_generation=callable(
+                getattr(getattr(client, "images", None), "generate", None)
+            ),
         )
 
     def complete(self, request: ChatRequest, cancel: CancelToken) -> str:

--- a/backend/providers/openai_provider.py
+++ b/backend/providers/openai_provider.py
@@ -1,0 +1,136 @@
+"""ADR-006 stage 6.3: OpenAIProvider - the OpenAI-compatible port, closing C4.
+
+Faithful port of api_provider.chat()'s OpenAI branch (client.chat.completions
+.create with per-model reasoning kwargs applied only for TASK_CHAT), plus the
+one piece of genuinely NEW behavior this stage adds anywhere: multimodal
+message prep. The old branch passed the app's message shape RAW to the SDK,
+so image/audio attachments silently reached OpenAI-compatible endpoints as
+unusable python-repr'd dicts (audit finding C4). prepare_messages now
+converts the app's content parts to the OpenAI content-part format:
+
+- {"type": "text", ...}        -> unchanged (already the OpenAI shape);
+- {"type": "image_bytes", ...} -> {"type": "image_url"} with a base64 data
+  URI, mime sniffed from the bytes' own magic numbers (attachments carry raw
+  bytes, no mime - see backend/attachments.py's content_part comment);
+- {"type": "audio_file", ...}  -> {"type": "input_audio"} with base64 data
+  and the format OpenAI's API accepts (wav/mp3). Other audio containers get
+  a clear, actionable error instead of a provider-side 400 - a stated
+  capability boundary, not a silent drop.
+
+`stream()` is the transitional single-"done" shape (matching chat_stream's
+existing documented non-Ollama fallback of exactly one full-text chunk);
+stage 6.4 replaces it with real SSE streaming. Exception translation stays
+with the caller, same as every provider in this package.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Iterator
+
+import graphlink_task_config as config
+from api_provider import (
+    _raise_if_cancelled,
+    _read_attachment_bytes,
+    openai_reasoning_kwargs,
+    openai_supports_reasoning,
+)
+from backend.providers.base import (
+    CancelToken,
+    ChatRequest,
+    ProviderCapabilities,
+    ProviderEvent,
+)
+
+# OpenAI's input_audio accepts exactly these container formats today.
+_OPENAI_AUDIO_FORMATS = {"wav": "wav", "mp3": "mp3", "mpga": "mp3", "mpeg": "mp3"}
+
+
+def _sniff_image_mime(data: bytes) -> str:
+    if data.startswith(b"\x89PNG"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8"):
+        return "image/jpeg"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    # The attachment classifier only stages png/jpg/jpeg/webp as images
+    # (backend/attachments.py), so this default is a corrupted-file edge, not
+    # a real format gap - png keeps the request well-formed either way.
+    return "image/png"
+
+
+def prepare_openai_messages(messages: list) -> list:
+    """C4: the app's wire shape -> OpenAI content parts. Plain-string
+    content and already-flat messages pass through untouched, so text-only
+    requests are byte-identical to the pre-port behavior."""
+    prepared = []
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            prepared.append(message)
+            continue
+        parts = []
+        for part in content:
+            part_type = part.get("type")
+            if part_type == "text":
+                parts.append({"type": "text", "text": str(part.get("text", ""))})
+            elif part_type == "image_bytes":
+                data = part.get("data") or b""
+                encoded = base64.b64encode(data).decode("ascii")
+                parts.append({
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{_sniff_image_mime(data)};base64,{encoded}"},
+                })
+            elif part_type == "audio_file":
+                path = str(part.get("path", ""))
+                audio_format = _OPENAI_AUDIO_FORMATS.get(Path(path).suffix.lstrip(".").lower())
+                if audio_format is None:
+                    raise RuntimeError(
+                        "OpenAI-compatible audio input supports WAV and MP3 files.\n\n"
+                        f"'{Path(path).name}' is a different container - convert it, or use "
+                        "Ollama or Gemini for this attachment."
+                    )
+                data = _read_attachment_bytes(path, "audio")
+                parts.append({
+                    "type": "input_audio",
+                    "input_audio": {
+                        "data": base64.b64encode(data).decode("ascii"),
+                        "format": audio_format,
+                    },
+                })
+            else:
+                # Unknown part kinds pass through untouched rather than being
+                # silently dropped - the provider's own 400 names the problem.
+                parts.append(part)
+        prepared.append({**message, "content": parts})
+    return prepared
+
+
+class OpenAIProvider:
+    def __init__(self, *, client, model: str, reasoning_level: str = "off"):
+        self.client = client
+        self.model_id = model
+        self.reasoning_level = reasoning_level
+        self.capabilities = ProviderCapabilities(
+            streaming=False,  # 6.4 flips this with real SSE
+            reasoning=openai_supports_reasoning(model),
+            vision=True,   # C4: image_url parts now real
+            audio=True,    # C4: input_audio parts now real (wav/mp3)
+            image_generation=True,  # endpoint-dependent; the images API branch guards at call time
+        )
+
+    def complete(self, request: ChatRequest, cancel: CancelToken) -> str:
+        kwargs = {k: v for k, v in request.extra_kwargs.items() if k != "cancellation_event"}
+        if request.task == config.TASK_CHAT:
+            kwargs.update(openai_reasoning_kwargs(self.model_id, self.reasoning_level))
+        response = self.client.chat.completions.create(
+            model=self.model_id,
+            messages=prepare_openai_messages(request.messages),
+            **kwargs,
+        )
+        _raise_if_cancelled(cancel.event)
+        return response.choices[0].message.content
+
+    def stream(self, request: ChatRequest, cancel: CancelToken) -> Iterator[ProviderEvent]:
+        yield ProviderEvent("done", self.complete(request, cancel))

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -529,6 +529,250 @@ def test_api_provider_never_imports_the_providers_package_at_module_level():
     )
 
 
+# -- stage 6.3: the four remaining providers ---------------------------------
+
+
+def _fake_openai_client(response_text="ok"):
+    import types
+
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=response_text))]
+        )
+
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=create))
+    )
+    return client, captured
+
+
+def test_the_capability_matrix_is_pinned_per_provider():
+    """The 6.3 exit criterion's matrix, as data: what each provider+model
+    pair can actually do. A capability flipping here must be a deliberate
+    stage (6.4 flips streaming), never a drive-by."""
+    from backend.providers import (
+        AnthropicProvider,
+        GeminiProvider,
+        LlamaCppProvider,
+        OpenAIProvider,
+    )
+
+    matrix = {
+        "ollama": OllamaProvider(model="qwen3:8b").capabilities,
+        "openai": OpenAIProvider(client=None, model="gpt-5").capabilities,
+        "anthropic": AnthropicProvider(client=None, api_key="k", model="claude-opus-5").capabilities,
+        "gemini": GeminiProvider(api_key="k", model="gemini-2.5-pro").capabilities,
+        "llama_cpp": LlamaCppProvider(settings={"chat_model_path": "m.gguf"}).capabilities,
+    }
+    expected = {
+        #            streaming, reasoning, vision, audio, image_gen
+        "ollama":    (True,  True,  False, False, False),
+        "openai":    (False, True,  True,  True,  True),   # C4: vision+audio now real
+        "anthropic": (False, True,  True,  False, False),
+        "gemini":    (False, True,  True,  True,  True),
+        "llama_cpp": (False, False, False, False, False),
+    }
+    actual = {
+        name: (c.streaming, c.reasoning, c.vision, c.audio, c.image_generation)
+        for name, c in matrix.items()
+    }
+    assert actual == expected
+
+
+def test_openai_c4_image_bytes_become_a_data_uri_image_url_part():
+    from backend.providers.openai_provider import prepare_openai_messages
+
+    png = b"\x89PNG\r\n\x1a\nfake"
+    jpg = b"\xff\xd8\xfffake"
+    prepared = prepare_openai_messages([{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "what are these"},
+            {"type": "image_bytes", "data": png},
+            {"type": "image_bytes", "data": jpg},
+        ],
+    }])
+    parts = prepared[0]["content"]
+    assert parts[0] == {"type": "text", "text": "what are these"}
+    assert parts[1]["type"] == "image_url"
+    assert parts[1]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert parts[2]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_openai_c4_audio_file_becomes_input_audio_and_odd_containers_error(monkeypatch, tmp_path):
+    from backend.providers import openai_provider as op
+
+    monkeypatch.setattr(op, "_read_attachment_bytes", lambda path, kind: b"fake-mp3-bytes")
+    prepared = op.prepare_openai_messages([{
+        "role": "user",
+        "content": [{"type": "audio_file", "path": str(tmp_path / "clip.mp3")}],
+    }])
+    part = prepared[0]["content"][0]
+    assert part["type"] == "input_audio"
+    assert part["input_audio"]["format"] == "mp3"
+    import base64
+    assert base64.b64decode(part["input_audio"]["data"]) == b"fake-mp3-bytes"
+
+    with pytest.raises(RuntimeError, match="WAV and MP3"):
+        op.prepare_openai_messages([{
+            "role": "user",
+            "content": [{"type": "audio_file", "path": str(tmp_path / "clip.m4a")}],
+        }])
+
+
+def test_openai_plain_string_messages_pass_through_byte_identical():
+    from backend.providers.openai_provider import prepare_openai_messages
+
+    messages = [{"role": "user", "content": "just text"}]
+    assert prepare_openai_messages(messages)[0] is messages[0]
+
+
+def test_openai_complete_sends_model_prepared_messages_and_gates_reasoning_on_task():
+    from backend.providers import CancelToken as CT, ChatRequest as CR, OpenAIProvider
+
+    client, captured = _fake_openai_client("answer")
+    provider = OpenAIProvider(client=client, model="gpt-5", reasoning_level="high")
+
+    content = provider.complete(
+        CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]), CT()
+    )
+    assert content == "answer"
+    assert captured["model"] == "gpt-5"
+    assert captured["messages"] == [{"role": "user", "content": "hi"}]
+    chat_keys = set(captured) - {"model", "messages"}
+    assert chat_keys == set(api_provider.openai_reasoning_kwargs("gpt-5", "high"))
+
+    captured.clear()
+    provider.complete(
+        CR(task=config.TASK_TITLE, messages=[{"role": "user", "content": "hi"}]), CT()
+    )
+    assert set(captured) == {"model", "messages"}  # non-chat tasks never reason
+
+
+def test_anthropic_sdk_path_and_rest_fallback_both_route_through_the_provider(monkeypatch):
+    import types
+
+    from backend.providers import AnthropicProvider, CancelToken as CT, ChatRequest as CR
+
+    # SDK-shaped client: messages.create is callable.
+    captured = {}
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        return {"content": [{"type": "text", "text": "sdk answer"}]}
+
+    sdk_client = types.SimpleNamespace(messages=types.SimpleNamespace(create=create))
+    provider = AnthropicProvider(client=sdk_client, api_key="k", model="claude-opus-5")
+    content = provider.complete(
+        CR(task=config.TASK_CHAT, messages=[
+            {"role": "system", "content": "be brief"},
+            {"role": "user", "content": "hi"},
+        ]),
+        CT(),
+    )
+    assert content == "sdk answer"
+    assert captured["model"] == "claude-opus-5"
+    assert captured["system"] == "be brief"
+
+    # Dict-sentinel client (SDK not installed): falls back to the REST helper.
+    rest_calls = {}
+
+    def fake_post(url, body, **kwargs):
+        rest_calls["url"] = url
+        rest_calls["body"] = body
+        return {"content": [{"type": "text", "text": "rest answer"}]}
+
+    monkeypatch.setattr("backend.providers.anthropic_provider._anthropic_post_json", fake_post)
+    provider = AnthropicProvider(
+        client={"provider": "anthropic", "transport": "rest"}, api_key="k", model="claude-opus-5"
+    )
+    content = provider.complete(
+        CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]), CT()
+    )
+    assert content == "rest answer"
+    assert rest_calls["url"].endswith("/v1/messages")
+    assert rest_calls["body"]["model"] == "claude-opus-5"
+
+
+def test_gemini_deletes_uploaded_files_even_when_the_generation_call_fails(monkeypatch):
+    from backend.providers import CancelToken as CT, ChatRequest as CR, GeminiProvider
+
+    deleted = []
+    monkeypatch.setattr(
+        "backend.providers.gemini_provider._prepare_gemini_contents",
+        lambda messages, cancel_event=None, api_key=None: (None, [{"parts": [{"text": "hi"}]}], ["files/abc"]),
+    )
+    monkeypatch.setattr(
+        "backend.providers.gemini_provider._gemini_delete_file",
+        lambda name, api_key=None: deleted.append(name),
+    )
+
+    def failing_post(url, body, **kwargs):
+        raise RuntimeError("503 from Gemini")
+
+    monkeypatch.setattr("backend.providers.gemini_provider._gemini_post_json", failing_post)
+    provider = GeminiProvider(api_key="k", model="gemini-2.5-pro")
+    with pytest.raises(RuntimeError, match="503"):
+        provider.complete(CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]), CT())
+    assert deleted == ["files/abc"]  # the load-bearing finally survived the port
+
+
+def test_llama_cpp_rejects_media_up_front_with_the_actionable_message():
+    from backend.providers import CancelToken as CT, ChatRequest as CR, LlamaCppProvider
+
+    provider = LlamaCppProvider(settings={"chat_model_path": "m.gguf"})
+    with pytest.raises(RuntimeError, match="Use Ollama or Gemini"):
+        provider.complete(
+            CR(task=config.TASK_CHAT, messages=[{
+                "role": "user",
+                "content": [{"type": "image_bytes", "data": b"\x89PNG"}],
+            }]),
+            CT(),
+        )
+
+
+def test_chat_routes_every_api_provider_through_its_provider_class(monkeypatch):
+    """Seam-wiring for the three API-mode branches - the same not-just-
+    behavior-parity proof the Ollama port got."""
+    import types
+
+    calls = []
+    for module_name, class_name in [
+        ("backend.providers.openai_provider", "OpenAIProvider"),
+        ("backend.providers.anthropic_provider", "AnthropicProvider"),
+        ("backend.providers.gemini_provider", "GeminiProvider"),
+    ]:
+        module = __import__(module_name, fromlist=[class_name])
+        real = getattr(module, class_name)
+
+        def make_counting(real_cls, label):
+            class Counting(real_cls):
+                def complete(self, request, cancel):
+                    calls.append(label)
+                    return f"{label} answer"
+            return Counting
+
+        monkeypatch.setattr(module, class_name, make_counting(real, class_name))
+
+    monkeypatch.setattr(api_provider, "USE_API_MODE", True)
+    monkeypatch.setattr(api_provider, "API_KEY", "k")
+    monkeypatch.setattr(api_provider, "API_CLIENT", _fake_openai_client()[0])
+    monkeypatch.setitem(api_provider.API_MODELS, config.TASK_CHAT, "some-model")
+
+    for provider_type, label in [
+        (config.API_PROVIDER_OPENAI, "OpenAIProvider"),
+        (config.API_PROVIDER_ANTHROPIC, "AnthropicProvider"),
+        (config.API_PROVIDER_GEMINI, "GeminiProvider"),
+    ]:
+        monkeypatch.setattr(api_provider, "API_PROVIDER_TYPE", provider_type)
+        response = _REAL_CHAT(config.TASK_CHAT, [{"role": "user", "content": "hi"}])
+        assert response == {"message": {"content": f"{label} answer", "role": "assistant"}}
+    assert calls == ["OpenAIProvider", "AnthropicProvider", "GeminiProvider"]
+
+
 def test_cancellation_through_the_real_chat_stream_is_the_untranslated_sentinel(
     monkeypatch, ollama_mode, ollama_chat
 ):

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -10,12 +10,18 @@ Layer map:
    reasoning retry with its "reset" event, cancellation closing the live
    stream, think-kwarg/system-hint gating on TASK_CHAT, and the
    empty-vs-reasoning-only error distinction.
-4. The stage's EXIT CRITERION - api_provider.chat_stream's REAL machinery
+4. The 6.1 EXIT CRITERION - api_provider.chat_stream's REAL machinery
    (not the suite-wide conftest stub, which this file explicitly restores
    the real function over) streams multiple incremental deltas end to end
    through the provider seam, with only the network call faked. Before this
    stage, that path was untestable without a live Ollama server - the seam
    is what makes it testable, which is the point of the stage.
+5. Stage 6.3 - the four remaining providers (OpenAI/Anthropic/Gemini/
+   llama.cpp): the pinned per-provider capability matrix (that stage's exit
+   criterion as data), the C4 multimodal conversion (image_bytes ->
+   image_url data URI, audio_file -> input_audio), per-provider port
+   fidelity against faked SDK clients/HTTP helpers, and seam-wiring proof
+   that chat()'s API branches construct and invoke the provider classes.
 """
 
 from __future__ import annotations
@@ -569,8 +575,8 @@ def test_the_capability_matrix_is_pinned_per_provider():
     }
     expected = {
         #            streaming, reasoning, vision, audio, image_gen
-        "ollama":    (True,  True,  False, False, False),
-        "openai":    (False, True,  True,  True,  True),   # C4: vision+audio now real
+        "ollama":    (True,  True,  True,  True,  False),  # media rides the images field; audio model-gated at request time
+        "openai":    (False, True,  True,  True,  False),  # C4: vision+audio real; image_gen probed from the client (None here)
         "anthropic": (False, True,  True,  False, False),
         "gemini":    (False, True,  True,  True,  True),
         "llama_cpp": (False, False, False, False, False),
@@ -580,6 +586,16 @@ def test_the_capability_matrix_is_pinned_per_provider():
         for name, c in matrix.items()
     }
     assert actual == expected
+
+    # OpenAI's image_generation is client-derived, not asserted: an endpoint
+    # actually exposing images.generate reports True.
+    from backend.providers import OpenAIProvider as _OP
+
+    client_with_images, _ = _fake_openai_client()
+    import types as _types
+
+    client_with_images.images = _types.SimpleNamespace(generate=lambda **kw: None)
+    assert _OP(client=client_with_images, model="gpt-5").capabilities.image_generation is True
 
 
 def test_openai_c4_image_bytes_become_a_data_uri_image_url_part():
@@ -790,3 +806,317 @@ def test_cancellation_through_the_real_chat_stream_is_the_untranslated_sentinel(
             lambda delta, reset: None,
             cancellation_event=cancel_event,
         )
+
+
+@pytest.fixture
+def openai_api_mode(monkeypatch):
+    """6.3 review fix: API-mode state pointing at the OpenAI branch, client
+    installable per-test. Mirrors the ollama_mode fixture pattern."""
+    monkeypatch.setattr(api_provider, "USE_API_MODE", True)
+    monkeypatch.setattr(api_provider, "API_PROVIDER_TYPE", config.API_PROVIDER_OPENAI)
+    monkeypatch.setattr(api_provider, "API_KEY", "k")
+    monkeypatch.setitem(api_provider.API_MODELS, config.TASK_CHAT, "some-model")
+
+    def install_client(client):
+        monkeypatch.setattr(api_provider, "API_CLIENT", client)
+
+    return install_client
+
+
+def test_openai_complete_routes_multimodal_messages_through_the_c4_conversion():
+    """6.3 review fix: the pure-function tests above prove prepare_openai_messages
+    works; nothing proved complete() actually CALLS it. A port that passed
+    request.messages raw to the SDK (the exact pre-C4 bug) would have passed
+    every prior test - here the fake client's captured messages must contain
+    the converted image_url data-URI part."""
+    import base64
+
+    from backend.providers import CancelToken as CT, ChatRequest as CR, OpenAIProvider
+
+    client, captured = _fake_openai_client("seen")
+    provider = OpenAIProvider(client=client, model="gpt-5")
+    png = b"\x89PNG\r\n\x1a\nfake"
+
+    content = provider.complete(
+        CR(task=config.TASK_CHAT, messages=[{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this"},
+                {"type": "image_bytes", "data": png},
+            ],
+        }]),
+        CT(),
+    )
+
+    assert content == "seen"
+    sent_parts = captured["messages"][0]["content"]
+    assert sent_parts[0] == {"type": "text", "text": "what is this"}
+    assert sent_parts[1]["type"] == "image_url"
+    expected_uri = "data:image/png;base64," + base64.b64encode(png).decode("ascii")
+    assert sent_parts[1]["image_url"]["url"] == expected_uri
+
+
+def test_llama_cpp_complete_happy_path_wires_prep_client_kwargs_and_extraction(monkeypatch):
+    """6.3 review fix: the llama.cpp port only had its media-rejection guard
+    tested - the happy path (prep -> cached-client lookup -> kwargs filter ->
+    create_chat_completion -> text extraction) never ran. All api_provider
+    helpers are faked at the provider module's namespace, so this pins the
+    provider's ORCHESTRATION of them, not their internals."""
+    from backend.providers import CancelToken as CT, ChatRequest as CR, LlamaCppProvider
+    from backend.providers import llama_cpp_provider as lp
+
+    prepared_marker = [{"role": "user", "content": "prepared"}]
+    captured = {}
+
+    class FakeLlamaClient:
+        def create_chat_completion(self, messages=None, **kwargs):
+            captured["messages"] = messages
+            captured["kwargs"] = kwargs
+            return {"choices": [{"message": {"content": "llama answer"}}]}
+
+    fake_client = FakeLlamaClient()
+    settings = {"chat_model_path": "m.gguf"}
+    monkeypatch.setattr(lp, "_prepare_llama_cpp_messages", lambda messages, task, s: prepared_marker)
+    monkeypatch.setattr(lp, "_get_llama_cpp_client", lambda task, s: fake_client)
+    monkeypatch.setattr(lp, "_prepare_llama_cpp_kwargs", lambda kwargs, s: dict(kwargs))
+    monkeypatch.setattr(lp, "_filter_kwargs_for_callable", lambda fn, kwargs: dict(kwargs))
+    monkeypatch.setattr(
+        lp, "_extract_llama_cpp_text",
+        lambda response: response["choices"][0]["message"]["content"],
+    )
+
+    provider = LlamaCppProvider(settings=settings)
+    content = provider.complete(
+        CR(
+            task=config.TASK_CHAT,
+            messages=[{"role": "user", "content": "hi"}],
+            extra_kwargs={"temperature": 0.5, "cancellation_event": threading.Event()},
+        ),
+        CT(),
+    )
+
+    assert content == "llama answer"
+    assert captured["messages"] is prepared_marker  # prepared, not raw, messages reached the client
+    assert captured["kwargs"] == {"temperature": 0.5}  # cancellation_event stripped
+
+
+def test_chat_routes_the_llama_cpp_local_branch_through_its_provider_class(monkeypatch):
+    """6.3 review fix: the seam-wiring proof covered the three API branches
+    but not the fourth ported branch - chat()'s llama.cpp local path. Same
+    counting-subclass pattern; also pins that the provider is constructed
+    from the request snapshot's settings dict."""
+    from backend.providers import llama_cpp_provider as lp
+
+    seen = {"complete": 0}
+    real = lp.LlamaCppProvider
+
+    class Counting(real):
+        def __init__(self, **kwargs):
+            seen["init"] = dict(kwargs)
+            super().__init__(**kwargs)
+
+        def complete(self, request, cancel):
+            seen["complete"] += 1
+            return "LlamaCppProvider answer"
+
+    monkeypatch.setattr(lp, "LlamaCppProvider", Counting)
+    monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+    monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_LLAMACPP)
+    settings = {"chat_model_path": "m.gguf", "reasoning_level": "off"}
+    monkeypatch.setattr(api_provider, "LLAMA_CPP_SETTINGS", settings)
+
+    response = _REAL_CHAT(config.TASK_CHAT, [{"role": "user", "content": "hi"}])
+
+    assert response == {"message": {"content": "LlamaCppProvider answer", "role": "assistant"}}
+    assert seen["complete"] == 1
+    assert seen["init"] == {"settings": settings}  # the snapshot's dict copy, values intact
+
+
+def test_a_preset_cancellation_event_escapes_chat_untranslated_in_api_mode(openai_api_mode):
+    """6.3 review fix: the cancellation sentinel was only proven through the
+    Ollama streaming path. chat() checks the event BEFORE dispatching to any
+    API branch, and _translate_chat_exception must re-raise the sentinel
+    untouched - so the fake client must never be reached."""
+    client, captured = _fake_openai_client()
+    openai_api_mode(client)
+    cancel_event = threading.Event()
+    cancel_event.set()  # cancelled before dispatch
+
+    with pytest.raises(api_provider.RequestCancelledError):
+        _REAL_CHAT(
+            config.TASK_CHAT,
+            [{"role": "user", "content": "hi"}],
+            cancellation_event=cancel_event,
+        )
+    assert captured == {}  # the provider/client was never invoked
+
+
+def test_connection_refused_in_api_mode_surfaces_the_friendly_endpoint_message(openai_api_mode):
+    """6.3 review fix: error translation was untested through the ported API
+    branches. A raw connection-refused from the OpenAI-compatible client must
+    surface as _translate_chat_exception's actionable Base-URL message (with
+    the raw detail appended), not as the raw exception text."""
+    import types
+
+    def refusing_create(**kwargs):
+        raise Exception("connection refused by endpoint")
+
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=refusing_create))
+    )
+    openai_api_mode(client)
+
+    with pytest.raises(ConnectionError) as excinfo:
+        _REAL_CHAT(config.TASK_CHAT, [{"role": "user", "content": "hi"}])
+
+    message = str(excinfo.value)
+    assert message.startswith(
+        "Failed to connect to the API endpoint. "
+        "Please verify your Base URL in settings and your network connection."
+    )
+    assert "Details: connection refused by endpoint" in message  # raw cause kept, as detail only
+
+
+def test_all_four_new_providers_satisfy_the_protocol_and_stream_exactly_one_done():
+    """6.3 review fix: protocol conformance was only pinned for FakeProvider
+    and Ollama; the transitional stream()-wraps-complete() shape (chat_stream's
+    documented one-full-chunk fallback) was never asserted for the new four."""
+    from backend.providers import (
+        AnthropicProvider,
+        GeminiProvider,
+        LlamaCppProvider,
+        OpenAIProvider,
+    )
+
+    assert isinstance(OpenAIProvider(client=None, model="gpt-5"), Provider)
+    assert isinstance(AnthropicProvider(client=None, api_key="k", model="claude-opus-5"), Provider)
+    assert isinstance(GeminiProvider(api_key="k", model="gemini-2.5-pro"), Provider)
+    assert isinstance(LlamaCppProvider(settings={"chat_model_path": "m.gguf"}), Provider)
+
+    client, _ = _fake_openai_client("full text")
+    provider = OpenAIProvider(client=client, model="gpt-5")
+    events = list(provider.stream(
+        ChatRequest(task=config.TASK_TITLE, messages=[{"role": "user", "content": "hi"}]),
+        CancelToken(),
+    ))
+    assert events == [ProviderEvent("done", "full text")]  # exactly one terminal event
+
+
+def test_chat_constructs_each_api_provider_from_the_snapshot_credentials(monkeypatch):
+    """6.3 review fix: the routing test proves the classes are INVOKED but not
+    that they're constructed correctly - a branch passing the wrong key/client/
+    level would still pass it. Recording subclasses pin the exact __init__
+    kwargs each branch draws from the request snapshot."""
+    init_kwargs = {}
+
+    for module_name, class_name in [
+        ("backend.providers.openai_provider", "OpenAIProvider"),
+        ("backend.providers.anthropic_provider", "AnthropicProvider"),
+        ("backend.providers.gemini_provider", "GeminiProvider"),
+    ]:
+        module = __import__(module_name, fromlist=[class_name])
+        real = getattr(module, class_name)
+
+        def make_recording(real_cls, label):
+            class Recording(real_cls):
+                def __init__(self, **kwargs):
+                    init_kwargs[label] = dict(kwargs)
+                    super().__init__(**kwargs)
+
+                def complete(self, request, cancel):
+                    return f"{label} answer"
+            return Recording
+
+        monkeypatch.setattr(module, class_name, make_recording(real, class_name))
+
+    client = _fake_openai_client()[0]
+    monkeypatch.setattr(api_provider, "USE_API_MODE", True)
+    monkeypatch.setattr(api_provider, "API_KEY", "secret-key")
+    monkeypatch.setattr(api_provider, "API_CLIENT", client)
+    monkeypatch.setattr(api_provider, "OPENAI_REASONING_LEVEL", "high")
+    monkeypatch.setattr(api_provider, "ANTHROPIC_REASONING_LEVEL", "medium")
+    monkeypatch.setattr(api_provider, "GEMINI_REASONING_LEVEL", "low")
+    monkeypatch.setitem(api_provider.API_MODELS, config.TASK_CHAT, "some-model")
+
+    for provider_type in [
+        config.API_PROVIDER_OPENAI,
+        config.API_PROVIDER_ANTHROPIC,
+        config.API_PROVIDER_GEMINI,
+    ]:
+        monkeypatch.setattr(api_provider, "API_PROVIDER_TYPE", provider_type)
+        _REAL_CHAT(config.TASK_CHAT, [{"role": "user", "content": "hi"}])
+
+    assert init_kwargs["OpenAIProvider"] == {
+        "client": client, "model": "some-model", "reasoning_level": "high",
+    }
+    assert init_kwargs["AnthropicProvider"] == {
+        "client": client, "api_key": "secret-key", "model": "some-model",
+        "reasoning_level": "medium",
+    }
+    assert init_kwargs["GeminiProvider"] == {
+        "api_key": "secret-key", "model": "some-model", "reasoning_level": "low",
+    }
+
+
+def test_anthropic_reasoning_level_gates_on_the_chat_task_at_the_provider(monkeypatch):
+    """6.3 review fix: the OpenAI port's task gating is pinned above; the
+    Anthropic port's equivalent (reasoning_level forwarded to
+    _prepare_anthropic_kwargs only for TASK_CHAT, "off" otherwise) was not."""
+    import types
+
+    from backend.providers import AnthropicProvider, CancelToken as CT, ChatRequest as CR
+
+    recorded = []
+
+    def recording_prepare(task, kwargs, model_id="", reasoning_level="off"):
+        recorded.append((task, reasoning_level))
+        return {"max_tokens": 64}
+
+    monkeypatch.setattr(
+        "backend.providers.anthropic_provider._prepare_anthropic_kwargs", recording_prepare
+    )
+
+    def create(**kwargs):
+        return {"content": [{"type": "text", "text": "a"}]}
+
+    sdk_client = types.SimpleNamespace(messages=types.SimpleNamespace(create=create))
+    provider = AnthropicProvider(
+        client=sdk_client, api_key="k", model="claude-opus-5", reasoning_level="high"
+    )
+
+    provider.complete(CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]), CT())
+    provider.complete(CR(task=config.TASK_TITLE, messages=[{"role": "user", "content": "hi"}]), CT())
+
+    assert recorded == [(config.TASK_CHAT, "high"), (config.TASK_TITLE, "off")]
+
+
+def test_gemini_thinking_config_gates_on_the_chat_task_at_the_provider(monkeypatch):
+    """6.3 review fix: same gating pin for the Gemini port - thinkingConfig
+    lands in the request body's generationConfig only for TASK_CHAT, and
+    gemini_thinking_config is never even consulted for other tasks."""
+    from backend.providers import CancelToken as CT, ChatRequest as CR, GeminiProvider
+
+    bodies = []
+    thinking_calls = []
+    monkeypatch.setattr(
+        "backend.providers.gemini_provider._prepare_gemini_contents",
+        lambda messages, cancel_event=None, api_key=None: (None, [{"parts": [{"text": "hi"}]}], []),
+    )
+    monkeypatch.setattr(
+        "backend.providers.gemini_provider.gemini_thinking_config",
+        lambda model_id, level: (thinking_calls.append((model_id, level)) or {"thinkingBudget": 128}),
+    )
+
+    def fake_post(url, body, **kwargs):
+        bodies.append(body)
+        return {"candidates": [{"content": {"parts": [{"text": "ok"}]}}]}
+
+    monkeypatch.setattr("backend.providers.gemini_provider._gemini_post_json", fake_post)
+
+    provider = GeminiProvider(api_key="k", model="gemini-2.5-pro", reasoning_level="high")
+    provider.complete(CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]), CT())
+    provider.complete(CR(task=config.TASK_TITLE, messages=[{"role": "user", "content": "hi"}]), CT())
+
+    assert thinking_calls == [("gemini-2.5-pro", "high")]  # only the chat task consults it
+    assert bodies[0]["generationConfig"]["thinkingConfig"] == {"thinkingBudget": 128}
+    assert "generationConfig" not in bodies[1]  # no stray config key for non-chat tasks


### PR DESCRIPTION
## Problem

After stage 6.1 ported Ollama, the other four providers still lived as inline if/elif branches in `api_provider.chat()`. Separately, audit finding C4: image and audio attachments sent to OpenAI-compatible endpoints were passed through **raw** in the app's internal message shape — unusable dicts the endpoint can't interpret — so multimodal simply didn't work on OpenAI-compatible providers.

## Change

All five providers now sit behind the Provider seam:

- **`OpenAIProvider`** — faithful port plus the one piece of new behavior in this stage: `prepare_openai_messages` converts `image_bytes` parts to base64 data-URI `image_url` parts (mime sniffed from the bytes' magic numbers) and `audio_file` parts to `input_audio` (WAV/MP3; other containers get an actionable client-side error instead of a provider-side 400). **C4 closed.** `image_generation` capability is probed from the client, not asserted — "OpenAI-compatible" includes endpoints with no images API.
- **`AnthropicProvider`** — preserves the SDK-or-REST duality, system-prompt extraction, and TASK_CHAT-gated reasoning.
- **`GeminiProvider`** — preserves the REST call, thinkingConfig gating, message-size-derived timeout, and the load-bearing `finally` that deletes uploaded files even on failure.
- **`LlamaCppProvider`** — preserves the up-front media rejection, frozen settings, cached in-process client, and kwargs filtering.
- `chat()`'s four branches construct each provider from the request's own snapshot (mid-request-swap immunity unchanged). The per-provider **capability matrix is pinned as a test** — the stage's exit criterion as data. `stream()` on the four is the transitional single-"done" event until 6.4's universal streaming.

## Test plan

- [x] 18 new tests across the two commits: pinned capability matrix, C4 image/audio conversion (pure function AND at the `complete()` seam), byte-identical text-only passthrough, Anthropic's both transport paths, Gemini's delete-on-failure invariant, llama.cpp media rejection AND happy path (provider + `chat()` branch), seam-wiring + construction-fidelity (each provider gets the snapshot's own client/key/model/level), reasoning gating per task, cancellation escaping untranslated, connection-refused translating to the friendly message, protocol conformance + single-done `stream()` for all four
- [x] Adversarial review (3 dimensions, 18 agents, findings verified with real reproductions — including an ffmpeg-built `.mpeg` fixture proving the audio-format edge): 15 confirmed findings, all fixed in the second commit (`.mpeg` mislabeling, overclaimed/underclaimed capabilities, non-dict part crash, empty-image data URI, contradictory error suffix)
- [x] Full backend suite: 1769 passed, 14 skipped