### PR TITLE
ADR-007: Tool calling, structured output, and MCP client

### DIFF
--- a/api_provider.py
+++ b/api_provider.py
@@ -1225,6 +1225,30 @@ def _assert_ollama_audio_support(model_name: str, messages: list):
 def _prepare_ollama_messages(messages: list) -> list:
     processed_messages = []
     for msg in messages:
+        # ADR-007 stage 7.1: the two tool-turn roles the app's generic
+        # message shape adds (ChatRequest's own docstring), translated to
+        # Ollama's native shape - checked BEFORE the multimodal-content
+        # branch below since neither ever carries list-shaped content.
+        # Ollama's ToolCall has no `id` field at all (unlike OpenAI/
+        # Anthropic), so the app's own call.id is simply dropped here - it
+        # only ever existed to correlate a result back to ITS call, and
+        # Ollama's own request/response cycle has no use for it.
+        role = msg.get("role")
+        if role == "tool":
+            processed_messages.append({"role": "tool", "content": str(msg.get("content") or "")})
+            continue
+        tool_calls = msg.get("tool_calls")
+        if tool_calls:
+            processed_messages.append({
+                "role": "assistant",
+                "content": str(msg.get("content") or ""),
+                "tool_calls": [
+                    {"function": {"name": call["name"], "arguments": call["arguments"]}}
+                    for call in tool_calls
+                ],
+            })
+            continue
+
         content = msg.get("content")
         if isinstance(content, list):
             text_parts = []
@@ -2248,6 +2272,38 @@ def _prepare_anthropic_messages(messages: list, cancel_event=None) -> tuple[str 
     for msg in messages:
         _raise_if_cancelled(cancel_event)
         role_name = str(msg.get("role") or "user").strip().lower()
+
+        # ADR-007 stage 7.1: the two tool-turn roles ChatRequest's docstring
+        # adds, translated to Anthropic's native shape - checked before the
+        # system/text branches below since neither carries plain string/
+        # part-list content the way ordinary turns do. Anthropic has no
+        # separate "tool" role: a tool's result travels as a "user"-role
+        # tool_result block, keyed by tool_use_id - the same value this
+        # app's ToolCall.id / the generic message's tool_call_id carries.
+        if role_name == "tool":
+            blocks = [{
+                "type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id", ""),
+                "content": str(msg.get("content") or ""),
+            }]
+            if anthropic_messages and anthropic_messages[-1]["role"] == "user":
+                anthropic_messages[-1]["content"].extend(blocks)
+            else:
+                anthropic_messages.append({"role": "user", "content": blocks})
+            continue
+        tool_calls = msg.get("tool_calls")
+        if tool_calls:
+            blocks = []
+            lead_in_text = str(msg.get("content") or "").strip()
+            if lead_in_text:
+                blocks.append({"type": "text", "text": lead_in_text})
+            blocks.extend(
+                {"type": "tool_use", "id": call["id"], "name": call["name"], "input": call["arguments"]}
+                for call in tool_calls
+            )
+            anthropic_messages.append({"role": "assistant", "content": blocks})
+            continue
+
         content = msg.get("content")
 
         if role_name == "system":
