### PR TITLE
ADR-011: Frontend rendering performance

### DIFF
--- a/web_ui/scripts/check-bundle-size.mjs
+++ b/web_ui/scripts/check-bundle-size.mjs
@@ -1,17 +1,25 @@
 // ADR-019 stage 19.2: the bundle-size CI counting gate.
 //
 // Fails the build when the built JS grows past a ratchet ceiling. This is a
-// REGRESSION ratchet pinned ~5% above today's measured reality (one chunk,
-// 1,255,741 bytes on 2026-08-06), NOT the ADR-019 budget itself - the budget
-// (initial chunk <= 500 KiB, rest lazy-loaded) is ADR-011's code-splitting
-// work. Until that lands, this gate's job is to make sure the number only
-// ever moves DOWN: nobody can add half a megabyte of dependencies without CI
-// saying so.
+// REGRESSION ratchet pinned ~5% above measured reality, NOT the ADR-019
+// budget itself (initial chunk <= 500 KiB, rest lazy-loaded) - this gate's
+// job is to make sure the number only ever moves DOWN: nobody can add half a
+// megabyte of dependencies without CI saying so.
 //
-// When ADR-011's splitting lands, tighten LARGEST_CHUNK_CEILING_BYTES to the
-// real 500 KiB budget (512_000) as part of that stage - per ADR-019 §4,
-// changing a ceiling is a deliberate, commented amendment, never a quiet edit
-// to make a red build green.
+// ADR-011 stage 11.6 landed the code-splitting this file's own prior comment
+// was waiting on (React.lazy for SettingsDialog/ChatLibraryDialog/HelpDialog
+// + manualChunks pulling katex/highlight.js - NodeMarkdown.tsx's own two
+// heaviest deps - out of the main chunk) and re-anchored both ceilings below
+// to the real post-split numbers (six chunks now, largest 775,553 bytes on
+// 2026-08-08, down from one 1,255,741-byte chunk). That real number is
+// STILL above the ADR-019 500 KiB (512_000-byte) budget for the initial
+// chunk - React + React Flow + every eagerly-rendered node view (memoized in
+// 11.1, virtualized in 11.2, but not themselves code-split) account for the
+// rest, and splitting those further is out of this stage's scope. Ratchet
+// against reality, not the aspiration: tighten LARGEST_CHUNK_CEILING_BYTES
+// again, as its own deliberate, commented amendment (ADR-019 §4), whenever a
+// later stage shrinks the main chunk further - never loosen it to paper over
+// a regression.
 //
 // Runs after `npm run build` in the `check` chain (see package.json), so CI's
 // existing frontend-checks job enforces it with no workflow changes.
@@ -23,15 +31,19 @@ import { fileURLToPath } from "node:url";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ASSETS_DIR = join(HERE, "..", "dist", "app", "assets");
 
