### PR TITLE
ADR-006 stage 6.5b: real streaming for OpenAI, Anthropic, Gemini, and llama.cpp

### DIFF
--- a/api_provider.py
+++ b/api_provider.py
@@ -1935,6 +1935,60 @@ def _anthropic_post_json(endpoint: str, body: dict, timeout: int = 180, cancel_e
         raise ConnectionError(f"Failed to reach Anthropic API: {exc.reason}") from exc
 
 
+def _anthropic_stream_sse(endpoint: str, body: dict, timeout: int = 180, cancel_event=None, api_key: str | None = None):
+    """Streaming sibling of _anthropic_post_json (ADR-006 stage 6.5b): POSTs
+    the same request with "stream": true and yields each SSE `data:` line's
+    parsed JSON event dict. The raw REST wire shape is identical to the SDK's
+    raw event stream from messages.create(stream=True), so AnthropicProvider
+    consumes both transports through one translation loop. urllib's
+    HTTPResponse is line-iterable; the finally's close() tears the live
+    connection down whether the stream ends, errors, is cancelled, or the
+    consumer close()es this generator mid-flight."""
+    _raise_if_cancelled(cancel_event)
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps({**body, "stream": True}).encode("utf-8"),
+        headers=_anthropic_headers(_get_anthropic_api_key(api_key)),
+        method="POST",
+    )
+
+    try:
+        response = urllib.request.urlopen(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        error_payload = exc.read().decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(error_payload)
+            message = (
+                parsed.get("error", {}).get("message")
+                or parsed.get("message")
+                or error_payload
+            )
+        except json.JSONDecodeError:
+            message = error_payload
+        raise RuntimeError(message) from exc
+    except urllib.error.URLError as exc:
+        raise ConnectionError(f"Failed to reach Anthropic API: {exc.reason}") from exc
+
+    try:
+        for raw_line in response:
+            _raise_if_cancelled(cancel_event)
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            # SSE frames: `event: <name>` naming lines are redundant (every
+            # data payload repeats its own "type") and blank lines are frame
+            # separators - only `data:` lines carry events.
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:"):].strip()
+            if not payload or payload == "[DONE]":
+                continue
+            try:
+                yield json.loads(payload)
+            except json.JSONDecodeError:
+                continue  # a torn/partial frame; the message_stop event is what ends the stream
+    finally:
+        response.close()
+
+
 def _anthropic_content_block_from_part(part: dict) -> dict | None:
     part_type = part.get("type")
 

--- a/api_provider.py
+++ b/api_provider.py
@@ -2723,14 +2723,15 @@ def _translate_chat_exception(exc: Exception, state, messages: list) -> None:
 def chat_stream(task: str, messages: list, on_chunk: Callable[[str, bool], None], **kwargs) -> dict:
     """Streaming sibling of chat() (Qt-removal R4.4: true token streaming).
 
-    Only the Ollama local provider streams real incremental chunks. Every other
-    provider/task combination (API mode, Llama.cpp local) silently falls back to one
-    ordinary blocking chat() call plus exactly one synthetic full-text chunk - an
-    intentional, explicit R4.4 scope decision, not a gap (see the design spec).
+    ADR-006 stage 6.5b: EVERY provider streams real incremental chunks now -
+    the old non-Ollama fallback (one blocking chat() call plus exactly one
+    synthetic full-text chunk) is gone; each branch below constructs the same
+    provider class chat() does, from the same snapshot credentials, and
+    consumes its stream().
 
     `on_chunk(delta, reset)` is called zero or more times with `reset=False` and
-    incremental DELTAS (never cumulative text - Ollama's streamed `message.content`
-    fragments must be concatenated, not replaced). It is called once with `("", True)`
+    incremental DELTAS (never cumulative text - streamed content fragments
+    must be concatenated, not replaced). It is called once with `("", True)`
     immediately before a reasoning-retry attempt discards the prior attempt's partial
     text.
 
@@ -2743,33 +2744,76 @@ def chat_stream(task: str, messages: list, on_chunk: Callable[[str, bool], None]
     runtime = kwargs.pop("runtime", None)
     state = runtime.snapshot() if runtime is not None else _snapshot_provider_state()
 
-    # Silent fallback: every provider/local-type this increment doesn't cover
-    # degenerates to one blocking chat() call + one synthetic chunk.
-    if state.use_api_mode or state.local_provider_type != config.LOCAL_PROVIDER_OLLAMA:
-        response = chat(task, messages, runtime=runtime, **kwargs)
-        on_chunk(response["message"].get("content", ""), False)
-        return response
-
     try:
         _raise_if_cancelled(cancel_event)
-        # ADR-006 stage 6.5 (H6): snapshot copy, not a live table read -
-        # see chat()'s twin comment.
-        model = state.ollama_models.get(task)
-        if not model:
-            raise ValueError(f"No Ollama model configured for task: {task}")
-
-        # ADR-006 stage 6.1: the streaming Ollama branch routes through the
-        # Provider seam (see chat()'s twin comment). The provider yields typed
-        # events; this adapter maps them onto the on_chunk(delta, reset)
-        # contract EXACTLY as before: "text" deltas forward incrementally,
-        # "reset" becomes on_chunk("", True), "reasoning" deltas are NOT
-        # forwarded (thinking never reached on_chunk here - it only surfaces
-        # in the final <think> block), and "done" carries the composed full
-        # text this function returns.
+        # Provider construction mirrors chat()'s branches exactly: same lazy
+        # imports (the top-level direction would be a genuine import cycle -
+        # see the pinning test), same snapshot-credential kwargs. The
+        # LAZY-GENERATOR CONTRACT (backend/providers/base.py) makes the
+        # placement load-bearing: NOTHING in a provider's stream() body runs
+        # until the first next(), so both construction and the whole
+        # consuming loop below must sit inside this try for
+        # _translate_chat_exception to see request-prep and mid-stream
+        # failures alike. (The old short-circuit got translation for free by
+        # recursing into chat(); real streaming owns its own.)
         from backend.providers.base import CancelToken, ChatRequest
-        from backend.providers.ollama_provider import OllamaProvider
 
-        provider = OllamaProvider(model=model, reasoning_level=state.ollama_reasoning_level)
+        if not state.use_api_mode:
+            if state.local_provider_type == config.LOCAL_PROVIDER_OLLAMA:
+                # ADR-006 stage 6.5 (H6): snapshot copy, not a live table
+                # read - see chat()'s twin comment.
+                model = state.ollama_models.get(task)
+                if not model:
+                    raise ValueError(f"No Ollama model configured for task: {task}")
+                from backend.providers.ollama_provider import OllamaProvider
+
+                provider = OllamaProvider(model=model, reasoning_level=state.ollama_reasoning_level)
+            elif state.local_provider_type == config.LOCAL_PROVIDER_LLAMACPP:
+                from backend.providers.llama_cpp_provider import LlamaCppProvider
+
+                provider = LlamaCppProvider(settings=state.llama_cpp_settings)
+            else:
+                raise RuntimeError(f"Unsupported local provider: {state.local_provider_type}")
+        else:
+            if not state.api_client:
+                raise RuntimeError("API client not initialized. Configure API settings first.")
+            api_model = state.api_models.get(task)
+            if not api_model:
+                raise RuntimeError(
+                    f"No API model configured for task '{task}'.\n"
+                    "Please configure models in API Settings."
+                )
+            if state.api_provider_type == config.API_PROVIDER_OPENAI:
+                from backend.providers.openai_provider import OpenAIProvider
+
+                provider = OpenAIProvider(
+                    client=state.api_client, model=api_model,
+                    reasoning_level=state.openai_reasoning_level,
+                )
+            elif state.api_provider_type == config.API_PROVIDER_ANTHROPIC:
+                from backend.providers.anthropic_provider import AnthropicProvider
+
+                provider = AnthropicProvider(
+                    client=state.api_client, api_key=state.api_key, model=api_model,
+                    reasoning_level=state.anthropic_reasoning_level,
+                )
+            elif state.api_provider_type == config.API_PROVIDER_GEMINI:
+                from backend.providers.gemini_provider import GeminiProvider
+
+                provider = GeminiProvider(
+                    api_key=state.api_key, model=api_model,
+                    reasoning_level=state.gemini_reasoning_level,
+                )
+            else:
+                raise RuntimeError(f"Unsupported API provider: {state.api_provider_type}")
+
+        # The provider yields typed events; this adapter maps them onto the
+        # on_chunk(delta, reset) contract: "text" deltas forward
+        # incrementally, "reset" becomes on_chunk("", True), "reasoning"
+        # deltas are NOT forwarded (a documented invariant - thinking never
+        # reaches on_chunk; it only surfaces in the final <think> block where
+        # a provider composes one), and "done" carries the full final text
+        # this function returns.
         full_response_content = None
         for event in provider.stream(
             ChatRequest(task=task, messages=messages, extra_kwargs=kwargs),
@@ -2789,10 +2833,10 @@ def chat_stream(task: str, messages: list, on_chunk: Callable[[str, bool], None]
             }
         }
     except Exception as exc:
-        # Same translation chat()'s Ollama branch gets - a real connection-
-        # refused/timeout/quota failure here must show the same friendly,
-        # actionable message as the non-streaming path, not raw exception
-        # text (this is now the ONLY code path Composer send uses).
+        # Same translation chat() gets - a real connection-refused/timeout/
+        # quota failure here must show the same friendly, actionable message
+        # as the blocking path, not raw exception text (this is the ONLY
+        # code path Composer send uses).
         _translate_chat_exception(exc, state, messages)
 
 

--- a/api_provider.py
+++ b/api_provider.py
@@ -2168,6 +2168,51 @@ def _gemini_post_json(endpoint: str, body: dict, timeout: int = 120, cancel_even
         raise RuntimeError(message) from exc
 
 
+def _gemini_stream_sse(endpoint: str, body: dict, timeout: int = 120, cancel_event=None, api_key: str | None = None):
+    """Streaming sibling of _gemini_post_json (ADR-006 stage 6.5b): POSTs to
+    :streamGenerateContent?alt=sse and yields each SSE `data:` line's parsed
+    JSON - every line is a full GenerateContentResponse payload with its own
+    candidates[0].content.parts[], the same shape _gemini_post_json returns
+    whole. urllib's HTTPResponse is line-iterable; the finally's close()
+    tears the live connection down on end, error, cancel, or consumer
+    close() alike."""
+    _raise_if_cancelled(cancel_event)
+    api_key = _get_gemini_api_key(api_key)
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps(body).encode("utf-8"),
+        headers=_gemini_headers(api_key),
+        method="POST",
+    )
+
+    try:
+        response = urllib.request.urlopen(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        error_payload = exc.read().decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(error_payload)
+            message = parsed.get("error", {}).get("message") or error_payload
+        except json.JSONDecodeError:
+            message = error_payload
+        raise RuntimeError(message) from exc
+
+    try:
+        for raw_line in response:
+            _raise_if_cancelled(cancel_event)
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line.startswith("data:"):
+                continue  # blank frame separators; Gemini's alt=sse sends no event: lines
+            payload = line[len("data:"):].strip()
+            if not payload or payload == "[DONE]":
+                continue
+            try:
+                yield json.loads(payload)
+            except json.JSONDecodeError:
+                continue  # a torn/partial frame - the stream simply ends when the server closes it
+    finally:
+        response.close()
+
+
 def _gemini_upload_file(
     file_path: str,
     mime_type: str,

--- a/backend/providers/anthropic_provider.py
+++ b/backend/providers/anthropic_provider.py
@@ -129,6 +129,7 @@ class AnthropicProvider:
 
         answer_parts: list[str] = []
         thinking_parts: list[str] = []
+        saw_message_stop = False
         try:
             for event in event_stream:
                 if cancel.is_set():
@@ -136,6 +137,21 @@ class AnthropicProvider:
                 _raise_if_cancelled(cancel.event)  # raises if just closed above
 
                 event_type = str(_extract_response_field(event, "type", "")).strip().lower()
+                if event_type == "error":
+                    # 6.5b review (HIGH): the streaming API can send an error
+                    # event on a 200 stream (overloaded_error, ...) and then
+                    # close - dropping it would compose a truncated answer as
+                    # if complete. Raise with the API's own type+message, the
+                    # same posture _anthropic_post_json takes for error
+                    # payloads, so translation treats both paths identically.
+                    error_info = _extract_response_field(event, "error", {})
+                    error_type = str(_extract_response_field(error_info, "type", "") or "").strip()
+                    error_message = str(
+                        _extract_response_field(error_info, "message", "") or ""
+                    ).strip() or "Anthropic returned an error mid-stream."
+                    raise RuntimeError(
+                        f"{error_type}: {error_message}" if error_type else error_message
+                    )
                 if event_type == "content_block_delta":
                     delta = _extract_response_field(event, "delta", {})
                     delta_type = str(_extract_response_field(delta, "type", "")).strip().lower()
@@ -150,9 +166,20 @@ class AnthropicProvider:
                             thinking_parts.append(thinking)
                             yield ProviderEvent("reasoning", thinking)
                 elif event_type == "message_stop":
+                    saw_message_stop = True
                     break
         finally:
             event_stream.close()  # idempotent on an already-closed/exhausted stream
+
+        # 6.5b review: a successful Anthropic stream ALWAYS ends with
+        # message_stop, on both transports. An iterator that just stops
+        # without one (proxy truncation, silent connection close) delivered
+        # a fragment - composing it would present a truncated answer as
+        # complete.
+        if not saw_message_stop:
+            raise RuntimeError(
+                "Anthropic stream ended unexpectedly before completion. Please try again."
+            )
 
         # The same composition contract as _extract_anthropic_text gives the
         # blocking path: answer + thinking through _compose_reasoned_response,

--- a/backend/providers/anthropic_provider.py
+++ b/backend/providers/anthropic_provider.py
@@ -6,8 +6,16 @@ installed, and this port preserves the exact same runtime dispatch
 prep, media handling (_prepare_anthropic_messages already converts image
 parts via _anthropic_content_block_from_part), reasoning gating on
 TASK_CHAT, and text extraction all come from the same api_provider helpers
-the branch used - behavior byte-identical. stream() is the transitional
-single-"done" shape until 6.4.
+the branch used - behavior byte-identical.
+
+stream() (ADR-006 stage 6.5b) is real streaming over BOTH transports:
+messages.create(stream=True) on the SDK path - create's raw event shape IS
+the REST SSE wire shape, unlike the messages.stream() helper's typed
+context manager - and _anthropic_stream_sse (the streaming sibling of
+_anthropic_post_json) on the dict-sentinel REST fallback, so one
+translation loop serves both. text_delta -> "text", thinking_delta ->
+"reasoning", and the final "done" composes via _compose_reasoned_response
+exactly as _extract_anthropic_text does for the blocking path.
 """
 
 from __future__ import annotations
@@ -17,7 +25,10 @@ from typing import Iterator
 import graphlink_task_config as config
 from api_provider import (
     _anthropic_post_json,
+    _anthropic_stream_sse,
+    _compose_reasoned_response,
     _extract_anthropic_text,
+    _extract_response_field,
     _filter_kwargs_for_callable,
     _prepare_anthropic_kwargs,
     _prepare_anthropic_messages,
@@ -41,7 +52,7 @@ class AnthropicProvider:
         self.model_id = model
         self.reasoning_level = reasoning_level
         self.capabilities = ProviderCapabilities(
-            streaming=False,
+            streaming=True,  # 6.5b: real streaming on both the SDK and REST transports
             reasoning=anthropic_supports_reasoning(model),
             vision=True,   # _prepare_anthropic_messages converts image parts
             audio=False,   # Anthropic has no audio input API; False is what
@@ -79,4 +90,79 @@ class AnthropicProvider:
         return _extract_anthropic_text(response)
 
     def stream(self, request: ChatRequest, cancel: CancelToken) -> Iterator[ProviderEvent]:
-        yield ProviderEvent("done", self.complete(request, cancel))
+        # ADR-006 stage 6.5b: same request prep as complete(), then one event
+        # loop over whichever transport the client duck-types to. Events are
+        # read through _extract_response_field because the SDK path yields
+        # typed objects while the REST path yields dicts - same wire shape,
+        # different containers.
+        _raise_if_cancelled(cancel.event)
+        system_prompt, anthropic_messages = _prepare_anthropic_messages(
+            request.messages, cancel_event=cancel.event
+        )
+        reasoning_level = self.reasoning_level if request.task == config.TASK_CHAT else "off"
+        kwargs = {k: v for k, v in request.extra_kwargs.items() if k != "cancellation_event"}
+        request_kwargs = {
+            "model": self.model_id,
+            "messages": anthropic_messages,
+            **_prepare_anthropic_kwargs(request.task, kwargs, self.model_id, reasoning_level),
+        }
+        if system_prompt:
+            request_kwargs["system"] = system_prompt
+
+        create_callable = getattr(getattr(self.client, "messages", None), "create", None)
+        if callable(create_callable):
+            # `stream` is a declared parameter on the real SDK's
+            # messages.create, but it is passed OUTSIDE the filtered kwargs
+            # anyway so a wrapped/faked create with a narrower signature can
+            # never silently drop it and degrade to a blocking call.
+            filtered_kwargs = _filter_kwargs_for_callable(create_callable, request_kwargs)
+            filtered_kwargs.pop("stream", None)
+            event_stream = create_callable(stream=True, **filtered_kwargs)
+        else:
+            event_stream = _anthropic_stream_sse(
+                _ANTHROPIC_MESSAGES_URL,
+                request_kwargs,
+                timeout=180,
+                cancel_event=cancel.event,
+                api_key=self.api_key,
+            )
+
+        answer_parts: list[str] = []
+        thinking_parts: list[str] = []
+        try:
+            for event in event_stream:
+                if cancel.is_set():
+                    event_stream.close()  # SDK Stream and generator alike expose close()
+                _raise_if_cancelled(cancel.event)  # raises if just closed above
+
+                event_type = str(_extract_response_field(event, "type", "")).strip().lower()
+                if event_type == "content_block_delta":
+                    delta = _extract_response_field(event, "delta", {})
+                    delta_type = str(_extract_response_field(delta, "type", "")).strip().lower()
+                    if delta_type == "text_delta":
+                        text = str(_extract_response_field(delta, "text", "") or "")
+                        if text:
+                            answer_parts.append(text)
+                            yield ProviderEvent("text", text)
+                    elif delta_type == "thinking_delta":
+                        thinking = str(_extract_response_field(delta, "thinking", "") or "")
+                        if thinking:
+                            thinking_parts.append(thinking)
+                            yield ProviderEvent("reasoning", thinking)
+                elif event_type == "message_stop":
+                    break
+        finally:
+            event_stream.close()  # idempotent on an already-closed/exhausted stream
+
+        # The same composition contract as _extract_anthropic_text gives the
+        # blocking path: answer + thinking through _compose_reasoned_response,
+        # so streamed and blocking runs produce identical final text (and the
+        # same reasoning-without-answer / empty-response failures).
+        yield ProviderEvent(
+            "done",
+            _compose_reasoned_response(
+                "".join(answer_parts).strip(),
+                "".join(thinking_parts).strip(),
+                "Anthropic Claude",
+            ),
+        )

--- a/backend/providers/gemini_provider.py
+++ b/backend/providers/gemini_provider.py
@@ -3,8 +3,14 @@ branch (raw REST :generateContent, no SDK). Preserves exactly: content prep
 with media upload via _prepare_gemini_contents (which returns the uploaded
 file names), thinkingConfig gated on TASK_CHAT, the message-size-derived
 timeout, and - load-bearing - the finally-block cleanup that deletes every
-uploaded file even when the generation call fails. stream() is the
-transitional single-"done" shape until 6.4.
+uploaded file even when the generation call fails.
+
+stream() (ADR-006 stage 6.5b) streams the same request through
+:streamGenerateContent?alt=sse via _gemini_stream_sse (the streaming
+sibling of _gemini_post_json): parts without "thought": true are "text"
+events, parts with it (thinkingConfig.includeThoughts) are "reasoning"
+events, and the uploaded-files cleanup finally runs on EVERY exit path,
+including mid-stream cancellation.
 """
 
 from __future__ import annotations
@@ -18,7 +24,9 @@ from api_provider import (
     _extract_gemini_text,
     _gemini_delete_file,
     _gemini_post_json,
+    _gemini_stream_sse,
     _prepare_gemini_contents,
+    _raise_if_cancelled,
     gemini_supports_reasoning,
     gemini_thinking_config,
 )
@@ -36,17 +44,16 @@ class GeminiProvider:
         self.model_id = model
         self.reasoning_level = reasoning_level
         self.capabilities = ProviderCapabilities(
-            streaming=False,
+            streaming=True,  # 6.5b: real SSE via :streamGenerateContent?alt=sse
             reasoning=gemini_supports_reasoning(model),
             vision=True,
             audio=True,   # media rides the Files API upload path in _prepare_gemini_contents
             image_generation=True,
         )
 
-    def complete(self, request: ChatRequest, cancel: CancelToken) -> str:
-        system_prompt, gemini_contents, uploaded_files = _prepare_gemini_contents(
-            request.messages, cancel_event=cancel.event, api_key=self.api_key
-        )
+    def _request_body(self, request: ChatRequest, system_prompt, gemini_contents) -> dict:
+        """The shared body build of both paths: passthrough kwargs as
+        generationConfig, thinkingConfig gated on TASK_CHAT."""
         kwargs = {k: v for k, v in request.extra_kwargs.items() if k != "cancellation_event"}
         generation_config = dict(kwargs) if kwargs else {}
         if request.task == config.TASK_CHAT:
@@ -58,6 +65,13 @@ class GeminiProvider:
             request_body["system_instruction"] = {"parts": [{"text": str(system_prompt)}]}
         if generation_config:
             request_body["generationConfig"] = generation_config
+        return request_body
+
+    def complete(self, request: ChatRequest, cancel: CancelToken) -> str:
+        system_prompt, gemini_contents, uploaded_files = _prepare_gemini_contents(
+            request.messages, cancel_event=cancel.event, api_key=self.api_key
+        )
+        request_body = self._request_body(request, system_prompt, gemini_contents)
 
         try:
             payload = _gemini_post_json(
@@ -74,4 +88,68 @@ class GeminiProvider:
         return _extract_gemini_text(payload)
 
     def stream(self, request: ChatRequest, cancel: CancelToken) -> Iterator[ProviderEvent]:
-        yield ProviderEvent("done", self.complete(request, cancel))
+        # ADR-006 stage 6.5b: same prep and body as complete(), streamed over
+        # SSE. The uploaded-files finally wraps EVERYTHING network-facing -
+        # a mid-stream cancel or consumer abandonment (GeneratorExit at any
+        # yield below) still deletes every uploaded file, exactly the
+        # invariant complete()'s own finally pins.
+        _raise_if_cancelled(cancel.event)
+        system_prompt, gemini_contents, uploaded_files = _prepare_gemini_contents(
+            request.messages, cancel_event=cancel.event, api_key=self.api_key
+        )
+        try:
+            request_body = self._request_body(request, system_prompt, gemini_contents)
+            text_parts: list[str] = []
+            sse = _gemini_stream_sse(
+                f"{GEMINI_BASE_URL}/v1beta/models/{self.model_id}:streamGenerateContent?alt=sse",
+                request_body,
+                timeout=_calculate_gemini_timeout(request.messages),
+                cancel_event=cancel.event,
+                api_key=self.api_key,
+            )
+            try:
+                for payload in sse:
+                    if cancel.is_set():
+                        sse.close()  # tears down the live urllib response
+                    _raise_if_cancelled(cancel.event)  # raises if just closed above
+
+                    # Same safety-filter contract as _extract_gemini_text.
+                    prompt_feedback = payload.get("promptFeedback", {}) or {}
+                    block_reason = (
+                        prompt_feedback.get("blockReason") or prompt_feedback.get("block_reason")
+                    )
+                    if block_reason:
+                        raise RuntimeError(
+                            f"The response was blocked by Google's Safety Filters ({block_reason})."
+                        )
+                    for candidate in payload.get("candidates", []) or []:
+                        content = candidate.get("content", {}) or {}
+                        for part in content.get("parts", []) or []:
+                            text = part.get("text")
+                            if not text:
+                                continue
+                            text_parts.append(text)
+                            # thinkingConfig.includeThoughts marks thought
+                            # parts with "thought": true - they stream on the
+                            # reasoning channel, but their text STAYS in the
+                            # final concatenation below.
+                            if part.get("thought") is True:
+                                yield ProviderEvent("reasoning", text)
+                            else:
+                                yield ProviderEvent("text", text)
+            finally:
+                sse.close()  # idempotent on an already-closed generator
+
+            # Deliberate parity with complete(): _extract_gemini_text
+            # concatenates EVERY text part, thought or not, and never calls
+            # _compose_reasoned_response - Gemini has no <think> composition
+            # today, and giving the streamed path one would be a silent
+            # behavior change. Revisit when Gemini gets composition.
+            final = "".join(text_parts).strip()
+            if not final:
+                raise RuntimeError("Gemini returned an empty response.")
+        finally:
+            for file_name in uploaded_files:
+                _gemini_delete_file(file_name, api_key=self.api_key)
+
+        yield ProviderEvent("done", final)

--- a/backend/providers/gemini_provider.py
+++ b/backend/providers/gemini_provider.py
@@ -113,6 +113,19 @@ class GeminiProvider:
                         sse.close()  # tears down the live urllib response
                     _raise_if_cancelled(cancel.event)  # raises if just closed above
 
+                    # 6.5b review (MEDIUM): a mid-stream error frame
+                    # ({"error": {"code": ..., "message": ...}}) matches
+                    # neither promptFeedback nor candidates - skipping it
+                    # would return the partial text as a complete response.
+                    # Raise with the same message extraction _gemini_post_json
+                    # applies to that exact payload shape.
+                    error_info = payload.get("error")
+                    if error_info:
+                        message = (
+                            error_info.get("message") if isinstance(error_info, dict) else None
+                        )
+                        raise RuntimeError(message or str(error_info))
+
                     # Same safety-filter contract as _extract_gemini_text.
                     prompt_feedback = payload.get("promptFeedback", {}) or {}
                     block_reason = (

--- a/backend/providers/llama_cpp_provider.py
+++ b/backend/providers/llama_cpp_provider.py
@@ -5,9 +5,14 @@ actionable "use Ollama or Gemini" message), per-task message prep against
 the FROZEN settings dict the caller snapshotted, the cached client lookup
 (_get_llama_cpp_client - a heavyweight in-process model load, cached in
 api_provider under its own lock), kwargs filtered to what
-create_chat_completion actually accepts, and text extraction. stream() is
-the transitional single-"done" shape; local token streaming lands in 6.4
-via the threaded-generator bridge the ADR names for this provider.
+create_chat_completion actually accepts, and text extraction.
+
+stream() (ADR-006 stage 6.5b) is real local token streaming:
+create_chat_completion(stream=True) returns a sync generator of OpenAI-
+chunk-shaped dicts, consumed with cooperative-only cancellation (there is
+no HTTP stream to tear down - inference runs in-process) and composed at
+"done" through the same _extract_llama_cpp_text the blocking path uses,
+so streamed and blocking runs produce identical final text.
 """
 
 from __future__ import annotations
@@ -17,6 +22,7 @@ from typing import Iterator
 from api_provider import (
     _assert_llama_cpp_message_support,
     _extract_llama_cpp_text,
+    _extract_response_field,
     _filter_kwargs_for_callable,
     _get_llama_cpp_client,
     _prepare_llama_cpp_kwargs,
@@ -40,7 +46,7 @@ class LlamaCppProvider:
         # in this package.
         self.settings = settings
         self.capabilities = ProviderCapabilities(
-            streaming=False,
+            streaming=True,  # 6.5b: real local token streaming via create_chat_completion(stream=True)
             reasoning=llama_cpp_supports_reasoning(str(settings.get("chat_model_path", ""))),
             vision=False,  # _assert_llama_cpp_message_support rejects media up front
             audio=False,
@@ -61,4 +67,67 @@ class LlamaCppProvider:
         return _extract_llama_cpp_text(response)
 
     def stream(self, request: ChatRequest, cancel: CancelToken) -> Iterator[ProviderEvent]:
-        yield ProviderEvent("done", self.complete(request, cancel))
+        # ADR-006 stage 6.5b: same prep pipeline as complete(), streamed.
+        _raise_if_cancelled(cancel.event)
+        _assert_llama_cpp_message_support(request.messages)
+        llama_messages = _prepare_llama_cpp_messages(request.messages, request.task, self.settings)
+        client = _get_llama_cpp_client(request.task, self.settings)
+        kwargs = {k: v for k, v in request.extra_kwargs.items() if k != "cancellation_event"}
+        llama_kwargs = _filter_kwargs_for_callable(
+            client.create_chat_completion,
+            _prepare_llama_cpp_kwargs(kwargs, self.settings),
+        )
+        # stream=True is passed OUTSIDE the filtered kwargs, explicitly:
+        # _filter_kwargs_for_callable keeps only names the callable's own
+        # signature declares, so routing it through the filter would let a
+        # wrapped/faked create_chat_completion without a spelled-out `stream`
+        # parameter silently degrade this into a blocking call.
+        llama_kwargs.pop("stream", None)
+        chunks = client.create_chat_completion(
+            messages=llama_messages, stream=True, **llama_kwargs
+        )
+
+        content_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        try:
+            for chunk in chunks:
+                # Cooperative-only cancellation: no live HTTP stream to close
+                # (inference runs in-process); the finally below still closes
+                # the generator so the shared cached client is never left
+                # with a partially-consumed completion.
+                _raise_if_cancelled(cancel.event)
+
+                choices = _extract_response_field(chunk, "choices", []) or []
+                if not choices:
+                    continue
+                delta = _extract_response_field(choices[0], "delta", {}) or {}
+                delta_content = _extract_response_field(delta, "content") or ""
+                if delta_content:
+                    content_parts.append(delta_content)
+                    yield ProviderEvent("text", delta_content)
+                # The same wide net _extract_llama_cpp_text casts for
+                # thinking output, at the delta level.
+                delta_reasoning = (
+                    _extract_response_field(delta, "reasoning")
+                    or _extract_response_field(delta, "reasoning_content")
+                    or _extract_response_field(delta, "thinking")
+                    or ""
+                )
+                if delta_reasoning:
+                    reasoning_parts.append(delta_reasoning)
+                    yield ProviderEvent("reasoning", delta_reasoning)
+        finally:
+            close = getattr(chunks, "close", None)
+            if callable(close):
+                close()
+
+        # Streamed and blocking paths compose through the SAME extraction:
+        # a synthetic blocking-shaped response through _extract_llama_cpp_text
+        # gives identical <think> composition, reasoning-without-answer
+        # detection, and empty-response error as complete() for the same data.
+        yield ProviderEvent("done", _extract_llama_cpp_text({
+            "choices": [{"message": {
+                "content": "".join(content_parts),
+                "reasoning": "".join(reasoning_parts),
+            }}],
+        }))

--- a/backend/providers/openai_provider.py
+++ b/backend/providers/openai_provider.py
@@ -17,10 +17,11 @@ converts the app's content parts to the OpenAI content-part format:
   a clear, actionable error instead of a provider-side 400 - a stated
   capability boundary, not a silent drop.
 
-`stream()` is the transitional single-"done" shape (matching chat_stream's
-existing documented non-Ollama fallback of exactly one full-text chunk);
-stage 6.4 replaces it with real SSE streaming. Exception translation stays
-with the caller, same as every provider in this package.
+`stream()` (ADR-006 stage 6.5b) is real SSE streaming: chat.completions
+.create(stream=True) with incremental deltas on the "text" channel and
+OpenAI-compatible servers' `reasoning_content`/`reasoning` extras on the
+"reasoning" channel. Exception translation stays with the caller, same as
+every provider in this package.
 """
 
 from __future__ import annotations
@@ -132,7 +133,7 @@ class OpenAIProvider:
         self.model_id = model
         self.reasoning_level = reasoning_level
         self.capabilities = ProviderCapabilities(
-            streaming=False,  # 6.4 flips this with real SSE
+            streaming=True,  # 6.5b: real SSE via chat.completions.create(stream=True)
             reasoning=openai_supports_reasoning(model),
             vision=True,   # C4: image_url parts now real
             audio=True,    # C4: input_audio parts now real (wav/mp3)
@@ -160,4 +161,57 @@ class OpenAIProvider:
         return response.choices[0].message.content
 
     def stream(self, request: ChatRequest, cancel: CancelToken) -> Iterator[ProviderEvent]:
-        yield ProviderEvent("done", self.complete(request, cancel))
+        # ADR-006 stage 6.5b: real SSE streaming, same request prep as
+        # complete() (C4 message conversion, reasoning kwargs gated on
+        # TASK_CHAT), same cancellation pattern as OllamaProvider.stream():
+        # check at the top of every iteration, close the live HTTP stream
+        # BEFORE raising, close again (idempotently) in the finally.
+        _raise_if_cancelled(cancel.event)
+        kwargs = {k: v for k, v in request.extra_kwargs.items() if k != "cancellation_event"}
+        kwargs.pop("stream", None)  # ours to set - a passthrough kwarg can't turn it back off
+        if request.task == config.TASK_CHAT:
+            kwargs.update(openai_reasoning_kwargs(self.model_id, self.reasoning_level))
+
+        content_parts: list[str] = []
+        stream = self.client.chat.completions.create(
+            model=self.model_id,
+            messages=prepare_openai_messages(request.messages),
+            stream=True,
+            **kwargs,
+        )
+        try:
+            for chunk in stream:
+                if cancel.is_set():
+                    stream.close()  # closes the SDK Stream's underlying HTTP response
+                _raise_if_cancelled(cancel.event)  # raises if just closed above
+
+                # Some OpenAI-compatible servers send usage-only/keep-alive
+                # chunks with an empty choices list - skip, don't IndexError.
+                choices = getattr(chunk, "choices", None) or []
+                if not choices:
+                    continue
+                delta = choices[0].delta
+                if delta is None:
+                    continue
+                delta_content = getattr(delta, "content", None) or ""
+                if delta_content:
+                    content_parts.append(delta_content)
+                    yield ProviderEvent("text", delta_content)
+                # ChoiceDelta has no typed reasoning field, but the model
+                # allows extras - OpenAI-compatible servers (vLLM,
+                # llama-server, LM Studio, ...) put thinking deltas under
+                # reasoning_content / reasoning.
+                delta_reasoning = (
+                    getattr(delta, "reasoning_content", None)
+                    or getattr(delta, "reasoning", None)
+                    or ""
+                )
+                if delta_reasoning:
+                    yield ProviderEvent("reasoning", delta_reasoning)
+        finally:
+            stream.close()  # idempotent on an already-closed/exhausted stream
+
+        # Deliberate parity with complete(), which returns message.content
+        # untouched (no <think> composition anywhere on the OpenAI path
+        # today): the final text is the raw concatenated content deltas.
+        yield ProviderEvent("done", "".join(content_parts))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -21,13 +21,14 @@ def _chat_stream_delegates_to_patched_chat(monkeypatch):
     fresh module-attribute read, not a captured reference), so it transparently
     picks up whatever fake_chat a given test has patched into api_provider.chat
     for the duration of its own `with patch.object(...)` block, and forwards it
-    through on_chunk as a single synthetic chunk - the exact shape
-    chat_stream's own documented non-Ollama fallback already uses. This tests
-    send_message's downstream logic (node creation, parsing, cancellation),
-    which is unaffected by whether the reply arrived in one chunk or many -
-    real incremental chunking is covered separately by
-    graphlink_app/tests/test_api_provider_chat_stream.py and this suite's own
-    dedicated streaming tests in test_agents.py."""
+    through on_chunk as a single synthetic chunk (the shape the real
+    function's non-Ollama fallback used before ADR-006 stage 6.5b made every
+    provider stream for real - still a valid double, since on_chunk's
+    contract is delta-agnostic). This tests send_message's downstream logic
+    (node creation, parsing, cancellation), which is unaffected by whether
+    the reply arrived in one chunk or many - real incremental chunking is
+    covered separately by backend/tests/test_providers.py's chat_stream
+    tests and this suite's own dedicated streaming tests in test_agents.py."""
 
     def _generic_chat_stream(task, messages, on_chunk, **kwargs):
         response = api_provider.chat(task, messages, **kwargs)

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -88,16 +88,17 @@ def _configure_fake_ollama(monkeypatch, chat_fn, *, model="test-model"):
     # built around mocking api_provider.chat alone - most of which predate
     # R4.4 - would otherwise fall through to chat_stream's REAL Ollama
     # branch (since these fixtures also set LOCAL_PROVIDER_TYPE to Ollama)
-    # and attempt a genuine network call. This fake mirrors
-    # api_provider.chat_stream's own documented non-streaming-provider
-    # fallback shape exactly (one blocking call plus one synthetic
-    # full-text on_chunk), just delegating the blocking call to chat_fn
-    # instead of the real chat() - so chat_fn's return value/exception/
-    # cancellation behavior is preserved unchanged for both the streaming
-    # and non-streaming dispatch paths. Tests that care about the streaming
-    # semantics THEMSELVES (batching, reset events, ...) monkeypatch
-    # api_provider.chat_stream directly instead - see the "R4.4: true token
-    # streaming" section below.
+    # and attempt a genuine network call. This fake delivers the reply as
+    # one blocking call plus one synthetic full-text on_chunk - the shape
+    # the real chat_stream's non-Ollama fallback used before ADR-006 stage
+    # 6.5b made every provider stream for real; it remains a valid TEST
+    # double because on_chunk's contract is delta-agnostic - just
+    # delegating the blocking call to chat_fn instead of the real chat(),
+    # so chat_fn's return value/exception/cancellation behavior is
+    # preserved unchanged for both dispatch paths. Tests that care about
+    # the streaming semantics THEMSELVES (batching, reset events, ...)
+    # monkeypatch api_provider.chat_stream directly instead - see the
+    # "R4.4: true token streaming" section below.
     #
     # Calls api_provider.chat (the module attribute, looked up fresh on
     # every invocation) rather than closing over chat_fn directly - this

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -579,7 +579,7 @@ def test_the_capability_matrix_is_pinned_per_provider():
         "ollama":    (True,  True,  True,  True,  False),  # media rides the images field; audio model-gated at request time
         "openai":    (True,  True,  True,  True,  False),  # C4: vision+audio real; image_gen probed from the client (None here)
         "anthropic": (True,  True,  True,  False, False),
-        "gemini":    (False, True,  True,  True,  True),
+        "gemini":    (True,  True,  True,  True,  True),
         "llama_cpp": (False, False, False, False, False),
     }
     actual = {
@@ -1270,6 +1270,95 @@ def test_anthropic_sse_reader_parses_data_lines_and_always_closes(monkeypatch):
     next(gen)
     gen.close()
     assert response2.closed is True
+
+
+def _gemini_sse_payload(*parts):
+    return {"candidates": [{"content": {"parts": list(parts)}}]}
+
+
+def test_gemini_stream_maps_thought_parts_to_reasoning_and_keeps_concatenation_parity(monkeypatch):
+    from backend.providers import CancelToken as CT, ChatRequest as CR, GeminiProvider
+
+    sse_calls = {}
+
+    def fake_stream_sse(url, body, timeout=120, cancel_event=None, api_key=None):
+        sse_calls.update(url=url, body=body, timeout=timeout)
+        yield _gemini_sse_payload({"text": "pondering... ", "thought": True})
+        yield _gemini_sse_payload({"text": "Ans"})
+        yield _gemini_sse_payload({"text": "wer."})
+
+    monkeypatch.setattr(
+        "backend.providers.gemini_provider._prepare_gemini_contents",
+        lambda messages, cancel_event=None, api_key=None: (None, [{"parts": [{"text": "hi"}]}], []),
+    )
+    monkeypatch.setattr("backend.providers.gemini_provider._gemini_stream_sse", fake_stream_sse)
+
+    provider = GeminiProvider(api_key="k", model="gemini-2.5-pro")
+    events = list(provider.stream(
+        CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]), CT()
+    ))
+
+    assert [e.type for e in events] == ["reasoning", "text", "text", "done"]
+    # Parity with complete(): _extract_gemini_text concatenates EVERY text
+    # part, thought parts included - no <think> composition for Gemini yet.
+    assert events[-1].text == "pondering... Answer."
+    assert ":streamGenerateContent?alt=sse" in sse_calls["url"]
+    assert sse_calls["body"]["contents"] == [{"parts": [{"text": "hi"}]}]
+
+
+def test_gemini_stream_cancellation_still_deletes_uploaded_files(monkeypatch):
+    from backend.providers import CancelToken as CT, ChatRequest as CR, GeminiProvider
+
+    cancel_event = threading.Event()
+    deleted = []
+    sse_closed = {"count": 0}
+
+    def fake_stream_sse(url, body, timeout=120, cancel_event=None, api_key=None):
+        try:
+            yield _gemini_sse_payload({"text": "par"})
+            cancel_event_outer.set()
+            yield _gemini_sse_payload({"text": "tial"})
+        finally:
+            sse_closed["count"] += 1
+
+    cancel_event_outer = cancel_event
+    monkeypatch.setattr(
+        "backend.providers.gemini_provider._prepare_gemini_contents",
+        lambda messages, cancel_event=None, api_key=None: (None, [{"parts": [{"text": "hi"}]}], ["files/abc"]),
+    )
+    monkeypatch.setattr("backend.providers.gemini_provider._gemini_stream_sse", fake_stream_sse)
+    monkeypatch.setattr(
+        "backend.providers.gemini_provider._gemini_delete_file",
+        lambda name, api_key=None: deleted.append(name),
+    )
+
+    provider = GeminiProvider(api_key="k", model="gemini-2.5-pro")
+    with pytest.raises(api_provider.RequestCancelledError):
+        list(provider.stream(
+            CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]),
+            CT(cancel_event),
+        ))
+    assert deleted == ["files/abc"]  # the load-bearing cleanup ran on the cancel path
+    assert sse_closed["count"] >= 1  # and the live SSE generator was closed
+
+
+def test_gemini_stream_surfaces_the_safety_block_as_the_exact_blocking_path_error(monkeypatch):
+    from backend.providers import CancelToken as CT, ChatRequest as CR, GeminiProvider
+
+    def fake_stream_sse(url, body, timeout=120, cancel_event=None, api_key=None):
+        yield {"promptFeedback": {"blockReason": "SAFETY"}, "candidates": []}
+
+    monkeypatch.setattr(
+        "backend.providers.gemini_provider._prepare_gemini_contents",
+        lambda messages, cancel_event=None, api_key=None: (None, [{"parts": [{"text": "hi"}]}], []),
+    )
+    monkeypatch.setattr("backend.providers.gemini_provider._gemini_stream_sse", fake_stream_sse)
+
+    provider = GeminiProvider(api_key="k", model="gemini-2.5-pro")
+    with pytest.raises(RuntimeError, match=r"Safety Filters \(SAFETY\)"):
+        list(provider.stream(
+            CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]), CT()
+        ))
 
 
 def test_chat_constructs_each_api_provider_from_the_snapshot_credentials(monkeypatch):

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -558,7 +558,8 @@ def _fake_openai_client(response_text="ok"):
 def test_the_capability_matrix_is_pinned_per_provider():
     """The 6.3 exit criterion's matrix, as data: what each provider+model
     pair can actually do. A capability flipping here must be a deliberate
-    stage (6.4 flips streaming), never a drive-by."""
+    stage (6.5b flipped streaming True for the four non-Ollama providers),
+    never a drive-by."""
     from backend.providers import (
         AnthropicProvider,
         GeminiProvider,
@@ -576,7 +577,7 @@ def test_the_capability_matrix_is_pinned_per_provider():
     expected = {
         #            streaming, reasoning, vision, audio, image_gen
         "ollama":    (True,  True,  True,  True,  False),  # media rides the images field; audio model-gated at request time
-        "openai":    (False, True,  True,  True,  False),  # C4: vision+audio real; image_gen probed from the client (None here)
+        "openai":    (True,  True,  True,  True,  False),  # C4: vision+audio real; image_gen probed from the client (None here)
         "anthropic": (False, True,  True,  False, False),
         "gemini":    (False, True,  True,  True,  True),
         "llama_cpp": (False, False, False, False, False),
@@ -977,10 +978,11 @@ def test_connection_refused_in_api_mode_surfaces_the_friendly_endpoint_message(o
     assert "Details: connection refused by endpoint" in message  # raw cause kept, as detail only
 
 
-def test_all_four_new_providers_satisfy_the_protocol_and_stream_exactly_one_done():
-    """6.3 review fix: protocol conformance was only pinned for FakeProvider
-    and Ollama; the transitional stream()-wraps-complete() shape (chat_stream's
-    documented one-full-chunk fallback) was never asserted for the new four."""
+def test_all_four_new_providers_satisfy_the_protocol():
+    """6.3: protocol conformance for the non-Ollama four. (The transitional
+    stream()-wraps-complete() single-"done" assertion that used to live here
+    died with 6.5b - real per-provider streaming is pinned in the dedicated
+    6.5b section below.)"""
     from backend.providers import (
         AnthropicProvider,
         GeminiProvider,
@@ -993,13 +995,122 @@ def test_all_four_new_providers_satisfy_the_protocol_and_stream_exactly_one_done
     assert isinstance(GeminiProvider(api_key="k", model="gemini-2.5-pro"), Provider)
     assert isinstance(LlamaCppProvider(settings={"chat_model_path": "m.gguf"}), Provider)
 
-    client, _ = _fake_openai_client("full text")
-    provider = OpenAIProvider(client=client, model="gpt-5")
+
+# -- ADR-006 stage 6.5b: real streaming for the non-Ollama four ---------------
+# -- Only the SDK/transport layer is faked in each of these; the provider's
+# -- own stream() machinery (prep, event mapping, cancellation, composition)
+# -- runs for real. The bar per provider: multiple incremental text deltas,
+# -- reasoning events where the wire carries them, a final "done" whose text
+# -- matches what complete() composes for the same data, and mid-stream
+# -- cancellation that closes the live stream and raises the untranslated
+# -- RequestCancelledError sentinel.
+
+
+class FakeSDKStream:
+    """Iterable-with-close() stand-in for openai's Stream / anthropic's raw
+    event Stream / a llama.cpp chunk generator - anything the providers
+    iterate and must close."""
+
+    def __init__(self, items, cancel_event=None, cancel_after=None):
+        self._items = list(items)
+        self._index = 0
+        self.close_calls = 0
+        self._cancel_event = cancel_event
+        self._cancel_after = cancel_after
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._index >= len(self._items):
+            raise StopIteration
+        item = self._items[self._index]
+        self._index += 1
+        if self._cancel_event is not None and self._index == self._cancel_after:
+            self._cancel_event.set()  # cancel lands after this item is delivered
+        return item
+
+    def close(self):
+        self.close_calls += 1
+
+
+def _openai_chunk(content=None, reasoning_content=None, choices_empty=False):
+    import types
+
+    if choices_empty:
+        return types.SimpleNamespace(choices=[])  # usage-only chunk shape
+    delta_fields = {"content": content}
+    if reasoning_content is not None:
+        delta_fields["reasoning_content"] = reasoning_content
+    return types.SimpleNamespace(
+        choices=[types.SimpleNamespace(delta=types.SimpleNamespace(**delta_fields), finish_reason=None)]
+    )
+
+
+def _fake_openai_streaming_client(chunks_or_stream):
+    import types
+
+    captured = {}
+    stream = (
+        chunks_or_stream
+        if isinstance(chunks_or_stream, FakeSDKStream)
+        else FakeSDKStream(chunks_or_stream)
+    )
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        assert kwargs.get("stream") is True
+        return stream
+
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=create))
+    )
+    return client, stream, captured
+
+
+def test_openai_stream_yields_incremental_deltas_reasoning_and_a_done_matching_complete():
+    from backend.providers import CancelToken as CT, ChatRequest as CR, OpenAIProvider
+
+    client, stream, captured = _fake_openai_streaming_client([
+        _openai_chunk(content="Hel"),
+        _openai_chunk(choices_empty=True),        # usage-only chunk must be skipped
+        _openai_chunk(reasoning_content="hmm "),  # compatible-server thinking delta
+        _openai_chunk(content="lo "),
+        _openai_chunk(content="world"),
+    ])
+    provider = OpenAIProvider(client=client, model="gpt-5", reasoning_level="high")
     events = list(provider.stream(
-        ChatRequest(task=config.TASK_TITLE, messages=[{"role": "user", "content": "hi"}]),
-        CancelToken(),
+        CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]), CT()
     ))
-    assert events == [ProviderEvent("done", "full text")]  # exactly one terminal event
+
+    assert [e.type for e in events] == ["text", "reasoning", "text", "text", "done"]
+    # Parity with complete(): raw concatenated content, no <think> composition
+    # (the OpenAI blocking path returns message.content untouched).
+    assert events[-1].text == "Hello world"
+    assert stream.close_calls >= 1  # the finally closed the exhausted stream
+    # Same request prep as complete(): reasoning kwargs applied for TASK_CHAT.
+    chat_keys = set(captured) - {"model", "messages", "stream"}
+    assert chat_keys == set(api_provider.openai_reasoning_kwargs("gpt-5", "high"))
+
+
+def test_openai_stream_cancellation_mid_stream_closes_the_live_stream_and_raises():
+    from backend.providers import CancelToken as CT, ChatRequest as CR, OpenAIProvider
+
+    cancel_event = threading.Event()
+    live = FakeSDKStream(
+        [_openai_chunk(content="par"), _openai_chunk(content="tial")],
+        cancel_event=cancel_event,
+        cancel_after=1,
+    )
+    client, _, _ = _fake_openai_streaming_client(live)
+    provider = OpenAIProvider(client=client, model="gpt-5")
+
+    with pytest.raises(api_provider.RequestCancelledError):
+        list(provider.stream(
+            CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]),
+            CT(cancel_event),
+        ))
+    assert live.close_calls >= 1  # the live HTTP stream was actively closed
 
 
 def test_chat_constructs_each_api_provider_from_the_snapshot_credentials(monkeypatch):

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -578,7 +578,7 @@ def test_the_capability_matrix_is_pinned_per_provider():
         #            streaming, reasoning, vision, audio, image_gen
         "ollama":    (True,  True,  True,  True,  False),  # media rides the images field; audio model-gated at request time
         "openai":    (True,  True,  True,  True,  False),  # C4: vision+audio real; image_gen probed from the client (None here)
-        "anthropic": (False, True,  True,  False, False),
+        "anthropic": (True,  True,  True,  False, False),
         "gemini":    (False, True,  True,  True,  True),
         "llama_cpp": (False, False, False, False, False),
     }
@@ -1111,6 +1111,165 @@ def test_openai_stream_cancellation_mid_stream_closes_the_live_stream_and_raises
             CT(cancel_event),
         ))
     assert live.close_calls >= 1  # the live HTTP stream was actively closed
+
+
+def _anthropic_raw_events(with_thinking=True):
+    """The raw wire shape shared by messages.create(stream=True) and the REST
+    SSE - dicts here, exactly what the REST path yields; the provider reads
+    both through _extract_response_field."""
+    events = [
+        {"type": "message_start", "message": {"role": "assistant"}},
+        {"type": "content_block_start", "index": 0},
+    ]
+    if with_thinking:
+        events += [
+            {"type": "content_block_delta", "delta": {"type": "thinking_delta", "thinking": "pondering"}},
+            {"type": "content_block_delta", "delta": {"type": "thinking_delta", "thinking": "..."}},
+        ]
+    events += [
+        {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Ans"}},
+        {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "wer."}},
+        {"type": "content_block_stop", "index": 0},
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+        {"type": "message_stop"},
+    ]
+    return events
+
+
+def test_anthropic_sdk_stream_yields_deltas_and_composes_done_like_the_blocking_path():
+    import types
+
+    from backend.providers import AnthropicProvider, CancelToken as CT, ChatRequest as CR
+
+    captured = {}
+    live = FakeSDKStream(_anthropic_raw_events())
+
+    def create(**kwargs):
+        captured.update(kwargs)
+        assert kwargs.get("stream") is True  # passed explicitly, outside the filter
+        return live
+
+    sdk_client = types.SimpleNamespace(messages=types.SimpleNamespace(create=create))
+    provider = AnthropicProvider(client=sdk_client, api_key="k", model="claude-opus-5")
+    events = list(provider.stream(
+        CR(task=config.TASK_CHAT, messages=[
+            {"role": "system", "content": "be brief"},
+            {"role": "user", "content": "hi"},
+        ]),
+        CT(),
+    ))
+
+    assert [e.type for e in events] == ["reasoning", "reasoning", "text", "text", "done"]
+    # Identical composition to _extract_anthropic_text's blocking contract.
+    assert events[-1].text == "<think>pondering...</think>\nAnswer."
+    assert captured["model"] == "claude-opus-5"
+    assert captured["system"] == "be brief"
+    assert live.close_calls >= 1
+
+
+def test_anthropic_rest_fallback_streams_through_the_new_sse_reader(monkeypatch):
+    from backend.providers import AnthropicProvider, CancelToken as CT, ChatRequest as CR
+
+    sse_calls = {}
+
+    def fake_stream_sse(url, body, timeout=180, cancel_event=None, api_key=None):
+        sse_calls.update(url=url, body=body, api_key=api_key)
+        yield from _anthropic_raw_events(with_thinking=False)
+
+    monkeypatch.setattr(
+        "backend.providers.anthropic_provider._anthropic_stream_sse", fake_stream_sse
+    )
+    provider = AnthropicProvider(
+        client={"provider": "anthropic", "transport": "rest"}, api_key="k", model="claude-opus-5"
+    )
+    events = list(provider.stream(
+        CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]), CT()
+    ))
+
+    assert [e.type for e in events] == ["text", "text", "done"]
+    assert events[-1].text == "Answer."
+    assert sse_calls["url"].endswith("/v1/messages")
+    assert sse_calls["body"]["model"] == "claude-opus-5"
+    assert sse_calls["api_key"] == "k"
+
+
+def test_anthropic_stream_cancellation_mid_stream_closes_the_live_stream_and_raises():
+    import types
+
+    from backend.providers import AnthropicProvider, CancelToken as CT, ChatRequest as CR
+
+    cancel_event = threading.Event()
+    live = FakeSDKStream(_anthropic_raw_events(), cancel_event=cancel_event, cancel_after=3)
+
+    def create(**kwargs):
+        return live
+
+    sdk_client = types.SimpleNamespace(messages=types.SimpleNamespace(create=create))
+    provider = AnthropicProvider(client=sdk_client, api_key="k", model="claude-opus-5")
+
+    with pytest.raises(api_provider.RequestCancelledError):
+        list(provider.stream(
+            CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]),
+            CT(cancel_event),
+        ))
+    assert live.close_calls >= 1
+
+
+def test_anthropic_sse_reader_parses_data_lines_and_always_closes(monkeypatch):
+    """The urllib-level unit for _anthropic_stream_sse itself: `event:` naming
+    lines and blank separators are skipped, each data: line parses to its
+    event dict, the request body carries \"stream\": true, and the response is
+    closed even when the consumer abandons the generator mid-stream."""
+    import io
+    import json as json_module
+
+    class FakeHTTPResponse:
+        def __init__(self, lines):
+            self._lines = lines
+            self.closed = False
+
+        def __iter__(self):
+            return iter(self._lines)
+
+        def close(self):
+            self.closed = True
+
+    wire = [
+        b"event: content_block_delta\n",
+        b"data: " + json_module.dumps(
+            {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "hi"}}
+        ).encode() + b"\n",
+        b"\n",
+        b"data: " + json_module.dumps({"type": "message_stop"}).encode() + b"\n",
+    ]
+    response = FakeHTTPResponse(wire)
+    captured = {}
+
+    def fake_urlopen(request, timeout=None):
+        captured["body"] = json_module.loads(request.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return response
+
+    monkeypatch.setattr(api_provider.urllib.request, "urlopen", fake_urlopen)
+
+    events = list(api_provider._anthropic_stream_sse(
+        "https://api.anthropic.com/v1/messages", {"model": "m"}, api_key="k"
+    ))
+    assert [e["type"] for e in events] == ["content_block_delta", "message_stop"]
+    assert captured["body"]["stream"] is True
+    assert response.closed is True
+
+    # Abandonment: close() on a mid-flight generator still closes the response.
+    response2 = FakeHTTPResponse(wire)
+    monkeypatch.setattr(
+        api_provider.urllib.request, "urlopen", lambda request, timeout=None: response2
+    )
+    gen = api_provider._anthropic_stream_sse(
+        "https://api.anthropic.com/v1/messages", {"model": "m"}, api_key="k"
+    )
+    next(gen)
+    gen.close()
+    assert response2.closed is True
 
 
 def test_chat_constructs_each_api_provider_from_the_snapshot_credentials(monkeypatch):

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -1215,6 +1215,95 @@ def test_anthropic_stream_cancellation_mid_stream_closes_the_live_stream_and_rai
     assert live.close_calls >= 1
 
 
+def _consume_expecting(provider_stream, exc_type, match):
+    """Drain a provider stream expecting it to raise; return the events that
+    made it out first, so callers can assert no \"done\" was emitted."""
+    events = []
+    with pytest.raises(exc_type, match=match):
+        for event in provider_stream:
+            events.append(event)
+    return events
+
+
+def _sdk_client_returning(live):
+    import types
+
+    return types.SimpleNamespace(messages=types.SimpleNamespace(create=lambda **kwargs: live))
+
+
+_ANTHROPIC_ERROR_EVENT = {
+    "type": "error",
+    "error": {"type": "overloaded_error", "message": "Overloaded"},
+}
+
+
+def test_anthropic_mid_stream_error_event_raises_on_both_transports(monkeypatch):
+    """6.5b review (HIGH): the streaming API can send an error event on a 200
+    stream and close - it must raise with the API's type+message (the
+    _anthropic_post_json posture), never compose the partial text as done."""
+    from backend.providers import AnthropicProvider, CancelToken as CT, ChatRequest as CR
+
+    request = CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}])
+    wire = _anthropic_raw_events(with_thinking=False)[:4] + [_ANTHROPIC_ERROR_EVENT]
+
+    # SDK transport: the fake stream yields the error-shaped event itself.
+    provider = AnthropicProvider(
+        client=_sdk_client_returning(FakeSDKStream(wire)), api_key="k", model="claude-opus-5"
+    )
+    events = _consume_expecting(
+        provider.stream(request, CT()), RuntimeError, "overloaded_error: Overloaded"
+    )
+    assert events and all(e.type != "done" for e in events)  # deltas out, no done
+
+    # REST transport: the SSE reader yields the same wire-shaped dict.
+    def fake_stream_sse(url, body, timeout=180, cancel_event=None, api_key=None):
+        yield from wire
+
+    monkeypatch.setattr(
+        "backend.providers.anthropic_provider._anthropic_stream_sse", fake_stream_sse
+    )
+    provider = AnthropicProvider(
+        client={"provider": "anthropic", "transport": "rest"}, api_key="k", model="claude-opus-5"
+    )
+    events = _consume_expecting(
+        provider.stream(request, CT()), RuntimeError, "overloaded_error: Overloaded"
+    )
+    assert events and all(e.type != "done" for e in events)
+
+
+def test_anthropic_stream_ending_without_message_stop_raises_on_both_transports(monkeypatch):
+    """6.5b review: a successful Anthropic stream always ends with
+    message_stop - an iterator that just stops (proxy truncation, silent
+    close) delivered a fragment, and composing it would present a truncated
+    answer as complete."""
+    from backend.providers import AnthropicProvider, CancelToken as CT, ChatRequest as CR
+
+    request = CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}])
+    truncated = _anthropic_raw_events(with_thinking=False)[:-1]  # everything but message_stop
+
+    provider = AnthropicProvider(
+        client=_sdk_client_returning(FakeSDKStream(truncated)), api_key="k", model="claude-opus-5"
+    )
+    events = _consume_expecting(
+        provider.stream(request, CT()), RuntimeError, "ended unexpectedly before completion"
+    )
+    assert events and all(e.type != "done" for e in events)
+
+    def fake_stream_sse(url, body, timeout=180, cancel_event=None, api_key=None):
+        yield from truncated
+
+    monkeypatch.setattr(
+        "backend.providers.anthropic_provider._anthropic_stream_sse", fake_stream_sse
+    )
+    provider = AnthropicProvider(
+        client={"provider": "anthropic", "transport": "rest"}, api_key="k", model="claude-opus-5"
+    )
+    events = _consume_expecting(
+        provider.stream(request, CT()), RuntimeError, "ended unexpectedly before completion"
+    )
+    assert events and all(e.type != "done" for e in events)
+
+
 def test_anthropic_sse_reader_parses_data_lines_and_always_closes(monkeypatch):
     """The urllib-level unit for _anthropic_stream_sse itself: `event:` naming
     lines and blank separators are skipped, each data: line parses to its
@@ -1361,6 +1450,35 @@ def test_gemini_stream_surfaces_the_safety_block_as_the_exact_blocking_path_erro
         ))
 
 
+def test_gemini_mid_stream_error_frame_raises_with_the_apis_message(monkeypatch):
+    """6.5b review (MEDIUM): an error frame ({\"error\": {\"code\": ...,
+    \"message\": ...}}) matches neither promptFeedback nor candidates - it
+    must raise with the parsed message (same extraction _gemini_post_json
+    applies to that payload shape), never let partial text return as done."""
+    from backend.providers import CancelToken as CT, ChatRequest as CR, GeminiProvider
+
+    def fake_stream_sse(url, body, timeout=120, cancel_event=None, api_key=None):
+        yield _gemini_sse_payload({"text": "par"})
+        yield {"error": {"code": 503, "message": "The model is overloaded.", "status": "UNAVAILABLE"}}
+        yield _gemini_sse_payload({"text": "tial"})  # never reached
+
+    monkeypatch.setattr(
+        "backend.providers.gemini_provider._prepare_gemini_contents",
+        lambda messages, cancel_event=None, api_key=None: (None, [{"parts": [{"text": "hi"}]}], []),
+    )
+    monkeypatch.setattr("backend.providers.gemini_provider._gemini_stream_sse", fake_stream_sse)
+
+    provider = GeminiProvider(api_key="k", model="gemini-2.5-pro")
+    events = _consume_expecting(
+        provider.stream(
+            CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]), CT()
+        ),
+        RuntimeError,
+        "The model is overloaded",
+    )
+    assert [e.type for e in events] == ["text"]  # the pre-error delta got out; no done followed
+
+
 def _llama_chunk(content=None, reasoning_key=None, reasoning=None, finish=None):
     delta = {}
     if content is not None:
@@ -1370,26 +1488,20 @@ def _llama_chunk(content=None, reasoning_key=None, reasoning=None, finish=None):
     return {"choices": [{"delta": delta, "finish_reason": finish}]}
 
 
-def _llama_streaming_setup(monkeypatch, chunks, declare_stream_param=False):
+def _llama_streaming_setup(monkeypatch, chunks):
     """Fake ONLY the client/prep seams; the provider's own stream() runs for
-    real. The fake create_chat_completion deliberately does NOT declare a
-    `stream` parameter (unless asked to) - proving stream=True is passed
-    explicitly, outside _filter_kwargs_for_callable, which would DROP it
-    against this signature and silently degrade to a blocking call."""
+    real. The fake create_chat_completion has a strict no-**kwargs signature
+    (what _filter_kwargs_for_callable filters passthrough kwargs against);
+    the drop-trap test below has its own signature-narrowed fake."""
     from backend.providers import llama_cpp_provider as lp
 
     live = FakeSDKStream(chunks) if not isinstance(chunks, FakeSDKStream) else chunks
     captured = {}
 
     class FakeLlamaClient:
-        if declare_stream_param:
-            def create_chat_completion(self, messages=None, stream=False, temperature=None):
-                captured.update(messages=messages, stream=stream, temperature=temperature)
-                return live
-        else:
-            def create_chat_completion(self, messages=None, temperature=None, **kwargs):
-                captured.update(messages=messages, temperature=temperature, **kwargs)
-                return live
+        def create_chat_completion(self, messages=None, stream=False, temperature=None):
+            captured.update(messages=messages, stream=stream, temperature=temperature)
+            return live
 
     monkeypatch.setattr(lp, "_prepare_llama_cpp_messages", lambda messages, task, s: messages)
     monkeypatch.setattr(lp, "_get_llama_cpp_client", lambda task, s: FakeLlamaClient())
@@ -1405,7 +1517,7 @@ def test_llama_cpp_stream_yields_deltas_reasoning_and_a_done_matching_completes_
         {"choices": []},  # defensive: empty-choices chunk must be skipped
         _llama_chunk(content="Ans"),
         _llama_chunk(content="wer.", finish="stop"),
-    ], declare_stream_param=True)
+    ])
 
     provider = LlamaCppProvider(settings={"chat_model_path": "m.gguf"})
     events = list(provider.stream(
@@ -1427,26 +1539,62 @@ def test_llama_cpp_stream_yields_deltas_reasoning_and_a_done_matching_completes_
 
 
 def test_llama_cpp_stream_true_survives_the_kwargs_filter_and_beats_a_passthrough_stream(monkeypatch):
-    """THE 6.5b trap test, both halves. (a) The strict-signature fake above
-    has NO **kwargs, so anything routed through _filter_kwargs_for_callable
-    that its signature doesn't declare is silently dropped - stream=True must
-    arrive because the provider passes it OUTSIDE the filtered dict. (b) A
-    passthrough extra_kwarg trying to force stream=False must lose to ours."""
-    from backend.providers import CancelToken as CT, ChatRequest as CR, LlamaCppProvider
+    """THE 6.5b drop-trap test (reworked per adversarial review - the first
+    version's fake DECLARED `stream`, so filter-routing would have passed it
+    anyway and the test couldn't fail on the wrong implementation). Genuine
+    discriminator: the fake's INSPECTABLE signature (a narrowed
+    __signature__, which inspect.signature honors and therefore what
+    _filter_kwargs_for_callable sees) declares neither `stream` nor
+    **kwargs - filter-routing WOULD drop stream=True (asserted directly
+    below), and the fake then returns a NON-generator blocking dict, so the
+    wrong path fails loudly on both the captured flag and the events. The
+    explicit out-of-band pass is what makes it arrive. Bonus half: a
+    passthrough extra_kwarg trying to force stream=False loses to ours."""
+    import inspect
 
-    _, captured = _llama_streaming_setup(
-        monkeypatch, [_llama_chunk(content="ok", finish="stop")], declare_stream_param=True
+    from backend.providers import CancelToken as CT, ChatRequest as CR, LlamaCppProvider
+    from backend.providers import llama_cpp_provider as lp
+
+    captured = {}
+    live = FakeSDKStream([_llama_chunk(content="ok", finish="stop")])
+
+    def create_chat_completion(messages=None, temperature=None, **kwargs):
+        captured.update(messages=messages, temperature=temperature, **kwargs)
+        if not kwargs.get("stream"):
+            return {"choices": [{"message": {"content": "BLOCKING RESPONSE"}}]}
+        return live
+
+    create_chat_completion.__signature__ = inspect.Signature([
+        inspect.Parameter("messages", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None),
+        inspect.Parameter("temperature", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None),
+    ])
+
+    class FakeLlamaClient:
+        pass
+
+    client = FakeLlamaClient()
+    client.create_chat_completion = create_chat_completion
+    monkeypatch.setattr(lp, "_prepare_llama_cpp_messages", lambda messages, task, s: messages)
+    monkeypatch.setattr(lp, "_get_llama_cpp_client", lambda task, s: client)
+    monkeypatch.setattr(lp, "_prepare_llama_cpp_kwargs", lambda kwargs, s: dict(kwargs))
+
+    # The discriminator's premise, asserted directly: routed through the
+    # filter, stream would never reach the callable.
+    assert "stream" not in api_provider._filter_kwargs_for_callable(
+        create_chat_completion, {"stream": True, "temperature": 0.5}
     )
+
     provider = LlamaCppProvider(settings={"chat_model_path": "m.gguf"})
     events = list(provider.stream(
         CR(
             task=config.TASK_CHAT,
             messages=[{"role": "user", "content": "hi"}],
-            extra_kwargs={"stream": False},  # (b): cannot turn real streaming back off
+            extra_kwargs={"stream": False, "temperature": 0.5},
         ),
         CT(),
     ))
-    assert captured["stream"] is True
+    assert captured["stream"] is True  # explicit pass survived where the filter would drop it
+    assert captured["temperature"] == 0.5  # declared passthrough kwargs still flow
     assert events[-1] == ProviderEvent("done", "ok")
 
 
@@ -1459,7 +1607,7 @@ def test_llama_cpp_stream_cancellation_closes_the_generator_and_raises(monkeypat
         cancel_event=cancel_event,
         cancel_after=1,
     )
-    _llama_streaming_setup(monkeypatch, live, declare_stream_param=True)
+    _llama_streaming_setup(monkeypatch, live)
 
     provider = LlamaCppProvider(settings={"chat_model_path": "m.gguf"})
     with pytest.raises(api_provider.RequestCancelledError):

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -580,7 +580,7 @@ def test_the_capability_matrix_is_pinned_per_provider():
         "openai":    (True,  True,  True,  True,  False),  # C4: vision+audio real; image_gen probed from the client (None here)
         "anthropic": (True,  True,  True,  False, False),
         "gemini":    (True,  True,  True,  True,  True),
-        "llama_cpp": (False, False, False, False, False),
+        "llama_cpp": (True,  False, False, False, False),
     }
     actual = {
         name: (c.streaming, c.reasoning, c.vision, c.audio, c.image_generation)
@@ -1359,6 +1359,117 @@ def test_gemini_stream_surfaces_the_safety_block_as_the_exact_blocking_path_erro
         list(provider.stream(
             CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]), CT()
         ))
+
+
+def _llama_chunk(content=None, reasoning_key=None, reasoning=None, finish=None):
+    delta = {}
+    if content is not None:
+        delta["content"] = content
+    if reasoning_key is not None:
+        delta[reasoning_key] = reasoning
+    return {"choices": [{"delta": delta, "finish_reason": finish}]}
+
+
+def _llama_streaming_setup(monkeypatch, chunks, declare_stream_param=False):
+    """Fake ONLY the client/prep seams; the provider's own stream() runs for
+    real. The fake create_chat_completion deliberately does NOT declare a
+    `stream` parameter (unless asked to) - proving stream=True is passed
+    explicitly, outside _filter_kwargs_for_callable, which would DROP it
+    against this signature and silently degrade to a blocking call."""
+    from backend.providers import llama_cpp_provider as lp
+
+    live = FakeSDKStream(chunks) if not isinstance(chunks, FakeSDKStream) else chunks
+    captured = {}
+
+    class FakeLlamaClient:
+        if declare_stream_param:
+            def create_chat_completion(self, messages=None, stream=False, temperature=None):
+                captured.update(messages=messages, stream=stream, temperature=temperature)
+                return live
+        else:
+            def create_chat_completion(self, messages=None, temperature=None, **kwargs):
+                captured.update(messages=messages, temperature=temperature, **kwargs)
+                return live
+
+    monkeypatch.setattr(lp, "_prepare_llama_cpp_messages", lambda messages, task, s: messages)
+    monkeypatch.setattr(lp, "_get_llama_cpp_client", lambda task, s: FakeLlamaClient())
+    monkeypatch.setattr(lp, "_prepare_llama_cpp_kwargs", lambda kwargs, s: dict(kwargs))
+    return live, captured
+
+
+def test_llama_cpp_stream_yields_deltas_reasoning_and_a_done_matching_completes_composition(monkeypatch):
+    from backend.providers import CancelToken as CT, ChatRequest as CR, LlamaCppProvider
+
+    live, captured = _llama_streaming_setup(monkeypatch, [
+        _llama_chunk(reasoning_key="reasoning_content", reasoning="pondering..."),
+        {"choices": []},  # defensive: empty-choices chunk must be skipped
+        _llama_chunk(content="Ans"),
+        _llama_chunk(content="wer.", finish="stop"),
+    ], declare_stream_param=True)
+
+    provider = LlamaCppProvider(settings={"chat_model_path": "m.gguf"})
+    events = list(provider.stream(
+        CR(
+            task=config.TASK_CHAT,
+            messages=[{"role": "user", "content": "hi"}],
+            extra_kwargs={"temperature": 0.5, "cancellation_event": threading.Event()},
+        ),
+        CT(),
+    ))
+
+    assert [e.type for e in events] == ["reasoning", "text", "text", "done"]
+    # Composed through _extract_llama_cpp_text, exactly as complete() would
+    # for the same content+reasoning - the shared-extraction parity contract.
+    assert events[-1].text == "<think>pondering...</think>\nAnswer."
+    assert captured["stream"] is True
+    assert captured["temperature"] == 0.5  # passthrough kwargs survived the filter
+    assert live.close_calls >= 1  # the generator over the shared client was closed
+
+
+def test_llama_cpp_stream_true_survives_the_kwargs_filter_and_beats_a_passthrough_stream(monkeypatch):
+    """THE 6.5b trap test, both halves. (a) The strict-signature fake above
+    has NO **kwargs, so anything routed through _filter_kwargs_for_callable
+    that its signature doesn't declare is silently dropped - stream=True must
+    arrive because the provider passes it OUTSIDE the filtered dict. (b) A
+    passthrough extra_kwarg trying to force stream=False must lose to ours."""
+    from backend.providers import CancelToken as CT, ChatRequest as CR, LlamaCppProvider
+
+    _, captured = _llama_streaming_setup(
+        monkeypatch, [_llama_chunk(content="ok", finish="stop")], declare_stream_param=True
+    )
+    provider = LlamaCppProvider(settings={"chat_model_path": "m.gguf"})
+    events = list(provider.stream(
+        CR(
+            task=config.TASK_CHAT,
+            messages=[{"role": "user", "content": "hi"}],
+            extra_kwargs={"stream": False},  # (b): cannot turn real streaming back off
+        ),
+        CT(),
+    ))
+    assert captured["stream"] is True
+    assert events[-1] == ProviderEvent("done", "ok")
+
+
+def test_llama_cpp_stream_cancellation_closes_the_generator_and_raises(monkeypatch):
+    from backend.providers import CancelToken as CT, ChatRequest as CR, LlamaCppProvider
+
+    cancel_event = threading.Event()
+    live = FakeSDKStream(
+        [_llama_chunk(content="par"), _llama_chunk(content="tial", finish="stop")],
+        cancel_event=cancel_event,
+        cancel_after=1,
+    )
+    _llama_streaming_setup(monkeypatch, live, declare_stream_param=True)
+
+    provider = LlamaCppProvider(settings={"chat_model_path": "m.gguf"})
+    with pytest.raises(api_provider.RequestCancelledError):
+        list(provider.stream(
+            CR(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}]),
+            CT(cancel_event),
+        ))
+    # Cooperative-only, but the shared cached client's generator must never
+    # be left partially consumed.
+    assert live.close_calls >= 1
 
 
 def test_chat_constructs_each_api_provider_from_the_snapshot_credentials(monkeypatch):

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -1472,6 +1472,182 @@ def test_llama_cpp_stream_cancellation_closes_the_generator_and_raises(monkeypat
     assert live.close_calls >= 1
 
 
+# -- 6.5b: the chat_stream seam - real dispatch replaces the fallback ---------
+# -- The old non-Ollama short-circuit (one blocking chat() call + one
+# -- synthetic full-text chunk) is gone: chat_stream now constructs every
+# -- provider exactly as chat() does and consumes its stream(), with the
+# -- consuming loop inside chat_stream's own _translate_chat_exception try
+# -- (the lazy-generator contract means the old path's free-via-recursion
+# -- translation no longer exists).
+
+
+def _install_scripted_provider(monkeypatch, module_name, class_name, events):
+    """Swap a provider class (at the module chat_stream lazily imports from)
+    for a protocol-shaped double that records its __init__ kwargs and yields
+    scripted events - the FakeFactory pattern from the 6.1 seam tests."""
+    module = __import__(module_name, fromlist=[class_name])
+    seen = {}
+
+    class Scripted:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+
+        def stream(self, request, cancel):
+            seen["task"] = request.task
+            return iter(events)
+
+    monkeypatch.setattr(module, class_name, Scripted)
+    return seen
+
+
+_SCRIPTED_STREAM_EVENTS = [
+    ProviderEvent("text", "one "),
+    ProviderEvent("reasoning", "never forwarded"),
+    ProviderEvent("text", "two "),
+    ProviderEvent("text", "three"),
+    ProviderEvent("done", "<think>never forwarded</think>\none two three"),
+]
+
+
+@pytest.mark.parametrize("provider_type, module_name, class_name, expected_init", [
+    (
+        config.API_PROVIDER_OPENAI,
+        "backend.providers.openai_provider", "OpenAIProvider",
+        {"model": "some-model", "reasoning_level": "high"},
+    ),
+    (
+        config.API_PROVIDER_ANTHROPIC,
+        "backend.providers.anthropic_provider", "AnthropicProvider",
+        {"api_key": "secret-key", "model": "some-model", "reasoning_level": "medium"},
+    ),
+    (
+        config.API_PROVIDER_GEMINI,
+        "backend.providers.gemini_provider", "GeminiProvider",
+        {"api_key": "secret-key", "model": "some-model", "reasoning_level": "low"},
+    ),
+])
+def test_chat_stream_streams_real_deltas_through_each_api_provider_branch(
+    monkeypatch, provider_type, module_name, class_name, expected_init
+):
+    """THE 6.5b EXIT CRITERION at the seam, per API provider: chat_stream's
+    real machinery constructs the provider from the snapshot credentials
+    (chat()'s exact kwargs) and forwards its incremental deltas through
+    on_chunk - multiple chunks, reasoning dropped, done as the return."""
+    monkeypatch.setattr(api_provider, "chat_stream", _REAL_CHAT_STREAM)
+    seen = _install_scripted_provider(monkeypatch, module_name, class_name, _SCRIPTED_STREAM_EVENTS)
+
+    client = _fake_openai_client()[0]
+    monkeypatch.setattr(api_provider, "USE_API_MODE", True)
+    monkeypatch.setattr(api_provider, "API_PROVIDER_TYPE", provider_type)
+    monkeypatch.setattr(api_provider, "API_KEY", "secret-key")
+    monkeypatch.setattr(api_provider, "API_CLIENT", client)
+    monkeypatch.setattr(api_provider, "OPENAI_REASONING_LEVEL", "high")
+    monkeypatch.setattr(api_provider, "ANTHROPIC_REASONING_LEVEL", "medium")
+    monkeypatch.setattr(api_provider, "GEMINI_REASONING_LEVEL", "low")
+    monkeypatch.setitem(api_provider.API_MODELS, config.TASK_CHAT, "some-model")
+
+    chunks: list[tuple[str, bool]] = []
+    response = api_provider.chat_stream(
+        config.TASK_CHAT,
+        [{"role": "user", "content": "count"}],
+        lambda delta, reset: chunks.append((delta, reset)),
+    )
+
+    assert chunks == [("one ", False), ("two ", False), ("three", False)]  # reasoning never forwarded
+    assert response == {
+        "message": {"content": "<think>never forwarded</think>\none two three", "role": "assistant"}
+    }
+    seen.pop("task")
+    if class_name in ("OpenAIProvider", "AnthropicProvider"):
+        expected_init = {**expected_init, "client": client}
+    assert seen == expected_init  # constructed from the snapshot, chat()'s exact kwargs
+
+
+def test_chat_stream_streams_real_deltas_through_the_llama_cpp_local_branch(monkeypatch):
+    """llama.cpp local mode sat in the same fallback short-circuit until
+    6.5b - it must now stream through LlamaCppProvider.stream()."""
+    monkeypatch.setattr(api_provider, "chat_stream", _REAL_CHAT_STREAM)
+    seen = _install_scripted_provider(
+        monkeypatch, "backend.providers.llama_cpp_provider", "LlamaCppProvider",
+        _SCRIPTED_STREAM_EVENTS,
+    )
+    monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+    monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_LLAMACPP)
+    settings = {"chat_model_path": "m.gguf", "reasoning_level": "off"}
+    monkeypatch.setattr(api_provider, "LLAMA_CPP_SETTINGS", settings)
+
+    chunks: list[tuple[str, bool]] = []
+    response = api_provider.chat_stream(
+        config.TASK_CHAT,
+        [{"role": "user", "content": "count"}],
+        lambda delta, reset: chunks.append((delta, reset)),
+    )
+
+    assert chunks == [("one ", False), ("two ", False), ("three", False)]
+    assert response["message"]["content"].endswith("one two three")
+    assert seen["settings"] == settings
+
+
+def test_chat_stream_translates_a_mid_stream_connection_error_to_the_friendly_message(
+    monkeypatch, openai_api_mode
+):
+    """The lazy-generator contract's teeth: the old short-circuit got error
+    translation for free by recursing into chat(); real streaming must own
+    it. A connection failure surfacing MID-stream (after deltas already
+    reached on_chunk) must still come out as _translate_chat_exception's
+    actionable Base-URL message, not raw exception text."""
+    monkeypatch.setattr(api_provider, "chat_stream", _REAL_CHAT_STREAM)
+
+    class DyingStream(FakeSDKStream):
+        def __next__(self):
+            if self._index >= 1:
+                raise Exception("connection refused by endpoint")
+            return super().__next__()
+
+    live = DyingStream([_openai_chunk(content="par")])
+    client, _, _ = _fake_openai_streaming_client(live)
+    openai_api_mode(client)
+
+    chunks: list[tuple[str, bool]] = []
+    with pytest.raises(ConnectionError) as excinfo:
+        api_provider.chat_stream(
+            config.TASK_CHAT,
+            [{"role": "user", "content": "hi"}],
+            lambda delta, reset: chunks.append((delta, reset)),
+        )
+
+    assert chunks == [("par", False)]  # the failure was genuinely mid-stream
+    message = str(excinfo.value)
+    assert message.startswith(
+        "Failed to connect to the API endpoint. "
+        "Please verify your Base URL in settings and your network connection."
+    )
+    assert "Details: connection refused by endpoint" in message
+
+
+def test_chat_stream_cancellation_in_api_mode_escapes_untranslated(monkeypatch, openai_api_mode):
+    """The RequestCancelledError sentinel contract, now on the API-mode
+    streaming path: backend/agents.py catches exactly this type."""
+    monkeypatch.setattr(api_provider, "chat_stream", _REAL_CHAT_STREAM)
+    cancel_event = threading.Event()
+    live = FakeSDKStream(
+        [_openai_chunk(content="par"), _openai_chunk(content="tial")],
+        cancel_event=cancel_event,
+        cancel_after=1,
+    )
+    client, _, _ = _fake_openai_streaming_client(live)
+    openai_api_mode(client)
+
+    with pytest.raises(api_provider.RequestCancelledError):
+        api_provider.chat_stream(
+            config.TASK_CHAT,
+            [{"role": "user", "content": "hi"}],
+            lambda delta, reset: None,
+            cancellation_event=cancel_event,
+        )
+    assert live.close_calls >= 1  # closed on the way out
+
+
 def test_chat_constructs_each_api_provider_from_the_snapshot_credentials(monkeypatch):
     """6.3 review fix: the routing test proves the classes are INVOKED but not
     that they're constructed correctly - a branch passing the wrong key/client/


### PR DESCRIPTION
## Problem

Since stage 6.1, only Ollama streamed real tokens. The other four providers' `stream()` was a transitional single-"done" event wrapping their blocking call, and `api_provider.chat_stream` short-circuited every non-Ollama request to one blocking `chat()` plus one synthetic full-text chunk — so API-endpoint and llama.cpp users got no live streaming anywhere in the app, and stage 6.4's partial-output preservation had nothing to preserve for them (no incremental text ever accumulated).

## Change

Each provider's `stream()` now yields real incremental events, meeting the same bar the 6.1 Ollama port set (cancel checked per iteration, live stream closed before raising, closed again in `finally`, final text composed at "done" to match `complete()` byte-for-byte):

- **OpenAI-compatible**: `chat.completions.create(stream=True)` chunks; `delta.content` streams as text, and OpenAI-compatible servers' untyped `reasoning_content`/`reasoning` extras (vLLM, DeepSeek-style) stream as reasoning; usage-only/empty-choice chunks skipped.
- **Anthropic**: real streaming on both transports — the SDK's `messages.create(stream=True)` raw events, and a new urllib-based SSE reader for the REST dict-sentinel fallback (same wire shape, one shared translation loop). `text_delta`→text, `thinking_delta`→reasoning, final text via the same `<think>` composition the blocking path uses.
- **Gemini**: new SSE helper posting to `:streamGenerateContent?alt=sse`; `thought: true` parts stream as reasoning while the final text keeps `complete()`'s exact concatenation contract (deliberate parity, commented). The uploaded-files cleanup `finally` wraps the whole streaming body, including the cancel path.
- **llama.cpp**: `create_chat_completion(stream=True)` generator of chunk dicts; `stream=True` is passed outside the signature-based kwargs filter (which would silently drop it and degrade to blocking); cooperative per-chunk cancellation with the generator always closed (the client is a shared cached singleton).

`chat_stream`'s short-circuit is deleted: every provider branch now constructs from the request snapshot exactly as `chat()` does and consumes the stream inside its own exception-translation scope (the lazy-generator contract means nothing runs until first `next()`, so the old free ride through `chat()`'s recursion no longer exists). llama.cpp local mode streams too. The four `streaming` capability flags flip to `True`.

**Review fixes** (adversarial review, one pass): both new SSE readers silently dropped in-band error frames — a mid-stream `{"type": "error"}` (Anthropic) or `{"error": {...}}` (Gemini) payload was skipped and the partial text returned as a *complete* response, masking retryable provider failures. Both now raise the API's own error message, matching their blocking twins. Anthropic additionally requires `message_stop` before composing, so a cleanly-severed stream (proxy truncation) surfaces as a retryable error instead of a silently truncated answer. A test that claimed to pin the llama.cpp kwargs-filter trap but couldn't actually fail was reworked to genuinely discriminate.

Because the streams are real, 6.4's partial-output preservation now works for every provider: a killed API-endpoint stream leaves the accumulated text as a retryable flagged partial instead of losing it.

## Test plan

- Per-provider multi-delta streaming tests with only the SDK/transport faked (fake OpenAI stream object, fake Anthropic SDK client + urllib-level SSE fakes, fake llama generator), each asserting incremental deltas, reasoning events where applicable, and a final "done" text identical to `complete()`'s composition of the same data.
- Per-provider mid-stream cancellation: cancel between chunks → live stream/generator closed, `RequestCancelledError` escapes untranslated.
- Seam tests: `chat_stream` delivers real deltas through `on_chunk` for each API branch and llama.cpp local; mid-stream connection errors surface the friendly translated messages; construction kwargs pinned against the snapshot-credential test.
- Review-fix tests: error-event frames raise the API's message with no "done" emitted (both Anthropic transports + Gemini); missing `message_stop` raises the truncation error on both transports; the reworked drop-trap test fails loudly if `stream=True` were filter-routed.
- Full suite green: `pytest -q` 1819 passed / 14 skipped (re-verified after rebasing onto the merged 6.5a).