### PR TITLE
ADR-009 stages 9.1-9.4: migrations, backups, secret scrubbing, .graphlink archive

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -48,7 +48,7 @@ from backend.auth import (
     token_matches,
 )
 from backend.canvas import register_canvas
-from backend.chat_library import register_chat_library
+from backend.chat_library import flush_dirty_session_before_teardown, register_chat_library
 from backend.composer import register_composer
 from backend.api.intents_diagnostics import register_diagnostics_intents
 from backend.crash_recovery import maybe_show_crash_notice
@@ -320,6 +320,40 @@ def _evict_idle_session(bus: SessionBus) -> bool:
     # AgentDispatcher.dispose_all_pycoder_repls' own docstring for why this
     # does NOT also remove each REPL's scratch directory.
     context.agent_dispatcher.dispose_all_pycoder_repls()
+
+    # ADR-009 stage 9.2 / ADR-004 stage 4.3 interaction: flush a dirty
+    # session's chat BEFORE cancelling its autosave task - see
+    # flush_dirty_session_before_teardown's own docstring for the real gap
+    # this closes (cancelling the task outright, the pre-9.2 behavior here,
+    # could silently lose up to one full autosave interval's worth of
+    # edits on every idle eviction) and for why it deliberately does NOT
+    # get a notifications reference from this call site (nothing could
+    # ever observe it - eviction only ever runs for a session with zero
+    # live connections). Only attempted when chat_library.py's own
+    # register_chat_library actually ran for this bus (bus.chat_db_path
+    # unset - e.g. several tests in this suite build a bare SessionBus/
+    # SessionContext directly, without ever registering the chat library -
+    # means there is nothing to flush) and when no write is already in
+    # flight (mutation_guard active): a tick genuinely mid-write will
+    # still complete and record its own result correctly once
+    # autosave_task.cancel() below lets it finish (see
+    # test_evict_idle_session_releases_the_mutation_guard_when_cancelling_
+    # mid_write in backend/tests/test_session_lifecycle.py) - racing a
+    # SECOND write against it here would only risk an avoidable lost-race
+    # warning for no benefit.
+    chat_db_path = getattr(bus, "chat_db_path", None)
+    last_saved = getattr(bus, "chat_save_state", None)
+    mutation_guard = getattr(bus, "chat_mutation_guard", None)
+    if (
+        chat_db_path is not None
+        and last_saved is not None
+        and not (mutation_guard is not None and mutation_guard.get("active"))
+    ):
+        try:
+            flush_dirty_session_before_teardown(chat_db_path, context.canvas_document, last_saved)
+        except Exception:
+            logger.exception("eviction flush crashed - proceeding with eviction anyway")
+
     autosave_task = getattr(bus, "autosave_task", None)
     if autosave_task is not None and not autosave_task.done():
         autosave_task.cancel()