@@ -2581,6 +2637,38 @@ def _prepare_gemini_contents(messages: list, cancel_event=None, api_key: str | N
     for msg in messages:
         _raise_if_cancelled(cancel_event)
         role_name = msg.get("role")
+
+        # ADR-007 stage 7.1: the two tool-turn roles ChatRequest's docstring
+        # adds, translated to Gemini's native shape - checked before the
+        # system/text branches below. Gemini has its own dedicated
+        # "function" role for a tool's result (unlike Anthropic's user-role
+        # tool_result block) and, like Ollama, provides no native call id -
+        # GeminiProvider.stream() synthesizes one the same way Ollama's does.
+        if role_name == "tool":
+            parts = [{
+                "functionResponse": {
+                    "name": msg.get("name", ""),
+                    "response": {"result": str(msg.get("content") or "")},
+                },
+            }]
+            if contents and contents[-1]["role"] == "function":
+                contents[-1]["parts"].extend(parts)
+            else:
+                contents.append({"role": "function", "parts": parts})
+            continue
+        tool_calls = msg.get("tool_calls")
+        if tool_calls:
+            parts = []
+            lead_in_text = str(msg.get("content") or "").strip()
+            if lead_in_text:
+                parts.append({"text": lead_in_text})
+            parts.extend(
+                {"functionCall": {"name": call["name"], "args": call["arguments"]}}
+                for call in tool_calls
+            )
+            contents.append({"role": "model", "parts": parts})
+            continue
+
         if role_name == "system":
             system_prompt = msg.get("content")
             continue
@@ -3440,6 +3528,28 @@ def gemini_supports_reasoning(model_id: str) -> bool:
 
 def openai_supports_reasoning(model_id: str) -> bool:
     return _is_openai_reasoning_model(model_id)
+
+
+def ollama_supports_tools(model_name: str) -> bool:
+    """ADR-007 stage 7.1: unlike reasoning (a pure string-family check) and
+    unlike vision/audio (the request path sends attachment bytes
+    unconditionally and lets the model ignore them), tool use is genuinely
+    per-model server-side - sending a `tools` param to a model whose chat
+    template doesn't support it is a real request-shape mismatch, not a
+    politely-ignored extra. Reuses the SAME cached show()-backed probe
+    _assert_ollama_audio_support already established (api_provider.py's
+    _get_ollama_capabilities / _OLLAMA_CAPABILITY_CACHE) - Ollama's own
+    /api/show response reports "tools" in its top-level `capabilities` list
+    for models whose template actually supports function calling. None
+    (server/model/metadata unavailable) is treated as NOT capable - the
+    conservative default, matching _get_ollama_context_window's own
+    fall-back-to-safe-default posture, since advertising tool support that
+    doesn't exist would fail loudly mid-request instead of degrading
+    gracefully to the no-tools path."""
+    capabilities = _get_ollama_capabilities(model_name)
+    if capabilities is None:
+        return False
+    return "tools" in capabilities
 
 
 def get_mode() -> str:

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 from collections import deque
 import itertools
+import json
 import math
 import uuid
 from dataclasses import dataclass, field
@@ -2010,6 +2011,24 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
             "promptTokens": n.state.prompt_tokens if isinstance(n.state, ChatState) else None,
             "completionTokens": (
                 n.state.completion_tokens if isinstance(n.state, ChatState) else None
+            ),
+            # ADR-007 stage 7.4: see ChatState.tool_invocations' own comment
+            # and ToolInvocationRow's own docstring (contracts/graphlink_
+            # scene_payload.py) for why `arguments` is JSON-encoded here
+            # rather than passed through as a nested object.
+            "toolCalls": (
+                [
+                    {
+                        "id": str(call.get("id", "")),
+                        "name": str(call.get("name", "")),
+                        "argumentsJson": json.dumps(call.get("arguments") or {}, sort_keys=True),
+                        "result": str(call.get("result", "")),
+                        "isError": bool(call.get("is_error", False)),
+                    }
+                    for call in n.state.tool_invocations
+                ]
+                if isinstance(n.state, ChatState)
+                else []
             ),
             "isFinalDeliverable": n.id == self.final_deliverable_node_id,
             "researchStage": n.state.research_stage if isinstance(n.state, WebResearchState) else "",

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -705,3 +705,14 @@ class ChatState(NodeState):
     # replies also stamp as of 6.8.
     prompt_tokens: int | None = None
     completion_tokens: int | None = None
+    # ADR-007 stage 7.4: this turn's tool calls + their results, in call
+    # order - empty for the overwhelming majority of chat nodes (no tool-use
+    # loop exists yet to populate this; ADR-008 is the first real writer).
+    # Each item: {"id", "name", "arguments" (a real dict - only JSON-encoded
+    # at the wire boundary, see graph.py's scene_payload()), "result",
+    # "is_error"} - directly ToolCall's own three fields plus ToolResult's
+    # two (backend/providers/base.py, backend/tools.py), not a new shape.
+    # Rendered as a collapsible section in ChatNodeView.tsx (the ADR's own
+    # "an assistant turn that calls tools renders the calls and their
+    # results (collapsible)").
+    tool_invocations: list[dict[str, Any]] = field(default_factory=list)

--- a/backend/mcp_client.py
+++ b/backend/mcp_client.py
@@ -1,0 +1,336 @@
+"""ADR-007 stage 7.5: a minimal, hand-rolled MCP (Model Context Protocol)
+CLIENT - stdio transport, JSON-RPC 2.0, newline-delimited framing (the
+transport MCP servers overwhelmingly ship as - a filesystem/git/search MCP
+server is a local subprocess, not a network service). Hand-rolled rather
+than depending on the official `mcp` package for the same reason
+graphlink_wire_schema.py hand-rolls its own dataclass->JSON-Schema
+generator instead of pydantic (see that module's own docstring): the
+protocol surface this app actually needs - initialize, tools/list,
+tools/call - is small and closed, and a new runtime dependency is not a
+decision to make lightly in a codebase whose own ADR-005 stage 5.5 exists
+specifically because of a hostile-sdist supply-chain finding. HTTP
+transport (the ADR's own "stdio/HTTP per the MCP spec" line) is deferred:
+every commonly-used MCP server today (filesystem, git, search) ships as a
+stdio subprocess, and adding a second transport with no server to
+exercise it against would be speculative surface, not a tested capability.
+
+NOT an MCP *server* (exposing GraphLink's own tools outward) - explicitly
+out of this ADR's scope (see its own "Decision" section, item 4).
+
+This module owns exactly two things:
+1. McpStdioClient - the JSON-RPC session with one running MCP server
+   subprocess (connect/list_tools/call_tool/close).
+2. register_mcp_server_tools - the glue that lists a connected client's
+   tools and registers each into a backend.tools.ToolRegistry, namespaced
+   `mcp:<server>:<tool>` (per the ADR's own decision), scope-mapped, and
+   approval-gated - MCP servers are untrusted by default (arbitrary user-
+   configured code, not a first-party tool), so approval defaults to
+   "always" unless the caller explicitly relaxes it.
+
+Where a configured server's settings actually LIVE (SettingsManager, see
+graphlink_settings_store.py's own get_mcp_servers/set_mcp_servers) and the
+Settings UI panel to edit them are separate concerns: the ADR's own
+"Consequences" section defers the UI surface to ADR-012 ("Settings gain an
+MCP configuration surface"). This stage's exit criterion - "a configured
+filesystem MCP server's tool is callable, namespaced, approval-gated" - is
+satisfied by the client + registry glue + the persisted config SHAPE, not
+by a finished settings panel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import queue
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from backend.providers.base import ToolSpec
+from backend.tools import RunContext, ToolResult
+
+# The MCP spec's own date-versioned protocol string - the most recent
+# stable revision at the time this client was written. Sent verbatim in
+# the initialize handshake; a server on a different revision negotiates
+# its own version back in the response, which this client does not
+# currently need to branch on (the tools/list + tools/call shapes this
+# client actually uses have been stable across every MCP revision to date).
+MCP_PROTOCOL_VERSION = "2024-11-05"
+_CLIENT_NAME = "graphlink"
+_CLIENT_VERSION = "1.0"
+
+# A reader-thread sentinel distinct from any real JSON-RPC payload (a plain
+# dict), so `is` identity unambiguously marks "the server's stdout closed",
+# never confusable with a legitimate (if unusual) server response.
+_READER_CLOSED = object()
+
+
+class McpError(RuntimeError):
+    """Raised for any MCP-level failure: the server process failed to
+    start, closed its output unexpectedly, returned a JSON-RPC error
+    response, or didn't respond within the configured timeout."""
+
+
+@dataclass(frozen=True)
+class McpServerConfig:
+    """One configured MCP server - the persisted shape SettingsManager
+    stores (graphlink_settings_store.py's own get_mcp_servers/
+    set_mcp_servers, as plain JSON-safe dicts via to_dict/from_dict below -
+    that module stays agnostic of this one's types, matching how every
+    other settings getter there returns a plain dict/primitive, never a
+    domain object from another module) and the shape a caller passes to
+    register_mcp_server_tools below. `scopes`/`approval` are the SAME
+    ToolRegistry vocabulary stage 7.2 already defines (backend/tools.py) -
+    granted once per server, applied to every tool that server advertises,
+    matching the ADR's own "granted scopes" per-server (not per-tool)
+    framing. `enabled_tools`, when non-empty, is an allow-list of raw
+    (un-namespaced) tool names - a server advertising a tool the user never
+    opted into is silently skipped, not registered read-only-by-default."""
+
+    name: str
+    command: str
+    args: tuple[str, ...] = ()
+    scopes: frozenset[str] = frozenset()
+    approval: str = "always"
+    enabled_tools: frozenset[str] = frozenset()
+    enabled: bool = True
+    timeout: float = 30.0
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "command": self.command,
+            "args": list(self.args),
+            "scopes": sorted(self.scopes),
+            "approval": self.approval,
+            "enabled_tools": sorted(self.enabled_tools),
+            "enabled": self.enabled,
+            "timeout": self.timeout,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "McpServerConfig":
+        return cls(
+            name=str(data.get("name", "")).strip(),
+            command=str(data.get("command", "")).strip(),
+            args=tuple(str(a) for a in (data.get("args") or [])),
+            scopes=frozenset(str(s) for s in (data.get("scopes") or [])),
+            approval=str(data.get("approval") or "always"),
+            enabled_tools=frozenset(str(t) for t in (data.get("enabled_tools") or [])),
+            enabled=bool(data.get("enabled", True)),
+            timeout=float(data.get("timeout", 30.0) or 30.0),
+        )
+
+
+class McpStdioClient:
+    """One running MCP server subprocess, spoken to over stdio JSON-RPC 2.0.
+    One instance per configured server - construct, connect() once, then
+    list_tools()/call_tool() as needed, close() when done. Not reentrant
+    across concurrent callers beyond the one in-flight-request-at-a-time
+    serialization _call already provides internally."""
+
+    def __init__(self, *, command: str, args: tuple[str, ...] = (), env: dict[str, str] | None = None,
+                 cwd: str | None = None, timeout: float = 30.0):
+        self.command = command
+        self.args = tuple(args)
+        self.env = env
+        self.cwd = cwd
+        self.timeout = timeout
+        self._process: subprocess.Popen | None = None
+        self._reader_thread: threading.Thread | None = None
+        self._responses: "queue.Queue[Any]" = queue.Queue()
+        self._next_id = 0
+        self._write_lock = threading.Lock()
+        self._call_lock = threading.Lock()
+
+    @property
+    def is_connected(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    def connect(self) -> None:
+        if self._process is not None:
+            return
+        try:
+            self._process = subprocess.Popen(
+                [self.command, *self.args],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=self.env,
+                cwd=self.cwd,
+                text=True,
+                bufsize=1,
+            )
+        except OSError as exc:
+            raise McpError(f"Failed to start MCP server {self.command!r}: {exc}") from exc
+
+        self._reader_thread = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader_thread.start()
+
+        try:
+            response = self._call("initialize", {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": _CLIENT_NAME, "version": _CLIENT_VERSION},
+            })
+        except McpError:
+            self.close()
+            raise
+        self._notify("notifications/initialized", {})
+        self.server_info = response.get("serverInfo") if isinstance(response, dict) else None
+
+    def close(self) -> None:
+        process = self._process
+        self._process = None
+        if process is None:
+            return
+        try:
+            if process.stdin:
+                process.stdin.close()
+        except Exception:
+            pass
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+    def list_tools(self) -> tuple[ToolSpec, ...]:
+        response = self._call("tools/list", {})
+        tools = response.get("tools", []) if isinstance(response, dict) else []
+        return tuple(
+            ToolSpec(
+                name=str(tool["name"]),
+                description=str(tool.get("description") or ""),
+                input_schema=tool.get("inputSchema") or {"type": "object"},
+            )
+            for tool in tools
+        )
+
+    def call_tool(self, name: str, arguments: dict) -> ToolResult:
+        response = self._call("tools/call", {"name": name, "arguments": dict(arguments or {})})
+        content = response.get("content", []) if isinstance(response, dict) else []
+        # MCP's own content-block shape (a list of {"type": "text", "text":
+        # ...} - the ADR's own ToolSpec docstring already documents the
+        # OpenAPI-schema caveat for the request side; this is the mirror
+        # concession on the response side) - only text blocks are supported
+        # today, matching every other ToolResult in this codebase being a
+        # plain string; a non-text block (image/resource) is skipped rather
+        # than crashing the call, since a partial answer beats a hard failure.
+        text_parts = [
+            str(block.get("text", ""))
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        return ToolResult(content="\n".join(text_parts), is_error=bool(response.get("isError", False)))
+
+    # -- JSON-RPC framing ------------------------------------------------
+
+    def _read_loop(self) -> None:
+        process = self._process
+        assert process is not None and process.stdout is not None
+        try:
+            for line in process.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue  # server-side logging on stdout, not JSON-RPC - skip
+                self._responses.put(payload)
+        finally:
+            self._responses.put(_READER_CLOSED)
+
+    def _write(self, message: dict) -> None:
+        process = self._process
+        if process is None or process.stdin is None:
+            raise McpError(f"MCP server {self.command!r} is not connected.")
+        with self._write_lock:
+            try:
+                process.stdin.write(json.dumps(message) + "\n")
+                process.stdin.flush()
+            except (BrokenPipeError, ValueError) as exc:
+                raise McpError(f"MCP server {self.command!r} is not accepting input: {exc}") from exc
+
+    def _notify(self, method: str, params: dict) -> None:
+        self._write({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def _call(self, method: str, params: dict) -> dict:
+        with self._call_lock:
+            self._next_id += 1
+            request_id = self._next_id
+            self._write({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+            deadline = time.monotonic() + self.timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise McpError(f"MCP server {self.command!r} timed out after {self.timeout}s calling {method!r}.")
+                try:
+                    payload = self._responses.get(timeout=remaining)
+                except queue.Empty:
+                    raise McpError(f"MCP server {self.command!r} timed out after {self.timeout}s calling {method!r}.")
+                if payload is _READER_CLOSED:
+                    stderr_tail = ""
+                    if self._process is not None and self._process.stderr is not None:
+                        stderr_tail = self._process.stderr.read(2000)
+                    raise McpError(
+                        f"MCP server {self.command!r} closed its output unexpectedly while calling {method!r}."
+                        + (f" stderr: {stderr_tail}" if stderr_tail.strip() else "")
+                    )
+                if not isinstance(payload, dict) or payload.get("id") != request_id:
+                    # A notification, or a response to a different in-flight
+                    # id - can't happen from THIS client (one call at a time
+                    # under _call_lock), but a server sending its own
+                    # unsolicited notification is legal MCP and must not be
+                    # mistaken for our response.
+                    continue
+                if "error" in payload:
+                    error = payload["error"]
+                    message_text = error.get("message", error) if isinstance(error, dict) else error
+                    raise McpError(f"{method} failed: {message_text}")
+                return payload.get("result", {}) or {}
+
+
+def register_mcp_server_tools(registry, client: McpStdioClient, config: McpServerConfig) -> tuple[str, ...]:
+    """Lists `client`'s tools and registers each into `registry` (a
+    backend.tools.ToolRegistry) as `mcp:<config.name>:<tool name>`, scoped
+    and approval-gated per `config` - see McpServerConfig's own docstring.
+    Returns the namespaced names actually registered (after the
+    enabled_tools allow-list filter), in server-advertised order."""
+    registered: list[str] = []
+    for spec in client.list_tools():
+        if config.enabled_tools and spec.name not in config.enabled_tools:
+            continue
+        namespaced_name = f"mcp:{config.name}:{spec.name}"
+        namespaced_spec = ToolSpec(
+            name=namespaced_name, description=spec.description, input_schema=spec.input_schema
+        )
+        registry.register(
+            namespaced_spec,
+            _make_mcp_handler(client, spec.name),
+            scopes=config.scopes,
+            approval=config.approval,
+        )
+        registered.append(namespaced_name)
+    return tuple(registered)
+
+
+def _make_mcp_handler(client: McpStdioClient, real_tool_name: str) -> Callable[[Any, "RunContext"], Awaitable[ToolResult]]:
+    """One handler per real (un-namespaced) tool name - a closure rather
+    than a shared handler keying off call.name, since call.name for an
+    MCP-backed registration is the NAMESPACED name (mcp:<server>:<tool>),
+    which McpStdioClient.call_tool must never see (the server itself only
+    knows its own un-namespaced tool names)."""
+
+    async def _handler(call, ctx) -> ToolResult:
+        return await asyncio.to_thread(client.call_tool, real_tool_name, call.arguments)
+
+    return _handler
+

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -15,6 +15,8 @@ from backend.providers.base import (
     Provider,
     ProviderCapabilities,
     ProviderEvent,
+    ToolCall,
+    ToolSpec,
 )
 from backend.providers.fake import FakeProvider
 from backend.providers.gemini_provider import GeminiProvider
@@ -34,4 +36,6 @@ __all__ = [
     "Provider",
     "ProviderCapabilities",
     "ProviderEvent",
+    "ToolCall",
+    "ToolSpec",
 ]

--- a/backend/providers/anthropic_provider.py
+++ b/backend/providers/anthropic_provider.py
@@ -20,6 +20,7 @@ exactly as _extract_anthropic_text does for the blocking path.
 
 from __future__ import annotations
 
+import json
 from typing import Iterator
 
 import graphlink_task_config as config
@@ -40,6 +41,7 @@ from backend.providers.base import (
     ChatRequest,
     ProviderCapabilities,
     ProviderEvent,
+    ToolCall,
     normalize_usage,
 )
 
@@ -76,7 +78,17 @@ class AnthropicProvider:
             audio=False,   # Anthropic has no audio input API; False is what
                            # keeps a future capability consumer from offering it
             image_generation=False,  # generate_image's branch raises the explicit "not yet" error
+            # ADR-007 stage 7.1: current Claude model families all support
+            # native tool use unconditionally (base.py's own
+            # ProviderCapabilities.tools comment) - no capability call needed.
+            tools=True,
         )
+
+    # ADR-007 stage 7.1: deliberately NOT given tool-call support, matching
+    # every other provider's complete() - it returns a bare str with no
+    # channel for ToolCall events, and its callers never supply
+    # request.tools. A future caller passing tools here has them silently
+    # ignored (no `tools` kwarg built below).
 
     def complete(self, request: ChatRequest, cancel: CancelToken) -> str:
         system_prompt, anthropic_messages = _prepare_anthropic_messages(
@@ -136,6 +148,15 @@ class AnthropicProvider:
         }
         if system_prompt:
             request_kwargs["system"] = _system_blocks_with_cache_control(system_prompt)
+        if request.tools:
+            # ADR-007 stage 7.1: Anthropic's native tool shape - {"name",
+            # "description", "input_schema"} - is the ToolSpec's own three
+            # fields verbatim, no wrapper object unlike OpenAI/Ollama's
+            # {"type":"function","function":{...}}.
+            request_kwargs["tools"] = [
+                {"name": tool.name, "description": tool.description, "input_schema": tool.input_schema}
+                for tool in request.tools
+            ]
 
         create_callable = getattr(getattr(self.client, "messages", None), "create", None)
         if callable(create_callable):
@@ -157,6 +178,12 @@ class AnthropicProvider:
 
         answer_parts: list[str] = []
         thinking_parts: list[str] = []
+        # ADR-007 stage 7.1: Anthropic streams a tool call as
+        # content_block_start (type "tool_use", carrying id/name) followed
+        # by zero or more content_block_delta "input_json_delta" events
+        # (partial_json fragments) - buffered per block INDEX, same shape
+        # as OpenAI's per-index buffering, then parsed once complete.
+        tool_call_buffers: dict = {}
         saw_message_stop = False
         # ADR-006 stage 6.8: input tokens arrive on message_start
         # (message.usage.input_tokens), output tokens on message_delta
@@ -200,6 +227,20 @@ class AnthropicProvider:
                         if thinking:
                             thinking_parts.append(thinking)
                             yield ProviderEvent("reasoning", thinking)
+                    elif delta_type == "input_json_delta":
+                        index = _extract_response_field(event, "index", None)
+                        buf = tool_call_buffers.get(index)
+                        if buf is not None:
+                            buf["json"] += str(_extract_response_field(delta, "partial_json", "") or "")
+                elif event_type == "content_block_start":
+                    content_block = _extract_response_field(event, "content_block", None)
+                    block_type = str(_extract_response_field(content_block, "type", "") or "").strip().lower()
+                    if block_type == "tool_use":
+                        tool_call_buffers[_extract_response_field(event, "index", None)] = {
+                            "id": str(_extract_response_field(content_block, "id", "") or ""),
+                            "name": str(_extract_response_field(content_block, "name", "") or ""),
+                            "json": "",
+                        }
                 elif event_type == "message_start":
                     message = _extract_response_field(event, "message", {})
                     start_usage = _extract_response_field(message, "usage", None)
@@ -224,6 +265,27 @@ class AnthropicProvider:
             raise RuntimeError(
                 "Anthropic stream ended unexpectedly before completion. Please try again."
             )
+
+        if tool_call_buffers:
+            # ADR-007 stage 7.1: a pure tool-call turn is a legitimate,
+            # complete outcome - it must NOT go through
+            # _compose_reasoned_response below, which raises for "thinking
+            # but no visible answer" (the exact, legitimate shape of a
+            # tool-call turn whose model reasoned before calling instead of
+            # answering), mirroring OllamaProvider.stream()'s own
+            # short-circuit ahead of its equivalent _compose() call.
+            for index in sorted(tool_call_buffers, key=str):
+                buf = tool_call_buffers[index]
+                yield ProviderEvent(
+                    "tool_call",
+                    tool_call=ToolCall(
+                        id=buf["id"],
+                        name=buf["name"],
+                        arguments=json.loads(buf["json"]) if buf["json"] else {},
+                    ),
+                )
+            yield ProviderEvent("done", "".join(answer_parts).strip())
+            return
 
         # The same composition contract as _extract_anthropic_text gives the
         # blocking path: answer + thinking through _compose_reasoned_response,

--- a/backend/providers/base.py
+++ b/backend/providers/base.py
@@ -13,10 +13,10 @@ between this file and the ADR's §1 sketch reads as a plan, not a drift):
   (async SDK ports) flip this async-native; the EVENT vocabulary below is
   already the ADR's, so that flip changes the iteration keyword, not the
   data model.
-- `usage` events (6.8) and `tool_call` events (ADR-007) are named in the
-  ADR's event union but deliberately absent from EVENT_TYPES until the stage
-  that makes them real - an event type nothing can emit yet would just be an
-  untestable claim.
+- `usage` events (6.8, done) and `tool_call` events (ADR-007 stage 7.1, done)
+  were named in the ADR's event union ahead of the stage that made them real
+  - an event type nothing can emit yet would just be an untestable claim.
+  Both are now live; see EVENT_TYPES' own comment for `tool_call`'s shape.
 - Cancellation rides the same `threading.Event` the whole run pipeline
   already uses (RunLifecycle claims one per run); `CancelToken` wraps it so
   the protocol owns the NAME while stage 6.2 swaps the mechanism underneath
@@ -38,7 +38,23 @@ from typing import Any, Iterator, Literal, Mapping, Protocol, runtime_checkable
 # attach normalized usage to the terminal "done" event (done.usage), which
 # keeps the chat_stream consuming loop simple. The type stays in this union
 # so the vocabulary matches the ADR's event union.
-EVENT_TYPES = ("text", "reasoning", "reset", "done", "usage")
+#
+# ADR-007 stage 7.1: "tool_call" DOES stand alone (unlike usage/reasoning),
+# because a single turn can request MULTIPLE independent tool calls and the
+# caller needs each one as its own addressable unit to invoke and answer
+# separately - collapsing them onto "done" would lose that plurality. Each
+# provider is responsible for accumulating its own native incremental shape
+# (OpenAI streams tool-call arguments as JSON text fragments keyed by
+# index; Anthropic streams them as input_json_delta events on a tool_use
+# content block; Ollama and Gemini both deliver a tool call as one already-
+# complete object, nothing to accumulate) into exactly ONE ProviderEvent
+# per complete call, with `arguments` always a parsed dict - never a raw
+# JSON string leaking a provider's wire format to the caller. The stream
+# still ends with exactly one "done" event after any tool_call events (its
+# `text` may be empty - a turn that is pure tool-calling has no answer
+# text yet); that keeps chat_stream's "ends with exactly one done" contract
+# true regardless of how many tools were called.
+EVENT_TYPES = ("text", "reasoning", "reset", "done", "usage", "tool_call")
 
 
 @dataclass(frozen=True)
@@ -57,10 +73,61 @@ class ProviderCapabilities:
     vision: bool = False
     audio: bool = False
     image_generation: bool = False
-    # ADR-007 / 6.8 - declared now so capability consumers have a stable
-    # shape, but nothing sets them True until the stage that implements them.
+    # ADR-007 stage 7.1: True where a provider's stream() actually translates
+    # ToolSpecs into native tool params and normalizes ToolCallEvents back -
+    # OpenAI, Anthropic, Gemini always (current model families all support
+    # native tool use); Ollama per-model via the same cached show() probe
+    # capabilities/vision/audio already use (some models genuinely lack
+    # tool support server-side); llama.cpp stays False - no reliable local
+    # detection of whether a GGUF's chat template supports tool syntax, and
+    # the ADR's own stage-7.1 provider list never names it. A caller whose
+    # target provider has tools=False must use the structured_output/
+    # respond_json fallback (7.3), not attempt native tools.
     tools: bool = False
+    # ADR-007 stage 7.3 - declared now so capability consumers have a
+    # stable shape, but nothing sets it True until that stage.
     structured_output: bool = False
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """ADR-007 stage 7.1: one tool a model may call, in the app's neutral
+    shape - each provider translates this into its own native tool
+    parameter (OpenAI `tools[].function`, Anthropic `tools[]`, Gemini
+    `tools[].functionDeclarations[]`, Ollama `tools[].function`).
+
+    `input_schema` is a JSON Schema object (Draft 2020-12, matching
+    `respond_json`'s contract in 7.3) describing the call's arguments -
+    NOT a full Draft 2020-12 feature set on every provider: Gemini's
+    `parameters` field is an OpenAPI 3.0 Schema subset (no `$defs`, no
+    `additionalProperties`), a known, documented impedance mismatch rather
+    than a bug - callers targeting Gemini should keep schemas to the
+    OpenAPI-compatible subset (type/properties/required/enum/items).
+
+    Deliberately NO `annotations` (read_only/destructive/idempotent/
+    requires_approval) field yet - the ADR's own §1 sketch marks that
+    "optional", and it is ToolRegistry's field to own (7.2), not the
+    provider-facing spec's: the provider only needs name/description/
+    schema to build its native tool param, never the approval policy."""
+
+    name: str
+    description: str
+    input_schema: dict
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """ADR-007 stage 7.1: one complete, normalized tool call a model
+    requested - `arguments` is always an already-parsed dict, regardless of
+    whether the provider streamed it as JSON text fragments (OpenAI,
+    Anthropic) or delivered it whole (Ollama, Gemini). `id` correlates this
+    call to the tool-result message fed back on the next turn; Ollama and
+    Gemini don't provide one natively, so their providers synthesize a
+    stable per-turn id (see each provider's own comment)."""
+
+    id: str
+    name: str
+    arguments: dict
 
 
 @dataclass(frozen=True)
@@ -71,9 +138,23 @@ class ChatRequest:
     "content": str | [part-dict]}], with "image_bytes"/"audio_file" parts) -
     each provider owns converting that to its SDK's format, exactly the
     per-provider `prepare_messages` responsibility ADR-006 §1 assigns.
+    ADR-007 stage 7.1 widens that shape by exactly two new message roles,
+    both provider-translated the same way as everything else: an assistant
+    turn that called tools carries a `tool_calls: list[dict]` key (each
+    `{"id", "name", "arguments"}`, `content` may still carry lead-in text);
+    a tool's result is fed back as `{"role": "tool", "tool_call_id": id,
+    "name": tool_name, "content": result_text}`.
+
     `extra_kwargs` is the passthrough surface today's chat(**kwargs) callers
     rely on (e.g. the chart agent's format hints); it shrinks as stages
     6.3-6.8 give its remaining uses first-class fields.
+
+    `tools`: ToolSpecs available this turn, or empty for no tool access -
+    ADR-007 stage 7.1. A provider whose `capabilities.tools` is False must
+    never receive a non-empty `tools` here (the caller's job to check
+    capabilities first, mirroring how streaming/vision gating already
+    works); providers do not re-validate this against their own
+    capabilities, matching every other field's caller-trusts-caller posture.
 
     Deliberately NO reasoning_level field: the level is provider
     configuration (each provider is constructed with it, from the caller's
@@ -86,6 +167,7 @@ class ChatRequest:
     task: str
     messages: list
     extra_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    tools: tuple[ToolSpec, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -101,19 +183,26 @@ class ProviderEvent:
                    retry discarded the prior attempt's partial output).
     - "done":      terminal; `text` carries the COMPLETE final content (for
                    Ollama that is the composed "<think>...</think>\\n{answer}"
-                   shape downstream response parsing depends on). ADR-006
-                   stage 6.8: `usage`, when the provider reported it, rides
-                   the done event as {"prompt_tokens": int | None,
+                   shape downstream response parsing depends on) - EMPTY when
+                   the turn was pure tool-calling with no answer text yet.
+                   ADR-006 stage 6.8: `usage`, when the provider reported it,
+                   rides the done event as {"prompt_tokens": int | None,
                    "completion_tokens": int | None} - normalized keys, never
                    a separate event.
     - "usage":     reserved in the union for protocol completeness; today no
                    provider emits it standalone (usage rides "done" - see
                    EVENT_TYPES' own comment).
+    - "tool_call": ADR-007 stage 7.1: `tool_call` carries one complete,
+                   normalized `ToolCall`. UNLIKE usage, this stands alone
+                   (not bundled onto "done") - see EVENT_TYPES' own comment
+                   for why. Zero or more of these precede the terminal
+                   "done" event; never after it.
     """
 
-    type: Literal["text", "reasoning", "reset", "done", "usage"]
+    type: Literal["text", "reasoning", "reset", "done", "usage", "tool_call"]
     text: str = ""
     usage: dict | None = None
+    tool_call: ToolCall | None = None
 
 
 def normalize_usage(prompt_tokens, completion_tokens) -> dict | None:

--- a/backend/providers/gemini_provider.py
+++ b/backend/providers/gemini_provider.py
@@ -73,6 +73,10 @@ class GeminiProvider:
             # is documentation-only, not SDK-source-verified (ToolSpec's own
             # docstring flags the same caveat for input_schema).
             tools=True,
+            # ADR-007 stage 7.3: native response_mime_type/response_schema
+            # structured outputs - see backend/structured_output.py's own
+            # _native_kwargs_for_active_provider comment.
+            structured_output=True,
         )
 
     def _request_body(self, request: ChatRequest, system_prompt, gemini_contents) -> dict:

--- a/backend/providers/gemini_provider.py
+++ b/backend/providers/gemini_provider.py
@@ -35,6 +35,7 @@ from backend.providers.base import (
     ChatRequest,
     ProviderCapabilities,
     ProviderEvent,
+    ToolCall,
     normalize_usage,
 )
 
@@ -63,6 +64,15 @@ class GeminiProvider:
             vision=True,
             audio=True,   # media rides the Files API upload path in _prepare_gemini_contents
             image_generation=True,
+            # ADR-007 stage 7.1: current Gemini model families all support
+            # native tool use unconditionally (base.py's own
+            # ProviderCapabilities.tools comment) - no capability call
+            # needed. NOTE: unlike the other three providers, this repo has
+            # no Gemini SDK to verify wire shapes against - stream()'s tool
+            # handling follows Gemini's documented public REST contract but
+            # is documentation-only, not SDK-source-verified (ToolSpec's own
+            # docstring flags the same caveat for input_schema).
+            tools=True,
         )
 
     def _request_body(self, request: ChatRequest, system_prompt, gemini_contents) -> dict:
@@ -80,6 +90,12 @@ class GeminiProvider:
         if generation_config:
             request_body["generationConfig"] = generation_config
         return request_body
+
+    # ADR-007 stage 7.1: deliberately NOT given tool-call support, matching
+    # every other provider's complete() - it returns a bare str with no
+    # channel for ToolCall events, and its callers never supply
+    # request.tools. A future caller passing tools here has them silently
+    # ignored (_request_body never reads request.tools; only stream() does).
 
     def complete(self, request: ChatRequest, cancel: CancelToken) -> str:
         system_prompt, gemini_contents, uploaded_files = _prepare_gemini_contents(
@@ -117,7 +133,22 @@ class GeminiProvider:
         )
         try:
             request_body = self._request_body(request, system_prompt, gemini_contents)
+            if request.tools:
+                # ADR-007 stage 7.1: Gemini's native shape wraps every tool
+                # in one functionDeclarations list under a single tools[0]
+                # entry (not one tools[] entry per tool, unlike the other
+                # three providers) - `parameters` is the ToolSpec's own
+                # input_schema passed through untouched; see ToolSpec's own
+                # docstring for the OpenAPI-subset caveat that imposes on
+                # callers targeting Gemini.
+                request_body["tools"] = [{
+                    "functionDeclarations": [
+                        {"name": tool.name, "description": tool.description, "parameters": tool.input_schema}
+                        for tool in request.tools
+                    ],
+                }]
             text_parts: list[str] = []
+            tool_calls: list[ToolCall] = []
             usage = None
             sse = _gemini_stream_sse(
                 f"{GEMINI_BASE_URL}/v1beta/models/{self.model_id}:streamGenerateContent?alt=sse",
@@ -161,6 +192,20 @@ class GeminiProvider:
                     for candidate in payload.get("candidates", []) or []:
                         content = candidate.get("content", {}) or {}
                         for part in content.get("parts", []) or []:
+                            # ADR-007 stage 7.1: Gemini delivers a function
+                            # call whole in one part - never incrementally,
+                            # like Ollama and unlike OpenAI/Anthropic's
+                            # per-delta JSON buffering - and, like Ollama,
+                            # gives it no native id, so one is synthesized
+                            # from this turn's call position.
+                            function_call = part.get("functionCall")
+                            if function_call is not None:
+                                tool_calls.append(ToolCall(
+                                    id=f"call_{len(tool_calls)}",
+                                    name=function_call.get("name", ""),
+                                    arguments=dict(function_call.get("args") or {}),
+                                ))
+                                continue
                             text = part.get("text")
                             if not text:
                                 continue
@@ -182,10 +227,21 @@ class GeminiProvider:
             # today, and giving the streamed path one would be a silent
             # behavior change. Revisit when Gemini gets composition.
             final = "".join(text_parts).strip()
-            if not final:
+            # ADR-007 stage 7.1: a pure tool-call turn legitimately has no
+            # text - only raise the empty-response error when there is
+            # ALSO no tool call to explain the silence, mirroring every
+            # other provider's short-circuit ahead of its own
+            # empty-response/reasoning-without-answer check.
+            if not final and not tool_calls:
                 raise RuntimeError("Gemini returned an empty response.")
         finally:
             for file_name in uploaded_files:
                 _gemini_delete_file(file_name, api_key=self.api_key)
+
+        if tool_calls:
+            for call in tool_calls:
+                yield ProviderEvent("tool_call", tool_call=call)
+            yield ProviderEvent("done", final)
+            return
 
         yield ProviderEvent("done", final, usage=usage)

--- a/backend/providers/llama_cpp_provider.py
+++ b/backend/providers/llama_cpp_provider.py
@@ -53,6 +53,14 @@ class LlamaCppProvider:
             vision=False,  # _assert_llama_cpp_message_support rejects media up front
             audio=False,
             image_generation=False,
+            # ADR-007 stage 7.3: create_chat_completion's response_format=
+            # {"type":"json_object","schema":...} compiles a GBNF grammar
+            # server-side (verified against the installed llama_cpp
+            # package's own ChatCompletionRequestResponseFormat shape) -
+            # unlike tools (deliberately out of ADR-007 stage 7.1's scope
+            # for this provider), structured output needs no per-model
+            # capability probe.
+            structured_output=True,
         )
 
     def complete(self, request: ChatRequest, cancel: CancelToken) -> str:

--- a/backend/providers/ollama_provider.py
+++ b/backend/providers/ollama_provider.py
@@ -112,6 +112,12 @@ class OllamaProvider:
             vision=True,
             audio=True,
             tools=ollama_supports_tools(model),
+            # ADR-007 stage 7.3: unlike tools (a genuine per-model probe),
+            # Ollama's `format` accepting a raw JSON Schema dict is a
+            # request-shape feature of the client/server protocol itself,
+            # not a per-model chat-template capability - True
+            # unconditionally, matching vision/audio's own reasoning above.
+            structured_output=True,
         )
 
     # -- shared request prep --------------------------------------------------

--- a/backend/providers/ollama_provider.py
+++ b/backend/providers/ollama_provider.py
@@ -57,6 +57,7 @@ from api_provider import (
     _is_ollama_bool_reasoning_model,
     _prepare_ollama_messages,
     _raise_if_cancelled,
+    ollama_supports_tools,
     ollama_think_kwarg,
     reasoning_budget_hint,
     split_reasoning_and_content,
@@ -66,6 +67,7 @@ from backend.providers.base import (
     ChatRequest,
     ProviderCapabilities,
     ProviderEvent,
+    ToolCall,
     normalize_usage,
 )
 
@@ -101,11 +103,15 @@ class OllamaProvider:
         # before; a False here would wrongly tell a future consumer to
         # disable attachments for vision-capable Ollama models (6.3
         # adversarial review finding on the first draft's under-claim).
+        # ADR-007 stage 7.1: unlike vision/audio (True unconditionally - see
+        # the comment above), tools IS a genuine per-model probe - see
+        # ollama_supports_tools' own docstring for why the two cases differ.
         self.capabilities = ProviderCapabilities(
             streaming=True,
             reasoning=ollama_think_kwarg(model, "high") is not None,
             vision=True,
             audio=True,
+            tools=ollama_supports_tools(model),
         )
 
     # -- shared request prep --------------------------------------------------
@@ -114,6 +120,24 @@ class OllamaProvider:
         _assert_ollama_audio_support(self.model_id, request.messages)
         messages = _prepare_ollama_messages(request.messages)
         kwargs = {k: v for k, v in request.extra_kwargs.items() if k != "cancellation_event"}
+        if request.tools:
+            # ADR-007 stage 7.1: Ollama's native shape mirrors OpenAI's -
+            # {"type":"function","function":{"name","description",
+            # "parameters"}} - `parameters` is the ToolSpec's own JSON
+            # Schema object, passed through untouched (Ollama does not
+            # narrow it to an OpenAPI subset the way Gemini's REST API
+            # does).
+            kwargs["tools"] = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": spec.name,
+                        "description": spec.description,
+                        "parameters": spec.input_schema,
+                    },
+                }
+                for spec in request.tools
+            ]
         if self.context_window:
             # Served context == budgeted context (see __init__). A caller's
             # own explicit options.num_ctx passthrough still wins.
@@ -152,6 +176,25 @@ class OllamaProvider:
             "Retry in Quick mode or choose a different chat format/model."
         )
 
+    @staticmethod
+    def _extract_tool_calls(message) -> tuple[ToolCall, ...]:
+        """ADR-007 stage 7.1: Ollama delivers tool calls whole - never
+        incrementally, so there is nothing to accumulate across chunks, in
+        contrast to OpenAI/Anthropic's per-delta buffers. Ollama's own
+        ToolCall has NO id field (see api_provider.ollama_supports_tools'
+        own docstring), so a stable per-turn id is synthesized from the
+        call's position - stable because Ollama's tool_calls list, once
+        delivered, is not re-ordered or re-delivered within the same turn."""
+        raw_calls = message.get("tool_calls") or []
+        return tuple(
+            ToolCall(
+                id=f"call_{index}",
+                name=raw["function"]["name"],
+                arguments=dict(raw["function"]["arguments"]),
+            )
+            for index, raw in enumerate(raw_calls)
+        )
+
     # -- the protocol ---------------------------------------------------------
 
     def stream(self, request: ChatRequest, cancel: CancelToken) -> Iterator[ProviderEvent]:
@@ -168,6 +211,7 @@ class OllamaProvider:
 
             content_parts: list[str] = []
             thinking_parts: list[str] = []
+            tool_calls: tuple[ToolCall, ...] = ()
             usage = None
             stream = ollama.chat(model=self.model_id, messages=messages, stream=True, **kwargs)
             try:
@@ -184,6 +228,14 @@ class OllamaProvider:
                     if delta_thinking:
                         thinking_parts.append(delta_thinking)
                         yield ProviderEvent("reasoning", delta_thinking)
+                    # ADR-007 stage 7.1: a tool-calling chunk is ALSO the
+                    # terminal chunk for this attempt (Ollama never streams
+                    # more content after tool_calls appear), so this check
+                    # sits ahead of the `done` check below rather than
+                    # inside it - `done` may not even be set the same chunk.
+                    if part["message"].get("tool_calls"):
+                        tool_calls = self._extract_tool_calls(part["message"])
+                        break
                     if part.get("done"):
                         # ADR-006 stage 6.8: the terminal chunk carries
                         # Ollama's real token counts.
@@ -193,6 +245,18 @@ class OllamaProvider:
                         break
             finally:
                 stream.close()  # idempotent on an already-exhausted generator
+
+            if tool_calls:
+                # ADR-007 stage 7.1: a pure tool-call turn is a legitimate,
+                # complete outcome - it must NOT enter the reasoning-retry
+                # loop below (that loop exists for "thinking but no visible
+                # ANSWER", not for "the model chose to call a tool instead
+                # of answering yet"). Any lead-in text before the call still
+                # streamed above as ordinary "text" events.
+                for call in tool_calls:
+                    yield ProviderEvent("tool_call", tool_call=call)
+                yield ProviderEvent("done", "".join(content_parts))
+                return
 
             try:
                 final = self._compose("".join(content_parts), "".join(thinking_parts))
@@ -204,6 +268,16 @@ class OllamaProvider:
         raise self._exhausted_retries_error() from last_reasoning_error
 
     # -- transitional non-streaming path (dies in stage 6.4) ------------------
+    #
+    # ADR-007 stage 7.1: deliberately NOT given tool-call support. complete()
+    # returns a bare str with no channel for ToolCall events to ride, and its
+    # only remaining callers (api_provider.chat()'s Ollama branch) never
+    # supply request.tools - the tool-use loop this stage introduces is
+    # built exclusively on stream()/chat_stream(), matching the ADR's own
+    # framing of tool calls as a streamed concept. If a future caller ever
+    # passes tools here, they are silently ignored (no `tools` kwarg is
+    # built below) rather than raising - consistent with `complete()`'s
+    # existing transitional-scope posture elsewhere in this class.
 
     def complete(self, request: ChatRequest, cancel: CancelToken) -> str:
         _raise_if_cancelled(cancel.event)

--- a/backend/providers/openai_provider.py
+++ b/backend/providers/openai_provider.py
@@ -27,6 +27,7 @@ every provider in this package.
 from __future__ import annotations
 
 import base64
+import json
 from pathlib import Path
 from typing import Iterator
 
@@ -42,6 +43,7 @@ from backend.providers.base import (
     ChatRequest,
     ProviderCapabilities,
     ProviderEvent,
+    ToolCall,
     normalize_usage,
 )
 
@@ -75,6 +77,40 @@ def prepare_openai_messages(messages: list) -> list:
     requests are byte-identical to the pre-port behavior."""
     prepared = []
     for message in messages:
+        # ADR-007 stage 7.1: the two tool-turn roles ChatRequest's docstring
+        # adds, translated to OpenAI's native shape - checked before the
+        # list-content branch below since neither ever carries part-list
+        # content. OpenAI's tool_call.function.arguments is a JSON STRING on
+        # the wire (unlike Ollama's already-parsed dict), so the app's
+        # parsed dict is re-serialized here, mirroring how api_provider.
+        # _prepare_ollama_messages handles the same two roles for Ollama.
+        role = message.get("role")
+        if role == "tool":
+            prepared.append({
+                "role": "tool",
+                "tool_call_id": message.get("tool_call_id", ""),
+                "content": str(message.get("content") or ""),
+            })
+            continue
+        tool_calls = message.get("tool_calls")
+        if tool_calls:
+            prepared.append({
+                "role": "assistant",
+                "content": message.get("content") or None,
+                "tool_calls": [
+                    {
+                        "id": call["id"],
+                        "type": "function",
+                        "function": {
+                            "name": call["name"],
+                            "arguments": json.dumps(call["arguments"]),
+                        },
+                    }
+                    for call in tool_calls
+                ],
+            })
+            continue
+
         content = message.get("content")
         if not isinstance(content, list):
             prepared.append(message)
@@ -148,7 +184,18 @@ class OpenAIProvider:
             image_generation=callable(
                 getattr(getattr(client, "images", None), "generate", None)
             ),
+            # ADR-007 stage 7.1: unlike Ollama's per-model probe, OpenAI's
+            # current model families all support native tool use
+            # unconditionally (base.py's own ProviderCapabilities.tools
+            # comment) - no capability call needed.
+            tools=True,
         )
+
+    # ADR-007 stage 7.1: deliberately NOT given tool-call support, matching
+    # OllamaProvider.complete()'s own exclusion comment - complete() returns
+    # a bare str with no channel for ToolCall events, and its callers never
+    # supply request.tools. A future caller passing tools here has them
+    # silently ignored (no `tools` kwarg built below).
 
     def complete(self, request: ChatRequest, cancel: CancelToken) -> str:
         kwargs = {k: v for k, v in request.extra_kwargs.items() if k != "cancellation_event"}
@@ -182,8 +229,26 @@ class OpenAIProvider:
         kwargs.pop("stream", None)  # ours to set - a passthrough kwarg can't turn it back off
         if request.task == config.TASK_CHAT:
             kwargs.update(openai_reasoning_kwargs(self.model_id, self.reasoning_level))
+        if request.tools:
+            kwargs["tools"] = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": tool.input_schema,
+                    },
+                }
+                for tool in request.tools
+            ]
 
         content_parts: list[str] = []
+        # ADR-007 stage 7.1: OpenAI streams each tool call's arguments as
+        # JSON TEXT FRAGMENTS keyed by the call's `index` (never by `id` -
+        # only the first delta for a given call carries one), unlike
+        # Ollama's whole-object delivery - buffered here and parsed once
+        # complete, so ToolCall.arguments is always an already-parsed dict.
+        tool_call_buffers: dict[int, dict] = {}
         prepared_messages = prepare_openai_messages(request.messages)
         # ADR-006 stage 6.8: ask for the final usage chunk. Some
         # OpenAI-compatible servers (older vLLM/LM Studio builds) reject
@@ -246,8 +311,40 @@ class OpenAIProvider:
                 )
                 if delta_reasoning:
                     yield ProviderEvent("reasoning", delta_reasoning)
+                # ADR-007 stage 7.1: each delta carries one fragment of one
+                # tool call, addressed by `index` - `id`/`function.name`
+                # arrive whole on that call's first delta (the `or` below
+                # preserves them against later empty-string deltas),
+                # `function.arguments` accumulates char-by-char.
+                for tc in getattr(delta, "tool_calls", None) or ():
+                    buf = tool_call_buffers.setdefault(
+                        tc.index, {"id": "", "name": "", "arguments": ""}
+                    )
+                    buf["id"] = getattr(tc, "id", None) or buf["id"]
+                    function = getattr(tc, "function", None)
+                    if function is not None:
+                        buf["name"] = getattr(function, "name", None) or buf["name"]
+                        buf["arguments"] += getattr(function, "arguments", None) or ""
         finally:
             stream.close()  # idempotent on an already-closed/exhausted stream
+
+        if tool_call_buffers:
+            # ADR-007 stage 7.1: mirrors OllamaProvider.stream()'s own
+            # tool_calls branch - a pure tool-call turn is a complete,
+            # legitimate outcome, so `done` carries whatever lead-in text
+            # streamed (often none) rather than being treated as an error.
+            for index in sorted(tool_call_buffers):
+                buf = tool_call_buffers[index]
+                yield ProviderEvent(
+                    "tool_call",
+                    tool_call=ToolCall(
+                        id=buf["id"] or f"call_{index}",
+                        name=buf["name"],
+                        arguments=json.loads(buf["arguments"]) if buf["arguments"] else {},
+                    ),
+                )
+            yield ProviderEvent("done", "".join(content_parts), usage=usage)
+            return
 
         # Deliberate parity with complete(), which returns message.content
         # untouched (no <think> composition anywhere on the OpenAI path

--- a/backend/providers/openai_provider.py
+++ b/backend/providers/openai_provider.py
@@ -189,6 +189,11 @@ class OpenAIProvider:
             # unconditionally (base.py's own ProviderCapabilities.tools
             # comment) - no capability call needed.
             tools=True,
+            # ADR-007 stage 7.3: native response_format:{"type":"json_schema"}
+            # structured outputs - see backend/structured_output.py's own
+            # _native_kwargs_for_active_provider comment for the verified
+            # SDK shape.
+            structured_output=True,
         )
 
     # ADR-007 stage 7.1: deliberately NOT given tool-call support, matching

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -384,6 +384,14 @@ def _restore_chat_payload(payload: dict[str, Any]) -> SceneNode:
             # matching the dataclass default ("not reported").
             prompt_tokens=payload.get("prompt_tokens"),
             completion_tokens=payload.get("completion_tokens"),
+            # ADR-007 stage 7.4: absent in every pre-7.4 save -> [], matching
+            # the dataclass default. Each item is validated only loosely
+            # (dict(...) below tolerates hand-edited/legacy entries missing a
+            # key - scene_payload()'s own .get()-based wire projection is
+            # what actually protects the frontend from a malformed one).
+            tool_invocations=[
+                dict(call) for call in (payload.get("tool_invocations") or []) if isinstance(call, dict)
+            ],
         ),
     )
 

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -215,6 +215,12 @@ def _serialize_chat_node(node: SceneNode) -> dict[str, Any]:
         # survives save/load like every other provenance field above.
         "prompt_tokens": node.state.prompt_tokens,
         "completion_tokens": node.state.completion_tokens,
+        # ADR-007 stage 7.4: a plain list-of-dicts copy - see ChatState.
+        # tool_invocations' own comment for the exact shape. Domain-side
+        # `arguments` stays a real dict here (only JSON-encoded at the wire
+        # boundary in graph.py's scene_payload()), so the saved session file
+        # keeps it structured too.
+        "tool_invocations": [dict(call) for call in node.state.tool_invocations],
     }
 
 

--- a/backend/structured_output.py
+++ b/backend/structured_output.py
@@ -1,0 +1,272 @@
+"""ADR-007 stage 7.3: respond_json - one schema-constrained JSON output path,
+used by every caller that needs a model's answer to conform to a schema
+(charts, plugins, the agentic planner) instead of each one hand-rolling its
+own JSON-mode kwargs and repair chain the way graphlink_chart_agent.py's
+ChartDataAgent currently does (five hardcoded chart schemas, a bespoke
+clean_response/repair_chart_data pair, and an if/elif on API_PROVIDER_TYPE
+picking response_format/response_mime_type/format by hand - exactly the
+per-caller sprawl this ADR's own "Alternatives considered" rejects).
+
+Two paths per provider, chosen from THIS request's own provider snapshot
+(api_provider._snapshot_provider_state()/ProviderRuntime.snapshot() - the
+same one api_provider.chat() itself reads, so this module never re-derives
+"which provider is active" a second, potentially-inconsistent way):
+
+- **Native** (OpenAI, Gemini, Ollama, llama.cpp): the schema rides the
+  provider's own hard-constrained JSON mode - OpenAI's `response_format:
+  {"type":"json_schema","json_schema":{...,"strict":True}}`, Gemini's
+  `response_mime_type`+`response_schema` (an extra_kwargs pass-through into
+  generationConfig, same snake_case convention ChartDataAgent's own Gemini
+  branch already relies on), Ollama's `format` accepting a raw JSON Schema
+  dict directly (not just the string "json"), llama.cpp's `response_format:
+  {"type":"json_object","schema":...}` (a GBNF grammar derived from the
+  schema, verified against the installed llama_cpp package's own
+  ChatCompletionRequestResponseFormat shape). The provider is contractually
+  constrained server-side, so this path should essentially never need
+  repair - but the response is still parsed+validated as a safety net, not
+  trusted blindly.
+- **Fallback** (Anthropic - no native JSON-schema mode today): the schema is
+  embedded in an extra system message (schema-guided generation, no
+  server-side enforcement) instead of native kwargs.
+
+Both paths converge on the SAME validate-and-repair tail: parse, validate
+against `schema` (a hand-rolled Draft-2020-12 SUBSET validator - type/
+properties/required/items/enum, the exact "OpenAPI-compatible subset"
+ToolSpec's own docstring already documents as the portable target across
+every provider, ADR-007 stage 7.1 - not a full implementation, and not a new
+third-party dependency for a subset this codebase already hand-validates
+elsewhere via graphlink_chart_data.canonicalize_chart_data's own precedent).
+On failure, exactly ONE repair turn is sent - a fresh, standalone system+user
+pair naming the validation errors and asking for a corrected object,
+directly generalizing ChartDataAgent.repair_chart_data's own single-attempt
+shape to an arbitrary caller-supplied schema instead of five hardcoded ones.
+Failing that, respond_json raises StructuredOutputError - unlike
+ChartDataAgent.get_response's legacy json.dumps({"error": ...}) string
+convention, a caller here gets a normal Python exception, matching how a
+plugin/planner caller actually wants to handle this (try/except), not a
+second JSON payload shape to parse.
+
+respond_json() is deliberately synchronous/blocking (api_provider.chat(),
+not chat_stream()) - every real caller (ChartDataAgent-shaped ones, a future
+plugin/planner call) wants the whole object back at once, not incremental
+deltas; ADR-006 stage 6.4's own precedent already keeps a blocking chat()
+path alive specifically for exactly this kind of single-shot request.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import api_provider
+import graphlink_task_config as config
+
+
+class StructuredOutputError(RuntimeError):
+    """Raised when respond_json cannot produce schema-conforming JSON even
+    after the one repair attempt - carries the validation errors that
+    doomed the repaired response in its own message."""
+
+
+# -- response cleanup (mirrors ChartDataAgent.clean_response's own two-stage
+# -- extraction - markdown fence first, then a raw brace-to-brace fallback -
+# -- generalized here beyond chart JSON, so kept as a free function rather
+# -- than importing graphlink_chart_agent, which this module has no other
+# -- reason to depend on) ------------------------------------------------
+
+
+def _clean_json_response(text: str) -> str:
+    text = re.sub(r"<think>[\s\S]*?</think>", "", text, flags=re.IGNORECASE).strip()
+    block_match = re.search(r"```(?:json)?\s*([\[{][\s\S]*?[\]}])\s*```", text, re.IGNORECASE)
+    if block_match:
+        return block_match.group(1).strip()
+    fallback_match = re.search(r"([\[{][\s\S]*[\]}])", text)
+    if fallback_match:
+        return fallback_match.group(1).strip()
+    return text.strip()
+
+
+# -- minimal JSON Schema subset validator ---------------------------------
+
+
+def _validate_against_schema(data, schema: dict, path: str = "$") -> list[str]:
+    """Returns human-readable error strings; an empty list means valid.
+    Deliberately narrow (type/properties/required/items/enum only - no
+    $ref/$defs/oneOf/pattern/...) - see this module's own docstring for why
+    that subset, not a general-purpose implementation, is the right scope."""
+    errors: list[str] = []
+    expected_type = schema.get("type")
+
+    if expected_type == "object":
+        if not isinstance(data, dict):
+            return [f"{path}: expected object, got {type(data).__name__}"]
+        for required_key in schema.get("required", []) or []:
+            if required_key not in data:
+                errors.append(f"{path}: missing required property {required_key!r}")
+        properties = schema.get("properties", {}) or {}
+        for key, value in data.items():
+            if key in properties:
+                errors.extend(_validate_against_schema(value, properties[key], f"{path}.{key}"))
+    elif expected_type == "array":
+        if not isinstance(data, list):
+            return [f"{path}: expected array, got {type(data).__name__}"]
+        item_schema = schema.get("items")
+        if item_schema:
+            for index, item in enumerate(data):
+                errors.extend(_validate_against_schema(item, item_schema, f"{path}[{index}]"))
+    elif expected_type == "string":
+        if not isinstance(data, str):
+            errors.append(f"{path}: expected string, got {type(data).__name__}")
+    elif expected_type == "number":
+        if not isinstance(data, (int, float)) or isinstance(data, bool):
+            errors.append(f"{path}: expected number, got {type(data).__name__}")
+    elif expected_type == "integer":
+        if not isinstance(data, int) or isinstance(data, bool):
+            errors.append(f"{path}: expected integer, got {type(data).__name__}")
+    elif expected_type == "boolean":
+        if not isinstance(data, bool):
+            errors.append(f"{path}: expected boolean, got {type(data).__name__}")
+
+    enum_values = schema.get("enum")
+    if enum_values is not None and data not in enum_values:
+        errors.append(f"{path}: {data!r} is not one of {enum_values!r}")
+
+    return errors
+
+
+# -- per-provider native-mode kwargs --------------------------------------
+
+
+def _native_kwargs_for_active_provider(state, schema: dict, schema_name: str) -> dict | None:
+    """None means the active provider/mode has no native structured-output
+    affordance (Anthropic today) - the caller falls back to a schema-guided
+    system message instead. Branches on the exact same snapshot fields
+    api_provider.chat() itself branches on (state.use_api_mode/
+    local_provider_type/api_provider_type), so "which provider is active"
+    is never derived two different, potentially-divergent ways."""
+    if not state.use_api_mode:
+        if state.local_provider_type == config.LOCAL_PROVIDER_OLLAMA:
+            # Ollama's `format` accepts a raw JSON Schema dict directly
+            # (not just the "json" string shortcut) - verified against the
+            # installed ollama SDK's own chat() signature.
+            return {"format": schema}
+        if state.local_provider_type == config.LOCAL_PROVIDER_LLAMACPP:
+            # Verified against llama_cpp.llama_types.
+            # ChatCompletionRequestResponseFormat: {"type": "json_object",
+            # "schema": <optional JSON Schema>} - llama-cpp-python compiles
+            # this into a GBNF grammar server-side.
+            return {"response_format": {"type": "json_object", "schema": schema}}
+        return None
+
+    if state.api_provider_type == config.API_PROVIDER_OPENAI:
+        # Verified against the installed openai SDK's
+        # ResponseFormatJSONSchema/JSONSchema TypedDicts - the modern
+        # Structured Outputs shape, strict=True for hard schema adherence.
+        return {
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": schema_name, "schema": schema, "strict": True},
+            }
+        }
+    if state.api_provider_type == config.API_PROVIDER_GEMINI:
+        # snake_case, matching ChartDataAgent.get_response's own existing
+        # (working) response_mime_type convention for this exact provider -
+        # both land as extra_kwargs merged wholesale into generationConfig
+        # by GeminiProvider._request_body, and Google's protobuf-JSON codec
+        # accepts either casing on ingest.
+        return {"response_mime_type": "application/json", "response_schema": schema}
+    # Anthropic (config.API_PROVIDER_ANTHROPIC): no native mode - None
+    # signals the schema-guided fallback below.
+    return None
+
+
+def _schema_guided_system_message(schema: dict, schema_name: str) -> dict:
+    return {
+        "role": "system",
+        "content": (
+            f"You must respond with exactly one raw JSON object named {schema_name!r} that "
+            "matches the following JSON Schema precisely. Do not include markdown fences, "
+            "explanations, or any wrapper keys - output only the JSON object itself.\n\n"
+            f"{json.dumps(schema, indent=2)}"
+        ),
+    }
+
+
+def _repair_messages(schema: dict, schema_name: str, raw_response: str, errors: list[str]) -> list:
+    # A fresh, standalone turn - NOT the original conversation - directly
+    # generalizing ChartDataAgent.repair_chart_data's own shape (a bespoke
+    # system+user pair naming the malformed payload, never threaded through
+    # the original request's messages).
+    return [
+        _schema_guided_system_message(schema, schema_name),
+        {
+            "role": "user",
+            "content": (
+                "The following response does not match the required schema.\n\n"
+                f"--- MALFORMED RESPONSE ---\n{raw_response}\n\n"
+                "--- VALIDATION ERRORS ---\n" + "\n".join(errors) + "\n\n"
+                "Rewrite it as exactly one valid JSON object matching the schema."
+            ),
+        },
+    ]
+
+
+def respond_json(
+    task: str,
+    messages: list,
+    schema: dict,
+    *,
+    schema_name: str = "response",
+    runtime=None,
+    **kwargs,
+) -> dict:
+    """One schema-constrained JSON call - see this module's own docstring
+    for the native-vs-fallback decision and the validate-repair tail.
+    `kwargs` passes through to api_provider.chat() exactly like any other
+    chat() caller's passthrough kwargs (e.g. cancellation_event); do not
+    pass response_format/format/response_mime_type/response_schema
+    yourself - this function owns building those."""
+    cancel_event = kwargs.pop("cancellation_event", None)
+    state = runtime.snapshot() if runtime is not None else api_provider._snapshot_provider_state()
+
+    call_kwargs = dict(kwargs)
+    if runtime is not None:
+        call_kwargs["runtime"] = runtime
+    if cancel_event is not None:
+        call_kwargs["cancellation_event"] = cancel_event
+
+    native_kwargs = _native_kwargs_for_active_provider(state, schema, schema_name)
+    first_messages = list(messages) if native_kwargs is not None else (
+        [_schema_guided_system_message(schema, schema_name)] + list(messages)
+    )
+
+    raw_response = api_provider.chat(
+        task=task, messages=first_messages, **call_kwargs, **(native_kwargs or {})
+    )["message"]["content"]
+
+    try:
+        data = json.loads(_clean_json_response(raw_response))
+    except json.JSONDecodeError:
+        data = None
+    errors = _validate_against_schema(data, schema) if data is not None else ["response was not valid JSON"]
+    if not errors:
+        return data
+
+    repaired_raw = api_provider.chat(
+        task=task,
+        messages=_repair_messages(schema, schema_name, raw_response, errors),
+        **call_kwargs,
+        **(native_kwargs or {}),
+    )["message"]["content"]
+
+    try:
+        repaired_data = json.loads(_clean_json_response(repaired_raw))
+    except json.JSONDecodeError as exc:
+        raise StructuredOutputError(f"Model response was not valid JSON after repair: {exc}") from exc
+
+    repair_errors = _validate_against_schema(repaired_data, schema)
+    if repair_errors:
+        raise StructuredOutputError(
+            "Model response did not match the required schema after repair: " + "; ".join(repair_errors)
+        )
+    return repaired_data

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -205,6 +205,26 @@ def test_scene_payload_includes_chat_fields_defaulted_for_placeholders():
     assert chat_row["kind"] == "chat"
     assert chat_row["content"] == "real content"
     assert chat_row["isUser"] is True
+    # ADR-007 stage 7.4: the overwhelming common case - no tool-use loop has
+    # ever run against this node - defaults to an empty list, both for a
+    # placeholder and for an ordinary tool-less chat node.
+    assert rows["plain"]["toolCalls"] == []
+    assert chat_row["toolCalls"] == []
+
+
+def test_scene_payload_emits_a_chat_nodes_tool_invocations_with_json_encoded_arguments():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "assistant reply", False)
+    node.state.tool_invocations = [
+        {"id": "call_1", "name": "echo", "arguments": {"message": "hi"}, "result": "hi", "is_error": False},
+        {"id": "call_2", "name": "broken_tool", "arguments": {}, "result": "boom", "is_error": True},
+    ]
+    rows = {n["id"]: n for n in doc.scene_payload()["nodes"]}
+    tool_calls = rows[node.id]["toolCalls"]
+    assert tool_calls == [
+        {"id": "call_1", "name": "echo", "argumentsJson": '{"message": "hi"}', "result": "hi", "isError": False},
+        {"id": "call_2", "name": "broken_tool", "argumentsJson": "{}", "result": "boom", "isError": True},
+    ]
 
 
 # -- R3.5: code nodes --------------------------------------------------------

--- a/backend/tests/test_mcp_client.py
+++ b/backend/tests/test_mcp_client.py
@@ -1,0 +1,253 @@
+"""ADR-007 stage 7.5: MCP client - stdio transport, JSON-RPC 2.0.
+
+Exit criterion this file proves: "A configured filesystem MCP server's tool
+is callable, namespaced, approval-gated." test_a_configured_filesystem_mcp_
+servers_tool_is_callable_namespaced_and_approval_gated below spawns a REAL
+subprocess (a minimal fake filesystem-shaped MCP server script, not a mock
+of subprocess.Popen) speaking real JSON-RPC over real pipes, and drives it
+through register_mcp_server_tools -> ToolRegistry.invoke end to end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import textwrap
+
+import pytest
+
+from backend.mcp_client import McpError, McpServerConfig, McpStdioClient, register_mcp_server_tools
+from backend.providers import ToolCall
+from backend.tools import RunContext, ToolRegistry
+
+# A minimal fake MCP server, shaped like a real filesystem MCP server (one
+# "read_file" tool) - just enough JSON-RPC 2.0 over stdio to prove this
+# client speaks the real wire protocol against a real subprocess, not a
+# mock of subprocess.Popen itself.
+_FAKE_FS_SERVER_SCRIPT = textwrap.dedent(r'''
+    import json
+    import sys
+
+    def send(message):
+        sys.stdout.write(json.dumps(message) + "\n")
+        sys.stdout.flush()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        request = json.loads(line)
+        method = request.get("method")
+        request_id = request.get("id")
+
+        if method == "initialize":
+            send({
+                "jsonrpc": "2.0", "id": request_id,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "fake-filesystem", "version": "0.0.1"},
+                },
+            })
+        elif method == "notifications/initialized":
+            pass  # a notification - no response
+        elif method == "tools/list":
+            send({
+                "jsonrpc": "2.0", "id": request_id,
+                "result": {"tools": [
+                    {
+                        "name": "read_file",
+                        "description": "Reads a file's contents.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {"path": {"type": "string"}},
+                            "required": ["path"],
+                        },
+                    },
+                    {"name": "unlisted_tool", "description": "Not enabled.", "inputSchema": {"type": "object"}},
+                ]},
+            })
+        elif method == "tools/call":
+            params = request.get("params", {})
+            path = (params.get("arguments") or {}).get("path", "")
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    text = f.read()
+                send({"jsonrpc": "2.0", "id": request_id, "result": {
+                    "content": [{"type": "text", "text": text}], "isError": False,
+                }})
+            except OSError as exc:
+                send({"jsonrpc": "2.0", "id": request_id, "result": {
+                    "content": [{"type": "text", "text": f"error: {exc}"}], "isError": True,
+                }})
+        else:
+            send({"jsonrpc": "2.0", "id": request_id, "error": {"code": -32601, "message": "unknown method"}})
+''')
+
+
+@pytest.fixture
+def fake_fs_server(tmp_path):
+    script_path = tmp_path / "fake_mcp_server.py"
+    script_path.write_text(_FAKE_FS_SERVER_SCRIPT, encoding="utf-8")
+    return str(script_path)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# -- McpStdioClient: real subprocess, real JSON-RPC --------------------------
+
+
+def test_connect_performs_the_initialize_handshake(fake_fs_server):
+    client = McpStdioClient(command=sys.executable, args=(fake_fs_server,))
+    try:
+        client.connect()
+        assert client.is_connected
+        assert client.server_info == {"name": "fake-filesystem", "version": "0.0.1"}
+    finally:
+        client.close()
+
+
+def test_list_tools_returns_normalized_toolspecs(fake_fs_server):
+    client = McpStdioClient(command=sys.executable, args=(fake_fs_server,))
+    try:
+        client.connect()
+        specs = client.list_tools()
+        names = [spec.name for spec in specs]
+        assert names == ["read_file", "unlisted_tool"]
+        read_file_spec = specs[0]
+        assert read_file_spec.description == "Reads a file's contents."
+        assert read_file_spec.input_schema == {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        }
+    finally:
+        client.close()
+
+
+def test_call_tool_returns_the_text_content_as_a_tool_result(fake_fs_server, tmp_path):
+    target = tmp_path / "hello.txt"
+    target.write_text("hello from disk", encoding="utf-8")
+    client = McpStdioClient(command=sys.executable, args=(fake_fs_server,))
+    try:
+        client.connect()
+        result = client.call_tool("read_file", {"path": str(target)})
+        assert result.content == "hello from disk"
+        assert result.is_error is False
+    finally:
+        client.close()
+
+
+def test_call_tool_surfaces_a_tool_level_error_without_raising(fake_fs_server, tmp_path):
+    client = McpStdioClient(command=sys.executable, args=(fake_fs_server,))
+    try:
+        client.connect()
+        result = client.call_tool("read_file", {"path": str(tmp_path / "does_not_exist.txt")})
+        assert result.is_error is True
+        assert "error" in result.content.lower()
+    finally:
+        client.close()
+
+
+def test_connect_raises_mcp_error_for_a_command_that_does_not_exist():
+    client = McpStdioClient(command="this-binary-does-not-exist-anywhere")
+    with pytest.raises(McpError):
+        client.connect()
+
+
+def test_call_before_connect_raises_mcp_error(fake_fs_server):
+    client = McpStdioClient(command=sys.executable, args=(fake_fs_server,))
+    with pytest.raises(McpError):
+        client.list_tools()
+
+
+def test_close_is_idempotent(fake_fs_server):
+    client = McpStdioClient(command=sys.executable, args=(fake_fs_server,))
+    client.connect()
+    client.close()
+    client.close()  # must not raise
+
+
+# -- register_mcp_server_tools: namespacing + enabled_tools filter ----------
+
+
+def test_register_mcp_server_tools_namespaces_and_filters_by_enabled_tools(fake_fs_server):
+    client = McpStdioClient(command=sys.executable, args=(fake_fs_server,))
+    registry = ToolRegistry()
+    try:
+        client.connect()
+        config = McpServerConfig(
+            name="fs", command=sys.executable, args=(fake_fs_server,),
+            scopes=frozenset({"fs.read"}), approval="always",
+            enabled_tools=frozenset({"read_file"}),
+        )
+        registered = register_mcp_server_tools(registry, client, config)
+        assert registered == ("mcp:fs:read_file",)
+        assert [spec.name for spec in registry.specs()] == ["mcp:fs:read_file"]
+    finally:
+        client.close()
+
+
+# -- exit criterion: end-to-end through ToolRegistry.invoke -----------------
+
+
+def test_a_configured_filesystem_mcp_servers_tool_is_callable_namespaced_and_approval_gated(fake_fs_server, tmp_path):
+    """THE 7.5 EXIT CRITERION."""
+    target = tmp_path / "readme.txt"
+    target.write_text("mcp end to end works", encoding="utf-8")
+
+    client = McpStdioClient(command=sys.executable, args=(fake_fs_server,))
+    registry = ToolRegistry()
+    try:
+        client.connect()
+        config = McpServerConfig(
+            name="fs", command=sys.executable, args=(fake_fs_server,),
+            scopes=frozenset({"fs.read"}), approval="always",
+        )
+        registered = register_mcp_server_tools(registry, client, config)
+        assert "mcp:fs:read_file" in registered
+
+        prompted = []
+
+        async def request_approval(call):
+            prompted.append(call)
+            return True
+
+        ctx = RunContext(granted_scopes=frozenset({"fs.read"}), request_approval=request_approval)
+        call = ToolCall(id="1", name="mcp:fs:read_file", arguments={"path": str(target)})
+        result = _run(registry.invoke(call, ctx))
+
+        assert result.content == "mcp end to end works"
+        assert result.is_error is False
+        assert len(prompted) == 1  # approval-gated: the human-approval callback WAS consulted
+    finally:
+        client.close()
+
+
+def test_an_out_of_scope_mcp_call_is_denied_pre_handler(fake_fs_server, tmp_path):
+    client = McpStdioClient(command=sys.executable, args=(fake_fs_server,))
+    registry = ToolRegistry()
+    try:
+        client.connect()
+        config = McpServerConfig(
+            name="fs", command=sys.executable, args=(fake_fs_server,), scopes=frozenset({"fs.read"})
+        )
+        register_mcp_server_tools(registry, client, config)
+
+        prompted = []
+
+        async def request_approval(call):
+            prompted.append(call)
+            return True
+
+        ctx = RunContext(granted_scopes=frozenset(), request_approval=request_approval)  # no fs.read granted
+        call = ToolCall(id="1", name="mcp:fs:read_file", arguments={"path": str(tmp_path)})
+        result = _run(registry.invoke(call, ctx))
+
+        assert result.is_error is True
+        assert "scope" in result.content.lower()
+        assert prompted == []  # denied before any approval prompt, let alone the handler
+    finally:
+        client.close()

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -562,6 +562,30 @@ def test_round_trip_preserves_chat_response_incomplete_marker():
     assert complete2.state.response_incomplete is False
 
 
+def test_round_trip_preserves_chat_tool_invocations():
+    # ADR-007 stage 7.4: a turn's tool calls + results survive save/load -
+    # `arguments` stays a real dict domain-side (only JSON-encoded at the
+    # wire boundary in graph.py's scene_payload()), so the round trip must
+    # preserve it as a dict, not a string. The untouched sibling node pins
+    # the load path's absent-key -> [] default (every pre-7.4 save lacks
+    # the key), same posture as the response_incomplete test above.
+    doc = SceneDocument()
+    doc.add_chat_node(0, 0, "no tools here", is_user=False)
+    with_tools = doc.add_chat_node(0, 160, "used a tool", is_user=False)
+    with_tools.state.tool_invocations = [
+        {"id": "call_1", "name": "echo", "arguments": {"message": "hi"}, "result": "hi", "is_error": False},
+    ]
+
+    doc2 = _round_trip(doc)
+    plain2 = next(n for n in doc2.nodes.values() if n.content == "no tools here")
+    tools2 = next(n for n in doc2.nodes.values() if n.content == "used a tool")
+
+    assert plain2.state.tool_invocations == []
+    assert tools2.state.tool_invocations == [
+        {"id": "call_1", "name": "echo", "arguments": {"message": "hi"}, "result": "hi", "is_error": False},
+    ]
+
+
 def test_round_trip_preserves_conversation_history_incomplete_marker():
     # ADR-006 stage 6.4 (H5): a conversation node's partial assistant
     # message carries its "incomplete" key through save/load untouched -

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -181,6 +181,79 @@ def test_an_old_settings_file_without_schema_version_is_backfilled(tmp_path):
     assert json.loads(state_file.read_text(encoding="utf-8"))["schema_version"] == SettingsManager.CURRENT_SCHEMA_VERSION
 
 
+# -- ADR-007 stage 7.5: MCP server configuration -----------------------------
+
+
+def test_get_mcp_servers_defaults_to_an_empty_list(manager):
+    assert manager.get_mcp_servers() == []
+
+
+def test_a_pre_7_5_settings_file_backfills_mcp_servers_to_an_empty_list(tmp_path):
+    import json
+
+    state_file = tmp_path / "session.dat"
+    state_file.write_text(json.dumps({"show_token_counter": True}), encoding="utf-8")
+
+    old_manager = SettingsManager(state_file)
+    assert old_manager.get_mcp_servers() == []
+
+
+def test_set_mcp_servers_persists_and_normalizes_a_round_trip(manager):
+    manager.set_mcp_servers([
+        {
+            "name": "fs",
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            "scopes": ["fs.read"],
+            "approval": "always",
+            "enabled_tools": ["read_file"],
+            "enabled": True,
+        },
+    ])
+    assert manager.get_mcp_servers() == [
+        {
+            "name": "fs",
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            "scopes": ["fs.read"],
+            "approval": "always",
+            "enabled_tools": ["read_file"],
+            "enabled": True,
+            "timeout": 30.0,
+        },
+    ]
+
+    reloaded = SettingsManager(manager.state_file)
+    assert reloaded.get_mcp_servers() == manager.get_mcp_servers()
+
+
+def test_set_mcp_servers_replaces_the_whole_list_not_a_merge(manager):
+    manager.set_mcp_servers([{"name": "fs", "command": "npx"}])
+    manager.set_mcp_servers([{"name": "git", "command": "uvx"}])
+    assert [entry["name"] for entry in manager.get_mcp_servers()] == ["git"]
+
+
+def test_set_mcp_servers_drops_an_entry_missing_a_name_or_command(manager):
+    manager.set_mcp_servers([
+        {"name": "", "command": "npx"},
+        {"name": "fs"},  # no command
+        {"name": "valid", "command": "npx"},
+    ])
+    assert [entry["name"] for entry in manager.get_mcp_servers()] == ["valid"]
+
+
+def test_get_mcp_servers_tolerates_a_malformed_entry_on_disk_without_dropping_the_rest(tmp_path):
+    import json
+
+    state_file = tmp_path / "session.dat"
+    state_file.write_text(
+        json.dumps({"mcp_servers": ["not a dict", {"name": "ok", "command": "npx"}, {"command": "no name"}]}),
+        encoding="utf-8",
+    )
+    manager = SettingsManager(state_file)
+    assert [entry["name"] for entry in manager.get_mcp_servers()] == ["ok"]
+
+
 # -- R7.4a: API-provider settings page. New intents on the same "app-settings"
 # -- topic: setViewingApiProvider (session-local, mirrors setActiveSection),
 # -- loadApiModels/saveApiConfiguration (async, wrap api_provider.py calls via

--- a/backend/tests/test_structured_output.py
+++ b/backend/tests/test_structured_output.py
@@ -1,0 +1,305 @@
+"""ADR-007 stage 7.3: respond_json - the unified schema-constrained JSON path.
+
+Exit criterion this file proves: "Same schema output across all 5 providers
+incl. Anthropic (golden tests)" - test_respond_json_returns_the_same_parsed_
+object_on_every_provider below drives all five provider branches of the REAL
+api_provider.chat() dispatch (not a fake of chat() itself) with each
+provider's own complete() overridden to return a canned string, and asserts
+every one parses to the identical dict.
+"""
+
+from __future__ import annotations
+
+import api_provider
+import graphlink_task_config as config
+import pytest
+
+import backend.structured_output as so
+
+SCHEMA = {
+    "type": "object",
+    "properties": {"answer": {"type": "string"}},
+    "required": ["answer"],
+}
+
+
+# -- schema-subset validator --------------------------------------------
+
+
+def test_validate_accepts_a_conforming_object():
+    assert so._validate_against_schema({"answer": "hi"}, SCHEMA) == []
+
+
+def test_validate_reports_a_missing_required_property():
+    errors = so._validate_against_schema({}, SCHEMA)
+    assert any("answer" in e and "missing" in e for e in errors)
+
+
+def test_validate_reports_a_wrong_top_level_type():
+    errors = so._validate_against_schema(["not", "an", "object"], SCHEMA)
+    assert any("expected object" in e for e in errors)
+
+
+def test_validate_reports_a_wrong_property_type():
+    errors = so._validate_against_schema({"answer": 42}, SCHEMA)
+    assert any("expected string" in e for e in errors)
+
+
+def test_validate_recurses_into_nested_objects_and_arrays():
+    schema = {
+        "type": "object",
+        "properties": {
+            "items": {"type": "array", "items": {"type": "object", "properties": {"n": {"type": "integer"}}, "required": ["n"]}}
+        },
+    }
+    errors = so._validate_against_schema({"items": [{"n": 1}, {"n": "not an int"}]}, schema)
+    assert any("items[1].n" in e for e in errors)
+
+
+def test_validate_enforces_enum():
+    schema = {"type": "string", "enum": ["red", "green", "blue"]}
+    assert so._validate_against_schema("purple", schema) != []
+    assert so._validate_against_schema("red", schema) == []
+
+
+# -- response cleanup -----------------------------------------------------
+
+
+def test_clean_json_response_strips_markdown_fences():
+    assert so._clean_json_response('```json\n{"a": 1}\n```') == '{"a": 1}'
+
+
+def test_clean_json_response_strips_think_blocks_and_falls_back_to_brace_matching():
+    text = "<think>reasoning...</think>Here you go: {\"a\": 1} thanks!"
+    assert so._clean_json_response(text) == '{"a": 1}'
+
+
+# -- per-provider native kwargs shape --------------------------------------
+
+
+def _snapshot(monkeypatch, **overrides):
+    for key, value in overrides.items():
+        monkeypatch.setattr(api_provider, key, value)
+    return api_provider._snapshot_provider_state()
+
+
+def test_native_kwargs_openai_shape(monkeypatch):
+    state = _snapshot(monkeypatch, USE_API_MODE=True, API_PROVIDER_TYPE=config.API_PROVIDER_OPENAI)
+    assert so._native_kwargs_for_active_provider(state, SCHEMA, "response") == {
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "response", "schema": SCHEMA, "strict": True},
+        }
+    }
+
+
+def test_native_kwargs_gemini_shape(monkeypatch):
+    state = _snapshot(monkeypatch, USE_API_MODE=True, API_PROVIDER_TYPE=config.API_PROVIDER_GEMINI)
+    assert so._native_kwargs_for_active_provider(state, SCHEMA, "response") == {
+        "response_mime_type": "application/json",
+        "response_schema": SCHEMA,
+    }
+
+
+def test_native_kwargs_ollama_shape(monkeypatch):
+    state = _snapshot(monkeypatch, USE_API_MODE=False, LOCAL_PROVIDER_TYPE=config.LOCAL_PROVIDER_OLLAMA)
+    assert so._native_kwargs_for_active_provider(state, SCHEMA, "response") == {"format": SCHEMA}
+
+
+def test_native_kwargs_llama_cpp_shape(monkeypatch):
+    state = _snapshot(monkeypatch, USE_API_MODE=False, LOCAL_PROVIDER_TYPE=config.LOCAL_PROVIDER_LLAMACPP)
+    assert so._native_kwargs_for_active_provider(state, SCHEMA, "response") == {
+        "response_format": {"type": "json_object", "schema": SCHEMA}
+    }
+
+
+def test_native_kwargs_anthropic_is_none_the_fallback_signal(monkeypatch):
+    state = _snapshot(monkeypatch, USE_API_MODE=True, API_PROVIDER_TYPE=config.API_PROVIDER_ANTHROPIC)
+    assert so._native_kwargs_for_active_provider(state, SCHEMA, "response") is None
+
+
+# -- full dispatch: the golden, all-5-providers exit criterion ------------
+
+
+def _activate_mode(monkeypatch, mode):
+    if mode == "ollama":
+        monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+        monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_OLLAMA)
+        monkeypatch.setitem(config.OLLAMA_MODELS, config.TASK_CHAT, "fake-model:1b")
+    elif mode == "llama_cpp":
+        monkeypatch.setattr(api_provider, "USE_API_MODE", False)
+        monkeypatch.setattr(api_provider, "LOCAL_PROVIDER_TYPE", config.LOCAL_PROVIDER_LLAMACPP)
+        monkeypatch.setattr(
+            api_provider, "LLAMA_CPP_SETTINGS", {"chat_model_path": "m.gguf", "reasoning_level": "off"}
+        )
+    else:
+        api_provider_type = {
+            "openai": config.API_PROVIDER_OPENAI,
+            "anthropic": config.API_PROVIDER_ANTHROPIC,
+            "gemini": config.API_PROVIDER_GEMINI,
+        }[mode]
+        monkeypatch.setattr(api_provider, "USE_API_MODE", True)
+        monkeypatch.setattr(api_provider, "API_PROVIDER_TYPE", api_provider_type)
+        monkeypatch.setattr(api_provider, "API_KEY", "k")
+        # complete() is overridden by every caller below and never touches
+        # self.client - a bare sentinel just needs to be truthy for chat()'s
+        # own "API client not initialized" guard.
+        monkeypatch.setattr(api_provider, "API_CLIENT", object())
+        monkeypatch.setitem(api_provider.API_MODELS, config.TASK_CHAT, "fake-model")
+
+
+_PROVIDER_MODES = [
+    ("ollama", "backend.providers.ollama_provider", "OllamaProvider"),
+    ("llama_cpp", "backend.providers.llama_cpp_provider", "LlamaCppProvider"),
+    ("openai", "backend.providers.openai_provider", "OpenAIProvider"),
+    ("anthropic", "backend.providers.anthropic_provider", "AnthropicProvider"),
+    ("gemini", "backend.providers.gemini_provider", "GeminiProvider"),
+]
+
+
+@pytest.mark.parametrize("mode, module_name, class_name", _PROVIDER_MODES)
+def test_respond_json_returns_the_same_parsed_object_on_every_provider(monkeypatch, mode, module_name, class_name):
+    _activate_mode(monkeypatch, mode)
+    module = __import__(module_name, fromlist=[class_name])
+    real = getattr(module, class_name)
+
+    class Fake(real):
+        def complete(self, request, cancel):
+            return '{"answer": "42"}'
+
+    monkeypatch.setattr(module, class_name, Fake)
+
+    result = so.respond_json(config.TASK_CHAT, [{"role": "user", "content": "hi"}], SCHEMA)
+    assert result == {"answer": "42"}
+
+
+def test_respond_json_does_not_prepend_a_system_message_for_a_native_provider(monkeypatch):
+    _activate_mode(monkeypatch, "openai")
+    from backend.providers import openai_provider as op
+
+    seen_messages = []
+
+    class Fake(op.OpenAIProvider):
+        def complete(self, request, cancel):
+            seen_messages.append(request.messages)
+            return '{"answer": "42"}'
+
+    monkeypatch.setattr(op, "OpenAIProvider", Fake)
+    so.respond_json(config.TASK_CHAT, [{"role": "user", "content": "hi"}], SCHEMA)
+
+    assert seen_messages[0] == [{"role": "user", "content": "hi"}]
+
+
+def test_respond_json_passes_native_kwargs_through_to_the_providers_complete_call(monkeypatch):
+    _activate_mode(monkeypatch, "openai")
+    from backend.providers import openai_provider as op
+
+    seen_kwargs = []
+
+    class Fake(op.OpenAIProvider):
+        def complete(self, request, cancel):
+            seen_kwargs.append(dict(request.extra_kwargs))
+            return '{"answer": "42"}'
+
+    monkeypatch.setattr(op, "OpenAIProvider", Fake)
+    so.respond_json(config.TASK_CHAT, [{"role": "user", "content": "hi"}], SCHEMA, schema_name="my_schema")
+
+    assert seen_kwargs[0] == {
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "my_schema", "schema": SCHEMA, "strict": True},
+        }
+    }
+
+
+def test_respond_json_embeds_the_schema_as_a_system_message_for_the_anthropic_fallback(monkeypatch):
+    _activate_mode(monkeypatch, "anthropic")
+    from backend.providers import anthropic_provider as ap
+
+    seen_messages = []
+
+    class Fake(ap.AnthropicProvider):
+        def complete(self, request, cancel):
+            seen_messages.append(request.messages)
+            return '{"answer": "42"}'
+
+    monkeypatch.setattr(ap, "AnthropicProvider", Fake)
+    so.respond_json(config.TASK_CHAT, [{"role": "user", "content": "hi"}], SCHEMA, schema_name="my_schema")
+
+    first_call_messages = seen_messages[0]
+    assert first_call_messages[0]["role"] == "system"
+    assert "my_schema" in first_call_messages[0]["content"]
+    assert first_call_messages[1] == {"role": "user", "content": "hi"}
+
+
+# -- validate-and-repair tail -----------------------------------------------
+
+
+def test_respond_json_repairs_a_malformed_first_response(monkeypatch):
+    _activate_mode(monkeypatch, "openai")
+    from backend.providers import openai_provider as op
+
+    calls = []
+
+    class Fake(op.OpenAIProvider):
+        def complete(self, request, cancel):
+            calls.append(request.messages)
+            if len(calls) == 1:
+                return "this is not json at all"
+            return '{"answer": "fixed"}'
+
+    monkeypatch.setattr(op, "OpenAIProvider", Fake)
+    result = so.respond_json(config.TASK_CHAT, [{"role": "user", "content": "hi"}], SCHEMA)
+
+    assert result == {"answer": "fixed"}
+    assert len(calls) == 2
+    # the repair turn is a fresh standalone system+user pair, not the
+    # original conversation threaded through.
+    assert calls[1][0]["role"] == "system"
+    assert "this is not json at all" in calls[1][1]["content"]
+
+
+def test_respond_json_repairs_a_schema_violating_first_response(monkeypatch):
+    _activate_mode(monkeypatch, "openai")
+    from backend.providers import openai_provider as op
+
+    calls = []
+
+    class Fake(op.OpenAIProvider):
+        def complete(self, request, cancel):
+            calls.append(request.messages)
+            if len(calls) == 1:
+                return '{"wrong_key": "nope"}'  # valid JSON, fails schema
+            return '{"answer": "fixed"}'
+
+    monkeypatch.setattr(op, "OpenAIProvider", Fake)
+    result = so.respond_json(config.TASK_CHAT, [{"role": "user", "content": "hi"}], SCHEMA)
+
+    assert result == {"answer": "fixed"}
+    assert len(calls) == 2
+
+
+def test_respond_json_raises_when_the_repair_attempt_is_still_not_valid_json(monkeypatch):
+    _activate_mode(monkeypatch, "openai")
+    from backend.providers import openai_provider as op
+
+    class Fake(op.OpenAIProvider):
+        def complete(self, request, cancel):
+            return "still not json"
+
+    monkeypatch.setattr(op, "OpenAIProvider", Fake)
+    with pytest.raises(so.StructuredOutputError, match="not valid JSON"):
+        so.respond_json(config.TASK_CHAT, [{"role": "user", "content": "hi"}], SCHEMA)
+
+
+def test_respond_json_raises_when_the_repair_attempt_still_violates_the_schema(monkeypatch):
+    _activate_mode(monkeypatch, "openai")
+    from backend.providers import openai_provider as op
+
+    class Fake(op.OpenAIProvider):
+        def complete(self, request, cancel):
+            return '{"wrong_key": "still nope"}'
+
+    monkeypatch.setattr(op, "OpenAIProvider", Fake)
+    with pytest.raises(so.StructuredOutputError, match="schema"):
+        so.respond_json(config.TASK_CHAT, [{"role": "user", "content": "hi"}], SCHEMA)

--- a/backend/tests/test_tool_calling.py
+++ b/backend/tests/test_tool_calling.py
@@ -1,0 +1,540 @@
+"""ADR-007 stage 7.1: the provider-neutral tool interface - ToolSpec/
+ToolCall/the "tool_call" event, native tool calling on OpenAI, Anthropic,
+Gemini, and Ollama (llama.cpp is deliberately out of this stage's scope -
+see ProviderCapabilities.tools' own comment), and the two new generic
+message roles (assistant `tool_calls`, `role: "tool"`) each provider
+translates to its native shape.
+
+The exit criterion this file proves per provider: a registered echo tool
+round-trips - the model calls it, the (test-scripted) result is fed back as
+a second turn, and the final answer reflects it - with only the SDK/
+transport faked, mirroring the construction-fidelity pattern established in
+test_providers.py.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from unittest.mock import patch
+
+import pytest
+
+import api_provider
+import graphlink_task_config as config
+from backend.providers import (
+    AnthropicProvider,
+    CancelToken,
+    ChatRequest,
+    GeminiProvider,
+    OllamaProvider,
+    OpenAIProvider,
+    ToolCall,
+    ToolSpec,
+)
+
+# The one tool every round-trip test registers: reflects its input back,
+# proving the call's arguments and the fed-back result both actually
+# traveled through the provider, not just that SOME tool_call fired.
+ECHO_TOOL = ToolSpec(
+    name="echo",
+    description="Echoes the given message back.",
+    input_schema={
+        "type": "object",
+        "properties": {"message": {"type": "string"}},
+        "required": ["message"],
+    },
+)
+
+
+def _collect(stream):
+    events = list(stream)
+    assert events[-1].type == "done", "every stream() call must end with exactly one done event"
+    assert sum(1 for e in events if e.type == "done") == 1
+    return events
+
+
+class FakeOllamaStream:
+    """Mirrors ollama's real chat(stream=True) return value closely enough
+    for OllamaProvider.stream()'s `finally: stream.close()` - a bare
+    iter([...]) has no .close() and blows up there, matching
+    test_providers.py's own FakeOllamaStream convention."""
+
+    def __init__(self, parts):
+        self._iter = iter(parts)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._iter)
+
+    def close(self):
+        pass
+
+
+# -- Ollama --------------------------------------------------------------------
+
+
+def test_ollama_capabilities_tools_is_a_real_per_model_probe(monkeypatch):
+    with patch("api_provider.ollama.show", return_value={"capabilities": ["completion", "tools"]}):
+        assert OllamaProvider(model="tool-capable-model").capabilities.tools is True
+    monkeypatch.setattr(api_provider, "_OLLAMA_CAPABILITY_CACHE", {})
+    with patch("api_provider.ollama.show", return_value={"capabilities": ["completion"]}):
+        assert OllamaProvider(model="no-tools-model").capabilities.tools is False
+
+
+def test_ollama_capabilities_tools_defaults_false_when_show_is_unavailable(monkeypatch):
+    monkeypatch.setattr(api_provider, "_OLLAMA_CAPABILITY_CACHE", {})
+    with patch("api_provider.ollama.show", side_effect=RuntimeError("daemon unreachable")):
+        assert OllamaProvider(model="unreachable-model").capabilities.tools is False
+
+
+def test_ollama_stream_translates_tools_into_the_native_function_shape(monkeypatch):
+    import ollama
+
+    captured = {}
+
+    def fake_chat(**kwargs):
+        captured.update(kwargs)
+        return FakeOllamaStream([{"message": {"content": "hi"}, "done": True, "prompt_eval_count": 1, "eval_count": 1}])
+
+    monkeypatch.setattr(ollama, "chat", fake_chat)
+    provider = OllamaProvider(model="m")
+    list(provider.stream(ChatRequest(task=config.TASK_CHAT, messages=[], tools=(ECHO_TOOL,)), CancelToken()))
+
+    assert captured["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "echo",
+                "description": "Echoes the given message back.",
+                "parameters": ECHO_TOOL.input_schema,
+            },
+        }
+    ]
+
+
+def test_ollama_round_trips_an_echo_tool_call(monkeypatch):
+    import ollama
+
+    calls = []
+
+    def fake_chat(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            # First turn: the model asks to call `echo`. Ollama delivers
+            # the whole call in one chunk (already-parsed arguments dict),
+            # then the stream ends without a separate done:true chunk for
+            # this attempt - the tool_calls chunk IS terminal.
+            return FakeOllamaStream([{
+                "message": {
+                    "content": "",
+                    "tool_calls": [{"function": {"name": "echo", "arguments": {"message": "hello"}}}],
+                },
+                "done": False,
+            }])
+        # Second turn: the model has the tool result and answers.
+        return FakeOllamaStream([{
+            "message": {"content": "The echo said: hello"},
+            "done": True,
+            "prompt_eval_count": 5,
+            "eval_count": 2,
+        }])
+
+    monkeypatch.setattr(ollama, "chat", fake_chat)
+    provider = OllamaProvider(model="m")
+
+    # Turn 1: model requests the tool call.
+    events = _collect(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "echo hello"}], tools=(ECHO_TOOL,)),
+        CancelToken(),
+    ))
+    tool_call_events = [e for e in events if e.type == "tool_call"]
+    assert len(tool_call_events) == 1
+    call = tool_call_events[0].tool_call
+    assert isinstance(call, ToolCall)
+    assert call.name == "echo"
+    assert call.arguments == {"message": "hello"}
+    assert call.id  # synthesized, but must be non-empty and usable as a correlation key
+    assert events[-1].text == ""  # a pure tool-call turn has no answer text yet
+
+    # Turn 2: the app appends the assistant's tool-call turn + the tool's
+    # result, then calls stream() again - proving the round trip, not just
+    # that a call was detected.
+    messages = [
+        {"role": "user", "content": "echo hello"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": call.id, "name": call.name, "arguments": call.arguments}]},
+        {"role": "tool", "tool_call_id": call.id, "name": "echo", "content": "hello"},
+    ]
+    events2 = _collect(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=messages, tools=(ECHO_TOOL,)), CancelToken(),
+    ))
+    assert events2[-1].text == "The echo said: hello"
+    assert events2[-1].usage == {"prompt_tokens": 5, "completion_tokens": 2}
+
+    # The second call's messages carry Ollama's native tool_calls/tool
+    # shapes, not the app's generic dicts verbatim.
+    second_call_messages = calls[1]["messages"]
+    assert second_call_messages[1] == {
+        "role": "assistant", "content": "",
+        "tool_calls": [{"function": {"name": "echo", "arguments": {"message": "hello"}}}],
+    }
+    assert second_call_messages[2] == {"role": "tool", "content": "hello"}
+
+
+def test_ollama_tool_call_turn_never_enters_the_reasoning_retry_loop(monkeypatch):
+    """A pure tool-call turn (no visible answer text) must NOT be treated
+    as the "reasoning but no answer" retryable case - that retry exists for
+    a genuinely different failure, and misfiring it here would silently
+    eat a real tool call."""
+    import ollama
+
+    def fake_chat(**kwargs):
+        return FakeOllamaStream([{
+            "message": {"content": "", "tool_calls": [{"function": {"name": "echo", "arguments": {}}}]},
+            "done": False,
+        }])
+
+    monkeypatch.setattr(ollama, "chat", fake_chat)
+    provider = OllamaProvider(model="gpt-oss:20b")  # a reasoning-capable family
+    events = _collect(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[], tools=(ECHO_TOOL,)), CancelToken(),
+    ))
+    assert [e.type for e in events] == ["tool_call", "done"]
+
+
+# -- OpenAI ----------------------------------------------------------------
+
+
+class FakeSDKStream:
+    """Iterable-with-close() stand-in for the OpenAI/Anthropic SDKs'
+    Stream types, mirroring test_providers.py's own FakeSDKStream
+    convention - shared across the OpenAI and Anthropic sections below
+    since both just need close()-on-exhaustion."""
+
+    def __init__(self, chunks):
+        self._iter = iter(chunks)
+        self.close_calls = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._iter)
+
+    def close(self):
+        self.close_calls += 1
+
+
+def _openai_chunk(content=None, tool_calls=None):
+    """tool_calls: list of {"index", "id"?, "name"?, "arguments"?} - id/name
+    omitted on continuation deltas, matching the real SDK only sending them
+    on a call's first delta."""
+    delta_fields = {"content": content, "tool_calls": None}
+    if tool_calls is not None:
+        delta_fields["tool_calls"] = [
+            types.SimpleNamespace(
+                index=tc["index"],
+                id=tc.get("id"),
+                function=types.SimpleNamespace(name=tc.get("name"), arguments=tc.get("arguments")),
+            )
+            for tc in tool_calls
+        ]
+    return types.SimpleNamespace(
+        usage=None,
+        choices=[types.SimpleNamespace(delta=types.SimpleNamespace(**delta_fields))],
+    )
+
+
+def _fake_openai_client(stream_sequence):
+    """stream_sequence: one chunk-list per expected create() call, in order -
+    lets a round-trip test script turn 1's tool call and turn 2's answer as
+    two distinct scripted responses, same shape as Ollama's own `calls`-
+    indexed fake_chat."""
+    calls = []
+
+    def create(**kwargs):
+        calls.append(kwargs)
+        return FakeSDKStream(stream_sequence[len(calls) - 1])
+
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=create))
+    )
+    return client, calls
+
+
+def test_openai_capabilities_tools_is_true_unconditionally():
+    assert OpenAIProvider(client=None, model="gpt-5").capabilities.tools is True
+
+
+def test_openai_stream_translates_tools_into_the_native_function_shape():
+    client, calls = _fake_openai_client([[_openai_chunk(content="hi")]])
+    provider = OpenAIProvider(client=client, model="gpt-5")
+    list(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[], tools=(ECHO_TOOL,)), CancelToken(),
+    ))
+
+    assert calls[0]["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "echo",
+                "description": "Echoes the given message back.",
+                "parameters": ECHO_TOOL.input_schema,
+            },
+        }
+    ]
+
+
+def test_openai_round_trips_an_echo_tool_call():
+    client, calls = _fake_openai_client([
+        [
+            # Arguments split across two deltas - proves the char-by-char
+            # JSON buffer, not just a single-chunk pass-through. id/name
+            # only appear on the call's first delta, per the real wire shape.
+            _openai_chunk(tool_calls=[{"index": 0, "id": "call_abc", "name": "echo", "arguments": '{"message": "hel'}]),
+            _openai_chunk(tool_calls=[{"index": 0, "arguments": 'lo"}'}]),
+        ],
+        [_openai_chunk(content="The echo said: hello")],
+    ])
+    provider = OpenAIProvider(client=client, model="gpt-5")
+
+    # Turn 1: model requests the tool call.
+    events = _collect(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "echo hello"}], tools=(ECHO_TOOL,)),
+        CancelToken(),
+    ))
+    tool_call_events = [e for e in events if e.type == "tool_call"]
+    assert len(tool_call_events) == 1
+    call = tool_call_events[0].tool_call
+    assert isinstance(call, ToolCall)
+    assert call.id == "call_abc"
+    assert call.name == "echo"
+    assert call.arguments == {"message": "hello"}
+    assert events[-1].text == ""  # a pure tool-call turn has no answer text yet
+
+    # Turn 2: the app appends the assistant's tool-call turn + the tool's
+    # result, then calls stream() again - proving the round trip.
+    messages = [
+        {"role": "user", "content": "echo hello"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": call.id, "name": call.name, "arguments": call.arguments}]},
+        {"role": "tool", "tool_call_id": call.id, "name": "echo", "content": "hello"},
+    ]
+    events2 = _collect(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=messages, tools=(ECHO_TOOL,)), CancelToken(),
+    ))
+    assert events2[-1].text == "The echo said: hello"
+
+    # The second call's messages carry OpenAI's native tool_calls/tool
+    # shapes (arguments re-serialized to a JSON string), not the app's
+    # generic dicts verbatim.
+    second_call_messages = calls[1]["messages"]
+    assert second_call_messages[1] == {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{
+            "id": "call_abc",
+            "type": "function",
+            "function": {"name": "echo", "arguments": json.dumps({"message": "hello"})},
+        }],
+    }
+    assert second_call_messages[2] == {"role": "tool", "tool_call_id": "call_abc", "content": "hello"}
+
+
+# -- Anthropic ---------------------------------------------------------------
+
+
+def _fake_anthropic_client(event_sequence):
+    """event_sequence: one list of raw SSE-shape dict events per expected
+    create() call - the same dict wire shape test_providers.py's own
+    _anthropic_raw_events uses (SDK and REST transports share it, both read
+    through _extract_response_field)."""
+    calls = []
+
+    def create(**kwargs):
+        calls.append(kwargs)
+        return FakeSDKStream(event_sequence[len(calls) - 1])
+
+    client = types.SimpleNamespace(messages=types.SimpleNamespace(create=create))
+    return client, calls
+
+
+def test_anthropic_capabilities_tools_is_true_unconditionally():
+    assert AnthropicProvider(client=None, api_key="k", model="claude-opus-5").capabilities.tools is True
+
+
+def test_anthropic_stream_translates_tools_into_the_native_shape():
+    client, calls = _fake_anthropic_client([[
+        {"type": "message_start", "message": {"role": "assistant"}},
+        {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "hi"}},
+        {"type": "message_stop"},
+    ]])
+    provider = AnthropicProvider(client=client, api_key="k", model="claude-opus-5")
+    list(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[], tools=(ECHO_TOOL,)), CancelToken(),
+    ))
+
+    assert calls[0]["tools"] == [
+        {"name": "echo", "description": "Echoes the given message back.", "input_schema": ECHO_TOOL.input_schema}
+    ]
+
+
+def test_anthropic_round_trips_an_echo_tool_call():
+    client, calls = _fake_anthropic_client([
+        [
+            # Arguments split across two input_json_delta events - proves
+            # the accumulate-then-parse buffer, not a single-event pass-
+            # through. id/name arrive on content_block_start only.
+            {"type": "message_start", "message": {"role": "assistant"}},
+            {
+                "type": "content_block_start", "index": 0,
+                "content_block": {"type": "tool_use", "id": "toolu_abc", "name": "echo"},
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": '{"message": "hel'}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": 'lo"}'}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "message_delta", "delta": {"stop_reason": "tool_use"}},
+            {"type": "message_stop"},
+        ],
+        [
+            {"type": "message_start", "message": {"role": "assistant"}},
+            {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "The echo said: hello"}},
+            {"type": "message_stop"},
+        ],
+    ])
+    provider = AnthropicProvider(client=client, api_key="k", model="claude-opus-5")
+
+    # Turn 1: model requests the tool call.
+    events = _collect(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "echo hello"}], tools=(ECHO_TOOL,)),
+        CancelToken(),
+    ))
+    tool_call_events = [e for e in events if e.type == "tool_call"]
+    assert len(tool_call_events) == 1
+    call = tool_call_events[0].tool_call
+    assert isinstance(call, ToolCall)
+    assert call.id == "toolu_abc"
+    assert call.name == "echo"
+    assert call.arguments == {"message": "hello"}
+    assert events[-1].text == ""  # a pure tool-call turn has no answer text yet
+
+    # Turn 2: the app appends the assistant's tool-call turn + the tool's
+    # result, then calls stream() again - proving the round trip.
+    messages = [
+        {"role": "user", "content": "echo hello"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": call.id, "name": call.name, "arguments": call.arguments}]},
+        {"role": "tool", "tool_call_id": call.id, "name": "echo", "content": "hello"},
+    ]
+    events2 = _collect(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=messages, tools=(ECHO_TOOL,)), CancelToken(),
+    ))
+    assert events2[-1].text == "The echo said: hello"
+
+    # The second call's messages carry Anthropic's native tool_use/
+    # tool_result shapes, not the app's generic dicts verbatim - and the
+    # tool result travels as a "user"-role message (Anthropic has no
+    # separate "tool" role).
+    second_call_messages = calls[1]["messages"]
+    assert second_call_messages[1] == {
+        "role": "assistant",
+        "content": [{"type": "tool_use", "id": "toolu_abc", "name": "echo", "input": {"message": "hello"}}],
+    }
+    assert second_call_messages[2] == {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "toolu_abc", "content": "hello"}],
+    }
+
+
+# -- Gemini --------------------------------------------------------------------
+#
+# Unlike the other three sections, Gemini's wire shapes here are
+# documentation-only (no SDK in this repo to verify against - GeminiProvider's
+# own capabilities.tools comment flags the same caveat), so these tests pin
+# behavior against the PUBLIC REST contract, not an installed library's types.
+
+
+def _gemini_sse_payload(*parts):
+    return {"candidates": [{"content": {"parts": list(parts)}}]}
+
+
+def test_gemini_capabilities_tools_is_true_unconditionally():
+    assert GeminiProvider(api_key="k", model="gemini-2.5-pro").capabilities.tools is True
+
+
+def test_gemini_stream_translates_tools_into_the_native_function_declarations_shape(monkeypatch):
+    sse_calls = {}
+
+    def fake_stream_sse(url, body, timeout=120, cancel_event=None, api_key=None):
+        sse_calls.update(body=body)
+        yield _gemini_sse_payload({"text": "hi"})
+
+    monkeypatch.setattr("backend.providers.gemini_provider._gemini_stream_sse", fake_stream_sse)
+    provider = GeminiProvider(api_key="k", model="gemini-2.5-pro")
+    list(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "hi"}], tools=(ECHO_TOOL,)),
+        CancelToken(),
+    ))
+
+    assert sse_calls["body"]["tools"] == [{
+        "functionDeclarations": [
+            {"name": "echo", "description": "Echoes the given message back.", "parameters": ECHO_TOOL.input_schema},
+        ],
+    }]
+
+
+def test_gemini_round_trips_an_echo_tool_call(monkeypatch):
+    calls = []
+
+    def fake_stream_sse(url, body, timeout=120, cancel_event=None, api_key=None):
+        calls.append(body)
+        if len(calls) == 1:
+            # Gemini delivers a function call whole in one part - no
+            # incremental args accumulation, unlike OpenAI/Anthropic.
+            yield {"candidates": [{"content": {"parts": [
+                {"functionCall": {"name": "echo", "args": {"message": "hello"}}},
+            ]}}]}
+        else:
+            yield _gemini_sse_payload({"text": "The echo said: hello"})
+
+    monkeypatch.setattr("backend.providers.gemini_provider._gemini_stream_sse", fake_stream_sse)
+    provider = GeminiProvider(api_key="k", model="gemini-2.5-pro")
+
+    # Turn 1: model requests the tool call.
+    events = _collect(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=[{"role": "user", "content": "echo hello"}], tools=(ECHO_TOOL,)),
+        CancelToken(),
+    ))
+    tool_call_events = [e for e in events if e.type == "tool_call"]
+    assert len(tool_call_events) == 1
+    call = tool_call_events[0].tool_call
+    assert isinstance(call, ToolCall)
+    assert call.id  # synthesized (Gemini gives no native id), but non-empty
+    assert call.name == "echo"
+    assert call.arguments == {"message": "hello"}
+    assert events[-1].text == ""  # a pure tool-call turn has no answer text yet
+
+    # Turn 2: the app appends the assistant's tool-call turn + the tool's
+    # result, then calls stream() again - proving the round trip.
+    messages = [
+        {"role": "user", "content": "echo hello"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": call.id, "name": call.name, "arguments": call.arguments}]},
+        {"role": "tool", "tool_call_id": call.id, "name": "echo", "content": "hello"},
+    ]
+    events2 = _collect(provider.stream(
+        ChatRequest(task=config.TASK_CHAT, messages=messages, tools=(ECHO_TOOL,)), CancelToken(),
+    ))
+    assert events2[-1].text == "The echo said: hello"
+
+    # The second call's contents carry Gemini's native functionCall/
+    # functionResponse shapes, not the app's generic dicts verbatim - and
+    # the tool result travels on Gemini's own dedicated "function" role.
+    second_call_contents = calls[1]["contents"]
+    assert second_call_contents[1] == {
+        "role": "model",
+        "parts": [{"functionCall": {"name": "echo", "args": {"message": "hello"}}}],
+    }
+    assert second_call_contents[2] == {
+        "role": "function",
+        "parts": [{"functionResponse": {"name": "echo", "response": {"result": "hello"}}}],
+    }

--- a/backend/tests/test_tool_registry.py
+++ b/backend/tests/test_tool_registry.py
@@ -1,0 +1,315 @@
+"""ADR-007 stage 7.2: ToolRegistry - scopes + approval policy wiring.
+
+Exit criterion this file proves: an out-of-scope call is denied BEFORE its
+handler ever runs, and a destructive (non-"auto") tool always goes through
+RunContext.request_approval before its handler runs - the two invariants
+backend/tools.py's own module docstring names.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import api_provider
+import pytest
+
+from backend.providers import CancelToken, ToolCall
+from backend.tools import (
+    CODE_EXECUTE,
+    FS_READ,
+    GRAPH_MUTATE,
+    GRAPH_READ,
+    NET_FETCH,
+    ToolRegistry,
+    ToolResult,
+    RunContext,
+)
+from backend.providers.base import ToolSpec
+
+ECHO_SPEC = ToolSpec(name="echo", description="Echoes back.", input_schema={"type": "object"})
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _echo_handler(call: ToolCall, ctx: RunContext) -> ToolResult:
+    return ToolResult(content=f"echo: {call.arguments.get('message', '')}")
+
+
+def _always_approve(call: ToolCall) -> bool:
+    return True
+
+
+def _always_deny(call: ToolCall) -> bool:
+    return False
+
+
+def _ctx(granted_scopes=(), approve=_always_approve, cancel=None) -> RunContext:
+    async def request_approval(call: ToolCall) -> bool:
+        return approve(call)
+
+    return RunContext(granted_scopes=frozenset(granted_scopes), request_approval=request_approval, cancel=cancel)
+
+
+# -- register() validation ------------------------------------------------
+
+
+def test_register_rejects_an_unknown_scope():
+    registry = ToolRegistry()
+    with pytest.raises(ValueError, match="Unknown scope"):
+        registry.register(ECHO_SPEC, _echo_handler, scopes={"not.a.real.scope"}, approval="auto")
+
+
+def test_register_rejects_an_unknown_approval_policy():
+    registry = ToolRegistry()
+    with pytest.raises(ValueError, match="Unknown approval policy"):
+        registry.register(ECHO_SPEC, _echo_handler, scopes={GRAPH_READ}, approval="sometimes")
+
+
+def test_register_rejects_a_duplicate_tool_name():
+    registry = ToolRegistry()
+    registry.register(ECHO_SPEC, _echo_handler, scopes={GRAPH_READ}, approval="auto")
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register(ECHO_SPEC, _echo_handler, scopes={GRAPH_READ}, approval="auto")
+
+
+def test_specs_returns_every_registered_tools_neutral_spec():
+    registry = ToolRegistry()
+    registry.register(ECHO_SPEC, _echo_handler, scopes={GRAPH_READ}, approval="auto")
+    assert registry.specs() == (ECHO_SPEC,)
+
+
+# -- unknown tool -----------------------------------------------------------
+
+
+def test_invoke_an_unregistered_tool_is_an_error_result_not_a_raise():
+    registry = ToolRegistry()
+    result = _run(registry.invoke(ToolCall(id="1", name="nope", arguments={}), _ctx()))
+    assert result.is_error is True
+    assert "Unknown tool" in result.content
+
+
+# -- scope gate: exit criterion "out-of-scope call denied pre-handler" -----
+
+
+def test_out_of_scope_call_is_denied_before_the_handler_runs():
+    registry = ToolRegistry()
+    handler_calls = []
+
+    async def tracked_handler(call, ctx):
+        handler_calls.append(call)
+        return ToolResult(content="should never run")
+
+    registry.register(ECHO_SPEC, tracked_handler, scopes={GRAPH_MUTATE}, approval="auto")
+
+    result = _run(registry.invoke(
+        ToolCall(id="1", name="echo", arguments={}), _ctx(granted_scopes={GRAPH_READ}),
+    ))
+
+    assert result.is_error is True
+    assert "scope" in result.content.lower()
+    assert handler_calls == [], "the handler must never run for an out-of-scope call"
+
+
+def test_in_scope_call_reaches_the_handler():
+    registry = ToolRegistry()
+    registry.register(ECHO_SPEC, _echo_handler, scopes={GRAPH_READ}, approval="auto")
+
+    result = _run(registry.invoke(
+        ToolCall(id="1", name="echo", arguments={"message": "hi"}), _ctx(granted_scopes={GRAPH_READ, GRAPH_MUTATE}),
+    ))
+
+    assert result == ToolResult(content="echo: hi")
+
+
+def test_a_run_must_be_granted_every_scope_the_tool_requires_not_just_one():
+    registry = ToolRegistry()
+    registry.register(ECHO_SPEC, _echo_handler, scopes={GRAPH_READ, FS_READ}, approval="auto")
+
+    result = _run(registry.invoke(
+        ToolCall(id="1", name="echo", arguments={}), _ctx(granted_scopes={GRAPH_READ}),  # missing FS_READ
+    ))
+    assert result.is_error is True
+
+
+# -- approval policy: exit criterion "destructive tool prompts approval" ---
+
+
+def test_auto_policy_never_calls_request_approval():
+    registry = ToolRegistry()
+    registry.register(ECHO_SPEC, _echo_handler, scopes={GRAPH_READ}, approval="auto")
+    prompted = []
+
+    async def request_approval(call):
+        prompted.append(call)
+        return True
+
+    ctx = RunContext(granted_scopes=frozenset({GRAPH_READ}), request_approval=request_approval)
+    result = _run(registry.invoke(ToolCall(id="1", name="echo", arguments={}), ctx))
+
+    assert result.is_error is False
+    assert prompted == [], "an auto-policy tool must never prompt for approval"
+
+
+def test_once_policy_prompts_every_single_call_even_with_identical_arguments():
+    registry = ToolRegistry()
+    registry.register(ECHO_SPEC, _echo_handler, scopes={CODE_EXECUTE}, approval="once")
+    prompted = []
+
+    async def request_approval(call):
+        prompted.append(call)
+        return True
+
+    ctx = RunContext(granted_scopes=frozenset({CODE_EXECUTE}), request_approval=request_approval)
+    call = ToolCall(id="1", name="echo", arguments={"message": "hi"})
+    _run(registry.invoke(call, ctx))
+    _run(registry.invoke(call, ctx))
+
+    assert len(prompted) == 2, "'once' must re-prompt every call, unlike 'always'"
+
+
+def test_destructive_tool_is_denied_when_approval_is_refused_and_the_handler_never_runs():
+    registry = ToolRegistry()
+    handler_calls = []
+
+    async def tracked_handler(call, ctx):
+        handler_calls.append(call)
+        return ToolResult(content="should never run")
+
+    registry.register(ECHO_SPEC, tracked_handler, scopes={CODE_EXECUTE}, approval="once")
+
+    result = _run(registry.invoke(
+        ToolCall(id="1", name="echo", arguments={}),
+        _ctx(granted_scopes={CODE_EXECUTE}, approve=_always_deny),
+    ))
+
+    assert result.is_error is True
+    assert "denied" in result.content.lower()
+    assert handler_calls == []
+
+
+def test_always_policy_remembers_an_approved_fingerprint_and_skips_the_second_prompt():
+    registry = ToolRegistry()
+    registry.register(ECHO_SPEC, _echo_handler, scopes={NET_FETCH}, approval="always")
+    prompted = []
+
+    async def request_approval(call):
+        prompted.append(call)
+        return True
+
+    ctx = RunContext(granted_scopes=frozenset({NET_FETCH}), request_approval=request_approval)
+    call = ToolCall(id="1", name="echo", arguments={"message": "hi"})
+
+    first = _run(registry.invoke(call, ctx))
+    second = _run(registry.invoke(ToolCall(id="2", name="echo", arguments={"message": "hi"}), ctx))
+
+    assert first.is_error is False and second.is_error is False
+    assert len(prompted) == 1, "'always' must not re-prompt an identical (name, arguments) call in the same run"
+
+
+def test_always_policy_still_prompts_for_a_call_with_different_arguments():
+    registry = ToolRegistry()
+    registry.register(ECHO_SPEC, _echo_handler, scopes={NET_FETCH}, approval="always")
+    prompted = []
+
+    async def request_approval(call):
+        prompted.append(call)
+        return True
+
+    ctx = RunContext(granted_scopes=frozenset({NET_FETCH}), request_approval=request_approval)
+    _run(registry.invoke(ToolCall(id="1", name="echo", arguments={"message": "hi"}), ctx))
+    _run(registry.invoke(ToolCall(id="2", name="echo", arguments={"message": "different"}), ctx))
+
+    assert len(prompted) == 2
+
+
+def test_always_policy_memory_does_not_leak_across_separate_run_contexts():
+    registry = ToolRegistry()
+    registry.register(ECHO_SPEC, _echo_handler, scopes={NET_FETCH}, approval="always")
+    prompted = []
+
+    async def request_approval(call):
+        prompted.append(call)
+        return True
+
+    call = ToolCall(id="1", name="echo", arguments={"message": "hi"})
+    ctx_a = RunContext(granted_scopes=frozenset({NET_FETCH}), request_approval=request_approval)
+    ctx_b = RunContext(granted_scopes=frozenset({NET_FETCH}), request_approval=request_approval)
+
+    _run(registry.invoke(call, ctx_a))
+    _run(registry.invoke(call, ctx_b))
+
+    assert len(prompted) == 2, "approval memory is per-RunContext, never global to the registry"
+
+
+# -- handler exceptions become error results, not raises --------------------
+
+
+def test_a_raising_handler_becomes_an_error_result_not_an_exception():
+    registry = ToolRegistry()
+
+    async def broken_handler(call, ctx):
+        raise RuntimeError("boom")
+
+    registry.register(ECHO_SPEC, broken_handler, scopes={GRAPH_READ}, approval="auto")
+    result = _run(registry.invoke(ToolCall(id="1", name="echo", arguments={}), _ctx(granted_scopes={GRAPH_READ})))
+
+    assert result.is_error is True
+    assert "boom" in result.content
+
+
+# -- cancellation: mirrors every Provider.stream()'s own first line ---------
+
+
+def test_invoke_raises_the_same_cancellation_error_a_provider_would():
+    import threading
+
+    registry = ToolRegistry()
+    registry.register(ECHO_SPEC, _echo_handler, scopes={GRAPH_READ}, approval="auto")
+
+    cancel_event = threading.Event()
+    cancel_event.set()
+    ctx = _ctx(granted_scopes={GRAPH_READ}, cancel=CancelToken(cancel_event))
+
+    with pytest.raises(api_provider.RequestCancelledError):
+        _run(registry.invoke(ToolCall(id="1", name="echo", arguments={}), ctx))
+
+
+def test_invoke_with_no_cancel_token_never_raises_for_cancellation():
+    registry = ToolRegistry()
+    registry.register(ECHO_SPEC, _echo_handler, scopes={GRAPH_READ}, approval="auto")
+    result = _run(registry.invoke(ToolCall(id="1", name="echo", arguments={}), _ctx(granted_scopes={GRAPH_READ})))
+    assert result.is_error is False
+
+
+def test_a_cancel_that_lands_during_a_long_approval_wait_still_raises_and_never_runs_the_handler():
+    """The approval prompt is the one place invoke() can be awaiting for a
+    genuinely long time (a human deciding) - cancellation that arrives DURING
+    that wait must still be caught on return, not just at entry."""
+    import threading
+
+    registry = ToolRegistry()
+    handler_calls = []
+
+    async def tracked_handler(call, ctx):
+        handler_calls.append(call)
+        return ToolResult(content="should never run")
+
+    registry.register(ECHO_SPEC, tracked_handler, scopes={CODE_EXECUTE}, approval="once")
+
+    cancel_event = threading.Event()
+
+    async def request_approval(call):
+        cancel_event.set()  # simulates a cancel landing while the human is deciding
+        return True
+
+    ctx = RunContext(
+        granted_scopes=frozenset({CODE_EXECUTE}),
+        request_approval=request_approval,
+        cancel=CancelToken(cancel_event),
+    )
+
+    with pytest.raises(api_provider.RequestCancelledError):
+        _run(registry.invoke(ToolCall(id="1", name="echo", arguments={}), ctx))
+    assert handler_calls == []

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -1,0 +1,214 @@
+"""ADR-007 stage 7.2: ToolRegistry - the capability/permission model gating
+every tool a model may call.
+
+Builds directly on stage 7.1's provider-neutral ToolSpec/ToolCall (backend/
+providers/base.py): a provider normalizes a model's request into a ToolCall,
+and THIS module decides whether it may actually run, against two independent
+gates named in the ADR's own §2:
+
+- **Scopes** (`graph.read`, `graph.mutate`, `fs.read`, `code.execute`,
+  `net.fetch`, `provider.call`) - a run is granted a scope set (RunContext.
+  granted_scopes); a tool registered outside it is denied BEFORE its handler
+  ever runs, matching the exit criterion's own wording ("denied pre-handler").
+- **Approval policy** (`auto` / `once` / `always`) - a per-tool choice the
+  registrant makes at register() time, never inferred from scopes. `auto`
+  tools (read-only/idempotent) run unprompted; `once`/`always` tools call
+  RunContext.request_approval - the caller's job to route that to whatever
+  UI/approval surface a real run uses (this module owns the GATE, not the
+  human-facing panel, mirroring how RunHandle.approval_future in backend/
+  agents.py is itself just a bookkeeping primitive that start_pycoder_run/
+  start_code_sandbox_run route to the approval panel). `always` additionally
+  remembers a fingerprint of (name, arguments) for the lifetime of the
+  RunContext, so a repeated IDENTICAL call in the same run does not re-prompt
+  - reusing _fingerprint_changes (graphlink_plugins/gitlink/agent.py, sha256
+  of canonical sort_keys JSON) exactly as backend/agents.py's own pycoder/
+  code_sandbox approval gates already do ("reused here rather than
+  reinvented" - node_states.py's own PycoderState docstring), not a
+  reinvented hash. Because the fingerprint is computed fresh from THIS call's
+  own arguments at invoke() time (never a separately-stored snapshot checked
+  again later), there is no TOCTOU window to guard against the way gitlink's
+  own atomic check-and-freeze does - a changed argument simply produces a
+  different fingerprint and is never considered pre-approved.
+
+invoke() never raises for an EXPECTED denial (unknown tool, out-of-scope,
+approval denied, handler exception) - each becomes an error ToolResult, the
+shape a tool-use loop feeds back to the model as the tool's own result text,
+not a crash of the whole turn. Cancellation is the one exception: mirroring
+every Provider.stream()'s own first line, invoke() raises the same
+RequestCancelledError a cancelled provider call would, so a tool-use loop's
+cancellation handling stays the ONE mechanism regardless of whether the
+in-flight step is a provider call or a tool call.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Literal
+
+from api_provider import RequestCancelledError, _raise_if_cancelled
+from backend.providers.base import CancelToken, ToolCall, ToolSpec
+from graphlink_plugins.gitlink.agent import _fingerprint_changes
+
+GRAPH_READ = "graph.read"
+GRAPH_MUTATE = "graph.mutate"
+FS_READ = "fs.read"
+CODE_EXECUTE = "code.execute"
+NET_FETCH = "net.fetch"
+PROVIDER_CALL = "provider.call"
+
+# The ADR's own closed vocabulary (§2) - register() rejects anything outside
+# it immediately, the same fail-fast posture EVENT_TYPES/ProviderEvent.type
+# already take for their own closed vocabularies (backend/providers/base.py).
+KNOWN_SCOPES = frozenset({GRAPH_READ, GRAPH_MUTATE, FS_READ, CODE_EXECUTE, NET_FETCH, PROVIDER_CALL})
+
+ApprovalPolicy = Literal["auto", "once", "always"]
+_KNOWN_APPROVAL_POLICIES = frozenset({"auto", "once", "always"})
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    """What invoke() always returns - `content` is exactly the string a tool-
+    use loop feeds back as the next turn's {"role": "tool", ..., "content":
+    content} message (ChatRequest's own docstring, ADR-007 stage 7.1).
+    `is_error` is informational for the loop/UI (e.g. to style a failed call
+    differently on the canvas in stage 7.4) - it does not change the wire
+    shape a denied/failed call still needs to hand back to the model."""
+
+    content: str
+    is_error: bool = False
+
+
+# A handler is the registrant's own async implementation - it receives the
+# normalized ToolCall and the run's RunContext (for anything scope/approval-
+# independent it still needs, e.g. reading which node/session this run is
+# for) and returns the ToolResult invoke() hands back untouched on success.
+ToolHandler = Callable[[ToolCall, "RunContext"], Awaitable[ToolResult]]
+
+
+@dataclass
+class RunContext:
+    """Everything ToolRegistry.invoke() needs beyond the call itself, all
+    supplied by the tool-use loop that owns this run - this module never
+    constructs one itself.
+
+    - granted_scopes: the scope set THIS run was started with; static for
+      the run's lifetime (a mid-run scope change is a new run, not a
+      mutation - mirrors how a provider's capabilities are fixed at
+      construction, never mutated by request).
+    - request_approval: routes a `once`/`always` tool's approval prompt to
+      whatever real surface the caller wires up (WS approval panel, a CLI
+      prompt, an always-True fake in tests) - this module owns only the
+      DECISION to call it, never the UI. Must not raise; a caller that wants
+      "approval unavailable" to read as denial should have this return
+      False, not throw.
+    - cancel: optional, mirrors every Provider.stream()'s own CancelToken -
+      None (the default) means this run has no cancellation affordance,
+      exactly like a provider's `CancelToken()` with no wrapped event.
+    - _approved_fingerprints: `always`-policy memory, private to this run -
+      external code has no reason to read or seed it directly."""
+
+    granted_scopes: frozenset[str]
+    request_approval: Callable[[ToolCall], Awaitable[bool]]
+    cancel: CancelToken | None = None
+    _approved_fingerprints: set[str] = field(default_factory=set)
+
+
+@dataclass(frozen=True)
+class _Registration:
+    spec: ToolSpec
+    handler: ToolHandler
+    scopes: frozenset[str]
+    approval: str
+
+
+def _tool_call_fingerprint(call: ToolCall) -> str:
+    # Deliberately excludes call.id: id correlates a specific call to its
+    # result (ToolCall's own docstring) and is provider-synthesized noise
+    # for approval-memory purposes - two calls with the same name+arguments
+    # are the same DECISION to a human approver regardless of which id a
+    # provider happened to mint for either one.
+    return _fingerprint_changes({"name": call.name, "arguments": call.arguments})
+
+
+class ToolRegistry:
+    """One registry per process/session (not per-run - RunContext is what's
+    per-run); registrations are typically made once at startup by whatever
+    wires up the agent runtime (ADR-008), not per tool call."""
+
+    def __init__(self) -> None:
+        self._registrations: dict[str, _Registration] = {}
+
+    def register(
+        self,
+        spec: ToolSpec,
+        handler: ToolHandler,
+        *,
+        scopes: set[str] | frozenset[str],
+        approval: str,
+    ) -> None:
+        if approval not in _KNOWN_APPROVAL_POLICIES:
+            raise ValueError(
+                f"Unknown approval policy {approval!r} for tool {spec.name!r} - "
+                f"must be one of {sorted(_KNOWN_APPROVAL_POLICIES)}."
+            )
+        scope_set = frozenset(scopes)
+        unknown_scopes = scope_set - KNOWN_SCOPES
+        if unknown_scopes:
+            raise ValueError(
+                f"Unknown scope(s) {sorted(unknown_scopes)} for tool {spec.name!r} - "
+                f"must be a subset of {sorted(KNOWN_SCOPES)}."
+            )
+        if spec.name in self._registrations:
+            raise ValueError(f"Tool {spec.name!r} is already registered.")
+        self._registrations[spec.name] = _Registration(spec, handler, scope_set, approval)
+
+    def specs(self) -> tuple[ToolSpec, ...]:
+        """Every registered tool's neutral spec, in registration order - what
+        a caller passes as ChatRequest.tools for a run granted access to all
+        of them (a real caller will usually filter this by RunContext.
+        granted_scopes first; this method does not filter, since "what
+        exists" and "what this run may use" are independent questions)."""
+        return tuple(registration.spec for registration in self._registrations.values())
+
+    async def invoke(self, call: ToolCall, ctx: RunContext) -> ToolResult:
+        _raise_if_cancelled(ctx.cancel.event if ctx.cancel is not None else None)
+
+        registration = self._registrations.get(call.name)
+        if registration is None:
+            return ToolResult(content=f"Unknown tool: {call.name!r}.", is_error=True)
+
+        # Scope check runs BEFORE any approval prompt - denied-by-scope
+        # is a static, cheap decision that must never cost a human an
+        # approval prompt for a call that was never going to be allowed.
+        missing_scopes = registration.scopes - ctx.granted_scopes
+        if missing_scopes:
+            return ToolResult(
+                content=(
+                    f"Tool {call.name!r} requires scope(s) {sorted(missing_scopes)} "
+                    "that this run was not granted."
+                ),
+                is_error=True,
+            )
+
+        if registration.approval != "auto":
+            fingerprint = _tool_call_fingerprint(call) if registration.approval == "always" else None
+            already_approved = fingerprint is not None and fingerprint in ctx._approved_fingerprints
+            if not already_approved:
+                approved = await ctx.request_approval(call)
+                # The approval prompt is the one place this function can be
+                # awaiting for a genuinely long time (a human deciding) -
+                # re-check cancellation on return, same cooperative-
+                # checkpoint posture cancel_pycoder/cancel_code_sandbox
+                # already document (backend/agents.py): not a true
+                # mid-await interrupt, but the run must not silently execute
+                # a handler after the user cancelled while this was pending.
+                _raise_if_cancelled(ctx.cancel.event if ctx.cancel is not None else None)
+                if not approved:
+                    return ToolResult(content=f"Tool call {call.name!r} was denied approval.", is_error=True)
+                if fingerprint is not None:
+                    ctx._approved_fingerprints.add(fingerprint)
+
+        try:
+            return await registration.handler(call, ctx)
+        except Exception as exc:
+            return ToolResult(content=f"Tool {call.name!r} raised {type(exc).__name__}: {exc}", is_error=True)

--- a/contracts/graphlink_scene_payload.py
+++ b/contracts/graphlink_scene_payload.py
@@ -145,6 +145,13 @@ but SceneCanvas.tsx never reads it today (a backend-only multimodal
 round-trip capability, not a rendered feature) - C9 is specifically
 about fields an unsafe CAST reaches for, and no cast reaches for this
 one, so adding it here would not serve this stage's own exit criterion.
+
+ADR-007 stage 7.4 adds `toolCalls` (a list of `ToolInvocationRow`): the
+tool calls + results an assistant chat-node's turn made, populated for
+kind=="chat" rows whose turn actually invoked tools, defaulted `[]` for
+every other kind and for tool-less chat turns - same additive rule as
+everything above. See ToolInvocationRow's own docstring for why its
+`arguments` field is a JSON-encoded string, not a nested object.
 """
 
 from __future__ import annotations
@@ -227,6 +234,28 @@ class GitlinkPendingChangeRow:
     # default value, so this must be Optional for a delete-only item to
     # validate.
     content: str | None = None
+
+
+@dataclass
+class ToolInvocationRow:
+    """ADR-007 stage 7.4: one tool call + its result, attached to the
+    chat-kind assistant node whose turn made it - see SceneNodeRow.toolCalls'
+    own comment. `argumentsJson` is the call's arguments JSON-ENCODED as a
+    string, not a nested object: ToolCall.arguments (backend/providers/
+    base.py) is an arbitrary caller-defined JSON object shaped by whatever
+    tool was called, and graphlink_wire_schema.py's generator has no
+    construct for "any JSON object" (its own module docstring lists the
+    closed type set this deliberately refuses to guess beyond) - the same
+    reasoning that already makes gitlinkContextXml/similar opaque blobs
+    cross the wire as strings rather than structured fields. The frontend
+    renders it as formatted JSON text, which needs no structural typing
+    anyway."""
+
+    id: str
+    name: str
+    argumentsJson: str
+    result: str
+    isError: bool = False
 
 
 @dataclass
@@ -455,6 +484,14 @@ class SceneNodeRow:
     # kind=="chat" respectively, defaulted for every other kind.
     htmlSplitterState: float | None = None
     chatScrollValue: float = 0.0
+    # ADR-007 stage 7.4: an assistant turn's tool calls + their results,
+    # in call order - populated for kind=="chat" rows whose turn actually
+    # invoked tools (the overwhelming majority of chat nodes have none, the
+    # same "empty list, not null" default `history`/`itemIds` above already
+    # use), defaulted [] for every other kind. Rendered as a collapsible
+    # section (the ADR's own "an assistant turn that calls tools renders
+    # the calls and their results (collapsible)") in ChatNodeView.tsx.
+    toolCalls: list[ToolInvocationRow] = field(default_factory=list)
 
 
 @dataclass

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -311,6 +311,14 @@ class SettingsManager:
                     state['update_latest_version'] = ''
                 if 'update_available' not in state:
                     state['update_available'] = False
+                if 'mcp_servers' not in state or not isinstance(state.get('mcp_servers'), list):
+                    # ADR-007 stage 7.5: absent in every pre-7.5 save -> no
+                    # configured MCP servers, matching the initial-state
+                    # default below - a settings surface with nothing
+                    # configured yet is the correct, safe starting point,
+                    # not an error.
+                    state['mcp_servers'] = []
+                    state_changed = True
                 if 'schema_version' not in state:
                     state['schema_version'] = self.CURRENT_SCHEMA_VERSION
                     state_changed = True
@@ -410,6 +418,9 @@ class SettingsManager:
             "update_last_checked_at": "",
             "update_latest_version": "",
             "update_available": False,
+            # ADR-007 stage 7.5: MCP client configuration - see
+            # get_mcp_servers/set_mcp_servers' own docstrings.
+            "mcp_servers": [],
         }
         self._save_state(state)
         return state
@@ -965,4 +976,66 @@ class SettingsManager:
         self.state["gemini_api_key"] = ""
         self.state["api_models"] = {}
         self.state["api_models_by_provider"] = {}
+        self._save_state()
+
+    def get_mcp_servers(self) -> list:
+        """ADR-007 stage 7.5: configured MCP servers - the persisted
+        counterpart of backend/mcp_client.py's McpServerConfig (plain JSON-
+        safe dicts here; that module owns converting to/from its own
+        dataclass via to_dict/from_dict, keeping this store agnostic of
+        that module's types, same posture as get_llama_cpp_settings'
+        plain-dict return). Malformed/legacy entries are dropped rather
+        than raised on - a corrupted single entry must never break every
+        other configured server, or settings loading itself."""
+        raw_servers = self.state.get("mcp_servers", [])
+        if not isinstance(raw_servers, list):
+            return []
+        servers = []
+        for entry in raw_servers:
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name", "")).strip()
+            command = str(entry.get("command", "")).strip()
+            if not name or not command:
+                continue
+            servers.append({
+                "name": name,
+                "command": command,
+                "args": [str(a) for a in (entry.get("args") or [])],
+                "scopes": sorted({str(s) for s in (entry.get("scopes") or [])}),
+                "approval": str(entry.get("approval") or "always"),
+                "enabled_tools": sorted({str(t) for t in (entry.get("enabled_tools") or [])}),
+                "enabled": bool(entry.get("enabled", True)),
+                "timeout": float(entry.get("timeout", 30.0) or 30.0),
+            })
+        return servers
+
+    def set_mcp_servers(self, servers: list) -> None:
+        """Replaces the WHOLE configured-server list, same "replace the
+        collection" posture as set_ollama_model_assignments - this is a
+        small, user-managed list edited as a unit (add/remove/edit one
+        server via a settings panel - ADR-012's own future surface, see
+        backend/mcp_client.py's module docstring), not an incrementally-
+        patched map. Validates the same way get_mcp_servers reads back
+        (name/command required, everything else normalized/defaulted) so
+        a round trip through set then get is always well-formed."""
+        normalized = []
+        for entry in (servers or []):
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name", "")).strip()
+            command = str(entry.get("command", "")).strip()
+            if not name or not command:
+                continue
+            normalized.append({
+                "name": name,
+                "command": command,
+                "args": [str(a) for a in (entry.get("args") or [])],
+                "scopes": sorted({str(s) for s in (entry.get("scopes") or [])}),
+                "approval": str(entry.get("approval") or "always"),
+                "enabled_tools": sorted({str(t) for t in (entry.get("enabled_tools") or [])}),
+                "enabled": bool(entry.get("enabled", True)),
+                "timeout": float(entry.get("timeout", 30.0) or 30.0),
+            })
+        self.state["mcp_servers"] = normalized
         self._save_state()

--- a/requirements.txt
+++ b/requirements.txt
@@ -519,7 +519,6 @@ h2==4.4.1 \
     --hash=sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6 \
     --hash=sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516
     # via httpx
-    # bumped 4.3.0 -> 4.4.1 for CVE-2026-71554 (pip-audit gate, 2026-08-07)
 hpack==4.2.0 \
     --hash=sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0 \
     --hash=sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986
@@ -1312,9 +1311,9 @@ pyparsing==3.3.2 \
     --hash=sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d \
     --hash=sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc
     # via matplotlib
-pypdf==6.14.2 \
-    --hash=sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946 \
-    --hash=sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25
+pypdf==6.15.0 \
+    --hash=sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee \
+    --hash=sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79
     # via -r requirements.in
 pyspellchecker==0.9.0 \
     --hash=sha256:97eaed776e0854f69aafb723f6962b403099e50c9a1d9c05525c819f4b0f5d54 \

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -263,11 +263,12 @@ def test_scene_node_core_field_count():
 
 
 # Captured from SceneDocument.scene_payload()'s real output pre-migration
-# (a single chat node, ADR-002 stage 2.5 PR1/image baseline) - sorted, 89
-# keys (87 pre-6.8 + promptTokens/completionTokens, ADR-006 stage 6.8).
-# scene_payload emits this SAME key set for every node regardless of
-# kind (one flat dict literal, no per-kind branching), so one representative
-# node is sufficient; the point is the KEY SET, not per-kind values.
+# (a single chat node, ADR-002 stage 2.5 PR1/image baseline) - sorted, 90
+# keys (87 pre-6.8 + promptTokens/completionTokens, ADR-006 stage 6.8 +
+# toolCalls, ADR-007 stage 7.4). scene_payload emits this SAME key set for
+# every node regardless of kind (one flat dict literal, no per-kind
+# branching), so one representative node is sufficient; the point is the
+# KEY SET, not per-kind values.
 _EXPECTED_SCENE_NODE_WIRE_KEYS = sorted([
     "artifactContent", "attachmentKind", "branchStatus", "byteSize",
     "chartAspectLocked", "chartAssetId", "chartAssetVersion", "chartData",
@@ -293,7 +294,7 @@ _EXPECTED_SCENE_NODE_WIRE_KEYS = sorted([
     "researchActiveSourceId", "researchCompleted", "researchError",
     "completionTokens", "promptTokens",
     "researchResult", "researchStage", "researchTotal", "responseIncomplete",
-    "synthesisInstructions", "title", "x", "y",
+    "synthesisInstructions", "title", "toolCalls", "x", "y",
 ])
 
 

--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -143,7 +143,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -506,7 +505,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -555,7 +553,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1851,6 +1848,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "dev": true,
@@ -2040,7 +2058,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2228,7 +2247,6 @@
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2244,7 +2262,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2256,7 +2273,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2312,7 +2328,6 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -2699,7 +2714,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2740,6 +2754,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2750,6 +2765,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2853,7 +2869,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -3080,7 +3095,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3224,7 +3238,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.392",
@@ -3338,7 +3353,6 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -4606,6 +4620,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5746,7 +5761,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5799,6 +5813,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5833,7 +5848,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5846,7 +5860,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5860,7 +5873,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6497,7 +6511,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6760,7 +6773,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7064,7 +7076,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -143,6 +143,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -505,6 +506,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -553,6 +555,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1848,27 +1851,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "dev": true,
@@ -2058,8 +2040,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2247,6 +2228,7 @@
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2262,6 +2244,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2273,6 +2256,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2328,6 +2312,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -2714,6 +2699,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2754,7 +2740,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2765,7 +2750,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2869,6 +2853,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -3095,6 +3080,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3238,8 +3224,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.392",
@@ -3353,6 +3338,7 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -4620,7 +4606,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5584,9 +5569,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -5761,6 +5746,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5813,7 +5799,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5848,6 +5833,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5860,6 +5846,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5873,8 +5860,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6511,6 +6497,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6773,6 +6760,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7076,6 +7064,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -59,8 +59,5 @@
     "typescript-eslint": "^8.65.0",
     "vite": "^6.0.5",
     "vitest": "^4.1.10"
-  },
-  "overrides": {
-    "nanoid": "^3.3.17"
   }
 }

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -59,5 +59,8 @@
     "typescript-eslint": "^8.65.0",
     "vite": "^6.0.5",
     "vitest": "^4.1.10"
+  },
+  "overrides": {
+    "nanoid": "^3.3.17"
   }
 }

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -80,6 +80,8 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}, selected:
         responseIncomplete: false,
         subscribeStream: vi.fn().mockReturnValue(vi.fn()),
         onCancelRegenerate,
+        // ADR-007 stage 7.4
+        toolInvocations: [],
         ...dataOverrides,
       },
     } as unknown as NodeProps<ChatFlowNode>;
@@ -926,5 +928,60 @@ describe("ChatNodeView interrupted banner (ADR-006 stage 6.4)", () => {
       subscribeStream: vi.fn().mockReturnValue(vi.fn()),
     });
     expect(screen.queryByText(/Response interrupted/)).toBeNull();
+  });
+});
+
+describe("ChatNodeView tool invocations (ADR-007 stage 7.4)", () => {
+  it("renders nothing when the turn made no tool calls (the overwhelming majority of chat nodes)", () => {
+    renderChatNode({ toolInvocations: [] });
+    expect(screen.queryByText(/tool call/)).toBeNull();
+  });
+
+  it("renders a collapsible summary, closed by default, with each call's name/arguments/result inside", async () => {
+    const user = userEvent.setup();
+    const { container } = renderChatNode({
+      isUser: false,
+      toolInvocations: [
+        {
+          id: "call_1",
+          name: "echo",
+          argumentsJson: '{"message": "hi"}',
+          result: "hi",
+          isError: false,
+        },
+      ],
+    });
+    const summary = screen.getByText("1 tool call");
+    const details = container.querySelector("details.chat-node-tool-invocations") as HTMLDetailsElement;
+    expect(details.open).toBe(false); // native <details> closed by default
+
+    await user.click(summary);
+    expect(details.open).toBe(true);
+    expect(screen.getByText("echo")).toBeInTheDocument();
+    expect(screen.getByText('{"message": "hi"}')).toBeInTheDocument();
+    expect(screen.getByText("hi")).toBeInTheDocument();
+  });
+
+  it("pluralizes the summary count for more than one call", () => {
+    renderChatNode({
+      isUser: false,
+      toolInvocations: [
+        { id: "call_1", name: "echo", argumentsJson: "{}", result: "one", isError: false },
+        { id: "call_2", name: "echo", argumentsJson: "{}", result: "two", isError: false },
+      ],
+    });
+    expect(screen.getByText("2 tool calls")).toBeInTheDocument();
+  });
+
+  it("marks a failed call visually distinct from a successful one", async () => {
+    const user = userEvent.setup();
+    const { container } = renderChatNode({
+      isUser: false,
+      toolInvocations: [
+        { id: "call_1", name: "broken_tool", argumentsJson: "{}", result: "boom", isError: true },
+      ],
+    });
+    await user.click(screen.getByText("1 tool call"));
+    expect(container.querySelector(".chat-node-tool-invocation.error")).not.toBeNull();
   });
 });

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -142,6 +142,26 @@ export interface ChatNodeData extends Record<string, unknown> {
   // established. Fires the SAME generic cancelChatRequest intent that
   // cancel path uses - no new intent (see SceneCanvas's chat branch).
   onCancelRegenerate: () => void;
+  // ADR-007 stage 7.4: this turn's tool calls + their results, in call
+  // order - [] for the overwhelming majority of chat nodes (no tool-use
+  // loop exists yet to populate this; ADR-008 is the first real writer).
+  // Rendered as a collapsible section below the content, the ADR's own "an
+  // assistant turn that calls tools renders the calls and their results
+  // (collapsible)".
+  toolInvocations: ToolInvocationData[];
+}
+
+// Mirrors the generated ToolInvocationRow (web_ui/src/lib/bridge-core/
+// generated/scene-state.ts) field-for-field - a local interface rather than
+// importing that generated type directly, matching how every other field on
+// ChatNodeData above is a plain, ChatNodeView-local shape rather than a
+// re-export of its own generated row type.
+export interface ToolInvocationData {
+  id: string;
+  name: string;
+  argumentsJson: string;
+  result: string;
+  isError: boolean;
 }
 
 export type ChatFlowNode = Node<ChatNodeData, "chat">;
@@ -854,6 +874,34 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
             </button>
           )}
         </div>
+      )}
+      {/* ADR-007 stage 7.4: an assistant turn's tool calls + results - the
+          ADR's own "renders the calls and their results (collapsible)".
+          Native <details>/<summary> rather than the useState-driven
+          expand/collapse pattern above (contentExpanded) - this section's
+          state doesn't need to survive a re-render triggered by anything
+          else on the node, and a native disclosure widget is free
+          keyboard/AT support for a debug-style panel like this one. Hidden
+          entirely (not just collapsed) when the turn made no tool calls -
+          the overwhelming majority of chat nodes. */}
+      {!collapsed && data.toolInvocations.length > 0 && (
+        <details className="chat-node-tool-invocations">
+          <summary>
+            {data.toolInvocations.length === 1
+              ? "1 tool call"
+              : `${data.toolInvocations.length} tool calls`}
+          </summary>
+          {data.toolInvocations.map((invocation, index) => (
+            <div
+              key={invocation.id || index}
+              className={`chat-node-tool-invocation${invocation.isError ? " error" : ""}`}
+            >
+              <div className="chat-node-tool-invocation-name">{invocation.name}</div>
+              <pre className="chat-node-tool-invocation-arguments">{invocation.argumentsJson}</pre>
+              <pre className="chat-node-tool-invocation-result">{invocation.result}</pre>
+            </div>
+          ))}
+        </details>
       )}
       {/* ADR-006 stage 6.4 review fix: per-node Stop for an in-flight
           streamed regenerate - see onCancelRegenerate's own comment on

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -127,6 +127,8 @@ function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
     chartSourceNodeId: "",
     htmlSplitterState: null,
     chatScrollValue: 0.0,
+    // ADR-007 stage 7.4
+    toolCalls: [],
     ...overrides,
   };
 }

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -527,6 +527,12 @@ export function toFlowNodes(
           onCancelRegenerate: () => {
             if (n.pendingRequestId) store.cancelConversationRequest(n.pendingRequestId);
           },
+          // ADR-007 stage 7.4: this turn's tool calls + results, in call
+          // order - [] for the overwhelming majority of chat nodes (see
+          // ToolInvocationRow's own comment, contracts/graphlink_scene_
+          // payload.py). Rendered as a collapsible section in
+          // ChatNodeView.tsx.
+          toolInvocations: n.toolCalls,
         },
       });
       continue;

--- a/web_ui/src/app/canvas/renderCountGate.test.tsx
+++ b/web_ui/src/app/canvas/renderCountGate.test.tsx
@@ -94,6 +94,7 @@ function chatRow(id: string, x: number): SceneNodeRow {
         chartAssetId: "", chartAssetVersion: 0, chartWidth: 680.0, chartHeight: 500.0,
         chartAspectLocked: true, chartSourceNodeId: "", htmlSplitterState: null,
         chatScrollValue: 0.0,
+        toolCalls: [], // ADR-007 stage 7.4
       }),
     ) as unknown as SceneNodeRow),
   };

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -179,6 +179,8 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         chartAspectLocked: true,
         chartSourceNodeId: "",
         chatScrollValue: 0.0,
+        // ADR-007 stage 7.4
+        toolCalls: [],
       },
     ],
     edges: [],

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -539,6 +539,57 @@ body,
   margin: 0 10px 8px;
 }
 
+/* ADR-007 stage 7.4: an assistant turn's tool calls + results - native
+   <details>/<summary>, styled to match the incomplete-banner's own bordered-
+   pill posture just above rather than a heavier custom disclosure widget. */
+.chat-node-tool-invocations {
+  margin: 0 10px 8px;
+  padding: 6px 10px;
+  font-size: 11px;
+  color: var(--gl-surface-text-primary);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 8px;
+}
+
+.chat-node-tool-invocations summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.chat-node-tool-invocations[open] summary {
+  margin-bottom: 6px;
+}
+
+.chat-node-tool-invocation {
+  padding: 6px 0;
+  border-top: 1px solid var(--gl-surface-border);
+}
+
+.chat-node-tool-invocation:first-of-type {
+  border-top: none;
+}
+
+.chat-node-tool-invocation-name {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.chat-node-tool-invocation.error .chat-node-tool-invocation-name {
+  color: var(--gl-semantic-status-error, currentColor);
+}
+
+.chat-node-tool-invocation-arguments,
+.chat-node-tool-invocation-result {
+  margin: 4px 0 0;
+  padding: 6px 8px;
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background-color: var(--gl-surface-inset, var(--gl-surface-node-body));
+  border-radius: 6px;
+}
+
 /* Node redesign, stage 2 ("typography and heading hierarchy"): headings
    were fixed px values (15/14/13/12) set independently of this element's
    own font-size, which itself is driven by the user-configurable

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -567,6 +567,37 @@
           "title": {
             "type": "string"
           },
+          "toolCalls": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "argumentsJson": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "isError": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "result": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "argumentsJson",
+                "result",
+                "isError"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "x": {
             "type": "number"
           },
@@ -649,7 +680,8 @@
           "chartHeight",
           "chartAspectLocked",
           "chartSourceNodeId",
-          "chatScrollValue"
+          "chatScrollValue",
+          "toolCalls"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -93,6 +93,7 @@ export interface SceneNodeRow {
   chartSourceNodeId: string;
   htmlSplitterState?: number | null;
   chatScrollValue: number;
+  toolCalls: ToolInvocationRow[];
 }
 
 export interface ConversationMessageRow {
@@ -157,6 +158,14 @@ export interface ChartFlowRow {
   source: string;
   target: string;
   value: number;
+}
+
+export interface ToolInvocationRow {
+  id: string;
+  name: string;
+  argumentsJson: string;
+  result: string;
+  isError: boolean;
 }
 
 export interface SceneEdgeRow {
@@ -653,6 +662,12 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.chatScrollValue: missing required field`);
     else { if (typeof fieldValue !== "number") errors.push(`${path}.chatScrollValue` + ": expected number"); }
   }
