### PR TITLE
ADR-016: Observability, telemetry, and cost accounting (local-only)

### DIFF
--- a/api_provider.py
+++ b/api_provider.py
@@ -3036,6 +3036,17 @@ def _translate_chat_exception(exc: Exception, state, messages: list) -> None:
     if isinstance(exc, RequestCancelledError):
         raise exc
 
+    # ADR-016 stage 16.3: the ONE choke point both chat() and chat_stream()
+    # funnel every non-cancel failure through - record it once here rather
+    # than at each of the two call sites (backend/diagnostics.py's own
+    # module docstring explains why this is process-global, not per-session).
+    from backend.diagnostics import record_provider_error
+
+    record_provider_error(
+        state.api_provider_type if state.use_api_mode else state.local_provider_type,
+        str(exc),
+    )
+
     error_str = str(exc).lower()
     status_code = getattr(exc, "status_code", None)
 

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -276,8 +276,13 @@ class AgentDispatcher:
     """One instance per session - never a module-level singleton, since two
     sessions must never share in-flight request state."""
 
-    def __init__(self, settings_manager: SettingsManager, provider_runtime=None):
+    def __init__(self, settings_manager: SettingsManager, provider_runtime=None, diagnostics=None):
         self._settings_manager = settings_manager
+        # ADR-016 stage 16.3: optional - None (every existing call site
+        # outside backend/app.py's real _configure_session) means "no
+        # diagnostics recording", exactly RunRegistry's own on_claim/on_end
+        # default. See backend/diagnostics.py's own module docstring.
+        self._diagnostics = diagnostics
         # ADR-006 stage 6.5: the session's ProviderRuntime. None means "the
         # default session": every provider call keeps going through
         # api_provider's module-level functions exactly as before (which the
@@ -295,7 +300,10 @@ class AgentDispatcher:
         # stage 2.4). "chat" is one shared kind for both start_chat_reply
         # and start_conversation_reply, mirroring the single dict they
         # already shared before this migration.
-        self._runs = RunRegistry()
+        self._runs = RunRegistry(
+            on_claim=diagnostics.record_run_claimed if diagnostics is not None else None,
+            on_end=diagnostics.record_run_ended if diagnostics is not None else None,
+        )
         # R4.4a/ADR-002 stage 2.4c: image generation ("image" kind, also
         # sharing self._runs now) is an INDEPENDENT single-slot kind,
         # separate from chat - preserves legacy's real, verified concurrent
@@ -3569,12 +3577,12 @@ def _call_gitlink_apply(local_root, pending_changes):
 
 
 def register_agents(
-    bus, composer_document, notifications_state, settings_manager, provider_runtime=None
+    bus, composer_document, notifications_state, settings_manager, provider_runtime=None, diagnostics=None
 ) -> AgentDispatcher:
     # ADR-006 stage 6.5: provider_runtime is None for the default session
     # (module-global path, byte-identical behavior) - see
     # AgentDispatcher.__init__'s own comment.
-    dispatcher = AgentDispatcher(settings_manager, provider_runtime=provider_runtime)
+    dispatcher = AgentDispatcher(settings_manager, provider_runtime=provider_runtime, diagnostics=diagnostics)
     # dispatcher.cancel is synchronous (just sets an Event and returns a
     # bool) - no publish/await needed here; the in-flight _run task's own
     # finally block handles the resulting state transition.