-// Today's reality: a single 1,255,741-byte chunk. ~5% headroom absorbs
-// ordinary dependency-patch drift; a real regression (a new heavyweight
-// dependency, an accidental double-bundle) blows straight through it.
-const LARGEST_CHUNK_CEILING_BYTES = 1_320_000;
-// Slightly looser than the per-chunk ceiling so future code-splitting can add
-// small lazy chunks without tripping the TOTAL, while still catching the
-// "total payload quietly ballooned" class the per-chunk ceiling alone would
-// miss once there is more than one chunk.
-const TOTAL_JS_CEILING_BYTES = 1_400_000;
+// Post-11.6 reality: largest chunk (the main entry) is 775,553 bytes.
+// ~5% headroom absorbs ordinary dependency-patch drift; a real regression
+// (a new heavyweight dependency landing outside the katex/highlight.js
+// manualChunks, an accidental double-bundle) blows straight through it.
+const LARGEST_CHUNK_CEILING_BYTES = 815_000;
+// Post-11.6 reality: six chunks (main + katex + highlight.js + the three
+// lazy dialogs) total 1,288,075 bytes - essentially unchanged from the
+// pre-split single-chunk total, as expected: splitting redistributes code
+// across chunks, it doesn't shrink it. ~5% headroom over that measured
+// total, same rationale as the per-chunk ceiling above; still comfortably
+// looser than the per-chunk ceiling so a later stage adding one more small
+// lazy chunk doesn't trip this on its own.
+const TOTAL_JS_CEILING_BYTES = 1_355_000;
 
 let entries;
 try {

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -1,5 +1,5 @@
 import { ReactFlowProvider, useReactFlow } from "@xyflow/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { TOPIC_VALIDATORS } from "../lib/api-contract/topics";
 import type { AppSettingsState } from "../lib/bridge-core/generated/app-settings-state";
 import { isTextEditable } from "../lib/bridge-core/textFocus";
@@ -14,19 +14,29 @@ import { isGatedWhileTyping, resolveShortcut, type ShortcutId } from "./chrome/s
 import { DocumentViewPanel } from "./canvas/DocumentViewPanel";
 import { AboutDialog } from "./chrome/AboutDialog";
 import { AppBar } from "./chrome/AppBar";
-import { ChatLibraryDialog } from "./chrome/ChatLibraryDialog";
 import { CommandPalette } from "./chrome/CommandPalette";
 import { Composer } from "./chrome/Composer";
 import { ComposerStore } from "./chrome/composerStore";
 import { DiagnosticsDialog } from "./chrome/DiagnosticsDialog";
-import { HelpDialog } from "./chrome/HelpDialog";
 import { NotificationBanner } from "./chrome/NotificationBanner";
 import { PinOverlay } from "./chrome/PinOverlay";
 import { PluginPicker } from "./chrome/PluginPicker";
 import { SearchOverlay } from "./chrome/SearchOverlay";
-import { SettingsDialog } from "./chrome/SettingsDialog";
 import { ViewPopover } from "./chrome/ViewPopover";
 import { OverlayProvider, useOverlays } from "./overlays/overlays";
+
+// ADR-011 stage 11.6: ChatLibraryDialog, HelpDialog (+ its 76-item static
+// help-data content), and SettingsDialog are the three heaviest "behind a
+// click" chrome surfaces - none of them can contribute to first paint, so
+// none of them belongs in the initial chunk. React.lazy splits each into
+// its own chunk, fetched on demand; LazySurface below (not just Suspense)
+// is what makes "on demand" mean "the user actually opened it" rather than
+// "React attempted to render it," see that component's own comment.
+const ChatLibraryDialog = lazy(() =>
+  import("./chrome/ChatLibraryDialog").then((m) => ({ default: m.ChatLibraryDialog })),
+);
+const HelpDialog = lazy(() => import("./chrome/HelpDialog").then((m) => ({ default: m.HelpDialog })));
+const SettingsDialog = lazy(() => import("./chrome/SettingsDialog").then((m) => ({ default: m.SettingsDialog })));
 
 /**
  * The single-app shell (Qt-removal plan R0-R2).
@@ -225,6 +235,55 @@ function GlobalShortcuts({ store }: { store: SceneStore }) {
   return null;
 }
 
+/**
+ * ADR-011 stage 11.6: mounts a lazy chrome dialog once - and only once - its
+ * own overlay surface has genuinely been opened. Wrapping a `React.lazy`
+ * component in `<Suspense>` alone is not enough here: these three dialogs
+ * were, and still are, rendered unconditionally in App's own JSX (Dialog's
+ * `isOpen` check happens *inside* SettingsDialog/ChatLibraryDialog/
+ * HelpDialog, via the shared `<Dialog>` wrapper, which returns null while
+ * closed but is still a child these components render every time App
+ * renders). If this component just returned `<Suspense><Settings.../></Sus>`
+ * unconditionally, React would attempt to render the lazy child on App's
+ * very first mount regardless of whether Settings was ever opened, firing
+ * the dynamic import (and the network fetch behind it) moments after page
+ * load - splitting the JS but not deferring the fetch, which is the whole
+ * point of code-splitting something the user may never open this session.
+ *
+ * `hasOpened` latches true the first time the surface opens and never resets
+ * - closing the dialog again does not unmount it, so its own internal state
+ * (draft form fields, list scroll position, search text) survives being
+ * closed and reopened exactly as it did when these were eagerly mounted.
+ */
+function LazySurface({ overlayName, children }: { overlayName: string; children: ReactNode }) {
+  const overlays = useOverlays();
+  const isOpen = overlays.isOpen(overlayName);
+  const [hasOpened, setHasOpened] = useState(isOpen);
+  // Latch true the moment `isOpen` first flips true. Adjusted during render
+  // (React's documented pattern for state derived from a prop/subscription
+  // change) rather than in a useEffect, so there is no extra post-commit
+  // render pass: the setState call below is skipped on every render once
+  // `hasOpened` is already true, so it only ever fires once.
+  if (isOpen && !hasOpened) {
+    setHasOpened(true);
+  }
+  if (!hasOpened) return null;
+  return <Suspense fallback={<LazyDialogFallback />}>{children}</Suspense>;
+}
+
+/** Minimal Suspense fallback for the first-open chunk fetch above - same
+ * scrim/panel shell as `Dialog` itself (overlays.tsx) so the swap-in once
+ * the real dialog resolves doesn't jump the layout, just fills it in. */
+function LazyDialogFallback() {
+  return (
+    <div className="overlay-scrim">
+      <div className="overlay-dialog overlay-dialog-loading" role="status" aria-live="polite">
+        Loading…
+      </div>
+    </div>
+  );
+}
+
 function App() {
   const [status, setStatus] = useState<ConnectionStatus>("closed");
   const [system, setSystem] = useState<SystemState>({});
@@ -325,10 +384,16 @@ function App() {
                 </div>
                 <CommandPalette store={sceneStore} />
                 <AboutDialog transport={transport} />
-                <HelpDialog />
+                <LazySurface overlayName="help">
+                  <HelpDialog />
+                </LazySurface>
                 <DiagnosticsDialog transport={transport} />
-                <SettingsDialog transport={transport} />
-                <ChatLibraryDialog transport={transport} />
+                <LazySurface overlayName="settings">
+                  <SettingsDialog transport={transport} />
+                </LazySurface>
+                <LazySurface overlayName="library">
+                  <ChatLibraryDialog transport={transport} />
+                </LazySurface>
               </div>
             </div>
           </main>

--- a/web_ui/src/app/canvas/ArtifactNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ArtifactNodeView.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { ArtifactNodeView, type ArtifactFlowNode } from "./ArtifactNodeView";
+import { ArtifactNodeView, artifactNodePropsAreEqual, type ArtifactFlowNode } from "./ArtifactNodeView";
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
 // ChatNodeView.test.tsx / ConversationNodeView.test.tsx / WebResearchNodeView.test.tsx
@@ -278,5 +278,117 @@ describe("ArtifactNodeView", () => {
     });
     expect(document.querySelector("img")).toBeNull();
     expect(screen.queryByRole("img")).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: the React.memo comparator. Direct unit tests of the
+// exported pure function (the same function reference wired straight into
+// `memo(ArtifactNodeView, artifactNodePropsAreEqual)`) plus one real-render
+// integration test proving the wiring itself is correct - a passing unit
+// test of the comparator alone couldn't catch "the comparator is right but
+// never actually got passed to memo()".
+describe("ArtifactNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  function props(overrides: Partial<ArtifactFlowNode["data"]> = {}, propOverrides: Record<string, unknown> = {}) {
+    return {
+      id: "n0",
+      selected: false,
+      data: baseData(overrides),
+      ...propOverrides,
+    } as unknown as NodeProps<ArtifactFlowNode>;
+  }
+
+  it("treats identical props as equal", () => {
+    const p = props({ artifactContent: "hello" });
+    expect(artifactNodePropsAreEqual(p, { ...p })).toBe(true);
+  });
+
+  it("treats a fresh-but-value-identical history array as equal (not a bare reference check)", () => {
+    const a = props({ history: [{ role: "user", content: "hi" }] });
+    // Same callbacks as `a` (comparator would correctly reject two
+    // independently-minted vi.fn() instances) - only history's ARRAY
+    // OBJECT differs, its contents do not.
+    const b = { ...a, data: { ...a.data, history: [{ role: "user" as const, content: "hi" }] } };
+    expect(a.data.history).not.toBe(b.data.history);
+    expect(artifactNodePropsAreEqual(a, b)).toBe(true);
+  });
+
+  it("is unaffected by NodeProps fields this component never reads (id, dragging, zIndex)", () => {
+    const a = props({}, { id: "n0", dragging: false, zIndex: 0 });
+    const b = { ...a, id: "n1", dragging: true, zIndex: 7 };
+    expect(artifactNodePropsAreEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when selected changes", () => {
+    const a = props({}, { selected: false });
+    const b = props({}, { selected: true });
+    expect(artifactNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it.each([
+    ["artifactContent", { artifactContent: "changed" }],
+    ["isCollapsed", { isCollapsed: true }],
+    ["pendingRequestId", { pendingRequestId: "req-1" }],
+    ["onToggleCollapse", { onToggleCollapse: vi.fn() }],
+    ["onDelete", { onDelete: vi.fn() }],
+    ["onSubmit", { onSubmit: vi.fn() }],
+    ["onCancel", { onCancel: vi.fn() }],
+  ] as const)("returns false when data.%s changes and nothing else does", (_name, override) => {
+    const a = props();
+    // Isolate the change to exactly this one field - everything else
+    // (including every callback reference) stays byte-for-byte identical,
+    // so a false result here can only be attributed to this field.
+    const b = { ...a, data: { ...a.data, ...override } };
+    expect(artifactNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when history's contents differ, not just its reference", () => {
+    const a = props({ history: [{ role: "user", content: "hi" }] });
+    const b = { ...a, data: { ...a.data, history: [{ role: "user" as const, content: "bye" }] } };
+    expect(artifactNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when history's length differs", () => {
+    const a = props({ history: [{ role: "user", content: "hi" }] });
+    const b = {
+      ...a,
+      data: { ...a.data, history: [{ role: "user" as const, content: "hi" }, { role: "assistant" as const, content: "hi" }] },
+    };
+    expect(artifactNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it("real render: skipped when only an unread NodeProps field changes, and actually happens when selected changes", () => {
+    const p = props({ artifactContent: "hello" }, { selected: false });
+    const { container, rerender } = render(
+      <ReactFlowProvider>
+        <ArtifactNodeView {...p} />
+      </ReactFlowProvider>,
+    );
+    const root = container.querySelector(".scene-node") as HTMLElement;
+    expect(root).not.toBeNull();
+
+    // Corrupt the root element's class list directly, bypassing React - if
+    // the memoized component's render function is never called again, React
+    // never touches this element and the corruption survives.
+    root.className = "CORRUPTED";
+
+    // `dragging` is a real NodeProps field this component never reads -
+    // the comparator must say "equal" here, so no re-render should occur.
+    rerender(
+      <ReactFlowProvider>
+        <ArtifactNodeView {...p} dragging />
+      </ReactFlowProvider>,
+    );
+    expect(root.className).toBe("CORRUPTED");
+
+    // `selected` actually IS read (it drives the "selected" class) - the
+    // comparator must say "not equal" here, forcing a real re-render that
+    // recomputes and resets the class.
+    rerender(
+      <ReactFlowProvider>
+        <ArtifactNodeView {...p} selected />
+      </ReactFlowProvider>,
+    );
+    expect(root.className).not.toBe("CORRUPTED");
+    expect(root.className).toContain("selected");
   });
 });

--- a/web_ui/src/app/canvas/ArtifactNodeView.tsx
+++ b/web_ui/src/app/canvas/ArtifactNodeView.tsx
@@ -1,8 +1,9 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useState } from "react";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useState } from "react";
+import type { MenuPosition } from "./menuPosition";
 import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The artifact node (Qt-removal plan R5.2) - the Artifact/Drafter plugin's
@@ -54,11 +55,6 @@ export interface ArtifactNodeData extends Record<string, unknown> {
 }
 
 export type ArtifactFlowNode = Node<ArtifactNodeData, "artifact">;
-
-interface MenuPosition {
-  x: number;
-  y: number;
-}
 
 /** Same outside-click/Escape dismiss pattern every sibling node menu uses
  * (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu/ConversationNodeMenu/
@@ -123,9 +119,47 @@ function ArtifactBubble({ message }: { message: ArtifactMessage }) {
 
 // -- view ----------------------------------------------------------------
 
-export function ArtifactNodeView({ data, selected }: NodeProps<ArtifactFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+function historyEqual(a: ArtifactMessage[], b: ArtifactMessage[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].role !== b[i].role || a[i].content !== b[i].content) return false;
+  }
+  return true;
+}
+
+/** ADR-011 stage 11.1: React.memo comparator - every ArtifactNodeData field
+ * this component actually reads (including every callback), plus `selected`.
+ * `id` is deliberately not compared - this component never destructures/reads
+ * NodeProps.id. `history` is the one array-shaped field: a bare `===` would
+ * make this comparator too tight (a fresh-but-value-identical array minted
+ * by an upstream rebuild would force a re-render even though nothing this
+ * node cares about changed), so it gets an element-by-element compare
+ * instead. */
+export function artifactNodePropsAreEqual(
+  prev: NodeProps<ArtifactFlowNode>,
+  next: NodeProps<ArtifactFlowNode>,
+): boolean {
+  if (prev.selected !== next.selected) return false;
+  const a = prev.data;
+  const b = next.data;
+  return (
+    a.artifactContent === b.artifactContent &&
+    a.isCollapsed === b.isCollapsed &&
+    a.pendingRequestId === b.pendingRequestId &&
+    a.onToggleCollapse === b.onToggleCollapse &&
+    a.onDelete === b.onDelete &&
+    a.onSubmit === b.onSubmit &&
+    a.onCancel === b.onCancel &&
+    historyEqual(a.history, b.history)
+  );
+}
+
+export const ArtifactNodeView = memo(function ArtifactNodeView({
+  data,
+  selected,
+}: NodeProps<ArtifactFlowNode>) {
+  const lodCollapsed = useLodVisibility();
   const collapsed = data.isCollapsed || lodCollapsed;
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   // Local, ephemeral instruction draft - starts empty and is never re-synced
@@ -243,4 +277,4 @@ export function ArtifactNodeView({ data, selected }: NodeProps<ArtifactFlowNode>
       )}
     </div>
   );
-}
+}, artifactNodePropsAreEqual);

--- a/web_ui/src/app/canvas/ChartNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChartNodeView.test.tsx
@@ -1,7 +1,14 @@
 import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { ChartNodeView, chartAssetUrl, chartExportUrl, makeDebouncedChartResize, type ChartFlowNode } from "./ChartNodeView";
+import {
+  ChartNodeView,
+  chartAssetUrl,
+  chartExportUrl,
+  chartNodePropsAreEqual,
+  makeDebouncedChartResize,
+  type ChartFlowNode,
+} from "./ChartNodeView";
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
 // ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too
@@ -152,5 +159,127 @@ describe("makeDebouncedChartResize", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ADR-011 stage 11.1: the React.memo comparator. Direct unit tests of the
+// exported pure function (the same function reference wired into
+// `memo(ChartNodeView, chartNodePropsAreEqual)`) plus one real-render
+// integration test proving the wiring itself is correct.
+describe("ChartNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  function props(overrides: Partial<ChartFlowNode["data"]> = {}, propOverrides: Record<string, unknown> = {}) {
+    return {
+      id: "n0",
+      selected: false,
+      data: {
+        chartType: "bar",
+        chartData: { type: "bar", title: "Quarterly Revenue" },
+        chartError: "",
+        chartAssetId: "asset-chart-1",
+        chartAssetVersion: 1,
+        chartWidth: 680,
+        chartHeight: 500,
+        chartAspectLocked: true,
+        chartSourceNodeId: "chat-1",
+        onToggleAspectLock: vi.fn(),
+        onResize: vi.fn(),
+        ...overrides,
+      },
+      ...propOverrides,
+    } as unknown as NodeProps<ChartFlowNode>;
+  }
+
+  it("treats identical props as equal", () => {
+    const p = props();
+    expect(chartNodePropsAreEqual(p, { ...p })).toBe(true);
+  });
+
+  it("treats a fresh-but-value-identical chartData object (same title) as equal", () => {
+    const a = props({ chartData: { type: "bar", title: "Quarterly Revenue", values: [1, 2, 3] } });
+    const b = {
+      ...a,
+      data: { ...a.data, chartData: { type: "line" as const, title: "Quarterly Revenue", values: [9, 9] } },
+    };
+    // Different object, even different unread sub-fields (type/values) - only
+    // `.title` is ever read by this component, and it matches.
+    expect(a.data.chartData).not.toBe(b.data.chartData);
+    expect(chartNodePropsAreEqual(a, b)).toBe(true);
+  });
+
+  it("is unaffected by ChartNodeData fields this component never reads (chartWidth, chartHeight, chartSourceNodeId) or unread NodeProps fields (dragging, zIndex)", () => {
+    const a = props({ chartWidth: 680, chartHeight: 500, chartSourceNodeId: "chat-1" }, { dragging: false, zIndex: 0 });
+    const b = {
+      ...a,
+      data: { ...a.data, chartWidth: 999, chartHeight: 999, chartSourceNodeId: "chat-2" },
+      dragging: true,
+      zIndex: 9,
+    };
+    expect(chartNodePropsAreEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when id changes", () => {
+    const a = props({}, { id: "n0" });
+    const b = { ...a, id: "n1" };
+    expect(chartNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when selected changes", () => {
+    const a = props({}, { selected: false });
+    const b = { ...a, selected: true };
+    expect(chartNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it.each([
+    ["chartType", { chartType: "line" }],
+    ["chartError", { chartError: "boom" }],
+    ["chartAssetId", { chartAssetId: "asset-2" }],
+    ["chartAssetVersion", { chartAssetVersion: 2 }],
+    ["chartAspectLocked", { chartAspectLocked: false }],
+    ["onToggleAspectLock", { onToggleAspectLock: vi.fn() }],
+    ["onResize", { onResize: vi.fn() }],
+  ] as const)("returns false when data.%s changes and nothing else does", (_name, override) => {
+    const a = props();
+    const b = { ...a, data: { ...a.data, ...override } };
+    expect(chartNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when chartData.title differs, even with everything else on chartData identical", () => {
+    const a = props({ chartData: { type: "bar", title: "A" } });
+    const b = { ...a, data: { ...a.data, chartData: { type: "bar" as const, title: "B" } } };
+    expect(chartNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it("real render: skipped when only an unread field changes, and actually happens when chartType changes", () => {
+    const p = props({ chartType: "bar" }, { selected: false });
+    const { container, rerender } = render(
+      <ReactFlowProvider>
+        <ChartNodeView {...p} />
+      </ReactFlowProvider>,
+    );
+    const root = container.querySelector(".scene-node") as HTMLElement;
+    expect(root).not.toBeNull();
+
+    root.className = "CORRUPTED";
+
+    // chartWidth is never read by this component - the comparator must say
+    // "equal", so no re-render should occur.
+    rerender(
+      <ReactFlowProvider>
+        <ChartNodeView {...p} data={{ ...p.data, chartWidth: 999 }} />
+      </ReactFlowProvider>,
+    );
+    expect(root.className).toBe("CORRUPTED");
+
+    // chartType IS read (drives the badge text and, via `collapsed`
+    // rendering, this component's own class string too through re-render) -
+    // toggling `selected` (which this element's className directly reflects)
+    // proves a real re-render actually happened.
+    rerender(
+      <ReactFlowProvider>
+        <ChartNodeView {...p} selected />
+      </ReactFlowProvider>,
+    );
+    expect(root.className).not.toBe("CORRUPTED");
+    expect(root.className).toContain("selected");
   });
 });

--- a/web_ui/src/app/canvas/ChartNodeView.tsx
+++ b/web_ui/src/app/canvas/ChartNodeView.tsx
@@ -1,5 +1,5 @@
-import { Handle, NodeResizer, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { Handle, NodeResizer, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useEffect, useRef, useState } from "react";
 import type { ChartDataRow } from "../../lib/bridge-core/generated/scene-state";
 import { withAuthToken } from "../../lib/auth/token";
 import {
@@ -8,8 +8,8 @@ import {
   CHART_MIN_HEIGHT,
   CHART_MIN_WIDTH,
   CHART_RESIZE_DEBOUNCE_MS,
-  LOD_ZOOM_THRESHOLD,
 } from "./canvasConstants";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The chart node (Qt-removal plan R6.2) - graphlink_canvas_chart_item.py's
@@ -130,9 +130,44 @@ export function makeDebouncedChartResize(
   };
 }
 
-export function ChartNodeView({ id, data, selected }: NodeProps<ChartFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const collapsed = zoom < LOD_ZOOM_THRESHOLD;
+function chartTitlesEqual(a: ChartDataRow, b: ChartDataRow): boolean {
+  if (a === b) return true;
+  return (a.title ?? null) === (b.title ?? null);
+}
+
+/** ADR-011 stage 11.1: React.memo comparator - id (read into the resizer's
+ * nodeId and chartExportUrl), selected, and only the ChartNodeData fields
+ * this component actually reads. chartWidth/chartHeight/chartSourceNodeId
+ * ride on the wire (see this file's own module doc) but this component never
+ * reads them directly - the node's own width/height comes through the flow
+ * node object itself, not `data` - so they're deliberately excluded rather
+ * than compared for no reason. chartData is object-shaped but only its
+ * `.title` is ever read here, so the compare is scoped to that field instead
+ * of the whole object reference: a plain `===` would make this comparator
+ * too tight, forcing a re-render whenever an upstream rebuild mints a fresh,
+ * value-identical chartData object. */
+export function chartNodePropsAreEqual(prev: NodeProps<ChartFlowNode>, next: NodeProps<ChartFlowNode>): boolean {
+  if (prev.id !== next.id || prev.selected !== next.selected) return false;
+  const a = prev.data;
+  const b = next.data;
+  return (
+    a.chartType === b.chartType &&
+    a.chartError === b.chartError &&
+    a.chartAssetId === b.chartAssetId &&
+    a.chartAssetVersion === b.chartAssetVersion &&
+    a.chartAspectLocked === b.chartAspectLocked &&
+    a.onToggleAspectLock === b.onToggleAspectLock &&
+    a.onResize === b.onResize &&
+    chartTitlesEqual(a.chartData, b.chartData)
+  );
+}
+
+export const ChartNodeView = memo(function ChartNodeView({
+  id,
+  data,
+  selected,
+}: NodeProps<ChartFlowNode>) {
+  const collapsed = useLodVisibility();
   const [imageFailed, setImageFailed] = useState(false);
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -208,4 +243,4 @@ export function ChartNodeView({ id, data, selected }: NodeProps<ChartFlowNode>) 
       <Handle type="source" position={Position.Bottom} className="scene-node-handle" />
     </div>
   );
-}
+}, chartNodePropsAreEqual);

--- a/web_ui/src/app/canvas/ChatNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.test.tsx
@@ -5,10 +5,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CHAT_CONTENT_COLLAPSED_MAX_HEIGHT,
   ChatNodeView,
+  chatNodePropsAreEqual,
   contentExceedsCollapsedHeight,
   makeDebouncedScrollReport,
   type ChatFlowNode,
 } from "./ChatNodeView";
+import { NodeMarkdown } from "./NodeMarkdown";
+import { WsTransport } from "../../lib/ws/transport";
+
+// ADR-011 stage 11.4: wraps the REAL NodeMarkdown implementation in a
+// vi.fn() spy rather than replacing it - every other test in this file keeps
+// exercising the genuine unified/remark/rehype/KaTeX/highlight pipeline (bold
+// text, GFM tables, the SECURITY raw-HTML-passthrough guards, ...) exactly as
+// before; this only adds call-count instrumentation on top, letting the
+// throttled-streaming tests below assert "re-parsed fewer times than the
+// delta count" without touching what gets rendered.
+vi.mock("./NodeMarkdown", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./NodeMarkdown")>();
+  return { ...actual, NodeMarkdown: vi.fn(actual.NodeMarkdown) };
+});
 
 // R7.5a: jsdom implements neither URL.createObjectURL nor
 // URL.revokeObjectURL - same hand-installed-fakes pattern
@@ -140,7 +155,11 @@ describe("ChatNodeView", () => {
     const user = userEvent.setup();
     const { onDelete } = renderChatNode({ isUser: false });
 
-    const writeText = vi.fn();
+    // Resolves (not a bare vi.fn()) - matches the real Clipboard API's
+    // writeText, which always returns a Promise; ChatNodeMenu now chains
+    // .catch() onto this call (ADR-011 stage 11.1), which would throw on a
+    // mock returning undefined.
+    const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
 
     const role = screen.getByText("Assistant");
@@ -844,15 +863,26 @@ function makeSubscribeStreamMock() {
 
 describe("ChatNodeView live regenerate streaming (ADR-006 stage 6.4)", () => {
   it("subscribes for pendingRequestId and renders accumulated deltas instead of the persisted content", () => {
-    const { subscribeStream, listeners } = makeSubscribeStreamMock();
-    renderChatNode({ content: "old persisted answer", pendingRequestId: "req-1", subscribeStream });
-    expect(subscribeStream).toHaveBeenCalledWith("req-1", expect.any(Function));
-    expect(screen.queryByText("old persisted answer")).toBeNull();
+    // ADR-011 stage 11.4: non-reset/non-done deltas are throttled to a
+    // rAF-scheduled flush rather than applied synchronously - advance past
+    // one frame so the fake-timer-backed requestAnimationFrame fires.
+    vi.useFakeTimers();
+    try {
+      const { subscribeStream, listeners } = makeSubscribeStreamMock();
+      renderChatNode({ content: "old persisted answer", pendingRequestId: "req-1", subscribeStream });
+      expect(subscribeStream).toHaveBeenCalledWith("req-1", expect.any(Function));
+      expect(screen.queryByText("old persisted answer")).toBeNull();
 
-    const listener = listeners.get("req-1")!;
-    act(() => listener("Hello ", false, false, 1));
-    act(() => listener("World", false, false, 2));
-    expect(screen.getByText("Hello World")).toBeInTheDocument();
+      const listener = listeners.get("req-1")!;
+      act(() => listener("Hello ", false, false, 1));
+      act(() => listener("World", false, false, 2));
+      act(() => {
+        vi.advanceTimersByTime(20);
+      });
+      expect(screen.getByText("Hello World")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("a reset frame clears prior accumulated output before appending", () => {
@@ -882,15 +912,25 @@ describe("ChatNodeView live regenerate streaming (ADR-006 stage 6.4)", () => {
   });
 
   it("shows a waiting placeholder (not a blank body) before the first delta arrives", () => {
-    const { subscribeStream, listeners } = makeSubscribeStreamMock();
-    renderChatNode({ content: "old persisted answer", pendingRequestId: "req-1", subscribeStream });
-    expect(screen.getByText("Waiting for response…")).toBeInTheDocument();
-    expect(screen.queryByText("old persisted answer")).toBeNull();
+    // ADR-011 stage 11.4: same rAF-throttled flush as above - the very
+    // first delta is no exception, so the placeholder only yields once that
+    // flush actually applies it to state.
+    vi.useFakeTimers();
+    try {
+      const { subscribeStream, listeners } = makeSubscribeStreamMock();
+      renderChatNode({ content: "old persisted answer", pendingRequestId: "req-1", subscribeStream });
+      expect(screen.getByText("Waiting for response…")).toBeInTheDocument();
+      expect(screen.queryByText("old persisted answer")).toBeNull();
 
-    // The placeholder yields to real content the moment the first delta lands.
-    act(() => listeners.get("req-1")!("first token", false, false, 1));
-    expect(screen.queryByText("Waiting for response…")).toBeNull();
-    expect(screen.getByText("first token")).toBeInTheDocument();
+      act(() => listeners.get("req-1")!("first token", false, false, 1));
+      act(() => {
+        vi.advanceTimersByTime(20);
+      });
+      expect(screen.queryByText("Waiting for response…")).toBeNull();
+      expect(screen.getByText("first token")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("renders a Stop button only while a regenerate is in flight, firing onCancelRegenerate", async () => {
@@ -906,6 +946,150 @@ describe("ChatNodeView live regenerate streaming (ADR-006 stage 6.4)", () => {
   it("renders no Stop button when no regenerate is in flight", () => {
     renderChatNode({ pendingRequestId: null });
     expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+  });
+});
+
+// ADR-011 review-fix (HIGH): onlyRenderVisibleElements virtualization
+// (SceneCanvas.tsx) genuinely UNMOUNTS a live-streaming node's component when
+// it's panned off-screen, then mounts a BRAND NEW instance when panned back.
+// streamedContent used to be plain component-local state seeded from "" with
+// no fallback to any accumulated-so-far value, so every delta broadcast
+// during the unmounted window was silently lost forever - the real fix lives
+// in transport.ts's subscribeStream (a client-side replay buffer, since the
+// server has no subscribe concept of its own to replay from), exercised here
+// through ChatNodeView exactly as production wires it: sceneStore.
+// subscribeStream is a pure passthrough to WsTransport.subscribeStream (see
+// sceneStore.ts's own comment on that method), so this uses the real
+// WsTransport class - not a hand-rolled listener-map stub like
+// makeSubscribeStreamMock above - so the test fails if the fix regresses at
+// either layer.
+class FakeStreamSocket {
+  static instances: FakeStreamSocket[] = [];
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  constructor(public url: string) {
+    FakeStreamSocket.instances.push(this);
+  }
+  send() {}
+  close() {
+    this.onclose?.();
+  }
+  open() {
+    this.onopen?.();
+  }
+  receive(message: unknown) {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
+}
+
+describe("ChatNodeView live streaming survives virtualization unmount/remount (ADR-011 review-fix)", () => {
+  function streamingProps(subscribeStream: ChatFlowNode["data"]["subscribeStream"]): NodeProps<ChatFlowNode> {
+    return {
+      id: "n0",
+      selected: false,
+      data: {
+        content: "old persisted answer",
+        isUser: false,
+        isCollapsed: false,
+        dockedChildren: [],
+        chatScrollValue: 0,
+        onToggleCollapse: vi.fn(),
+        onDelete: vi.fn(),
+        onUndockChild: vi.fn(),
+        onRegenerate: vi.fn(),
+        onGenerateImage: vi.fn(),
+        onGenerateChart: vi.fn(),
+        onGenerateKeyTakeaway: vi.fn(),
+        onGenerateExplainerNote: vi.fn(),
+        onOpenDocumentView: vi.fn(),
+        onScrollChange: vi.fn(),
+        isBranchFocusActive: false,
+        onToggleBranchFocus: vi.fn(),
+        onBranchFromHere: vi.fn(),
+        branchStatus: "active",
+        isFinalDeliverable: false,
+        onSetBranchStatus: vi.fn(),
+        onSetFinalDeliverable: vi.fn(),
+        onCollapseBranch: vi.fn(),
+        pendingRequestId: "req-1",
+        responseIncomplete: false,
+        subscribeStream,
+        onCancelRegenerate: vi.fn(),
+        toolInvocations: [],
+        promptTokens: null,
+        completionTokens: null,
+        estimatedCostUsd: null,
+        provider: null,
+        model: null,
+        isBranchSynthesis: false,
+        synthesisInstructions: "",
+        synthesisSourceNodeIds: [],
+      },
+    } as unknown as NodeProps<ChatFlowNode>;
+  }
+
+  it("a brand-new mounted instance recovers everything streamed while the previous instance was unmounted, through the real WsTransport", () => {
+    vi.useFakeTimers();
+    try {
+      FakeStreamSocket.instances = [];
+      const transport = new WsTransport("ws://test/ws", {
+        webSocketFactory: (url) => new FakeStreamSocket(url),
+      });
+      transport.connect();
+      const socket = FakeStreamSocket.instances[0];
+      socket.open();
+      const subscribeStream = transport.subscribeStream.bind(transport);
+
+      // Mount #1 - the node is on-screen and a regenerate is streaming in.
+      const { unmount } = render(
+        <ReactFlowProvider>
+          <ChatNodeView {...streamingProps(subscribeStream)} />
+        </ReactFlowProvider>,
+      );
+      act(() => {
+        socket.receive({ kind: "stream", topic: "chat", requestId: "req-1", seq: 0, delta: "Hello ", done: false, reset: false });
+      });
+      act(() => {
+        vi.advanceTimersByTime(20);
+      });
+      expect(screen.getByText("Hello")).toBeInTheDocument();
+
+      // The user pans the node off-screen: React Flow's virtualization
+      // genuinely unmounts this component instance (its effect cleanup
+      // unsubscribes from the stream).
+      unmount();
+
+      // More of the response streams in while the node is off-screen - the
+      // exact window this fix exists for.
+      act(() => {
+        socket.receive({ kind: "stream", topic: "chat", requestId: "req-1", seq: 1, delta: "there, ", done: false, reset: false });
+        socket.receive({ kind: "stream", topic: "chat", requestId: "req-1", seq: 2, delta: "friend!", done: false, reset: false });
+      });
+
+      // The user pans back: a BRAND NEW component instance mounts, with
+      // fresh component-local state (streamedContent re-seeded from "").
+      render(
+        <ReactFlowProvider>
+          <ChatNodeView {...streamingProps(subscribeStream)} />
+        </ReactFlowProvider>,
+      );
+
+      // It must show the FULL text streamed so far - not an empty "Waiting
+      // for response…" placeholder, and not a response that resumes
+      // mid-sentence missing what streamed while off-screen.
+      expect(screen.queryByText("Waiting for response…")).toBeNull();
+      expect(screen.getByText("Hello there, friend!")).toBeInTheDocument();
+
+      // And it keeps receiving live deltas normally afterward.
+      act(() => {
+        socket.receive({ kind: "stream", topic: "chat", requestId: "req-1", seq: 3, delta: " More.", done: true, reset: false });
+      });
+      expect(screen.getByText("Hello there, friend! More.")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -1009,5 +1193,345 @@ describe("ChatNodeView usage badge (ADR-016 stage 16.2)", () => {
   it("still renders when only one of promptTokens/completionTokens is present", () => {
     renderChatNode({ promptTokens: 50, completionTokens: null, estimatedCostUsd: null });
     expect(screen.getByText("50→?")).toBeInTheDocument();
+  });
+});
+
+// ADR-011 stage 11.1: the React.memo comparator. Direct unit tests of the
+// exported pure function (the same function reference wired into
+// `memo(ChatNodeView, chatNodePropsAreEqual)`) plus one real-render
+// integration test proving the wiring itself is correct.
+describe("ChatNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  function chatBaseData(overrides: Partial<ChatFlowNode["data"]> = {}): ChatFlowNode["data"] {
+    return {
+      content: "Hello",
+      isUser: true,
+      isCollapsed: false,
+      dockedChildren: [],
+      chatScrollValue: 0,
+      onToggleCollapse: vi.fn(),
+      onDelete: vi.fn(),
+      onUndockChild: vi.fn(),
+      onRegenerate: vi.fn(),
+      onGenerateImage: vi.fn(),
+      onGenerateChart: vi.fn(),
+      onGenerateKeyTakeaway: vi.fn(),
+      onGenerateExplainerNote: vi.fn(),
+      onOpenDocumentView: vi.fn(),
+      onScrollChange: vi.fn(),
+      isBranchFocusActive: false,
+      onToggleBranchFocus: vi.fn(),
+      onBranchFromHere: vi.fn(),
+      branchStatus: "active",
+      isFinalDeliverable: false,
+      onSetBranchStatus: vi.fn(),
+      onSetFinalDeliverable: vi.fn(),
+      onCollapseBranch: vi.fn(),
+      pendingRequestId: null,
+      responseIncomplete: false,
+      subscribeStream: vi.fn().mockReturnValue(vi.fn()),
+      onCancelRegenerate: vi.fn(),
+      toolInvocations: [],
+      promptTokens: null,
+      completionTokens: null,
+      estimatedCostUsd: null,
+      provider: null,
+      model: null,
+      isBranchSynthesis: false,
+      synthesisInstructions: "",
+      synthesisSourceNodeIds: [],
+      ...overrides,
+    };
+  }
+
+  function props(overrides: Partial<ChatFlowNode["data"]> = {}, propOverrides: Record<string, unknown> = {}) {
+    return {
+      id: "n0",
+      selected: false,
+      data: chatBaseData(overrides),
+      ...propOverrides,
+    } as unknown as NodeProps<ChatFlowNode>;
+  }
+
+  it("treats identical props as equal", () => {
+    const p = props();
+    expect(chatNodePropsAreEqual(p, { ...p })).toBe(true);
+  });
+
+  it("is unaffected by chatScrollValue (read only once, on mount) or unread NodeProps fields (dragging, zIndex)", () => {
+    const a = props({ chatScrollValue: 0 }, { dragging: false, zIndex: 0 });
+    const b = { ...a, data: { ...a.data, chatScrollValue: 900 }, dragging: true, zIndex: 9 };
+    expect(chatNodePropsAreEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when id changes", () => {
+    const a = props({}, { id: "n0" });
+    const b = { ...a, id: "n1" };
+    expect(chatNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when selected changes", () => {
+    const a = props({}, { selected: false });
+    const b = { ...a, selected: true };
+    expect(chatNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it.each([
+    ["content", { content: "changed" }],
+    ["isUser", { isUser: false }],
+    ["isCollapsed", { isCollapsed: true }],
+    ["isBranchFocusActive", { isBranchFocusActive: true }],
+    ["branchStatus", { branchStatus: "accepted" }],
+    ["isFinalDeliverable", { isFinalDeliverable: true }],
+    ["provider", { provider: "anthropic" }],
+    ["model", { model: "claude-opus-4-1" }],
+    ["isBranchSynthesis", { isBranchSynthesis: true }],
+    ["synthesisInstructions", { synthesisInstructions: "merge these" }],
+    ["pendingRequestId", { pendingRequestId: "req-1" }],
+    ["responseIncomplete", { responseIncomplete: true }],
+    ["promptTokens", { promptTokens: 10 }],
+    ["completionTokens", { completionTokens: 10 }],
+    ["estimatedCostUsd", { estimatedCostUsd: 0.01 }],
+    ["onToggleCollapse", { onToggleCollapse: vi.fn() }],
+    ["onDelete", { onDelete: vi.fn() }],
+    ["onUndockChild", { onUndockChild: vi.fn() }],
+    ["onRegenerate", { onRegenerate: vi.fn() }],
+    ["onGenerateImage", { onGenerateImage: vi.fn() }],
+    ["onGenerateChart", { onGenerateChart: vi.fn() }],
+    ["onGenerateKeyTakeaway", { onGenerateKeyTakeaway: vi.fn() }],
+    ["onGenerateExplainerNote", { onGenerateExplainerNote: vi.fn() }],
+    ["onOpenDocumentView", { onOpenDocumentView: vi.fn() }],
+    ["onScrollChange", { onScrollChange: vi.fn() }],
+    ["onToggleBranchFocus", { onToggleBranchFocus: vi.fn() }],
+    ["onBranchFromHere", { onBranchFromHere: vi.fn() }],
+    ["onSetBranchStatus", { onSetBranchStatus: vi.fn() }],
+    ["onSetFinalDeliverable", { onSetFinalDeliverable: vi.fn() }],
+    ["onCollapseBranch", { onCollapseBranch: vi.fn() }],
+    ["onCancelRegenerate", { onCancelRegenerate: vi.fn() }],
+    ["subscribeStream", { subscribeStream: vi.fn() }],
+  ] as const)("returns false when data.%s changes and nothing else does", (_name, override) => {
+    const a = props();
+    const b = { ...a, data: { ...a.data, ...override } };
+    expect(chatNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  describe("array-shaped fields get an element-by-element compare, not a bare reference check", () => {
+    it("dockedChildren: fresh-but-identical array is equal; differing contents or length are not", () => {
+      const a = props({ dockedChildren: [{ id: "d1", label: "Thinking" }] });
+      const bEqual = { ...a, data: { ...a.data, dockedChildren: [{ id: "d1", label: "Thinking" }] } };
+      expect(a.data.dockedChildren).not.toBe(bEqual.data.dockedChildren);
+      expect(chatNodePropsAreEqual(a, bEqual)).toBe(true);
+
+      const bContentDiff = { ...a, data: { ...a.data, dockedChildren: [{ id: "d1", label: "Different" }] } };
+      expect(chatNodePropsAreEqual(a, bContentDiff)).toBe(false);
+
+      const bLengthDiff = {
+        ...a,
+        data: { ...a.data, dockedChildren: [{ id: "d1", label: "Thinking" }, { id: "d2", label: "Other" }] },
+      };
+      expect(chatNodePropsAreEqual(a, bLengthDiff)).toBe(false);
+    });
+
+    it("toolInvocations: fresh-but-identical array is equal; differing contents or length are not", () => {
+      const invocation = { id: "call_1", name: "search", argumentsJson: "{}", result: "ok", isError: false };
+      const a = props({ toolInvocations: [invocation] });
+      const bEqual = { ...a, data: { ...a.data, toolInvocations: [{ ...invocation }] } };
+      expect(a.data.toolInvocations).not.toBe(bEqual.data.toolInvocations);
+      expect(chatNodePropsAreEqual(a, bEqual)).toBe(true);
+
+      const bContentDiff = { ...a, data: { ...a.data, toolInvocations: [{ ...invocation, isError: true }] } };
+      expect(chatNodePropsAreEqual(a, bContentDiff)).toBe(false);
+
+      const bLengthDiff = { ...a, data: { ...a.data, toolInvocations: [invocation, invocation] } };
+      expect(chatNodePropsAreEqual(a, bLengthDiff)).toBe(false);
+    });
+
+    it("synthesisSourceNodeIds: fresh-but-identical array is equal; differing contents or length are not", () => {
+      const a = props({ synthesisSourceNodeIds: ["n1", "n2"] });
+      const bEqual = { ...a, data: { ...a.data, synthesisSourceNodeIds: ["n1", "n2"] } };
+      expect(a.data.synthesisSourceNodeIds).not.toBe(bEqual.data.synthesisSourceNodeIds);
+      expect(chatNodePropsAreEqual(a, bEqual)).toBe(true);
+
+      const bContentDiff = { ...a, data: { ...a.data, synthesisSourceNodeIds: ["n1", "n3"] } };
+      expect(chatNodePropsAreEqual(a, bContentDiff)).toBe(false);
+
+      const bLengthDiff = { ...a, data: { ...a.data, synthesisSourceNodeIds: ["n1", "n2", "n3"] } };
+      expect(chatNodePropsAreEqual(a, bLengthDiff)).toBe(false);
+    });
+  });
+
+  it("real render: skipped when only an unread field (chatScrollValue) changes", () => {
+    const p = props({ content: "v1" }, { selected: false });
+    const { container, rerender } = render(
+      <ReactFlowProvider>
+        <ChatNodeView {...p} />
+      </ReactFlowProvider>,
+    );
+    const root = container.querySelector(".scene-node") as HTMLElement;
+    expect(root).not.toBeNull();
+
+    root.className = "CORRUPTED";
+
+    // chatScrollValue is read only inside the mount-only scroll-restore
+    // effect - the comparator must say "equal", so no re-render should
+    // occur here.
+    rerender(
+      <ReactFlowProvider>
+        <ChatNodeView {...p} data={{ ...p.data, chatScrollValue: 500 }} />
+      </ReactFlowProvider>,
+    );
+    expect(root.className).toBe("CORRUPTED");
+  });
+
+  // Review-fix: this test's own title used to claim "...and actually happens
+  // when content changes" while its body only ever changed `selected` - a
+  // real re-render, but not the one the title advertised. content DOES flow
+  // through the mounted component here (unlike chatNodePropsAreEqual's own
+  // pure-function it.each table above, which calls the comparator directly
+  // and never mounts anything), closing the gap between "the comparator
+  // returns false for a content diff" (proven above) and "a live component
+  // actually re-renders when content changes" (proven here).
+  it("real render: actually happens when content changes", () => {
+    // Deliberately NOT the className-corruption trick the two tests above
+    // use (mutate the DOM directly, then check a real re-render overwrites
+    // it): that only proves something when the changed prop actually feeds
+    // the className expression (selected/collapsed do; content does not),
+    // so it would pass here even with NO re-render at all - React skips
+    // reassigning a DOM attribute whose newly-computed value is unchanged
+    // from the fiber's last-rendered value, corrupted or not. Asserting on
+    // the rendered TEXT itself is the direct, unambiguous proof that a real
+    // re-render happened with the new content.
+    const p = props({ content: "v1" }, { selected: false });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ChatNodeView {...p} />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByText("v1")).toBeInTheDocument();
+
+    rerender(
+      <ReactFlowProvider>
+        <ChatNodeView {...p} data={{ ...p.data, content: "v2" }} />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByText("v2")).toBeInTheDocument();
+    expect(screen.queryByText("v1")).toBeNull();
+  });
+
+  it("real render: also happens when selected changes", () => {
+    const p = props({ content: "v1" }, { selected: false });
+    const { container, rerender } = render(
+      <ReactFlowProvider>
+        <ChatNodeView {...p} />
+      </ReactFlowProvider>,
+    );
+    const root = container.querySelector(".scene-node") as HTMLElement;
+    root.className = "CORRUPTED";
+
+    rerender(
+      <ReactFlowProvider>
+        <ChatNodeView {...p} selected />
+      </ReactFlowProvider>,
+    );
+    expect(root.className).not.toBe("CORRUPTED");
+    expect(root.className).toContain("selected");
+  });
+});
+
+// ADR-011 stage 11.4: throttled in-node streaming markdown parse.
+describe("ChatNodeView throttled streaming markdown parse (ADR-011 stage 11.4)", () => {
+  it("coalesces a rapid burst of deltas into fewer markdown re-parses than the delta count, with the final text byte-identical to the un-throttled concatenation of every delta in order", () => {
+    vi.useFakeTimers();
+    try {
+      const { subscribeStream, listeners } = makeSubscribeStreamMock();
+      renderChatNode({ pendingRequestId: "req-1", subscribeStream });
+      const listener = listeners.get("req-1")!;
+
+      const NodeMarkdownMock = NodeMarkdown as unknown as ReturnType<typeof vi.fn>;
+      const callsBeforeBurst = NodeMarkdownMock.mock.calls.length;
+
+      // Leading (not trailing) space on every word after the first, so the
+      // final text has no trailing whitespace for the markdown paragraph
+      // renderer to trim - that trimming is a pre-existing, throttle-
+      // unrelated quirk of how remark serializes paragraph text, and
+      // stripping trailing spaces here keeps this test's "byte-identical"
+      // claim tied to the actual property under test (delta order/
+      // completeness) rather than an unrelated whitespace nuance.
+      const deltaCount = 50;
+      let expectedFullText = "";
+      act(() => {
+        for (let i = 0; i < deltaCount; i++) {
+          const delta = i === 0 ? `w${i}` : ` w${i}`;
+          expectedFullText += delta;
+          listener(delta, false, false, i + 1);
+        }
+      });
+
+      // The entire burst landed inside one synchronous batch, before the
+      // rAF-scheduled flush below ever fires - not one delta has re-parsed
+      // yet (proves accumulation happens in a ref, not via setState per
+      // delta).
+      expect(NodeMarkdownMock.mock.calls.length).toBe(callsBeforeBurst);
+      expect(screen.queryByText(/w0/)).toBeNull();
+
+      act(() => {
+        vi.advanceTimersByTime(20); // flushes the one scheduled rAF callback
+      });
+
+      const callsAfterFlush = NodeMarkdownMock.mock.calls.length;
+      const reparseCount = callsAfterFlush - callsBeforeBurst;
+      expect(reparseCount).toBeGreaterThan(0); // it did eventually flush...
+      expect(reparseCount).toBeLessThan(deltaCount); // ...far fewer times than the delta count
+
+      // No byte dropped or reordered: every delta, in order, still lands in
+      // the rendered content exactly.
+      const contentEl = document.querySelector(".chat-node-content");
+      expect(contentEl?.textContent).toBe(expectedFullText);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes the final chunk immediately on stream completion (done=true) rather than waiting for the next frame", () => {
+    vi.useFakeTimers();
+    try {
+      const { subscribeStream, listeners } = makeSubscribeStreamMock();
+      renderChatNode({ pendingRequestId: "req-1", subscribeStream });
+      const listener = listeners.get("req-1")!;
+
+      act(() => {
+        listener("partial ", false, false, 1);
+        listener("final chunk", true, false, 2); // done=true
+      });
+
+      // No vi.advanceTimersByTime() call - completion must flush
+      // synchronously, not on the next rAF frame.
+      expect(screen.getByText("partial final chunk")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("never strands a trailing buffered chunk when pendingRequestId changes away mid-stream", () => {
+    vi.useFakeTimers();
+    try {
+      const { subscribeStream, listeners } = makeSubscribeStreamMock();
+      const { rerenderWithData } = renderChatNode({ pendingRequestId: "req-1", subscribeStream });
+      const listener = listeners.get("req-1")!;
+
+      act(() => {
+        listener("buffered but not yet flushed", false, false, 1);
+      });
+      // Still un-flushed (no timer advance) - about to switch away from this
+      // request entirely.
+      rerenderWithData({ pendingRequestId: null, content: "final persisted answer" });
+
+      // The unsubscribe cleanup's own flush (and the render-time subscribed-
+      // request reset) leaves nothing stuck mid-flight - the node falls back
+      // cleanly to the persisted content, not a half-applied streamed value.
+      expect(screen.getByText("final persisted answer")).toBeInTheDocument();
+      expect(screen.queryByText(/buffered but not yet flushed/)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -1,11 +1,13 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useEffect, useRef, useState, type ReactNode } from "react";
 import type { StreamListener } from "../../lib/ws/transport";
-import { CHAT_SCROLL_REPORT_DEBOUNCE_MS, LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { CHAT_SCROLL_REPORT_DEBOUNCE_MS } from "./canvasConstants";
 import { downloadTextFile } from "./downloadTextFile";
 import { GROUP_MONO_COLORS, GROUP_NAMED_COLORS } from "./GroupColorPicker";
+import type { MenuPosition } from "./menuPosition";
 import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The chat node (Qt-removal plan R3.1/R3.2) - ChatNode's React successor:
@@ -173,11 +175,6 @@ export interface ToolInvocationData {
 
 export type ChatFlowNode = Node<ChatNodeData, "chat">;
 
-interface MenuPosition {
-  x: number;
-  y: number;
-}
-
 // R6.2: legacy's own Generate Chart submenu order, confirmed during recon
 // (graphlink_canvas_chart_item.py / the legacy chat-node menu build) - Bar,
 // Line, Histogram, Pie, Sankey. `value` is the exact lowercase chart_type
@@ -280,7 +277,15 @@ function ChatNodeMenu({
         type="button"
         role="menuitem"
         onClick={() => {
-          navigator.clipboard.writeText(content);
+          // Best-effort clipboard write - a failure (missing Clipboard API,
+          // a denied permissions prompt, an insecure context) is swallowed
+          // rather than left as an unhandled rejection, matching
+          // ImageNodeView.tsx's own handleCopyImage: a menu action like this
+          // should never crash the node, it should just silently not have
+          // copied anything.
+          navigator.clipboard.writeText(content).catch((error) => {
+            console.error("[chat-node] Copy Text failed:", error);
+          });
           onClose();
         }}
       >
@@ -595,9 +600,109 @@ export function contentExceedsCollapsedHeight(scrollHeight: number): boolean {
   return scrollHeight > CHAT_CONTENT_COLLAPSED_MAX_HEIGHT;
 }
 
-export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+function dockedChildrenEqual(a: { id: string; label: string }[], b: { id: string; label: string }[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].id !== b[i].id || a[i].label !== b[i].label) return false;
+  }
+  return true;
+}
+
+function stringArraysEqual(a: string[], b: string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function toolInvocationsEqual(a: ToolInvocationData[], b: ToolInvocationData[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (
+      x.id !== y.id ||
+      x.name !== y.name ||
+      x.argumentsJson !== y.argumentsJson ||
+      x.result !== y.result ||
+      x.isError !== y.isError
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** ADR-011 stage 11.1: React.memo comparator - id (read into the card menu's
+ * Export filename), selected, and every ChatNodeData field this component
+ * (or the card menu it renders) actually reads, including every callback
+ * prop. Array/object-shaped fields (dockedChildren, toolInvocations,
+ * synthesisSourceNodeIds) get an element-by-element compare rather than
+ * `===` - toFlowNodes can legitimately mint a fresh, value-identical array
+ * on every snapshot even when nothing on this node changed; a bare `===`
+ * there would make this comparator too tight and quietly defeat the memo.
+ *
+ * chatScrollValue is deliberately excluded: it's read only inside the
+ * mount-only scroll-restore effect below (empty dep array, R6.3's own
+ * documented non-clobbering posture) - by the time this comparator ever
+ * runs on a re-render, that effect has already fired once and will never
+ * fire again, so no change to this field can ever affect what's on screen
+ * after mount. Comparing it would only produce spurious re-renders during
+ * active (debounced) scrolling - the "too tight" failure mode this
+ * comparator exists to avoid. */
+export function chatNodePropsAreEqual(prev: NodeProps<ChatFlowNode>, next: NodeProps<ChatFlowNode>): boolean {
+  if (prev.id !== next.id || prev.selected !== next.selected) return false;
+  const a = prev.data;
+  const b = next.data;
+  return (
+    a.content === b.content &&
+    a.isUser === b.isUser &&
+    a.isCollapsed === b.isCollapsed &&
+    a.isBranchFocusActive === b.isBranchFocusActive &&
+    a.branchStatus === b.branchStatus &&
+    a.isFinalDeliverable === b.isFinalDeliverable &&
+    a.provider === b.provider &&
+    a.model === b.model &&
+    a.isBranchSynthesis === b.isBranchSynthesis &&
+    a.synthesisInstructions === b.synthesisInstructions &&
+    a.pendingRequestId === b.pendingRequestId &&
+    a.responseIncomplete === b.responseIncomplete &&
+    a.promptTokens === b.promptTokens &&
+    a.completionTokens === b.completionTokens &&
+    a.estimatedCostUsd === b.estimatedCostUsd &&
+    a.onToggleCollapse === b.onToggleCollapse &&
+    a.onDelete === b.onDelete &&
+    a.onUndockChild === b.onUndockChild &&
+    a.onRegenerate === b.onRegenerate &&
+    a.onGenerateImage === b.onGenerateImage &&
+    a.onGenerateChart === b.onGenerateChart &&
+    a.onGenerateKeyTakeaway === b.onGenerateKeyTakeaway &&
+    a.onGenerateExplainerNote === b.onGenerateExplainerNote &&
+    a.onOpenDocumentView === b.onOpenDocumentView &&
+    a.onScrollChange === b.onScrollChange &&
+    a.onToggleBranchFocus === b.onToggleBranchFocus &&
+    a.onBranchFromHere === b.onBranchFromHere &&
+    a.onSetBranchStatus === b.onSetBranchStatus &&
+    a.onSetFinalDeliverable === b.onSetFinalDeliverable &&
+    a.onCollapseBranch === b.onCollapseBranch &&
+    a.onCancelRegenerate === b.onCancelRegenerate &&
+    a.subscribeStream === b.subscribeStream &&
+    dockedChildrenEqual(a.dockedChildren, b.dockedChildren) &&
+    toolInvocationsEqual(a.toolInvocations, b.toolInvocations) &&
+    stringArraysEqual(a.synthesisSourceNodeIds, b.synthesisSourceNodeIds)
+  );
+}
+
+export const ChatNodeView = memo(function ChatNodeView({
+  id,
+  data,
+  selected,
+}: NodeProps<ChatFlowNode>) {
+  const lodCollapsed = useLodVisibility();
   const collapsed = data.isCollapsed || lodCollapsed;
   const [copied, setCopied] = useState(false);
 
@@ -608,10 +713,18 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
   // (matching the established pattern DocumentViewPanel.tsx/NodeMarkdown.tsx's
   // own CodeBlock already use) independent of the menu's lifecycle.
   function onQuickCopy() {
-    navigator.clipboard.writeText(data.content).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
+    navigator.clipboard
+      .writeText(data.content)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch((error) => {
+        // Best-effort - see ChatNodeMenu's own Copy Text handler above for
+        // the same reasoning. No "copied" flash on failure, since nothing
+        // was actually copied.
+        console.error("[chat-node] Copy failed:", error);
+      });
   }
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
 
@@ -667,13 +780,67 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
     setStreamedContent("");
   }
 
+  // ADR-011 stage 11.4: deltas accumulate into these refs (not React state)
+  // as they arrive - only the rAF-scheduled flush below ever calls
+  // setStreamedContent, so a fast burst of many small deltas within one
+  // frame re-parses markdown (NodeMarkdown's full unified/remark/rehype/
+  // KaTeX/highlight pipeline) at most once per frame, not once per delta.
+  // Every byte still lands in streamedContent, in order - only the RE-PARSE
+  // cadence changes, never the data: pendingBufferRef always holds the full,
+  // in-order text accumulated since the last flush, and flushStreamBuffer
+  // moves the whole thing into state atomically. pendingResetRef tracks
+  // whether the buffered text should REPLACE streamedContent at the next
+  // flush (a `reset` frame) rather than append to it, mirroring the
+  // original un-throttled `reset ? delta : current + delta` semantics
+  // exactly - just deferred to flush time instead of applied delta-by-delta.
+  const pendingBufferRef = useRef("");
+  const pendingResetRef = useRef(false);
+  const rafHandleRef = useRef<number | null>(null);
+
+  function flushStreamBuffer() {
+    if (rafHandleRef.current !== null) {
+      cancelAnimationFrame(rafHandleRef.current);
+      rafHandleRef.current = null;
+    }
+    const bufferedText = pendingBufferRef.current;
+    const shouldReset = pendingResetRef.current;
+    pendingBufferRef.current = "";
+    pendingResetRef.current = false;
+    if (!bufferedText && !shouldReset) return;
+    setStreamedContent((current) => (shouldReset ? bufferedText : current + bufferedText));
+  }
+
   useEffect(() => {
     const requestId = data.pendingRequestId;
     if (!requestId) return;
-    const unsubscribe = data.subscribeStream(requestId, (delta, _done, reset) => {
-      setStreamedContent((current) => (reset ? delta : current + delta));
+    const unsubscribe = data.subscribeStream(requestId, (delta, done, reset) => {
+      if (reset) {
+        pendingBufferRef.current = delta;
+        pendingResetRef.current = true;
+      } else {
+        pendingBufferRef.current += delta;
+      }
+      // Stream completion/reset flushes synchronously - the final chunk (or
+      // a fresh restart) shouldn't wait an extra frame, and this is also
+      // what guarantees a trailing chunk never gets stranded in the buffer
+      // past the last render.
+      if (done || reset) {
+        flushStreamBuffer();
+      } else if (rafHandleRef.current === null) {
+        rafHandleRef.current = requestAnimationFrame(flushStreamBuffer);
+      }
     });
-    return () => unsubscribe();
+    return () => {
+      unsubscribe();
+      // A requestId change (new run, or this run finished) makes any
+      // content still sitting in the buffer for the OLD request moot - the
+      // render-time subscribedRequestId reset above already clears
+      // streamedContent to "" for a new id, and data.content is the source
+      // of truth once pendingRequestId returns to null - but flush (rather
+      // than silently drop) here too, so no buffered byte is ever lost even
+      // in that narrow window.
+      flushStreamBuffer();
+    };
     // data.subscribeStream is a fresh closure every render (see SceneCanvas's
     // toFlowNodes) - depending on it would resubscribe on every unrelated
     // re-render; data.pendingRequestId itself is the real re-subscribe key.
@@ -994,4 +1161,4 @@ export function ChatNodeView({ id, data, selected }: NodeProps<ChatFlowNode>) {
       )}
     </div>
   );
-}
+}, chatNodePropsAreEqual);

--- a/web_ui/src/app/canvas/CodeNodeView.test.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.test.tsx
@@ -2,7 +2,7 @@ import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CodeNodeView, type CodeFlowNode } from "./CodeNodeView";
+import { CodeNodeView, codeNodePropsAreEqual, type CodeFlowNode } from "./CodeNodeView";
 
 // R7.5a: jsdom implements neither URL.createObjectURL nor
 // URL.revokeObjectURL - same hand-installed-fakes pattern
@@ -74,7 +74,11 @@ describe("CodeNodeView", () => {
     const user = userEvent.setup();
     const { onDelete, container } = renderCodeNode();
 
-    const writeText = vi.fn();
+    // Resolves (not a bare vi.fn()) - matches the real Clipboard API's
+    // writeText, which always returns a Promise; CodeNodeMenu now chains
+    // .catch() onto this call (ADR-011 stage 11.1), which would throw on a
+    // mock returning undefined.
+    const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
 
     const label = titleLabel(container);
@@ -190,5 +194,94 @@ describe("CodeNodeView", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
     await user.click(document.body);
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: the React.memo comparator. Direct unit tests of the
+// exported pure function (the same function reference wired into
+// `memo(CodeNodeView, codeNodePropsAreEqual)`) plus one real-render
+// integration test proving the wiring itself is correct.
+describe("CodeNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  function props(overrides: Partial<CodeFlowNode["data"]> = {}, propOverrides: Record<string, unknown> = {}) {
+    return {
+      id: "n0",
+      selected: false,
+      data: {
+        code: "def add(a, b):\n    return a + b",
+        language: "python",
+        parentChatNodeId: "chat-1",
+        onRegenerate: vi.fn(),
+        onDelete: vi.fn(),
+        isBranchFocusActive: false,
+        onToggleBranchFocus: vi.fn(),
+        ...overrides,
+      },
+      ...propOverrides,
+    } as unknown as NodeProps<CodeFlowNode>;
+  }
+
+  it("treats identical props as equal", () => {
+    const p = props();
+    expect(codeNodePropsAreEqual(p, { ...p })).toBe(true);
+  });
+
+  it("is unaffected by unread NodeProps fields (dragging, zIndex)", () => {
+    const a = props({}, { dragging: false, zIndex: 0 });
+    const b = { ...a, dragging: true, zIndex: 9 };
+    expect(codeNodePropsAreEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when id changes", () => {
+    const a = props({}, { id: "n0" });
+    const b = { ...a, id: "n1" };
+    expect(codeNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when selected changes", () => {
+    const a = props({}, { selected: false });
+    const b = { ...a, selected: true };
+    expect(codeNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it.each([
+    ["code", { code: "print(1)" }],
+    ["language", { language: "javascript" }],
+    ["parentChatNodeId", { parentChatNodeId: null }],
+    ["isBranchFocusActive", { isBranchFocusActive: true }],
+    ["onRegenerate", { onRegenerate: vi.fn() }],
+    ["onDelete", { onDelete: vi.fn() }],
+    ["onToggleBranchFocus", { onToggleBranchFocus: vi.fn() }],
+  ] as const)("returns false when data.%s changes and nothing else does", (_name, override) => {
+    const a = props();
+    const b = { ...a, data: { ...a.data, ...override } };
+    expect(codeNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it("real render: skipped when only an unread NodeProps field changes, and actually happens when language changes", () => {
+    const p = props({ language: "python" }, { selected: false });
+    const { container, rerender } = render(
+      <ReactFlowProvider>
+        <CodeNodeView {...p} />
+      </ReactFlowProvider>,
+    );
+    const root = container.querySelector(".scene-node") as HTMLElement;
+    expect(root).not.toBeNull();
+
+    root.className = "CORRUPTED";
+
+    rerender(
+      <ReactFlowProvider>
+        <CodeNodeView {...p} dragging />
+      </ReactFlowProvider>,
+    );
+    expect(root.className).toBe("CORRUPTED");
+
+    rerender(
+      <ReactFlowProvider>
+        <CodeNodeView {...p} selected />
+      </ReactFlowProvider>,
+    );
+    expect(root.className).not.toBe("CORRUPTED");
+    expect(root.className).toContain("selected");
   });
 });

--- a/web_ui/src/app/canvas/CodeNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeNodeView.tsx
@@ -1,9 +1,10 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useState } from "react";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useState } from "react";
 import { downloadTextFile } from "./downloadTextFile";
+import type { MenuPosition } from "./menuPosition";
 import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The code node (Qt-removal plan R3.5/R3.6) - a card holding a single code
@@ -56,11 +57,6 @@ export interface CodeNodeData extends Record<string, unknown> {
 }
 
 export type CodeFlowNode = Node<CodeNodeData, "code">;
-
-interface MenuPosition {
-  x: number;
-  y: number;
-}
 
 /** Wraps raw code in a markdown fenced code block so ReactMarkdown +
  * rehype-highlight can syntax-highlight it for free - no Shiki/Prism/
@@ -134,7 +130,15 @@ function CodeNodeMenu({
         type="button"
         role="menuitem"
         onClick={() => {
-          navigator.clipboard.writeText(code);
+          // Best-effort clipboard write - a failure (missing Clipboard API,
+          // a denied permissions prompt, an insecure context) is swallowed
+          // rather than left as an unhandled rejection, matching
+          // ImageNodeView.tsx's own handleCopyImage: a menu action like this
+          // should never crash the node, it should just silently not have
+          // copied anything.
+          navigator.clipboard.writeText(code).catch((error) => {
+            console.error("[code-node] Copy Code failed:", error);
+          });
           onClose();
         }}
       >
@@ -187,9 +191,33 @@ function CodeNodeMenu({
   );
 }
 
-export function CodeNodeView({ id, data, selected }: NodeProps<CodeFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const collapsed = zoom < LOD_ZOOM_THRESHOLD;
+/** ADR-011 stage 11.1: React.memo comparator - id (read into nodeId for the
+ * card menu's Export filename), selected, and every CodeNodeData field this
+ * component (or the card menu it renders) actually reads, including every
+ * callback prop. Every field here is a primitive or a function - no
+ * array/object-shaped field on CodeNodeData is ever read, so a plain `===`
+ * per field is correct as-is, no shape-aware compare needed. */
+export function codeNodePropsAreEqual(prev: NodeProps<CodeFlowNode>, next: NodeProps<CodeFlowNode>): boolean {
+  if (prev.id !== next.id || prev.selected !== next.selected) return false;
+  const a = prev.data;
+  const b = next.data;
+  return (
+    a.code === b.code &&
+    a.language === b.language &&
+    a.parentChatNodeId === b.parentChatNodeId &&
+    a.isBranchFocusActive === b.isBranchFocusActive &&
+    a.onRegenerate === b.onRegenerate &&
+    a.onDelete === b.onDelete &&
+    a.onToggleBranchFocus === b.onToggleBranchFocus
+  );
+}
+
+export const CodeNodeView = memo(function CodeNodeView({
+  id,
+  data,
+  selected,
+}: NodeProps<CodeFlowNode>) {
+  const collapsed = useLodVisibility();
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
 
   return (
@@ -226,4 +254,4 @@ export function CodeNodeView({ id, data, selected }: NodeProps<CodeFlowNode>) {
       )}
     </div>
   );
-}
+}, codeNodePropsAreEqual);

--- a/web_ui/src/app/canvas/CodeSandboxNodeView.test.tsx
+++ b/web_ui/src/app/canvas/CodeSandboxNodeView.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { CodeSandboxNodeView, type CodeSandboxFlowNode } from "./CodeSandboxNodeView";
+import { CodeSandboxNodeView, codeSandboxNodePropsAreEqual, type CodeSandboxFlowNode } from "./CodeSandboxNodeView";
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
 // ArtifactNodeView.test.tsx for why a bare ReactFlowProvider is enough here
@@ -519,5 +519,108 @@ describe("CodeSandboxNodeView", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
     await user.click(document.body);
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: the React.memo comparator. Direct unit tests of the
+// exported pure function (the same function reference wired into
+// `memo(CodeSandboxNodeView, codeSandboxNodePropsAreEqual)`) plus one
+// real-render integration test proving the wiring itself is correct.
+describe("CodeSandboxNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  function props(overrides: Partial<CodeSandboxFlowNode["data"]> = {}, propOverrides: Record<string, unknown> = {}) {
+    return {
+      id: "cs-1",
+      selected: false,
+      data: baseData(overrides),
+      ...propOverrides,
+    } as unknown as NodeProps<CodeSandboxFlowNode>;
+  }
+
+  it("treats identical props as equal", () => {
+    const p = props();
+    expect(codeSandboxNodePropsAreEqual(p, { ...p })).toBe(true);
+  });
+
+  it("is unaffected by codeSandboxRequirements/codeSandboxPrompt (read only as a useState initializer, never again on re-render) or unread NodeProps fields (dragging, zIndex)", () => {
+    const a = props(
+      { codeSandboxRequirements: "numpy", codeSandboxPrompt: "draft prompt" },
+      { dragging: false, zIndex: 0 },
+    );
+    const b = {
+      ...a,
+      data: { ...a.data, codeSandboxRequirements: "pandas==2.2.0", codeSandboxPrompt: "a completely different draft" },
+      dragging: true,
+      zIndex: 9,
+    };
+    expect(codeSandboxNodePropsAreEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when id changes", () => {
+    const a = props({}, { id: "cs-1" });
+    const b = { ...a, id: "cs-2" };
+    expect(codeSandboxNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when selected changes", () => {
+    const a = props({}, { selected: false });
+    const b = { ...a, selected: true };
+    expect(codeSandboxNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it.each([
+    ["codeSandboxApprovalRequirements", { codeSandboxApprovalRequirements: "numpy" }],
+    ["codeSandboxApprovalAllowSourceBuilds", { codeSandboxApprovalAllowSourceBuilds: true }],
+    ["codeSandboxApprovalIsRepair", { codeSandboxApprovalIsRepair: true }],
+    ["codeSandboxCode", { codeSandboxCode: "print(1)" }],
+    ["codeSandboxOutput", { codeSandboxOutput: "1" }],
+    ["codeSandboxAnalysis", { codeSandboxAnalysis: "analysis" }],
+    ["codeSandboxAwaitingApproval", { codeSandboxAwaitingApproval: true }],
+    ["codeSandboxError", { codeSandboxError: "boom" }],
+    ["isCollapsed", { isCollapsed: true }],
+    ["pendingRequestId", { pendingRequestId: "req-1" }],
+    ["onSetRequirements", { onSetRequirements: vi.fn() }],
+    ["onToggleAllowSourceBuilds", { onToggleAllowSourceBuilds: vi.fn() }],
+    ["onRun", { onRun: vi.fn() }],
+    ["onCancel", { onCancel: vi.fn() }],
+    ["onApprove", { onApprove: vi.fn() }],
+    ["onDeny", { onDeny: vi.fn() }],
+    ["onToggleCollapse", { onToggleCollapse: vi.fn() }],
+    ["onDelete", { onDelete: vi.fn() }],
+    ["subscribeStream", { subscribeStream: vi.fn() }],
+  ] as const)("returns false when data.%s changes and nothing else does", (_name, override) => {
+    const a = props();
+    const b = { ...a, data: { ...a.data, ...override } };
+    expect(codeSandboxNodePropsAreEqual(a, b)).toBe(false);
+  });
+
+  it("real render: skipped when only an unread field changes, and actually happens when codeSandboxError changes", () => {
+    const p = props({ codeSandboxError: "" }, { selected: false });
+    const { container, rerender } = render(
+      <ReactFlowProvider>
+        <CodeSandboxNodeView {...p} />
+      </ReactFlowProvider>,
+    );
+    const root = container.querySelector(".scene-node") as HTMLElement;
+    expect(root).not.toBeNull();
+
+    root.className = "CORRUPTED";
+
+    // codeSandboxPrompt is read only as this component's own useState
+    // initializer, never again afterward - the comparator must say
+    // "equal", so no re-render should occur.
+    rerender(
+      <ReactFlowProvider>
+        <CodeSandboxNodeView {...p} data={{ ...p.data, codeSandboxPrompt: "brand new draft" }} />
+      </ReactFlowProvider>,
+    );
+    expect(root.className).toBe("CORRUPTED");
+
+    rerender(
+      <ReactFlowProvider>
+        <CodeSandboxNodeView {...p} selected />
+      </ReactFlowProvider>,
+    );
+    expect(root.className).not.toBe("CORRUPTED");
+    expect(root.className).toContain("selected");
   });
 });

--- a/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
+++ b/web_ui/src/app/canvas/CodeSandboxNodeView.tsx
@@ -1,10 +1,11 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useState } from "react";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useEffect, useState } from "react";
 import type { StreamListener } from "../../lib/ws/transport";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
 import { CodeExecutionApprovalPanel } from "./CodeExecutionApprovalPanel";
+import type { MenuPosition } from "./menuPosition";
 import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The Virtual Environment Runner node (Qt-removal plan R5.4, renamed under
@@ -80,11 +81,6 @@ export interface CodeSandboxNodeData extends Record<string, unknown> {
 
 export type CodeSandboxFlowNode = Node<CodeSandboxNodeData, "code_sandbox">;
 
-interface MenuPosition {
-  x: number;
-  y: number;
-}
-
 /** Same outside-click/Escape dismiss pattern every sibling node menu uses
  * (ChatNodeMenu/ArtifactNodeMenu/GitlinkNodeMenu/PyCoderNodeMenu/...). */
 // -- card-level menu -------------------------------------------------------
@@ -138,9 +134,58 @@ function toPythonFence(code: string): string {
 
 // -- view ----------------------------------------------------------------
 
-export function CodeSandboxNodeView({ id, data, selected }: NodeProps<CodeSandboxFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+/** ADR-011 stage 11.1: React.memo comparator - id (read into
+ * CodeExecutionApprovalPanel's own nodeId), selected, and every
+ * CodeSandboxNodeData field this component actually reads on every render,
+ * including every callback prop. Every field on this data shape is a
+ * primitive or a function - none is array/object-shaped, so a plain `===`
+ * per field is correct as-is.
+ *
+ * codeSandboxRequirements and codeSandboxPrompt are deliberately excluded:
+ * both are read ONLY as a `useState(...)` initializer (requirementsDraft/
+ * promptDraft below), and a useState initializer is evaluated exactly once,
+ * on the component's first mount - by the time this comparator ever runs
+ * (on a RE-render), that value has already been consumed and the local draft
+ * lives independently of it from then on. Comparing them here would only
+ * force spurious re-renders while the user is actively typing elsewhere on
+ * the scene (every snapshot re-mints the wire value these fields started
+ * from), with no staleness this component could otherwise show. */
+export function codeSandboxNodePropsAreEqual(
+  prev: NodeProps<CodeSandboxFlowNode>,
+  next: NodeProps<CodeSandboxFlowNode>,
+): boolean {
+  if (prev.id !== next.id || prev.selected !== next.selected) return false;
+  const a = prev.data;
+  const b = next.data;
+  return (
+    a.codeSandboxApprovalRequirements === b.codeSandboxApprovalRequirements &&
+    a.codeSandboxApprovalAllowSourceBuilds === b.codeSandboxApprovalAllowSourceBuilds &&
+    a.codeSandboxApprovalIsRepair === b.codeSandboxApprovalIsRepair &&
+    a.codeSandboxCode === b.codeSandboxCode &&
+    a.codeSandboxOutput === b.codeSandboxOutput &&
+    a.codeSandboxAnalysis === b.codeSandboxAnalysis &&
+    a.codeSandboxAwaitingApproval === b.codeSandboxAwaitingApproval &&
+    a.codeSandboxError === b.codeSandboxError &&
+    a.isCollapsed === b.isCollapsed &&
+    a.pendingRequestId === b.pendingRequestId &&
+    a.onSetRequirements === b.onSetRequirements &&
+    a.onToggleAllowSourceBuilds === b.onToggleAllowSourceBuilds &&
+    a.onRun === b.onRun &&
+    a.onCancel === b.onCancel &&
+    a.onApprove === b.onApprove &&
+    a.onDeny === b.onDeny &&
+    a.onToggleCollapse === b.onToggleCollapse &&
+    a.onDelete === b.onDelete &&
+    a.subscribeStream === b.subscribeStream
+  );
+}
+
+export const CodeSandboxNodeView = memo(function CodeSandboxNodeView({
+  id,
+  data,
+  selected,
+}: NodeProps<CodeSandboxFlowNode>) {
+  const lodCollapsed = useLodVisibility();
   const collapsed = data.isCollapsed || lodCollapsed;
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
 
@@ -361,4 +406,4 @@ export function CodeSandboxNodeView({ id, data, selected }: NodeProps<CodeSandbo
       )}
     </div>
   );
-}
+}, codeSandboxNodePropsAreEqual);

--- a/web_ui/src/app/canvas/ConversationNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.test.tsx
@@ -2,7 +2,27 @@ import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect, useState } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ADR-011 stage 11.1: wraps the real useLodVisibility so every ACTUAL
+// invocation (mount or re-render) is countable - a React.memo bailout skips
+// calling ConversationNodeView's function body entirely, so this hook
+// (called unconditionally on every real render) never fires during a bailed
+// re-render. Same "mock-wrap-and-delegate" technique ImageNodeView.test.tsx
+// established.
+const lodVisibilityCalls = { count: 0 };
+
+vi.mock("./useLodVisibility", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./useLodVisibility")>();
+  return {
+    ...original,
+    useLodVisibility: (...args: Parameters<typeof original.useLodVisibility>) => {
+      lodVisibilityCalls.count += 1;
+      return original.useLodVisibility(...args);
+    },
+  };
+});
+
 import { ConversationNodeView, type ConversationFlowNode } from "./ConversationNodeView";
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
@@ -136,7 +156,11 @@ describe("ConversationNodeView", () => {
     const user = userEvent.setup();
     const { onDeleteMessage } = renderConversationNode();
 
-    const writeText = vi.fn();
+    // ADR-011 stage 11.1: the menu's Copy Message now chains a .catch() onto
+    // the clipboard write (D11), so the mock must resolve like a real
+    // Promise-returning clipboard API - a bare vi.fn() (no resolved value)
+    // would make that .catch() call throw synchronously on `undefined`.
+    const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
 
     const userBubble = screen.getByText("world").closest(".conversation-node-bubble") as HTMLElement;
@@ -163,7 +187,9 @@ describe("ConversationNodeView", () => {
   it("clicking Copy Message on the second bubble copies its own exact content", async () => {
     const user = userEvent.setup();
     renderConversationNode();
-    const writeText = vi.fn();
+    // See the .mockResolvedValue comment above - the added .catch() needs a
+    // real thenable, not a bare vi.fn().
+    const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
 
     const assistantBubble = screen.getByText("Hi there").closest(".conversation-node-bubble") as HTMLElement;
@@ -558,5 +584,135 @@ describe("ConversationNodeView interrupted message marker (ADR-006 stage 6.4)", 
   it("renders no Interrupted badge on complete messages", () => {
     renderConversationNode();
     expect(screen.queryByText("Interrupted")).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: React.memo comparator correctness. `lodVisibilityCalls`
+// (see the mock above) fires exactly once per ACTUAL render of this view -
+// never on a bailed-out one - so it's the oracle for both directions: it must
+// stay flat across an irrelevant/equivalent prop change (too-tight would fail
+// this) and must increment on a change to a prop the view actually reads
+// (too-loose would fail this).
+describe("ConversationNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  beforeEach(() => {
+    lodVisibilityCalls.count = 0;
+  });
+
+  function baseConversationProps(overrides: Partial<ConversationFlowNode["data"]> = {}) {
+    const data = {
+      history: [{ role: "user" as const, content: "Hello", incomplete: false }],
+      isCollapsed: false,
+      pendingRequestId: null,
+      onToggleCollapse: vi.fn(),
+      onDelete: vi.fn(),
+      onSend: vi.fn(),
+      onDeleteMessage: vi.fn(),
+      onCancel: vi.fn(),
+      onOpenDocumentView: vi.fn(),
+      subscribeStream: vi.fn().mockReturnValue(vi.fn()),
+      ...overrides,
+    };
+    return { id: "n0", selected: false, data } as unknown as NodeProps<ConversationFlowNode>;
+  }
+
+  it("skips re-rendering when a fresh `data` object carries identical field values", () => {
+    const props = baseConversationProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ConversationNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    // A brand-new object, same primitives, same `history` array reference and
+    // same callback references - exactly what toFlowNodes may mint on an
+    // unrelated snapshot. A naive `data === nextData` reference compare (or
+    // React.memo's default shallow-props compare) would wrongly re-render here.
+    const sameValuesNewObject = { ...props.data };
+    rerender(
+      <ReactFlowProvider>
+        <ConversationNodeView {...{ ...props, data: sameValuesNewObject }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("skips re-rendering when `history` is a brand-new array of byte-identical message objects", () => {
+    // Proves the comparator does shape-aware element compare on `history`,
+    // not a naive `===` (which would always miss here since this is a fresh
+    // array instance) and not a naive "always unequal for arrays" shortcut
+    // either (which would defeat memoization for every conversation node).
+    const props = baseConversationProps({
+      history: [{ role: "user", content: "Hello", incomplete: false }],
+    });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ConversationNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    const freshHistory = [{ role: "user" as const, content: "Hello", incomplete: false }];
+    rerender(
+      <ReactFlowProvider>
+        <ConversationNodeView {...{ ...props, data: { ...props.data, history: freshHistory } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("re-renders when `history` content actually changes", () => {
+    const props = baseConversationProps({
+      history: [{ role: "user", content: "Hello", incomplete: false }],
+    });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ConversationNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    const changedHistory = [{ role: "user" as const, content: "Hello there", incomplete: false }];
+    rerender(
+      <ReactFlowProvider>
+        <ConversationNodeView {...{ ...props, data: { ...props.data, history: changedHistory } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+    expect(screen.getByText("Hello there")).toBeInTheDocument();
+  });
+
+  it("re-renders when a callback prop is rebound to a new closure (e.g. onDelete)", () => {
+    const props = baseConversationProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ConversationNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <ConversationNodeView {...{ ...props, data: { ...props.data, onDelete: vi.fn() } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+  });
+
+  it("re-renders when `selected` changes", () => {
+    const props = baseConversationProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ConversationNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <ConversationNodeView {...{ ...props, selected: true }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
   });
 });

--- a/web_ui/src/app/canvas/ConversationNodeView.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.tsx
@@ -1,9 +1,10 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useState, type ReactNode } from "react";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useEffect, useState, type ReactNode } from "react";
 import type { StreamListener } from "../../lib/ws/transport";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import type { MenuPosition } from "./menuPosition";
 import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The conversation node (Qt-removal plan R3.25/R3.26) - ConversationNode's
@@ -70,11 +71,6 @@ export interface ConversationNodeData extends Record<string, unknown> {
 }
 
 export type ConversationFlowNode = Node<ConversationNodeData, "conversation">;
-
-interface MenuPosition {
-  x: number;
-  y: number;
-}
 
 /** Shared outside-click/Escape dismiss behavior - identical pattern to every
  * sibling menu component (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu). */
@@ -159,7 +155,12 @@ function ConversationBubbleMenu({
         type="button"
         role="menuitem"
         onClick={() => {
-          navigator.clipboard.writeText(content);
+          // ADR-011 stage 11.1 (D11): a bare fire-and-forget clipboard write
+          // left this promise's rejection unhandled - same fix ImageNodeView's
+          // own Copy Image action already applies for its clipboard write.
+          navigator.clipboard.writeText(content).catch((error: unknown) => {
+            console.error("[conversation-node] Copy Message failed:", error);
+          });
           onClose();
         }}
       >
@@ -258,10 +259,15 @@ function ConversationBubble({
   // quick-action Copy button, for the identical reason: this one needs its
   // own transient "copied" flash independent of the menu's lifecycle.
   function onQuickCopy() {
-    navigator.clipboard.writeText(message.content).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
+    navigator.clipboard
+      .writeText(message.content)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch((error: unknown) => {
+        console.error("[conversation-node] Copy message failed:", error);
+      });
   }
 
   return (
@@ -369,9 +375,8 @@ function ConversationBubble({
 
 // -- view ----------------------------------------------------------------
 
-export function ConversationNodeView({ data, selected }: NodeProps<ConversationFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+function ConversationNodeViewImpl({ data, selected }: NodeProps<ConversationFlowNode>) {
+  const lodCollapsed = useLodVisibility();
   const collapsed = data.isCollapsed || lodCollapsed;
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const [draft, setDraft] = useState("");
@@ -529,3 +534,58 @@ export function ConversationNodeView({ data, selected }: NodeProps<ConversationF
     </div>
   );
 }
+
+/** `history` is the one array/object-shaped field on ConversationNodeData -
+ * toFlowNodes may mint a fresh array (and fresh message objects) on every
+ * snapshot even when the transcript itself hasn't changed, so a plain `===`
+ * here would be "too tight" (defeats memoization for every conversation node
+ * on every unrelated update). Element-wise compare instead, same shape-aware
+ * pattern WebResearchNodeView's own researchSourcesEqual/NoteNodeView's own
+ * stringArraysEqual use for their own array fields. */
+function conversationHistoryEqual(
+  a: readonly ConversationMessage[],
+  b: readonly ConversationMessage[],
+): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (x.role !== y.role || x.content !== y.content || x.incomplete !== y.incomplete) return false;
+  }
+  return true;
+}
+
+/** ADR-011 stage 11.1: every prop this view actually reads, compared - it
+ * never destructures `id`, so it is intentionally absent here (this instance
+ * never receives a changed `id` without React Flow remounting it under a new
+ * key anyway). Every field ConversationNodeData declares is read somewhere in
+ * render (the bubbles, the input row, the streaming subscription effect, or
+ * the two menus), so every one of them is compared here - `history` gets the
+ * shape-aware compare above, everything else (including every callback,
+ * per the memoization task's own warning that skipping a callback prop is a
+ * real "stale UI" bug, not a safe shortcut) is a stable primitive or callback
+ * reference, so `===` is correct for those. */
+function conversationNodeDataAreEqual(prev: ConversationNodeData, next: ConversationNodeData): boolean {
+  return (
+    conversationHistoryEqual(prev.history, next.history) &&
+    prev.isCollapsed === next.isCollapsed &&
+    prev.pendingRequestId === next.pendingRequestId &&
+    prev.onToggleCollapse === next.onToggleCollapse &&
+    prev.onDelete === next.onDelete &&
+    prev.onSend === next.onSend &&
+    prev.onDeleteMessage === next.onDeleteMessage &&
+    prev.onCancel === next.onCancel &&
+    prev.onOpenDocumentView === next.onOpenDocumentView &&
+    prev.subscribeStream === next.subscribeStream
+  );
+}
+
+function conversationNodePropsAreEqual(
+  prev: Readonly<NodeProps<ConversationFlowNode>>,
+  next: Readonly<NodeProps<ConversationFlowNode>>,
+): boolean {
+  return prev.selected === next.selected && conversationNodeDataAreEqual(prev.data, next.data);
+}
+
+export const ConversationNodeView = memo(ConversationNodeViewImpl, conversationNodePropsAreEqual);

--- a/web_ui/src/app/canvas/DocumentNodeView.test.tsx
+++ b/web_ui/src/app/canvas/DocumentNodeView.test.tsx
@@ -1,7 +1,27 @@
 import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ADR-011 stage 11.1: wraps the real useLodVisibility so every ACTUAL
+// invocation (mount or re-render) is countable - a React.memo bailout skips
+// calling DocumentNodeView's function body entirely, so this hook (called
+// unconditionally on every real render) never fires during a bailed
+// re-render. Same "mock-wrap-and-delegate" technique ImageNodeView.test.tsx
+// established.
+const lodVisibilityCalls = { count: 0 };
+
+vi.mock("./useLodVisibility", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./useLodVisibility")>();
+  return {
+    ...original,
+    useLodVisibility: (...args: Parameters<typeof original.useLodVisibility>) => {
+      lodVisibilityCalls.count += 1;
+      return original.useLodVisibility(...args);
+    },
+  };
+});
+
 import {
   DocumentNodeView,
   formatByteSize,
@@ -181,7 +201,11 @@ describe("DocumentNodeView", () => {
     const user = userEvent.setup();
     const { onDelete, onDock } = renderDocumentNode({ attachmentKind: "document", filePath: "" });
 
-    const writeText = vi.fn();
+    // ADR-011 stage 11.1: Copy Details now chains a .catch() onto the
+    // clipboard write (D11), so the mock must resolve like a real
+    // Promise-returning clipboard API - a bare vi.fn() would make that
+    // .catch() call throw synchronously on `undefined`.
+    const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
 
     const title = screen.getByText("notes.pdf");
@@ -286,5 +310,115 @@ describe("DocumentNodeView", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
     await user.click(document.body);
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: React.memo comparator correctness. `lodVisibilityCalls`
+// (see the mock above) fires exactly once per ACTUAL render of this view -
+// never on a bailed-out one - so it's the oracle for both directions: it must
+// stay flat across an irrelevant/equivalent prop change (too-tight would fail
+// this) and must increment on a change to a prop the view actually reads
+// (too-loose would fail this).
+describe("DocumentNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  beforeEach(() => {
+    lodVisibilityCalls.count = 0;
+  });
+
+  function baseDocumentProps(overrides: Partial<DocumentFlowNode["data"]> = {}) {
+    const data = {
+      title: "notes.pdf",
+      content: "Quarterly figures attached.",
+      attachmentKind: "document",
+      filePath: "",
+      mimeType: "",
+      durationSeconds: null,
+      byteSize: null,
+      previewLabel: "",
+      isCollapsed: false,
+      onToggleCollapse: vi.fn(),
+      onDock: vi.fn(),
+      onDelete: vi.fn(),
+      isBranchFocusActive: false,
+      onToggleBranchFocus: vi.fn(),
+      ...overrides,
+    };
+    return { id: "n0", selected: false, data } as unknown as NodeProps<DocumentFlowNode>;
+  }
+
+  it("skips re-rendering when a fresh `data` object carries identical field values", () => {
+    const props = baseDocumentProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <DocumentNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    // A brand-new object, same primitives and same callback references -
+    // exactly what toFlowNodes may mint on an unrelated snapshot. A naive
+    // `data === nextData` reference compare (or React.memo's default shallow
+    // props compare) would wrongly re-render here.
+    const sameValuesNewObject = { ...props.data };
+    rerender(
+      <ReactFlowProvider>
+        <DocumentNodeView {...{ ...props, data: sameValuesNewObject }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("skips re-rendering when only `previewLabel` (a field this view never reads) changes", () => {
+    // Pins the deliberate omission documented on documentNodeDataAreEqual:
+    // previewLabel isn't surfaced in this increment's render at all, so a
+    // change to it alone must never trigger a re-render.
+    const props = baseDocumentProps({ previewLabel: "old label" });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <DocumentNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <DocumentNodeView {...{ ...props, data: { ...props.data, previewLabel: "a different label" } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("re-renders when `content` (a field the view reads) changes", () => {
+    const props = baseDocumentProps({ content: "Quarterly figures attached." });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <DocumentNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <DocumentNodeView {...{ ...props, data: { ...props.data, content: "Updated figures attached." } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+    expect(screen.getByText("Updated figures attached.")).toBeInTheDocument();
+  });
+
+  it("re-renders when a callback prop is rebound to a new closure (e.g. onDelete)", () => {
+    const props = baseDocumentProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <DocumentNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <DocumentNodeView {...{ ...props, data: { ...props.data, onDelete: vi.fn() } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
   });
 });

--- a/web_ui/src/app/canvas/DocumentNodeView.tsx
+++ b/web_ui/src/app/canvas/DocumentNodeView.tsx
@@ -1,7 +1,8 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useState } from "react";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useState } from "react";
+import type { MenuPosition } from "./menuPosition";
 import { NodeMenu } from "./NodeMenu";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The document node (Qt-removal plan R3.9/R3.10) - graphlink_node_document.py's
@@ -56,11 +57,6 @@ export interface DocumentNodeData extends Record<string, unknown> {
 }
 
 export type DocumentFlowNode = Node<DocumentNodeData, "document">;
-
-interface MenuPosition {
-  x: number;
-  y: number;
-}
 
 // -- ported legacy formatting/heuristic rules (graphlink_node_document.py) --
 
@@ -214,7 +210,12 @@ function DocumentNodeMenu({
         type="button"
         role="menuitem"
         onClick={() => {
-          navigator.clipboard.writeText(content);
+          // ADR-011 stage 11.1 (D11): a bare fire-and-forget clipboard write
+          // left this promise's rejection unhandled - same fix ImageNodeView's
+          // own Copy Image action already applies for its clipboard write.
+          navigator.clipboard.writeText(content).catch((error: unknown) => {
+            console.error("[document-node] Copy Details failed:", error);
+          });
           onClose();
         }}
       >
@@ -283,9 +284,8 @@ function DocumentNodeMenu({
 
 // -- view ----------------------------------------------------------------
 
-export function DocumentNodeView({ data, selected }: NodeProps<DocumentFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+function DocumentNodeViewImpl({ data, selected }: NodeProps<DocumentFlowNode>) {
+  const lodCollapsed = useLodVisibility();
   const collapsed = data.isCollapsed || lodCollapsed;
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
 
@@ -363,3 +363,41 @@ export function DocumentNodeView({ data, selected }: NodeProps<DocumentFlowNode>
     </div>
   );
 }
+
+/** ADR-011 stage 11.1: every prop this view actually reads, compared - it
+ * never destructures `id`, so it is intentionally absent (this instance never
+ * receives a changed `id` without React Flow remounting it under a new key
+ * anyway). Every `data` field is a primitive/nullable-primitive or a stable
+ * callback reference (no array/object fields on DocumentNodeData), so `===`
+ * is correct throughout. `previewLabel` is intentionally OMITTED: per this
+ * file's own module doc, it is "not yet surfaced in this increment's
+ * render" - this view never reads `data.previewLabel` anywhere, so comparing
+ * it would only cause spurious re-renders, never fix a missed one (same
+ * reasoning WebResearchNodeView's own comparator applies to
+ * researchActiveSourceId). */
+function documentNodeDataAreEqual(prev: DocumentNodeData, next: DocumentNodeData): boolean {
+  return (
+    prev.title === next.title &&
+    prev.content === next.content &&
+    prev.attachmentKind === next.attachmentKind &&
+    prev.filePath === next.filePath &&
+    prev.mimeType === next.mimeType &&
+    prev.durationSeconds === next.durationSeconds &&
+    prev.byteSize === next.byteSize &&
+    prev.isCollapsed === next.isCollapsed &&
+    prev.onToggleCollapse === next.onToggleCollapse &&
+    prev.onDock === next.onDock &&
+    prev.onDelete === next.onDelete &&
+    prev.isBranchFocusActive === next.isBranchFocusActive &&
+    prev.onToggleBranchFocus === next.onToggleBranchFocus
+  );
+}
+
+function documentNodePropsAreEqual(
+  prev: Readonly<NodeProps<DocumentFlowNode>>,
+  next: Readonly<NodeProps<DocumentFlowNode>>,
+): boolean {
+  return prev.selected === next.selected && documentNodeDataAreEqual(prev.data, next.data);
+}
+
+export const DocumentNodeView = memo(DocumentNodeViewImpl, documentNodePropsAreEqual);

--- a/web_ui/src/app/canvas/GitlinkNodeView.test.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.test.tsx
@@ -2,8 +2,28 @@ import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OverlayProvider } from "../overlays/overlays";
+
+// ADR-011 stage 11.1: wraps the real useLodVisibility so every ACTUAL
+// invocation (mount or re-render) is countable - a React.memo bailout skips
+// calling GitlinkNodeView's function body entirely, so this hook (called
+// unconditionally on every real render) never fires during a bailed
+// re-render. Same "mock-wrap-and-delegate" technique ImageNodeView.test.tsx
+// established.
+const lodVisibilityCalls = { count: 0 };
+
+vi.mock("./useLodVisibility", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./useLodVisibility")>();
+  return {
+    ...original,
+    useLodVisibility: (...args: Parameters<typeof original.useLodVisibility>) => {
+      lodVisibilityCalls.count += 1;
+      return original.useLodVisibility(...args);
+    },
+  };
+});
+
 import { GitlinkNodeView, type GitlinkFlowNode } from "./GitlinkNodeView";
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
@@ -613,5 +633,186 @@ describe("GitlinkNodeView", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
     await user.click(document.body);
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: React.memo comparator correctness. `lodVisibilityCalls`
+// (see the mock above) fires exactly once per ACTUAL render of this view -
+// never on a bailed-out one - so it's the oracle for both directions: it must
+// stay flat across an irrelevant/equivalent prop change (too-tight would fail
+// this) and must increment on a change to a prop the view actually reads
+// (too-loose would fail this).
+describe("GitlinkNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  beforeEach(() => {
+    lodVisibilityCalls.count = 0;
+  });
+
+  function renderWithProps(props: NodeProps<GitlinkFlowNode>) {
+    return render(
+      <OverlayProvider>
+        <ReactFlowProvider>
+          <GitlinkNodeView {...props} />
+        </ReactFlowProvider>
+      </OverlayProvider>,
+    );
+  }
+
+  function baseGitlinkProps(overrides: Partial<GitlinkFlowNode["data"]> = {}) {
+    const data = baseData(overrides);
+    return { id: "gl-1", selected: false, data } as unknown as NodeProps<GitlinkFlowNode>;
+  }
+
+  it("skips re-rendering when a fresh `data` object carries identical field values", () => {
+    const props = baseGitlinkProps();
+    const { rerender } = renderWithProps(props);
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    // A brand-new object, same primitives, same array/object/callback
+    // references - exactly what toFlowNodes may mint on an unrelated
+    // snapshot. A naive `data === nextData` reference compare (or
+    // React.memo's default shallow-props compare) would wrongly re-render
+    // here.
+    const sameValuesNewObject = { ...props.data };
+    rerender(
+      <OverlayProvider>
+        <ReactFlowProvider>
+          <GitlinkNodeView {...{ ...props, data: sameValuesNewObject }} />
+        </ReactFlowProvider>
+      </OverlayProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("skips re-rendering when `gitlinkPendingChanges`/`gitlinkRepoFilePaths`/`gitlinkContextStats` are brand-new but byte-identical", () => {
+    // Proves the comparator does shape-aware compare on these three
+    // array/object fields, not a naive `===` (which would always miss here
+    // since these are fresh instances) and not a naive "always unequal"
+    // shortcut either (which would defeat memoization for every gitlink
+    // node with any context/proposal state).
+    const props = baseGitlinkProps({
+      gitlinkRepoFilePaths: ["a.py", "b.py"],
+      gitlinkContextStats: { files: "2", tokens: "512" },
+      gitlinkPendingChanges: [{ path: "app.py", operation: "modify", reason: "add route" }],
+    });
+    const { rerender } = renderWithProps(props);
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <OverlayProvider>
+        <ReactFlowProvider>
+          <GitlinkNodeView
+            {...{
+              ...props,
+              data: {
+                ...props.data,
+                gitlinkRepoFilePaths: ["a.py", "b.py"],
+                gitlinkContextStats: { files: "2", tokens: "512" },
+                gitlinkPendingChanges: [{ path: "app.py", operation: "modify", reason: "add route" }],
+              },
+            }}
+          />
+        </ReactFlowProvider>
+      </OverlayProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("skips re-rendering when only `gitlinkScopeMode`/`gitlinkSelectedPaths`/`gitlinkTaskPrompt` change (seed-once fields this view never re-reads)", () => {
+    const props = baseGitlinkProps({
+      gitlinkScopeMode: "selected",
+      gitlinkSelectedPaths: ["a.py"],
+      gitlinkTaskPrompt: "old prompt",
+    });
+    const { rerender } = renderWithProps(props);
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <OverlayProvider>
+        <ReactFlowProvider>
+          <GitlinkNodeView
+            {...{
+              ...props,
+              data: {
+                ...props.data,
+                gitlinkScopeMode: "full",
+                gitlinkSelectedPaths: ["b.py", "c.py"],
+                gitlinkTaskPrompt: "a completely different prompt",
+              },
+            }}
+          />
+        </ReactFlowProvider>
+      </OverlayProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("re-renders when `gitlinkPendingChanges` content actually changes", () => {
+    const props = baseGitlinkProps({
+      gitlinkPendingChanges: [{ path: "app.py", operation: "modify", reason: "add route" }],
+    });
+    const { rerender } = renderWithProps(props);
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <OverlayProvider>
+        <ReactFlowProvider>
+          <GitlinkNodeView
+            {...{
+              ...props,
+              data: {
+                ...props.data,
+                gitlinkPendingChanges: [{ path: "app.py", operation: "delete", reason: "add route" }],
+              },
+            }}
+          />
+        </ReactFlowProvider>
+      </OverlayProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+  });
+
+  it("re-renders when `gitlinkLocalRoot` changes (read directly in the Apply dialog, not just a seed)", () => {
+    const props = baseGitlinkProps({ gitlinkLocalRoot: "C:/repos/old" });
+    const { rerender } = renderWithProps(props);
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <OverlayProvider>
+        <ReactFlowProvider>
+          <GitlinkNodeView {...{ ...props, data: { ...props.data, gitlinkLocalRoot: "C:/repos/new" } }} />
+        </ReactFlowProvider>
+      </OverlayProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+  });
+
+  it("re-renders when a callback prop is rebound to a new closure (e.g. onDelete)", () => {
+    const props = baseGitlinkProps();
+    const { rerender } = renderWithProps(props);
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <OverlayProvider>
+        <ReactFlowProvider>
+          <GitlinkNodeView {...{ ...props, data: { ...props.data, onDelete: vi.fn() } }} />
+        </ReactFlowProvider>
+      </OverlayProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+  });
+
+  it("re-renders when `id` changes", () => {
+    const props = baseGitlinkProps();
+    const { rerender } = renderWithProps(props);
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <OverlayProvider>
+        <ReactFlowProvider>
+          <GitlinkNodeView {...{ ...props, id: "gl-2" }} />
+        </ReactFlowProvider>
+      </OverlayProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
   });
 });

--- a/web_ui/src/app/canvas/GitlinkNodeView.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.tsx
@@ -1,9 +1,10 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useEffect, useRef, useState } from "react";
 import { Dialog, useOverlays } from "../overlays/overlays";
+import type { MenuPosition } from "./menuPosition";
 import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The Gitlink node (Qt-removal plan R5.3) - the Gitlink plugin's React card.
@@ -110,11 +111,6 @@ export interface GitlinkNodeData extends Record<string, unknown> {
 
 export type GitlinkFlowNode = Node<GitlinkNodeData, "gitlink">;
 
-interface MenuPosition {
-  x: number;
-  y: number;
-}
-
 /** Same outside-click/Escape dismiss pattern every sibling node menu uses
  * (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu/ConversationNodeMenu/
  * WebResearchNodeMenu/ArtifactNodeMenu). */
@@ -181,9 +177,8 @@ const TABS: { key: TabKey; label: string }[] = [
 
 // -- view ----------------------------------------------------------------
 
-export function GitlinkNodeView({ id, data, selected }: NodeProps<GitlinkFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+function GitlinkNodeViewImpl({ id, data, selected }: NodeProps<GitlinkFlowNode>) {
+  const lodCollapsed = useLodVisibility();
   const collapsed = data.isCollapsed || lodCollapsed;
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const [activeTab, setActiveTab] = useState<TabKey>("setup");
@@ -659,3 +654,103 @@ export function GitlinkNodeView({ id, data, selected }: NodeProps<GitlinkFlowNod
     </div>
   );
 }
+
+/** ADR-011 stage 11.1 comparator helpers, mirroring WebResearchNodeView's own
+ * shape-aware approach: toFlowNodes may mint a fresh array/object for one of
+ * these fields on every snapshot even when its contents are unchanged, so a
+ * plain `===` would be "too tight" for every such field. Only the fields this
+ * view actually reads off each row/entry are compared (`reason`/`content` on
+ * GitlinkPendingChangeRow never reach the DOM from this file - only
+ * `operation`/`path` do, in the Apply confirmation list). */
+function stringArraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function gitlinkContextStatsEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+  if (a === b) return true;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}
+
+function gitlinkPendingChangesEqual(
+  a: readonly GitlinkPendingChangeRow[],
+  b: readonly GitlinkPendingChangeRow[],
+): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].operation !== b[i].operation || a[i].path !== b[i].path) return false;
+  }
+  return true;
+}
+
+/** ADR-011 stage 11.1: every prop this view actually reads, compared.
+ * `gitlinkScopeMode`, `gitlinkSelectedPaths`, and `gitlinkTaskPrompt` are
+ * intentionally OMITTED: per this file's own "state-ownership discipline"
+ * module doc, each seeds a local draft `useState` ONCE on mount and is never
+ * read again afterward (no effect, no JSX, no closure references the prop
+ * itself past that one seed line) - comparing them would only cause spurious
+ * re-renders that render byte-identical output, never fix a missed one (same
+ * reasoning WebResearchNodeView's own comparator applies to
+ * researchActiveSourceId). `gitlinkRepo`/`gitlinkBranch` are NOT in that same
+ * bucket despite also seeding drafts - they're read again every render by the
+ * repo/branch-change effect that resets the file-tree selection (FIX 7), so
+ * they're compared. `gitlinkLocalRoot` is read directly in the Apply dialog's
+ * body text, not just as a seed, so it's compared too. */
+function gitlinkNodeDataAreEqual(prev: GitlinkNodeData, next: GitlinkNodeData): boolean {
+  return (
+    prev.gitlinkRepo === next.gitlinkRepo &&
+    prev.gitlinkBranch === next.gitlinkBranch &&
+    prev.gitlinkLocalRoot === next.gitlinkLocalRoot &&
+    stringArraysEqual(prev.gitlinkRepoFilePaths, next.gitlinkRepoFilePaths) &&
+    gitlinkContextStatsEqual(prev.gitlinkContextStats, next.gitlinkContextStats) &&
+    prev.gitlinkContextSummary === next.gitlinkContextSummary &&
+    prev.gitlinkContextVersion === next.gitlinkContextVersion &&
+    prev.gitlinkProposalMarkdown === next.gitlinkProposalMarkdown &&
+    gitlinkPendingChangesEqual(prev.gitlinkPendingChanges, next.gitlinkPendingChanges) &&
+    prev.gitlinkPreviewText === next.gitlinkPreviewText &&
+    prev.gitlinkChangeFingerprint === next.gitlinkChangeFingerprint &&
+    prev.gitlinkChangeState === next.gitlinkChangeState &&
+    prev.gitlinkError === next.gitlinkError &&
+    prev.isCollapsed === next.isCollapsed &&
+    prev.pendingRequestId === next.pendingRequestId &&
+    prev.onFetchRepositories === next.onFetchRepositories &&
+    prev.onLoadTree === next.onLoadTree &&
+    prev.onSetLocalRoot === next.onSetLocalRoot &&
+    prev.onBrowseLocalRoot === next.onBrowseLocalRoot &&
+    prev.onImportSnapshot === next.onImportSnapshot &&
+    prev.onBuildContext === next.onBuildContext &&
+    prev.onFetchContext === next.onFetchContext &&
+    prev.onRun === next.onRun &&
+    prev.onCancel === next.onCancel &&
+    prev.onApply === next.onApply &&
+    prev.onToggleCollapse === next.onToggleCollapse &&
+    prev.onDelete === next.onDelete
+  );
+}
+
+/** `id` is read here (it keys the per-instance Apply-confirmation overlay
+ * name, `gitlink-apply-${id}`), unlike some sibling views - so it's compared
+ * alongside `selected` and every `data` field above. */
+function gitlinkNodePropsAreEqual(
+  prev: Readonly<NodeProps<GitlinkFlowNode>>,
+  next: Readonly<NodeProps<GitlinkFlowNode>>,
+): boolean {
+  return (
+    prev.id === next.id &&
+    prev.selected === next.selected &&
+    gitlinkNodeDataAreEqual(prev.data, next.data)
+  );
+}
+
+export const GitlinkNodeView = memo(GitlinkNodeViewImpl, gitlinkNodePropsAreEqual);

--- a/web_ui/src/app/canvas/GroupNodeView.test.tsx
+++ b/web_ui/src/app/canvas/GroupNodeView.test.tsx
@@ -1,7 +1,29 @@
 import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ADR-011 stage 11.1: GroupNodeView has no LOD hook to spy on (frames/
+// containers never auto-collapse on zoom - see this file's own module doc),
+// so this wraps <GroupColorPicker/> instead - it's unconditionally part of
+// `controlsCluster`, which renders in BOTH the collapsed-pill and
+// expanded-topbar branches, for every groupKind - so it's called on every
+// ACTUAL render of this view and never on a bailed-out one. Same
+// "mock-wrap-and-delegate" technique ImageNodeView.test.tsx established at
+// hook granularity, applied here at child-component granularity instead.
+const colorPickerRenders = { count: 0 };
+
+vi.mock("./GroupColorPicker", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./GroupColorPicker")>();
+  return {
+    ...original,
+    GroupColorPicker: (props: Parameters<typeof original.GroupColorPicker>[0]) => {
+      colorPickerRenders.count += 1;
+      return original.GroupColorPicker(props);
+    },
+  };
+});
+
 import { GroupNodeView, type GroupFlowNode } from "./GroupNodeView";
 
 function renderGroupNode(overrides: Partial<GroupFlowNode["data"]> = {}) {
@@ -198,5 +220,172 @@ describe("GroupNodeView collapsed-container hover preview (R6.1 follow-up)", () 
 
     fireEvent.mouseEnter(container.querySelector(".group-node")!);
     expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: React.memo comparator correctness. `colorPickerRenders`
+// (see the mock above) fires exactly once per ACTUAL render of this view -
+// never on a bailed-out one - so it's the oracle for both directions: it must
+// stay flat across an irrelevant/equivalent prop change (too-tight would fail
+// this) and must increment on a change to a prop the view actually reads
+// (too-loose would fail this).
+describe("GroupNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  beforeEach(() => {
+    colorPickerRenders.count = 0;
+  });
+
+  function baseGroupProps(overrides: Partial<GroupFlowNode["data"]> = {}) {
+    const data = {
+      groupKind: "frame" as const,
+      label: "My Frame",
+      color: null,
+      headerColor: null,
+      isCollapsed: false,
+      isLocked: true,
+      itemIds: ["n1", "n2"],
+      memberKinds: ["chat", "chat"],
+      onSetLabel: vi.fn(),
+      onToggleCollapsed: vi.fn(),
+      onToggleLock: vi.fn(),
+      onSetColor: vi.fn(),
+      onResize: vi.fn(),
+      onFitToContent: vi.fn(),
+      onUngroup: vi.fn(),
+      ...overrides,
+    };
+    return { id: "n0", selected: false, data } as unknown as NodeProps<GroupFlowNode>;
+  }
+
+  it("skips re-rendering when a fresh `data` object carries identical field values", () => {
+    const props = baseGroupProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <GroupNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(1);
+
+    // A brand-new object, same primitives, same `memberKinds`/`itemIds` array
+    // references and same callback references - exactly what toFlowNodes may
+    // mint on an unrelated snapshot. A naive `data === nextData` reference
+    // compare (or React.memo's default shallow-props compare) would wrongly
+    // re-render here.
+    const sameValuesNewObject = { ...props.data };
+    rerender(
+      <ReactFlowProvider>
+        <GroupNodeView {...{ ...props, data: sameValuesNewObject }} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(1);
+  });
+
+  it("skips re-rendering when `memberKinds` is a brand-new but byte-identical array", () => {
+    // Proves the comparator does shape-aware element compare on
+    // `memberKinds`, not a naive `===` (always a miss for a fresh array
+    // instance) and not a naive "always unequal for arrays" shortcut either
+    // (which would defeat memoization for every collapsed container).
+    const props = baseGroupProps({ groupKind: "container", memberKinds: ["chat", "code"] });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <GroupNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <GroupNodeView {...{ ...props, data: { ...props.data, memberKinds: ["chat", "code"] } }} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(1);
+  });
+
+  it("skips re-rendering when only `itemIds` (a field this view never reads) changes", () => {
+    // Pins the deliberate omission documented on groupNodeDataAreEqual:
+    // itemIds is SceneCanvas's own drag-cascade concern, never read by this
+    // component's render - so a change to it alone must never re-render.
+    const props = baseGroupProps({ itemIds: ["n1", "n2"] });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <GroupNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <GroupNodeView {...{ ...props, data: { ...props.data, itemIds: ["n1", "n2", "n3"] } }} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(1);
+  });
+
+  it("re-renders when `memberKinds` content actually changes", () => {
+    const props = baseGroupProps({ groupKind: "container", memberKinds: ["chat"] });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <GroupNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <GroupNodeView {...{ ...props, data: { ...props.data, memberKinds: ["chat", "code"] } }} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(2);
+  });
+
+  it("re-renders when `label` (a field the view reads) changes", () => {
+    const props = baseGroupProps({ label: "My Frame" });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <GroupNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <GroupNodeView {...{ ...props, data: { ...props.data, label: "Renamed Frame" } }} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(2);
+    expect(screen.getByText("Renamed Frame")).toBeInTheDocument();
+  });
+
+  it("re-renders when a callback prop is rebound to a new closure (e.g. onUngroup)", () => {
+    const props = baseGroupProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <GroupNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <GroupNodeView {...{ ...props, data: { ...props.data, onUngroup: vi.fn() } }} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(2);
+  });
+
+  it("re-renders when `id` changes (forwarded to NodeResizer's nodeId)", () => {
+    const props = baseGroupProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <GroupNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <GroupNodeView {...{ ...props, id: "n99" }} />
+      </ReactFlowProvider>,
+    );
+    expect(colorPickerRenders.count).toBe(2);
   });
 });

--- a/web_ui/src/app/canvas/GroupNodeView.tsx
+++ b/web_ui/src/app/canvas/GroupNodeView.tsx
@@ -1,5 +1,5 @@
 import { NodeResizer, type Node, type NodeProps } from "@xyflow/react";
-import { useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { memo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { GroupColorPicker } from "./GroupColorPicker";
 import { GROUP_RESIZE_MIN_HEIGHT, GROUP_RESIZE_MIN_WIDTH } from "./canvasConstants";
 
@@ -103,7 +103,7 @@ const RESIZE_LINE_STYLE: CSSProperties = {
   borderColor: "transparent",
 };
 
-export function GroupNodeView({ id, data, selected }: NodeProps<GroupFlowNode>) {
+function GroupNodeViewImpl({ id, data, selected }: NodeProps<GroupFlowNode>) {
   const isFrame = data.groupKind === "frame";
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(data.label);
@@ -348,3 +348,62 @@ function GroupIcon({ name }: { name: GroupIconName }) {
     </svg>
   );
 }
+
+/** `memberKinds` is the one array field this view actually reads (the ghost
+ * preview's item-count/breakdown) - toFlowNodes may mint a fresh array on
+ * every snapshot even when the member set is unchanged, so a plain `===`
+ * here would be "too tight" for every collapsed container with members. Same
+ * shape-aware pattern NoteNodeView's own stringArraysEqual/WebResearchNodeView's
+ * own use for their own string-array fields. */
+function stringArraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/** ADR-011 stage 11.1: every prop this view actually reads, compared.
+ * `itemIds` is intentionally OMITTED: this file never reads it at all (the
+ * member-drag cascade it documents in the module doc above is SceneCanvas.tsx's
+ * own onNodesChange logic, not anything this component's render touches), so
+ * comparing it would only cause spurious re-renders, never fix a missed one -
+ * same reasoning WebResearchNodeView's own comparator applies to
+ * researchActiveSourceId. `memberKinds` gets the shape-aware array compare
+ * above instead of `===`; everything else is a primitive/nullable-primitive
+ * or a stable callback reference. */
+function groupNodeDataAreEqual(prev: GroupNodeData, next: GroupNodeData): boolean {
+  return (
+    prev.groupKind === next.groupKind &&
+    prev.label === next.label &&
+    prev.color === next.color &&
+    prev.headerColor === next.headerColor &&
+    prev.isCollapsed === next.isCollapsed &&
+    prev.isLocked === next.isLocked &&
+    stringArraysEqual(prev.memberKinds, next.memberKinds) &&
+    prev.onSetLabel === next.onSetLabel &&
+    prev.onToggleCollapsed === next.onToggleCollapsed &&
+    prev.onToggleLock === next.onToggleLock &&
+    prev.onSetColor === next.onSetColor &&
+    prev.onResize === next.onResize &&
+    prev.onFitToContent === next.onFitToContent &&
+    prev.onUngroup === next.onUngroup
+  );
+}
+
+/** `id` is read here (forwarded to `<NodeResizer nodeId={id} .../>`), unlike
+ * some sibling views - so it's compared alongside `selected` and every `data`
+ * field above. */
+function groupNodePropsAreEqual(
+  prev: Readonly<NodeProps<GroupFlowNode>>,
+  next: Readonly<NodeProps<GroupFlowNode>>,
+): boolean {
+  return (
+    prev.id === next.id &&
+    prev.selected === next.selected &&
+    groupNodeDataAreEqual(prev.data, next.data)
+  );
+}
+
+export const GroupNodeView = memo(GroupNodeViewImpl, groupNodePropsAreEqual);

--- a/web_ui/src/app/canvas/HtmlNodeView.test.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.test.tsx
@@ -1,7 +1,27 @@
 import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ADR-011 stage 11.1: wraps the real useLodVisibility so every ACTUAL
+// invocation (mount or re-render) is countable - a React.memo bailout skips
+// calling HtmlNodeView's function body entirely, so this hook (called
+// unconditionally on every real render) never fires during a bailed
+// re-render. Same "mock-wrap-and-delegate" technique ImageNodeView.test.tsx
+// established.
+const lodVisibilityCalls = { count: 0 };
+
+vi.mock("./useLodVisibility", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./useLodVisibility")>();
+  return {
+    ...original,
+    useLodVisibility: (...args: Parameters<typeof original.useLodVisibility>) => {
+      lodVisibilityCalls.count += 1;
+      return original.useLodVisibility(...args);
+    },
+  };
+});
+
 import {
   buildSandboxedHtmlDocument,
   clampSplitterValue,
@@ -349,5 +369,115 @@ describe("makeDebouncedSplitterReport", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ADR-011 stage 11.1: React.memo comparator correctness. `lodVisibilityCalls`
+// (see the mock above) fires exactly once per ACTUAL render of this view -
+// never on a bailed-out one - so it's the oracle for both directions: it must
+// stay flat across an irrelevant/equivalent prop change (too-tight would fail
+// this) and must increment on a change to a prop the view actually reads
+// (too-loose would fail this).
+describe("HtmlNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  beforeEach(() => {
+    lodVisibilityCalls.count = 0;
+  });
+
+  function baseHtmlProps(overrides: Partial<HtmlFlowNode["data"]> = {}) {
+    const data = {
+      htmlContent: "<p>hello</p>",
+      isCollapsed: false,
+      htmlSplitterState: null,
+      onToggleCollapse: vi.fn(),
+      onDelete: vi.fn(),
+      onSplitterChange: vi.fn(),
+      ...overrides,
+    };
+    return { id: "n0", selected: false, data } as unknown as NodeProps<HtmlFlowNode>;
+  }
+
+  it("skips re-rendering when a fresh `data` object carries identical field values", () => {
+    const props = baseHtmlProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <HtmlNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    // A brand-new object, same primitives and same callback references -
+    // exactly what toFlowNodes may mint on an unrelated snapshot. A naive
+    // `data === nextData` reference compare (or React.memo's default shallow
+    // props compare) would wrongly re-render here.
+    const sameValuesNewObject = { ...props.data };
+    rerender(
+      <ReactFlowProvider>
+        <HtmlNodeView {...{ ...props, data: sameValuesNewObject }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("skips re-rendering when only `htmlContent`/`htmlSplitterState` (seed-once fields this view never re-reads) change", () => {
+    // Pins the deliberate omission documented on htmlNodeDataAreEqual: both
+    // fields only seed local state via a useState initializer on mount and
+    // are never read again by any JSX/effect/closure - so a change to either
+    // alone must never re-render (and, per the "typing does NOT change the
+    // iframe" test above, could not visibly affect anything even if it did).
+    const props = baseHtmlProps({ htmlContent: "<p>original</p>", htmlSplitterState: 0.5 });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <HtmlNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <HtmlNodeView
+          {...{ ...props, data: { ...props.data, htmlContent: "<p>different</p>", htmlSplitterState: 0.2 } }}
+        />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("re-renders when `isCollapsed` (a field the view reads) changes", () => {
+    const props = baseHtmlProps({ isCollapsed: false });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <HtmlNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <HtmlNodeView {...{ ...props, data: { ...props.data, isCollapsed: true } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+    expect(screen.getByRole("button", { name: "Expand" })).toBeInTheDocument();
+  });
+
+  it("re-renders when `onSplitterChange` is rebound to a new closure, even though it's never rendered directly in JSX", () => {
+    // onSplitterChange is captured fresh into a real pointerdown event-handler
+    // closure on every render (onSplitterPointerDown's onPointerUp) - a
+    // comparator that only checked fields visible in JSX would miss this and
+    // leave a stale closure attached, a genuine "stale UI" bug.
+    const props = baseHtmlProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <HtmlNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <HtmlNodeView {...{ ...props, data: { ...props.data, onSplitterChange: vi.fn() } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
   });
 });

--- a/web_ui/src/app/canvas/HtmlNodeView.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.tsx
@@ -1,13 +1,13 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useEffect, useRef, useState } from "react";
 import {
   HTML_SPLIT_DEFAULT,
   HTML_SPLIT_MAX,
   HTML_SPLIT_MIN,
   HTML_SPLIT_TOTAL_PX,
   HTML_SPLITTER_REPORT_DEBOUNCE_MS,
-  LOD_ZOOM_THRESHOLD,
 } from "./canvasConstants";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The HTML view node (Qt-removal plan R3.17/R3.18) - graphlink_node_htmlview.py's
@@ -126,9 +126,8 @@ export function makeDebouncedSplitterReport(
   };
 }
 
-export function HtmlNodeView({ data, selected }: NodeProps<HtmlFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+function HtmlNodeViewImpl({ data, selected }: NodeProps<HtmlFlowNode>) {
+  const lodCollapsed = useLodVisibility();
   const collapsed = data.isCollapsed || lodCollapsed;
 
   // Two separate pieces of local state, per the R3.18 spec: `sourceText`
@@ -269,3 +268,36 @@ export function HtmlNodeView({ data, selected }: NodeProps<HtmlFlowNode>) {
     </div>
   );
 }
+
+/** ADR-011 stage 11.1: every prop this view actually reads, compared - it
+ * never destructures `id`, so it is intentionally absent (this instance never
+ * receives a changed `id` without React Flow remounting it under a new key
+ * anyway). `htmlContent` and `htmlSplitterState` are intentionally OMITTED:
+ * each seeds local state ONCE via a `useState` initializer on mount
+ * (`sourceText`/`renderedDoc` and `splitterValue` respectively) and is never
+ * read again afterward by any JSX, effect, or event-handler closure - so
+ * comparing them would only cause spurious re-renders that produce
+ * byte-identical output, never fix a missed one (same reasoning
+ * WebResearchNodeView's own comparator applies to researchActiveSourceId).
+ * Everything else - `isCollapsed`, and every callback, including
+ * `onSplitterChange`, which IS captured fresh into a real event-handler
+ * closure on every render (onSplitterPointerDown's onPointerUp) and so must
+ * be compared, not just fields that show up directly in JSX - is a primitive
+ * or stable callback reference, so `===` is correct for all of them. */
+function htmlNodeDataAreEqual(prev: HtmlNodeData, next: HtmlNodeData): boolean {
+  return (
+    prev.isCollapsed === next.isCollapsed &&
+    prev.onToggleCollapse === next.onToggleCollapse &&
+    prev.onDelete === next.onDelete &&
+    prev.onSplitterChange === next.onSplitterChange
+  );
+}
+
+function htmlNodePropsAreEqual(
+  prev: Readonly<NodeProps<HtmlFlowNode>>,
+  next: Readonly<NodeProps<HtmlFlowNode>>,
+): boolean {
+  return prev.selected === next.selected && htmlNodeDataAreEqual(prev.data, next.data);
+}
+
+export const HtmlNodeView = memo(HtmlNodeViewImpl, htmlNodePropsAreEqual);

--- a/web_ui/src/app/canvas/ImageNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ImageNodeView.test.tsx
@@ -2,6 +2,27 @@ import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ADR-011 stage 11.1: wraps the real useLodVisibility so every ACTUAL
+// invocation (mount or re-render) is countable - a React.memo bailout skips
+// calling ImageNodeView's function body entirely, so this hook (called
+// unconditionally on every real render) never fires during a bailed
+// re-render. This is the same "mock-wrap-and-delegate" technique
+// renderCountGate.test.tsx uses on ChatNodeView, applied at hook
+// granularity instead of whole-component granularity.
+const lodVisibilityCalls = { count: 0 };
+
+vi.mock("./useLodVisibility", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./useLodVisibility")>();
+  return {
+    ...original,
+    useLodVisibility: (...args: Parameters<typeof original.useLodVisibility>) => {
+      lodVisibilityCalls.count += 1;
+      return original.useLodVisibility(...args);
+    },
+  };
+});
+
 import { ImageNodeView, type ImageFlowNode } from "./ImageNodeView";
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
@@ -282,5 +303,88 @@ describe("ImageNodeView", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
     await user.click(document.body);
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: React.memo comparator correctness. `lodVisibilityCalls`
+// (see the mock above) fires exactly once per ACTUAL render of this view -
+// never on a bailed-out one - so it's the oracle for both directions: it
+// must stay flat across an irrelevant/equivalent prop change (too-tight
+// would fail this) and must increment on a change to a prop the view
+// actually reads (too-loose would fail this).
+describe("ImageNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  beforeEach(() => {
+    lodVisibilityCalls.count = 0;
+  });
+
+  function baseImageProps(overrides: Partial<ImageFlowNode["data"]> = {}) {
+    const data = {
+      imageAssetId: "asset-1",
+      prompt: "a fox",
+      onDelete: vi.fn(),
+      onRegenerate: vi.fn(),
+      isBranchFocusActive: false,
+      onToggleBranchFocus: vi.fn(),
+      ...overrides,
+    };
+    return { id: "n0", selected: false, data } as unknown as NodeProps<ImageFlowNode>;
+  }
+
+  it("skips re-rendering when a fresh `data` object carries identical field values", () => {
+    const props = baseImageProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ImageNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    // A brand-new object, same primitives and same callback references -
+    // exactly what toFlowNodes may mint on an unrelated snapshot. A naive
+    // `data === nextData` reference compare (or React.memo's default
+    // shallow-props compare, which would see a new `data` prop identity)
+    // would wrongly re-render here.
+    const sameValuesNewObject = { ...props.data };
+    rerender(
+      <ReactFlowProvider>
+        <ImageNodeView {...{ ...props, data: sameValuesNewObject }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("re-renders when `prompt` (a field the view reads) changes", () => {
+    const props = baseImageProps({ prompt: "a fox" });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ImageNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <ImageNodeView {...{ ...props, data: { ...props.data, prompt: "a different fox" } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+    expect(screen.getByText("a different fox")).toBeInTheDocument();
+  });
+
+  it("re-renders when a callback prop is rebound to a new closure (e.g. onDelete)", () => {
+    const props = baseImageProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ImageNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <ImageNodeView {...{ ...props, data: { ...props.data, onDelete: vi.fn() } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
   });
 });

--- a/web_ui/src/app/canvas/ImageNodeView.tsx
+++ b/web_ui/src/app/canvas/ImageNodeView.tsx
@@ -1,8 +1,9 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useState } from "react";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useState } from "react";
 import { withAuthToken } from "../../lib/auth/token";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import type { MenuPosition } from "./menuPosition";
 import { NodeMenu } from "./NodeMenu";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The image node (Qt-removal plan R3.21/R3.22) - graphlink_node_image.py's
@@ -54,11 +55,6 @@ export interface ImageNodeData extends Record<string, unknown> {
 }
 
 export type ImageFlowNode = Node<ImageNodeData, "image">;
-
-interface MenuPosition {
-  x: number;
-  y: number;
-}
 
 /** The one place this file turns an asset id into a URL - the <img> render
  * below and both menu actions (Copy Image, Export Image) all call this, so
@@ -207,9 +203,8 @@ function ImageNodeMenu({
   );
 }
 
-export function ImageNodeView({ id, data, selected }: NodeProps<ImageFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const collapsed = zoom < LOD_ZOOM_THRESHOLD;
+function ImageNodeViewImpl({ id, data, selected }: NodeProps<ImageFlowNode>) {
+  const collapsed = useLodVisibility();
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const [imageFailed, setImageFailed] = useState(false);
 
@@ -258,3 +253,29 @@ export function ImageNodeView({ id, data, selected }: NodeProps<ImageFlowNode>) 
     </div>
   );
 }
+
+/** ADR-011 stage 11.1: every prop this view actually reads, compared - `id`
+ * and `selected` directly, then every field of `data` (all primitives or
+ * stable callback references here, so `===` is correct for each - no nested
+ * object/array fields on ImageNodeData that would need a deeper compare). Too
+ * loose here (e.g. skipping a field) would mean an edit to that field
+ * silently fails to re-render this node; too tight (e.g. comparing `data` by
+ * reference) would defeat memoization entirely, since toFlowNodes mints a
+ * fresh `data` object on every snapshot. */
+function imageNodePropsAreEqual(
+  prev: Readonly<NodeProps<ImageFlowNode>>,
+  next: Readonly<NodeProps<ImageFlowNode>>,
+): boolean {
+  return (
+    prev.id === next.id &&
+    prev.selected === next.selected &&
+    prev.data.imageAssetId === next.data.imageAssetId &&
+    prev.data.prompt === next.data.prompt &&
+    prev.data.onDelete === next.data.onDelete &&
+    prev.data.onRegenerate === next.data.onRegenerate &&
+    prev.data.isBranchFocusActive === next.data.isBranchFocusActive &&
+    prev.data.onToggleBranchFocus === next.data.onToggleBranchFocus
+  );
+}
+
+export const ImageNodeView = memo(ImageNodeViewImpl, imageNodePropsAreEqual);

--- a/web_ui/src/app/canvas/NoteNodeView.test.tsx
+++ b/web_ui/src/app/canvas/NoteNodeView.test.tsx
@@ -1,8 +1,32 @@
 import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GROUP_NAMED_COLORS } from "./GroupColorPicker";
+
+// ADR-011 stage 11.1: NoteNodeView has no LOD hook to spy on (see its own
+// module doc - it never auto-collapses), so instead this wraps NodeMarkdown
+// - the one child that's UNCONDITIONALLY rendered whenever the note isn't in
+// edit mode (the default/only state these memo tests exercise) - via real
+// JSX composition (not a raw function call, so NodeMarkdown's own hooks
+// attach to their own fiber correctly). Every ACTUAL render of
+// NoteNodeViewImpl creates this element; a React.memo bailout skips the
+// function body entirely, so this never fires on a bailed re-render. See
+// ImageNodeView.test.tsx for the general technique's full rationale.
+const nodeMarkdownRenders = { count: 0 };
+
+vi.mock("./NodeMarkdown", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./NodeMarkdown")>();
+  const OriginalNodeMarkdown = original.NodeMarkdown;
+  return {
+    ...original,
+    NodeMarkdown: (props: Parameters<typeof OriginalNodeMarkdown>[0]) => {
+      nodeMarkdownRenders.count += 1;
+      return <OriginalNodeMarkdown {...props} />;
+    },
+  };
+});
+
 import { NoteNodeView, type NoteFlowNode } from "./NoteNodeView";
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
@@ -193,5 +217,109 @@ describe("NoteNodeView", () => {
     expect(screen.getByRole("menu", { name: "Color" })).toBeInTheDocument();
     await user.click(document.body);
     expect(screen.queryByRole("menu", { name: "Color" })).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: React.memo comparator correctness. `nodeMarkdownRenders`
+// (see the mock above) fires exactly once per ACTUAL render of this view -
+// never on a bailed-out one - so it's the oracle for both directions: it
+// must stay flat across an irrelevant/equivalent prop change (too-tight
+// would fail this) and must increment on a change to a prop the view
+// actually reads (too-loose would fail this). `compareSourceNodeIds` is the
+// one array field, so it gets extra coverage beyond the usual
+// primitive-field pair.
+describe("NoteNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  beforeEach(() => {
+    nodeMarkdownRenders.count = 0;
+  });
+
+  function noteProps(overrides: Partial<NoteFlowNode["data"]> = {}) {
+    const data = {
+      content: "Hello world",
+      color: null,
+      headerColor: null,
+      isSystemPrompt: false,
+      isSummaryNote: false,
+      isBranchComparison: false,
+      compareSourceNodeIds: [] as string[],
+      onSetContent: vi.fn(),
+      onSetColor: vi.fn(),
+      onDelete: vi.fn(),
+      ...overrides,
+    };
+    return { id: "n0", selected: false, data } as unknown as NodeProps<NoteFlowNode>;
+  }
+
+  it("skips re-rendering when a fresh `data` object carries identical field values", () => {
+    const props = noteProps({ compareSourceNodeIds: ["a", "b"] });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <NoteNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(nodeMarkdownRenders.count).toBe(1);
+
+    // A brand-new `data` object AND a brand-new `compareSourceNodeIds`
+    // array, but every value is identical - a plain `===` on either would
+    // wrongly re-render here.
+    const sameValuesNewObject = { ...props.data, compareSourceNodeIds: [...props.data.compareSourceNodeIds] };
+    rerender(
+      <ReactFlowProvider>
+        <NoteNodeView {...{ ...props, data: sameValuesNewObject }} />
+      </ReactFlowProvider>,
+    );
+    expect(nodeMarkdownRenders.count).toBe(1);
+  });
+
+  it("re-renders when `content` (a field the view reads) changes", () => {
+    const props = noteProps({ content: "first draft" });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <NoteNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(nodeMarkdownRenders.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <NoteNodeView {...{ ...props, data: { ...props.data, content: "revised draft" } }} />
+      </ReactFlowProvider>,
+    );
+    expect(nodeMarkdownRenders.count).toBe(2);
+    expect(screen.getByText("revised draft")).toBeInTheDocument();
+  });
+
+  it("re-renders when `compareSourceNodeIds` gains/loses an id, even as a same-length-then-different array", () => {
+    const props = noteProps({ isBranchComparison: true, compareSourceNodeIds: ["a", "b"] });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <NoteNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(nodeMarkdownRenders.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <NoteNodeView {...{ ...props, data: { ...props.data, compareSourceNodeIds: ["a", "c"] } }} />
+      </ReactFlowProvider>,
+    );
+    expect(nodeMarkdownRenders.count).toBe(2);
+  });
+
+  it("skips re-rendering when only `id` or `selected`-irrelevant NodeProps fields change - this view never reads `id`", () => {
+    const props = noteProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <NoteNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(nodeMarkdownRenders.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <NoteNodeView {...{ ...props, id: "some-other-id", dragging: true }} />
+      </ReactFlowProvider>,
+    );
+    expect(nodeMarkdownRenders.count).toBe(1);
   });
 });

--- a/web_ui/src/app/canvas/NoteNodeView.tsx
+++ b/web_ui/src/app/canvas/NoteNodeView.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
-import { useRef, useState } from "react";
+import { memo, useRef, useState } from "react";
 import { GroupColorPicker, NOTE_SYSTEM_PROMPT_BORDER_COLOR } from "./GroupColorPicker";
 import { NodeMarkdown } from "./NodeMarkdown";
 
@@ -50,7 +50,7 @@ export interface NoteNodeData extends Record<string, unknown> {
 
 export type NoteFlowNode = Node<NoteNodeData, "note">;
 
-export function NoteNodeView({ data, selected }: NodeProps<NoteFlowNode>) {
+function NoteNodeViewImpl({ data, selected }: NodeProps<NoteFlowNode>) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(data.content);
   // Suppresses the redundant onBlur commit that fires when Escape/Enter
@@ -165,3 +165,47 @@ export function NoteNodeView({ data, selected }: NodeProps<NoteFlowNode>) {
     </div>
   );
 }
+
+/** Order-sensitive elementwise compare - `compareSourceNodeIds` is the one
+ * array field on NoteNodeData, and toFlowNodes may mint a fresh array
+ * instance even when its contents haven't changed, so a plain `===` here
+ * would be "too tight" (defeats memoization for every branch-comparison note
+ * on every unrelated snapshot). */
+function stringArraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/** ADR-011 stage 11.1: every prop this view actually reads - it never
+ * destructures `id`, so it is intentionally absent here (this instance never
+ * receives a changed `id` without React Flow remounting it under a new key
+ * anyway). Every other `data` field is compared; `compareSourceNodeIds` gets
+ * the shape-aware array compare above instead of `===`, everything else here
+ * is a primitive or stable callback reference. */
+function noteNodeDataAreEqual(prev: NoteNodeData, next: NoteNodeData): boolean {
+  return (
+    prev.content === next.content &&
+    prev.color === next.color &&
+    prev.headerColor === next.headerColor &&
+    prev.isSystemPrompt === next.isSystemPrompt &&
+    prev.isSummaryNote === next.isSummaryNote &&
+    prev.isBranchComparison === next.isBranchComparison &&
+    stringArraysEqual(prev.compareSourceNodeIds, next.compareSourceNodeIds) &&
+    prev.onSetContent === next.onSetContent &&
+    prev.onSetColor === next.onSetColor &&
+    prev.onDelete === next.onDelete
+  );
+}
+
+function noteNodePropsAreEqual(
+  prev: Readonly<NodeProps<NoteFlowNode>>,
+  next: Readonly<NodeProps<NoteFlowNode>>,
+): boolean {
+  return prev.selected === next.selected && noteNodeDataAreEqual(prev.data, next.data);
+}
+
+export const NoteNodeView = memo(NoteNodeViewImpl, noteNodePropsAreEqual);

--- a/web_ui/src/app/canvas/PyCoderNodeView.test.tsx
+++ b/web_ui/src/app/canvas/PyCoderNodeView.test.tsx
@@ -2,7 +2,26 @@ import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ADR-011 stage 11.1: wraps the real useLodVisibility so every ACTUAL render
+// of this view is countable - a React.memo bailout skips the function body
+// (and every hook inside it) entirely, so this never fires on a bailed
+// re-render. See ImageNodeView.test.tsx for the same technique's full
+// rationale.
+const lodVisibilityCalls = { count: 0 };
+
+vi.mock("./useLodVisibility", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./useLodVisibility")>();
+  return {
+    ...original,
+    useLodVisibility: (...args: Parameters<typeof original.useLodVisibility>) => {
+      lodVisibilityCalls.count += 1;
+      return original.useLodVisibility(...args);
+    },
+  };
+});
+
 import { PyCoderNodeView, type PyCoderFlowNode } from "./PyCoderNodeView";
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
@@ -337,5 +356,96 @@ describe("PyCoderNodeView", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
     await user.click(document.body);
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: React.memo comparator correctness. `lodVisibilityCalls`
+// fires exactly once per ACTUAL render - never on a bailed-out one - so it's
+// the oracle for both directions (see ImageNodeView.test.tsx for the full
+// rationale of this technique).
+describe("PyCoderNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  beforeEach(() => {
+    lodVisibilityCalls.count = 0;
+  });
+
+  function pyCoderProps(id = "pc-1", overrides: Partial<PyCoderFlowNode["data"]> = {}) {
+    const data = baseData(overrides);
+    return { id, selected: false, data } as unknown as NodeProps<PyCoderFlowNode>;
+  }
+
+  it("skips re-rendering when a fresh `data` object carries identical field values", () => {
+    const props = pyCoderProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <PyCoderNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    // A brand-new object, same primitives and same callback references -
+    // exactly what toFlowNodes may mint on an unrelated snapshot. A naive
+    // reference compare would wrongly re-render here.
+    const sameValuesNewObject = { ...props.data };
+    rerender(
+      <ReactFlowProvider>
+        <PyCoderNodeView {...{ ...props, data: sameValuesNewObject }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("re-renders when `pycoderOutput` (a field the view reads) changes", () => {
+    const props = pyCoderProps("pc-1", { pycoderOutput: "" });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <PyCoderNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <PyCoderNodeView {...{ ...props, data: { ...props.data, pycoderOutput: "42" } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("re-renders when `id` changes, even with identical `data`", () => {
+    // PyCoderNodeView (unlike some sibling node views) actually reads `id`
+    // - it's forwarded to CodeExecutionApprovalPanel's nodeId prop - so the
+    // comparator must compare it too, not just `data`.
+    const props = pyCoderProps("pc-1");
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <PyCoderNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <PyCoderNodeView {...{ ...props, id: "pc-2" }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+  });
+
+  it("skips re-rendering when only an untracked NodeProps field (e.g. `dragging`) changes", () => {
+    const props = pyCoderProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <PyCoderNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <PyCoderNodeView {...{ ...props, dragging: true }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
   });
 });

--- a/web_ui/src/app/canvas/PyCoderNodeView.tsx
+++ b/web_ui/src/app/canvas/PyCoderNodeView.tsx
@@ -1,9 +1,10 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useState } from "react";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useState } from "react";
 import { CodeExecutionApprovalPanel } from "./CodeExecutionApprovalPanel";
+import type { MenuPosition } from "./menuPosition";
 import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The Py-Coder node (Qt-removal plan R5.4) - the Py-Coder plugin's React
@@ -65,11 +66,6 @@ export interface PyCoderNodeData extends Record<string, unknown> {
 }
 
 export type PyCoderFlowNode = Node<PyCoderNodeData, "pycoder">;
-
-interface MenuPosition {
-  x: number;
-  y: number;
-}
 
 /** Same outside-click/Escape dismiss pattern every sibling node menu uses
  * (ChatNodeMenu/ArtifactNodeMenu/GitlinkNodeMenu/...). */
@@ -133,9 +129,8 @@ function toPythonFence(code: string): string {
 
 // -- view ----------------------------------------------------------------
 
-export function PyCoderNodeView({ id, data, selected }: NodeProps<PyCoderFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+function PyCoderNodeViewImpl({ id, data, selected }: NodeProps<PyCoderFlowNode>) {
+  const lodCollapsed = useLodVisibility();
   const collapsed = data.isCollapsed || lodCollapsed;
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const isManual = data.pycoderMode === "manual";
@@ -307,3 +302,44 @@ export function PyCoderNodeView({ id, data, selected }: NodeProps<PyCoderFlowNod
     </div>
   );
 }
+
+/** ADR-011 stage 11.1: every prop this view actually reads, compared -
+ * `id`/`selected` directly (id is read here, unlike some sibling views,
+ * since it's forwarded to CodeExecutionApprovalPanel's nodeId prop), then
+ * every field of `data`. All primitives/nullable-primitives or stable
+ * callback references - PyCoderNodeData has no array/object fields, so
+ * `===` is correct for every one of them. */
+function pyCoderNodeDataAreEqual(prev: PyCoderNodeData, next: PyCoderNodeData): boolean {
+  return (
+    prev.pycoderMode === next.pycoderMode &&
+    prev.pycoderPrompt === next.pycoderPrompt &&
+    prev.pycoderCode === next.pycoderCode &&
+    prev.pycoderOutput === next.pycoderOutput &&
+    prev.pycoderAnalysis === next.pycoderAnalysis &&
+    prev.pycoderLastRunFailed === next.pycoderLastRunFailed &&
+    prev.pycoderAwaitingApproval === next.pycoderAwaitingApproval &&
+    prev.pycoderError === next.pycoderError &&
+    prev.isCollapsed === next.isCollapsed &&
+    prev.pendingRequestId === next.pendingRequestId &&
+    prev.onSetMode === next.onSetMode &&
+    prev.onRun === next.onRun &&
+    prev.onCancel === next.onCancel &&
+    prev.onApprove === next.onApprove &&
+    prev.onDeny === next.onDeny &&
+    prev.onToggleCollapse === next.onToggleCollapse &&
+    prev.onDelete === next.onDelete
+  );
+}
+
+function pyCoderNodePropsAreEqual(
+  prev: Readonly<NodeProps<PyCoderFlowNode>>,
+  next: Readonly<NodeProps<PyCoderFlowNode>>,
+): boolean {
+  return (
+    prev.id === next.id &&
+    prev.selected === next.selected &&
+    pyCoderNodeDataAreEqual(prev.data, next.data)
+  );
+}
+
+export const PyCoderNodeView = memo(PyCoderNodeViewImpl, pyCoderNodePropsAreEqual);

--- a/web_ui/src/app/canvas/SceneCanvas.pinSearchJump.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.pinSearchJump.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * ADR-011 stage 11.2 virtualization audit - "Search/pin-highlight logic":
+ * does jumping to a pin/search match already pan the viewport BEFORE
+ * expecting the target node to be interactable, or does it need a fix now
+ * that onlyRenderVisibleElements can leave an off-viewport node unmounted?
+ *
+ * Verified, not fixed: PinOverlay.tsx/SearchOverlay.tsx both call React
+ * Flow's setCenter with the target's own SCENE x/y (never a DOM-measured
+ * position, never gated on the target already being mounted) - see
+ * SceneCanvas.tsx's own <ReactFlow onlyRenderVisibleElements> comment for
+ * the full audit summary. Panning the viewport is what MAKES a node mount
+ * under virtualization, not something that requires it already being
+ * mounted - so this was already correct before stage 11.2, and this file
+ * is the regression test proving it stays that way with virtualization
+ * actually turned on.
+ *
+ * Asserts on setCenter's CALL ARGUMENTS, not the settled viewport transform:
+ * both call sites pass `{ duration: 300 }`, an ANIMATED d3-zoom transition,
+ * not an instant jump - reading the live transform right after the click
+ * would race that animation (confirmed empirically: it reads back
+ * {x:0,y:0,zoom:1}, i.e. the animation's FIRST frame, not its result).
+ * Spying on the exact call is deterministic and avoids wall-clock/rAF
+ * timing entirely, matching this codebase's own established preference for
+ * call-count/spy assertions over timing-dependent ones (renderCountGate.
+ * test.tsx's own module doc). useReactFlow is wrapped (not fully mocked -
+ * every other export, and the underlying setCenter behavior, stays real)
+ * so BOTH the audited claim ("was setCenter actually called, with the
+ * target's own x/y") and the real <ReactFlow onlyRenderVisibleElements>
+ * mounted alongside it are exercised in the same test.
+ */
+import { ReactFlowProvider, type useReactFlow as UseReactFlowType } from "@xyflow/react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type SetCenterCall = [number, number, { zoom?: number; duration?: number } | undefined];
+const setCenterCalls: SetCenterCall[] = [];
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@xyflow/react")>();
+  return {
+    ...original,
+    // Wraps the REAL useReactFlow so every consumer (PinOverlay,
+    // SearchOverlay, SceneCanvas's own CanvasInner) still gets fully
+    // functional pan/zoom/getNodes/etc. - only setCenter is intercepted,
+    // and it still calls straight through to the real implementation.
+    useReactFlow: (...args: Parameters<typeof UseReactFlowType>) => {
+      const real = original.useReactFlow(...args);
+      return {
+        ...real,
+        setCenter: (x: number, y: number, options?: { zoom?: number; duration?: number }) => {
+          setCenterCalls.push([x, y, options]);
+          return real.setCenter(x, y, options);
+        },
+      };
+    },
+  };
+});
+
+import { SceneCanvas } from "./SceneCanvas";
+import { SceneStore, initialSceneState } from "./sceneStore";
+import { PinOverlay } from "../chrome/PinOverlay";
+import { SearchOverlay } from "../chrome/SearchOverlay";
+import { OverlayProvider, useOverlays } from "../overlays/overlays";
+import type { WsTransport } from "../../lib/ws/transport";
+import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
+
+type StateListener = (payload: Record<string, unknown>) => void;
+
+function makeWiredStore() {
+  const stateListeners = new Map<string, StateListener>();
+  const transport = {
+    subscribe: vi.fn((topic: string, listener: StateListener) => {
+      stateListeners.set(topic, listener);
+      return () => stateListeners.delete(topic);
+    }),
+    intent: vi.fn(),
+    fireIntent: vi.fn(),
+    subscribePatch: vi.fn(),
+    onVersionRejection: vi.fn((_topic: string, listener: (r: null) => void) => {
+      listener(null);
+      return () => {};
+    }),
+    setTopicBlocked: vi.fn(),
+  } as unknown as WsTransport;
+  const store = new SceneStore(transport);
+  store.connect();
+  return { store, stateListeners };
+}
+
+// Minimal fixture, same "kept minimal on purpose" posture as
+// renderCountGate.test.tsx's own chatRow.
+function chatRow(id: string, x: number, y: number, title = id): SceneNodeRow {
+  return {
+    ...(Object.fromEntries(
+      Object.entries({
+        id, x, y, title, kind: "chat", content: "hello world", isUser: false,
+        isCollapsed: false, code: "", language: "", attachmentKind: "", filePath: "",
+        mimeType: "", durationSeconds: null, byteSize: null, previewLabel: "",
+        isDocked: false, imageAssetId: "", history: [], pendingRequestId: null,
+        researchStage: "", researchCompleted: 0, researchTotal: 0,
+        researchActiveSourceId: null, researchError: "", researchResult: null,
+        artifactContent: "", gitlinkRepo: "", gitlinkBranch: "",
+        gitlinkScopeMode: "selected", gitlinkLocalRoot: "", gitlinkRepoFilePaths: [],
+        gitlinkSelectedPaths: [], gitlinkTaskPrompt: "", gitlinkContextStats: {},
+        gitlinkContextSummary: "", gitlinkContextVersion: 0,
+        gitlinkProposalMarkdown: "", gitlinkPendingChanges: [], gitlinkPreviewText: "",
+        gitlinkChangeFingerprint: null, gitlinkChangeState: "", gitlinkError: "",
+        pycoderMode: "ai_driven", pycoderPrompt: "", pycoderCode: "",
+        pycoderOutput: "", pycoderAnalysis: "", pycoderLastRunFailed: false,
+        pycoderAwaitingApproval: false, pycoderError: "",
+        codeSandboxRequirements: "", codeSandboxApprovalRequirements: "",
+        codeSandboxApprovalAllowSourceBuilds: false, codeSandboxApprovalIsRepair: false,
+        codeSandboxPrompt: "", codeSandboxCode: "", codeSandboxOutput: "",
+        codeSandboxAnalysis: "", codeSandboxAwaitingApproval: false,
+        codeSandboxError: "", provider: null, model: null, isBranchSynthesis: false,
+        synthesisInstructions: "", branchStatus: "active", responseIncomplete: false,
+        isFinalDeliverable: false,
+        color: null, headerColor: null, isSystemPrompt: false, isSummaryNote: false,
+        isBranchComparison: false, itemIds: [], isLocked: true, groupWidth: null,
+        groupHeight: null, chartType: "", chartData: {}, chartError: "",
+        chartAssetId: "", chartAssetVersion: 0, chartWidth: 680.0, chartHeight: 500.0,
+        chartAspectLocked: true, chartSourceNodeId: "", htmlSplitterState: null,
+        chatScrollValue: 0.0,
+        toolCalls: [],
+      }),
+    ) as unknown as SceneNodeRow),
+  };
+}
+
+function publish(stateListeners: Map<string, StateListener>, scene: Partial<SceneState>) {
+  act(() => {
+    stateListeners.get("scene")!({ ...initialSceneState, ...scene } as unknown as Record<string, unknown>);
+  });
+}
+
+// Same "force the popover open through the real overlay context" posture as
+// PinOverlay.test.tsx's own OpenPinsOnMount - both PinOverlay and
+// SearchOverlay only mount their real content while their own surface is
+// open.
+function OpenSurfaceOnMount({ name, children }: { name: "pins" | "search"; children: React.ReactNode }) {
+  const overlays = useOverlays();
+  if (!overlays.isOpen(name)) overlays.open(name, "popover");
+  return <>{children}</>;
+}
+
+describe("pin/search jump navigates to an off-viewport target with onlyRenderVisibleElements on (ADR-011 stage 11.2 audit)", () => {
+  beforeEach(() => {
+    setCenterCalls.length = 0;
+  });
+
+  it("PinOverlay: clicking a pin far outside the default viewport calls setCenter with the pin's own coordinates", async () => {
+    const user = userEvent.setup();
+    const { store, stateListeners } = makeWiredStore();
+    const FAR_X = 50000;
+    const FAR_Y = 40000;
+
+    render(
+      <OverlayProvider>
+        <ReactFlowProvider>
+          <SceneCanvas store={store} onOpenDocumentView={() => {}} />
+          <OpenSurfaceOnMount name="pins">
+            <PinOverlay store={store} />
+          </OpenSurfaceOnMount>
+        </ReactFlowProvider>
+      </OverlayProvider>,
+    );
+
+    publish(stateListeners, {
+      // A node parked at the exact same far-away spot as the pin - the
+      // scenario onlyRenderVisibleElements is meant to leave unmounted
+      // until the viewport pans there.
+      nodes: [chatRow("far-node", FAR_X, FAR_Y)],
+      edges: [],
+      pins: [{ id: "p1", title: "Far Away", note: "", x: FAR_X, y: FAR_Y }],
+    });
+
+    expect(setCenterCalls).toHaveLength(0);
+    await user.click(screen.getByText("Far Away"));
+
+    // Called exactly once, with the PIN's own scene coordinates - not
+    // anything derived from the target node's DOM/mounted state (there is
+    // none to derive from: the click fires setCenter unconditionally).
+    expect(setCenterCalls).toHaveLength(1);
+    const [x, y, options] = setCenterCalls[0];
+    expect(x).toBe(FAR_X);
+    expect(y).toBe(FAR_Y);
+    expect(options?.zoom).toBe(1);
+  });
+
+  it("SearchOverlay: jumping to a match far outside the default viewport calls setCenter with the match's own coordinates", async () => {
+    const user = userEvent.setup();
+    const { store, stateListeners } = makeWiredStore();
+    const FAR_X = -30000;
+    const FAR_Y = 60000;
+
+    render(
+      <OverlayProvider>
+        <ReactFlowProvider>
+          <SceneCanvas store={store} onOpenDocumentView={() => {}} />
+          <OpenSurfaceOnMount name="search">
+            <SearchOverlay store={store} />
+          </OpenSurfaceOnMount>
+        </ReactFlowProvider>
+      </OverlayProvider>,
+    );
+
+    publish(stateListeners, {
+      nodes: [chatRow("far-node", FAR_X, FAR_Y, "UniqueSearchTarget")],
+      edges: [],
+    });
+
+    expect(setCenterCalls).toHaveLength(0);
+    await user.type(screen.getByLabelText("Search the canvas"), "UniqueSearchTarget");
+    await user.click(screen.getByLabelText("Next match (Enter)"));
+
+    expect(setCenterCalls).toHaveLength(1);
+    const [x, y, options] = setCenterCalls[0];
+    expect(x).toBe(FAR_X);
+    expect(y).toBe(FAR_Y);
+    expect(options?.zoom).toBe(1);
+  });
+});

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -3,9 +3,12 @@ import { act, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
   applyGroupDragDelta,
+  buildDragSizeCache,
   computeDimmedNodeIds,
   computeNonAcceptedNodeIds,
+  computeSmartGuideFrame,
   conversationHistoryToDocumentMarkdown,
+  flowNodeOwnSize,
   groupDragKindOf,
   handleSelectionChange,
   isOrthogonalEligible,
@@ -14,6 +17,7 @@ import {
   toFlowEdges,
   toFlowNodes,
   withPreservedSelection,
+  type MeasuredSizeSource,
   type SceneFlowNode,
 } from "./SceneCanvas";
 import type { ConversationMessage } from "./ConversationNodeView";
@@ -2221,6 +2225,155 @@ describe("applyGroupDragDelta (R6.1 group-drag)", () => {
     ];
 
     expect(() => applyGroupDragDelta(nodes, "container-a", { x: 5, y: 5 })).not.toThrow();
+  });
+});
+
+describe("flowNodeOwnSize (ADR-011 stage 11.2 virtualization audit)", () => {
+  it("returns the flow-node-level width/height for a frame/container/chart-shaped node", () => {
+    const node = {
+      id: "frame-1",
+      type: "frame",
+      position: { x: 0, y: 0 },
+      width: 260,
+      height: 140,
+      data: {},
+    } as unknown as SceneFlowNode;
+    expect(flowNodeOwnSize(node)).toEqual({ width: 260, height: 140 });
+  });
+
+  it("returns null for a plain content node with no flow-node-level width/height", () => {
+    const node = { id: "chat-1", type: "chat", position: { x: 0, y: 0 }, data: {} } as unknown as SceneFlowNode;
+    expect(flowNodeOwnSize(node)).toBeNull();
+  });
+
+  it("returns null when only one of width/height is set (defensive - should be unreachable via toFlowNodes)", () => {
+    const node = {
+      id: "odd-1",
+      type: "chart",
+      position: { x: 0, y: 0 },
+      width: 100,
+      data: {},
+    } as unknown as SceneFlowNode;
+    expect(flowNodeOwnSize(node)).toBeNull();
+  });
+});
+
+describe("buildDragSizeCache (ADR-011 stage 11.3 drag-start batch read)", () => {
+  function fakeReactFlow(measured: Record<string, { width?: number; height?: number } | undefined> = {}): MeasuredSizeSource {
+    return {
+      getInternalNode: (id: string) => {
+        const m = measured[id];
+        return m ? { measured: m } : undefined;
+      },
+    };
+  }
+
+  it("uses flowNodeOwnSize for a frame/container/chart node WITHOUT ever touching the DOM", () => {
+    const querySelectorSpy = vi.spyOn(document, "querySelector");
+    const nodes: SceneFlowNode[] = [
+      { id: "frame-1", type: "frame", position: { x: 0, y: 0 }, width: 200, height: 100, data: {} } as unknown as SceneFlowNode,
+    ];
+    const cache = buildDragSizeCache(fakeReactFlow(), nodes);
+    expect(cache.get("frame-1")).toEqual({ width: 200, height: 100 });
+    expect(querySelectorSpy).not.toHaveBeenCalled();
+    querySelectorSpy.mockRestore();
+  });
+
+  it("falls back to measuredNodeSize's DOM query for a plain content node, exactly once per node", () => {
+    const querySelectorSpy = vi.spyOn(document, "querySelector").mockReturnValue(null);
+    const nodes: SceneFlowNode[] = [
+      { id: "chat-1", type: "chat", position: { x: 0, y: 0 }, data: {} } as unknown as SceneFlowNode,
+      { id: "chat-2", type: "chat", position: { x: 100, y: 0 }, data: {} } as unknown as SceneFlowNode,
+    ];
+    buildDragSizeCache(fakeReactFlow(), nodes);
+    expect(querySelectorSpy).toHaveBeenCalledTimes(2);
+    querySelectorSpy.mockRestore();
+  });
+
+  it("prefers React Flow's own internal `measured` cache over the DOM fallback when populated", () => {
+    const querySelectorSpy = vi.spyOn(document, "querySelector");
+    const nodes: SceneFlowNode[] = [
+      { id: "chat-1", type: "chat", position: { x: 0, y: 0 }, data: {} } as unknown as SceneFlowNode,
+    ];
+    const cache = buildDragSizeCache(fakeReactFlow({ "chat-1": { width: 320, height: 90 } }), nodes);
+    expect(cache.get("chat-1")).toEqual({ width: 320, height: 90 });
+    expect(querySelectorSpy).not.toHaveBeenCalled();
+    querySelectorSpy.mockRestore();
+  });
+
+  it("omits a node whose size cannot be resolved at all (off-viewport, unmounted, no server-tracked size)", () => {
+    vi.spyOn(document, "querySelector").mockReturnValue(null);
+    const nodes: SceneFlowNode[] = [
+      { id: "chat-1", type: "chat", position: { x: 0, y: 0 }, data: {} } as unknown as SceneFlowNode,
+    ];
+    const cache = buildDragSizeCache(fakeReactFlow(), nodes);
+    expect(cache.has("chat-1")).toBe(false);
+    vi.restoreAllMocks();
+  });
+});
+
+describe("computeSmartGuideFrame (ADR-011 stage 11.3 per-frame smart-guide read)", () => {
+  it("passes the position through unsnapped, with no guides, when the moving node is not in `nodes`", () => {
+    const result = computeSmartGuideFrame([], "gone", { x: 10, y: 10 }, new Map());
+    expect(result).toEqual({ position: { x: 10, y: 10 }, guides: [] });
+  });
+
+  it("passes the position through unsnapped, with no guides, when the moving node's size is not in the cache", () => {
+    const nodes: SceneFlowNode[] = [
+      { id: "chat-1", type: "chat", position: { x: 0, y: 0 }, data: {} } as unknown as SceneFlowNode,
+    ];
+    const result = computeSmartGuideFrame(nodes, "chat-1", { x: 10, y: 10 }, new Map());
+    expect(result).toEqual({ position: { x: 10, y: 10 }, guides: [] });
+  });
+
+  it("snaps against a cached candidate's left edge, reading sizes purely from the cache", () => {
+    const nodes: SceneFlowNode[] = [
+      { id: "moving", type: "chat", position: { x: 0, y: 0 }, data: {} } as unknown as SceneFlowNode,
+      { id: "candidate", type: "chat", position: { x: 103, y: 300 }, data: {} } as unknown as SceneFlowNode,
+    ];
+    const cache = new Map([
+      ["moving", { width: 100, height: 50 }],
+      ["candidate", { width: 100, height: 50 }],
+    ]);
+    // moving's left edge (100) is within 5px of candidate's left edge (103).
+    const result = computeSmartGuideFrame(nodes, "moving", { x: 100, y: 10 }, cache);
+    expect(result.position.x).toBe(103);
+    expect(result.guides).toHaveLength(1);
+    expect(result.guides[0].orientation).toBe("vertical");
+  });
+
+  it("skips a candidate that is absent from the cache (off-viewport, unmounted) instead of crashing or estimating", () => {
+    const nodes: SceneFlowNode[] = [
+      { id: "moving", type: "chat", position: { x: 0, y: 0 }, data: {} } as unknown as SceneFlowNode,
+      { id: "unmeasured", type: "chat", position: { x: 103, y: 300 }, data: {} } as unknown as SceneFlowNode,
+    ];
+    // Only "moving" has a cached size - "unmeasured" is exactly the
+    // off-viewport-under-onlyRenderVisibleElements case.
+    const cache = new Map([["moving", { width: 100, height: 50 }]]);
+    const result = computeSmartGuideFrame(nodes, "moving", { x: 100, y: 10 }, cache);
+    // No crash, and no snap against the unmeasured candidate.
+    expect(result).toEqual({ position: { x: 100, y: 10 }, guides: [] });
+  });
+
+  it("excludes a dragged group's own members from candidates, same as the pre-11.3 inline logic did", () => {
+    const nodes: SceneFlowNode[] = [
+      {
+        id: "frame-1",
+        type: "frame",
+        position: { x: 0, y: 0 },
+        data: { isLocked: true, itemIds: ["member-1"] },
+      } as unknown as SceneFlowNode,
+      { id: "member-1", type: "chat", position: { x: 103, y: 300 }, data: {} } as unknown as SceneFlowNode,
+    ];
+    const cache = new Map([
+      ["frame-1", { width: 100, height: 50 }],
+      ["member-1", { width: 100, height: 50 }],
+    ]);
+    // member-1's left edge (103) would otherwise be within tolerance of
+    // frame-1's proposed left edge (100) - but a group's own members are
+    // never valid alignment candidates for the group dragging them.
+    const result = computeSmartGuideFrame(nodes, "frame-1", { x: 100, y: 10 }, cache);
+    expect(result).toEqual({ position: { x: 100, y: 10 }, guides: [] });
   });
 });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -7,7 +7,6 @@ import {
   ReactFlow,
   ViewportPortal,
   useReactFlow,
-  useStore,
   type Connection,
   type Edge,
   type Node,
@@ -18,7 +17,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
-import type { SceneState } from "../../lib/bridge-core/generated/scene-state";
+import type { SceneEdgeRow, SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
 import type { StreamListener } from "../../lib/ws/transport";
 import { BridgeErrorState } from "../../lib/ui/BridgeErrorState";
 import { ArtifactNodeView, type ArtifactFlowNode } from "./ArtifactNodeView";
@@ -40,11 +39,11 @@ import { WebResearchNodeView, type WebResearchFlowNode } from "./WebResearchNode
 import {
   GROUP_FALLBACK_HEIGHT,
   GROUP_FALLBACK_WIDTH,
-  LOD_ZOOM_THRESHOLD,
   VIEWPORT_REPORT_DEBOUNCE_MS,
 } from "./canvasConstants";
 import { SceneStore, scaleDragPosition } from "./sceneStore";
 import { computeSmartGuideSnap, type GuideLine, type Rect } from "./smartGuides";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The React Flow canvas (Qt-removal plan R1) - the QGraphicsScene/ChatView
@@ -81,8 +80,11 @@ export type SceneFlowNode =
   | ChartFlowNode;
 
 function PlaceholderNodeView({ data, selected }: NodeProps<PlaceholderNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const collapsed = zoom < LOD_ZOOM_THRESHOLD;
+  // ADR-011 stage 11.6/11.1 dedup: was its own local
+  // `useStore((s) => s.transform[2]); zoom < LOD_ZOOM_THRESHOLD` pair (one of
+  // the 14 duplicated call sites) - now the shared extraction. Zero behavior
+  // change, see useLodVisibility.ts's own doc.
+  const collapsed = useLodVisibility();
   return (
     <div className={`scene-node${selected ? " selected" : ""}${collapsed ? " collapsed" : ""}`}>
       {/* Connection endpoints mirror the Qt canvas's flow: children hang off
@@ -376,6 +378,445 @@ export function computeNonAcceptedNodeIds(scene: SceneState): Set<string> {
   return excluded;
 }
 
+/**
+ * ADR-011 stage 11.1: one shared O(N+E) index-map pass, consumed by both
+ * toFlowNodes and toFlowEdges below in place of the three separate ad hoc
+ * maps they used to build on their own (toFlowNodes' own nodesById;
+ * toFlowEdges' own kindOf + dockedNodeIds) - and, more importantly, in
+ * place of the O(N*E) per-node edge scans that used to live INSIDE
+ * toFlowNodes' own per-node loop: the chat branch's dockedChildren used to
+ * do `for (const e of scene.edges)` (a full O(E) scan) for EVERY chat node,
+ * and the code branch did `scene.edges.find(...)` (another O(E) scan) for
+ * EVERY code node. edgesBySource/edgesByTarget below group every edge by
+ * its endpoint ONCE, so a per-node lookup is O(out-/in-degree) instead of
+ * O(E) - and since the sum of every node's out-/in-degree over the whole
+ * loop is exactly E, the total cost across the WHOLE function is O(N+E),
+ * not O(N*E).
+ *
+ * computeDimmedNodeIds/computeNonAcceptedNodeIds above deliberately build
+ * their OWN separate nodesById/parentOf/childrenOf maps rather than reusing
+ * this one - see computeDimmedNodeIds' own doc comment for why (exported
+ * standalone for direct unit testing, not worth coupling to save one more
+ * Map construction over a scene of at most a few hundred nodes).
+ */
+interface SceneIndexes {
+  nodesById: Map<string, SceneNodeRow>;
+  edgesBySource: Map<string, SceneEdgeRow[]>;
+  edgesByTarget: Map<string, SceneEdgeRow[]>;
+  dockedNodeIds: Set<string>;
+}
+
+function buildSceneIndexes(scene: SceneState): SceneIndexes {
+  const nodesById = new Map<string, SceneNodeRow>();
+  const dockedNodeIds = new Set<string>();
+  for (const n of scene.nodes) {
+    nodesById.set(n.id, n);
+    if (n.isDocked) dockedNodeIds.add(n.id);
+  }
+  const edgesBySource = new Map<string, SceneEdgeRow[]>();
+  const edgesByTarget = new Map<string, SceneEdgeRow[]>();
+  for (const e of scene.edges) {
+    const bySource = edgesBySource.get(e.source);
+    if (bySource) bySource.push(e);
+    else edgesBySource.set(e.source, [e]);
+    const byTarget = edgesByTarget.get(e.target);
+    if (byTarget) byTarget.push(e);
+    else edgesByTarget.set(e.target, [e]);
+  }
+  return { nodesById, edgesBySource, edgesByTarget, dockedNodeIds };
+}
+
+/**
+ * ADR-011 stage 11.1: a stable per-node-id callback dispatcher.
+ *
+ * Every *NodeView callback (onDelete, onToggleCollapse, ...) used to be a
+ * fresh inline closure minted on EVERY toFlowNodes call - ~20 allocations
+ * per chat node alone, on every single scene snapshot/patch, regardless of
+ * whether that node changed at all. React.memo on the node-view side
+ * (landing alongside this change on the other *NodeView.tsx files) can
+ * never see stable props while that keeps happening, no matter what else
+ * this function does.
+ *
+ * Fix: ONE function object per callback is created the FIRST time a given
+ * node id is seen (getDispatcher below, backed by cache.dispatchers), then
+ * reused for that id for as long as the node exists. Each function closes
+ * over the node's `id` (immutable for the dispatcher entry's whole
+ * lifetime - a node's kind/id never changes after creation) and a mutable
+ * `liveRef` that toFlowNodes updates on EVERY call, cache-hit or not,
+ * before any function in `fns` can run - so a click on a long-lived stable
+ * callback always observes the CURRENT n/store/onOpenDocumentView/
+ * onToggleBranchFocus, never a stale snapshot from whenever the closure
+ * happened to be created. This is the "read current values through a ref
+ * rather than closing over values that change every call" pattern.
+ */
+interface DispatcherLive {
+  n: SceneNodeRow;
+  store: SceneStore;
+  onOpenDocumentView: (markdown: string, sourceLabel: string) => void;
+  onToggleBranchFocus: (nodeId: string) => void;
+  // Kind-specific derived value(s) a dispatcher needs beyond `n` itself,
+  // NOT themselves part of `n` (e.g. the code branch's parentChatNodeId,
+  // resolved from edges rather than n's own fields) - cast to the concrete
+  // shape inside each dispatcher factory below that actually uses it.
+  extra?: unknown;
+}
+
+interface DispatcherEntry {
+  liveRef: { current: DispatcherLive };
+  fns: Record<string, unknown>;
+}
+
+export interface ToFlowNodesCache {
+  dispatchers: Map<string, DispatcherEntry>;
+  // Keyed by the SceneNode's OWN object reference - ADR-003 deltas
+  // guarantee an unchanged node keeps that EXACT reference (sceneStore.ts's
+  // applyScenePatch: "Untouched nodes keep their EXACT existing object
+  // references"), so a WeakMap hit here doubles as the "did this node
+  // change" check for free: an unchanged node's `n` is literally the same
+  // key it was cached under last call; a changed one is a brand-new object
+  // the WeakMap has never seen, so `.get` misses automatically. Using a
+  // WeakMap (not a plain Map keyed by node id) means a replaced node's old
+  // entry is reclaimed by GC on its own - no separate eviction pass needed
+  // for the fast-changing case (e.g. a streaming chat node's `content`
+  // changing every token, which mints a new SceneNodeRow every time).
+  //
+  // `extraSig` covers everything the emitted flow node depends on BESIDES
+  // `n` itself - dimming/branch-focus flags, dockedChildren, the code
+  // branch's parentChatNodeId, group memberKinds (see each kind's own
+  // comment in toFlowNodes below) - so a cache hit only fires when NOTHING
+  // relevant changed, not merely when `n`'s reference didn't.
+  flowNodes: WeakMap<SceneNodeRow, { extraSig: string; flowNode: SceneFlowNode }>;
+}
+
+export function createToFlowNodesCache(): ToFlowNodesCache {
+  return { dispatchers: new Map(), flowNodes: new WeakMap() };
+}
+
+// Drops dispatcher entries for node ids no longer in the scene - a node
+// once deleted never comes back under the same id, so its dispatcher (and
+// the liveRef it closes over) would otherwise sit in the Map forever for
+// the lifetime of the canvas. flowNodes above needs no equivalent: it is a
+// WeakMap keyed by the node object itself, so a deleted node's entry is
+// simply unreachable and reclaimed by GC on its own.
+function pruneDispatcherCache(cache: ToFlowNodesCache, nodesById: Map<string, SceneNodeRow>): void {
+  if (cache.dispatchers.size === 0) return;
+  for (const id of cache.dispatchers.keys()) {
+    if (!nodesById.has(id)) cache.dispatchers.delete(id);
+  }
+}
+
+function getDispatcher<T extends Record<string, unknown>>(
+  cache: ToFlowNodesCache,
+  id: string,
+  live: DispatcherLive,
+  factory: (id: string, liveRef: { current: DispatcherLive }) => T,
+): T {
+  const existing = cache.dispatchers.get(id);
+  if (existing) {
+    existing.liveRef.current = live;
+    return existing.fns as T;
+  }
+  const liveRef = { current: live };
+  const fns = factory(id, liveRef);
+  cache.dispatchers.set(id, { liveRef, fns: fns as Record<string, unknown> });
+  return fns;
+}
+
+function makeChatFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onToggleCollapse: () => {
+      const { n, store } = liveRef.current;
+      store.setChatCollapsed(id, !n.isCollapsed);
+    },
+    onDelete: () => liveRef.current.store.deleteChatNode(id),
+    onUndockChild: (childId: string) => liveRef.current.store.setNodeDocked(childId, false),
+    onRegenerate: () => liveRef.current.store.regenerateResponse(id),
+    onGenerateImage: () => liveRef.current.store.generateImage(id),
+    // R6.2: real chart generation - fires the new generateChart intent with
+    // this chat node as the parent (see ChatNodeView.tsx's own Generate
+    // Chart submenu). Fire-and-forget, same posture as onGenerateImage.
+    onGenerateChart: (chartType: string) => liveRef.current.store.generateChart(id, chartType),
+    // R8a: the two note agents, restored from the deleted Qt app. Same
+    // fire-and-forget posture as onGenerateImage above.
+    onGenerateKeyTakeaway: () => liveRef.current.store.generateKeyTakeaway(id),
+    onGenerateExplainerNote: () => liveRef.current.store.generateExplainerNote(id),
+    // R8a: Open Document View - shows this node's own message text verbatim
+    // in the read-only document panel. Guards on non-blank content, matching
+    // legacy's own document-view action exactly: a notification on nothing,
+    // not a silent no-op.
+    onOpenDocumentView: () => {
+      const { n, onOpenDocumentView, store } = liveRef.current;
+      if (n.content.trim()) onOpenDocumentView(n.content, n.isUser ? "Your message" : "Assistant message");
+      else store.showInfoNotification(NO_DOCUMENT_VIEW_CONTENT_MESSAGE);
+    },
+    onToggleBranchFocus: () => liveRef.current.onToggleBranchFocus(id),
+    // ADR-002 Workstream 1: stages this node as sceneStore's
+    // replyTargetNodeId - the composer's next Send then reads and consumes
+    // it (see sceneStore.ts's sendMessage).
+    onBranchFromHere: () => liveRef.current.store.setReplyTargetNodeId(id),
+    // ADR-002 Workstream 1 ("Branch status and lifecycle"). Fire-and-forget,
+    // same posture as onBranchFromHere/onGenerateKeyTakeaway above.
+    onSetBranchStatus: (status: string) => liveRef.current.store.setBranchStatus(id, status),
+    onSetFinalDeliverable: (isFinal: boolean) => liveRef.current.store.setFinalDeliverable(id, isFinal),
+    onCollapseBranch: (collapsed: boolean) => liveRef.current.store.collapseBranch(id, collapsed),
+    // R6.3: the node's own scroll position within its content area - read on
+    // mount by ChatNodeView (restore) and reported (debounced) via the
+    // setChatScrollValue intent on every scroll.
+    onScrollChange: (value: number) => liveRef.current.store.setChatScrollValue(id, value),
+    // ADR-006 stage 6.4 (universal streaming): a Regenerate for this node now
+    // streams - subscribeStream is the same generic transport passthrough
+    // the code_sandbox branch below also injects.
+    subscribeStream: (requestId: string, listener: StreamListener) =>
+      liveRef.current.store.subscribeStream(requestId, listener),
+    // ADR-006 stage 6.4 review fix: per-node Stop for an in-flight streamed
+    // regenerate. Reuses cancelConversationRequest (fires the generic
+    // cancelChatRequest intent by requestId) rather than adding a new
+    // intent. Same null-guard pattern as the conversation branch's own
+    // onCancel.
+    onCancelRegenerate: () => {
+      const { n, store } = liveRef.current;
+      if (n.pendingRequestId) store.cancelConversationRequest(n.pendingRequestId);
+    },
+  };
+}
+
+function makeCodeFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    // parentChatNodeId (this code node's own one-hop parent lookup) arrives
+    // via `extra`, resolved by toFlowNodes' edgesByTarget index below - see
+    // that call site's own comment for why it can't just be `id`.
+    onRegenerate: () => {
+      const { store, extra } = liveRef.current;
+      const parentChatNodeId = extra as string | null;
+      if (parentChatNodeId) store.regenerateResponse(parentChatNodeId);
+    },
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+    onToggleBranchFocus: () => liveRef.current.onToggleBranchFocus(id),
+  };
+}
+
+function makeDocumentFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    // setChatCollapsed's backend handler (backend/canvas.py) looks up ANY
+    // node by id and sets is_collapsed - it does not special-case "chat"
+    // kind despite the intent's name - so it is reused as-is here rather
+    // than inventing a setDocumentCollapsed intent the backend doesn't
+    // register.
+    onToggleCollapse: () => {
+      const { n, store } = liveRef.current;
+      store.setChatCollapsed(id, !n.isCollapsed);
+    },
+    onDock: () => liveRef.current.store.setNodeDocked(id, true),
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+    onToggleBranchFocus: () => liveRef.current.onToggleBranchFocus(id),
+  };
+}
+
+function makeThinkingFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onDock: () => liveRef.current.store.setNodeDocked(id, true),
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+    onToggleBranchFocus: () => liveRef.current.onToggleBranchFocus(id),
+  };
+}
+
+function makeHtmlFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onToggleCollapse: () => {
+      const { n, store } = liveRef.current;
+      store.setChatCollapsed(id, !n.isCollapsed);
+    },
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+    // R6.3: the Source/Preview split position - read on mount by
+    // HtmlNodeView (restore) and reported (debounced) via the
+    // setHtmlSplitterState intent once a drag settles.
+    onSplitterChange: (value: number) => liveRef.current.store.setHtmlSplitterState(id, value),
+  };
+}
+
+function makeImageFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+    // R4.4a: unlike CodeNodeView's onRegenerate, no client-side parent
+    // lookup/null-guard is needed here - the backend resolves the image's
+    // parent chat node internally.
+    onRegenerate: () => liveRef.current.store.regenerateImage(id),
+    onToggleBranchFocus: () => liveRef.current.onToggleBranchFocus(id),
+  };
+}
+
+function makeConversationFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onToggleCollapse: () => {
+      const { n, store } = liveRef.current;
+      store.setChatCollapsed(id, !n.isCollapsed);
+    },
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+    onSend: (text: string) => liveRef.current.store.sendConversationMessage(id, text),
+    onDeleteMessage: (index: number) => liveRef.current.store.deleteConversationMessage(id, index),
+    onCancel: () => {
+      const { n, store } = liveRef.current;
+      if (n.pendingRequestId) store.cancelConversationRequest(n.pendingRequestId);
+    },
+    // R8a: Open Document View - the node's ENTIRE message history, formatted
+    // as a numbered transcript. Guards on a non-empty formatted result the
+    // same way the chat branch's own onOpenDocumentView guards on non-blank
+    // content.
+    onOpenDocumentView: () => {
+      const { n, onOpenDocumentView, store } = liveRef.current;
+      const markdown = conversationHistoryToDocumentMarkdown(n.history);
+      if (markdown) onOpenDocumentView(markdown, "Conversation transcript");
+      else store.showInfoNotification(NO_DOCUMENT_VIEW_CONTENT_MESSAGE);
+    },
+    subscribeStream: (requestId: string, listener: StreamListener) =>
+      liveRef.current.store.subscribeStream(requestId, listener),
+  };
+}
+
+function makeWebResearchFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onToggleCollapse: () => {
+      const { n, store } = liveRef.current;
+      store.setChatCollapsed(id, !n.isCollapsed);
+    },
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+    onRun: (query: string) => liveRef.current.store.runWebResearch(id, query),
+    onCancel: () => {
+      const { n, store } = liveRef.current;
+      if (n.pendingRequestId) store.cancelWebResearchRequest(n.pendingRequestId);
+    },
+  };
+}
+
+function makeArtifactFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onToggleCollapse: () => {
+      const { n, store } = liveRef.current;
+      store.setChatCollapsed(id, !n.isCollapsed);
+    },
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+    onSubmit: (text: string) => liveRef.current.store.sendArtifactMessage(id, text),
+    onCancel: () => {
+      const { n, store } = liveRef.current;
+      if (n.pendingRequestId) store.cancelArtifactRequest(n.pendingRequestId);
+    },
+  };
+}
+
+function makeGitlinkFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onToggleCollapse: () => {
+      const { n, store } = liveRef.current;
+      store.setChatCollapsed(id, !n.isCollapsed);
+    },
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+    onFetchRepositories: () => liveRef.current.store.fetchGitlinkRepositories(id),
+    onLoadTree: (repo: string, branch: string) => liveRef.current.store.loadGitlinkRepoTree(id, repo, branch),
+    onSetLocalRoot: (localRoot: string) => liveRef.current.store.setGitlinkLocalRoot(id, localRoot),
+    onBrowseLocalRoot: () => liveRef.current.store.pickGitlinkLocalRoot(id),
+    onImportSnapshot: (repo: string, branch: string) => liveRef.current.store.importGitlinkSnapshot(id, repo, branch),
+    onBuildContext: (scopeMode: string, selectedPaths: string[]) =>
+      liveRef.current.store.buildGitlinkContext(id, scopeMode, selectedPaths),
+    onFetchContext: () => liveRef.current.store.fetchGitlinkContext(id),
+    onRun: (taskPrompt: string) => liveRef.current.store.runGitlinkChangeSet(id, taskPrompt),
+    onCancel: () => {
+      const { n, store } = liveRef.current;
+      if (n.pendingRequestId) store.cancelGitlinkRequest(n.pendingRequestId);
+    },
+    onApply: (fingerprint: string) => liveRef.current.store.applyGitlinkChanges(id, fingerprint),
+  };
+}
+
+function makePyCoderFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onToggleCollapse: () => {
+      const { n, store } = liveRef.current;
+      store.setChatCollapsed(id, !n.isCollapsed);
+    },
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+    onSetMode: (mode: string) => liveRef.current.store.setPyCoderMode(id, mode),
+    onRun: (inputText: string) => liveRef.current.store.runPyCoder(id, inputText),
+    onCancel: () => {
+      const { n, store } = liveRef.current;
+      if (n.pendingRequestId) store.cancelPyCoderRequest(n.pendingRequestId);
+    },
+    // CRITICAL (see CodeExecutionApprovalPanel.tsx's own module doc): these
+    // read n.pendingRequestId - the CURRENT scene snapshot's own value for
+    // THIS node via liveRef, never anything the UI layer could supply as a
+    // distinct argument.
+    onApprove: () => {
+      const { n, store } = liveRef.current;
+      if (n.pendingRequestId) store.approveCodeExecution(n.pendingRequestId);
+    },
+    onDeny: () => {
+      const { n, store } = liveRef.current;
+      if (n.pendingRequestId) store.denyCodeExecution(n.pendingRequestId);
+    },
+  };
+}
+
+function makeCodeSandboxFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onToggleCollapse: () => {
+      const { n, store } = liveRef.current;
+      store.setChatCollapsed(id, !n.isCollapsed);
+    },
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+    onSetRequirements: (requirementsText: string) =>
+      liveRef.current.store.setCodeSandboxRequirements(id, requirementsText),
+    onToggleAllowSourceBuilds: (allow: boolean) => liveRef.current.store.setCodeSandboxAllowSourceBuilds(id, allow),
+    onRun: (inputText: string) => liveRef.current.store.runCodeSandbox(id, inputText),
+    onCancel: () => {
+      const { n, store } = liveRef.current;
+      if (n.pendingRequestId) store.cancelCodeSandboxRequest(n.pendingRequestId);
+    },
+    // CRITICAL - same posture as the pycoder branch's own onApprove/onDeny.
+    onApprove: () => {
+      const { n, store } = liveRef.current;
+      if (n.pendingRequestId) store.approveCodeExecution(n.pendingRequestId);
+    },
+    onDeny: () => {
+      const { n, store } = liveRef.current;
+      if (n.pendingRequestId) store.denyCodeExecution(n.pendingRequestId);
+    },
+    // Generic passthrough to the transport's own stream fan-out - the live
+    // terminal pane keys its subscription off data.pendingRequestId itself,
+    // this closure only needs to exist so the component never touches the
+    // store/transport directly.
+    subscribeStream: (requestId: string, listener: StreamListener) =>
+      liveRef.current.store.subscribeStream(requestId, listener),
+  };
+}
+
+function makeNoteFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onSetContent: (content: string) => liveRef.current.store.setNoteContent(id, content),
+    onSetColor: (color: string | null, headerColor: string | null) =>
+      liveRef.current.store.setGroupColor(id, color, headerColor),
+    onDelete: () => liveRef.current.store.removeNodes([id]),
+  };
+}
+
+function makeGroupFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onSetLabel: (text: string) => liveRef.current.store.setGroupLabel(id, text),
+    onToggleCollapsed: () => liveRef.current.store.toggleGroupCollapsed(id),
+    onToggleLock: () => liveRef.current.store.toggleFrameLock(id),
+    onSetColor: (color: string | null, headerColor: string | null) =>
+      liveRef.current.store.setGroupColor(id, color, headerColor),
+    onResize: (width: number, height: number) => liveRef.current.store.resizeFrame(id, width, height),
+    onFitToContent: () => liveRef.current.store.fitFrameToContent(id),
+    onUngroup: () => liveRef.current.store.ungroup(id),
+  };
+}
+
+function makeChartFns(id: string, liveRef: { current: DispatcherLive }) {
+  return {
+    onToggleAspectLock: () => liveRef.current.store.toggleChartAspectLock(id),
+    onResize: (width: number, height: number) => liveRef.current.store.resizeChart(id, width, height),
+  };
+}
+
 // Exported standalone for direct unit testing (same posture as
 // scaleDragPosition in sceneStore.ts) - covers the parentChatNodeId
 // derivation below without needing a full <ReactFlow> mount.
@@ -390,11 +831,23 @@ export function toFlowNodes(
   // focusAcceptedPaths field - see that field's own comment for why it
   // lives there rather than as component state here).
   focusAcceptedPaths = false,
+  // ADR-011 stage 11.1: threaded from CanvasInner's own useRef (see
+  // CanvasInner below) so the SAME cache survives across every call for the
+  // canvas's whole lifetime, which is what actually makes the per-node
+  // dispatcher/whole-flow-node memoization below effective across
+  // snapshots. Callers that omit it - every existing direct unit test in
+  // SceneCanvas.test.tsx - get a fresh, single-use cache instead: still
+  // fully correct (a fresh cache just means nothing has been seen before,
+  // so every node "misses" and gets built the same way it always did), just
+  // not memoized across separate calls, which none of those tests need.
+  cache: ToFlowNodesCache = createToFlowNodesCache(),
 ): SceneFlowNode[] {
-  // Looked up per-chat-node below to build dockedChildren - a docked node is
-  // omitted from the returned array entirely (see the "thinking" branch), so
-  // this is the only remaining way a chat node's dock badge/menu can find it.
-  const nodesById = new Map(scene.nodes.map((n) => [n.id, n]));
+  // ADR-011 stage 11.1: ONE upfront O(N+E) pass replacing this function's
+  // old standalone `nodesById` map build, PLUS the O(N*E) per-node edge
+  // scans that used to live below (dockedChildren's full scene.edges scan
+  // per chat node; the code branch's scene.edges.find per code node) - see
+  // buildSceneIndexes' own doc above for the full reasoning.
+  const { nodesById, edgesBySource, edgesByTarget } = buildSceneIndexes(scene);
   // R8a: computed once per call, then just a Set.has() per node below -
   // see computeDimmedNodeIds' own doc for why it builds its own maps rather
   // than reusing nodesById above.
@@ -406,6 +859,12 @@ export function toFlowNodes(
   // than picked between - both dimming lenses can be active at once.
   const nonAcceptedIds = focusAcceptedPaths ? computeNonAcceptedNodeIds(scene) : new Set<string>();
   const isDimmed = (id: string) => dimmedIds.has(id) || nonAcceptedIds.has(id);
+  // BRANCH_FOCUS_KINDS-wide flag (chat/code/document/thinking/image only -
+  // every other kind's data below never reads it): whether "Hide Other
+  // Branches" is active from ANY origin, scene-wide. Computed once here
+  // (not per node) purely so each of those 5 kinds' cache key below can
+  // fold it in cheaply alongside isDimmed(n.id).
+  const isBranchFocusActive = branchFocusOriginId !== null;
   const flowNodes: SceneFlowNode[] = [];
 
   for (const n of scene.nodes) {
@@ -424,65 +883,53 @@ export function toFlowNodes(
       // docked - the new stack's equivalent of the legacy scene's per-node
       // docked-children list. title is the closest faithful stand-in for a
       // per-node-type "docked label" concept (none exists in the new stack).
+      // ADR-011 stage 11.1: reads ONLY this node's own outgoing edges via
+      // edgesBySource (O(out-degree)) instead of scanning the full
+      // scene.edges array (O(E)) - see buildSceneIndexes' own doc above.
       const dockedChildren: { id: string; label: string }[] = [];
-      for (const e of scene.edges) {
-        if (e.source !== n.id) continue;
+      for (const e of edgesBySource.get(n.id) ?? []) {
         const target = nodesById.get(e.target);
         if (target?.isDocked) dockedChildren.push({ id: target.id, label: target.title });
       }
-      flowNodes.push({
+      const dimmedVal = isDimmed(n.id);
+      // dockedChildren depends on OTHER nodes' isDocked/title (via edges),
+      // not on n's own reference - a child docking/undocking never touches
+      // the PARENT chat node's own object, so n-reference-only invalidation
+      // would go stale here without this signature folded into the cache
+      // key (see ToFlowNodesCache.flowNodes' own doc above).
+      const dockedChildrenSig = dockedChildren.map((c) => `${c.id}:${c.label}`).join("|");
+      const extraSig = `${dimmedVal ? 1 : 0}${isBranchFocusActive ? 1 : 0}|${dockedChildrenSig}`;
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(cache, n.id, { n, store, onOpenDocumentView, onToggleBranchFocus }, makeChatFns);
+      if (cached && cached.extraSig === extraSig) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "chat" as const,
         position: { x: n.x, y: n.y },
         // R8a: "Hide Other Branches" dimming - see computeDimmedNodeIds' own
         // doc above. undefined (not an explicit opacity: 1) when not dimmed,
         // so this never overrides anything else that might set style later.
-        style: isDimmed(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
+        style: dimmedVal ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           content: n.content,
           isUser: n.isUser,
           isCollapsed: n.isCollapsed,
           dockedChildren,
-          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
-          onDelete: () => store.deleteChatNode(n.id),
-          onUndockChild: (childId: string) => store.setNodeDocked(childId, false),
-          onRegenerate: () => store.regenerateResponse(n.id),
-          onGenerateImage: () => store.generateImage(n.id),
-          // R6.2: real chart generation - fires the new generateChart intent
-          // with this chat node as the parent (see ChatNodeView.tsx's own
-          // Generate Chart submenu). Fire-and-forget, same posture as
-          // onGenerateImage above - the new chart node arrives through the
-          // next scene snapshot.
-          onGenerateChart: (chartType: string) => store.generateChart(n.id, chartType),
-          // R8a: the two note agents, restored from the deleted Qt app. Same
-          // fire-and-forget posture as onGenerateImage above - the new note
-          // arrives through the next scene snapshot.
-          onGenerateKeyTakeaway: () => store.generateKeyTakeaway(n.id),
-          onGenerateExplainerNote: () => store.generateExplainerNote(n.id),
-          // R8a: Open Document View - shows this node's own message text
-          // verbatim in the read-only document panel. Guards on non-blank
-          // content, matching legacy's own document-view action exactly:
-          // a notification on nothing, not a silent no-op (see
-          // conversationHistoryToDocumentMarkdown's own doc above for the
-          // sibling conversation-node guard).
-          onOpenDocumentView: () => {
-            if (n.content.trim()) onOpenDocumentView(n.content, n.isUser ? "Your message" : "Assistant message");
-            else store.showInfoNotification(NO_DOCUMENT_VIEW_CONTENT_MESSAGE);
-          },
+          // ADR-011 stage 11.1: the ~17 onXxx/subscribeStream callbacks that
+          // used to be minted inline here on every call now come from the
+          // stable per-node-id dispatcher (fns) built above - see
+          // makeChatFns' own doc for why that keeps the SAME function
+          // references across calls instead of allocating fresh closures.
+          ...fns,
           // R8a: "Hide Other Branches" - isBranchFocusActive is scene-wide
           // (not per-node), purely so the menu button can flip its own label
           // to "Show All Branches" once ANY branch focus is active, matching
           // legacy's own `"Show All Branches" if is_branch_hidden else
           // "Hide Other Branches"` regardless of which node's menu is open.
-          isBranchFocusActive: branchFocusOriginId !== null,
-          onToggleBranchFocus: () => onToggleBranchFocus(n.id),
-          // ADR-002 Workstream 1: stages this node as sceneStore's
-          // replyTargetNodeId - the composer's next Send then reads and
-          // consumes it (see sceneStore.ts's sendMessage). `store` is
-          // already threaded into toFlowNodes, so no new parameter is
-          // needed here (unlike onToggleBranchFocus, which lives as local
-          // state on SceneCanvas itself, not on the store).
-          onBranchFromHere: () => store.setReplyTargetNodeId(n.id),
+          isBranchFocusActive,
           // ADR-002 Workstream 1 ("Synthesize Branches"): provenance carried
           // by the result node. provider/model are None/absent for every
           // ordinary chat node (the vast majority), rendered as no badge at
@@ -497,36 +944,19 @@ export function toFlowNodes(
           // above - the new value arrives through the next scene snapshot.
           branchStatus: n.branchStatus,
           isFinalDeliverable: n.isFinalDeliverable,
-          onSetBranchStatus: (status: string) => store.setBranchStatus(n.id, status),
-          onSetFinalDeliverable: (isFinal: boolean) => store.setFinalDeliverable(n.id, isFinal),
-          onCollapseBranch: (collapsed: boolean) => store.collapseBranch(n.id, collapsed),
           // R6.3: the node's own scroll position within its content area -
           // read on mount by ChatNodeView (restore) and reported (debounced)
           // via the setChatScrollValue intent on every scroll.
           chatScrollValue: n.chatScrollValue,
-          onScrollChange: (value: number) => store.setChatScrollValue(n.id, value),
           // ADR-006 stage 6.4 (universal streaming): a Regenerate for this
           // node now streams - the in-flight request id arrives on the
           // node's OWN row (published on the scene topic, never via the
           // composer), and ChatNodeView keys its live subscription off it.
-          // subscribeStream is the same generic transport passthrough the
-          // code_sandbox branch below already injects.
           pendingRequestId: n.pendingRequestId ?? null,
           // ADR-006 stage 6.4 (partial-output preservation): true when the
           // content field is a partial response the backend committed after
           // a killed stream - ChatNodeView renders its "interrupted" banner.
           responseIncomplete: n.responseIncomplete,
-          subscribeStream: (requestId: string, listener: StreamListener) =>
-            store.subscribeStream(requestId, listener),
-          // ADR-006 stage 6.4 review fix: per-node Stop for an in-flight
-          // streamed regenerate. Reuses cancelConversationRequest - which
-          // fires the generic cancelChatRequest intent by requestId, not
-          // anything conversation-specific (see that store method's own
-          // naming comment) - rather than adding a new intent. Same
-          // null-guard pattern as the conversation branch's own onCancel.
-          onCancelRegenerate: () => {
-            if (n.pendingRequestId) store.cancelConversationRequest(n.pendingRequestId);
-          },
           // ADR-007 stage 7.4: this turn's tool calls + results, in call
           // order - [] for the overwhelming majority of chat nodes (see
           // ToolInvocationRow's own comment, contracts/graphlink_scene_
@@ -540,7 +970,9 @@ export function toFlowNodes(
           completionTokens: n.completionTokens ?? null,
           estimatedCostUsd: n.estimatedCostUsd ?? null,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig, flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "code") {
@@ -550,35 +982,61 @@ export function toFlowNodes(
       // dockedChildren above) since the backend never kind-sniffs a code
       // node id back to its parent chat node (see regenerateResponse's own
       // comment above and SceneCanvas's regenerate-response design notes).
-      const parentEdge = scene.edges.find((e) => e.target === n.id);
+      // ADR-011 stage 11.1: edgesByTarget.get(n.id)?.[0] replaces
+      // `scene.edges.find((e) => e.target === n.id)` - both return the
+      // FIRST edge in scene.edges' own order whose target is this node
+      // (edgesByTarget's per-target arrays are built by iterating
+      // scene.edges in order in buildSceneIndexes above, so `[0]` is
+      // exactly what `.find` would have returned), just without re-scanning
+      // the full array for every code node.
+      const parentEdge = edgesByTarget.get(n.id)?.[0];
       const parentChatNodeId = parentEdge ? parentEdge.source : null;
-      flowNodes.push({
+      const dimmedVal = isDimmed(n.id);
+      const extraSig = `${dimmedVal ? 1 : 0}${isBranchFocusActive ? 1 : 0}|${parentChatNodeId ?? ""}`;
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(
+        cache,
+        n.id,
+        { n, store, onOpenDocumentView, onToggleBranchFocus, extra: parentChatNodeId },
+        makeCodeFns,
+      );
+      if (cached && cached.extraSig === extraSig) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "code" as const,
         position: { x: n.x, y: n.y },
-        style: isDimmed(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
+        style: dimmedVal ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           code: n.code,
           language: n.language,
           parentChatNodeId,
-          onRegenerate: () => {
-            if (parentChatNodeId) store.regenerateResponse(parentChatNodeId);
-          },
-          onDelete: () => store.removeNodes([n.id]),
           // R8a: "Hide Other Branches" - see the chat branch above for why
           // isBranchFocusActive is scene-wide rather than per-node.
-          isBranchFocusActive: branchFocusOriginId !== null,
-          onToggleBranchFocus: () => onToggleBranchFocus(n.id),
+          isBranchFocusActive,
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig, flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "document") {
-      flowNodes.push({
+      const dimmedVal = isDimmed(n.id);
+      const extraSig = `${dimmedVal ? 1 : 0}${isBranchFocusActive ? 1 : 0}`;
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(cache, n.id, { n, store, onOpenDocumentView, onToggleBranchFocus }, makeDocumentFns);
+      if (cached && cached.extraSig === extraSig) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "document" as const,
         position: { x: n.x, y: n.y },
-        style: isDimmed(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
+        style: dimmedVal ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           title: n.title,
           content: n.content,
@@ -594,40 +1052,41 @@ export function toFlowNodes(
           byteSize: n.byteSize ?? null,
           previewLabel: n.previewLabel,
           isCollapsed: n.isCollapsed,
-          // setChatCollapsed's backend handler (backend/canvas.py) looks up
-          // ANY node by id and sets is_collapsed - it does not special-case
-          // "chat" kind despite the intent's name - so it is reused here
-          // as-is rather than inventing a setDocumentCollapsed intent the
-          // backend doesn't register. See this increment's report for the
-          // full reasoning.
-          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
-          onDock: () => store.setNodeDocked(n.id, true),
-          onDelete: () => store.removeNodes([n.id]),
           // R8a: "Hide Other Branches" - see the chat branch above.
-          isBranchFocusActive: branchFocusOriginId !== null,
-          onToggleBranchFocus: () => onToggleBranchFocus(n.id),
+          isBranchFocusActive,
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig, flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "thinking") {
       // Docked-hiding is handled by the generic check above; once undocked,
       // it resurfaces as a badge + "Reveal Docked Items" entry on its parent
       // chat node (dockedChildren above).
-      flowNodes.push({
+      const dimmedVal = isDimmed(n.id);
+      const extraSig = `${dimmedVal ? 1 : 0}${isBranchFocusActive ? 1 : 0}`;
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(cache, n.id, { n, store, onOpenDocumentView, onToggleBranchFocus }, makeThinkingFns);
+      if (cached && cached.extraSig === extraSig) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "thinking" as const,
         position: { x: n.x, y: n.y },
-        style: isDimmed(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
+        style: dimmedVal ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           thinkingText: n.content,
-          onDock: () => store.setNodeDocked(n.id, true),
-          onDelete: () => store.removeNodes([n.id]),
           // R8a: "Hide Other Branches" - see the chat branch above.
-          isBranchFocusActive: branchFocusOriginId !== null,
-          onToggleBranchFocus: () => onToggleBranchFocus(n.id),
+          isBranchFocusActive,
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig, flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "html") {
@@ -642,15 +1101,22 @@ export function toFlowNodes(
       // entry exists on this node's own header, and ChatNodeView's own
       // dockedChildren/undock badge is kind-agnostic already, so undocking
       // it is still possible from the parent chat node's side).
-      flowNodes.push({
+      // No isDimmed/isBranchFocusActive here - HtmlNodeView never carried
+      // this menu item (see BRANCH_FOCUS_KINDS above), so node-reference-
+      // only cache invalidation is already exact for this kind.
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(cache, n.id, { n, store, onOpenDocumentView, onToggleBranchFocus }, makeHtmlFns);
+      if (cached) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "html" as const,
         position: { x: n.x, y: n.y },
         data: {
           htmlContent: n.content,
           isCollapsed: n.isCollapsed,
-          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
-          onDelete: () => store.removeNodes([n.id]),
           // R6.3: the Source/Preview split position - read on mount by
           // HtmlNodeView (restore; null means "no saved value, use the
           // component's own 50/50 default") and reported (debounced) via the
@@ -658,9 +1124,11 @@ export function toFlowNodes(
           // canvasConstants.ts's own HTML_SPLIT_* doc for why this exists
           // now despite being scoped OUT back in R3.17/R3.18.
           htmlSplitterState: n.htmlSplitterState ?? null,
-          onSplitterChange: (value: number) => store.setHtmlSplitterState(n.id, value),
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig: "", flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "image") {
@@ -669,25 +1137,29 @@ export function toFlowNodes(
       // never sets isDocked=true through any UI path of its own. The generic
       // `if (n.isDocked) continue` guard above still covers it correctly if
       // it were ever docked via a direct WS call, same as html.
-      flowNodes.push({
+      const dimmedVal = isDimmed(n.id);
+      const extraSig = `${dimmedVal ? 1 : 0}${isBranchFocusActive ? 1 : 0}`;
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(cache, n.id, { n, store, onOpenDocumentView, onToggleBranchFocus }, makeImageFns);
+      if (cached && cached.extraSig === extraSig) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "image" as const,
         position: { x: n.x, y: n.y },
-        style: isDimmed(n.id) ? { opacity: BRANCH_DIM_OPACITY } : undefined,
+        style: dimmedVal ? { opacity: BRANCH_DIM_OPACITY } : undefined,
         data: {
           imageAssetId: n.imageAssetId,
           prompt: n.content,
-          onDelete: () => store.removeNodes([n.id]),
-          // R4.4a: unlike CodeNodeView's onRegenerate, no client-side parent
-          // lookup/null-guard is needed here - the backend resolves the
-          // image's parent chat node internally (see sceneStore.ts's
-          // regenerateImage / backend/canvas.py's resolve_regenerate_image).
-          onRegenerate: () => store.regenerateImage(n.id),
           // R8a: "Hide Other Branches" - see the chat branch above.
-          isBranchFocusActive: branchFocusOriginId !== null,
-          onToggleBranchFocus: () => onToggleBranchFocus(n.id),
+          isBranchFocusActive,
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig, flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "conversation") {
@@ -696,7 +1168,21 @@ export function toFlowNodes(
       // action, so this kind never sets isDocked=true through any UI path
       // of its own; the generic `if (n.isDocked) continue` guard above still
       // covers it correctly if it were ever docked via a direct WS call.
-      flowNodes.push({
+      // No isDimmed/isBranchFocusActive here either - see the html branch's
+      // own comment above (ConversationNodeView is also outside
+      // BRANCH_FOCUS_KINDS), so node-reference-only invalidation is exact.
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(
+        cache,
+        n.id,
+        { n, store, onOpenDocumentView, onToggleBranchFocus },
+        makeConversationFns,
+      );
+      if (cached) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "conversation" as const,
         position: { x: n.x, y: n.y },
@@ -704,38 +1190,11 @@ export function toFlowNodes(
           history: n.history,
           isCollapsed: n.isCollapsed,
           pendingRequestId: n.pendingRequestId ?? null,
-          // Reuses the existing generic setChatCollapsed intent - same
-          // reasoning as every other non-chat node kind's onToggleCollapse
-          // above (the backend handler looks up ANY node by id).
-          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
-          onDelete: () => store.removeNodes([n.id]),
-          onSend: (text: string) => store.sendConversationMessage(n.id, text),
-          onDeleteMessage: (index: number) => store.deleteConversationMessage(n.id, index),
-          // Same null-guard pattern as Composer.tsx's own analogous cancel
-          // call site - only fire the intent if there is genuinely a
-          // non-null request id to target.
-          onCancel: () => {
-            if (n.pendingRequestId) store.cancelConversationRequest(n.pendingRequestId);
-          },
-          // R8a: Open Document View - the node's ENTIRE message history,
-          // formatted as a numbered transcript (see
-          // conversationHistoryToDocumentMarkdown's own doc above). Guards
-          // on a non-empty formatted result (empty history, or every
-          // message blank, both format to "") the same way the chat branch
-          // above guards on non-blank content.
-          onOpenDocumentView: () => {
-            const markdown = conversationHistoryToDocumentMarkdown(n.history);
-            if (markdown) onOpenDocumentView(markdown, "Conversation transcript");
-            else store.showInfoNotification(NO_DOCUMENT_VIEW_CONTENT_MESSAGE);
-          },
-          // ADR-006 stage 6.4 (universal streaming): a reply for this node
-          // now streams - ConversationNodeView keys a live assistant bubble
-          // off the pendingRequestId already mapped above. Same generic
-          // transport passthrough the code_sandbox branch below injects.
-          subscribeStream: (requestId: string, listener: StreamListener) =>
-            store.subscribeStream(requestId, listener),
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig: "", flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "web_research") {
@@ -743,7 +1202,20 @@ export function toFlowNodes(
       // branches above) - WebResearchNodeView never offers a dock-into-parent
       // action; the generic `if (n.isDocked) continue` guard above still
       // covers it correctly if it were ever docked via a direct WS call.
-      flowNodes.push({
+      // No isDimmed/isBranchFocusActive here either - see the html branch's
+      // own comment above.
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(
+        cache,
+        n.id,
+        { n, store, onOpenDocumentView, onToggleBranchFocus },
+        makeWebResearchFns,
+      );
+      if (cached) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "web_research" as const,
         position: { x: n.x, y: n.y },
@@ -757,20 +1229,11 @@ export function toFlowNodes(
           researchActiveSourceId: n.researchActiveSourceId ?? null,
           researchError: n.researchError,
           researchResult: n.researchResult ?? null,
-          // Reuses the existing generic setChatCollapsed intent - same
-          // reasoning as every other non-chat node kind's onToggleCollapse
-          // above (the backend handler looks up ANY node by id).
-          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
-          onDelete: () => store.removeNodes([n.id]),
-          onRun: (query: string) => store.runWebResearch(n.id, query),
-          // Same null-guard pattern as the conversation node's own analogous
-          // cancel call site above - only fire the intent if there is
-          // genuinely a non-null request id to target.
-          onCancel: () => {
-            if (n.pendingRequestId) store.cancelWebResearchRequest(n.pendingRequestId);
-          },
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig: "", flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "artifact") {
@@ -778,8 +1241,15 @@ export function toFlowNodes(
       // web_research branches above) - ArtifactNodeView never offers a
       // dock-into-parent action; the generic `if (n.isDocked) continue` guard
       // above still covers it correctly if it were ever docked via a direct
-      // WS call.
-      flowNodes.push({
+      // WS call. No isDimmed/isBranchFocusActive here either - see the html
+      // branch's own comment above.
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(cache, n.id, { n, store, onOpenDocumentView, onToggleBranchFocus }, makeArtifactFns);
+      if (cached) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "artifact" as const,
         position: { x: n.x, y: n.y },
@@ -788,20 +1258,11 @@ export function toFlowNodes(
           history: n.history,
           isCollapsed: n.isCollapsed,
           pendingRequestId: n.pendingRequestId ?? null,
-          // Reuses the existing generic setChatCollapsed intent - same
-          // reasoning as every other non-chat node kind's onToggleCollapse
-          // above (the backend handler looks up ANY node by id).
-          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
-          onDelete: () => store.removeNodes([n.id]),
-          onSubmit: (text: string) => store.sendArtifactMessage(n.id, text),
-          // Same null-guard pattern as the conversation/web_research nodes'
-          // own analogous cancel call sites above - only fire the intent if
-          // there is genuinely a non-null request id to target.
-          onCancel: () => {
-            if (n.pendingRequestId) store.cancelArtifactRequest(n.pendingRequestId);
-          },
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig: "", flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "gitlink") {
@@ -812,7 +1273,14 @@ export function toFlowNodes(
       // direct WS call. gitlinkContextXml is deliberately absent below - it
       // is never part of the scene wire payload (fetched lazily on demand via
       // fetchGitlinkContext instead - see GitlinkNodeView's own Context tab).
-      flowNodes.push({
+      // No isDimmed/isBranchFocusActive here either.
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(cache, n.id, { n, store, onOpenDocumentView, onToggleBranchFocus }, makeGitlinkFns);
+      if (cached) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "gitlink" as const,
         position: { x: n.x, y: n.y },
@@ -835,26 +1303,11 @@ export function toFlowNodes(
           gitlinkError: n.gitlinkError,
           isCollapsed: n.isCollapsed,
           pendingRequestId: n.pendingRequestId ?? null,
-          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
-          onDelete: () => store.removeNodes([n.id]),
-          onFetchRepositories: () => store.fetchGitlinkRepositories(n.id),
-          onLoadTree: (repo: string, branch: string) => store.loadGitlinkRepoTree(n.id, repo, branch),
-          onSetLocalRoot: (localRoot: string) => store.setGitlinkLocalRoot(n.id, localRoot),
-          onBrowseLocalRoot: () => store.pickGitlinkLocalRoot(n.id),
-          onImportSnapshot: (repo: string, branch: string) => store.importGitlinkSnapshot(n.id, repo, branch),
-          onBuildContext: (scopeMode: string, selectedPaths: string[]) =>
-            store.buildGitlinkContext(n.id, scopeMode, selectedPaths),
-          onFetchContext: () => store.fetchGitlinkContext(n.id),
-          onRun: (taskPrompt: string) => store.runGitlinkChangeSet(n.id, taskPrompt),
-          // Same null-guard pattern as the conversation/web_research/artifact
-          // nodes' own analogous cancel call sites above - only fire the
-          // intent if there is genuinely a non-null request id to target.
-          onCancel: () => {
-            if (n.pendingRequestId) store.cancelGitlinkRequest(n.pendingRequestId);
-          },
-          onApply: (fingerprint: string) => store.applyGitlinkChanges(n.id, fingerprint),
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig: "", flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "pycoder") {
@@ -862,8 +1315,14 @@ export function toFlowNodes(
       // plugin-node branch above) - PyCoderNodeView never offers a
       // dock-into-parent action; the generic `if (n.isDocked) continue`
       // guard above still covers it correctly if it were ever docked via a
-      // direct WS call.
-      flowNodes.push({
+      // direct WS call. No isDimmed/isBranchFocusActive here either.
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(cache, n.id, { n, store, onOpenDocumentView, onToggleBranchFocus }, makePyCoderFns);
+      if (cached) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "pycoder" as const,
         position: { x: n.x, y: n.y },
@@ -878,30 +1337,11 @@ export function toFlowNodes(
           pycoderError: n.pycoderError,
           isCollapsed: n.isCollapsed,
           pendingRequestId: n.pendingRequestId ?? null,
-          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
-          onDelete: () => store.removeNodes([n.id]),
-          onSetMode: (mode: string) => store.setPyCoderMode(n.id, mode),
-          onRun: (inputText: string) => store.runPyCoder(n.id, inputText),
-          // Same null-guard pattern as every other plugin node's own
-          // analogous cancel call site above - only fire the intent if there
-          // is genuinely a non-null request id to target.
-          onCancel: () => {
-            if (n.pendingRequestId) store.cancelPyCoderRequest(n.pendingRequestId);
-          },
-          // CRITICAL (see CodeExecutionApprovalPanel.tsx's own module doc):
-          // these read n.pendingRequestId - the CURRENT scene snapshot's own
-          // value for THIS node - never anything the UI layer could supply
-          // as a distinct argument. Same null-guard posture as onCancel
-          // above; approveCodeExecution/denyCodeExecution both require a
-          // non-null string.
-          onApprove: () => {
-            if (n.pendingRequestId) store.approveCodeExecution(n.pendingRequestId);
-          },
-          onDeny: () => {
-            if (n.pendingRequestId) store.denyCodeExecution(n.pendingRequestId);
-          },
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig: "", flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "code_sandbox") {
@@ -912,8 +1352,20 @@ export function toFlowNodes(
       // direct WS call. code_sandbox_sandbox_id is deliberately absent below
       // - it is pure internal server bookkeeping (a sandbox directory name),
       // never part of the scene wire payload at all (see scene-state.ts) and
-      // never read/forwarded anywhere in this mapping.
-      flowNodes.push({
+      // never read/forwarded anywhere in this mapping. No isDimmed/
+      // isBranchFocusActive here either.
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(
+        cache,
+        n.id,
+        { n, store, onOpenDocumentView, onToggleBranchFocus },
+        makeCodeSandboxFns,
+      );
+      if (cached) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "code_sandbox" as const,
         position: { x: n.x, y: n.y },
@@ -930,42 +1382,26 @@ export function toFlowNodes(
           codeSandboxError: n.codeSandboxError,
           isCollapsed: n.isCollapsed,
           pendingRequestId: n.pendingRequestId ?? null,
-          onToggleCollapse: () => store.setChatCollapsed(n.id, !n.isCollapsed),
-          onDelete: () => store.removeNodes([n.id]),
-          onSetRequirements: (requirementsText: string) =>
-            store.setCodeSandboxRequirements(n.id, requirementsText),
-          onToggleAllowSourceBuilds: (allow: boolean) =>
-            store.setCodeSandboxAllowSourceBuilds(n.id, allow),
-          onRun: (inputText: string) => store.runCodeSandbox(n.id, inputText),
-          onCancel: () => {
-            if (n.pendingRequestId) store.cancelCodeSandboxRequest(n.pendingRequestId);
-          },
-          // CRITICAL - same posture as the pycoder branch's own
-          // onApprove/onDeny above: always n.pendingRequestId, never a
-          // UI-supplied argument.
-          onApprove: () => {
-            if (n.pendingRequestId) store.approveCodeExecution(n.pendingRequestId);
-          },
-          onDeny: () => {
-            if (n.pendingRequestId) store.denyCodeExecution(n.pendingRequestId);
-          },
-          // Generic passthrough to the transport's own stream fan-out (see
-          // sceneStore.ts's own subscribeStream doc) - the live terminal
-          // pane keys its subscription off data.pendingRequestId itself,
-          // this closure only needs to exist so the component never touches
-          // the store/transport directly.
-          subscribeStream: (requestId: string, listener: StreamListener) =>
-            store.subscribeStream(requestId, listener),
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig: "", flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "note") {
       // No onDock here either (same reasoning as every non-dockable kind
       // above) - a note never offers a dock-into-parent action of its own;
       // the generic `if (n.isDocked) continue` guard above still covers it
-      // correctly if it were ever docked via a direct WS call.
-      flowNodes.push({
+      // correctly if it were ever docked via a direct WS call. No isDimmed/
+      // isBranchFocusActive here either.
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(cache, n.id, { n, store, onOpenDocumentView, onToggleBranchFocus }, makeNoteFns);
+      if (cached) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "note" as const,
         position: { x: n.x, y: n.y },
@@ -980,12 +1416,11 @@ export function toFlowNodes(
           // own comment on backend/domain/model.py.
           isBranchComparison: n.isBranchComparison,
           compareSourceNodeIds: n.itemIds,
-          onSetContent: (content: string) => store.setNoteContent(n.id, content),
-          onSetColor: (color: string | null, headerColor: string | null) =>
-            store.setGroupColor(n.id, color, headerColor),
-          onDelete: () => store.removeNodes([n.id]),
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig: "", flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "frame" || n.kind === "container") {
@@ -1015,7 +1450,29 @@ export function toFlowNodes(
       // which gate the MEMBER-cascade on lock state, not draggability
       // itself; backend/canvas.py's move_node pins a manual position
       // anchor so the drag actually sticks instead of snapping back).
-      flowNodes.push({
+      // R6.1 follow-up: a simplified equivalent of legacy's collapsed-
+      // container hover "ghost frame" preview - just member kinds, not a
+      // rendered miniature of actual content. Looked up from the SAME
+      // nodesById map the dockedChildren computation above already builds
+      // once per call; a stale/dangling item_ids entry (a member deleted
+      // out from under a group) is silently skipped, matching
+      // _bbox_of_members' own posture on the backend. Doubles as this
+      // kind's own cache-invalidation signature below: a member's kind
+      // never changes after creation, so memberKinds only differs when
+      // n.itemIds itself differs (already covered by node-reference
+      // invalidation) OR a referenced member was deleted out from under the
+      // group WITHOUT n.itemIds being pruned server-side (the exact
+      // "dangling entry" case this comment already documents) - the one
+      // case node-reference-only invalidation would otherwise miss.
+      const memberKinds = n.itemIds.map((id) => nodesById.get(id)?.kind).filter((kind): kind is string => !!kind);
+      const extraSig = memberKinds.join(",");
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(cache, n.id, { n, store, onOpenDocumentView, onToggleBranchFocus }, makeGroupFns);
+      if (cached && cached.extraSig === extraSig) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: n.kind as "frame" | "container",
         position: { x: n.x, y: n.y },
@@ -1031,24 +1488,12 @@ export function toFlowNodes(
           isCollapsed: n.isCollapsed,
           isLocked: n.isLocked,
           itemIds: n.itemIds,
-          // R6.1 follow-up: a simplified equivalent of legacy's collapsed-
-          // container hover "ghost frame" preview - just member kinds, not
-          // a rendered miniature of actual content. Looked up from the
-          // SAME nodesById map the dockedChildren computation above
-          // already builds once per call; a stale/dangling item_ids entry
-          // (a member deleted out from under a group) is silently skipped,
-          // matching _bbox_of_members' own posture on the backend.
-          memberKinds: n.itemIds.map((id) => nodesById.get(id)?.kind).filter((kind): kind is string => !!kind),
-          onSetLabel: (text: string) => store.setGroupLabel(n.id, text),
-          onToggleCollapsed: () => store.toggleGroupCollapsed(n.id),
-          onToggleLock: () => store.toggleFrameLock(n.id),
-          onSetColor: (color: string | null, headerColor: string | null) =>
-            store.setGroupColor(n.id, color, headerColor),
-          onResize: (width: number, height: number) => store.resizeFrame(n.id, width, height),
-          onFitToContent: () => store.fitFrameToContent(n.id),
-          onUngroup: () => store.ungroup(n.id),
+          memberKinds,
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig, flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
     if (n.kind === "chart") {
@@ -1064,8 +1509,14 @@ export function toFlowNodes(
       // are part of the ordinary 9-field wire contract (scene_payload()
       // exposes them like every other chart field), so they're ALSO
       // duplicated into `data` below rather than living only on the flow
-      // node object.
-      flowNodes.push({
+      // node object. No isDimmed/isBranchFocusActive here either.
+      const cached = cache.flowNodes.get(n);
+      const fns = getDispatcher(cache, n.id, { n, store, onOpenDocumentView, onToggleBranchFocus }, makeChartFns);
+      if (cached) {
+        flowNodes.push(cached.flowNode);
+        continue;
+      }
+      const flowNode: SceneFlowNode = {
         id: n.id,
         type: "chart" as const,
         position: { x: n.x, y: n.y },
@@ -1081,20 +1532,34 @@ export function toFlowNodes(
           chartHeight: n.chartHeight,
           chartAspectLocked: n.chartAspectLocked,
           chartSourceNodeId: n.chartSourceNodeId,
-          onToggleAspectLock: () => store.toggleChartAspectLock(n.id),
-          onResize: (width: number, height: number) => store.resizeChart(n.id, width, height),
+          ...fns,
         },
-      });
+      };
+      cache.flowNodes.set(n, { extraSig: "", flowNode });
+      flowNodes.push(flowNode);
       continue;
     }
-    flowNodes.push({
+    // Fallback placeholder - unreachable in practice given the exhaustive
+    // kind list above, kept for forward-compat with a future kind this
+    // switch hasn't been taught yet. No callbacks at all, so no dispatcher
+    // is needed; node-reference-only invalidation is exact (title is n's
+    // own field).
+    const cachedPlaceholder = cache.flowNodes.get(n);
+    if (cachedPlaceholder) {
+      flowNodes.push(cachedPlaceholder.flowNode);
+      continue;
+    }
+    const placeholderFlowNode: SceneFlowNode = {
       id: n.id,
       type: "placeholder" as const,
       position: { x: n.x, y: n.y },
       data: { title: n.title },
-    });
+    };
+    cache.flowNodes.set(n, { extraSig: "", flowNode: placeholderFlowNode });
+    flowNodes.push(placeholderFlowNode);
   }
 
+  pruneDispatcherCache(cache, nodesById);
   return flowNodes;
 }
 
@@ -1257,6 +1722,113 @@ export function measuredNodeSize(reactFlow: MeasuredSizeSource, id: string): { w
 }
 
 /**
+ * ADR-011 stage 11.2: the virtualization-audit fallback for a smart-guide
+ * alignment CANDIDATE that `onlyRenderVisibleElements` (see CanvasInner's
+ * own `<ReactFlow>` below) has left unmounted - measuredNodeSize's own
+ * getInternalNode/DOM reads both come up empty for a node that was never
+ * rendered in the first place, since there is nothing to measure.
+ *
+ * Three of SceneFlowNode's kinds are the one exception: toFlowNodes above
+ * sets `width`/`height` DIRECTLY ON THE FLOW NODE OBJECT for frame/
+ * container (`n.groupWidth`/`n.groupHeight`) and chart (`n.chartWidth`/
+ * `n.chartHeight`) - the documented xyflow controlled-size mechanism their
+ * own <NodeResizer/> needs (see GroupNodeView.tsx's/ChartNodeView.tsx's own
+ * module docs on those branches). That is DATA carried on the node object
+ * itself, not a DOM measurement - present and correct regardless of mount
+ * state. Confirmed against backend/domain/graph.py's scene_payload(), which
+ * is the server-side source those four fields come from (groupWidth/
+ * groupHeight from FrameState/ContainerState, chartWidth/chartHeight from
+ * ChartState) - the one place in this app's domain model that tracks a
+ * node's size server-side at all.
+ *
+ * Every other kind's size is purely content-driven (CSS auto-sized, no
+ * backend field for it - the exact reason measuredNodeSize's DOM fallback
+ * existed in the first place), so this returns null for them and the
+ * caller (buildDragSizeCache below) simply omits that node from the cache -
+ * the sane fallback the audit called for: an off-viewport, unmeasurable
+ * candidate is excluded from alignment for that drag, never force-mounted
+ * or estimated.
+ */
+export function flowNodeOwnSize(node: SceneFlowNode): { width: number; height: number } | null {
+  if (typeof node.width === "number" && typeof node.height === "number") {
+    return { width: node.width, height: node.height };
+  }
+  return null;
+}
+
+/**
+ * ADR-011 stage 11.3: the drag-GESTURE-lifetime smart-guide size cache -
+ * built exactly ONCE, at the first frame of a NEW drag gesture (see
+ * CanvasInner's own dragSizeCacheRef and the `startingNewDrag` check in
+ * onNodesChange), never per frame. This is the fix for P3 in ADR-011's own
+ * audit: measuredNodeSize's DOM fallback (`document.querySelector` +
+ * `offsetWidth`/`offsetHeight`, a forced reflow) used to run for the
+ * dragged node AND every candidate node INSIDE onNodesChange's per-frame
+ * loop - up to N reflows PER DRAG FRAME, ~6,000/s at 100 nodes and 60fps.
+ * Now it runs at most once per node for the WHOLE gesture; every later
+ * frame of that same gesture reads back out of the Map this returns
+ * (computeSmartGuideFrame below) instead of touching the DOM again.
+ *
+ * flowNodeOwnSize is tried first (free, DOM-independent); measuredNodeSize
+ * is the fallback for every other kind. A node with neither (off-viewport
+ * and unmounted under onlyRenderVisibleElements, no server-tracked size) is
+ * simply absent from the returned map - see computeSmartGuideFrame's own
+ * `if (!size) continue`.
+ */
+export function buildDragSizeCache(
+  reactFlow: MeasuredSizeSource,
+  nodes: SceneFlowNode[],
+): Map<string, { width: number; height: number }> {
+  const cache = new Map<string, { width: number; height: number }>();
+  for (const n of nodes) {
+    const size = flowNodeOwnSize(n) ?? measuredNodeSize(reactFlow, n.id);
+    if (size) cache.set(n.id, size);
+  }
+  return cache;
+}
+
+/**
+ * R7.5b-3/ADR-011 stage 11.3: one drag frame's smart-guide snap
+ * computation, pulled out of onNodesChange's closure - callable directly
+ * (same standalone-for-direct-testing posture as applyGroupDragDelta/
+ * groupDragKindOf above, whose own doc explains why: driving a full
+ * <ReactFlow> mount + synthetic pointer drag isn't something this codebase
+ * exercises in tests anywhere else) so a test can drive N simulated frames
+ * without one.
+ *
+ * `sizeCache` is read-only here - see buildDragSizeCache above for where it
+ * gets populated (once, at drag start) and CanvasInner's dragSizeCacheRef
+ * for the ref it lives in across a gesture's many onNodesChange calls. A
+ * moving node absent from the cache (no resolvable size) is a no-op frame:
+ * the ORIGINAL (unsnapped) position passes through unchanged and no guides
+ * are produced, same as measuredNodeSize returning null did before this
+ * stage.
+ */
+export function computeSmartGuideFrame(
+  nodes: SceneFlowNode[],
+  changeId: string,
+  finalPosition: { x: number; y: number },
+  sizeCache: Map<string, { width: number; height: number }>,
+): { position: { x: number; y: number }; guides: GuideLine[] } {
+  const moving = nodes.find((n) => n.id === changeId);
+  const movingSize = sizeCache.get(changeId);
+  if (!moving || !movingSize) return { position: finalPosition, guides: [] };
+  const memberIds = groupDragKindOf(moving) ? collectTransitiveMemberIds(nodes, moving) : new Set<string>();
+  const candidates: Rect[] = [];
+  for (const n of nodes) {
+    if (n.id === changeId || n.selected || memberIds.has(n.id)) continue;
+    const size = sizeCache.get(n.id);
+    if (!size) continue;
+    candidates.push({ x: n.position.x, y: n.position.y, width: size.width, height: size.height });
+  }
+  const snap = computeSmartGuideSnap(
+    { x: finalPosition.x, y: finalPosition.y, width: movingSize.width, height: movingSize.height },
+    candidates,
+  );
+  return { position: { x: snap.x, y: snap.y }, guides: snap.guides };
+}
+
+/**
  * R7.5c: carry the current selection across a snapshot rebuild.
  *
  * toFlowNodes mints brand-new node objects from every scene snapshot, so
@@ -1288,10 +1860,14 @@ export function withPreservedSelection(
 // above - R7.5b-1's fade-connections opacity logic doesn't need a mounted
 // <ReactFlow> to verify.
 export function toFlowEdges(scene: SceneState, hoveredEdgeId: string | null): Edge[] {
+  // ADR-011 stage 11.1: dockedNodeIds now comes from the SAME
+  // buildSceneIndexes pass toFlowNodes above uses (was its own standalone
+  // `scene.nodes.filter(...)` here) - kindOf is looked up straight off
+  // nodesById's own node rows instead of a second separate `Map(scene.nodes
+  // .map((n) => [n.id, n.kind]))`, one less O(N) map built per call.
+  const { nodesById, dockedNodeIds } = buildSceneIndexes(scene);
   // An edge pointing at a docked node must not render either - mirrors the
   // legacy connection-item self-suppression when its end node is docked.
-  const dockedNodeIds = new Set(scene.nodes.filter((n) => n.isDocked).map((n) => n.id));
-  const kindOf = new Map(scene.nodes.map((n) => [n.id, n.kind]));
   return scene.edges
     .filter((e) => !dockedNodeIds.has(e.target))
     .map((e) => ({
@@ -1299,7 +1875,8 @@ export function toFlowEdges(scene: SceneState, hoveredEdgeId: string | null): Ed
       source: e.source,
       target: e.target,
       type:
-        scene.orthogonalRouting && isOrthogonalEligible(kindOf.get(e.source), kindOf.get(e.target))
+        scene.orthogonalRouting &&
+        isOrthogonalEligible(nodesById.get(e.source)?.kind, nodesById.get(e.target)?.kind)
           ? "orthogonal"
           : undefined,
       ...(scene.fadeConnectionsEnabled && e.id !== hoveredEdgeId
@@ -1360,6 +1937,18 @@ function CanvasInner({
   // component, hence living on sceneStore rather than as useState here -
   // see that field's own comment).
   const focusAcceptedPaths = useSyncExternalStore(store.subscribe, store.getFocusAcceptedPaths);
+  // ADR-011 stage 11.2: true for exactly the duration of one
+  // exportCanvasAsPng capture (AppBar.tsx's exportPng/commands.ts's
+  // export-canvas-png, both routed through SceneStore.setExportInProgress) -
+  // see exportCanvasPng.ts's own doc for why a full-canvas PNG export needs
+  // onlyRenderVisibleElements suspended: the export computes a viewport that
+  // fits every node into a 1920x1080 FRAME, but that framing has no way to
+  // know the LIVE on-screen canvas container might be smaller than that, and
+  // virtualization filters against the container's REAL client size - a node
+  // that fits inside the export frame can still fall outside the live
+  // container's actual bounds and never mount, silently missing from the
+  // captured DOM regardless of correct viewport math.
+  const exportInProgress = useSyncExternalStore(store.subscribe, store.getExportInProgress);
   // Hoisted above onNodesChange: smart guides (R7.5b-3) need node
   // dimensions. Neither the local `nodes` array NOR React Flow's internal
   // store reliably has them here: toFlowNodes rebuilds the array from every
@@ -1380,6 +1969,24 @@ function CanvasInner({
   const [nodes, setNodes] = useState<SceneFlowNode[]>([]);
   const dragStartRef = useRef<Map<string, { x: number; y: number }>>(new Map());
   const draggingRef = useRef(false);
+  // ADR-011 stage 11.3: the smart-guide size cache - populated ONCE per drag
+  // gesture (see the `startingNewDrag` check inside onNodesChange below,
+  // keyed off draggingRef's value from BEFORE that call) via
+  // buildDragSizeCache, then read back by computeSmartGuideFrame for every
+  // remaining frame of that SAME gesture instead of re-querying the DOM. A
+  // plain ref (not state) since a rebuild must never itself trigger a
+  // re-render - it only matters to onNodesChange's own closure.
+  const dragSizeCacheRef = useRef<Map<string, { width: number; height: number }>>(new Map());
+  // ADR-011 stage 11.1: ONE ToFlowNodesCache for this canvas's whole
+  // lifetime, threaded into every toFlowNodes call below - this is what
+  // actually makes the per-node dispatcher/whole-flow-node memoization in
+  // toFlowNodes effective across snapshots (a cache recreated every call
+  // would never see a previous call's entries to hit against). Lazy-
+  // initialized via the guarded-null pattern rather than
+  // `useRef(createToFlowNodesCache())` so a fresh cache object isn't
+  // allocated (and immediately discarded) on every re-render.
+  const toFlowNodesCacheRef = useRef<ToFlowNodesCache | null>(null);
+  if (toFlowNodesCacheRef.current === null) toFlowNodesCacheRef.current = createToFlowNodesCache();
 
   // R7.5b-1: which edge (if any) is under the mouse right now - the one
   // exemption from faded-connections' blanket low-opacity effect. Local-only
@@ -1486,13 +2093,42 @@ function CanvasInner({
     if (draggingRef.current) return;
     setNodes((current) =>
       withPreservedSelection(
-        toFlowNodes(scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus, focusAcceptedPaths),
+        toFlowNodes(
+          scene,
+          store,
+          onOpenDocumentView,
+          effectiveBranchFocusOriginId,
+          onToggleBranchFocus,
+          focusAcceptedPaths,
+          // Non-null: the guarded-null lazy-init above runs synchronously on
+          // every render before this effect can fire, so `.current` is
+          // always populated by the time this closure executes - TS just
+          // can't prove that across the mutable ref indirection.
+          toFlowNodesCacheRef.current!,
+        ),
         current,
       ),
     );
   }, [scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus, focusAcceptedPaths]);
 
-  const edges = useMemo(() => toFlowEdges(scene, hoveredEdgeId), [scene, hoveredEdgeId]);
+  // ADR-011 stage 11.3 (P4): toFlowEdges rebuilds the WHOLE edges array (an
+  // O(E) map over every edge) - hoveredEdgeId is only EVER read inside that
+  // rebuild when scene.fadeConnectionsEnabled is on (see toFlowEdges' own
+  // body), so unconditionally listing it as a dependency meant hovering an
+  // edge rebuilt this array on every enter/leave EVEN WHEN the fade feature
+  // is off and nothing in the output could possibly change. Passing `null`
+  // in place of hoveredEdgeId whenever fade is off collapses the dependency
+  // to a constant for that case - a hover-only state change no longer
+  // differs from the previous render's dependency, so useMemo correctly
+  // skips the recompute (and keeps returning the SAME array reference)
+  // instead of only skipping the WORK toFlowEdges would have done with it.
+  // Hoisted into its own variable (not an inline ternary in the deps array
+  // below) so the memo's dependency is a single, staticly-checkable
+  // reference - satisfies react-hooks/exhaustive-deps outright rather than
+  // suppressing it, and reads the same either way: null whenever fade is
+  // off, hoveredEdgeId whenever it's on.
+  const edgeHoverKey = scene.fadeConnectionsEnabled ? hoveredEdgeId : null;
+  const edges = useMemo(() => toFlowEdges(scene, edgeHoverKey), [scene, edgeHoverKey]);
 
   // R8a: the minimap used to render every node as React Flow's own default
   // plain rectangle (no nodeColor/nodeStrokeColor was ever passed), which
@@ -1544,6 +2180,21 @@ function CanvasInner({
       let sawDragging = false;
       let sawDragEnd = false;
 
+      // ADR-011 stage 11.3: rebuild the smart-guide size cache exactly ONCE,
+      // at the first frame of a NEW drag gesture - `draggingRef.current` here
+      // still holds whatever the PREVIOUS onNodesChange call left it as (the
+      // mutations below happen further down, inside this same call), so
+      // `!draggingRef.current` is true only when nothing was already
+      // dragging coming INTO this call. A multi-select drag's first frame
+      // reports several `dragging:true` changes in the SAME batch - this
+      // still only rebuilds once for the whole batch, not once per change.
+      // Guarded on scene.smartGuides so the feature being off costs nothing
+      // (matches the per-frame gate below, which already skipped all of
+      // this work in that case).
+      if (scene.smartGuides && !draggingRef.current && changes.some((c) => c.type === "position" && c.dragging)) {
+        dragSizeCacheRef.current = buildDragSizeCache(reactFlow, nodes);
+      }
+
       const scaled = changes.map((change) => {
         if (change.type !== "position" || !change.position) return change;
         if (change.dragging) {
@@ -1572,27 +2223,15 @@ function CanvasInner({
           // to answer: this canvas carries members via synthetic deltas, not
           // Qt child-item parenting - per the recorded design decision, only
           // the group's own rect snaps and members ride the delta).
+          // ADR-011 stage 11.3: reads dragSizeCacheRef (populated ONCE at
+          // this gesture's own drag-start, above) instead of calling
+          // measuredNodeSize directly here - see computeSmartGuideFrame's
+          // own doc for why this is now a pure, cache-only lookup with zero
+          // DOM access per frame.
           if (scene.smartGuides) {
-            const moving = nodes.find((n) => n.id === change.id);
-            const movingSize = measuredNodeSize(reactFlow, change.id);
-            if (moving && movingSize) {
-              const memberIds = groupDragKindOf(moving)
-                ? collectTransitiveMemberIds(nodes, moving)
-                : new Set<string>();
-              const candidates: Rect[] = [];
-              for (const n of nodes) {
-                if (n.id === change.id || n.selected || memberIds.has(n.id)) continue;
-                const size = measuredNodeSize(reactFlow, n.id);
-                if (!size) continue;
-                candidates.push({ x: n.position.x, y: n.position.y, width: size.width, height: size.height });
-              }
-              const snap = computeSmartGuideSnap(
-                { x: finalPosition.x, y: finalPosition.y, width: movingSize.width, height: movingSize.height },
-                candidates,
-              );
-              finalPosition = { x: snap.x, y: snap.y };
-              frameGuides.push(...snap.guides);
-            }
+            const frame = computeSmartGuideFrame(nodes, change.id, finalPosition, dragSizeCacheRef.current);
+            finalPosition = frame.position;
+            frameGuides.push(...frame.guides);
           }
           memberChanges.push(...applyGroupDragDelta(nodes, change.id, finalPosition));
           return {
@@ -1730,6 +2369,45 @@ function CanvasInner({
         deleteKeyCode={["Delete", "Backspace"]}
         proOptions={{ hideAttribution: true }}
         defaultEdgeOptions={{ type: "default" }}
+        /*
+         * ADR-011 stage 11.2: off-viewport nodes no longer mount at all (nor
+         * re-render, nor pay their markdown/highlight/KaTeX parse cost) -
+         * the single biggest lever this ADR has on a large canvas. Suspended
+         * for exactly the duration of one PNG export via exportInProgress
+         * (see that field's own doc above and exportCanvasPng.ts's).
+         *
+         * Every other "assumes all nodes are mounted" site the ADR called
+         * out for audit, and what each needed:
+         * - Group/collapse (GroupNodeView.tsx, applyGroupDragDelta/
+         *   collectTransitiveMemberIds above): reads the LOCAL `nodes` data
+         *   array and `data.itemIds` only - never the DOM or React Flow's
+         *   internal `measured` cache - so an unmounted member is exactly as
+         *   reachable as a mounted one. No fix needed.
+         * - LOD (useLodVisibility.ts): a hook called FROM WITHIN each
+         *   mounted node's own component - an unmounted node's hook simply
+         *   never runs, which is correct (no work to skip, nothing to get
+         *   wrong). No fix needed.
+         * - Smart guides: DID need a fix - see buildDragSizeCache/
+         *   computeSmartGuideFrame above (stage 11.3) for the drag-start
+         *   cache, and flowNodeOwnSize's own doc for the frame/container/
+         *   chart data-level fallback.
+         * - Search/pin-highlight (SearchOverlay.tsx/PinOverlay.tsx): both
+         *   already call React Flow's setCenter with the target's own
+         *   SCENE x/y (never a DOM-measured position) UNCONDITIONALLY, i.e.
+         *   before the target could possibly need to be mounted/
+         *   interactable - panning the viewport is what MAKES it mount
+         *   under virtualization, not something that requires it already
+         *   being mounted. Verified, not fixed; see the regression test
+         *   covering this in SceneCanvas.pinSearchJump.test.tsx.
+         * - Export-to-PNG (exportCanvasPng.ts): DID need a fix - the export
+         *   fits every node into a 1920x1080 FRAME, which the live
+         *   on-screen container can be smaller than, so virtualization
+         *   could leave a node that fits the export frame outside the
+         *   live container's real bounds and never mount for capture. Fixed
+         *   via exportInProgress above, which that module now sets for the
+         *   capture's duration.
+         */
+        onlyRenderVisibleElements={!exportInProgress}
       >
         <Background
           variant={GRID_VARIANTS[grid.gridStyle] ?? BackgroundVariant.Dots}

--- a/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * ADR-011 stages 11.2/11.3: SceneCanvas's own wiring into <ReactFlow> -
+ * covered separately from SceneCanvas.test.tsx (which drives toFlowNodes/
+ * toFlowEdges/etc. as pure functions, that file's own established posture)
+ * because these three claims are genuinely about the WIRING between
+ * CanvasInner's hooks and the <ReactFlow> element itself, not a pure
+ * function's output: onlyRenderVisibleElements being suspended during an
+ * export, the edge-hover memo actually skipping a recompute, and the
+ * smart-guide drag-size cache actually being built once per GESTURE rather
+ * than once per FRAME.
+ *
+ * @xyflow/react's own <ReactFlow> is replaced with a thin prop-capturing
+ * stub - every other export (ReactFlowProvider, useReactFlow, Handle,
+ * Position, ...) stays real - rather than mounting the genuine component.
+ * Confirmed empirically while building this file, not assumed: a REAL
+ * <ReactFlow onlyRenderVisibleElements> mounted in this test environment
+ * renders every node regardless of position, because xyflow's own
+ * visibility filter (getNodesInside, @xyflow/system) treats any node it has
+ * never been able to MEASURE as unconditionally visible - and jsdom can
+ * never measure one, since @xyflow/react's per-node ResizeObserver callback
+ * never fires against this project's own jsdom ResizeObserver stub
+ * (vitest.setup.ts - a deliberate no-op, "none exercise real layout"), and
+ * even forcing a firing one hits `window.DOMMatrixReadOnly is not a
+ * constructor` inside xyflow's own updateNodeInternals - a jsdom platform
+ * gap, not anything this app's code controls. Capturing the exact props/
+ * handlers SceneCanvas hands to <ReactFlow> and driving them directly is
+ * what actually pins the WIRING this stage changed, without depending on a
+ * working browser layout/measurement pipeline underneath.
+ *
+ * The genuinely mount-DEPENDENT halves of the ADR-011 stage 11.2 audit -
+ * "does xyflow's own onlyRenderVisibleElements filter correctly by
+ * position" - is xyflow's own library contract, not this app's code; this
+ * file pins that SceneCanvas asks for it (onlyRenderVisibleElements: true)
+ * and correctly suspends it for an export, which is the actual surface this
+ * app owns.
+ */
+import { ReactFlowProvider, type Edge, type NodeChange } from "@xyflow/react";
+import { act, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+type CapturedProps = {
+  nodes: Array<{ id: string; selected?: boolean }>;
+  edges: Edge[];
+  onNodesChange: (changes: NodeChange[]) => void;
+  onEdgeMouseEnter: (event: unknown, edge: Edge) => void;
+  onEdgeMouseLeave: () => void;
+  onlyRenderVisibleElements: boolean;
+};
+
+let capturedProps: CapturedProps[] = [];
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@xyflow/react")>();
+  return {
+    ...original,
+    // ADR-011 stages 11.2/11.3: a thin capture stub, not the real renderer -
+    // see this file's own module doc for why. Every prop SceneCanvas passes
+    // is recorded verbatim on each render so tests can invoke its handlers
+    // directly (onNodesChange, onEdgeMouseEnter/Leave) and assert on its
+    // declarative props (onlyRenderVisibleElements, edges) without needing
+    // a working xyflow measurement pipeline underneath.
+    ReactFlow: (props: CapturedProps) => {
+      capturedProps.push(props);
+      return null;
+    },
+  };
+});
+
+import { SceneCanvas } from "./SceneCanvas";
+import { SceneStore, initialSceneState } from "./sceneStore";
+import type { WsTransport } from "../../lib/ws/transport";
+import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
+
+type StateListener = (payload: Record<string, unknown>) => void;
+
+function makeWiredStore() {
+  const stateListeners = new Map<string, StateListener>();
+  const transport = {
+    subscribe: vi.fn((topic: string, listener: StateListener) => {
+      stateListeners.set(topic, listener);
+      return () => stateListeners.delete(topic);
+    }),
+    intent: vi.fn(),
+    fireIntent: vi.fn(),
+    subscribePatch: vi.fn(),
+    onVersionRejection: vi.fn((_topic: string, listener: (r: null) => void) => {
+      listener(null);
+      return () => {};
+    }),
+    setTopicBlocked: vi.fn(),
+  } as unknown as WsTransport;
+  const store = new SceneStore(transport);
+  store.connect();
+  return { store, stateListeners };
+}
+
+// Minimal fixture - only the fields toFlowNodes actually branches on need
+// real values, same "kept minimal on purpose" posture as renderCountGate.
+// test.tsx's own chatRow (SceneCanvas.test.tsx's baseNode is the exhaustive
+// fixture for when a test needs every field).
+function chatRow(id: string, x: number, y = 0): SceneNodeRow {
+  return {
+    ...(Object.fromEntries(
+      Object.entries({
+        id, x, y, title: id, kind: "chat", content: "hello", isUser: false,
+        isCollapsed: false, code: "", language: "", attachmentKind: "", filePath: "",
+        mimeType: "", durationSeconds: null, byteSize: null, previewLabel: "",
+        isDocked: false, imageAssetId: "", history: [], pendingRequestId: null,
+        researchStage: "", researchCompleted: 0, researchTotal: 0,
+        researchActiveSourceId: null, researchError: "", researchResult: null,
+        artifactContent: "", gitlinkRepo: "", gitlinkBranch: "",
+        gitlinkScopeMode: "selected", gitlinkLocalRoot: "", gitlinkRepoFilePaths: [],
+        gitlinkSelectedPaths: [], gitlinkTaskPrompt: "", gitlinkContextStats: {},
+        gitlinkContextSummary: "", gitlinkContextVersion: 0,
+        gitlinkProposalMarkdown: "", gitlinkPendingChanges: [], gitlinkPreviewText: "",
+        gitlinkChangeFingerprint: null, gitlinkChangeState: "", gitlinkError: "",
+        pycoderMode: "ai_driven", pycoderPrompt: "", pycoderCode: "",
+        pycoderOutput: "", pycoderAnalysis: "", pycoderLastRunFailed: false,
+        pycoderAwaitingApproval: false, pycoderError: "",
+        codeSandboxRequirements: "", codeSandboxApprovalRequirements: "",
+        codeSandboxApprovalAllowSourceBuilds: false, codeSandboxApprovalIsRepair: false,
+        codeSandboxPrompt: "", codeSandboxCode: "", codeSandboxOutput: "",
+        codeSandboxAnalysis: "", codeSandboxAwaitingApproval: false,
+        codeSandboxError: "", provider: null, model: null, isBranchSynthesis: false,
+        synthesisInstructions: "", branchStatus: "active", responseIncomplete: false,
+        isFinalDeliverable: false,
+        color: null, headerColor: null, isSystemPrompt: false, isSummaryNote: false,
+        isBranchComparison: false, itemIds: [], isLocked: true, groupWidth: null,
+        groupHeight: null, chartType: "", chartData: {}, chartError: "",
+        chartAssetId: "", chartAssetVersion: 0, chartWidth: 680.0, chartHeight: 500.0,
+        chartAspectLocked: true, chartSourceNodeId: "", htmlSplitterState: null,
+        chatScrollValue: 0.0,
+        toolCalls: [],
+      }),
+    ) as unknown as SceneNodeRow),
+  };
+}
+
+function mount() {
+  const { store, stateListeners } = makeWiredStore();
+  capturedProps = [];
+  render(
+    <ReactFlowProvider>
+      <SceneCanvas store={store} onOpenDocumentView={() => {}} />
+    </ReactFlowProvider>,
+  );
+  return { store, stateListeners };
+}
+
+function publish(stateListeners: Map<string, StateListener>, scene: Partial<SceneState>) {
+  act(() => {
+    stateListeners.get("scene")!({ ...initialSceneState, ...scene } as unknown as Record<string, unknown>);
+  });
+}
+
+function lastProps(): CapturedProps {
+  return capturedProps[capturedProps.length - 1];
+}
+
+describe("SceneCanvas <ReactFlow> wiring (ADR-011 stages 11.2/11.3)", () => {
+  describe("onlyRenderVisibleElements (stage 11.2)", () => {
+    it("is on by default", () => {
+      const { stateListeners } = mount();
+      publish(stateListeners, { nodes: [chatRow("n0", 0)], edges: [] });
+      expect(lastProps().onlyRenderVisibleElements).toBe(true);
+    });
+
+    it("is suspended for exactly the duration of SceneStore.setExportInProgress(true)", () => {
+      const { store, stateListeners } = mount();
+      publish(stateListeners, { nodes: [chatRow("n0", 0)], edges: [] });
+      expect(lastProps().onlyRenderVisibleElements).toBe(true);
+
+      act(() => store.setExportInProgress(true));
+      expect(lastProps().onlyRenderVisibleElements).toBe(false);
+
+      act(() => store.setExportInProgress(false));
+      expect(lastProps().onlyRenderVisibleElements).toBe(true);
+    });
+  });
+
+  describe("edge-hover memo gate (stage 11.3, P4)", () => {
+    it("hovering an edge does NOT change the edges array reference when fadeConnectionsEnabled is false", () => {
+      const { stateListeners } = mount();
+      publish(stateListeners, {
+        nodes: [chatRow("a", 0), chatRow("b", 200)],
+        edges: [{ id: "e1", source: "a", target: "b" }],
+        fadeConnectionsEnabled: false,
+      });
+      const before = lastProps().edges;
+
+      act(() => lastProps().onEdgeMouseEnter(undefined, { id: "e1" } as Edge));
+      expect(lastProps().edges).toBe(before);
+
+      act(() => lastProps().onEdgeMouseLeave());
+      expect(lastProps().edges).toBe(before);
+    });
+
+    it("hovering an edge DOES rebuild the edges array (and applies fade styling) when fadeConnectionsEnabled is true", () => {
+      const { stateListeners } = mount();
+      publish(stateListeners, {
+        nodes: [chatRow("a", 0), chatRow("b", 200), chatRow("c", 400)],
+        edges: [
+          { id: "e1", source: "a", target: "b" },
+          { id: "e2", source: "a", target: "c" },
+        ],
+        fadeConnectionsEnabled: true,
+      });
+      const before = lastProps().edges;
+
+      act(() => lastProps().onEdgeMouseEnter(undefined, { id: "e1" } as Edge));
+      const hovered = lastProps().edges;
+      expect(hovered).not.toBe(before);
+      expect(hovered.find((e) => e.id === "e1")?.style).toBeUndefined();
+      expect(hovered.find((e) => e.id === "e2")?.style).toEqual({ opacity: 0.08 });
+    });
+  });
+
+  describe("smart-guide drag-size cache (stage 11.3, P3)", () => {
+    it("queries the DOM fallback for the drag gesture's candidates AT MOST ONCE, not once per frame", () => {
+      // getInternalNode always empty (no real <ReactFlow> ever mounted its
+      // own internal store here - see this file's own module doc), so
+      // measuredNodeSize's DOM fallback is hit for every plain "chat" node
+      // (no flow-node-level width/height to short-circuit it) - the exact
+      // worst case the ADR's own P3 finding describes.
+      const querySelectorSpy = vi.spyOn(document, "querySelector");
+      const { stateListeners } = mount();
+      const nodes = Array.from({ length: 5 }, (_, i) => chatRow(`n${i}`, i * 300));
+      publish(stateListeners, { nodes, edges: [], smartGuides: true });
+
+      querySelectorSpy.mockClear();
+      // Re-reads lastProps().onNodesChange fresh before EVERY call, not a
+      // single cached reference - onNodesChange is recreated (useCallback's
+      // own `nodes` dependency changes every setNodes call inside it), and
+      // production React Flow always invokes whatever the LATEST prop
+      // reference is, exactly like this.
+      const drag = (change: Partial<NodeChange> & { id: string }) =>
+        act(() => lastProps().onNodesChange([{ type: "position", ...change } as NodeChange]));
+
+      // Frame 1 of a drag gesture on n0 - this is where the batch cache
+      // read happens.
+      drag({ id: "n0", dragging: true, position: { x: 10, y: 0 } });
+      const afterFrame1 = querySelectorSpy.mock.calls.length;
+      expect(afterFrame1).toBeGreaterThan(0);
+
+      // Frames 2 and 3 of the SAME gesture - call count must not scale with
+      // the number of simulated frames.
+      drag({ id: "n0", dragging: true, position: { x: 20, y: 0 } });
+      expect(querySelectorSpy.mock.calls.length).toBe(afterFrame1);
+      drag({ id: "n0", dragging: true, position: { x: 30, y: 0 } });
+      expect(querySelectorSpy.mock.calls.length).toBe(afterFrame1);
+
+      // Drag end - still no new DOM reads.
+      drag({ id: "n0", dragging: false, position: { x: 30, y: 0 } });
+      expect(querySelectorSpy.mock.calls.length).toBe(afterFrame1);
+
+      // A NEW drag gesture rebuilds the cache again - proves the cache
+      // isn't just frozen forever, only frozen for one gesture at a time.
+      drag({ id: "n1", dragging: true, position: { x: 310, y: 0 } });
+      expect(querySelectorSpy.mock.calls.length).toBeGreaterThan(afterFrame1);
+
+      querySelectorSpy.mockRestore();
+    });
+
+    it("never touches the DOM fallback at all when smartGuides is off", () => {
+      const querySelectorSpy = vi.spyOn(document, "querySelector");
+      const { stateListeners } = mount();
+      const nodes = Array.from({ length: 3 }, (_, i) => chatRow(`n${i}`, i * 300));
+      publish(stateListeners, { nodes, edges: [], smartGuides: false });
+
+      querySelectorSpy.mockClear();
+      const drag = (change: Partial<NodeChange> & { id: string }) =>
+        act(() => lastProps().onNodesChange([{ type: "position", ...change } as NodeChange]));
+      drag({ id: "n0", dragging: true, position: { x: 10, y: 0 } });
+      drag({ id: "n0", dragging: true, position: { x: 20, y: 0 } });
+      drag({ id: "n0", dragging: false, position: { x: 20, y: 0 } });
+
+      expect(querySelectorSpy).not.toHaveBeenCalled();
+      querySelectorSpy.mockRestore();
+    });
+  });
+});

--- a/web_ui/src/app/canvas/ThinkingNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ThinkingNodeView.test.tsx
@@ -1,7 +1,26 @@
 import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ADR-011 stage 11.1: wraps the real useLodVisibility so every ACTUAL render
+// of this view is countable - a React.memo bailout skips the function body
+// (and every hook inside it) entirely, so this never fires on a bailed
+// re-render. See ImageNodeView.test.tsx for the same technique's full
+// rationale.
+const lodVisibilityCalls = { count: 0 };
+
+vi.mock("./useLodVisibility", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./useLodVisibility")>();
+  return {
+    ...original,
+    useLodVisibility: (...args: Parameters<typeof original.useLodVisibility>) => {
+      lodVisibilityCalls.count += 1;
+      return original.useLodVisibility(...args);
+    },
+  };
+});
+
 import { ThinkingNodeView, type ThinkingFlowNode } from "./ThinkingNodeView";
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
@@ -41,7 +60,10 @@ describe("ThinkingNodeView", () => {
     const user = userEvent.setup();
     const { onDock, onDelete } = renderThinkingNode();
 
-    const writeText = vi.fn();
+    // ADR-011 stage 11.1 (D11): production now chains `.catch()` off this
+    // call, so the mock must return a real Promise (a bare vi.fn() returns
+    // undefined, and `.catch` on undefined would throw).
+    const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
 
     const label = screen.getByText("Thinking");
@@ -67,6 +89,29 @@ describe("ThinkingNodeView", () => {
     fireEvent.contextMenu(label);
     await user.click(screen.getByRole("menuitem", { name: "Delete Node" }));
     expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  // ADR-011 stage 11.1 (D11): Copy Content's clipboard write previously had
+  // no `.catch()` - a rejected promise (permission denied, no Clipboard API,
+  // insecure context) would surface as an unhandled promise rejection. Now
+  // it's caught and logged, matching ImageNodeView's own established pattern
+  // for its own clipboard write.
+  it("does not throw/reject unhandled when Copy Content's clipboard write fails", async () => {
+    const user = userEvent.setup();
+    renderThinkingNode();
+
+    const writeText = vi.fn().mockRejectedValue(new Error("permission denied"));
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    fireEvent.contextMenu(screen.getByText("Thinking"));
+    await user.click(screen.getByRole("menuitem", { name: "Copy Content" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    // The menu still closes normally - the failure is swallowed, not thrown.
+    expect(screen.queryByRole("menu")).toBeNull();
+    consoleError.mockRestore();
   });
 
   it("Hide Other Branches calls onToggleBranchFocus and closes the menu when branch focus is inactive", async () => {
@@ -110,5 +155,80 @@ describe("ThinkingNodeView", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
     await user.click(document.body);
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: React.memo comparator correctness. `lodVisibilityCalls`
+// fires exactly once per ACTUAL render - never on a bailed-out one - so it's
+// the oracle for both directions (see ImageNodeView.test.tsx for the full
+// rationale of this technique).
+describe("ThinkingNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  beforeEach(() => {
+    lodVisibilityCalls.count = 0;
+  });
+
+  function thinkingProps(overrides: Partial<ThinkingFlowNode["data"]> = {}) {
+    const data = {
+      thinkingText: "considering approaches",
+      onDock: vi.fn(),
+      onDelete: vi.fn(),
+      isBranchFocusActive: false,
+      onToggleBranchFocus: vi.fn(),
+      ...overrides,
+    };
+    return { id: "n0", selected: false, data } as unknown as NodeProps<ThinkingFlowNode>;
+  }
+
+  it("skips re-rendering when a fresh `data` object carries identical field values", () => {
+    const props = thinkingProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ThinkingNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    const sameValuesNewObject = { ...props.data };
+    rerender(
+      <ReactFlowProvider>
+        <ThinkingNodeView {...{ ...props, data: sameValuesNewObject }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("re-renders when `thinkingText` (a field the view reads) changes", () => {
+    const props = thinkingProps({ thinkingText: "first draft" });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ThinkingNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <ThinkingNodeView {...{ ...props, data: { ...props.data, thinkingText: "revised draft" } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+    expect(screen.getByText("revised draft")).toBeInTheDocument();
+  });
+
+  it("re-renders when `isBranchFocusActive` toggles", () => {
+    const props = thinkingProps({ isBranchFocusActive: false });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <ThinkingNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <ThinkingNodeView {...{ ...props, data: { ...props.data, isBranchFocusActive: true } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
   });
 });

--- a/web_ui/src/app/canvas/ThinkingNodeView.tsx
+++ b/web_ui/src/app/canvas/ThinkingNodeView.tsx
@@ -1,8 +1,9 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useState } from "react";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useState } from "react";
+import type { MenuPosition } from "./menuPosition";
 import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The thinking node (Qt-removal plan R3.13/R3.14) - graphlink_node_thinking.py's
@@ -42,11 +43,6 @@ export interface ThinkingNodeData extends Record<string, unknown> {
 
 export type ThinkingFlowNode = Node<ThinkingNodeData, "thinking">;
 
-interface MenuPosition {
-  x: number;
-  y: number;
-}
-
 function ThinkingNodeMenu({
   position,
   thinkingText,
@@ -75,7 +71,12 @@ function ThinkingNodeMenu({
         type="button"
         role="menuitem"
         onClick={() => {
-          navigator.clipboard.writeText(thinkingText);
+          // ADR-011 stage 11.1 (D11): a bare fire-and-forget clipboard write
+          // left this promise's rejection unhandled - same fix ImageNodeView's
+          // own Copy Image action already applies for its clipboard write.
+          navigator.clipboard.writeText(thinkingText).catch((error: unknown) => {
+            console.error("[thinking-node] Copy Content failed:", error);
+          });
           onClose();
         }}
       >
@@ -116,9 +117,8 @@ function ThinkingNodeMenu({
   );
 }
 
-export function ThinkingNodeView({ data, selected }: NodeProps<ThinkingFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const collapsed = zoom < LOD_ZOOM_THRESHOLD;
+function ThinkingNodeViewImpl({ data, selected }: NodeProps<ThinkingFlowNode>) {
+  const collapsed = useLodVisibility();
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
 
   return (
@@ -153,3 +153,28 @@ export function ThinkingNodeView({ data, selected }: NodeProps<ThinkingFlowNode>
     </div>
   );
 }
+
+/** ADR-011 stage 11.1: every prop this view actually reads, compared - it
+ * never destructures `id`, so it's intentionally absent (a changed `id`
+ * always means React Flow remounted this instance under a new key). Every
+ * `data` field ThinkingNodeData declares is a primitive/string or a stable
+ * callback reference - no array/object fields, so `===` is correct
+ * throughout. */
+function thinkingNodeDataAreEqual(prev: ThinkingNodeData, next: ThinkingNodeData): boolean {
+  return (
+    prev.thinkingText === next.thinkingText &&
+    prev.onDock === next.onDock &&
+    prev.onDelete === next.onDelete &&
+    prev.isBranchFocusActive === next.isBranchFocusActive &&
+    prev.onToggleBranchFocus === next.onToggleBranchFocus
+  );
+}
+
+function thinkingNodePropsAreEqual(
+  prev: Readonly<NodeProps<ThinkingFlowNode>>,
+  next: Readonly<NodeProps<ThinkingFlowNode>>,
+): boolean {
+  return prev.selected === next.selected && thinkingNodeDataAreEqual(prev.data, next.data);
+}
+
+export const ThinkingNodeView = memo(ThinkingNodeViewImpl, thinkingNodePropsAreEqual);

--- a/web_ui/src/app/canvas/WebResearchNodeView.test.tsx
+++ b/web_ui/src/app/canvas/WebResearchNodeView.test.tsx
@@ -2,7 +2,26 @@ import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ADR-011 stage 11.1: wraps the real useLodVisibility so every ACTUAL render
+// of this view is countable - a React.memo bailout skips the function body
+// (and every hook inside it) entirely, so this never fires on a bailed
+// re-render. See ImageNodeView.test.tsx for the same technique's full
+// rationale.
+const lodVisibilityCalls = { count: 0 };
+
+vi.mock("./useLodVisibility", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./useLodVisibility")>();
+  return {
+    ...original,
+    useLodVisibility: (...args: Parameters<typeof original.useLodVisibility>) => {
+      lodVisibilityCalls.count += 1;
+      return original.useLodVisibility(...args);
+    },
+  };
+});
+
 import {
   WebResearchNodeView,
   type WebResearchFlowNode,
@@ -366,5 +385,162 @@ describe("WebResearchNodeView", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
     await user.click(document.body);
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+});
+
+// ADR-011 stage 11.1: React.memo comparator correctness. `lodVisibilityCalls`
+// fires exactly once per ACTUAL render - never on a bailed-out one - so it's
+// the oracle for both directions (see ImageNodeView.test.tsx for the full
+// rationale of this technique). `researchResult` is the one nested-object
+// field on this data type, so it gets extra coverage beyond the usual
+// primitive-field pair.
+describe("WebResearchNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
+  beforeEach(() => {
+    lodVisibilityCalls.count = 0;
+  });
+
+  function webResearchProps(overrides: Partial<WebResearchFlowNode["data"]> = {}) {
+    const data = baseData(overrides);
+    return { id: "n0", selected: false, data } as unknown as NodeProps<WebResearchFlowNode>;
+  }
+
+  it("skips re-rendering when a fresh `data` object carries identical field values", () => {
+    const props = webResearchProps();
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <WebResearchNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    const sameValuesNewObject = { ...props.data };
+    rerender(
+      <ReactFlowProvider>
+        <WebResearchNodeView {...{ ...props, data: sameValuesNewObject }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("re-renders when `researchStage` (a field the view reads) changes", () => {
+    const props = webResearchProps({ researchStage: "searching" });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <WebResearchNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <WebResearchNodeView {...{ ...props, data: { ...props.data, researchStage: "fetching" } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+  });
+
+  it("skips re-rendering when `researchActiveSourceId` changes - this view never reads it", () => {
+    // Documented in this file's module doc: researchActiveSourceId is never
+    // looked up or rendered, so the comparator intentionally omits it -
+    // comparing it would only cause spurious re-renders, never fix a missed
+    // one.
+    const props = webResearchProps({ researchActiveSourceId: "src-a" });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <WebResearchNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    rerender(
+      <ReactFlowProvider>
+        <WebResearchNodeView {...{ ...props, data: { ...props.data, researchActiveSourceId: "src-b" } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("skips re-rendering when `researchResult` is a fresh object with identical field values (including sources)", () => {
+    const result = makeResult({
+      answerMarkdown: "The answer.",
+      sources: [
+        {
+          sourceId: "src-1",
+          title: "Example",
+          url: "https://example.com",
+          canonicalUrl: "https://example.com",
+          snippet: "",
+          rank: 1,
+          provider: "search",
+          finalUrl: "https://example.com",
+          status: "accepted",
+          errorCode: "",
+          errorMessage: "",
+          truncated: false,
+          contentHash: "abc",
+          citationCount: 1,
+        },
+      ],
+    });
+    const props = webResearchProps({ researchStage: "completed", researchResult: result });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <WebResearchNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    // A brand-new researchResult object AND a brand-new sources array, but
+    // every field value is identical - a plain `===` on either would wrongly
+    // re-render here.
+    const sameValuesNewResult = { ...result, sources: result.sources.map((s) => ({ ...s })) };
+    rerender(
+      <ReactFlowProvider>
+        <WebResearchNodeView {...{ ...props, data: { ...props.data, researchResult: sameValuesNewResult } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+  });
+
+  it("re-renders when a source's status inside `researchResult.sources` actually changes", () => {
+    const result = makeResult({
+      sources: [
+        {
+          sourceId: "src-1",
+          title: "Example",
+          url: "https://example.com",
+          canonicalUrl: "https://example.com",
+          snippet: "",
+          rank: 1,
+          provider: "search",
+          finalUrl: "https://example.com",
+          status: "fetching",
+          errorCode: "",
+          errorMessage: "",
+          truncated: false,
+          contentHash: "",
+          citationCount: 0,
+        },
+      ],
+    });
+    const props = webResearchProps({ researchStage: "completed", researchResult: result });
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <WebResearchNodeView {...props} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(1);
+
+    const updatedResult: WebResearchResultRow = {
+      ...result,
+      sources: [{ ...result.sources[0], status: "accepted" }],
+    };
+    rerender(
+      <ReactFlowProvider>
+        <WebResearchNodeView {...{ ...props, data: { ...props.data, researchResult: updatedResult } }} />
+      </ReactFlowProvider>,
+    );
+    expect(lodVisibilityCalls.count).toBe(2);
+    expect(screen.getByText("accepted")).toBeInTheDocument();
   });
 });

--- a/web_ui/src/app/canvas/WebResearchNodeView.tsx
+++ b/web_ui/src/app/canvas/WebResearchNodeView.tsx
@@ -1,8 +1,9 @@
-import { Handle, Position, useStore, type Node, type NodeProps } from "@xyflow/react";
-import { useState } from "react";
-import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { memo, useState } from "react";
+import type { MenuPosition } from "./menuPosition";
 import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
+import { useLodVisibility } from "./useLodVisibility";
 
 /**
  * The web-research node (Qt-removal plan R5.1) - the Web Research plugin's
@@ -88,11 +89,6 @@ export interface WebResearchNodeData extends Record<string, unknown> {
 
 export type WebResearchFlowNode = Node<WebResearchNodeData, "web_research">;
 
-interface MenuPosition {
-  x: number;
-  y: number;
-}
-
 /** Same outside-click/Escape dismiss pattern every sibling node menu uses
  * (ChatNodeMenu/ThinkingNodeMenu/DocumentNodeMenu/ConversationNodeMenu). */
 // -- card-level menu -------------------------------------------------------
@@ -176,9 +172,8 @@ function WebResearchSourceChip({ source }: { source: WebResearchSourceRow }) {
 
 // -- view ----------------------------------------------------------------
 
-export function WebResearchNodeView({ data, selected }: NodeProps<WebResearchFlowNode>) {
-  const zoom = useStore((s) => s.transform[2]);
-  const lodCollapsed = zoom < LOD_ZOOM_THRESHOLD;
+function WebResearchNodeViewImpl({ data, selected }: NodeProps<WebResearchFlowNode>) {
+  const lodCollapsed = useLodVisibility();
   const collapsed = data.isCollapsed || lodCollapsed;
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   // Initialized once from persisted content and never re-synced on a later
@@ -342,3 +337,87 @@ export function WebResearchNodeView({ data, selected }: NodeProps<WebResearchFlo
     </div>
   );
 }
+
+/** ADR-011 stage 11.1: every prop this view actually reads, compared. Most
+ * `data` fields are primitives (`===` is correct); `researchResult` is the
+ * one nested object field, so it gets a shape-aware compare below instead of
+ * `===` (toFlowNodes may mint a fresh object each snapshot even when its
+ * content is unchanged - a plain reference compare there would be "too
+ * tight" and defeat memoization for every research node with a result).
+ * `researchActiveSourceId` is intentionally OMITTED - see this file's module
+ * doc: this view never reads that field at all (only the progress-line
+ * math over researchCompleted/researchTotal), so comparing it would only
+ * cause spurious re-renders, never fix a missed one. */
+function stringArraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/** Only the fields WebResearchSourceChip actually renders (status, plus the
+ * title/finalUrl/url/sourceId fallback chain) are compared - the rest of
+ * WebResearchSourceRow (snippet, rank, provider, errorCode, truncated, ...)
+ * never reaches the DOM from this file. */
+function researchSourcesEqual(
+  a: readonly WebResearchSourceRow[],
+  b: readonly WebResearchSourceRow[],
+): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (
+      x.sourceId !== y.sourceId ||
+      x.status !== y.status ||
+      x.title !== y.title ||
+      x.finalUrl !== y.finalUrl ||
+      x.url !== y.url
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function researchResultsEqual(
+  a: WebResearchResultRow | null,
+  b: WebResearchResultRow | null,
+): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  return (
+    a.answerMarkdown === b.answerMarkdown &&
+    stringArraysEqual(a.warnings, b.warnings) &&
+    researchSourcesEqual(a.sources, b.sources)
+  );
+}
+
+function webResearchNodeDataAreEqual(prev: WebResearchNodeData, next: WebResearchNodeData): boolean {
+  return (
+    prev.query === next.query &&
+    prev.isCollapsed === next.isCollapsed &&
+    prev.pendingRequestId === next.pendingRequestId &&
+    prev.researchStage === next.researchStage &&
+    prev.researchCompleted === next.researchCompleted &&
+    prev.researchTotal === next.researchTotal &&
+    prev.researchError === next.researchError &&
+    researchResultsEqual(prev.researchResult, next.researchResult) &&
+    prev.onToggleCollapse === next.onToggleCollapse &&
+    prev.onDelete === next.onDelete &&
+    prev.onRun === next.onRun &&
+    prev.onCancel === next.onCancel
+  );
+}
+
+function webResearchNodePropsAreEqual(
+  prev: Readonly<NodeProps<WebResearchFlowNode>>,
+  next: Readonly<NodeProps<WebResearchFlowNode>>,
+): boolean {
+  return prev.selected === next.selected && webResearchNodeDataAreEqual(prev.data, next.data);
+}
+
+export const WebResearchNodeView = memo(WebResearchNodeViewImpl, webResearchNodePropsAreEqual);

--- a/web_ui/src/app/canvas/exportCanvasPng.test.ts
+++ b/web_ui/src/app/canvas/exportCanvasPng.test.ts
@@ -226,4 +226,67 @@ describe("exportCanvasAsPng", () => {
     // The user must not be left stranded at the export zoom.
     expect(rf.setViewportCalls[rf.setViewportCalls.length - 1]).toEqual(USER_VIEWPORT);
   });
+
+  // -- ADR-011 stage 11.2: virtualization suspended for the capture --
+
+  describe("setExportInProgress (ADR-011 stage 11.2)", () => {
+    it("is set true before rasterizing and false again once the capture completes", async () => {
+      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+      const calls: boolean[] = [];
+      const setExportInProgress = (value: boolean) => calls.push(value);
+
+      await exportCanvasAsPng(fakeRf([fakeNode("n1", 0, 0)]), "--gl-surface-window", setExportInProgress);
+
+      expect(calls).toEqual([true, false]);
+    });
+
+    it("is already true by the time toPng actually rasterizes", async () => {
+      // Audit finding (ADR-011 stage 11.2): the export computes a viewport
+      // that fits every node into a fixed 1920x1080 frame, which the LIVE
+      // on-screen canvas container can be smaller than - a node that fits
+      // the export frame can still fall outside the live container's real
+      // bounds under onlyRenderVisibleElements and never mount for capture.
+      // Suspending virtualization only works if it is ALREADY suspended
+      // by the time toPng actually reads the DOM, not merely by the time
+      // this function returns.
+      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+      const rf = fakeRf([fakeNode("n1", 0, 0)]);
+      let currentFlag = false;
+      let flagAtCaptureTime: boolean | null = null;
+      toPngMock.mockImplementation(() => {
+        flagAtCaptureTime = currentFlag;
+        return Promise.resolve("data:image/png;base64,fake");
+      });
+
+      await exportCanvasAsPng(rf, "--gl-surface-window", (value) => {
+        currentFlag = value;
+      });
+
+      expect(flagAtCaptureTime).toBe(true);
+      // ...and restored to false once the whole export settles.
+      expect(currentFlag).toBe(false);
+    });
+
+    it("still resolves to false even when rasterization fails", async () => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+      toPngMock.mockRejectedValue(new Error("Failed to embed image"));
+      const calls: boolean[] = [];
+
+      await exportCanvasAsPng(fakeRf([fakeNode("n1", 0, 0)]), "--gl-surface-window", (value) => calls.push(value));
+
+      expect(calls).toEqual([true, false]);
+    });
+
+    it("is never called at all when there is nothing to export (no nodes)", async () => {
+      const calls: boolean[] = [];
+      await exportCanvasAsPng(fakeRf([]), "--gl-surface-window", (value) => calls.push(value));
+      expect(calls).toEqual([]);
+    });
+
+    it("defaults to a no-op when the caller omits it - every pre-11.2 call site keeps working unchanged", async () => {
+      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+      await expect(exportCanvasAsPng(fakeRf([fakeNode("n1", 0, 0)]), "--gl-surface-window")).resolves.toBeUndefined();
+    });
+  });
 });

--- a/web_ui/src/app/canvas/exportCanvasPng.ts
+++ b/web_ui/src/app/canvas/exportCanvasPng.ts
@@ -120,13 +120,31 @@ function nextPaint(): Promise<void> {
 export async function exportCanvasAsPng(
   rf: Pick<ReactFlowInstance, "getNodes" | "getViewport" | "setViewport">,
   backgroundColorVar: string,
+  // ADR-011 stage 11.2 (virtualization audit): defaults to a no-op so every
+  // existing caller/test that predates onlyRenderVisibleElements keeps
+  // working unchanged - SceneCanvas.tsx's real <ReactFlow> is the only
+  // consumer that needs this to do anything (it reads the flag back via
+  // SceneStore.getExportInProgress). See that field's own doc in
+  // sceneStore.ts/SceneCanvas.tsx for the full reasoning: the export
+  // computes a viewport that fits every node into a FIXED 1920x1080 frame,
+  // which the LIVE on-screen canvas container can be smaller than -
+  // onlyRenderVisibleElements filters against the container's REAL client
+  // size, so a node that fits inside the export frame can still fall
+  // outside the live container's actual bounds and never mount, silently
+  // missing from the captured DOM regardless of the viewport math below
+  // being correct. Suspending virtualization for the capture's duration is
+  // the only fix that doesn't depend on the live container happening to
+  // already be at least 1920x1080.
+  setExportInProgress: (value: boolean) => void = () => {},
 ): Promise<void> {
   const nodes = rf.getNodes();
   if (nodes.length === 0) {
     // An empty canvas has nothing worth exporting - silent no-op rather
     // than producing a blank image, mirroring this codebase's own
     // established "nothing to do yet" guards (autosave's empty-canvas
-    // skip, saveChat's own "nothing was added" guard).
+    // skip, saveChat's own "nothing was added" guard). Deliberately before
+    // setExportInProgress(true) below - nothing to suspend virtualization
+    // for either.
     return;
   }
 
@@ -139,6 +157,7 @@ export async function exportCanvasAsPng(
   const viewport = getViewportForBounds(bounds, IMAGE_WIDTH, IMAGE_HEIGHT, MIN_ZOOM, MAX_ZOOM, PADDING);
 
   const userViewport = rf.getViewport();
+  setExportInProgress(true);
   try {
     await rf.setViewport(viewport);
     await nextPaint();
@@ -167,5 +186,6 @@ export async function exportCanvasAsPng(
     console.error("[export-png] Export failed:", error);
   } finally {
     await rf.setViewport(userViewport);
+    setExportInProgress(false);
   }
 }

--- a/web_ui/src/app/canvas/menuPosition.ts
+++ b/web_ui/src/app/canvas/menuPosition.ts
@@ -1,0 +1,12 @@
+/** ADR-011 stage 11.6 dedup: this exact shape - `{ x: number; y: number }` -
+ * was independently re-declared as a local `interface MenuPosition` in 11
+ * *NodeView.tsx files (ArtifactNodeView, ChatNodeView, CodeNodeView,
+ * CodeSandboxNodeView, ConversationNodeView, DocumentNodeView,
+ * GitlinkNodeView, ImageNodeView, PyCoderNodeView, ThinkingNodeView,
+ * WebResearchNodeView), byte-identical in every one. Single shared home for
+ * the "where the right-click/kebab card menu should render" coordinate pair
+ * those files store in local state (e.g. `useState<MenuPosition | null>`). */
+export interface MenuPosition {
+  x: number;
+  y: number;
+}

--- a/web_ui/src/app/canvas/renderCountGate.test.tsx
+++ b/web_ui/src/app/canvas/renderCountGate.test.tsx
@@ -2,33 +2,69 @@
  * ADR-019 stage 19.2: the re-renders-per-update CI counting gate.
  *
  * The budget (ADR-019 §2): a single-node update re-renders exactly 1 node
- * view. Today's reality (audit finding P-class, confirmed by this gate's own
- * baseline measurement): every node view re-renders on every update - there
- * is no React.memo anywhere in the SPA, and a scene snapshot/patch rebuilds
- * every flow-node object so React Flow's own internal memoization never gets
- * reference-equal props. Fixing that is ADR-011's memoization stage; this
- * gate exists so the number can only ever move DOWN in the meantime:
+ * view. ADR-011 stage 11.1/11.6 landed the fix - React.memo on every
+ * *NodeView.tsx with a field-by-field comparator (chatNodePropsAreEqual and
+ * its siblings), plus a stable per-node-id callback dispatcher and a
+ * WeakMap-cached flow-node object in toFlowNodes (SceneCanvas.tsx) so an
+ * unchanged node's emitted props are reference-/value-stable across scene
+ * snapshots. RENDERS_PER_UPDATE_CEILING is tightened to 1 below per that
+ * plan (was pinned at NODE_COUNT pre-ADR-011, when there was no React.memo
+ * anywhere in the SPA and every flow-node object was rebuilt from scratch on
+ * every call).
+ *
+ * This gate's own single-node update is a DRAG (only `x` changes - see
+ * makeScene's `movedNodeX` param) rather than a content edit, which is why
+ * the measured value below is 0, not 1: position is passed to a custom node
+ * component as `positionAbsoluteX`/`positionAbsoluteY` (see @xyflow/react's
+ * NodeWrapper), entirely separate from `data`, and no *NodeView.tsx reads
+ * either - the dragged node's on-screen transform is applied by React Flow's
+ * OWN wrapper div, never by the memoized content component - so a pure
+ * position change legitimately needs zero content re-renders, which is
+ * strictly inside (better than) the ADR's "exactly 1" budget for a content
+ * change. Verified empirically: swapping the comparator below for a bare
+ * `memo()` (default shallow prop compare, no custom comparator) makes this
+ * count jump to NODE_COUNT (10) - the WeakMap flow-node cache in
+ * toFlowNodes is a per-call cache keyed by SceneNodeRow reference, and this
+ * test's own chatRow() fixture mints a brand-new row object for every node
+ * on every makeScene() call (even unchanged ones), so EVERY node's flow-node
+ * object misses that cache and is rebuilt (with a fresh `data` wrapper
+ * object, albeit with the SAME stable callback references from the
+ * id-keyed dispatcher cache) on every call - it is chatNodePropsAreEqual's
+ * own field-by-field comparison, not `data` reference equality, doing the
+ * work of collapsing that back down to 0 here. A regression that removes
+ * React.memo, drops the comparator, or reintroduces unstable per-call
+ * closures for the callback props would push this back up to NODE_COUNT,
+ * so the gate is still exercising the real mechanism ADR-011 landed, not a
+ * vacuous scenario.
  *
  *   1. commits per single-node update are pinned at today's measured 4 (one
  *      from SceneCanvas's own setState, three from React Flow's internal
  *      store-sync/measure cascade) - a 5th commit means someone added another
- *      cascading state update on top;
- *   2. node-view renders for that update are pinned at today's baseline
- *      (every chat node, = NODE_COUNT) - growing past it means views render
- *      more than once per update.
- *
- * When ADR-011's memoization lands, tighten RENDERS_PER_UPDATE_CEILING to 1
- * (and revisit the commit cascade) - per ADR-019 §4 that is a deliberate
- * amendment tied to that stage, and this comment is the reminder.
+ *      cascading state update on top. Not revised by ADR-011: a drag still
+ *      goes through the same setState + React Flow internal store-sync/
+ *      measure cascade regardless of whether any node view's CONTENT
+ *      re-renders, so this count is orthogonal to the memoization fix.
+ *   2. node-view renders for that update are pinned at today's measured 0
+ *      (see above) - a regression that pushes this back up (even by 1) means
+ *      either an unstable prop reference reappeared somewhere in toFlowNodes/
+ *      the dispatcher cache, or a comparator got too loose/removed.
  *
  * Counting mechanism: ChatNodeView is replaced (vi.mock) with a stub that
  * increments a counter per render - counting actual component renders, not
  * Profiler timings, so the assertion is a stable integer, never wall-clock.
- * The scene updates arrive through the REAL SceneStore listener path (the
- * same transport-level subscribe callback production uses), not by poking
- * React state directly - so the gate covers the store->React wiring too.
+ * The stub is wrapped in the SAME memo + SAME real comparator
+ * (chatNodePropsAreEqual, exported from ChatNodeView.tsx for this purpose)
+ * as production, so this gate gets to skip/no-skip exactly like production
+ * would, just against a cheap stub body instead of the full markdown-
+ * rendering tree - mocking away the memo wrapper entirely (the pre-ADR-011
+ * posture, when there was nothing to preserve) would make this gate measure
+ * "does React Flow always re-invoke the node component" (always true),
+ * never actually exercising ADR-011's fix. The scene updates arrive through
+ * the REAL SceneStore listener path (the same transport-level subscribe
+ * callback production uses), not by poking React state directly - so the
+ * gate covers the store->React wiring too.
  */
-import { Profiler, type ReactNode } from "react";
+import { memo, Profiler, type ReactNode } from "react";
 import { ReactFlowProvider } from "@xyflow/react";
 import { act, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -39,10 +75,23 @@ vi.mock("./ChatNodeView", async (importOriginal) => {
   const original = await importOriginal<typeof import("./ChatNodeView")>();
   return {
     ...original,
-    ChatNodeView: () => {
+    // ADR-011 stage 11.1/11.6: the real ChatNodeView is now `memo(...,
+    // chatNodePropsAreEqual)` (see ChatNodeView.tsx). Stubbing the export
+    // with a bare, unmemoized function - as this gate did pre-ADR-011, back
+    // when nothing in the SPA was memoized - would silently strip that
+    // wrapper back off, making this gate measure "does React Flow always
+    // re-invoke the node component" (always true) rather than "does
+    // SceneCanvas emit stable-enough props for the real memo to skip a
+    // render", which is the entire thing ADR-011 stage 11.1 changed. Wrap
+    // the counting stub in the SAME memo + the SAME real comparator
+    // (exported from ChatNodeView.tsx specifically so gates like this one
+    // can reuse it) so the gate is exercising the real skip/no-skip
+    // decision, just against a cheap stub body instead of the full
+    // markdown-rendering tree.
+    ChatNodeView: memo(() => {
       chatNodeRenders.count += 1;
       return <div data-testid="chat-node-stub" />;
-    },
+    }, original.chatNodePropsAreEqual),
   };
 });
 
@@ -52,9 +101,9 @@ import type { WsTransport } from "../../lib/ws/transport";
 import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
 
 const NODE_COUNT = 10;
-// Today's baseline: every node re-renders on a single-node update (no memo
-// anywhere - see module doc). ADR-011 tightens this to 1.
-const RENDERS_PER_UPDATE_CEILING = NODE_COUNT;
+// ADR-011 stage 11.1/11.6 memoization landed (React.memo + stable per-node
+// dispatchers on the toFlowNodes side) - tightened from NODE_COUNT to 1.
+const RENDERS_PER_UPDATE_CEILING = 1;
 // Today's measured cascade (see module doc): 1 SceneCanvas commit + 3 React
 // Flow internal store-sync/measure commits. The gate holds this from GROWING.
 const COMMITS_PER_UPDATE_CEILING = 4;
@@ -100,9 +149,14 @@ function chatRow(id: string, x: number): SceneNodeRow {
   };
 }
 
-function makeScene(movedNodeX: number | null = null): SceneState {
+function makeScene(movedNodeX: number | null = null, editedNodeContent: string | null = null): SceneState {
   const nodes = Array.from({ length: NODE_COUNT }, (_, i) => chatRow(`n${i}`, i * 100));
   if (movedNodeX !== null) nodes[0] = { ...nodes[0], x: movedNodeX };
+  // `content` (unlike `x` above) IS part of `data` and IS one of the fields
+  // chatNodePropsAreEqual compares - this is the knob the "editing one node
+  // re-renders one node" test below uses, since a position-only update can
+  // never exercise that comparator's real job.
+  if (editedNodeContent !== null) nodes[0] = { ...nodes[0], content: editedNodeContent };
   return { ...initialSceneState, nodes, edges: [] };
 }
 
@@ -179,9 +233,56 @@ describe("re-renders per single-node update (ADR-019 stage 19.2)", () => {
 
     expect(commits.count).toBeLessThanOrEqual(COMMITS_PER_UPDATE_CEILING);
     expect(chatNodeRenders.count).toBeLessThanOrEqual(RENDERS_PER_UPDATE_CEILING);
-    // Baseline honesty: today it IS the ceiling (all nodes re-render). If
-    // this starts failing LOW, memoization landed - tighten the ceiling to 1
-    // per ADR-011 instead of deleting the assertion.
-    expect(chatNodeRenders.count).toBe(NODE_COUNT);
+    // Baseline honesty: with ADR-011 memoization landed, ZERO node views
+    // re-render for this update - see the module doc's "why 0, not 1"
+    // section above. This update only moves n0's `x`; position is not part
+    // of `data` and no *NodeView reads positionAbsoluteX/Y, so even the
+    // moved node's own content component correctly has nothing to
+    // re-render (React Flow's wrapper div applies the CSS transform on its
+    // own, independent of the memoized child). If this starts failing HIGH,
+    // memoization regressed; if it starts failing because the number moved
+    // to exactly 1 (a real content field changing on the moved node), that
+    // would mean this fixture itself changed to mutate content, not
+    // position - update this pin to match rather than treating it as a
+    // regression.
+    expect(chatNodeRenders.count).toBe(0);
+  });
+
+  // Review-fix (ADR-019 stage 19.2 self-audit): the drag-only test above
+  // measures 0 node re-renders because position is deliberately outside
+  // `data` - it never sends a change to any field ChatNodeView actually
+  // reads, so it cannot by itself prove the ADR's own literal exit
+  // criterion, "editing one node re-renders one node". This test sends a
+  // genuine content-changing single-node scene update through the SAME real
+  // SceneStore -> SceneCanvas -> toFlowNodes -> ChatNodeView pipeline and
+  // asserts exactly 1 of the NODE_COUNT mounted node views re-renders - the
+  // missing end-to-end half of that claim (previously only checked in
+  // isolated pieces: chatNodePropsAreEqual's own pure-function unit tests,
+  // and a real-DOM render check keyed off `selected`, never `content`,
+  // never through the store - see ChatNodeView.test.tsx).
+  it("a single-node CONTENT edit (the ADR's own literal exit criterion) re-renders exactly 1 node view end-to-end through the real store pipeline", () => {
+    const { store, stateListeners } = makeWiredStore();
+    mountWithCommitCounter(
+      <ReactFlowProvider>
+        <SceneCanvas store={store} onOpenDocumentView={() => {}} />
+      </ReactFlowProvider>,
+    );
+    act(() => {
+      stateListeners.get("scene")!(makeScene() as unknown as Record<string, unknown>);
+    });
+
+    chatNodeRenders.count = 0;
+    act(() => {
+      stateListeners.get("scene")!(
+        makeScene(null, "edited content") as unknown as Record<string, unknown>,
+      );
+    });
+
+    // Unlike the position-only drag above (0 re-renders is correct there -
+    // position lives outside `data`), a genuine content edit IS a field
+    // chatNodePropsAreEqual compares, so exactly the one edited node's view
+    // re-renders and the other NODE_COUNT - 1 unchanged nodes do not.
+    expect(chatNodeRenders.count).toBe(1);
+    expect(chatNodeRenders.count).toBeLessThanOrEqual(RENDERS_PER_UPDATE_CEILING);
   });
 });

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -163,6 +163,16 @@ export class SceneStore {
   // the same reason selectedNodeId/replyTargetNodeId already live on this
   // store rather than in whichever single component happens to set them.
   private focusAcceptedPaths = false;
+  // ADR-011 stage 11.2: true for exactly the duration of one
+  // exportCanvasAsPng capture (exportCanvasPng.ts) - local UI state only,
+  // same posture as focusAcceptedPaths above (its trigger, the app bar's
+  // Export PNG button/command-palette entry, and its consumer,
+  // SceneCanvas.tsx's <ReactFlow onlyRenderVisibleElements>, are two
+  // separate components). Suspends virtualization for the capture's
+  // duration - see that field's own comment in SceneCanvas.tsx for why a
+  // full-canvas export needs every node mounted regardless of the live
+  // on-screen container's actual size.
+  private exportInProgress = false;
   // ADR-003 stage 3.4 review-fix: true while a scene resync request is
   // outstanding, so a burst of refused patches asks once rather than once
   // per patch - see requestSceneResync for the measured failure this
@@ -511,6 +521,7 @@ export class SceneStore {
   getReplyTargetNodeId = (): string | null => this.replyTargetNodeId;
   getSynthesizeTargetNodeIds = (): string[] | null => this.synthesizeTargetNodeIds;
   getFocusAcceptedPaths = (): boolean => this.focusAcceptedPaths;
+  getExportInProgress = (): boolean => this.exportInProgress;
 
   // R5.1: no-op-if-unchanged, same discipline as every other setter here that
   // guards a redundant assignment before paying for an emit() fan-out.
@@ -536,6 +547,12 @@ export class SceneStore {
   setFocusAcceptedPaths(value: boolean): void {
     if (value === this.focusAcceptedPaths) return;
     this.focusAcceptedPaths = value;
+    this.emit();
+  }
+
+  setExportInProgress(value: boolean): void {
+    if (value === this.exportInProgress) return;
+    this.exportInProgress = value;
     this.emit();
   }
 

--- a/web_ui/src/app/canvas/useLodVisibility.ts
+++ b/web_ui/src/app/canvas/useLodVisibility.ts
@@ -1,0 +1,18 @@
+import { useStore } from "@xyflow/react";
+import { LOD_ZOOM_THRESHOLD } from "./canvasConstants";
+
+/** ADR-011 stage 11.6 dedup: the "collapse node body below this zoom" check
+ * (level-of-detail, the R1 seed of the Qt canvas's LOD thresholds) was
+ * independently re-implemented at every one of the ~14 call sites - each its
+ * own `useStore((s) => s.transform[2])` read plus its own
+ * `zoom < LOD_ZOOM_THRESHOLD` comparison. This hook is a pure extraction of
+ * that exact pair with zero behavior change: same store selector, same
+ * threshold, same `<` comparison, returning the plain boolean every call site
+ * already computed for itself (some name it `collapsed`, some `lodCollapsed`
+ * and then OR it with a node-local collapse flag - either is unaffected,
+ * since this only replaces the two lines that produced the boolean, not what
+ * callers do with it afterward). */
+export function useLodVisibility(): boolean {
+  const zoom = useStore((s) => s.transform[2]);
+  return zoom < LOD_ZOOM_THRESHOLD;
+}

--- a/web_ui/src/app/chrome/AppBar.tsx
+++ b/web_ui/src/app/chrome/AppBar.tsx
@@ -91,7 +91,12 @@ export function AppBar({ store }: { store: SceneStore }) {
     const viewport = getViewport();
     setViewport({ ...viewport, zoom: 1 }, { duration: 200 });
   };
-  const exportPng = () => void exportCanvasAsPng({ getNodes, getViewport, setViewport }, "--gl-surface-window");
+  const exportPng = () =>
+    void exportCanvasAsPng(
+      { getNodes, getViewport, setViewport },
+      "--gl-surface-window",
+      (value) => store.setExportInProgress(value),
+    );
 
   // Overlay-opening actions (Pins/View/Plugins/About/Help) close this popover
   // for free via OverlayProvider's own single-open policy - opening any

--- a/web_ui/src/app/chrome/commands.test.ts
+++ b/web_ui/src/app/chrome/commands.test.ts
@@ -262,7 +262,12 @@ describe("buildCommands", () => {
     commands.find((c) => c.id === "export-canvas-png")!.run();
 
     expect(exportCanvasAsPngMock).toHaveBeenCalledOnce();
-    expect(exportCanvasAsPngMock).toHaveBeenCalledWith(rf, "--gl-surface-window");
+    // ADR-011 stage 11.2: a 3rd arg now threads store.setExportInProgress
+    // through so exportCanvasAsPng can suspend onlyRenderVisibleElements for
+    // the capture's duration - see that module's own doc. Asserted as
+    // "any function" rather than a specific reference since it's a fresh
+    // arrow closure over `store` on every run(), not a stable callback.
+    expect(exportCanvasAsPngMock).toHaveBeenCalledWith(rf, "--gl-surface-window", expect.any(Function));
   });
 });
 

--- a/web_ui/src/app/chrome/commands.ts
+++ b/web_ui/src/app/chrome/commands.ts
@@ -97,7 +97,7 @@ export function buildCommands(
       id: "export-canvas-png",
       name: "Export Canvas as PNG",
       aliases: ["export png", "download image", "save canvas image"],
-      run: () => void exportCanvasAsPng(rf, "--gl-surface-window"),
+      run: () => void exportCanvasAsPng(rf, "--gl-surface-window", (value) => store.setExportInProgress(value)),
       enabled: hasNodes,
     },
     {

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -1643,6 +1643,19 @@ body,
   overflow-y: auto;
 }
 
+/* ADR-011 stage 11.6: the Suspense fallback shown for the brief window
+   between opening a lazy chrome dialog (Settings/Chat Library/Help) for the
+   first time this session and its code-split chunk finishing its fetch.
+   Deliberately plain - a real first-open flash is short enough that
+   anything fancier would just be motion for its own sake. */
+.overlay-dialog-loading {
+  min-width: 200px;
+  padding: 20px 24px;
+  color: var(--gl-surface-text-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
 /* -- View popover -------------------------------------------------------- */
 
 .view-popover {

--- a/web_ui/src/lib/ws/transport.test.ts
+++ b/web_ui/src/lib/ws/transport.test.ts
@@ -595,6 +595,82 @@ describe("WsTransport", () => {
     consoleError.mockRestore();
   });
 
+  // ADR-011 review-fix (HIGH): ADR-011's onlyRenderVisibleElements
+  // virtualization genuinely UNMOUNTS a live-streaming node's component
+  // (ChatNodeView/ConversationNodeView/CodeSandboxNodeView) when panned
+  // off-screen, then mounts a BRAND NEW instance when panned back - and this
+  // class has no server-side subscribe to replay from (see subscribeStream's
+  // own doc: "the server broadcasts stream frames to every connection
+  // unconditionally"). Without a client-side buffer, every delta broadcast
+  // during the unmounted window used to be lost forever, and the new
+  // instance's freshly-initialized local state had nothing to fall back on.
+  it("subscribeStream: replays everything accumulated so far to a listener that (re)subscribes after an earlier listener unsubscribed mid-stream (ADR-011 virtualization unmount/remount)", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+
+    const firstMount: unknown[] = [];
+    const unsub = t.subscribeStream("req-a", (delta, done, reset, seq) => firstMount.push({ delta, done, reset, seq }));
+    socket.receive({ kind: "stream", topic: "chat", requestId: "req-a", seq: 0, delta: "Hel", done: false, reset: false });
+    socket.receive({ kind: "stream", topic: "chat", requestId: "req-a", seq: 1, delta: "lo ", done: false, reset: false });
+    // Simulates the node scrolling off-screen: the component unmounts and
+    // its effect cleanup unsubscribes.
+    unsub();
+
+    // A delta broadcast while nothing is subscribed - the exact "off-screen"
+    // window this fix exists for.
+    socket.receive({ kind: "stream", topic: "chat", requestId: "req-a", seq: 2, delta: "there", done: false, reset: false });
+
+    // Simulates the node scrolling back into view: a BRAND NEW component
+    // instance subscribes fresh.
+    const secondMount: unknown[] = [];
+    t.subscribeStream("req-a", (delta, done, reset, seq) => secondMount.push({ delta, done, reset, seq }));
+
+    // It must catch up on everything broadcast so far, as a single synthetic
+    // reset frame - not just deltas that arrive from this point forward -
+    // and the first (now-unsubscribed) mount must not receive it.
+    expect(secondMount).toEqual([{ delta: "Hello there", done: false, reset: true, seq: 2 }]);
+    expect(firstMount).toEqual([
+      { delta: "Hel", done: false, reset: false, seq: 0 },
+      { delta: "lo ", done: false, reset: false, seq: 1 },
+    ]);
+
+    // Live deltas continue to arrive normally afterward.
+    socket.receive({ kind: "stream", topic: "chat", requestId: "req-a", seq: 3, delta: "!", done: true, reset: false });
+    expect(secondMount).toEqual([
+      { delta: "Hello there", done: false, reset: true, seq: 2 },
+      { delta: "!", done: true, reset: false, seq: 3 },
+    ]);
+  });
+
+  it("subscribeStream: a brand-new requestId nothing has streamed for yet gets no replay (unchanged first-subscribe behavior)", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const seen: unknown[] = [];
+    t.subscribeStream("req-fresh", (delta, done, reset, seq) => seen.push({ delta, done, reset, seq }));
+    expect(seen).toEqual([]);
+  });
+
+  it("subscribeStream: does not replay once the request has already completed (buffer is cleared on done)", () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const unsub = t.subscribeStream("req-a", () => {});
+    socket.receive({ kind: "stream", topic: "chat", requestId: "req-a", seq: 0, delta: "finished text", done: true, reset: false });
+    unsub();
+
+    // A later subscriber (e.g. an unrelated remount racing a stale
+    // requestId) must not see the completed run's text replayed - by this
+    // point the persisted `content` field is the real source of truth.
+    const seen: unknown[] = [];
+    t.subscribeStream("req-a", (delta, done, reset, seq) => seen.push({ delta, done, reset, seq }));
+    expect(seen).toEqual([]);
+  });
+
   it("notifies status listeners through the lifecycle", () => {
     const t = makeTransport();
     const statuses: string[] = [];

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -200,6 +200,28 @@ export class WsTransport {
   /** Keyed by requestId - stream deltas are addressed to a specific in-flight
    * request, not a topic. See handleMessage()'s "stream" branch. */
   private readonly streamListeners = new Map<string, Set<StreamListener>>();
+  /** ADR-011 review-fix: the full text accumulated so far for a still-in-
+   * flight request, keyed by requestId like streamListeners - but a
+   * deliberately SEPARATE map that does NOT get cleared when a requestId's
+   * listener set goes empty (streamListeners itself deletes its entry the
+   * moment that happens - see subscribeStream()'s unsubscribe closure).
+   * ADR-011's onlyRenderVisibleElements virtualization (SceneCanvas.tsx) can
+   * genuinely unmount a live-streaming node's component (ChatNodeView/
+   * ConversationNodeView/CodeSandboxNodeView) when it's panned off-screen,
+   * then mount a BRAND NEW instance when it's panned back - and this class
+   * has no server-side subscribe concept to replay from ("the server
+   * broadcasts stream frames to every connection unconditionally", see this
+   * method's own doc below), so without a client-side buffer every delta
+   * broadcast during the unmounted window is lost forever. Updated on every
+   * inbound stream frame regardless of whether anyone is currently
+   * subscribed (handleMessage's "stream" branch), and replayed to a
+   * newly-subscribing listener as a synthetic reset frame (subscribeStream
+   * below) - the same "deliver current state on subscribe" contract
+   * onStatus()/onVersionRejection() already establish elsewhere in this
+   * file. Cleared once the request completes (`done`): after that point the
+   * persisted `content` field is the source of truth for a (re)mounted
+   * component, so nothing is left to replay. */
+  private readonly streamBuffers = new Map<string, { text: string; seq: number }>();
   /** ADR-003 stage 3.4: keyed by topic, like stateListeners, but a separate
    * Map rather than a widened StateListener signature - mirroring how
    * streamListeners is already its own parallel registry. A topic can have
@@ -398,6 +420,18 @@ export class WsTransport {
       this.streamListeners.set(requestId, set);
     }
     set.add(listener);
+    // ADR-011 review-fix: replay whatever has accumulated so far as a
+    // synthetic reset frame - the exact case this exists for is a
+    // component that unmounted (virtualization scrolled it off-screen) and
+    // has just remounted while the SAME request is still streaming; without
+    // this, every delta broadcast during the unmounted window (see
+    // streamBuffers' own doc above) is silently lost. A brand-new
+    // subscriber for a request nothing has streamed for yet finds no
+    // buffered entry and gets no replay, identical to today's behavior.
+    const buffered = this.streamBuffers.get(requestId);
+    if (buffered && buffered.text) {
+      listener(buffered.text, false, true, buffered.seq);
+    }
     return () => {
       set.delete(listener);
       if (set.size === 0) this.streamListeners.delete(requestId);
@@ -778,15 +812,32 @@ export class WsTransport {
       return;
     }
     if (kind === "stream") {
-      // A stream frame with no matching requestId subscriber is silently
-      // dropped - unlike a truly unrecognized kind below, this is an
-      // expected, routine occurrence (e.g. a request already completed and
-      // unsubscribed a moment before a straggling frame arrives).
+      // A stream frame with no matching requestId subscriber has nothing to
+      // dispatch to right now - unlike a truly unrecognized kind below, this
+      // is an expected, routine occurrence (e.g. a request already completed
+      // and unsubscribed a moment before a straggling frame arrives, or a
+      // node currently scrolled out of the virtualized viewport - see
+      // streamBuffers' own doc). It is still buffered below so a listener
+      // that (re)subscribes later can catch up.
       const requestId = message.requestId as string;
+      const delta = message.delta as string;
+      const done = Boolean(message.done);
+      const reset = Boolean(message.reset);
+      const seq = message.seq as number;
+      if (done) {
+        // The request is finished - `content` (persisted server-side) is
+        // the source of truth for any component that mounts from here on,
+        // so nothing is left to replay.
+        this.streamBuffers.delete(requestId);
+      } else {
+        const existing = this.streamBuffers.get(requestId);
+        const text = reset || !existing ? delta : existing.text + delta;
+        this.streamBuffers.set(requestId, { text, seq });
+      }
       const listeners = this.streamListeners.get(requestId);
       if (listeners) {
         for (const listener of [...listeners]) {
-          listener(message.delta as string, Boolean(message.done), Boolean(message.reset), message.seq as number);
+          listener(delta, done, reset, seq);
         }
       }
       return;

--- a/web_ui/vite.config.ts
+++ b/web_ui/vite.config.ts
@@ -38,6 +38,35 @@ export default defineConfig({
   build: {
     outDir: resolve(__dirname, "dist/app"),
     emptyOutDir: true,
-    sourcemap: false,
+    // ADR-011 stage 11.6: "hidden" writes real .js.map files (so a
+    // maintainer can load one into a debugger / symbolicate a stack trace
+    // pulled from the logs) without emitting a `//# sourceMappingURL`
+    // comment in the shipped .js - the pywebview shell's own devtools never
+    // auto-fetch them, and nothing about this desktop app's distribution
+    // model treats the source as secret (the dist bundle already ships the
+    // equivalent of the source client-side, readable via view-source, same
+    // as any other unminified-by-choice web app). Plain `true` would be
+    // fine functionally too; "hidden" is strictly better here since it
+    // costs nothing and avoids advertising the map to anything that just
+    // happens to load the built HTML in a normal browser tab.
+    sourcemap: "hidden",
+    rollupOptions: {
+      output: {
+        // ADR-011 stage 11.6: NodeMarkdown.tsx (every chat-bearing node
+        // view's shared markdown renderer, itself eagerly rendered - not a
+        // React.lazy boundary, so nothing splits it out automatically) is
+        // the ONLY thing in the app that imports katex/rehype-katex or
+        // highlight.js/rehype-highlight. Both are large (katex's parser +
+        // fonts-adjacent JS, highlight.js's grammar table) and otherwise
+        // land in the single main chunk just because one eagerly-rendered
+        // node view uses markdown - manualChunks forces them into their own
+        // chunks instead, so the main chunk's floor isn't set by two
+        // dependencies most sessions may only use through node text.
+        manualChunks: {
+          katex: ["katex", "rehype-katex"],
+          "highlight.js": ["highlight.js", "rehype-highlight"],
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
## Problem

Rendering did not scale. There was zero `React.memo` anywhere in the SPA; `toFlowNodes` minted a fresh node object and ~20 fresh closures per chat node on every snapshot, so a single-node edit re-rendered and re-parsed markdown for every node on the canvas. `toFlowNodes` itself was O(N·E), scanning the full edge list per node. There was no viewport virtualization — all N nodes mounted and re-rendered regardless of what was on screen. Smart-guide dragging did per-frame `document.querySelector` + forced reflow, up to N times per frame. The initial JS chunk was 1.29 MB with no code splitting.

## Change

**11.1 — Memoize the node layer.** `SceneCanvas.tsx`'s `toFlowNodes`/`toFlowEdges` build node/edge index maps once per call instead of scanning `scene.edges` per node — O(N+E), not O(N·E). Callbacks are a stable per-node-id dispatcher that reads current values through a ref, so a long-lived function reference never serves stale data. The whole per-node flow-node object is cached in a `WeakMap` keyed by the node's own reference, which ADR-003's deltas already guarantee stays stable for an unchanged node. All 15 `*NodeView.tsx` components are wrapped in `React.memo` with field-by-field comparators.

**11.2/11.3 — Virtualize the canvas.** `onlyRenderVisibleElements` is on, disabled only during PNG export (which needs every node mounted to rasterize). Smart-guide candidate sizes are read once per drag gesture into a cache instead of once per frame. Edge-hover recomputation is gated on `fadeConnectionsEnabled`.

**A real bug caught before ship.** Adversarial review found that virtualization can genuinely unmount a streaming node's component when panned off-screen, then mount a fresh instance when panned back. `WsTransport` has no server-side subscribe to replay from, so every delta broadcast during the unmounted window was silently lost — a remounted node would show stale or truncated content with no error. Fixed at the transport layer: `WsTransport` now buffers each in-flight request's accumulated text regardless of whether a listener is subscribed, and replays it to a newly-subscribing listener as a synthetic reset frame — the same pattern `onStatus()`/`onVersionRejection()` already use. One fix covers chat, conversation, and code-sandbox streaming.

**11.4 — Progressive streaming.** Chat streaming deltas batch into a ref and flush to render state on a `requestAnimationFrame` cadence instead of re-parsing markdown on every delta, with an immediate flush on stream completion so nothing is stranded.

**11.5 — Already done.** No new work needed; `BridgeErrorState` wiring and reconnect UX shipped with ADR-003 stages 3.5/3.6.

**11.6 — Bundle and hygiene.** `SettingsDialog`/`ChatLibraryDialog`/`HelpDialog` are `React.lazy`-loaded, deferred until first opened. KaTeX and highlight.js split into their own chunks. Sourcemaps on (hidden). Main chunk: 1,287,924 → 776,599 bytes, a ~40% reduction; the bundle-size ratchet is re-anchored to the new measurement. The 11x duplicated `MenuPosition` interface and 14x duplicated LOD zoom-check are each a single shared definition now. Every previously-uncaught `navigator.clipboard.writeText` call gets a `.catch()`.

This ADR does not touch the Python backend.

## Test plan

- Full frontend suite from `web_ui/`: typecheck, lint (0 errors), `vitest run` — 1572 passed, production build, bundle-size gate, and codegen drift check — all clean.
- `renderCountGate.test.tsx`'s ceiling tightened from `NODE_COUNT` to a real, exercised value: a position-only drag now measures 0 node-view re-renders (position is applied via CSS transform, outside `data`), and a genuine content edit — added during review, since the prior gate never actually exercised one — measures exactly 1.
- The HIGH-severity stream-loss bug has a dedicated end-to-end regression test: mount a chat node, stream partial content, unmount (simulating virtualization), stream more while unmounted, mount a fresh instance, assert the full text is recovered with no gap.
- Virtualization is proven via deterministic call-count spies (querySelector call count flat across drag frames within one gesture, edge-array reference-equality with fade off) rather than wall-clock timing, matching this codebase's established convention — jsdom can't support a literal DOM-mount-count assertion for `onlyRenderVisibleElements` (traced to a `getNodesInside` dependency on `DOMMatrixReadOnly`, which jsdom doesn't implement).