+  {
+    const fieldValue = value["toolCalls"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.toolCalls: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.toolCalls` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { checkToolInvocationRow(item, `${path}.toolCalls` + `[${i}]`, errors); }); }
+  }
 }
 
 function checkConversationMessageRow(value: unknown, path: string, errors: string[]): void {
@@ -893,6 +908,35 @@ function checkChartFlowRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["value"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.value: missing required field`);
     else { if (typeof fieldValue !== "number") errors.push(`${path}.value` + ": expected number"); }
+  }
+}
+
+function checkToolInvocationRow(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["id"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.id: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.id` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["name"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.name: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.name` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["argumentsJson"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.argumentsJson: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.argumentsJson` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["result"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.result: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.result` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["isError"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.isError: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.isError` + ": expected boolean"); }
   }
 }
 


### PR DESCRIPTION
## Summary

Implements ADR-007 in full (all 5 stages, one PR per the project's standing process):

- **7.1** — Provider-neutral tool calling: `ToolSpec`/`ToolCall` in the provider protocol, native tool calling wired into all 4 non-llama.cpp providers (OpenAI, Anthropic, Gemini, Ollama), with a round-trip echo-tool test per provider.
- **7.2** — `ToolRegistry` (`backend/tools.py`): scope gating (`graph.read`/`graph.mutate`/`fs.read`/`code.execute`/`net.fetch`/`provider.call`) and a per-tool approval policy (`auto`/`once`/`always`), with out-of-scope calls denied before the handler runs.
- **7.3** — `respond_json(schema)` (`backend/structured_output.py`): one schema-constrained JSON path across all 5 providers, using each provider's native structured-output mode where available and a schema-guided prompt + one-repair-turn fallback for Anthropic (which has none). Replaces the chart agent's hand-rolled per-provider repair chain as the target consolidation point.
- **7.4** — Tool-call/result rendering: the wire contract gained `toolCalls` on chat-kind nodes, and `ChatNodeView` renders them as a collapsible section (empty/hidden today — no tool-use loop exists yet to populate it; that's ADR-008).
- **7.5** — MCP client (`backend/mcp_client.py`): a minimal, hand-rolled stdio JSON-RPC 2.0 client (not the official `mcp` package — same reasoning as this codebase's own hand-rolled JSON-Schema generator, keeping the dependency surface narrow) that lists and calls a configured server's tools, namespaced `mcp:<server>:<tool>` and registered into `ToolRegistry` scope-mapped and approval-gated. `SettingsManager` persists the server config list; the Settings UI panel itself is explicitly deferred to ADR-012 per the ADR's own Consequences section.

## Test plan

- [x] Full backend suite green: 1944 passed, 14 skipped
- [x] Full frontend suite green: 1369 passed; `typecheck`/`lint` clean
- [x] Golden cross-provider test for `respond_json` (identical parsed output on all 5 providers, same schema)
- [x] MCP exit criterion proven end-to-end against a real subprocess (fake filesystem-shaped MCP server) speaking real JSON-RPC — tool listed, namespaced, approval-gated, callable through `ToolRegistry.invoke()`
- [x] Browser-verified: app boots, creates/renders chat nodes correctly with the new `toolCalls` wire field, no console errors