--- a/backend/api/intents_chat.py
+++ b/backend/api/intents_chat.py
@@ -179,6 +179,12 @@ def _make_on_usage(
             target = document.nodes[node_id]
             target.state.prompt_tokens = usage.get("prompt_tokens")
             target.state.completion_tokens = usage.get("completion_tokens")
+            # ADR-016 stage 16.2: a point-in-time cost snapshot - see
+            # ChatState.estimated_cost_usd's own comment.
+            target.state.estimated_cost_usd = token_counter.estimate_cost_for(
+                usage.get("prompt_tokens"), usage.get("completion_tokens"),
+                provider=provider, model=model,
+            )
             await publish_scene()
 
     return _on_usage

--- a/backend/api/intents_diagnostics.py
+++ b/backend/api/intents_diagnostics.py
@@ -1,0 +1,52 @@
+"""ADR-016 stage 16.4: the "diagnostics" topic's two WS intents.
+
+The topic itself is registered in backend/app.py by stage 16.3
+(`bus.register_topic("diagnostics", diagnostics.payload)`) - this module
+adds intents ONTO that already-existing topic, it does not create a new one.
+Both intents take no arguments and neither mutates the document, so neither
+belongs on the undo stack (see tests/undo_classification.py's own entries
+for these two).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from backend import crash_recovery, diagnostic_bundle
+from backend.diagnostics import DiagnosticsState
+from backend.domain.graph import SceneDocument
+from backend.events import SessionBus
+
+
+def register_diagnostics_intents(
+    bus: SessionBus,
+    document: SceneDocument,
+    diagnostics_state: DiagnosticsState,
+) -> None:
+    async def export_diagnostic_bundle():
+        """Builds the redacted bundle (backend/diagnostic_bundle.py - see
+        its own docstring for the exact allowlist) and writes it to
+        ~/.graphlink/diagnostics/bundle-<UTC timestamp>.json, so a user can
+        find and attach it to an issue report without a terminal. Returns
+        both the bundle dict (for an in-app "copy to clipboard" affordance)
+        and the path it was written to (so the UI can tell the user where
+        it landed)."""
+        bundle = diagnostic_bundle.build_diagnostic_bundle(document, diagnostics_state)
+        utcnow = datetime.now(timezone.utc)
+        # backend.crash_recovery._data_dir() (not log_path()/crash_dir()) is
+        # the shared ~/.graphlink root every one of those helpers is itself
+        # built from - reused directly here so the bundle lands as a sibling
+        # of graphlink.log and the crash/ directory, not a second, divergent
+        # notion of "where this app's data lives".
+        directory = crash_recovery._data_dir() / "diagnostics"
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f"bundle-{utcnow.strftime('%Y%m%dT%H%M%SZ')}.json"
+        path.write_text(json.dumps(bundle, indent=2), encoding="utf-8")
+        return {"bundle": bundle, "path": str(path)}
+
+    async def open_log_folder():
+        return {"opened": diagnostic_bundle.open_log_folder()}
+
+    bus.register_intent("diagnostics", "exportDiagnosticBundle", export_diagnostic_bundle)
+    bus.register_intent("diagnostics", "openLogFolder", open_log_folder)

--- a/backend/api/intents_settings_general.py
+++ b/backend/api/intents_settings_general.py
@@ -22,6 +22,7 @@ import graphlink_task_config as config
 from backend.api._settings_shared import SettingsSessionState, run_locked
 from backend.events import SessionBus
 from backend.notifications import NotificationState
+from backend.observability import apply_log_level
 from graphlink_settings_store import SettingsManager
 
 # ADR-006 stage 6.5: the three persisted provider-mode strings
@@ -62,6 +63,18 @@ def register_settings_general_intents(
 
     async def set_enable_system_prompt(enabled: bool):
         await asyncio.to_thread(run_locked, manager.set_enable_system_prompt, bool(enabled))
+        await bus.publish("app-settings")
+
+    async def set_log_level(level: str):
+        # ADR-016 stage 16.1: persists AND applies live - unlike the boot-time
+        # read in graphlink_desktop.py's main(), a user flipping this in a
+        # running app expects the next log line to honor it immediately, not
+        # after a restart. apply_log_level no-ops on an unrecognized string
+        # (same closed-vocabulary posture as manager.set_log_level itself),
+        # so a malformed intent arg is silently ignored rather than raising.
+        level = str(level)
+        await asyncio.to_thread(run_locked, manager.set_log_level, level)
+        apply_log_level(level)
         await bus.publish("app-settings")
 
     async def set_notification_preference(notification_type: str, enabled: bool):
@@ -117,6 +130,7 @@ def register_settings_general_intents(
     bus.register_intent("app-settings", "setActiveSection", set_active_section)
     bus.register_intent("app-settings", "setShowTokenCounter", set_show_token_counter)
     bus.register_intent("app-settings", "setEnableSystemPrompt", set_enable_system_prompt)
+    bus.register_intent("app-settings", "setLogLevel", set_log_level)
     bus.register_intent("app-settings", "setNotificationPreference", set_notification_preference)
     bus.register_intent("app-settings", "setGithubToken", set_github_token)
     bus.register_intent("app-settings", "clearGithubToken", clear_github_token)

--- a/backend/app.py
+++ b/backend/app.py
@@ -194,7 +194,7 @@ def _configure_session(
     # into/out of "generating" state, and a real AgentDispatcher to hand off
     # to - both must exist before register_canvas builds the sendMessage
     # intent that calls them.
-    token_counter = register_token_counter(bus)
+    token_counter = register_token_counter(bus, settings_manager)
     composer_document = register_composer(bus, token_counter, settings_manager, notifications_state)
 
     # R4 (doc/QT_REMOVAL_PLAN.md): the agent-dispatch service - one

--- a/backend/app.py
+++ b/backend/app.py
@@ -50,6 +50,7 @@ from backend.auth import (
 from backend.canvas import register_canvas
 from backend.chat_library import register_chat_library
 from backend.composer import register_composer
+from backend.api.intents_diagnostics import register_diagnostics_intents
 from backend.crash_recovery import maybe_show_crash_notice
 from backend.diagnostics import DiagnosticsState
 from backend.events import (
@@ -244,6 +245,14 @@ def _configure_session(
     canvas_document = register_canvas(
         bus, notifications_state, agent_dispatcher, composer_document, token_counter
     )
+
+    # ADR-016 stage 16.4: the diagnostics topic's two intents (export bundle,
+    # open log folder) - registered here, not immediately next to stage
+    # 16.3's `bus.register_topic("diagnostics", diagnostics.payload)` call
+    # above, because both need canvas_document (the SceneDocument the bundle
+    # tallies node counts from), which does not exist until register_canvas
+    # returns it, right above this line.
+    register_diagnostics_intents(bus, canvas_document, diagnostics)
 
     # ADR-002 stage 2.1d: ONE typed reference from here on
     # (backend/session_context.py), replacing what used to be two loose

--- a/backend/app.py
+++ b/backend/app.py
@@ -51,6 +51,7 @@ from backend.canvas import register_canvas
 from backend.chat_library import register_chat_library
 from backend.composer import register_composer
 from backend.crash_recovery import maybe_show_crash_notice
+from backend.diagnostics import DiagnosticsState
 from backend.events import (
     DEFAULT_COALESCE_WINDOW_SECONDS,
     DEFAULT_SESSION_ID,
@@ -164,6 +165,7 @@ def _configure_session(
     settings_manager: SettingsManager,
     chat_db_path: Path | None,
     previous_run_crashed: bool = False,
+    session_count_fn=None,
 ) -> None:
     """Give every session the R0 topic surface. Later phases extend this
     with canvas/chrome/node topics - one registrar, one place to read the
@@ -197,6 +199,17 @@ def _configure_session(
     token_counter = register_token_counter(bus, settings_manager)
     composer_document = register_composer(bus, token_counter, settings_manager, notifications_state)
 
+    # ADR-016 stage 16.3: in-app diagnostics - fresh per session, same
+    # posture as token_counter/composer_document above (see backend/
+    # diagnostics.py's own module docstring for why this is safe despite
+    # RunRegistry's own logging already existing - explicit callbacks, not
+    # a shared logging.Handler). set_publish_recorder is a post-construction
+    # hook because bus (SessionBus) is already built by the time
+    # _configure_session runs (EventBus.session() constructs it).
+    diagnostics = DiagnosticsState(session_count_fn=session_count_fn)
+    bus.set_publish_recorder(diagnostics.record_publish)
+    bus.register_topic("diagnostics", diagnostics.payload)
+
     # R4 (doc/QT_REMOVAL_PLAN.md): the agent-dispatch service - one
     # AgentDispatcher per session (never a module-level singleton). Reachable
     # via SessionContext (backend/session_context.py) so ws_endpoint's
@@ -219,7 +232,7 @@ def _configure_session(
             api_provider.DEFAULT_RUNTIME.snapshot()
         )
     agent_dispatcher = register_agents(
-        bus, composer_document, notifications_state, settings_manager, provider_runtime
+        bus, composer_document, notifications_state, settings_manager, provider_runtime, diagnostics
     )
 
     # R1 (doc/QT_REMOVAL_PLAN.md): scene document + grid topics.
@@ -346,7 +359,13 @@ def create_app(
     # side effect of building the app.
     bus = EventBus(
         configure_session=lambda session_bus: _configure_session(
-            session_bus, settings_manager, chat_db_path, previous_run_crashed
+            session_bus, settings_manager, chat_db_path, previous_run_crashed,
+            # ADR-016 stage 16.3: `bus` here is EventBus.session()'s host
+            # instance, resolved by Python's normal closure late-binding -
+            # this lambda only ever RUNS after `bus = EventBus(...)` has
+            # fully returned and bound the name in the enclosing scope, even
+            # though it's syntactically referenced mid-construction here.
+            session_count_fn=lambda: len(bus._sessions),
         ),
         # ADR-004 stage 4.3: see _evict_idle_session's own docstring.
         evict_idle_session=_evict_idle_session,

--- a/backend/app.py
+++ b/backend/app.py
@@ -334,6 +334,16 @@ def create_app(
     # SettingsManager exactly ONCE per process - process-global state, not
     # session state (see backend/agents.py's docstring).
     bootstrap_provider_state(settings_manager)
+    # ADR-016 stage 16.1: deliberately NOT calling apply_log_level here -
+    # create_app() is constructed dozens of times per pytest run (every test
+    # that touches the WS/HTTP surface), and mutating the ROOT logger's level
+    # as a side effect of that would silently change what caplog captures for
+    # every unrelated test running afterward (root defaults to WARNING;
+    # nothing here would ever set it back). The real boot path
+    # (graphlink_desktop.py's main(), never invoked by tests) applies the
+    # persisted level once; the live intent (setLogLevel, app-settings topic)
+    # applies a user-initiated change - both explicit, neither an invisible
+    # side effect of building the app.
     bus = EventBus(
         configure_session=lambda session_bus: _configure_session(
             session_bus, settings_manager, chat_db_path, previous_run_crashed

--- a/backend/crash_recovery.py
+++ b/backend/crash_recovery.py
@@ -16,9 +16,12 @@ Same file path/shape as the legacy app for continuity - it's plain JSON with
 no Qt dependency, nothing here needs to change about it.
 
 LOGGING + UNHANDLED-EXCEPTION CAPTURE (ported): configure_logging() attaches
-a RotatingFileHandler to the root logger, same path/rotation/format as
+a RotatingFileHandler to the root logger, same path/rotation as
 graphlink_logging.py's configure_logging() (~/.graphlink/graphlink.log, 2MB
-x3 backups), so the many logger.exception()/logger.error() calls already
+x3 backups). ADR-016 stage 16.1 changed the FILE handler's format from plain
+text to JSON-lines (backend/observability.py's JsonLogFormatter) so the log
+is machine-parseable; the stderr handler below stays plain text. So the
+many logger.exception()/logger.error() calls already
 scattered across backend/ (app.py, autosave.py, agents.py, canvas.py, ...)
 land somewhere durable instead of going nowhere (no root handler is
 configured anywhere in backend/ today) or to stderr, invisible in a
@@ -69,6 +72,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from backend.notifications import NotificationState
+from backend.observability import JsonLogFormatter
 
 _LOG_MAX_BYTES = 2 * 1024 * 1024
 _LOG_BACKUP_COUNT = 3
@@ -118,7 +122,12 @@ def configure_logging(base_dir: Path | str | None = None, level: int = logging.I
     handler = logging.handlers.RotatingFileHandler(
         resolved, maxBytes=_LOG_MAX_BYTES, backupCount=_LOG_BACKUP_COUNT, encoding="utf-8",
     )
-    handler.setFormatter(formatter)
+    # ADR-016 stage 16.1: the file is JSON-lines (one JSON object per line,
+    # with run_id/session/kind/node_id when a call site supplies them via
+    # extra=) so it is machine-parseable - by the diagnostics bundle builder
+    # (stage 16.4) and by grep/jq alike. See observability.py's own
+    # docstring for why stderr below stays plain text.
+    handler.setFormatter(JsonLogFormatter())
 
     root_logger = logging.getLogger()
     root_logger.addHandler(handler)

--- a/backend/diagnostic_bundle.py
+++ b/backend/diagnostic_bundle.py
@@ -1,0 +1,105 @@
+"""ADR-016 stage 16.4: redacted diagnostic bundle + open-log-folder.
+
+REDACTION IS STRUCTURAL, NOT RUNTIME FILTERING. build_diagnostic_bundle's own
+signature is the enforcement mechanism: it accepts exactly a SceneDocument and
+a DiagnosticsState, nothing else - no SettingsManager, no raw log file access,
+no provider/API-key object of any kind. There is no code path inside this
+function that COULD reach an API key, a saved chat, or a node's own
+content/text/title fields, because nothing that owns those values is ever
+passed in. This mirrors the existing crash-report design's own posture
+(backend/crash_recovery.py: an unhandled exception's traceback lands in
+graphlink.log via the excepthook, never in a separate "here is your API key"
+artifact) - "never chat content" is guaranteed by what the builder is even
+capable of reading, not by a filter that could regress by one missed field.
+
+The bundle contains exactly this allowlist, and nothing else:
+  - bundleSchemaVersion: a plain int, bumped whenever this shape changes.
+  - generatedAt: UTC ISO-8601 timestamp of when the bundle was built.
+  - appVersion: graphlink_version.APP_VERSION (the same constant about.py's
+    own about_payload() uses - never graphlink_update.py, which imports
+    PySide6 at module scope; see backend/about.py's own docstring).
+  - os: platform.system()/release()/python_version() - OS/interpreter
+    identification, nothing environment- or account-specific.
+  - nodeCounts: a tally of SceneNode.kind -> count, e.g. {"chat": 3,
+    "code": 1}. COUNTS ONLY - this iterates document.nodes.values() and
+    reads ONLY the `kind` attribute off each node; it never reads `content`,
+    `title`, `history`, or any per-kind state field, so a chat node's actual
+    message text can never reach the bundle through this path.
+  - diagnostics: diagnostics_state.payload() embedded verbatim - itself
+    already redacted by construction (backend/diagnostics.py's own
+    DiagnosticsState.payload(): recentRuns carries only runId/kind/nodeId/
+    outcome/durationSeconds, providerErrors only provider/message/at). The
+    recentRuns fields are content-free by construction the same way
+    nodeCounts is above. providerErrors' `message` is the one field that
+    ISN'T inherently content-free - it starts life as raw str(exc) from
+    whatever exception fired during a chat call, which can embed an
+    absolute filesystem path or even literal chat content (see
+    backend/diagnostics.py's own module docstring and
+    _redact_provider_error_message) - so record_provider_error() itself
+    redacts it down to one of a small, fixed vocabulary of category labels
+    before it is ever stored, and it is THAT already-redacted value this
+    function embeds verbatim, not the original exception text.
+
+See backend/tests/test_diagnostic_bundle.py for the empirical proof: a
+SceneDocument holding a chat node whose content is a canary string, with the
+whole bundle serialized and searched for that string.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from graphlink_version import APP_VERSION
+
+from backend import crash_recovery
+
+if TYPE_CHECKING:
+    from backend.diagnostics import DiagnosticsState
+    from backend.domain.graph import SceneDocument
+
+logger = logging.getLogger(__name__)
+
+BUNDLE_SCHEMA_VERSION = 1
+
+
+def build_diagnostic_bundle(document: SceneDocument, diagnostics_state: DiagnosticsState) -> dict[str, Any]:
+    """Assemble the redacted diagnostic snapshot for an issue report. See
+    this module's own docstring for the exact allowlist and why this
+    function's signature - exactly (document, diagnostics_state), nothing
+    settings- or API-key-shaped - is itself the redaction guarantee."""
+    node_kind_counts: dict[str, int] = {}
+    for node in document.nodes.values():
+        node_kind_counts[node.kind] = node_kind_counts.get(node.kind, 0) + 1
+
+    return {
+        "bundleSchemaVersion": BUNDLE_SCHEMA_VERSION,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "appVersion": APP_VERSION,
+        "os": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "pythonVersion": platform.python_version(),
+        },
+        "nodeCounts": node_kind_counts,
+        "diagnostics": diagnostics_state.payload(),
+    }
+
+
+def open_log_folder() -> bool:
+    """Opens the OS file browser at the log folder (Windows only). A
+    convenience action, never allowed to crash the app: any failure - a
+    non-Windows OS, a missing/unreadable directory, os.startfile itself
+    raising - is caught here and reported as a plain False, never a raised
+    exception reaching the caller."""
+    try:
+        if os.name != "nt":
+            return False
+        os.startfile(str(crash_recovery.log_path().parent))  # noqa: S606 - Windows-only, guarded above
+        return True
+    except Exception:
+        logger.warning("Failed to open log folder", exc_info=True)
+        return False

--- a/backend/diagnostics.py
+++ b/backend/diagnostics.py
@@ -1,0 +1,145 @@
+"""ADR-016 stage 16.3: in-app diagnostics.
+
+Local-only, in-memory, bounded - this is field visibility for the
+maintainer (and a curious user), not a metrics pipeline. Nothing here is
+persisted or leaves the machine.
+
+DiagnosticsState is constructed fresh per session (backend/app.py's
+_configure_session, same posture as TokenCounterState/ComposerDocument) and
+fed by explicit callbacks rather than a shared logging.Handler: RunRegistry
+(backend/run_lifecycle.py) already logs "run claimed"/"run cancelled"/"run
+released" to the "graphlink.run" logger for stage 16.1, but attaching a
+Handler per session to that ONE shared, process-lifetime logger would leak
+a handler every time a session is constructed (this codebase's own test
+suite builds hundreds of SessionBus/AgentDispatcher instances per run) -
+explicit on_claim/on_end callbacks threaded through RunRegistry's
+constructor carry the same data with no such leak, and are trivially
+testable without touching global logging state.
+
+Provider errors are the one genuinely PROCESS-GLOBAL piece: api_provider.py
+is module-level state serving the default session (ADR-006 stage 6.5's own
+"None means the default session" contract), so _translate_chat_exception -
+the single choke point BOTH chat() and chat_stream() funnel every non-cancel
+failure through - records into a module-level bounded deque here, and every
+session's DiagnosticsState.payload() reads the same shared view. This
+matches every session already seeing the same module-global provider
+config today for the default session.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+# -- provider errors (process-global - see module docstring) ---------------
+
+_MAX_PROVIDER_ERRORS = 10
+_provider_errors: deque[dict[str, Any]] = deque(maxlen=_MAX_PROVIDER_ERRORS)
+
+
+def record_provider_error(provider: str, message: str) -> None:
+    _provider_errors.append({"provider": provider, "message": message, "at": time.time()})
+
+
+def provider_errors() -> list[dict[str, Any]]:
+    return list(_provider_errors)
+
+
+def reset_provider_errors() -> None:
+    """Test-only: process-global state must not leak between tests."""
+    _provider_errors.clear()
+
+
+# -- per-session diagnostics -------------------------------------------------
+
+_MAX_RECENT_RUNS = 30
+_MAX_PUBLISH_SAMPLES = 50
+# Publish rate is a trailing window, not a cumulative average - a burst 10
+# minutes ago should not still be inflating "now".
+_PUBLISH_RATE_WINDOW_SECONDS = 10.0
+
+
+@dataclass
+class _RunRecord:
+    run_id: str
+    kind: str
+    node_id: str | None
+    started_at: float
+    ended_at: float | None = None
+    outcome: str | None = None  # "completed" | "cancelled", None while in flight
+
+
+@dataclass
+class DiagnosticsState:
+    session_count_fn: Callable[[], int] | None = None
+    _runs: dict[str, _RunRecord] = field(default_factory=dict, repr=False)
+    _recent_run_ids: deque[str] = field(default_factory=lambda: deque(maxlen=_MAX_RECENT_RUNS), repr=False)
+    _publish_samples: deque[tuple[float, str, int]] = field(
+        default_factory=lambda: deque(maxlen=_MAX_PUBLISH_SAMPLES), repr=False
+    )
+    _publish_count: int = 0
+    _publish_bytes_total: int = 0
+
+    def record_run_claimed(self, run_id: str, kind: str, node_id: str | None) -> None:
+        self._runs[run_id] = _RunRecord(run_id=run_id, kind=kind, node_id=node_id, started_at=time.time())
+        self._recent_run_ids.append(run_id)
+        # A recycled dict never grows unbounded: any run pushed out of the
+        # bounded _recent_run_ids deque is also dropped here, keyed by the
+        # exact ids the deque still references.
+        live_ids = set(self._recent_run_ids)
+        for stale_id in [rid for rid in self._runs if rid not in live_ids]:
+            del self._runs[stale_id]
+
+    def record_run_ended(self, run_id: str, outcome: str) -> None:
+        run = self._runs.get(run_id)
+        if run is None:
+            return  # already evicted by the bounded-history trim above
+        run.ended_at = time.time()
+        run.outcome = outcome
+
+    def record_publish(self, topic: str, byte_size: int) -> None:
+        now = time.time()
+        self._publish_samples.append((now, topic, byte_size))
+        self._publish_count += 1
+        self._publish_bytes_total += byte_size
+
+    def _publish_rate_bytes_per_second(self) -> float:
+        if not self._publish_samples:
+            return 0.0
+        now = time.time()
+        window_start = now - _PUBLISH_RATE_WINDOW_SECONDS
+        windowed = [size for (at, _topic, size) in self._publish_samples if at >= window_start]
+        if not windowed:
+            return 0.0
+        return round(sum(windowed) / _PUBLISH_RATE_WINDOW_SECONDS, 1)
+
+    def payload(self) -> dict[str, Any]:
+        recent_runs = []
+        for run_id in reversed(self._recent_run_ids):
+            run = self._runs.get(run_id)
+            if run is None:
+                continue
+            duration = (run.ended_at - run.started_at) if run.ended_at is not None else None
+            recent_runs.append({
+                "runId": run.run_id,
+                "kind": run.kind,
+                "nodeId": run.node_id,
+                "outcome": run.outcome or "running",
+                "durationSeconds": round(duration, 3) if duration is not None else None,
+            })
+        last_publish = self._publish_samples[-1] if self._publish_samples else None
+        return {
+            "recentRuns": recent_runs,
+            "publishCount": self._publish_count,
+            "publishBytesTotal": self._publish_bytes_total,
+            "lastPublishBytes": last_publish[2] if last_publish is not None else None,
+            "lastPublishTopic": last_publish[1] if last_publish is not None else None,
+            "publishBytesPerSecond": self._publish_rate_bytes_per_second(),
+            "sessionCount": self.session_count_fn() if self.session_count_fn is not None else None,
+            "providerErrors": [
+                {"provider": e["provider"], "message": e["message"], "at": e["at"]}
+                for e in provider_errors()
+            ],
+        }

--- a/backend/diagnostics.py
+++ b/backend/diagnostics.py
@@ -24,6 +24,20 @@ failure through - records into a module-level bounded deque here, and every
 session's DiagnosticsState.payload() reads the same shared view. This
 matches every session already seeing the same module-global provider
 config today for the default session.
+
+record_provider_error's own `message` argument is raw str(exc) from
+whatever exception fired - there is no way to structurally guarantee an
+arbitrary exception's text contains neither a filesystem path (an OSError's
+__str__ embeds the FULL absolute path, including the OS username and any
+private folder/file names - see api_provider.py's _read_attachment_bytes,
+whose own error text interpolates a raw OSError) nor literal chat content
+(some provider SDKs' client-side request validation echoes the offending
+field's literal value). So the raw text is NEVER stored here: see
+_redact_provider_error_message below, which classifies it into one of a
+small, fixed vocabulary of category labels instead - this is the ONE place
+in the whole diagnostics allowlist that isn't inherently content-free by
+construction, so it gets its own explicit redaction step rather than
+inheriting "never chat content" for free the way every other field does.
 """
 
 from __future__ import annotations
@@ -38,9 +52,58 @@ from typing import Any, Callable
 _MAX_PROVIDER_ERRORS = 10
 _provider_errors: deque[dict[str, Any]] = deque(maxlen=_MAX_PROVIDER_ERRORS)
 
+# Keyword (lowercase substring) -> fixed category label, checked in order -
+# first match wins. Deliberately never echoes back any substring of the
+# original message: only ever one of the fixed strings on the right below,
+# or the generic fallback (see _redact_provider_error_message's own
+# docstring for why this can't be a best-effort filter instead).
+_PROVIDER_ERROR_CATEGORIES: tuple[tuple[str, str], ...] = (
+    ("no longer available", "attachment file unavailable"),
+    ("failed to read attached", "attachment file unavailable"),
+    ("timed out", "request timed out"),
+    ("timeout", "request timed out"),
+    ("429", "rate limited or quota exceeded"),
+    ("quota", "rate limited or quota exceeded"),
+    ("resourceexhausted", "rate limited or quota exceeded"),
+    ("rate limit", "rate limited or quota exceeded"),
+    ("401", "authentication failed"),
+    ("403", "authentication failed"),
+    ("unauthorized", "authentication failed"),
+    ("forbidden", "authentication failed"),
+    ("api key", "authentication failed"),
+    ("apikey", "authentication failed"),
+    ("404", "resource not found"),
+    ("not found", "resource not found"),
+    ("connection", "connection failed"),
+    ("connect", "connection failed"),
+    ("network", "connection failed"),
+    ("refused", "connection failed"),
+)
+_GENERIC_PROVIDER_ERROR_CATEGORY = "provider error (see application log for detail)"
+
+
+def _redact_provider_error_message(message: str) -> str:
+    """Classifies `message` (raw str(exc)) into one of the fixed category
+    labels in _PROVIDER_ERROR_CATEGORIES above, falling back to a generic
+    label when nothing matches. NEVER returns any substring of `message`
+    itself - a regex that only strips out "known-dangerous-looking"
+    patterns (e.g. absolute paths) would still leak whatever it doesn't
+    recognize (arbitrary chat content echoed by an SDK's own validation
+    error, say), which is exactly the failure this function exists to
+    close off structurally rather than best-effort."""
+    lowered = message.lower()
+    for needle, category in _PROVIDER_ERROR_CATEGORIES:
+        if needle in lowered:
+            return category
+    return _GENERIC_PROVIDER_ERROR_CATEGORY
+
 
 def record_provider_error(provider: str, message: str) -> None:
-    _provider_errors.append({"provider": provider, "message": message, "at": time.time()})
+    _provider_errors.append({
+        "provider": provider,
+        "message": _redact_provider_error_message(message),
+        "at": time.time(),
+    })
 
 
 def provider_errors() -> list[dict[str, Any]]:

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -2012,6 +2012,11 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
             "completionTokens": (
                 n.state.completion_tokens if isinstance(n.state, ChatState) else None
             ),
+            # ADR-016 stage 16.2: the cost snapshot taken when usage was
+            # stamped - see ChatState.estimated_cost_usd's own comment.
+            "estimatedCostUsd": (
+                n.state.estimated_cost_usd if isinstance(n.state, ChatState) else None
+            ),
             # ADR-007 stage 7.4: see ChatState.tool_invocations' own comment
             # and ToolInvocationRow's own docstring (contracts/graphlink_
             # scene_payload.py) for why `arguments` is JSON-encoded here

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -705,6 +705,14 @@ class ChatState(NodeState):
     # replies also stamp as of 6.8.
     prompt_tokens: int | None = None
     completion_tokens: int | None = None
+    # ADR-016 stage 16.2: the USD cost estimated AT THE TIME this reply's
+    # usage was stamped (backend/api/intents_chat.py's _on_usage, via
+    # TokenCounterState.estimate_cost_for) - a snapshot, not a live
+    # recomputation, so an override changed later does not retroactively
+    # rewrite what an already-completed reply is shown to have cost. None
+    # for every node prompt_tokens/completion_tokens is also None for, plus
+    # local providers' genuine $0.00 and unknown-model's genuine "no guess".
+    estimated_cost_usd: float | None = None
     # ADR-007 stage 7.4: this turn's tool calls + their results, in call
     # order - empty for the overwhelming majority of chat nodes (no tool-use
     # loop exists yet to populate this; ADR-008 is the first real writer).

--- a/backend/evals/README.md
+++ b/backend/evals/README.md
@@ -1,0 +1,116 @@
+# Local evals harness (ADR-016 stage 16.5)
+
+A lightweight, local eval harness: golden fixtures + optional live-provider
+run for the agent/chart/structured-output paths (see
+`doc/adr/ADR-016-observability-and-cost.md`, section "4. Evals harness").
+Kept off-CI on purpose: the default mode is deterministic and CI-safe (see
+`backend/tests/test_evals_harness.py`), but the point of the harness is to
+be reproducible locally with either a scripted response or a real model.
+
+## The three dimensions
+
+- **chart** - drives the real `ChartDataAgent.get_response` (in
+  `graphlink_chart_agent.py`) and canonicalizes the result the same way
+  `backend/api/intents_chart.py`'s `generate_chart` does downstream, via
+  `graphlink_chart_data.canonicalize_chart_data`.
+- **structured_output** - drives the real `backend.structured_output.respond_json`
+  against a JSON Schema + scripted model response.
+- **agent_build** - ADR-008's Builder agent tool-use loop does not exist as
+  shipped code yet (design-doc only - see
+  `doc/adr/ADR-008-agentic-graph-construction.md`, stages 8.1-8.6). This
+  dimension always reports `status="not_implemented"`, on every fixture,
+  and never raises - it exists as honest scaffolding for when the loop
+  actually ships.
+
+## Running it
+
+```
+python -m backend.evals            # default: scripted responses, deterministic, no network
+python -m backend.evals --live     # real, already-configured provider
+```
+
+Default mode patches `api_provider.chat` with `unittest.mock.patch.object`
+so it never touches a real provider or the network - safe to run anytime,
+on any machine, with no configuration. It exits nonzero if any fixture's
+`status == "failed"`. `status == "not_implemented"` (the whole agent_build
+dimension, today) is informational and never fails the exit code.
+
+`--live` skips the patch and calls straight through to whatever provider is
+actually configured for this machine (a real API key, or a running Ollama/
+llama.cpp instance) - this is the "optional LLM-judge" mode the ADR
+mentions; there is no separate judging model wired in beyond that
+straight call-through, and a live run's result depends on that day's real
+model output, so it is not expected to be as stable as the default mode.
+
+The same fixtures also run under `pytest` in default (patched) mode - see
+`backend/tests/test_evals_harness.py`, part of the normal CI suite.
+
+## Fixture shape
+
+Each fixture is one JSON file under `backend/evals/fixtures/<kind>/`, where
+`<kind>` is `chart`, `structured_output`, or `agent_build`:
+
+```json
+{
+  "name": "unique_fixture_name",
+  "kind": "chart",
+  "input": { "...": "whatever the scorer for this kind needs" },
+  "scripted_response": "the exact raw text a model would emit",
+  "expected": { "...": "the exact value a passing run should produce" }
+}
+```
+
+- `name` is optional (falls back to the filename minus `.json`).
+- `scripted_response` and `expected` may both be `null` (used by the
+  `agent_build` placeholder fixture, since that dimension never reads
+  either field).
+
+### chart fixtures
+
+`input` needs `chart_type` (`"bar"` / `"line"` / `"pie"` / `"histogram"` /
+`"sankey"`) and `source_text` (what a user's node history would contain).
+`scripted_response` is the exact raw JSON text a model would emit for that
+`chart_type`, matching the `STRUCTURE` documented in
+`ChartDataAgent.CHART_PROMPTS[chart_type]` in `graphlink_chart_agent.py`.
+
+`expected` must be the **actual** output of
+`canonicalize_chart_data(json.loads(scripted_response), chart_type)` - do
+not hand-write it. Some chart types add defaulted fields that are easy to
+miss by inspection alone (for example, `canonicalize_chart_data` adds
+`xAxis`/`yAxis` defaults for `pie` charts even though pie's own model-facing
+prompt never asks for them) - derive `expected` by actually running the
+function:
+
+```python
+import json
+from graphlink_chart_data import canonicalize_chart_data
+
+data = json.loads(scripted_response)
+print(json.dumps(canonicalize_chart_data(data, chart_type), indent=2))
+```
+
+### structured_output fixtures
+
+`input` needs `schema` (a JSON Schema dict, in the subset
+`backend/structured_output.py` validates - `type`/`properties`/`required`/
+`items`/`enum`), `messages` (the chat messages list), and optionally `task`
+(defaults to `"task_chat"`) and `schema_name` (defaults to `"response"`).
+`scripted_response` is the exact raw text a model would emit;  `expected` is
+the parsed dict `respond_json` should return.
+
+### agent_build fixtures
+
+`input` can be anything descriptive (for example `{"goal": "..."}`) - the
+scorer never inspects it. These fixtures exist to name the builds this
+dimension will eventually cover, not to be scored today.
+
+## Adding a fixture
+
+1. Pick the right `fixtures/<kind>/` directory.
+2. Write a new `*.json` file following the shape above - any filename
+   works, fixtures are loaded in filename-sorted order.
+3. For a chart fixture, derive `expected` by actually running
+   `canonicalize_chart_data` (see above) - never hand-write it.
+4. Run `python -m backend.evals` and confirm your new fixture shows `PASS`.
+5. If it should be part of CI, add or extend a case in
+   `backend/tests/test_evals_harness.py`.

--- a/backend/evals/__init__.py
+++ b/backend/evals/__init__.py
@@ -1,0 +1,41 @@
+"""ADR-016 stage 16.5: local evals harness (goldens + optional judge) for the
+agent/chart/structured-output paths.
+
+Local-only, reproducible, off-CI by default. Three dimensions:
+
+- **chart**: does ``ChartDataAgent.get_response`` + ``canonicalize_chart_data``
+  turn a scripted model response into the exact canonical chart payload
+  (backend/api/intents_chart.py's own downstream shape)? Real, working code.
+- **structured_output**: does ``backend.structured_output.respond_json`` parse
+  a scripted model response into the exact expected dict for a given JSON
+  Schema? Real, working code.
+- **agent_build**: ADR-008's Builder agent tool-use loop (plan -> propose
+  tool call -> execute -> observe -> checkpoint) is design-doc text only
+  today - no ``create_node``/``run_node`` tool, no loop, no checkpoints ship
+  yet (see doc/adr/ADR-008-agentic-graph-construction.md, stages 8.1-8.6, all
+  pending). This dimension is honest scaffolding: it always reports
+  ``not_implemented``, never a fake pass and never an exception.
+
+Run it: ``python -m backend.evals`` (add ``--live`` to hit a real,
+already-configured provider instead of a scripted/patched response - see
+backend/evals/README.md).
+"""
+
+from backend.evals.fixtures import EvalFixture, load_fixtures
+from backend.evals.runner import (
+    EvalResult,
+    run_agent_build_fixture,
+    run_all,
+    run_chart_fixture,
+    run_structured_output_fixture,
+)
+
+__all__ = [
+    "EvalFixture",
+    "load_fixtures",
+    "EvalResult",
+    "run_agent_build_fixture",
+    "run_all",
+    "run_chart_fixture",
+    "run_structured_output_fixture",
+]

--- a/backend/evals/__main__.py
+++ b/backend/evals/__main__.py
@@ -1,0 +1,69 @@
+"""ADR-016 stage 16.5 eval harness CLI.
+
+    python -m backend.evals            # default: scripted responses, deterministic, no network
+    python -m backend.evals --live     # real, already-configured provider - see README.md
+
+Prints a pass/fail/not_implemented table and exits nonzero if ANY result has
+status == "failed". A "not_implemented" result (the agent_build dimension,
+today) is expected/informational and never affects the exit code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from backend.evals.runner import EvalResult, run_all
+
+_STATUS_LABEL = {
+    "passed": "PASS",
+    "failed": "FAIL",
+    "not_implemented": "N/A ",
+}
+
+
+def _print_table(results: list[EvalResult]) -> None:
+    if not results:
+        print("No eval fixtures found.")
+        return
+
+    name_width = max(len("fixture"), *(len(r.fixture_name) for r in results))
+    kind_width = max(len("kind"), *(len(r.kind) for r in results))
+
+    header = f"{'STATUS':<5} {'kind':<{kind_width}} {'fixture':<{name_width}}  detail"
+    print(header)
+    print("-" * len(header))
+    for result in results:
+        label = _STATUS_LABEL.get(result.status, result.status.upper())
+        first_line = result.detail.splitlines()[0] if result.detail else ""
+        print(f"{label:<5} {result.kind:<{kind_width}} {result.fixture_name:<{name_width}}  {first_line}")
+        for extra_line in result.detail.splitlines()[1:]:
+            print(" " * (5 + 1 + kind_width + 1 + name_width + 2) + extra_line)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m backend.evals",
+        description="ADR-016 stage 16.5 local eval harness (chart / structured_output / agent_build).",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="skip the scripted-response patch and call the real, already-configured provider",
+    )
+    args = parser.parse_args(argv)
+
+    results = run_all(live=args.live)
+    _print_table(results)
+
+    passed = sum(1 for r in results if r.status == "passed")
+    failed = sum(1 for r in results if r.status == "failed")
+    not_implemented = sum(1 for r in results if r.status == "not_implemented")
+    print()
+    print(f"{passed} passed, {failed} failed, {not_implemented} not_implemented ({len(results)} total)")
+
+    return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/evals/fixtures.py
+++ b/backend/evals/fixtures.py
@@ -1,0 +1,56 @@
+"""Golden-fixture loading for the ADR-016 stage 16.5 eval harness.
+
+A fixture is a plain JSON file under ``backend/evals/fixtures/<kind>/``. See
+backend/evals/README.md for the exact on-disk shape and how to add one.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+FIXTURES_ROOT = Path(__file__).resolve().parent / "fixtures"
+
+# The three ADR-016 eval dimensions - see backend/evals/__init__.py's own
+# docstring for what real code (or, for agent_build, honest stub) backs each.
+VALID_KINDS = ("chart", "structured_output", "agent_build")
+
+
+@dataclass(frozen=True)
+class EvalFixture:
+    name: str
+    kind: str  # one of VALID_KINDS
+    input: dict
+    scripted_response: str | None
+    expected: dict | None
+
+
+def load_fixtures(kind: str) -> list[EvalFixture]:
+    """Reads every ``*.json`` file under ``backend/evals/fixtures/<kind>/``
+    and returns one :class:`EvalFixture` per file, sorted by filename for a
+    stable, reproducible run order. A ``kind`` directory that does not exist
+    yet is not an error - it simply contributes zero fixtures (mirrors the
+    agent_build dimension today, which ships scaffolding but no goldens are
+    required for it to be meaningful)."""
+    if kind not in VALID_KINDS:
+        raise ValueError(f"Unknown eval fixture kind: {kind!r} (expected one of {VALID_KINDS})")
+
+    kind_dir = FIXTURES_ROOT / kind
+    if not kind_dir.is_dir():
+        return []
+
+    fixtures: list[EvalFixture] = []
+    for path in sorted(kind_dir.glob("*.json")):
+        with path.open("r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+        fixtures.append(
+            EvalFixture(
+                name=raw.get("name", path.stem),
+                kind=kind,
+                input=raw.get("input", {}) or {},
+                scripted_response=raw.get("scripted_response"),
+                expected=raw.get("expected"),
+            )
+        )
+    return fixtures

--- a/backend/evals/fixtures/agent_build/research_and_summarize_branch.json
+++ b/backend/evals/fixtures/agent_build/research_and_summarize_branch.json
@@ -1,0 +1,9 @@
+{
+  "name": "research_and_summarize_branch",
+  "kind": "agent_build",
+  "input": {
+    "goal": "Research a topic and produce a cited summary + chart branch on the canvas."
+  },
+  "scripted_response": null,
+  "expected": null
+}

--- a/backend/evals/fixtures/chart/bar_support_tickets.json
+++ b/backend/evals/fixtures/chart/bar_support_tickets.json
@@ -1,0 +1,17 @@
+{
+  "name": "bar_support_tickets",
+  "kind": "chart",
+  "input": {
+    "chart_type": "bar",
+    "source_text": "Our support team resolved this month's tickets by category: 42 tickets for billing issues, 87 for login problems, 65 for feature requests, and 23 for bug reports."
+  },
+  "scripted_response": "{\"type\": \"bar\", \"title\": \"Support Tickets by Category\", \"labels\": [\"Billing Issues\", \"Login Problems\", \"Feature Requests\", \"Bug Reports\"], \"values\": [42, 87, 65, 23], \"xAxis\": \"Category\", \"yAxis\": \"Ticket Count\"}",
+  "expected": {
+    "type": "bar",
+    "title": "Support Tickets by Category",
+    "labels": ["Billing Issues", "Login Problems", "Feature Requests", "Bug Reports"],
+    "values": [42, 87, 65, 23],
+    "xAxis": "Category",
+    "yAxis": "Ticket Count"
+  }
+}

--- a/backend/evals/fixtures/chart/line_daily_active_users.json
+++ b/backend/evals/fixtures/chart/line_daily_active_users.json
@@ -1,0 +1,17 @@
+{
+  "name": "line_daily_active_users",
+  "kind": "chart",
+  "input": {
+    "chart_type": "line",
+    "source_text": "Daily active users this week: Monday 3200, Tuesday 3450, Wednesday 3100, Thursday 3800, Friday 4200, Saturday 2900, Sunday 2700."
+  },
+  "scripted_response": "{\"type\": \"line\", \"title\": \"Daily Active Users This Week\", \"labels\": [\"Monday\", \"Tuesday\", \"Wednesday\", \"Thursday\", \"Friday\", \"Saturday\", \"Sunday\"], \"values\": [3200, 3450, 3100, 3800, 4200, 2900, 2700], \"xAxis\": \"Day\", \"yAxis\": \"Active Users\"}",
+  "expected": {
+    "type": "line",
+    "title": "Daily Active Users This Week",
+    "labels": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+    "values": [3200, 3450, 3100, 3800, 4200, 2900, 2700],
+    "xAxis": "Day",
+    "yAxis": "Active Users"
+  }
+}

--- a/backend/evals/fixtures/chart/pie_engineering_budget.json
+++ b/backend/evals/fixtures/chart/pie_engineering_budget.json
@@ -1,0 +1,17 @@
+{
+  "name": "pie_engineering_budget",
+  "kind": "chart",
+  "input": {
+    "chart_type": "pie",
+    "source_text": "Our engineering budget breaks down as follows: 45% infrastructure, 30% personnel, 15% tooling, and 10% contingency."
+  },
+  "scripted_response": "{\"type\": \"pie\", \"title\": \"Engineering Budget Allocation\", \"labels\": [\"Infrastructure\", \"Personnel\", \"Tooling\", \"Contingency\"], \"values\": [45, 30, 15, 10]}",
+  "expected": {
+    "type": "pie",
+    "title": "Engineering Budget Allocation",
+    "labels": ["Infrastructure", "Personnel", "Tooling", "Contingency"],
+    "values": [45, 30, 15, 10],
+    "xAxis": "Sequence",
+    "yAxis": "Value"
+  }
+}

--- a/backend/evals/fixtures/structured_output/summary_with_confidence.json
+++ b/backend/evals/fixtures/structured_output/summary_with_confidence.json
@@ -1,0 +1,26 @@
+{
+  "name": "summary_with_confidence",
+  "kind": "structured_output",
+  "input": {
+    "task": "task_chat",
+    "schema_name": "summary_response",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "summary": {"type": "string"},
+        "confidence": {"type": "number"},
+        "tags": {"type": "array", "items": {"type": "string"}}
+      },
+      "required": ["summary", "confidence", "tags"]
+    },
+    "messages": [
+      {"role": "user", "content": "Summarize: Quarterly revenue grew 12%, driven by the EU region."}
+    ]
+  },
+  "scripted_response": "{\"summary\": \"Quarterly revenue grew 12%, driven by the EU region.\", \"confidence\": 0.82, \"tags\": [\"revenue\", \"quarterly\", \"EU\"]}",
+  "expected": {
+    "summary": "Quarterly revenue grew 12%, driven by the EU region.",
+    "confidence": 0.82,
+    "tags": ["revenue", "quarterly", "EU"]
+  }
+}

--- a/backend/evals/runner.py
+++ b/backend/evals/runner.py
@@ -1,0 +1,179 @@
+"""ADR-016 stage 16.5 eval scorers: one function per eval dimension, plus
+``run_all`` to run every shipped fixture across all three.
+
+Default (``live=False``) mode patches ``api_provider.chat`` with
+``unittest.mock.patch.object`` so a run is fully deterministic and safe on
+any machine, with no configured provider and no network - this is the mode
+backend/tests/test_evals_harness.py exercises, and the mode
+``python -m backend.evals`` uses unless ``--live`` is passed. ``patch.object``
+is used (not pytest's own ``monkeypatch`` fixture) specifically because this
+module must also work as a plain script outside pytest - see
+backend/evals/README.md.
+
+``live=True`` skips the patch and lets api_provider.chat() reach whatever
+provider is actually configured (a real API key, or a running Ollama/
+llama.cpp) - a human running this manually, per the ADR's own "+ optional
+LLM-judge" language. This module does not implement judging logic beyond
+that straight call-through: there is no scoring model in the loop, only the
+same deterministic scorers used in patched mode, now fed a real response.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from unittest import mock
+
+import api_provider
+from graphlink_chart_agent import ChartDataAgent
+from graphlink_chart_data import ChartDataError, canonicalize_chart_data
+
+from backend.evals.fixtures import EvalFixture, load_fixtures
+from backend.structured_output import StructuredOutputError, respond_json
+
+# Valid EvalResult.status values. "not_implemented" is informational, never
+# a failure - see run_agent_build_fixture and backend/evals/__main__.py's
+# exit-code logic.
+_STATUSES = ("passed", "failed", "not_implemented")
+
+
+@dataclass(frozen=True)
+class EvalResult:
+    fixture_name: str
+    kind: str
+    status: str  # one of _STATUSES
+    detail: str
+
+
+def _pretty(data) -> str:
+    return json.dumps(data, indent=2, sort_keys=True, default=str)
+
+
+def _mismatch_detail(actual, expected) -> str:
+    return (
+        "output did not match the golden fixture's expected value.\n"
+        f"--- actual ---\n{_pretty(actual)}\n"
+        f"--- expected ---\n{_pretty(expected)}"
+    )
+
+
+def _scripted_chat(fixture: EvalFixture):
+    """The single fake-response seam: every call to api_provider.chat()
+    returns fixture.scripted_response verbatim, regardless of task/messages/
+    kwargs. Works both inside pytest and as a standalone script (unlike
+    pytest's own monkeypatch fixture, which only exists inside a test)."""
+    return mock.patch.object(
+        api_provider, "chat", return_value={"message": {"content": fixture.scripted_response}}
+    )
+
+
+# -- chart ------------------------------------------------------------------
+
+
+def run_chart_fixture(fixture: EvalFixture, *, live: bool = False) -> EvalResult:
+    """Drives the real ChartDataAgent.get_response, then canonicalizes the
+    result exactly the way backend/api/intents_chart.py's generate_chart
+    does downstream (``canonicalize_chart_data(result, chart_type)`` on the
+    parsed agent output) before diffing against fixture.expected."""
+    chart_type = fixture.input["chart_type"]
+    source_text = fixture.input["source_text"]
+    agent = ChartDataAgent()
+
+    if live:
+        raw = agent.get_response(source_text, chart_type)
+    else:
+        with _scripted_chat(fixture):
+            raw = agent.get_response(source_text, chart_type)
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return EvalResult(
+            fixture.name, "chart", "failed",
+            f"agent response was not valid JSON: {exc}\nraw response: {raw[:500]}",
+        )
+
+    # Mirrors start_chart_generation's own check (backend/agents.py) for
+    # ChartDataAgent's fully-degraded case.
+    if isinstance(parsed, dict) and "error" in parsed:
+        return EvalResult(fixture.name, "chart", "failed", f"agent returned an error payload: {parsed['error']}")
+
+    try:
+        canonical = canonicalize_chart_data(parsed, chart_type)
+    except ChartDataError as exc:
+        return EvalResult(fixture.name, "chart", "failed", f"agent output failed canonicalization: {exc}")
+
+    if fixture.expected is not None and canonical != fixture.expected:
+        return EvalResult(fixture.name, "chart", "failed", _mismatch_detail(canonical, fixture.expected))
+
+    return EvalResult(fixture.name, "chart", "passed", "canonical chart output matched the golden fixture")
+
+
+# -- structured_output --------------------------------------------------
+
+
+def run_structured_output_fixture(fixture: EvalFixture, *, live: bool = False) -> EvalResult:
+    """Drives the real backend.structured_output.respond_json against
+    fixture.input's schema/messages, and diffs the parsed dict against
+    fixture.expected."""
+    task = fixture.input.get("task", "task_chat")
+    schema = fixture.input["schema"]
+    schema_name = fixture.input.get("schema_name", "response")
+    messages = fixture.input["messages"]
+
+    try:
+        if live:
+            result = respond_json(task, messages, schema, schema_name=schema_name)
+        else:
+            with _scripted_chat(fixture):
+                result = respond_json(task, messages, schema, schema_name=schema_name)
+    except StructuredOutputError as exc:
+        return EvalResult(
+            fixture.name, "structured_output", "failed",
+            f"respond_json raised StructuredOutputError: {exc}",
+        )
+
+    if fixture.expected is not None and result != fixture.expected:
+        return EvalResult(fixture.name, "structured_output", "failed", _mismatch_detail(result, fixture.expected))
+
+    return EvalResult(fixture.name, "structured_output", "passed", "parsed object matched the golden fixture")
+
+
+# -- agent_build (ADR-008 stub) ----------------------------------------------
+
+
+def run_agent_build_fixture(fixture: EvalFixture, *, live: bool = False) -> EvalResult:
+    """ADR-008's Builder agent tool-use loop (plan -> propose tool call ->
+    execute -> observe -> checkpoint) does not exist as shipped code - it is
+    design-doc text only (doc/adr/ADR-008-agentic-graph-construction.md,
+    stages 8.1-8.6, all pending: no create_node/run_node tool, no loop, no
+    checkpoints). Scoring "did the build succeed" against nothing to run is
+    not meaningful, so this dimension is honest scaffolding: it ALWAYS
+    reports not_implemented, on every fixture, regardless of input - never a
+    fake pass, and never an exception that would misread as a harness bug
+    once a real loop lands here. ``live`` is accepted for interface
+    symmetry with the other two runners but has no effect."""
+    return EvalResult(
+        fixture.name,
+        "agent_build",
+        "not_implemented",
+        "ADR-008 Builder agent loop is not implemented yet - this dimension is "
+        "scaffolding only, see doc/adr/ADR-008-agentic-graph-construction.md",
+    )
+
+
+# -- run everything -----------------------------------------------------
+
+
+def run_all(*, live: bool = False) -> list[EvalResult]:
+    """Loads and runs every fixture across all three eval kinds, in a
+    stable order (chart, then structured_output, then agent_build)."""
+    results: list[EvalResult] = []
+    for kind, run_fixture in (
+        ("chart", run_chart_fixture),
+        ("structured_output", run_structured_output_fixture),
+        ("agent_build", run_agent_build_fixture),
+    ):
+        for fixture in load_fixtures(kind):
+            results.append(run_fixture(fixture, live=live))
+    return results

--- a/backend/events.py
+++ b/backend/events.py
@@ -78,6 +78,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import inspect
+import json
 import logging
 import time
 from typing import Any, Awaitable, Callable, Protocol
@@ -375,6 +376,7 @@ class SessionBus:
         *,
         coalesce_window_seconds: float = 0.0,
         send_queue_maxsize: int = DEFAULT_SEND_QUEUE_MAXSIZE,
+        on_publish: Callable[[str, int], None] | None = None,
     ):
         """`coalesce_window_seconds` > 0 batches publishes of the SAME topic
         arriving within that window into one outbound message (ADR-003 stage
@@ -388,6 +390,14 @@ class SessionBus:
         `send_queue_maxsize` bounds each BUFFERED connection's outbound queue
         (see attach(buffered=True) and _BufferedConnection)."""
         self.session_id = session_id
+        # ADR-016 stage 16.3: optional - fires with (topic, serialized byte
+        # size) from _broadcast, once per outbound message. None by default
+        # (every test-constructed SessionBus, and this codebase has
+        # hundreds) - a single None-check, so nothing pays the extra
+        # json.dumps _broadcast otherwise has no reason to do (send_json
+        # implementations serialize on their own; this is diagnostics-only
+        # measurement, not the real wire encode).
+        self._on_publish = on_publish
         self._topics: dict[str, _Topic] = {}
         self._intents: dict[tuple[str, str], _IntentRegistration] = {}
         self._connections: set[Connection] = set()
@@ -406,6 +416,13 @@ class SessionBus:
         # its idle clock immediately, rather than being permanently exempt
         # from eviction by never having transitioned FROM connected.
         self.idle_since: float | None = time.monotonic()
+
+    def set_publish_recorder(self, on_publish: Callable[[str, int], None] | None) -> None:
+        """ADR-016 stage 16.3: post-construction hook for callers like
+        backend/app.py's _configure_session, which only receives the
+        already-constructed bus (via EventBus.session()) - never a chance
+        to pass on_publish at __init__ time."""
+        self._on_publish = on_publish
 
     # -- registration ------------------------------------------------------
 
@@ -678,6 +695,14 @@ class SessionBus:
         """Send one message to every attached connection, detaching any that
         fails. Snapshot the set first: a failed send detaches mid-loop, and a
         dead socket must never poison the broadcast for the rest."""
+        if self._on_publish is not None:
+            # ADR-016 stage 16.3: measured once per broadcast, not per
+            # connection - every attached connection receives the SAME
+            # message, so the size is a property of the publish, not the
+            # fan-out. json.dumps mirrors what a real send_json would
+            # serialize closely enough for a diagnostics estimate (exact
+            # wire bytes depend on the transport's own encoder).
+            self._on_publish(message.get("topic", ""), len(json.dumps(message)))
         for conn in list(self._connections):
             buffered_conn = self._buffered.get(conn)
             if buffered_conn is not None:

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -1,0 +1,78 @@
+"""ADR-016 stage 16.1: structured JSON-lines logging for the run lifecycle.
+
+JsonLogFormatter renders one JSON object per log line - timestamp, level,
+logger name, message, thread, plus whatever of `run_id`/`session_id`/`kind`/
+`node_id` the call site attached via `extra={...}`. Wired onto the ROTATING
+FILE handler only (backend/crash_recovery.py's configure_logging) - the
+stderr StreamHandler stays plain-text, because that channel exists purely so
+`python graphlink_desktop.py` run from a terminal is readable at a glance
+(see that module's own docstring on why stderr was restored after the audit
+fix that had silently dropped it). The file is what tooling/diagnostics
+bundles (ADR-016 stage 16.4) and a human `grep`/`jq` actually parse, so that
+is the one that needs a machine-readable shape.
+
+Extra fields are passed explicitly via `extra={"run_id": ...}` at each call
+site rather than threaded through a contextvars.ContextVar. A ContextVar set
+inside RunRegistry.claim() would leak into unrelated log lines processed
+later by the SAME long-lived coroutine (the WS read loop handles many
+requests over its lifetime in one coroutine - see run_lifecycle.py's own
+docstring on why claim() must stay a plain synchronous call with no `await`
+in between); explicit `extra=` at each call site has no such cross-call
+leak risk and matches how every existing `logger.exception(...)` call in
+this codebase already looks.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+
+_VALID_LEVEL_NAMES = ("DEBUG", "INFO", "WARNING", "ERROR")
+
+# The record attributes this formatter promotes into the JSON payload when a
+# call site supplies them via extra=. Never required - a plain
+# `logger.info("message")` with no extra still produces valid JSON, just
+# without these keys.
+_EXTRA_FIELDS = ("run_id", "session_id", "kind", "node_id")
+
+
+class JsonLogFormatter(logging.Formatter):
+    """One JSON object per line. Not a subclass of any stdlib JSON logging
+    helper - stdlib ships none; this is a small, dependency-free formatter
+    matching the codebase's established "hand-roll a narrow, purpose-fit
+    implementation instead of adding a dependency" precedent (structured_output.py,
+    mcp_client.py)."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "ts": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+            "thread": record.threadName,
+        }
+        for field in _EXTRA_FIELDS:
+            value = getattr(record, field, None)
+            if value is not None:
+                payload[field] = value
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+        # ensure_ascii=False: this is a local log file, not a network
+        # payload - keep non-ASCII text (user content in exception messages)
+        # readable rather than \uXXXX-escaped.
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def apply_log_level(level_name: str) -> None:
+    """Sets the ROOT logger's level at runtime - safe to call any time after
+    configure_logging() has attached its handlers (backend/crash_recovery.py),
+    including from a live settings-change intent, unlike configure_logging()
+    itself which is a one-shot, idempotent, process-wide setup call. An
+    unrecognized name is a silent no-op (matches every other SettingsManager
+    setter's closed-vocabulary posture - see set_log_level's own validation)
+    rather than raising, since a stale/corrupted settings value must never
+    crash startup over something as low-stakes as verbosity."""
+    if level_name not in _VALID_LEVEL_NAMES:
+        return
+    logging.getLogger().setLevel(getattr(logging, level_name))

--- a/backend/run_lifecycle.py
+++ b/backend/run_lifecycle.py
@@ -71,12 +71,26 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 import threading
 import uuid
 from dataclasses import dataclass
 from typing import Any, Callable
 
 from backend.events import SessionBus  # type hint only
+
+# ADR-016 stage 16.1: every one of the app's dispatch surfaces (chat, chart,
+# note, image, web research, artifact, gitlink x2, pycoder, code sandbox - 12
+# kinds and counting) claims into and releases from ONE RunRegistry per
+# session (see this module's own docstring above). Logging at claim()/
+# cancel()/_pop() instead of at each of those 12 call sites gives every run,
+# past and future, a traced lifecycle for free - no per-surface duplication,
+# and no surface can forget to log. Deliberately explicit extra={} fields
+# rather than a contextvars-based run_id (see backend/observability.py's own
+# docstring for why): claim() is a plain synchronous method called from many
+# different call sites, so there is no single "task body" to scope a
+# ContextVar.set()/reset() around here.
+_logger = logging.getLogger("graphlink.run")
 
 
 @dataclass
@@ -220,6 +234,10 @@ class RunRegistry:
             loop=loop,
         )
         self._handles[handle.request_id] = handle
+        _logger.info(
+            "run claimed",
+            extra={"run_id": handle.request_id, "kind": kind, "node_id": node_id},
+        )
         return handle
 
     def attach_task(self, handle: RunHandle, task: asyncio.Task) -> None:
@@ -243,6 +261,10 @@ class RunRegistry:
             future = handle.approval_future
             if future is not None and not future.done():
                 future.set_result(False)
+            _logger.info(
+                "run released",
+                extra={"run_id": request_id, "kind": handle.kind, "node_id": handle.node_id},
+            )
         return handle
 
     def release(self, request_id: str) -> bool:
@@ -287,6 +309,10 @@ class RunRegistry:
             handle.on_cancel()
             fired = True
         if fired:
+            _logger.info(
+                "run cancelled",
+                extra={"run_id": request_id, "kind": handle.kind, "node_id": handle.node_id},
+            )
             # ADR-006 stage 6.2: cancel frees the slot IMMEDIATELY. Before
             # this, release() lived only in the run's `finally`, downstream
             # of an uninterruptible asyncio.to_thread - so is_busy stayed
@@ -342,6 +368,10 @@ class RunRegistry:
                 handle.on_cancel()
                 fired = True
             if fired:
+                _logger.info(
+                    "run cancelled",
+                    extra={"run_id": handle.request_id, "kind": handle.kind, "node_id": handle.node_id},
+                )
                 self._finish_cancel(handle.request_id, handle)
 
     def has_any_live_work(self) -> bool:

--- a/backend/run_lifecycle.py
+++ b/backend/run_lifecycle.py
@@ -187,7 +187,22 @@ class RunRegistry:
     """One in-flight-run registry per AgentDispatcher (session-scoped,
     like the dicts it replaces - never a module-level singleton)."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        on_claim: Callable[[str, str, str | None], None] | None = None,
+        on_end: Callable[[str, str], None] | None = None,
+    ) -> None:
+        # ADR-016 stage 16.3: optional diagnostics hooks - on_claim(run_id,
+        # kind, node_id) fires alongside the "run claimed" log line, on_end
+        # (run_id, outcome) alongside "run cancelled"/"run released".
+        # Explicit callbacks rather than a shared logging.Handler on
+        # "graphlink.run" (see backend/diagnostics.py's own docstring for
+        # why that would leak a handler per session). None by default so
+        # every existing RunRegistry() call site (dozens across the test
+        # suite) is unaffected.
+        self._on_claim = on_claim
+        self._on_end = on_end
         self._handles: dict[str, RunHandle] = {}
         # ADR-006 stage 6.2: tasks whose handle was popped by cancel() while
         # the task still runs. Held ONLY as an anti-GC reference (the event
@@ -238,6 +253,8 @@ class RunRegistry:
             "run claimed",
             extra={"run_id": handle.request_id, "kind": kind, "node_id": node_id},
         )
+        if self._on_claim is not None:
+            self._on_claim(handle.request_id, kind, node_id)
         return handle
 
     def attach_task(self, handle: RunHandle, task: asyncio.Task) -> None:
@@ -274,7 +291,18 @@ class RunRegistry:
         cancelled run's late teardown never re-runs the end transition that
         cancel() already performed (and never clobbers a newer run's state -
         see RunHandle.finalize)."""
-        return self._pop(request_id) is not None
+        handle = self._pop(request_id)
+        # ADR-016 stage 16.3: "completed" specifically - NOT fired from _pop
+        # itself, since _pop is also the cancel path's own pop (via
+        # _finish_cancel below), which already records "cancelled" from
+        # cancel()/cancel_all() before ever reaching here. Firing it here
+        # unconditionally would overwrite a cancelled run's outcome back to
+        # "completed" the instant its worker's own late `finally` calls
+        # release() - see run_single_shot's docstring on why that always
+        # happens regardless of which path actually freed the slot.
+        if handle is not None and self._on_end is not None:
+            self._on_end(request_id, "completed")
+        return handle is not None
 
     def _schedule_finalize(self, handle: RunHandle) -> None:
         if handle.finalize is None or handle.loop is None or handle.loop.is_closed():
@@ -313,6 +341,8 @@ class RunRegistry:
                 "run cancelled",
                 extra={"run_id": request_id, "kind": handle.kind, "node_id": handle.node_id},
             )
+            if self._on_end is not None:
+                self._on_end(request_id, "cancelled")
             # ADR-006 stage 6.2: cancel frees the slot IMMEDIATELY. Before
             # this, release() lived only in the run's `finally`, downstream
             # of an uninterruptible asyncio.to_thread - so is_busy stayed
@@ -372,6 +402,8 @@ class RunRegistry:
                     "run cancelled",
                     extra={"run_id": handle.request_id, "kind": handle.kind, "node_id": handle.node_id},
                 )
+                if self._on_end is not None:
+                    self._on_end(handle.request_id, "cancelled")
                 self._finish_cancel(handle.request_id, handle)
 
     def has_any_live_work(self) -> bool:

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -384,6 +384,9 @@ def _restore_chat_payload(payload: dict[str, Any]) -> SceneNode:
             # matching the dataclass default ("not reported").
             prompt_tokens=payload.get("prompt_tokens"),
             completion_tokens=payload.get("completion_tokens"),
+            # ADR-016 stage 16.2: absent in every pre-16.2 save -> None,
+            # matching the dataclass default.
+            estimated_cost_usd=payload.get("estimated_cost_usd"),
             # ADR-007 stage 7.4: absent in every pre-7.4 save -> [], matching
             # the dataclass default. Each item is validated only loosely
             # (dict(...) below tolerates hand-edited/legacy entries missing a

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -215,6 +215,9 @@ def _serialize_chat_node(node: SceneNode) -> dict[str, Any]:
         # survives save/load like every other provenance field above.
         "prompt_tokens": node.state.prompt_tokens,
         "completion_tokens": node.state.completion_tokens,
+        # ADR-016 stage 16.2: the cost snapshot taken when usage was stamped
+        # - survives save/load like prompt_tokens/completion_tokens above.
+        "estimated_cost_usd": node.state.estimated_cost_usd,
         # ADR-007 stage 7.4: a plain list-of-dicts copy - see ChatState.
         # tool_invocations' own comment for the exact shape. Domain-side
         # `arguments` stays a real dict here (only JSON-encoded at the wire

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -196,6 +196,11 @@ def settings_payload(manager: SettingsManager) -> dict[str, Any]:
         # graphlink_secrets.dpapi_available's own docstring for exactly
         # what this does and doesn't mean.
         "secretsEncryptedAtRest": manager.secrets_encrypted_at_rest(),
+        # ADR-016 stage 16.1: the log-level setting's current value - the
+        # Diagnostics panel (stage 16.3) renders the actual control; this
+        # field exists now so the backend contract carries it from the start
+        # rather than needing a second wire-payload touch later.
+        "logLevel": manager.get_log_level(),
     }
 
 

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -711,6 +711,13 @@ def test_real_usage_flows_to_the_token_counter_and_reply_node(monkeypatch):
         assert reply.state.completion_tokens == 22
         assert reply.state.provider == "ollama"
         assert reply.state.model  # the fake-configured chat model id