--- a/backend/autosave.py
+++ b/backend/autosave.py
@@ -85,8 +85,11 @@ from typing import Any
 from backend.canvas import SceneDocument
 from backend.chat_library import (
     AUTOSAVE_OWNER,
+    LOST_RACE_MESSAGE_AUTOSAVE,
+    ConcurrentSaveConflict,
     _content_digest,
     _fallback_title,
+    _maybe_backup_before_write,
     _resolve_seed_message,
     load_chat_row,
     save_chat_atomically_row,
@@ -136,6 +139,13 @@ async def autosave_tick(
         return
 
     chat_id_for_save: int | None = None
+    # ADR-009 stage 9.2: what THIS session believes is on disk for the chat
+    # it's about to (re)save - see backend/chat_library.py's own saveChat
+    # closure for the identical reasoning (only trusted when it actually
+    # describes the SAME row; otherwise expected_updated_at stays None and
+    # save_chat_atomically_row falls back to a blind UPDATE, matching this
+    # function's pre-9.2 behavior for that case).
+    expected_updated_at: str | None = None
     current_id = canvas_document.current_chat_id
     if current_id:
         try:
@@ -162,15 +172,40 @@ async def autosave_tick(
             # saveChat's own resave path follows.
             title = str(existing_row.get("title") or "Untitled")
             chat_id_for_save = int(current_id)
+            if last_saved.get("chat_id") == int(current_id):
+                expected_updated_at = last_saved.get("updated_at")
         else:
             title = _fallback_title(_resolve_seed_message(canvas_document))
     else:
         title = _fallback_title(_resolve_seed_message(canvas_document))
 
     try:
-        new_chat_id = await asyncio.to_thread(
+        # ADR-009 stage 9.2: backup-before-write, the SAME call
+        # backend/chat_library.py's own saveChat closure makes - see
+        # _maybe_backup_before_write's own docstring for why this one call
+        # covers both "before the first mutating write of a session" and
+        # the ongoing periodic cadence, reusing THIS tick loop as the clock
+        # rather than a second timer. Best-effort: a backup failure is
+        # logged inside that function and never raised.
+        await asyncio.to_thread(_maybe_backup_before_write, db_path, last_saved)
+        new_chat_id, new_updated_at = await asyncio.to_thread(
             save_chat_atomically_row, db_path, chat_id_for_save, title, chat_data, notes_data, pins_data,
+            expected_updated_at=expected_updated_at,
         )
+    except ConcurrentSaveConflict:
+        # ADR-009 stage 9.2 exit criterion: a lost autosave race must
+        # neither clobber the newer version NOR crash this tick/the loop -
+        # last_saved is deliberately left untouched (still pointing at the
+        # STALE updated_at), so the very next tick detects the same
+        # conflict again rather than silently believing it caught up.
+        logger.warning(
+            "autosave: lost a save race for chat %r (session=%r) - not clobbering the newer version",
+            current_id, bus.session_id,
+        )
+        if notifications is not None:
+            notifications.show(LOST_RACE_MESSAGE_AUTOSAVE, "warning")
+            await bus.publish("notification")
+        return
     except Exception as exc:
         logger.exception("autosave: DB write failed for session %r", bus.session_id)
         if notifications is not None:
@@ -181,6 +216,7 @@ async def autosave_tick(
     canvas_document.current_chat_id = int(new_chat_id)
     last_saved["digest"] = digest
     last_saved["chat_id"] = int(new_chat_id)
+    last_saved["updated_at"] = new_updated_at
     await bus.publish("app-chat-library")
 
 

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -38,32 +38,100 @@ import logging
 import os
 import re
 import sqlite3
-from datetime import datetime
+import time
+from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
+from backend import db_backup
 from backend.canvas import SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.session_load import restore_chat_into_document
 from backend.session_save import build_chat_data
+from graphlink_migrations import run_sqlite_migrations
 
 DEFAULT_DB_PATH = Path.home() / ".graphlink" / "chats.db"
 
+# ADR-009 stage 9.2. How often, at most, a session's autosave tick (or a
+# manual Save) is allowed to trigger a fresh backend/db_backup.py snapshot -
+# see _maybe_backup_before_write's own docstring for the full cadence
+# design (this same constant covers BOTH "before the first mutating write
+# of a session" - the very first write always backs up immediately, since
+# last_backup_at starts unset - AND the ongoing periodic cadence
+# afterward, with no second timer). 10 minutes: frequent enough that a
+# corruption discovered later never has to fall back past a handful of
+# recent snapshots (bounded by backend/db_backup.py's own KEEP_MOST_RECENT
+# at this cadence), infrequent enough that a long, active session doesn't
+# spend disk churn re-backing-up a multi-tens-of-MB chats.db (embedded
+# images can make a single chat's own row substantial) every single 30s
+# autosave tick.
+BACKUP_CADENCE_SECONDS = 600.0
+
+
+class ConcurrentSaveConflict(RuntimeError):
+    """Raised by save_chat_atomically_row when the caller supplied
+    expected_updated_at but the UPDATE affected zero rows: another writer
+    (a different session/window, or - pre ADR-004's single-instance model -
+    a different process) already saved a newer version of this exact chat
+    row since this session last loaded or saved it. The exit criterion this
+    whole stage is built around ("a lost write race is surfaced, never
+    clobbered") is enforced structurally, not just by convention: this is
+    raised BEFORE either notes/pins DELETE statement runs (see that
+    function's own body), so the entire write - including the row UPDATE
+    itself - rolls back via the enclosing `with conn:` transaction. Nothing
+    from this call is ever partially applied; the row a concurrent writer
+    already committed is left completely untouched."""
+
+# ADR-009 stage 9.1. PRAGMA user_version target for chats.db - bumped
+# whenever a new migration function is added to _MIGRATIONS below. A
+# genuinely fresh (never-opened) database reads user_version 0, so version
+# "1" is the first real migration: it takes a brand-new DB from nothing to
+# the full schema every _ensure_* probe used to (re)create piecemeal on
+# every connection - see _migration_001_initial_schema's own docstring for
+# exactly what that migration does and does not assume about the DB it's
+# handed.
+CHATS_DB_SCHEMA_VERSION = 1
+
+
+# ADR-009 stage 9.2: `created_at`/rename_chat's own `updated_at` are written
+# via SQLite's inline `CURRENT_TIMESTAMP` (second resolution, no fractional
+# part) - the format every pre-9.2 row's timestamps are still in.
+# save_chat_atomically_row's own `now` (see that function's own docstring)
+# is now generated in PYTHON at microsecond resolution instead, specifically
+# so two writes issued in close succession (the exact optimistic-concurrency
+# scenario this stage exists for - two sessions racing a save) are NEVER
+# indistinguishable the way two same-second CURRENT_TIMESTAMP values would
+# be. Both formats are real, both must parse - _TIMESTAMP_DISPLAY_FORMATS is
+# tried in order (second-resolution first, since it's still the more common
+# case across created_at + every non-chat-save write).
+_TIMESTAMP_DISPLAY_FORMATS = ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S.%f")
+
+
+def _parse_stored_timestamp(value: Any) -> datetime | None:
+    raw = str(value)
+    for fmt in _TIMESTAMP_DISPLAY_FORMATS:
+        try:
+            return datetime.strptime(raw, fmt)
+        except ValueError:
+            continue
+    return None
+
 
 def _format_timestamp(value: Any) -> str:
-    """Moved verbatim from graphlink_chat_library_bridge.py - the stored
-    format is sqlite's `"%Y-%m-%d %H:%M:%S"`; unparseable/empty values echo
-    back unchanged, matching the legacy behavior exactly."""
+    """Moved verbatim from graphlink_chat_library_bridge.py, extended for
+    ADR-009 stage 9.2 - see _TIMESTAMP_DISPLAY_FORMATS' own comment for why
+    a second format is now tried. Unparseable/empty values echo back
+    unchanged, matching the legacy behavior exactly."""
     if not value:
         return "Unknown"
-    try:
-        parsed = datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S")
-        return parsed.strftime("%b %d, %Y %I:%M %p")
-    except ValueError:
+    parsed = _parse_stored_timestamp(value)
+    if parsed is None:
         return str(value)
+    return parsed.strftime("%b %d, %Y %I:%M %p")
 
 
 def _format_timestamp_iso(value: Any) -> str | None:
@@ -72,13 +140,12 @@ def _format_timestamp_iso(value: Any) -> str | None:
     display label from _format_timestamp above is deliberately locale/human
     formatted and not meant to be parsed back. None (not a sentinel string)
     on anything unparseable/empty, so the frontend can cleanly bucket those
-    rows as "Unknown" rather than crash on a bad date."""
+    rows as "Unknown" rather than crash on a bad date. Extended for ADR-009
+    stage 9.2 - see _TIMESTAMP_DISPLAY_FORMATS' own comment."""
     if not value:
         return None
-    try:
-        return datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S").isoformat()
-    except ValueError:
-        return None
+    parsed = _parse_stored_timestamp(value)
+    return parsed.isoformat() if parsed is not None else None
 
 
 _PREVIEW_MAX_CHARS = 140
@@ -115,21 +182,79 @@ def _extract_preview_and_message_count(chat_data: dict[str, Any]) -> tuple[str, 
     return preview, len(chat_nodes)
 
 
-def _connect(db_path: Path) -> sqlite3.Connection:
+def _connect(
+    db_path: Path, *, notifications: NotificationState | None = None, _retry: bool = False,
+) -> sqlite3.Connection:
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(db_path, timeout=30)
-    conn.execute("PRAGMA foreign_keys = ON")
+    conn: sqlite3.Connection | None = None
+    try:
+        conn = sqlite3.connect(db_path, timeout=30)
+        conn.execute("PRAGMA foreign_keys = ON")
+        # These two PRAGMAs are inside the SAME try/except as the connect()
+        # call above (not split off into their own block further down) -
+        # empirically, "file is not a database" surfaces on the FIRST real
+        # touch of the file's header, which for a fresh Python-level
+        # connect() is exactly here (PRAGMA journal_mode is the earliest
+        # statement in this function that forces SQLite to actually read
+        # the file), not necessarily at connect() itself (SQLite's own
+        # connect is lazy - see this function's own corruption-handling
+        # comment above for the empirical verification this rests on).
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA busy_timeout = 30000")
+    except sqlite3.OperationalError:
+        # ADR-009 stage 9.2: a locked/busy file or a real disk I/O error -
+        # genuinely transient conditions (a concurrent writer, a slow
+        # disk), never evidence of corruption. sqlite3.OperationalError is
+        # - verified directly, not assumed, see backend/tests/
+        # test_chat_library.py's own hierarchy-pinning test - a SUBCLASS of
+        # sqlite3.DatabaseError, so it must be caught and re-raised HERE,
+        # strictly before the broader except clause below, or a plain lock
+        # timeout would be wrongly treated as a corrupt file and quarantined.
+        # Closed for the same "never leak an open handle on a raise path"
+        # reason as the DatabaseError branch below.
+        if conn is not None:
+            conn.close()
+        raise
+    except sqlite3.DatabaseError as exc:
+        # Genuine corruption ("file is not a database" / "database disk
+        # image is malformed") - both confirmed empirically (not from
+        # documentation alone) to raise the base sqlite3.DatabaseError
+        # itself, never a locked/busy-shaped subclass, which is exactly
+        # what makes the except-order above safe to rely on. _retry bounds
+        # this to at most ONE rescue attempt per call: if the file is STILL
+        # unopenable immediately after quarantine+restore (quarantine
+        # itself failed, or there was no backup to restore and something
+        # keeps re-corrupting it), this re-raises for real rather than
+        # recursing forever.
+        #
+        # MUST close conn here, before _rescue_corrupt_chats_db attempts to
+        # rename db_path out from under it - verified empirically (not
+        # assumed): on Windows, renaming a file with an open handle raises
+        # WinError 32 ("the process cannot access the file because it is
+        # being used by another process"), which would make the rescue
+        # itself fail every single time on this platform if conn were left
+        # open. sqlite3.connect() succeeding is exactly the case that
+        # leaves `conn` non-None here even though a LATER statement in the
+        # same try block is what actually raised.
+        if conn is not None:
+            conn.close()
+        if _retry:
+            raise
+        _rescue_corrupt_chats_db(db_path, exc, notifications)
+        return _connect(db_path, notifications=notifications, _retry=True)
     # ADR-004 stage 4.4 follow-up (adversarial-review finding): WAL mode,
-    # not SQLite's default rollback-journal. journal_mode is a database-
-    # level setting persisted in the file header, not a per-connection
-    # default - this PRAGMA only needs to actually FLIP the mode once ever
-    # (every later connection, including from a pre-existing chats.db,
-    # inherits it automatically; re-issuing it when already WAL is a cheap
-    # no-op). The rollback journal materializes a `<db>-journal` sidecar
-    # ONLY transiently, mid-transaction (SQLite creates and deletes it
-    # around each write with no Python-level hook to chmod it before it's
-    # gone), which meant it was the one piece of ADR-004 stage 4.4's own
-    # permission hardening that couldn't be closed.
+    # not SQLite's default rollback-journal - set inside the try block
+    # above, not here (see this function's own corruption-handling comment
+    # for why). journal_mode is a database-level setting persisted in the
+    # file header, not a per-connection default - this PRAGMA only needs to
+    # actually FLIP the mode once ever (every later connection, including
+    # from a pre-existing chats.db, inherits it automatically; re-issuing
+    # it when already WAL is a cheap no-op). The rollback journal
+    # materializes a `<db>-journal` sidecar ONLY transiently, mid-
+    # transaction (SQLite creates and deletes it around each write with no
+    # Python-level hook to chmod it before it's gone), which meant it was
+    # the one piece of ADR-004 stage 4.4's own permission hardening that
+    # couldn't be closed.
     #
     # WAL's `<db>-wal`/`<db>-shm` sidecars behave differently, verified
     # empirically (this module opens-does-work-closes a fresh connection
@@ -155,7 +280,20 @@ def _connect(db_path: Path) -> sqlite3.Connection:
     # "sqlite hygiene: WAL mode" bullet, done ahead of that stage's larger
     # bundle (user_version/migration runner/FK indexes/one-time DDL) since
     # it's purely additive and doesn't block any of that later work.
-    conn.execute("PRAGMA journal_mode = WAL")
+    #
+    # busy_timeout (also moved into the try block above): an explicit
+    # PRAGMA so a writer that finds chats.db locked by another connection
+    # (e.g. autosave's tick and a manual Save's own DB call briefly
+    # overlapping under WAL) retries for a while before raising "database
+    # is locked", instead of failing immediately. Deliberately NOT the ADR
+    # text's own illustrative "e.g. 5000ms" and deliberately set to 30000,
+    # matching (not shortening) the existing 30-second convention this
+    # module's own AUTOSAVE_YIELD_TIMEOUT_SECONDS docstring and several
+    # tests already reason about explicitly as "sqlite's own 30s lock
+    # timeout" - self-documenting and independently correct here even
+    # though it is also, empirically, already what this function's own
+    # `timeout=30` connect() kwarg sets via the same underlying C API.
+    #
     # chats.db holds real conversation content, POSIX 0600 like
     # session.dat (graphlink_settings_store.py's own SettingsManager).
     # sqlite3.connect()/the PRAGMA above create these files with no mode
@@ -175,14 +313,212 @@ def _connect(db_path: Path) -> sqlite3.Connection:
                 os.chmod(path, 0o600)
             except OSError:
                 logger.warning("could not chmod %s to 0600 - continuing with existing permissions", path)
+
+    # ADR-009 stage 9.1: runs on EVERY connect, not just the first ever, but
+    # is a cheap no-op (a single "PRAGMA user_version" read, no transaction
+    # opened, no other statement executed) once this database is already at
+    # CHATS_DB_SCHEMA_VERSION - see run_sqlite_migrations' own docstring for
+    # why that no-op path is safe to leave on the hot path. This is what
+    # makes the old "_ensure_*, re-probed on every call" pattern this
+    # replaces unreachable on a normal connect: schema creation now happens
+    # AT MOST ONCE per database, ever, the moment it first falls behind
+    # target - never again after that. Positioned after the chmod loop
+    # above (not before) so the very-first-ever-WAL-connection bootstrap gap
+    # documented on that loop's own comment is unaffected: chmod still runs
+    # before this migration's first real write to a brand-new db_path.
+    #
+    # ADR-009 stage 9.2: wrapped in the same corruption try/except shape as
+    # the connect+PRAGMA block above - a corrupt page can just as easily
+    # surface here (e.g. PRAGMA table_info reading a malformed page) as at
+    # the earlier PRAGMAs, and this call site needs its own `conn.close()`
+    # first (the earlier block never got as far as opening one).
+    try:
+        run_sqlite_migrations(conn, CHATS_DB_SCHEMA_VERSION, _MIGRATIONS)
+    except sqlite3.OperationalError:
+        conn.close()
+        raise
+    except sqlite3.DatabaseError as exc:
+        conn.close()
+        if _retry:
+            raise
+        _rescue_corrupt_chats_db(db_path, exc, notifications)
+        return _connect(db_path, notifications=notifications, _retry=True)
     return conn
 
 
-def _ensure_chats_table(conn: sqlite3.Connection) -> None:
-    # Mirrors ChatDatabase.init_database()'s chats table exactly - this
-    # library only ever reads/writes this one table, so it's the only one
-    # this reimplementation needs to guarantee exists (matters if the SPA
-    # backend runs before the legacy app has ever created chats.db).
+def _quarantine_corrupt_chats_db(db_path: Path, error: Exception) -> Path | None:
+    """Mirrors graphlink_settings_store.py's own _backup_corrupt_state_file
+    EXACTLY on the naming/permission convention: the same ISO8601-compact-
+    UTC timestamp format (`strftime("%Y%m%dT%H%M%SZ")`), the same
+    `Path.replace()` rename (a rename, not a copy-then-delete, so it
+    preserves the source inode's mode bits and is atomic - the corrupt file
+    is either still at db_path or already fully at quarantine_path, never
+    briefly duplicated or lost), and the same explicit chmod 0600
+    afterward (a corrupt chats.db can hold the same real conversation
+    content the live file did, and is kept indefinitely "for forensic
+    recovery" - same reasoning as that function's own comment on why it
+    needs its own explicit permissioning independent of the source file's).
+
+    NOT extracted into a module BOTH files import: the two call sites
+    differ in one real respect (chats.db has WAL sidecars to clean up
+    afterward; session.dat does not), and graphlink_settings_store.py is a
+    root-level module SettingsManager already depends on directly - adding
+    a NEW shared dependency between it and backend/chat_library.py for
+    ~15 lines of logic was judged a worse trade than duplicating this small
+    amount of logic with this comment explaining why, matching this
+    module's own established "reimplement, don't cross-import" precedent
+    for exactly this kind of small, self-contained algorithm (see this
+    file's own module docstring).
+
+    Returns the quarantine path, or None if the rename itself failed (a
+    permissions issue, or the file vanished between the caller detecting
+    corruption and this call) - in which case NOTHING else is touched: see
+    this function's own caller (_rescue_corrupt_chats_db) for why leaving
+    an un-quarantined corrupt file exactly where it was is the safe
+    direction to fail in, rather than attempting a restore that could
+    collide with it."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    quarantine_path = db_path.with_name(f"{db_path.name}.corrupted-{timestamp}")
+    try:
+        db_path.replace(quarantine_path)
+    except OSError as quarantine_error:
+        logger.error(
+            "%s is corrupt (%s) and could not be quarantined (%s) - leaving it in place",
+            db_path, error, quarantine_error,
+        )
+        return None
+    try:
+        os.chmod(quarantine_path, 0o600)
+    except OSError:
+        logger.warning("could not chmod %s to 0600 - continuing", quarantine_path)
+
+    # The corrupt file's own -wal/-shm sidecars (if any survived whatever
+    # crash caused the corruption) describe writes against THAT specific,
+    # now-quarantined file's page layout - left in place, a later connect
+    # to the freshly-restored db_path could find and try to replay them,
+    # grafting unrelated transactions onto a completely different file's
+    # content. Deleting them is safe: they are derived, recoverable-from-
+    # nowhere-else-anyway state, never primary data - the corrupt MAIN file
+    # (the one thing that might hold forensic value) is exactly what got
+    # preserved above.
+    for suffix in ("-wal", "-shm"):
+        sidecar = db_path.with_name(db_path.name + suffix)
+        if sidecar.exists():
+            try:
+                sidecar.unlink()
+            except OSError:
+                logger.warning("could not remove stale sidecar %s - continuing", sidecar)
+
+    logger.error("%s was corrupt (%s) - quarantined to %s", db_path, error, quarantine_path)
+    return quarantine_path
+
+
+def _rescue_corrupt_chats_db(
+    db_path: Path, error: Exception, notifications: NotificationState | None,
+) -> None:
+    """The chats.db analog of graphlink_settings_store.py's own
+    _backup_corrupt_state_file - but genuinely BETTER, not just a reset to
+    empty, per this stage's own ground rules: session.dat has no backup
+    store to restore from and resets to defaults after quarantining (see
+    that function's own docstring); chats.db has backend/db_backup.py's
+    real retained snapshots, so this restores the newest good one instead,
+    whenever one exists, rather than starting the user over from nothing.
+
+    Called from _connect() itself, for EVERY caller in this module (the
+    self-healing is transparent - a caller that hits this never sees the
+    exception at all, unless quarantine+restore also fails). `notifications`
+    is optional and None for most call sites (get_all_chats is the one
+    exception - see that function's own comment for why it is safe to wire
+    a live NotificationState through specifically there and not the
+    others): a rescue is ALWAYS logged via logger.error regardless (durable
+    in graphlink.log - see backend/crash_recovery.py's own docstring on
+    every unhandled condition in this codebase landing somewhere durable),
+    so silence from `notifications` here is never silence altogether."""
+    quarantine_path = _quarantine_corrupt_chats_db(db_path, error)
+    if quarantine_path is None:
+        # Could not even move the corrupt file out of the way - leave
+        # EVERYTHING else alone rather than attempting a restore that could
+        # collide with a file we can't prove is actually gone from
+        # db_path. The caller's own retry will hit the exact same
+        # DatabaseError again and this time let it propagate for real
+        # (_retry=True) - safer than silently overwriting an unquarantined
+        # file.
+        if notifications is not None:
+            notifications.show(
+                "Your chat history file (chats.db) appears to be corrupted and could not be "
+                "automatically repaired. See graphlink.log for details.",
+                "error",
+            )
+        return
+
+    restored_from = db_backup.restore_from_newest_backup(db_path)
+    if restored_from is not None:
+        message = (
+            "Your chat history file was corrupted and has been restored from a recent backup. "
+            f"The corrupted file was saved as {quarantine_path.name} in your .graphlink folder in case "
+            "you need it."
+        )
+    else:
+        message = (
+            "Your chat history file was corrupted and no backup was available, so a new, empty chat "
+            f"library was started. The corrupted file was saved as {quarantine_path.name} in your "
+            ".graphlink folder in case it can be recovered."
+        )
+    logger.error(
+        "%s corruption rescue complete: quarantined=%s restored_from_backup=%s",
+        db_path, quarantine_path, restored_from,
+    )
+    if notifications is not None:
+        notifications.show(message, "warning")
+
+
+def _migration_001_initial_schema(conn: sqlite3.Connection) -> None:
+    """ADR-009 stage 9.1, migration "1" (0 -> 1): the one-time replacement
+    for the old _ensure_chats_table/_ensure_notes_table/_ensure_pins_table
+    trio, which used to run this exact DDL - CREATE TABLE IF NOT EXISTS +
+    PRAGMA table_info + conditional ALTER TABLE - on EVERY single connect,
+    from EVERY query function in this module. Landing on user_version = 1
+    now does it once, ever, per database.
+
+    Must be correct for BOTH of two starting shapes, since both are real:
+
+      1. A genuinely fresh, empty chats.db (nothing in sqlite_master at
+         all). This is the "0 -> 1" case the version number literally
+         names - every CREATE TABLE below actually creates something.
+
+      2. An EXISTING real chats.db that was created and evolved entirely by
+         the OLD per-connection _ensure_* probes, which never once touched
+         PRAGMA user_version - so it reads 0 today no differently than a
+         truly empty database, even though every table and column below
+         already exists and likely holds real chat rows. This is the
+         upgrade path every actual user's machine takes the first time a
+         build containing this migration runs - see
+         TestMigrationUpgradesAPreExistingRealShapedDatabase in
+         backend/tests/test_chat_library.py, which builds a database in
+         exactly this shape by hand (raw DDL, real rows, user_version left
+         at 0) and asserts the data survives byte-for-byte.
+
+      Every statement below is IF NOT EXISTS or a guarded "column already
+      there?" ALTER TABLE for exactly that reason - re-running this against
+      an already-correct schema (case 2) must be a pure no-op on the tables/
+      columns themselves, identical to what the old probes already
+      guaranteed by construction.
+
+    Schema is byte-for-byte what the three old _ensure_* functions produced
+    together: chats (+ R8a's preview/message_count columns), notes (+ R6.4's
+    is_system_prompt/is_summary_note columns), pins (+ R6.4's pin_id/
+    sort_order/anchor_item_id/created_at columns) - plus this stage's own
+    new work, CREATE INDEX IF NOT EXISTS on the two foreign-key columns that
+    never had one (notes.chat_id, pins.chat_id - the schema's only two FK
+    columns; chats itself declares no FK). Without these, delete_chat's
+    "DELETE FROM chats WHERE id=?" - which cascades via ON DELETE CASCADE -
+    and every load_notes_rows/load_pins_rows "WHERE chat_id=?" lookup did a
+    full table scan of notes/pins instead of an index seek.
+
+    Runs inside run_sqlite_migrations' own managed transaction (manual
+    BEGIN/COMMIT/ROLLBACK around isolation_level=None - see that function's
+    docstring for why `with conn:` alone is not atomic for DDL) - must not
+    BEGIN, COMMIT, or ROLLBACK anything itself."""
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS chats (
@@ -194,25 +530,12 @@ def _ensure_chats_table(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    # R8a: the redesigned Chat Library list needs a preview snippet + message
-    # count per row (see _extract_preview_and_message_count) - mirrors the
-    # notes/pins tables' own PRAGMA table_info + ALTER TABLE migration idiom
-    # exactly, so a chats.db written before this change gains the columns in
-    # place rather than needing a destructive rebuild. Defaults keep
-    # pre-migration rows valid (empty preview, zero count) until their next
-    # save recomputes both for real.
-    columns = [info[1] for info in conn.execute("PRAGMA table_info(chats)").fetchall()]
-    if "preview" not in columns:
+    chats_columns = [info[1] for info in conn.execute("PRAGMA table_info(chats)").fetchall()]
+    if "preview" not in chats_columns:
         conn.execute("ALTER TABLE chats ADD COLUMN preview TEXT DEFAULT ''")
-    if "message_count" not in columns:
+    if "message_count" not in chats_columns:
         conn.execute("ALTER TABLE chats ADD COLUMN message_count INTEGER DEFAULT 0")
 
-
-def _ensure_notes_table(conn: sqlite3.Connection) -> None:
-    # R6.4: mirrors ChatDatabase.init_database()'s notes table + its own
-    # is_system_prompt/is_summary_note migration ALTER TABLEs exactly - a
-    # chats.db written by an OLDER legacy build may still be missing these
-    # two columns, and load_notes_rows below unconditionally SELECTs them.
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS notes (
@@ -229,16 +552,12 @@ def _ensure_notes_table(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    columns = [info[1] for info in conn.execute("PRAGMA table_info(notes)").fetchall()]
-    if "is_system_prompt" not in columns:
+    notes_columns = [info[1] for info in conn.execute("PRAGMA table_info(notes)").fetchall()]
+    if "is_system_prompt" not in notes_columns:
         conn.execute("ALTER TABLE notes ADD COLUMN is_system_prompt INTEGER DEFAULT 0")
-    if "is_summary_note" not in columns:
+    if "is_summary_note" not in notes_columns:
         conn.execute("ALTER TABLE notes ADD COLUMN is_summary_note INTEGER DEFAULT 0")
 
-
-def _ensure_pins_table(conn: sqlite3.Connection) -> None:
-    # R6.4: mirrors ChatDatabase.init_database()'s pins table + its own
-    # pin_id/sort_order/anchor_item_id/created_at migration ALTER TABLEs.
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS pins (
@@ -252,23 +571,51 @@ def _ensure_pins_table(conn: sqlite3.Connection) -> None:
         )
         """
     )
-    columns = [info[1] for info in conn.execute("PRAGMA table_info(pins)").fetchall()]
-    if "pin_id" not in columns:
+    pins_columns = [info[1] for info in conn.execute("PRAGMA table_info(pins)").fetchall()]
+    if "pin_id" not in pins_columns:
         conn.execute("ALTER TABLE pins ADD COLUMN pin_id TEXT")
-    if "sort_order" not in columns:
+    if "sort_order" not in pins_columns:
         conn.execute("ALTER TABLE pins ADD COLUMN sort_order INTEGER DEFAULT 0")
-    if "anchor_item_id" not in columns:
+    if "anchor_item_id" not in pins_columns:
         conn.execute("ALTER TABLE pins ADD COLUMN anchor_item_id TEXT")
-    if "created_at" not in columns:
+    if "created_at" not in pins_columns:
         conn.execute("ALTER TABLE pins ADD COLUMN created_at TEXT")
 
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_notes_chat_id ON notes (chat_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_pins_chat_id ON pins (chat_id)")
 
-def get_all_chats(db_path: Path) -> list[dict[str, Any]]:
+
+# Keyed by the version each function PRODUCES (migration "1" takes a
+# database from 0 -> 1), matching graphlink_migrations' own ordering
+# convention - see run_sqlite_migrations' docstring. The stage 9.2 agent
+# building backups/corrupt-rescue on top of this: add step "2" here (and
+# bump CHATS_DB_SCHEMA_VERSION to 2) for any further schema change, never
+# renumber or replace step "1" - it must stay exactly what it is today so it
+# keeps correctly upgrading every already-migrated real database.
+_MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
+    1: _migration_001_initial_schema,
+}
+
+
+def get_all_chats(db_path: Path, notifications: NotificationState | None = None) -> list[dict[str, Any]]:
+    # ADR-009 stage 9.2: the ONE call in this module that threads a real
+    # `notifications` reference into _connect()'s corruption rescue (every
+    # other function below stays silent-except-log - see _rescue_corrupt_
+    # chats_db's own docstring for why). This is the safest single spot to
+    # wire it: get_all_chats has no OTHER notifications.show() call of its
+    # own to race against (unlike loadChat/saveChat's own closures, which
+    # already show a "Loaded"/"Saved" toast right after their own DB call -
+    # a rescue notice set moments earlier would be silently overwritten
+    # before ever being seen), and it backs the "app-chat-library" topic,
+    # which is rebuilt on essentially every real user action in this
+    # module (a fresh subscribe, and every rename/delete/save/load/new-chat
+    # republish) - the single most-likely first real touch of chats.db
+    # after a relaunch.
+    #
     # closing() + the connection's own transaction context: sqlite3's
     # `with conn:` commits/rolls back but does NOT close the connection -
     # without closing() the handle would linger until garbage collection.
-    with contextlib.closing(_connect(db_path)) as conn, conn:
-        _ensure_chats_table(conn)
+    with contextlib.closing(_connect(db_path, notifications=notifications)) as conn, conn:
         rows = conn.execute(
             "SELECT id, title, created_at, updated_at, preview, message_count "
             "FROM chats ORDER BY updated_at DESC"
@@ -290,7 +637,6 @@ def get_all_chats(db_path: Path) -> list[dict[str, Any]]:
 
 def rename_chat(db_path: Path, chat_id: int, new_title: str) -> None:
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        _ensure_chats_table(conn)
         conn.execute(
             "UPDATE chats SET title = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
             (new_title, chat_id),
@@ -299,21 +645,31 @@ def rename_chat(db_path: Path, chat_id: int, new_title: str) -> None:
 
 def delete_chat(db_path: Path, chat_id: int) -> None:
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        _ensure_chats_table(conn)
         conn.execute("DELETE FROM chats WHERE id = ?", (chat_id,))
 
 
 def load_chat_row(db_path: Path, chat_id: int) -> dict[str, Any] | None:
-    """Mirrors ChatDatabase.load_chat exactly: {"title", "data"} with `data`
-    already json.loads()'d, or None if the id doesn't exist (a chat deleted
-    from another window/process between the library listing and this call -
-    the caller shows a real notice, not a crash)."""
+    """Mirrors ChatDatabase.load_chat, extended for ADR-009 stage 9.2:
+    {"title", "data", "updated_at"} with `data` already json.loads()'d, or
+    None if the id doesn't exist (a chat deleted from another window/
+    process between the library listing and this call - the caller shows a
+    real notice, not a crash).
+
+    `updated_at` (new in stage 9.2) is the value optimistic concurrency is
+    built on: the caller that loads a chat is expected to carry THIS exact
+    string forward (see backend/chat_library.py's own register_chat_library
+    loadChat closure, which seeds it into the shared last_saved cell) and
+    hand it back as save_chat_atomically_row's expected_updated_at when it
+    later saves - never re-read moments before that save, which would
+    trivially always match and defeat the whole point of detecting a race
+    against some OTHER writer that saved in between."""
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        _ensure_chats_table(conn)
-        row = conn.execute("SELECT title, data FROM chats WHERE id = ?", (chat_id,)).fetchone()
+        row = conn.execute(
+            "SELECT title, data, updated_at FROM chats WHERE id = ?", (chat_id,)
+        ).fetchone()
     if row is None:
         return None
-    return {"title": row[0], "data": json.loads(row[1])}
+    return {"title": row[0], "data": json.loads(row[1]), "updated_at": row[2]}
 
 
 def load_notes_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
@@ -321,7 +677,6 @@ def load_notes_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
     SELECT column list; shape matches what backend/session_load.py's
     _restore_notes expects (nested "position"/"size" dicts)."""
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        _ensure_notes_table(conn)
         rows = conn.execute(
             """
             SELECT content, position_x, position_y, width, height,
@@ -348,7 +703,6 @@ def load_pins_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
     """Mirrors ChatDatabase.load_pins exactly, including its own
     sort_order-defaults-to-enumerate-index fallback for pre-migration rows."""
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        _ensure_pins_table(conn)
         rows = conn.execute(
             """
             SELECT pin_id, title, note, position_x, position_y,
@@ -379,36 +733,93 @@ def save_chat_atomically_row(
     chat_data: dict[str, Any],
     notes_data: list[dict[str, Any]],
     pins_data: list[dict[str, Any]],
-) -> int:
-    """Mirrors ChatDatabase.save_chat_atomically exactly (database.py:271-
-    315): ONE shared connection - UPDATE if `chat_id` is truthy, else INSERT
-    (the SQLite AUTOINCREMENT rowid becomes the new chat's id) - then an
+    *,
+    expected_updated_at: str | None = None,
+) -> tuple[int, str]:
+    """Mirrors ChatDatabase.save_chat_atomically (database.py:271-315): ONE
+    shared connection - UPDATE if `chat_id` is truthy, else INSERT (the
+    SQLite AUTOINCREMENT rowid becomes the new chat's id) - then an
     unconditional full delete-then-reinsert of notes and pins for the
     resolved id, all inside the SAME transaction (Python's sqlite3 `with
     conn:` commits everything together, or rolls all of it back on any
     exception - never a partial chat/notes/pins write). `chat_data` here is
     the dict AFTER notes_data/pins_data have already been popped out by the
     caller (mirrors _prepare_chat_payload's own pop, done once at the
-    boundary rather than inside this function)."""
+    boundary rather than inside this function).
+
+    Returns (resolved_chat_id, new_updated_at) - ADR-009 stage 9.2 extends
+    the pre-9.2 bare-int return with the fresh updated_at this write just
+    committed, so a caller can carry it forward as the NEXT save's own
+    expected_updated_at (see this function's own optimistic-concurrency
+    paragraph below for why that value must always come from a real write/
+    load, never be re-derived independently).
+
+    OPTIMISTIC CONCURRENCY (stage 9.2, the exit criterion this whole stage
+    is built around): when `chat_id` is truthy AND `expected_updated_at` is
+    given, the UPDATE is `WHERE id = ? AND updated_at = ?` instead of a
+    blind `WHERE id = ?` - if some OTHER writer already committed a newer
+    version of this row since the caller last loaded/saved it (the
+    `updated_at` it is holding is stale), the UPDATE affects zero rows and
+    this raises ConcurrentSaveConflict BEFORE either notes/pins DELETE
+    statement below ever runs - so the whole write, not just the row
+    UPDATE, rolls back via the enclosing `with conn:` transaction the
+    instant that happens. Nothing here is ever partially applied, and the
+    concurrent writer's own already-committed row is left byte-for-byte
+    untouched. `expected_updated_at=None` (the default) skips this check
+    entirely - a blind `WHERE id = ?`, byte-identical to this function's
+    pre-9.2 behavior - for the (legitimate) case of a caller that has no
+    real prior version to compare against (never loaded through
+    load_chat_row for this session, or the INSERT branch below, which has
+    no prior row to race against in the first place).
+
+    `now` is generated in PYTHON (datetime.now(timezone.utc), microsecond
+    resolution) rather than via SQLite's own inline `CURRENT_TIMESTAMP`
+    function (this function's pre-9.2 behavior, and what rename_chat still
+    uses) - SECOND resolution alone is not fine-grained enough for a real
+    optimistic-concurrency token: two writes issued within the same wall-
+    clock second (verified directly - this is not a theoretical concern;
+    it is exactly what a fast two-session race, including this stage's own
+    test suite driving two saves back-to-back with no real delay, produces)
+    would otherwise share the identical CURRENT_TIMESTAMP string, making a
+    genuinely stale expected_updated_at indistinguishable from a fresh one
+    and silently defeating the whole check. Bound as an explicit parameter
+    for the UPDATE/INSERT's own `updated_at` column - this also guarantees
+    the exact string returned to the caller is the exact string that landed
+    in the row, with no possibility of drift from a second, separate read-
+    back after the write. See _TIMESTAMP_DISPLAY_FORMATS' own comment for
+    how the display-formatting functions handle both this and the older,
+    second-resolution format that pre-9.2 rows and rename_chat's own writes
+    still use."""
     chat_data_json = json.dumps(chat_data)
     preview, message_count = _extract_preview_and_message_count(chat_data)
     with contextlib.closing(_connect(db_path)) as conn:
-        _ensure_chats_table(conn)
-        _ensure_notes_table(conn)
-        _ensure_pins_table(conn)
         with conn:
+            now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
             if chat_id:
-                conn.execute(
-                    "UPDATE chats SET title = ?, data = ?, preview = ?, message_count = ?, "
-                    "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
-                    (title, chat_data_json, preview, message_count, chat_id),
-                )
+                if expected_updated_at is not None:
+                    cursor = conn.execute(
+                        "UPDATE chats SET title = ?, data = ?, preview = ?, message_count = ?, "
+                        "updated_at = ? WHERE id = ? AND updated_at = ?",
+                        (title, chat_data_json, preview, message_count, now, chat_id, expected_updated_at),
+                    )
+                    if cursor.rowcount == 0:
+                        raise ConcurrentSaveConflict(
+                            f"chat {chat_id} was modified elsewhere since it was last loaded/saved "
+                            "in this session (expected updated_at "
+                            f"{expected_updated_at!r} did not match)"
+                        )
+                else:
+                    conn.execute(
+                        "UPDATE chats SET title = ?, data = ?, preview = ?, message_count = ?, "
+                        "updated_at = ? WHERE id = ?",
+                        (title, chat_data_json, preview, message_count, now, chat_id),
+                    )
                 resolved_chat_id = chat_id
             else:
                 cursor = conn.execute(
                     "INSERT INTO chats (title, data, preview, message_count, updated_at) "
-                    "VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
-                    (title, chat_data_json, preview, message_count),
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (title, chat_data_json, preview, message_count, now),
                 )
                 resolved_chat_id = cursor.lastrowid
 
@@ -460,7 +871,7 @@ def save_chat_atomically_row(
                     ),
                 )
 
-        return resolved_chat_id
+        return resolved_chat_id, now
 
 
 _FALLBACK_TITLE_WORD_RE = re.compile(r"[\w']+", re.UNICODE)
@@ -569,8 +980,87 @@ def _new_save_state() -> dict[str, Any]:
        every subsequent tick short-circuited and autosave silently stopped
        protecting the session entirely. Comparing chat_id too means a row
        that vanished underneath the session can no longer be mistaken for
-       "already saved"."""
-    return {"digest": None, "chat_id": None}
+       "already saved".
+
+    ADR-009 stage 9.2 adds two more cells to this SAME shared dict, for the
+    same "one shared home, never a closure-local" reason as the two above:
+
+    3. "updated_at" - the exact value optimistic concurrency's
+       expected_updated_at is read from before every save (see
+       save_chat_atomically_row's own docstring). Sourced from a real
+       load_chat_row read or a real save's own return value - NEVER a
+       fresh re-read taken moments before the save that will use it, which
+       would trivially always match and defeat the whole point of
+       detecting a race against some OTHER writer.
+    4. "last_backup_at" - a time.monotonic() timestamp of this session's
+       last backend/db_backup.py snapshot, so _maybe_backup_before_write
+       can implement BOTH "before the first mutating write of a session"
+       (this starts at None, which always backs up immediately) and the
+       ongoing periodic cadence afterward (see that function's own
+       docstring) from ONE piece of state, with no second timer."""
+    return {"digest": None, "chat_id": None, "updated_at": None, "last_backup_at": None}
+
+
+# ADR-009 stage 9.2: shown via the SAME NotificationState channel every
+# other user-visible chat-library warning already uses (backend/
+# notifications.py) - both the manual saveChat closure and autosave_tick
+# route through one of these two constants so the two surfaces never drift
+# apart on wording. Deliberately distinct from _busy_message above (a
+# TEMPORARY contention the guard already resolves on its own) - this is a
+# genuine, not-self-resolving conflict: the user's own edit was NOT
+# written, and nothing will retry it automatically in a way that could
+# still lose the newer version, so the message says so plainly and points
+# at the one safe recovery action (reload).
+LOST_RACE_MESSAGE_MANUAL = (
+    "This chat changed elsewhere. Your latest edit was not saved - reload the chat to see the "
+    "current version before making further changes."
+)
+LOST_RACE_MESSAGE_AUTOSAVE = (
+    "Autosave couldn't save - this chat changed elsewhere. Reload the chat to see the current "
+    "version and avoid losing further edits."
+)
+
+
+def _maybe_backup_before_write(db_path: Path, last_saved: dict[str, Any]) -> None:
+    """ADR-009 stage 9.2: the ONE call site both backup triggers the ADR
+    text asks for route through - "before the first mutating write of a
+    session" and "on a periodic cadence" are the SAME check on the SAME
+    shared last_saved cell (see _new_save_state's own docstring for why
+    last_backup_at lives there), not two separate mechanisms:
+
+      - First write of a session: last_saved["last_backup_at"] is still
+        None (_new_save_state's own initial value), so the condition below
+        is unconditionally true - a backup is always taken before that
+        write lands.
+      - Every write after that: only once BACKUP_CADENCE_SECONDS have
+        elapsed since the last one - reusing whatever clock already drove
+        THIS call (a manual Save's own call, or an autosave tick that
+        decided to write - see backend/autosave.py's own autosave_tick and
+        this module's own save_chat closure, the two real callers), never
+        a second, independently-scheduled timer task.
+
+    Called from a synchronous context in both real callers (already inside
+    an asyncio.to_thread worker thread, same as the DB write it precedes) -
+    this function does real (bounded, local) file I/O itself and must
+    never be awaited directly.
+
+    A backup FAILURE (disk full, permissions) is logged and swallowed, not
+    raised - a failed backup must never block the actual chat save it
+    precedes; losing a redundancy layer is a strictly smaller problem than
+    losing the user's actual edit over it. last_backup_at is still
+    advanced on a failure, deliberately: retrying every single tick against
+    a systemic problem (e.g. a genuinely full disk) would just waste cycles
+    for the whole BACKUP_CADENCE_SECONDS window either way; the next
+    natural write will try again."""
+    now = time.monotonic()
+    last_backup_at = last_saved.get("last_backup_at")
+    if last_backup_at is not None and (now - last_backup_at) < BACKUP_CADENCE_SECONDS:
+        return
+    try:
+        db_backup.take_backup(db_path)
+    except Exception:
+        logger.exception("chats.db backup failed - continuing with the write anyway")
+    last_saved["last_backup_at"] = now
 
 
 def make_serialize_mutating_intent(
@@ -632,17 +1122,243 @@ def make_serialize_mutating_intent(
     return _serialize_mutating_intent
 
 
-def chat_library_payload(db_path: Path) -> dict[str, Any]:
+def chat_library_payload(db_path: Path, notifications: NotificationState | None = None) -> dict[str, Any]:
     try:
-        rows = get_all_chats(db_path)
+        rows = get_all_chats(db_path, notifications=notifications)
         notice = None
     except sqlite3.Error as exc:
         # Recoverable inline message, matching ChatLibraryBridge's own
         # try/except around get_all_chats - the surface stays up rather
-        # than the whole dialog erroring out.
+        # than the whole dialog erroring out. Only reachable today for a
+        # failure _connect()'s own corruption rescue could not recover from
+        # (a genuinely unopenable file even after quarantine+restore, or a
+        # real lock/IO error) - a plain corruption has already self-healed
+        # silently by the time get_all_chats would ever raise.
         rows = []
         notice = f"Could not load saved chats: {exc}"
     return {"rows": rows, "notice": notice}
+
+
+def make_load_chat(
+    bus: SessionBus,
+    resolved_path: Path,
+    canvas_document: SceneDocument | None,
+    notifications: NotificationState | None,
+    record_saved: Callable[..., None],
+    last_saved: dict[str, Any],
+):
+    """Factory for register_chat_library's own loadChat intent - lifted out
+    to a top-level function purely to keep register_chat_library itself
+    under ADR-002's 300-line registration-function cap (stage 2.7), the
+    same "one definition, kept under the cap" precedent make_serialize_
+    mutating_intent already established in this file (see that function's
+    own docstring). Captures nothing register_chat_library's own callers
+    couldn't already reach via bus.chat_save_state, which is the SAME dict
+    passed in here as last_saved."""
+
+    async def load_chat(chat_id: int):
+        # R6.4: replicates ChatSessionManager.load_chat's own orchestration
+        # order (load row -> load notes/pins -> restore) and
+        # SceneDeserializer._handle_load_error's "notification, not a
+        # crash" posture for anything that goes wrong - canvas_document/
+        # notifications are only None in a test harness that didn't wire
+        # them; a real running session always has both (see backend/app.py's
+        # _configure_session ordering).
+        try:
+            row = await asyncio.to_thread(load_chat_row, resolved_path, int(chat_id))
+            if row is None:
+                if notifications is not None:
+                    notifications.show("This chat could not be found. It may have already been deleted.", "error")
+                    await bus.publish("notification")
+                return
+
+            notes_rows = await asyncio.to_thread(load_notes_rows, resolved_path, int(chat_id))
+            pins_rows = await asyncio.to_thread(load_pins_rows, resolved_path, int(chat_id))
+
+            if canvas_document is None:
+                return
+
+            restore_chat_into_document(canvas_document, row, notes_rows, pins_rows)
+            # R6.5: remember which row this scene now corresponds to, so a
+            # later Save updates THIS row instead of always inserting a new
+            # one - the backend analog of ChatSessionManager.current_chat_id
+            # being set from the load path, not just the save path.
+            canvas_document.current_chat_id = int(chat_id)
+            # Audit fix: the document now matches this row exactly, so record
+            # that. Without it the first tick after a load rewrote a
+            # byte-identical row and bumped updated_at, re-sorting the Chat
+            # Library under the user for a session they had only just opened.
+            try:
+                fresh = build_chat_data(canvas_document)
+                fresh_notes = fresh.pop("notes_data", [])
+                fresh_pins = fresh.pop("pins_data", [])
+                # ADR-009 stage 9.2: row["updated_at"] is the value that
+                # will be carried forward as expected_updated_at on this
+                # session's NEXT save of this chat - see load_chat_row's
+                # own docstring for why it must come from exactly here
+                # (this load), never re-read moments before that later
+                # save.
+                record_saved(fresh, fresh_notes, fresh_pins, chat_id, row.get("updated_at"))
+            except Exception:
+                # Never fail a successful load over bookkeeping - leaving the
+                # digest unset just means one redundant tick, the pre-fix
+                # behavior. updated_at is still recorded from the real row
+                # (not lost to the same failure) so optimistic concurrency
+                # for this session's next save stays correct even when this
+                # narrower bookkeeping step failed.
+                last_saved["digest"] = None
+                last_saved["chat_id"] = int(chat_id)
+                last_saved["updated_at"] = row.get("updated_at")
+        except Exception as exc:
+            # Adversarial review finding: load_notes_rows/load_pins_rows (a
+            # real sqlite3.Error, e.g. a locked/corrupted db file) previously
+            # had no safety net here, unlike load_chat_row's None-check and
+            # restore_chat_into_document's own try/except - it would
+            # propagate uncaught out of dispatch_intent. Since the frontend's
+            # loadChat call is fire-and-forget (no msg_id), the generic WS-
+            # level error reply that DOES still get sent lands nowhere the
+            # user can see (console.error only) - the dialog just closes and
+            # goes silent. Wrapping the whole load sequence, not just the
+            # restore step, guarantees a real, visible notification for
+            # every failure mode here, matching legacy's own
+            # _handle_load_error posture (one catch-all around the entire
+            # load, not per-step).
+            if notifications is not None:
+                notifications.show(f"Failed to load the chat session. It may be corrupted.\nError: {exc}", "error")
+                await bus.publish("notification")
+            return
+
+        await bus.publish("scene")
+        if notifications is not None:
+            title = str(row.get("title") or "chat")
+            notifications.show(f'Loaded "{title}".', "success")
+            await bus.publish("notification")
+
+    return load_chat
+
+
+def make_save_chat(
+    bus: SessionBus,
+    resolved_path: Path,
+    canvas_document: SceneDocument | None,
+    notifications: NotificationState | None,
+    record_saved: Callable[..., None],
+    last_saved: dict[str, Any],
+):
+    """Factory for register_chat_library's own saveChat intent - see
+    make_load_chat's own docstring (immediately above) for why this is a
+    top-level factory rather than a closure defined inline."""
+
+    async def save_chat():
+        # R6.5: replicates ChatSessionManager.save_current_chat's own
+        # orchestration (manager.py:83-133) - serialize -> resolve title/
+        # chat_id -> one atomic DB write -> adopt the resolved chat_id.
+        # Unlike legacy, this runs synchronously start-to-finish on the
+        # event loop rather than handing off to a background QThread; the
+        # _serialize_mutating_intent wrapper this is registered through
+        # (see register_chat_library's own docstring above it) is this
+        # function's actual reentrancy guard - see that comment for why one
+        # is needed at all (a naive "nothing else runs during an await" -
+        # this file's own ORIGINAL, WRONG assumption - does not hold once a
+        # session can have more than one attached WS connection).
+        if canvas_document is None:
+            return
+
+        has_any_nodes = bool(canvas_document.nodes)
+        if not has_any_nodes and canvas_document.current_chat_id is None:
+            # Mirrors save_current_chat's own "Nothing was added to the chat
+            # canvas yet." guard (manager.py:94-96) - an empty, never-saved
+            # canvas has nothing worth writing a row for.
+            if notifications is not None:
+                notifications.show("Nothing was added to the chat canvas yet.", "warning")
+                await bus.publish("notification")
+            return
+
+        try:
+            chat_data = build_chat_data(canvas_document)
+        except Exception as exc:
+            if notifications is not None:
+                notifications.show(f"Failed to prepare chat save payload: {exc}", "error")
+                await bus.publish("notification")
+            return
+
+        notes_data = chat_data.pop("notes_data", [])
+        pins_data = chat_data.pop("pins_data", [])
+
+        chat_id_for_save: int | None = None
+        title: str
+        # ADR-009 stage 9.2: what THIS session believes is on disk for the
+        # chat it's about to (re)save - only trusted as expected_updated_at
+        # below when it actually describes the SAME row (chat_id match);
+        # otherwise there is no real prior version to compare against
+        # (current_chat_id set some other way than a load/save this cell
+        # ever saw), and save_chat_atomically_row's own
+        # expected_updated_at=None falls back to a blind UPDATE, matching
+        # this function's pre-9.2 behavior exactly for that case.
+        expected_updated_at: str | None = None
+        current_id = canvas_document.current_chat_id
+        if not current_id:
+            title = _fallback_title(_resolve_seed_message(canvas_document))
+        else:
+            existing_row = await asyncio.to_thread(load_chat_row, resolved_path, int(current_id))
+            if existing_row is not None:
+                # Resaving an existing chat NEVER regenerates its title,
+                # matching SaveWorkerThread.run()'s own `title = chat["title"]`
+                # (workers.py:69) exactly.
+                title = str(existing_row.get("title") or "Untitled")
+                chat_id_for_save = int(current_id)
+                if last_saved.get("chat_id") == int(current_id):
+                    expected_updated_at = last_saved.get("updated_at")
+            else:
+                # The row was deleted elsewhere between load and this save -
+                # falls back to a fresh INSERT, matching legacy's own
+                # tolerance for this race (workers.py:71-72) rather than
+                # erroring.
+                title = _fallback_title(_resolve_seed_message(canvas_document))
+
+        try:
+            # ADR-009 stage 9.2: backup-before-write - see
+            # _maybe_backup_before_write's own docstring for why this ONE
+            # call covers both "before the first mutating write of a
+            # session" and the ongoing periodic cadence. Best-effort: a
+            # backup failure is logged inside that function and never
+            # raised, so it can't block the real save below.
+            await asyncio.to_thread(_maybe_backup_before_write, resolved_path, last_saved)
+            new_chat_id, new_updated_at = await asyncio.to_thread(
+                save_chat_atomically_row, resolved_path, chat_id_for_save, title, chat_data, notes_data, pins_data,
+                expected_updated_at=expected_updated_at,
+            )
+        except ConcurrentSaveConflict:
+            # ADR-009 stage 9.2 exit criterion: a lost write race is
+            # surfaced, never clobbered. last_saved is deliberately left
+            # exactly as it was (still pointing at the STALE updated_at) -
+            # this session's edit was NOT written, so nothing here should
+            # look like it now matches what's on disk.
+            logger.warning(
+                "saveChat: lost a save race for chat %r (session=%r) - not clobbering the newer version",
+                current_id, bus.session_id,
+            )
+            if notifications is not None:
+                notifications.show(LOST_RACE_MESSAGE_MANUAL, "warning")
+                await bus.publish("notification")
+            return
+        except Exception as exc:
+            if notifications is not None:
+                notifications.show(f"Failed to save the chat session.\nError: {exc}", "error")
+                await bus.publish("notification")
+            return
+
+        canvas_document.current_chat_id = int(new_chat_id)
+        # Audit fix: record what this manual Save just put on disk, so the
+        # next autosave tick recognizes it as already-saved instead of
+        # rewriting a byte-identical row 30 seconds later.
+        record_saved(chat_data, notes_data, pins_data, new_chat_id, new_updated_at)
+        await bus.publish("app-chat-library")
+        if notifications is not None:
+            notifications.show(f'Saved "{title}".', "success")
+            await bus.publish("notification")
+
+    return save_chat
 
 
 def register_chat_library(
@@ -654,8 +1370,16 @@ def register_chat_library(
     autosave_interval_seconds: float | None = 30.0,
 ) -> None:
     resolved_path = db_path if db_path is not None else DEFAULT_DB_PATH
+    # ADR-009 stage 9.2: stashed on the bus for the same reason bus.
+    # chat_mutation_guard/bus.chat_save_state/bus.autosave_task already
+    # are - per-session state a caller outside this closure legitimately
+    # needs to reach (backend/app.py's _evict_idle_session, for the
+    # flush-before-teardown fix - see flush_dirty_session_before_teardown's
+    # own docstring), and a closure-local is unreachable to anything else,
+    # including the tests that prove the sharing actually works.
+    bus.chat_db_path = resolved_path
 
-    bus.register_topic("app-chat-library", lambda: chat_library_payload(resolved_path))
+    bus.register_topic("app-chat-library", lambda: chat_library_payload(resolved_path, notifications))
 
     # Adversarial review finding: loadChat/saveChat/newChat all mutate the
     # SAME canvas_document and each awaits at least one asyncio.to_thread DB
@@ -704,10 +1428,16 @@ def register_chat_library(
     bus.chat_save_state = _last_saved
 
     def _record_saved(
-        chat_data: dict[str, Any], notes_data: list, pins_data: list, chat_id: int | None
+        chat_data: dict[str, Any], notes_data: list, pins_data: list, chat_id: int | None,
+        updated_at: str | None = None,
     ) -> None:
         _last_saved["digest"] = _content_digest(chat_data, notes_data, pins_data)
         _last_saved["chat_id"] = int(chat_id) if chat_id is not None else None
+        # ADR-009 stage 9.2: the value the NEXT save on this session will
+        # hand back as expected_updated_at - see save_chat_atomically_row's
+        # own optimistic-concurrency docstring for why this must always be
+        # a real value from a real load/save, never independently derived.
+        _last_saved["updated_at"] = updated_at
 
     _serialize_mutating_intent = make_serialize_mutating_intent(bus, _mutation_in_progress, notifications)
 
@@ -744,151 +1474,11 @@ def register_chat_library(
             canvas_document.current_chat_id = None
             _last_saved["digest"] = None
             _last_saved["chat_id"] = None
+            _last_saved["updated_at"] = None
         await bus.publish("app-chat-library")
 
-    async def load_chat(chat_id: int):
-        # R6.4: replicates ChatSessionManager.load_chat's own orchestration
-        # order (load row -> load notes/pins -> restore) and
-        # SceneDeserializer._handle_load_error's "notification, not a
-        # crash" posture for anything that goes wrong - canvas_document/
-        # notifications are only None in a test harness that didn't wire
-        # them; a real running session always has both (see backend/app.py's
-        # _configure_session ordering).
-        try:
-            row = await asyncio.to_thread(load_chat_row, resolved_path, int(chat_id))
-            if row is None:
-                if notifications is not None:
-                    notifications.show("This chat could not be found. It may have already been deleted.", "error")
-                    await bus.publish("notification")
-                return
-
-            notes_rows = await asyncio.to_thread(load_notes_rows, resolved_path, int(chat_id))
-            pins_rows = await asyncio.to_thread(load_pins_rows, resolved_path, int(chat_id))
-
-            if canvas_document is None:
-                return
-
-            restore_chat_into_document(canvas_document, row, notes_rows, pins_rows)
-            # R6.5: remember which row this scene now corresponds to, so a
-            # later Save updates THIS row instead of always inserting a new
-            # one - the backend analog of ChatSessionManager.current_chat_id
-            # being set from the load path, not just the save path.
-            canvas_document.current_chat_id = int(chat_id)
-            # Audit fix: the document now matches this row exactly, so record
-            # that. Without it the first tick after a load rewrote a
-            # byte-identical row and bumped updated_at, re-sorting the Chat
-            # Library under the user for a session they had only just opened.
-            try:
-                fresh = build_chat_data(canvas_document)
-                fresh_notes = fresh.pop("notes_data", [])
-                fresh_pins = fresh.pop("pins_data", [])
-                _record_saved(fresh, fresh_notes, fresh_pins, chat_id)
-            except Exception:
-                # Never fail a successful load over bookkeeping - leaving the
-                # digest unset just means one redundant tick, the pre-fix
-                # behavior.
-                _last_saved["digest"] = None
-                _last_saved["chat_id"] = int(chat_id)
-        except Exception as exc:
-            # Adversarial review finding: load_notes_rows/load_pins_rows (a
-            # real sqlite3.Error, e.g. a locked/corrupted db file) previously
-            # had no safety net here, unlike load_chat_row's None-check and
-            # restore_chat_into_document's own try/except - it would
-            # propagate uncaught out of dispatch_intent. Since the frontend's
-            # loadChat call is fire-and-forget (no msg_id), the generic WS-
-            # level error reply that DOES still get sent lands nowhere the
-            # user can see (console.error only) - the dialog just closes and
-            # goes silent. Wrapping the whole load sequence, not just the
-            # restore step, guarantees a real, visible notification for
-            # every failure mode here, matching legacy's own
-            # _handle_load_error posture (one catch-all around the entire
-            # load, not per-step).
-            if notifications is not None:
-                notifications.show(f"Failed to load the chat session. It may be corrupted.\nError: {exc}", "error")
-                await bus.publish("notification")
-            return
-
-        await bus.publish("scene")
-        if notifications is not None:
-            title = str(row.get("title") or "chat")
-            notifications.show(f'Loaded "{title}".', "success")
-            await bus.publish("notification")
-
-    async def save_chat():
-        # R6.5: replicates ChatSessionManager.save_current_chat's own
-        # orchestration (manager.py:83-133) - serialize -> resolve title/
-        # chat_id -> one atomic DB write -> adopt the resolved chat_id.
-        # Unlike legacy, this runs synchronously start-to-finish on the
-        # event loop rather than handing off to a background QThread; the
-        # _serialize_mutating_intent wrapper this is registered through
-        # (see register_chat_library's own docstring above it) is this
-        # function's actual reentrancy guard - see that comment for why one
-        # is needed at all (a naive "nothing else runs during an await" -
-        # this file's own ORIGINAL, WRONG assumption - does not hold once a
-        # session can have more than one attached WS connection).
-        if canvas_document is None:
-            return
-
-        has_any_nodes = bool(canvas_document.nodes)
-        if not has_any_nodes and canvas_document.current_chat_id is None:
-            # Mirrors save_current_chat's own "Nothing was added to the chat
-            # canvas yet." guard (manager.py:94-96) - an empty, never-saved
-            # canvas has nothing worth writing a row for.
-            if notifications is not None:
-                notifications.show("Nothing was added to the chat canvas yet.", "warning")
-                await bus.publish("notification")
-            return
-
-        try:
-            chat_data = build_chat_data(canvas_document)
-        except Exception as exc:
-            if notifications is not None:
-                notifications.show(f"Failed to prepare chat save payload: {exc}", "error")
-                await bus.publish("notification")
-            return
-
-        notes_data = chat_data.pop("notes_data", [])
-        pins_data = chat_data.pop("pins_data", [])
-
-        chat_id_for_save: int | None = None
-        title: str
-        current_id = canvas_document.current_chat_id
-        if not current_id:
-            title = _fallback_title(_resolve_seed_message(canvas_document))
-        else:
-            existing_row = await asyncio.to_thread(load_chat_row, resolved_path, int(current_id))
-            if existing_row is not None:
-                # Resaving an existing chat NEVER regenerates its title,
-                # matching SaveWorkerThread.run()'s own `title = chat["title"]`
-                # (workers.py:69) exactly.
-                title = str(existing_row.get("title") or "Untitled")
-                chat_id_for_save = int(current_id)
-            else:
-                # The row was deleted elsewhere between load and this save -
-                # falls back to a fresh INSERT, matching legacy's own
-                # tolerance for this race (workers.py:71-72) rather than
-                # erroring.
-                title = _fallback_title(_resolve_seed_message(canvas_document))
-
-        try:
-            new_chat_id = await asyncio.to_thread(
-                save_chat_atomically_row, resolved_path, chat_id_for_save, title, chat_data, notes_data, pins_data,
-            )
-        except Exception as exc:
-            if notifications is not None:
-                notifications.show(f"Failed to save the chat session.\nError: {exc}", "error")
-                await bus.publish("notification")
-            return
-
-        canvas_document.current_chat_id = int(new_chat_id)
-        # Audit fix: record what this manual Save just put on disk, so the
-        # next autosave tick recognizes it as already-saved instead of
-        # rewriting a byte-identical row 30 seconds later.
-        _record_saved(chat_data, notes_data, pins_data, new_chat_id)
-        await bus.publish("app-chat-library")
-        if notifications is not None:
-            notifications.show(f'Saved "{title}".', "success")
-            await bus.publish("notification")
+    load_chat = make_load_chat(bus, resolved_path, canvas_document, notifications, _record_saved, _last_saved)
+    save_chat = make_save_chat(bus, resolved_path, canvas_document, notifications, _record_saved, _last_saved)
 
     async def new_chat():
         # R6.5: the backend counterpart of legacy's "start with an empty
@@ -904,6 +1494,7 @@ def register_chat_library(
         # described the old document no longer describes anything.
         _last_saved["digest"] = None
         _last_saved["chat_id"] = None
+        _last_saved["updated_at"] = None
         await bus.publish("scene")
 
     bus.register_intent("app-chat-library", "renameChat", rename)
@@ -926,3 +1517,112 @@ def register_chat_library(
             bus, resolved_path, canvas_document, notifications, _mutation_in_progress, _last_saved,
             interval_seconds=autosave_interval_seconds,
         )
+
+
+def flush_dirty_session_before_teardown(
+    db_path: Path,
+    canvas_document: SceneDocument,
+    last_saved: dict[str, Any],
+    notifications: NotificationState | None = None,
+) -> None:
+    """ADR-009 stage 9.2 / ADR-004 stage 4.3 interaction: backend/app.py's
+    _evict_idle_session (idle-session teardown) used to just CANCEL the
+    autosave task outright with no final write - any edit made since the
+    LAST successful tick (up to autosave's own interval_seconds, 30s by
+    default) was silently lost the instant this session's SceneDocument
+    became unreachable. Confirmed as a real, live gap (not a hypothetical)
+    by reading _evict_idle_session as it stood before this stage: it calls
+    cancel_all/cancel_all_pending_approvals/dispose_all_pycoder_repls, then
+    autosave_task.cancel() - no flush anywhere in between.
+
+    This is the SYNCHRONOUS counterpart of backend/autosave.py's
+    autosave_tick, for the one caller (eviction teardown) that has no
+    natural async dispatch to await asyncio.to_thread the way every other
+    write path in this codebase does - _evict_idle_session already performs
+    other blocking teardown work synchronously (cancel_all,
+    dispose_all_pycoder_repls), so one more small, bounded blocking DB
+    write here is consistent with that existing posture, not a new kind of
+    risk.
+
+    Deliberately mirrors autosave_tick's own change-guard (skip if nothing
+    changed since last_saved) and title-resolution (never regenerate an
+    existing chat's title) - not extracted into one shared function with
+    autosave_tick because that function is async (uses asyncio.to_thread
+    throughout) and this caller has no event loop to dispatch onto; see
+    that function's own docstring for the shared reasoning behind each
+    step mirrored here.
+
+    A write failure (including a lost optimistic-concurrency race) is
+    logged and swallowed here, never raised - the session is being torn
+    down either way, and there is no later tick that will retry. Passing a
+    real `notifications` reference is supported for callers that have one
+    and could plausibly still reach the user (this function does not
+    assume anything about who might be watching), but note that
+    backend/app.py's own eviction call site deliberately does NOT wire one
+    through: eviction only ever runs for a session with ZERO live
+    connections (that is what "idle" means), so nothing set on THIS
+    session's own NotificationState could ever be seen by anyone - the
+    bus itself, and the NotificationState instance with it, is discarded
+    the moment eviction finishes. A reconnect later gets a genuinely fresh
+    session with its own fresh NotificationState. logger.error/.warning
+    calls below are therefore the real, durable signal for this path (see
+    backend/crash_recovery.py's own docstring on everything unhandled in
+    this codebase landing somewhere durable) - not a gap, a deliberate
+    choice given who could possibly observe a notification here."""
+    if not canvas_document.nodes and canvas_document.current_chat_id is None:
+        return
+
+    try:
+        chat_data = build_chat_data(canvas_document)
+    except Exception:
+        logger.exception("eviction flush: failed to build chat data - the last edit may be lost")
+        return
+    notes_data = chat_data.pop("notes_data", [])
+    pins_data = chat_data.pop("pins_data", [])
+
+    digest = _content_digest(chat_data, notes_data, pins_data)
+    if digest == last_saved.get("digest") and canvas_document.current_chat_id == last_saved.get("chat_id"):
+        return  # already matches what's on disk - nothing to protect
+
+    current_id = canvas_document.current_chat_id
+    expected_updated_at: str | None = None
+    chat_id_for_save: int | None = None
+    if current_id:
+        try:
+            existing_row = load_chat_row(db_path, int(current_id))
+        except Exception:
+            logger.exception("eviction flush: failed to read the existing chat row - the last edit may be lost")
+            return
+        if existing_row is not None:
+            title = str(existing_row.get("title") or "Untitled")
+            chat_id_for_save = int(current_id)
+            if last_saved.get("chat_id") == int(current_id):
+                expected_updated_at = last_saved.get("updated_at")
+        else:
+            title = _fallback_title(_resolve_seed_message(canvas_document))
+    else:
+        title = _fallback_title(_resolve_seed_message(canvas_document))
+
+    try:
+        _maybe_backup_before_write(db_path, last_saved)
+        new_chat_id, new_updated_at = save_chat_atomically_row(
+            db_path, chat_id_for_save, title, chat_data, notes_data, pins_data,
+            expected_updated_at=expected_updated_at,
+        )
+    except ConcurrentSaveConflict:
+        logger.warning(
+            "eviction flush: lost a save race for chat %r - not clobbering the newer version", current_id,
+        )
+        if notifications is not None:
+            notifications.show(LOST_RACE_MESSAGE_AUTOSAVE, "warning")
+        return
+    except Exception:
+        logger.exception("eviction flush: DB write failed - the last edit may be lost")
+        if notifications is not None:
+            notifications.show("Your last edits could not be saved before this session closed.", "error")
+        return
+
+    canvas_document.current_chat_id = int(new_chat_id)
+    last_saved["digest"] = digest
+    last_saved["chat_id"] = int(new_chat_id)
+    last_saved["updated_at"] = new_updated_at

--- a/backend/db_backup.py
+++ b/backend/db_backup.py
@@ -1,0 +1,313 @@
+"""ADR-009 stage 9.2: chats.db backup rotation, retention, and restore.
+
+Owns the whole lifecycle of a backup FILE (take one, decide which ones
+survive pruning, restore the newest one back into place) - the write/prune
+side and the restore side share one module because they share the exact
+same filename convention (`_parse_backup_timestamp` is the one place that
+convention is parsed back out of a path), and keeping "what counts as a
+backup for db_path" in a single spot means the two directions can never
+quietly disagree about it.
+
+WAL-SAFE SNAPSHOT, NOT A RAW FILE COPY: take_backup() uses SQLite's own
+online backup API (`sqlite3.Connection.backup()`) rather than
+`shutil.copy` on the live file. chats.db can genuinely be open elsewhere at
+the moment a backup is taken (autosave's own tick, a manual Save, another
+window) - a raw byte copy of a file that might be mid-write (even under
+WAL, where the main file and the -wal sidecar can be inconsistent with
+each other at any instant) could copy a torn, inconsistent snapshot. The
+backup API instead reads through SQLite's own page cache/locking exactly
+the way a live query would, so the destination is always a complete,
+internally-consistent copy of SOME real commit, never a partial one -
+this is precisely what the API exists for (it's the same mechanism behind
+the `sqlite3` CLI's own `.backup` command and `VACUUM INTO`).
+
+RESTORING is the opposite direction and does NOT need the backup API: the
+source is a backup file THIS module itself already wrote via that API into
+a directory nothing else ever opens for writing - a plain, static file no
+concurrent writer can be mid-write against. A byte copy of an already-
+inert file is safe; see restore_from_newest_backup's own docstring for how
+that copy is still made atomic against a crash mid-restore.
+
+RETENTION POLICY (the exact numbers, and why): keep the KEEP_MOST_RECENT
+(10) most recent snapshots unconditionally, PLUS - among anything OLDER
+than that cutoff - the single newest snapshot for each distinct UTC
+calendar day still on disk (a "daily" bucket). Backups are taken at most
+once per BACKUP_CADENCE_SECONDS (backend/chat_library.py's own constant,
+10 minutes) per active session, so keeping the most-recent 10 covers
+roughly the last ~100 minutes of activity at full resolution - enough to
+recover from "the last several saves introduced a problem" without
+special-casing WHY a recent backup might be bad. The daily bucket then
+keeps the recovery window open indefinitely into the past (one snapshot
+per day, forever) without retention ever growing unbounded - chats.db can
+carry embedded image bytes (see backend/canvas.py's own asset-embedding
+docstring), so an unbounded "keep everything" policy would grow backups/
+without limit on a long-running install.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+BACKUP_FILENAME_PREFIX = "chats-"
+BACKUP_FILENAME_SUFFIX = ".db"
+_TIMESTAMP_FORMAT = "%Y%m%dT%H%M%SZ"
+
+# See this module's own docstring ("RETENTION POLICY") for the full
+# reasoning behind this exact number.
+KEEP_MOST_RECENT = 10
+
+
+def backups_dir_for(db_path: Path) -> Path:
+    """Mirrors backend/crash_recovery.py's own base_dir override pattern
+    (`_data_dir(base_dir)`  Path.home()/".graphlink" by default,
+    overridable) WITHOUT a second, independently-overridable parameter to
+    keep in sync with db_path's own: backups live NEXT TO the database
+    they back up (`db_path.parent / "backups"`). Every test that already
+    passes an isolated `tmp_path / "chats.db"` gets an isolated backups/
+    directory for free (never the real ~/.graphlink), and the real
+    default (`backend/chat_library.py`'s `DEFAULT_DB_PATH`, `Path.home() /
+    ".graphlink" / "chats.db"`) naturally lands backups at
+    `~/.graphlink/backups/` - exactly the path the ADR text itself
+    names."""
+    return db_path.parent / "backups"
+
+
+def _timestamp_now() -> str:
+    return datetime.now(timezone.utc).strftime(_TIMESTAMP_FORMAT)
+
+
+def backup_filename(timestamp: str) -> str:
+    return f"{BACKUP_FILENAME_PREFIX}{timestamp}{BACKUP_FILENAME_SUFFIX}"
+
+
+def _parse_backup_timestamp(path: Path) -> datetime | None:
+    """None for anything that isn't one of OUR OWN backup filenames -
+    list_backups/prune_backups must never trip over an unrelated file a
+    user (or a future feature) happens to drop into the same directory;
+    silently ignoring it, not raising, is the safe direction here since
+    this is a read-only classification, not a delete decision by itself."""
+    name = path.name
+    if not (name.startswith(BACKUP_FILENAME_PREFIX) and name.endswith(BACKUP_FILENAME_SUFFIX)):
+        return None
+    raw = name[len(BACKUP_FILENAME_PREFIX):-len(BACKUP_FILENAME_SUFFIX)]
+    try:
+        return datetime.strptime(raw, _TIMESTAMP_FORMAT).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def list_backups(db_path: Path) -> list[Path]:
+    """Every recognized backup for db_path, newest first. Empty (not an
+    error) when the backups directory doesn't exist yet - a session that
+    has never taken a backup is a normal, common state, not a fault."""
+    backups_dir = backups_dir_for(db_path)
+    if not backups_dir.is_dir():
+        return []
+    entries: list[tuple[datetime, Path]] = []
+    for candidate in backups_dir.iterdir():
+        if not candidate.is_file():
+            continue
+        timestamp = _parse_backup_timestamp(candidate)
+        if timestamp is not None:
+            entries.append((timestamp, candidate))
+    entries.sort(key=lambda pair: pair[0], reverse=True)
+    return [path for _, path in entries]
+
+
+def newest_backup(db_path: Path) -> Path | None:
+    backups = list_backups(db_path)
+    return backups[0] if backups else None
+
+
+def prune_backups(db_path: Path) -> list[Path]:
+    """Applies the retention policy described in this module's own
+    docstring and deletes whatever doesn't survive it. Returns the paths
+    actually deleted (empty if nothing needed pruning) - real signal for
+    tests, not just a side effect to infer from what's left.
+
+    A single backup that fails to delete (a transient permission/lock
+    issue) is logged and skipped, not raised - one stuck file must never
+    block every other backup this call would otherwise have pruned, and
+    the next prune_backups call (the very next take_backup) will simply
+    try it again."""
+    backups = list_backups(db_path)  # newest first
+    recent = backups[:KEEP_MOST_RECENT]
+    older = backups[KEEP_MOST_RECENT:]
+    keep: set[Path] = set(recent)
+
+    # A calendar day already represented in the most-recent-N window must
+    # NOT also get a second, older representative kept via the daily
+    # bucket below - otherwise a burst of activity that happens to fall
+    # entirely within one day (the common case: several saves in a single
+    # active session) would keep KEEP_MOST_RECENT + 1 backups instead of
+    # exactly KEEP_MOST_RECENT, since the (N+1)th-newest backup would
+    # always be "the first one seen for its day" from a naive scan of
+    # `older` alone.
+    covered_days: set[str] = set()
+    for path in recent:
+        timestamp = _parse_backup_timestamp(path)
+        if timestamp is not None:
+            covered_days.add(timestamp.strftime("%Y-%m-%d"))
+
+    for path in older:
+        # `older` is still newest-first (list_backups' own ordering,
+        # sliced) - the FIRST entry seen for a given day is therefore
+        # already the newest one for that day, so a plain "seen this day
+        # yet?" check is enough; no separate max-by-day pass is needed.
+        timestamp = _parse_backup_timestamp(path)
+        if timestamp is None:
+            continue
+        day_key = timestamp.strftime("%Y-%m-%d")
+        if day_key not in covered_days:
+            covered_days.add(day_key)
+            keep.add(path)
+
+    deleted: list[Path] = []
+    for path in backups:
+        if path in keep:
+            continue
+        try:
+            path.unlink()
+            deleted.append(path)
+        except OSError:
+            logger.warning("could not delete old backup %s - continuing", path)
+    return deleted
+
+
+def take_backup(db_path: Path) -> Path | None:
+    """Snapshots db_path into backups_dir_for(db_path) via SQLite's own
+    online backup API - see this module's own docstring for why that API,
+    not a raw file copy. Returns the new backup's path, or None when
+    db_path does not exist yet at all (a session that has never saved
+    anything has no file worth snapshotting - this is a normal no-op, not
+    an error).
+
+    Written to a temp name first, then os.replace'd into its final name -
+    the same atomic-rename pattern graphlink_settings_store.py's own
+    _save_state already establishes for exactly this reason: a crash mid-
+    backup (the destination .backup() call is itself interrupted) can
+    then only ever leave the TEMP file incomplete, never a file wearing a
+    real backup's final name that a later restore might trust as
+    complete. Calls prune_backups() on every successful backup, so
+    retention is enforced continuously rather than needing a separate
+    scheduled sweep."""
+    if not db_path.exists():
+        return None
+
+    backups_dir = backups_dir_for(db_path)
+    backups_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = _timestamp_now()
+    final_name = backup_filename(timestamp)
+    final_path = backups_dir / final_name
+    tmp_path = backups_dir / f".{final_name}.tmp"
+
+    # A stale .tmp from a previous crash mid-backup must never make
+    # sqlite3.connect(tmp_path) below open (and back up INTO) a leftover
+    # partial file - always start this backup from a clean slate.
+    if tmp_path.exists():
+        try:
+            tmp_path.unlink()
+        except OSError:
+            logger.warning("could not remove stale temp backup %s - continuing", tmp_path)
+
+    source_conn = sqlite3.connect(db_path, timeout=30)
+    try:
+        dest_conn = sqlite3.connect(tmp_path, timeout=30)
+        try:
+            # chats.db holds real conversation content - same 0600
+            # sensitivity as the live file (backend/chat_library.py's own
+            # _connect docstring). Chmod'd immediately after the
+            # destination file is created, before .backup() writes any
+            # page data into it - mirrors _save_state's own "chmod before
+            # content lands" ordering.
+            try:
+                os.chmod(tmp_path, 0o600)
+            except OSError:
+                logger.warning("could not chmod %s to 0600 before writing - continuing", tmp_path)
+            source_conn.backup(dest_conn)
+        finally:
+            dest_conn.close()
+    finally:
+        source_conn.close()
+
+    try:
+        os.chmod(tmp_path, 0o600)
+    except OSError:
+        logger.warning("could not chmod %s to 0600 - continuing", tmp_path)
+    os.replace(tmp_path, final_path)
+
+    prune_backups(db_path)
+    return final_path
+
+
+def restore_from_newest_backup(db_path: Path) -> Path | None:
+    """Copies the newest surviving backup for db_path INTO db_path,
+    overwriting whatever (if anything) is currently there. Returns the
+    backup path that was restored, or None when no backup exists at all
+    (db_path is left untouched in that case - see this function's own
+    caller, backend/chat_library.py's _rescue_corrupt_chats_db, for why a
+    missing-backup outcome must never fabricate a fresh empty file itself:
+    that decision belongs one layer up, where it can be reported honestly
+    rather than silently masked as "restored").
+
+    ATOMICITY: reads the backup and writes to a TEMP name next to db_path
+    first, then os.replace's it into db_path only once the full copy has
+    landed and been fsync'd - the same atomic-rename discipline this
+    module's own take_backup and graphlink_settings_store.py's own
+    _save_state already use. This is the difference between "a second
+    crash mid-restore leaves db_path exactly as absent/quarantined as it
+    already was" (safe - the caller's own retry lands here again) and "a
+    second crash mid-restore leaves a half-written db_path that looks like
+    it might be fine" (exactly the kind of half-applied operation ground-
+    rule #2 for this whole stage forbids). The destination file is opened
+    with mode 0600 from its very first byte (this function's caller only
+    ever runs after the corrupt live file has already been fully removed
+    from db_path, so there is no pre-existing file whose permissions could
+    otherwise be inherited) and chmod'd again explicitly afterward for
+    certainty regardless of umask, matching this codebase's established
+    "chmod, don't assume" posture elsewhere.
+
+    The source backup file itself is never touched (not deleted, not
+    moved) - restoring from it must be repeatable, e.g. if this exact
+    restore is itself somehow interrupted and retried."""
+    source = newest_backup(db_path)
+    if source is None:
+        return None
+
+    tmp_path = db_path.with_name(db_path.name + ".restoring.tmp")
+    if tmp_path.exists():
+        try:
+            tmp_path.unlink()
+        except OSError:
+            logger.warning("could not remove stale restore temp file %s - continuing", tmp_path)
+
+    fd = os.open(tmp_path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    try:
+        try:
+            os.chmod(tmp_path, 0o600)
+        except OSError:
+            logger.warning("could not chmod %s to 0600 - continuing", tmp_path)
+        with os.fdopen(fd, "wb") as dest, open(source, "rb") as src:
+            shutil.copyfileobj(src, dest)
+            dest.flush()
+            os.fsync(dest.fileno())
+    except BaseException:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+    os.replace(tmp_path, db_path)
+    try:
+        os.chmod(db_path, 0o600)
+    except OSError:
+        logger.warning("could not chmod %s to 0600 - continuing", db_path)
+    return source

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -10,23 +10,33 @@ import stat
 import sys
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 import backend.autosave as autosave_module
 import backend.chat_library as chat_library_module
+import backend.db_backup as db_backup_module
 from backend.autosave import autosave_tick, register_autosave
 from backend.canvas import SceneDocument
 from backend.chat_library import (
     AUTOSAVE_OWNER,
+    BACKUP_CADENCE_SECONDS,
+    CHATS_DB_SCHEMA_VERSION,
+    LOST_RACE_MESSAGE_AUTOSAVE,
+    LOST_RACE_MESSAGE_MANUAL,
     USER_OWNER,
+    ConcurrentSaveConflict,
     _extract_preview_and_message_count,
     _fallback_title,
     _format_timestamp,
     _format_timestamp_iso,
+    _maybe_backup_before_write,
+    _new_save_state,
     _resolve_seed_message,
     chat_library_payload,
     delete_chat,
+    flush_dirty_session_before_teardown,
     get_all_chats,
     load_chat_row,
     load_notes_rows,
@@ -240,6 +250,214 @@ class TestChatsDbUsesWalModeForChmoddableSidecars:
         monkeypatch.setattr(os, "chmod", _boom)
 
         assert get_all_chats(db_path) == []
+
+
+# -- ADR-009 stage 9.1: busy_timeout + user_version migration runner --------
+
+
+class TestChatsDbBusyTimeout:
+    """An explicit PRAGMA busy_timeout, matching (not shortening) the
+    pre-existing 30-second convention this module's own `timeout=30`
+    sqlite3.connect() argument already established - see _connect's own
+    comment for why both statements exist without being in tension (the
+    connect() kwarg already sets this value via the same underlying sqlite3
+    C API; the explicit PRAGMA makes it self-documenting and independent of
+    that kwarg ever changing)."""
+
+    def test_busy_timeout_reads_back_as_the_established_30_second_convention(self, db_path):
+        conn = chat_library_module._connect(db_path)
+        try:
+            assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 30000
+        finally:
+            conn.close()
+
+
+class TestChatsDbSchemaMigration:
+    """PRAGMA user_version-gated migration replacing the old per-connection
+    _ensure_chats_table/_ensure_notes_table/_ensure_pins_table probes -
+    CHATS_DB_SCHEMA_VERSION is the version stamped once migration "1"
+    (0 -> 1) has run. See backend/chat_library.py's own
+    _migration_001_initial_schema docstring for exactly what that migration
+    does and why it must behave identically on a fresh db and a real
+    pre-existing one (covered separately below by
+    TestMigrationUpgradesAPreExistingRealShapedDatabase)."""
+
+    def test_fresh_db_lands_on_the_target_schema_version(self, db_path):
+        get_all_chats(db_path)  # any query function bootstraps a fresh db
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == CHATS_DB_SCHEMA_VERSION
+        finally:
+            conn.close()
+
+    def test_fresh_db_gets_the_new_fk_indexes(self, db_path):
+        get_all_chats(db_path)
+
+        conn = sqlite3.connect(db_path)
+        try:
+            notes_indexes = {row[1] for row in conn.execute("PRAGMA index_list(notes)").fetchall()}
+            pins_indexes = {row[1] for row in conn.execute("PRAGMA index_list(pins)").fetchall()}
+            assert "idx_notes_chat_id" in notes_indexes
+            assert "idx_pins_chat_id" in pins_indexes
+        finally:
+            conn.close()
+
+    def test_second_connect_issues_no_pragma_table_info_or_create_table_probes(self, db_path, monkeypatch):
+        # Proves the "no longer re-probed per connection" claim at the real
+        # SQL-wire level (via a sqlite3.Connection subclass swapped in as
+        # the connect factory) rather than by inferring it from some
+        # internal function not being called - the old _ensure_* trio's own
+        # signature move (CREATE TABLE IF NOT EXISTS, then PRAGMA
+        # table_info, then conditional ALTER TABLE) used to run on every
+        # single call to get_all_chats/rename_chat/delete_chat/
+        # load_chat_row/load_notes_rows/load_pins_rows/
+        # save_chat_atomically_row. After this stage it must run AT MOST
+        # ONCE per database, ever - never again once user_version reads
+        # CHATS_DB_SCHEMA_VERSION.
+        get_all_chats(db_path)  # first-ever connect: migrates 0 -> target
+
+        executed_sql = []
+
+        class _SpyConnection(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):
+                executed_sql.append(sql)
+                return super().execute(sql, *args, **kwargs)
+
+        real_connect = sqlite3.connect
+
+        def _connect_with_spy_factory(*args, **kwargs):
+            kwargs["factory"] = _SpyConnection
+            return real_connect(*args, **kwargs)
+
+        monkeypatch.setattr(chat_library_module.sqlite3, "connect", _connect_with_spy_factory)
+
+        get_all_chats(db_path)  # second connect: already at target version
+
+        table_info_calls = [sql for sql in executed_sql if "table_info" in sql]
+        create_table_calls = [sql for sql in executed_sql if "CREATE TABLE" in sql]
+        assert table_info_calls == [], (
+            f"a connect to an already-migrated db must not re-probe schema via "
+            f"PRAGMA table_info - saw: {table_info_calls}"
+        )
+        assert create_table_calls == [], (
+            f"a connect to an already-migrated db must not re-run schema DDL - "
+            f"saw: {create_table_calls}"
+        )
+
+
+def _create_pre_migration_shaped_db(db_path):
+    """Builds a chats.db in EXACTLY the shape the old per-connection
+    _ensure_chats_table/_ensure_notes_table/_ensure_pins_table probes left
+    behind on a real, long-lived install: the full current schema
+    (including every column those probes' own conditional ALTER TABLEs
+    would eventually add), real chat/notes/pins rows already in it, but
+    PRAGMA user_version never once touched - reads 0, exactly like every
+    actual pre-9.1 chats.db on a real user's machine does today. Raw DDL
+    directly, rather than importing the now-deleted _ensure_* functions,
+    matching this test file's own pre-existing convention (_insert_chat/
+    _insert_note/_insert_pin above already do the same thing for their own,
+    narrower purposes). Returns the inserted chat's id."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE chats (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, "
+            "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+            "data TEXT NOT NULL, preview TEXT DEFAULT '', message_count INTEGER DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE notes (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id INTEGER NOT NULL, "
+            "content TEXT NOT NULL, position_x REAL NOT NULL, position_y REAL NOT NULL, width REAL NOT NULL, "
+            "height REAL NOT NULL, color TEXT NOT NULL, header_color TEXT, "
+            "is_system_prompt INTEGER DEFAULT 0, is_summary_note INTEGER DEFAULT 0, "
+            "FOREIGN KEY (chat_id) REFERENCES chats (id) ON DELETE CASCADE)"
+        )
+        conn.execute(
+            "CREATE TABLE pins (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id INTEGER NOT NULL, "
+            "title TEXT NOT NULL, note TEXT, position_x REAL NOT NULL, position_y REAL NOT NULL, "
+            "pin_id TEXT, sort_order INTEGER DEFAULT 0, anchor_item_id TEXT, created_at TEXT, "
+            "FOREIGN KEY (chat_id) REFERENCES chats (id) ON DELETE CASCADE)"
+        )
+        cursor = conn.execute(
+            "INSERT INTO chats (title, data, created_at, updated_at, preview, message_count) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "Real Chat",
+                json.dumps({"nodes": [{"node_type": "chat", "raw_content": "hi"}]}),
+                "2026-01-01 10:00:00", "2026-01-02 11:30:00", "hi", 1,
+            ),
+        )
+        chat_id = cursor.lastrowid
+        conn.execute(
+            "INSERT INTO notes (chat_id, content, position_x, position_y, width, height, color, "
+            "header_color, is_system_prompt, is_summary_note) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (chat_id, "A real note", 1.0, 2.0, 100.0, 50.0, "#111111", None, 0, 0),
+        )
+        conn.execute(
+            "INSERT INTO pins (chat_id, title, note, position_x, position_y, pin_id, sort_order, "
+            "anchor_item_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (chat_id, "A real pin", "", 5.0, 6.0, "pin-1", 0, None, "2026-01-01 00:00:00"),
+        )
+        conn.commit()
+        # user_version is deliberately left untouched here - reads 0, exactly
+        # like every real pre-9.1 chats.db does before its first post-upgrade
+        # connect.
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+        return chat_id
+    finally:
+        conn.close()
+
+
+class TestMigrationUpgradesAPreExistingRealShapedDatabase:
+    """CRITICAL correctness case (this task's own ground rules): a migration
+    that only works on a fresh, empty db and silently loses or corrupts data
+    on a real pre-existing one would leave a user worse off than never
+    shipping the migration at all. This builds a database in exactly the
+    shape a real pre-9.1 chats.db has (full schema, real rows already in it,
+    user_version=0) and proves the upgrade is completely lossless."""
+
+    def test_existing_data_survives_and_version_and_indexes_land(self, db_path):
+        chat_id = _create_pre_migration_shaped_db(db_path)
+
+        # The real, production connect path - any query function drives it.
+        rows = get_all_chats(db_path)
+
+        assert len(rows) == 1
+        assert rows[0]["id"] == chat_id
+        assert rows[0]["title"] == "Real Chat"
+        assert rows[0]["preview"] == "hi"
+        assert rows[0]["messageCount"] == 1
+
+        chat_row = load_chat_row(db_path, chat_id)
+        assert chat_row["title"] == "Real Chat"
+        assert chat_row["data"] == {"nodes": [{"node_type": "chat", "raw_content": "hi"}]}
+        assert chat_row["updated_at"] == "2026-01-02 11:30:00"
+
+        notes = load_notes_rows(db_path, chat_id)
+        assert len(notes) == 1 and notes[0]["content"] == "A real note"
+
+        pins = load_pins_rows(db_path, chat_id)
+        assert len(pins) == 1 and pins[0]["title"] == "A real pin"
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == CHATS_DB_SCHEMA_VERSION
+            notes_indexes = {row[1] for row in conn.execute("PRAGMA index_list(notes)").fetchall()}
+            pins_indexes = {row[1] for row in conn.execute("PRAGMA index_list(pins)").fetchall()}
+            assert "idx_notes_chat_id" in notes_indexes
+            assert "idx_pins_chat_id" in pins_indexes
+        finally:
+            conn.close()
+
+    def test_upgrade_is_safe_to_run_twice_in_a_row(self, db_path):
+        # The second connect (now already at target) must be a true no-op -
+        # not a second attempt to re-create or re-alter anything - and the
+        # data must still be intact and reachable afterward either way.
+        chat_id = _create_pre_migration_shaped_db(db_path)
+        get_all_chats(db_path)
+        rows_after_second_connect = get_all_chats(db_path)
+        assert len(rows_after_second_connect) == 1
+        assert rows_after_second_connect[0]["id"] == chat_id
 
 
 def test_get_all_chats_reads_real_rows(db_path):
@@ -466,7 +684,11 @@ def _insert_pin(db_path, chat_id: int, **overrides) -> None:
 def test_load_chat_row_returns_title_and_parsed_data(db_path):
     chat_id = _insert_chat(db_path, "Loadable", data=json.dumps({"nodes": [{"node_type": "chat"}]}))
     row = load_chat_row(db_path, chat_id)
-    assert row == {"title": "Loadable", "data": {"nodes": [{"node_type": "chat"}]}}
+    assert row["title"] == "Loadable"
+    assert row["data"] == {"nodes": [{"node_type": "chat"}]}
+    # ADR-009 stage 9.2: the value optimistic concurrency carries forward -
+    # _insert_chat's own fixed updated_at (see this test file's own helper).
+    assert row["updated_at"] == "2026-01-02 11:30:00"
 
 
 def test_load_chat_row_returns_none_for_missing_id(db_path):
@@ -571,16 +793,20 @@ def test_load_chat_intent_restores_notes_and_pins_too(db_path):
 
 
 def test_save_chat_atomically_row_inserts_when_chat_id_is_none(db_path):
-    new_id = save_chat_atomically_row(db_path, None, "New Title", {"nodes": []}, [], [])
+    new_id, new_updated_at = save_chat_atomically_row(db_path, None, "New Title", {"nodes": []}, [], [])
     row = load_chat_row(db_path, new_id)
-    assert row == {"title": "New Title", "data": {"nodes": []}}
+    assert row["title"] == "New Title"
+    assert row["data"] == {"nodes": []}
+    # ADR-009 stage 9.2: the returned updated_at is exactly what the row
+    # was actually written with - no separate read-back involved.
+    assert row["updated_at"] == new_updated_at
 
 
 def test_save_chat_atomically_row_persists_a_real_preview_and_message_count(db_path):
     chat_data = {
         "nodes": [{"node_type": "chat", "raw_content": "hello there world", "is_user": True}],
     }
-    chat_id = save_chat_atomically_row(db_path, None, "T", chat_data, [], [])
+    chat_id, _ = save_chat_atomically_row(db_path, None, "T", chat_data, [], [])
 
     row = next(r for r in get_all_chats(db_path) if r["id"] == chat_id)
     assert row["preview"] == "hello there world"
@@ -588,8 +814,8 @@ def test_save_chat_atomically_row_persists_a_real_preview_and_message_count(db_p
 
 
 def test_save_chat_atomically_row_updates_the_same_row_when_chat_id_given(db_path):
-    first_id = save_chat_atomically_row(db_path, None, "First", {"nodes": [1]}, [], [])
-    second_id = save_chat_atomically_row(db_path, first_id, "First", {"nodes": [1, 2]}, [], [])
+    first_id, _ = save_chat_atomically_row(db_path, None, "First", {"nodes": [1]}, [], [])
+    second_id, _ = save_chat_atomically_row(db_path, first_id, "First", {"nodes": [1, 2]}, [], [])
     assert second_id == first_id
     assert len(get_all_chats(db_path)) == 1
     row = load_chat_row(db_path, first_id)
@@ -597,7 +823,7 @@ def test_save_chat_atomically_row_updates_the_same_row_when_chat_id_given(db_pat
 
 
 def test_save_chat_atomically_row_replaces_notes_and_pins_wholesale(db_path):
-    chat_id = save_chat_atomically_row(
+    chat_id, _ = save_chat_atomically_row(
         db_path, None, "T", {"nodes": []},
         [{"content": "note A", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
           "color": "#fff", "header_color": None, "is_system_prompt": False, "is_summary_note": False}],
@@ -1104,3 +1330,434 @@ def test_the_yield_still_works_on_a_LATER_autosave_tick_not_just_the_first(db_pa
 
     assert notifications.visible and notifications.msg_type == "success", notifications.message
     assert notifications.message.startswith("Saved ")
+
+
+# =============================================================================
+# ADR-009 stage 9.2: backup-before-write, corrupt-DB rescue, optimistic
+# concurrency, and the eviction-flush interaction.
+# =============================================================================
+
+
+# -- backup-before-write: first write of a session + periodic cadence --------
+
+
+class TestBackupBeforeWrite:
+    def test_a_backup_is_taken_before_the_very_first_write_of_a_session(self, db_path):
+        last_saved = _new_save_state()
+        assert last_saved["last_backup_at"] is None
+
+        save_chat_atomically_row(db_path, None, "T", {"nodes": []}, [], [])
+        assert db_backup_module.list_backups(db_path) == [], (
+            "save_chat_atomically_row itself must not take a backup - only "
+            "_maybe_backup_before_write (the caller's own explicit step) does"
+        )
+
+        _maybe_backup_before_write(db_path, last_saved)
+
+        backups = db_backup_module.list_backups(db_path)
+        assert len(backups) == 1
+        assert last_saved["last_backup_at"] is not None
+
+    def test_a_second_call_within_the_cadence_window_does_not_take_another_backup(self, db_path):
+        save_chat_atomically_row(db_path, None, "T", {"nodes": []}, [], [])
+        last_saved = _new_save_state()
+        _maybe_backup_before_write(db_path, last_saved)
+        assert len(db_backup_module.list_backups(db_path)) == 1
+
+        _maybe_backup_before_write(db_path, last_saved)
+
+        assert len(db_backup_module.list_backups(db_path)) == 1
+
+    def test_a_call_past_the_cadence_window_takes_a_second_backup(self, db_path, monkeypatch):
+        # A fake, incrementing clock for backup FILENAMES specifically -
+        # backend/tests/test_db_backup.py already covers take_backup's own
+        # timestamp format at the unit level; this test only needs two
+        # calls to land on two DISTINCT filenames, which real wall-clock
+        # time cannot guarantee when both calls happen inside the same
+        # wall-clock second (a real, if practically rare in production -
+        # see BACKUP_CADENCE_SECONDS' own 600s default - possibility this
+        # module doesn't currently guard against, and not what THIS test
+        # is trying to pin down).
+        counter = {"n": 0}
+        real_timestamp_now = db_backup_module._timestamp_now
+
+        def fake_timestamp_now():
+            counter["n"] += 1
+            return (datetime.now(timezone.utc) + timedelta(seconds=counter["n"])).strftime("%Y%m%dT%H%M%SZ")
+
+        monkeypatch.setattr(db_backup_module, "_timestamp_now", fake_timestamp_now)
+
+        save_chat_atomically_row(db_path, None, "T", {"nodes": []}, [], [])
+        last_saved = _new_save_state()
+        _maybe_backup_before_write(db_path, last_saved)
+        assert len(db_backup_module.list_backups(db_path)) == 1
+
+        # Simulate the cadence having elapsed without a real sleep.
+        last_saved["last_backup_at"] -= (BACKUP_CADENCE_SECONDS + 1.0)
+
+        _maybe_backup_before_write(db_path, last_saved)
+
+        assert len(db_backup_module.list_backups(db_path)) == 2
+
+    def test_a_backup_failure_is_swallowed_and_never_blocks_the_real_save(self, db_path, monkeypatch):
+        save_chat_atomically_row(db_path, None, "T", {"nodes": []}, [], [])
+        last_saved = _new_save_state()
+
+        def boom(*args, **kwargs):
+            raise OSError("simulated disk full")
+
+        monkeypatch.setattr(chat_library_module.db_backup, "take_backup", boom)
+
+        # Must not raise.
+        _maybe_backup_before_write(db_path, last_saved)
+        assert last_saved["last_backup_at"] is not None
+
+    def test_the_periodic_cadence_actually_fires_through_a_real_autosave_tick(self, db_path, monkeypatch):
+        # The exact mechanism the ADR text asks for: reusing autosave's own
+        # tick/dirty-check loop as the clock, not a second timer.
+        #
+        # A pre-existing chats.db is seeded first (a separate, earlier
+        # "session"'s own save) - db_backup.take_backup is correctly a
+        # no-op for a db_path that doesn't exist yet at all (see that
+        # function's own docstring: nothing to back up before ANY chat has
+        # ever been saved), so a session's genuinely first-ever write to a
+        # brand-new file has nothing to protect and would not itself
+        # produce a backup - that is not what this test is exercising.
+        save_chat_atomically_row(db_path, None, "Pre-existing", {"nodes": []}, [], [])
+
+        monkeypatch.setattr(chat_library_module, "BACKUP_CADENCE_SECONDS", 0.0)
+        # Same fake-clock reasoning as
+        # test_a_call_past_the_cadence_window_takes_a_second_backup above -
+        # two backups fired back-to-back (BACKUP_CADENCE_SECONDS=0.0) could
+        # otherwise land on the identical real-wall-clock-second filename.
+        counter = {"n": 0}
+
+        def fake_timestamp_now():
+            counter["n"] += 1
+            return (datetime.now(timezone.utc) + timedelta(seconds=counter["n"])).strftime("%Y%m%dT%H%M%SZ")
+
+        monkeypatch.setattr(db_backup_module, "_timestamp_now", fake_timestamp_now)
+
+        bus, document, notifications = _library_session(db_path)
+        document.add_chat_node(0, 0, "first message", is_user=True)
+        asyncio.run(autosave_tick(bus, db_path, document, notifications, bus.chat_save_state))
+        first_backup_count = len(db_backup_module.list_backups(db_path))
+        assert first_backup_count >= 1, "the first tick's write must itself trigger a backup"
+
+        document.add_chat_node(200, 0, "a second, real change", is_user=True)
+        asyncio.run(autosave_tick(bus, db_path, document, notifications, bus.chat_save_state))
+
+        assert len(db_backup_module.list_backups(db_path)) > first_backup_count, (
+            "a later tick, past the (zeroed) cadence window, must take another backup"
+        )
+
+
+# -- backup rotation/retention exact behavior, driven through this module's --
+# -- own real save path (backend/tests/test_db_backup.py covers the backup ---
+# -- module's unit-level behavior directly; this proves the wiring) ----------
+
+
+class TestBackupRotationThroughRealSaves:
+    def test_more_backups_than_the_retention_limit_prunes_to_exactly_the_right_set(self, db_path, monkeypatch):
+        save_chat_atomically_row(db_path, None, "T", {"nodes": []}, [], [])
+        now = datetime.now(timezone.utc)
+        backups_dir = db_backup_module.backups_dir_for(db_path)
+        backups_dir.mkdir(parents=True, exist_ok=True)
+        # KEEP_MOST_RECENT-worth of same-day snapshots (all survive via the
+        # recency rule) plus one clearly older, distinct-day snapshot (must
+        # survive via the daily rule) plus a SECOND, older-still snapshot on
+        # THAT SAME older day (must be pruned - not the newest for its day).
+        recent_timestamps = [now - timedelta(minutes=i) for i in range(db_backup_module.KEEP_MOST_RECENT)]
+        older_day_keep = now - timedelta(days=2, hours=1)
+        older_day_prune = now - timedelta(days=2, hours=5)
+        for ts in recent_timestamps + [older_day_keep, older_day_prune]:
+            path = backups_dir / db_backup_module.backup_filename(ts.strftime("%Y%m%dT%H%M%SZ"))
+            sqlite3.connect(path).close()
+
+        db_backup_module.prune_backups(db_path)
+
+        survivors = {p.name for p in db_backup_module.list_backups(db_path)}
+        assert db_backup_module.backup_filename(older_day_keep.strftime("%Y%m%dT%H%M%SZ")) in survivors
+        assert db_backup_module.backup_filename(older_day_prune.strftime("%Y%m%dT%H%M%SZ")) not in survivors
+        assert len(survivors) == db_backup_module.KEEP_MOST_RECENT + 1
+
+
+# -- corrupt-DB rescue: a real kill-9-mid-save simulation ---------------------
+
+
+class TestCorruptDbRescue:
+    def test_kill_9_mid_save_relaunches_to_the_newest_good_backup(self, db_path):
+        # 1. A real chat is saved (the "good state" a backup will capture).
+        chat_id, _ = save_chat_atomically_row(
+            db_path, None, "Good Chat", {"nodes": [{"node_type": "chat", "raw_content": "hello"}]}, [], [],
+        )
+        backup_path = db_backup_module.take_backup(db_path)
+        assert backup_path is not None
+
+        # 2. A LATER edit lands on disk (so the live file, if it were still
+        # readable, would legitimately differ from the backup) - then the
+        # process is "kill -9"'d mid-write: simulated directly by truncating
+        # the live file to a few garbage bytes, exactly like a torn write
+        # would leave it.
+        save_chat_atomically_row(
+            db_path, chat_id, "Good Chat", {"nodes": [{"node_type": "chat", "raw_content": "a later edit"}]}, [], [],
+        )
+        for suffix in ("", "-wal", "-shm"):
+            sidecar = db_path.with_name(db_path.name + suffix)
+            if sidecar.exists():
+                sidecar.unlink()
+        db_path.write_bytes(b"\x00\x01garbage-not-a-real-sqlite-file")
+
+        notifications = NotificationState()
+
+        # 3. Drive the app's NORMAL connect/open path - get_all_chats is
+        # exactly what backend/chat_library.py's own "app-chat-library"
+        # topic builder calls on every real subscribe/relaunch.
+        rows = get_all_chats(db_path, notifications=notifications)
+
+        # The corruption was detected and transparently recovered - the
+        # caller gets a normal, successful result, not an exception.
+        assert len(rows) == 1
+        assert rows[0]["title"] == "Good Chat"
+        loaded = load_chat_row(db_path, chat_id)
+        assert loaded["data"] == {"nodes": [{"node_type": "chat", "raw_content": "hello"}]}, (
+            "the newest GOOD BACKUP's data must be live - not the torn file, "
+            "and not a silently-reset-to-empty database"
+        )
+
+        # The bad file is quarantined, present on disk, matching the exact
+        # naming convention graphlink_settings_store.py's own
+        # _backup_corrupt_state_file establishes.
+        quarantined = list(db_path.parent.glob(f"{db_path.name}.corrupted-*"))
+        assert len(quarantined) == 1
+        # ISO8601-compact-UTC, matching strftime("%Y%m%dT%H%M%SZ") exactly.
+        suffix = quarantined[0].name.split(".corrupted-", 1)[1]
+        datetime.strptime(suffix, "%Y%m%dT%H%M%SZ")  # raises ValueError if the shape is wrong
+
+        # A notice was surfaced via the SAME NotificationState channel every
+        # other user-visible chat-library warning uses.
+        assert notifications.visible
+        assert notifications.msg_type == "warning"
+        assert "restored" in notifications.message.lower()
+
+    def test_quarantine_survives_even_when_there_is_no_backup_to_restore_from(self, db_path):
+        # No backup was ever taken - the honest fallback (quarantine only,
+        # no fabricated restore) - matching session.dat's own precedent for
+        # "nothing better to offer", while STILL quarantining (never just
+        # silently overwriting the corrupt file with an empty db).
+        save_chat_atomically_row(db_path, None, "Never Backed Up", {"nodes": []}, [], [])
+        for suffix in ("", "-wal", "-shm"):
+            sidecar = db_path.with_name(db_path.name + suffix)
+            if sidecar.exists():
+                sidecar.unlink()
+        db_path.write_bytes(b"garbage")
+        notifications = NotificationState()
+
+        rows = get_all_chats(db_path, notifications=notifications)
+
+        assert rows == []  # a genuinely fresh, empty db - not a crash
+        quarantined = list(db_path.parent.glob(f"{db_path.name}.corrupted-*"))
+        assert len(quarantined) == 1
+        assert notifications.visible
+        assert notifications.msg_type == "warning"
+        assert "no backup" in notifications.message.lower()
+
+    def test_a_plain_locked_database_is_never_mistaken_for_corruption(self, db_path):
+        # sqlite3.OperationalError ("database is locked") is empirically a
+        # SUBCLASS of sqlite3.DatabaseError - this is the exact hazard
+        # _connect's own except-ordering exists to avoid. A real, healthy
+        # file must never be quarantined just because it's momentarily busy.
+        save_chat_atomically_row(db_path, None, "Fine", {"nodes": []}, [], [])
+        assert not list(db_path.parent.glob(f"{db_path.name}.corrupted-*"))
+
+        holder = sqlite3.connect(db_path, timeout=30)
+        holder.execute("PRAGMA journal_mode=WAL")
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("UPDATE chats SET title = 'locked-write'")
+        try:
+            # A short timeout so this test doesn't hang for 30s waiting out
+            # the real busy_timeout - a fresh connect() with its own short
+            # timeout is what actually raises "database is locked".
+            with pytest.raises(sqlite3.OperationalError):
+                blocked = sqlite3.connect(db_path, timeout=0.2)
+                blocked.execute("BEGIN IMMEDIATE")
+        finally:
+            holder.rollback()
+            holder.close()
+
+        assert not list(db_path.parent.glob(f"{db_path.name}.corrupted-*")), (
+            "a transient lock must never trigger quarantine"
+        )
+
+    def test_get_all_chats_without_a_notifications_reference_still_self_heals_silently(self, db_path):
+        # Every OTHER call site in this module (rename_chat, delete_chat,
+        # load_chat_row, ...) calls _connect() with no notifications
+        # reference at all - self-healing must still work (log-only), by
+        # design (see _rescue_corrupt_chats_db's own docstring).
+        save_chat_atomically_row(db_path, None, "Good", {"nodes": []}, [], [])
+        db_backup_module.take_backup(db_path)
+        for suffix in ("", "-wal", "-shm"):
+            sidecar = db_path.with_name(db_path.name + suffix)
+            if sidecar.exists():
+                sidecar.unlink()
+        db_path.write_bytes(b"garbage")
+
+        rows = get_all_chats(db_path)  # no notifications= argument at all
+
+        assert len(rows) == 1
+        assert rows[0]["title"] == "Good"
+
+
+# -- optimistic concurrency: two sessions racing a save on the same chat -----
+
+
+class TestOptimisticConcurrency:
+    def test_a_lost_race_at_the_primitive_level_does_not_clobber_the_winner(self, db_path):
+        chat_id, first_updated_at = save_chat_atomically_row(
+            db_path, None, "T", {"nodes": ["v0"]}, [], [],
+        )
+        # Two "sessions" both loaded the chat at v0 and both hold the SAME
+        # (now about to become stale) expected_updated_at.
+        stale_expected = first_updated_at
+
+        # Session A saves first - succeeds, and updated_at moves forward.
+        _, second_updated_at = save_chat_atomically_row(
+            db_path, chat_id, "T", {"nodes": ["v1-from-A"]}, [], [],
+            expected_updated_at=stale_expected,
+        )
+        assert second_updated_at != first_updated_at or True  # sqlite CURRENT_TIMESTAMP has 1s resolution
+
+        # Session B, STILL holding the original stale value, tries to save
+        # next - must be detected as a lost race, not silently applied.
+        with pytest.raises(ConcurrentSaveConflict):
+            save_chat_atomically_row(
+                db_path, chat_id, "T", {"nodes": ["v2-from-B-should-not-land"]}, [], [],
+                expected_updated_at=stale_expected,
+            )
+
+        # The FIRST save's data (session A's) must be exactly what's live -
+        # not session B's, and not some blend of the two.
+        row = load_chat_row(db_path, chat_id)
+        assert row["data"] == {"nodes": ["v1-from-A"]}
+        assert row["updated_at"] == second_updated_at
+
+    def test_a_lost_race_does_not_touch_notes_or_pins_either(self, db_path):
+        # The whole write must roll back atomically - not just the chats
+        # row UPDATE - see save_chat_atomically_row's own docstring for why
+        # the conflict is raised BEFORE either DELETE statement runs.
+        chat_id, updated_at = save_chat_atomically_row(
+            db_path, None, "T", {"nodes": []},
+            [{"content": "keep me", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
+              "color": "#fff", "header_color": None, "is_system_prompt": False, "is_summary_note": False}],
+            [],
+        )
+        # Advance updated_at once (a legitimate OTHER save), so the ORIGINAL
+        # value is now stale.
+        save_chat_atomically_row(db_path, chat_id, "T", {"nodes": []}, [], [], expected_updated_at=updated_at)
+
+        with pytest.raises(ConcurrentSaveConflict):
+            save_chat_atomically_row(
+                db_path, chat_id, "T", {"nodes": []},
+                [{"content": "should never land", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
+                  "color": "#fff", "header_color": None, "is_system_prompt": False, "is_summary_note": False}],
+                [],
+                expected_updated_at=updated_at,  # the now-stale value
+            )
+
+        # The winning save's own notes state (empty, from its own write)
+        # survives untouched - the loser's note was never inserted.
+        assert load_notes_rows(db_path, chat_id) == []
+
+    def test_expected_updated_at_none_skips_the_check_entirely_backward_compatible(self, db_path):
+        chat_id, _ = save_chat_atomically_row(db_path, None, "T", {"nodes": ["v0"]}, [], [])
+        save_chat_atomically_row(db_path, chat_id, "T", {"nodes": ["v1"]}, [], [])  # another writer moves it on
+
+        # A caller with NO known prior version (expected_updated_at=None,
+        # the default) must still succeed with a blind UPDATE - byte-
+        # identical to this function's pre-9.2 behavior.
+        new_id, _ = save_chat_atomically_row(db_path, chat_id, "T", {"nodes": ["v2-blind"]}, [], [])
+        assert new_id == chat_id
+        assert load_chat_row(db_path, chat_id)["data"] == {"nodes": ["v2-blind"]}
+
+    def test_two_sessions_racing_through_the_real_saveChat_intent_surfaces_the_lost_race_notice(self, db_path):
+        # End-to-end through the real register_chat_library wiring: two
+        # SEPARATE sessions (separate SceneDocuments/buses, exactly like two
+        # windows/tabs would be) both load the same chat, then both save in
+        # sequence with the loader's own stale updated_at.
+        chat_id, _ = save_chat_atomically_row(
+            db_path, None, "Shared Chat", {"nodes": [{"node_type": "chat", "raw_content": "v0", "is_user": True}]}, [], [],
+        )
+
+        bus_a, document_a, notifications_a = _library_session(db_path)
+        bus_b, document_b, notifications_b = _library_session(db_path)
+        asyncio.run(bus_a.dispatch_intent("app-chat-library", "loadChat", [chat_id]))
+        asyncio.run(bus_b.dispatch_intent("app-chat-library", "loadChat", [chat_id]))
+        assert bus_a.chat_save_state["updated_at"] == bus_b.chat_save_state["updated_at"]
+
+        # Session A edits and saves first - succeeds.
+        document_a.add_chat_node(200, 0, "A's edit", is_user=True)
+        asyncio.run(bus_a.dispatch_intent("app-chat-library", "saveChat", []))
+        assert notifications_a.visible and notifications_a.msg_type == "success"
+
+        # Session B, still holding the ORIGINAL (now stale) updated_at,
+        # edits and tries to save next.
+        document_b.add_chat_node(200, 0, "B's edit - must not land", is_user=True)
+        asyncio.run(bus_b.dispatch_intent("app-chat-library", "saveChat", []))
+
+        assert notifications_b.visible
+        assert notifications_b.msg_type == "warning"
+        assert notifications_b.message == LOST_RACE_MESSAGE_MANUAL
+
+        # The winner's data (A's) is what's actually live - B's edit never
+        # landed.
+        row = load_chat_row(db_path, chat_id)
+        assert any(
+            isinstance(node, dict) and node.get("raw_content") == "A's edit"
+            for node in row["data"].get("nodes", [])
+        )
+        assert not any(
+            isinstance(node, dict) and node.get("raw_content") == "B's edit - must not land"
+            for node in row["data"].get("nodes", [])
+        )
+
+    def test_autosave_lost_race_does_not_crash_the_tick_and_surfaces_its_own_notice(self, db_path):
+        chat_id, first_updated_at = save_chat_atomically_row(
+            db_path, None, "T", {"nodes": [{"node_type": "chat", "raw_content": "v0", "is_user": True}]}, [], [],
+        )
+        # Someone else saves in between - the value autosave is about to
+        # rely on is now stale.
+        save_chat_atomically_row(
+            db_path, chat_id, "T", {"nodes": [{"node_type": "chat", "raw_content": "v1-elsewhere", "is_user": True}]},
+            [], [], expected_updated_at=first_updated_at,
+        )
+
+        bus, document, notifications = _library_session(db_path)
+        document.add_chat_node(0, 0, "seed", is_user=True)
+        document.current_chat_id = chat_id
+        last_saved = bus.chat_save_state
+        last_saved["chat_id"] = chat_id
+        last_saved["updated_at"] = first_updated_at  # deliberately stale
+        last_saved["digest"] = "deliberately-different-so-the-tick-writes"
+
+        # Must not raise - LOUD ON FAILURE, not a crashed loop.
+        asyncio.run(autosave_tick(bus, db_path, document, notifications, last_saved))
+
+        assert notifications.visible
+        assert notifications.msg_type == "warning"
+        assert notifications.message == LOST_RACE_MESSAGE_AUTOSAVE
+        # last_saved must NOT have been advanced as if the write succeeded.
+        assert last_saved["updated_at"] == first_updated_at
+        row = load_chat_row(db_path, chat_id)
+        assert row["data"]["nodes"][0]["raw_content"] == "v1-elsewhere", "the winning write must survive untouched"
+
+
+# -- ConcurrentSaveConflict exception identity/message sanity ---------------
+
+
+def test_concurrent_save_conflict_message_names_the_chat(db_path):
+    chat_id, updated_at = save_chat_atomically_row(db_path, None, "T", {"nodes": []}, [], [])
+    save_chat_atomically_row(db_path, chat_id, "T", {"nodes": []}, [], [], expected_updated_at=updated_at)
+    with pytest.raises(ConcurrentSaveConflict, match=str(chat_id)):
+        save_chat_atomically_row(
+            db_path, chat_id, "T", {"nodes": []}, [], [], expected_updated_at=updated_at,
+        )

--- a/backend/tests/test_db_backup.py
+++ b/backend/tests/test_db_backup.py
@@ -1,0 +1,376 @@
+"""ADR-009 stage 9.2: backend/db_backup.py - backup rotation, retention,
+and restore.
+
+Every test uses tmp_path (via the db_path fixture) - never Path.home() or
+the real ~/.graphlink, matching this codebase's established pattern for
+anything touching persistence (see backend/chat_library.py's own tests)."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.db_backup import (
+    BACKUP_FILENAME_PREFIX,
+    KEEP_MOST_RECENT,
+    backup_filename,
+    backups_dir_for,
+    list_backups,
+    newest_backup,
+    prune_backups,
+    restore_from_newest_backup,
+    take_backup,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "chats.db"
+
+
+def _make_real_db(db_path, title="Hello"):
+    """A minimal but REAL sqlite file (not a stand-in) - take_backup uses
+    the sqlite3 backup API, which requires a genuinely openable database,
+    not an arbitrary blob."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE chats (id INTEGER PRIMARY KEY, title TEXT)")
+        conn.execute("INSERT INTO chats (title) VALUES (?)", (title,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _write_fake_backup(db_path, timestamp: str) -> None:
+    """Directly creates a backup FILE with a specific timestamp in its
+    name, bypassing take_backup's own clock - the only way to deterministically
+    test retention across many synthetic points in time without a real
+    sleep between each one."""
+    backups_dir = backups_dir_for(db_path)
+    backups_dir.mkdir(parents=True, exist_ok=True)
+    path = backups_dir / backup_filename(timestamp)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("CREATE TABLE chats (id INTEGER PRIMARY KEY, title TEXT)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _ts(dt: datetime) -> str:
+    return dt.strftime("%Y%m%dT%H%M%SZ")
+
+
+# -- take_backup: real WAL-safe snapshot via the sqlite3 backup API ----------
+
+
+def test_take_backup_returns_none_for_a_db_that_does_not_exist_yet(db_path):
+    assert take_backup(db_path) is None
+    assert not backups_dir_for(db_path).exists()
+
+
+def test_take_backup_creates_a_real_openable_sqlite_file_with_the_same_data(db_path):
+    _make_real_db(db_path, title="Real Chat")
+
+    backup_path = take_backup(db_path)
+
+    assert backup_path is not None
+    assert backup_path.exists()
+    assert backup_path.parent == backups_dir_for(db_path)
+    conn = sqlite3.connect(backup_path)
+    try:
+        rows = conn.execute("SELECT title FROM chats").fetchall()
+    finally:
+        conn.close()
+    assert rows == [("Real Chat",)]
+
+
+def test_take_backup_filename_matches_the_documented_convention(db_path):
+    _make_real_db(db_path)
+    backup_path = take_backup(db_path)
+    assert backup_path.name.startswith(BACKUP_FILENAME_PREFIX)
+    assert backup_path.name.endswith(".db")
+    # The exact timestamp segment must round-trip through list_backups' own
+    # parser - proven indirectly via list_backups picking it up below, and
+    # directly here via the format string itself.
+    raw = backup_path.name[len(BACKUP_FILENAME_PREFIX):-len(".db")]
+    datetime.strptime(raw, "%Y%m%dT%H%M%SZ")  # raises ValueError if wrong shape
+
+
+def test_take_backup_is_wal_safe_against_a_live_writer_holding_a_transaction(db_path):
+    # This is the property that distinguishes the backup API from a raw
+    # shutil.copy: a writer holding an open transaction on the SOURCE at
+    # the exact moment of backup must not produce a torn/inconsistent
+    # snapshot, and must not be blocked/broken by the backup itself.
+    _make_real_db(db_path, title="Before")
+    writer = sqlite3.connect(db_path, timeout=30)
+    writer.execute("PRAGMA journal_mode=WAL")
+    writer.execute("BEGIN IMMEDIATE")
+    writer.execute("INSERT INTO chats (title) VALUES ('mid-write')")
+    try:
+        backup_path = take_backup(db_path)
+        assert backup_path is not None
+        # The uncommitted INSERT must NOT appear in the backup (a real
+        # snapshot of a real committed state, not of in-flight work).
+        conn = sqlite3.connect(backup_path)
+        try:
+            rows = {row[0] for row in conn.execute("SELECT title FROM chats").fetchall()}
+        finally:
+            conn.close()
+        assert rows == {"Before"}
+    finally:
+        writer.rollback()
+        writer.close()
+
+
+def test_take_backup_chmods_the_backup_to_0600(db_path):
+    import os
+    import stat
+    import sys
+
+    if sys.platform == "win32":
+        pytest.skip("chmod is a no-op on Windows")
+    _make_real_db(db_path)
+    backup_path = take_backup(db_path)
+    assert stat.S_IMODE(backup_path.stat().st_mode) == 0o600
+
+
+def test_take_backup_calls_prune_after_every_backup(db_path, monkeypatch):
+    _make_real_db(db_path)
+    calls = []
+    import backend.db_backup as db_backup_module
+
+    real_prune = db_backup_module.prune_backups
+    monkeypatch.setattr(
+        db_backup_module, "prune_backups", lambda p: (calls.append(p), real_prune(p))[1],
+    )
+    take_backup(db_path)
+    assert calls == [db_path]
+
+
+# -- list_backups / newest_backup ---------------------------------------------
+
+
+def test_list_backups_is_empty_when_nothing_has_ever_been_backed_up(db_path):
+    assert list_backups(db_path) == []
+    assert newest_backup(db_path) is None
+
+
+def test_list_backups_ignores_unrelated_files_in_the_backups_dir(db_path):
+    backups_dir = backups_dir_for(db_path)
+    backups_dir.mkdir(parents=True)
+    (backups_dir / "not-a-backup.txt").write_text("junk")
+    (backups_dir / "chats-not-a-real-timestamp.db").write_text("junk")
+    assert list_backups(db_path) == []
+
+
+def test_list_backups_orders_newest_first(db_path):
+    now = datetime.now(timezone.utc)
+    _write_fake_backup(db_path, _ts(now - timedelta(minutes=5)))
+    _write_fake_backup(db_path, _ts(now))
+    _write_fake_backup(db_path, _ts(now - timedelta(minutes=2)))
+
+    names = [p.name for p in list_backups(db_path)]
+    assert names == sorted(names, reverse=True)
+    assert newest_backup(db_path) == list_backups(db_path)[0]
+
+
+# -- prune_backups: the exact retention policy --------------------------------
+
+
+def test_prune_keeps_everything_when_under_the_retention_limit(db_path):
+    now = datetime.now(timezone.utc)
+    for i in range(KEEP_MOST_RECENT - 2):
+        _write_fake_backup(db_path, _ts(now - timedelta(minutes=i)))
+
+    deleted = prune_backups(db_path)
+
+    assert deleted == []
+    assert len(list_backups(db_path)) == KEEP_MOST_RECENT - 2
+
+
+def test_prune_keeps_exactly_the_most_recent_N_when_all_on_the_same_day(db_path):
+    # All within the SAME UTC calendar day, well past the retention count -
+    # the daily bucket must add NOTHING here (there is no "older, different
+    # day" backup for it to rescue), so the surviving set is exactly
+    # KEEP_MOST_RECENT, not one more.
+    now = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
+    total = KEEP_MOST_RECENT + 5
+    timestamps = [now - timedelta(minutes=i) for i in range(total)]
+    for ts in timestamps:
+        _write_fake_backup(db_path, _ts(ts))
+
+    deleted = prune_backups(db_path)
+
+    survivors = list_backups(db_path)
+    assert len(survivors) == KEEP_MOST_RECENT
+    assert len(deleted) == total - KEEP_MOST_RECENT
+    # The survivors are EXACTLY the most-recent N, not an arbitrary subset.
+    expected_survivor_names = {backup_filename(_ts(ts)) for ts in timestamps[:KEEP_MOST_RECENT]}
+    assert {p.name for p in survivors} == expected_survivor_names
+
+
+def test_prune_keeps_one_per_calendar_day_beyond_the_recent_window(db_path):
+    # Exercises the exact policy this module's own docstring documents:
+    # KEEP_MOST_RECENT most recent survive unconditionally, PLUS one
+    # (the newest) per distinct UTC calendar day among anything older.
+    base = datetime(2026, 1, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+    # KEEP_MOST_RECENT backups, all "today" (base), 1 minute apart -
+    # these must ALL survive via the most-recent-N rule alone.
+    recent = [base - timedelta(minutes=i) for i in range(KEEP_MOST_RECENT)]
+    # Three older backups on three separate distinct days, TWO snapshots
+    # on the oldest of those three days (only the newer of that pair
+    # should survive via the daily rule).
+    day_minus_1_a = base - timedelta(days=1, hours=1)
+    day_minus_1_b = base - timedelta(days=1, hours=3)  # older same-day duplicate
+    day_minus_2 = base - timedelta(days=2)
+    day_minus_5 = base - timedelta(days=5)
+    older = [day_minus_1_a, day_minus_1_b, day_minus_2, day_minus_5]
+
+    for ts in recent + older:
+        _write_fake_backup(db_path, _ts(ts))
+
+    deleted = prune_backups(db_path)
+
+    survivor_names = {p.name for p in list_backups(db_path)}
+    expected_survivors = {backup_filename(_ts(ts)) for ts in recent} | {
+        backup_filename(_ts(day_minus_1_a)),  # newer of the day-minus-1 pair
+        backup_filename(_ts(day_minus_2)),
+        backup_filename(_ts(day_minus_5)),
+    }
+    assert survivor_names == expected_survivors
+    # The older, same-day duplicate is the ONE that must be gone.
+    assert backup_filename(_ts(day_minus_1_b)) in {p.name for p in deleted}
+    assert len(deleted) == len(recent) + len(older) - len(expected_survivors)
+
+
+def test_prune_is_idempotent_a_second_call_deletes_nothing_more(db_path):
+    now = datetime.now(timezone.utc)
+    # Two snapshots per calendar day among the older ones, so there is
+    # genuinely something for the daily bucket to prune (one distinct day
+    # each would keep every single one, proving nothing about idempotency).
+    for i in range(KEEP_MOST_RECENT + 10):
+        day = i // 2
+        ts = now - timedelta(days=day, hours=(i % 2))
+        _write_fake_backup(db_path, _ts(ts))
+
+    first_pass_deleted = prune_backups(db_path)
+    assert first_pass_deleted != []
+
+    second_pass_deleted = prune_backups(db_path)
+    assert second_pass_deleted == []
+
+
+def test_prune_tolerates_a_single_backup_it_cannot_delete(db_path, monkeypatch):
+    # A precisely deterministic scenario (not "however many happen to be
+    # prunable"): KEEP_MOST_RECENT snapshots today (all unconditionally
+    # kept), plus exactly ONE older day with TWO snapshots on it - only the
+    # OLDER of that pair is prunable at all (the daily rule keeps the
+    # newer one), so exactly one deletable backup exists, and it is the
+    # one this test makes stuck.
+    now = datetime.now(timezone.utc)
+    for i in range(KEEP_MOST_RECENT):
+        _write_fake_backup(db_path, _ts(now - timedelta(minutes=i)))
+    older_day_newer = now - timedelta(days=3, hours=1)
+    older_day_older = now - timedelta(days=3, hours=5)
+    _write_fake_backup(db_path, _ts(older_day_newer))
+    _write_fake_backup(db_path, _ts(older_day_older))
+
+    stuck_path = backups_dir_for(db_path) / backup_filename(_ts(older_day_older))
+    assert stuck_path.exists(), "test setup did not produce the expected file"
+
+    import pathlib
+    real_unlink = pathlib.Path.unlink
+
+    def flaky_unlink(self, *args, **kwargs):
+        if self == stuck_path:
+            raise OSError("simulated: file locked")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "unlink", flaky_unlink)
+
+    deleted = prune_backups(db_path)
+
+    assert stuck_path not in deleted
+    assert stuck_path.exists(), "a single stuck backup must not block pruning everything else"
+    assert deleted == [], "the only prunable backup was the stuck one - nothing else should be touched"
+    # The newer of the older-day pair, and every recent one, must all
+    # still survive regardless of the stuck-unlink failure elsewhere.
+    survivor_names = {p.name for p in list_backups(db_path)}
+    assert backup_filename(_ts(older_day_newer)) in survivor_names
+    assert stuck_path.name in survivor_names
+
+
+# -- restore_from_newest_backup ------------------------------------------------
+
+
+def test_restore_returns_none_when_no_backup_exists(db_path):
+    assert restore_from_newest_backup(db_path) is None
+    assert not db_path.exists()
+
+
+def test_restore_copies_the_newest_backups_data_into_db_path(db_path):
+    _make_real_db(db_path, title="Version 1")
+    take_backup(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("UPDATE chats SET title = 'Version 2'")
+        conn.commit()
+    finally:
+        conn.close()
+    take_backup(db_path)
+
+    # Simulate the live file having since become garbage (the corrupt-DB
+    # rescue scenario this function exists for).
+    db_path.write_bytes(b"garbage")
+
+    restored_from = restore_from_newest_backup(db_path)
+
+    assert restored_from == newest_backup(db_path) or restored_from is not None
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute("SELECT title FROM chats").fetchall()
+    finally:
+        conn.close()
+    assert rows == [("Version 2",)], "must restore the NEWEST backup, not just any backup"
+
+
+def test_restore_is_atomic_no_leftover_temp_file_on_success(db_path):
+    _make_real_db(db_path, title="Original")
+    take_backup(db_path)
+    db_path.write_bytes(b"garbage")
+
+    restore_from_newest_backup(db_path)
+
+    tmp_path = db_path.with_name(db_path.name + ".restoring.tmp")
+    assert not tmp_path.exists()
+
+
+def test_restore_chmods_the_restored_file_to_0600(db_path):
+    import stat
+    import sys
+
+    if sys.platform == "win32":
+        pytest.skip("chmod is a no-op on Windows")
+    _make_real_db(db_path)
+    take_backup(db_path)
+    db_path.write_bytes(b"garbage")
+
+    restore_from_newest_backup(db_path)
+
+    assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+
+
+def test_restore_never_touches_the_source_backup_file(db_path):
+    _make_real_db(db_path, title="Keep me")
+    backup_path = take_backup(db_path)
+    original_bytes = backup_path.read_bytes()
+
+    restore_from_newest_backup(db_path)
+
+    assert backup_path.exists()
+    assert backup_path.read_bytes() == original_bytes

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,322 @@
+"""Tests for graphlink_migrations.py (ADR-009 stage 9.1): the shared
+ordered-migration-chain primitive both chats.db (SQLite) and session.dat
+(plain dict) will build their real migration chains on top of.
+
+Every fixture below uses a fresh in-memory or tmp_path-scoped SQLite
+connection / plain dict - never a real ~/.graphlink path - matching this
+codebase's isolated-test-fixture rule for anything that touches persistence
+primitives."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+import graphlink_migrations as migrations_mod
+from graphlink_migrations import (
+    MigrationGapError,
+    run_dict_migrations,
+    run_sqlite_migrations,
+)
+
+
+# ---------------------------------------------------------------------------
+# SQLite runner
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def conn():
+    connection = sqlite3.connect(":memory:")
+    yield connection
+    connection.close()
+
+
+class TestRunSqliteMigrationsOrdering:
+    def test_three_step_chain_applies_in_ascending_order_not_dict_literal_order(self, conn):
+        # Deliberately written out of order (3, 1, 2) in the literal - if
+        # this ran in insertion/dict order instead of sorted-by-version
+        # order, step "3" (which INSERTs into a table step "1" hasn't
+        # created yet) would raise immediately.
+        applied_order = []
+
+        def step_1(c):
+            applied_order.append(1)
+            c.execute("CREATE TABLE marker (step INTEGER)")
+            c.execute("INSERT INTO marker VALUES (1)")
+
+        def step_2(c):
+            applied_order.append(2)
+            c.execute("INSERT INTO marker VALUES (2)")
+
+        def step_3(c):
+            applied_order.append(3)
+            c.execute("INSERT INTO marker VALUES (3)")
+
+        landed = run_sqlite_migrations(conn, 3, {3: step_3, 1: step_1, 2: step_2})
+
+        assert applied_order == [1, 2, 3]
+        assert landed == 3
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 3
+        rows = [row[0] for row in conn.execute("SELECT step FROM marker ORDER BY step")]
+        assert rows == [1, 2, 3]
+
+    def test_partial_range_only_applies_missing_versions(self, conn):
+        # Simulates re-opening a chats.db that's already at version 1: only
+        # versions 2 and 3 should run, never 1 again.
+        conn.execute("PRAGMA user_version = 1")
+        applied = []
+        migrations = {
+            1: lambda c: applied.append(1),
+            2: lambda c: applied.append(2),
+            3: lambda c: applied.append(3),
+        }
+
+        landed = run_sqlite_migrations(conn, 3, migrations)
+
+        assert applied == [2, 3]
+        assert landed == 3
+
+
+class TestRunSqliteMigrationsFailureLeavesVersionUnbumped:
+    def test_failing_step_rolls_back_ddl_and_version_bump_together(self, tmp_path):
+        # A real ON-DISK db file, not :memory: - re-opening via a BRAND NEW
+        # connection afterward is the whole point of this test: it proves
+        # the rollback actually reached the file, not just this process's
+        # in-memory view of a connection that might be lying to itself.
+        db_path = tmp_path / "chats.db"
+        setup_conn = sqlite3.connect(db_path)
+        setup_conn.close()
+
+        def step_1(c):
+            c.execute("CREATE TABLE t1 (id INTEGER)")
+
+        def step_2_raises(c):
+            c.execute("CREATE TABLE t2 (id INTEGER)")
+            raise RuntimeError("boom mid-migration")
+
+        def step_3_never_runs(c):
+            c.execute("CREATE TABLE t3 (id INTEGER)")
+
+        conn1 = sqlite3.connect(db_path)
+        with pytest.raises(RuntimeError, match="boom mid-migration"):
+            run_sqlite_migrations(
+                conn1, 3, {1: step_1, 2: step_2_raises, 3: step_3_never_runs}
+            )
+        conn1.close()
+
+        # Fresh connection, fresh process-level view of the file on disk.
+        conn2 = sqlite3.connect(db_path)
+        try:
+            assert conn2.execute("PRAGMA user_version").fetchone()[0] == 0
+            table_names = {
+                row[0]
+                for row in conn2.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                )
+            }
+            assert table_names == set(), (
+                "step_1's CREATE TABLE t1 and step_2's CREATE TABLE t2 must both "
+                "be rolled back together with the failed step, not left behind "
+                "as a partially-applied schema"
+            )
+        finally:
+            conn2.close()
+
+    def test_original_isolation_level_restored_after_failure(self, conn):
+        original = conn.isolation_level
+
+        def raises(c):
+            raise ValueError("nope")
+
+        with pytest.raises(ValueError):
+            run_sqlite_migrations(conn, 1, {1: raises})
+
+        assert conn.isolation_level == original
+
+    def test_original_isolation_level_restored_after_success(self, conn):
+        original = conn.isolation_level
+
+        run_sqlite_migrations(conn, 1, {1: lambda c: None})
+
+        assert conn.isolation_level == original
+
+
+class TestRunSqliteMigrationsNoOp:
+    def test_already_at_target_is_a_noop(self, conn):
+        conn.execute("PRAGMA user_version = 5")
+        called = []
+
+        landed = run_sqlite_migrations(conn, 5, {5: lambda c: called.append(True)})
+
+        assert landed == 5
+        assert called == []
+
+    def test_current_ahead_of_target_is_a_noop_not_a_downgrade(self, conn):
+        conn.execute("PRAGMA user_version = 7")
+        called = []
+
+        landed = run_sqlite_migrations(conn, 3, {1: lambda c: called.append(1)})
+
+        assert landed == 7
+        assert called == []
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 7
+
+    def test_noop_does_not_require_migrations_dict_to_cover_current_version(self, conn):
+        # Already-at-target must short-circuit before gap detection ever
+        # looks at the migrations mapping - an empty mapping must not raise.
+        landed = run_sqlite_migrations(conn, 0, {})
+        assert landed == 0
+
+
+class TestRunSqliteMigrationsMissingFunctionRaisesLoudly:
+    def test_gap_in_the_middle_of_the_range_raises_before_applying_anything(self, conn):
+        applied = []
+        # version 2 is missing entirely.
+        migrations = {1: lambda c: applied.append(1), 3: lambda c: applied.append(3)}
+
+        with pytest.raises(MigrationGapError, match=r"\[2\]"):
+            run_sqlite_migrations(conn, 3, migrations)
+
+        assert applied == [], "no step may run when the chain has a gap in it"
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+
+    def test_gap_error_is_not_a_generic_exception_type(self, conn):
+        assert issubclass(MigrationGapError, RuntimeError)
+
+
+class TestRunSqliteMigrationsRequiresFreshConnection:
+    def test_open_transaction_on_entry_raises(self, conn):
+        conn.execute("BEGIN")
+        conn.execute("CREATE TABLE pending (id INTEGER)")
+        try:
+            with pytest.raises(RuntimeError, match="no transaction already open"):
+                run_sqlite_migrations(conn, 1, {1: lambda c: None})
+        finally:
+            conn.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Dict runner
+# ---------------------------------------------------------------------------
+
+
+class TestRunDictMigrationsOrdering:
+    def test_three_step_chain_applies_in_ascending_order_not_dict_literal_order(self):
+        applied_order = []
+
+        def step_1(state):
+            applied_order.append(1)
+            state = dict(state)
+            state["log"] = state.get("log", []) + [1]
+            return state
+
+        def step_2(state):
+            applied_order.append(2)
+            state = dict(state)
+            state["log"] = state.get("log", []) + [2]
+            return state
+
+        def step_3(state):
+            applied_order.append(3)
+            state = dict(state)
+            state["log"] = state.get("log", []) + [3]
+            return state
+
+        result, landed = run_dict_migrations(
+            {"log": []}, 0, 3, {3: step_3, 1: step_1, 2: step_2}
+        )
+
+        assert applied_order == [1, 2, 3]
+        assert result["log"] == [1, 2, 3]
+        assert landed == 3
+
+
+class TestRunDictMigrationsFailureLeavesInputUntouched:
+    def test_failing_step_propagates_and_original_state_is_unchanged(self):
+        original_state = {"schema_version": 0, "value": "original"}
+
+        def step_1(state):
+            state["value"] = "changed by step 1"
+            return state
+
+        def step_2_raises(state):
+            state["value"] = "changed by step 2, but about to blow up"
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            run_dict_migrations(original_state, 0, 2, {1: step_1, 2: step_2_raises})
+
+        # The caller's own dict object must come back exactly as it went
+        # in - migration functions were fed a deep copy, not this object.
+        assert original_state == {"schema_version": 0, "value": "original"}
+
+    def test_none_return_from_a_migration_raises_typeerror_not_silently_propagating(self):
+        def forgets_to_return(state):
+            state["touched"] = True
+            # no return -> None
+
+        with pytest.raises(TypeError, match="returned None"):
+            run_dict_migrations({}, 0, 1, {1: forgets_to_return})
+
+
+class TestRunDictMigrationsNoOp:
+    def test_already_at_target_is_a_noop_and_returns_same_object_identity(self):
+        original_state = {"schema_version": 4}
+        called = []
+
+        result, landed = run_dict_migrations(
+            original_state, 4, 4, {4: lambda s: called.append(True) or s}
+        )
+
+        assert landed == 4
+        assert called == []
+        assert result is original_state
+
+    def test_current_ahead_of_target_is_a_noop(self):
+        original_state = {"schema_version": 9}
+        called = []
+
+        result, landed = run_dict_migrations(
+            original_state, 9, 3, {1: lambda s: called.append(1) or s}
+        )
+
+        assert landed == 9
+        assert called == []
+        assert result is original_state
+
+
+class TestRunDictMigrationsMissingFunctionRaisesLoudly:
+    def test_gap_in_the_middle_of_the_range_raises_before_applying_anything(self):
+        applied = []
+        original_state = {"value": "untouched"}
+
+        def step_1(state):
+            applied.append(1)
+            return state
+
+        def step_3(state):
+            applied.append(3)
+            return state
+
+        with pytest.raises(MigrationGapError, match=r"\[2\]"):
+            run_dict_migrations(original_state, 0, 3, {1: step_1, 3: step_3})
+
+        assert applied == []
+        assert original_state == {"value": "untouched"}
+
+
+# ---------------------------------------------------------------------------
+# Shared planning helper (exercised indirectly above; a couple of direct
+# checks here since both public runners depend on it for correctness).
+# ---------------------------------------------------------------------------
+
+
+class TestOrderedStepsHelper:
+    def test_empty_migrations_and_target_equal_current_returns_empty_list(self):
+        assert migrations_mod._ordered_steps(2, 2, {}) == []
+
+    def test_full_gap_check_lists_every_missing_version_not_just_the_first(self):
+        with pytest.raises(MigrationGapError, match=r"\[2, 4\]"):
+            migrations_mod._ordered_steps(0, 4, {1: object(), 3: object()})

--- a/backend/tests/test_session_lifecycle.py
+++ b/backend/tests/test_session_lifecycle.py
@@ -29,6 +29,7 @@ from fastapi.testclient import TestClient
 
 from backend.app import create_app, _evict_idle_session
 from backend.events import DEFAULT_SESSION_ID, EventBus, SessionBus, UnknownSessionError
+from backend.notifications import NotificationState
 from backend.session_context import SessionContext, attach_session_context, get_session_context
 
 
@@ -422,7 +423,13 @@ def test_evict_idle_session_releases_the_mutation_guard_when_cancelling_mid_writ
         def slow_write(*args, **kwargs):
             loop.call_soon_threadsafe(write_entered.set)
             time.sleep(0.3)
-            return 1  # any truthy chat_id; DB unused for this assertion
+            # ADR-009 stage 9.2: (chat_id, updated_at) - any truthy chat_id
+            # and a well-formed timestamp string; DB unused for this
+            # assertion, but the shape must match the real function's
+            # contract so autosave_tick's own unpacking doesn't itself
+            # raise (masking this test's actual assertion behind a
+            # swallowed TypeError in autosave_tick's own except Exception).
+            return 1, "2026-01-01 00:00:00"
 
         state_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         db_path = Path(state_dir.name) / "chats.db"
@@ -505,3 +512,121 @@ def test_evict_idle_session_does_not_remove_the_repls_scratch_dir():
 
     assert result is True
     assert repl.cwd.is_dir(), "eviction must not delete the REPL's scratch directory"
+
+
+# -- ADR-009 stage 9.2 / ADR-004 stage 4.3 interaction: flush-before-evict ---
+
+
+def test_evict_idle_session_flushes_a_dirty_chat_before_teardown(tmp_path):
+    """Before this fix, _evict_idle_session cancelled the autosave task
+    outright with no final write - any edit made since the last successful
+    autosave tick (up to a full interval_seconds, 30s by default) was
+    silently lost the instant an idle session was torn down. Confirmed as
+    a real, live gap by reading the pre-9.2 _evict_idle_session directly:
+    cancel_all -> cancel_all_pending_approvals -> dispose_all_pycoder_repls
+    -> autosave_task.cancel(), with no flush anywhere in that sequence.
+
+    Drives the REAL backend.chat_library.register_chat_library wiring (so
+    bus.chat_db_path/bus.chat_save_state/bus.chat_mutation_guard are all
+    genuinely set, not stand-ins a test constructed by hand) with
+    autosave's own background timer explicitly DISABLED
+    (autosave_interval_seconds=None) - so only the eviction-time flush
+    itself, never a lucky prior tick, could possibly be what persists the
+    edit below."""
+    from backend.chat_library import get_all_chats, load_chat_row, register_chat_library
+
+    db_path = tmp_path / "chats.db"
+    bus = SessionBus("s1")
+    context, _tmp = _real_session_context()
+    attach_session_context(bus, context)
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    register_chat_library(bus, db_path, context.canvas_document, notifications, autosave_interval_seconds=None)
+    assert getattr(bus, "autosave_task", None) is None, (
+        "test setup: no background autosave timer should be running"
+    )
+
+    context.canvas_document.add_chat_node(0, 0, "unsaved edit", is_user=True)
+    assert get_all_chats(db_path) == [], "test setup: nothing saved yet is the whole point of this test"
+
+    result = _evict_idle_session(bus)
+
+    assert result is True
+    rows = get_all_chats(db_path)
+    assert len(rows) == 1, "the dirty edit must be flushed to disk before the session is torn down"
+    row = load_chat_row(db_path, rows[0]["id"])
+    assert row["data"]["nodes"][0]["raw_content"] == "unsaved edit"
+
+
+def test_evict_idle_session_does_not_write_a_redundant_row_for_a_clean_session(tmp_path):
+    # The flush must honor the SAME change-guard autosave_tick's own docstring
+    # establishes - a session that has nothing unsaved must not get a
+    # pointless extra write (and re-sorted Chat Library) just because it
+    # happened to go idle.
+    from backend.chat_library import get_all_chats, register_chat_library
+
+    db_path = tmp_path / "chats.db"
+    bus = SessionBus("s1")
+    context, _tmp = _real_session_context()
+    attach_session_context(bus, context)
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    register_chat_library(bus, db_path, context.canvas_document, notifications, autosave_interval_seconds=None)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+    assert bus.chat_save_state["digest"] is None, (
+        "test setup: an empty, never-touched canvas has nothing to save at all"
+    )
+    assert get_all_chats(db_path) == []
+
+    context.canvas_document.add_chat_node(0, 0, "hello", is_user=True)
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+    saved_updated_at = bus.chat_save_state["updated_at"]
+    assert len(get_all_chats(db_path)) == 1
+
+    result = _evict_idle_session(bus)
+
+    assert result is True
+    rows = get_all_chats(db_path)
+    assert len(rows) == 1, "eviction must not duplicate the already-saved row"
+    assert rows[0]["updatedAtIso"] is not None
+    # The row's own updated_at must be byte-identical to what the manual
+    # Save already wrote - a redundant flush write would have bumped it.
+    from backend.chat_library import load_chat_row
+    assert load_chat_row(db_path, rows[0]["id"])["updated_at"] == saved_updated_at
+
+
+def test_evict_idle_session_does_not_flush_while_a_write_is_genuinely_in_flight(tmp_path):
+    # If the mutation guard is already held (a tick or manual op mid-write),
+    # the flush must not race a SECOND write against it - autosave_task.
+    # cancel() below still lets any genuinely in-flight tick finish and
+    # record its own result correctly (see
+    # test_evict_idle_session_releases_the_mutation_guard_when_cancelling_
+    # mid_write above), so attempting a flush here would only risk an
+    # avoidable spurious lost-race warning for no real benefit.
+    from backend.chat_library import register_chat_library
+
+    db_path = tmp_path / "chats.db"
+    bus = SessionBus("s1")
+    context, _tmp = _real_session_context()
+    attach_session_context(bus, context)
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    register_chat_library(bus, db_path, context.canvas_document, notifications, autosave_interval_seconds=None)
+    context.canvas_document.add_chat_node(0, 0, "unsaved edit", is_user=True)
+
+    bus.chat_mutation_guard["active"] = True
+    bus.chat_mutation_guard["owner"] = "autosave"
+
+    import backend.app as app_module
+
+    flush_calls = []
+    real_flush = app_module.flush_dirty_session_before_teardown
+    app_module.flush_dirty_session_before_teardown = lambda *a, **k: flush_calls.append(a)
+    try:
+        result = _evict_idle_session(bus)
+    finally:
+        app_module.flush_dirty_session_before_teardown = real_flush
+
+    assert result is True
+    assert flush_calls == [], "a flush must not be attempted while a write is already in flight"

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -226,6 +226,127 @@ def test_an_old_settings_file_without_schema_version_is_backfilled(tmp_path):
     assert json.loads(state_file.read_text(encoding="utf-8"))["schema_version"] == SettingsManager.CURRENT_SCHEMA_VERSION
 
 
+# -- ADR-009 stage 9.1: scattered `if 'field' not in state` backfills refactored
+# -- into an explicit, ordered migration chain (graphlink_migrations.
+# -- run_dict_migrations). These are before/after equivalence tests: loading an
+# -- OLD-shape state dict through the new chain must land on exactly what the
+# -- old scattered-if-check code produced, not just "doesn't crash".
+
+
+def test_migration_chain_backfills_baseline_fields_to_documented_defaults(tmp_path):
+    import json
+
+    state_file = tmp_path / "session.dat"
+    # A genuinely old file: only two of the ~35 migration-"1" (baseline)
+    # fields present, everything else - including schema_version itself -
+    # absent, the same shape a pre-schema-version session.dat had.
+    state_file.write_text(
+        json.dumps({"api_provider": "Anthropic", "current_mode": "API Endpoint"}),
+        encoding="utf-8",
+    )
+
+    manager = SettingsManager(state_file)
+
+    # Values that were already present survive untouched...
+    assert manager.get_api_provider() == "Anthropic"
+    assert manager.get_current_mode() == "API Endpoint"
+    # ...and every missing baseline field lands on exactly the default
+    # _create_initial_state() documents for a brand-new file - the retired
+    # scattered if-check chain and the new migration chain must agree byte
+    # for byte on these.
+    assert manager.get_show_token_counter() is False
+    assert manager.get_ollama_chat_model() == ""
+    assert manager.get_ollama_scanned_models() == []
+    assert manager.get_llama_cpp_n_ctx() == 4096
+    assert manager.get_llama_cpp_n_gpu_layers() == 0
+    assert manager.get_llama_cpp_n_threads() == 0
+    assert manager.get_api_base_url() == "https://api.openai.com/v1"
+    assert manager.get_openai_key() == ""
+    assert manager.get_enable_system_prompt() is True
+    assert manager.get_update_notifications_enabled() is False
+    assert manager.get_notification_preferences() == {
+        notification_type: True for notification_type in SettingsManager.NOTIFICATION_TYPES
+    }
+    assert manager.get_update_status_message() == "Automatic update checks are off."
+    assert manager.get_update_status_level() == "info"
+    assert manager.get_update_available() is False
+    assert manager.get_schema_version() == SettingsManager.CURRENT_SCHEMA_VERSION
+
+
+def test_migration_chain_applies_in_order_across_multiple_version_boundaries(tmp_path):
+    # A file old enough to predate every version boundary at once: no
+    # schema_version, no api_provider/api_models (migration "1", baseline),
+    # no api_models_by_provider (migration "2") or
+    # api_model_catalog_by_provider (migration "3"), and the pre-R8a 2-value
+    # reasoning "mode" instead of the graded "level" (migration "4").
+    #
+    # api_provider is deliberately OMITTED (not just left at its default)
+    # rather than set explicitly, so this test actually proves ordering, not
+    # just presence: migration "2"'s api_models_by_provider default is keyed
+    # by state['api_provider'] - which exists in the working dict ONLY
+    # because migration "1" already ran and backfilled it earlier in the
+    # SAME chain application. If the runner applied these out of order (or a
+    # future edit reordered the migrations dict), this would key
+    # api_models_by_provider by "" or crash instead of landing on the
+    # documented "OpenAI-Compatible" default.
+    import json
+
+    state_file = tmp_path / "session.dat"
+    state_file.write_text(
+        json.dumps({
+            "ollama_reasoning_mode": "Quick",
+            "llama_cpp_reasoning_mode": "Thinking",
+        }),
+        encoding="utf-8",
+    )
+
+    manager = SettingsManager(state_file)
+
+    # Migration "1" backfilled api_provider to its documented default...
+    assert manager.get_api_provider() == "OpenAI-Compatible"
+    # ...and migration "2" read that freshly-backfilled value (not a
+    # missing/blank one) when it built api_models_by_provider - asserted
+    # directly against the stored dict's own key, not through get_api_models'
+    # provider-defaulting fallback, which would pass even if the key were
+    # wrong.
+    assert set(manager.state["api_models_by_provider"].keys()) == {"OpenAI-Compatible"}
+    assert manager.state["api_models_by_provider"]["OpenAI-Compatible"] == {}
+    # Migration "3" backfilled the empty catalog table.
+    assert manager.get_api_model_catalog("OpenAI-Compatible") == []
+    # Migration "4" faithfully translated the legacy 2-value mode fields
+    # (Quick -> off, Thinking -> high), added the 3 new cloud fields, and
+    # removed the retired legacy keys - and its own mcp_servers backfill
+    # (added later, no version bump of its own - see that migration's
+    # docstring) still ran too.
+    assert manager.get_ollama_reasoning_level() == "off"
+    assert manager.get_llama_cpp_reasoning_level() == "high"
+    assert manager.get_anthropic_reasoning_level() == "off"
+    assert manager.get_gemini_reasoning_level() == "off"
+    assert manager.get_openai_reasoning_level() == "off"
+    assert manager.get_mcp_servers() == []
+    assert manager.get_schema_version() == SettingsManager.CURRENT_SCHEMA_VERSION
+
+    assert "ollama_reasoning_mode" not in manager.state
+    assert "llama_cpp_reasoning_mode" not in manager.state
+
+
+def test_migration_chain_is_a_no_op_on_an_already_current_freshly_created_file(tmp_path):
+    # Pin for the eager-save timing this refactor had to preserve
+    # (test_migration_does_not_rewrite_when_nothing_needs_migrating in
+    # test_backend_secrets_at_rest.py already covers the on-disk mtime side
+    # of this from a fresh file; this covers the in-memory signal the
+    # refactor derives that from) - re-running every migration function
+    # against a dict _create_initial_state() already fully populated must
+    # change nothing at all, not even incidentally.
+    state_file = tmp_path / "session.dat"
+    first = SettingsManager(state_file)  # creates the file fresh
+    on_disk_after_create = state_file.read_text(encoding="utf-8")
+
+    SettingsManager(state_file)  # second load - every migration is a no-op
+
+    assert state_file.read_text(encoding="utf-8") == on_disk_after_create
+
+
 # -- ADR-007 stage 7.5: MCP server configuration -----------------------------
 
 

--- a/graphlink_migrations.py
+++ b/graphlink_migrations.py
@@ -1,0 +1,233 @@
+"""ADR-009 stage 9.1: a reusable ordered-migration-chain primitive shared by
+`backend/chat_library.py` (chats.db, a real SQLite connection) and
+`graphlink_settings_store.py` (session.dat, a plain JSON-loaded dict). Lives
+at the repo root, not backend/, for the same reason graphlink_settings_store.py
+and graphlink_scratch_dirs.py do: it is imported by BOTH a root-level module
+(graphlink_settings_store.py) and a backend/ module (backend/chat_library.py),
+and this codebase's dependency direction is backend/ -> root graphlink_*.py,
+never the reverse - a root module importing from backend/ would invert that
+and risk a circular import the day backend/ needs this module too.
+
+Both runners share one thing: the calling convention is a dict/mapping keyed
+by the version a migration function PRODUCES (migration N takes you from
+N-1 to N), not the version it starts from - the same convention Rails/Django
+migrations use. `_ordered_steps` is the one place that convention is
+interpreted; everything else just applies whatever list it returns.
+
+WHY TWO FUNCTIONS, NOT ONE SHARED RUNNER: the two callers have genuinely
+different commit semantics - chats.db has a real ACID transaction a failed
+step can be rolled back out of by SQLite itself; session.dat is a plain
+in-memory dict with no such primitive, and the caller (SettingsManager) owns
+the actual atomic temp-file+os.replace disk write, done only after this
+module hands back a fully-migrated dict. Forcing both through one "pluggable
+commit strategy" function would mean a fake commit/rollback shim on the dict
+side standing in for something that doesn't exist there. They share the one
+piece that genuinely is identical - `_ordered_steps`, the ordering/gap-
+detection planning logic - and stay separate for the part that isn't.
+"""
+
+from __future__ import annotations
+
+import copy
+import sqlite3
+from collections.abc import Callable, Mapping
+from typing import Any
+
+
+class MigrationGapError(RuntimeError):
+    """Raised when a migration chain has no registered function for a
+    version it must pass through to reach the target. This is a
+    configuration bug in the caller's migration table (a step renumbered,
+    deleted, or never added) - not a data problem - so it is never caught
+    and silently skipped anywhere in this module. Skipping a gap would leave
+    the store's version number claiming schema properties that later code
+    is entitled to assume are true but that were, in fact, never applied."""
+
+
+def _ordered_steps(
+    current_version: int,
+    target_version: int,
+    migrations: Mapping[int, Callable[..., Any]],
+) -> list[tuple[int, Callable[..., Any]]]:
+    """Pure planning step shared by both runners below: given where a store
+    currently is and where it needs to end up, returns
+    [(version, migration_fn), ...] for every version in
+    (current_version, target_version], strictly ascending - regardless of
+    what order `migrations` happens to be written or iterated in, since this
+    always sorts by the explicit integer key, never dict/list insertion
+    order. That is what makes a `{3: fn3, 1: fn1, 2: fn2}` literal apply as
+    1 -> 2 -> 3 rather than whatever order Python happened to keep it in.
+
+    Already-at-or-past target (target_version <= current_version) returns an
+    empty list - a correct, cheap no-op for both "nothing to do" and a
+    theoretical downgrade request (a newer-schema store opened by an older
+    build). This function never moves a store backward; it only ever
+    refuses to move it forward when there's nothing to apply.
+
+    Raises MigrationGapError up front, before returning anything, if ANY
+    version in the required range has no registered function - even one
+    hole partway through the range - so a caller can never end up applying
+    a chain that silently stops short of target because of a gap, then
+    reporting success anyway."""
+    if target_version <= current_version:
+        return []
+
+    needed_versions = range(current_version + 1, target_version + 1)
+    missing = [version for version in needed_versions if version not in migrations]
+    if missing:
+        raise MigrationGapError(
+            f"no migration registered for version(s) {missing} "
+            f"(need to go from {current_version} to {target_version})"
+        )
+    return [(version, migrations[version]) for version in needed_versions]
+
+
+def run_sqlite_migrations(
+    conn: sqlite3.Connection,
+    target_version: int,
+    migrations: Mapping[int, Callable[[sqlite3.Connection], None]],
+) -> int:
+    """Applies every migration from `conn`'s current `PRAGMA user_version`
+    up to `target_version`, in order, inside a single transaction - and only
+    issues `PRAGMA user_version = target_version` after every step has
+    succeeded. A migration function raising anything rolls back EVERYTHING
+    from this call, including any DDL/PRAGMA earlier steps already ran, so
+    `PRAGMA user_version` is left exactly where it was before this call was
+    made - never a partially-applied schema wearing a version number that
+    claims otherwise.
+
+    Each `migrations[version]` function receives `conn` itself and applies
+    its schema change directly against it (CREATE TABLE/ALTER TABLE/data
+    backfill/etc.) - it must not commit, rollback, or otherwise manage the
+    transaction itself; this function owns that for the whole chain.
+
+    Already-at-or-past target is a correct no-op: returns the current
+    version immediately without opening a transaction or touching
+    PRAGMA user_version at all (no write, no lock taken) - important since
+    this can run on every connection open, not just the first one for a
+    given database.
+
+    TRANSACTIONAL SUBTLETY (verified empirically, not from a documentation
+    read alone - see this module's own test file): Python's sqlite3 module
+    defaults every Connection to "legacy transaction control"
+    (isolation_level=""), under which it implicitly COMMITS any open
+    transaction before running a non-DML statement - which includes exactly
+    the statements a schema migration needs (CREATE TABLE, ALTER TABLE,
+    PRAGMA). Under that default, wrapping a migration chain in `with conn:`
+    is NOT atomic - each DDL/PRAGMA statement lands on disk immediately as
+    it runs, so a later step raising leaves the earlier steps' changes (and
+    a stray `PRAGMA user_version` write, if one happened to run before the
+    failure) permanently in place despite the exception. This function
+    avoids that entirely by taking manual control: it temporarily sets
+    `conn.isolation_level = None` (pure autocommit - Python does no implicit
+    transaction management at all) and drives `BEGIN`/`COMMIT`/`ROLLBACK`
+    itself as literal SQL, which SQLite honors as one real ACID transaction
+    covering DDL and PRAGMA exactly the same as DML. The connection's
+    original isolation_level is restored in a `finally`, so this call has no
+    lasting effect on how the caller's connection behaves afterward.
+
+    Requires `conn` to have no transaction already open when called
+    (`conn.in_transaction` must be False) - raises RuntimeError immediately
+    if it does, rather than silently taking over a transaction some other
+    code on the same connection was already mid-way through. Every caller in
+    this codebase opens a fresh connection per call (see
+    backend/chat_library.py's `_connect`), so this is never a real
+    constraint in practice, only a guard against a future misuse."""
+    current_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    target_version = int(target_version)
+    steps = _ordered_steps(current_version, target_version, migrations)
+    if not steps:
+        return current_version
+
+    if conn.in_transaction:
+        raise RuntimeError(
+            "run_sqlite_migrations requires a connection with no transaction "
+            "already open - pass a fresh connection, or one that has just "
+            "committed or rolled back."
+        )
+
+    previous_isolation_level = conn.isolation_level
+    conn.isolation_level = None
+    try:
+        conn.execute("BEGIN")
+        try:
+            for _version, migration_fn in steps:
+                migration_fn(conn)
+            # PRAGMA statements do not accept bound parameters ("?") - the
+            # int() cast two lines above and the int() re-cast here are what
+            # make splicing this into the SQL string safe (an int can never
+            # carry a SQL-injection payload).
+            conn.execute(f"PRAGMA user_version = {target_version}")
+        except BaseException:
+            conn.rollback()
+            raise
+        else:
+            conn.commit()
+    finally:
+        conn.isolation_level = previous_isolation_level
+
+    return target_version
+
+
+def run_dict_migrations(
+    state: dict[str, Any],
+    current_version: int,
+    target_version: int,
+    migrations: Mapping[int, Callable[[dict[str, Any]], dict[str, Any]]],
+) -> tuple[dict[str, Any], int]:
+    """Applies every migration from `current_version` up to `target_version`,
+    in order, to a plain Python dict (session.dat's already-`json.load`-ed
+    state) and returns `(migrated_state, version_landed_on)`. Writes nothing
+    to disk - the caller (graphlink_settings_store.py's SettingsManager)
+    already owns an atomic temp-file+os.replace write and should persist the
+    returned dict itself, stamping whatever version key it uses
+    (`state["schema_version"]`, currently) from the returned version. This
+    function is deliberately agnostic of that key's name: it takes
+    `current_version` as an explicit argument rather than reading a
+    hardcoded key out of `state`, so it stays reusable by any future
+    dict-shaped store that names its version field differently.
+
+    Each `migrations[version]` function receives the in-progress dict and
+    must return the migrated dict (in place mutate-and-return-self, or
+    return a new dict - both are accepted, see below).
+
+    Never mutates the caller's `state` argument in place: the very first
+    thing this does is take a deep copy, and every migration function in the
+    chain is fed that copy (or whatever it returned last), never the
+    original object. If any migration raises, the exception propagates
+    immediately and `state` - the object the caller passed in - is
+    guaranteed byte-for-byte unchanged, exactly as if this had never been
+    called; nothing partially migrated ever becomes visible to the caller on
+    a failure path, matching this module's SQLite side never leaving
+    `PRAGMA user_version` bumped on a failed chain. (The deep copy also
+    means a migration function is free to mutate its input in place without
+    corrupting the pre-migration `state` the caller still holds a reference
+    to - useful for the common case of `state[key] = value; return state`.)
+
+    A migration function that returns `None` (a common accidental bug -
+    mutate in place, forget the `return state`) raises TypeError immediately
+    rather than silently feeding `None` into the next step in the chain,
+    where it would fail confusingly deep inside that step's own `.get(...)`
+    call instead of at the actual point of the mistake.
+
+    Already-at-or-past target is a correct no-op: returns `(state,
+    current_version)` - note this is the ORIGINAL `state` object, not a
+    copy, since nothing needed transforming and there is no reason to pay
+    for (or return a different identity than) a copy that was never used."""
+    current_version = int(current_version)
+    target_version = int(target_version)
+    steps = _ordered_steps(current_version, target_version, migrations)
+    if not steps:
+        return state, current_version
+
+    working_state = copy.deepcopy(state)
+    for version, migration_fn in steps:
+        working_state = migration_fn(working_state)
+        if working_state is None:
+            raise TypeError(
+                f"migration for version {version} returned None - migration "
+                "functions must return the migrated dict, not mutate it and "
+                "return nothing"
+            )
+
+    return working_state, target_version

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import graphlink_secrets
+from graphlink_migrations import run_dict_migrations
 from graphlink_model_catalog import (
     AUTO_MODEL,
     INHERIT_MODEL,
@@ -200,142 +201,253 @@ class SettingsManager:
         if migrated:
             self._save_state()
 
+    # ADR-009 stage 9.1: keyed by the version each function PRODUCES
+    # (migration "1" takes a state dict from 0 -> 1), matching
+    # graphlink_migrations' own ordering convention and
+    # backend/chat_library.py's sibling _MIGRATIONS table - see
+    # run_dict_migrations' own docstring for the calling contract each
+    # function below must honor (receive the in-progress dict, return the
+    # migrated dict, never manage a "changed" side channel - _load_state
+    # derives that from a single whole-state comparison instead, see its
+    # own comment). Built fresh per call (not a class-level dict) because
+    # these are bound instance methods - _migration_002_provider_scoped_
+    # cloud_profiles reaches self._migrate_model_settings, and
+    # _migration_001_baseline_fields reaches self.NOTIFICATION_TYPES.
+    def _dict_migrations(self):
+        return {
+            1: self._migration_001_baseline_fields,
+            2: self._migration_002_provider_scoped_cloud_profiles,
+            3: self._migration_003_cloud_model_catalogs,
+            4: self._migration_004_graded_reasoning_levels,
+        }
+
+    def _migration_001_baseline_fields(self, state: dict) -> dict:
+        """Migration "1" (0 -> 1): every field that already existed in
+        session.dat before schema_version existed at all (see commit
+        6a7e326, "schema_version fields added to session.dat and chat
+        payloads" - CURRENT_SCHEMA_VERSION was introduced there as 1, over a
+        file shape every one of these fields was already part of). None of
+        these were ever gated on a version number, only on the field's own
+        presence - ported verbatim from the old scattered
+        `if 'x' not in state` chain that used to live directly in
+        _load_state."""
+        if 'show_token_counter' not in state:
+            state['show_token_counter'] = False
+        if 'ollama_chat_model' not in state:
+            state['ollama_chat_model'] = ''
+        if 'ollama_title_model' not in state:
+            state['ollama_title_model'] = ''
+        if 'ollama_chart_model' not in state:
+            state['ollama_chart_model'] = ''
+        if 'ollama_web_validate_model' not in state:
+            state['ollama_web_validate_model'] = ''
+        if 'ollama_web_summarize_model' not in state:
+            state['ollama_web_summarize_model'] = ''
+        if 'ollama_scanned_models' not in state:
+            state['ollama_scanned_models'] = []
+        if 'ollama_model_scan_mode' not in state:
+            state['ollama_model_scan_mode'] = ''
+        if 'ollama_model_scan_path' not in state:
+            state['ollama_model_scan_path'] = ''
+        if 'ollama_model_scan_locations' not in state:
+            state['ollama_model_scan_locations'] = []
+        if 'llama_cpp_chat_model_path' not in state:
+            state['llama_cpp_chat_model_path'] = ''
+        if 'llama_cpp_title_model_path' not in state:
+            state['llama_cpp_title_model_path'] = ''
+        if 'llama_cpp_chat_format' not in state:
+            state['llama_cpp_chat_format'] = ''
+        if 'llama_cpp_n_ctx' not in state:
+            state['llama_cpp_n_ctx'] = 4096
+        if 'llama_cpp_n_gpu_layers' not in state:
+            state['llama_cpp_n_gpu_layers'] = 0
+        if 'llama_cpp_n_threads' not in state:
+            state['llama_cpp_n_threads'] = 0
+        if 'llama_cpp_scanned_models' not in state:
+            state['llama_cpp_scanned_models'] = []
+        if 'llama_cpp_model_scan_mode' not in state:
+            state['llama_cpp_model_scan_mode'] = ''
+        if 'llama_cpp_model_scan_path' not in state:
+            state['llama_cpp_model_scan_path'] = ''
+        if 'llama_cpp_model_scan_locations' not in state:
+            state['llama_cpp_model_scan_locations'] = []
+        if 'current_mode' not in state:
+            state['current_mode'] = 'Ollama (Local)'
+        if 'api_provider' not in state:
+            state['api_provider'] = 'OpenAI-Compatible'
+        if 'api_base_url' not in state:
+            state['api_base_url'] = 'https://api.openai.com/v1'
+        if 'openai_api_key' not in state:
+            state['openai_api_key'] = ''
+        if 'anthropic_api_key' not in state:
+            state['anthropic_api_key'] = ''
+        if 'gemini_api_key' not in state:
+            state['gemini_api_key'] = ''
+        if 'github_access_token' not in state:
+            state['github_access_token'] = ''
+        if 'api_models' not in state:
+            state['api_models'] = {}
+        if 'enable_system_prompt' not in state:
+            state['enable_system_prompt'] = True
+        if 'update_notifications_enabled' not in state:
+            state['update_notifications_enabled'] = False
+        if 'notification_preferences' not in state or not isinstance(state.get('notification_preferences'), dict):
+            state['notification_preferences'] = {}
+        for notification_type in self.NOTIFICATION_TYPES:
+            if notification_type not in state['notification_preferences']:
+                state['notification_preferences'][notification_type] = True
+        if 'update_status_message' not in state:
+            state['update_status_message'] = 'Automatic update checks are off.'
+        if 'update_status_level' not in state:
+            state['update_status_level'] = 'info'
+        if 'update_last_checked_at' not in state:
+            state['update_last_checked_at'] = ''
+        if 'update_latest_version' not in state:
+            state['update_latest_version'] = ''
+        if 'update_available' not in state:
+            state['update_available'] = False
+        return state
+
+    def _migration_002_provider_scoped_cloud_profiles(self, state: dict) -> dict:
+        """Migration "2" (1 -> 2, commit a1dbaeda): provider-scoped cloud
+        model profiles (api_models_by_provider) and explicit local model
+        assignment modes (ollama_model_assignments, via the pre-existing
+        _migrate_model_settings helper) - see that commit's own
+        CURRENT_SCHEMA_VERSION bump comment ("provider-scoped cloud profiles
+        and explicit local model assignment modes"). Depends on
+        ollama_chat_model/ollama_title_model/ollama_chart_model/
+        ollama_web_validate_model/ollama_web_summarize_model/api_provider/
+        api_models all already being present, which migration "1" above
+        guarantees by running first."""
+        if 'api_models_by_provider' not in state or not isinstance(state.get('api_models_by_provider'), dict):
+            state['api_models_by_provider'] = {
+                str(state.get('api_provider', 'OpenAI-Compatible')): dict(state.get('api_models', {}) or {})
+            }
+        self._migrate_model_settings(state)
+        return state
+
+    def _migration_003_cloud_model_catalogs(self, state: dict) -> dict:
+        """Migration "3" (2 -> 3, commit 7a1f19e): persisted refreshed cloud
+        model catalogs (api_model_catalog_by_provider), so the composer can
+        offer a useful selector without a network request on every render -
+        see that commit's own CURRENT_SCHEMA_VERSION bump comment."""
+        if 'api_model_catalog_by_provider' not in state or not isinstance(state.get('api_model_catalog_by_provider'), dict):
+            state['api_model_catalog_by_provider'] = {}
+        return state
+
+    def _migration_004_graded_reasoning_levels(self, state: dict) -> dict:
+        """Migration "4" (3 -> 4, commit ed467c9 / R8a): the 2-value
+        Ollama/Llama.cpp reasoning "mode" (Thinking/Quick) becomes a graded
+        4-value "level" (off/low/medium/high) shared by all 5 providers -
+        migrate any already-persisted choice faithfully rather than
+        resetting it ("Quick" meant no reasoning at all -> off, "Thinking"
+        meant full reasoning -> high, this field's own default), and add the
+        3 new cloud reasoning-level fields that had no equivalent before,
+        defaulting to off (extended thinking on a paid API is an opt-in
+        cost/latency tradeoff, never a silent default, unlike the local
+        providers whose compute is free to the user) - see that commit's own
+        CURRENT_SCHEMA_VERSION bump comment.
+
+        mcp_servers (ADR-007 stage 7.5) is grouped in here too even though
+        it was added later without its own CURRENT_SCHEMA_VERSION bump -
+        there is no version number to place it at. Since every migration in
+        this chain always runs on every load regardless of the file's own
+        declared version (see _load_state's own comment on why), attaching
+        it to the chain's current terminal function is the deliberate,
+        least-surprising home for it, not a guess."""
+        if 'ollama_reasoning_level' not in state:
+            # R8a: reasoning went from a 2-value Ollama/Llama.cpp bool
+            # "mode" to a graded 4-value level shared by every provider -
+            # migrate any already-persisted choice faithfully rather than
+            # silently resetting it: "Quick" meant no reasoning at all
+            # (-> off), "Thinking" meant full reasoning (-> high, this
+            # field's own default).
+            state['ollama_reasoning_level'] = 'off' if state.get('ollama_reasoning_mode') == 'Quick' else 'high'
+        state.pop('ollama_reasoning_mode', None)
+        if 'llama_cpp_reasoning_level' not in state:
+            # Same migration story as ollama_reasoning_level above.
+            state['llama_cpp_reasoning_level'] = 'off' if state.get('llama_cpp_reasoning_mode') == 'Quick' else 'high'
+        state.pop('llama_cpp_reasoning_mode', None)
+        if 'anthropic_reasoning_level' not in state:
+            # New cloud-provider fields (R8a) - "off" by default, matching
+            # api_provider.py's own conservative default: extended thinking
+            # on a paid API is an opt-in cost/latency tradeoff, never a
+            # silent default.
+            state['anthropic_reasoning_level'] = 'off'
+        if 'gemini_reasoning_level' not in state:
+            state['gemini_reasoning_level'] = 'off'
+        if 'openai_reasoning_level' not in state:
+            state['openai_reasoning_level'] = 'off'
+        if 'mcp_servers' not in state or not isinstance(state.get('mcp_servers'), list):
+            # ADR-007 stage 7.5: absent in every pre-7.5 save -> no
+            # configured MCP servers, matching the initial-state default in
+            # _create_initial_state - a settings surface with nothing
+            # configured yet is the correct, safe starting point, not an
+            # error.
+            state['mcp_servers'] = []
+        return state
+
     def _load_state(self):
         if not self.state_file.exists():
             return self._create_initial_state()
         try:
             with open(self.state_file, 'r') as f:
-                state = json.load(f)
-                if 'show_token_counter' not in state:
-                    state['show_token_counter'] = False
-                state_changed = False
-                if 'ollama_chat_model' not in state:
-                    state['ollama_chat_model'] = ''
-                    state_changed = True
-                if 'ollama_title_model' not in state:
-                    state['ollama_title_model'] = ''
-                if 'ollama_chart_model' not in state:
-                    state['ollama_chart_model'] = ''
-                if 'ollama_web_validate_model' not in state:
-                    state['ollama_web_validate_model'] = ''
-                if 'ollama_web_summarize_model' not in state:
-                    state['ollama_web_summarize_model'] = ''
-                if 'ollama_reasoning_level' not in state:
-                    # R8a: reasoning went from a 2-value Ollama/Llama.cpp
-                    # bool "mode" to a graded 4-value level shared by every
-                    # provider - migrate any already-persisted choice
-                    # faithfully rather than silently resetting it: "Quick"
-                    # meant no reasoning at all (-> off), "Thinking" meant
-                    # full reasoning (-> high, this field's own default).
-                    state['ollama_reasoning_level'] = 'off' if state.get('ollama_reasoning_mode') == 'Quick' else 'high'
-                state.pop('ollama_reasoning_mode', None)
-                if 'ollama_scanned_models' not in state:
-                    state['ollama_scanned_models'] = []
-                if 'ollama_model_scan_mode' not in state:
-                    state['ollama_model_scan_mode'] = ''
-                if 'ollama_model_scan_path' not in state:
-                    state['ollama_model_scan_path'] = ''
-                if 'ollama_model_scan_locations' not in state:
-                    state['ollama_model_scan_locations'] = []
-                if 'llama_cpp_chat_model_path' not in state:
-                    state['llama_cpp_chat_model_path'] = ''
-                if 'llama_cpp_title_model_path' not in state:
-                    state['llama_cpp_title_model_path'] = ''
-                if 'llama_cpp_reasoning_level' not in state:
-                    # Same migration story as ollama_reasoning_level above.
-                    state['llama_cpp_reasoning_level'] = 'off' if state.get('llama_cpp_reasoning_mode') == 'Quick' else 'high'
-                state.pop('llama_cpp_reasoning_mode', None)
-                if 'anthropic_reasoning_level' not in state:
-                    # New cloud-provider fields (R8a) - "off" by default,
-                    # matching api_provider.py's own conservative default:
-                    # extended thinking on a paid API is an opt-in cost/
-                    # latency tradeoff, never a silent default.
-                    state['anthropic_reasoning_level'] = 'off'
-                if 'gemini_reasoning_level' not in state:
-                    state['gemini_reasoning_level'] = 'off'
-                if 'openai_reasoning_level' not in state:
-                    state['openai_reasoning_level'] = 'off'
-                if 'llama_cpp_chat_format' not in state:
-                    state['llama_cpp_chat_format'] = ''
-                if 'llama_cpp_n_ctx' not in state:
-                    state['llama_cpp_n_ctx'] = 4096
-                if 'llama_cpp_n_gpu_layers' not in state:
-                    state['llama_cpp_n_gpu_layers'] = 0
-                if 'llama_cpp_n_threads' not in state:
-                    state['llama_cpp_n_threads'] = 0
-                if 'llama_cpp_scanned_models' not in state:
-                    state['llama_cpp_scanned_models'] = []
-                if 'llama_cpp_model_scan_mode' not in state:
-                    state['llama_cpp_model_scan_mode'] = ''
-                if 'llama_cpp_model_scan_path' not in state:
-                    state['llama_cpp_model_scan_path'] = ''
-                if 'llama_cpp_model_scan_locations' not in state:
-                    state['llama_cpp_model_scan_locations'] = []
-                if 'current_mode' not in state:
-                    state['current_mode'] = 'Ollama (Local)'
-                if 'api_provider' not in state:
-                    state['api_provider'] = 'OpenAI-Compatible'
-                if 'api_base_url' not in state:
-                    state['api_base_url'] = 'https://api.openai.com/v1'
-                if 'openai_api_key' not in state:
-                    state['openai_api_key'] = ''
-                if 'anthropic_api_key' not in state:
-                    state['anthropic_api_key'] = ''
-                if 'gemini_api_key' not in state:
-                    state['gemini_api_key'] = ''
-                if 'github_access_token' not in state:
-                    state['github_access_token'] = ''
-                if 'api_models' not in state:
-                    state['api_models'] = {}
-                    state_changed = True
-                if 'api_models_by_provider' not in state or not isinstance(state.get('api_models_by_provider'), dict):
-                    state['api_models_by_provider'] = {
-                        str(state.get('api_provider', 'OpenAI-Compatible')): dict(state.get('api_models', {}) or {})
-                    }
-                    state_changed = True
-                if 'api_model_catalog_by_provider' not in state or not isinstance(state.get('api_model_catalog_by_provider'), dict):
-                    state['api_model_catalog_by_provider'] = {}
-                    state_changed = True
-                state_changed = self._migrate_model_settings(state) or state_changed
-                if 'enable_system_prompt' not in state:
-                    state['enable_system_prompt'] = True
-                if 'update_notifications_enabled' not in state:
-                    state['update_notifications_enabled'] = False
-                if 'notification_preferences' not in state or not isinstance(state.get('notification_preferences'), dict):
-                    state['notification_preferences'] = {}
-                for notification_type in self.NOTIFICATION_TYPES:
-                    if notification_type not in state['notification_preferences']:
-                        state['notification_preferences'][notification_type] = True
-                if 'update_status_message' not in state:
-                    state['update_status_message'] = 'Automatic update checks are off.'
-                if 'update_status_level' not in state:
-                    state['update_status_level'] = 'info'
-                if 'update_last_checked_at' not in state:
-                    state['update_last_checked_at'] = ''
-                if 'update_latest_version' not in state:
-                    state['update_latest_version'] = ''
-                if 'update_available' not in state:
-                    state['update_available'] = False
-                if 'mcp_servers' not in state or not isinstance(state.get('mcp_servers'), list):
-                    # ADR-007 stage 7.5: absent in every pre-7.5 save -> no
-                    # configured MCP servers, matching the initial-state
-                    # default below - a settings surface with nothing
-                    # configured yet is the correct, safe starting point,
-                    # not an error.
-                    state['mcp_servers'] = []
-                    state_changed = True
-                if 'schema_version' not in state:
-                    state['schema_version'] = self.CURRENT_SCHEMA_VERSION
-                    state_changed = True
-                elif state.get('schema_version', 0) < self.CURRENT_SCHEMA_VERSION:
-                    state['schema_version'] = self.CURRENT_SCHEMA_VERSION
-                    state_changed = True
-                if state_changed:
-                    self._state_needs_save = True
-                return state
+                raw_state = json.load(f)
         except (json.JSONDecodeError, IOError) as e:
             self._backup_corrupt_state_file(e)
             return self._create_initial_state()
+
+        # ADR-009 stage 9.1: every backfill above now runs through
+        # graphlink_migrations.run_dict_migrations instead of one long
+        # inline `if 'field' not in state: ...` chain. Deliberately always
+        # called with current_version=0 here - never
+        # `raw_state.get('schema_version', 0)` - so migrations 1 through
+        # CURRENT_SCHEMA_VERSION run on EVERY load, exactly matching what
+        # the old inline chain did: those if-checks were never actually
+        # gated on the file's own declared schema_version at all (that is
+        # the "scattered, no explicit boundary" shape this refactor was
+        # asked to fix structurally, not a version-gated migration system to
+        # begin with) - they ran unconditionally, keyed only on whether each
+        # individual field was already present. Switching to a genuinely
+        # version-gated read (skipping migration N whenever the stored
+        # schema_version is already >= N) would be a real behavior change: a
+        # file that already claims the current version but is missing a
+        # field an earlier migration would have added (hand-edited,
+        # corrupted, or written by a future build this one doesn't fully
+        # understand) would stop being self-healed on load. Each migration
+        # function is idempotent (the same `if key not in state` shape as
+        # before), so re-running all of them against an already-fully-
+        # populated state is a correct, cheap no-op - not wasted risk.
+        migrated_state, _ = run_dict_migrations(
+            raw_state, 0, self.CURRENT_SCHEMA_VERSION, self._dict_migrations()
+        )
+
+        # The persisted version stamp itself is bumped separately from the
+        # migrations dict above, since its "never move it backward" rule
+        # doesn't fit run_dict_migrations' landed-on-target contract: a file
+        # that already declares a NEWER version than this build knows about
+        # (opened by an older build after a downgrade) must keep that
+        # number, not have it overwritten with this build's lower
+        # CURRENT_SCHEMA_VERSION.
+        if 'schema_version' not in migrated_state:
+            migrated_state['schema_version'] = self.CURRENT_SCHEMA_VERSION
+        elif migrated_state.get('schema_version', 0) < self.CURRENT_SCHEMA_VERSION:
+            migrated_state['schema_version'] = self.CURRENT_SCHEMA_VERSION
+
+        # Save immediately only if this load actually changed something -
+        # the refactored equivalent of the old per-field state_changed flag
+        # (persist a migrated file right away rather than leaving it only in
+        # memory until the next explicit set_*() call), expressed as one
+        # whole-state comparison instead of that flag's own inconsistent
+        # per-field coverage (several fields - e.g. a missing
+        # ollama_title_model alone - never flipped it at all in the old
+        # code). run_dict_migrations guarantees raw_state itself is never
+        # mutated in place, so this compares the untouched on-disk shape
+        # against the fully migrated+stamped result.
+        if migrated_state != raw_state:
+            self._state_needs_save = True
+
+        return migrated_state
 
     def _backup_corrupt_state_file(self, error):
         # Preserve the unreadable file for forensic recovery instead of silently

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ py-modules = [
     "graphlink_execution_guard",
     "graphlink_grid_view_settings",
     "graphlink_memory",
+    "graphlink_migrations",
     "graphlink_model_catalog",
     "graphlink_navigation_pins",
     "graphlink_note_agent",


### PR DESCRIPTION
## Problem

Local storage had no schema-migration mechanism, no backups, and no
recovery path from a corrupt database. Two saves of the same chat could
silently clobber each other. There was no way to get data out of the app,
and no single place deciding what counts as a secret.

## Change

**9.1 — schema migrations.** A shared `run_sqlite_migrations` driver keyed
on `PRAGMA user_version`, with ordered steps and a gap check. Both stores
move onto it: `chats.db` gets an explicit initial-schema step, and the
settings store's scattered backfills become an ordered chain. Migrations
run under a manual `BEGIN`/`COMMIT`/`ROLLBACK` — `sqlite3`'s legacy
transaction control implicitly commits before DDL, so `with conn:` is not
atomic here.

**9.2 — backups, corruption recovery, concurrent-save safety.** Backups
via SQLite's online backup API, pruned to the ten most recent plus one
per day. A corrupt database is quarantined (including its `-wal`/`-shm`
sidecars, which would otherwise replay onto the restored file) and
restored from the newest good backup. Saves are optimistically
concurrency-checked on `updated_at` and raise `ConcurrentSaveConflict`
rather than overwriting, using microsecond timestamps — second resolution
defeats the check.

**9.3 — secret scrubbing.** One chokepoint, `backend/secret_scrub.py`,
matching both on key name and on credential-shaped values, plus absolute
paths in all three forms (Windows, UNC, POSIX).

**9.4 — the `.graphlink` archive.** A plain zip: chats as JSON, assets as
real files, so it is readable without this app. Every payload is scrubbed
on the way out. Import validates before writing anything, refuses zip-slip
and absolute member names, caps member size against decompression bombs,
refuses newer format versions rather than guessing, and drops assets whose
bytes do not hash to their own ref.

## What is not here

Stages 9.5 (asset externalization) and 9.6 (flat edge format) — the two
on-disk format changes. They ship separately.

## Test plan

- `backend/tests/test_migrations.py`, `test_db_backup.py`,
  `test_chat_library.py` — migration ordering and gap detection,
  transaction rollback, backup/prune/restore, quarantine including
  sidecars, concurrent-save conflict.
- `backend/tests/test_secret_scrub.py` (12) — written as attempts to sneak
  a secret past the scrubber, not as a happy-path walk.
- `backend/tests/test_workspace_archive.py` (16) — round-trip into a
  *different* asset store (the second-machine case), zero secrets in the
  archive, and the hostile-input set.
- Full suite from repo root: 2142 passed, 16 skipped.
