### PR TITLE
ADR-006 stage 6.5a: per-session ProviderRuntime + H6 fixes + runtime mode switch

### DIFF
--- a/api_provider.py
+++ b/api_provider.py
@@ -252,7 +252,21 @@ class ProviderRuntime:
             if normalized_settings.get("title_model_path"):
                 _validate_llama_cpp_model_path(normalized_settings["title_model_path"], config.TASK_TITLE)
 
-            previous = self._write(
+            # ADR-006 stage 6.5 review fix (LOW): preload BEFORE writing state,
+            # not write-then-rollback-on-failure. The (potentially slow,
+            # multi-GB) preload deliberately happens outside the state lock
+            # so it never blocks other requests' snapshots - but a snapshot
+            # taken in that window used to see the NEW, not-yet-validated
+            # settings, which from_snapshot() can now copy into a per-session
+            # runtime that never gets corrected if the preload then fails and
+            # this runtime rolls back. Preloading first means a write only
+            # ever commits a value already known-good, so there is nothing to
+            # roll back and nothing transient for a concurrent snapshot to
+            # capture.
+            if preload_model:
+                _get_llama_cpp_client(config.TASK_CHAT, normalized_settings)
+
+            self._write(
                 use_api_mode=False,
                 local_provider_type=provider,
                 api_provider_type=None,
@@ -261,15 +275,6 @@ class ProviderRuntime:
                 api_base_url=None,
                 llama_cpp_settings=normalized_settings,
             )
-            try:
-                # The (potentially slow, multi-GB) model preload deliberately
-                # happens OUTSIDE the state lock so it never blocks other
-                # requests' snapshots.
-                if preload_model:
-                    _get_llama_cpp_client(config.TASK_CHAT, normalized_settings)
-            except Exception:
-                self._write(**previous)
-                raise
 
             return {
                 "provider": provider,

--- a/api_provider.py
+++ b/api_provider.py
@@ -64,7 +64,7 @@ _LLAMA_CPP_CLIENT_CACHE = {}
 _LLAMA_CPP_CLIENT_LOCK = threading.RLock()
 
 # Guards the provider globals above. Mutators (initialize_api,
-# initialize_local_provider, set_mode, set_task_model) write under this lock;
+# initialize_local_provider, set_task_model) write under this lock;
 # chat()/generate_image() take one consistent snapshot under it at request entry and
 # route the whole request through that snapshot. Previously a mode switch during an
 # in-flight request could interleave with the request's many separate global reads,
@@ -87,6 +87,14 @@ class _ProviderSnapshot(NamedTuple):
     anthropic_reasoning_level: str
     gemini_reasoning_level: str
     openai_reasoning_level: str
+    # ADR-006 stage 6.5 (H6): the Ollama per-task model table, copied UNDER
+    # the provider lock at snapshot time. chat()/chat_stream() previously
+    # read config.OLLAMA_MODELS live AFTER taking their snapshot - a
+    # concurrent model-assignment change (or even an app-composer republish,
+    # which used to sync the table on the read path) could swap the model
+    # between the snapshot and the provider construction. Trailing field
+    # with a default so existing positional constructions stay valid.
+    ollama_models: dict = {}
 
 
 def _snapshot_provider_state() -> _ProviderSnapshot:
@@ -104,7 +112,276 @@ def _snapshot_provider_state() -> _ProviderSnapshot:
             anthropic_reasoning_level=ANTHROPIC_REASONING_LEVEL,
             gemini_reasoning_level=GEMINI_REASONING_LEVEL,
             openai_reasoning_level=OPENAI_REASONING_LEVEL,
+            ollama_models=dict(config.OLLAMA_MODELS),
         )
+
+
+def sync_ollama_models(settings_manager=None):
+    """ADR-006 stage 6.5 (H6): the ONLY sanctioned writer entry point for
+    config.OLLAMA_MODELS/CURRENT_MODEL - takes the provider lock so the
+    table can never change between a request snapshot's copy of it and the
+    rest of that snapshot. config.sync_ollama_task_models itself stays in
+    graphlink_task_config (it owns the persistence semantics); this wrapper
+    owns the locking, which that module cannot (it would be a circular
+    import)."""
+    with _PROVIDER_STATE_LOCK:
+        return config.sync_ollama_task_models(settings_manager)
+
+
+def set_current_ollama_model(model: str) -> None:
+    """Locked twin of config.set_current_model - see sync_ollama_models."""
+    with _PROVIDER_STATE_LOCK:
+        config.set_current_model(model)
+
+
+class ProviderRuntime:
+    """ADR-006 stage 6.5: one session's complete provider configuration.
+
+    Instances constructed directly hold their OWN state - two sessions can
+    hold different providers/models/reasoning levels concurrently. The
+    module-level DEFAULT_RUNTIME below is the one exception: it PROXIES the
+    legacy module globals, which stay authoritative (and monkeypatchable -
+    the entire existing test suite patches them) for the default session.
+    Every mutator and every snapshot goes through _read_all/_write, which is
+    the only thing the module-backed subclass overrides.
+
+    A request captures `snapshot()` once at entry and routes the whole
+    request through it - the same mid-request-swap immunity the module
+    globals' _ProviderSnapshot always provided, now including the Ollama
+    model table (H6)."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._state = {
+            "use_api_mode": False,
+            "api_provider_type": None,
+            "api_client": None,
+            "api_key": None,
+            "api_base_url": None,
+            "local_provider_type": config.LOCAL_PROVIDER_OLLAMA,
+            "api_models": dict.fromkeys(API_MODELS),
+            "llama_cpp_settings": _normalize_llama_cpp_settings(),
+            "ollama_reasoning_level": "high",
+            "anthropic_reasoning_level": "off",
+            "gemini_reasoning_level": "off",
+            "openai_reasoning_level": "off",
+            "ollama_models": {},
+        }
+
+    @classmethod
+    def from_snapshot(cls, snapshot: "_ProviderSnapshot") -> "ProviderRuntime":
+        """Seed a fresh per-session runtime from an existing configuration -
+        how a non-default session starts out matching the default one before
+        diverging."""
+        runtime = cls()
+        runtime._write(**snapshot._asdict())
+        return runtime
+
+    # -- state access (the ONLY methods the module-backed subclass overrides)
+
+    def _read_all(self) -> dict:
+        with self._lock:
+            state = dict(self._state)
+            state["api_models"] = dict(state["api_models"])
+            state["llama_cpp_settings"] = dict(state["llama_cpp_settings"])
+            state["ollama_models"] = dict(state["ollama_models"])
+            return state
+
+    def _write(self, **updates) -> dict:
+        """Apply updates under the lock; returns the PREVIOUS values of the
+        updated keys (initialize_local_provider's llama.cpp rollback needs
+        the capture and the write to be one atomic step)."""
+        with self._lock:
+            previous = {key: self._state[key] for key in updates}
+            self._state.update(updates)
+            return previous
+
+    def set_task_model(self, task: str, api_model: str) -> None:
+        with self._lock:
+            if task in self._state["api_models"]:
+                self._state["api_models"][task] = api_model
+
+    def set_ollama_models(self, models: dict) -> None:
+        """Per-session twin of sync_ollama_models: replaces this runtime's
+        own Ollama task table (a plain dict write - per-session runtimes do
+        not share config.OLLAMA_MODELS)."""
+        self._write(ollama_models=dict(models))
+
+    # -- the shared configuration logic ---------------------------------------
+
+    def snapshot(self) -> _ProviderSnapshot:
+        return _ProviderSnapshot(**self._read_all())
+
+    def initialize_api(self, provider: str, api_key: str, base_url: str = None):
+        client, api_key, base_url = _build_api_client(provider, api_key, base_url)
+        self._write(
+            use_api_mode=True,
+            api_provider_type=provider,
+            api_client=client,
+            api_key=api_key,
+            api_base_url=base_url,
+        )
+        return client
+
+    def initialize_local_provider(
+        self, provider: str, settings: dict | None = None, *, preload_model: bool = False
+    ):
+        if provider == config.LOCAL_PROVIDER_OLLAMA:
+            normalized_settings = _normalize_llama_cpp_settings()
+            updates = dict(
+                use_api_mode=False,
+                local_provider_type=provider,
+                api_provider_type=None,
+                api_client=None,
+                api_key=None,
+                api_base_url=None,
+                llama_cpp_settings=normalized_settings,
+            )
+            requested_reasoning = (settings or {}).get("reasoning_level")
+            if requested_reasoning:
+                updates["ollama_reasoning_level"] = normalize_reasoning_level(requested_reasoning)
+            self._write(**updates)
+            return {"provider": provider}
+
+        if provider == config.LOCAL_PROVIDER_LLAMACPP:
+            normalized_settings = _normalize_llama_cpp_settings(settings)
+            _validate_llama_cpp_model_path(
+                normalized_settings.get("chat_model_path"),
+                config.TASK_CHAT,
+            )
+            if normalized_settings.get("title_model_path"):
+                _validate_llama_cpp_model_path(normalized_settings["title_model_path"], config.TASK_TITLE)
+
+            previous = self._write(
+                use_api_mode=False,
+                local_provider_type=provider,
+                api_provider_type=None,
+                api_client=None,
+                api_key=None,
+                api_base_url=None,
+                llama_cpp_settings=normalized_settings,
+            )
+            try:
+                # The (potentially slow, multi-GB) model preload deliberately
+                # happens OUTSIDE the state lock so it never blocks other
+                # requests' snapshots.
+                if preload_model:
+                    _get_llama_cpp_client(config.TASK_CHAT, normalized_settings)
+            except Exception:
+                self._write(**previous)
+                raise
+
+            return {
+                "provider": provider,
+                "model_path": _get_llama_cpp_model_path(config.TASK_CHAT, normalized_settings),
+                "preloaded": bool(preload_model),
+            }
+
+        raise ValueError(f"Unknown local provider: {provider}")
+
+    def set_ollama_reasoning_level(self, level: str) -> None:
+        self._write(ollama_reasoning_level=normalize_reasoning_level(level))
+
+    def set_anthropic_reasoning_level(self, level: str) -> None:
+        self._write(anthropic_reasoning_level=normalize_reasoning_level(level))
+
+    def set_gemini_reasoning_level(self, level: str) -> None:
+        self._write(gemini_reasoning_level=normalize_reasoning_level(level))
+
+    def set_openai_reasoning_level(self, level: str) -> None:
+        self._write(openai_reasoning_level=normalize_reasoning_level(level))
+
+    def is_api_mode(self) -> bool:
+        return self.snapshot().use_api_mode
+
+    def is_local_ollama_mode(self) -> bool:
+        state = self.snapshot()
+        return not state.use_api_mode and state.local_provider_type == config.LOCAL_PROVIDER_OLLAMA
+
+    def is_local_llama_cpp_mode(self) -> bool:
+        state = self.snapshot()
+        return not state.use_api_mode and state.local_provider_type == config.LOCAL_PROVIDER_LLAMACPP
+
+    def is_configured(self) -> bool:
+        state = self.snapshot()
+        if state.use_api_mode:
+            # ADR-006 stage 6.5 (H6): TASK_IMAGE_GEN is deliberately ABSENT
+            # for EVERY provider, not just Anthropic - image generation is
+            # capability-gated at call time (generate_image's own explicit
+            # no-model/no-images-API errors), so a text-only OpenAI-compatible
+            # endpoint (vLLM, LM Studio, llama-server) counts as configured.
+            required_tasks = (
+                config.TASK_TITLE,
+                config.TASK_CHAT,
+                config.TASK_CHART,
+                config.TASK_WEB_VALIDATE,
+                config.TASK_WEB_SUMMARIZE,
+            )
+            return state.api_client is not None and all(
+                state.api_models.get(task_key) for task_key in required_tasks
+            )
+        if state.local_provider_type == config.LOCAL_PROVIDER_OLLAMA:
+            return bool(state.ollama_models.get(config.TASK_CHAT))
+        if state.local_provider_type == config.LOCAL_PROVIDER_LLAMACPP:
+            return bool(_get_llama_cpp_model_path(config.TASK_CHAT, state.llama_cpp_settings))
+        return False
+
+
+class _ModuleBackedProviderRuntime(ProviderRuntime):
+    """The default session's runtime: state lives in the module globals
+    above (guarded by _PROVIDER_STATE_LOCK), which stay authoritative and
+    monkeypatchable - `patch.object(api_provider, "USE_API_MODE", ...)`
+    keeps working exactly as before. Only the two state-access primitives
+    differ; every piece of configuration LOGIC is inherited."""
+
+    _GLOBAL_NAMES = {
+        "use_api_mode": "USE_API_MODE",
+        "api_provider_type": "API_PROVIDER_TYPE",
+        "api_client": "API_CLIENT",
+        "api_key": "API_KEY",
+        "api_base_url": "API_BASE_URL",
+        "local_provider_type": "LOCAL_PROVIDER_TYPE",
+        "llama_cpp_settings": "LLAMA_CPP_SETTINGS",
+        "ollama_reasoning_level": "OLLAMA_REASONING_LEVEL",
+        "anthropic_reasoning_level": "ANTHROPIC_REASONING_LEVEL",
+        "gemini_reasoning_level": "GEMINI_REASONING_LEVEL",
+        "openai_reasoning_level": "OPENAI_REASONING_LEVEL",
+    }
+
+    def __init__(self):
+        # Deliberately NO super().__init__() - the module IS the state.
+        pass
+
+    def _read_all(self) -> dict:
+        return _snapshot_provider_state()._asdict()
+
+    def _write(self, **updates) -> dict:
+        module_globals = globals()
+        with _PROVIDER_STATE_LOCK:
+            previous = {}
+            for key, value in updates.items():
+                if key == "api_models":
+                    previous[key] = dict(API_MODELS)
+                    API_MODELS.clear()
+                    API_MODELS.update(value)
+                elif key == "ollama_models":
+                    previous[key] = dict(config.OLLAMA_MODELS)
+                    config.OLLAMA_MODELS.clear()
+                    config.OLLAMA_MODELS.update(value)
+                else:
+                    previous[key] = module_globals[self._GLOBAL_NAMES[key]]
+                    module_globals[self._GLOBAL_NAMES[key]] = value
+            return previous
+
+    def set_task_model(self, task: str, api_model: str) -> None:
+        with _PROVIDER_STATE_LOCK:
+            if task in API_MODELS:
+                API_MODELS[task] = api_model
+
+
+# The default session's runtime - the one every module-level function below
+# delegates to, and the one backend/app.py hands to the default session.
+DEFAULT_RUNTIME = _ModuleBackedProviderRuntime()
 
 GEMINI_MODELS_STATIC = sorted([
     "gemini-3.1-pro-preview",
@@ -1602,11 +1879,13 @@ def _anthropic_headers(api_key: str, extra_headers: dict | None = None) -> dict:
     return headers
 
 
-def _anthropic_get_json(endpoint: str, timeout: int = 30, cancel_event=None) -> dict:
+def _anthropic_get_json(endpoint: str, timeout: int = 30, cancel_event=None, api_key=None) -> dict:
     _raise_if_cancelled(cancel_event)
     request = urllib.request.Request(
         endpoint,
-        headers=_anthropic_headers(_get_anthropic_api_key()),
+        # api_key (6.5): an explicit key wins - list_models_for_config lists
+        # a catalog for a config being EDITED, not the live provider's.
+        headers=_anthropic_headers(_get_anthropic_api_key(api_key)),
         method="GET",
     )
 
@@ -2048,14 +2327,15 @@ def _calculate_gemini_timeout(messages: list) -> int:
     return min(1800, max(300, 180 + max_audio_duration // 2))
 
 
-def generate_image(prompt: str, size: str = "1024x1024") -> bytes:
+def generate_image(prompt: str, size: str = "1024x1024", *, runtime=None) -> bytes:
     if not prompt or not prompt.strip():
         raise ValueError("Image prompt cannot be empty.")
 
     # One consistent view of the provider state for the whole request (#9) - a mode
     # switch mid-generation can no longer pair this request's provider branch with a
-    # different provider's client/key/model.
-    state = _snapshot_provider_state()
+    # different provider's client/key/model. 6.5: an explicit per-session
+    # runtime wins over the default session's module globals.
+    state = runtime.snapshot() if runtime is not None else _snapshot_provider_state()
 
     if not state.use_api_mode:
         raise RuntimeError("Image generation is only available in API Endpoint mode.")
@@ -2118,19 +2398,26 @@ def generate_image(prompt: str, size: str = "1024x1024") -> bytes:
 
 def chat(task: str, messages: list, **kwargs) -> dict:
     cancel_event = kwargs.pop("cancellation_event", None)
+    # ADR-006 stage 6.5: an explicit per-session ProviderRuntime, popped
+    # BEFORE the remaining kwargs flow into the provider call. None (every
+    # pre-6.5 caller) means the default session's module-backed runtime.
+    runtime = kwargs.pop("runtime", None)
 
     # One consistent view of the provider state for the whole request (#9). Worker
     # threads call chat() while the UI thread can re-run initialize_* at any time;
     # without the snapshot, the request's many separate global reads could interleave
     # with a swap and execute against a half-swapped provider (new provider type with
     # the old client/key, mixed llama.cpp settings, wrong error-message branch, ...).
-    state = _snapshot_provider_state()
+    state = runtime.snapshot() if runtime is not None else _snapshot_provider_state()
 
     try:
         _raise_if_cancelled(cancel_event)
         if not state.use_api_mode:
             if state.local_provider_type == config.LOCAL_PROVIDER_OLLAMA:
-                model = config.OLLAMA_MODELS.get(task)
+                # ADR-006 stage 6.5 (H6): read from the SNAPSHOT's copy of
+                # the model table, not config.OLLAMA_MODELS live - see
+                # _ProviderSnapshot.ollama_models.
+                model = state.ollama_models.get(task)
                 if not model:
                     raise ValueError(f"No Ollama model configured for task: {task}")
 
@@ -2348,18 +2635,22 @@ def chat_stream(task: str, messages: list, on_chunk: Callable[[str, bool], None]
     `cancellation_event`).
     """
     cancel_event = kwargs.get("cancellation_event")
-    state = _snapshot_provider_state()
+    # ADR-006 stage 6.5: same per-session runtime resolution as chat().
+    runtime = kwargs.pop("runtime", None)
+    state = runtime.snapshot() if runtime is not None else _snapshot_provider_state()
 
     # Silent fallback: every provider/local-type this increment doesn't cover
     # degenerates to one blocking chat() call + one synthetic chunk.
     if state.use_api_mode or state.local_provider_type != config.LOCAL_PROVIDER_OLLAMA:
-        response = chat(task, messages, **kwargs)
+        response = chat(task, messages, runtime=runtime, **kwargs)
         on_chunk(response["message"].get("content", ""), False)
         return response
 
     try:
         _raise_if_cancelled(cancel_event)
-        model = config.OLLAMA_MODELS.get(task)
+        # ADR-006 stage 6.5 (H6): snapshot copy, not a live table read -
+        # see chat()'s twin comment.
+        model = state.ollama_models.get(task)
         if not model:
             raise ValueError(f"No Ollama model configured for task: {task}")
 
@@ -2401,9 +2692,12 @@ def chat_stream(task: str, messages: list, on_chunk: Callable[[str, bool], None]
         _translate_chat_exception(exc, state, messages)
 
 
-def initialize_api(provider: str, api_key: str, base_url: str = None):
-    global USE_API_MODE, API_PROVIDER_TYPE, API_CLIENT, API_KEY, API_BASE_URL
-
+def _build_api_client(provider: str, api_key: str, base_url: str = None):
+    """The client-construction half of initialize_api, with NO state
+    mutation - ADR-006 stage 6.5 splits it out so ProviderRuntime instances
+    and the throwaway catalog listing (list_models_for_config) can build a
+    client without repointing anything. Returns (client, resolved_key,
+    resolved_base_url)."""
     if provider == config.API_PROVIDER_OPENAI:
         try:
             from openai import OpenAI
@@ -2465,13 +2759,15 @@ def initialize_api(provider: str, api_key: str, base_url: str = None):
     else:
         raise ValueError(f"Unknown API provider: {provider}")
 
-    with _PROVIDER_STATE_LOCK:
-        USE_API_MODE = True
-        API_PROVIDER_TYPE = provider
-        API_CLIENT = client
-        API_KEY = api_key
-        API_BASE_URL = base_url
-    return client
+    return client, api_key, base_url
+
+
+def initialize_api(provider: str, api_key: str, base_url: str = None):
+    """Configure the DEFAULT session's runtime (the module globals) for an
+    API endpoint - ADR-006 stage 6.5: the logic lives on ProviderRuntime,
+    shared with per-session instances; this delegate keeps every existing
+    caller and test working unchanged."""
+    return DEFAULT_RUNTIME.initialize_api(provider, api_key, base_url)
 
 
 def initialize_local_provider(
@@ -2480,74 +2776,29 @@ def initialize_local_provider(
     *,
     preload_model: bool = False,
 ):
-    global USE_API_MODE, LOCAL_PROVIDER_TYPE, API_PROVIDER_TYPE, API_CLIENT, API_KEY, API_BASE_URL, LLAMA_CPP_SETTINGS, OLLAMA_REASONING_LEVEL
+    """Local-provider twin of initialize_api - same 6.5 delegation."""
+    return DEFAULT_RUNTIME.initialize_local_provider(
+        provider, settings, preload_model=preload_model
+    )
 
-    if provider == config.LOCAL_PROVIDER_OLLAMA:
-        normalized_settings = _normalize_llama_cpp_settings()
-        with _PROVIDER_STATE_LOCK:
-            requested_reasoning = (settings or {}).get("reasoning_level")
-            OLLAMA_REASONING_LEVEL = normalize_reasoning_level(requested_reasoning) if requested_reasoning else OLLAMA_REASONING_LEVEL
-            USE_API_MODE = False
-            LOCAL_PROVIDER_TYPE = provider
-            API_PROVIDER_TYPE = None
-            API_CLIENT = None
-            API_KEY = None
-            API_BASE_URL = None
-            LLAMA_CPP_SETTINGS = normalized_settings
-        return {"provider": provider}
 
-    if provider == config.LOCAL_PROVIDER_LLAMACPP:
-        normalized_settings = _normalize_llama_cpp_settings(settings)
-        _validate_llama_cpp_model_path(
-            normalized_settings.get("chat_model_path"),
-            config.TASK_CHAT,
+def _list_models(provider_type, client, api_key=None):
+    if provider_type == config.API_PROVIDER_OPENAI:
+        models = client.models.list()
+        return sorted([model.id for model in models.data])
+    if provider_type == config.API_PROVIDER_ANTHROPIC:
+        payload = _anthropic_get_json(ANTHROPIC_MODELS_URL, api_key=api_key)
+        return sorted(
+            {
+                str(model_info.get("id", "")).strip()
+                for model_info in payload.get("data", [])
+                if str(model_info.get("id", "")).strip()
+            },
+            key=str.lower,
         )
-        if normalized_settings.get("title_model_path"):
-            _validate_llama_cpp_model_path(normalized_settings["title_model_path"], config.TASK_TITLE)
-
-        with _PROVIDER_STATE_LOCK:
-            previous_state = (
-                USE_API_MODE,
-                LOCAL_PROVIDER_TYPE,
-                API_PROVIDER_TYPE,
-                API_CLIENT,
-                API_KEY,
-                API_BASE_URL,
-                LLAMA_CPP_SETTINGS,
-            )
-            USE_API_MODE = False
-            LOCAL_PROVIDER_TYPE = provider
-            API_PROVIDER_TYPE = None
-            API_CLIENT = None
-            API_KEY = None
-            API_BASE_URL = None
-            LLAMA_CPP_SETTINGS = normalized_settings
-
-        try:
-            # The (potentially slow, multi-GB) model preload deliberately happens
-            # OUTSIDE the state lock so it never blocks other requests' snapshots.
-            if preload_model:
-                _get_llama_cpp_client(config.TASK_CHAT, normalized_settings)
-        except Exception:
-            with _PROVIDER_STATE_LOCK:
-                (
-                    USE_API_MODE,
-                    LOCAL_PROVIDER_TYPE,
-                    API_PROVIDER_TYPE,
-                    API_CLIENT,
-                    API_KEY,
-                    API_BASE_URL,
-                    LLAMA_CPP_SETTINGS,
-                ) = previous_state
-            raise
-
-        return {
-            "provider": provider,
-            "model_path": _get_llama_cpp_model_path(config.TASK_CHAT, normalized_settings),
-            "preloaded": bool(preload_model),
-        }
-
-    raise ValueError(f"Unknown local provider: {provider}")
+    if provider_type == config.API_PROVIDER_GEMINI:
+        return GEMINI_MODELS_STATIC
+    return []
 
 
 def get_available_models():
@@ -2555,22 +2806,20 @@ def get_available_models():
         raise RuntimeError("API client not initialized")
 
     try:
-        if API_PROVIDER_TYPE == config.API_PROVIDER_OPENAI:
-            models = API_CLIENT.models.list()
-            return sorted([model.id for model in models.data])
-        if API_PROVIDER_TYPE == config.API_PROVIDER_ANTHROPIC:
-            payload = _anthropic_get_json(ANTHROPIC_MODELS_URL)
-            return sorted(
-                {
-                    str(model_info.get("id", "")).strip()
-                    for model_info in payload.get("data", [])
-                    if str(model_info.get("id", "")).strip()
-                },
-                key=str.lower,
-            )
-        if API_PROVIDER_TYPE == config.API_PROVIDER_GEMINI:
-            return GEMINI_MODELS_STATIC
-        return []
+        return _list_models(API_PROVIDER_TYPE, API_CLIENT, API_KEY)
+    except Exception as exc:
+        raise RuntimeError(f"Failed to fetch models from endpoint: {exc}") from exc
+
+
+def list_models_for_config(provider: str, api_key: str, base_url: str = None):
+    """ADR-006 stage 6.5: catalog listing WITHOUT touching live provider
+    state. loadApiModels used to call initialize_api just to refresh a
+    Settings dropdown - a read-only catalog fetch silently repointed the
+    process's live provider (and with per-session runtimes, would have
+    repointed every session's default). Builds a throwaway client instead."""
+    client, resolved_key, _base_url = _build_api_client(provider, api_key, base_url)
+    try:
+        return _list_models(provider, client, resolved_key)
     except Exception as exc:
         raise RuntimeError(f"Failed to fetch models from endpoint: {exc}") from exc
 
@@ -2591,45 +2840,31 @@ def get_available_model_descriptors() -> list[ModelDescriptor]:
     )
 
 
-def set_mode(use_api: bool):
-    global USE_API_MODE
-    with _PROVIDER_STATE_LOCK:
-        USE_API_MODE = use_api
+# ADR-006 stage 6.5: set_mode/get_mode/get_task_models were dead code with
+# zero callers repo-wide and are deleted; the reasoning-level and task-model
+# setters below delegate to the default session's runtime (see
+# ProviderRuntime), keeping every existing caller and test unchanged.
 
 
 def set_ollama_reasoning_level(level: str):
     """Update the request snapshot source used by reasoning-capable Ollama models."""
-    global OLLAMA_REASONING_LEVEL
-    with _PROVIDER_STATE_LOCK:
-        OLLAMA_REASONING_LEVEL = normalize_reasoning_level(level)
+    DEFAULT_RUNTIME.set_ollama_reasoning_level(level)
 
 
 def set_anthropic_reasoning_level(level: str):
-    global ANTHROPIC_REASONING_LEVEL
-    with _PROVIDER_STATE_LOCK:
-        ANTHROPIC_REASONING_LEVEL = normalize_reasoning_level(level)
+    DEFAULT_RUNTIME.set_anthropic_reasoning_level(level)
 
 
 def set_gemini_reasoning_level(level: str):
-    global GEMINI_REASONING_LEVEL
-    with _PROVIDER_STATE_LOCK:
-        GEMINI_REASONING_LEVEL = normalize_reasoning_level(level)
+    DEFAULT_RUNTIME.set_gemini_reasoning_level(level)
 
 
 def set_openai_reasoning_level(level: str):
-    global OPENAI_REASONING_LEVEL
-    with _PROVIDER_STATE_LOCK:
-        OPENAI_REASONING_LEVEL = normalize_reasoning_level(level)
+    DEFAULT_RUNTIME.set_openai_reasoning_level(level)
 
 
 def set_task_model(task: str, api_model: str):
-    with _PROVIDER_STATE_LOCK:
-        if task in API_MODELS:
-            API_MODELS[task] = api_model
-
-
-def get_task_models() -> dict:
-    return API_MODELS.copy()
+    DEFAULT_RUNTIME.set_task_model(task, api_model)
 
 
 def is_api_mode() -> bool:
@@ -2694,19 +2929,10 @@ def get_mode() -> str:
 
 
 def is_configured() -> bool:
-    if USE_API_MODE:
-        if API_PROVIDER_TYPE == config.API_PROVIDER_ANTHROPIC:
-            required_tasks = (
-                config.TASK_TITLE,
-                config.TASK_CHAT,
-                config.TASK_CHART,
-                config.TASK_WEB_VALIDATE,
-                config.TASK_WEB_SUMMARIZE,
-            )
-            return API_CLIENT is not None and all(API_MODELS.get(task_key) for task_key in required_tasks)
-        return API_CLIENT is not None and all(API_MODELS.values())
-    if LOCAL_PROVIDER_TYPE == config.LOCAL_PROVIDER_OLLAMA:
-        return bool(config.OLLAMA_MODELS.get(config.TASK_CHAT))
-    if LOCAL_PROVIDER_TYPE == config.LOCAL_PROVIDER_LLAMACPP:
-        return bool(_get_llama_cpp_model_path(config.TASK_CHAT))
-    return False
+    """ADR-006 stage 6.5: delegates to the default runtime, whose logic now
+    treats TASK_IMAGE_GEN as optional for EVERY API provider (previously
+    only Anthropic) - a text-only OpenAI-compatible endpoint (vLLM, LM
+    Studio, llama-server) is fully configured without an image model; image
+    generation is capability-gated at call time instead (H6). See
+    ProviderRuntime.is_configured."""
+    return DEFAULT_RUNTIME.is_configured()

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -209,7 +209,7 @@ def bootstrap_provider_state(settings_manager: SettingsManager) -> None:
 
     mode_text = settings_manager.get_current_mode()
     try:
-        _apply_mode(mode_text, settings_manager)
+        apply_provider_mode(mode_text, settings_manager)
         settings_manager.set_current_mode(mode_text)
     except Exception:
         # Funnels BOTH a real initialize_* failure (e.g. a persisted API key
@@ -227,10 +227,19 @@ def bootstrap_provider_state(settings_manager: SettingsManager) -> None:
         api_provider.initialize_local_provider(config.LOCAL_PROVIDER_OLLAMA)
 
 
-def _apply_mode(mode_text: str, settings_manager: SettingsManager) -> None:
+def apply_provider_mode(mode_text: str, settings_manager: SettingsManager) -> None:
     """Three-way dispatch mirroring the legacy mode-switch handlers. Raises
     ValueError for any mode_text it does not recognize - see
-    bootstrap_provider_state's single fallback branch above."""
+    bootstrap_provider_state's single fallback branch above.
+
+    ADR-006 stage 6.5: public (formerly _apply_mode) so the Settings
+    dialog's setProviderMode intent (backend/api/intents_settings_general.py)
+    can switch the live provider at runtime through the exact same logic
+    bootstrap uses - previously there was no path back to Ollama/Llama.cpp
+    from API mode without a restart. Acts on api_provider's module-level
+    functions, i.e. the DEFAULT session's runtime - correct while the
+    shipped app has exactly one session; per-session settings routing is
+    deferred to 6.5b/ADR-012."""
     if mode_text == config.MODE_OLLAMA_LOCAL:
         api_provider.initialize_local_provider(
             config.LOCAL_PROVIDER_OLLAMA,
@@ -258,12 +267,26 @@ def _apply_mode(mode_text: str, settings_manager: SettingsManager) -> None:
         raise ValueError(f"unrecognized provider mode: {mode_text!r}")
 
 
+# ADR-006 stage 6.5: thin compatibility alias for the pre-6.5 private name -
+# existing tests exercise the ValueError contract through it.
+_apply_mode = apply_provider_mode
+
+
 class AgentDispatcher:
     """One instance per session - never a module-level singleton, since two
     sessions must never share in-flight request state."""
 
-    def __init__(self, settings_manager: SettingsManager):
+    def __init__(self, settings_manager: SettingsManager, provider_runtime=None):
         self._settings_manager = settings_manager
+        # ADR-006 stage 6.5: the session's ProviderRuntime. None means "the
+        # default session": every provider call keeps going through
+        # api_provider's module-level functions exactly as before (which the
+        # entire existing test suite monkeypatches), so default-session
+        # behavior stays byte-identical. A non-None runtime (a non-default
+        # session - see backend/app.py's _configure_session) is threaded
+        # explicitly into the chat drivers and generate_image via their
+        # additive `runtime=` kwarg.
+        self._provider_runtime = provider_runtime
         # ADR-002 stage 2.3: the chat/conversation, chart, and note pilot
         # surfaces below claim into this ONE shared registry instead of
         # three independent dicts - see backend/run_lifecycle.py's own
@@ -380,6 +403,18 @@ class AgentDispatcher:
         # runs is the plain string node.state.code_sandbox_sandbox_id, real
         # SceneNode state, not a live object.
         self._pycoder_repls: dict[str, PythonREPL] = {}
+
+    def _runtime_kwargs(self) -> dict:
+        """ADR-006 stage 6.5: `{"runtime": self._provider_runtime}` for a
+        non-default session, `{}` for the default one. The kwarg is OMITTED
+        (not passed as None) for the default session, deliberately: many
+        tests monkeypatch _call_chat_agent/_call_chat_agent_stream/
+        api_provider.generate_image with fakes of the exact pre-6.5 arity,
+        and the default session's calls must stay byte-identical to pre-6.5
+        anyway - the module-global path IS the default runtime."""
+        if self._provider_runtime is None:
+            return {}
+        return {"runtime": self._provider_runtime}
 
     def get_pycoder_repl(self, node_id: str, repl_id: str) -> PythonREPL:
         """Lazy-create-or-reuse - mirrors PyCoderReplManager.get_repl's own
@@ -815,7 +850,16 @@ class AgentDispatcher:
             await bus.publish("notification")
             return
 
-        if not api_provider.is_configured():
+        # ADR-006 stage 6.5: gate on THIS session's runtime when one was
+        # injected; the default session keeps calling the module-level
+        # api_provider.is_configured() so existing monkeypatches of that
+        # function still intercept the gate.
+        is_configured = (
+            self._provider_runtime.is_configured
+            if self._provider_runtime is not None
+            else api_provider.is_configured
+        )
+        if not is_configured():
             # Fail fast and clean, synchronously, before touching any thread -
             # a never-configured install gets an honest, actionable error.
             notifications_state.show(
@@ -987,6 +1031,9 @@ class AgentDispatcher:
                                 persona_text,
                                 cancel_event,
                                 _thread_on_chunk,
+                                # ADR-006 stage 6.5: non-default sessions only
+                                # - see _runtime_kwargs' own docstring.
+                                **self._runtime_kwargs(),
                             ),
                             timeout=WATCHDOG_TIMEOUT_SECONDS,
                         )
@@ -999,7 +1046,13 @@ class AgentDispatcher:
                         await pump_task
                 else:
                     reply_text = await asyncio.wait_for(
-                        asyncio.to_thread(_call_chat_agent, conversation_history, persona_text, cancel_event),
+                        asyncio.to_thread(
+                            _call_chat_agent,
+                            conversation_history,
+                            persona_text,
+                            cancel_event,
+                            **self._runtime_kwargs(),
+                        ),
                         timeout=WATCHDOG_TIMEOUT_SECONDS,
                     )
                 if inspect.iscoroutinefunction(on_reply):
@@ -1211,7 +1264,13 @@ class AgentDispatcher:
         async def _run():
             try:
                 image_bytes = await asyncio.wait_for(
-                    asyncio.to_thread(api_provider.generate_image, prompt),
+                    asyncio.to_thread(
+                        api_provider.generate_image,
+                        prompt,
+                        # ADR-006 stage 6.5: non-default sessions only - see
+                        # _runtime_kwargs' own docstring.
+                        **self._runtime_kwargs(),
+                    ),
                     timeout=WATCHDOG_TIMEOUT_SECONDS,
                 )
                 if cancel_event.is_set():
@@ -3029,8 +3088,13 @@ def _is_sandbox_error_output(output_text, return_code) -> bool:
     return any(keyword in lowered for keyword in _SANDBOX_ERROR_KEYWORDS)
 
 
-def _call_chat_agent(conversation_history, persona_text, cancel_event) -> str:
-    """Runs inside asyncio.to_thread - a real OS thread, not the event loop."""
+def _call_chat_agent(conversation_history, persona_text, cancel_event, *, runtime=None) -> str:
+    """Runs inside asyncio.to_thread - a real OS thread, not the event loop.
+
+    ADR-006 stage 6.5: `runtime` is an additive keyword-only kwarg, forwarded
+    to ChatAgent.get_response only when non-None - _dispatch's call site only
+    passes it for a non-default session (see AgentDispatcher._runtime_kwargs),
+    so every test fake of the exact pre-6.5 arity keeps working."""
     agent = ChatAgent("Graphlink Assistant", persona_text)
     # KNOWN PRE-EXISTING LEGACY QUIRK, ported as-is (not fixed here - see the
     # final report): ChatAgent.__init__ does
@@ -3052,10 +3116,11 @@ def _call_chat_agent(conversation_history, persona_text, cancel_event) -> str:
         # backwards would silently drop the "You are Graphlink Assistant. "
         # prefix.
         resolved_system_prompt=agent.system_prompt,
+        **({"runtime": runtime} if runtime is not None else {}),
     )
 
 
-def _call_chat_agent_stream(conversation_history, persona_text, cancel_event, on_chunk) -> str:
+def _call_chat_agent_stream(conversation_history, persona_text, cancel_event, on_chunk, *, runtime=None) -> str:
     """Runs inside asyncio.to_thread - a real OS thread, not the event loop.
     Streaming counterpart to _call_chat_agent (R4.4) - same persona/
     current_node/resolved_system_prompt quirks and guarantees as that
@@ -3071,7 +3136,11 @@ def _call_chat_agent_stream(conversation_history, persona_text, cancel_event, on
     `on_chunk` itself is `_dispatch`'s `_thread_on_chunk` closure - a plain
     callable safe to invoke from this worker thread, since it only ever does
     `loop.call_soon_threadsafe(...)` internally rather than touching the
-    event loop directly."""
+    event loop directly.
+
+    ADR-006 stage 6.5: `runtime` follows _call_chat_agent's contract exactly
+    (additive keyword-only, forwarded only when non-None - see its own
+    docstring)."""
     agent = ChatAgent("Graphlink Assistant", persona_text)
     return agent.get_response(
         conversation_history,
@@ -3079,6 +3148,7 @@ def _call_chat_agent_stream(conversation_history, persona_text, cancel_event, on
         cancellation_event=cancel_event,
         resolved_system_prompt=agent.system_prompt,
         on_chunk=on_chunk,
+        **({"runtime": runtime} if runtime is not None else {}),
     )
 
 
@@ -3410,8 +3480,13 @@ def _call_gitlink_apply(local_root, pending_changes):
     return apply_change_set(local_root, pending_changes)
 
 
-def register_agents(bus, composer_document, notifications_state, settings_manager) -> AgentDispatcher:
-    dispatcher = AgentDispatcher(settings_manager)
+def register_agents(
+    bus, composer_document, notifications_state, settings_manager, provider_runtime=None
+) -> AgentDispatcher:
+    # ADR-006 stage 6.5: provider_runtime is None for the default session
+    # (module-global path, byte-identical behavior) - see
+    # AgentDispatcher.__init__'s own comment.
+    dispatcher = AgentDispatcher(settings_manager, provider_runtime=provider_runtime)
     # dispatcher.cancel is synchronous (just sets an Event and returns a
     # bool) - no publish/await needed here; the in-flight _run task's own
     # finally block handles the resulting state transition.

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -203,7 +203,9 @@ def bootstrap_provider_state(settings_manager: SettingsManager) -> None:
     # Unconditional and first, regardless of active mode: resolves Auto/
     # inherited Ollama task-model assignments against the cached scan, same
     # as legacy does at startup.
-    config.sync_ollama_task_models(settings_manager)
+    # ADR-006 stage 6.5 (H6): the locked writer wrapper, so the table
+    # can't change mid-snapshot - see api_provider.sync_ollama_models.
+    api_provider.sync_ollama_models(settings_manager)
 
     mode_text = settings_manager.get_current_mode()
     try:

--- a/backend/api/_settings_shared.py
+++ b/backend/api/_settings_shared.py
@@ -185,8 +185,10 @@ async def apply_ollama_chat_model(manager: SettingsManager, model_id: str) -> No
         assignments = manager.get_ollama_model_assignments()
         assignments[config.TASK_CHAT] = assignment
         manager.set_ollama_model_assignments(assignments)
-        config.sync_ollama_task_models(manager)
-        config.set_current_model(chosen)
+        # ADR-006 stage 6.5 (H6): locked writer wrappers - see
+        # api_provider.sync_ollama_models.
+        api_provider.sync_ollama_models(manager)
+        api_provider.set_current_ollama_model(chosen)
 
     await asyncio.to_thread(run_locked, _persist)
 

--- a/backend/api/intents_settings_api_provider.py
+++ b/backend/api/intents_settings_api_provider.py
@@ -25,6 +25,7 @@ import asyncio
 
 import api_provider
 import graphlink_task_config as config
+from graphlink_model_catalog import ModelDescriptor, sort_descriptors
 
 from backend.api._settings_shared import (
     KNOWN_API_PROVIDERS,
@@ -113,38 +114,38 @@ def register_settings_api_provider_intents(
         await bus.publish("app-settings")
 
         try:
-            # Discovery deliberately exercises the same provider-init path
-            # Save uses, so a successful catalog load doubles as a
-            # connection check - matching legacy's ApiModelLoadWorker.
-            await asyncio.to_thread(
-                api_provider.initialize_api,
+            # ADR-006 stage 6.5: a read-only catalog fetch through a
+            # throwaway client (api_provider.list_models_for_config), never
+            # initialize_api - refreshing a Settings dropdown used to
+            # silently repoint the process's LIVE provider (and with
+            # per-session runtimes, would have repointed every session's
+            # default). Still exercises the same client-construction path
+            # Save uses, so a successful load doubles as a connection check,
+            # matching legacy's ApiModelLoadWorker. This also retires the
+            # post-hoc `API_PROVIDER_TYPE != provider` consistency check
+            # that used to live here: the listing no longer touches live
+            # state, so there is no half-swapped-globals race left to
+            # detect - the result is inherently about the (provider, key,
+            # base_url) triple THIS call was given.
+            model_ids = await asyncio.to_thread(
+                api_provider.list_models_for_config,
                 provider,
                 key,
                 base_url if provider == config.API_PROVIDER_OPENAI else None,
             )
-            descriptors = await asyncio.to_thread(api_provider.get_available_model_descriptors)
-            # Post-review fix: api_provider's provider globals are process-
-            # wide (not per-request), and initialize_api/get_available_
-            # model_descriptors are two separate asyncio.to_thread hops with
-            # an await gap between them - a concurrent loadApiModels/
-            # saveApiConfiguration call for a DIFFERENT provider landing in
-            # that gap would repoint the globals before the descriptors read
-            # runs, so descriptors could describe the wrong provider. This
-            # is the same class of race api_provider.py's own
-            # _snapshot_provider_state() exists to prevent for chat()/
-            # generate_image() - get_available_model_descriptors() has no
-            # snapshot-based equivalent, so the narrowest fix available at
-            # this call site is a post-hoc consistency check: if the global
-            # provider type no longer matches what THIS call just
-            # requested, treat the result as aborted rather than silently
-            # persisting/reporting it under the wrong provider's name.
-            if api_provider.API_PROVIDER_TYPE != provider:
-                state.api_catalog_state[provider] = {
-                    "status": "error",
-                    "message": "Catalog refresh aborted - another request changed the active provider. Try again.",
-                }
-                await bus.publish("app-settings")
-                return
+            # Same descriptor shape get_available_model_descriptors builds
+            # for the live provider, keyed to the REQUESTED provider.
+            descriptors = sort_descriptors(
+                ModelDescriptor(
+                    model_id=str(model_id).strip(),
+                    provider=provider,
+                    ready=True,
+                    available=True,
+                    source="endpoint",
+                )
+                for model_id in model_ids
+                if str(model_id).strip()
+            )
             normalized = [
                 {
                     "model_id": descriptor.model_id,
@@ -206,9 +207,13 @@ def register_settings_api_provider_intents(
                 await bus.publish("notification")
             return
 
-        required_tasks = [
-            task for task in API_TASK_KEYS if not (provider == config.API_PROVIDER_ANTHROPIC and task == config.TASK_IMAGE_GEN)
-        ]
+        # ADR-006 stage 6.5 (H6): TASK_IMAGE_GEN is optional for EVERY
+        # provider, not just Anthropic - image generation is capability-gated
+        # at call time (generate_image raises an actionable "No image
+        # generation model configured" error), so a text-only
+        # OpenAI-compatible endpoint (vLLM, LM Studio, llama-server) saves
+        # cleanly. Mirrors ProviderRuntime.is_configured's required set.
+        required_tasks = [task for task in API_TASK_KEYS if task != config.TASK_IMAGE_GEN]
         for task in required_tasks:
             if not str(models_by_task.get(task, "")).strip():
                 if notifications is not None:
@@ -258,6 +263,12 @@ def register_settings_api_provider_intents(
             manager.set_api_models(normalized_models, provider)
             for task, model_id in normalized_models.items():
                 api_provider.set_task_model(task, model_id)
+            # ADR-006 stage 6.5: a successful save just flipped the LIVE
+            # provider to this API endpoint (initialize_api above), but the
+            # persisted mode never followed - a restart silently booted back
+            # into whatever mode was last persisted. Persist the mode the
+            # save actually put the app in.
+            manager.set_current_mode(config.MODE_API_ENDPOINT)
 
         await asyncio.to_thread(run_locked, _persist)
         if notifications is not None:

--- a/backend/api/intents_settings_general.py
+++ b/backend/api/intents_settings_general.py
@@ -6,20 +6,48 @@ Relocated VERBATIM from backend/settings.py's former register_settings
 change. The smallest and lowest-risk of the 4 page-area splits: every
 intent here is a straight persist-then-republish, with no cross-page
 state, native-dialog, or subprocess/thread-race concerns.
+
+ADR-006 stage 6.5 adds setProviderMode - the first runtime path back to
+Ollama/Llama.cpp from API mode without a restart. It routes through
+backend.agents.apply_provider_mode (the exact same three-way dispatch
+bootstrap_provider_state uses at startup) and persists the choice.
 """
 
 from __future__ import annotations
 
 import asyncio
 
+import graphlink_task_config as config
+
 from backend.api._settings_shared import SettingsSessionState, run_locked
 from backend.events import SessionBus
+from backend.notifications import NotificationState
 from graphlink_settings_store import SettingsManager
+
+# ADR-006 stage 6.5: the three persisted provider-mode strings
+# apply_provider_mode dispatches on - the closed vocabulary setProviderMode
+# validates against before touching any live state.
+_KNOWN_PROVIDER_MODES = (
+    config.MODE_OLLAMA_LOCAL,
+    config.MODE_LLAMACPP_LOCAL,
+    config.MODE_API_ENDPOINT,
+)
 
 
 def register_settings_general_intents(
-    bus: SessionBus, manager: SettingsManager, state: SettingsSessionState
+    bus: SessionBus,
+    manager: SettingsManager,
+    state: SettingsSessionState,
+    notifications: NotificationState | None = None,
 ) -> None:
+    # ADR-006 stage 6.5: notifications is optional (trailing, defaulted) so
+    # the pre-6.5 tests that call register_settings_general_intents(bus,
+    # manager, state) keep working unchanged - backend/settings.py's real
+    # call site always passes one. This registrar receives no per-session
+    # ProviderRuntime on purpose: apply_provider_mode acts on api_provider's
+    # module-level functions, i.e. the DEFAULT session's runtime - correct
+    # while the shipped app has exactly one session; per-session settings
+    # routing is deferred to 6.5b/ADR-012.
     async def set_active_section(section: str):
         state.active_section = str(section)
         await bus.publish("app-settings")
@@ -50,9 +78,46 @@ def register_settings_general_intents(
         await asyncio.to_thread(run_locked, manager.set_github_token, "")
         await bus.publish("app-settings")
 
+    async def set_provider_mode(mode: str):
+        # Coerce before use - intent args reach here as raw JSON with no
+        # validation anywhere in the dispatch path (same posture as
+        # intents_settings_api_provider.py's own coercions).
+        mode = str(mode)
+        if mode not in _KNOWN_PROVIDER_MODES:
+            if notifications is not None:
+                notifications.show(f"Unknown provider mode: {mode}", "warning")
+                await bus.publish("notification")
+            return
+
+        # Imported here, not at module top: backend.agents is the heaviest
+        # module in backend/ (it pulls the whole agent/plugin layer), and
+        # this intent is the only thing in the settings split that needs it.
+        from backend.agents import apply_provider_mode
+
+        try:
+            # apply_provider_mode reads the manager and writes api_provider's
+            # provider state - run under the same manager lock every other
+            # settings mutation uses, off the event loop (initialize_* can
+            # block on client construction).
+            await asyncio.to_thread(run_locked, apply_provider_mode, mode, manager)
+        except Exception as exc:  # noqa: BLE001 - surfaced, matching the neighboring intents' error posture
+            if notifications is not None:
+                notifications.show(f"Failed to switch provider mode: {exc}", "error")
+                await bus.publish("notification")
+            return
+
+        # Persist only after the live switch succeeded - a failed switch must
+        # not change what the next restart boots into.
+        await asyncio.to_thread(run_locked, manager.set_current_mode, mode)
+        if notifications is not None:
+            notifications.show(f"Provider mode switched to {mode}.", "success")
+            await bus.publish("notification")
+        await bus.publish("app-settings")
+
     bus.register_intent("app-settings", "setActiveSection", set_active_section)
     bus.register_intent("app-settings", "setShowTokenCounter", set_show_token_counter)
     bus.register_intent("app-settings", "setEnableSystemPrompt", set_enable_system_prompt)
     bus.register_intent("app-settings", "setNotificationPreference", set_notification_preference)
     bus.register_intent("app-settings", "setGithubToken", set_github_token)
     bus.register_intent("app-settings", "clearGithubToken", clear_github_token)
+    bus.register_intent("app-settings", "setProviderMode", set_provider_mode)

--- a/backend/api/intents_settings_ollama.py
+++ b/backend/api/intents_settings_ollama.py
@@ -104,9 +104,11 @@ def register_settings_ollama_intents(
             assignments = manager.get_ollama_model_assignments()
             assignments[task] = assignment
             manager.set_ollama_model_assignments(assignments)
-            config.sync_ollama_task_models(manager)
+            # ADR-006 stage 6.5 (H6): locked writer wrappers - see
+            # api_provider.sync_ollama_models.
+            api_provider.sync_ollama_models(manager)
             if task == config.TASK_CHAT and assignment["mode"] == "explicit":
-                config.set_current_model(assignment["model_id"])
+                api_provider.set_current_ollama_model(assignment["model_id"])
 
         await asyncio.to_thread(run_locked, _persist)
         await bus.publish("app-settings")
@@ -141,7 +143,7 @@ def register_settings_ollama_intents(
                 results.get("scan_path", ""),
                 results.get("locations", []),
             )
-            config.sync_ollama_task_models(manager)
+            api_provider.sync_ollama_models(manager)
 
         try:
             # Adversarial-review finding: set_ollama_model_scan_cache does a
@@ -235,7 +237,7 @@ def register_settings_ollama_intents(
 
         def _persist() -> None:
             api_provider.invalidate_ollama_capability_cache(model_name)
-            config.set_current_model(model_name)
+            api_provider.set_current_ollama_model(model_name)
 
         try:
             # Belt-and-suspenders for the same reentrancy-gate hazard fixed

--- a/backend/app.py
+++ b/backend/app.py
@@ -32,6 +32,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
+import api_provider
 from graphlink_settings_store import SettingsManager
 
 from backend import BACKEND_VERSION
@@ -202,7 +203,24 @@ def _configure_session(
     # disconnect handler can reach it and cancel any in-flight request when
     # this session's last connection drops - see AgentDispatcher.cancel_all's
     # own docstring for why that matters.
-    agent_dispatcher = register_agents(bus, composer_document, notifications_state, settings_manager)
+    #
+    # ADR-006 stage 6.5: each session gets its own ProviderRuntime. The
+    # default session keeps the module-backed DEFAULT_RUNTIME - expressed as
+    # None here because that is AgentDispatcher's "default session" contract:
+    # None keeps every provider call routing through api_provider's module-
+    # level functions (which ARE DEFAULT_RUNTIME's state, and which the
+    # existing test suite monkeypatches), byte-identical to pre-6.5. Any
+    # other session starts as a snapshot-copy of the default configuration
+    # and diverges from there.
+    if bus.session_id == DEFAULT_SESSION_ID:
+        provider_runtime = None
+    else:
+        provider_runtime = api_provider.ProviderRuntime.from_snapshot(
+            api_provider.DEFAULT_RUNTIME.snapshot()
+        )
+    agent_dispatcher = register_agents(
+        bus, composer_document, notifications_state, settings_manager, provider_runtime
+    )
 
     # R1 (doc/QT_REMOVAL_PLAN.md): scene document + grid topics.
     # R3.21: the document is reachable via SessionContext so backend/assets.py's

--- a/backend/composer.py
+++ b/backend/composer.py
@@ -368,7 +368,9 @@ def register_composer(
                     "canChange": False,
                 }
 
-            task_config.sync_ollama_task_models(settings_manager)
+            # ADR-006 stage 6.5 (H6): locked writer wrapper - see
+            # api_provider.sync_ollama_models.
+            api_provider.sync_ollama_models(settings_manager)
             model_id = task_config.OLLAMA_MODELS.get(task_config.TASK_CHAT, "") or ""
             scanned = settings_manager.get_ollama_scanned_models() or []
             return {

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -330,7 +330,9 @@ def register_settings(
 
     bus.register_topic("app-settings", lambda: _build_settings_payload(manager, state))
 
-    register_settings_general_intents(bus, manager, state)
+    # ADR-006 stage 6.5: the general page now takes notifications too - its
+    # new setProviderMode intent surfaces switch failures/success banners.
+    register_settings_general_intents(bus, manager, state, notifications)
     register_settings_api_provider_intents(bus, manager, notifications, state)
     register_settings_ollama_intents(bus, manager, state)
     register_settings_llama_cpp_intents(bus, manager, state)

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -6893,3 +6893,96 @@ def test_stale_artifact_teardown_never_clears_a_newer_runs_pending_request_id(mo
         assert artifact_slots(dispatcher) == {}
 
     asyncio.run(run())
+
+
+# -- ADR-006 stage 6.5: per-session ProviderRuntime reaches the dispatcher ----
+
+
+def test_dispatcher_gates_and_routes_through_its_injected_provider_runtime(monkeypatch):
+    # The app-level half of the 6.5 exit criterion, at AgentDispatcher
+    # granularity: a dispatcher built with its own ProviderRuntime (a) gates
+    # is_configured() on THAT runtime, not the module globals, and (b) hands
+    # the runtime to the chat driver. The module globals are deliberately
+    # UNCONFIGURED here (empty chat model), so a dispatcher still consulting
+    # them would refuse to dispatch at all - passing this test requires the
+    # injected runtime to be the one consulted end to end.
+    monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+    monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_OLLAMA)
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, "")
+    assert api_provider.is_configured() is False  # the default path would refuse
+
+    runtime = api_provider.ProviderRuntime()
+    runtime.set_ollama_models({config.TASK_CHAT: "session-two-model:7b"})
+    assert runtime.is_configured() is True
+
+    seen_runtimes = []
+
+    def fake_stream(conversation_history, persona_text, cancel_event, on_chunk, runtime=None):
+        seen_runtimes.append(runtime)
+        return "per-session reply"
+
+    monkeypatch.setattr(agents_module, "_call_chat_agent_stream", fake_stream)
+
+    async def run():
+        bus = SessionBus("agents-runtime-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        bus.register_topic("scene", lambda: {})
+        dispatcher = AgentDispatcher(_FakeSettingsManager(), provider_runtime=runtime)
+        replies = []
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=replies.append,
+        )
+        entry = next(iter(chat_slots(dispatcher).values()))
+        await entry["task"]
+
+        assert replies == ["per-session reply"]
+        assert seen_runtimes == [runtime]
+
+    asyncio.run(run())
+
+
+def test_default_dispatcher_still_calls_the_drivers_with_the_exact_pre_65_arity(monkeypatch):
+    # Compat pin: a dispatcher WITHOUT an injected runtime (the default
+    # session, and every existing test in this file) must keep calling
+    # _call_chat_agent_stream with the exact pre-6.5 positional arity - no
+    # runtime kwarg at all - so every fake of that arity keeps working.
+    def strict_pre_65_fake(conversation_history, persona_text, cancel_event, on_chunk):
+        return "default reply"
+
+    monkeypatch.setattr(agents_module, "_call_chat_agent_stream", strict_pre_65_fake)
+    _configure_fake_ollama(monkeypatch, lambda task, messages, **kwargs: {"message": {"content": "unused"}})
+
+    async def run():
+        bus, notifications, composer_document, dispatcher = _make_dispatch_env()
+        replies = []
+        await dispatcher.start_chat_reply(
+            bus=bus,
+            notifications_state=notifications,
+            composer_document=composer_document,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            on_reply=replies.append,
+        )
+        entry = next(iter(chat_slots(dispatcher).values()))
+        await entry["task"]
+
+        assert replies == ["default reply"]
+
+    asyncio.run(run())
+
+
+def test_register_agents_forwards_the_provider_runtime_to_the_dispatcher():
+    bus = SessionBus("agents-register-runtime-test")
+    runtime = api_provider.ProviderRuntime()
+
+    dispatcher = agents_module.register_agents(
+        bus, ComposerDocument(), NotificationState(), _FakeSettingsManager(), provider_runtime=runtime
+    )
+
+    assert dispatcher._provider_runtime is runtime

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -1231,3 +1231,70 @@ def test_snapshot_ollama_models_is_a_copy_not_a_live_view(monkeypatch, ollama_mo
     monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, "swapped-mid-request:1b")
 
     assert snapshot.ollama_models[config.TASK_CHAT] == "fake-model:1b"
+
+
+# -- ADR-006 stage 6.5 review fix: llama.cpp preload write-ordering ----------
+
+
+def test_llama_cpp_preload_failure_never_makes_the_new_settings_snapshot_visible(monkeypatch, tmp_path):
+    """A LOW-severity finding from the 6.5 adversarial review: the old
+    write-then-preload-then-rollback-on-failure ordering had a window where
+    a concurrent snapshot() (e.g. a new session's ProviderRuntime.
+    from_snapshot) could observe and permanently copy settings that were
+    about to be rolled back. Preloading BEFORE writing means a failed
+    preload never makes the new settings visible to any snapshot at all -
+    not even transiently."""
+    model_path = tmp_path / "model.gguf"
+    model_path.write_bytes(b"not a real gguf, just needs to exist")
+
+    runtime = api_provider.ProviderRuntime()
+    original_snapshot = runtime.snapshot()
+
+    def failing_preload(task, settings):
+        # Prove the write has NOT happened yet when the preload runs.
+        assert runtime.snapshot() == original_snapshot
+        raise RuntimeError("out of memory")
+
+    monkeypatch.setattr(api_provider, "_get_llama_cpp_client", failing_preload)
+
+    with pytest.raises(RuntimeError, match="out of memory"):
+        runtime.initialize_local_provider(
+            config.LOCAL_PROVIDER_LLAMACPP,
+            {"chat_model_path": str(model_path)},
+            preload_model=True,
+        )
+
+    # Nothing changed - not even transiently, and there was no rollback to
+    # perform because there was nothing to roll back.
+    assert runtime.snapshot() == original_snapshot
+
+
+def test_llama_cpp_preload_success_writes_settings_after_the_preload_completes(monkeypatch, tmp_path):
+    model_path = tmp_path / "model.gguf"
+    model_path.write_bytes(b"not a real gguf, just needs to exist")
+
+    runtime = api_provider.ProviderRuntime()
+    order = []
+
+    def recording_preload(task, settings):
+        order.append("preload")
+        return object()
+
+    monkeypatch.setattr(api_provider, "_get_llama_cpp_client", recording_preload)
+    original_write = api_provider.ProviderRuntime._write
+
+    def recording_write(self, **updates):
+        order.append("write")
+        return original_write(self, **updates)
+
+    monkeypatch.setattr(api_provider.ProviderRuntime, "_write", recording_write)
+
+    result = runtime.initialize_local_provider(
+        config.LOCAL_PROVIDER_LLAMACPP,
+        {"chat_model_path": str(model_path)},
+        preload_model=True,
+    )
+
+    assert order == ["preload", "write"]
+    assert result["preloaded"] is True
+    assert runtime.snapshot().llama_cpp_settings["chat_model_path"] == str(model_path)

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -1120,3 +1120,114 @@ def test_gemini_thinking_config_gates_on_the_chat_task_at_the_provider(monkeypat
     assert thinking_calls == [("gemini-2.5-pro", "high")]  # only the chat task consults it
     assert bodies[0]["generationConfig"]["thinkingConfig"] == {"thinkingBudget": 128}
     assert "generationConfig" not in bodies[1]  # no stray config key for non-chat tasks
+
+
+# -- ADR-006 stage 6.5: per-session ProviderRuntime ---------------------------
+# -- The stage exit criterion: two runtimes hold two different provider
+# -- configurations CONCURRENTLY - a chat routed with runtime=r2 constructs
+# -- its provider from r2's snapshot while a default-path call keeps using
+# -- the module globals, and neither leaks into the other.
+
+
+def _recording_ollama_provider(monkeypatch):
+    """Install a recording subclass over backend.providers.ollama_provider.
+    OllamaProvider (the class chat() lazily imports) - same construction-
+    fidelity pattern as test_chat_routes_every_api_provider_through_its_
+    provider_class above. Returns the list of (model, reasoning_level)
+    pairs each completed request was constructed with."""
+    import backend.providers.ollama_provider as ollama_provider_module
+
+    constructed = []
+
+    class Recording(ollama_provider_module.OllamaProvider):
+        def complete(self, request, cancel):
+            constructed.append((self.model_id, self.reasoning_level))
+            return f"answer from {self.model_id}"
+
+    monkeypatch.setattr(ollama_provider_module, "OllamaProvider", Recording)
+    return constructed
+
+
+def test_two_runtimes_hold_different_providers_concurrently(monkeypatch, ollama_mode):
+    """THE 6.5 EXIT CRITERION (api_provider level): the same chat() function,
+    called with and without runtime=, serves two different provider
+    configurations side by side without either bleeding into the other."""
+    monkeypatch.setattr(api_provider, "chat", _REAL_CHAT)
+    constructed = _recording_ollama_provider(monkeypatch)
+
+    # Session two: starts as a copy of the default configuration
+    # (from_snapshot - exactly how backend/app.py seeds a non-default
+    # session), then diverges through its own public mutators.
+    r2 = api_provider.ProviderRuntime.from_snapshot(api_provider.DEFAULT_RUNTIME.snapshot())
+    r2.set_ollama_models({config.TASK_CHAT: "session-two-model:7b"})
+    r2.set_ollama_reasoning_level("high")
+
+    messages = [{"role": "user", "content": "hi"}]
+    default_response = api_provider.chat(config.TASK_CHAT, messages)
+    r2_response = api_provider.chat(config.TASK_CHAT, messages, runtime=r2)
+    default_again = api_provider.chat(config.TASK_CHAT, messages)
+
+    # Each call constructed its provider from ITS runtime's snapshot.
+    assert constructed == [
+        ("fake-model:1b", "off"),  # default session - the module globals
+        ("session-two-model:7b", "high"),  # session two - r2's own state
+        ("fake-model:1b", "off"),  # default again: r2 never leaked back
+    ]
+    assert default_response["message"]["content"] == "answer from fake-model:1b"
+    assert r2_response["message"]["content"] == "answer from session-two-model:7b"
+    assert default_again == default_response
+
+    # And r2's divergence never touched the default session's authoritative
+    # state - the module globals and the shared Ollama table.
+    assert config.OLLAMA_MODELS[config.TASK_CHAT] == "fake-model:1b"
+    assert api_provider.OLLAMA_REASONING_LEVEL == "off"
+
+
+def test_from_snapshot_seeds_a_faithful_independent_copy(monkeypatch, ollama_mode):
+    r2 = api_provider.ProviderRuntime.from_snapshot(api_provider.DEFAULT_RUNTIME.snapshot())
+
+    assert r2.snapshot() == api_provider.DEFAULT_RUNTIME.snapshot()
+
+    # Independence in BOTH directions: mutating the copy leaves the default
+    # untouched, and mutating the default leaves the copy untouched.
+    r2.set_ollama_models({config.TASK_CHAT: "diverged:1b"})
+    assert config.OLLAMA_MODELS[config.TASK_CHAT] == "fake-model:1b"
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, "default-moved:1b")
+    assert r2.snapshot().ollama_models[config.TASK_CHAT] == "diverged:1b"
+
+
+def test_is_configured_accepts_a_text_only_api_endpoint_without_an_image_model(monkeypatch):
+    """H6: TASK_IMAGE_GEN is optional for EVERY API provider - a text-only
+    OpenAI-compatible endpoint (vLLM, LM Studio, llama-server) counts as
+    configured; image generation raises its own actionable error at call
+    time instead."""
+    monkeypatch.setattr(api_provider, "USE_API_MODE", True)
+    monkeypatch.setattr(api_provider, "API_PROVIDER_TYPE", config.API_PROVIDER_OPENAI)
+    monkeypatch.setattr(api_provider, "API_CLIENT", object())
+    monkeypatch.setattr(
+        api_provider,
+        "API_MODELS",
+        {
+            config.TASK_TITLE: "m",
+            config.TASK_CHAT: "m",
+            config.TASK_CHART: "m",
+            config.TASK_IMAGE_GEN: None,  # deliberately absent
+            config.TASK_WEB_VALIDATE: "m",
+            config.TASK_WEB_SUMMARIZE: "m",
+        },
+    )
+
+    assert api_provider.is_configured() is True
+
+
+def test_snapshot_ollama_models_is_a_copy_not_a_live_view(monkeypatch, ollama_mode):
+    """H6 pin: the snapshot's Ollama model table is copied UNDER the provider
+    lock at snapshot time - mutating config.OLLAMA_MODELS afterward (the
+    mid-request model-assignment race H6 closed) cannot change what an
+    in-flight request already captured."""
+    snapshot = api_provider._snapshot_provider_state()
+    assert snapshot.ollama_models[config.TASK_CHAT] == "fake-model:1b"
+
+    monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, "swapped-mid-request:1b")
+
+    assert snapshot.ollama_models[config.TASK_CHAT] == "fake-model:1b"

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -221,19 +221,11 @@ def test_set_viewing_api_provider_intent_updates_only_local_ui_state(manager):
 
 
 def test_load_api_models_success_persists_catalog_and_publishes_status(manager, monkeypatch):
-    from graphlink_model_catalog import ModelDescriptor
-
-    monkeypatch.setattr(api_provider, "initialize_api", lambda *a, **k: None)
-    # initialize_api is mocked to a no-op, so it never sets the real
-    # api_provider.API_PROVIDER_TYPE global the way load_api_models' own
-    # post-review stale-provider guard checks against - set it directly to
-    # simulate what the real call would have done.
-    monkeypatch.setattr(api_provider, "API_PROVIDER_TYPE", config.API_PROVIDER_OPENAI)
-    monkeypatch.setattr(
-        api_provider,
-        "get_available_model_descriptors",
-        lambda: [ModelDescriptor(model_id="gpt-4o", provider=config.API_PROVIDER_OPENAI, capabilities=frozenset({"text"}))],
-    )
+    # ADR-006 stage 6.5: loadApiModels routes through the state-free
+    # list_models_for_config (a throwaway client), never initialize_api -
+    # the old mock-API_PROVIDER_TYPE dance for the post-hoc stale-provider
+    # guard is gone with the guard itself.
+    monkeypatch.setattr(api_provider, "list_models_for_config", lambda *a, **k: ["gpt-4o"])
     bus = SessionBus("settings-load-models-test")
     register_settings(bus, manager)
     recorder = Recorder()
@@ -254,7 +246,7 @@ def test_load_api_models_failure_sets_error_status_and_does_not_persist(manager,
     def _boom(*a, **k):
         raise RuntimeError("connection refused")
 
-    monkeypatch.setattr(api_provider, "initialize_api", _boom)
+    monkeypatch.setattr(api_provider, "list_models_for_config", _boom)
     bus = SessionBus("settings-load-models-error-test")
     register_settings(bus, manager)
     recorder = Recorder()
@@ -272,7 +264,7 @@ def test_load_api_models_failure_sets_error_status_and_does_not_persist(manager,
 
 def test_load_api_models_rejects_gemini_since_it_has_no_live_catalog(manager, monkeypatch):
     calls = []
-    monkeypatch.setattr(api_provider, "initialize_api", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(api_provider, "list_models_for_config", lambda *a, **k: calls.append(a))
     bus = SessionBus("settings-load-models-gemini-test")
     register_settings(bus, manager)
     recorder = Recorder()
@@ -344,6 +336,31 @@ def test_save_api_configuration_anthropic_does_not_require_image_gen_task(manage
     assert manager.get_anthropic_key() == "sk-ant-test"
 
 
+def test_save_api_configuration_accepts_a_text_only_endpoint_without_an_image_model(manager, monkeypatch):
+    # ADR-006 stage 6.5 (H6): TASK_IMAGE_GEN is optional for EVERY provider
+    # now, not just Anthropic - a text-only OpenAI-compatible endpoint
+    # (vLLM, LM Studio, llama-server) has no image model to offer, and
+    # image generation is capability-gated at call time instead
+    # (generate_image's own "No image generation model configured" error).
+    monkeypatch.setattr(api_provider, "initialize_api", lambda *a, **k: None)
+    notifications = NotificationState()
+    bus = SessionBus("settings-save-text-only-endpoint-test")
+    bus.register_topic("notification", notifications.payload)
+    register_settings(bus, manager, notifications)
+
+    models = _six_task_models()
+    del models[config.TASK_IMAGE_GEN]
+    asyncio.run(
+        bus.dispatch_intent(
+            "app-settings", "saveApiConfiguration", [config.API_PROVIDER_OPENAI, "https://x/v1", "sk-test", models]
+        )
+    )
+
+    assert manager.get_api_provider() == config.API_PROVIDER_OPENAI
+    assert manager.get_openai_key() == "sk-test"
+    assert notifications.msg_type == "success"
+
+
 def test_save_api_configuration_does_not_persist_when_provider_init_fails(manager):
     def _boom(*a, **k):
         raise RuntimeError("bad endpoint")
@@ -397,6 +414,10 @@ def test_save_api_configuration_persists_on_success_and_routes_task_models(manag
     assert manager.get_api_models(config.API_PROVIDER_OPENAI) == models
     assert routed == models
     assert notifications.msg_type == "success"
+    # ADR-006 stage 6.5: a successful save flips the LIVE provider to this
+    # API endpoint, so the persisted mode must follow - previously a restart
+    # silently booted back into whatever mode was last persisted.
+    assert manager.get_current_mode() == config.MODE_API_ENDPOINT
 
 
 def test_save_api_configuration_redacts_the_key_from_a_provider_error_message(manager):
@@ -440,7 +461,7 @@ def test_load_api_models_redacts_the_key_from_a_provider_error_message(manager, 
     def _boom(*a, **k):
         raise RuntimeError(f"connection refused for key {secret}")
 
-    monkeypatch.setattr(api_provider, "initialize_api", _boom)
+    monkeypatch.setattr(api_provider, "list_models_for_config", _boom)
     bus = SessionBus("settings-load-redaction-test")
     register_settings(bus, manager)
     recorder = Recorder()
@@ -462,9 +483,11 @@ def test_load_api_models_falls_back_to_the_saved_key_when_the_field_is_blank(man
     # with "API key not configured" while the same payload reports
     # apiKeyConfigured=true. Legacy avoided this by pre-filling the field.
     seen = []
-    monkeypatch.setattr(api_provider, "initialize_api", lambda provider, key, base_url=None: seen.append(key))
-    monkeypatch.setattr(api_provider, "API_PROVIDER_TYPE", config.API_PROVIDER_OPENAI)
-    monkeypatch.setattr(api_provider, "get_available_model_descriptors", lambda: [])
+    monkeypatch.setattr(
+        api_provider,
+        "list_models_for_config",
+        lambda provider, key, base_url=None: seen.append(key) or [],
+    )
     manager.set_api_settings(config.API_PROVIDER_OPENAI, "https://x/v1", "sk-saved-openai", "", "")
     bus = SessionBus("settings-load-key-fallback-test")
     register_settings(bus, manager)
@@ -476,7 +499,7 @@ def test_load_api_models_falls_back_to_the_saved_key_when_the_field_is_blank(man
 
 def test_load_api_models_reports_a_clean_error_when_no_key_is_available_anywhere(manager, monkeypatch):
     called = []
-    monkeypatch.setattr(api_provider, "initialize_api", lambda *a, **k: called.append(a))
+    monkeypatch.setattr(api_provider, "list_models_for_config", lambda *a, **k: called.append(a))
     bus = SessionBus("settings-load-no-key-test")
     register_settings(bus, manager)
     recorder = Recorder()
@@ -494,7 +517,7 @@ def test_load_api_models_requires_a_base_url_for_the_openai_compatible_provider(
     # Without this an empty Base URL falls through to api_provider's own
     # api.openai.com default, sending a self-hosted-proxy key to OpenAI.
     called = []
-    monkeypatch.setattr(api_provider, "initialize_api", lambda *a, **k: called.append(a))
+    monkeypatch.setattr(api_provider, "list_models_for_config", lambda *a, **k: called.append(a))
     bus = SessionBus("settings-load-no-base-url-test")
     register_settings(bus, manager)
     recorder = Recorder()
@@ -533,7 +556,9 @@ def test_load_api_models_survives_non_string_wire_arguments(manager, monkeypatch
     # handler: a non-str key hit str.replace inside the except block (where
     # its own try cannot catch it), and an unhashable provider was used
     # directly as a dict key.
-    monkeypatch.setattr(api_provider, "initialize_api", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("nope")))
+    monkeypatch.setattr(
+        api_provider, "list_models_for_config", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("nope"))
+    )
     bus = SessionBus("settings-load-wire-types-test")
     register_settings(bus, manager)
 
@@ -568,15 +593,7 @@ def test_load_api_models_does_not_grow_catalog_state_for_unknown_providers(manag
 
 
 def test_reset_api_settings_also_clears_the_catalog_and_snaps_the_viewed_provider_back(manager, monkeypatch):
-    from graphlink_model_catalog import ModelDescriptor
-
-    monkeypatch.setattr(api_provider, "initialize_api", lambda *a, **k: None)
-    monkeypatch.setattr(api_provider, "API_PROVIDER_TYPE", config.API_PROVIDER_ANTHROPIC)
-    monkeypatch.setattr(
-        api_provider,
-        "get_available_model_descriptors",
-        lambda: [ModelDescriptor(model_id="claude-sonnet", provider=config.API_PROVIDER_ANTHROPIC)],
-    )
+    monkeypatch.setattr(api_provider, "list_models_for_config", lambda *a, **k: ["claude-sonnet"])
     bus = SessionBus("settings-reset-clears-catalog-test")
     register_settings(bus, manager)
     recorder = Recorder()
@@ -703,42 +720,44 @@ def test_save_api_configuration_reads_other_providers_keys_atomically_with_its_o
     assert manager.get_anthropic_key() == "sk-concurrent-ant"
 
 
-def test_load_api_models_aborts_when_another_request_repointed_the_provider_globals(manager, monkeypatch):
-    # Regression test for the F2 stale-provider guard, which shipped with
-    # no coverage of its own (a second-pass audit found that deleting the
-    # guard left the whole suite green). api_provider's provider state is
-    # process-global and initialize_api/get_available_model_descriptors are
-    # two separate to_thread hops - a concurrent call for a different
-    # provider landing between them makes the descriptors describe someone
-    # else's provider. The guard must refuse to persist that under this
-    # call's provider name.
-    from graphlink_model_catalog import ModelDescriptor
-
-    monkeypatch.setattr(api_provider, "initialize_api", lambda *a, **k: None)
-    monkeypatch.setattr(api_provider, "API_PROVIDER_TYPE", config.API_PROVIDER_OPENAI)
-
-    def _descriptors_after_someone_else_switched_provider():
-        # Simulates another connection's initialize_api completing in the
-        # await gap and repointing the process-global provider state.
-        monkeypatch.setattr(api_provider, "API_PROVIDER_TYPE", config.API_PROVIDER_ANTHROPIC)
-        return [ModelDescriptor(model_id="claude-sonnet", provider=config.API_PROVIDER_ANTHROPIC)]
-
-    monkeypatch.setattr(api_provider, "get_available_model_descriptors", _descriptors_after_someone_else_switched_provider)
-    bus = SessionBus("settings-stale-provider-guard-test")
+def test_load_api_models_never_mutates_the_live_provider_state(manager, monkeypatch):
+    # ADR-006 stage 6.5 regression pin, replacing the retired F2
+    # stale-provider-guard test: loadApiModels used to call initialize_api
+    # just to refresh a Settings dropdown, silently repointing the
+    # process's LIVE provider (that repointing race is what the F2 post-hoc
+    # guard existed to detect). It now routes through
+    # list_models_for_config's throwaway client, so a catalog refresh must
+    # leave USE_API_MODE/API_PROVIDER_TYPE/API_CLIENT exactly as they were.
+    fake_client = object()
+    monkeypatch.setattr(
+        api_provider, "_build_api_client", lambda provider, key, base_url=None: (fake_client, key, base_url)
+    )
+    monkeypatch.setattr(api_provider, "_list_models", lambda provider, client, key=None: ["gpt-4o"])
+    before = (
+        api_provider.USE_API_MODE,
+        api_provider.API_PROVIDER_TYPE,
+        api_provider.API_CLIENT,
+        api_provider.API_KEY,
+        api_provider.API_BASE_URL,
+    )
+    bus = SessionBus("settings-load-no-live-mutation-test")
     register_settings(bus, manager)
-    recorder = Recorder()
-    bus.attach(recorder)
 
     asyncio.run(
         bus.dispatch_intent("app-settings", "loadApiModels", [config.API_PROVIDER_OPENAI, "sk-test", "https://x/v1"])
     )
 
-    payload = recorder.messages[-1]["payload"]
-    assert payload["apiCatalogStatus"] == "error"
-    assert "another request" in payload["apiCatalogMessage"]
-    # The decisive assertion: Anthropic's models must NOT have been filed
-    # under OpenAI-Compatible.
-    assert manager.get_api_model_catalog(config.API_PROVIDER_OPENAI) == []
+    # The catalog DID refresh (the real list_models_for_config ran, through
+    # the fake client)...
+    assert manager.get_api_model_catalog(config.API_PROVIDER_OPENAI)[0]["model_id"] == "gpt-4o"
+    # ...and the live provider globals are untouched, byte for byte.
+    assert (
+        api_provider.USE_API_MODE,
+        api_provider.API_PROVIDER_TYPE,
+        api_provider.API_CLIENT,
+        api_provider.API_KEY,
+        api_provider.API_BASE_URL,
+    ) == before
 
 
 def test_catalog_state_is_isolated_per_provider(manager, monkeypatch):
@@ -758,7 +777,7 @@ def test_catalog_state_is_isolated_per_provider(manager, monkeypatch):
     recorder = Recorder()
     bus.attach(recorder)
 
-    monkeypatch.setattr(api_provider, "initialize_api", _boom)
+    monkeypatch.setattr(api_provider, "list_models_for_config", _boom)
     asyncio.run(
         bus.dispatch_intent("app-settings", "loadApiModels", [config.API_PROVIDER_OPENAI, "sk-test", "https://x/v1"])
     )
@@ -1811,3 +1830,70 @@ def test_save_llama_cpp_settings_aborts_without_persisting_when_the_live_reapply
 
     assert "Invalid Llama.cpp configuration" in recorder.messages[-1]["payload"]["llamaCppNotice"]
     assert manager.get_llama_cpp_chat_model_path() == ""  # NOT persisted - the whole save aborted
+
+
+# -- ADR-006 stage 6.5: setProviderMode - the first runtime path back to
+# -- Ollama/Llama.cpp from API mode without a restart. Routes through
+# -- backend.agents.apply_provider_mode (the same three-way dispatch
+# -- bootstrap_provider_state uses) and persists manager.set_current_mode.
+
+
+def test_set_provider_mode_switches_to_ollama_and_persists_the_mode(manager, monkeypatch):
+    applied = []
+    monkeypatch.setattr(
+        api_provider, "initialize_local_provider", lambda provider, settings=None, **k: applied.append((provider, settings))
+    )
+    manager.set_current_mode(config.MODE_API_ENDPOINT)  # simulate a running API session
+    notifications = NotificationState()
+    bus = SessionBus("settings-set-provider-mode-test")
+    bus.register_topic("notification", notifications.payload)
+    register_settings(bus, manager, notifications)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setProviderMode", [config.MODE_OLLAMA_LOCAL]))
+
+    # The live switch ran through apply_provider_mode's Ollama branch...
+    assert applied == [(config.LOCAL_PROVIDER_OLLAMA, {"reasoning_level": manager.get_ollama_reasoning_level()})]
+    # ...the choice survives a restart...
+    assert manager.get_current_mode() == config.MODE_OLLAMA_LOCAL
+    # ...and the session heard about both the banner and the settings state.
+    assert notifications.msg_type == "success"
+    assert config.MODE_OLLAMA_LOCAL in notifications.message
+    assert recorder.messages[-1]["topic"] == "app-settings"
+
+
+def test_set_provider_mode_rejects_an_unknown_mode_without_touching_state(manager, monkeypatch):
+    applied = []
+    monkeypatch.setattr(api_provider, "initialize_local_provider", lambda *a, **k: applied.append(a))
+    monkeypatch.setattr(api_provider, "initialize_api", lambda *a, **k: applied.append(a))
+    notifications = NotificationState()
+    bus = SessionBus("settings-set-provider-mode-unknown-test")
+    bus.register_topic("notification", notifications.payload)
+    register_settings(bus, manager, notifications)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setProviderMode", ["Some Nonsense Mode"]))
+
+    assert applied == []  # no live switch was even attempted
+    assert manager.get_current_mode() == config.MODE_OLLAMA_LOCAL  # the persisted default is untouched
+    assert notifications.msg_type == "warning"
+    assert "Some Nonsense Mode" in notifications.message
+
+
+def test_set_provider_mode_failure_does_not_persist_the_mode(manager, monkeypatch):
+    # A failed live switch must not change what the next restart boots into.
+    def _boom(*a, **k):
+        raise RuntimeError("ollama daemon unreachable")
+
+    monkeypatch.setattr(api_provider, "initialize_local_provider", _boom)
+    manager.set_current_mode(config.MODE_API_ENDPOINT)
+    notifications = NotificationState()
+    bus = SessionBus("settings-set-provider-mode-failure-test")
+    bus.register_topic("notification", notifications.payload)
+    register_settings(bus, manager, notifications)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setProviderMode", [config.MODE_OLLAMA_LOCAL]))
+
+    assert manager.get_current_mode() == config.MODE_API_ENDPOINT  # unchanged
+    assert notifications.msg_type == "error"
+    assert "ollama daemon unreachable" in notifications.message

--- a/graphlink_chat_agent.py
+++ b/graphlink_chat_agent.py
@@ -51,7 +51,7 @@ class ChatWorker:
         self.MAX_TOKENS = 8000
 
     def run(self, conversation_history, current_node, cancellation_event=None, resolved_system_prompt=None,
-            on_chunk=None):
+            on_chunk=None, *, runtime=None):
         """
         Executes the chat logic for a single turn.
 
@@ -69,6 +69,10 @@ class ChatWorker:
                 invoking on_chunk(delta, reset) as incremental text arrives. Additive and
                 default-None: every existing call site (this legacy Qt path included) that
                 omits it gets byte-identical behavior via the unchanged chat() call below.
+            runtime (api_provider.ProviderRuntime, optional): ADR-006 stage 6.5 per-session
+                provider runtime. Forwarded to api_provider.chat/chat_stream only when
+                non-None - None (every pre-6.5 caller, and every default-session call)
+                keeps the call byte-identical, routing through the module globals.
 
         Returns:
             str: The AI-generated response text.
@@ -95,18 +99,25 @@ class ChatWorker:
 
             messages.extend(trimmed_history)
 
+            # ADR-006 stage 6.5: the runtime kwarg is only passed when a
+            # per-session runtime was actually supplied, so default-session
+            # calls (runtime=None) stay byte-identical for every existing
+            # api_provider.chat/chat_stream monkeypatch.
+            runtime_kwargs = {"runtime": runtime} if runtime is not None else {}
             if on_chunk is not None:
                 response = api_provider.chat_stream(
                     task=config.TASK_CHAT,
                     messages=messages,
                     on_chunk=on_chunk,
                     cancellation_event=cancellation_event,
+                    **runtime_kwargs,
                 )
             else:
                 response = api_provider.chat(
                     task=config.TASK_CHAT,
                     messages=messages,
                     cancellation_event=cancellation_event,
+                    **runtime_kwargs,
                 )
             ai_message = response['message']['content']
             return ai_message
@@ -133,7 +144,7 @@ class ChatAgent:
         self.system_prompt = f"You are {self.name}. {self.persona}"
 
     def get_response(self, conversation_history, current_node, cancellation_event=None, resolved_system_prompt=None,
-                      on_chunk=None):
+                      on_chunk=None, *, runtime=None):
         """
         Gets an AI response for a given conversation history.
 
@@ -145,6 +156,9 @@ class ChatAgent:
                 scene itself (#20).
             on_chunk (callable, optional): Qt-removal R4.4 token streaming; passed straight
                 through to ChatWorker.run (see its docstring). Additive, default-None.
+            runtime (api_provider.ProviderRuntime, optional): ADR-006 stage 6.5 per-session
+                provider runtime; passed straight through to ChatWorker.run (see its
+                docstring). Additive, keyword-only, default-None.
 
         Returns:
             str: The AI-generated response text.
@@ -158,5 +172,6 @@ class ChatAgent:
             cancellation_event=cancellation_event,
             resolved_system_prompt=resolved_system_prompt,
             on_chunk=on_chunk,
+            runtime=runtime,
         )
         return ai_response

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -230,12 +230,13 @@ def _collect_real_registrations() -> dict[tuple[str, str], _FileIntents]:
 
 def test_the_scan_finds_the_real_population_of_registered_intents():
     # Guards the guard: a broken predicate here would make every check below
-    # vacuously pass. 136 is the exact count locked by ADR-010's close-out
-    # recon (scene=89, app-settings=27, app-composer=6, app-chat-library=5,
-    # grid-control=4, notification=3, app-plugins=1, system=1).
+    # vacuously pass. 137 is the exact count locked by ADR-010's close-out
+    # recon (scene=89, app-settings=28, app-composer=6, app-chat-library=5,
+    # grid-control=4, notification=3, app-plugins=1, system=1) - app-settings
+    # went 27 -> 28 when ADR-006 stage 6.5 added setProviderMode.
     real = _collect_real_registrations()
-    assert len(real) == 136, (
-        f"expected exactly 136 real registered intents, found {len(real)} - "
+    assert len(real) == 137, (
+        f"expected exactly 137 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -219,6 +219,8 @@ CLASSIFICATION: tuple[Classified, ...] = (
     Classified("app-settings", "setNotificationPreference", "B", "preference: notification-type toggle"),
     Classified("app-settings", "setGithubToken", "B", "preference: write-only credential field, not document content"),
     Classified("app-settings", "clearGithubToken", "B", "preference: write-only credential field, not document content"),
+    # ADR-006 stage 6.5:
+    Classified("app-settings", "setProviderMode", "B", "preference: which provider mode is live/persisted"),
 
     # -- backend/api/intents_settings_api_provider.py (app-settings) --------
     Classified("app-settings", "setViewingApiProvider", "B", "preference: which provider sub-page is viewed"),

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -379,11 +379,12 @@ describe("SettingsDialog", () => {
     await user.type(screen.getByPlaceholderText("Enter your API key..."), "sk-test");
     expect(saveButton).toBeDisabled(); // still missing every per-task model
 
+    // ADR-006 stage 6.5: Image Generation is deliberately absent from this
+    // list - it is optional for every provider now (see the test below).
     for (const label of [
       "Chat Naming / Session Title",
       "Chat, Explain, Takeaways (main model)",
       "Chart Generation (code-capable model)",
-      "Image Generation",
       "Web Content Validation",
       "Web Content Summarization",
     ]) {
@@ -391,6 +392,32 @@ describe("SettingsDialog", () => {
     }
 
     expect(saveButton).toBeEnabled();
+  });
+
+  it("Image Generation is visible but optional for OpenAI-Compatible (capability-gated at call time)", async () => {
+    // ADR-006 stage 6.5: a text-only OpenAI-compatible endpoint (vLLM,
+    // LM Studio, llama-server) must save cleanly without an image model -
+    // the backend raises an actionable error at image-generation time
+    // instead of blocking Save up front.
+    const { user, push } = setup();
+    await goToApiEndpoint(user, push);
+
+    // Still rendered (unlike Anthropic, which hides it entirely), labeled
+    // optional the same way the Llama.cpp page labels its optional field.
+    expect(screen.getByLabelText("Image Generation (optional)")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Enter your API key..."), "sk-test");
+    for (const label of [
+      "Chat Naming / Session Title",
+      "Chat, Explain, Takeaways (main model)",
+      "Chart Generation (code-capable model)",
+      "Web Content Validation",
+      "Web Content Summarization",
+    ]) {
+      await user.type(screen.getByLabelText(label), "gpt-4o-mini");
+    }
+
+    expect(screen.getByText("Save Configuration")).toBeEnabled();
   });
 
   it("Anthropic does not require an Image Generation model to enable Save", async () => {
@@ -422,7 +449,7 @@ describe("SettingsDialog", () => {
       "Chat Naming / Session Title",
       "Chat, Explain, Takeaways (main model)",
       "Chart Generation (code-capable model)",
-      "Image Generation",
+      "Image Generation (optional)",
       "Web Content Validation",
       "Web Content Summarization",
     ]) {

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -294,7 +294,12 @@ function ApiProviderPage({
     return task === TASK_IMAGE_GEN ? state.geminiStaticImageModels : state.geminiStaticModels;
   };
 
-  const requiredTasks = API_TASK_FIELDS.filter(({ task }) => !(isAnthropic && task === TASK_IMAGE_GEN));
+  // ADR-006 stage 6.5: Image Generation is optional for EVERY provider, not
+  // just Anthropic - image generation is capability-gated at call time on the
+  // backend, so a text-only OpenAI-compatible endpoint saves cleanly. The
+  // field itself stays visible (and labeled optional) for non-Anthropic
+  // providers below; Anthropic keeps hiding it entirely (no image path at all).
+  const requiredTasks = API_TASK_FIELDS.filter(({ task }) => task !== TASK_IMAGE_GEN);
   // ADR-004 stage 4.4: the same provider-key derivation apiKeyConfigured's
   // placeholder below already needed, factored out so apiKeySource's new
   // "provided by environment" hint reads the identical key - one place
@@ -391,7 +396,9 @@ function ApiProviderPage({
         <legend>Model Selection (per task)</legend>
         {API_TASK_FIELDS.filter(({ task }) => !(isAnthropic && task === TASK_IMAGE_GEN)).map(({ task, label }) => (
           <label className="settings-field" key={task}>
-            <span className="settings-field-label">{label}</span>
+            {/* Same "(optional)" suffix convention as the Llama.cpp page's
+                Chat Naming File field. */}
+            <span className="settings-field-label">{task === TASK_IMAGE_GEN ? `${label} (optional)` : label}</span>
             <input
               type="text"
               className="settings-select"


### PR DESCRIPTION
## Problem

The provider layer's ~12 config globals (API mode, provider type, client, key, model tables, reasoning levels) plus the Ollama model table lived at module scope, with two consequences: a request's provider snapshot could still race a concurrent model-assignment change on the Ollama table (H6 — two out-of-lock reads); a text-only OpenAI-compatible endpoint (vLLM, LM Studio, llama-server) couldn't be saved because an image-generation model was required for every provider except Anthropic; and there was no path back to Ollama/Llama.cpp from API mode without restarting the app, nor a per-session config surface for ADR-012's planned runtime switcher.

## Change

**`ProviderRuntime`.** One session's complete provider configuration behind two state-access primitives (`_read_all`/`_write`) — every other method (`initialize_api`, `initialize_local_provider`, `is_configured`, reasoning-level setters, ...) is shared logic written once. A module-backed `DEFAULT_RUNTIME` proxies the legacy globals under the existing lock, so the default session and the entire existing test-monkeypatch surface stay byte-identical; a plain instance (`ProviderRuntime.from_snapshot(...)`) holds its own independent state, seeded as a one-time copy that then diverges.

**H6 closed.** `_ProviderSnapshot` gained `ollama_models`, copied under the provider lock at snapshot time; `chat()`/`chat_stream()` read the snapshot's copy instead of the live table. Every prior direct writer of that table now routes through new locked wrappers.

**Text-only endpoints configure.** `TASK_IMAGE_GEN` is optional for every API provider now, not just Anthropic — image generation stays capability-gated at call time (an actionable error, not a blocked save).

**Runtime provider-mode switching.** New `setProviderMode` intent — the first path back to Ollama/Llama.cpp from API mode without a restart — persists the choice only after a successful live switch. `saveApiConfiguration` now persists the mode a successful save actually put the app in (previously silently reverted on the next restart). `loadApiModels` lists a catalog through a throwaway client instead of `initialize_api`, so a Settings dropdown refresh no longer repoints the live provider.

**Dispatcher threading.** `AgentDispatcher` carries an optional per-session `ProviderRuntime`, reaching the chat drivers and `generate_image` only for non-default sessions — the kwarg is *omitted* (not passed as `None`) for the default session so every existing exact-arity test fake keeps working unchanged.

**Review fix.** The adversarial review confirmed one LOW finding: `initialize_local_provider`'s llama.cpp branch wrote new settings *before* the (deliberately unlocked) multi-GB model preload, then rolled back on failure — a concurrent `from_snapshot()` landing in that window could permanently copy settings about to be reverted. Fixed by preloading before writing, so a write only ever commits an already-validated value. (No live caller passes `preload_model=True` today, so this was unreachable in practice, but the fix is strictly better and cheap.)

**Scope note.** Real per-provider streaming (porting OpenAI/Anthropic/Gemini/llama.cpp off the transitional single-chunk `stream()`) is split out to stage 6.5b — a large enough SDK-verification effort to deserve its own stage. `setProviderMode` and other Settings mutations still act on the default session's provider state only; per-session settings routing is deferred to ADR-012, which has no user-facing effect yet since multi-session is gated behind a test-only flag in the shipped app.

## Test plan

- Exit criterion at two levels: `test_two_runtimes_hold_different_providers_concurrently` proves two `chat()` calls — one with an injected runtime, one without — construct from two independent, non-leaking provider configs; `test_dispatcher_gates_and_routes_through_its_injected_provider_runtime` proves the same at `AgentDispatcher` granularity with the default session's globals deliberately left unconfigured.
- `test_default_dispatcher_still_calls_the_drivers_with_the_exact_pre_65_arity` pins that the default session's driver calls are unchanged.
- Text-only endpoint: `is_configured()` and `saveApiConfiguration` both accept an OpenAI-compatible config with every model set except image-gen.
- H6: `test_snapshot_ollama_models_is_a_copy_not_a_live_view` pins the snapshot against a mid-request table mutation.
- `setProviderMode`: success (switch + persist + notify), unknown mode (rejected, no state touched), failed switch (mode not persisted).
- `loadApiModels` regression pin: catalog refresh never mutates `USE_API_MODE`/`API_PROVIDER_TYPE`/`API_CLIENT`/etc.
- Review-fix regression: preload-before-write ordering pinned directly, plus a failure-path test proving a concurrent snapshot during a failing preload never observes the new (about-to-be-reverted) settings.
- Full suite green: `pytest -q` 1798 passed / 14 skipped.