+        # ADR-016 stage 16.2: local providers cost $0.00, not None (a real
+        # answer, not "unknown") - stamped as a point-in-time snapshot
+        # alongside the counts above.
+        assert reply.state.estimated_cost_usd == 0.0
+        assert payload["sessionPromptTokens"] == 111
+        assert payload["sessionCompletionTokens"] == 22
+        assert payload["sessionEstimatedCostUsd"] == 0.0
 
     asyncio.run(run())
 

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -2,6 +2,8 @@
 subscribe snapshots, the system/ping acceptance round-trip, and error paths.
 Runs the real ASGI app through Starlette's TestClient - no network, no Qt."""
 
+import asyncio
+import os
 import tempfile
 import threading
 import time
@@ -9,7 +11,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from backend import BACKEND_VERSION
+from backend import BACKEND_VERSION, crash_recovery
 from backend.app import create_app
 from backend.session_context import get_session_context
 from backend.tests.conftest import chat_slots, pycoder_slots
@@ -586,3 +588,43 @@ def test_disconnect_auto_denies_any_pending_pycoder_approval(monkeypatch):
         time.sleep(0.01)
     assert approval_future.done(), "the pending approval must be auto-denied on disconnect"
     assert approval_future.result() is False
+
+
+def test_diagnostics_intents_dispatch_through_the_real_bus(tmp_path, monkeypatch):
+    # ADR-016 stage 16.4: exportDiagnosticBundle/openLogFolder registered by
+    # backend/api/intents_diagnostics.py, wired into the real create_app()
+    # via backend/app.py's _configure_session - dispatched here directly
+    # against the real SessionBus (not a hand-rolled make_session() bus),
+    # same "the real app.py wiring" posture as
+    # test_showerror_intent_round_trips_through_the_real_app_and_updates_the_notification_snapshot
+    # above.
+    #
+    # backend.crash_recovery._data_dir() is monkeypatched to a tmp_path so
+    # this never writes into the developer's real ~/.graphlink/diagnostics,
+    # and os.startfile is monkeypatched so openLogFolder never actually
+    # spawns Explorer during the test run.
+    monkeypatch.setattr(crash_recovery, "_data_dir", lambda *args, **kwargs: tmp_path)
+    monkeypatch.setattr(os, "name", "nt")
+    startfile_calls = []
+    monkeypatch.setattr(os, "startfile", lambda path: startfile_calls.append(path), raising=False)
+
+    client = make_client()
+    with client.websocket_connect("/ws?session=default") as ws:
+        # Force this session to exist and be fully configured before
+        # dispatching straight into its bus.
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        ws.receive_json()
+
+        session_bus = client.app.state.bus.session("default")
+
+        bundle_result = asyncio.run(session_bus.dispatch_intent("diagnostics", "exportDiagnosticBundle", []))
+        assert set(bundle_result.keys()) == {"bundle", "path"}
+        assert bundle_result["bundle"]["bundleSchemaVersion"] == 1
+        assert bundle_result["bundle"]["appVersion"]
+        written_path = Path(bundle_result["path"])
+        assert written_path.exists()
+        assert written_path.parent == tmp_path / "diagnostics"
+
+        log_folder_result = asyncio.run(session_bus.dispatch_intent("diagnostics", "openLogFolder", []))
+        assert log_folder_result == {"opened": True}
+        assert len(startfile_calls) == 1

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -147,14 +147,16 @@ def test_subscribe_without_topics_sends_every_registered_topic():
         ws.send_json({"kind": "subscribe"})
         # R2 surface: canvas + View-popover + composer/counter/notification +
         # R2.5 about/plugins/settings/chat-library topics + ADR-005 stage 5.4's
-        # execution-limits topic, sorted.
-        topics = [ws.receive_json()["topic"] for _ in range(13)]
+        # execution-limits topic + ADR-016 stage 16.3's diagnostics topic,
+        # sorted.
+        topics = [ws.receive_json()["topic"] for _ in range(14)]
         assert topics == [
             "app-about",
             "app-chat-library",
             "app-composer",
             "app-plugins",
             "app-settings",
+            "diagnostics",
             "drag-speed",
             "execution-limits",
             "font-control",

--- a/backend/tests/test_backend_composer.py
+++ b/backend/tests/test_backend_composer.py
@@ -344,10 +344,14 @@ def test_token_counter_payload_totals_all_three():
     assert set(payload) == {
         "inputTokens", "outputTokens", "contextTokens", "totalTokens",
         "promptTokens", "completionTokens", "usageIsReal", "estimatedCostUsd",
+        "sessionPromptTokens", "sessionCompletionTokens", "sessionEstimatedCostUsd",
     }
     assert payload["promptTokens"] is None
     assert payload["usageIsReal"] is False
     assert payload["estimatedCostUsd"] is None
+    assert payload["sessionPromptTokens"] == 0
+    assert payload["sessionCompletionTokens"] == 0
+    assert payload["sessionEstimatedCostUsd"] == 0.0
 
 
 def test_token_counter_real_usage_switches_total_and_estimates_cost():
@@ -380,6 +384,72 @@ def test_token_counter_unknown_cloud_model_has_no_cost_guess():
     assert estimate_cost_usd("OpenAI-Compatible", "totally-unknown", 100, 100) is None
     assert estimate_cost_usd("ollama", "anything", 100, 100) == 0.0
     assert estimate_cost_usd("Anthropic Claude", "claude-opus-5", None, None) is None
+
+
+# -- ADR-016 stage 16.2: pricing overrides + session-cumulative totals ------
+
+
+def test_estimate_cost_usd_prefers_an_exact_override_over_the_built_in_table():
+    from backend.token_counter import estimate_cost_usd
+
+    overrides = {"claude-sonnet-4-5": {"input": 1.0, "output": 2.0}}
+    cost = estimate_cost_usd(
+        "Anthropic Claude", "claude-sonnet-4-5", 1_000_000, 1_000_000, overrides=overrides,
+    )
+    assert cost == 3.0  # 1.0 + 2.0, not the built-in 3.0/15.0 claude-sonnet prices
+
+
+def test_estimate_cost_usd_falls_back_to_the_built_in_table_when_no_override_matches():
+    from backend.token_counter import estimate_cost_usd
+
+    overrides = {"some-other-model": {"input": 1.0, "output": 2.0}}
+    cost = estimate_cost_usd(
+        "Anthropic Claude", "claude-sonnet-4-5", 1_000_000, 1_000_000, overrides=overrides,
+    )
+    assert cost == 18.0  # the built-in claude-sonnet price, override didn't match
+
+
+def test_token_counter_state_reads_overrides_live_via_the_accessor():
+    # Not a stored snapshot at construction time - a later change to
+    # whatever pricing_overrides_fn returns is picked up on the next
+    # set_real_usage/payload() call, matching every other live-settings read
+    # in this codebase.
+    overrides = {}
+    state = TokenCounterState(pricing_overrides_fn=lambda: overrides)
+    state.set_real_usage(1_000_000, 1_000_000, provider="Anthropic Claude", model="claude-sonnet-4-5")
+    assert state.payload()["estimatedCostUsd"] == 18.0  # built-in price, no override yet
+
+    overrides["claude-sonnet-4-5"] = {"input": 0.0, "output": 0.0}
+    assert state.payload()["estimatedCostUsd"] == 0.0  # now free, override applied live
+
+
+def test_session_totals_accumulate_across_replies_and_survive_a_new_draft():
+    state = TokenCounterState()
+    state.set_real_usage(10, 20, provider="ollama", model="llama3:8b")
+    state.set_input_text("typing a new draft")  # resets prompt/completion, not session totals
+    state.set_real_usage(5, 15, provider="ollama", model="llama3:8b")
+
+    payload = state.payload()
+    assert payload["sessionPromptTokens"] == 15
+    assert payload["sessionCompletionTokens"] == 35
+
+
+def test_session_estimated_cost_accumulates_across_replies():
+    state = TokenCounterState()
+    state.set_real_usage(1_000_000, 1_000_000, provider="Anthropic Claude", model="claude-sonnet-4-5")
+    state.set_real_usage(1_000_000, 1_000_000, provider="Anthropic Claude", model="claude-sonnet-4-5")
+
+    assert state.payload()["sessionEstimatedCostUsd"] == 36.0  # 18.0 twice
+
+
+def test_session_totals_are_unaffected_by_a_reply_with_no_real_usage():
+    state = TokenCounterState()
+    state.set_real_usage(10, 20, provider="ollama", model="llama3:8b")
+    state.set_real_usage(None, None)  # e.g. a provider that reports nothing
+
+    payload = state.payload()
+    assert payload["sessionPromptTokens"] == 10
+    assert payload["sessionCompletionTokens"] == 20
 
 
 def test_set_output_text_estimates_the_same_way_as_set_input_text():

--- a/backend/tests/test_crash_recovery.py
+++ b/backend/tests/test_crash_recovery.py
@@ -282,6 +282,25 @@ def test_configure_logging_keeps_a_stderr_handler_so_terminal_runs_still_print(t
     assert stream_handlers, "terminal runs must still see log output"
 
 
+def test_configure_logging_file_handler_writes_json_lines(tmp_path, isolated_logging_state):
+    # ADR-016 stage 16.1: the FILE channel is JSON-lines (backend/
+    # observability.py.JsonLogFormatter); stderr stays plain text - see
+    # this module's own docstring on why.
+    configure_logging(tmp_path)
+    logging.getLogger("graphlink.test.jsonlines").info(
+        "hello world", extra={"run_id": "r-1", "kind": "chat"}
+    )
+
+    lines = [line for line in log_path(tmp_path).read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert lines, "expected at least one log line"
+    payload = json.loads(lines[-1])
+    assert payload["msg"] == "hello world"
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "graphlink.test.jsonlines"
+    assert payload["run_id"] == "r-1"
+    assert payload["kind"] == "chat"
+
+
 def test_install_exception_handlers_can_be_retried_after_a_failure(
     tmp_path, monkeypatch, isolated_exception_handler_state
 ):

--- a/backend/tests/test_diagnostic_bundle.py
+++ b/backend/tests/test_diagnostic_bundle.py
@@ -1,0 +1,205 @@
+"""ADR-016 stage 16.4: redacted diagnostic bundle + open-log-folder.
+
+The single most important test in this file is
+test_bundle_never_contains_chat_content below - the literal, empirical proof
+the ADR's own exit criterion demands ("Bundle proves no chat content
+(redaction test)"), not an inference from reading build_diagnostic_bundle's
+code.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+
+import pytest
+
+from backend.diagnostic_bundle import (
+    BUNDLE_SCHEMA_VERSION,
+    build_diagnostic_bundle,
+    open_log_folder,
+)
+from backend.diagnostics import DiagnosticsState, provider_errors, record_provider_error, reset_provider_errors
+from backend.domain.graph import SceneDocument
+from graphlink_version import APP_VERSION
+
+CANARY = "CANARY-SECRET-CHAT-CONTENT-DO-NOT-LEAK-12345"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_provider_errors():
+    """provider_errors() is module-global (see backend/diagnostics.py's own
+    docstring) - reset around every test in this file so a canary recorded
+    by one test can never leak into another test's bundle."""
+    reset_provider_errors()
+    yield
+    reset_provider_errors()
+
+
+# -- the redaction proof ------------------------------------------------------
+
+
+def test_bundle_never_contains_chat_content():
+    document = SceneDocument()
+    document.add_chat_node(0, 0, CANARY, is_user=True)
+
+    bundle = build_diagnostic_bundle(document, DiagnosticsState())
+
+    serialized = json.dumps(bundle)
+    assert CANARY not in serialized, (
+        "the diagnostic bundle leaked chat content - the whole point of the "
+        "builder's narrow (document, diagnostics_state) signature is that "
+        "this can never happen"
+    )
+
+
+def test_bundle_never_contains_chat_content_even_with_a_run_history_present():
+    # Belt-and-suspenders: the canary must stay absent even when the OTHER
+    # allowlisted piece (diagnostics_state.payload()) is non-empty, proving
+    # the two pieces don't somehow interact to leak the node's own content.
+    document = SceneDocument()
+    node = document.add_chat_node(0, 0, CANARY, is_user=True)
+    diagnostics_state = DiagnosticsState()
+    diagnostics_state.record_run_claimed("r-1", "chat", node.id)
+    diagnostics_state.record_run_ended("r-1", "completed")
+
+    bundle = build_diagnostic_bundle(document, diagnostics_state)
+
+    assert CANARY not in json.dumps(bundle)
+    # The run history legitimately carries the node id (not chat content -
+    # see DiagnosticsState.payload()'s own docstring) - confirms the two
+    # allowlisted pieces compose without the canary leaking through either.
+    assert bundle["diagnostics"]["recentRuns"][0]["nodeId"] == node.id
+
+
+def test_bundle_never_contains_chat_content_leaked_through_a_provider_error_message():
+    """The field the two tests above never touch: providerErrors[].message
+    is raw str(exc) from whatever exception fired during a chat call (see
+    backend/diagnostics.py's own module docstring) - the one genuinely
+    unredacted-by-construction field in the whole allowlist before
+    record_provider_error's own redaction step. This is the realistic
+    trigger: a provider SDK exception (or, concretely, an OSError raised by
+    api_provider.py's _read_attachment_bytes when a chat attachment becomes
+    unreadable) can embed literal chat content or an absolute filesystem
+    path, and record_provider_error(provider, str(exc)) is called
+    unconditionally, BEFORE any friendly-message translation. Without
+    redaction at that choke point, this is exactly the leak this whole
+    module's docstring claims is structurally impossible."""
+    document = SceneDocument()
+    document.add_chat_node(0, 0, "unrelated node content", is_user=True)
+    record_provider_error("openai", f"request failed while sending: {CANARY}")
+
+    bundle = build_diagnostic_bundle(document, DiagnosticsState())
+
+    serialized = json.dumps(bundle)
+    assert CANARY not in serialized, (
+        "a provider error's raw exception text leaked into the diagnostic bundle - "
+        "record_provider_error() must redact `message` before it is ever stored, "
+        "not just before this builder's own signature is examined"
+    )
+    # Not just "the canary is gone" - the field itself must still be
+    # present and non-empty, proving this is real redaction (a bounded,
+    # fixed category label), not the field silently vanishing.
+    assert bundle["diagnostics"]["providerErrors"] == provider_errors()
+    assert bundle["diagnostics"]["providerErrors"][0]["provider"] == "openai"
+    assert bundle["diagnostics"]["providerErrors"][0]["message"]
+
+
+# -- structural-redaction signature guarantee ---------------------------------
+
+
+def test_build_diagnostic_bundle_signature_accepts_exactly_document_and_diagnostics_state():
+    # Positive assertion that nothing settings/API-key-shaped can even be
+    # passed in - the builder's own signature IS the redaction mechanism
+    # (see this module's docstring and diagnostic_bundle.py's own).
+    params = list(inspect.signature(build_diagnostic_bundle).parameters)
+    assert params == ["document", "diagnostics_state"], (
+        f"build_diagnostic_bundle must take exactly (document, diagnostics_state) - got {params}. "
+        "Widening this signature (e.g. adding a settings manager or raw log access) would defeat "
+        "the whole structural-redaction design."
+    )
+
+
+# -- node-kind tally -----------------------------------------------------------
+
+
+def test_node_counts_tally_by_kind_across_multiple_kinds():
+    document = SceneDocument()
+    document.add_chat_node(0, 0, "hello", is_user=True)
+    document.add_chat_node(0, 0, "world", is_user=False)
+    document.add_code_node(0, 0, "print(1)", "python")
+    document.add_node(0, 0, "untitled")  # kind="placeholder"
+
+    bundle = build_diagnostic_bundle(document, DiagnosticsState())
+
+    assert bundle["nodeCounts"] == {"chat": 2, "code": 1, "placeholder": 1}
+
+
+def test_node_counts_empty_document_is_an_empty_dict():
+    bundle = build_diagnostic_bundle(SceneDocument(), DiagnosticsState())
+    assert bundle["nodeCounts"] == {}
+
+
+# -- allowlisted fields present -----------------------------------------------
+
+
+def test_app_version_and_os_fields_are_present_and_non_empty():
+    bundle = build_diagnostic_bundle(SceneDocument(), DiagnosticsState())
+
+    assert bundle["appVersion"] == APP_VERSION
+    assert bundle["appVersion"]
+
+    assert bundle["os"]["system"]
+    assert bundle["os"]["release"] is not None  # some platforms report ""; must at least be present
+    assert bundle["os"]["pythonVersion"]
+
+
+def test_bundle_schema_version_and_generated_at_are_present():
+    bundle = build_diagnostic_bundle(SceneDocument(), DiagnosticsState())
+
+    assert bundle["bundleSchemaVersion"] == BUNDLE_SCHEMA_VERSION
+    assert isinstance(bundle["bundleSchemaVersion"], int)
+    assert bundle["generatedAt"]  # ISO-8601 string; just needs to be present and non-empty
+
+
+def test_diagnostics_payload_is_embedded_verbatim():
+    diagnostics_state = DiagnosticsState()
+    diagnostics_state.record_publish("scene", 512)
+
+    bundle = build_diagnostic_bundle(SceneDocument(), diagnostics_state)
+
+    assert bundle["diagnostics"] == diagnostics_state.payload()
+    assert bundle["diagnostics"]["publishBytesTotal"] == 512
+
+
+# -- open_log_folder: never raises, only ever True/False ---------------------
+
+
+def test_open_log_folder_returns_false_when_os_startfile_raises(monkeypatch):
+    monkeypatch.setattr(os, "name", "nt")
+
+    def _raising_startfile(_path):
+        raise OSError("no shell association")
+
+    monkeypatch.setattr(os, "startfile", _raising_startfile, raising=False)
+
+    assert open_log_folder() is False
+
+
+def test_open_log_folder_returns_false_on_non_windows(monkeypatch):
+    monkeypatch.setattr(os, "name", "posix")
+    # Sanity: even if startfile were somehow callable, os.name gates it -
+    # give it a definitely-would-raise callable to prove the gate, not luck.
+    monkeypatch.setattr(os, "startfile", lambda _path: (_ for _ in ()).throw(AssertionError("must not be called")), raising=False)
+
+    assert open_log_folder() is False
+
+
+def test_open_log_folder_returns_true_on_success(monkeypatch):
+    calls = []
+    monkeypatch.setattr(os, "name", "nt")
+    monkeypatch.setattr(os, "startfile", lambda path: calls.append(path), raising=False)
+
+    assert open_log_folder() is True
+    assert len(calls) == 1

--- a/backend/tests/test_diagnostics.py
+++ b/backend/tests/test_diagnostics.py
@@ -1,0 +1,158 @@
+"""ADR-016 stage 16.3: in-app diagnostics."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.diagnostics import (
+    DiagnosticsState,
+    provider_errors,
+    record_provider_error,
+    reset_provider_errors,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_provider_errors():
+    """The provider-errors deque is module-global by design (see the
+    module docstring) - reset around every test so this file's own
+    assertions never see another test's leftovers, and vice versa."""
+    reset_provider_errors()
+    yield
+    reset_provider_errors()
+
+
+# -- provider errors (process-global) ---------------------------------------
+
+
+def test_provider_errors_starts_empty():
+    assert provider_errors() == []
+
+
+def test_record_provider_error_appends_provider_and_message():
+    record_provider_error("ollama", "connection refused")
+    errors = provider_errors()
+    assert len(errors) == 1
+    assert errors[0]["provider"] == "ollama"
+    assert errors[0]["message"] == "connection refused"
+    assert isinstance(errors[0]["at"], float)
+
+
+def test_provider_errors_is_bounded():
+    for i in range(15):
+        record_provider_error("ollama", f"error {i}")
+    errors = provider_errors()
+    assert len(errors) == 10  # _MAX_PROVIDER_ERRORS
+    assert errors[0]["message"] == "error 5"  # oldest 5 evicted
+    assert errors[-1]["message"] == "error 14"
+
+
+# -- DiagnosticsState: run history --------------------------------------
+
+
+def test_recent_runs_starts_empty():
+    diagnostics = DiagnosticsState()
+    assert diagnostics.payload()["recentRuns"] == []
+
+
+def test_record_run_claimed_shows_up_as_running():
+    diagnostics = DiagnosticsState()
+    diagnostics.record_run_claimed("r-1", "chat", "n-1")
+
+    runs = diagnostics.payload()["recentRuns"]
+    assert len(runs) == 1
+    assert runs[0]["runId"] == "r-1"
+    assert runs[0]["kind"] == "chat"
+    assert runs[0]["nodeId"] == "n-1"
+    assert runs[0]["outcome"] == "running"
+    assert runs[0]["durationSeconds"] is None
+
+
+def test_record_run_ended_sets_outcome_and_duration():
+    diagnostics = DiagnosticsState()
+    diagnostics.record_run_claimed("r-1", "chat", "n-1")
+    diagnostics.record_run_ended("r-1", "completed")
+
+    runs = diagnostics.payload()["recentRuns"]
+    assert runs[0]["outcome"] == "completed"
+    assert runs[0]["durationSeconds"] is not None
+    assert runs[0]["durationSeconds"] >= 0
+
+
+def test_record_run_ended_for_an_unknown_run_id_is_a_safe_noop():
+    diagnostics = DiagnosticsState()
+    diagnostics.record_run_ended("never-claimed", "completed")  # must not raise
+    assert diagnostics.payload()["recentRuns"] == []
+
+
+def test_recent_runs_lists_newest_first():
+    diagnostics = DiagnosticsState()
+    diagnostics.record_run_claimed("r-1", "chat", None)
+    diagnostics.record_run_claimed("r-2", "chart", None)
+
+    runs = diagnostics.payload()["recentRuns"]
+    assert [r["runId"] for r in runs] == ["r-2", "r-1"]
+
+
+def test_recent_runs_is_bounded():
+    diagnostics = DiagnosticsState()
+    for i in range(35):
+        diagnostics.record_run_claimed(f"r-{i}", "chat", None)
+
+    runs = diagnostics.payload()["recentRuns"]
+    assert len(runs) == 30  # _MAX_RECENT_RUNS
+    assert runs[0]["runId"] == "r-34"  # newest first
+    assert runs[-1]["runId"] == "r-5"  # oldest 5 evicted
+
+
+# -- DiagnosticsState: publish size/rate ---------------------------------
+
+
+def test_publish_stats_start_at_zero():
+    diagnostics = DiagnosticsState()
+    payload = diagnostics.payload()
+    assert payload["publishCount"] == 0
+    assert payload["publishBytesTotal"] == 0
+    assert payload["lastPublishBytes"] is None
+    assert payload["lastPublishTopic"] is None
+    assert payload["publishBytesPerSecond"] == 0.0
+
+
+def test_record_publish_updates_count_total_and_last():
+    diagnostics = DiagnosticsState()
+    diagnostics.record_publish("scene", 100)
+    diagnostics.record_publish("scene", 250)
+
+    payload = diagnostics.payload()
+    assert payload["publishCount"] == 2
+    assert payload["publishBytesTotal"] == 350
+    assert payload["lastPublishBytes"] == 250
+    assert payload["lastPublishTopic"] == "scene"
+
+
+def test_publish_bytes_per_second_reflects_recent_samples():
+    diagnostics = DiagnosticsState()
+    diagnostics.record_publish("scene", 1000)
+    assert diagnostics.payload()["publishBytesPerSecond"] > 0.0
+
+
+# -- DiagnosticsState: session count + provider errors in the payload ---
+
+
+def test_session_count_is_none_without_a_session_count_fn():
+    diagnostics = DiagnosticsState()
+    assert diagnostics.payload()["sessionCount"] is None
+
+
+def test_session_count_reads_the_live_accessor():
+    diagnostics = DiagnosticsState(session_count_fn=lambda: 3)
+    assert diagnostics.payload()["sessionCount"] == 3
+
+
+def test_payload_includes_provider_errors_from_the_shared_process_global_view():
+    record_provider_error("Anthropic Claude", "timeout")
+    diagnostics = DiagnosticsState()
+    errors = diagnostics.payload()["providerErrors"]
+    assert len(errors) == 1
+    assert errors[0]["provider"] == "Anthropic Claude"
+    assert errors[0]["message"] == "timeout"

--- a/backend/tests/test_diagnostics.py
+++ b/backend/tests/test_diagnostics.py
@@ -30,21 +30,26 @@ def test_provider_errors_starts_empty():
 
 
 def test_record_provider_error_appends_provider_and_message():
+    # "connection refused" is redacted to its fixed category label - see
+    # the redaction tests below for why the raw text is never stored.
     record_provider_error("ollama", "connection refused")
     errors = provider_errors()
     assert len(errors) == 1
     assert errors[0]["provider"] == "ollama"
-    assert errors[0]["message"] == "connection refused"
+    assert errors[0]["message"] == "connection failed"
     assert isinstance(errors[0]["at"], float)
 
 
 def test_provider_errors_is_bounded():
+    # Distinguish entries by `provider` (not `message`, which is now
+    # collapsed to a redacted category label - see the redaction tests
+    # below) to keep proving FIFO eviction of the bounded deque.
     for i in range(15):
-        record_provider_error("ollama", f"error {i}")
+        record_provider_error(f"provider-{i}", "some transient failure")
     errors = provider_errors()
     assert len(errors) == 10  # _MAX_PROVIDER_ERRORS
-    assert errors[0]["message"] == "error 5"  # oldest 5 evicted
-    assert errors[-1]["message"] == "error 14"
+    assert errors[0]["provider"] == "provider-5"  # oldest 5 evicted
+    assert errors[-1]["provider"] == "provider-14"
 
 
 # -- DiagnosticsState: run history --------------------------------------
@@ -150,9 +155,65 @@ def test_session_count_reads_the_live_accessor():
 
 
 def test_payload_includes_provider_errors_from_the_shared_process_global_view():
-    record_provider_error("Anthropic Claude", "timeout")
+    record_provider_error("Anthropic Claude", "the request timed out")
     diagnostics = DiagnosticsState()
     errors = diagnostics.payload()["providerErrors"]
     assert len(errors) == 1
     assert errors[0]["provider"] == "Anthropic Claude"
-    assert errors[0]["message"] == "timeout"
+    assert errors[0]["message"] == "request timed out"
+
+
+# -- provider error message redaction (see backend/diagnostics.py's own ----
+# -- module docstring: this is the one field in the whole diagnostics ------
+# -- allowlist that isn't inherently content-free by construction) ---------
+
+
+CANARY = "CANARY-SECRET-CHAT-CONTENT-DO-NOT-LEAK-12345"
+
+
+def test_record_provider_error_never_stores_arbitrary_message_text():
+    """The empirical proof: literal content passed as `message` (standing
+    in for a provider SDK's raw exception text, which can embed anything -
+    an absolute filesystem path, or even echoed chat content) must never
+    survive into provider_errors() verbatim."""
+    record_provider_error("openai", CANARY)
+    errors = provider_errors()
+    assert len(errors) == 1
+    assert CANARY not in errors[0]["message"]
+    assert errors[0]["message"] == "provider error (see application log for detail)"
+
+
+def test_record_provider_error_redacts_an_absolute_windows_path_in_an_os_error():
+    """The concretely-demonstrated real-world trigger: api_provider.py's
+    _read_attachment_bytes interpolates a raw OSError, whose __str__ for a
+    failed open() embeds the FULL absolute path - including the OS
+    username and any private folder/file names."""
+    leaky_message = (
+        r"Failed to read attached image file 'secret_photo.png': "
+        r"[Errno 2] No such file or directory: "
+        r"'C:\\Users\\Someone\\Documents\\Private\\secret_photo.png'"
+    )
+    record_provider_error("openai", leaky_message)
+    errors = provider_errors()
+    assert "Someone" not in errors[0]["message"]
+    assert "Private" not in errors[0]["message"]
+    assert "secret_photo" not in errors[0]["message"]
+    assert errors[0]["message"] == "attachment file unavailable"
+
+
+@pytest.mark.parametrize(
+    "message,expected_category",
+    [
+        ("Request timed out after 30s", "request timed out"),
+        ("HTTP 429: rate limit exceeded", "rate limited or quota exceeded"),
+        ("google.api_core.exceptions.ResourceExhausted: quota exceeded", "rate limited or quota exceeded"),
+        ("401 Unauthorized: invalid API key provided", "authentication failed"),
+        ("Connection refused by remote host", "connection failed"),
+        ("HTTP 404: model not found", "resource not found"),
+        ("Attached audio file is no longer available: clip.wav", "attachment file unavailable"),
+    ],
+)
+def test_record_provider_error_classifies_known_shapes_without_echoing_them(message, expected_category):
+    record_provider_error("openai", message)
+    errors = provider_errors()
+    assert errors[0]["message"] == expected_category

--- a/backend/tests/test_evals_harness.py
+++ b/backend/tests/test_evals_harness.py
@@ -1,0 +1,210 @@
+"""ADR-016 stage 16.5: deterministic, CI-safe coverage for the local eval
+harness (backend/evals/). Every test here runs in the default (live=False)
+mode, where backend.evals.runner patches api_provider.chat via
+unittest.mock.patch.object itself - no real provider, no network, safe on
+every CI run.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from backend.evals.fixtures import EvalFixture, load_fixtures
+from backend.evals.runner import (
+    EvalResult,
+    run_agent_build_fixture,
+    run_all,
+    run_chart_fixture,
+    run_structured_output_fixture,
+)
+
+
+# -- fixture loading ----------------------------------------------------
+
+
+def test_load_fixtures_finds_the_shipped_chart_goldens():
+    fixtures = load_fixtures("chart")
+    assert len(fixtures) >= 3
+    assert all(isinstance(f, EvalFixture) for f in fixtures)
+    assert all(f.kind == "chart" for f in fixtures)
+    chart_types = {f.input["chart_type"] for f in fixtures}
+    assert {"bar", "line", "pie"} <= chart_types
+
+
+def test_load_fixtures_finds_the_shipped_structured_output_golden():
+    fixtures = load_fixtures("structured_output")
+    assert len(fixtures) >= 1
+    assert all(f.kind == "structured_output" for f in fixtures)
+
+
+def test_load_fixtures_finds_the_shipped_agent_build_placeholder():
+    fixtures = load_fixtures("agent_build")
+    assert len(fixtures) >= 1
+    assert all(f.kind == "agent_build" for f in fixtures)
+
+
+def test_load_fixtures_rejects_an_unknown_kind():
+    with pytest.raises(ValueError):
+        load_fixtures("not_a_real_kind")
+
+
+# -- chart scorer ---------------------------------------------------------
+
+
+def _chart_fixture_by_name(name):
+    fixtures = {f.name: f for f in load_fixtures("chart")}
+    return fixtures[name]
+
+
+def test_a_correct_bar_chart_fixture_scores_passed():
+    fixture = _chart_fixture_by_name("bar_support_tickets")
+    result = run_chart_fixture(fixture)
+    assert result.status == "passed", result.detail
+    assert result.kind == "chart"
+    assert result.fixture_name == "bar_support_tickets"
+
+
+def test_a_correct_line_chart_fixture_scores_passed():
+    fixture = _chart_fixture_by_name("line_daily_active_users")
+    result = run_chart_fixture(fixture)
+    assert result.status == "passed", result.detail
+
+
+def test_a_correct_pie_chart_fixture_scores_passed():
+    # Pins the exact case the harness must actually catch by RUNNING
+    # canonicalize_chart_data rather than guessing: pie's own model-facing
+    # prompt never asks for xAxis/yAxis, but canonicalize_chart_data still
+    # defaults them in ("Sequence"/"Value") since pie is in the same
+    # {"bar","line","pie"} branch as the other two - the shipped fixture's
+    # `expected` includes them for exactly that reason.
+    fixture = _chart_fixture_by_name("pie_engineering_budget")
+    assert "xAxis" not in fixture.scripted_response
+    assert fixture.expected["xAxis"] == "Sequence"
+    assert fixture.expected["yAxis"] == "Value"
+
+    result = run_chart_fixture(fixture)
+    assert result.status == "passed", result.detail
+
+
+def test_a_deliberately_wrong_chart_fixture_scores_failed():
+    """Proves the scorer actually discriminates, not just always reports
+    success: mutate one expected value away from what
+    canonicalize_chart_data really produces, and confirm the harness
+    reports failed rather than silently passing."""
+    original = _chart_fixture_by_name("bar_support_tickets")
+    wrong_expected = dict(original.expected)
+    wrong_expected["values"] = [999999] + list(wrong_expected["values"][1:])
+    wrong_fixture = dataclasses.replace(original, expected=wrong_expected)
+
+    result = run_chart_fixture(wrong_fixture)
+
+    assert result.status == "failed"
+    assert "did not match" in result.detail
+
+
+def test_chart_fixture_with_an_error_scripted_response_scores_failed():
+    """The agent's own fully-degraded case (a top-level "error" key, its
+    own heuristic fallback found nothing usable either) must score failed,
+    not raise and not silently pass."""
+    fixture = EvalFixture(
+        name="unanswerable",
+        kind="chart",
+        input={"chart_type": "bar", "source_text": "asdf"},
+        scripted_response='{"error": "Could not find sufficient data to generate a bar chart."}',
+        expected=None,
+    )
+    result = run_chart_fixture(fixture)
+    assert result.status == "failed"
+    assert "error" in result.detail.lower()
+
+
+# -- structured_output scorer ----------------------------------------------
+
+
+def test_the_structured_output_fixture_scores_passed():
+    fixtures = load_fixtures("structured_output")
+    assert fixtures, "expected at least one shipped structured_output fixture"
+    result = run_structured_output_fixture(fixtures[0])
+    assert result.status == "passed", result.detail
+    assert result.kind == "structured_output"
+
+
+def test_a_deliberately_wrong_structured_output_fixture_scores_failed():
+    original = load_fixtures("structured_output")[0]
+    wrong_expected = dict(original.expected)
+    wrong_expected["confidence"] = 0.0
+    wrong_fixture = dataclasses.replace(original, expected=wrong_expected)
+
+    result = run_structured_output_fixture(wrong_fixture)
+
+    assert result.status == "failed"
+
+
+# -- agent_build stub -----------------------------------------------------
+
+
+def test_run_agent_build_fixture_always_reports_not_implemented_and_names_adr_008():
+    fixture = EvalFixture(
+        name="anything",
+        kind="agent_build",
+        input={"goal": "whatever"},
+        scripted_response=None,
+        expected=None,
+    )
+    result = run_agent_build_fixture(fixture)
+    assert result.status == "not_implemented"
+    assert "ADR-008" in result.detail
+
+
+def test_run_agent_build_fixture_never_raises_regardless_of_input_shape():
+    """The stub must never look hard enough at fixture content to crash on
+    it - not even garbage scripted_response/expected values."""
+    fixture = EvalFixture(
+        name="garbage",
+        kind="agent_build",
+        input={},
+        scripted_response="not json at all {{{",
+        expected={"whatever": object()},
+    )
+    result = run_agent_build_fixture(fixture)
+    assert result.status == "not_implemented"
+
+
+def test_run_agent_build_fixture_never_scores_passed_or_failed():
+    for fixture in load_fixtures("agent_build"):
+        result = run_agent_build_fixture(fixture)
+        assert result.status == "not_implemented"
+
+
+# -- run_all ----------------------------------------------------------------
+
+
+def test_run_all_covers_every_shipped_fixture_with_no_crashes():
+    expected_count = sum(len(load_fixtures(kind)) for kind in ("chart", "structured_output", "agent_build"))
+    assert expected_count > 0
+
+    results = run_all()
+
+    assert len(results) == expected_count
+    assert all(isinstance(r, EvalResult) for r in results)
+    assert all(r.status in ("passed", "failed", "not_implemented") for r in results)
+
+
+def test_run_all_shipped_chart_and_structured_output_fixtures_all_pass():
+    """The goldens actually shipped in backend/evals/fixtures/ must be
+    correct, not just loadable - a regression in canonicalize_chart_data or
+    respond_json should show up here."""
+    results = run_all()
+    scored = [r for r in results if r.kind != "agent_build"]
+    assert scored, "expected at least one non-agent_build fixture"
+    failures = [(r.fixture_name, r.detail) for r in scored if r.status != "passed"]
+    assert failures == []
+
+
+def test_run_all_agent_build_fixtures_are_all_not_implemented():
+    results = run_all()
+    agent_build_results = [r for r in results if r.kind == "agent_build"]
+    assert agent_build_results
+    assert all(r.status == "not_implemented" for r in agent_build_results)

--- a/backend/tests/test_event_bus.py
+++ b/backend/tests/test_event_bus.py
@@ -68,6 +68,52 @@ def test_broadcast_reaches_all_connections_and_drops_dead_ones():
     asyncio.run(run())
 
 
+# -- ADR-016 stage 16.3: publish-size recording --------------------------
+
+
+def test_on_publish_is_a_no_op_by_default():
+    # Every SessionBus() in this file (and the hundreds elsewhere in the
+    # suite) constructs with no on_publish - must never raise just from
+    # publishing.
+    bus, _ = make_session()
+    asyncio.run(bus.publish("counter"))  # must not raise
+
+
+def test_on_publish_fires_with_topic_and_a_positive_byte_size():
+    calls = []
+    bus = SessionBus("s1", on_publish=lambda topic, size: calls.append((topic, size)))
+    bus.register_topic("counter", lambda: {"count": 0})
+
+    asyncio.run(bus.publish("counter"))
+
+    assert len(calls) == 1
+    topic, size = calls[0]
+    assert topic == "counter"
+    assert size > 0
+
+
+def test_set_publish_recorder_applies_to_the_next_publish():
+    calls = []
+    bus, _ = make_session()
+    bus.set_publish_recorder(lambda topic, size: calls.append((topic, size)))
+
+    asyncio.run(bus.publish("counter"))
+
+    assert len(calls) == 1
+    assert calls[0][0] == "counter"
+
+
+def test_set_publish_recorder_of_none_disables_recording():
+    calls = []
+    bus = SessionBus("s1", on_publish=lambda topic, size: calls.append((topic, size)))
+    bus.register_topic("counter", lambda: {"count": 0})
+    bus.set_publish_recorder(None)
+
+    asyncio.run(bus.publish("counter"))
+
+    assert calls == []
+
+
 def test_intent_dispatch_sync_handler_runs_and_returns():
     bus, state = make_session()
     result = asyncio.run(bus.dispatch_intent("counter", "bump", [5]))

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,88 @@
+"""ADR-016 stage 16.1: backend/observability.py - JsonLogFormatter and
+apply_log_level."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from backend.observability import JsonLogFormatter, apply_log_level
+
+
+def _make_record(msg="hello", level=logging.INFO, extra=None):
+    record = logging.LogRecord(
+        name="graphlink.test", level=level, pathname=__file__, lineno=1,
+        msg=msg, args=(), exc_info=None,
+    )
+    for key, value in (extra or {}).items():
+        setattr(record, key, value)
+    return record
+
+
+def test_format_produces_valid_json():
+    formatted = JsonLogFormatter().format(_make_record())
+    payload = json.loads(formatted)  # must not raise
+    assert payload["msg"] == "hello"
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "graphlink.test"
+    assert "ts" in payload
+    assert "thread" in payload
+
+
+def test_format_omits_extra_fields_when_not_supplied():
+    payload = json.loads(JsonLogFormatter().format(_make_record()))
+    for field in ("run_id", "session_id", "kind", "node_id"):
+        assert field not in payload
+
+
+def test_format_includes_extra_fields_when_supplied():
+    record = _make_record(extra={"run_id": "r-1", "kind": "chat", "node_id": "n-1"})
+    payload = json.loads(JsonLogFormatter().format(record))
+    assert payload["run_id"] == "r-1"
+    assert payload["kind"] == "chat"
+    assert payload["node_id"] == "n-1"
+    assert "session_id" not in payload
+
+
+def test_format_includes_formatted_exception_when_present():
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+        exc_info = sys.exc_info()
+    record = logging.LogRecord(
+        name="graphlink.test", level=logging.ERROR, pathname=__file__, lineno=1,
+        msg="failed", args=(), exc_info=exc_info,
+    )
+    payload = json.loads(JsonLogFormatter().format(record))
+    assert "ValueError" in payload["exc"]
+    assert "boom" in payload["exc"]
+
+
+def test_format_preserves_non_ascii_text_unescaped():
+    payload_text = JsonLogFormatter().format(_make_record(msg="café"))
+    assert "café" in payload_text  # not \u-escaped
+
+
+@pytest.fixture
+def isolated_root_level():
+    root_logger = logging.getLogger()
+    level_before = root_logger.level
+    yield
+    root_logger.setLevel(level_before)
+
+
+def test_apply_log_level_sets_the_root_logger_level(isolated_root_level):
+    apply_log_level("DEBUG")
+    assert logging.getLogger().level == logging.DEBUG
+
+    apply_log_level("ERROR")
+    assert logging.getLogger().level == logging.ERROR
+
+
+def test_apply_log_level_is_a_silent_noop_for_an_unrecognized_name(isolated_root_level):
+    logging.getLogger().setLevel(logging.WARNING)
+    apply_log_level("NOT_A_REAL_LEVEL")  # must not raise
+    assert logging.getLogger().level == logging.WARNING

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -1037,7 +1037,16 @@ def test_translated_provider_failure_is_recorded_in_diagnostics(openai_api_mode)
     both chat() and chat_stream() funnel every non-cancel failure through -
     prove a real translated failure actually reaches
     backend.diagnostics.record_provider_error, not just that the friendly
-    message comes out right (already pinned above)."""
+    message comes out right (already pinned above).
+
+    ADR-016 stage 16.4 additionally proves the END-TO-END redaction here,
+    which the unit tests in test_diagnostics.py cannot: those call
+    record_provider_error directly, so they never exercise the real
+    exception text a live provider failure actually produces. This drives a
+    REAL raw exception through _translate_chat_exception and asserts none of
+    its text survives - only the fixed category label does (see
+    backend/diagnostics.py's _redact_provider_error_message for why raw
+    str(exc) is never storable)."""
     import types
 
     from backend.diagnostics import provider_errors, reset_provider_errors
@@ -1058,7 +1067,10 @@ def test_translated_provider_failure_is_recorded_in_diagnostics(openai_api_mode)
         errors = provider_errors()
         assert len(errors) == 1
         assert errors[0]["provider"] == config.API_PROVIDER_OPENAI
-        assert errors[0]["message"] == "connection refused by endpoint"
+        assert errors[0]["message"] == "connection failed"
+        assert "endpoint" not in errors[0]["message"], (
+            "no substring of the raw exception text may survive redaction"
+        )
     finally:
         reset_provider_errors()
 

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -1032,6 +1032,62 @@ def test_connection_refused_in_api_mode_surfaces_the_friendly_endpoint_message(o
     assert "Details: connection refused by endpoint" in message  # raw cause kept, as detail only
 
 
+def test_translated_provider_failure_is_recorded_in_diagnostics(openai_api_mode):
+    """ADR-016 stage 16.3: _translate_chat_exception is the one choke point
+    both chat() and chat_stream() funnel every non-cancel failure through -
+    prove a real translated failure actually reaches
+    backend.diagnostics.record_provider_error, not just that the friendly
+    message comes out right (already pinned above)."""
+    import types
+
+    from backend.diagnostics import provider_errors, reset_provider_errors
+
+    reset_provider_errors()
+    try:
+        def refusing_create(**kwargs):
+            raise Exception("connection refused by endpoint")
+
+        client = types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=refusing_create))
+        )
+        openai_api_mode(client)
+
+        with pytest.raises(ConnectionError):
+            _REAL_CHAT(config.TASK_CHAT, [{"role": "user", "content": "hi"}])
+
+        errors = provider_errors()
+        assert len(errors) == 1
+        assert errors[0]["provider"] == config.API_PROVIDER_OPENAI
+        assert errors[0]["message"] == "connection refused by endpoint"
+    finally:
+        reset_provider_errors()
+
+
+def test_cancelled_requests_are_not_recorded_as_provider_errors(openai_api_mode):
+    """The RequestCancelledError sentinel re-raises before the diagnostics
+    recording line - a user-initiated cancel must never show up next to real
+    provider failures in the diagnostics panel."""
+    from backend.diagnostics import provider_errors, reset_provider_errors
+
+    reset_provider_errors()
+    try:
+        client, _ = _fake_openai_client()
+        openai_api_mode(client)
+        cancel_event = threading.Event()
+        cancel_event.set()
+
+        with pytest.raises(api_provider.RequestCancelledError):
+            _REAL_CHAT(
+                config.TASK_CHAT,
+                [{"role": "user", "content": "hi"}],
+                cancellation_event=cancel_event,
+            )
+
+        assert provider_errors() == []
+    finally:
+        reset_provider_errors()
+
+
 def test_all_four_new_providers_satisfy_the_protocol():
     """6.3: protocol conformance for the non-Ollama four. (The transitional
     stream()-wraps-complete() single-"done" assertion that used to live here

--- a/backend/tests/test_run_lifecycle.py
+++ b/backend/tests/test_run_lifecycle.py
@@ -483,3 +483,86 @@ def test_has_any_live_work_counts_a_popped_but_unfinished_orphan_task():
         assert registry.has_any_live_work() is False
 
     asyncio.run(run())
+
+
+# -- ADR-016 stage 16.1: run-lifecycle logging --------------------------
+#
+# Instrumented at the registry (claim/cancel/_pop) rather than at each of
+# the app's 12 dispatch surfaces - see run_lifecycle.py's own module-level
+# comment on _logger for why. These tests prove every kind gets a traced
+# lifecycle "for free" through the shared primitive, without needing a
+# real chat/chart/etc. dispatch surface in the loop.
+
+
+def test_claim_logs_run_claimed_with_run_id_kind_and_node_id(caplog):
+    registry = RunRegistry()
+    with caplog.at_level("INFO", logger="graphlink.run"):
+        handle = registry.claim("chart", node_id="n-1")
+
+    records = [r for r in caplog.records if r.name == "graphlink.run"]
+    assert len(records) == 1
+    assert records[0].message == "run claimed"
+    assert records[0].run_id == handle.request_id
+    assert records[0].kind == "chart"
+    assert records[0].node_id == "n-1"
+
+
+def test_release_logs_run_released(caplog):
+    registry = RunRegistry()
+    handle = registry.claim("note")
+    with caplog.at_level("INFO", logger="graphlink.run"):
+        registry.release(handle.request_id)
+
+    records = [r for r in caplog.records if r.name == "graphlink.run"]
+    assert len(records) == 1
+    assert records[0].message == "run released"
+    assert records[0].run_id == handle.request_id
+    assert records[0].kind == "note"
+
+
+def test_release_of_an_unknown_request_id_logs_nothing(caplog):
+    registry = RunRegistry()
+    with caplog.at_level("INFO", logger="graphlink.run"):
+        registry.release("never-claimed")
+
+    assert [r for r in caplog.records if r.name == "graphlink.run"] == []
+
+
+def test_cancel_logs_run_cancelled_then_run_released(caplog):
+    registry = RunRegistry()
+    handle = registry.claim("chat", cancel_event=threading.Event())
+    with caplog.at_level("INFO", logger="graphlink.run"):
+        assert registry.cancel(handle.request_id) is True
+
+    records = [r for r in caplog.records if r.name == "graphlink.run"]
+    messages = [r.message for r in records]
+    assert messages == ["run cancelled", "run released"], (
+        "cancel() fires the mechanism and immediately pops the slot - both "
+        "must be traced, in order"
+    )
+    assert all(r.run_id == handle.request_id for r in records)
+    assert all(r.kind == "chat" for r in records)
+
+
+def test_cancel_of_a_kind_with_no_mechanism_logs_nothing(caplog):
+    # Matches cancel()'s own "kind that cannot be cancelled" contract - a
+    # handle with neither cancel_event nor on_cancel never fires, so nothing
+    # about it should be logged either.
+    registry = RunRegistry()
+    handle = registry.claim("chart")
+    with caplog.at_level("INFO", logger="graphlink.run"):
+        assert registry.cancel(handle.request_id) is False
+
+    assert [r for r in caplog.records if r.name == "graphlink.run"] == []
+
+
+def test_cancel_all_logs_every_fired_handle(caplog):
+    registry = RunRegistry()
+    chat_handle = registry.claim("chat", cancel_event=threading.Event())
+    web_handle = registry.claim("web_research", on_cancel=lambda: None)
+    with caplog.at_level("INFO", logger="graphlink.run"):
+        registry.cancel_all()
+
+    records = [r for r in caplog.records if r.name == "graphlink.run"]
+    cancelled_run_ids = {r.run_id for r in records if r.message == "run cancelled"}
+    assert cancelled_run_ids == {chat_handle.request_id, web_handle.request_id}

--- a/backend/tests/test_run_lifecycle.py
+++ b/backend/tests/test_run_lifecycle.py
@@ -566,3 +566,62 @@ def test_cancel_all_logs_every_fired_handle(caplog):
     records = [r for r in caplog.records if r.name == "graphlink.run"]
     cancelled_run_ids = {r.run_id for r in records if r.message == "run cancelled"}
     assert cancelled_run_ids == {chat_handle.request_id, web_handle.request_id}
+
+
+# -- ADR-016 stage 16.3: diagnostics on_claim/on_end callbacks ----------
+#
+# Explicit callbacks (not derived from the caplog-visible logging above) -
+# see backend/diagnostics.py's own module docstring for why. None by
+# default (every test above this point never passes them) - these tests
+# prove the callbacks fire with the right arguments and in the right order
+# relative to each other, independent of backend/diagnostics.py's own
+# DiagnosticsState (which has its own dedicated test file).
+
+
+def test_on_claim_fires_with_run_id_kind_and_node_id():
+    calls = []
+    registry = RunRegistry(on_claim=lambda *args: calls.append(args))
+    handle = registry.claim("chart", node_id="n-1")
+    assert calls == [(handle.request_id, "chart", "n-1")]
+
+
+def test_on_end_fires_completed_on_release():
+    calls = []
+    registry = RunRegistry(on_end=lambda *args: calls.append(args))
+    handle = registry.claim("note")
+    registry.release(handle.request_id)
+    assert calls == [(handle.request_id, "completed")]
+
+
+def test_on_end_does_not_fire_on_release_of_an_unknown_request_id():
+    calls = []
+    registry = RunRegistry(on_end=lambda *args: calls.append(args))
+    registry.release("never-claimed")
+    assert calls == []
+
+
+def test_on_end_fires_cancelled_not_completed_on_cancel():
+    calls = []
+    registry = RunRegistry(on_end=lambda *args: calls.append(args))
+    handle = registry.claim("chat", cancel_event=threading.Event())
+    registry.cancel(handle.request_id)
+    # cancel() pops via _finish_cancel -> _pop, but release() is never
+    # called for a cancelled run - the worker's own late `finally` calls
+    # release() too, and _pop only returns non-None once, so on_end must
+    # fire exactly once, as "cancelled", never overwritten to "completed".
+    assert calls == [(handle.request_id, "cancelled")]
+
+    # The worker's own late release() (registry.release is idempotent -
+    # _pop returns None the second time) must not re-fire on_end.
+    registry.release(handle.request_id)
+    assert calls == [(handle.request_id, "cancelled")]
+
+
+def test_on_end_fires_cancelled_for_every_fired_handle_in_cancel_all():
+    calls = []
+    registry = RunRegistry(on_end=lambda *args: calls.append(args))
+    chat_handle = registry.claim("chat", cancel_event=threading.Event())
+    chart_handle = registry.claim("chart")  # no cancel mechanism - never fires
+    registry.cancel_all()
+    assert calls == [(chat_handle.request_id, "cancelled")]
+    assert chart_handle.request_id not in [c[0] for c in calls]

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -586,6 +586,24 @@ def test_round_trip_preserves_chat_tool_invocations():
     ]
 
 
+def test_round_trip_preserves_chat_estimated_cost_usd():
+    # ADR-016 stage 16.2: the cost snapshot survives save/load, same
+    # posture as prompt_tokens/completion_tokens. The untouched sibling
+    # node pins the load path's absent-key -> None default (every pre-16.2
+    # save lacks the key).
+    doc = SceneDocument()
+    doc.add_chat_node(0, 0, "no cost recorded", is_user=False)
+    priced = doc.add_chat_node(0, 160, "a priced reply", is_user=False)
+    priced.state.estimated_cost_usd = 0.0042
+
+    doc2 = _round_trip(doc)
+    plain2 = next(n for n in doc2.nodes.values() if n.content == "no cost recorded")
+    priced2 = next(n for n in doc2.nodes.values() if n.content == "a priced reply")
+
+    assert plain2.state.estimated_cost_usd is None
+    assert priced2.state.estimated_cost_usd == 0.0042
+
+
 def test_round_trip_preserves_conversation_history_incomplete_marker():
     # ADR-006 stage 6.4 (H5): a conversation node's partial assistant
     # message carries its "incomplete" key through save/load untouched -

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -40,6 +40,7 @@ def test_settings_payload_shape_matches_generated_validator_shape(manager):
         "notificationPreferences",
         "githubTokenConfigured",
         "secretsEncryptedAtRest",
+        "logLevel",
     }
 
 
@@ -50,6 +51,7 @@ def test_settings_payload_reflects_real_manager_defaults(manager):
     assert payload["enableSystemPrompt"] is True
     assert payload["githubTokenConfigured"] is False
     assert set(payload["notificationPreferences"]) == set(SettingsManager.NOTIFICATION_TYPES)
+    assert payload["logLevel"] == "INFO"
 
 
 def test_settings_never_imports_qt():
@@ -116,6 +118,49 @@ def test_set_enable_system_prompt_intent(manager):
 
     asyncio.run(bus.dispatch_intent("app-settings", "setEnableSystemPrompt", [False]))
     assert manager.get_enable_system_prompt() is False
+
+
+# -- ADR-016 stage 16.1: log-level setting -------------------------------
+
+
+def test_get_log_level_defaults_to_info(manager):
+    assert manager.get_log_level() == "INFO"
+
+
+def test_set_log_level_persists_and_rejects_unknown_levels(manager):
+    manager.set_log_level("DEBUG")
+    assert manager.get_log_level() == "DEBUG"
+
+    manager.set_log_level("not-a-real-level")
+    assert manager.get_log_level() == "DEBUG"  # unchanged, not overwritten with garbage
+
+
+def test_set_log_level_intent_persists_and_applies_live(manager):
+    import logging
+
+    bus = SessionBus("settings-log-level-test")
+    register_settings(bus, manager)
+    root_level_before = logging.getLogger().level
+    try:
+        asyncio.run(bus.dispatch_intent("app-settings", "setLogLevel", ["DEBUG"]))
+        assert manager.get_log_level() == "DEBUG"
+        assert logging.getLogger().level == logging.DEBUG
+    finally:
+        logging.getLogger().setLevel(root_level_before)
+
+
+def test_set_log_level_intent_rejects_unknown_level_without_touching_root_logger(manager):
+    import logging
+
+    bus = SessionBus("settings-log-level-reject-test")
+    register_settings(bus, manager)
+    root_level_before = logging.getLogger().level
+    try:
+        asyncio.run(bus.dispatch_intent("app-settings", "setLogLevel", ["not-a-real-level"]))
+        assert manager.get_log_level() == "INFO"  # unchanged
+        assert logging.getLogger().level == root_level_before  # unchanged
+    finally:
+        logging.getLogger().setLevel(root_level_before)
 
 
 def test_set_notification_preference_intent_updates_a_single_type(manager):

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -299,6 +299,48 @@ def test_get_mcp_servers_tolerates_a_malformed_entry_on_disk_without_dropping_th
     assert [entry["name"] for entry in manager.get_mcp_servers()] == ["ok"]
 
 
+# -- ADR-016 stage 16.2: pricing overrides -----------------------------------
+
+
+def test_get_pricing_overrides_defaults_to_empty(manager):
+    assert manager.get_pricing_overrides() == {}
+
+
+def test_set_pricing_overrides_persists_and_normalizes_a_round_trip(manager):
+    manager.set_pricing_overrides({"My-Custom-Model": {"input": 1.5, "output": 3.0}})
+    assert manager.get_pricing_overrides() == {
+        "my-custom-model": {"input": 1.5, "output": 3.0},  # lowercased key
+    }
+
+    reloaded = SettingsManager(manager.state_file)
+    assert reloaded.get_pricing_overrides() == manager.get_pricing_overrides()
+
+
+def test_set_pricing_overrides_replaces_the_whole_table_not_a_merge(manager):
+    manager.set_pricing_overrides({"model-a": {"input": 1.0, "output": 1.0}})
+    manager.set_pricing_overrides({"model-b": {"input": 2.0, "output": 2.0}})
+    assert set(manager.get_pricing_overrides()) == {"model-b"}
+
+
+def test_set_pricing_overrides_drops_malformed_entries(manager):
+    manager.set_pricing_overrides({
+        "": {"input": 1.0, "output": 1.0},  # empty key
+        "negative": {"input": -1.0, "output": 1.0},  # negative price
+        "not-a-dict": "oops",
+        "valid": {"input": 1.0, "output": 2.0},
+    })
+    assert manager.get_pricing_overrides() == {"valid": {"input": 1.0, "output": 2.0}}
+
+
+def test_get_pricing_overrides_tolerates_a_malformed_table_on_disk(tmp_path):
+    import json
+
+    state_file = tmp_path / "session.dat"
+    state_file.write_text(json.dumps({"pricing_overrides": "not a dict"}), encoding="utf-8")
+    manager = SettingsManager(state_file)
+    assert manager.get_pricing_overrides() == {}
+
+
 # -- R7.4a: API-provider settings page. New intents on the same "app-settings"
 # -- topic: setViewingApiProvider (session-local, mirrors setActiveSection),
 # -- loadApiModels/saveApiConfiguration (async, wrap api_provider.py calls via

--- a/backend/token_counter.py
+++ b/backend/token_counter.py
@@ -20,15 +20,19 @@ the provider's prompt count already covers context + input (the entire
 request), so summing it with the estimate columns would double-count. The
 four estimate keys stay in the payload either way - they remain the honest
 pre-flight view, and the only view for providers that report nothing
-(llama.cpp streams). A user-editable pricing config is deliberately out of
-scope here - that is ADR-016 stage 16.2's job; _MODEL_PRICES_PER_MTOK is a
-small built-in table for the common families only.
+(llama.cpp streams). _MODEL_PRICES_PER_MTOK is a small built-in table for
+the common families only; ADR-016 stage 16.2 adds a user-editable local
+override on top (SettingsManager.get_pricing_overrides), keyed by EXACT
+model id (not prefix-matched like the built-in table - a user typing their
+own model id wants that exact string priced, not a substring guess) and
+checked first, so a user can price a model this table doesn't know about,
+or correct a stale built-in price.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 from backend.events import SessionBus
 from graphlink_token_estimator import TokenEstimator
@@ -67,14 +71,31 @@ _MODEL_PRICES_PER_MTOK: tuple[tuple[str, tuple[float, float]], ...] = (
 _LOCAL_PROVIDERS = {"ollama", "llama.cpp", "llamacpp", "local"}
 
 
-def estimate_cost_usd(provider, model, prompt_tokens, completion_tokens) -> float | None:
+def estimate_cost_usd(
+    provider, model, prompt_tokens, completion_tokens, *, overrides: dict[str, dict[str, float]] | None = None,
+) -> float | None:
     """Best-effort USD cost for one reply. None when the model is unknown
-    (never guess a price) or no real counts exist; 0.0 for local providers."""
+    (never guess a price) or no real counts exist; 0.0 for local providers.
+
+    `overrides` (ADR-016 stage 16.2): a user-editable local pricing table
+    (SettingsManager.get_pricing_overrides), keyed by the EXACT model id -
+    checked BEFORE the built-in prefix table, so a user's own price always
+    wins over a built-in guess. Local-provider $0.00 still short-circuits
+    first: overriding a free local model's price is not a use case this
+    supports."""
     if prompt_tokens is None and completion_tokens is None:
         return None
     if str(provider or "").strip().lower() in _LOCAL_PROVIDERS:
         return 0.0
     normalized_model = str(model or "").strip().lower()
+    if overrides:
+        entry = overrides.get(normalized_model)
+        if entry is not None:
+            return round(
+                (prompt_tokens or 0) / 1_000_000 * float(entry.get("input", 0.0))
+                + (completion_tokens or 0) / 1_000_000 * float(entry.get("output", 0.0)),
+                6,
+            )
     for prefix, (input_price, output_price) in _MODEL_PRICES_PER_MTOK:
         if normalized_model.startswith(prefix):
             return round(
@@ -96,6 +117,35 @@ class TokenCounterState:
     usage_is_real: bool = False
     provider_name: str = ""
     model_id: str = ""
+    # ADR-016 stage 16.2: cumulative across every real-usage reply this
+    # session has seen so far (never reset by set_input_text/
+    # reset_real_usage - those describe the CURRENT draft/reply only). Session-
+    # scoped because TokenCounterState itself is one-per-session (see
+    # register_token_counter) - restarting the app or evicting the session
+    # starts a fresh counter, matching every other in-memory session total in
+    # this codebase (no persistence claim is made here).
+    session_prompt_tokens: int = 0
+    session_completion_tokens: int = 0
+    session_estimated_cost_usd: float = 0.0
+    # A zero-arg accessor rather than a stored dict: register_token_counter
+    # wires this to settings_manager.get_pricing_overrides so every read
+    # sees the LIVE value (a setPricingOverrides intent takes effect on the
+    # very next reply, no restart needed) - the same "read fresh, don't
+    # cache" posture every other settings-backed payload in this codebase
+    # already has.
+    pricing_overrides_fn: Callable[[], dict[str, dict[str, float]]] | None = None
+
+    def _pricing_overrides(self) -> dict[str, dict[str, float]] | None:
+        return self.pricing_overrides_fn() if self.pricing_overrides_fn is not None else None
+
+    def estimate_cost_for(self, prompt_tokens, completion_tokens, *, provider: str, model: str) -> float | None:
+        """Public wrapper around estimate_cost_usd, using this counter's own
+        LIVE pricing-overrides accessor. ADR-016 stage 16.2: lets a caller
+        (backend/api/intents_chat.py's _on_usage) compute the SAME cost
+        estimate the composer's token counter would, to stamp onto a reply
+        node as a point-in-time snapshot - see ChatState.estimated_cost_usd's
+        own comment for why that's a snapshot, not a live recomputation."""
+        return estimate_cost_usd(provider, model, prompt_tokens, completion_tokens, overrides=self._pricing_overrides())
 
     def set_input_text(self, text: str) -> None:
         self.input_tokens = estimate_tokens(text)
@@ -123,7 +173,10 @@ class TokenCounterState:
     def set_real_usage(self, prompt_tokens, completion_tokens, *, provider: str = "", model: str = "") -> None:
         """Record provider-reported counts for the reply that just
         completed. provider/model feed the cost estimate; omitted values
-        keep whatever was last recorded."""
+        keep whatever was last recorded. ADR-016 stage 16.2: also folds this
+        reply's counts/cost into the session-cumulative totals, exactly
+        once per real reply (never re-accumulated by reset_real_usage or a
+        later payload() read, which are non-mutating)."""
         self.prompt_tokens = prompt_tokens
         self.completion_tokens = completion_tokens
         self.usage_is_real = prompt_tokens is not None or completion_tokens is not None
@@ -131,6 +184,15 @@ class TokenCounterState:
             self.provider_name = provider
         if model:
             self.model_id = model
+        if self.usage_is_real:
+            self.session_prompt_tokens += prompt_tokens or 0
+            self.session_completion_tokens += completion_tokens or 0
+            reply_cost = estimate_cost_usd(
+                self.provider_name, self.model_id, prompt_tokens, completion_tokens,
+                overrides=self._pricing_overrides(),
+            )
+            if reply_cost is not None:
+                self.session_estimated_cost_usd += reply_cost
 
     def payload(self) -> dict[str, Any]:
         if self.usage_is_real:
@@ -149,15 +211,23 @@ class TokenCounterState:
             "usageIsReal": self.usage_is_real,
             "estimatedCostUsd": (
                 estimate_cost_usd(
-                    self.provider_name, self.model_id, self.prompt_tokens, self.completion_tokens
+                    self.provider_name, self.model_id, self.prompt_tokens, self.completion_tokens,
+                    overrides=self._pricing_overrides(),
                 )
                 if self.usage_is_real
                 else None
             ),
+            "sessionPromptTokens": self.session_prompt_tokens,
+            "sessionCompletionTokens": self.session_completion_tokens,
+            "sessionEstimatedCostUsd": self.session_estimated_cost_usd,
         }
 
 
-def register_token_counter(bus: SessionBus) -> TokenCounterState:
-    state = TokenCounterState()
+def register_token_counter(bus: SessionBus, settings_manager=None) -> TokenCounterState:
+    # ADR-016 stage 16.2: settings_manager is optional (many existing tests
+    # construct a bare register_token_counter(bus)) - None means "no
+    # overrides", i.e. exactly the pre-16.2 built-in-table-only behavior.
+    pricing_overrides_fn = settings_manager.get_pricing_overrides if settings_manager is not None else None
+    state = TokenCounterState(pricing_overrides_fn=pricing_overrides_fn)
     bus.register_topic("token-counter", state.payload)
     return state

--- a/contracts/codegen.py
+++ b/contracts/codegen.py
@@ -437,6 +437,15 @@ GENERATED_ARTIFACTS = [
         "schema_path": _REPO_ROOT / "web_ui" / "src" / "lib" / "bridge-core" / "generated" / "app-chat-library-state.schema.json",
         "ts_path": _REPO_ROOT / "web_ui" / "src" / "lib" / "bridge-core" / "generated" / "app-chat-library-state.ts",
     },
+    {
+        # ADR-016 stage 16.3: the diagnostics topic (backend/diagnostics.py).
+        "dataclass": None,  # resolved lazily in main() to avoid importing
+        "dataclass_import": ("graphlink_diagnostics_payload", "DiagnosticsStatePayload"),
+        "title": "DiagnosticsState",
+        "source": "contracts/graphlink_diagnostics_payload.py::DiagnosticsStatePayload",
+        "schema_path": _REPO_ROOT / "web_ui" / "src" / "lib" / "bridge-core" / "generated" / "diagnostics-state.schema.json",
+        "ts_path": _REPO_ROOT / "web_ui" / "src" / "lib" / "bridge-core" / "generated" / "diagnostics-state.ts",
+    },
 ]
 
 

--- a/contracts/graphlink_app_settings_payload.py
+++ b/contracts/graphlink_app_settings_payload.py
@@ -44,6 +44,8 @@ class AppSettingsStatePayload:
     # written in plaintext - the Settings UI renders a persistent badge
     # when this is false (closes audit finding H12's silence).
     secretsEncryptedAtRest: bool
+    # ADR-016 stage 16.1: General page - the log-level setting.
+    logLevel: str
     # R7.4a: API-provider page.
     activeApiProvider: str
     viewingApiProvider: str

--- a/contracts/graphlink_diagnostics_payload.py
+++ b/contracts/graphlink_diagnostics_payload.py
@@ -1,0 +1,43 @@
+"""ADR-016 stage 16.3: the in-app diagnostics topic's wire contract.
+
+Mirrors backend/diagnostics.py's DiagnosticsState.payload() field-for-field.
+Local-only, in-memory, bounded (see that module's own docstring) - this
+topic exists so a maintainer (or a curious user) can see recent run
+outcomes, publish-size/rate, session count, and recent provider errors
+live in the app, without a metrics pipeline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class DiagnosticsRunRowPayload:
+    runId: str
+    kind: str
+    nodeId: str | None
+    outcome: str  # "running" | "completed" | "cancelled"
+    durationSeconds: float | None
+
+
+@dataclass
+class DiagnosticsProviderErrorPayload:
+    provider: str
+    message: str
+    at: float  # time.time() epoch seconds
+
+
+@dataclass
+class DiagnosticsStatePayload:
+    schemaVersion: int
+    revision: int
+    recentRuns: list[DiagnosticsRunRowPayload]
+    publishCount: int
+    publishBytesTotal: int
+    lastPublishBytes: int | None
+    lastPublishTopic: str | None
+    publishBytesPerSecond: float
+    sessionCount: int | None
+    providerErrors: list[DiagnosticsProviderErrorPayload]
+    minCompatibleSchemaVersion: int | None = None

--- a/contracts/graphlink_scene_payload.py
+++ b/contracts/graphlink_scene_payload.py
@@ -450,6 +450,9 @@ class SceneNodeRow:
     # providers that report nothing).
     promptTokens: int | None = None
     completionTokens: int | None = None
+    # ADR-016 stage 16.2: the USD cost estimated when usage was stamped -
+    # see backend/domain/node_states.py's ChatState.estimated_cost_usd.
+    estimatedCostUsd: float | None = None
     isFinalDeliverable: bool = False
     # R6.1: Notes/Frames/Containers - color/headerColor/itemIds are generic
     # (SceneNode core fields, any kind), the rest populated for kind in

--- a/contracts/graphlink_token_counter_payload.py
+++ b/contracts/graphlink_token_counter_payload.py
@@ -37,6 +37,12 @@ class TokenCounterStatePayload:
     completionTokens: int | None = None
     usageIsReal: bool = False
     estimatedCostUsd: float | None = None
+    # ADR-016 stage 16.2: cumulative across every real-usage reply this
+    # session has seen so far (never reset by a new draft/reply, unlike the
+    # fields above) - see backend/token_counter.py's TokenCounterState.
+    sessionPromptTokens: int = 0
+    sessionCompletionTokens: int = 0
+    sessionEstimatedCostUsd: float = 0.0
     # See ComposerStatePayload's identical field for the full negotiation
     # rationale; optional for the same reason (models a sender predating this
     # field, not today's - IslandBridge.publish() always emits it).

--- a/graphlink_chat_agent.py
+++ b/graphlink_chat_agent.py
@@ -27,6 +27,7 @@ independent reimplementation against SceneDocument, not this function.
 """
 
 import json
+import logging
 from collections import OrderedDict
 
 import graphlink_task_config as config
@@ -34,6 +35,8 @@ import api_provider
 from graphlink_prompts import CONTEXT_SUMMARY_SYSTEM_PROMPT
 from graphlink_token_estimator import TokenEstimator
 from graphlink_memory import clone_history, history_to_transcript, trim_history
+
+logger = logging.getLogger(__name__)
 
 
 # ADR-006 stage 6.8 review fix (summary re-run + toast spam): dropped-turn
@@ -229,9 +232,9 @@ class ChatWorker:
                         pass  # accounting must never fail the reply
             ai_message = response['message']['content']
             return ai_message
-        except Exception as e:
-            print(f"  [LOG-CHATWORKER] API call failed: {e}")
-            raise e
+        except Exception:
+            logger.exception("ChatWorker API call failed")
+            raise
 
     def _summary_for_dropped_turns(self, dropped_messages, cancellation_event, runtime_kwargs):
         """Cache-aware wrapper around _summarize_dropped_turns (6.8 review

--- a/graphlink_desktop.py
+++ b/graphlink_desktop.py
@@ -135,8 +135,17 @@ def main() -> int:
         previous_run_crashed,
     )
     from graphlink_scratch_dirs import sweep_stale_scratch_dirs_on_launch
+    from graphlink_settings_store import SettingsManager
 
-    configure_logging()
+    # ADR-016 stage 16.1: read the persisted log level before attaching
+    # handlers, so the very first log line already honors it. A throwaway
+    # SettingsManager here (create_app() below constructs its own, separate
+    # instance moments later, reading the same file) is safe: _load_state/
+    # _save_state and the secrets migration it runs are idempotent, and this
+    # function is the real entry point, never invoked by the test suite (see
+    # backend/crash_recovery.py's own docstring on that same guarantee).
+    configured_level = getattr(logging, SettingsManager().get_log_level(), logging.INFO)
+    configure_logging(level=configured_level)
     install_exception_handlers()
     crashed = previous_run_crashed()
     mark_running()

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -27,6 +27,11 @@ class SettingsManager:
     # reasoning-level fields below - see api_provider.py's own REASONING_LEVELS
     # docstring for the full per-provider mapping story this feeds.
     REASONING_LEVELS = ("off", "low", "medium", "high")
+    # ADR-016 stage 16.1: the log-level setting's closed vocabulary - the
+    # same names Python's logging module already uses, so
+    # backend/observability.py.apply_log_level can pass this straight to
+    # logging.getLevelName without a translation table.
+    LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR")
     # Bumped whenever session.dat's shape changes in a way future code needs to branch
     # on. Version 2 introduces provider-scoped cloud profiles and explicit local
     # model assignment modes. Version 3 persists refreshed cloud model catalogs so
@@ -352,14 +357,14 @@ class SettingsManager:
                 os.chmod(backup_path, 0o600)
             except OSError:
                 logger.warning("could not chmod %s to 0600 - continuing with existing permissions", backup_path)
-            print(
-                f"Warning: {self.state_file} could not be read ({error}). "
-                f"Backed it up to {backup_path} and reset settings to defaults."
+            logger.warning(
+                "%s could not be read (%s). Backed it up to %s and reset settings to defaults.",
+                self.state_file, error, backup_path,
             )
         except OSError as backup_error:
-            print(
-                f"Warning: {self.state_file} could not be read ({error}) and could not "
-                f"be backed up ({backup_error}). Resetting settings to defaults."
+            logger.warning(
+                "%s could not be read (%s) and could not be backed up (%s). Resetting settings to defaults.",
+                self.state_file, error, backup_error,
             )
 
     def _create_initial_state(self):
@@ -513,7 +518,7 @@ class SettingsManager:
                 os.fsync(f.fileno())
             os.replace(tmp_path, self.state_file)
         except IOError as e:
-            print(f"Error: Could not save session state to {self.state_file}. Reason: {e}")
+            logger.error("Could not save session state to %s. Reason: %s", self.state_file, e)
             try:
                 tmp_path.unlink(missing_ok=True)
             except OSError:
@@ -536,6 +541,18 @@ class SettingsManager:
     def set_enable_system_prompt(self, enabled: bool):
         self.state["enable_system_prompt"] = bool(enabled)
         self._save_state()
+
+    def get_log_level(self):
+        # ADR-016 stage 16.1. INFO by default - matches
+        # backend/crash_recovery.py's own pre-existing default so a fresh
+        # install's boot-time behavior is unchanged until a user opts into
+        # more or less verbosity.
+        return self.state.get("log_level", "INFO")
+
+    def set_log_level(self, level: str):
+        if level in self.LOG_LEVELS:
+            self.state["log_level"] = level
+            self._save_state()
 
     def get_notification_preferences(self):
         saved_preferences = self.state.get("notification_preferences", {}) or {}

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -1056,3 +1056,53 @@ class SettingsManager:
             })
         self.state["mcp_servers"] = normalized
         self._save_state()
+
+    def get_pricing_overrides(self) -> dict:
+        """ADR-016 stage 16.2: user-editable local pricing table, keyed by
+        EXACT model id (lowercased) -> {"input": usd_per_mtok, "output":
+        usd_per_mtok} - see backend/token_counter.py's estimate_cost_usd for
+        how this is consumed (checked before the built-in prefix table).
+        Malformed entries are dropped, not raised on - same posture as
+        get_mcp_servers above."""
+        raw = self.state.get("pricing_overrides", {})
+        if not isinstance(raw, dict):
+            return {}
+        overrides = {}
+        for model_id, prices in raw.items():
+            if not isinstance(prices, dict):
+                continue
+            key = str(model_id).strip().lower()
+            if not key:
+                continue
+            try:
+                input_price = float(prices.get("input", 0.0))
+                output_price = float(prices.get("output", 0.0))
+            except (TypeError, ValueError):
+                continue
+            if input_price < 0 or output_price < 0:
+                continue
+            overrides[key] = {"input": input_price, "output": output_price}
+        return overrides
+
+    def set_pricing_overrides(self, overrides: dict) -> None:
+        """Replaces the WHOLE override table, same "replace the collection"
+        posture as set_mcp_servers - a small, user-managed table edited as a
+        unit. Validates the same way get_pricing_overrides reads back, so a
+        round trip through set then get is always well-formed."""
+        normalized = {}
+        for model_id, prices in (overrides or {}).items():
+            if not isinstance(prices, dict):
+                continue
+            key = str(model_id).strip().lower()
+            if not key:
+                continue
+            try:
+                input_price = float(prices.get("input", 0.0))
+                output_price = float(prices.get("output", 0.0))
+            except (TypeError, ValueError):
+                continue
+            if input_price < 0 or output_price < 0:
+                continue
+            normalized[key] = {"input": input_price, "output": output_price}
+        self.state["pricing_overrides"] = normalized
+        self._save_state()

--- a/graphlink_token_estimator.py
+++ b/graphlink_token_estimator.py
@@ -6,11 +6,15 @@ it was originally introduced alongside the widget that displays its output.
 Nothing here has ever imported Qt.
 """
 
+import logging
+
 try:
     import tiktoken
     TIKTOKEN_AVAILABLE = True
 except ImportError:
     TIKTOKEN_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
 
 
 class TokenEstimator:
@@ -25,7 +29,9 @@ class TokenEstimator:
                     cls._encoding = tiktoken.get_encoding("cl100k_base")
                 except Exception:
                     cls._encoding = None
-                    print("Warning: tiktoken installed, but failed to get encoding. Falling back to character count.")
+                    logger.warning(
+                        "tiktoken installed, but failed to get encoding. Falling back to character count."
+                    )
         return cls._instance
 
     def count_tokens(self, text: str) -> int:

--- a/tests/test_graphlink_desktop.py
+++ b/tests/test_graphlink_desktop.py
@@ -37,6 +37,7 @@ import pytest
 import graphlink_desktop
 import backend.crash_recovery as crash_recovery_module
 import graphlink_scratch_dirs as scratch_dirs_module
+import graphlink_settings_store as settings_store_module
 
 
 class _FakeThread:
@@ -185,6 +186,20 @@ def desktop_harness(tmp_path, monkeypatch):
     monkeypatch.setattr(crash_recovery_module, "configure_logging", lambda *a, **k: None)
     monkeypatch.setattr(crash_recovery_module, "install_exception_handlers", lambda *a, **k: None)
     monkeypatch.setattr(crash_recovery_module, "previous_run_crashed", lambda *a, **k: False)
+
+    # ADR-016 stage 16.1: main() reads the persisted log level via a
+    # throwaway SettingsManager() BEFORE configure_logging() - a real
+    # instance would touch ~/.graphlink/session.dat on whatever machine
+    # runs this suite. Same "patch the source module, not graphlink_desktop's
+    # local name" reasoning as configure_logging above (a fresh `from
+    # graphlink_settings_store import SettingsManager` runs every call).
+    class _FakeLogLevelSettingsManager:
+        def get_log_level(self):
+            return "INFO"
+
+    monkeypatch.setattr(
+        settings_store_module, "SettingsManager", lambda *a, **k: _FakeLogLevelSettingsManager()
+    )
 
     def fake_mark_running(*_a, **_k):
         state.mark_running_calls += 1

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -263,12 +263,12 @@ def test_scene_node_core_field_count():
 
 
 # Captured from SceneDocument.scene_payload()'s real output pre-migration
-# (a single chat node, ADR-002 stage 2.5 PR1/image baseline) - sorted, 90
+# (a single chat node, ADR-002 stage 2.5 PR1/image baseline) - sorted, 91
 # keys (87 pre-6.8 + promptTokens/completionTokens, ADR-006 stage 6.8 +
-# toolCalls, ADR-007 stage 7.4). scene_payload emits this SAME key set for
-# every node regardless of kind (one flat dict literal, no per-kind
-# branching), so one representative node is sufficient; the point is the
-# KEY SET, not per-kind values.
+# toolCalls, ADR-007 stage 7.4 + estimatedCostUsd, ADR-016 stage 16.2).
+# scene_payload emits this SAME key set for every node regardless of kind
+# (one flat dict literal, no per-kind branching), so one representative node
+# is sufficient; the point is the KEY SET, not per-kind values.
 _EXPECTED_SCENE_NODE_WIRE_KEYS = sorted([
     "artifactContent", "attachmentKind", "branchStatus", "byteSize",
     "chartAspectLocked", "chartAssetId", "chartAssetVersion", "chartData",
@@ -278,7 +278,8 @@ _EXPECTED_SCENE_NODE_WIRE_KEYS = sorted([
     "codeSandboxApprovalRequirements",
     "codeSandboxAwaitingApproval", "codeSandboxCode", "codeSandboxError",
     "codeSandboxOutput", "codeSandboxPrompt", "codeSandboxRequirements", "color",
-    "content", "contentParts", "durationSeconds", "filePath", "gitlinkBranch",
+    "content", "contentParts", "durationSeconds", "estimatedCostUsd", "filePath",
+    "gitlinkBranch",
     "gitlinkChangeFingerprint", "gitlinkChangeState", "gitlinkContextStats",
     "gitlinkContextSummary", "gitlinkContextVersion", "gitlinkError",
     "gitlinkLocalRoot", "gitlinkPendingChanges", "gitlinkPreviewText",

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -230,14 +230,16 @@ def _collect_real_registrations() -> dict[tuple[str, str], _FileIntents]:
 
 def test_the_scan_finds_the_real_population_of_registered_intents():
     # Guards the guard: a broken predicate here would make every check below
-    # vacuously pass. 138 is the exact count locked by ADR-010's close-out
+    # vacuously pass. 140 is the exact count locked by ADR-010's close-out
     # recon (scene=89, app-settings=29, app-composer=6, app-chat-library=5,
-    # grid-control=4, notification=3, app-plugins=1, system=1) - app-settings
-    # went 27 -> 28 when ADR-006 stage 6.5 added setProviderMode, and 28 -> 29
-    # when ADR-016 stage 16.1 added setLogLevel.
+    # grid-control=4, notification=3, app-plugins=1, system=1, diagnostics=2)
+    # - app-settings went 27 -> 28 when ADR-006 stage 6.5 added
+    # setProviderMode, 28 -> 29 when ADR-016 stage 16.1 added setLogLevel, and
+    # 138 -> 140 when ADR-016 stage 16.4 added the diagnostics topic's two
+    # intents (exportDiagnosticBundle, openLogFolder).
     real = _collect_real_registrations()
-    assert len(real) == 138, (
-        f"expected exactly 138 real registered intents, found {len(real)} - "
+    assert len(real) == 140, (
+        f"expected exactly 140 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -230,13 +230,14 @@ def _collect_real_registrations() -> dict[tuple[str, str], _FileIntents]:
 
 def test_the_scan_finds_the_real_population_of_registered_intents():
     # Guards the guard: a broken predicate here would make every check below
-    # vacuously pass. 137 is the exact count locked by ADR-010's close-out
-    # recon (scene=89, app-settings=28, app-composer=6, app-chat-library=5,
+    # vacuously pass. 138 is the exact count locked by ADR-010's close-out
+    # recon (scene=89, app-settings=29, app-composer=6, app-chat-library=5,
     # grid-control=4, notification=3, app-plugins=1, system=1) - app-settings
-    # went 27 -> 28 when ADR-006 stage 6.5 added setProviderMode.
+    # went 27 -> 28 when ADR-006 stage 6.5 added setProviderMode, and 28 -> 29
+    # when ADR-016 stage 16.1 added setLogLevel.
     real = _collect_real_registrations()
-    assert len(real) == 137, (
-        f"expected exactly 137 real registered intents, found {len(real)} - "
+    assert len(real) == 138, (
+        f"expected exactly 138 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -221,6 +221,8 @@ CLASSIFICATION: tuple[Classified, ...] = (
     Classified("app-settings", "clearGithubToken", "B", "preference: write-only credential field, not document content"),
     # ADR-006 stage 6.5:
     Classified("app-settings", "setProviderMode", "B", "preference: which provider mode is live/persisted"),
+    # ADR-016 stage 16.1:
+    Classified("app-settings", "setLogLevel", "B", "preference: local logging verbosity"),
 
     # -- backend/api/intents_settings_api_provider.py (app-settings) --------
     Classified("app-settings", "setViewingApiProvider", "B", "preference: which provider sub-page is viewed"),

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -250,4 +250,9 @@ CLASSIFICATION: tuple[Classified, ...] = (
     Classified("app-settings", "scanLlamaCppSystem", "B", "run-lifecycle: scans/caches locally installed models"),
     Classified("app-settings", "pickLlamaCppScanFolder", "B", "run-lifecycle: native folder pick + scan"),
     Classified("app-settings", "saveLlamaCppSettings", "B", "preference: runtime configuration"),
+
+    # -- backend/api/intents_diagnostics.py (diagnostics) --------------------
+    # ADR-016 stage 16.4:
+    Classified("diagnostics", "exportDiagnosticBundle", "B", "read-only: assembles a redacted diagnostic snapshot, no document mutation"),
+    Classified("diagnostics", "openLogFolder", "B", "read-only: opens the OS file browser, no document mutation"),
 )

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -18,6 +18,7 @@ import { ChatLibraryDialog } from "./chrome/ChatLibraryDialog";
 import { CommandPalette } from "./chrome/CommandPalette";
 import { Composer } from "./chrome/Composer";
 import { ComposerStore } from "./chrome/composerStore";
+import { DiagnosticsDialog } from "./chrome/DiagnosticsDialog";
 import { HelpDialog } from "./chrome/HelpDialog";
 import { NotificationBanner } from "./chrome/NotificationBanner";
 import { PinOverlay } from "./chrome/PinOverlay";
@@ -325,6 +326,7 @@ function App() {
                 <CommandPalette store={sceneStore} />
                 <AboutDialog transport={transport} />
                 <HelpDialog />
+                <DiagnosticsDialog transport={transport} />
                 <SettingsDialog transport={transport} />
                 <ChatLibraryDialog transport={transport} />
               </div>

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -82,6 +82,10 @@ function renderChatNode(overrides: Partial<ChatFlowNode["data"]> = {}, selected:
         onCancelRegenerate,
         // ADR-007 stage 7.4
         toolInvocations: [],
+        // ADR-016 stage 16.2
+        promptTokens: null,
+        completionTokens: null,
+        estimatedCostUsd: null,
         ...dataOverrides,
       },
     } as unknown as NodeProps<ChatFlowNode>;
@@ -983,5 +987,27 @@ describe("ChatNodeView tool invocations (ADR-007 stage 7.4)", () => {
     });
     await user.click(screen.getByText("1 tool call"));
     expect(container.querySelector(".chat-node-tool-invocation.error")).not.toBeNull();
+  });
+});
+
+describe("ChatNodeView usage badge (ADR-016 stage 16.2)", () => {
+  it("renders nothing when neither promptTokens nor completionTokens is present", () => {
+    const { container } = renderChatNode({ promptTokens: null, completionTokens: null });
+    expect(container.querySelector(".chat-node-usage-badge")).toBeNull();
+  });
+
+  it("renders prompt/completion counts and the estimated cost when present", () => {
+    renderChatNode({ promptTokens: 111, completionTokens: 22, estimatedCostUsd: 0.0042 });
+    expect(screen.getByText("111→22 · $0.0042")).toBeInTheDocument();
+  });
+
+  it("renders the token counts without a cost suffix when estimatedCostUsd is null (unpriced model)", () => {
+    renderChatNode({ promptTokens: 111, completionTokens: 22, estimatedCostUsd: null });
+    expect(screen.getByText("111→22")).toBeInTheDocument();
+  });
+
+  it("still renders when only one of promptTokens/completionTokens is present", () => {
+    renderChatNode({ promptTokens: 50, completionTokens: null, estimatedCostUsd: null });
+    expect(screen.getByText("50→?")).toBeInTheDocument();
   });
 });

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -149,6 +149,13 @@ export interface ChatNodeData extends Record<string, unknown> {
   // assistant turn that calls tools renders the calls and their results
   // (collapsible)".
   toolInvocations: ToolInvocationData[];
+  // ADR-016 stage 16.2: provider-reported real usage + the cost snapshot
+  // taken when it was stamped - null for user messages, non-chat kinds,
+  // and any reply whose provider reports nothing (e.g. llama.cpp streams).
+  // Rendered alongside the model badge below when present.
+  promptTokens: number | null;
+  completionTokens: number | null;
+  estimatedCostUsd: number | null;
 }
 
 // Mirrors the generated ToolInvocationRow (web_ui/src/lib/bridge-core/
@@ -763,6 +770,21 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
           {data.model && (
             <span className="chat-node-model-badge" title={data.provider ?? undefined}>
               {data.model}
+            </span>
+          )}
+          {(data.promptTokens != null || data.completionTokens != null) && (
+            // ADR-016 stage 16.2: real usage on the node itself - data
+            // exists on the wire since ADR-006 stage 6.8 but was never
+            // rendered until now (only the composer's own live counter
+            // showed it). estimatedCostUsd is null for local providers'
+            // genuine $0 vs an unpriced model - the "$" prefix distinguishes
+            // a real, if free, answer from nothing to show.
+            <span
+              className="chat-node-usage-badge"
+              title={`Prompt: ${data.promptTokens ?? "?"} · Completion: ${data.completionTokens ?? "?"}`}
+            >
+              {`${data.promptTokens ?? "?"}→${data.completionTokens ?? "?"}`}
+              {data.estimatedCostUsd != null && ` · $${data.estimatedCostUsd.toFixed(4)}`}
             </span>
           )}
           {data.isFinalDeliverable && (

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -533,6 +533,12 @@ export function toFlowNodes(
           // payload.py). Rendered as a collapsible section in
           // ChatNodeView.tsx.
           toolInvocations: n.toolCalls,
+          // ADR-016 stage 16.2: real usage + the cost snapshot taken when it
+          // was stamped - null for user messages and replies whose provider
+          // reports nothing. See ChatNodeView.tsx's own render guard.
+          promptTokens: n.promptTokens ?? null,
+          completionTokens: n.completionTokens ?? null,
+          estimatedCostUsd: n.estimatedCostUsd ?? null,
         },
       });
       continue;

--- a/web_ui/src/app/chrome/AppBar.test.tsx
+++ b/web_ui/src/app/chrome/AppBar.test.tsx
@@ -130,6 +130,7 @@ describe("AppBar", () => {
         "Fit All",
         "About",
         "Help",
+        "Diagnostics",
       ]) {
         expect(menuItems.getByRole("button", { name: label })).toBeInTheDocument();
       }
@@ -174,7 +175,7 @@ describe("AppBar", () => {
       expect(screen.getByRole("button", { name: "About" }).className).toContain("checked");
     });
 
-    it("the five overlay-opening overflow items (Pins/View/Plugins/About/Help) carry aria-pressed, matching their inline copies' real-state contract", async () => {
+    it("the six overlay-opening overflow items (Pins/View/Plugins/About/Help/Diagnostics) carry aria-pressed, matching their inline copies' real-state contract", async () => {
       // Cannot be driven to aria-pressed="true" through normal interaction
       // in this test: OverlayProvider is single-open, so the instant any of
       // these becomes the open surface, "toolbar-overflow" stops being it
@@ -185,7 +186,7 @@ describe("AppBar", () => {
       renderAppBar();
       await user.click(screen.getByRole("button", { name: "More toolbar actions" }));
       const menu = within(screen.getByRole("dialog"));
-      for (const label of ["Pins", "View", "Plugins", "About", "Help"]) {
+      for (const label of ["Pins", "View", "Plugins", "About", "Help", "Diagnostics"]) {
         expect(menu.getByRole("button", { name: label })).toHaveAttribute("aria-pressed", "false");
       }
     });
@@ -208,6 +209,7 @@ describe("AppBar", () => {
         ["Fit All", "3"],
         ["About", "1"],
         ["Help", "1"],
+        ["Diagnostics", "1"],
       ];
       for (const [label, tier] of pairs) {
         // Every duplicated pair shares its exact label except Plugins (the

--- a/web_ui/src/app/chrome/AppBar.tsx
+++ b/web_ui/src/app/chrome/AppBar.tsx
@@ -343,6 +343,15 @@ export function AppBar({ store }: { store: SceneStore }) {
         >
           Help
         </button>
+        <button
+          type="button"
+          className={"appbar-overflow-item" + (overlays.isOpen("diagnostics") ? " checked" : "")}
+          data-tier="1"
+          aria-pressed={overlays.isOpen("diagnostics")}
+          onClick={() => overlays.toggle("diagnostics", "dialog")}
+        >
+          Diagnostics
+        </button>
       </Popover>
 
       <button
@@ -373,6 +382,16 @@ export function AppBar({ store }: { store: SceneStore }) {
         onClick={() => overlays.toggle("help", "dialog")}
       >
         Help
+      </button>
+      <button
+        type="button"
+        className={chip("diagnostics") + " appbar-tier"}
+        data-tier="1"
+        data-overlay-trigger="diagnostics"
+        aria-pressed={overlays.isOpen("diagnostics")}
+        onClick={() => overlays.toggle("diagnostics", "dialog")}
+      >
+        Diagnostics
       </button>
     </div>
   );

--- a/web_ui/src/app/chrome/DiagnosticsDialog.test.tsx
+++ b/web_ui/src/app/chrome/DiagnosticsDialog.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DiagnosticsDialog } from "./DiagnosticsDialog";
 import { OverlayProvider, useOverlays } from "../overlays/overlays";
 import type { WsTransport } from "../../lib/ws/transport";
@@ -22,8 +22,18 @@ const snapshot = {
   providerErrors: [{ provider: "ollama", message: "connection refused", at: 1700000000 }],
 };
 
+// Matches ChatLibraryDialog.test.tsx's exact makeTransport() shape
+// (intents array + intent/fireIntent recording into it) - PLUS a `request`
+// mock, since exportDiagnosticBundle needs the actual reply
+// (fireIntent()/intent() are both `: void` on the real transport, see
+// transport.ts and DiagnosticsDialog.tsx's own exportDiagnosticBundle() doc
+// for why that call goes through transport.request() instead). `request` is
+// wired to also record into the same `intents` array so a single assertion
+// list covers all three call shapes.
 function makeTransport() {
+  const intents: unknown[][] = [];
   let listener: ((payload: Record<string, unknown>) => void) | null = null;
+  const request = vi.fn<(topic: string, intent: string, args?: unknown[]) => Promise<unknown>>();
   const transport = {
     subscribe: (_topic: string, l: (payload: Record<string, unknown>) => void) => {
       listener = l;
@@ -31,9 +41,21 @@ function makeTransport() {
         listener = null;
       };
     },
+    intent: (topic: string, intent: string, args: unknown[]) => {
+      intents.push([topic, intent, args]);
+    },
+    fireIntent: (topic: string, intent: string, args: unknown[] = []) => {
+      intents.push([topic, intent, args]);
+    },
+    request: (topic: string, intent: string, args: unknown[] = []) => {
+      intents.push([topic, intent, args]);
+      return request(topic, intent, args);
+    },
   } as unknown as WsTransport;
   return {
     transport,
+    intents,
+    request,
     push: (payload: Record<string, unknown>) => listener?.(payload),
   };
 }
@@ -107,5 +129,57 @@ describe("DiagnosticsDialog", () => {
 
     expect(screen.getByText("No runs yet this session.")).toBeInTheDocument();
     expect(screen.getByText("No provider errors this session.")).toBeInTheDocument();
+  });
+
+  it("clicking 'Open log folder' fires openLogFolder with no args (fire-and-forget, no reply awaited)", async () => {
+    const { user, intents } = await setup();
+
+    await user.click(screen.getByRole("button", { name: "Open log folder" }));
+
+    expect(intents).toContainEqual(["diagnostics", "openLogFolder", []]);
+  });
+
+  it("clicking 'Export diagnostic bundle' requests exportDiagnosticBundle, then renders the bundle JSON and a working Copy button once it resolves", async () => {
+    const bundle = {
+      bundleSchemaVersion: 1,
+      generatedAt: "2026-08-08T00:00:00Z",
+      appVersion: "0.9.0",
+      os: { system: "Windows", release: "11", pythonVersion: "3.12.4" },
+      nodeCounts: { chat: 2, document: 1 },
+      diagnostics: snapshot,
+    };
+    const path = "C:\\Users\\test\\.graphlink\\diagnostics\\bundle-20260808T000000Z.json";
+
+    const { user, intents, request } = await setup();
+    // userEvent.setup() (inside setup() above) installs its OWN
+    // navigator.clipboard stub internally - defining this mock any earlier
+    // gets silently clobbered the moment that runs (see DocumentViewPanel.
+    // test.tsx's own "Copy button" describe block for the same fix).
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true, writable: true });
+    request.mockResolvedValueOnce({ bundle, path });
+
+    await user.click(screen.getByRole("button", { name: "Export diagnostic bundle" }));
+
+    expect(intents).toContainEqual(["diagnostics", "exportDiagnosticBundle", []]);
+
+    // The Copy button only renders once the export has resolved - a safe
+    // readiness signal for the async state update. The path/JSON assertions
+    // below go through querySelector + raw .textContent instead of
+    // getByText: the caption's text is split across a static "Also written
+    // to " text node and a sibling {path} expression (so the <p>'s own
+    // textContent includes both, not path alone), and getByText also
+    // normalizes whitespace (collapses newlines/indentation) before
+    // comparing, which would falsely mismatch pretty-printed JSON's real
+    // newlines.
+    await screen.findByRole("button", { name: "Copy to clipboard" });
+
+    const expectedJson = JSON.stringify(bundle, null, 2);
+    const pre = document.querySelector(".diagnostics-bundle-preview");
+    expect(pre?.textContent).toBe(expectedJson);
+    expect(document.querySelector(".diagnostics-bundle-path")?.textContent).toBe(`Also written to ${path}`);
+
+    await user.click(screen.getByRole("button", { name: "Copy to clipboard" }));
+    expect(writeText).toHaveBeenCalledWith(expectedJson);
   });
 });

--- a/web_ui/src/app/chrome/DiagnosticsDialog.test.tsx
+++ b/web_ui/src/app/chrome/DiagnosticsDialog.test.tsx
@@ -1,0 +1,111 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { DiagnosticsDialog } from "./DiagnosticsDialog";
+import { OverlayProvider, useOverlays } from "../overlays/overlays";
+import type { WsTransport } from "../../lib/ws/transport";
+
+const snapshot = {
+  schemaVersion: 1,
+  minCompatibleSchemaVersion: 1,
+  revision: 1,
+  recentRuns: [
+    { runId: "r-2", kind: "chat", nodeId: "n-2", outcome: "running", durationSeconds: null },
+    { runId: "r-1", kind: "chat", nodeId: "n-1", outcome: "completed", durationSeconds: 1.5 },
+  ],
+  publishCount: 42,
+  publishBytesTotal: 2048,
+  lastPublishBytes: 512,
+  lastPublishTopic: "scene",
+  publishBytesPerSecond: 100.5,
+  sessionCount: 3,
+  providerErrors: [{ provider: "ollama", message: "connection refused", at: 1700000000 }],
+};
+
+function makeTransport() {
+  let listener: ((payload: Record<string, unknown>) => void) | null = null;
+  const transport = {
+    subscribe: (_topic: string, l: (payload: Record<string, unknown>) => void) => {
+      listener = l;
+      return () => {
+        listener = null;
+      };
+    },
+  } as unknown as WsTransport;
+  return {
+    transport,
+    push: (payload: Record<string, unknown>) => listener?.(payload),
+  };
+}
+
+function OpenDiagnosticsButton() {
+  const overlays = useOverlays();
+  return (
+    <button type="button" onClick={() => overlays.open("diagnostics", "dialog")}>
+      open diagnostics
+    </button>
+  );
+}
+
+async function setup() {
+  const user = userEvent.setup();
+  const fake = makeTransport();
+  render(
+    <OverlayProvider>
+      <OpenDiagnosticsButton />
+      <DiagnosticsDialog transport={fake.transport} />
+    </OverlayProvider>,
+  );
+  act(() => fake.push(snapshot));
+  await user.click(screen.getByRole("button", { name: "open diagnostics" }));
+  return { user, ...fake };
+}
+
+describe("DiagnosticsDialog", () => {
+  it("renders publish size/rate and session count from the live snapshot", async () => {
+    await setup();
+    expect(screen.getByText("3")).toBeInTheDocument(); // sessionCount
+    expect(screen.getByText("42")).toBeInTheDocument(); // publishCount
+    expect(screen.getByText("2.0 KB")).toBeInTheDocument(); // publishBytesTotal
+    expect(screen.getByText("scene · 512 B")).toBeInTheDocument(); // last publish
+  });
+
+  it("renders recent runs newest-first with outcome and duration", async () => {
+    await setup();
+    const rows = screen.getAllByRole("row").slice(1); // drop the header row
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent("n-2");
+    expect(rows[0]).toHaveTextContent("running");
+    expect(rows[1]).toHaveTextContent("n-1");
+    expect(rows[1]).toHaveTextContent("completed");
+    expect(rows[1]).toHaveTextContent("1.50s");
+  });
+
+  it("renders a real provider error, matching the ADR-016 16.3 exit criterion", async () => {
+    await setup();
+    expect(screen.getByText("ollama")).toBeInTheDocument();
+    expect(screen.getByText("connection refused")).toBeInTheDocument();
+  });
+
+  it("shows empty-state copy when there are no runs or provider errors yet", async () => {
+    const user = userEvent.setup();
+    const fake = makeTransport();
+    render(
+      <OverlayProvider>
+        <OpenDiagnosticsButton />
+        <DiagnosticsDialog transport={fake.transport} />
+      </OverlayProvider>,
+    );
+    act(() =>
+      fake.push({
+        ...snapshot,
+        recentRuns: [],
+        providerErrors: [],
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "open diagnostics" }));
+
+    expect(screen.getByText("No runs yet this session.")).toBeInTheDocument();
+    expect(screen.getByText("No provider errors this session.")).toBeInTheDocument();
+  });
+});

--- a/web_ui/src/app/chrome/DiagnosticsDialog.tsx
+++ b/web_ui/src/app/chrome/DiagnosticsDialog.tsx
@@ -12,6 +12,13 @@ import { Dialog } from "../overlays/overlays";
  * is field visibility for the maintainer/a curious user, not a metrics
  * pipeline. Mirrors AboutDialog.tsx's "no client store class needed for a
  * single read-only, never-mutated topic" subscribe pattern.
+ *
+ * ADR-016 stage 16.4: adds the action row - "Open log folder" (fire-and-
+ * forget openLogFolder) and "Export diagnostic bundle" (exportDiagnosticBundle,
+ * a real request/reply since the point is the returned bundle+path - see
+ * exportDiagnosticBundle() below for why that is NOT fireIntent). Both
+ * intents live on the same "diagnostics" topic (backend/api/
+ * intents_diagnostics.py) and are read-only/non-undoable.
  */
 
 const initialState: DiagnosticsState = {
@@ -38,8 +45,22 @@ function formatTimestamp(epochSeconds: number): string {
   return new Date(epochSeconds * 1000).toLocaleTimeString();
 }
 
+/** ADR-016 stage 16.4: the shape `exportDiagnosticBundle` replies with -
+ * `bundle` is intentionally untyped here (a free-form redacted snapshot of
+ * appVersion/os/nodeCounts/the diagnostics topic's own fields) since it
+ * exists to be pretty-printed and copied, not read field-by-field by this
+ * component. */
+interface DiagnosticBundleResult {
+  bundle: unknown;
+  path: string;
+}
+
 export function DiagnosticsDialog({ transport }: { transport: WsTransport }) {
   const [state, setState] = useState<DiagnosticsState>(initialState);
+  const [exportResult, setExportResult] = useState<DiagnosticBundleResult | null>(null);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     return transport.subscribe("diagnostics", (payload) => {
@@ -48,6 +69,40 @@ export function DiagnosticsDialog({ transport }: { transport: WsTransport }) {
       else console.error("[diagnostics] rejected snapshot:", validated.errors);
     });
   }, [transport]);
+
+  // Fire-and-forget, matching every other "trigger a native OS action, no
+  // reply worth waiting on" call site (e.g. SettingsDialog's Ollama/Llama.cpp
+  // "Scan Folder..." buttons) - the backend's `{opened: boolean}` reply
+  // exists for its own test coverage, not for this UI to branch on.
+  function openLogFolder() {
+    transport.fireIntent("diagnostics", "openLogFolder", []);
+  }
+
+  // Unlike openLogFolder, this call's whole point is its reply (the bundle
+  // to preview/copy and the path it was written to) - fireIntent()/intent()
+  // are both declared `: void` (see transport.ts's own doc), so this goes
+  // through transport.request() directly instead, the same primitive
+  // sceneStore.ts's fetchGitlinkRepositories/fetchGitlinkContext already use
+  // for exactly this "I need the actual return value" case.
+  function exportDiagnosticBundle() {
+    setExporting(true);
+    setExportError(null);
+    transport
+      .request("diagnostics", "exportDiagnosticBundle", [])
+      .then((value) => setExportResult(value as DiagnosticBundleResult))
+      .catch(() => setExportError("Could not export the diagnostic bundle."))
+      .finally(() => setExporting(false));
+  }
+
+  // Matches ChatNodeView/DocumentViewPanel's own quick-copy pattern: a
+  // transient "Copied" flash rather than a persistent state change.
+  function copyBundleToClipboard() {
+    if (!exportResult) return;
+    navigator.clipboard.writeText(JSON.stringify(exportResult.bundle, null, 2)).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
 
   return (
     <Dialog name="diagnostics" title="Diagnostics" className="diagnostics-dialog">
@@ -117,6 +172,38 @@ export function DiagnosticsDialog({ transport }: { transport: WsTransport }) {
             </li>
           ))}
         </ul>
+      )}
+
+      <div className="diagnostics-actions">
+        <button type="button" className="diagnostics-action-button" onClick={openLogFolder}>
+          Open log folder
+        </button>
+        <button
+          type="button"
+          className="diagnostics-action-button"
+          onClick={exportDiagnosticBundle}
+          disabled={exporting}
+        >
+          {exporting ? "Exporting…" : "Export diagnostic bundle"}
+        </button>
+      </div>
+
+      {exportError && (
+        <p className="diagnostics-empty" role="alert">
+          {exportError}
+        </p>
+      )}
+
+      {exportResult && (
+        <div className="diagnostics-bundle-preview-wrap">
+          <div className="diagnostics-actions">
+            <button type="button" className="diagnostics-action-button" onClick={copyBundleToClipboard}>
+              {copied ? "Copied" : "Copy to clipboard"}
+            </button>
+          </div>
+          <pre className="diagnostics-bundle-preview">{JSON.stringify(exportResult.bundle, null, 2)}</pre>
+          <p className="diagnostics-bundle-path">Also written to {exportResult.path}</p>
+        </div>
       )}
     </Dialog>
   );

--- a/web_ui/src/app/chrome/DiagnosticsDialog.tsx
+++ b/web_ui/src/app/chrome/DiagnosticsDialog.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import type { WsTransport } from "../../lib/ws/transport";
+import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
+import type { DiagnosticsState } from "../../lib/bridge-core/generated/diagnostics-state";
+import { Dialog } from "../overlays/overlays";
+
+/**
+ * ADR-016 stage 16.3: the in-app diagnostics dialog - recent run outcomes,
+ * publish size/rate, session count, and recent provider errors, all
+ * computed by backend/diagnostics.py and pushed live over the "diagnostics"
+ * topic. Local-only, in-memory, bounded (see that module's docstring); this
+ * is field visibility for the maintainer/a curious user, not a metrics
+ * pipeline. Mirrors AboutDialog.tsx's "no client store class needed for a
+ * single read-only, never-mutated topic" subscribe pattern.
+ */
+
+const initialState: DiagnosticsState = {
+  schemaVersion: 1,
+  minCompatibleSchemaVersion: 1,
+  revision: 0,
+  recentRuns: [],
+  publishCount: 0,
+  publishBytesTotal: 0,
+  lastPublishBytes: null,
+  lastPublishTopic: null,
+  publishBytesPerSecond: 0,
+  sessionCount: null,
+  providerErrors: [],
+};
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatTimestamp(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toLocaleTimeString();
+}
+
+export function DiagnosticsDialog({ transport }: { transport: WsTransport }) {
+  const [state, setState] = useState<DiagnosticsState>(initialState);
+
+  useEffect(() => {
+    return transport.subscribe("diagnostics", (payload) => {
+      const validated = TOPIC_VALIDATORS["diagnostics"](payload);
+      if (validated.ok) setState(validated.value as DiagnosticsState);
+      else console.error("[diagnostics] rejected snapshot:", validated.errors);
+    });
+  }, [transport]);
+
+  return (
+    <Dialog name="diagnostics" title="Diagnostics" className="diagnostics-dialog">
+      <div className="diagnostics-stats">
+        <div className="diagnostics-stat">
+          <span className="diagnostics-stat-label">Sessions</span>
+          <span className="diagnostics-stat-value">{state.sessionCount ?? "—"}</span>
+        </div>
+        <div className="diagnostics-stat">
+          <span className="diagnostics-stat-label">Publishes</span>
+          <span className="diagnostics-stat-value">{state.publishCount}</span>
+        </div>
+        <div className="diagnostics-stat">
+          <span className="diagnostics-stat-label">Total published</span>
+          <span className="diagnostics-stat-value">{formatBytes(state.publishBytesTotal)}</span>
+        </div>
+        <div className="diagnostics-stat">
+          <span className="diagnostics-stat-label">Publish rate</span>
+          <span className="diagnostics-stat-value">{formatBytes(state.publishBytesPerSecond)}/s</span>
+        </div>
+        <div className="diagnostics-stat">
+          <span className="diagnostics-stat-label">Last publish</span>
+          <span className="diagnostics-stat-value">
+            {state.lastPublishTopic != null
+              ? `${state.lastPublishTopic} · ${formatBytes(state.lastPublishBytes ?? 0)}`
+              : "—"}
+          </span>
+        </div>
+      </div>
+
+      <h2 className="diagnostics-section-title">Recent runs</h2>
+      {state.recentRuns.length === 0 ? (
+        <p className="diagnostics-empty">No runs yet this session.</p>
+      ) : (
+        <table className="diagnostics-table">
+          <thead>
+            <tr>
+              <th>Kind</th>
+              <th>Node</th>
+              <th>Outcome</th>
+              <th>Duration</th>
+            </tr>
+          </thead>
+          <tbody>
+            {state.recentRuns.map((run) => (
+              <tr key={run.runId}>
+                <td>{run.kind}</td>
+                <td>{run.nodeId ?? "—"}</td>
+                <td className={`diagnostics-outcome diagnostics-outcome-${run.outcome}`}>{run.outcome}</td>
+                <td>{run.durationSeconds != null ? `${run.durationSeconds.toFixed(2)}s` : "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <h2 className="diagnostics-section-title">Provider errors</h2>
+      {state.providerErrors.length === 0 ? (
+        <p className="diagnostics-empty">No provider errors this session.</p>
+      ) : (
+        <ul className="diagnostics-error-list">
+          {state.providerErrors.map((err, index) => (
+            <li key={`${err.at}-${index}`} className="diagnostics-error-item">
+              <span className="diagnostics-error-provider">{err.provider}</span>
+              <span className="diagnostics-error-time">{formatTimestamp(err.at)}</span>
+              <span className="diagnostics-error-message">{err.message}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Dialog>
+  );
+}

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -22,6 +22,7 @@ const snapshot = {
   notificationPreferences: { info: true, success: true, warning: true, error: true },
   githubTokenConfigured: false,
   secretsEncryptedAtRest: true,
+  logLevel: "INFO",
   activeApiProvider: "OpenAI-Compatible",
   viewingApiProvider: "OpenAI-Compatible",
   apiBaseUrl: "https://api.openai.com/v1",

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -100,6 +100,8 @@ const initialState: AppSettingsState = {
   // on the very first "app-settings" publish, same as every other field
   // here.
   secretsEncryptedAtRest: true,
+  // ADR-016 stage 16.1: mirrors SettingsManager.get_log_level()'s own default.
+  logLevel: "INFO",
   activeApiProvider: API_PROVIDER_OPENAI,
   viewingApiProvider: API_PROVIDER_OPENAI,
   apiBaseUrl: DEFAULT_OPENAI_BASE_URL,

--- a/web_ui/src/app/chrome/composerStore.test.ts
+++ b/web_ui/src/app/chrome/composerStore.test.ts
@@ -112,6 +112,10 @@ describe("ComposerStore", () => {
       completionTokens: null,
       usageIsReal: false,
       estimatedCostUsd: null,
+      // ADR-016 stage 16.2: session-cumulative keys (required by the validator).
+      sessionPromptTokens: 0,
+      sessionCompletionTokens: 0,
+      sessionEstimatedCostUsd: 0,
     });
     listeners.get("notification")!({
       schemaVersion: 1,

--- a/web_ui/src/app/chrome/composerStore.ts
+++ b/web_ui/src/app/chrome/composerStore.ts
@@ -59,6 +59,11 @@ export const initialTokenCounterState: TokenCounterState = {
   completionTokens: null,
   usageIsReal: false,
   estimatedCostUsd: null,
+  // ADR-016 stage 16.2: cumulative across every real-usage reply this
+  // session has seen so far - see backend/token_counter.py.
+  sessionPromptTokens: 0,
+  sessionCompletionTokens: 0,
+  sessionEstimatedCostUsd: 0,
 };
 
 export const initialNotificationState: NotificationState = {

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2808,6 +2808,67 @@ body,
   color: var(--gl-surface-text-primary);
 }
 
+/* ADR-016 stage 16.4: the action row (Open log folder / Export diagnostic
+   bundle) - same neutral-button language as .settings-button-row/.settings-
+   button (SettingsDialog's Ollama "Scan Folder..." row), just a size step
+   down to match this dialog's own 11-13px scale rather than settings'
+   13-14px chrome. */
+.diagnostics-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.diagnostics-action-button {
+  padding: 6px 12px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-hover);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.diagnostics-action-button:hover:not(:disabled) {
+  background-color: var(--gl-neutral-button-border);
+}
+
+.diagnostics-action-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.diagnostics-bundle-preview-wrap {
+  margin-top: 12px;
+}
+
+/* Same monospace/inset-surface treatment as .chat-node-tool-invocation-
+   arguments/-result (the app's other "pretty-printed JSON in a scrollable
+   box" precedent), just bounded with a max-height since a bundle can run
+   long (recentRuns/providerErrors are both included). */
+.diagnostics-bundle-preview {
+  margin: 8px 0 6px;
+  padding: 10px;
+  max-height: 240px;
+  overflow: auto;
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-surface-inset, var(--gl-surface-node-body));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.diagnostics-bundle-path {
+  margin: 0;
+  font-size: 11px;
+  color: var(--gl-surface-text-muted);
+  word-break: break-all;
+}
+
 /* -- Document view panel (R8a follow-up) ------------------------------------
    Docked flush-left, border-right only - restores legacy's
    DocumentViewerPanel chrome (a permanent embedded QWidget, corner_radius=0,

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1101,6 +1101,17 @@ body,
   max-width: 140px;
 }
 
+/* ADR-016 stage 16.2: real per-node token/cost usage, same plain-text
+   scale as .chat-node-model-badge next to it - a compact "prompt→completion
+   · $cost" label, not a pill (numbers vary too widely in width). */
+.chat-node-usage-badge {
+  font-size: 10px;
+  line-height: 1;
+  color: var(--gl-surface-text-muted);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
 /* ADR-002 Workstream 1 ("Branch status and lifecycle"): a small filled dot,
    ALWAYS rendered (unlike every other badge above, which is conditional) -
    backgroundColor is set inline per-node (one of 4 real, visually-distinct

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2229,9 +2229,20 @@ body,
 .token-counter-popout {
   position: absolute;
   bottom: calc(100% + 8px);
-  left: 0;
+  /* ADR-016 stage 16.2 fix: the trigger sits at the composer's far right
+     edge (next to Send), and ADR-006 stage 6.8 grew this from 4 columns to
+     7 (prompt/completion/est. cost added) without revisiting this rule -
+     left:0 + nowrap let it grow rightward, unbounded, off the composer and
+     over whatever sat past it (reported: overlapping Document View).
+     Anchoring right and wrapping keeps it inside the viewport regardless
+     of column count. */
+  right: 0;
+  left: auto;
   display: flex;
-  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px 14px;
+  max-width: min(360px, 90vw);
   padding: 12px 14px;
   background-color: var(--gl-surface-node-body);
   border: 1px solid var(--gl-surface-border);
@@ -2242,7 +2253,6 @@ body,
      app, it just isn't driven by the shared overlay system (a hover
      fold-out has no "open surface" to register - see TokenCounter.tsx). */
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
-  white-space: nowrap;
 }
 
 .token-counter-row {
@@ -2250,6 +2260,7 @@ body,
   flex-direction: column;
   align-items: center;
   gap: 1px;
+  white-space: nowrap;
 }
 
 .token-counter-label {
@@ -2683,6 +2694,118 @@ body,
 .help-shell {
   display: flex;
   height: 100%;
+}
+
+/* -- Diagnostics dialog (ADR-016 stage 16.3) ------------------------------ */
+
+.diagnostics-dialog {
+  min-width: 480px;
+  max-width: min(640px, calc(100vw - 64px));
+  max-height: min(600px, calc(100vh - 96px));
+  overflow-y: auto;
+}
+
+.diagnostics-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px 14px;
+  margin-bottom: 16px;
+}
+
+.diagnostics-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.diagnostics-stat-label {
+  font-size: 11px;
+  color: var(--gl-surface-text-muted);
+}
+
+.diagnostics-stat-value {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--gl-surface-text-primary);
+}
+
+.diagnostics-section-title {
+  margin: 16px 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--gl-surface-text-muted);
+}
+
+.diagnostics-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--gl-surface-text-muted);
+}
+
+.diagnostics-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.diagnostics-table th,
+.diagnostics-table td {
+  text-align: left;
+  padding: 4px 8px 4px 0;
+  border-bottom: 1px solid var(--gl-surface-border);
+  color: var(--gl-surface-text-primary);
+}
+
+.diagnostics-table th {
+  color: var(--gl-surface-text-muted);
+  font-weight: 600;
+}
+
+.diagnostics-outcome-completed {
+  color: var(--gl-semantic-status-success, var(--gl-surface-text-primary));
+}
+
+.diagnostics-outcome-cancelled {
+  color: var(--gl-surface-text-muted);
+}
+
+.diagnostics-outcome-running {
+  color: var(--gl-semantic-status-warning, var(--gl-surface-text-primary));
+}
+
+.diagnostics-error-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.diagnostics-error-item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  font-size: 12px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background: var(--gl-surface-node-body);
+}
+
+.diagnostics-error-provider {
+  font-weight: 600;
+  color: var(--gl-surface-text-primary);
+}
+
+.diagnostics-error-time {
+  color: var(--gl-surface-text-muted);
+}
+
+.diagnostics-error-message {
+  flex-basis: 100%;
+  color: var(--gl-surface-text-primary);
 }
 
 /* -- Document view panel (R8a follow-up) ------------------------------------

--- a/web_ui/src/lib/api-contract/topics.ts
+++ b/web_ui/src/lib/api-contract/topics.ts
@@ -8,6 +8,7 @@ import { type AppChatLibraryState, validateAppChatLibraryState } from "../bridge
 import { type AppComposerState, validateAppComposerState } from "../bridge-core/generated/app-composer-state";
 import { type AppPluginsState, validateAppPluginsState } from "../bridge-core/generated/app-plugins-state";
 import { type AppSettingsState, validateAppSettingsState } from "../bridge-core/generated/app-settings-state";
+import { type DiagnosticsState, validateDiagnosticsState } from "../bridge-core/generated/diagnostics-state";
 import { type DragSpeedState, validateDragSpeedState } from "../bridge-core/generated/drag-speed-state";
 import { type ExecutionLimitsState, validateExecutionLimitsState } from "../bridge-core/generated/execution-limits-state";
 import { type FontControlState, validateFontControlState } from "../bridge-core/generated/font-control-state";
@@ -22,6 +23,7 @@ export const TOPIC_VALIDATORS = {
   "app-composer": validateAppComposerState,
   "app-plugins": validateAppPluginsState,
   "app-settings": validateAppSettingsState,
+  "diagnostics": validateDiagnosticsState,
   "drag-speed": validateDragSpeedState,
   "execution-limits": validateExecutionLimitsState,
   "font-control": validateFontControlState,
@@ -39,6 +41,7 @@ export interface TopicStates {
   "app-composer": AppComposerState;
   "app-plugins": AppPluginsState;
   "app-settings": AppSettingsState;
+  "diagnostics": DiagnosticsState;
   "drag-speed": DragSpeedState;
   "execution-limits": ExecutionLimitsState;
   "font-control": FontControlState;

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
@@ -123,6 +123,9 @@
     "llamaCppTitleModelPath": {
       "type": "string"
     },
+    "logLevel": {
+      "type": "string"
+    },
     "minCompatibleSchemaVersion": {
       "type": "integer"
     },
@@ -187,6 +190,7 @@
     "notificationPreferences",
     "githubTokenConfigured",
     "secretsEncryptedAtRest",
+    "logLevel",
     "activeApiProvider",
     "viewingApiProvider",
     "apiBaseUrl",

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
@@ -19,6 +19,7 @@ export interface AppSettingsState {
   notificationPreferences: Record<string, boolean>;
   githubTokenConfigured: boolean;
   secretsEncryptedAtRest: boolean;
+  logLevel: string;
   activeApiProvider: string;
   viewingApiProvider: string;
   apiBaseUrl: string;
@@ -139,6 +140,11 @@ function checkAppSettingsState(value: unknown, path: string, errors: string[]): 
     const fieldValue = value["secretsEncryptedAtRest"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.secretsEncryptedAtRest: missing required field`);
     else { if (typeof fieldValue !== "boolean") errors.push(`${path}.secretsEncryptedAtRest` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["logLevel"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.logLevel: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.logLevel` + ": expected string"); }
   }
   {
     const fieldValue = value["activeApiProvider"];

--- a/web_ui/src/lib/bridge-core/generated/diagnostics-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/diagnostics-state.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "lastPublishBytes": {
+      "type": "integer"
+    },
+    "lastPublishTopic": {
+      "type": "string"
+    },
+    "minCompatibleSchemaVersion": {
+      "type": "integer"
+    },
+    "providerErrors": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "at": {
+            "type": "number"
+          },
+          "message": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "message",
+          "at"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "publishBytesPerSecond": {
+      "type": "number"
+    },
+    "publishBytesTotal": {
+      "type": "integer"
+    },
+    "publishCount": {
+      "type": "integer"
+    },
+    "recentRuns": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "durationSeconds": {
+            "type": "number"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "nodeId": {
+            "type": "string"
+          },
+          "outcome": {
+            "type": "string"
+          },
+          "runId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "kind",
+          "outcome"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "revision": {
+      "type": "integer"
+    },
+    "schemaVersion": {
+      "type": "integer"
+    },
+    "sessionCount": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "revision",
+    "recentRuns",
+    "publishCount",
+    "publishBytesTotal",
+    "publishBytesPerSecond",
+    "providerErrors"
+  ],
+  "title": "DiagnosticsState",
+  "type": "object"
+}

--- a/web_ui/src/lib/bridge-core/generated/diagnostics-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/diagnostics-state.ts
@@ -1,0 +1,157 @@
+/* GENERATED - do not hand-edit. Source of truth: contracts/graphlink_diagnostics_payload.py::DiagnosticsStatePayload.
+ * Regenerate with codegen.py; a pytest fails if this file
+ * drifts from what regenerating it now would produce. */
+
+export interface DiagnosticsRunRow {
+  runId: string;
+  kind: string;
+  nodeId?: string | null;
+  outcome: string;
+  durationSeconds?: number | null;
+}
+
+export interface DiagnosticsProviderError {
+  provider: string;
+  message: string;
+  at: number;
+}
+
+export interface DiagnosticsState {
+  schemaVersion: number;
+  revision: number;
+  recentRuns: DiagnosticsRunRow[];
+  publishCount: number;
+  publishBytesTotal: number;
+  lastPublishBytes?: number | null;
+  lastPublishTopic?: string | null;
+  publishBytesPerSecond: number;
+  sessionCount?: number | null;
+  providerErrors: DiagnosticsProviderError[];
+  minCompatibleSchemaVersion?: number | null;
+}
+
+export type ValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; errors: string[] };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Unknown keys are tolerated on purpose. The JSON Schema marks the contract
+// additionalProperties:false because Python and the schema must not drift, but
+// an incoming payload carrying a field this build has never heard of is the
+// normal, expected shape of a NEWER compatible sender - rejecting it here would
+// defeat the additive-forward-compatibility the version negotiation exists to
+// provide. Missing or wrongly-typed KNOWN fields are still hard errors.
+
+function checkDiagnosticsRunRow(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["runId"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.runId: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.runId` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["kind"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.kind: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.kind` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["nodeId"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.nodeId` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["outcome"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.outcome: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.outcome` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["durationSeconds"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.durationSeconds` + ": expected number"); }
+  }
+}
+
+function checkDiagnosticsProviderError(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["provider"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.provider: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.provider` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["message"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.message: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.message` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["at"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.at: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.at` + ": expected number"); }
+  }
+}
+
+function checkDiagnosticsState(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["schemaVersion"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.schemaVersion: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.schemaVersion` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["revision"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.revision: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.revision` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["recentRuns"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.recentRuns: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.recentRuns` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { checkDiagnosticsRunRow(item, `${path}.recentRuns` + `[${i}]`, errors); }); }
+  }
+  {
+    const fieldValue = value["publishCount"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.publishCount: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.publishCount` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["publishBytesTotal"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.publishBytesTotal: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.publishBytesTotal` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["lastPublishBytes"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.lastPublishBytes` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["lastPublishTopic"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "string") errors.push(`${path}.lastPublishTopic` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["publishBytesPerSecond"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.publishBytesPerSecond: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.publishBytesPerSecond` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["sessionCount"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.sessionCount` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["providerErrors"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.providerErrors: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.providerErrors` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { checkDiagnosticsProviderError(item, `${path}.providerErrors` + `[${i}]`, errors); }); }
+  }
+  {
+    const fieldValue = value["minCompatibleSchemaVersion"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.minCompatibleSchemaVersion` + ": expected number"); }
+  }
+}
+
+export function validateDiagnosticsState(value: unknown): ValidationResult<DiagnosticsState> {
+  const errors: string[] = [];
+  checkDiagnosticsState(value, "$", errors);
+  return errors.length === 0
+    ? { ok: true, value: value as DiagnosticsState }
+    : { ok: false, errors };
+}

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -204,6 +204,9 @@
           "durationSeconds": {
             "type": "number"
           },
+          "estimatedCostUsd": {
+            "type": "number"
+          },
           "filePath": {
             "type": "string"
           },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -72,6 +72,7 @@ export interface SceneNodeRow {
   responseIncomplete: boolean;
   promptTokens?: number | null;
   completionTokens?: number | null;
+  estimatedCostUsd?: number | null;
   isFinalDeliverable: boolean;
   color?: string | null;
   headerColor?: string | null;
@@ -560,6 +561,10 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
   {
     const fieldValue = value["completionTokens"];
     if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.completionTokens` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["estimatedCostUsd"];
+    if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.estimatedCostUsd` + ": expected number"); }
   }
   {
     const fieldValue = value["isFinalDeliverable"];

--- a/web_ui/src/lib/bridge-core/generated/token-counter-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/token-counter-state.schema.json
@@ -29,6 +29,15 @@
     "schemaVersion": {
       "type": "integer"
     },
+    "sessionCompletionTokens": {
+      "type": "integer"
+    },
+    "sessionEstimatedCostUsd": {
+      "type": "number"
+    },
+    "sessionPromptTokens": {
+      "type": "integer"
+    },
     "totalTokens": {
       "type": "integer"
     },
@@ -43,7 +52,10 @@
     "outputTokens",
     "contextTokens",
     "totalTokens",
-    "usageIsReal"
+    "usageIsReal",
+    "sessionPromptTokens",
+    "sessionCompletionTokens",
+    "sessionEstimatedCostUsd"
   ],
   "title": "TokenCounterState",
   "type": "object"

--- a/web_ui/src/lib/bridge-core/generated/token-counter-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/token-counter-state.ts
@@ -13,6 +13,9 @@ export interface TokenCounterState {
   completionTokens?: number | null;
   usageIsReal: boolean;
   estimatedCostUsd?: number | null;
+  sessionPromptTokens: number;
+  sessionCompletionTokens: number;
+  sessionEstimatedCostUsd: number;
   minCompatibleSchemaVersion?: number | null;
 }
 
@@ -79,6 +82,21 @@ function checkTokenCounterState(value: unknown, path: string, errors: string[]):
   {
     const fieldValue = value["estimatedCostUsd"];
     if (fieldValue !== undefined && fieldValue !== null) { if (typeof fieldValue !== "number") errors.push(`${path}.estimatedCostUsd` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["sessionPromptTokens"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.sessionPromptTokens: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.sessionPromptTokens` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["sessionCompletionTokens"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.sessionCompletionTokens: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.sessionCompletionTokens` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["sessionEstimatedCostUsd"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.sessionEstimatedCostUsd: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.sessionEstimatedCostUsd` + ": expected number"); }
   }
   {
     const fieldValue = value["minCompatibleSchemaVersion"];


### PR DESCRIPTION
## Problem

The app was close to unobservable. Logging was a rotating file plus `logger.exception` on failure only, with some paths `print()`ing into a windowed app that has no console. There were no publish-size or rate counters, no run history, and no provider error visibility — so the audit's headline costs were invisible in the field.

Token accounting was fiction: the UI counter was a word count, budgeting used a mismatched tokenizer, and provider `usage` blocks were never read at all (audit H9). There was no way for a user to know what a run cost, and no local substrate for the budgets ADR-008 will need.

## Change

Five stages, all local-only — nothing leaves the machine.

**16.1 — Structured logging.** JSON-lines file format via `backend/observability.py`, carrying `run_id`/session/kind/node_id on lines that supply them. `RunRegistry` logs claim/cancel/release. Remaining `print()` sites converted to module loggers; a user-facing log-level setting applies live.

**16.2 — Real usage and cost.** Provider `usage` is the source of truth. A user-editable per-model pricing table (exact-model-id overrides checked before the built-in prefix table) turns usage into estimated cost, surfaced per node, per reply, and per session. A reply's cost is a snapshot taken when usage is stamped, so a later pricing edit doesn't retroactively rewrite completed replies.

**16.3 — In-app diagnostics.** A new `diagnostics` topic and dialog showing recent run outcomes and durations, publish count/bytes/rate, session count, and recent provider errors. Fed by explicit `on_claim`/`on_end` callbacks on `RunRegistry` and a publish-size recorder on `SessionBus` rather than a shared logging handler, which would leak a handler per session across the hundreds of bus instances the suite constructs.

**16.4 — Diagnostic bundle and open-log-folder.** `build_diagnostic_bundle(document, diagnostics_state)` assembles app version, OS, node counts by kind, and the diagnostics payload. Redaction is structural: that two-argument signature is the enforcement mechanism, since no settings manager, log handle, or provider object is reachable from inside the function.

One field was not content-free by construction. `providerErrors[].message` began as raw `str(exc)`, which for an `OSError` embeds the full absolute path including the OS username, and which some provider SDKs use to echo the offending request field verbatim. `record_provider_error` now classifies it into a fixed vocabulary of category labels and stores no substring of the original; the full text still reaches `graphlink.log`.

**16.5 — Local evals harness.** `python -m backend.evals` runs golden fixtures against the chart and structured-output paths, deterministic by default with the provider seam patched, or `--live` against a real configured provider.

## Known gap

16.5's agent-build dimension is scaffolding and reports `not_implemented`, never a pass — ADR-008's Builder loop does not exist as shipped code yet. So that stage's exit criterion is met for chart-spec correctness but **not** for "ADR-008 build success"; the ADR doc now records this rather than claiming the stage is fully closed. The harness is shaped to receive that dimension when ADR-008 lands.

## Test plan

- Full `pytest -q` from repo root: 2045 passed, 14 skipped.
- `web_ui`: typecheck, lint, `vitest run` (1382 passed), production build, and `codegen.py --check` all clean.
- `python -m backend.evals` exits 0 — 4 passed, 1 not_implemented.
- Redaction proven empirically, not asserted: a canary string planted in a chat node's content is searched for across the entire serialized bundle, and the raw-exception path is driven end to end through `_translate_chat_exception` to confirm no substring survives.
- The evals scorer is proven to discriminate: a deliberately-wrong fixture must score `failed`, so it cannot silently always-pass.
- Stage 16.3's panel was verified live against a running backend with a real Ollama provider error.