### PR TITLE
ADR-014: Plugin SDK — from hardcoded menu to real extension model

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -445,6 +445,7 @@ class AgentDispatcher:
             register_knowledge_tools(registry)
             register_builder_control_tools(registry)
             self._register_configured_mcp_tools(registry)
+            self._register_plugin_tools(registry, document)
             self._builder_registry = registry
         return self._builder_registry
 
@@ -493,6 +494,32 @@ class AgentDispatcher:
                     client.close()
                 except Exception:
                     pass
+
+    def _register_plugin_tools(self, registry, document) -> None:
+        """ADR-014 stage 14.5: plugin-declared custom intents (HostContext.
+        register_intent, both in-process and out-of-process plugins) become
+        real Builder-loop tools - see backend/plugins.py's
+        register_plugin_tools for the full contract (namespacing, scopes,
+        approval, the install-time-grant re-check). Uses discover_plugins()'s
+        own memoized registry (the SAME one register_plugins() populates for
+        the session's bus-level executePlugin/invokePluginIntent dispatch,
+        by resolved plugins_root path) - discovery itself already ran by the
+        time any session can reach this point (register_plugins() runs at
+        session activation, before the Builder can ever start), so this is
+        just a second consumer of an already-populated registry, not a
+        second discovery pass - matching _register_configured_mcp_tools'
+        own "read the persisted config, tolerate per-item failure" shape
+        directly above."""
+        if self._settings_manager is None:
+            return
+        from backend.plugin_sdk import discover_plugins
+        from backend.plugins import register_plugin_tools
+
+        try:
+            plugin_registry = discover_plugins()
+            register_plugin_tools(registry, plugin_registry, self._settings_manager, document)
+        except Exception:
+            logger.exception("could not register plugin-declared tools")
 
     async def start_builder_run(
         self,

--- a/backend/app.py
+++ b/backend/app.py
@@ -285,7 +285,11 @@ def _configure_session(
     # (built above) so loadChat can actually restore a session into it, and
     # notifications_state so a failed/empty load can surface a real banner -
     # same load-bearing ordering precedent as register_plugins above.
-    register_chat_library(bus, chat_db_path, canvas_document, notifications_state)
+    # ADR-014 review-fix: settings_manager threaded through too, the same
+    # reason register_plugins gets it two lines up - a plugin node's own
+    # serialize/deserialize hook must respect its Settings > Plugins grant
+    # on save/load/autosave, not just live-wire scene publishes.
+    register_chat_library(bus, chat_db_path, canvas_document, notifications_state, settings_manager=settings_manager)
 
 
 def _evict_idle_session(bus: SessionBus) -> bool:

--- a/backend/app.py
+++ b/backend/app.py
@@ -271,7 +271,10 @@ def _configure_session(
     # R5.1: register_plugins needs the same session's canvas_document (built
     # just above) so "Web Research" can create a real node - this ordering
     # (canvas_document exists before register_plugins runs) is load-bearing.
-    register_plugins(bus, notifications_state, canvas_document)
+    # ADR-014 stage 14.4: settings_manager threaded through too - it's the
+    # deny-by-default grant store _execute_discovered_plugin/
+    # invokePluginIntent consult before letting a non-built-in plugin act.
+    register_plugins(bus, notifications_state, canvas_document, settings_manager)
     # R7.4a: register_settings now takes notifications_state too, so the
     # API-provider page's save-validation/init-failure paths can surface a
     # real banner (same load-bearing ordering precedent as register_plugins/

--- a/backend/autosave.py
+++ b/backend/autosave.py
@@ -98,6 +98,7 @@ from backend.chat_library import (
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.session_save import build_chat_data
+from graphlink_settings_store import SettingsManager
 
 logger = logging.getLogger(__name__)
 
@@ -110,12 +111,20 @@ async def autosave_tick(
     canvas_document: SceneDocument,
     notifications: NotificationState | None,
     last_saved: dict[str, Any],
+    settings_manager: "SettingsManager | None" = None,
 ) -> None:
     """One autosave attempt - directly callable (no timer involved), so
     tests can exercise the actual decision/write logic deterministically
     rather than waiting on a real sleep. `last_saved` is the mutable cell
     backend/chat_library.py's _new_save_state() creates and every write path
-    shares (see this module's own docstring, and that function's)."""
+    shares (see this module's own docstring, and that function's).
+
+    ADR-014 review-fix: `settings_manager`, when given, is threaded to
+    build_chat_data so a plugin's own serialize hook is gated on its
+    current Settings > Plugins grant on every autosave tick too, not just
+    a manual Save - see session_save.py's _serialize_plugin_node for the
+    actual check. `None` (this parameter's own default) preserves the
+    exact prior ungated behavior."""
     if not canvas_document.nodes and canvas_document.current_chat_id is None:
         # Mirrors saveChat's own "Nothing was added to the chat canvas yet"
         # guard - an empty, never-saved canvas has nothing worth protecting.
@@ -126,7 +135,9 @@ async def autosave_tick(
         # and only a ref is written into the row. This path is the whole
         # reason that stage exists - without it every 30-second tick
         # rewrote megabytes of base64 for pictures that had not changed.
-        chat_data = build_chat_data(canvas_document, asset_store=store_for(db_path))
+        chat_data = build_chat_data(
+            canvas_document, asset_store=store_for(db_path), settings_manager=settings_manager,
+        )
     except Exception:
         logger.exception("autosave: failed to build chat data for session %r", bus.session_id)
         return
@@ -234,6 +245,7 @@ def register_autosave(
     last_saved: dict[str, Any],
     *,
     interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+    settings_manager: "SettingsManager | None" = None,
 ) -> None:
     """Starts the one long-lived per-session background task. Stashed on
     `bus.autosave_task` purely so a caller COULD cancel it (e.g. a future
@@ -243,7 +255,10 @@ def register_autosave(
     `last_saved` is owned by the caller (register_chat_library), not created
     here, precisely so the manual save/load/delete paths can seed and
     invalidate the same cell - see this module's own CHANGE-GUARDED
-    paragraph."""
+    paragraph.
+
+    ADR-014 review-fix: `settings_manager` is threaded straight through to
+    autosave_tick - see that function's own docstring."""
 
     async def _guarded_tick() -> None:
         if mutation_guard["active"]:
@@ -262,7 +277,7 @@ def register_autosave(
         mutation_guard["owner"] = AUTOSAVE_OWNER
         mutation_guard["released"].clear()
         try:
-            await autosave_tick(bus, db_path, canvas_document, notifications, last_saved)
+            await autosave_tick(bus, db_path, canvas_document, notifications, last_saved, settings_manager)
         finally:
             mutation_guard["active"] = False
             mutation_guard["owner"] = None

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -54,6 +54,7 @@ from backend.session_load import restore_chat_into_document
 from backend.asset_store import store_for
 from backend.session_save import build_chat_data
 from graphlink_migrations import run_sqlite_migrations
+from graphlink_settings_store import SettingsManager
 
 DEFAULT_DB_PATH = Path.home() / ".graphlink" / "chats.db"
 
@@ -1147,6 +1148,7 @@ def make_load_chat(
     notifications: NotificationState | None,
     record_saved: Callable[..., None],
     last_saved: dict[str, Any],
+    settings_manager: "SettingsManager | None" = None,
 ):
     """Factory for register_chat_library's own loadChat intent - lifted out
     to a top-level function purely to keep register_chat_library itself
@@ -1181,7 +1183,7 @@ def make_load_chat(
 
             restore_chat_into_document(
                 canvas_document, row, notes_rows, pins_rows,
-                asset_store=store_for(resolved_path),
+                asset_store=store_for(resolved_path), settings_manager=settings_manager,
             )
             # R6.5: remember which row this scene now corresponds to, so a
             # later Save updates THIS row instead of always inserting a new
@@ -1197,7 +1199,9 @@ def make_load_chat(
                 # first tick after a load would see a payload that
                 # differs only in image representation and rewrite a
                 # row that is already correct.
-                fresh = build_chat_data(canvas_document, asset_store=store_for(resolved_path))
+                fresh = build_chat_data(
+                    canvas_document, asset_store=store_for(resolved_path), settings_manager=settings_manager,
+                )
                 fresh_notes = fresh.pop("notes_data", [])
                 fresh_pins = fresh.pop("pins_data", [])
                 # ADR-009 stage 9.2: row["updated_at"] is the value that
@@ -1252,6 +1256,7 @@ def make_save_chat(
     notifications: NotificationState | None,
     record_saved: Callable[..., None],
     last_saved: dict[str, Any],
+    settings_manager: "SettingsManager | None" = None,
 ):
     """Factory for register_chat_library's own saveChat intent - see
     make_load_chat's own docstring (immediately above) for why this is a
@@ -1283,7 +1288,9 @@ def make_save_chat(
             return
 
         try:
-            chat_data = build_chat_data(canvas_document, asset_store=store_for(resolved_path))
+            chat_data = build_chat_data(
+                canvas_document, asset_store=store_for(resolved_path), settings_manager=settings_manager,
+            )
         except Exception as exc:
             if notifications is not None:
                 notifications.show(f"Failed to prepare chat save payload: {exc}", "error")
@@ -1376,7 +1383,17 @@ def register_chat_library(
     notifications: NotificationState | None = None,
     *,
     autosave_interval_seconds: float | None = 30.0,
+    settings_manager: "SettingsManager | None" = None,
 ) -> None:
+    # ADR-014 review-fix: threaded through to build_chat_data/
+    # restore_chat_into_document (via make_load_chat/make_save_chat/
+    # register_autosave below) so a plugin node's own serialize/deserialize
+    # hook is gated on its current Settings > Plugins grant on every real
+    # save/load/autosave-tick, not just live-wire scene publishes - see
+    # session_save.py's _serialize_plugin_node and session_load.py's
+    # _restore_plugin_payload for the actual check. `None` (every existing
+    # test call site of this function) preserves the exact prior ungated
+    # behavior.
     resolved_path = db_path if db_path is not None else DEFAULT_DB_PATH
     # ADR-009 stage 9.2: stashed on the bus for the same reason bus.
     # chat_mutation_guard/bus.chat_save_state/bus.autosave_task already
@@ -1485,8 +1502,12 @@ def register_chat_library(
             _last_saved["updated_at"] = None
         await bus.publish("app-chat-library")
 
-    load_chat = make_load_chat(bus, resolved_path, canvas_document, notifications, _record_saved, _last_saved)
-    save_chat = make_save_chat(bus, resolved_path, canvas_document, notifications, _record_saved, _last_saved)
+    load_chat = make_load_chat(
+        bus, resolved_path, canvas_document, notifications, _record_saved, _last_saved, settings_manager,
+    )
+    save_chat = make_save_chat(
+        bus, resolved_path, canvas_document, notifications, _record_saved, _last_saved, settings_manager,
+    )
 
     async def new_chat():
         # R6.5: the backend counterpart of legacy's "start with an empty
@@ -1523,7 +1544,7 @@ def register_chat_library(
 
         register_autosave(
             bus, resolved_path, canvas_document, notifications, _mutation_in_progress, _last_saved,
-            interval_seconds=autosave_interval_seconds,
+            interval_seconds=autosave_interval_seconds, settings_manager=settings_manager,
         )
 
 

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -97,6 +97,7 @@ from backend.domain.node_states import (
     GitlinkState,
     HtmlState,
     ImageState,
+    NodeState,
     NoteState,
     PlanState,
     PycoderState,
@@ -1944,6 +1945,32 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
                 # there is no longer a chart-owned image_assets entry to
                 # clean up here.
                 self._detach_node_from_membership(node_id)
+
+    # -- ADR-014 stage 14.1: Plugin SDK node-creation primitive -------------
+
+    def add_plugin_node(
+        self, kind: str, x: float, y: float, parent_id: str, *,
+        title: str = "", content: str = "", state: NodeState | None = None,
+    ) -> SceneNode:
+        """Generic node-creation primitive for ADR-014's Plugin SDK
+        (backend/plugin_sdk.py). Mirrors add_web_research_node's own body
+        exactly - mint an id off the SAME self._counter every add_X_node
+        method already uses, insert into self.nodes, connect to the
+        parent. `kind` arrives here ALREADY namespaced as
+        f"{plugin_id}.{local_kind}" (backend/plugin_sdk.py's HostContext.
+        register_node_kind) - this method itself does no namespacing or
+        validation of its own, same "trust the caller, one required-parent
+        posture" contract as add_web_research_node/add_gitlink_node/etc."""
+        if parent_id not in self.nodes:
+            raise SceneError(f"unknown parent node: {parent_id}")
+        node_id = f"n{next(self._counter)}"
+        node = SceneNode(
+            id=node_id, x=float(x), y=float(y),
+            title=str(title) or kind, kind=str(kind), content=str(content), state=state,
+        )
+        self.nodes[node_id] = node
+        self.connect(parent_id, node_id)
+        return node
 
     # -- edges -------------------------------------------------------------
 

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -35,10 +35,11 @@ from __future__ import annotations
 from collections import deque
 import itertools
 import json
+import logging
 import math
 import uuid
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable
 
 from graphlink_chart_data import SUPPORTED_CHART_TYPES
 from graphlink_grid_view_settings import (
@@ -203,6 +204,41 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
     # New Chat confirm skips only when the canvas is empty AND there is no
     # current chat - a predicate the frontend cannot evaluate without it.
     current_chat_id: int | None = None
+    # ADR-014 stage 14.2: the live-wire half of the Plugin SDK's generic
+    # persistence seam - keyed by a plugin's ALREADY-namespaced node kind
+    # (f"{plugin_id}.{kind}", HostContext.register_node_kind's own
+    # contract), value is that plugin's own `serialize(node) -> dict` hook,
+    # verbatim (the SAME callable HostContext.register_node_kind's
+    # `serialize` parameter stores on NodeKindSpec - see backend/plugin_sdk.
+    # py's own docstring there for the full contract shared with
+    # session_save.py's persisted-file use of the same hook).
+    #
+    # WHY A PLAIN dict[str, Callable] HERE, RATHER THAN THIS MODULE
+    # IMPORTING backend.plugin_sdk.PluginRegistry AND CONSULTING IT
+    # DIRECTLY: backend/plugin_sdk.py imports backend.canvas (for
+    # SceneDocument's own type), and backend/canvas.py imports THIS module
+    # back (see this module's own docstring) - a domain-layer import of
+    # plugin_sdk would be a real circular import (ImportError on a
+    # partially-initialized backend.canvas), not just a domain-purity
+    # style violation tests/test_domain_purity.py happens not to enumerate
+    # by name. A bare, duck-typed dict of callables carries zero import
+    # coupling either direction.
+    #
+    # POPULATED BY: backend/plugins.py's register_plugins(), once per
+    # session activation, from the (already-discovered) PluginRegistry -
+    # NOT by this dataclass's own constructor (defaults empty), and NOT
+    # reset by clear_for_load below (a plugin's live registration is a
+    # session-lifecycle capability, exactly like grid/font settings below,
+    # not per-loaded-chat-file data - reloading a DIFFERENT chat into the
+    # same session must not un-register a still-active plugin).
+    #
+    # A lookup miss (the overwhelming majority of nodes: every built-in
+    # kind, AND any plugin kind whose author never opted into
+    # register_node_kind(..., serialize=...)) is not an error - see
+    # _plugin_state_wire's own docstring.
+    plugin_node_serializers: dict[str, Callable[["SceneNode"], dict[str, Any]]] = field(
+        default_factory=dict, repr=False, compare=False,
+    )
     # ADR-010 stage 10.1: every invertible mutation this session has
     # recorded, oldest first. Bounded per the ADR's own durability boundary
     # ("session-scoped and in-memory (bounded, e.g. 100 composite commands),
@@ -2320,7 +2356,40 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
                 n.state.builder_approval_summary if isinstance(n.state, PlanState) else ""
             ),
             "builderStatusDetail": n.state.builder_status_detail if isinstance(n.state, PlanState) else "",
+            # ADR-014 stage 14.2: the Plugin SDK's generic live-wire
+            # fallback - see plugin_node_serializers' own field comment and
+            # _plugin_state_wire's own docstring below.
+            "pluginState": self._plugin_state_wire(n),
         }
+
+    def _plugin_state_wire(self, n: SceneNode) -> dict[str, str]:
+        """ADR-014 stage 14.2: the live-WS-wire analog of session_save.py's
+        generic plugin persistence fallback. `plugin_node_serializers` is
+        keyed by a plugin's already-namespaced kind string (never a
+        built-in kind - no built-in kind string contains "."), so a lookup
+        miss covers every non-plugin node AND any plugin node whose author
+        never opted into HostContext.register_node_kind(...,
+        serialize=...) - both are the ordinary case, not an error.
+
+        Coerced to dict[str, str] (never a richer nested shape): mirrors
+        contracts/graphlink_scene_payload.py's own ResearchResultRow.
+        providerSnapshot precedent for "genuinely free-form data under a
+        schema generator with a closed, dict[str, X]-only type set" - see
+        that field's own comment. A plugin's serializer raising, or
+        returning something that isn't a plain dict, degrades to {} rather
+        than breaking the whole scene publish that every other node on the
+        canvas rides along with."""
+        serializer = self.plugin_node_serializers.get(n.kind)
+        if serializer is None:
+            return {}
+        try:
+            raw = serializer(n)
+        except Exception:
+            logging.warning("plugin node %s (%s): serialize hook raised", n.id, n.kind, exc_info=True)
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        return {str(k): str(v) for k, v in raw.items()}
 
     def _edge_wire(self, e: SceneEdge) -> dict[str, Any]:
         return {"id": e.id, "source": e.source, "target": e.target}

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -68,7 +68,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - not exercised on this repo's CI (3.12+)
     import tomli as tomllib  # type: ignore[no-redef]
 
-from backend.canvas import SceneDocument
+from backend.canvas import SceneDocument, SceneNode
 from backend.domain.node_states import NodeState
 from backend.notifications import NotificationState
 
@@ -119,13 +119,13 @@ class PluginNodeSeed:
     SceneNode.state. This works TODAY for the live session: WS updates and
     undo/redo both operate on the live/deepcopied SceneNode object, which
     is kind-agnostic (record_command's snapshot is
-    copy.deepcopy(self.nodes[nid]) - no isinstance check anywhere). What
-    does NOT happen yet in 14.1: _node_wire only reads state fields behind
-    isinstance(n.state, XState) checks for the built-in dataclasses - a
-    plugin's own subclass matches none of them, so any field beyond
-    title/content is invisible on the wire until stage 14.2 teaches
-    _node_wire/session_save/session_load to consult a plugin's own
-    serializer."""
+    copy.deepcopy(self.nodes[nid]) - no isinstance check anywhere).
+
+    ADR-014 stage 14.2 closed the two gaps this docstring used to name here
+    (live-wire visibility beyond title/content, and save/reload dropping the
+    node entirely): a plugin that wants either now passes `serialize`/
+    `deserialize` to `HostContext.register_node_kind` - see that method's own
+    docstring and NodeKindSpec's own fields."""
 
     title: str
     content: str = ""
@@ -134,6 +134,18 @@ class PluginNodeSeed:
 
 NodeFactory = Callable[[SceneDocument, "PluginRunContext", str], PluginNodeSeed]
 PluginIntentHandler = Callable[..., Any]  # (document, run_ctx, *args) -> Any; sync or async
+# ADR-014 stage 14.2: the generic persistence/wire seam. `NodeSerializeHook`
+# is reused for BOTH the live WS wire's pluginState field (backend/domain/
+# graph.py's _node_wire, via SceneDocument.plugin_node_serializers - see that
+# field's own comment for why the domain layer consults a plain dict of
+# callables rather than importing this module) AND the persisted save file's
+# "plugin_state" key (backend/session_save.py) - one function a plugin author
+# writes once, read from two different call sites for two different
+# purposes. `NodeDeserializeHook` is the save-side-only mirror (there is no
+# live-wire equivalent to deserialize INTO - the wire is write-only from the
+# backend's perspective).
+NodeSerializeHook = Callable[[SceneNode], "dict[str, Any]"]
+NodeDeserializeHook = Callable[["dict[str, Any]"], "NodeState | None"]
 
 
 @dataclass(frozen=True)
@@ -154,6 +166,14 @@ class NodeKindSpec:
     kind: str  # ALREADY namespaced: f"{plugin_id}.{local_kind}"
     factory: NodeFactory
     requires_parent: bool  # always True in v1
+    # ADR-014 stage 14.2: OPTIONAL persistence/wire hooks - see
+    # HostContext.register_node_kind's own docstring for the full contract.
+    # A plugin that passes neither still gets its node's universal title/
+    # content/is_collapsed fields persisted and reloaded (session_save.py's
+    # own generic fallback default) - these two are strictly for a plugin's
+    # OWN NodeState subclass fields, beyond that baseline.
+    serialize: NodeSerializeHook | None = None
+    deserialize: NodeDeserializeHook | None = None
 
 
 @dataclass(frozen=True)
@@ -193,6 +213,8 @@ class HostContext:
         factory: NodeFactory,
         *,
         requires_parent: bool = True,
+        serialize: NodeSerializeHook | None = None,
+        deserialize: NodeDeserializeHook | None = None,
     ) -> None:
         """Registers 'factory' as this plugin's creation primitive for
         'kind'. The kind actually stored (and later stamped onto
@@ -204,7 +226,37 @@ class HostContext:
         v1 ONLY supports requires_parent=True. False is rejected outright:
         PluginPicker.tsx's executePlugin(name, parentId) wire call carries
         no x/y at all, so a parentless node has no host-decided place to
-        spawn."""
+        spawn.
+
+        ADR-014 stage 14.2: 'serialize'/'deserialize' are the OPTIONAL
+        generic persistence/wire seam for a plugin's own NodeState subclass
+        (the "'state' IS the real ADR-002 seam" seam PluginNodeSeed's own
+        docstring names). Neither is required - a plugin with no state
+        (like plugins/hello_node/, which fits its one string in `content`)
+        passes neither and its node's title/content/is_collapsed still
+        round-trips through save/reload via session_save.py's generic
+        fallback default; a plugin WITH real state opts in to round-trip it
+        too:
+          - serialize(node) -> dict: called with the live SceneNode both by
+            backend/domain/graph.py's _node_wire (the live WS wire's
+            pluginState field - see SceneDocument.plugin_node_serializers'
+            own comment for why THAT call site is wired separately, from
+            outside this class, to keep the domain layer import-free of
+            this module) and by backend/session_save.py (the persisted
+            "plugin_state" key). Must return a plain, JSON-serializable
+            dict - session_save.py drops (never crashes on) a dict that
+            isn't; the live-wire path coerces every value through str()
+            regardless (SceneNodeRow.pluginState is dict[str, str], the
+            same "narrowest accurate supertype under a closed schema
+            generator" precedent already established by ResearchResultRow.
+            providerSnapshot - see contracts/graphlink_scene_payload.py).
+          - deserialize(data) -> NodeState | None: the save-side-only
+            mirror, called by backend/session_load.py with whatever dict
+            serialize(node) most recently produced, to reconstruct the
+            plugin's own NodeState subclass instance. A raised exception
+            here is caught by the caller - the node still restores with
+            its title/content, just without its extra state - never a
+            failed load."""
         if not requires_parent:
             raise PluginRegistrationError(
                 f'plugin "{self.plugin_id}": requires_parent=False is not supported in SDK '
@@ -223,6 +275,7 @@ class HostContext:
             )
         self._node_kinds[namespaced] = NodeKindSpec(
             plugin_id=self.plugin_id, kind=namespaced, factory=factory, requires_parent=True,
+            serialize=serialize, deserialize=deserialize,
         )
 
     def register_picker_entry(

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -26,22 +26,30 @@ collide with one; no reserved-kind blocklist is needed. `requires_parent`
 is v1-only-True: `PluginPicker.tsx`'s `executePlugin(name, parentId)` wire
 call carries no x/y for a parentless node to spawn at.
 
-DEVIATION from the design's own sketch, recorded here: `HostContext.
-register_intent()` is real and fully functional (a plugin's `register()`
-call populates `PluginRegistry.intents`), but backend/plugins.py does NOT
-yet wire a discovered intent onto a session's live SessionBus. That
-activation step collides with a real, pre-existing, deliberately
-hard-locked invariant - tests/test_undo_classification_gate.py (ADR-010
-close-out) requires every `bus.register_intent()` call under backend/ to
-use a source-literal `(topic, intent)` pair, so every mutating action can
-be enumerated in one static, hand-reviewed undo A/B table. A
-plugin-declared intent name is inherently dynamic (unknown until a
-third-party plugin - living outside backend/, invisible to that gate's
-own scan regardless - is discovered at runtime), so it can never be a
-fixed table entry by construction. See backend/plugins.py's own comment,
-right where the design's session-activation loop would have gone, for the
-full reasoning. This is scoped to stage 14.4 (plugin scope/consent), an
-adjacent governance decision, rather than made unilaterally here.
+DEVIATION from the design's own sketch, recorded here (RESOLVED at stage
+14.4, see below): the design's own text said a plugin's `HostContext.
+register_intent()`-declared custom intent would be "wired at
+SESSION-ACTIVATION time" onto the bus, one live registration per declared
+intent. That collided with a real, pre-existing, deliberately hard-locked
+invariant - tests/test_undo_classification_gate.py (ADR-010 close-out)
+requires every `bus.register_intent()` call under backend/ to use a
+source-literal `(topic, intent)` pair, so every mutating action can be
+enumerated in one static, hand-reviewed undo A/B table. A plugin-declared
+intent name is inherently dynamic (unknown until a third-party plugin -
+living outside backend/, invisible to that gate's own scan regardless - is
+discovered at runtime), so it can never be a fixed table entry by
+construction. Stage 14.1 left this activation step deliberately undone,
+scoped to stage 14.4 (plugin scope/consent) as the natural adjacent-
+governance decision rather than made unilaterally here.
+
+Stage 14.4 resolved it with ONE new static (topic, intent) pair instead of
+one-per-declared-intent: `("app-plugins", "invokePluginIntent")`
+(backend/plugins.py) looks up the real target DYNAMICALLY at call time from
+`PluginRegistry.intents` and grant-checks (SettingsManager.
+get_plugin_grants) before dispatch - see
+`_invoke_discovered_plugin_intent`'s own docstring for the full mechanism.
+`HostContext.register_intent()`/`PluginIntentSpec`/`PluginRegistry.intents`
+are unchanged by this - still populated exactly as stage 14.1 built them.
 
 See doc/adr/ADR-014 stage 14.1's design for the full rationale (private,
 not part of this repo)."""
@@ -71,6 +79,12 @@ except ModuleNotFoundError:  # pragma: no cover - not exercised on this repo's C
 from backend.canvas import SceneDocument, SceneNode
 from backend.domain.node_states import NodeState
 from backend.notifications import NotificationState
+# ADR-014 stage 14.4: reused, never re-declared - a plugin manifest's
+# [scopes].grants entries are validated against the SAME closed vocabulary
+# backend/tools.py's ToolRegistry already gates real tool calls with, so
+# "graph.mutate" means the same thing whether it is a plugin's self-reported
+# manifest checklist or a tool-call's enforced scope set.
+from backend.tools import KNOWN_SCOPES
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +118,21 @@ class PluginManifest:
     description: str
     view: str  # always "generic" in this stage; validated at load
     source_dir: Path
+    # ADR-014 stage 14.4: the plugin's SELF-REPORTED declared-scope checklist
+    # from an optional [scopes] table - a subset of backend.tools.KNOWN_SCOPES
+    # (reused, never re-declared), validated at discovery time so an unknown
+    # scope string fails this ONE plugin's load, same fail-soft per-plugin
+    # skip as every other manifest error. Omitting [scopes] entirely yields
+    # frozenset() here - NOT the same as "trusted": this stage has no way to
+    # verify a plugin's code actually stays within what it declares (real
+    # capability sandboxing is stage 14.5's job, out-of-process execution);
+    # this field only feeds the Settings grants list's read-only "scopes"
+    # column and the discovery-time validation above. The separate, actually
+    # enforced gate - "has the user granted this plugin at all" - lives in
+    # SettingsManager.get_plugin_grants()/set_plugin_grant(), consulted by
+    # backend/plugins.py's _execute_discovered_plugin BEFORE any factory
+    # call, not here.
+    scopes_grants: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -152,9 +181,23 @@ NodeDeserializeHook = Callable[["dict[str, Any]"], "NodeState | None"]
 class PluginRunContext:
     """Handed to a NodeFactory/intent handler at CALL time, per invocation -
     the SDK's analog of backend/tools.py's RunContext. Deliberately minimal
-    in v1: no granted_scopes/approval fields yet - a later stage adds those
-    as NEW FIELDS here rather than plugins needing a second, later-invented
-    context object."""
+    in v1: no granted_scopes/approval fields here.
+
+    ADR-014 stage 14.4 (plugin scope/consent) resolved the gap this
+    docstring used to flag ("a later stage adds those as NEW FIELDS here")
+    WITHOUT adding fields here after all: the grant check
+    (SettingsManager.get_plugin_grants, deny-by-default) runs entirely in
+    backend/plugins.py's _execute_discovered_plugin/
+    _invoke_discovered_plugin_intent, BEFORE a PluginRunContext is even
+    constructed for a given call - a plugin whose factory/intent handler
+    actually runs has, by construction, already passed the gate, so there is
+    nothing for the handler itself to inspect or re-check via its own
+    context object. This is deliberately COARSER than backend/tools.py's own
+    RunContext.granted_scopes (a per-tool-call scope SET a handler can
+    consult mid-call) - 14.4's gate is a single install-time yes/no per
+    plugin, not a scope-by-scope capability boundary; see PluginManifest.
+    scopes_grants' own field comment for the honest limit of what a
+    manifest's declared scopes actually verify."""
 
     plugin_id: str
     notifications: NotificationState
@@ -419,6 +462,15 @@ class PluginRegistry:
         self.builtin_actions: dict[str, BuiltinActionSpec] = {}  # display name -> spec
         self.intents: list[PluginIntentSpec] = []
         self.load_errors: list[PluginLoadError] = []
+        # ADR-014 stage 14.4: plugin_id -> its own parsed manifest, populated
+        # ONLY for a plugin that finished loading successfully (same
+        # all-or-nothing posture as every other registry dict here - a
+        # plugin whose merge collided never gets an entry either). The
+        # Settings grants payload (backend/plugins.py's plugins_payload)
+        # reads this for each non-built-in plugin's display name and
+        # declared scopes list - the registry held no manifest at all before
+        # this stage, since nothing needed one past discovery time.
+        self.manifests: dict[str, PluginManifest] = {}
 
     def resolve_picker_name(self, name: str) -> "tuple[NodeKindSpec, PickerEntrySpec] | None":
         entry = self.picker_entries.get(name)
@@ -496,6 +548,27 @@ def _load_manifest(manifest_path: Path, plugin_dir: Path) -> PluginManifest:
                 f'14.5 - "generic" is the only legal value'
             )
 
+    # ADR-014 stage 14.4: optional [scopes] table - see PluginManifest.
+    # scopes_grants' own field comment for the full "self-reported checklist,
+    # not an enforced boundary" contract. Absent entirely -> frozenset()
+    # (still requires an explicit Settings grant to run at all - that gate
+    # is independent of what a plugin declares here).
+    scopes_table = raw.get("scopes", {})
+    scopes_grants: frozenset[str] = frozenset()
+    if isinstance(scopes_table, dict) and "grants" in scopes_table:
+        raw_grants = scopes_table["grants"]
+        if not isinstance(raw_grants, list) or not all(isinstance(g, str) for g in raw_grants):
+            raise PluginRegistrationError(
+                f"{manifest_path}: [scopes].grants must be a list of strings"
+            )
+        scopes_grants = frozenset(raw_grants)
+        unknown_scopes = scopes_grants - KNOWN_SCOPES
+        if unknown_scopes:
+            raise PluginRegistrationError(
+                f"{manifest_path}: [scopes].grants contains unknown scope(s) "
+                f"{sorted(unknown_scopes)} - must be a subset of {sorted(KNOWN_SCOPES)}"
+            )
+
     return PluginManifest(
         id=plugin_id,
         name=str(plugin_table["name"]),
@@ -505,6 +578,7 @@ def _load_manifest(manifest_path: Path, plugin_dir: Path) -> PluginManifest:
         description=str(plugin_table.get("description", "")),
         view=view,
         source_dir=plugin_dir,
+        scopes_grants=scopes_grants,
     )
 
 
@@ -629,6 +703,7 @@ def discover_plugins(
                 host = HostContext(manifest.id)
                 register_fn(host)
                 _merge_into_registry(registry, host, builtin_names)
+                registry.manifests[manifest.id] = manifest
             except Exception as exc:
                 registry.load_errors.append(
                     PluginLoadError(plugin_dir.name, f"{type(exc).__name__}: {exc}")

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -564,7 +564,28 @@ class HostContext:
         in stage 14.1 - see this module's own docstring for why (collides
         with tests/test_undo_classification_gate.py's hard-locked
         literal-(topic,intent) invariant). This method's registration-time
-        behavior is fully real and tested regardless."""
+        behavior is fully real and tested regardless.
+
+        ADR-014 review-fix: rejects a same-name duplicate from THIS SAME
+        plugin, mirroring register_picker_entry/register_builtin_plugin's
+        own duplicate-name guards immediately above - self._intents is a
+        list (not a dict keyed by name) purely because two DIFFERENT
+        plugins may legitimately each declare an intent named "run" (the
+        registry namespaces by plugin_id, not this class), but a single
+        plugin declaring "run" twice is always an authoring mistake, never
+        legitimate. Left unguarded, a duplicate here would resolve
+        (silently, to whichever entry happened first) at TWO downstream
+        chokepoints: _invoke_discovered_plugin_intent's own next(...)
+        lookup, and register_plugin_tools' ToolRegistry.register(), where
+        it previously raised "Tool ... is already registered" and aborted
+        registration for every plugin enumerated after the offender -
+        see register_plugin_tools' own docstring (backend/plugins.py) for
+        the belt-and-suspenders per-item isolation added there too."""
+        if any(spec.name == name for spec in self._intents):
+            raise PluginRegistrationError(
+                f'plugin "{self.plugin_id}": intent "{name}" already registered by '
+                f"this plugin"
+            )
         self._intents.append(PluginIntentSpec(
             plugin_id=self.plugin_id, name=name, handler=handler, args_schema=args_schema,
         ))
@@ -776,7 +797,22 @@ class PluginWorkerClient:
         """Synchronous, blocking - see this section's own module-level
         comment for why. Returns the JSON-RPC response's "result" object
         (or {} if absent), matching McpStdioClient._call's own return
-        contract exactly."""
+        contract exactly.
+
+        ADR-014 review-fix: an explicit is_connected check up front, so a
+        call on an already-dead worker (crashed since a PRIOR call - the
+        reader thread already pushed _WORKER_READER_CLOSED and self._process
+        has exited, but the attribute itself is only cleared by close(),
+        which nothing calls automatically here) fails immediately with the
+        documented PluginWorkerError rather than reaching _write() and
+        racing whatever raw OSError the dead pipe happens to produce (empirically
+        confirmed: `OSError: [Errno 22] Invalid argument` writing to a dead
+        process's stdin on Windows - not a BrokenPipeError, so it silently
+        escaped _write()'s prior narrower except clause). _write() itself
+        also now catches OSError as defense in depth for the remaining race
+        (the process dying between this check and the actual write)."""
+        if not self.is_connected:
+            raise PluginWorkerError(f'Plugin worker "{self.plugin_id}" is not connected.')
         with self._call_lock:
             self._next_id += 1
             request_id = self._next_id
@@ -844,7 +880,18 @@ class PluginWorkerClient:
             try:
                 process.stdin.write(json.dumps(message) + "\n")
                 process.stdin.flush()
-            except (BrokenPipeError, ValueError) as exc:
+            except (OSError, ValueError) as exc:
+                # ADR-014 review-fix: OSError (BrokenPipeError's own actual
+                # base class) replaces the narrower (BrokenPipeError,
+                # ValueError) this used to catch - empirically, writing to a
+                # crashed worker's stdin raises a PLAIN OSError on Windows
+                # (`[Errno 22] Invalid argument`), not BrokenPipeError, so it
+                # previously escaped uncaught as a raw platform-specific
+                # exception instead of the documented PluginWorkerError every
+                # other failure mode here raises. BrokenPipeError still
+                # matches first where it's the real cause (POSIX); this is a
+                # strict widening, not a behavior change for the case that
+                # already worked.
                 raise PluginWorkerError(
                     f'Plugin worker "{self.plugin_id}" is not accepting input: {exc}'
                 ) from exc
@@ -966,6 +1013,25 @@ def _discover_out_of_process_plugin(
 
 
 _REGISTRY_CACHE: dict[Path, PluginRegistry] = {}
+# ADR-014 review-fix: guards the whole check-then-scan-then-set sequence
+# below against a concurrent-first-caller race. discover_plugins() is
+# UNREACHABLE via any real production call path today with more than one OS
+# thread in play (backend/agents.py:519, backend/plugins.py:499, backend/
+# session_load.py, backend/session_save.py all call it from plain
+# synchronous code on the event-loop thread, never inside asyncio.to_thread
+# or a second thread) - this lock is prevention against a future regression,
+# not a fix for an active leak. Without it, two threads racing a
+# never-before-seen plugins_root could both miss the cache, both scan, and
+# (for an out-of-process plugin) both spawn a REAL resident worker
+# subprocess - the loser's PluginRegistry (and its live PluginWorkerClient)
+# is then simply discarded by whichever thread's `_REGISTRY_CACHE[resolved]
+# = registry` assignment runs last, orphaning the winner's subprocess with
+# no reference anywhere ever able to close() it. Held across the ENTIRE
+# scan (not just the get/set), which also serializes two genuinely
+# DIFFERENT plugins_root paths against each other - an accepted, harmless
+# cost (discovery is a rare, one-time-per-path operation) for the simplest
+# correct fix.
+_REGISTRY_CACHE_LOCK = threading.Lock()
 
 
 def _load_manifest(manifest_path: Path, plugin_dir: Path) -> PluginManifest:
@@ -1177,49 +1243,56 @@ def discover_plugins(
     process that calls this many times (every create_app() in a pytest
     run, via register_plugins) only pays the real cost once. Tests that
     need isolation pass a distinct tmp_path-derived plugins_root - a fresh
-    key, never touching the shared cache entry for the real repo path."""
-    resolved = plugins_root.resolve()
-    cached = _REGISTRY_CACHE.get(resolved)
-    if cached is not None:
-        return cached
+    key, never touching the shared cache entry for the real repo path.
 
-    registry = PluginRegistry()
-    if resolved.is_dir():
-        for manifest_path in sorted(resolved.glob(f"*/{MANIFEST_FILENAME}")):
-            plugin_dir = manifest_path.parent
-            try:
-                manifest = _load_manifest(manifest_path, plugin_dir)
-                _check_sdk_api_version(manifest)
-                # ADR-014 stage 14.5: the ONLY branch point discovery gained
-                # this stage. "in-process" (every plugin before this stage,
-                # and every plugin that omits [runtime] entirely) keeps the
-                # EXACT pre-14.5 path - import the module into the host
-                # process, call its real register(host) directly - byte-
-                # identical to before. "out-of-process" never imports the
-                # plugin's module into this process at all; see
-                # _discover_out_of_process_plugin's own docstring.
-                worker_client = None
-                if manifest.runtime_isolation == "out-of-process":
-                    host, worker_client = _discover_out_of_process_plugin(manifest, plugin_dir)
-                else:
-                    module = _import_entry_module(manifest, plugin_dir)
-                    _module_name, _, fn_name = manifest.entry_point.partition(":")
-                    register_fn = getattr(module, fn_name)
-                    host = HostContext(manifest.id)
-                    register_fn(host)
+    ADR-014 review-fix: the whole check-then-scan-then-set body now runs
+    under _REGISTRY_CACHE_LOCK - see that lock's own module-level comment
+    for the concurrent-first-caller race this closes and why holding it for
+    the full scan (not just the dict access) is the right, simplest fix."""
+    resolved = plugins_root.resolve()
+    with _REGISTRY_CACHE_LOCK:
+        cached = _REGISTRY_CACHE.get(resolved)
+        if cached is not None:
+            return cached
+
+        registry = PluginRegistry()
+        if resolved.is_dir():
+            for manifest_path in sorted(resolved.glob(f"*/{MANIFEST_FILENAME}")):
+                plugin_dir = manifest_path.parent
                 try:
-                    _merge_into_registry(registry, host, builtin_names)
-                except Exception:
+                    manifest = _load_manifest(manifest_path, plugin_dir)
+                    _check_sdk_api_version(manifest)
+                    # ADR-014 stage 14.5: the ONLY branch point discovery
+                    # gained this stage. "in-process" (every plugin before
+                    # this stage, and every plugin that omits [runtime]
+                    # entirely) keeps the EXACT pre-14.5 path - import the
+                    # module into the host process, call its real
+                    # register(host) directly - byte-identical to before.
+                    # "out-of-process" never imports the plugin's module
+                    # into this process at all; see
+                    # _discover_out_of_process_plugin's own docstring.
+                    worker_client = None
+                    if manifest.runtime_isolation == "out-of-process":
+                        host, worker_client = _discover_out_of_process_plugin(manifest, plugin_dir)
+                    else:
+                        module = _import_entry_module(manifest, plugin_dir)
+                        _module_name, _, fn_name = manifest.entry_point.partition(":")
+                        register_fn = getattr(module, fn_name)
+                        host = HostContext(manifest.id)
+                        register_fn(host)
+                    try:
+                        _merge_into_registry(registry, host, builtin_names)
+                    except Exception:
+                        if worker_client is not None:
+                            worker_client.close()
+                        raise
+                    registry.manifests[manifest.id] = manifest
                     if worker_client is not None:
-                        worker_client.close()
-                    raise
-                registry.manifests[manifest.id] = manifest
-                if worker_client is not None:
-                    registry.worker_clients[manifest.id] = worker_client
-            except Exception as exc:
-                registry.load_errors.append(
-                    PluginLoadError(plugin_dir.name, f"{type(exc).__name__}: {exc}")
-                )
-                logger.warning("plugin discovery: skipping %s (%s)", plugin_dir.name, exc)
-    _REGISTRY_CACHE[resolved] = registry
-    return registry
+                        registry.worker_clients[manifest.id] = worker_client
+                except Exception as exc:
+                    registry.load_errors.append(
+                        PluginLoadError(plugin_dir.name, f"{type(exc).__name__}: {exc}")
+                    )
+                    logger.warning("plugin discovery: skipping %s (%s)", plugin_dir.name, exc)
+        _REGISTRY_CACHE[resolved] = registry
+        return registry

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -195,6 +195,27 @@ class PluginIntentSpec:
     args_schema: "type | None" = None
 
 
+# ADR-014 stage 14.3: the first-party migration escape hatch. 'document' is
+# the live SceneDocument, 'run_ctx' the same per-invocation context a
+# NodeFactory receives, 'parent_node_id' whatever executePlugin's wire call
+# carried (may be None/unknown - the handler validates it itself, exactly
+# like every pre-migration hardcoded branch did). Returns the created/
+# resolved node's id on success, or None if it already showed its own
+# notification - see HostContext.register_builtin_plugin's own docstring for
+# the full contract this signature encodes.
+BuiltinActionHandler = Callable[[SceneDocument, PluginRunContext, "str | None"], "str | None"]
+
+
+@dataclass(frozen=True)
+class BuiltinActionSpec:
+    plugin_id: str
+    name: str  # the picker label AND executePlugin's dispatch key - same
+    # name-doubles-as-key contract PickerEntrySpec already uses
+    description: str
+    category: str
+    handler: BuiltinActionHandler
+
+
 class HostContext:
     """Constructed fresh per plugin, once, at discovery time - NEVER shared
     across plugins, so plugin_id provenance is free on every call and one
@@ -205,6 +226,7 @@ class HostContext:
         self.plugin_id = plugin_id
         self._node_kinds: dict[str, NodeKindSpec] = {}  # namespaced kind -> spec
         self._picker_entries: dict[str, PickerEntrySpec] = {}  # display name -> entry
+        self._builtin_actions: dict[str, BuiltinActionSpec] = {}  # display name -> spec
         self._intents: list[PluginIntentSpec] = []
 
     def register_node_kind(
@@ -305,6 +327,61 @@ class HostContext:
             category=category, node_kind=namespaced,
         )
 
+    def register_builtin_plugin(
+        self, *, name: str, description: str, category: str, handler: BuiltinActionHandler,
+    ) -> None:
+        """ADR-014 stage 14.3: the first-party migration escape hatch - lets
+        a plugin's register() call attach a picker entry directly to an
+        existing, already-rich SceneDocument mutator (e.g.
+        add_web_research_node) rather than going through register_node_kind/
+        PluginNodeSeed/add_plugin_node's generic, auto-namespaced wire
+        format. Exists ONLY to migrate the 8 pre-SDK built-in picker actions
+        onto real plugin packages under plugins/ without renaming their
+        already-shipped, already-persisted kind strings (web_research,
+        gitlink, pycoder, code_sandbox, html, artifact, conversation, note) -
+        renaming any of those would be an invasive, unnecessary breaking
+        change across the frontend's NODE_TYPES map, the wire contract, and
+        session_save.py/session_load.py's hand-written per-kind
+        serializers, for zero benefit. A third-party plugin should almost
+        always use register_node_kind/register_picker_entry instead; this
+        method is NOT namespaced and performs NO validation of any kind
+        (node existence, parent liveness, ...) - 'handler' is trusted to do
+        exactly what it needs, including its own record_command call
+        (with whatever command_type string it chooses), its own
+        parent-validation notification text, and its own
+        return-None-on-failure/return-created-or-resolved-id-on-success
+        contract.
+
+        'handler' is SYNC, not async - every one of the 8 branches this
+        method replaces has a fully synchronous body (record_command's
+        mutator is always a plain zero-arg closure); wrapping it in an
+        async def would be needless ceremony this call path has no use for.
+        The caller (backend/plugins.py's _execute_discovered_plugin) applies
+        one uniform post-handler rule around every registered handler:
+        publish "scene" if the handler returned a real id, else publish
+        "notification" - matching every one of the 8 migrated branches'
+        own "show warning, return None" vs "create/resolve, return id"
+        shape, including System Prompt's dedup path (resolves an EXISTING
+        note's id, creates nothing new, still publishes "scene").
+
+        'name' is the picker label AND executePlugin's dispatch key - same
+        name-doubles-as-key contract PickerEntrySpec already uses. Same-
+        plugin name reuse (two register_builtin_plugin calls with equal
+        'name' from ONE plugin) is an error, raised here; cross-plugin
+        collisions (against every other plugin's register_picker_entry AND
+        register_builtin_plugin names) are checked once, globally, by
+        _merge_into_registry - not here, since a single HostContext never
+        sees another plugin's declarations."""
+        if name in self._builtin_actions:
+            raise PluginRegistrationError(
+                f'plugin "{self.plugin_id}": builtin action "{name}" already registered by '
+                f"this plugin"
+            )
+        self._builtin_actions[name] = BuiltinActionSpec(
+            plugin_id=self.plugin_id, name=name, description=description,
+            category=category, handler=handler,
+        )
+
     def register_intent(
         self, name: str, handler: PluginIntentHandler, *, args_schema: "type | None" = None,
     ) -> None:
@@ -339,6 +416,7 @@ class PluginRegistry:
     def __init__(self) -> None:
         self.node_kinds: dict[str, NodeKindSpec] = {}  # namespaced kind -> spec
         self.picker_entries: dict[str, PickerEntrySpec] = {}  # display name -> entry
+        self.builtin_actions: dict[str, BuiltinActionSpec] = {}  # display name -> spec
         self.intents: list[PluginIntentSpec] = []
         self.load_errors: list[PluginLoadError] = []
 
@@ -347,6 +425,14 @@ class PluginRegistry:
         if entry is None:
             return None
         return self.node_kinds[entry.node_kind], entry
+
+    def resolve_builtin_action(self, name: str) -> "BuiltinActionSpec | None":
+        """ADR-014 stage 14.3's lookup mirror of resolve_picker_name above -
+        None for any name that isn't a registered builtin action (including
+        one that IS a real picker_entries name; the two dicts are checked
+        by the caller in whichever order it prefers, since _merge_into_
+        registry already guarantees no name is ever in both)."""
+        return self.builtin_actions.get(name)
 
 
 _REGISTRY_CACHE: dict[Path, PluginRegistry] = {}
@@ -467,28 +553,53 @@ def _merge_into_registry(
     """Folds one plugin's HostContext declarations into the shared registry.
     Node-kind collisions are structurally impossible (namespaced per
     plugin_id, checked already within HostContext itself) so need no check
-    here. Picker NAME collisions - against the built-in plugin names AND
-    against every already-merged plugin - ARE checked here, raising rather
-    than silently overwriting."""
-    for name, entry in host._picker_entries.items():
+    here. Picker NAME collisions - against 'builtin_names' AND against
+    every already-merged plugin's picker_entries/builtin_actions - ARE
+    checked here, raising rather than silently overwriting.
+
+    ADR-014 stage 14.3: 'builtin_names' has no real caller-supplied argument
+    left in this repo (the 8 pre-SDK built-ins are now real discovered
+    plugins themselves, checked against every other plugin the same way any
+    two plugins are), but stays a real, generic, tested SDK mechanism - any
+    host embedding this SDK can still reserve a name that has no registry
+    entry of its own yet. 'builtin_actions' is the ADR-014 stage 14.3 sibling
+    of 'picker_entries' - a name must be globally unique across BOTH dicts,
+    checked below, so the picker's displayed/dispatched name space is one
+    flat namespace regardless of which registration mechanism produced an
+    entry."""
+    for name in host._picker_entries:
         if name in builtin_names:
             raise PluginRegistrationError(
                 f'plugin "{host.plugin_id}": picker entry "{name}" collides with a '
                 f"built-in plugin name"
             )
-        existing = registry.picker_entries.get(name)
+        existing = registry.picker_entries.get(name) or registry.builtin_actions.get(name)
         if existing is not None:
             raise PluginRegistrationError(
                 f'plugin "{host.plugin_id}": picker entry "{name}" collides with the same '
                 f'entry already registered by plugin "{existing.plugin_id}"'
             )
+    for name in host._builtin_actions:
+        if name in builtin_names:
+            raise PluginRegistrationError(
+                f'plugin "{host.plugin_id}": builtin action "{name}" collides with a '
+                f"built-in plugin name"
+            )
+        existing = registry.picker_entries.get(name) or registry.builtin_actions.get(name)
+        if existing is not None:
+            raise PluginRegistrationError(
+                f'plugin "{host.plugin_id}": builtin action "{name}" collides with the same '
+                f'entry already registered by plugin "{existing.plugin_id}"'
+            )
     # Two passes (validate-all-then-merge-all) so a collision on the SECOND
-    # picker entry a plugin declares doesn't leave the FIRST one partially
-    # merged into the shared registry.
+    # picker entry/builtin action a plugin declares doesn't leave the FIRST
+    # one partially merged into the shared registry.
     for kind, spec in host._node_kinds.items():
         registry.node_kinds[kind] = spec
     for name, entry in host._picker_entries.items():
         registry.picker_entries[name] = entry
+    for name, spec in host._builtin_actions.items():
+        registry.builtin_actions[name] = spec
     registry.intents.extend(host._intents)
 
 

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -1,0 +1,474 @@
+"""ADR-014 stage 14.1: the Plugin SDK - manifest format, discovery, and the
+host API v1 (`HostContext`) a third-party plugin's `register()` call
+receives.
+
+Two context objects, mirroring ADR-007's `ToolRegistry.register()` (trusted
+caller, once) vs. `RunContext` (per-invocation) split (backend/tools.py):
+
+- `HostContext` is constructed fresh per plugin, once, at DISCOVERY time -
+  before any `SceneDocument`/bus/notifications exist for a real session, so
+  it deliberately holds none of those. A plugin's `register()` call uses it
+  only to declare capabilities (register_node_kind/register_picker_entry/
+  register_intent).
+- `PluginRunContext` is handed to a `NodeFactory`/intent handler at CALL
+  time, per invocation - the SDK's analog of `RunContext`.
+
+Discovery is LAZY + MEMOIZED (by resolved plugins_root path), first
+triggered from inside `backend/plugins.py`'s `register_plugins()` - never
+from `create_app()`/`backend/app.py` directly, since that constructor runs
+"dozens of times per pytest run" (its own comment) and eager discovery
+there would re-glob/re-import/re-run every plugin's `register()` on every
+test's app construction.
+
+Node kinds are namespaced automatically as `f"{plugin_id}.{kind}"` - no
+built-in kind string contains ".", so a namespaced kind can never literally
+collide with one; no reserved-kind blocklist is needed. `requires_parent`
+is v1-only-True: `PluginPicker.tsx`'s `executePlugin(name, parentId)` wire
+call carries no x/y for a parentless node to spawn at.
+
+DEVIATION from the design's own sketch, recorded here: `HostContext.
+register_intent()` is real and fully functional (a plugin's `register()`
+call populates `PluginRegistry.intents`), but backend/plugins.py does NOT
+yet wire a discovered intent onto a session's live SessionBus. That
+activation step collides with a real, pre-existing, deliberately
+hard-locked invariant - tests/test_undo_classification_gate.py (ADR-010
+close-out) requires every `bus.register_intent()` call under backend/ to
+use a source-literal `(topic, intent)` pair, so every mutating action can
+be enumerated in one static, hand-reviewed undo A/B table. A
+plugin-declared intent name is inherently dynamic (unknown until a
+third-party plugin - living outside backend/, invisible to that gate's
+own scan regardless - is discovered at runtime), so it can never be a
+fixed table entry by construction. See backend/plugins.py's own comment,
+right where the design's session-activation loop would have gone, for the
+full reasoning. This is scoped to stage 14.4 (plugin scope/consent), an
+adjacent governance decision, rather than made unilaterally here.
+
+See doc/adr/ADR-014 stage 14.1's design for the full rationale (private,
+not part of this repo)."""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+# Python version note: this repo's pyproject.toml declares
+# requires-python = ">=3.10", but tomllib is stdlib only from 3.11 onward.
+# CI/dev both run 3.12+ (tomllib present natively) so this fallback is
+# currently dead in practice, but is real correctness for the declared
+# support floor - not speculative. `tomli` is declared as a conditional
+# dependency in pyproject.toml (`python_version < "3.11"`) for exactly this
+# branch.
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - not exercised on this repo's CI (3.12+)
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from backend.canvas import SceneDocument
+from backend.domain.node_states import NodeState
+from backend.notifications import NotificationState
+
+logger = logging.getLogger(__name__)
+
+SDK_API_VERSION = 1
+MIN_COMPATIBLE_SDK_API_VERSION = 1
+MANIFEST_FILENAME = "plugin.toml"
+DEFAULT_PLUGINS_ROOT = Path(__file__).resolve().parent.parent / "plugins"
+
+_ID_PATTERN = re.compile(r"[a-z0-9_]+")
+
+
+class PluginRegistrationError(Exception):
+    """Raised for one plugin's own malformed manifest, bad register() call,
+    or a picker-name collision. Always raised at DISCOVERY time, never at
+    request-handling time. discover_plugins() catches this (and any other
+    exception a plugin's own register() raises) PER PLUGIN and skips just
+    that one - a bad plugin.toml must never take down every other plugin
+    or the app itself."""
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """The parsed, validated shape of one plugin's plugin.toml [plugin]
+    (+ optional [frontend]) table."""
+
+    id: str
+    name: str
+    version: str
+    sdk_api_version: int
+    entry_point: str
+    description: str
+    view: str  # always "generic" in this stage; validated at load
+    source_dir: Path
+
+
+@dataclass(frozen=True)
+class PluginNodeSeed:
+    """What a plugin's NodeFactory returns - the kind-specific slice of a
+    new node. Position, id, kind, and the parent edge are ALL host-decided
+    (SceneDocument.add_plugin_node) so a v1 factory cannot get positioning
+    or id-minting wrong; only title/content/state are its job.
+
+    'state' IS the real ADR-002 seam: a plugin MAY define its own dataclass
+    subclassing NodeState in its own module and pass an instance here,
+    exactly like the built-in per-kind dataclasses attach to
+    SceneNode.state. This works TODAY for the live session: WS updates and
+    undo/redo both operate on the live/deepcopied SceneNode object, which
+    is kind-agnostic (record_command's snapshot is
+    copy.deepcopy(self.nodes[nid]) - no isinstance check anywhere). What
+    does NOT happen yet in 14.1: _node_wire only reads state fields behind
+    isinstance(n.state, XState) checks for the built-in dataclasses - a
+    plugin's own subclass matches none of them, so any field beyond
+    title/content is invisible on the wire until stage 14.2 teaches
+    _node_wire/session_save/session_load to consult a plugin's own
+    serializer."""
+
+    title: str
+    content: str = ""
+    state: NodeState | None = None
+
+
+NodeFactory = Callable[[SceneDocument, "PluginRunContext", str], PluginNodeSeed]
+PluginIntentHandler = Callable[..., Any]  # (document, run_ctx, *args) -> Any; sync or async
+
+
+@dataclass(frozen=True)
+class PluginRunContext:
+    """Handed to a NodeFactory/intent handler at CALL time, per invocation -
+    the SDK's analog of backend/tools.py's RunContext. Deliberately minimal
+    in v1: no granted_scopes/approval fields yet - a later stage adds those
+    as NEW FIELDS here rather than plugins needing a second, later-invented
+    context object."""
+
+    plugin_id: str
+    notifications: NotificationState
+
+
+@dataclass(frozen=True)
+class NodeKindSpec:
+    plugin_id: str
+    kind: str  # ALREADY namespaced: f"{plugin_id}.{local_kind}"
+    factory: NodeFactory
+    requires_parent: bool  # always True in v1
+
+
+@dataclass(frozen=True)
+class PickerEntrySpec:
+    plugin_id: str
+    name: str  # the picker label AND executePlugin's dispatch key - same
+    # name-doubles-as-key contract every built-in already uses
+    description: str
+    category: str
+    node_kind: str  # references a NodeKindSpec.kind, same plugin
+
+
+@dataclass(frozen=True)
+class PluginIntentSpec:
+    plugin_id: str
+    name: str  # local name; namespaced at session-wiring time as
+    # f"plugin:{plugin_id}:{name}"
+    handler: PluginIntentHandler
+    args_schema: "type | None" = None
+
+
+class HostContext:
+    """Constructed fresh per plugin, once, at discovery time - NEVER shared
+    across plugins, so plugin_id provenance is free on every call and one
+    plugin can never see or mutate another's declarations. Holds no
+    bus/document/notifications: those don't exist yet at discovery time."""
+
+    def __init__(self, plugin_id: str) -> None:
+        self.plugin_id = plugin_id
+        self._node_kinds: dict[str, NodeKindSpec] = {}  # namespaced kind -> spec
+        self._picker_entries: dict[str, PickerEntrySpec] = {}  # display name -> entry
+        self._intents: list[PluginIntentSpec] = []
+
+    def register_node_kind(
+        self,
+        kind: str,
+        factory: NodeFactory,
+        *,
+        requires_parent: bool = True,
+    ) -> None:
+        """Registers 'factory' as this plugin's creation primitive for
+        'kind'. The kind actually stored (and later stamped onto
+        SceneNode.kind) is namespaced as f"{plugin_id}.{kind}" - a
+        structural guarantee, not just convention: no built-in kind string
+        contains ".", so a namespaced kind can never literally collide with
+        one, and no separate reserved-kind blocklist is needed.
+
+        v1 ONLY supports requires_parent=True. False is rejected outright:
+        PluginPicker.tsx's executePlugin(name, parentId) wire call carries
+        no x/y at all, so a parentless node has no host-decided place to
+        spawn."""
+        if not requires_parent:
+            raise PluginRegistrationError(
+                f'plugin "{self.plugin_id}": requires_parent=False is not supported in SDK '
+                f"v1 - the picker's executePlugin(name, parentId) call carries no spawn "
+                f'position for a parentless node.'
+            )
+        if not kind or not all(c.isalnum() or c == "_" for c in kind):
+            raise PluginRegistrationError(
+                f'plugin "{self.plugin_id}": invalid node kind "{kind}" '
+                f'(must be non-empty, letters/digits/underscore only)'
+            )
+        namespaced = f"{self.plugin_id}.{kind}"
+        if namespaced in self._node_kinds:
+            raise PluginRegistrationError(
+                f'plugin "{self.plugin_id}": node kind "{kind}" already registered'
+            )
+        self._node_kinds[namespaced] = NodeKindSpec(
+            plugin_id=self.plugin_id, kind=namespaced, factory=factory, requires_parent=True,
+        )
+
+    def register_picker_entry(
+        self, *, node_kind: str, name: str, description: str, category: str = "More Plugins",
+    ) -> None:
+        """Adds one row to the Plugins picker. PluginPicker.tsx already
+        renders whatever the "app-plugins" topic sends (fully data-driven,
+        zero frontend change needed). 'node_kind' is the LOCAL kind string
+        passed to register_node_kind - must already be registered BY THIS
+        SAME plugin. 'category' matching one of backend/plugins.py's fixed
+        _CATEGORY_META names joins that existing flyout; any other string
+        (including the default "More Plugins") falls into the existing
+        synthetic catch-all."""
+        namespaced = f"{self.plugin_id}.{node_kind}"
+        if namespaced not in self._node_kinds:
+            raise PluginRegistrationError(
+                f'plugin "{self.plugin_id}": register_picker_entry references node_kind '
+                f'"{node_kind}" but register_node_kind("{node_kind}", ...) was not called first'
+            )
+        if name in self._picker_entries:
+            raise PluginRegistrationError(
+                f'plugin "{self.plugin_id}": picker entry "{name}" already registered by '
+                f'this plugin'
+            )
+        self._picker_entries[name] = PickerEntrySpec(
+            plugin_id=self.plugin_id, name=name, description=description,
+            category=category, node_kind=namespaced,
+        )
+
+    def register_intent(
+        self, name: str, handler: PluginIntentHandler, *, args_schema: "type | None" = None,
+    ) -> None:
+        """Declares one custom action beyond node creation. NOT used by the
+        trivial demo plugin (node creation alone proves the loop) - included
+        because ADR-014's own stage description names "node kind/intent/
+        picker" as the three registration surfaces this stage's host API
+        must offer. Stored in PluginRegistry.intents, namespaced at the
+        REGISTRY layer as f"plugin:{plugin_id}:{name}" so two plugins each
+        naming their own intent "run" can never collide. 'handler' is
+        called as handler(document, run_ctx, *args) and may be sync or
+        async.
+
+        DEVIATION from the design's own sketch: live SessionBus wiring
+        (actually dispatching this over the wire) is deliberately NOT done
+        in stage 14.1 - see this module's own docstring for why (collides
+        with tests/test_undo_classification_gate.py's hard-locked
+        literal-(topic,intent) invariant). This method's registration-time
+        behavior is fully real and tested regardless."""
+        self._intents.append(PluginIntentSpec(
+            plugin_id=self.plugin_id, name=name, handler=handler, args_schema=args_schema,
+        ))
+
+
+@dataclass
+class PluginLoadError:
+    plugin_dir: str
+    message: str
+
+
+class PluginRegistry:
+    def __init__(self) -> None:
+        self.node_kinds: dict[str, NodeKindSpec] = {}  # namespaced kind -> spec
+        self.picker_entries: dict[str, PickerEntrySpec] = {}  # display name -> entry
+        self.intents: list[PluginIntentSpec] = []
+        self.load_errors: list[PluginLoadError] = []
+
+    def resolve_picker_name(self, name: str) -> "tuple[NodeKindSpec, PickerEntrySpec] | None":
+        entry = self.picker_entries.get(name)
+        if entry is None:
+            return None
+        return self.node_kinds[entry.node_kind], entry
+
+
+_REGISTRY_CACHE: dict[Path, PluginRegistry] = {}
+
+
+def _load_manifest(manifest_path: Path, plugin_dir: Path) -> PluginManifest:
+    try:
+        with manifest_path.open("rb") as fh:
+            raw = tomllib.load(fh)
+    except tomllib.TOMLDecodeError as exc:
+        raise PluginRegistrationError(f"malformed TOML in {manifest_path}: {exc}") from exc
+
+    plugin_table = raw.get("plugin")
+    if not isinstance(plugin_table, dict):
+        raise PluginRegistrationError(f"{manifest_path}: missing required [plugin] table")
+
+    required = ("id", "name", "version", "sdk_api_version", "entry_point")
+    missing = [key for key in required if key not in plugin_table]
+    if missing:
+        raise PluginRegistrationError(
+            f"{manifest_path}: [plugin] table missing required field(s): {', '.join(missing)}"
+        )
+
+    plugin_id = plugin_table["id"]
+    if not isinstance(plugin_id, str) or not _ID_PATTERN.fullmatch(plugin_id):
+        raise PluginRegistrationError(
+            f"{manifest_path}: [plugin].id must match [a-z0-9_]+, got {plugin_id!r}"
+        )
+    if plugin_id != plugin_dir.name:
+        raise PluginRegistrationError(
+            f'{manifest_path}: [plugin].id "{plugin_id}" must equal this plugin\'s own '
+            f'directory name "{plugin_dir.name}"'
+        )
+
+    sdk_api_version = plugin_table["sdk_api_version"]
+    if not isinstance(sdk_api_version, int) or isinstance(sdk_api_version, bool):
+        raise PluginRegistrationError(
+            f"{manifest_path}: [plugin].sdk_api_version must be an integer"
+        )
+
+    entry_point = plugin_table["entry_point"]
+    if not isinstance(entry_point, str) or entry_point.count(":") != 1:
+        raise PluginRegistrationError(
+            f'{manifest_path}: [plugin].entry_point must be "<module>:<callable>", got '
+            f"{entry_point!r}"
+        )
+    module_name, _, fn_name = entry_point.partition(":")
+    if not module_name or not fn_name:
+        raise PluginRegistrationError(
+            f'{manifest_path}: [plugin].entry_point must be "<module>:<callable>", got '
+            f"{entry_point!r}"
+        )
+
+    frontend_table = raw.get("frontend", {})
+    view = "generic"
+    if isinstance(frontend_table, dict) and "view" in frontend_table:
+        view = frontend_table["view"]
+        if view != "generic":
+            raise PluginRegistrationError(
+                f'{manifest_path}: [frontend].view "{view}" is not supported before stage '
+                f'14.5 - "generic" is the only legal value'
+            )
+
+    return PluginManifest(
+        id=plugin_id,
+        name=str(plugin_table["name"]),
+        version=str(plugin_table["version"]),
+        sdk_api_version=int(sdk_api_version),
+        entry_point=entry_point,
+        description=str(plugin_table.get("description", "")),
+        view=view,
+        source_dir=plugin_dir,
+    )
+
+
+def _check_sdk_api_version(manifest: PluginManifest) -> None:
+    if not (MIN_COMPATIBLE_SDK_API_VERSION <= manifest.sdk_api_version <= SDK_API_VERSION):
+        raise PluginRegistrationError(
+            f'plugin "{manifest.id}": sdk_api_version {manifest.sdk_api_version} is outside '
+            f"the supported range [{MIN_COMPATIBLE_SDK_API_VERSION}, {SDK_API_VERSION}]"
+        )
+
+
+def _import_entry_module(manifest: PluginManifest, plugin_dir: Path):
+    """Imports the entry_point's module via a SYNTHETIC unique module name
+    registered in sys.modules - never a bare sys.path insert - so two
+    plugins each shipping their own "plugin.py" can never collide or shadow
+    each other."""
+    module_name, _, fn_name = manifest.entry_point.partition(":")
+    module_path = plugin_dir / f"{module_name}.py"
+    if not module_path.is_file():
+        raise PluginRegistrationError(
+            f'plugin "{manifest.id}": entry_point module not found: {module_path}'
+        )
+    synthetic_name = f"_graphlink_plugin__{manifest.id}__{module_name}"
+    spec = importlib.util.spec_from_file_location(synthetic_name, module_path)
+    if spec is None or spec.loader is None:
+        raise PluginRegistrationError(
+            f'plugin "{manifest.id}": could not load entry_point module {module_path}'
+        )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[synthetic_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(synthetic_name, None)
+        raise
+    if not hasattr(module, fn_name):
+        raise PluginRegistrationError(
+            f'plugin "{manifest.id}": entry_point callable "{fn_name}" not found in {module_path}'
+        )
+    return module
+
+
+def _merge_into_registry(
+    registry: PluginRegistry, host: HostContext, builtin_names: frozenset[str]
+) -> None:
+    """Folds one plugin's HostContext declarations into the shared registry.
+    Node-kind collisions are structurally impossible (namespaced per
+    plugin_id, checked already within HostContext itself) so need no check
+    here. Picker NAME collisions - against the built-in plugin names AND
+    against every already-merged plugin - ARE checked here, raising rather
+    than silently overwriting."""
+    for name, entry in host._picker_entries.items():
+        if name in builtin_names:
+            raise PluginRegistrationError(
+                f'plugin "{host.plugin_id}": picker entry "{name}" collides with a '
+                f"built-in plugin name"
+            )
+        existing = registry.picker_entries.get(name)
+        if existing is not None:
+            raise PluginRegistrationError(
+                f'plugin "{host.plugin_id}": picker entry "{name}" collides with the same '
+                f'entry already registered by plugin "{existing.plugin_id}"'
+            )
+    # Two passes (validate-all-then-merge-all) so a collision on the SECOND
+    # picker entry a plugin declares doesn't leave the FIRST one partially
+    # merged into the shared registry.
+    for kind, spec in host._node_kinds.items():
+        registry.node_kinds[kind] = spec
+    for name, entry in host._picker_entries.items():
+        registry.picker_entries[name] = entry
+    registry.intents.extend(host._intents)
+
+
+def discover_plugins(
+    plugins_root: Path = DEFAULT_PLUGINS_ROOT, *, builtin_names: frozenset[str] = frozenset(),
+) -> PluginRegistry:
+    """Real filesystem scan + import, memoized by resolved path so a
+    process that calls this many times (every create_app() in a pytest
+    run, via register_plugins) only pays the real cost once. Tests that
+    need isolation pass a distinct tmp_path-derived plugins_root - a fresh
+    key, never touching the shared cache entry for the real repo path."""
+    resolved = plugins_root.resolve()
+    cached = _REGISTRY_CACHE.get(resolved)
+    if cached is not None:
+        return cached
+
+    registry = PluginRegistry()
+    if resolved.is_dir():
+        for manifest_path in sorted(resolved.glob(f"*/{MANIFEST_FILENAME}")):
+            plugin_dir = manifest_path.parent
+            try:
+                manifest = _load_manifest(manifest_path, plugin_dir)
+                _check_sdk_api_version(manifest)
+                module = _import_entry_module(manifest, plugin_dir)
+                _module_name, _, fn_name = manifest.entry_point.partition(":")
+                register_fn = getattr(module, fn_name)
+                host = HostContext(manifest.id)
+                register_fn(host)
+                _merge_into_registry(registry, host, builtin_names)
+            except Exception as exc:
+                registry.load_errors.append(
+                    PluginLoadError(plugin_dir.name, f"{type(exc).__name__}: {exc}")
+                )
+                logger.warning("plugin discovery: skipping %s (%s)", plugin_dir.name, exc)
+    _REGISTRY_CACHE[resolved] = registry
+    return registry

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -51,15 +51,67 @@ get_plugin_grants) before dispatch - see
 `HostContext.register_intent()`/`PluginIntentSpec`/`PluginRegistry.intents`
 are unchanged by this - still populated exactly as stage 14.1 built them.
 
+ADR-014 STAGE 14.5 STATUS NOTES (out-of-process third-party execution):
+
+- DEVIATION from the design's own sketch: the design described an
+  out-of-process NodeKindSpec's `factory` wrapper closure as doing
+  `asyncio.to_thread(worker_client.call, ...)`. The real, already-landed
+  `_execute_discovered_plugin` (backend/plugins.py) calls `kind_spec.
+  factory(...)` SYNCHRONOUSLY, inside a plain zero-arg `_mutator` closure
+  passed to `SceneDocument.record_command` - never awaited, never inside
+  `asyncio.to_thread` itself. Wrapping the RPC call in `asyncio.to_thread`
+  would require `_mutator`/`record_command` to become async too, which
+  the design's own "ZERO changes needed to _execute_discovered_plugin"
+  requirement forbids. `PluginWorkerClient.call()` is therefore a plain
+  synchronous, blocking method (mirroring McpStdioClient's own private
+  `_call`, not its `async def _handler` wrapper) - see PluginWorkerClient's
+  own class-level comment block for the full reasoning and the accepted
+  consequence (an out-of-process factory call blocks the event loop for its
+  RPC round-trip, exactly as an in-process third-party factory already can
+  today via the same synchronous call site).
+- Confirmed TRUE, not just assumed: `_execute_discovered_plugin` needed
+  ZERO changes for out-of-process plugins to work - `kind_spec.factory` is
+  called with the exact same 3-argument signature regardless of whether it
+  is a direct Python function or an RPC-backed wrapper closure
+  (_make_worker_factory below), and the stage-14.4 grant gate
+  (SettingsManager.get_plugin_grants(), checked BEFORE `kind_spec.factory`
+  ever runs) applies identically either way - see backend/tests/
+  test_plugin_worker.py's own "D" section for the empirical proof.
+- Out-of-process v1 simplification versus the in-process serialize/
+  deserialize hook contract: an out-of-process plugin's own NodeState
+  subclass, if any, needs NO explicit serialize/deserialize hook - the
+  worker (backend/plugin_worker.py) auto-serializes it via
+  `dataclasses.asdict()`, and the host wraps the resulting plain dict in a
+  single generic `GenericPluginState` (below) with generic serialize/
+  deserialize hooks wired onto EVERY out-of-process NodeKindSpec uniformly
+  - there is no unserializable callable to avoid shipping across the RPC
+  boundary the way an in-process factory function itself is unserializable,
+  so requiring one here would be pure ceremony.
+- What is NOT enforced, stated plainly (matching stage 14.4's own honesty
+  about its grant gate): this is a process boundary against the WORKER
+  reading the HOST's secrets/state (proven empirically - a planted
+  GRAPHLINK_OPENAI_API_KEY is genuinely absent from the worker's own
+  os.environ). It is NOT a general-purpose security sandbox - a plugin's
+  own code, once running inside its worker, can still make outbound network
+  calls, write files, or do anything else a plain Python process can do on
+  this machine, bounded only by graphlink_execution_guard's resource caps
+  (memory, active-process count), never by capability. See ADR-014 stage
+  14.5's own "what 14.5 does NOT do" scope note for the full boundary.
+
 See doc/adr/ADR-014 stage 14.1's design for the full rationale (private,
 not part of this repo)."""
 
 from __future__ import annotations
 
 import importlib.util
+import json
 import logging
+import queue
 import re
+import subprocess
 import sys
+import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -85,6 +137,14 @@ from backend.notifications import NotificationState
 # "graph.mutate" means the same thing whether it is a plugin's self-reported
 # manifest checklist or a tool-call's enforced scope set.
 from backend.tools import KNOWN_SCOPES
+# ADR-014 stage 14.5: the SAME resource-cap/env-allowlist primitives
+# PythonREPL/VirtualEnvSandbox already wrap their own subprocesses with
+# (graphlink_execution_guard.py, graphlink_process_env.py) - reused exactly,
+# never reinvented, for the out-of-process plugin worker's own Popen call.
+# See PluginWorkerClient.connect's own docstring for the full call-order
+# contract these two enforce together.
+from graphlink_execution_guard import create_execution_guard
+from graphlink_process_env import safe_subprocess_env
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +152,22 @@ SDK_API_VERSION = 1
 MIN_COMPATIBLE_SDK_API_VERSION = 1
 MANIFEST_FILENAME = "plugin.toml"
 DEFAULT_PLUGINS_ROOT = Path(__file__).resolve().parent.parent / "plugins"
+# ADR-014 stage 14.5: the repo root - one level above backend/, the SAME
+# base DEFAULT_PLUGINS_ROOT above is itself derived from. Passed as `cwd=`
+# to the worker subprocess's own Popen call so `python -m backend.
+# plugin_worker` resolves the `backend` package via cwd-insertion into
+# sys.path (Python's own documented -m behavior), regardless of whatever
+# directory the HOST process itself happens to be running from (a pytest
+# run's cwd is not guaranteed to be the repo root) or whether this package
+# is pip-installed at all.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ADR-014 stage 14.5: the [runtime].isolation closed vocabulary - "in-process"
+# (the default, and the ONLY value every plugin shipped before this stage
+# implicitly had) or "out-of-process" (this stage's new opt-in). Anything
+# else is a discovery-time PluginRegistrationError, same fail-soft
+# per-plugin-skip posture as every other malformed-manifest case.
+KNOWN_RUNTIME_ISOLATION = frozenset({"in-process", "out-of-process"})
 
 _ID_PATTERN = re.compile(r"[a-z0-9_]+")
 
@@ -133,6 +209,15 @@ class PluginManifest:
     # backend/plugins.py's _execute_discovered_plugin BEFORE any factory
     # call, not here.
     scopes_grants: frozenset[str] = frozenset()
+    # ADR-014 stage 14.5: "in-process" (the default - discover_plugins()
+    # imports the plugin's own module directly into the HOST process, byte-
+    # identical to every plugin's behavior before this stage) or
+    # "out-of-process" (discover_plugins() instead spawns a resident worker
+    # subprocess - backend/plugin_worker.py - and never imports this
+    # plugin's code into the host at all). See KNOWN_RUNTIME_ISOLATION's own
+    # comment and _discover_out_of_process_plugin's docstring for the full
+    # mechanism this opts into.
+    runtime_isolation: str = "in-process"
 
 
 @dataclass(frozen=True)
@@ -159,6 +244,42 @@ class PluginNodeSeed:
     title: str
     content: str = ""
     state: NodeState | None = None
+
+
+@dataclass
+class GenericPluginState(NodeState):
+    """ADR-014 stage 14.5: the host-side stand-in for an OUT-OF-PROCESS
+    plugin's PluginNodeSeed.state. An out-of-process plugin's own NodeState
+    subclass (if it declares one, e.g. counter_node's real CounterState) is
+    defined inside the WORKER subprocess and can never be imported by the
+    host - the host importing third-party code at all, for an
+    out-of-process plugin, is exactly the thing this stage's isolation
+    property forbids. So instead of a typed subclass, the host wraps
+    whatever plain, JSON-safe dict the worker's invoke_factory response
+    carried under "state" (backend/plugin_worker.py auto-serializes a
+    dataclass instance via dataclasses.asdict() on the worker side - no
+    explicit serialize/deserialize hook is required of an out-of-process
+    plugin author, unlike the in-process contract, since there is no
+    unserializable callable to avoid shipping across the RPC boundary here).
+
+    _out_of_process_state_serialize/_out_of_process_state_deserialize below
+    are the two generic (never per-plugin) hooks wired onto EVERY
+    out-of-process NodeKindSpec by _discover_out_of_process_plugin - so this
+    class's own `data` dict IS both the live-wire pluginState payload and
+    the persisted save-file plugin_state payload, unchanged, exactly
+    mirroring NodeSerializeHook's existing dual call-site contract."""
+
+    data: dict = field(default_factory=dict)
+
+
+def _out_of_process_state_serialize(node: SceneNode) -> dict:
+    if isinstance(node.state, GenericPluginState):
+        return dict(node.state.data)
+    return {}
+
+
+def _out_of_process_state_deserialize(data: dict) -> "NodeState | None":
+    return GenericPluginState(data=dict(data)) if data else None
 
 
 NodeFactory = Callable[[SceneDocument, "PluginRunContext", str], PluginNodeSeed]
@@ -471,6 +592,22 @@ class PluginRegistry:
         # declared scopes list - the registry held no manifest at all before
         # this stage, since nothing needed one past discovery time.
         self.manifests: dict[str, PluginManifest] = {}
+        # ADR-014 stage 14.5: plugin_id -> its RESIDENT worker subprocess
+        # client, populated ONLY for a successfully-discovered
+        # out-of-process plugin (see _discover_out_of_process_plugin's own
+        # docstring for the spawn-once-at-discovery,
+        # kept-alive-for-process-lifetime v1 lifecycle choice - a crashed
+        # worker's plugin fails until the app restarts, not a live-reload
+        # story). Empty for every registry whose plugins are all in-process
+        # (the overwhelming common case, including every built-in and both
+        # original demo plugins - neither hello_node nor counter_node opts
+        # in). A caller that wants to release these subprocesses explicitly
+        # (tests; a future app-shutdown hook) iterates this dict and calls
+        # .close() on each - production code today has no such caller,
+        # matching how backend/agents.py's own self._mcp_clients are never
+        # explicitly closed either (both rely on OS process-exit cleanup, an
+        # accepted gap ADR-007 stage 8.5 already ships with, not new here).
+        self.worker_clients: dict[str, "PluginWorkerClient"] = {}
 
     def resolve_picker_name(self, name: str) -> "tuple[NodeKindSpec, PickerEntrySpec] | None":
         entry = self.picker_entries.get(name)
@@ -485,6 +622,347 @@ class PluginRegistry:
         by the caller in whichever order it prefers, since _merge_into_
         registry already guarantees no name is ever in both)."""
         return self.builtin_actions.get(name)
+
+
+# ---------------------------------------------------------------------------
+# ADR-014 stage 14.5: out-of-process plugin worker client.
+#
+# PluginWorkerClient is the HOST side of a plugin worker subprocess - one
+# instance per out-of-process plugin, spawned once at discovery time and
+# kept resident for the process's lifetime (see PluginRegistry.
+# worker_clients' own comment). It closely mirrors backend/mcp_client.py's
+# McpStdioClient: newline-delimited JSON-RPC 2.0 over stdio, a reader thread
+# pushing parsed dicts onto a queue.Queue, auto-incrementing integer id
+# correlation, a _READER_CLOSED sentinel for "the worker's stdout closed
+# unexpectedly." Reused as a direct template, not reinvented - the ONE real
+# difference is that `call()` is a synchronous, blocking method (matching
+# McpStdioClient's own private `_call`), never wrapped in `async def` here:
+# the caller this stage actually has (an out-of-process NodeKindSpec's
+# `factory` field, invoked synchronously inside backend/plugins.py's
+# `_execute_discovered_plugin` -> `record_command` -> a plain zero-arg
+# `_mutator` closure, never awaited) is itself fully synchronous by
+# construction (NodeFactory = Callable[[SceneDocument, PluginRunContext,
+# str], PluginNodeSeed], no `async` in that signature) - wrapping `call()`
+# in `asyncio.to_thread` the way backend/mcp_client.py's own
+# `_make_mcp_handler` does would require also making the wrapper factory
+# `async def` and awaiting it, which would in turn require making
+# `_mutator`/`record_command` async too. That is a real, deliberate
+# DEVIATION from this stage's own design sketch (which described the
+# wrapper closure as doing `asyncio.to_thread(...)`) - see this module's own
+# stage-14.5 status notes for why the sketch's assumption did not match the
+# real, already-landed `record_command` contract. The practical consequence:
+# an out-of-process plugin's node-creation RPC round-trip blocks the event
+# loop for its duration, exactly like an IN-PROCESS third-party plugin's
+# factory already can today (that call is ALSO synchronous, ALSO inside the
+# same `_mutator`) - this is not a new regression, just the same
+# already-accepted architecture extended to a second call mechanism.
+# ---------------------------------------------------------------------------
+
+# A reader-thread sentinel distinct from any real JSON-RPC payload (a plain
+# dict) - see McpStdioClient's own _READER_CLOSED for the identical
+# reasoning; a fresh instance here rather than importing backend/
+# mcp_client.py's, so this module has no import-time dependency on that one.
+_WORKER_READER_CLOSED = object()
+
+_DEFAULT_WORKER_TIMEOUT = 30.0
+
+
+class PluginWorkerError(RuntimeError):
+    """Raised for any plugin-worker-level failure: the subprocess failed to
+    start, closed its output unexpectedly (crashed, or exited before
+    responding), returned a JSON-RPC error response, or didn't respond
+    within the configured timeout. Callers (discover_plugins() at discovery
+    time, an RPC-backed factory/intent wrapper at call time) let this
+    propagate as a plain exception - discover_plugins()'s existing per-
+    plugin `except Exception` catches it at discovery time exactly like any
+    other PluginRegistrationError; backend/app.py's existing WS intent
+    dispatch catch-all (`except Exception` around `session.dispatch_intent`)
+    catches it at call time exactly like any other handler bug - NEITHER
+    needed a single new line of exception-handling code to cover this,
+    since both were already generic, pre-existing infrastructure."""
+
+
+class PluginWorkerClient:
+    """One resident worker subprocess for ONE out-of-process plugin -
+    construct, connect() once, then call() as needed, close() when done
+    (app shutdown; a test's own teardown). Not reentrant across concurrent
+    callers beyond the one in-flight-request-at-a-time serialization
+    `_call_lock` already provides internally - matching McpStdioClient's own
+    concurrency contract exactly."""
+
+    def __init__(self, *, plugin_id: str, source_dir: Path, timeout: float = _DEFAULT_WORKER_TIMEOUT):
+        self.plugin_id = plugin_id
+        self.source_dir = source_dir
+        self.timeout = timeout
+        self._process: subprocess.Popen | None = None
+        self._guard = None
+        self._reader_thread: threading.Thread | None = None
+        self._responses: "queue.Queue[Any]" = queue.Queue()
+        self._next_id = 0
+        self._write_lock = threading.Lock()
+        self._call_lock = threading.Lock()
+
+    @property
+    def is_connected(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    def connect(self) -> None:
+        """Spawns the worker subprocess. Call order, matching
+        graphlink_execution_guard.create_execution_guard's own documented
+        contract exactly: (1) create the guard, (2) Popen with
+        guard.popen_kwargs() merged in - POSIX applies its rlimits between
+        fork and exec, so the guard must exist BEFORE the spawn, (3)
+        guard.assign(process.pid) once the real pid exists. `env=
+        safe_subprocess_env()` (graphlink_process_env.py's allowlist, NOT a
+        blocklist of secret names) is the load-bearing containment
+        primitive for this whole stage - the worker never inherits the
+        host's GRAPHLINK_*_API_KEY/etc. environment variables, so a plugin's
+        own os.environ.get(...) call structurally cannot recover them. `cwd=
+        _REPO_ROOT` makes `-m backend.plugin_worker` resolve regardless of
+        the host process's own current directory - see _REPO_ROOT's own
+        comment."""
+        if self._process is not None:
+            return
+        self._guard = create_execution_guard()
+        try:
+            self._process = subprocess.Popen(
+                [sys.executable, "-m", "backend.plugin_worker", self.plugin_id, str(self.source_dir)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=safe_subprocess_env(),
+                cwd=str(_REPO_ROOT),
+                text=True,
+                bufsize=1,
+                **self._guard.popen_kwargs(),
+            )
+        except OSError as exc:
+            raise PluginWorkerError(
+                f'Failed to start plugin worker for "{self.plugin_id}": {exc}'
+            ) from exc
+        self._guard.assign(self._process.pid)
+        self._reader_thread = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader_thread.start()
+
+    def close(self) -> None:
+        process = self._process
+        self._process = None
+        if process is not None:
+            try:
+                if process.stdin:
+                    process.stdin.close()
+            except Exception:
+                pass
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
+        # Exactly-once close, whether or not a process was ever spawned -
+        # create_execution_guard()'s own close() is itself idempotent
+        # (double-close-safe, see graphlink_execution_guard.py's own
+        # adversarial-review fix comment), but this guards the ATTRIBUTE
+        # (None-out after) so a second PluginWorkerClient.close() call is
+        # unambiguously a no-op too.
+        guard, self._guard = self._guard, None
+        if guard is not None:
+            guard.close()
+
+    def call(self, method: str, params: dict) -> dict:
+        """Synchronous, blocking - see this section's own module-level
+        comment for why. Returns the JSON-RPC response's "result" object
+        (or {} if absent), matching McpStdioClient._call's own return
+        contract exactly."""
+        with self._call_lock:
+            self._next_id += 1
+            request_id = self._next_id
+            self._write({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+            deadline = time.monotonic() + self.timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise PluginWorkerError(
+                        f'Plugin worker "{self.plugin_id}" timed out after {self.timeout}s '
+                        f"calling {method!r}."
+                    )
+                try:
+                    payload = self._responses.get(timeout=remaining)
+                except queue.Empty:
+                    raise PluginWorkerError(
+                        f'Plugin worker "{self.plugin_id}" timed out after {self.timeout}s '
+                        f"calling {method!r}."
+                    )
+                if payload is _WORKER_READER_CLOSED:
+                    stderr_tail = ""
+                    if self._process is not None and self._process.stderr is not None:
+                        stderr_tail = self._process.stderr.read(2000)
+                    raise PluginWorkerError(
+                        f'Plugin worker "{self.plugin_id}" closed its output unexpectedly '
+                        f"while calling {method!r}."
+                        + (f" stderr: {stderr_tail}" if stderr_tail.strip() else "")
+                    )
+                if not isinstance(payload, dict) or payload.get("id") != request_id:
+                    # Malformed/unsolicited line - can't happen from a
+                    # well-behaved worker (one call in flight at a time
+                    # under _call_lock), but a corrupted or unexpected line
+                    # must not be mistaken for our response. Matches
+                    # McpStdioClient._call's own tolerance exactly.
+                    continue
+                if "error" in payload:
+                    error = payload["error"]
+                    message_text = error.get("message", error) if isinstance(error, dict) else error
+                    raise PluginWorkerError(f'plugin worker "{self.plugin_id}" {method} failed: {message_text}')
+                return payload.get("result", {}) or {}
+
+    # -- JSON-RPC framing (mirrors McpStdioClient's own private methods) ----
+
+    def _read_loop(self) -> None:
+        process = self._process
+        assert process is not None and process.stdout is not None
+        try:
+            for line in process.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue  # not a JSON-RPC line - skip, don't crash the reader
+                self._responses.put(payload)
+        finally:
+            self._responses.put(_WORKER_READER_CLOSED)
+
+    def _write(self, message: dict) -> None:
+        process = self._process
+        if process is None or process.stdin is None:
+            raise PluginWorkerError(f'Plugin worker "{self.plugin_id}" is not connected.')
+        with self._write_lock:
+            try:
+                process.stdin.write(json.dumps(message) + "\n")
+                process.stdin.flush()
+            except (BrokenPipeError, ValueError) as exc:
+                raise PluginWorkerError(
+                    f'Plugin worker "{self.plugin_id}" is not accepting input: {exc}'
+                ) from exc
+
+
+def _worker_parent_snapshot(document: SceneDocument, parent_id: str) -> dict:
+    """The data-in half of the "data-in/data-out only" factory contract an
+    out-of-process plugin's factory gets, instead of a live SceneDocument -
+    see this module's own stage-14.5 status notes ("Why host-initiated-only
+    RPC is sufficient") for the full reasoning. Exactly the parent node's
+    public fields (id/title/content/kind) - NOT the whole graph."""
+    parent = document.nodes[parent_id]
+    return {"id": parent.id, "title": parent.title, "content": parent.content, "kind": parent.kind}
+
+
+def _make_worker_factory(worker_client: PluginWorkerClient, local_kind: str) -> NodeFactory:
+    """One RPC-backed wrapper closure per out-of-process node kind - the
+    SAME NodeFactory shape (Callable[[SceneDocument, PluginRunContext, str],
+    PluginNodeSeed]) an in-process plugin's own factory function has, so it
+    slots into backend/plugins.py's `_execute_discovered_plugin` dispatch
+    with ZERO changes needed there (verified against the real landed code,
+    not just asserted - see this module's own stage-14.5 status notes)."""
+
+    def _factory(document: SceneDocument, run_ctx: "PluginRunContext", parent_id: str) -> PluginNodeSeed:
+        result = worker_client.call(
+            "invoke_factory",
+            {"kind": local_kind, "parent_snapshot": _worker_parent_snapshot(document, parent_id)},
+        )
+        raw_state = result.get("state")
+        state = GenericPluginState(data=dict(raw_state)) if isinstance(raw_state, dict) else None
+        return PluginNodeSeed(
+            title=str(result.get("title", "")), content=str(result.get("content", "")), state=state,
+        )
+
+    return _factory
+
+
+def _make_worker_intent_handler(worker_client: PluginWorkerClient, name: str) -> PluginIntentHandler:
+    """One RPC-backed wrapper closure per out-of-process custom intent - a
+    plain sync callable (document, run_ctx) -> Any, the same shape
+    HostContext.register_intent already accepts for an in-process handler.
+    `document`/`run_ctx` are accepted (matching PluginIntentHandler's own
+    signature) but not forwarded across the RPC boundary - v1 out-of-process
+    intents are zero-argument, same limitation InvokePluginIntentArgs
+    already documents for the in-process bus-level path (backend/
+    plugins.py)."""
+
+    def _handler(document: SceneDocument, run_ctx: "PluginRunContext"):
+        result = worker_client.call("invoke_intent", {"name": name, "args": {}})
+        return result.get("result")
+
+    return _handler
+
+
+def _discover_out_of_process_plugin(
+    manifest: PluginManifest, plugin_dir: Path,
+) -> "tuple[HostContext, PluginWorkerClient]":
+    """The out-of-process counterpart of discover_plugins()'s existing
+    in-process branch (import module, construct HostContext, call
+    register(host) directly) - spawns a resident PluginWorkerClient, asks it
+    for its plugin's own registrations via "get_registrations", and
+    reconstructs them into a REAL HostContext using HostContext's OWN
+    PUBLIC register_node_kind/register_picker_entry/register_intent methods
+    (never hand-built dataclass instances) - so namespacing/validation is
+    byte-identical to the in-process path, and _merge_into_registry (the
+    caller) needs no special-casing at all for an out-of-process host's
+    declarations.
+
+    The worker's "get_registrations" response reports each node kind's
+    LOCAL (non-namespaced) name - re-namespacing it here via
+    host.register_node_kind(local_kind, ...) mints the exact same
+    f"{manifest.id}.{local_kind}" string the worker's own HostContext
+    already minted internally, since manifest.id == the worker's own
+    plugin_id by construction (_load_manifest already enforces
+    plugin_id == plugin_dir.name on both sides of the RPC boundary
+    independently).
+
+    On ANY failure (connect failure, a malformed/erroring RPC response, a
+    registration collision inside the reconstructed HostContext itself) the
+    worker subprocess is closed here and the exception re-raised - the
+    caller's own per-plugin `except Exception` records one load_errors entry
+    and moves on to the next plugin, and no half-alive worker is left
+    resident for a plugin that never actually finished loading.
+
+    Returns `(host, worker_client)` rather than registering the worker into
+    a PluginRegistry itself - the CALLER (discover_plugins()) is what adds
+    it to `registry.worker_clients`, and only AFTER `_merge_into_registry`
+    has ALSO succeeded, so a plugin that spawns a working worker but then
+    loses a picker-name collision against a sibling plugin does not leave
+    an orphaned resident subprocess behind for a plugin that never actually
+    finished loading."""
+    worker_client = PluginWorkerClient(plugin_id=manifest.id, source_dir=plugin_dir)
+    try:
+        worker_client.connect()
+        response = worker_client.call("get_registrations", {})
+        host = HostContext(manifest.id)
+        for entry in response.get("node_kinds", []):
+            host.register_node_kind(
+                str(entry["local_kind"]),
+                _make_worker_factory(worker_client, str(entry["local_kind"])),
+                requires_parent=True,
+                serialize=_out_of_process_state_serialize,
+                deserialize=_out_of_process_state_deserialize,
+            )
+        for entry in response.get("picker_entries", []):
+            host.register_picker_entry(
+                node_kind=str(entry["local_kind"]),
+                name=str(entry["name"]),
+                description=str(entry.get("description", "")),
+                category=str(entry.get("category", "More Plugins")),
+            )
+        for entry in response.get("intents", []):
+            name = str(entry["name"])
+            host.register_intent(name, _make_worker_intent_handler(worker_client, name))
+    except Exception:
+        worker_client.close()
+        raise
+    return host, worker_client
 
 
 _REGISTRY_CACHE: dict[Path, PluginRegistry] = {}
@@ -548,6 +1026,20 @@ def _load_manifest(manifest_path: Path, plugin_dir: Path) -> PluginManifest:
                 f'14.5 - "generic" is the only legal value'
             )
 
+    # ADR-014 stage 14.5: optional [runtime] table - see PluginManifest.
+    # runtime_isolation's own field comment. Absent entirely -> "in-process",
+    # byte-identical to every plugin's discovery-time behavior before this
+    # stage existed.
+    runtime_table = raw.get("runtime", {})
+    runtime_isolation = "in-process"
+    if isinstance(runtime_table, dict) and "isolation" in runtime_table:
+        runtime_isolation = str(runtime_table["isolation"])
+        if runtime_isolation not in KNOWN_RUNTIME_ISOLATION:
+            raise PluginRegistrationError(
+                f'{manifest_path}: [runtime].isolation "{runtime_isolation}" is not a known '
+                f"isolation mode - must be one of {sorted(KNOWN_RUNTIME_ISOLATION)}"
+            )
+
     # ADR-014 stage 14.4: optional [scopes] table - see PluginManifest.
     # scopes_grants' own field comment for the full "self-reported checklist,
     # not an enforced boundary" contract. Absent entirely -> frozenset()
@@ -579,6 +1071,7 @@ def _load_manifest(manifest_path: Path, plugin_dir: Path) -> PluginManifest:
         view=view,
         source_dir=plugin_dir,
         scopes_grants=scopes_grants,
+        runtime_isolation=runtime_isolation,
     )
 
 
@@ -697,13 +1190,32 @@ def discover_plugins(
             try:
                 manifest = _load_manifest(manifest_path, plugin_dir)
                 _check_sdk_api_version(manifest)
-                module = _import_entry_module(manifest, plugin_dir)
-                _module_name, _, fn_name = manifest.entry_point.partition(":")
-                register_fn = getattr(module, fn_name)
-                host = HostContext(manifest.id)
-                register_fn(host)
-                _merge_into_registry(registry, host, builtin_names)
+                # ADR-014 stage 14.5: the ONLY branch point discovery gained
+                # this stage. "in-process" (every plugin before this stage,
+                # and every plugin that omits [runtime] entirely) keeps the
+                # EXACT pre-14.5 path - import the module into the host
+                # process, call its real register(host) directly - byte-
+                # identical to before. "out-of-process" never imports the
+                # plugin's module into this process at all; see
+                # _discover_out_of_process_plugin's own docstring.
+                worker_client = None
+                if manifest.runtime_isolation == "out-of-process":
+                    host, worker_client = _discover_out_of_process_plugin(manifest, plugin_dir)
+                else:
+                    module = _import_entry_module(manifest, plugin_dir)
+                    _module_name, _, fn_name = manifest.entry_point.partition(":")
+                    register_fn = getattr(module, fn_name)
+                    host = HostContext(manifest.id)
+                    register_fn(host)
+                try:
+                    _merge_into_registry(registry, host, builtin_names)
+                except Exception:
+                    if worker_client is not None:
+                        worker_client.close()
+                    raise
                 registry.manifests[manifest.id] = manifest
+                if worker_client is not None:
+                    registry.worker_clients[manifest.id] = worker_client
             except Exception as exc:
                 registry.load_errors.append(
                     PluginLoadError(plugin_dir.name, f"{type(exc).__name__}: {exc}")

--- a/backend/plugin_worker.py
+++ b/backend/plugin_worker.py
@@ -1,0 +1,240 @@
+"""ADR-014 stage 14.5: the out-of-process plugin worker subprocess entry
+point. Runs INSIDE the spawned child process only - launched as
+`python -m backend.plugin_worker <plugin_id> <source_dir>` by
+backend/plugin_sdk.py's PluginWorkerClient.connect(), never imported by the
+host process itself.
+
+THIS is the one and only place an out-of-process plugin's own Python code
+(its plugin.py entry module, imported here via the SAME importlib.util.
+spec_from_file_location mechanism backend/plugin_sdk.py's in-process
+discovery already uses - see _load_manifest/_check_sdk_api_version/
+_import_entry_module, imported and reused here verbatim, not reinvented)
+ever executes. The host process never imports it, directly or transitively
+- that is the entire isolation property this stage buys: whatever lives in
+the HOST process's own memory (decrypted API keys read via os.environ,
+DPAPI-decrypted secrets, the live SceneDocument, other sessions' state) is
+simply not reachable from code running in a DIFFERENT OS process, regardless
+of what that code tries to do. Resource/lifecycle containment (memory cap,
+process-count cap, whole-tree kill) and the environment allowlist (this
+worker never sees GRAPHLINK_*_API_KEY/etc.) are the HOST's job, applied at
+Popen time (graphlink_execution_guard.create_execution_guard(),
+graphlink_process_env.safe_subprocess_env()) - nothing in this module does
+anything special for either; it just runs as whatever process the host
+decided to spawn it as, with whatever environment the host decided to hand
+it.
+
+HONESTY NOTE on what this DOES NOT isolate: this is a process boundary
+against reading the HOST's secrets/state, not a general-purpose security
+sandbox. A plugin's own code, once running inside this worker process, can
+still do anything a plain Python process can do on this machine - open
+files, make outbound network calls, spawn its own children (bounded by the
+guard's own process-count/memory caps, not blocked outright). See ADR-014
+stage 14.5's own "what 14.5 does NOT do" scope note for the full, honest
+boundary - matching stage 14.4's own honesty about what its grant gate does
+and doesn't verify.
+
+Serves a newline-delimited JSON-RPC 2.0 loop over stdin/stdout - the SAME
+wire shape backend/mcp_client.py's McpStdioClient speaks from the CLIENT
+side, mirrored here from the SERVER side: one line in, one line out, no
+concurrent requests in flight (PluginWorkerClient serializes calls under one
+lock, so this loop is never asked to interleave two in-flight requests).
+Three methods only - "get_registrations", "invoke_factory", "invoke_intent"
+- see each branch's own comment below for its exact contract.
+
+WHY HOST-INITIATED-ONLY RPC IS SUFFICIENT: a factory needs READ access to
+its parent node's public fields, but must never receive a live, mutable
+SceneDocument (that would defeat isolation outright - a malicious factory
+could reach into the whole graph). So a factory here receives a plain,
+read-only stand-in (_WorkerDocumentStandin/_WorkerParentSnapshot below)
+carrying exactly the one parent node's id/title/content/kind - nothing else
+- and returns a plain dict the HOST reconstructs into a PluginNodeSeed. The
+host is what calls SceneDocument.add_plugin_node(...), never this process.
+This means the worker never needs to call BACK into the host mid-flight -
+every exchange is one host request, one worker response - so this loop
+stays a plain request/response server, never needing to become a client
+itself."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import sys
+from pathlib import Path
+
+from backend.notifications import NotificationState
+from backend.plugin_sdk import (
+    MANIFEST_FILENAME,
+    HostContext,
+    PluginRunContext,
+    _check_sdk_api_version,
+    _import_entry_module,
+    _load_manifest,
+)
+
+
+class _WorkerParentSnapshot:
+    """A read-only stand-in for the parent SceneNode a factory would
+    normally read from a live SceneDocument - carries exactly the public
+    fields plugins/hello_node's own in-process factory reads (parent.title),
+    plus content/kind for parity, and NOTHING else. No live document
+    reference, no other node, ever crosses into this process."""
+
+    def __init__(self, data: dict) -> None:
+        self.id = str(data.get("id", ""))
+        self.title = str(data.get("title", ""))
+        self.content = str(data.get("content", ""))
+        self.kind = str(data.get("kind", ""))
+
+
+class _WorkerDocumentStandin:
+    """Handed to a worker-side factory/intent handler in place of a live
+    SceneDocument. `.nodes` is a plain dict - the ONE access pattern every
+    real factory in this codebase uses (`document.nodes[parent_id]`, e.g.
+    plugins/hello_node's own _make_hello_note) is satisfied; any OTHER
+    SceneDocument attribute/method a buggy or malicious factory reaches for
+    (`.edges`, `.add_node`, anything else real) raises AttributeError
+    immediately - the absence of a live document is enforced by this
+    class's own minimalism, not by convention or by trusting the plugin not
+    to try."""
+
+    def __init__(self, nodes: dict) -> None:
+        self.nodes = nodes
+
+
+def _send(message: dict) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+def _local_kind(host: HostContext, namespaced_kind: str) -> str:
+    prefix = f"{host.plugin_id}."
+    return namespaced_kind[len(prefix):] if namespaced_kind.startswith(prefix) else namespaced_kind
+
+
+def _node_kinds_payload(host: HostContext) -> list:
+    return [
+        {"local_kind": _local_kind(host, kind), "requires_parent": spec.requires_parent}
+        for kind, spec in host._node_kinds.items()
+    ]
+
+
+def _picker_entries_payload(host: HostContext) -> list:
+    return [
+        {
+            "local_kind": _local_kind(host, entry.node_kind),
+            "name": entry.name,
+            "description": entry.description,
+            "category": entry.category,
+        }
+        for entry in host._picker_entries.values()
+    ]
+
+
+def _intents_payload(host: HostContext) -> list:
+    return [{"name": spec.name} for spec in host._intents]
+
+
+def _state_to_plain_dict(state) -> "dict | None":
+    """ADR-014 stage 14.5's deliberate simplification versus the in-process
+    serialize/deserialize hook contract (NodeSerializeHook/NodeDeserializeHook,
+    backend/plugin_sdk.py): an out-of-process plugin's own NodeState
+    subclass, if it declares one, is auto-serialized here via
+    dataclasses.asdict() rather than requiring the plugin author to also
+    write and register an explicit serialize hook - there is no
+    unserializable CALLABLE to avoid shipping across the RPC boundary the
+    way an in-process factory function itself is unserializable, so
+    requiring one here would be pure ceremony with no matching benefit.
+    Returns None for a state that isn't a plain dataclass (never raises) -
+    the node still gets created with its title/content; only the extra
+    state is dropped, matching every other "degrade, don't crash" posture
+    in this SDK (e.g. a raising in-process serialize hook)."""
+    if state is None:
+        return None
+    if dataclasses.is_dataclass(state) and not isinstance(state, type):
+        try:
+            return dataclasses.asdict(state)
+        except Exception:
+            return None
+    return None
+
+
+def main() -> None:
+    plugin_id = sys.argv[1]
+    source_dir = Path(sys.argv[2])
+    manifest_path = source_dir / MANIFEST_FILENAME
+    manifest = _load_manifest(manifest_path, source_dir)
+    _check_sdk_api_version(manifest)
+    module = _import_entry_module(manifest, source_dir)
+    _module_name, _, fn_name = manifest.entry_point.partition(":")
+    register_fn = getattr(module, fn_name)
+
+    host = HostContext(manifest.id)
+    register_fn(host)
+
+    # Constructed once, never observed by anything outside this process - a
+    # plugin's factory/intent handler calling run_ctx.notifications.show(...)
+    # in this worker has no visible effect on the host's real session, same
+    # documented limitation backend/plugins.py's register_plugin_tools()
+    # accepts for its own ToolRegistry-invoked dispatch path.
+    notifications = NotificationState()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue  # not JSON-RPC - skip rather than crash the whole loop
+        request_id = request.get("id")
+        method = request.get("method")
+        params = request.get("params") or {}
+        try:
+            if method == "get_registrations":
+                result = {
+                    "node_kinds": _node_kinds_payload(host),
+                    "picker_entries": _picker_entries_payload(host),
+                    "intents": _intents_payload(host),
+                }
+            elif method == "invoke_factory":
+                local_kind = str(params.get("kind", ""))
+                namespaced_kind = f"{host.plugin_id}.{local_kind}"
+                kind_spec = host._node_kinds.get(namespaced_kind)
+                if kind_spec is None:
+                    raise ValueError(f"unknown node kind: {local_kind!r}")
+                parent_data = params.get("parent_snapshot") or {}
+                parent_id = str(parent_data.get("id", ""))
+                document = _WorkerDocumentStandin({parent_id: _WorkerParentSnapshot(parent_data)})
+                run_ctx = PluginRunContext(plugin_id=host.plugin_id, notifications=notifications)
+                seed = kind_spec.factory(document, run_ctx, parent_id)
+                result = {
+                    "title": seed.title,
+                    "content": seed.content,
+                    "state": _state_to_plain_dict(seed.state),
+                }
+            elif method == "invoke_intent":
+                name = str(params.get("name", ""))
+                spec = next((s for s in host._intents if s.name == name), None)
+                if spec is None:
+                    raise ValueError(f"unknown intent: {name!r}")
+                document = _WorkerDocumentStandin({})
+                run_ctx = PluginRunContext(plugin_id=host.plugin_id, notifications=notifications)
+                value = spec.handler(document, run_ctx)
+                result = {"result": value}
+            else:
+                _send({
+                    "jsonrpc": "2.0", "id": request_id,
+                    "error": {"code": -32601, "message": f"unknown method: {method!r}"},
+                })
+                continue
+        except Exception as exc:
+            _send({
+                "jsonrpc": "2.0", "id": request_id,
+                "error": {"code": -32000, "message": f"{type(exc).__name__}: {exc}"},
+            })
+            continue
+        _send({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -33,6 +33,7 @@ from typing import Any
 from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
+from backend.plugin_sdk import PluginRegistry, PluginRunContext, discover_plugins
 
 
 @dataclass
@@ -81,15 +82,30 @@ _PLUGINS = [
 ]
 
 
-def get_plugin_categories() -> list[dict[str, Any]]:
-    """Reproduces PluginPortal.get_plugin_categories()'s exact algorithm."""
+def get_plugin_categories(plugin_registry: "PluginRegistry | None" = None) -> list[dict[str, Any]]:
+    """Reproduces PluginPortal.get_plugin_categories()'s exact algorithm.
+
+    ADR-014 stage 14.1: `plugin_registry`, when given, contributes every
+    discovered plugin's picker entries alongside the 8 built-ins BEFORE the
+    existing category-grouping loop runs, unchanged - a discovered entry's
+    `category` joining one of _CATEGORY_META's 5 fixed names lands in that
+    flyout exactly like a built-in would; any other category (including the
+    HostContext default "More Plugins") falls into the same synthetic
+    catch-all uncategorized entries already fall into."""
+    entries = list(_PLUGINS)
+    if plugin_registry is not None:
+        entries += [
+            (entry.name, entry.description, entry.category)
+            for entry in plugin_registry.picker_entries.values()
+        ]
+
     categorized_names: set[str] = set()
     grouped: list[dict[str, Any]] = []
 
     for category in _CATEGORY_META:
         plugins = [
             {"name": name, "description": description}
-            for name, description, category_name in _PLUGINS
+            for name, description, category_name in entries
             if category_name == category["name"]
         ]
         if not plugins:
@@ -103,7 +119,7 @@ def get_plugin_categories() -> list[dict[str, Any]]:
 
     uncategorized = [
         {"name": name, "description": description}
-        for name, description, category_name in _PLUGINS
+        for name, description, category_name in entries
         if name not in categorized_names
     ]
     if uncategorized:
@@ -116,26 +132,91 @@ def get_plugin_categories() -> list[dict[str, Any]]:
     return grouped
 
 
-def plugins_payload() -> dict[str, Any]:
-    return {"categories": get_plugin_categories()}
+def plugins_payload(plugin_registry: "PluginRegistry | None" = None) -> dict[str, Any]:
+    return {"categories": get_plugin_categories(plugin_registry)}
+
+
+async def _execute_discovered_plugin(
+    bus: SessionBus,
+    notifications: NotificationState,
+    canvas_document: SceneDocument,
+    plugin_registry: "PluginRegistry",
+    name: str,
+    parent_node_id: str | None,
+):
+    """ADR-014 stage 14.1: the generic executePlugin path for anything
+    discover_plugins() found that is NOT a built-in _PLUGINS name. Kept as
+    a top-level function (not nested inside register_plugins) so
+    register_plugins itself stays under tests/test_register_function_length.py's
+    300-line register* cap."""
+    resolved = plugin_registry.resolve_picker_name(name)
+    if resolved is None:
+        notifications.show(f'Unknown plugin: "{name}"', "warning")
+        await bus.publish("notification")
+        return None
+    kind_spec, picker_entry = resolved
+
+    if not parent_node_id or parent_node_id not in canvas_document.nodes:
+        notifications.show(
+            f'Please select a valid node to branch from before adding a '
+            f'{picker_entry.name} node.', "warning",
+        )
+        await bus.publish("notification")
+        return None
+    parent = canvas_document.nodes[parent_node_id]
+    run_ctx = PluginRunContext(plugin_id=kind_spec.plugin_id, notifications=notifications)
+
+    def _mutator():
+        seed = kind_spec.factory(canvas_document, run_ctx, parent_node_id)
+        return canvas_document.add_plugin_node(
+            kind_spec.kind, parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id,
+            title=seed.title, content=seed.content, state=seed.state,
+        )
+
+    node, _command = canvas_document.record_command(
+        f"plugin:{kind_spec.kind}", "user", _mutator, node_ids=[parent_node_id],
+    )
+    await bus.publish("scene")
+    return node.id
 
 
 def register_plugins(
-    bus: SessionBus, notifications: NotificationState, canvas_document: SceneDocument
+    bus: SessionBus,
+    notifications: NotificationState,
+    canvas_document: SceneDocument,
+    plugin_registry: "PluginRegistry | None" = None,
 ) -> None:
+    # ADR-014 stage 14.1: real discovery is triggered HERE, lazily, the
+    # first time a session activates - never from create_app()/backend/
+    # app.py, which is constructed "dozens of times per pytest run" (its
+    # own comment) and would re-glob/re-import/re-run every plugin's
+    # register() on every test's app construction otherwise. discover_
+    # plugins() itself is memoized by resolved plugins_root path, so every
+    # session after the first pays no real cost. `plugin_registry` stays
+    # injectable (None triggers the real scan) purely for test isolation -
+    # the signature and every existing call site
+    # (register_plugins(bus, notifications_state, canvas_document)) are
+    # otherwise UNCHANGED.
+    if plugin_registry is None:
+        plugin_registry = discover_plugins(builtin_names=frozenset(p[0] for p in _PLUGINS))
+
     # Topic name "app-plugins" (matching the codegen artifact's derived
     # name - same reasoning as "app-composer"/"app-about"): no existing
     # "plugins" schema collision today, but the pattern is now consistent
     # across every R2.3-R2.5 topic that has a distinct SPA payload.
-    bus.register_topic("app-plugins", plugins_payload)
+    bus.register_topic("app-plugins", lambda: plugins_payload(plugin_registry))
 
     async def execute_plugin(plugin_name: str, parent_node_id: str | None = None):
         name = str(plugin_name).strip()
         valid_names = {p[0] for p in _PLUGINS}
         if name not in valid_names:
-            notifications.show(f'Unknown plugin: "{name}"', "warning")
-            await bus.publish("notification")
-            return None
+            # ADR-014 stage 14.1: not a built-in name - the generic plugin-SDK
+            # path (a discovered plugin's picker entry), extracted to a
+            # top-level helper so register_plugins itself stays under the
+            # 300-line register* cap (tests/test_register_function_length.py).
+            return await _execute_discovered_plugin(
+                bus, notifications, canvas_document, plugin_registry, name, parent_node_id,
+            )
 
         if name == "Web Research":
             # R5.1: the first real node-creation plugin - every other plugin
@@ -362,3 +443,29 @@ def register_plugins(
         return None
 
     bus.register_intent("app-plugins", "executePlugin", execute_plugin, args_schema=ExecutePluginArgs)
+
+    # ADR-014 stage 14.1 DEVIATION from the design sketch, recorded here
+    # rather than silently dropped: the design's own text says a plugin's
+    # HostContext.register_intent()-declared custom intents are "Wired at
+    # SESSION-ACTIVATION time" onto the bus. That collides with a real,
+    # pre-existing, deliberately hard-locked invariant this repo already
+    # enforces - tests/test_undo_classification_gate.py (ADR-010 close-out)
+    # raises AssertionError on ANY backend/ register_intent() call whose
+    # (topic, intent) isn't a source-literal string pair, specifically so
+    # every mutating action can be enumerated in a static, hand-reviewed
+    # A/B undo-classification table ("no more wandering or patchwork...
+    # all doors closed on this matter" - that file's own docstring). A
+    # plugin-declared intent name (f"plugin:{plugin_id}:{name}") is
+    # necessarily dynamic - it does not exist until a THIRD-PARTY plugin,
+    # living entirely outside backend/ (so invisible to that gate's own
+    # SCAN_DIR regardless), is discovered at runtime - so it can never be
+    # a fixed entry in that closed table by construction, not just today.
+    # HostContext.register_intent()/PluginIntentSpec/PluginRegistry.intents
+    # are still fully real and populated (a plugin's register() call
+    # collecting one is exercised and tested) - only the LIVE bus wiring is
+    # deferred, pending a real decision on how undo-classification should
+    # treat a dynamically-sized, third-party-declared action surface. That
+    # decision belongs with stage 14.4 (scope/consent enforcement for
+    # plugin actions), a natural adjacent-governance companion, not a call
+    # this stage should make unilaterally by quietly loosening someone
+    # else's explicit gate.

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -38,6 +38,7 @@ catch-all appended last."""
 from __future__ import annotations
 
 import inspect
+import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -51,6 +52,8 @@ from backend.plugin_sdk import PluginRegistry, PluginRunContext, discover_plugin
 # specs from; ToolResult is what a handler must return.
 from backend.providers.base import ToolSpec
 from backend.tools import ToolResult
+
+logger = logging.getLogger(__name__)
 from graphlink_settings_store import SettingsManager
 
 
@@ -119,6 +122,44 @@ _CATEGORY_META = [
 ]
 
 
+# ADR-014 review-fix: the original hand-ordered _PLUGINS tuple literal
+# (deleted by the stage 14.3 migration onto real discovered plugin
+# packages under plugins/ - see `git show beb927b:backend/plugins.py` for
+# the exact byte-for-byte source this is copied from) is recreated here as
+# a pure display-order priority list, NOT a registration mechanism -
+# discover_plugins()'s sorted(glob(...)) (backend/plugin_sdk.py) walks
+# plugin DIRECTORIES alphabetically, an axis that has nothing to do with
+# this curated, hand-picked display sequence. Without this, get_plugin_
+# categories below inherited raw discovery order, and Build & Execution
+# silently reflowed to alphabetical-by-directory-name (Virtual Environment
+# Runner/code_sandbox, Gitlink, HTML Renderer, Py-Coder) instead of the
+# original Gitlink, Py-Coder, Virtual Environment Runner, HTML Renderer -
+# a real, user-visible regression for a migration meant to be a
+# byte-faithful relocation. Only these 8 pre-SDK built-ins get a curated
+# slot; every other plugin (a third-party or demo plugin, none of which
+# shipped before this stage existed) sorts AFTER every curated entry
+# within its own category, in whatever order discovery naturally produced
+# - see _builtin_picker_sort_key's own docstring for the stable-sort
+# mechanics that guarantee that.
+_BUILTIN_PICKER_ORDER = (
+    "System Prompt", "Conversation Node", "Web Research", "Gitlink",
+    "Py-Coder", "Virtual Environment Runner", "HTML Renderer", "Artifact / Drafter",
+)
+
+
+def _builtin_picker_sort_key(name: str) -> int:
+    """`name`'s position in _BUILTIN_PICKER_ORDER, or len(...) (one past
+    the last curated index) for anything not in that list. Used as a
+    sort() key, never a comparator - Python's sort is STABLE, so every
+    non-curated name (all sharing the identical fallback key) keeps its
+    original relative order among itself; only the 8 curated names get
+    reordered, into their exact curated sequence."""
+    try:
+        return _BUILTIN_PICKER_ORDER.index(name)
+    except ValueError:
+        return len(_BUILTIN_PICKER_ORDER)
+
+
 def get_plugin_categories(plugin_registry: "PluginRegistry | None" = None) -> list[dict[str, Any]]:
     """Groups every discovered picker entry (both `picker_entries` - the
     generic PluginNodeSeed path - and `builtin_actions` - the ADR-014 stage
@@ -129,7 +170,12 @@ def get_plugin_categories(plugin_registry: "PluginRegistry | None" = None) -> li
     Plugins" catch-all appended last. `plugin_registry=None` (the default)
     yields an empty listing - unlike the pre-14.3 hardcoded 8, there is no
     picker entry that exists independent of a real discovered registry
-    anymore."""
+    anymore.
+
+    ADR-014 review-fix: within each category, `plugins` is now sorted by
+    _builtin_picker_sort_key - see that function's own docstring and
+    _BUILTIN_PICKER_ORDER's own comment for the within-category ordering
+    regression this restores."""
     entries: list[tuple[str, str, str]] = []
     if plugin_registry is not None:
         entries += [
@@ -152,6 +198,7 @@ def get_plugin_categories(plugin_registry: "PluginRegistry | None" = None) -> li
         ]
         if not plugins:
             continue
+        plugins.sort(key=lambda p: _builtin_picker_sort_key(p["name"]))
         categorized_names.update(p["name"] for p in plugins)
         grouped.append({
             "name": category["name"],
@@ -348,6 +395,12 @@ async def _invoke_discovered_plugin_intent(
     function's job ends at "was this dispatch allowed to happen at all"."""
     plugin_id = str(plugin_id).strip()
     name = str(name).strip()
+    # ADR-014 review-fix: HostContext.register_intent (backend/plugin_sdk.py)
+    # now rejects a same-name duplicate intent from the same plugin at
+    # declaration time, so at most one PluginIntentSpec can ever match this
+    # (plugin_id, name) pair - next(..., None) is a genuine lookup here, not
+    # an arbitrary silent tie-break among duplicates (which is what it would
+    # have been before that guard existed).
     spec = next(
         (s for s in plugin_registry.intents if s.plugin_id == plugin_id and s.name == name),
         None,
@@ -407,22 +460,44 @@ def register_plugin_tools(
     ToolRegistry itself has no install-time-consent concept of its own, only
     scopes/approval. Without this, a Builder tool call would be a SECOND,
     ungated way to fire a plugin's custom action the user never approved in
-    Settings > Plugins - this closes that gap rather than leaving it open."""
+    Settings > Plugins - this closes that gap rather than leaving it open.
+
+    ADR-014 review-fix: each spec's registration is now wrapped in its own
+    try/except, mirroring _register_configured_mcp_tools' own real
+    per-server isolation (backend/agents.py) - previously a single raising
+    ToolRegistry.register() call (e.g. two PluginIntentSpec entries that
+    resolve to the same namespaced_name - possible before HostContext.
+    register_intent's own duplicate-name guard existed, and still
+    theoretically reachable from a hand-built PluginRegistry that bypasses
+    HostContext entirely) would raise straight out of the `for` loop and
+    silently strip every plugin ENUMERATED AFTER the offender of its
+    Builder tools too, not just the offending one - a single plugin's
+    authoring mistake taking down every later plugin's tools. Logged, not
+    silently swallowed, so a real registration failure is still visible."""
     registered: list[str] = []
     for spec in plugin_registry.intents:
         manifest = plugin_registry.manifests.get(spec.plugin_id)
         namespaced_name = f"plugin:{spec.plugin_id}:{spec.name}"
-        tool_spec = ToolSpec(
-            name=namespaced_name,
-            description=f'Invokes plugin "{spec.plugin_id}"\'s "{spec.name}" action.',
-            input_schema={"type": "object", "properties": {}},
-        )
-        tool_registry.register(
-            tool_spec,
-            _make_plugin_tool_handler(plugin_registry, settings_manager, canvas_document, spec.plugin_id, spec.name),
-            scopes=manifest.scopes_grants if manifest is not None else frozenset(),
-            approval="always",
-        )
+        try:
+            tool_spec = ToolSpec(
+                name=namespaced_name,
+                description=f'Invokes plugin "{spec.plugin_id}"\'s "{spec.name}" action.',
+                input_schema={"type": "object", "properties": {}},
+            )
+            tool_registry.register(
+                tool_spec,
+                _make_plugin_tool_handler(
+                    plugin_registry, settings_manager, canvas_document, spec.plugin_id, spec.name,
+                ),
+                scopes=manifest.scopes_grants if manifest is not None else frozenset(),
+                approval="always",
+            )
+        except Exception:
+            logger.exception(
+                'plugin "%s": failed to register intent "%s" as a Builder tool - skipping',
+                spec.plugin_id, spec.name,
+            )
+            continue
         registered.append(namespaced_name)
     return tuple(registered)
 
@@ -454,6 +529,8 @@ def _make_plugin_tool_handler(
                 f'this action can run.',
                 is_error=True,
             )
+        # Same duplicate-proof lookup as _invoke_discovered_plugin_intent
+        # above - see that call site's own comment.
         spec = next(
             (s for s in plugin_registry.intents if s.plugin_id == plugin_id and s.name == name), None,
         )
@@ -468,6 +545,41 @@ def _make_plugin_tool_handler(
         return ToolResult(content="" if result is None else str(result), is_error=False)
 
     return _handler
+
+
+def _grant_gated_serialize(plugin_id: str, serialize, settings_manager: SettingsManager):
+    """ADR-014 review-fix: wraps a plugin's own HostContext.register_node_
+    kind(..., serialize=...) hook so a revoked Settings > Plugins grant
+    actually stops it from running, rather than merely hiding the plugin's
+    PICKER entry while its serializer keeps firing on every scene publish
+    forever after. The SAME settings_manager.get_plugin_grants() check
+    _execute_discovered_plugin/_invoke_discovered_plugin_intent/
+    register_plugin_tools' own handler already apply before calling into a
+    plugin's code, extended to this fourth call site.
+
+    Checked FRESH on every call (never cached at wrap time, since this
+    closure is built once per session at register_plugins() time but a
+    grant can be flipped in Settings at any later point in that same
+    session) - a revoke takes effect on the very next scene publish, not
+    just the next session/reload.
+
+    Returns None (not a dict) when ungranted, rather than raising: the
+    caller (backend/domain/graph.py's _plugin_state_wire) already treats
+    any non-dict return as "no plugin state to show" and degrades to {}
+    with no warning logged - correct here, since an ungranted plugin is
+    expected policy, not a plugin bug worth a warning on every publish.
+    session_save.py's own _serialize_plugin_node applies the identical
+    grant check independently for the persisted-file path (build_chat_data
+    threads `settings_manager` through for that, rather than relying on
+    this SceneDocument-only wrapper, since save/load run outside any one
+    session's live SceneDocument)."""
+
+    def _serialize(node):
+        if not settings_manager.get_plugin_grants().get(plugin_id, False):
+            return None
+        return serialize(node)
+
+    return _serialize
 
 
 def register_plugins(
@@ -505,9 +617,21 @@ def register_plugins(
     # itself, is what _node_wire's pluginState field actually reads.
     # Generic against whatever discover_plugins() found - adding a NEW
     # plugin with its own serialize hook needs no edit here.
+    #
+    # ADR-014 review-fix: wrapped in _grant_gated_serialize rather than
+    # stored verbatim - previously this ran a plugin's own serialize(node)
+    # on EVERY scene publish regardless of Settings > Plugins' granted
+    # state, unlike node creation/invokePluginIntent/register_plugin_tools'
+    # handler (all three already check settings_manager.get_plugin_grants()
+    # before calling into a plugin), so revoking a plugin's grant did not
+    # actually stop its code from continuing to run on every live-wire
+    # broadcast. See _grant_gated_serialize's own docstring for the
+    # checked-fresh-per-call/degrade-to-{}-not-crash mechanics.
     for kind, kind_spec in plugin_registry.node_kinds.items():
         if kind_spec.serialize is not None:
-            canvas_document.plugin_node_serializers[kind] = kind_spec.serialize
+            canvas_document.plugin_node_serializers[kind] = _grant_gated_serialize(
+                kind_spec.plugin_id, kind_spec.serialize, settings_manager,
+            )
 
     # Topic name "app-plugins" (matching the codegen artifact's derived
     # name - same reasoning as "app-composer"/"app-about"): no existing

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -45,6 +45,12 @@ from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.plugin_sdk import PluginRegistry, PluginRunContext, discover_plugins
+# ADR-014 stage 14.5: register_plugin_tools' own ToolRegistry-facing
+# dependencies - ToolSpec is the SAME provider-neutral shape every other
+# tool family (backend/tools_graph.py, backend/mcp_client.py) builds its
+# specs from; ToolResult is what a handler must return.
+from backend.providers.base import ToolSpec
+from backend.tools import ToolResult
 from graphlink_settings_store import SettingsManager
 
 
@@ -363,6 +369,105 @@ async def _invoke_discovered_plugin_intent(
     if inspect.iscoroutinefunction(spec.handler):
         return await spec.handler(canvas_document, run_ctx)
     return spec.handler(canvas_document, run_ctx)
+
+
+def register_plugin_tools(
+    tool_registry, plugin_registry: "PluginRegistry", settings_manager: SettingsManager,
+    canvas_document: SceneDocument,
+) -> tuple[str, ...]:
+    """ADR-014 stage 14.5: "tools flow to the registry" - registers every
+    discovered plugin's HostContext.register_intent()-declared custom action
+    as a real Builder-loop tool, namespaced `plugin:<plugin_id>:<name>`.
+    Mirrors backend/mcp_client.py's own register_mcp_server_tools exactly
+    (list, namespace, register with scopes + approval) - the SAME pattern,
+    a different source of specs.
+
+    Works uniformly for BOTH in-process and out-of-process plugins:
+    plugin_registry.intents' PluginIntentSpec.handler is a plain Python
+    callable either way - a direct function for an in-process plugin, an
+    RPC-backed wrapper closure for an out-of-process one (backend/
+    plugin_sdk.py's _make_worker_intent_handler) - this function never knows
+    or cares which, verified against the real landed
+    _invoke_discovered_plugin_intent (stage 14.4), which already treats
+    every PluginIntentSpec.handler identically regardless of origin.
+
+    `scopes=manifest.scopes_grants` - the SAME self-reported [scopes].grants
+    checklist Settings > Plugins already shows (see PluginManifest.
+    scopes_grants' own field comment for the "self-reported, not itself
+    enforced BY ITSELF" honesty note) - ToolRegistry.invoke() DOES enforce
+    it here, the same pre-handler scope gate every other tool gets.
+    `approval="always"` - untrusted third-party code, the SAME posture
+    register_mcp_server_tools' own McpServerConfig default takes for a
+    configured MCP server (backend/mcp_client.py) - a plugin is exactly as
+    trusted as a user-configured MCP server: neither is first-party.
+
+    ALSO enforces the SAME install-time SettingsManager.get_plugin_grants()
+    gate _invoke_discovered_plugin_intent already enforces for the bus-level
+    invokePluginIntent path - checked INSIDE the handler below, since
+    ToolRegistry itself has no install-time-consent concept of its own, only
+    scopes/approval. Without this, a Builder tool call would be a SECOND,
+    ungated way to fire a plugin's custom action the user never approved in
+    Settings > Plugins - this closes that gap rather than leaving it open."""
+    registered: list[str] = []
+    for spec in plugin_registry.intents:
+        manifest = plugin_registry.manifests.get(spec.plugin_id)
+        namespaced_name = f"plugin:{spec.plugin_id}:{spec.name}"
+        tool_spec = ToolSpec(
+            name=namespaced_name,
+            description=f'Invokes plugin "{spec.plugin_id}"\'s "{spec.name}" action.',
+            input_schema={"type": "object", "properties": {}},
+        )
+        tool_registry.register(
+            tool_spec,
+            _make_plugin_tool_handler(plugin_registry, settings_manager, canvas_document, spec.plugin_id, spec.name),
+            scopes=manifest.scopes_grants if manifest is not None else frozenset(),
+            approval="always",
+        )
+        registered.append(namespaced_name)
+    return tuple(registered)
+
+
+def _make_plugin_tool_handler(
+    plugin_registry: "PluginRegistry", settings_manager: SettingsManager,
+    canvas_document: SceneDocument, plugin_id: str, name: str,
+):
+    """One handler per (plugin_id, name) - re-resolves the PluginIntentSpec
+    fresh from plugin_registry.intents on every call (rather than closing
+    over the spec found at registration time) so a plugin's handler is
+    never called from a stale reference, mirroring
+    _invoke_discovered_plugin_intent's own fresh-lookup-per-call pattern.
+
+    NotificationState() is constructed fresh, throwaway, per call - nothing
+    outside this function ever observes it. ToolRegistry's own RunContext
+    has no notification channel at all (a handler's ToolResult.content is
+    the ONLY thing the caller ever sees back), so a plugin handler that
+    calls run_ctx.notifications.show(...) when invoked through THIS path
+    has no visible effect - an honest, documented limitation, not a silent
+    bug: the bus-level invokePluginIntent path (backend/plugins.py's
+    _invoke_discovered_plugin_intent) is what threads a REAL, observed
+    NotificationState through, for a plugin author who needs one."""
+
+    async def _handler(call, ctx) -> ToolResult:
+        if not settings_manager.get_plugin_grants().get(plugin_id, False):
+            return ToolResult(
+                content=f'Plugin "{plugin_id}" needs your approval in Settings > Plugins before '
+                f'this action can run.',
+                is_error=True,
+            )
+        spec = next(
+            (s for s in plugin_registry.intents if s.plugin_id == plugin_id and s.name == name), None,
+        )
+        if spec is None:
+            return ToolResult(content=f'Unknown plugin intent: "{plugin_id}:{name}".', is_error=True)
+        run_ctx = PluginRunContext(plugin_id=plugin_id, notifications=NotificationState())
+        result = (
+            await spec.handler(canvas_document, run_ctx)
+            if inspect.iscoroutinefunction(spec.handler)
+            else spec.handler(canvas_document, run_ctx)
+        )
+        return ToolResult(content="" if result is None else str(result), is_error=False)
+
+    return _handler
 
 
 def register_plugins(

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -37,6 +37,7 @@ catch-all appended last."""
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from typing import Any
 
@@ -44,6 +45,7 @@ from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.plugin_sdk import PluginRegistry, PluginRunContext, discover_plugins
+from graphlink_settings_store import SettingsManager
 
 
 @dataclass
@@ -54,6 +56,38 @@ class ExecutePluginArgs:
 
     plugin_name: str
     parent_node_id: str | None = None
+
+
+@dataclass
+class InvokePluginIntentArgs:
+    """ADR-014 stage 14.4: args schema for invokePluginIntent - mirrors
+    invoke_plugin_intent's own signature below exactly (dataclass field
+    order is the positional mapping dispatch_intent validates against).
+    v1 supports zero-argument custom intents only: the two demo plugins
+    (hello_node/counter_node) don't call HostContext.register_intent at
+    all, and no production caller needs a richer variadic payload yet -
+    extending this to forward real positional arguments to a plugin's own
+    handler is a natural follow-up once a real third-party plugin needs
+    it, not a gap this addition's own purpose (closing stage 14.1's
+    deferred custom-intent-wiring gap, see backend/plugin_sdk.py's module
+    docstring) requires closing now."""
+
+    plugin_id: str
+    name: str
+
+
+@dataclass
+class SetPluginGrantArgs:
+    """ADR-014 stage 14.4: args schema for setPluginGrant - the Settings >
+    Plugins page's one write path (a single checkbox per row, mirroring
+    McpServersPage's own per-field setters rather than setMcpServers' whole-
+    collection replace - see SettingsManager.set_plugin_grant's own
+    docstring for why this intent is a single-plugin write, not a bulk
+    one)."""
+
+    plugin_id: str
+    granted: bool
+
 
 _CATEGORY_META = [
     {
@@ -134,8 +168,47 @@ def get_plugin_categories(plugin_registry: "PluginRegistry | None" = None) -> li
     return grouped
 
 
-def plugins_payload(plugin_registry: "PluginRegistry | None" = None) -> dict[str, Any]:
-    return {"categories": get_plugin_categories(plugin_registry)}
+def _plugin_grants_payload(
+    plugin_registry: "PluginRegistry | None", settings_manager: "SettingsManager | None",
+) -> list[dict[str, Any]]:
+    """ADR-014 stage 14.4: one row per DISTINCT non-built-in plugin_id - NOT
+    one row per picker entry (a plugin with multiple picker entries still
+    gets exactly one grants row). Built-ins never appear here at all: this
+    walks `plugin_registry.picker_entries` (the generic PluginNodeSeed path
+    every third-party plugin, and the two demo plugins, register through),
+    never `plugin_registry.builtin_actions` (the ADR-014 stage 14.3 escape
+    hatch the 8 first-party built-ins use) - the same distinction backend/
+    plugins.py's own module docstring draws between the two dispatch
+    mechanisms. `settings_manager=None` (a bare plugins_payload() call with
+    no manager available) yields every discovered plugin as ungranted -
+    the same deny-by-default answer a real manager with no stored entry for
+    that plugin_id would give, just without a store to read from."""
+    if plugin_registry is None:
+        return []
+    grants_state = settings_manager.get_plugin_grants() if settings_manager is not None else {}
+    plugin_ids = sorted({entry.plugin_id for entry in plugin_registry.picker_entries.values()})
+    rows = []
+    for plugin_id in plugin_ids:
+        manifest = plugin_registry.manifests.get(plugin_id)
+        rows.append({
+            "pluginId": plugin_id,
+            "name": manifest.name if manifest is not None else plugin_id,
+            "scopes": sorted(manifest.scopes_grants) if manifest is not None else [],
+            "granted": bool(grants_state.get(plugin_id, False)),
+        })
+    return rows
+
+
+def plugins_payload(
+    plugin_registry: "PluginRegistry | None" = None,
+    settings_manager: "SettingsManager | None" = None,
+) -> dict[str, Any]:
+    return {
+        "categories": get_plugin_categories(plugin_registry),
+        # ADR-014 stage 14.4: the Settings > Plugins grants list - see
+        # _plugin_grants_payload's own docstring.
+        "grants": _plugin_grants_payload(plugin_registry, settings_manager),
+    }
 
 
 async def _execute_discovered_plugin(
@@ -143,6 +216,7 @@ async def _execute_discovered_plugin(
     notifications: NotificationState,
     canvas_document: SceneDocument,
     plugin_registry: "PluginRegistry",
+    settings_manager: SettingsManager,
     name: str,
     parent_node_id: str | None,
 ):
@@ -162,9 +236,22 @@ async def _execute_discovered_plugin(
        real id, else "notification") matches every one of the 8 migrated
        branches, including System Prompt's dedup path, which publishes
        "scene" and returns an EXISTING id without creating anything new.
+       ADR-014 stage 14.4 deliberately does NOT gate this branch on any
+       grant - built-ins are first-party, ship with the app, and are never
+       subject to install-time consent (see this module's own docstring).
     2. `plugin_registry.picker_entries` (via resolve_picker_name) - the
        generic PluginNodeSeed/add_plugin_node path every third-party plugin
-       (and the two demo plugins, hello_node/counter_node) uses.
+       (and the two demo plugins, hello_node/counter_node) uses. ADR-014
+       stage 14.4: gated on SettingsManager.get_plugin_grants() BEFORE the
+       parent-node validation and BEFORE `kind_spec.factory(...)` ever runs -
+       the same "cheap, static check first" ordering ToolRegistry.invoke()
+       already uses for its own scope gate (backend/tools.py) - so an
+       ungranted plugin is denied regardless of what parent was selected,
+       never even reaching the factory that would otherwise mutate the
+       document. This is a COARSE, binary, install-time gate ("has the user
+       consented to this plugin acting at all"), not a per-scope-string
+       enforcement boundary - see PluginManifest.scopes_grants' own field
+       comment for the honest limit of what this actually verifies.
 
     A name matching neither shows the same "Unknown plugin" warning
     regardless of which mechanism a real match would have used."""
@@ -181,6 +268,14 @@ async def _execute_discovered_plugin(
         await bus.publish("notification")
         return None
     kind_spec, picker_entry = resolved
+
+    if not settings_manager.get_plugin_grants().get(kind_spec.plugin_id, False):
+        notifications.show(
+            f'"{picker_entry.name}" needs your approval before it can create nodes - '
+            f'grant it in Settings > Plugins.', "warning",
+        )
+        await bus.publish("notification")
+        return None
 
     if not parent_node_id or parent_node_id not in canvas_document.nodes:
         notifications.show(
@@ -206,10 +301,75 @@ async def _execute_discovered_plugin(
     return node.id
 
 
+async def _invoke_discovered_plugin_intent(
+    bus: SessionBus,
+    notifications: NotificationState,
+    canvas_document: SceneDocument,
+    plugin_registry: "PluginRegistry",
+    settings_manager: SettingsManager,
+    plugin_id: str,
+    name: str,
+):
+    """The single invokePluginIntent dispatch path - ADR-014 stage 14.4's
+    resolution of stage 14.1's own deferred gap (see backend/plugin_sdk.py's
+    module docstring): a plugin's HostContext.register_intent()-declared
+    custom intent is inherently dynamic (unknown until a third-party plugin,
+    living outside backend/, is discovered at runtime), so it can never be a
+    fixed tests/undo_classification.py table entry the way a literal
+    (topic, intent) pair can. Rather than wire each discovered intent onto
+    the bus individually (which tests/test_undo_classification_gate.py's
+    hard-locked literal-(topic, intent) invariant structurally forbids), this
+    is the ONE static chokepoint every dynamically-discovered plugin intent
+    funnels through - "invokePluginIntent" itself IS the literal (topic,
+    intent) pair the gate sees; what it dispatches to at runtime is this
+    function's own business, exactly the same relationship executePlugin
+    already has to whichever picker entry/builtin action a given call
+    resolves to.
+
+    Looks up the matching PluginIntentSpec by (plugin_id, name), then checks
+    the SAME grant _execute_discovered_plugin does BEFORE calling
+    spec.handler - mirroring ToolRegistry.invoke()'s own "scope check runs
+    before any approval/handler" ordering (backend/tools.py): an ungranted
+    plugin's custom intent can never fire, a structural property of this one
+    chokepoint rather than something every future plugin author has to
+    remember to check themselves.
+
+    Deliberately does NOT itself call record_command - if a plugin's own
+    handler mutates the document, IT calls record_command (same "handler
+    is trusted to do exactly what it needs, including its own
+    record_command call" contract HostContext.register_builtin_plugin's own
+    docstring already documents for the built-in escape hatch); this
+    function's job ends at "was this dispatch allowed to happen at all"."""
+    plugin_id = str(plugin_id).strip()
+    name = str(name).strip()
+    spec = next(
+        (s for s in plugin_registry.intents if s.plugin_id == plugin_id and s.name == name),
+        None,
+    )
+    if spec is None:
+        notifications.show(f'Unknown plugin intent: "{plugin_id}:{name}"', "warning")
+        await bus.publish("notification")
+        return None
+
+    if not settings_manager.get_plugin_grants().get(plugin_id, False):
+        notifications.show(
+            f'"{plugin_id}" needs your approval before it can run this action - '
+            f'grant it in Settings > Plugins.', "warning",
+        )
+        await bus.publish("notification")
+        return None
+
+    run_ctx = PluginRunContext(plugin_id=plugin_id, notifications=notifications)
+    if inspect.iscoroutinefunction(spec.handler):
+        return await spec.handler(canvas_document, run_ctx)
+    return spec.handler(canvas_document, run_ctx)
+
+
 def register_plugins(
     bus: SessionBus,
     notifications: NotificationState,
     canvas_document: SceneDocument,
+    settings_manager: SettingsManager,
     plugin_registry: "PluginRegistry | None" = None,
 ) -> None:
     # ADR-014 stage 14.1: real discovery is triggered HERE, lazily, the
@@ -247,43 +407,56 @@ def register_plugins(
     # Topic name "app-plugins" (matching the codegen artifact's derived
     # name - same reasoning as "app-composer"/"app-about"): no existing
     # "plugins" schema collision today, but the pattern is now consistent
-    # across every R2.3-R2.5 topic that has a distinct SPA payload.
-    bus.register_topic("app-plugins", lambda: plugins_payload(plugin_registry))
+    # across every R2.3-R2.5 topic that has a distinct SPA payload. ADR-014
+    # stage 14.4: now also carries the "grants" array (settings_manager
+    # threaded through so it can answer the current granted/not-granted
+    # state for every non-built-in discovered plugin) - see
+    # _plugin_grants_payload's own docstring.
+    bus.register_topic("app-plugins", lambda: plugins_payload(plugin_registry, settings_manager))
 
     async def execute_plugin(plugin_name: str, parent_node_id: str | None = None):
         name = str(plugin_name).strip()
         # ADR-014 stage 14.3: every name - built-in or third-party alike -
         # flows through the same generic dispatch helper now. See
         # _execute_discovered_plugin's own docstring for the two
-        # registration mechanisms it checks, in order.
+        # registration mechanisms it checks, in order, and (stage 14.4) the
+        # grant gate the generic path now enforces.
         return await _execute_discovered_plugin(
-            bus, notifications, canvas_document, plugin_registry, name, parent_node_id,
+            bus, notifications, canvas_document, plugin_registry, settings_manager, name, parent_node_id,
         )
 
     bus.register_intent("app-plugins", "executePlugin", execute_plugin, args_schema=ExecutePluginArgs)
 
-    # ADR-014 stage 14.1 DEVIATION from the design sketch, recorded here
-    # rather than silently dropped: the design's own text says a plugin's
-    # HostContext.register_intent()-declared custom intents are "Wired at
-    # SESSION-ACTIVATION time" onto the bus. That collides with a real,
-    # pre-existing, deliberately hard-locked invariant this repo already
-    # enforces - tests/test_undo_classification_gate.py (ADR-010 close-out)
-    # raises AssertionError on ANY backend/ register_intent() call whose
-    # (topic, intent) isn't a source-literal string pair, specifically so
-    # every mutating action can be enumerated in a static, hand-reviewed
-    # A/B undo-classification table ("no more wandering or patchwork...
-    # all doors closed on this matter" - that file's own docstring). A
-    # plugin-declared intent name (f"plugin:{plugin_id}:{name}") is
-    # necessarily dynamic - it does not exist until a THIRD-PARTY plugin,
-    # living entirely outside backend/ (so invisible to that gate's own
-    # SCAN_DIR regardless), is discovered at runtime - so it can never be
-    # a fixed entry in that closed table by construction, not just today.
-    # HostContext.register_intent()/PluginIntentSpec/PluginRegistry.intents
-    # are still fully real and populated (a plugin's register() call
-    # collecting one is exercised and tested) - only the LIVE bus wiring is
-    # deferred, pending a real decision on how undo-classification should
-    # treat a dynamically-sized, third-party-declared action surface. That
-    # decision belongs with stage 14.4 (scope/consent enforcement for
-    # plugin actions), a natural adjacent-governance companion, not a call
-    # this stage should make unilaterally by quietly loosening someone
-    # else's explicit gate.
+    # ADR-014 stage 14.4: closes stage 14.1's own deferred gap (see this
+    # module's own former comment here, and backend/plugin_sdk.py's module
+    # docstring) - ONE new static (topic, intent) pair,
+    # ("app-plugins", "invokePluginIntent"), whose handler looks up its real
+    # target DYNAMICALLY at call time and grant-checks before dispatch. This
+    # satisfies tests/test_undo_classification_gate.py's literal-(topic,
+    # intent) requirement trivially (one more entry, same as "executePlugin"
+    # already is) while making every dynamically-discovered plugin intent
+    # name gate-compliant by construction, regardless of how many plugins/
+    # intents exist at runtime - see _invoke_discovered_plugin_intent's own
+    # docstring for the full mechanism.
+    async def invoke_plugin_intent(plugin_id: str, name: str):
+        return await _invoke_discovered_plugin_intent(
+            bus, notifications, canvas_document, plugin_registry, settings_manager, plugin_id, name,
+        )
+
+    bus.register_intent(
+        "app-plugins", "invokePluginIntent", invoke_plugin_intent, args_schema=InvokePluginIntentArgs,
+    )
+
+    async def set_plugin_grant(plugin_id: str, granted: bool):
+        # ADR-014 stage 14.4: the Settings > Plugins page's one write path -
+        # persists via SettingsManager.set_plugin_grant (single-plugin write,
+        # not a whole-collection replace - see that method's own docstring),
+        # then re-publishes "app-plugins" so both the picker and any
+        # Settings UI observing the same topic pick up the new granted/not-
+        # granted state immediately, same "mutate then re-publish this
+        # topic" shape every other settings-store write in this codebase
+        # already uses (e.g. setMcpServers).
+        settings_manager.set_plugin_grant(str(plugin_id).strip(), bool(granted))
+        await bus.publish("app-plugins")
+
+    bus.register_intent("app-plugins", "setPluginGrant", set_plugin_grant, args_schema=SetPluginGrantArgs)

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -200,6 +200,17 @@ def register_plugins(
     if plugin_registry is None:
         plugin_registry = discover_plugins(builtin_names=frozenset(p[0] for p in _PLUGINS))
 
+    # ADR-014 stage 14.2: populate the live-wire half of the Plugin SDK's
+    # generic persistence seam - see SceneDocument.plugin_node_serializers'
+    # own field comment (backend/domain/graph.py) for why this dict of bare
+    # callables, rather than the domain layer importing PluginRegistry
+    # itself, is what _node_wire's pluginState field actually reads.
+    # Generic against whatever discover_plugins() found - adding a NEW
+    # plugin with its own serialize hook needs no edit here.
+    for kind, kind_spec in plugin_registry.node_kinds.items():
+        if kind_spec.serialize is not None:
+            canvas_document.plugin_node_serializers[kind] = kind_spec.serialize
+
     # Topic name "app-plugins" (matching the codegen artifact's derived
     # name - same reasoning as "app-composer"/"app-about"): no existing
     # "plugins" schema collision today, but the pattern is now consistent

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -1,29 +1,39 @@
-"""Plugin picker listing for the new architecture (Qt-removal plan R2.5).
+"""Plugin picker listing for the new architecture (Qt-removal plan R2.5,
+migrated onto the ADR-014 Plugin SDK at stage 14.3).
 
-An INDEPENDENT Qt-free reimplementation of PluginPortal.get_plugin_categories()
-- not an import - because graphlink_plugin_portal.py imports PySide6.QtCore
-at module scope AND every node_cls it registers (ChatNode, PyCoderNode,
-WebNode, GitlinkNode, ArtifactNode, CodeSandboxNode, HtmlViewNode,
-ConversationNode) is itself transitively Qt-coupled through 8+ modules,
-invisible to test_no_qt_anywhere.py's single-file scan. Same reimplement-
-not-import precedent as backend/composer.py.
+ADR-014 stage 14.3: the 8 built-in picker actions that used to be a
+hardcoded if-chain here (System Prompt, Conversation Node, Web Research,
+Gitlink, Py-Coder, Virtual Environment Runner, HTML Renderer, Artifact /
+Drafter) are now real discovered plugin packages under plugins/ - see
+plugins/web_research/plugin.py (and its 7 siblings) for the migrated
+handler bodies. Each registers via
+`backend.plugin_sdk.HostContext.register_builtin_plugin` rather than
+`register_node_kind`/`register_picker_entry`: their kind strings
+(web_research, gitlink, pycoder, code_sandbox, html, artifact,
+conversation, note) are already baked into web_ui's NODE_TYPES map, the
+wire contract, and session_save.py/session_load.py's hand-written per-kind
+serializers - routing them through the generic, auto-namespaced
+PluginNodeSeed/add_plugin_node path would rename every one of those kinds
+and be an invasive, unnecessary breaking change for zero benefit. See
+HostContext.register_builtin_plugin's own docstring (backend/plugin_sdk.py)
+for the full escape-hatch rationale.
 
-The category/plugin metadata below (names, descriptions, grouping) is
-hand-ported VERBATIM from PLUGIN_CATEGORY_META and the 8 _register_plugin()
-call sites in graphlink_plugin_portal.py, reproducing get_plugin_categories()'s
-exact algorithm: iterate categories in order, skip empty ones, append a
-synthetic "More Plugins" catch-all only if any plugin is uncategorized
-(today: none are). Icons are dropped everywhere in this migration, per the
-established About/Help precedent - no icon-library dependency exists in the
-web layer.
+This means EVERY name executePlugin sees today - built-in or third-party -
+flows through the exact same generic dispatch path
+(_execute_discovered_plugin below): look up plugin_registry.builtin_actions
+first (the migrated built-ins' escape hatch), then
+plugin_registry.picker_entries (the generic PluginNodeSeed path). There is
+no longer a separate hardcoded fast path for the built-ins, and no
+"_PLUGINS" static list - discover_plugins() is the single source of truth
+for every picker entry's existence, and get_plugin_categories' grouping
+below reflects whatever it found.
 
-executePlugin's real effect - instantiating a typed QGraphicsItem node - is
-NOT reimplemented here: it is out of scope until R3 (real node types in the
-scene model) and R5 (a redesigned, replayable plugin-portal-v2 intent
-contract), per recon. Selecting a plugin in R2.5 surfaces a real, honest
-notification via the already-shipped notifications topic rather than
-silently doing nothing or fabricating node creation.
-"""
+_CATEGORY_META is NOT built-in-specific scaffolding - it is the general,
+fixed 5-category taxonomy any discovered plugin's `category` (built-in or
+third-party) joins; it stays exactly as it was pre-migration. A category
+with zero entries is skipped; anything landing in the HostContext default
+"More Plugins" (or naming an unrecognized category) falls into a synthetic
+catch-all appended last."""
 
 from __future__ import annotations
 
@@ -68,35 +78,27 @@ _CATEGORY_META = [
     },
 ]
 
-# (name, description, category) - registration order matches
-# PluginPortal._discover_plugins() exactly.
-_PLUGINS = [
-    ("System Prompt", "Adds a special node to override the default system prompt for a conversation branch.", "Branch Foundations"),
-    ("Conversation Node", "Adds a node for a self-contained, linear chat conversation.", "Branch Foundations"),
-    ("Web Research", "Searches, retrieves, and summarizes cited web sources under a bounded network policy.", "Reasoning & Research"),
-    ("Gitlink", "Loads a GitHub repository into structured XML context, prepares file-level changes, and only writes after explicit approval.", "Build & Execution"),
-    ("Py-Coder", "Opens a Python execution environment to run code and get AI analysis.", "Build & Execution"),
-    ("Virtual Environment Runner", "Runs Python inside an isolated virtualenv with your full user-account privileges (isolates installed packages, not the operating system) and lets you declare per-node requirements.txt dependencies.", "Build & Execution"),
-    ("HTML Renderer", "Adds a node to render HTML code from a parent node.", "Build & Execution"),
-    ("Artifact / Drafter", "A split-pane node for iteratively drafting and refining living documents (Markdown).", "Workflow & Drafting"),
-]
-
 
 def get_plugin_categories(plugin_registry: "PluginRegistry | None" = None) -> list[dict[str, Any]]:
-    """Reproduces PluginPortal.get_plugin_categories()'s exact algorithm.
-
-    ADR-014 stage 14.1: `plugin_registry`, when given, contributes every
-    discovered plugin's picker entries alongside the 8 built-ins BEFORE the
-    existing category-grouping loop runs, unchanged - a discovered entry's
-    `category` joining one of _CATEGORY_META's 5 fixed names lands in that
-    flyout exactly like a built-in would; any other category (including the
-    HostContext default "More Plugins") falls into the same synthetic
-    catch-all uncategorized entries already fall into."""
-    entries = list(_PLUGINS)
+    """Groups every discovered picker entry (both `picker_entries` - the
+    generic PluginNodeSeed path - and `builtin_actions` - the ADR-014 stage
+    14.3 first-party escape hatch the 8 migrated built-ins use) by
+    _CATEGORY_META, in that fixed order, skipping any category with zero
+    entries; anything uncategorized (including every entry whose category
+    doesn't match a _CATEGORY_META name) falls into a synthetic "More
+    Plugins" catch-all appended last. `plugin_registry=None` (the default)
+    yields an empty listing - unlike the pre-14.3 hardcoded 8, there is no
+    picker entry that exists independent of a real discovered registry
+    anymore."""
+    entries: list[tuple[str, str, str]] = []
     if plugin_registry is not None:
         entries += [
             (entry.name, entry.description, entry.category)
             for entry in plugin_registry.picker_entries.values()
+        ]
+        entries += [
+            (spec.name, spec.description, spec.category)
+            for spec in plugin_registry.builtin_actions.values()
         ]
 
     categorized_names: set[str] = set()
@@ -144,11 +146,35 @@ async def _execute_discovered_plugin(
     name: str,
     parent_node_id: str | None,
 ):
-    """ADR-014 stage 14.1: the generic executePlugin path for anything
-    discover_plugins() found that is NOT a built-in _PLUGINS name. Kept as
-    a top-level function (not nested inside register_plugins) so
-    register_plugins itself stays under tests/test_register_function_length.py's
-    300-line register* cap."""
+    """The single executePlugin dispatch path for EVERY name - built-in or
+    third-party alike, since ADR-014 stage 14.3 migrated the last hardcoded
+    branch off this file. Extracted to a top-level function (not nested
+    inside register_plugins) so register_plugins itself stays under
+    tests/test_register_function_length.py's 300-line register* cap.
+
+    Two registration mechanisms, checked in this order:
+
+    1. `plugin_registry.builtin_actions` - ADR-014 stage 14.3's first-party
+       escape hatch (HostContext.register_builtin_plugin). 'handler' is
+       SYNC and does its own record_command/parent-validation internally,
+       exactly like the pre-migration hardcoded branch it replaces - this
+       uniform post-handler publish rule ("scene" if the handler returned a
+       real id, else "notification") matches every one of the 8 migrated
+       branches, including System Prompt's dedup path, which publishes
+       "scene" and returns an EXISTING id without creating anything new.
+    2. `plugin_registry.picker_entries` (via resolve_picker_name) - the
+       generic PluginNodeSeed/add_plugin_node path every third-party plugin
+       (and the two demo plugins, hello_node/counter_node) uses.
+
+    A name matching neither shows the same "Unknown plugin" warning
+    regardless of which mechanism a real match would have used."""
+    builtin_spec = plugin_registry.builtin_actions.get(name)
+    if builtin_spec is not None:
+        run_ctx = PluginRunContext(plugin_id=builtin_spec.plugin_id, notifications=notifications)
+        result = builtin_spec.handler(canvas_document, run_ctx, parent_node_id)
+        await bus.publish("scene" if result is not None else "notification")
+        return result
+
     resolved = plugin_registry.resolve_picker_name(name)
     if resolved is None:
         notifications.show(f'Unknown plugin: "{name}"', "warning")
@@ -197,8 +223,15 @@ def register_plugins(
     # the signature and every existing call site
     # (register_plugins(bus, notifications_state, canvas_document)) are
     # otherwise UNCHANGED.
+    #
+    # ADR-014 stage 14.3: no more `builtin_names=` argument here - the 8
+    # built-ins are real discovered plugins now, checked for name
+    # collisions against every OTHER plugin the same way any two plugins
+    # are (PluginRegistry.picker_entries/builtin_actions, via
+    # _merge_into_registry in backend/plugin_sdk.py), not via a
+    # separately-supplied reserved-name set.
     if plugin_registry is None:
-        plugin_registry = discover_plugins(builtin_names=frozenset(p[0] for p in _PLUGINS))
+        plugin_registry = discover_plugins()
 
     # ADR-014 stage 14.2: populate the live-wire half of the Plugin SDK's
     # generic persistence seam - see SceneDocument.plugin_node_serializers'
@@ -219,239 +252,13 @@ def register_plugins(
 
     async def execute_plugin(plugin_name: str, parent_node_id: str | None = None):
         name = str(plugin_name).strip()
-        valid_names = {p[0] for p in _PLUGINS}
-        if name not in valid_names:
-            # ADR-014 stage 14.1: not a built-in name - the generic plugin-SDK
-            # path (a discovered plugin's picker entry), extracted to a
-            # top-level helper so register_plugins itself stays under the
-            # 300-line register* cap (tests/test_register_function_length.py).
-            return await _execute_discovered_plugin(
-                bus, notifications, canvas_document, plugin_registry, name, parent_node_id,
-            )
-
-        if name == "Web Research":
-            # R5.1: the first real node-creation plugin - every other plugin
-            # name below is still an honest deferred notice. A Web Research
-            # node is a branch-point child (same posture as thinking/html/
-            # image/conversation nodes), so it always requires a real, valid
-            # parent to branch from - there is no unparented/root form.
-            if not parent_node_id or parent_node_id not in canvas_document.nodes:
-                notifications.show(
-                    "Please select a valid node to branch from before adding a Web Node.",
-                    "warning",
-                )
-                await bus.publish("notification")
-                return None
-            parent = canvas_document.nodes[parent_node_id]
-            node, _command = canvas_document.record_command(
-                "pluginWebResearch", "user",
-                lambda: canvas_document.add_web_research_node(
-                    parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
-                ),
-                node_ids=[parent_node_id],
-            )
-            await bus.publish("scene")
-            return node.id
-
-        if name == "Gitlink":
-            # R5.3: the third real node-creation plugin, same posture as Web
-            # Research/Artifact above - Gitlink is a branch-point child (same
-            # as thinking/html/image/conversation/web_research/artifact
-            # nodes), so it always requires a real, valid parent to branch
-            # from - there is no unparented/root form (confirmed against
-            # graphlink_plugin_portal.py's own no_selection_message/
-            # invalid_parent_message for Gitlink).
-            if not parent_node_id or parent_node_id not in canvas_document.nodes:
-                notifications.show(
-                    "Please select a valid node to branch from before adding a Gitlink node.",
-                    "warning",
-                )
-                await bus.publish("notification")
-                return None
-            parent = canvas_document.nodes[parent_node_id]
-            node, _command = canvas_document.record_command(
-                "pluginGitlink", "user",
-                lambda: canvas_document.add_gitlink_node(
-                    parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
-                ),
-                node_ids=[parent_node_id],
-            )
-            await bus.publish("scene")
-            return node.id
-
-        if name == "Py-Coder":
-            # R5.4: the fourth real node-creation plugin, same posture as
-            # Web Research/Artifact/Gitlink above - Py-Coder is a
-            # branch-point child (same as thinking/html/image/conversation/
-            # web_research/artifact/gitlink nodes), so it always requires a
-            # real, valid parent to branch from - there is no unparented/
-            # root form.
-            if not parent_node_id or parent_node_id not in canvas_document.nodes:
-                notifications.show(
-                    "Please select a valid node to branch from before adding a Py-Coder node.",
-                    "warning",
-                )
-                await bus.publish("notification")
-                return None
-            parent = canvas_document.nodes[parent_node_id]
-            node, _command = canvas_document.record_command(
-                "pluginPyCoder", "user",
-                lambda: canvas_document.add_pycoder_node(
-                    parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
-                ),
-                node_ids=[parent_node_id],
-            )
-            await bus.publish("scene")
-            return node.id
-
-        if name == "Virtual Environment Runner":
-            # R5.4: the fifth real node-creation plugin, same posture as
-            # every prior real node-creation plugin above.
-            if not parent_node_id or parent_node_id not in canvas_document.nodes:
-                notifications.show(
-                    "Please select a valid node to branch from before adding a Virtual Environment Runner node.",
-                    "warning",
-                )
-                await bus.publish("notification")
-                return None
-            parent = canvas_document.nodes[parent_node_id]
-            node, _command = canvas_document.record_command(
-                "pluginCodeSandbox", "user",
-                lambda: canvas_document.add_code_sandbox_node(
-                    parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
-                ),
-                node_ids=[parent_node_id],
-            )
-            await bus.publish("scene")
-            return node.id
-
-        if name == "Artifact / Drafter":
-            # R5.2: the second real node-creation plugin, same posture as
-            # Web Research above - an Artifact node is a branch-point child
-            # (same as thinking/html/image/conversation/web_research nodes),
-            # so it always requires a real, valid parent to branch from -
-            # there is no unparented/root form.
-            if not parent_node_id or parent_node_id not in canvas_document.nodes:
-                notifications.show(
-                    "Please select a valid node to branch from before adding an Artifact node.",
-                    "warning",
-                )
-                await bus.publish("notification")
-                return None
-            parent = canvas_document.nodes[parent_node_id]
-            node, _command = canvas_document.record_command(
-                "pluginArtifact", "user",
-                lambda: canvas_document.add_artifact_node(
-                    parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
-                ),
-                node_ids=[parent_node_id],
-            )
-            await bus.publish("scene")
-            return node.id
-
-        if name == "System Prompt":
-            # R6.1: the sixth real node-creation plugin, same "requires a
-            # real, valid parent_node_id" posture as every real
-            # node-creation plugin above - legacy places a System Prompt
-            # note near/above a branch root, which only makes sense relative
-            # to a selected node. UNLIKE the branch-point-child plugins
-            # above (which attach as a CHILD of parent_node_id, one
-            # MESSAGE_VERTICAL_SPACING below it), this note attaches to
-            # parent_node_id's BRANCH ROOT (SceneDocument.get_branch_root -
-            # the same parent-edge walk backend/agents.py's
-            # _resolve_branch_system_prompt uses at send time), positioned
-            # roughly 150px ABOVE that root, and connects note -> root (the
-            # edge DIRECTION _resolve_branch_system_prompt looks for -
-            # reversed from the child-plugins' root -> child edges above).
-            if not parent_node_id or parent_node_id not in canvas_document.nodes:
-                notifications.show(
-                    "Please select a valid node to branch from before adding a System Prompt node.",
-                    "warning",
-                )
-                await bus.publish("notification")
-                return None
-            root = canvas_document.get_branch_root(parent_node_id)
-            # A root can only ever have ONE effective system-prompt note -
-            # backend/agents.py._resolve_branch_system_prompt has no
-            # deterministic "which one wins" rule for two at once. Reuse an
-            # existing one instead of creating a silently-inert duplicate.
-            existing = next(
-                (
-                    canvas_document.nodes[edge.source]
-                    for edge in canvas_document.edges.values()
-                    if edge.target == root.id
-                    and edge.source in canvas_document.nodes
-                    and canvas_document.nodes[edge.source].kind == "note"
-                    and canvas_document.nodes[edge.source].state.is_system_prompt
-                ),
-                None,
-            )
-            if existing is not None:
-                await bus.publish("scene")
-                return existing.id
-            # The only plugin branch that creates AND connects - both are
-            # captured by one command, so undoing it removes the note and
-            # its edge together rather than leaving a dangling edge.
-            def _create_system_prompt_note():
-                created = canvas_document.add_note(root.x, root.y - 150, is_system_prompt=True)
-                canvas_document.connect(created.id, root.id)
-                return created
-
-            note, _command = canvas_document.record_command(
-                "pluginSystemPrompt", "user", _create_system_prompt_note,
-                node_ids=[root.id],
-            )
-            await bus.publish("scene")
-            return note.id
-
-        if name == "Conversation Node":
-            # R7.5a: ConversationNode has existed since R3.25 with zero
-            # creation path - add_conversation_node was only ever reachable
-            # from backend tests, never from a real UI action. Same
-            # "branch-point child, real valid parent required" posture as
-            # every real node-creation plugin above.
-            if not parent_node_id or parent_node_id not in canvas_document.nodes:
-                notifications.show(
-                    "Please select a valid node to branch from before adding a Conversation Node.",
-                    "warning",
-                )
-                await bus.publish("notification")
-                return None
-            parent = canvas_document.nodes[parent_node_id]
-            node, _command = canvas_document.record_command(
-                "pluginConversationNode", "user",
-                lambda: canvas_document.add_conversation_node(parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id),
-                node_ids=[parent_node_id],
-            )
-            await bus.publish("scene")
-            return node.id
-
-        if name == "HTML Renderer":
-            # R7.5a: HtmlViewNode has existed since R3.17 with zero creation
-            # path, same gap class as Conversation Node above. Starts with
-            # empty html_content - the same "create blank, then edit in
-            # place" posture add_note's System Prompt branch above and the
-            # plain "Add Note" command already use, since the plugin picker
-            # has no field to source initial HTML from.
-            if not parent_node_id or parent_node_id not in canvas_document.nodes:
-                notifications.show(
-                    "Please select a valid node to branch from before adding an HTML Renderer node.",
-                    "warning",
-                )
-                await bus.publish("notification")
-                return None
-            parent = canvas_document.nodes[parent_node_id]
-            node, _command = canvas_document.record_command(
-                "pluginHtmlRenderer", "user",
-                lambda: canvas_document.add_html_node(parent.x, parent.y + MESSAGE_VERTICAL_SPACING, "", parent_node_id),
-                node_ids=[parent_node_id],
-            )
-            await bus.publish("scene")
-            return node.id
-
-        notifications.show(f'"{name}" node creation isn\'t available yet.', "info")
-        await bus.publish("notification")
-        return None
+        # ADR-014 stage 14.3: every name - built-in or third-party alike -
+        # flows through the same generic dispatch helper now. See
+        # _execute_discovered_plugin's own docstring for the two
+        # registration mechanisms it checks, in order.
+        return await _execute_discovered_plugin(
+            bus, notifications, canvas_document, plugin_registry, name, parent_node_id,
+        )
 
     bus.register_intent("app-plugins", "executePlugin", execute_plugin, args_schema=ExecutePluginArgs)
 

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -204,6 +204,7 @@ from backend.canvas import (
     _content_codec,
     _placeholder_chart_data,
 )
+from backend.plugin_sdk import NodeKindSpec, PluginRegistry, discover_plugins
 from graphlink_chart_data import ChartDataError, canonicalize_chart_data
 from graphlink_navigation_pins import NavigationPinRecord
 
@@ -738,6 +739,45 @@ def _restore_plan_payload(payload: dict[str, Any]) -> SceneNode:
     )
 
 
+def _restore_plugin_payload(payload: dict[str, Any], kind_spec: "NodeKindSpec") -> SceneNode:
+    """ADR-014 stage 14.2: the load-side mirror of session_save.py's
+    _serialize_plugin_node - restores the universal title/content/
+    is_collapsed fields that generic fallback always wrote, unconditionally
+    (every plugin-kind payload this project's own save path ever produced
+    carries them, with no opt-in required), then - only when THIS SAME
+    kind is still registered with a `deserialize` hook today - reconstructs
+    the plugin's own NodeState subclass from the isolated 'plugin_state'
+    dict serialize(node) most recently produced.
+
+    A plugin that dropped its serialize/deserialize opt-in since this node
+    was saved (or never had one) degrades to a plain title/content node
+    rather than losing it outright - matches every other per-kind
+    restorer's own "a missing/unusable piece of state is not fatal" posture
+    (e.g. _restore_gitlink_payload's repo_state/proposal_data isinstance
+    guards). The caller (_restore_node) is the one that decides whether to
+    call this at all - it requires `kind_spec` (i.e. the kind is currently
+    registered in the discovered PluginRegistry) BEFORE reaching here; an
+    unregistered plugin kind is treated exactly like any other unrecognized
+    node_type (skipped, not resurrected from a bare payload string with no
+    validation)."""
+    x, y = _position(payload)
+    kind = str(payload.get("node_type", "") or "")
+    title = str(payload.get("title", "") or kind)
+    content = str(payload.get("content", "") or "")
+    state = None
+    if kind_spec.deserialize is not None:
+        plugin_state = payload.get("plugin_state")
+        if isinstance(plugin_state, dict):
+            try:
+                state = kind_spec.deserialize(plugin_state)
+            except Exception:
+                state = None
+    return SceneNode(
+        id="", x=x, y=y, title=title, kind=kind, content=content, state=state,
+        is_collapsed=bool(payload.get("is_collapsed", False)),
+    )
+
+
 _NODE_RESTORERS = {
     "chat": lambda payload, document: _restore_chat_payload(payload),
     "code": lambda payload, document: _restore_code_payload(payload),
@@ -777,7 +817,11 @@ _CHILD_LINK_KINDS = {"chat", "conversation", "html"}
 
 
 def _restore_node(
-    document: SceneDocument, node_type: str, payload: dict[str, Any], all_nodes_map: dict[int, str],
+    document: SceneDocument,
+    node_type: str,
+    payload: dict[str, Any],
+    all_nodes_map: dict[int, str],
+    plugin_registry: "PluginRegistry | None" = None,
 ) -> tuple[SceneNode | None, str | None]:
     """Ports deserialize_node's own dispatch: default to "chat" for an
     untagged payload (old-old sessions predating the node_type tag), and
@@ -786,9 +830,30 @@ def _restore_node(
     fall-through / `if parent_node:` guard. Returns (node_or_None,
     resolved_parent_new_id_or_None) - the caller connects the edge itself
     once the node is registered, since register_restored_node needs to run
-    first to mint the child's own id."""
+    first to mint the child's own id.
+
+    ADR-014 stage 14.2: a node_type not in _NODE_RESTORERS at all is no
+    longer AUTOMATICALLY unrecognized - it now ALSO falls back to
+    `plugin_registry.node_kinds`, generic against whatever discover_
+    plugins() found (never a per-plugin branch here). This path returns
+    parent_new_id=None unconditionally (a plugin kind is never in
+    _PARENT_CONTENT_INDEX_KINDS/_PARENT_NODE_INDEX_KINDS - it has no legacy
+    index-based parent field to read at all) - its parent edge is restored
+    separately, generically, by _restore_flat_edges below (session_save.py
+    ALWAYS writes the authoritative flat `edges` list for any file this
+    project's own build produces, so this is not a gap for a plugin kind,
+    which only this project's own build could ever have written in the
+    first place)."""
     restorer = _NODE_RESTORERS.get(node_type or "chat")
     if restorer is None:
+        if plugin_registry is not None:
+            kind_spec = plugin_registry.node_kinds.get(node_type)
+            if kind_spec is not None:
+                try:
+                    plugin_node = _restore_plugin_payload(payload, kind_spec)
+                except Exception:
+                    return None, None
+                return document.register_restored_node(plugin_node), None
         return None, None
 
     parent_new_id: str | None = None
@@ -1231,21 +1296,32 @@ def restore_chat_into_document(
     notes_data: list,
     pins_data: list,
     asset_store: Any | None = None,
+    plugin_registry: "PluginRegistry | None" = None,
 ) -> None:
     """ADR-009 stage 9.5 entry point. Publishes `asset_store` for the
     duration of this restore (see _ACTIVE_ASSET_STORE's own comment for why
     a contextvar and not a parameter), then delegates. The reset is in a
     finally so a failed restore can never leave a stale store visible to
-    the next one."""
+    the next one.
+
+    ADR-014 stage 14.2: `plugin_registry` mirrors backend/session_save.py's
+    build_chat_data(..., plugin_registry=None) precedent exactly - None
+    (every real call site: backend/chat_library.py) triggers a real
+    discover_plugins() call, memoized by resolved path; tests inject a
+    specific registry for isolation."""
     token = _ACTIVE_ASSET_STORE.set(asset_store)
     try:
-        _restore_chat_into_document(document, chat, notes_data, pins_data)
+        _restore_chat_into_document(document, chat, notes_data, pins_data, plugin_registry)
     finally:
         _ACTIVE_ASSET_STORE.reset(token)
 
 
 def _restore_chat_into_document(
-    document: SceneDocument, chat: dict[str, Any], notes_data: list, pins_data: list,
+    document: SceneDocument,
+    chat: dict[str, Any],
+    notes_data: list,
+    pins_data: list,
+    plugin_registry: "PluginRegistry | None" = None,
 ) -> None:
     """The top-level orchestrator - ports SceneDeserializer.restore_chat()'s
     own exact ordering, reimplemented against SceneDocument. See this
@@ -1258,6 +1334,9 @@ def _restore_chat_into_document(
     escapes."""
     if not isinstance(chat, dict):
         raise ValueError("chat payload must be a mapping")
+
+    if plugin_registry is None:
+        plugin_registry = discover_plugins()
 
     document.clear_for_load()
 
@@ -1276,7 +1355,7 @@ def _restore_chat_into_document(
         if not isinstance(node_payload, dict):
             continue
         node_type = node_payload.get("node_type", "chat")
-        node, parent_new_id = _restore_node(document, node_type, node_payload, all_nodes_map)
+        node, parent_new_id = _restore_node(document, node_type, node_payload, all_nodes_map, plugin_registry)
         if node is not None:
             all_nodes_map[index] = node.id
             kind_by_new_id[node.id] = node.kind

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -207,6 +207,7 @@ from backend.canvas import (
 from backend.plugin_sdk import NodeKindSpec, PluginRegistry, discover_plugins
 from graphlink_chart_data import ChartDataError, canonicalize_chart_data
 from graphlink_navigation_pins import NavigationPinRecord
+from graphlink_settings_store import SettingsManager
 
 # ADR-009 stage 9.5: the asset store in effect for the CURRENT restore.
 #
@@ -739,7 +740,11 @@ def _restore_plan_payload(payload: dict[str, Any]) -> SceneNode:
     )
 
 
-def _restore_plugin_payload(payload: dict[str, Any], kind_spec: "NodeKindSpec") -> SceneNode:
+def _restore_plugin_payload(
+    payload: dict[str, Any],
+    kind_spec: "NodeKindSpec",
+    settings_manager: "SettingsManager | None" = None,
+) -> SceneNode:
     """ADR-014 stage 14.2: the load-side mirror of session_save.py's
     _serialize_plugin_node - restores the universal title/content/
     is_collapsed fields that generic fallback always wrote, unconditionally
@@ -759,13 +764,28 @@ def _restore_plugin_payload(payload: dict[str, Any], kind_spec: "NodeKindSpec") 
     registered in the discovered PluginRegistry) BEFORE reaching here; an
     unregistered plugin kind is treated exactly like any other unrecognized
     node_type (skipped, not resurrected from a bare payload string with no
-    validation)."""
+    validation).
+
+    ADR-014 review-fix: `settings_manager`, when given, gates the
+    kind_spec.deserialize(plugin_state) call on settings_manager.
+    get_plugin_grants() - the load-side mirror of session_save.py's
+    _serialize_plugin_node's own new grant check, see that function's
+    docstring for the full contract. `None` (this parameter's own default)
+    preserves the exact prior ungated behavior. A denied/ungranted node
+    still restores with its universal title/content fields; it just comes
+    back without its custom state for this one load, the same degrade this
+    function already applies when deserialize itself raises or the kind
+    dropped its opt-in entirely."""
     x, y = _position(payload)
     kind = str(payload.get("node_type", "") or "")
     title = str(payload.get("title", "") or kind)
     content = str(payload.get("content", "") or "")
     state = None
-    if kind_spec.deserialize is not None:
+    granted = (
+        settings_manager is None
+        or settings_manager.get_plugin_grants().get(kind_spec.plugin_id, False)
+    )
+    if granted and kind_spec.deserialize is not None:
         plugin_state = payload.get("plugin_state")
         if isinstance(plugin_state, dict):
             try:
@@ -822,6 +842,7 @@ def _restore_node(
     payload: dict[str, Any],
     all_nodes_map: dict[int, str],
     plugin_registry: "PluginRegistry | None" = None,
+    settings_manager: "SettingsManager | None" = None,
 ) -> tuple[SceneNode | None, str | None]:
     """Ports deserialize_node's own dispatch: default to "chat" for an
     untagged payload (old-old sessions predating the node_type tag), and
@@ -850,7 +871,7 @@ def _restore_node(
             kind_spec = plugin_registry.node_kinds.get(node_type)
             if kind_spec is not None:
                 try:
-                    plugin_node = _restore_plugin_payload(payload, kind_spec)
+                    plugin_node = _restore_plugin_payload(payload, kind_spec, settings_manager)
                 except Exception:
                     return None, None
                 return document.register_restored_node(plugin_node), None
@@ -1297,6 +1318,7 @@ def restore_chat_into_document(
     pins_data: list,
     asset_store: Any | None = None,
     plugin_registry: "PluginRegistry | None" = None,
+    settings_manager: "SettingsManager | None" = None,
 ) -> None:
     """ADR-009 stage 9.5 entry point. Publishes `asset_store` for the
     duration of this restore (see _ACTIVE_ASSET_STORE's own comment for why
@@ -1308,10 +1330,16 @@ def restore_chat_into_document(
     build_chat_data(..., plugin_registry=None) precedent exactly - None
     (every real call site: backend/chat_library.py) triggers a real
     discover_plugins() call, memoized by resolved path; tests inject a
-    specific registry for isolation."""
+    specific registry for isolation.
+
+    ADR-014 review-fix: `settings_manager`, when given, is threaded down to
+    _restore_plugin_payload so a plugin's own deserialize hook is gated on
+    its current Settings > Plugins grant - the load-side mirror of
+    build_chat_data's own new `settings_manager` parameter. `None` (this
+    parameter's own default) preserves the exact prior ungated behavior."""
     token = _ACTIVE_ASSET_STORE.set(asset_store)
     try:
-        _restore_chat_into_document(document, chat, notes_data, pins_data, plugin_registry)
+        _restore_chat_into_document(document, chat, notes_data, pins_data, plugin_registry, settings_manager)
     finally:
         _ACTIVE_ASSET_STORE.reset(token)
 
@@ -1322,6 +1350,7 @@ def _restore_chat_into_document(
     notes_data: list,
     pins_data: list,
     plugin_registry: "PluginRegistry | None" = None,
+    settings_manager: "SettingsManager | None" = None,
 ) -> None:
     """The top-level orchestrator - ports SceneDeserializer.restore_chat()'s
     own exact ordering, reimplemented against SceneDocument. See this
@@ -1355,7 +1384,9 @@ def _restore_chat_into_document(
         if not isinstance(node_payload, dict):
             continue
         node_type = node_payload.get("node_type", "chat")
-        node, parent_new_id = _restore_node(document, node_type, node_payload, all_nodes_map, plugin_registry)
+        node, parent_new_id = _restore_node(
+            document, node_type, node_payload, all_nodes_map, plugin_registry, settings_manager,
+        )
         if node is not None:
             all_nodes_map[index] = node.id
             kind_by_new_id[node.id] = node.kind

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -110,11 +110,13 @@ from __future__ import annotations
 
 import contextvars
 import json
+import logging
 import re
 from typing import Any
 
 from backend.canvas import SceneDocument, SceneNode, _content_codec
 from backend.plugin_sdk import NodeKindSpec, PluginRegistry, discover_plugins
+from graphlink_settings_store import SettingsManager
 
 # ADR-009 stage 9.5: the asset store in effect for the CURRENT save. Same
 # contextvar rationale as session_load.py's own _ACTIVE_ASSET_STORE - the
@@ -425,7 +427,11 @@ def _serialize_plan_node(node: SceneNode) -> dict[str, Any]:
     }
 
 
-def _serialize_plugin_node(node: SceneNode, kind_spec: "NodeKindSpec | None") -> dict[str, Any]:
+def _serialize_plugin_node(
+    node: SceneNode,
+    kind_spec: "NodeKindSpec | None",
+    settings_manager: "SettingsManager | None" = None,
+) -> dict[str, Any]:
     """ADR-014 stage 14.2: the generic persistence fallback for any node
     whose kind is not one of the built-ins above (i.e. not a key in
     _NODE_SERIALIZERS) - a Plugin SDK node kind, always namespaced as
@@ -452,7 +458,23 @@ def _serialize_plugin_node(node: SceneNode, kind_spec: "NodeKindSpec | None") ->
     (every other node on the canvas) either - it just drops its own extra
     state for this one node, the same "one bad item never sinks everything"
     posture every other per-kind serializer/restorer in this file and
-    session_load.py already keeps."""
+    session_load.py already keeps.
+
+    ADR-014 review-fix: `settings_manager`, when given, gates the actual
+    kind_spec.serialize(node) call on settings_manager.get_plugin_grants()
+    - the SAME install-time consent check node creation/invokePluginIntent/
+    register_plugin_tools already enforce before running a plugin's own
+    code, extended to this save-path call site (this was the one place a
+    revoked plugin's serializer kept running unconditionally, since a save
+    happens outside any one session's live SceneDocument and previously had
+    no access to Settings > Plugins' grant state at all). `None` (every
+    call site this project's own test suite that predates this fix uses)
+    preserves the exact prior ungated behavior - see build_chat_data's own
+    docstring for why that default is safe. A denied/ungranted node still
+    round-trips its universal title/content/is_collapsed fields; it just
+    loses its custom plugin_state for this one save, matching the
+    already-raising-serializer degrade path immediately below rather than
+    inventing a new failure mode."""
     payload: dict[str, Any] = {
         "node_type": node.kind,
         "title": node.title,
@@ -460,17 +482,30 @@ def _serialize_plugin_node(node: SceneNode, kind_spec: "NodeKindSpec | None") ->
         "is_collapsed": bool(node.is_collapsed),
     }
     if kind_spec is not None and kind_spec.serialize is not None:
-        try:
-            extra = kind_spec.serialize(node)
-        except Exception:
-            extra = None
-        if isinstance(extra, dict):
+        granted = (
+            settings_manager is None
+            or settings_manager.get_plugin_grants().get(kind_spec.plugin_id, False)
+        )
+        if granted:
             try:
-                json.dumps(extra)  # validate JSON-safety NOW, isolated to this one node
-            except (TypeError, ValueError):
+                extra = kind_spec.serialize(node)
+            except Exception:
+                # ADR-014 review-fix: logged, matching the wire-path
+                # equivalent's own exact message shape (backend/domain/
+                # graph.py's _plugin_state_wire) - previously this dropped a
+                # raising plugin serializer with zero signal anywhere,
+                # unlike every other place a plugin's own code runs.
+                logging.warning(
+                    "plugin node %s (%s): serialize hook raised", node.id, node.kind, exc_info=True,
+                )
                 extra = None
-        if isinstance(extra, dict):
-            payload["plugin_state"] = extra
+            if isinstance(extra, dict):
+                try:
+                    json.dumps(extra)  # validate JSON-safety NOW, isolated to this one node
+                except (TypeError, ValueError):
+                    extra = None
+            if isinstance(extra, dict):
+                payload["plugin_state"] = extra
     return payload
 
 
@@ -717,6 +752,7 @@ def build_chat_data(
     document: SceneDocument,
     asset_store: Any | None = None,
     plugin_registry: "PluginRegistry | None" = None,
+    settings_manager: "SettingsManager | None" = None,
 ) -> dict[str, Any]:
     """ADR-009 stage 9.5 entry point. Publishes `asset_store` for the
     duration of this save so _serialize_image_node can externalize bytes
@@ -729,16 +765,28 @@ def build_chat_data(
     triggers a real discover_plugins() call, memoized by resolved path so
     repeat saves within one process pay no rescan cost; tests inject a
     specific registry for isolation, the same reason register_plugins
-    itself takes this same parameter."""
+    itself takes this same parameter.
+
+    ADR-014 review-fix: `settings_manager`, when given, is threaded down to
+    _serialize_plugin_node so a plugin's own serialize hook is gated on its
+    current Settings > Plugins grant, the same install-time consent check
+    node creation already enforces - see that function's own docstring for
+    the exact contract. `None` (this parameter's own default, and every
+    call site in this project's test suite that predates this fix) means
+    "no grant store available" and preserves the exact prior ungated
+    behavior - real production callers (backend/chat_library.py's saveChat,
+    backend/autosave.py's tick) pass a real one."""
     token = _ACTIVE_SAVE_ASSET_STORE.set(asset_store)
     try:
-        return _build_chat_data(document, plugin_registry)
+        return _build_chat_data(document, plugin_registry, settings_manager)
     finally:
         _ACTIVE_SAVE_ASSET_STORE.reset(token)
 
 
 def _build_chat_data(
-    document: SceneDocument, plugin_registry: "PluginRegistry | None" = None,
+    document: SceneDocument,
+    plugin_registry: "PluginRegistry | None" = None,
+    settings_manager: "SettingsManager | None" = None,
 ) -> dict[str, Any]:
     """The top-level orchestrator - ports SceneSerializer.serialize_chat_
     data()'s own exact top-level shape. notes_data/pins_data are nested
@@ -814,7 +862,7 @@ def _build_chat_data(
             # filter above already guarantees this is a currently-
             # recognized plugin kind, so the generic fallback below (never
             # a per-plugin branch) is what persists it.
-            payload = _serialize_plugin_node(node, plugin_kinds.get(node.kind))
+            payload = _serialize_plugin_node(node, plugin_kinds.get(node.kind), settings_manager)
         payload["position"] = _position(node)
         payload["id"] = node.id
 

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -109,10 +109,12 @@ dedicated recon/design/test cycle, not bolted onto a serializer):
 from __future__ import annotations
 
 import contextvars
+import json
 import re
 from typing import Any
 
 from backend.canvas import SceneDocument, SceneNode, _content_codec
+from backend.plugin_sdk import NodeKindSpec, PluginRegistry, discover_plugins
 
 # ADR-009 stage 9.5: the asset store in effect for the CURRENT save. Same
 # contextvar rationale as session_load.py's own _ACTIVE_ASSET_STORE - the
@@ -423,6 +425,55 @@ def _serialize_plan_node(node: SceneNode) -> dict[str, Any]:
     }
 
 
+def _serialize_plugin_node(node: SceneNode, kind_spec: "NodeKindSpec | None") -> dict[str, Any]:
+    """ADR-014 stage 14.2: the generic persistence fallback for any node
+    whose kind is not one of the built-ins above (i.e. not a key in
+    _NODE_SERIALIZERS) - a Plugin SDK node kind, always namespaced as
+    f"{plugin_id}.{kind}" (backend/plugin_sdk.py's HostContext.
+    register_node_kind). Always persists the same universal fields
+    SceneDocument.add_plugin_node/_node_wire already guarantee exist for
+    EVERY node regardless of kind - node_type/title/content/is_collapsed -
+    so a plugin with no NodeState subclass at all (like plugins/hello_node/,
+    which fits its one string in `content`) still round-trips through
+    save/reload with zero opt-in.
+
+    `kind_spec` is `None` when this save's PluginRegistry doesn't currently
+    recognize the node's kind at all (a plugin removed/renamed since this
+    node was created) - the universal fields above still get written (a
+    later reload's own registry-membership check decides whether to
+    restore the node at all; see session_load.py's own _restore_node), this
+    function itself never drops a node outright.
+
+    When the plugin DID opt into HostContext.register_node_kind(...,
+    serialize=...), that hook's own dict is nested under 'plugin_state' -
+    deliberately isolated from the universal fields above so a raising or
+    non-JSON-serializable plugin serializer can never corrupt title/content/
+    is_collapsed sitting right next to it, and never abort the WHOLE save
+    (every other node on the canvas) either - it just drops its own extra
+    state for this one node, the same "one bad item never sinks everything"
+    posture every other per-kind serializer/restorer in this file and
+    session_load.py already keeps."""
+    payload: dict[str, Any] = {
+        "node_type": node.kind,
+        "title": node.title,
+        "content": node.content,
+        "is_collapsed": bool(node.is_collapsed),
+    }
+    if kind_spec is not None and kind_spec.serialize is not None:
+        try:
+            extra = kind_spec.serialize(node)
+        except Exception:
+            extra = None
+        if isinstance(extra, dict):
+            try:
+                json.dumps(extra)  # validate JSON-safety NOW, isolated to this one node
+            except (TypeError, ValueError):
+                extra = None
+        if isinstance(extra, dict):
+            payload["plugin_state"] = extra
+    return payload
+
+
 _NODE_SERIALIZERS = {
     "chat": lambda node, document: _serialize_chat_node(node),
     "code": lambda node, document: _serialize_code_node(node),
@@ -662,19 +713,33 @@ def _classify_edges(
     }
 
 
-def build_chat_data(document: SceneDocument, asset_store: Any | None = None) -> dict[str, Any]:
+def build_chat_data(
+    document: SceneDocument,
+    asset_store: Any | None = None,
+    plugin_registry: "PluginRegistry | None" = None,
+) -> dict[str, Any]:
     """ADR-009 stage 9.5 entry point. Publishes `asset_store` for the
     duration of this save so _serialize_image_node can externalize bytes
     instead of inlining base64, then delegates. Reset in a finally so a
-    failed save cannot leave a stale store visible to the next one."""
+    failed save cannot leave a stale store visible to the next one.
+
+    ADR-014 stage 14.2: `plugin_registry` mirrors backend/plugins.py's own
+    register_plugins(..., plugin_registry=None) precedent exactly - None
+    (every real call site: backend/chat_library.py, backend/autosave.py)
+    triggers a real discover_plugins() call, memoized by resolved path so
+    repeat saves within one process pay no rescan cost; tests inject a
+    specific registry for isolation, the same reason register_plugins
+    itself takes this same parameter."""
     token = _ACTIVE_SAVE_ASSET_STORE.set(asset_store)
     try:
-        return _build_chat_data(document)
+        return _build_chat_data(document, plugin_registry)
     finally:
         _ACTIVE_SAVE_ASSET_STORE.reset(token)
 
 
-def _build_chat_data(document: SceneDocument) -> dict[str, Any]:
+def _build_chat_data(
+    document: SceneDocument, plugin_registry: "PluginRegistry | None" = None,
+) -> dict[str, Any]:
     """The top-level orchestrator - ports SceneSerializer.serialize_chat_
     data()'s own exact top-level shape. notes_data/pins_data are nested
     INSIDE this single returned dict (matching legacy's own
@@ -682,7 +747,22 @@ def _build_chat_data(document: SceneDocument) -> dict[str, Any]:
     saveChat intent) pops them back out before writing, mirroring
     SaveWorkerThread.run()'s own `self.chat_data.get("notes_data", [])`
     pattern precisely."""
-    all_nodes = [n for n in document.nodes.values() if n.kind in _REGULAR_KINDS]
+    if plugin_registry is None:
+        plugin_registry = discover_plugins()
+    # ADR-014 stage 14.2: a plugin-registered node kind (namespaced
+    # "plugin_id.kind", so it can never collide with _REGULAR_KINDS) is
+    # now ALSO a "regular" node for save purposes - included in the exact
+    # same `all_nodes` list/index/parent-tracking machinery below rather
+    # than a parallel code path, so every one of the invariants this
+    # module's own docstring documents (nodes_index, the edge classifier,
+    # children_indices, ...) already covers it too. Adding a NEW plugin
+    # later needs zero changes here: this membership check is generic
+    # against whatever discover_plugins() finds, not a per-plugin branch.
+    plugin_kinds = plugin_registry.node_kinds
+    all_nodes = [
+        n for n in document.nodes.values()
+        if n.kind in _REGULAR_KINDS or n.kind in plugin_kinds
+    ]
     notes = [n for n in document.nodes.values() if n.kind == "note"]
     charts = [n for n in document.nodes.values() if n.kind == "chart"]
     frames = [n for n in document.nodes.values() if n.kind == "frame"]
@@ -727,9 +807,14 @@ def _build_chat_data(document: SceneDocument) -> dict[str, Any]:
     node_payloads: list[dict[str, Any]] = []
     for node in all_nodes:
         serializer = _NODE_SERIALIZERS.get(node.kind)
-        if serializer is None:
-            continue
-        payload = serializer(node, document)
+        if serializer is not None:
+            payload = serializer(node, document)
+        else:
+            # ADR-014 stage 14.2: not a built-in kind - the `all_nodes`
+            # filter above already guarantees this is a currently-
+            # recognized plugin kind, so the generic fallback below (never
+            # a per-plugin branch) is what persists it.
+            payload = _serialize_plugin_node(node, plugin_kinds.get(node.kind))
         payload["position"] = _position(node)
         payload["id"] = node.id
 

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -377,7 +377,7 @@ def test_junk_args_never_crash_or_disconnect_any_registered_intent():
         assert ws.receive_json()["kind"] == "result"
 
 
-def test_args_schema_is_scoped_to_exactly_the_3_intents_this_stage_migrated():
+def test_args_schema_is_scoped_to_exactly_the_known_5_intents():
     # ADR-003 stage 3.2 review-fix: the fuzz sweep above proves every intent
     # replies safely, but it only checks message["kind"], not the error TEXT
     # - a schema-validation rejection and an unmigrated handler's own generic
@@ -385,9 +385,14 @@ def test_args_schema_is_scoped_to_exactly_the_3_intents_this_stage_migrated():
     # sweep alone could not catch a FUTURE mutation that accidentally added
     # (or removed) an args_schema on the wrong intent. This test asserts the
     # real registry's args_schema is not None set directly against the exact
-    # 3 intents this stage's own PR description claims to have migrated -
-    # silent scope drift on this security/correctness-adjacent mechanism
-    # would fail here even though it wouldn't fail the fuzz sweep.
+    # intents that carry one - silent scope drift on this security/
+    # correctness-adjacent mechanism would fail here even though it wouldn't
+    # fail the fuzz sweep. Originally the exact 3 intents ADR-003 stage 3.2's
+    # own PR description claimed to have migrated (showInfo/showError/
+    # executePlugin); ADR-014 stage 14.4 added 2 more
+    # (invokePluginIntent/setPluginGrant), both deliberately, not drift -
+    # a real intentional additions to this set updates it explicitly, the
+    # same discipline this test itself exists to enforce.
     client = make_client()
     with client.websocket_connect("/ws") as ws:
         ws.send_json({"kind": "subscribe", "topics": ["system"]})
@@ -402,6 +407,8 @@ def test_args_schema_is_scoped_to_exactly_the_3_intents_this_stage_migrated():
             ("notification", "showInfo"),
             ("notification", "showError"),
             ("app-plugins", "executePlugin"),
+            ("app-plugins", "invokePluginIntent"),
+            ("app-plugins", "setPluginGrant"),
         }
 
 

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -1468,8 +1468,22 @@ class TestBackupRotationThroughRealSaves:
         # survive via the daily rule) plus a SECOND, older-still snapshot on
         # THAT SAME older day (must be pruned - not the newest for its day).
         recent_timestamps = [now - timedelta(minutes=i) for i in range(db_backup_module.KEEP_MOST_RECENT)]
-        older_day_keep = now - timedelta(days=2, hours=1)
-        older_day_prune = now - timedelta(days=2, hours=5)
+        # Anchored at a fixed noon-UTC time-of-day, 2 days back, rather than
+        # naive `now - timedelta(hours=N)` offsets: a real CI failure showed
+        # that when the real wall-clock `now` a test runs at happens to fall
+        # within a few hours of UTC midnight, `now - timedelta(days=2,
+        # hours=1)` and `now - timedelta(days=2, hours=5)` can land on TWO
+        # DIFFERENT UTC calendar days (the 4-hour gap between them straddles
+        # the boundary) - at which point prune_backups (correctly) keeps
+        # BOTH as "the newest for its own day," and this test's own
+        # assertion that the older one gets pruned fails - a test bug, not a
+        # prune_backups bug (its day-bucketing logic, backend/db_backup.py,
+        # is correct). Anchoring at noon and offsetting by only ±a few hours
+        # keeps both timestamps on the SAME calendar day regardless of what
+        # real time this test happens to run at.
+        anchor_day = (now - timedelta(days=2)).replace(hour=12, minute=0, second=0, microsecond=0)
+        older_day_keep = anchor_day + timedelta(hours=1)
+        older_day_prune = anchor_day - timedelta(hours=3)
         for ts in recent_timestamps + [older_day_keep, older_day_prune]:
             path = backups_dir / db_backup_module.backup_filename(ts.strftime("%Y%m%dT%H%M%SZ"))
             sqlite3.connect(path).close()

--- a/backend/tests/test_code_sandbox_domain.py
+++ b/backend/tests/test_code_sandbox_domain.py
@@ -1,0 +1,736 @@
+"""ADR-014 H3: graphlink_plugins/code_sandbox/domain.py had ZERO direct unit
+tests before this file - only indirect coverage via backend/tests/
+test_execution_guard.py (guard wiring only), test_scratch_dirs.py (scratch-dir
+plumbing only) and test_code_sandbox_only_binary.py (the --only-binary
+security fix only). None of those exercise this module's OWN logic: request
+normalization/extraction, the two LLM-calling agents, VirtualEnvSandbox's
+stop()/cleanup semantics, or sync_requirements' caching branch. This file
+closes that gap directly, mirroring the real-subprocess-where-it-matters /
+mock-only-what's-heavy-or-flaky discipline the three files above already
+established for this exact module and its siblings (PythonREPL).
+
+Layout:
+  - Pure functions (_normalize_requirements, _extract_python_block,
+    _subprocess_kwargs) - fast, no subprocess, no mocks needed.
+  - The two LLM agents - api_provider.chat mocked (matches conftest.py's own
+    autouse chat_stream fixture's established pattern: patch api_provider's
+    module attribute, never the class in isolation).
+  - VirtualEnvSandbox construction/python_executable - fast, no I/O.
+  - VirtualEnvSandbox.stop() - MagicMock processes for the exception/fallback
+    branches (mirrors test_execution_guard.py's _FakeGuard technique).
+  - VirtualEnvSandbox._run_subprocess/execute_code - real subprocesses for
+    the happy path, timeout, and interrupted-then-reused paths (a mock
+    cannot prove a real timeout or a real InterruptedError recovery works).
+  - VirtualEnvSandbox.sync_requirements - mock-based for the caching branch
+    (fast, deterministic), one real end-to-end failure case for genuinely
+    malformed manifest content (needs a real venv + real pip to prove the
+    RuntimeError path, same tradeoff test_code_sandbox_only_binary.py
+    already accepted for this same method).
+  - One full real end-to-end happy path: real venv creation +
+    real script execution, the "construct a sandbox, run simple Python, get
+    real output" case the plugin's users actually depend on.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import api_provider
+import graphlink_scratch_dirs as scratch_dirs
+import graphlink_task_config as task_config
+from graphlink_plugins.code_sandbox import domain as domain_module
+from graphlink_plugins.code_sandbox.domain import (
+    SandboxGenerationAgent,
+    SandboxRepairAgent,
+    SandboxStage,
+    VirtualEnvSandbox,
+    _extract_python_block,
+    _normalize_requirements,
+    _subprocess_kwargs,
+)
+
+
+# -- SandboxStage -------------------------------------------------------
+
+
+class TestSandboxStage:
+    def test_all_five_stages_exist_with_distinct_values(self):
+        # Cheap sanity pin on the enum this module exports as part of its
+        # public surface - nothing else in this file exercises it, and a
+        # careless edit (duplicate value, renamed member) would otherwise
+        # go completely unnoticed by every existing indirect caller.
+        assert [s.name for s in SandboxStage] == [
+            "GENERATE",
+            "PREPARE",
+            "INSTALL",
+            "EXECUTE",
+            "ANALYZE",
+        ]
+        assert len({s.value for s in SandboxStage}) == 5
+
+
+# -- _normalize_requirements ---------------------------------------------
+
+
+class TestNormalizeRequirements:
+    def test_crlf_and_cr_line_endings_both_become_lf(self):
+        assert _normalize_requirements("a\r\nb\rc\n") == "a\nb\nc"
+
+    def test_trailing_whitespace_is_stripped_per_line(self):
+        assert _normalize_requirements("foo   \nbar\t\n") == "foo\nbar"
+
+    def test_leading_whitespace_on_an_interior_line_is_preserved(self):
+        # str.strip() at the very end only trims the ENDS of the whole
+        # string - leading whitespace on a line that isn't the first or
+        # last line survives untouched. Worth pinning explicitly: it is
+        # easy to assume this function fully re-indents every line.
+        assert _normalize_requirements("a\n  b\nc") == "a\n  b\nc"
+
+    def test_leading_whitespace_on_the_first_line_is_stripped_as_a_side_effect(self):
+        # The mirror image of the test above: because this whitespace sits
+        # at the very START of the whole string, the final overall
+        # .strip() removes it - even though nothing in this function
+        # specifically targets "the first line".
+        assert _normalize_requirements("  foo\nbar") == "foo\nbar"
+
+    def test_blank_or_whitespace_only_input_normalizes_to_empty_string(self):
+        assert _normalize_requirements("") == ""
+        assert _normalize_requirements("   \n  \n\t") == ""
+
+    def test_blank_interior_lines_are_preserved_by_position(self):
+        assert _normalize_requirements("a\n\nb") == "a\n\nb"
+
+
+# -- _extract_python_block -------------------------------------------------
+
+
+class TestExtractPythonBlock:
+    def test_extracts_from_tool_python_tags_ignoring_surrounding_prose(self):
+        text = "Sure, here you go:\n[TOOL:PYTHON]\nprint('hi')\n[/TOOL]\nHope that helps!"
+        assert _extract_python_block(text) == "print('hi')"
+
+    def test_extracts_from_a_fenced_python_block_when_no_tool_tag_present(self):
+        text = "Here:\n```python\nprint('hi')\n```\n"
+        assert _extract_python_block(text) == "print('hi')"
+
+    def test_fenced_block_language_tag_is_case_insensitive(self):
+        text = "```PYTHON\nprint(1)\n```"
+        assert _extract_python_block(text) == "print(1)"
+
+    def test_tool_tag_takes_priority_over_a_fenced_block_when_both_present(self):
+        text = "[TOOL:PYTHON]\nprint('from tool')\n[/TOOL]\n```python\nprint('from fence')\n```"
+        assert _extract_python_block(text) == "print('from tool')"
+
+    def test_lowercase_tool_tag_is_not_recognized_case_sensitively(self):
+        # The [TOOL:PYTHON] regex has no re.IGNORECASE (unlike the fenced
+        # regex, which does) - a lowercase tag must fall through, not match.
+        text = "[tool:python]\nprint('nope')\n[/tool]"
+        assert _extract_python_block(text) is None
+
+    def test_a_bare_fence_with_no_language_tag_is_not_recognized(self):
+        text = "```\nprint('no language tag')\n```"
+        assert _extract_python_block(text) is None
+
+    def test_plain_prose_with_no_code_block_returns_none(self):
+        assert _extract_python_block("The answer is 4, no code needed.") is None
+
+    def test_extracted_code_is_stripped_of_surrounding_whitespace(self):
+        text = "[TOOL:PYTHON]\n\n   print(1)   \n\n[/TOOL]"
+        assert _extract_python_block(text) == "print(1)"
+
+
+# -- _subprocess_kwargs ----------------------------------------------------
+
+
+class TestSubprocessKwargs:
+    def test_env_key_is_always_present(self):
+        kwargs = _subprocess_kwargs()
+        assert "env" in kwargs
+        assert isinstance(kwargs["env"], dict)
+
+    def test_windows_adds_create_no_window(self, monkeypatch):
+        monkeypatch.setattr(domain_module.sys, "platform", "win32")
+        kwargs = _subprocess_kwargs()
+        assert kwargs["creationflags"] == subprocess.CREATE_NO_WINDOW
+
+    def test_non_windows_has_no_creationflags_key(self, monkeypatch):
+        monkeypatch.setattr(domain_module.sys, "platform", "linux")
+        kwargs = _subprocess_kwargs()
+        assert "creationflags" not in kwargs
+
+
+# -- SandboxGenerationAgent -------------------------------------------------
+
+
+class TestSandboxGenerationAgent:
+    def test_get_response_forwards_prompt_and_manifest_and_returns_the_reply(self, monkeypatch):
+        captured = {}
+
+        def fake_chat(task, messages, **kwargs):
+            captured["task"] = task
+            captured["messages"] = messages
+            return {"message": {"content": "print('ok')"}}
+
+        monkeypatch.setattr(api_provider, "chat", fake_chat)
+
+        agent = SandboxGenerationAgent()
+        result = agent.get_response(
+            conversation_history=[{"role": "user", "content": "earlier turn"}],
+            user_prompt="write a hello world script",
+            requirements_manifest="requests==2.31.0",
+        )
+
+        assert result == "print('ok')"
+        assert captured["task"] == task_config.TASK_CHAT
+        assert captured["messages"][0]["role"] == "system"
+        user_message = captured["messages"][1]["content"]
+        assert captured["messages"][1]["role"] == "user"
+        assert "earlier turn" in user_message
+        assert "requests==2.31.0" in user_message
+        assert "write a hello world script" in user_message
+
+    def test_an_empty_requirements_manifest_renders_as_none_specified(self, monkeypatch):
+        captured = {}
+
+        def fake_chat(task, messages, **kwargs):
+            captured["messages"] = messages
+            return {"message": {"content": "..."}}
+
+        monkeypatch.setattr(api_provider, "chat", fake_chat)
+
+        SandboxGenerationAgent().get_response(
+            conversation_history=[], user_prompt="hi", requirements_manifest=""
+        )
+
+        assert "[none specified]" in captured["messages"][1]["content"]
+
+
+# -- SandboxRepairAgent ------------------------------------------------------
+
+
+class TestSandboxRepairAgent:
+    def test_get_response_returns_raw_reply_when_no_fenced_block_present(self, monkeypatch):
+        monkeypatch.setattr(
+            api_provider, "chat", lambda task, messages, **kwargs: {"message": {"content": "  fixed_code()  "}}
+        )
+        result = SandboxRepairAgent().get_response(
+            code="broken_code()",
+            error_output="NameError: broken_code not defined",
+            requirements_manifest="",
+        )
+        assert result == "fixed_code()"
+
+    def test_get_response_extracts_code_from_a_fenced_reply(self, monkeypatch):
+        monkeypatch.setattr(
+            api_provider,
+            "chat",
+            lambda task, messages, **kwargs: {"message": {"content": "```python\nfixed_code()\n```"}},
+        )
+        result = SandboxRepairAgent().get_response(
+            code="broken_code()", error_output="boom", requirements_manifest=""
+        )
+        assert result == "fixed_code()"
+
+    def test_missing_original_prompt_falls_back_to_manual_execution_label(self, monkeypatch):
+        captured = {}
+
+        def fake_chat(task, messages, **kwargs):
+            captured["messages"] = messages
+            return {"message": {"content": "fixed()"}}
+
+        monkeypatch.setattr(api_provider, "chat", fake_chat)
+
+        SandboxRepairAgent().get_response(
+            code="x", error_output="y", requirements_manifest="", original_prompt=None
+        )
+
+        assert "[manual execution]" in captured["messages"][1]["content"]
+
+    def test_forwards_the_broken_code_and_error_output_verbatim(self, monkeypatch):
+        captured = {}
+
+        def fake_chat(task, messages, **kwargs):
+            captured["messages"] = messages
+            return {"message": {"content": "fixed()"}}
+
+        monkeypatch.setattr(api_provider, "chat", fake_chat)
+
+        SandboxRepairAgent().get_response(
+            code="def broken(:",
+            error_output="SyntaxError: invalid syntax",
+            requirements_manifest="numpy",
+            original_prompt="build a broken thing",
+        )
+
+        user_message = captured["messages"][1]["content"]
+        assert "def broken(:" in user_message
+        assert "SyntaxError: invalid syntax" in user_message
+        assert "numpy" in user_message
+        assert "build a broken thing" in user_message
+
+
+# -- VirtualEnvSandbox construction / python_executable ---------------------
+
+
+class TestVirtualEnvSandboxConstruction:
+    def test_paths_are_derived_from_the_sanitized_sandbox_id(self):
+        raw_id = "weird id/../etc"
+        sandbox = VirtualEnvSandbox(raw_id)
+
+        assert sandbox.base_dir.name == scratch_dirs.safe_scratch_id(raw_id)
+        assert sandbox.base_dir.parent == scratch_dirs.EXECUTION_SANDBOX_ROOT
+        assert sandbox.venv_dir == sandbox.base_dir / "venv"
+        assert sandbox.requirements_file == sandbox.base_dir / "requirements.txt"
+        assert sandbox.requirements_hash_file == sandbox.base_dir / ".requirements.sha256"
+        assert sandbox.script_path == sandbox.base_dir / "sandbox_entry.py"
+
+    def test_starts_with_no_process_or_guard(self):
+        sandbox = VirtualEnvSandbox("fresh-sandbox-test")
+        assert sandbox.current_process is None
+        assert sandbox.guard is None
+
+
+class TestPythonExecutableProperty:
+    def test_windows_points_at_scripts_python_exe(self, monkeypatch):
+        monkeypatch.setattr(domain_module.os, "name", "nt")
+        sandbox = VirtualEnvSandbox("python-exe-windows-test")
+        assert sandbox.python_executable == sandbox.venv_dir / "Scripts" / "python.exe"
+
+    def test_posix_points_at_bin_python(self, monkeypatch):
+        monkeypatch.setattr(domain_module.os, "name", "posix")
+        sandbox = VirtualEnvSandbox("python-exe-posix-test")
+        assert sandbox.python_executable == sandbox.venv_dir / "bin" / "python"
+
+
+# -- VirtualEnvSandbox.stop() -------------------------------------------
+
+
+class TestStop:
+    def test_stop_with_nothing_running_is_a_silent_no_op(self):
+        sandbox = VirtualEnvSandbox("stop-noop-test")
+        sandbox.stop()  # must not raise
+        assert sandbox.current_process is None
+        assert sandbox.guard is None
+
+    def test_stop_closes_a_guard_even_with_no_process(self):
+        sandbox = VirtualEnvSandbox("stop-guard-only-test")
+        fake_guard = MagicMock()
+        sandbox.guard = fake_guard
+        sandbox.stop()
+        fake_guard.close.assert_called_once()
+        assert sandbox.guard is None
+
+    def test_an_already_exited_process_is_not_terminated_again(self):
+        sandbox = VirtualEnvSandbox("stop-already-exited-test")
+        fake_process = MagicMock()
+        fake_process.poll.return_value = 0  # already exited
+        sandbox.current_process = fake_process
+        sandbox.stop()
+        fake_process.terminate.assert_not_called()
+        assert sandbox.current_process is None
+
+    def test_a_running_process_is_terminated_and_waited_on(self):
+        sandbox = VirtualEnvSandbox("stop-terminate-test")
+        fake_process = MagicMock()
+        fake_process.poll.return_value = None
+        sandbox.current_process = fake_process
+        sandbox.stop()
+        fake_process.terminate.assert_called_once()
+        fake_process.wait.assert_called_once_with(timeout=3)
+        fake_process.kill.assert_not_called()
+        assert sandbox.current_process is None
+
+    def test_terminate_raising_falls_back_to_kill(self):
+        sandbox = VirtualEnvSandbox("stop-terminate-raises-test")
+        fake_process = MagicMock()
+        fake_process.poll.return_value = None
+        fake_process.terminate.side_effect = OSError("access denied")
+        sandbox.current_process = fake_process
+        sandbox.stop()
+        fake_process.kill.assert_called_once()
+        assert sandbox.current_process is None
+
+    def test_wait_timing_out_after_terminate_falls_back_to_kill(self):
+        sandbox = VirtualEnvSandbox("stop-wait-timeout-test")
+        fake_process = MagicMock()
+        fake_process.poll.return_value = None
+        fake_process.wait.side_effect = subprocess.TimeoutExpired(cmd="x", timeout=3)
+        sandbox.current_process = fake_process
+        sandbox.stop()
+        fake_process.terminate.assert_called_once()
+        fake_process.kill.assert_called_once()
+        assert sandbox.current_process is None
+
+    def test_a_kill_failure_after_terminate_failure_does_not_raise(self):
+        sandbox = VirtualEnvSandbox("stop-kill-also-fails-test")
+        fake_process = MagicMock()
+        fake_process.poll.return_value = None
+        fake_process.terminate.side_effect = OSError("nope")
+        fake_process.kill.side_effect = OSError("nope either")
+        sandbox.current_process = fake_process
+        sandbox.stop()  # must not raise
+        assert sandbox.current_process is None
+
+    def test_the_guard_is_closed_before_the_process_is_terminated(self):
+        # Pins the ordering ADR-005 stage 5.2's own comment on stop()
+        # requires: on Windows, closing the guard first is what actually
+        # kills the whole process tree - closing it after an already-
+        # terminated direct child would be too late to catch anything the
+        # child itself spawned.
+        order = []
+        fake_guard = MagicMock()
+        fake_guard.close.side_effect = lambda: order.append("guard_closed")
+        fake_process = MagicMock()
+        fake_process.poll.return_value = None
+        fake_process.terminate.side_effect = lambda: order.append("terminated")
+
+        sandbox = VirtualEnvSandbox("stop-order-test")
+        sandbox.guard = fake_guard
+        sandbox.current_process = fake_process
+        sandbox.stop()
+
+        assert order == ["guard_closed", "terminated"]
+
+
+# -- VirtualEnvSandbox._run_subprocess (real subprocesses) ------------------
+
+
+class TestRunSubprocessRealHappyPath:
+    def test_captures_real_stdout_and_a_zero_return_code(self):
+        sandbox = VirtualEnvSandbox("run-subprocess-happy-test")
+        output, code = sandbox._run_subprocess(
+            [sys.executable, "-c", "print('hello from sandbox')"],
+            should_continue=lambda: True,
+            timeout_seconds=30,
+        )
+        assert code == 0
+        assert "hello from sandbox" in output
+        assert sandbox.current_process is None
+        assert sandbox.guard is None
+
+    def test_emit_line_receives_each_line_of_real_output(self):
+        sandbox = VirtualEnvSandbox("run-subprocess-emit-test")
+        emitted = []
+        sandbox._run_subprocess(
+            [sys.executable, "-c", "print('line1'); print('line2')"],
+            should_continue=lambda: True,
+            emit_line=emitted.append,
+            timeout_seconds=30,
+        )
+        joined = "".join(emitted)
+        assert "line1" in joined
+        assert "line2" in joined
+
+    def test_a_nonzero_exit_is_reported_without_raising(self):
+        sandbox = VirtualEnvSandbox("run-subprocess-nonzero-test")
+        output, code = sandbox._run_subprocess(
+            [sys.executable, "-c", "import sys; print('failing'); sys.exit(3)"],
+            should_continue=lambda: True,
+            timeout_seconds=30,
+        )
+        assert code == 3
+        assert "failing" in output
+
+
+class TestRunSubprocessTimeout:
+    def test_a_real_timeout_raises_runtimeerror_and_cleans_up(self):
+        sandbox = VirtualEnvSandbox("run-subprocess-timeout-test")
+        with pytest.raises(RuntimeError, match="timed out after"):
+            sandbox._run_subprocess(
+                [sys.executable, "-c", "import time; time.sleep(30)"],
+                should_continue=lambda: True,
+                timeout_seconds=1,
+            )
+        assert sandbox.current_process is None
+        assert sandbox.guard is None
+
+
+class TestRunSubprocessInterruptedThenReused:
+    def test_should_continue_false_raises_interrupted_error_and_cleans_up(self):
+        sandbox = VirtualEnvSandbox("run-subprocess-interrupt-test")
+        with pytest.raises(InterruptedError, match="stopped"):
+            sandbox._run_subprocess(
+                [sys.executable, "-c", "import time; time.sleep(30)"],
+                should_continue=lambda: False,
+                timeout_seconds=30,
+            )
+        assert sandbox.current_process is None
+        assert sandbox.guard is None
+
+    def test_the_same_sandbox_instance_runs_a_fresh_subprocess_cleanly_afterward(self):
+        # Cleanup-on-error coverage: an interrupted/failed run must not
+        # leave the instance in a state that poisons the NEXT call on the
+        # same object - current_process/guard must be genuinely reset, not
+        # just appear reset.
+        sandbox = VirtualEnvSandbox("run-subprocess-reuse-after-interrupt-test")
+        with pytest.raises(InterruptedError):
+            sandbox._run_subprocess(
+                [sys.executable, "-c", "import time; time.sleep(30)"],
+                should_continue=lambda: False,
+                timeout_seconds=30,
+            )
+
+        output, code = sandbox._run_subprocess(
+            [sys.executable, "-c", "print('still works')"],
+            should_continue=lambda: True,
+            timeout_seconds=30,
+        )
+        assert code == 0
+        assert "still works" in output
+
+
+class TestReentrancyGapOnASingleSandboxInstance:
+    """Documents a genuine gap in the domain code (flagged in the task
+    report, not fixed - see this file's PR/task notes): VirtualEnvSandbox
+    has no lock guarding self.guard/self.current_process against a second,
+    overlapping _run_subprocess call on the SAME instance. Each call
+    unconditionally overwrites both attributes at its own start, so an
+    earlier in-flight call's own tracking is silently orphaned - its
+    eventual `finally` block closes/nulls whatever the SECOND call put
+    there, never its own guard/process. In production this is masked by
+    VirtualEnvSandbox being constructed fresh per run (see backend/
+    agents.py's own AgentDispatcher.__init__ docstring: "Execution Sandbox
+    needs NO equivalent manager...constructed fresh per run"), so two
+    overlapping runs never share one instance today - but nothing in
+    domain.py itself enforces that; it is a caller convention, not a
+    guarantee this module provides."""
+
+    def test_a_second_run_subprocess_call_orphans_the_firsts_tracking(self):
+        sandbox = VirtualEnvSandbox("reentrancy-gap-test")
+        first_guard = MagicMock()
+        first_process = MagicMock()
+        first_process.poll.return_value = None
+        sandbox.guard = first_guard
+        sandbox.current_process = first_process
+
+        output, code = sandbox._run_subprocess(
+            [sys.executable, "-c", "print('second call')"],
+            should_continue=lambda: True,
+            timeout_seconds=30,
+        )
+
+        assert code == 0
+        # Nothing about the second, successful call ever closed/terminated
+        # the first call's own guard/process - they were simply overwritten.
+        first_guard.close.assert_not_called()
+        first_process.terminate.assert_not_called()
+
+
+# -- VirtualEnvSandbox.execute_code ------------------------------------------
+
+
+@pytest.fixture
+def sandbox_using_system_python(monkeypatch, tmp_path):
+    """execute_code() always runs against self.python_executable (the
+    venv's own interpreter) - building a real venv for every execute_code
+    test would make this whole class as slow as the one genuine end-to-end
+    test below. Redirecting the read-only python_executable property to the
+    real system interpreter keeps execute_code's OWN logic (script writing,
+    stdout/stderr merging, non-raising nonzero-exit contract) under real
+    subprocess test coverage without paying for venv creation on every case."""
+    monkeypatch.setattr(VirtualEnvSandbox, "python_executable", property(lambda self: Path(sys.executable)))
+    sandbox = VirtualEnvSandbox("execute-code-fast-test")
+    sandbox.base_dir = tmp_path / "sandbox"
+    sandbox.script_path = sandbox.base_dir / "sandbox_entry.py"
+    yield sandbox
+
+
+class TestExecuteCode:
+    def test_writes_the_exact_code_to_script_path(self, sandbox_using_system_python):
+        sandbox = sandbox_using_system_python
+        sandbox.execute_code("print('written and run')", should_continue=lambda: True)
+        assert sandbox.script_path.read_text(encoding="utf-8") == "print('written and run')"
+
+    def test_returns_stripped_output_and_the_real_return_code(self, sandbox_using_system_python):
+        sandbox = sandbox_using_system_python
+        output, code = sandbox.execute_code("print('  padded by print, not by us  ')", should_continue=lambda: True)
+        assert code == 0
+        assert output == "padded by print, not by us"  # print() adds no extra padding; edges are trimmed by execute_code
+
+    def test_stdout_and_stderr_are_merged_into_one_stream(self, sandbox_using_system_python):
+        sandbox = sandbox_using_system_python
+        code_str = "import sys; print('to stdout'); print('to stderr', file=sys.stderr)"
+        output, return_code = sandbox.execute_code(code_str, should_continue=lambda: True)
+        assert return_code == 0
+        assert "to stdout" in output
+        assert "to stderr" in output
+
+    def test_a_script_that_raises_returns_the_traceback_and_nonzero_code_without_raising(self, sandbox_using_system_python):
+        sandbox = sandbox_using_system_python
+        output, code = sandbox.execute_code("raise ValueError('boom')", should_continue=lambda: True)
+        assert code != 0
+        assert "ValueError" in output
+        assert "boom" in output
+
+    def test_emit_line_is_invoked_with_the_sandbox_running_banner_and_output(self, sandbox_using_system_python):
+        sandbox = sandbox_using_system_python
+        emitted = []
+        sandbox.execute_code("print('payload')", should_continue=lambda: True, emit_line=emitted.append)
+        joined = "".join(emitted)
+        assert "Running" in joined
+        assert "payload" in joined
+
+
+# -- VirtualEnvSandbox.ensure_base_environment (mock-based) -----------------
+
+
+class TestEnsureBaseEnvironment:
+    def test_skips_venv_creation_when_the_interpreter_already_exists(self, tmp_path):
+        sandbox = VirtualEnvSandbox("ensure-base-skip-test")
+        sandbox.base_dir = tmp_path / "sandbox"
+        sandbox.venv_dir = sandbox.base_dir / "venv"
+        sandbox.python_executable.parent.mkdir(parents=True, exist_ok=True)
+        sandbox.python_executable.write_text("", encoding="utf-8")
+
+        with patch.object(sandbox, "_run_subprocess") as fake_run:
+            sandbox.ensure_base_environment(should_continue=lambda: True)
+            fake_run.assert_not_called()
+
+    def test_a_nonzero_venv_creation_return_code_raises_with_the_captured_output(self, tmp_path):
+        sandbox = VirtualEnvSandbox("ensure-base-fail-test")
+        sandbox.base_dir = tmp_path / "sandbox"
+        sandbox.venv_dir = sandbox.base_dir / "venv"
+
+        with patch.object(sandbox, "_run_subprocess", return_value=("boom: disk full", 1)):
+            with pytest.raises(RuntimeError, match="Failed to create sandbox environment"):
+                sandbox.ensure_base_environment(should_continue=lambda: True)
+
+
+# -- VirtualEnvSandbox.sync_requirements (mock-based caching logic) ---------
+
+
+def _bare_sandbox(tmp_path, sandbox_id):
+    sandbox = VirtualEnvSandbox(sandbox_id)
+    sandbox.base_dir = tmp_path / "sandbox"
+    sandbox.base_dir.mkdir(parents=True, exist_ok=True)
+    sandbox.venv_dir = sandbox.base_dir / "venv"
+    sandbox.requirements_file = sandbox.base_dir / "requirements.txt"
+    sandbox.requirements_hash_file = sandbox.base_dir / ".requirements.sha256"
+    return sandbox
+
+
+class TestSyncRequirementsCaching:
+    def test_an_identical_manifest_on_a_second_call_skips_pip_entirely(self, tmp_path):
+        sandbox = _bare_sandbox(tmp_path, "sync-cache-hit-test")
+        calls = []
+        with patch.object(sandbox, "_run_subprocess", side_effect=lambda *a, **k: (calls.append(1), ("", 0))[1]):
+            sandbox.sync_requirements("requests==2.31.0", should_continue=lambda: True)
+            assert len(calls) == 1
+
+            emitted = []
+            sandbox.sync_requirements(
+                "requests==2.31.0", should_continue=lambda: True, emit_line=emitted.append
+            )
+            assert len(calls) == 1, "pip must not run again for an unchanged manifest"
+            assert any("Reusing cached environment" in line for line in emitted)
+
+    def test_manifests_that_normalize_identically_are_treated_as_a_cache_hit(self, tmp_path):
+        # CRLF line endings + trailing whitespace differ from the original
+        # byte-for-byte, but _normalize_requirements makes them equivalent -
+        # the hash (and therefore the cache decision) must follow the
+        # NORMALIZED text, not the raw manifest string.
+        sandbox = _bare_sandbox(tmp_path, "sync-cache-normalize-test")
+        calls = []
+        with patch.object(sandbox, "_run_subprocess", side_effect=lambda *a, **k: (calls.append(1), ("", 0))[1]):
+            sandbox.sync_requirements("requests==2.31.0\n", should_continue=lambda: True)
+            assert len(calls) == 1
+
+            sandbox.sync_requirements("requests==2.31.0  \r\n", should_continue=lambda: True)
+            assert len(calls) == 1, "trailing-whitespace/CRLF-only differences must still hit the cache"
+
+    def test_a_changed_manifest_invalidates_the_cache_and_runs_pip_again(self, tmp_path):
+        sandbox = _bare_sandbox(tmp_path, "sync-cache-invalidate-test")
+        calls = []
+        with patch.object(sandbox, "_run_subprocess", side_effect=lambda *a, **k: (calls.append(1), ("", 0))[1]):
+            sandbox.sync_requirements("requests==2.31.0", should_continue=lambda: True)
+            assert len(calls) == 1
+
+            sandbox.sync_requirements("requests==2.32.0", should_continue=lambda: True)
+            assert len(calls) == 2, "a genuinely different manifest must re-invoke pip"
+
+    def test_an_empty_manifest_writes_the_hash_without_ever_calling_pip(self, tmp_path):
+        sandbox = _bare_sandbox(tmp_path, "sync-cache-empty-test")
+        emitted = []
+        with patch.object(sandbox, "_run_subprocess") as fake_run:
+            sandbox.sync_requirements("   \n  ", should_continue=lambda: True, emit_line=emitted.append)
+            fake_run.assert_not_called()
+        assert sandbox.requirements_hash_file.exists()
+        assert any("No extra dependencies requested" in line for line in emitted)
+
+    def test_a_failed_pip_install_raises_and_does_not_write_the_hash_file(self, tmp_path):
+        sandbox = _bare_sandbox(tmp_path, "sync-cache-fail-test")
+        with patch.object(sandbox, "_run_subprocess", return_value=("ERROR: no matching distribution", 1)):
+            with pytest.raises(RuntimeError, match="Dependency installation failed"):
+                sandbox.sync_requirements("nonexistent-package==0.0.0", should_continue=lambda: True)
+        assert not sandbox.requirements_hash_file.exists(), (
+            "a failed install must not be cached as if it had succeeded - "
+            "otherwise the NEXT call with the same manifest would silently "
+            "skip pip and report success"
+        )
+
+
+# -- VirtualEnvSandbox real end-to-end coverage ------------------------------
+
+
+def _make_sandbox_with_real_venv(tmp_path, sandbox_id):
+    """Real venv, mirroring test_code_sandbox_only_binary.py's own
+    identically-named helper - duplicated here rather than shared, matching
+    that file's own precedent of each test module being self-contained."""
+    sandbox = VirtualEnvSandbox(sandbox_id)
+    sandbox.base_dir = tmp_path / "sandbox"
+    sandbox.venv_dir = sandbox.base_dir / "venv"
+    sandbox.requirements_file = sandbox.base_dir / "requirements.txt"
+    sandbox.requirements_hash_file = sandbox.base_dir / ".requirements.sha256"
+    sandbox.script_path = sandbox.base_dir / "sandbox_entry.py"
+    sandbox.base_dir.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(sandbox.venv_dir)],
+        check=True, capture_output=True, text=True, timeout=180,
+    )
+    return sandbox
+
+
+class TestRealEndToEndHappyPath:
+    def test_construct_a_sandbox_run_simple_python_and_get_real_output(self, tmp_path):
+        # The scenario the plugin's users actually depend on: a fresh
+        # sandbox, a real (already-provisioned, per ensure_base_environment's
+        # own early-return contract) virtualenv, and a real script producing
+        # real, observable output through the real interpreter at
+        # sandbox.python_executable - not sys.executable, not a mock.
+        sandbox = _make_sandbox_with_real_venv(tmp_path, "e2e-happy-path-test")
+
+        sandbox.ensure_base_environment(should_continue=lambda: True)  # early-returns: venv already built above
+
+        output, return_code = sandbox.execute_code(
+            "print('the real venv interpreter ran this')",
+            should_continue=lambda: True,
+        )
+
+        assert return_code == 0
+        assert output == "the real venv interpreter ran this"
+        assert sandbox.script_path.read_text(encoding="utf-8") == "print('the real venv interpreter ran this')"
+
+
+class TestSyncRequirementsRealMalformedManifest:
+    def test_a_malformed_requirement_line_fails_with_dependency_installation_failed(self, tmp_path):
+        # --no-index as an embedded option line keeps this deterministic and
+        # network-free (same technique test_code_sandbox_only_binary.py
+        # uses) - pip's own requirement-file parser rejects the unmatched
+        # bracket before any resolution/network step is ever reached.
+        sandbox = _make_sandbox_with_real_venv(tmp_path, "e2e-bad-manifest-test")
+        manifest = "--no-index\ntotally-not-a-package[unclosed-extra"
+
+        with pytest.raises(RuntimeError, match="Dependency installation failed"):
+            sandbox.sync_requirements(manifest, should_continue=lambda: True)
+
+        # The malformed text is still written to disk verbatim BEFORE pip
+        # ever runs (sync_requirements writes the file unconditionally,
+        # ahead of the cache check) - worth pinning since it means a
+        # subsequent read of requirements.txt reflects the attempted
+        # manifest even when the install itself failed.
+        assert "totally-not-a-package[unclosed-extra" in sandbox.requirements_file.read_text(encoding="utf-8")

--- a/backend/tests/test_gitlink_domain.py
+++ b/backend/tests/test_gitlink_domain.py
@@ -1,0 +1,1291 @@
+"""Direct unit tests for the Gitlink plugin's domain logic (ADR-014 H3
+close-out: graphlink_plugins/** had zero direct tests).
+
+Everything in backend/tests/test_agents.py's "R5.3: Gitlink" section (and the
+G3/G6 pinning tests from the ADR-002 approval-guards audit) exercises this
+logic ONLY indirectly, through AgentDispatcher.start_gitlink_run/
+start_gitlink_apply - GitlinkAgent.get_response and apply_change_set are
+monkeypatched away there specifically so the dispatcher's own orchestration
+(busy-guards, cancellation, the 3-way fingerprint compare-and-freeze) can be
+pinned in isolation. This file targets what that isolation deliberately
+skips: agent.py's and repository.py's own logic (XML context construction,
+path-safety normalization, fingerprint hashing itself, the JSON write-intent
+state machine, the on-disk apply/rollback mechanics) plus
+common/github_client.py, the shared low-level GitHub REST helper both this
+plugin and Code Review hang off of.
+
+Mocking conventions mirrored from the rest of this suite:
+  - api_provider.chat is monkeypatched to a plain lambda returning
+    {"message": {"content": ...}} (see test_agents.py, conftest.py).
+  - GitHub REST calls are faked via a duck-typed stand-in exposing
+    `.request(url, params=None, *, expect_json=True, timeout=25)` - the
+    exact shape GitlinkRepository depends on (it "owns nothing but a
+    github_client reference" per its own module docstring) - so
+    GitlinkRepository's own logic is tested without needing a real
+    GitHubRestClient/requests.Session in play. github_client.py itself is
+    covered separately, directly, by faking `requests.get` with a stand-in
+    response object exposing status_code/json()/text/reason/content -
+    matching test_web_research_providers_fetcher.py's established
+    fake-response-object convention for this codebase.
+  - All filesystem operations (apply_change_set, scan_local_repo_paths,
+    read_local_repo_file, download_repository_snapshot) run against a real
+    pytest tmp_path - no filesystem mocking - since these functions' whole
+    job is a real on-disk contract (byte-exact writes, atomic rollback).
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+import api_provider
+import graphlink_task_config as config
+from graphlink_plugins.common import github_client as github_client_module
+from graphlink_plugins.common.github_client import GitHubRestClient
+from graphlink_plugins.gitlink import agent as agent_module
+from graphlink_plugins.gitlink import repository as repository_module
+from graphlink_plugins.gitlink.agent import (
+    GitlinkAgent,
+    _clean_text,
+    _compact_label_text,
+    _decode_text_bytes,
+    _extract_json_object,
+    _fingerprint_changes,
+    _is_repo_text_path,
+    _normalize_repo_path,
+    _safe_local_target,
+    _truncate_for_context,
+    _wrap_cdata,
+    _xml_file_block,
+)
+from graphlink_plugins.gitlink.repository import (
+    ContextBundleResult,
+    GitlinkRepository,
+    apply_change_set,
+    default_import_root,
+    read_local_repo_file,
+    resolve_scope_paths,
+    scan_local_repo_paths,
+    validate_pending_changes,
+)
+
+
+# =============================================================================
+# graphlink_plugins/common/github_client.py
+# =============================================================================
+
+
+class _FakeHTTPResponse:
+    """Stands in for requests.Response - exposes only what
+    GitHubRestClient.request reads (status_code/json()/text/reason/content),
+    mirroring test_web_research_providers_fetcher.py's _FakeResponse
+    convention for this codebase."""
+
+    def __init__(self, status_code=200, json_body=None, text="", reason="", content=b"", json_raises=False):
+        self.status_code = status_code
+        self._json_body = json_body
+        self.text = text
+        self.reason = reason
+        self.content = content
+        self._json_raises = json_raises
+
+    def json(self):
+        if self._json_raises:
+            raise ValueError("not json")
+        return self._json_body
+
+
+class _FakeSettingsManagerWithToken:
+    def __init__(self, token):
+        self._token = token
+
+    def get_github_token(self):
+        return self._token
+
+
+def test_get_token_returns_empty_string_when_no_settings_manager():
+    client = GitHubRestClient(settings_manager=None)
+    assert client.get_token() == ""
+
+
+def test_get_token_strips_whitespace_from_settings_manager_token():
+    client = GitHubRestClient(settings_manager=_FakeSettingsManagerWithToken("  ghp_abc123  \n"))
+    assert client.get_token() == "ghp_abc123"
+
+
+def test_build_headers_always_includes_accept_and_api_version():
+    client = GitHubRestClient(settings_manager=None)
+    headers = client.build_headers()
+    assert headers["Accept"] == "application/vnd.github+json"
+    assert headers["X-GitHub-Api-Version"] == "2022-11-28"
+    assert "Authorization" not in headers
+
+
+def test_build_headers_includes_bearer_token_when_present():
+    client = GitHubRestClient(settings_manager=_FakeSettingsManagerWithToken("ghp_xyz"))
+    headers = client.build_headers()
+    assert headers["Authorization"] == "Bearer ghp_xyz"
+
+
+def test_request_success_returns_parsed_json_and_forwards_params_and_timeout(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        captured.update(url=url, headers=headers, params=params, timeout=timeout)
+        return _FakeHTTPResponse(status_code=200, json_body={"ok": True})
+
+    monkeypatch.setattr(github_client_module.requests, "get", fake_get)
+    client = GitHubRestClient(settings_manager=_FakeSettingsManagerWithToken("tok"))
+
+    result = client.request("https://api.github.com/repos/o/r", params={"ref": "main"}, timeout=17)
+
+    assert result == {"ok": True}
+    assert captured["url"] == "https://api.github.com/repos/o/r"
+    assert captured["params"] == {"ref": "main"}
+    assert captured["timeout"] == 17
+    assert captured["headers"]["Authorization"] == "Bearer tok"
+
+
+def test_request_expect_json_false_returns_raw_content_bytes(monkeypatch):
+    monkeypatch.setattr(
+        github_client_module.requests, "get",
+        lambda *a, **k: _FakeHTTPResponse(status_code=200, content=b"raw-bytes-here"),
+    )
+    client = GitHubRestClient(settings_manager=None)
+    assert client.request("https://example.com/x", expect_json=False) == b"raw-bytes-here"
+
+
+def test_request_404_raises_friendly_not_found_message(monkeypatch):
+    monkeypatch.setattr(
+        github_client_module.requests, "get",
+        lambda *a, **k: _FakeHTTPResponse(status_code=404, json_body={"message": "Not Found"}),
+    )
+    client = GitHubRestClient(settings_manager=None)
+    with pytest.raises(RuntimeError, match="GitHub resource not found"):
+        client.request("https://api.github.com/repos/o/r")
+
+
+def test_request_401_raises_friendly_invalid_token_message(monkeypatch):
+    monkeypatch.setattr(
+        github_client_module.requests, "get",
+        lambda *a, **k: _FakeHTTPResponse(status_code=401, json_body={"message": "Bad credentials"}),
+    )
+    client = GitHubRestClient(settings_manager=None)
+    with pytest.raises(RuntimeError, match="GitHub rejected the saved token"):
+        client.request("https://api.github.com/repos/o/r")
+
+
+def test_request_403_rate_limit_message_raises_rate_limit_error(monkeypatch):
+    monkeypatch.setattr(
+        github_client_module.requests, "get",
+        lambda *a, **k: _FakeHTTPResponse(
+            status_code=403, json_body={"message": "API rate limit exceeded for xxx."}
+        ),
+    )
+    client = GitHubRestClient(settings_manager=None)
+    with pytest.raises(RuntimeError, match="rate limit reached"):
+        client.request("https://api.github.com/repos/o/r")
+
+
+def test_request_403_non_rate_limit_uses_raw_github_message(monkeypatch):
+    monkeypatch.setattr(
+        github_client_module.requests, "get",
+        lambda *a, **k: _FakeHTTPResponse(status_code=403, json_body={"message": "Forbidden: access denied"}),
+    )
+    client = GitHubRestClient(settings_manager=None)
+    with pytest.raises(RuntimeError, match="^Forbidden: access denied$"):
+        client.request("https://api.github.com/repos/o/r")
+
+
+def test_request_error_body_not_json_falls_back_to_text_then_reason(monkeypatch):
+    monkeypatch.setattr(
+        github_client_module.requests, "get",
+        lambda *a, **k: _FakeHTTPResponse(
+            status_code=500, json_raises=True, text="", reason="Internal Server Error"
+        ),
+    )
+    client = GitHubRestClient(settings_manager=None)
+    with pytest.raises(RuntimeError, match="Internal Server Error"):
+        client.request("https://api.github.com/repos/o/r")
+
+
+def test_request_error_body_not_json_prefers_text_over_reason(monkeypatch):
+    monkeypatch.setattr(
+        github_client_module.requests, "get",
+        lambda *a, **k: _FakeHTTPResponse(
+            status_code=502, json_raises=True, text="upstream timeout", reason="Bad Gateway"
+        ),
+    )
+    client = GitHubRestClient(settings_manager=None)
+    with pytest.raises(RuntimeError, match="^upstream timeout$"):
+        client.request("https://api.github.com/repos/o/r")
+
+
+# =============================================================================
+# graphlink_plugins/gitlink/agent.py - pure helpers
+# =============================================================================
+
+
+def test_clean_text_strips_and_collapses_three_or_more_blank_lines():
+    text = "  hello\n\n\n\nworld  "
+    assert _clean_text(text) == "hello\n\nworld"
+
+
+def test_clean_text_truncates_with_ellipsis_at_limit():
+    result = _clean_text("a" * 50, limit=10)
+    assert result == "a" * 7 + "..."
+    assert len(result) == 10
+
+
+def test_clean_text_handles_none_value():
+    assert _clean_text(None) == ""
+    assert _clean_text(None, limit=10) == ""
+
+
+def test_clean_text_no_limit_returns_full_text_unbounded():
+    assert _clean_text("a" * 500) == "a" * 500
+
+
+def test_compact_label_text_passthrough_under_limit():
+    assert _compact_label_text("short label") == "short label"
+
+
+def test_compact_label_text_truncates_over_default_limit():
+    result = _compact_label_text("x" * 100)
+    assert result == "x" * 31 + "..."
+    assert len(result) == 34
+
+
+def test_decode_text_bytes_prefers_utf8():
+    assert _decode_text_bytes("héllo wörld".encode("utf-8")) == "héllo wörld"
+
+
+def test_decode_text_bytes_does_not_strip_bom_because_plain_utf8_wins_first():
+    # "utf-8-sig" is listed second in the fallback tuple specifically to
+    # strip a BOM, but the BOM bytes (EF BB BF) are themselves a valid
+    # UTF-8 encoding of U+FEFF - plain "utf-8" (tried first) decodes them
+    # without raising, so the loop never reaches "utf-8-sig" and the BOM
+    # survives as a leading ﻿ character. Pinning actual behavior here,
+    # not the behavior the encoding-list order implies.
+    raw = b"\xef\xbb\xbfhello"
+    assert _decode_text_bytes(raw) == "﻿hello"
+
+
+def test_decode_text_bytes_falls_back_to_cp1252_for_smart_quotes():
+    # 0x93/0x94 are cp1252 "smart quotes" - invalid lead bytes in UTF-8
+    # (both plain and BOM-sniffed), so this must fall through to cp1252.
+    raw = b"\x93hello\x94"
+    assert _decode_text_bytes(raw) == "\u201chello\u201d"
+
+
+def test_decode_text_bytes_falls_back_to_latin1_when_cp1252_undefined():
+    # 0x81 is undefined in cp1252 (raises), but latin-1 maps every byte
+    # 0-255 losslessly, so this is the last fallback that actually succeeds.
+    raw = b"\x81"
+    assert _decode_text_bytes(raw) == "\x81"
+
+
+def test_is_repo_text_path_excludes_known_binary_suffixes_case_insensitively():
+    assert _is_repo_text_path("assets/logo.PNG") is False
+    assert _is_repo_text_path("bin/app.exe") is False
+    assert _is_repo_text_path("archive.tar.gz") is False
+
+
+def test_is_repo_text_path_includes_normal_source_files():
+    assert _is_repo_text_path("src/module.py") is True
+    assert _is_repo_text_path("README.md") is True
+    assert _is_repo_text_path("") is True
+
+
+def test_normalize_repo_path_converts_backslashes_and_normalizes():
+    assert _normalize_repo_path("src\\pkg\\module.py") == "src/pkg/module.py"
+
+
+def test_normalize_repo_path_rejects_empty_string():
+    with pytest.raises(RuntimeError, match="cannot be empty"):
+        _normalize_repo_path("")
+    with pytest.raises(RuntimeError, match="cannot be empty"):
+        _normalize_repo_path("   ")
+
+
+def test_normalize_repo_path_rejects_leading_slash():
+    with pytest.raises(RuntimeError, match="must stay inside"):
+        _normalize_repo_path("/etc/passwd")
+
+
+def test_normalize_repo_path_rejects_dotdot_traversal():
+    with pytest.raises(RuntimeError, match="must stay inside"):
+        _normalize_repo_path("../../etc/passwd")
+    with pytest.raises(RuntimeError, match="must stay inside"):
+        _normalize_repo_path("src/../../secret.txt")
+
+
+def test_normalize_repo_path_rejects_unc_path():
+    with pytest.raises(RuntimeError, match="must stay inside"):
+        _normalize_repo_path("//server/share/file.txt")
+
+
+def test_normalize_repo_path_rejects_windows_drive_letter():
+    # Regression guard for audit finding referenced in the module docstring:
+    # "C:/config/app.txt" is NOT PurePosixPath.is_absolute(), so only the
+    # ":"-in-a-part check (not the is_absolute() check) catches this.
+    with pytest.raises(RuntimeError, match="must stay inside"):
+        _normalize_repo_path("C:/config/app.txt")
+    with pytest.raises(RuntimeError, match="must stay inside"):
+        _normalize_repo_path("C:app.txt")
+
+
+def test_normalize_repo_path_rejects_alternate_data_stream_colon():
+    with pytest.raises(RuntimeError, match="must stay inside"):
+        _normalize_repo_path("file.txt:hidden")
+
+
+def test_safe_local_target_resolves_inside_root(tmp_path):
+    target = _safe_local_target(tmp_path, "src/module.py")
+    assert target == (tmp_path / "src" / "module.py").resolve()
+
+
+def test_safe_local_target_propagates_normalize_repo_path_rejection(tmp_path):
+    with pytest.raises(RuntimeError, match="must stay inside"):
+        _safe_local_target(tmp_path, "../outside.txt")
+
+
+def test_safe_local_target_root_itself_is_a_valid_target(tmp_path):
+    # repo_path "." normalizes to "." via PurePosixPath -> as_posix() == "."
+    # -> Path(*()) with zero parts -> target resolves to root itself.
+    target = _safe_local_target(tmp_path, ".")
+    assert target == tmp_path.resolve()
+
+
+def test_fingerprint_changes_is_deterministic_for_same_input():
+    changes = [{"path": "a.py", "operation": "update", "content": "x"}]
+    assert _fingerprint_changes(changes) == _fingerprint_changes(changes)
+
+
+def test_fingerprint_changes_is_a_64_char_hex_sha256_digest():
+    fp = _fingerprint_changes([{"path": "a.py"}])
+    assert len(fp) == 64
+    assert all(c in "0123456789abcdef" for c in fp)
+
+
+def test_fingerprint_changes_is_independent_of_dict_key_order():
+    a = [{"path": "a.py", "operation": "update", "content": "x"}]
+    b = [{"content": "x", "path": "a.py", "operation": "update"}]
+    assert _fingerprint_changes(a) == _fingerprint_changes(b)
+
+
+def test_fingerprint_changes_differs_for_different_content():
+    a = [{"path": "a.py", "content": "x"}]
+    b = [{"path": "a.py", "content": "y"}]
+    assert _fingerprint_changes(a) != _fingerprint_changes(b)
+
+
+def test_fingerprint_changes_is_sensitive_to_list_order():
+    # Documents a real, non-obvious property: sort_keys=True only sorts
+    # dict KEYS, never reorders list elements - so json.dumps (and thus the
+    # fingerprint the 3-way approval compare in backend/agents.py relies
+    # on) treats the same two file-changes in a different order as a
+    # DIFFERENT change set. In production this is masked by
+    # GitlinkAgent._normalize_files always emitting files sorted by path,
+    # so callers never actually see this - but the hash function itself
+    # has no such guarantee on its own.
+    a = [{"path": "a.py"}, {"path": "b.py"}]
+    b = [{"path": "b.py"}, {"path": "a.py"}]
+    assert _fingerprint_changes(a) != _fingerprint_changes(b)
+
+
+def test_fingerprint_changes_handles_non_json_serializable_values_via_default_str():
+    # default=str means a value json.dumps can't natively serialize (e.g. a
+    # Path) is coerced via str() instead of raising - must not crash on
+    # whatever a caller happens to stash in a change dict.
+    changes = [{"path": "a.py", "note": Path("weird/object")}]
+    fp = _fingerprint_changes(changes)
+    assert len(fp) == 64
+
+
+def test_fingerprint_changes_empty_list_is_a_stable_well_known_value():
+    # json.dumps([], sort_keys=True) == "[]" - pin the exact digest so any
+    # accidental change to the canonicalization (e.g. separators) is caught.
+    import hashlib
+    expected = hashlib.sha256(b"[]").hexdigest()
+    assert _fingerprint_changes([]) == expected
+
+
+def test_wrap_cdata_wraps_plain_text():
+    assert _wrap_cdata("hello") == "<![CDATA[hello]]>"
+
+
+def test_wrap_cdata_escapes_embedded_cdata_close_sequence():
+    # A raw "]]>" inside the source text would otherwise prematurely close
+    # the CDATA section - splitting it must let it round-trip literally in
+    # any downstream XML parse.
+    wrapped = _wrap_cdata("before]]>after")
+    assert wrapped == "<![CDATA[before]]]]><![CDATA[>after]]>"
+    assert "]]>after]]>" not in wrapped.replace("]]]]><![CDATA[>", "")
+
+
+def test_wrap_cdata_handles_none_as_empty_string():
+    assert _wrap_cdata(None) == "<![CDATA[]]>"
+
+
+def test_xml_file_block_escapes_path_attribute():
+    block = _xml_file_block('src/"quoted".py', "content", original_chars=7)
+    assert 'path="src/&quot;quoted&quot;.py"' in block
+
+
+def test_xml_file_block_includes_chars_and_truncated_attrs():
+    block = _xml_file_block("a.py", "hi", truncated=True, original_chars=1234)
+    assert 'chars="1234"' in block
+    assert 'truncated="true"' in block
+
+
+def test_xml_file_block_defaults_truncated_false_and_clamps_negative_chars():
+    block = _xml_file_block("a.py", "hi", original_chars=-5)
+    assert 'truncated="false"' in block
+    assert 'chars="0"' in block
+
+
+def test_xml_file_block_wraps_source_text_in_cdata():
+    block = _xml_file_block("a.py", "print(1)", original_chars=8)
+    assert "<![CDATA[print(1)]]>" in block
+
+
+def test_truncate_for_context_returns_unchanged_when_under_limit():
+    text, truncated = _truncate_for_context("short text", max_chars=100)
+    assert text == "short text"
+    assert truncated is False
+
+
+def test_truncate_for_context_exact_boundary_is_not_truncated():
+    text, truncated = _truncate_for_context("x" * 100, max_chars=100)
+    assert text == "x" * 100
+    assert truncated is False
+
+
+def test_truncate_for_context_truncates_and_flags_when_over_limit():
+    text, truncated = _truncate_for_context("x" * 150, max_chars=100)
+    assert truncated is True
+    assert len(text) == 100
+    assert text.endswith("...")
+    assert text == "x" * 97 + "..."
+
+
+def test_extract_json_object_pulls_fenced_json_block():
+    raw = 'Sure, here you go:\n```json\n{"a": 1}\n```\nHope that helps.'
+    assert _extract_json_object(raw) == '{"a": 1}'
+
+
+def test_extract_json_object_pulls_bare_json_object_without_fence():
+    raw = 'preamble text {"a": 1, "b": [1,2]} trailing text'
+    assert json.loads(_extract_json_object(raw)) == {"a": 1, "b": [1, 2]}
+
+
+def test_extract_json_object_falls_back_to_raw_text_when_no_object_found():
+    raw = "no json here at all"
+    assert _extract_json_object(raw) == "no json here at all"
+
+
+# =============================================================================
+# graphlink_plugins/gitlink/agent.py - GitlinkAgent
+# =============================================================================
+
+
+def _file_item(path="a.py", operation="update", reason="r", content="x"):
+    item = {"path": path, "operation": operation, "reason": reason}
+    if operation != "delete":
+        item["content"] = content
+    return item
+
+
+def test_normalize_files_sorts_by_path_case_insensitively():
+    agent = GitlinkAgent()
+    items = [_file_item(path="Zebra.py"), _file_item(path="apple.py"), _file_item(path="Banana.py")]
+    result = agent._normalize_files(items)
+    assert [item["path"] for item in result] == ["apple.py", "Banana.py", "Zebra.py"]
+
+
+def test_normalize_files_drops_items_with_invalid_or_unsafe_path():
+    agent = GitlinkAgent()
+    items = [_file_item(path="../escape.py"), _file_item(path="ok.py")]
+    result = agent._normalize_files(items)
+    assert [item["path"] for item in result] == ["ok.py"]
+
+
+def test_normalize_files_defaults_unknown_operation_to_update():
+    agent = GitlinkAgent()
+    result = agent._normalize_files([{"path": "a.py", "operation": "rewrite", "content": "x"}])
+    assert result[0]["operation"] == "update"
+
+
+def test_normalize_files_dedupes_by_path_last_write_wins():
+    agent = GitlinkAgent()
+    items = [
+        _file_item(path="a.py", content="first"),
+        _file_item(path="a.py", content="second"),
+    ]
+    result = agent._normalize_files(items)
+    assert len(result) == 1
+    assert result[0]["content"] == "second"
+
+
+def test_normalize_files_drops_update_items_missing_string_content():
+    agent = GitlinkAgent()
+    items = [
+        {"path": "a.py", "operation": "update", "reason": "r"},  # no content key
+        {"path": "b.py", "operation": "create", "reason": "r", "content": 123},  # not a str
+        {"path": "c.py", "operation": "update", "reason": "r", "content": "ok"},
+    ]
+    result = agent._normalize_files(items)
+    assert [item["path"] for item in result] == ["c.py"]
+
+
+def test_normalize_files_delete_items_do_not_require_content():
+    agent = GitlinkAgent()
+    result = agent._normalize_files([{"path": "old.py", "operation": "delete", "reason": "cleanup"}])
+    assert len(result) == 1
+    assert result[0]["operation"] == "delete"
+    assert "content" not in result[0]
+
+
+def test_normalize_files_defaults_reason_when_missing():
+    agent = GitlinkAgent()
+    result = agent._normalize_files([{"path": "a.py", "operation": "update", "content": "x"}])
+    assert result[0]["reason"] == "No reason supplied."
+
+
+def test_normalize_files_skips_non_dict_items():
+    agent = GitlinkAgent()
+    result = agent._normalize_files(["not-a-dict", 42, None, _file_item(path="a.py")])
+    assert [item["path"] for item in result] == ["a.py"]
+
+
+def test_normalize_files_none_or_empty_input_returns_empty_list():
+    agent = GitlinkAgent()
+    assert agent._normalize_files(None) == []
+    assert agent._normalize_files([]) == []
+
+
+def _fake_chat(content_dict):
+    def _chat(task, messages, **kwargs):
+        return {"message": {"content": json.dumps(content_dict)}}
+    return _chat
+
+
+def test_get_response_happy_path_changes_ready_with_files(monkeypatch):
+    monkeypatch.setattr(api_provider, "chat", _fake_chat({
+        "summary": "Add health check",
+        "write_intent": "changes_ready",
+        "rationale": "Improves ops visibility",
+        "notes": ["be careful"],
+        "files": [{"path": "app.py", "operation": "update", "reason": "add route", "content": "code"}],
+    }))
+    agent = GitlinkAgent()
+
+    result = agent.get_response({
+        "task_prompt": "add a health check", "context_xml": "<x/>",
+        "repo": "octocat/hello-world", "branch": "main",
+    })
+
+    assert result["write_intent"] == "changes_ready"
+    assert result["summary"] == "Add health check"
+    assert result["rationale"] == "Improves ops visibility"
+    assert result["notes"] == ["be careful"]
+    assert result["change_count"] == 1
+    assert result["files"] == [
+        {"path": "app.py", "operation": "update", "reason": "add route", "content": "code"}
+    ]
+    assert json.loads(result["raw_response"])["write_intent"] == "changes_ready"
+
+
+def test_get_response_malformed_json_falls_back_to_blocked_with_exact_note(monkeypatch):
+    monkeypatch.setattr(api_provider, "chat", lambda task, messages, **kwargs: {
+        "message": {"content": "this is not JSON at all, no braces"}
+    })
+    agent = GitlinkAgent()
+
+    result = agent.get_response({"task_prompt": "x", "context_xml": "<x/>", "repo": "o/r", "branch": "main"})
+
+    assert result["write_intent"] == "blocked"
+    assert result["files"] == []
+    assert result["notes"] == [
+        "The model response was not valid JSON, so no approved file writes can be prepared."
+    ]
+    assert result["summary"] == "No structured change summary was returned."
+    assert result["rationale"] == "No structured rationale was returned."
+
+
+def test_get_response_changes_ready_but_no_files_downgrades_further_to_blocked(monkeypatch):
+    # write_intent starts as the VALID value "changes_ready", so the first
+    # fallback (invalid-value check) never fires. The "claimed ready but no
+    # files" guard then downgrades it to "no_changes" AND appends a note -
+    # but that note makes `notes` non-empty, so the trailing "notes present
+    # + not already blocked + no files" guard immediately re-escalates it
+    # one more step, all the way to "blocked". A claimed-ready-but-empty
+    # response therefore never actually surfaces as "no_changes" to a
+    # caller - it always ends up "blocked".
+    monkeypatch.setattr(api_provider, "chat", _fake_chat({
+        "summary": "s", "write_intent": "changes_ready", "rationale": "r", "notes": [], "files": [],
+    }))
+    agent = GitlinkAgent()
+
+    result = agent.get_response({"task_prompt": "x", "context_xml": "<x/>", "repo": "o/r", "branch": "main"})
+
+    assert result["write_intent"] == "blocked"
+    assert result["files"] == []
+    assert (
+        "The model claimed a ready change set, but it did not return any valid file payloads."
+        in result["notes"]
+    )
+
+
+def test_get_response_invalid_write_intent_with_no_notes_defaults_to_no_changes(monkeypatch):
+    monkeypatch.setattr(api_provider, "chat", _fake_chat({
+        "summary": "s", "write_intent": "banana", "rationale": "r", "notes": [], "files": [],
+    }))
+    agent = GitlinkAgent()
+
+    result = agent.get_response({"task_prompt": "x", "context_xml": "<x/>", "repo": "o/r", "branch": "main"})
+
+    assert result["write_intent"] == "no_changes"
+
+
+def test_get_response_invalid_write_intent_with_notes_and_no_files_flips_to_blocked(monkeypatch):
+    # Pins the trailing "notes present + not already blocked + no files ->
+    # force blocked" guard: write_intent starts invalid ("banana", no notes
+    # yet at that check) -> falls back to "no_changes" first, THEN the
+    # model's own notes are appended, and the final guard re-escalates to
+    # "blocked" because notes exist but no files were ever produced.
+    monkeypatch.setattr(api_provider, "chat", _fake_chat({
+        "summary": "s", "write_intent": "banana", "rationale": "r",
+        "notes": ["heads up"], "files": [],
+    }))
+    agent = GitlinkAgent()
+
+    result = agent.get_response({"task_prompt": "x", "context_xml": "<x/>", "repo": "o/r", "branch": "main"})
+
+    assert result["write_intent"] == "blocked"
+    assert result["notes"] == ["heads up"]
+
+
+def test_get_response_passes_through_raw_response_verbatim(monkeypatch):
+    raw = '```json\n{"summary": "s", "write_intent": "no_changes", "rationale": "r", "notes": [], "files": []}\n```'
+    monkeypatch.setattr(api_provider, "chat", lambda task, messages, **kwargs: {"message": {"content": raw}})
+    agent = GitlinkAgent()
+
+    result = agent.get_response({"task_prompt": "x", "context_xml": "<x/>", "repo": "o/r", "branch": "main"})
+
+    assert result["raw_response"] == raw
+
+
+def test_get_response_normalizes_and_sorts_returned_files(monkeypatch):
+    monkeypatch.setattr(api_provider, "chat", _fake_chat({
+        "summary": "s", "write_intent": "changes_ready", "rationale": "r", "notes": [],
+        "files": [
+            {"path": "z.py", "operation": "update", "reason": "r", "content": "z"},
+            {"path": "a.py", "operation": "bogus_op", "reason": "r", "content": "a"},
+        ],
+    }))
+    agent = GitlinkAgent()
+
+    result = agent.get_response({"task_prompt": "x", "context_xml": "<x/>", "repo": "o/r", "branch": "main"})
+
+    assert [f["path"] for f in result["files"]] == ["a.py", "z.py"]
+    assert result["files"][0]["operation"] == "update"  # "bogus_op" normalized
+
+
+def test_get_response_builds_message_with_repo_branch_scope_and_fallback_defaults(monkeypatch):
+    captured = {}
+
+    def fake_chat(task, messages, **kwargs):
+        captured["task"] = task
+        captured["messages"] = messages
+        return {"message": {"content": json.dumps({
+            "summary": "s", "write_intent": "no_changes", "rationale": "r", "notes": [], "files": [],
+        })}}
+
+    monkeypatch.setattr(api_provider, "chat", fake_chat)
+    agent = GitlinkAgent()
+
+    agent.get_response({
+        "task_prompt": "",  # blank -> fallback text
+        "context_xml": "<gitlink_context/>",
+        "branch_transcript": "",  # blank -> fallback text
+        "repo": "octocat/hello-world",
+        "branch": "main",
+        "scope_label": "Selected files",
+        "context_summary": "Scanned 3 files",
+    })
+
+    assert captured["task"] == config.TASK_CHAT
+    user_message = captured["messages"][1]["content"]
+    assert captured["messages"][0]["content"] == GitlinkAgent.SYSTEM_PROMPT
+    assert "Repository: octocat/hello-world@main" in user_message
+    assert "Scope: Selected files" in user_message
+    assert "Context Summary: Scanned 3 files" in user_message
+    assert "No task prompt supplied." in user_message
+    assert "No prior branch context." in user_message
+    assert "<gitlink_context/>" in user_message
+
+
+# =============================================================================
+# graphlink_plugins/gitlink/repository.py - module-level free functions
+# =============================================================================
+
+
+def test_default_import_root_replaces_slashes_in_repo_and_branch():
+    root = default_import_root("octocat/hello-world", "feature/my-branch")
+    parts = root.parts
+    assert parts[-2:] == ("octocat__hello-world", "feature__my-branch")
+    assert ".graphlink" in parts and "gitlink_repos" in parts
+
+
+def test_scan_local_repo_paths_raises_when_root_missing(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(RuntimeError, match="does not exist"):
+        scan_local_repo_paths(missing)
+
+
+def test_scan_local_repo_paths_excludes_ignored_dirs_and_binary_suffixes(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print(1)")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "pkg.js").write_text("//")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "HEAD").write_text("ref: refs/heads/main")
+    (tmp_path / "assets").mkdir()
+    (tmp_path / "assets" / "logo.png").write_bytes(b"\x89PNG")
+
+    result = scan_local_repo_paths(tmp_path)
+
+    assert result == ["src/main.py"]
+
+
+def test_scan_local_repo_paths_returns_sorted_case_insensitive(tmp_path):
+    for name in ("Zebra.py", "apple.py", "Banana.py"):
+        (tmp_path / name).write_text("x")
+
+    result = scan_local_repo_paths(tmp_path)
+
+    assert result == ["apple.py", "Banana.py", "Zebra.py"]
+
+
+def test_resolve_scope_paths_selected_mode_returns_selected_list():
+    result = resolve_scope_paths("selected", ["a.py", "b.py"], repo_file_paths=["z.py"])
+    assert result == ["a.py", "b.py"]
+
+
+def test_resolve_scope_paths_selected_mode_empty_selection_raises():
+    with pytest.raises(RuntimeError, match="Select one or more files"):
+        resolve_scope_paths("selected", [], repo_file_paths=["z.py"])
+
+
+def test_resolve_scope_paths_full_mode_prefers_repo_file_paths():
+    result = resolve_scope_paths("full", selected_paths=[], repo_file_paths=["a.py", "b.py"], local_root="/somewhere")
+    assert result == ["a.py", "b.py"]
+
+
+def test_resolve_scope_paths_full_mode_falls_back_to_local_scan(tmp_path):
+    (tmp_path / "only.py").write_text("x")
+    result = resolve_scope_paths("full", selected_paths=[], repo_file_paths=[], local_root=tmp_path)
+    assert result == ["only.py"]
+
+
+def test_resolve_scope_paths_full_mode_raises_without_tree_or_local_root():
+    with pytest.raises(RuntimeError, match="Load the file tree first"):
+        resolve_scope_paths("full", selected_paths=[], repo_file_paths=[], local_root=None)
+
+
+def test_read_local_repo_file_reads_and_decodes(tmp_path):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "f.py").write_text("hello world", encoding="utf-8")
+    assert read_local_repo_file(tmp_path, "sub/f.py") == "hello world"
+
+
+def test_read_local_repo_file_raises_when_missing(tmp_path):
+    with pytest.raises(RuntimeError, match="missing `sub/missing.py`"):
+        read_local_repo_file(tmp_path, "sub/missing.py")
+
+
+def test_read_local_repo_file_raises_when_path_is_a_directory(tmp_path):
+    (tmp_path / "adir").mkdir()
+    with pytest.raises(RuntimeError, match="resolves to a directory"):
+        read_local_repo_file(tmp_path, "adir")
+
+
+def test_read_local_repo_file_blocks_path_traversal(tmp_path):
+    with pytest.raises(RuntimeError, match="must stay inside"):
+        read_local_repo_file(tmp_path, "../../etc/passwd")
+
+
+def test_validate_pending_changes_passes_for_valid_update_and_delete_mix():
+    changes = [
+        {"path": "a.py", "operation": "update", "content": "x"},
+        {"path": "b.py", "operation": "delete"},
+    ]
+    validate_pending_changes(changes)  # must not raise
+
+
+def test_validate_pending_changes_raises_naming_path_for_missing_content():
+    changes = [{"path": "a.py", "operation": "update"}]  # no content key at all
+    with pytest.raises(RuntimeError, match="`a.py`"):
+        validate_pending_changes(changes)
+
+
+def test_validate_pending_changes_raises_when_content_is_not_a_string():
+    changes = [{"path": "a.py", "operation": "create", "content": 42}]
+    with pytest.raises(RuntimeError, match="missing its file content"):
+        validate_pending_changes(changes)
+
+
+def test_validate_pending_changes_unrecognized_operation_still_requires_content():
+    # Mirrors apply_change_set's own dispatch: only "delete" skips the write.
+    # A typo'd/corrupted operation value must NOT slip past this guard just
+    # because it isn't literally "update" or "create".
+    changes = [{"path": "a.py", "operation": "typo-op"}]  # no content
+    with pytest.raises(RuntimeError, match="`a.py`"):
+        validate_pending_changes(changes)
+
+
+# -- apply_change_set: the write/rollback core --------------------------------
+
+
+def test_apply_change_set_writes_create_update_and_delete(tmp_path):
+    (tmp_path / "existing.py").write_text("old content")
+    changes = [
+        {"path": "existing.py", "operation": "update", "content": "new content"},
+        {"path": "new/nested.py", "operation": "create", "content": "brand new"},
+        {"path": "existing.py", "operation": "delete"},
+    ]
+    # Note: same path updated then deleted in one changeset is a valid
+    # (if unusual) sequence - exercised here to also prove ordering is
+    # applied strictly in list order.
+    written = apply_change_set(tmp_path, changes[:2])
+
+    assert written == 2
+    assert (tmp_path / "existing.py").read_text() == "new content"
+    assert (tmp_path / "new" / "nested.py").read_text() == "brand new"
+
+
+def test_apply_change_set_delete_removes_file_and_counts_it(tmp_path):
+    (tmp_path / "gone.py").write_text("bye")
+    written = apply_change_set(tmp_path, [{"path": "gone.py", "operation": "delete"}])
+    assert written == 1
+    assert not (tmp_path / "gone.py").exists()
+
+
+def test_apply_change_set_delete_of_nonexistent_file_is_a_silent_noop():
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        written = apply_change_set(Path(tmp), [{"path": "never-existed.py", "operation": "delete"}])
+        assert written == 0
+
+
+def test_apply_change_set_writes_byte_exact_newlines(tmp_path):
+    # newline="" must write content byte-for-byte, not translate \n -> \r\n
+    # (see repository.py's own comment on why this matters for diff parity
+    # with what the user approved in preview).
+    content = "line1\nline2\r\nline3\n"
+    apply_change_set(tmp_path, [{"path": "f.txt", "operation": "create", "content": content}])
+    raw = (tmp_path / "f.txt").read_bytes()
+    assert raw == content.encode("utf-8")
+
+
+def test_apply_change_set_rolls_back_all_writes_on_mid_loop_failure(tmp_path):
+    (tmp_path / "first.py").write_text("original first")
+    # "blocker" exists as a DIRECTORY - writing text to it as the second
+    # change item forces a mid-loop failure (IsADirectoryError) after the
+    # first item has already been written successfully.
+    (tmp_path / "blocker").mkdir()
+
+    changes = [
+        {"path": "first.py", "operation": "update", "content": "mutated"},
+        {"path": "blocker", "operation": "update", "content": "cannot write, it's a dir"},
+    ]
+
+    with pytest.raises(Exception):
+        apply_change_set(tmp_path, changes)
+
+    # The first item's write must have been rolled back to its pre-existing
+    # content - not left mutated just because a LATER item failed.
+    assert (tmp_path / "first.py").read_text() == "original first"
+
+
+def test_apply_change_set_rollback_deletes_newly_created_file(tmp_path):
+    # "new.py" did not exist before this call - if the changeset fails
+    # partway through, rollback must delete it entirely (backup=None case),
+    # not leave a half-approved file behind.
+    (tmp_path / "blocker").mkdir()
+    changes = [
+        {"path": "new.py", "operation": "create", "content": "brand new content"},
+        {"path": "blocker", "operation": "update", "content": "boom"},
+    ]
+
+    with pytest.raises(Exception):
+        apply_change_set(tmp_path, changes)
+
+    assert not (tmp_path / "new.py").exists()
+
+
+def test_apply_change_set_original_exception_message_is_preserved(tmp_path):
+    (tmp_path / "blocker").mkdir()
+    with pytest.raises(Exception) as excinfo:
+        apply_change_set(tmp_path, [{"path": "blocker", "operation": "update", "content": "x"}])
+    # write_text against a directory raises IsADirectoryError/PermissionError
+    # depending on platform - either way it must propagate, not be swallowed.
+    assert excinfo.value is not None
+
+
+# =============================================================================
+# graphlink_plugins/gitlink/repository.py - GitlinkRepository
+# =============================================================================
+
+
+class _FakeGithubClient:
+    """Duck-types GitHubRestClient.request for GitlinkRepository unit tests -
+    GitlinkRepository "owns nothing but a github_client reference" per its
+    own module docstring, so its own logic is fully testable against any
+    object exposing this one method."""
+
+    def __init__(self, responses):
+        self.responses = responses  # url -> value, or url -> callable
+        self.calls = []
+
+    def request(self, url, params=None, *, expect_json=True, timeout=25):
+        self.calls.append({"url": url, "params": params, "expect_json": expect_json, "timeout": timeout})
+        if url not in self.responses:
+            raise AssertionError(f"unscripted request to {url}")
+        value = self.responses[url]
+        return value() if callable(value) else value
+
+
+def test_fetch_github_file_text_decodes_base64_content():
+    import base64
+    encoded = base64.b64encode("print('hi')".encode("utf-8")).decode("ascii")
+    url = "https://api.github.com/repos/o/r/contents/src/app.py"
+    client = _FakeGithubClient({url: {"encoding": "base64", "content": encoded}})
+    repo = GitlinkRepository(client)
+
+    text = repo.fetch_github_file_text("o/r", "main", "src/app.py")
+
+    assert text == "print('hi')"
+    assert client.calls[0]["params"] == {"ref": "main"}
+
+
+def test_fetch_github_file_text_directory_response_raises():
+    url = "https://api.github.com/repos/o/r/contents/src"
+    client = _FakeGithubClient({url: [{"name": "a.py"}, {"name": "b.py"}]})
+    repo = GitlinkRepository(client)
+
+    with pytest.raises(RuntimeError, match="resolves to a directory"):
+        repo.fetch_github_file_text("o/r", "main", "src")
+
+
+def test_fetch_github_file_text_falls_back_to_download_url():
+    contents_url = "https://api.github.com/repos/o/r/contents/big.bin"
+    download_url = "https://raw.githubusercontent.com/o/r/main/big.bin"
+    client = _FakeGithubClient({
+        contents_url: {"download_url": download_url},  # no inline content/encoding
+        download_url: "raw text content".encode("utf-8"),
+    })
+    repo = GitlinkRepository(client)
+
+    text = repo.fetch_github_file_text("o/r", "main", "big.bin")
+
+    assert text == "raw text content"
+    download_call = next(c for c in client.calls if c["url"] == download_url)
+    assert download_call["expect_json"] is False
+    assert download_call["timeout"] == 25
+
+
+def test_fetch_github_file_text_raises_when_no_content_or_download_url():
+    url = "https://api.github.com/repos/o/r/contents/empty.txt"
+    client = _FakeGithubClient({url: {}})
+    repo = GitlinkRepository(client)
+
+    with pytest.raises(RuntimeError, match="did not return file contents"):
+        repo.fetch_github_file_text("o/r", "main", "empty.txt")
+
+
+def test_fetch_github_file_text_url_quotes_the_repo_path():
+    captured_urls = []
+
+    class _RecordingClient:
+        def request(self, url, params=None, *, expect_json=True, timeout=25):
+            captured_urls.append(url)
+            return {"encoding": "base64", "content": "aGk="}
+
+    GitlinkRepository(_RecordingClient()).fetch_github_file_text("o/r", "main", "src/my file.py")
+    assert captured_urls[0].endswith("src/my%20file.py")
+
+
+def _zip_bytes(entries, top_dir="repo-abc123"):
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for relative_path, content in entries.items():
+            archive.writestr(f"{top_dir}/{relative_path}", content)
+    return buffer.getvalue()
+
+
+def test_download_repository_snapshot_short_circuits_when_target_already_populated(tmp_path):
+    target = tmp_path / "already-here"
+    target.mkdir()
+    (target / "marker.txt").write_text("existing checkout")
+
+    client = _FakeGithubClient({})  # no URLs scripted - must never be called
+    repo = GitlinkRepository(client)
+
+    result = repo.download_repository_snapshot("o/r", "main", target)
+
+    assert result == target
+    assert client.calls == []
+    assert (target / "marker.txt").read_text() == "existing checkout"
+
+
+def test_download_repository_snapshot_extracts_zip_and_moves_to_target(tmp_path):
+    zip_url = "https://api.github.com/repos/o/r/zipball/main"
+    archive_bytes = _zip_bytes({"file1.txt": b"hello", "sub/file2.txt": b"world"})
+    client = _FakeGithubClient({zip_url: archive_bytes})
+    repo = GitlinkRepository(client)
+    target = tmp_path / "checkout"
+
+    result = repo.download_repository_snapshot("o/r", "main", target)
+
+    assert result == target
+    assert (target / "file1.txt").read_bytes() == b"hello"
+    assert (target / "sub" / "file2.txt").read_bytes() == b"world"
+    zip_call = next(c for c in client.calls if c["url"] == zip_url)
+    assert zip_call["expect_json"] is False
+    assert zip_call["timeout"] == 60
+
+
+def test_download_repository_snapshot_quotes_branch_name_fully():
+    # safe='' -> even "/" in a branch name must be percent-escaped, unlike
+    # fetch_github_file_text's repo-path quoting (safe='/').
+    captured_urls = []
+
+    class _RecordingClient:
+        def request(self, url, params=None, *, expect_json=True, timeout=25):
+            captured_urls.append(url)
+            return _zip_bytes({"f.txt": b"x"})
+
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        GitlinkRepository(_RecordingClient()).download_repository_snapshot(
+            "o/r", "feature/my-branch", Path(tmp) / "out"
+        )
+    assert captured_urls[0].endswith("/zipball/feature%2Fmy-branch")
+
+
+def test_download_repository_snapshot_handles_concurrent_creation_race(tmp_path):
+    # Simulates another in-flight call finishing first: by the time THIS
+    # call's own extraction completes, target_root already exists (created
+    # mid-flight) - it must return that pre-existing target untouched
+    # rather than shutil.move-ing over it (which would raise).
+    target = tmp_path / "checkout"
+    zip_url = "https://api.github.com/repos/o/r/zipball/main"
+
+    def _scripted_zip():
+        target.mkdir(parents=True)
+        (target / "winner.txt").write_text("the other download won the race")
+        return _zip_bytes({"loser.txt": b"should not appear"})
+
+    client = _FakeGithubClient({zip_url: _scripted_zip})
+    repo = GitlinkRepository(client)
+
+    result = repo.download_repository_snapshot("o/r", "main", target)
+
+    assert result == target
+    assert (target / "winner.txt").exists()
+    assert not (target / "loser.txt").exists()
+
+
+# -- build_context_bundle: XML context construction ---------------------------
+
+
+def test_build_context_bundle_local_mode_builds_expected_xml_structure(tmp_path):
+    (tmp_path / "a.py").write_text("print('a')")
+    (tmp_path / "b.py").write_text("print('b')")
+    repo = GitlinkRepository(github_client=None)
+
+    result = repo.build_context_bundle(
+        repo_name="octocat/hello-world", branch_name="main", scope_mode="selected",
+        selected_paths=["a.py", "b.py"], repo_file_paths=[], local_root=tmp_path,
+    )
+
+    assert isinstance(result, ContextBundleResult)
+    assert result.context_xml.startswith(
+        '<gitlink_context repository="octocat/hello-world" branch="main" scope="selected_files">'
+    )
+    assert result.context_xml.endswith("</gitlink_context>")
+    assert 'scanned_files="2"' in result.context_xml
+    assert 'loaded_files="2"' in result.context_xml
+    assert 'included_files="2"' in result.context_xml
+    assert 'load_errors="0"' in result.context_xml
+    assert "<![CDATA[print('a')]]>" in result.context_xml
+    assert "<![CDATA[print('b')]]>" in result.context_xml
+    assert result.included_paths == ["a.py", "b.py"]
+    assert result.context_stats["source_root"] == str(tmp_path)
+    assert "Scanned 2 files" in result.context_summary
+
+
+def test_build_context_bundle_github_mode_uses_github_client():
+    url_a = "https://api.github.com/repos/o/r/contents/a.py"
+    client = _FakeGithubClient({url_a: {"encoding": "base64", "content": "cHJpbnQoJ2EnKQ=="}})
+    repo = GitlinkRepository(client)
+
+    result = repo.build_context_bundle(
+        repo_name="o/r", branch_name="main", scope_mode="selected",
+        selected_paths=["a.py"], repo_file_paths=[], local_root=None,
+    )
+
+    assert 'source="github"' in result.context_xml
+    assert result.context_stats["source_root"] == "github"
+    assert "<![CDATA[print('a')]]>" in result.context_xml
+
+
+def test_build_context_bundle_counts_load_errors_and_excludes_them_from_file_blocks(tmp_path):
+    (tmp_path / "good.py").write_text("ok")
+    # "missing.py" is never created on disk -> read_local_repo_file raises.
+    repo = GitlinkRepository(github_client=None)
+
+    result = repo.build_context_bundle(
+        repo_name="o/r", branch_name="main", scope_mode="selected",
+        selected_paths=["good.py", "missing.py"], repo_file_paths=[], local_root=tmp_path,
+    )
+
+    assert result.context_stats["scanned_files"] == 2
+    assert result.context_stats["loaded_files"] == 1
+    assert result.context_stats["load_errors"] == 1
+    assert "good.py" in result.included_paths
+    assert "missing.py" not in result.included_paths
+    # source_origin is initialized to "github" and only flipped to "local"
+    # AFTER a successful read_local_repo_file call - since this read raises
+    # before that reassignment, the error record's "source" attr stays
+    # "github" even though this whole call is in local-root mode. A minor
+    # existing inconsistency, pinned here as actual behavior.
+    assert 'path="missing.py" source="github" error=' in result.context_xml
+    # The errored file must never appear inside <files>, only <manifest>.
+    files_section = result.context_xml.split("<files>")[1]
+    assert "missing.py" not in files_section
+
+
+def test_build_context_bundle_raises_immediately_for_a_malformed_scope_path(tmp_path):
+    # Unlike per-file load errors (caught individually, above),
+    # _normalize_repo_path is called OUTSIDE the per-file try/except at the
+    # top of the loop, so a single malformed scope path aborts the WHOLE
+    # bundle build with an uncaught RuntimeError rather than being recorded
+    # as one more load_errors entry. This is real existing behavior worth
+    # pinning explicitly - a malformed/inaccessible repo tree entry doesn't
+    # degrade gracefully the way a missing/unreadable file does.
+    (tmp_path / "good.py").write_text("ok")
+    repo = GitlinkRepository(github_client=None)
+
+    with pytest.raises(RuntimeError, match="must stay inside"):
+        repo.build_context_bundle(
+            repo_name="o/r", branch_name="main", scope_mode="selected",
+            selected_paths=["good.py", "../escape.py"], repo_file_paths=[], local_root=tmp_path,
+        )
+
+
+def test_build_context_bundle_escapes_xml_special_characters(tmp_path):
+    (tmp_path / "a.py").write_text("x")
+    repo = GitlinkRepository(github_client=None)
+
+    result = repo.build_context_bundle(
+        repo_name='o/r"with-quote', branch_name="main&branch", scope_mode="selected",
+        selected_paths=["a.py"], repo_file_paths=[], local_root=tmp_path,
+    )
+
+    assert 'repository="o/r&quot;with-quote"' in result.context_xml
+    assert 'branch="main&amp;branch"' in result.context_xml
+
+
+def test_build_context_bundle_context_budget_omits_files_over_max_chars(tmp_path, monkeypatch):
+    (tmp_path / "a.py").write_text("a" * 50)
+    (tmp_path / "b.py").write_text("b" * 50)
+    # Force the overall document budget so small that only the FIRST file's
+    # block fits - the omission guard only fires once file_blocks is
+    # already non-empty, so this also implicitly proves at least one file
+    # always gets in regardless of budget.
+    monkeypatch.setattr(repository_module, "MAX_CONTEXT_CHARS", 120)
+    repo = GitlinkRepository(github_client=None)
+
+    result = repo.build_context_bundle(
+        repo_name="o/r", branch_name="main", scope_mode="selected",
+        selected_paths=["a.py", "b.py"], repo_file_paths=[], local_root=tmp_path,
+    )
+
+    assert result.context_stats["included_files"] == 1
+    assert result.context_stats["context_omissions"] == 1
+    assert len(result.included_paths) == 1
+    assert 'omitted="true"' in result.context_xml
+    assert 'reason="context_budget"' in result.context_xml
+
+
+def test_build_context_bundle_manifest_budget_truncates_entries(tmp_path, monkeypatch):
+    for i in range(5):
+        (tmp_path / f"f{i}.py").write_text("x")
+    monkeypatch.setattr(repository_module, "MAX_MANIFEST_ENTRIES", 2)
+    repo = GitlinkRepository(github_client=None)
+
+    result = repo.build_context_bundle(
+        repo_name="o/r", branch_name="main", scope_mode="selected",
+        selected_paths=[f"f{i}.py" for i in range(5)], repo_file_paths=[], local_root=tmp_path,
+    )
+
+    assert '<more count="3" reason="manifest_budget" />' in result.context_xml
+    # Manifest lines themselves are capped at 2, but ALL 5 files are still
+    # loaded and included in the <files> section (the manifest budget only
+    # limits the human-readable listing, not what actually gets sent).
+    assert result.context_stats["included_files"] == 5
+
+
+def test_build_context_bundle_scope_label_full_vs_selected(tmp_path):
+    (tmp_path / "a.py").write_text("x")
+    repo = GitlinkRepository(github_client=None)
+
+    selected = repo.build_context_bundle(
+        repo_name="o/r", branch_name="main", scope_mode="selected",
+        selected_paths=["a.py"], repo_file_paths=[], local_root=tmp_path,
+    )
+    full = repo.build_context_bundle(
+        repo_name="o/r", branch_name="main", scope_mode="full",
+        selected_paths=[], repo_file_paths=["a.py"], local_root=tmp_path,
+    )
+
+    assert 'scope="selected_files"' in selected.context_xml
+    assert 'scope="full_repo"' in full.context_xml
+
+
+def test_build_context_bundle_per_file_truncation_flows_through_to_xml(tmp_path):
+    # Exceeds agent.py's MAX_FILE_CONTEXT_CHARS (24000) so _truncate_for_context
+    # actually engages for this one file, end to end through build_context_bundle.
+    big_content = "x" * 24050
+    (tmp_path / "big.py").write_text(big_content)
+    repo = GitlinkRepository(github_client=None)
+
+    result = repo.build_context_bundle(
+        repo_name="o/r", branch_name="main", scope_mode="selected",
+        selected_paths=["big.py"], repo_file_paths=[], local_root=tmp_path,
+    )
+
+    assert 'path="big.py" source="local" included="true" chars="24050" truncated="true"' in result.context_xml
+    files_section = result.context_xml.split("<files>")[1]
+    assert files_section.count("x") < 24050  # the CDATA body itself was cut down
+
+
+def test_build_context_bundle_empty_scope_produces_empty_but_valid_shell(tmp_path):
+    (tmp_path / "unused.py").write_text("x")
+    repo = GitlinkRepository(github_client=None)
+
+    result = repo.build_context_bundle(
+        repo_name="o/r", branch_name="main", scope_mode="full",
+        selected_paths=[], repo_file_paths=[], local_root=tmp_path,
+    )
+    # scope_mode="full" with no repo_file_paths falls back to a full local
+    # scan, so "unused.py" IS included here - this pins that fallback path.
+    assert result.included_paths == ["unused.py"]

--- a/backend/tests/test_plugin_builtin_migration.py
+++ b/backend/tests/test_plugin_builtin_migration.py
@@ -29,6 +29,8 @@ adds only the picker-entry pin and the command_type/undo pin that section
 didn't previously need."""
 
 import asyncio
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -37,6 +39,7 @@ from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.plugin_sdk import discover_plugins
 from backend.plugins import get_plugin_categories, register_plugins
+from graphlink_settings_store import SettingsManager
 
 
 def _make_bus():
@@ -45,7 +48,14 @@ def _make_bus():
     bus.register_topic("notification", notifications.payload)
     canvas_document = SceneDocument()
     bus.register_topic("scene", canvas_document.scene_payload)
-    register_plugins(bus, notifications, canvas_document)
+    # ADR-014 stage 14.4: register_plugins now requires a real
+    # SettingsManager - every case in this file dispatches a BUILT-IN
+    # picker action (never grant-gated), so a throwaway store is enough;
+    # see backend/tests/test_plugins.py's own _fresh_settings_manager for
+    # the same "tempfile dir, explicitly sanctioned by conftest.py's own
+    # guard docstring" posture.
+    settings_manager = SettingsManager(Path(tempfile.mkdtemp()) / "session.dat")
+    register_plugins(bus, notifications, canvas_document, settings_manager)
     return bus, notifications, canvas_document
 
 

--- a/backend/tests/test_plugin_builtin_migration.py
+++ b/backend/tests/test_plugin_builtin_migration.py
@@ -1,0 +1,243 @@
+"""ADR-014 stage 14.3 pinning tests: migrating the 8 built-in plugin picker
+actions (backend/plugins.py's old hardcoded if-chain) onto
+HostContext.register_builtin_plugin (backend/plugin_sdk.py), backed by 8
+real packages under plugins/ (plugins/web_research/, plugins/gitlink/,
+plugins/pycoder/, plugins/code_sandbox/, plugins/artifact/,
+plugins/system_prompt/, plugins/conversation_node/,
+plugins/html_renderer/).
+
+Proves, for each migrated built-in:
+
+- the picker categories payload lists it with the EXACT SAME name/
+  description/category it had pre-migration (a regression here is a real
+  UI regression);
+- the exact same parent-validation warning text fires on a missing/invalid
+  parent, and no node is created;
+- invoking executePlugin with a valid parent still creates the exact same
+  node kind, via the exact same command_type in record_command (undo-stack
+  identity, not just node shape);
+- undo still removes exactly what it created, and nothing more.
+
+System Prompt (the one built-in whose shape genuinely differs - attaches
+to the branch ROOT with a REVERSED note -> root edge, and dedups instead
+of creating a second note) is handled separately below: its full
+dedup/reversed-edge/branch-root-walk behavior is already covered end to
+end by backend/tests/test_plugins.py's own R6.1 section (unchanged by this
+migration - same command_type, same warning text, same logic, now sourced
+from plugins/system_prompt/ instead of a hardcoded if-branch); this file
+adds only the picker-entry pin and the command_type/undo pin that section
+didn't previously need."""
+
+import asyncio
+
+import pytest
+
+from backend.canvas import SceneDocument
+from backend.events import SessionBus
+from backend.notifications import NotificationState
+from backend.plugin_sdk import discover_plugins
+from backend.plugins import get_plugin_categories, register_plugins
+
+
+def _make_bus():
+    bus = SessionBus("plugin-builtin-migration-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    canvas_document = SceneDocument()
+    bus.register_topic("scene", canvas_document.scene_payload)
+    register_plugins(bus, notifications, canvas_document)
+    return bus, notifications, canvas_document
+
+
+# (picker_name, description, category, command_type, expected_kind,
+#  warning_text, expected_title) - description/category/warning_text are
+# byte-identical to the pre-migration hardcoded _PLUGINS list / if-chain.
+_BUILTIN_CASES = [
+    pytest.param(
+        "Web Research",
+        "Searches, retrieves, and summarizes cited web sources under a bounded network policy.",
+        "Reasoning & Research",
+        "pluginWebResearch",
+        "web_research",
+        "Please select a valid node to branch from before adding a Web Node.",
+        "Web Research",
+        id="web_research",
+    ),
+    pytest.param(
+        "Gitlink",
+        "Loads a GitHub repository into structured XML context, prepares file-level changes, and only writes after explicit approval.",
+        "Build & Execution",
+        "pluginGitlink",
+        "gitlink",
+        "Please select a valid node to branch from before adding a Gitlink node.",
+        "Gitlink",
+        id="gitlink",
+    ),
+    pytest.param(
+        "Py-Coder",
+        "Opens a Python execution environment to run code and get AI analysis.",
+        "Build & Execution",
+        "pluginPyCoder",
+        "pycoder",
+        "Please select a valid node to branch from before adding a Py-Coder node.",
+        "Py-Coder",
+        id="pycoder",
+    ),
+    pytest.param(
+        "Virtual Environment Runner",
+        "Runs Python inside an isolated virtualenv with your full user-account privileges (isolates installed packages, not the operating system) and lets you declare per-node requirements.txt dependencies.",
+        "Build & Execution",
+        "pluginCodeSandbox",
+        "code_sandbox",
+        "Please select a valid node to branch from before adding a Virtual Environment Runner node.",
+        "Virtual Environment Runner",
+        id="code_sandbox",
+    ),
+    pytest.param(
+        "Artifact / Drafter",
+        "A split-pane node for iteratively drafting and refining living documents (Markdown).",
+        "Workflow & Drafting",
+        "pluginArtifact",
+        "artifact",
+        "Please select a valid node to branch from before adding an Artifact node.",
+        "Artifact",
+        id="artifact",
+    ),
+    pytest.param(
+        "Conversation Node",
+        "Adds a node for a self-contained, linear chat conversation.",
+        "Branch Foundations",
+        "pluginConversationNode",
+        "conversation",
+        "Please select a valid node to branch from before adding a Conversation Node.",
+        "Conversation",
+        id="conversation_node",
+    ),
+    pytest.param(
+        "HTML Renderer",
+        "Adds a node to render HTML code from a parent node.",
+        "Build & Execution",
+        "pluginHtmlRenderer",
+        "html",
+        "Please select a valid node to branch from before adding an HTML Renderer node.",
+        "HTML",
+        id="html_renderer",
+    ),
+]
+
+_CASE_FIELDS = "picker_name, description, category, command_type, expected_kind, warning_text, expected_title"
+
+
+@pytest.mark.parametrize(_CASE_FIELDS, _BUILTIN_CASES)
+def test_builtin_picker_entry_pinned_in_categories_payload(
+    picker_name, description, category, command_type, expected_kind, warning_text, expected_title,
+):
+    grouped = get_plugin_categories(discover_plugins())
+    entry_category = next(
+        (c for c in grouped if any(p["name"] == picker_name for p in c["plugins"])), None,
+    )
+    assert entry_category is not None, f'"{picker_name}" missing from the picker categories payload'
+    assert entry_category["name"] == category
+    plugin_entry = next(p for p in entry_category["plugins"] if p["name"] == picker_name)
+    assert plugin_entry["description"] == description
+
+
+@pytest.mark.parametrize(_CASE_FIELDS, _BUILTIN_CASES)
+def test_builtin_requires_a_selected_parent_with_the_exact_warning(
+    picker_name, description, category, command_type, expected_kind, warning_text, expected_title,
+):
+    bus, notifications, canvas_document = _make_bus()
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", [picker_name]))
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == warning_text
+    assert not any(n.kind == expected_kind for n in canvas_document.nodes.values())
+
+
+@pytest.mark.parametrize(_CASE_FIELDS, _BUILTIN_CASES)
+def test_builtin_rejects_an_unknown_parent_id_with_the_exact_warning(
+    picker_name, description, category, command_type, expected_kind, warning_text, expected_title,
+):
+    bus, notifications, canvas_document = _make_bus()
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", [picker_name, "ghost-node-id"])
+    )
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert notifications.message == warning_text
+    assert not any(n.kind == expected_kind for n in canvas_document.nodes.values())
+
+
+@pytest.mark.parametrize(_CASE_FIELDS, _BUILTIN_CASES)
+def test_builtin_creates_the_exact_kind_with_the_exact_command_type_and_undoes_cleanly(
+    picker_name, description, category, command_type, expected_kind, warning_text, expected_title,
+):
+    bus, notifications, canvas_document = _make_bus()
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", [picker_name, parent.id])
+    )
+
+    assert result is not None
+    node = canvas_document.nodes[result]
+    assert node.kind == expected_kind
+    assert node.title == expected_title
+    assert any(
+        e.source == parent.id and e.target == node.id for e in canvas_document.edges.values()
+    )
+    assert notifications.visible is False, "success is not a deferral - no notification fires"
+    assert canvas_document.command_log[-1].command_type == command_type
+    assert canvas_document.can_undo()
+
+    canvas_document.undo()
+
+    assert result not in canvas_document.nodes
+    assert not any(
+        e.source == parent.id and e.target == result for e in canvas_document.edges.values()
+    )
+    assert parent.id in canvas_document.nodes
+
+
+# -- System Prompt: the one built-in whose shape genuinely differs ----------
+
+
+def test_system_prompt_picker_entry_pinned_in_categories_payload():
+    grouped = get_plugin_categories(discover_plugins())
+    entry_category = next(
+        (c for c in grouped if any(p["name"] == "System Prompt" for p in c["plugins"])), None,
+    )
+    assert entry_category is not None
+    assert entry_category["name"] == "Branch Foundations"
+    plugin_entry = next(p for p in entry_category["plugins"] if p["name"] == "System Prompt")
+    assert plugin_entry["description"] == (
+        "Adds a special node to override the default system prompt for a "
+        "conversation branch."
+    )
+
+
+def test_system_prompt_command_type_is_pinned_and_undo_removes_note_and_edge():
+    bus, notifications, canvas_document = _make_bus()
+    root = canvas_document.add_node(100, 200, "root")
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["System Prompt", root.id])
+    )
+
+    assert result is not None
+    assert canvas_document.command_log[-1].command_type == "pluginSystemPrompt"
+    assert canvas_document.can_undo()
+
+    canvas_document.undo()
+
+    assert result not in canvas_document.nodes
+    assert not any(
+        e.source == result and e.target == root.id for e in canvas_document.edges.values()
+    )
+    assert root.id in canvas_document.nodes

--- a/backend/tests/test_plugin_grants.py
+++ b/backend/tests/test_plugin_grants.py
@@ -43,6 +43,8 @@ from backend.plugin_sdk import (
     discover_plugins,
 )
 from backend.plugins import plugins_payload, register_plugins
+from backend.session_load import restore_chat_into_document
+from backend.session_save import build_chat_data
 from graphlink_settings_store import SettingsManager
 
 
@@ -227,6 +229,155 @@ def test_builtin_plugin_always_works_regardless_of_grant_state_and_has_no_manife
     assert "web_research" not in granted_plugin_ids
 
 
+# -- 3b: revoking a grant actually stops serialize/deserialize hooks --------
+# -- from running (finding 2) ------------------------------------------------
+#
+# BEFORE this fix, backend/plugins.py's register_plugins wired a plugin's
+# HostContext.register_node_kind(..., serialize=...) hook into
+# SceneDocument.plugin_node_serializers UNCONDITIONALLY - unlike node
+# creation/invokePluginIntent/register_plugin_tools' handler (all three
+# already check settings_manager.get_plugin_grants() before running a
+# plugin's own code), so revoking a plugin's grant in Settings did NOT stop
+# its serialize/deserialize code from continuing to run on every live-wire
+# scene publish, save, and load. These three tests prove each of the three
+# now-gated call sites independently.
+
+
+def _stateful_grant_py_body(picker_name: str) -> str:
+    return textwrap.dedent(f"""\
+        from dataclasses import dataclass
+
+        from backend.domain.node_states import NodeState
+        from backend.plugin_sdk import HostContext, PluginNodeSeed
+
+
+        @dataclass
+        class WidgetState(NodeState):
+            clicks: int = 0
+
+
+        def _make(document, run_ctx, parent_id):
+            return PluginNodeSeed(title="Widget", content="", state=WidgetState(clicks=3))
+
+
+        def _serialize(node):
+            return {{"clicks": node.state.clicks}}
+
+
+        def _deserialize(data):
+            return WidgetState(clicks=int(data.get("clicks", 0)))
+
+
+        def register(host: HostContext) -> None:
+            host.register_node_kind(
+                "widget", _make, requires_parent=True, serialize=_serialize, deserialize=_deserialize,
+            )
+            host.register_picker_entry(
+                node_kind="widget", name="{picker_name}", description="d", category="More Plugins",
+            )
+    """)
+
+
+def test_revoking_a_plugins_grant_stops_its_live_wire_serializer_from_running(tmp_path):
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "statefulgrant1", register_body=_stateful_grant_py_body("Grant Widget 1"),
+    )
+    registry = discover_plugins(tmp_path / "plugins")
+    bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+    settings_manager.set_plugin_grant("statefulgrant1", True)
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Grant Widget 1", parent.id])
+    )
+    assert node_id is not None
+
+    # Granted: the live wire carries the plugin's own custom state.
+    wire = canvas_document.scene_payload()
+    node_wire = next(n for n in wire["nodes"] if n["id"] == node_id)
+    assert node_wire["pluginState"] == {"clicks": "3"}
+
+    # Revoke - the SAME live node, no re-registration, no session restart.
+    settings_manager.set_plugin_grant("statefulgrant1", False)
+
+    wire2 = canvas_document.scene_payload()
+    node_wire2 = next(n for n in wire2["nodes"] if n["id"] == node_id)
+    # Degrades to {} (the same "no plugin state to show" shape a plugin
+    # with no serializer at all produces) - proving the wrapper re-checks
+    # the CURRENT grant on every publish, not just at registration time.
+    assert node_wire2["pluginState"] == {}
+
+
+def test_ungranted_plugins_serializer_is_skipped_on_save_when_settings_manager_is_passed(tmp_path):
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "statefulgrant2", register_body=_stateful_grant_py_body("Grant Widget 2"),
+    )
+    registry = discover_plugins(tmp_path / "plugins")
+    bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+    settings_manager.set_plugin_grant("statefulgrant2", True)
+    parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
+
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Grant Widget 2", parent.id])
+    )
+    assert node_id is not None
+
+    # Revoke BEFORE saving.
+    settings_manager.set_plugin_grant("statefulgrant2", False)
+
+    chat_data = build_chat_data(canvas_document, plugin_registry=registry, settings_manager=settings_manager)
+    saved_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "statefulgrant2.widget")
+    # The node's universal title/content still saves; plugin_state is
+    # withheld because the grant was revoked before this save.
+    assert saved_payload["title"] == "Widget"
+    assert "plugin_state" not in saved_payload
+
+    # Backward-compat sanity: WITHOUT settings_manager (this parameter's
+    # own default, and every pre-fix call site), the exact same document
+    # still saves its plugin_state - preserving prior ungated behavior for
+    # any caller that doesn't opt in.
+    chat_data_ungated = build_chat_data(canvas_document, plugin_registry=registry)
+    saved_ungated = next(n for n in chat_data_ungated["nodes"] if n["node_type"] == "statefulgrant2.widget")
+    assert saved_ungated["plugin_state"] == {"clicks": 3}
+
+
+def test_ungranted_plugins_deserializer_is_skipped_on_load_when_settings_manager_is_passed(tmp_path):
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "statefulgrant3", register_body=_stateful_grant_py_body("Grant Widget 3"),
+    )
+    registry = discover_plugins(tmp_path / "plugins")
+    bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+    settings_manager.set_plugin_grant("statefulgrant3", True)
+    parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
+
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Grant Widget 3", parent.id])
+    )
+    assert node_id is not None
+
+    # Save while GRANTED, so plugin_state genuinely made it into the file.
+    chat_data = build_chat_data(canvas_document, plugin_registry=registry, settings_manager=settings_manager)
+    notes_data = chat_data.pop("notes_data")
+    pins_data = chat_data.pop("pins_data")
+    saved_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "statefulgrant3.widget")
+    assert saved_payload["plugin_state"] == {"clicks": 3}
+
+    # Revoke BEFORE reloading.
+    settings_manager.set_plugin_grant("statefulgrant3", False)
+
+    doc2 = SceneDocument()
+    restore_chat_into_document(
+        doc2, {"data": chat_data}, notes_data, pins_data,
+        plugin_registry=registry, settings_manager=settings_manager,
+    )
+    reloaded = next(n for n in doc2.nodes.values() if n.kind == "statefulgrant3.widget")
+    # The node itself still round-trips (title/content survive) - only its
+    # custom deserialize()-produced state is withheld because the grant was
+    # revoked before this reload.
+    assert reloaded.title == "Widget"
+    assert reloaded.state is None
+
+
 # -- 4: unknown scope string rejected at discovery, fail-soft ----------------
 
 
@@ -253,6 +404,86 @@ def test_unknown_scope_in_manifest_is_rejected_at_discovery_fail_soft_per_plugin
     # takes down anyone else's discovery.
     assert "goodsibling" in registry.manifests
     assert "Good Sibling Node" in registry.picker_entries
+
+
+# -- 4b: malformed [scopes].grants TYPE (not a list-of-strings at all) -------
+#
+# A distinct code path from "unknown scope string" above: this is the
+# isinstance/type-shape guard (backend/plugin_sdk.py's `if not isinstance(
+# raw_grants, list) or not all(isinstance(g, str) for g in raw_grants)`),
+# not the "known scope set" membership check - a malformed TOML value (a
+# bare string instead of an array, or an array holding a non-string
+# element) never even reaches the KNOWN_SCOPES comparison.
+
+
+def test_grants_value_that_is_a_bare_string_not_a_list_is_rejected_at_discovery_fail_soft_per_plugin(tmp_path):
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "badgrantstype",
+        # TOML-valid, but [scopes].grants must be an array - a bare string
+        # is exactly the "not isinstance(raw_grants, list)" branch.
+        scopes_toml='[scopes]\ngrants = "graph.mutate"',
+        picker_name="Bad Grants Type Node",
+    )
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "goodsibling2",
+        scopes_toml='[scopes]\ngrants = ["graph.mutate"]',
+        picker_name="Good Sibling Two Node",
+    )
+
+    registry = discover_plugins(tmp_path / "plugins")
+
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "badgrantstype"
+    assert "must be a list of strings" in registry.load_errors[0].message
+    assert "badgrantstype" not in registry.manifests
+    assert "Bad Grants Type Node" not in registry.picker_entries
+    # The sibling plugin is completely unaffected.
+    assert "goodsibling2" in registry.manifests
+    assert "Good Sibling Two Node" in registry.picker_entries
+
+
+def test_grants_list_containing_a_non_string_element_is_rejected_at_discovery_fail_soft_per_plugin(tmp_path):
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "badgrantselement",
+        # A syntactically real TOML array, but one element is an integer,
+        # not a string - "not all(isinstance(g, str) for g in raw_grants)".
+        scopes_toml="[scopes]\ngrants = [\"graph.mutate\", 42]",
+        picker_name="Bad Grants Element Node",
+    )
+
+    registry = discover_plugins(tmp_path / "plugins")
+
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "badgrantselement"
+    assert "must be a list of strings" in registry.load_errors[0].message
+    assert "badgrantselement" not in registry.manifests
+    assert "Bad Grants Element Node" not in registry.picker_entries
+
+
+def test_grants_value_that_is_a_bare_string_raises_at_manifest_load_time_directly():
+    from backend.plugin_sdk import _load_manifest
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / "badgrantstype"
+        plugin_dir.mkdir()
+        (plugin_dir / "plugin.toml").write_text(
+            textwrap.dedent("""\
+                [plugin]
+                id = "badgrantstype"
+                name = "Bad Grants Type Plugin"
+                version = "0.1.0"
+                sdk_api_version = 1
+                entry_point = "plugin:register"
+
+                [scopes]
+                grants = "graph.mutate"
+            """),
+            encoding="utf-8",
+        )
+        with pytest.raises(PluginRegistrationError, match="must be a list of strings"):
+            _load_manifest(plugin_dir / "plugin.toml", plugin_dir)
 
 
 def test_unknown_scope_error_raises_at_manifest_load_time_directly():

--- a/backend/tests/test_plugin_grants.py
+++ b/backend/tests/test_plugin_grants.py
@@ -1,0 +1,566 @@
+"""ADR-014 stage 14.4: scope model + install-time consent + Settings grants.
+
+Proves the stage's own exit criterion literally, not just in prose: "a
+plugin acting outside its grant is denied." Four load-bearing claims,
+each with its own dedicated test group below:
+
+1. A non-granted third-party (generic-path) plugin's node-creation attempt
+   via executePlugin is DENIED - a clear notification fires, no node is
+   created, and nothing lands on the undo stack (because nothing happened).
+2. Granting that SAME plugin (via SettingsManager.set_plugin_grant,
+   simulating the Settings UI's own write path) then lets the identical
+   dispatch succeed.
+3. A built-in (register_builtin_plugin escape hatch, e.g. "Web Research")
+   is completely unaffected by grant state in either direction - it has no
+   manifest [scopes] table at all and never consults the grant store.
+4. An unknown scope string in a manifest's [scopes].grants is rejected AT
+   DISCOVERY with a PluginLoadError, fail-soft (this one plugin is skipped,
+   every sibling still loads) - the same posture every other malformed-
+   manifest case already gets (backend/tests/test_plugin_sdk.py).
+5. The new "invokePluginIntent" dispatch denies an ungranted plugin's
+   custom intent the same way, and allows it once granted.
+
+Also covers the surrounding machinery this enforcement depends on:
+SettingsManager.get_plugin_grants()/set_plugin_grant() persistence,
+PluginManifest.scopes_grants parsing, the "app-plugins" topic's new
+"grants" array shape (built-ins absent, one row per distinct third-party
+plugin_id), and the new setPluginGrant intent's persist-then-republish
+behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import textwrap
+
+import pytest
+
+from backend.canvas import SceneDocument
+from backend.events import SessionBus
+from backend.notifications import NotificationState
+from backend.plugin_sdk import (
+    HostContext,
+    PluginRegistrationError,
+    discover_plugins,
+)
+from backend.plugins import plugins_payload, register_plugins
+from graphlink_settings_store import SettingsManager
+
+
+def _write_grant_test_plugin(
+    plugins_root, plugin_id, *, scopes_toml="", picker_name=None, register_body=None,
+):
+    """Writes one real plugin.toml + plugin.py under plugins_root/plugin_id -
+    a minimal node-creation plugin (generic PluginNodeSeed path, same shape
+    as plugins/hello_node/), optionally carrying a [scopes] table verbatim
+    (or none at all, the "omitted -> frozenset()" case)."""
+    plugin_dir = plugins_root / plugin_id
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    picker_name = picker_name or f"{plugin_id} Node"
+    (plugin_dir / "plugin.toml").write_text(
+        textwrap.dedent(f"""\
+            [plugin]
+            id = "{plugin_id}"
+            name = "{plugin_id} Plugin"
+            version = "0.1.0"
+            sdk_api_version = 1
+            entry_point = "plugin:register"
+            {scopes_toml}
+        """),
+        encoding="utf-8",
+    )
+    if register_body is None:
+        register_body = textwrap.dedent(f"""\
+            from backend.plugin_sdk import HostContext, PluginNodeSeed
+
+
+            def _make(document, run_ctx, parent_id):
+                return PluginNodeSeed(title="Grant Test Node", content="made it")
+
+
+            def register(host: HostContext) -> None:
+                host.register_node_kind("thing", _make, requires_parent=True)
+                host.register_picker_entry(
+                    node_kind="thing", name="{picker_name}", description="d",
+                    category="More Plugins",
+                )
+        """)
+    (plugin_dir / "plugin.py").write_text(register_body, encoding="utf-8")
+    return plugin_dir
+
+
+def _wired_bus(registry, tmp_path, *, dirname="grant-test-store"):
+    settings_manager = SettingsManager(tmp_path / dirname / "session.dat")
+    notifications = NotificationState()
+    bus = SessionBus("plugin-grants-test")
+    bus.register_topic("notification", notifications.payload)
+    canvas_document = SceneDocument()
+    bus.register_topic("scene", canvas_document.scene_payload)
+    register_plugins(bus, notifications, canvas_document, settings_manager, plugin_registry=registry)
+    return bus, notifications, canvas_document, settings_manager
+
+
+# -- 1 & 2: deny-by-default, then allow after a real grant -------------------
+
+
+def test_ungranted_generic_plugin_denies_node_creation_with_a_clear_notification(tmp_path):
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "denyme", scopes_toml='[scopes]\ngrants = ["graph.mutate"]',
+        picker_name="Deny Me Node",
+    )
+    registry = discover_plugins(tmp_path / "plugins")
+    bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    # Never granted - settings_manager.get_plugin_grants() is empty.
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Deny Me Node", parent.id])
+    )
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert "Deny Me Node" in notifications.message
+    assert "approval" in notifications.message.lower()
+    # No node created...
+    assert len(canvas_document.nodes) == 1  # only the parent
+    # ...and nothing recorded - undo is unaffected because nothing happened.
+    assert canvas_document.can_undo() is False
+
+
+def test_granting_the_same_plugin_then_allows_the_identical_dispatch_to_succeed(tmp_path):
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "allowme", scopes_toml='[scopes]\ngrants = ["graph.mutate"]',
+        picker_name="Allow Me Node",
+    )
+    registry = discover_plugins(tmp_path / "plugins")
+    bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    denied = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Allow Me Node", parent.id])
+    )
+    assert denied is None
+    assert len(canvas_document.nodes) == 1
+
+    # Simulates the Settings UI's own write path.
+    settings_manager.set_plugin_grant("allowme", True)
+
+    created = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Allow Me Node", parent.id])
+    )
+
+    assert created is not None
+    node = canvas_document.nodes[created]
+    assert node.kind == "allowme.thing"
+    assert canvas_document.can_undo() is True
+    # Revoking again must deny the NEXT attempt (not a one-time unlock).
+    settings_manager.set_plugin_grant("allowme", False)
+    revoked = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Allow Me Node", parent.id])
+    )
+    assert revoked is None
+    assert len(canvas_document.nodes) == 2  # the one real creation above, no more
+
+
+def test_ungranted_plugin_denies_even_with_no_parent_selected_grant_checked_first(tmp_path):
+    # The grant gate runs BEFORE parent validation (cheapest static check
+    # first, mirroring ToolRegistry.invoke()) - an ungranted plugin is
+    # denied regardless of what parent (if any) was passed.
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "denyme2", scopes_toml='[scopes]\ngrants = ["graph.mutate"]',
+        picker_name="Deny Me Two",
+    )
+    registry = discover_plugins(tmp_path / "plugins")
+    bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Deny Me Two"]))
+
+    assert result is None
+    assert notifications.visible is True
+    assert "approval" in notifications.message.lower()
+
+
+def test_a_plugin_with_no_scopes_table_still_requires_an_explicit_grant(tmp_path):
+    # Omitting [scopes] entirely -> scopes_grants == frozenset(), which is
+    # NOT the same as "trusted" - install-time consent is still required.
+    _write_grant_test_plugin(tmp_path / "plugins", "noscopes", picker_name="No Scopes Node")
+    registry = discover_plugins(tmp_path / "plugins")
+    assert registry.manifests["noscopes"].scopes_grants == frozenset()
+
+    bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["No Scopes Node", parent.id])
+    )
+    assert result is None
+    assert len(canvas_document.nodes) == 1
+
+
+# -- 3: built-ins are completely unaffected by grant state --------------------
+
+
+def test_builtin_plugin_always_works_regardless_of_grant_state_and_has_no_manifest_scopes(tmp_path):
+    registry = discover_plugins()  # the real, shipped plugins/ root
+    bus, notifications, canvas_document, settings_manager = _wired_bus(
+        registry, tmp_path, dirname="builtin-store",
+    )
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    # Nothing was ever granted for ANY plugin_id in this fresh store.
+    assert settings_manager.get_plugin_grants() == {}
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Web Research", parent.id])
+    )
+
+    assert result is not None
+    node = canvas_document.nodes[result]
+    assert node.kind == "web_research"
+    assert notifications.visible is False
+
+    # Built-ins never appear in the grants payload at all (see _plugin_grants
+    # _payload's own docstring) - "web_research" is a builtin_actions plugin
+    # id, not a picker_entries one.
+    payload = plugins_payload(registry, settings_manager)
+    granted_plugin_ids = {row["pluginId"] for row in payload["grants"]}
+    assert "web_research" not in granted_plugin_ids
+
+
+# -- 4: unknown scope string rejected at discovery, fail-soft ----------------
+
+
+def test_unknown_scope_in_manifest_is_rejected_at_discovery_fail_soft_per_plugin(tmp_path):
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "badscope",
+        scopes_toml='[scopes]\ngrants = ["not.a.real.scope"]',
+        picker_name="Bad Scope Node",
+    )
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "goodsibling",
+        scopes_toml='[scopes]\ngrants = ["graph.mutate"]',
+        picker_name="Good Sibling Node",
+    )
+
+    registry = discover_plugins(tmp_path / "plugins")
+
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "badscope"
+    assert "not.a.real.scope" in registry.load_errors[0].message
+    assert "badscope" not in registry.manifests
+    assert "Bad Scope Node" not in registry.picker_entries
+    # The sibling plugin is completely unaffected - a bad manifest never
+    # takes down anyone else's discovery.
+    assert "goodsibling" in registry.manifests
+    assert "Good Sibling Node" in registry.picker_entries
+
+
+def test_unknown_scope_error_raises_at_manifest_load_time_directly():
+    from backend.plugin_sdk import _load_manifest
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / "badscope"
+        plugin_dir.mkdir()
+        manifest_path = plugin_dir / "plugin.toml"
+        manifest_path.write_text(
+            textwrap.dedent("""\
+                [plugin]
+                id = "badscope"
+                name = "Bad Scope"
+                version = "0.1.0"
+                sdk_api_version = 1
+                entry_point = "plugin:register"
+
+                [scopes]
+                grants = ["totally.unknown"]
+            """),
+            encoding="utf-8",
+        )
+        with pytest.raises(PluginRegistrationError, match="unknown scope"):
+            _load_manifest(manifest_path, plugin_dir)
+
+
+def test_scopes_grants_parses_a_valid_subset_of_known_scopes():
+    from backend.plugin_sdk import _load_manifest
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / "goodscope"
+        plugin_dir.mkdir()
+        manifest_path = plugin_dir / "plugin.toml"
+        manifest_path.write_text(
+            textwrap.dedent("""\
+                [plugin]
+                id = "goodscope"
+                name = "Good Scope"
+                version = "0.1.0"
+                sdk_api_version = 1
+                entry_point = "plugin:register"
+
+                [scopes]
+                grants = ["graph.mutate", "net.fetch"]
+            """),
+            encoding="utf-8",
+        )
+        manifest = _load_manifest(manifest_path, plugin_dir)
+        assert manifest.scopes_grants == frozenset({"graph.mutate", "net.fetch"})
+
+
+def test_scopes_grants_defaults_to_empty_frozenset_when_table_omitted():
+    from backend.plugin_sdk import _load_manifest
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / "noscope"
+        plugin_dir.mkdir()
+        manifest_path = plugin_dir / "plugin.toml"
+        manifest_path.write_text(
+            textwrap.dedent("""\
+                [plugin]
+                id = "noscope"
+                name = "No Scope"
+                version = "0.1.0"
+                sdk_api_version = 1
+                entry_point = "plugin:register"
+            """),
+            encoding="utf-8",
+        )
+        manifest = _load_manifest(manifest_path, plugin_dir)
+        assert manifest.scopes_grants == frozenset()
+
+
+# -- 5: invokePluginIntent denies/allows a custom plugin intent -------------
+
+
+def _write_intent_plugin(plugins_root, plugin_id):
+    """A plugin declaring ONE custom intent via HostContext.register_intent -
+    the mechanism 14.1 left unwired, closed by this stage's invokePluginIntent
+    chokepoint. `_do_thing` returns a plugin_id-derived string, proof enough
+    that it (and not some other plugin's handler) actually ran."""
+    plugin_dir = plugins_root / plugin_id
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.toml").write_text(
+        textwrap.dedent(f"""\
+            [plugin]
+            id = "{plugin_id}"
+            name = "{plugin_id} Plugin"
+            version = "0.1.0"
+            sdk_api_version = 1
+            entry_point = "plugin:register"
+
+            [scopes]
+            grants = ["graph.mutate"]
+        """),
+        encoding="utf-8",
+    )
+    (plugin_dir / "plugin.py").write_text(
+        textwrap.dedent("""\
+            from backend.plugin_sdk import HostContext
+
+
+            def _do_thing(document, run_ctx):
+                return f"did-the-thing:{run_ctx.plugin_id}"
+
+
+            def register(host: HostContext) -> None:
+                host.register_intent("do_thing", _do_thing)
+        """),
+        encoding="utf-8",
+    )
+    return plugin_dir
+
+
+def test_invoke_plugin_intent_denies_an_ungranted_plugins_custom_intent(tmp_path):
+    _write_intent_plugin(tmp_path / "plugins", "intentplug")
+    registry = discover_plugins(tmp_path / "plugins")
+    assert len(registry.intents) == 1
+    bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "invokePluginIntent", ["intentplug", "do_thing"])
+    )
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert "approval" in notifications.message.lower()
+
+
+def test_invoke_plugin_intent_allows_the_same_dispatch_once_granted(tmp_path):
+    _write_intent_plugin(tmp_path / "plugins", "intentplug2")
+    registry = discover_plugins(tmp_path / "plugins")
+    bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+
+    denied = asyncio.run(
+        bus.dispatch_intent("app-plugins", "invokePluginIntent", ["intentplug2", "do_thing"])
+    )
+    assert denied is None
+
+    settings_manager.set_plugin_grant("intentplug2", True)
+
+    allowed = asyncio.run(
+        bus.dispatch_intent("app-plugins", "invokePluginIntent", ["intentplug2", "do_thing"])
+    )
+    assert allowed == "did-the-thing:intentplug2"
+
+
+def test_invoke_plugin_intent_shows_a_warning_for_an_unknown_plugin_or_intent_name(tmp_path):
+    registry = discover_plugins(tmp_path / "empty-plugins")
+    bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "invokePluginIntent", ["ghost_plugin", "ghost_intent"])
+    )
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert "Unknown plugin intent" in notifications.message
+
+
+# -- SettingsManager.get_plugin_grants()/set_plugin_grant() persistence -----
+
+
+def test_get_plugin_grants_defaults_to_empty_dict_on_a_fresh_store(tmp_path):
+    manager = SettingsManager(tmp_path / "session.dat")
+    assert manager.get_plugin_grants() == {}
+
+
+def test_set_plugin_grant_persists_and_round_trips_through_a_reload(tmp_path):
+    state_file = tmp_path / "session.dat"
+    manager = SettingsManager(state_file)
+    manager.set_plugin_grant("hello_node", True)
+
+    reloaded = SettingsManager(state_file)
+    assert reloaded.get_plugin_grants() == {"hello_node": True}
+
+
+def test_set_plugin_grant_touches_only_the_named_plugin_leaving_others_untouched(tmp_path):
+    manager = SettingsManager(tmp_path / "session.dat")
+    manager.set_plugin_grant("plugin_a", True)
+    manager.set_plugin_grant("plugin_b", True)
+    manager.set_plugin_grant("plugin_a", False)
+
+    grants = manager.get_plugin_grants()
+    assert grants["plugin_a"] is False
+    assert grants["plugin_b"] is True
+
+
+def test_a_plugin_id_with_no_stored_entry_reads_as_not_granted_via_caller_default(tmp_path):
+    manager = SettingsManager(tmp_path / "session.dat")
+    manager.set_plugin_grant("known_plugin", True)
+
+    # get_plugin_grants() itself does not synthesize a default for
+    # "unknown_plugin" - the caller's own .get(plugin_id, False) does, same
+    # as every real call site in backend/plugins.py.
+    assert manager.get_plugin_grants().get("unknown_plugin", False) is False
+
+
+def test_set_plugin_grant_with_a_blank_plugin_id_is_a_no_op(tmp_path):
+    manager = SettingsManager(tmp_path / "session.dat")
+    manager.set_plugin_grant("", True)
+    manager.set_plugin_grant("   ", True)
+    assert manager.get_plugin_grants() == {}
+
+
+# -- setPluginGrant intent: persist + republish ------------------------------
+
+
+def test_set_plugin_grant_intent_persists_and_republishes_the_app_plugins_topic(tmp_path):
+    _write_grant_test_plugin(
+        tmp_path / "plugins", "livegrant", scopes_toml='[scopes]\ngrants = ["graph.mutate"]',
+        picker_name="Live Grant Node",
+    )
+    registry = discover_plugins(tmp_path / "plugins")
+    bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+
+    class Recorder:
+        def __init__(self):
+            self.messages = []
+
+        async def send_json(self, data):
+            self.messages.append(data)
+
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "setPluginGrant", ["livegrant", True])
+    )
+
+    assert settings_manager.get_plugin_grants() == {"livegrant": True}
+    # Re-published so any observer (picker, Settings UI) sees the new state
+    # immediately.
+    published = [m for m in recorder.messages if m.get("topic") == "app-plugins"]
+    assert published
+    grants_row = next(r for r in published[-1]["payload"]["grants"] if r["pluginId"] == "livegrant")
+    assert grants_row["granted"] is True
+
+    # Now the grant is real - the SAME plugin can create a node.
+    parent = canvas_document.add_node(10, 20, "parent")
+    created = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Live Grant Node", parent.id])
+    )
+    assert created is not None
+
+
+# -- "grants" payload shape: one row per distinct plugin_id, built-ins absent
+
+
+def test_grants_payload_has_one_row_per_distinct_plugin_id_not_per_picker_entry(tmp_path):
+    # A single plugin registering TWO picker entries under one plugin_id
+    # must still produce exactly ONE grants row.
+    plugin_dir = tmp_path / "plugins" / "multientry"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.toml").write_text(
+        textwrap.dedent("""\
+            [plugin]
+            id = "multientry"
+            name = "Multi Entry Plugin"
+            version = "0.1.0"
+            sdk_api_version = 1
+            entry_point = "plugin:register"
+
+            [scopes]
+            grants = ["graph.mutate"]
+        """),
+        encoding="utf-8",
+    )
+    (plugin_dir / "plugin.py").write_text(
+        textwrap.dedent("""\
+            from backend.plugin_sdk import HostContext, PluginNodeSeed
+
+
+            def _make_a(document, run_ctx, parent_id):
+                return PluginNodeSeed(title="A", content="")
+
+
+            def _make_b(document, run_ctx, parent_id):
+                return PluginNodeSeed(title="B", content="")
+
+
+            def register(host: HostContext) -> None:
+                host.register_node_kind("kind_a", _make_a, requires_parent=True)
+                host.register_node_kind("kind_b", _make_b, requires_parent=True)
+                host.register_picker_entry(
+                    node_kind="kind_a", name="Multi A", description="d", category="More Plugins",
+                )
+                host.register_picker_entry(
+                    node_kind="kind_b", name="Multi B", description="d", category="More Plugins",
+                )
+        """),
+        encoding="utf-8",
+    )
+    registry = discover_plugins(tmp_path / "plugins")
+    settings_manager = SettingsManager(tmp_path / "store" / "session.dat")
+
+    payload = plugins_payload(registry, settings_manager)
+    rows = [r for r in payload["grants"] if r["pluginId"] == "multientry"]
+    assert len(rows) == 1
+    assert rows[0]["name"] == "Multi Entry Plugin"
+    assert rows[0]["scopes"] == ["graph.mutate"]
+    assert rows[0]["granted"] is False

--- a/backend/tests/test_plugin_sdk.py
+++ b/backend/tests/test_plugin_sdk.py
@@ -10,6 +10,7 @@ conftest.py-style real-data-dir guard (discovery never reads/writes
 ~/.graphlink)."""
 
 import asyncio
+import logging
 import textwrap
 
 import pytest
@@ -251,6 +252,29 @@ def test_host_context_register_intent_stores_a_real_spec():
     assert spec.plugin_id == "intent_plugin"
     assert spec.name == "do_thing"
     assert spec.handler is handler
+
+
+def test_host_context_register_intent_same_plugin_name_reuse_raises():
+    # ADR-014 review-fix (finding 1): without this guard, a plugin author's
+    # copy-paste mistake (two register_intent("run", ...) calls from the
+    # SAME plugin) silently produced two PluginIntentSpec entries sharing
+    # one (plugin_id, name) pair - discover_plugins() itself never caught
+    # it (self._intents is a list, not a dict, so no collision check ran
+    # here before this fix), and the duplicate only surfaced much later, as
+    # a raw ToolRegistry "already registered" ValueError inside
+    # register_plugin_tools' loop - see that function's own per-item
+    # try/except (backend/plugins.py) for the belt-and-suspenders fix on
+    # that side too. Mirrors register_builtin_plugin's own identical
+    # duplicate-name test immediately below.
+    host = HostContext("intent_plugin")
+    host.register_intent("run", lambda d, r, *a: None)
+
+    with pytest.raises(PluginRegistrationError):
+        host.register_intent("run", lambda d, r, *a: None)
+
+    # Exactly one real registration survives - the rejected call left no
+    # partial/duplicate trace behind.
+    assert len(host._intents) == 1
 
 
 # -- ADR-014 stage 14.3: HostContext.register_builtin_plugin() --------------
@@ -714,6 +738,54 @@ def test_a_plugin_serializer_that_raises_degrades_to_empty_plugin_state_on_the_w
     saved_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "raising_plugin.boom")
     assert saved_payload["title"] == "Boom"
     assert "plugin_state" not in saved_payload
+
+
+def test_a_plugin_serializer_that_raises_logs_a_warning_on_the_save_path_too(tmp_path, caplog):
+    # ADR-014 review-fix (finding 6): session_save.py's own
+    # _serialize_plugin_node used to silently drop a raising plugin
+    # serializer with ZERO logging, unlike the wire-path equivalent proven
+    # implicitly by the test immediately above (backend/domain/graph.py's
+    # _plugin_state_wire, which already logs "plugin node %s (%s):
+    # serialize hook raised"). This pins save-path parity: the exact same
+    # message shape now fires on save too.
+    raising_body = textwrap.dedent("""\
+        from backend.plugin_sdk import HostContext, PluginNodeSeed
+
+
+        def _make(document, run_ctx, parent_id):
+            return PluginNodeSeed(title="Boom", content="")
+
+
+        def _serialize(node):
+            raise RuntimeError("this plugin's serializer is broken")
+
+
+        def register(host: HostContext) -> None:
+            host.register_node_kind("boom", _make, requires_parent=True, serialize=_serialize)
+            host.register_picker_entry(
+                node_kind="boom", name="Boom Thing", description="raises", category="More Plugins",
+            )
+    """)
+    _write_plugin(tmp_path, "raising_plugin", py_body=raising_body, kind="boom", picker_name="Boom Thing")
+    registry = discover_plugins(tmp_path)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Boom Thing", parent.id])
+    )
+    assert node_id is not None
+
+    with caplog.at_level(logging.WARNING):
+        chat_data = build_chat_data(canvas_document, plugin_registry=registry)
+
+    saved_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "raising_plugin.boom")
+    assert saved_payload["title"] == "Boom"
+    assert "plugin_state" not in saved_payload
+    assert any(
+        "serialize hook raised" in record.message and node_id in record.message
+        for record in caplog.records
+    )
 
 
 # -- Integration coverage using the REAL shipped demo plugins ---------------

--- a/backend/tests/test_plugin_sdk.py
+++ b/backend/tests/test_plugin_sdk.py
@@ -26,6 +26,7 @@ from backend.plugin_sdk import (
 from backend.plugins import register_plugins
 from backend.session_load import restore_chat_into_document
 from backend.session_save import build_chat_data
+from graphlink_settings_store import SettingsManager
 
 
 def _write_plugin(
@@ -367,13 +368,32 @@ def test_discover_plugins_is_memoized_by_resolved_path(tmp_path):
 # -- end-to-end through register_plugins + execute_plugin -------------------
 
 
-def _make_wired_bus(plugin_registry):
+def _make_wired_bus(plugin_registry, tmp_path):
+    # ADR-014 stage 14.4: register_plugins now requires a real
+    # SettingsManager (the deny-by-default plugin-grant store) and every
+    # non-built-in plugin dispatch is now grant-gated - every plugin_id this
+    # registry knows about (both node_kinds' and picker_entries' plugin_id,
+    # covering a kind registered but not yet exposed via a picker entry too)
+    # is pre-granted here so the pre-existing tests in this file keep
+    # proving the mechanism they were written for (discovery, dispatch,
+    # persistence, undo, live-wire) rather than incidentally re-proving the
+    # grant gate on every single call site. The grant gate itself gets its
+    # own dedicated tests further down this file.
+    settings_manager = SettingsManager(tmp_path / "session.dat")
+    plugin_ids = {spec.plugin_id for spec in plugin_registry.node_kinds.values()} | {
+        entry.plugin_id for entry in plugin_registry.picker_entries.values()
+    }
+    for plugin_id in plugin_ids:
+        settings_manager.set_plugin_grant(plugin_id, True)
+
     bus = SessionBus("plugin-sdk-e2e-test")
     notifications = NotificationState()
     bus.register_topic("notification", notifications.payload)
     canvas_document = SceneDocument()
     bus.register_topic("scene", canvas_document.scene_payload)
-    register_plugins(bus, notifications, canvas_document, plugin_registry=plugin_registry)
+    register_plugins(
+        bus, notifications, canvas_document, settings_manager, plugin_registry=plugin_registry,
+    )
     return bus, notifications, canvas_document
 
 
@@ -381,7 +401,7 @@ def test_execute_plugin_end_to_end_creates_a_real_node_with_content_and_parent_e
     _write_plugin(tmp_path, "e2e_plugin", kind="thing", picker_name="E2E Thing")
     registry = discover_plugins(tmp_path)
 
-    bus, notifications, canvas_document = _make_wired_bus(registry)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
     parent = canvas_document.add_node(10, 20, "parent")
 
     result = asyncio.run(
@@ -401,7 +421,7 @@ def test_execute_plugin_end_to_end_creates_a_real_node_with_content_and_parent_e
 def test_execute_plugin_requires_a_valid_parent_for_a_discovered_plugin(tmp_path):
     _write_plugin(tmp_path, "needs_parent_plugin", kind="thing", picker_name="Needs Parent Thing")
     registry = discover_plugins(tmp_path)
-    bus, notifications, canvas_document = _make_wired_bus(registry)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
 
     result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Needs Parent Thing"]))
 
@@ -419,7 +439,7 @@ def test_undo_reverts_a_plugin_created_node_and_its_parent_edge(tmp_path):
     _write_plugin(tmp_path, "undo_plugin", kind="thing", picker_name="Undo Thing")
     registry = discover_plugins(tmp_path)
 
-    bus, notifications, canvas_document = _make_wired_bus(registry)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
     parent = canvas_document.add_node(10, 20, "parent")
 
     result = asyncio.run(
@@ -514,7 +534,7 @@ def test_plugin_node_with_no_serializer_round_trips_title_and_content_only(tmp_p
     # reload regardless of anything this stage changes.
     _write_plugin(tmp_path, "no_state_plugin", kind="thing", picker_name="No State Thing")
     registry = discover_plugins(tmp_path)
-    bus, notifications, canvas_document = _make_wired_bus(registry)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
     parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
 
     node_id = asyncio.run(
@@ -548,7 +568,7 @@ def test_plugin_node_with_real_state_round_trips_custom_fields_through_save_and_
         picker_name="Stateful Widget",
     )
     registry = discover_plugins(tmp_path)
-    bus, notifications, canvas_document = _make_wired_bus(registry)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
     parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
 
     node_id = asyncio.run(
@@ -586,7 +606,7 @@ def test_plugin_node_whose_kind_is_no_longer_registered_is_dropped_not_crashed(t
     # R5-closeout deleted with the exact same tolerant behavior).
     _write_plugin(tmp_path, "temporary_plugin", kind="thing", picker_name="Temporary Thing")
     registry = discover_plugins(tmp_path)
-    bus, notifications, canvas_document = _make_wired_bus(registry)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
     parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
     node_id = asyncio.run(
         bus.dispatch_intent("app-plugins", "executePlugin", ["Temporary Thing", parent.id])
@@ -620,7 +640,7 @@ def test_live_wire_scene_payload_includes_plugin_state_when_serializer_registere
         picker_name="Stateful Widget",
     )
     registry = discover_plugins(tmp_path)
-    bus, notifications, canvas_document = _make_wired_bus(registry)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
     parent = canvas_document.add_node(10, 20, "parent")
 
     node_id = asyncio.run(
@@ -641,7 +661,7 @@ def test_live_wire_scene_payload_includes_plugin_state_when_serializer_registere
 def test_live_wire_plugin_state_is_empty_for_a_plugin_kind_with_no_serializer(tmp_path):
     _write_plugin(tmp_path, "no_state_plugin", kind="thing", picker_name="No State Thing")
     registry = discover_plugins(tmp_path)
-    bus, notifications, canvas_document = _make_wired_bus(registry)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
     parent = canvas_document.add_node(10, 20, "parent")
 
     node_id = asyncio.run(
@@ -674,7 +694,7 @@ def test_a_plugin_serializer_that_raises_degrades_to_empty_plugin_state_on_the_w
     """)
     _write_plugin(tmp_path, "raising_plugin", py_body=raising_body, kind="boom", picker_name="Boom Thing")
     registry = discover_plugins(tmp_path)
-    bus, notifications, canvas_document = _make_wired_bus(registry)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
     parent = canvas_document.add_node(10, 20, "parent")
 
     node_id = asyncio.run(
@@ -705,9 +725,9 @@ def test_a_plugin_serializer_that_raises_degrades_to_empty_plugin_state_on_the_w
 # discovery root - the production configuration, not just the test harness.
 
 
-def test_real_hello_node_plugin_round_trips_through_save_and_reload():
+def test_real_hello_node_plugin_round_trips_through_save_and_reload(tmp_path):
     registry = discover_plugins()
-    bus, notifications, canvas_document = _make_wired_bus(registry)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
     parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
 
     node_id = asyncio.run(
@@ -723,9 +743,9 @@ def test_real_hello_node_plugin_round_trips_through_save_and_reload():
     assert plugin_node.state is None
 
 
-def test_real_counter_node_plugin_round_trips_its_custom_state_through_save_and_reload():
+def test_real_counter_node_plugin_round_trips_its_custom_state_through_save_and_reload(tmp_path):
     registry = discover_plugins()
-    bus, notifications, canvas_document = _make_wired_bus(registry)
+    bus, notifications, canvas_document = _make_wired_bus(registry, tmp_path)
     parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
 
     node_id = asyncio.run(

--- a/backend/tests/test_plugin_sdk.py
+++ b/backend/tests/test_plugin_sdk.py
@@ -24,6 +24,8 @@ from backend.plugin_sdk import (
     discover_plugins,
 )
 from backend.plugins import _PLUGINS, register_plugins
+from backend.session_load import restore_chat_into_document
+from backend.session_save import build_chat_data
 
 
 def _write_plugin(
@@ -306,3 +308,306 @@ def test_undo_reverts_a_plugin_created_node_and_its_parent_edge(tmp_path):
     # The parent itself must survive the undo - only the plugin's own
     # command_type ("plugin:undo_plugin.thing") should have been reversed.
     assert parent.id in canvas_document.nodes
+
+
+# -- ADR-014 stage 14.2: generic node persistence/serialization -------------
+#
+# Every test below deliberately uses a FRESH tmp_path plugin, never known to
+# session_save.py/session_load.py's own source code, to prove the mechanism
+# is genuinely generic - not a special case for plugins/hello_node/ or
+# plugins/counter_node/ (which get their own, separate, real-plugin-
+# integration coverage further down). No test in this section adds a single
+# line to session_save.py/session_load.py to pass - that IS the proof that
+# a future plugin needs zero edits there.
+
+# A real NodeState subclass + real serialize/deserialize hooks, written out
+# as a plugin.py body string so _write_plugin can place it under a tmp_path
+# plugin directory exactly like a real third-party plugin would ship it.
+_STATEFUL_PY_BODY = textwrap.dedent("""\
+    from dataclasses import dataclass
+
+    from backend.domain.node_states import NodeState
+    from backend.plugin_sdk import HostContext, PluginNodeSeed, PluginRunContext
+
+
+    @dataclass
+    class WidgetState(NodeState):
+        clicks: int = 0
+        label: str = ""
+
+
+    def _make(document, run_ctx, parent_id):
+        return PluginNodeSeed(
+            title="Widget", content="", state=WidgetState(clicks=3, label="initial"),
+        )
+
+
+    def _serialize(node):
+        return {"clicks": node.state.clicks, "label": node.state.label}
+
+
+    def _deserialize(data):
+        return WidgetState(clicks=int(data.get("clicks", 0)), label=str(data.get("label", "")))
+
+
+    def register(host: HostContext) -> None:
+        host.register_node_kind(
+            "widget", _make, requires_parent=True,
+            serialize=_serialize, deserialize=_deserialize,
+        )
+        host.register_picker_entry(
+            node_kind="widget", name="Stateful Widget",
+            description="a test plugin with real NodeState", category="More Plugins",
+        )
+""")
+
+
+def _round_trip_via_files(document, plugin_registry):
+    """Mirrors test_session_save.py's own _round_trip helper exactly, plus
+    the plugin_registry threading this stage adds - build_chat_data's
+    output, popped/re-nested exactly the way backend/chat_library.py's own
+    saveChat/loadChat intents do it, fed straight back through
+    restore_chat_into_document."""
+    chat_data = build_chat_data(document, plugin_registry=plugin_registry)
+    notes_data = chat_data.pop("notes_data")
+    pins_data = chat_data.pop("pins_data")
+    doc2 = SceneDocument()
+    restore_chat_into_document(doc2, {"data": chat_data}, notes_data, pins_data, plugin_registry=plugin_registry)
+    return chat_data, doc2
+
+
+def test_plugin_node_with_no_serializer_round_trips_title_and_content_only(tmp_path):
+    # _write_plugin's default py_body registers a factory with NO `state=`
+    # at all - the "no opt-in" baseline case. The parent is a real "chat"
+    # node (add_chat_node), not add_node's bare "placeholder" kind - a
+    # placeholder was never a persisted kind even before ADR-014 (it isn't
+    # in session_save.py's own _REGULAR_KINDS), so it would vanish on
+    # reload regardless of anything this stage changes.
+    _write_plugin(tmp_path, "no_state_plugin", kind="thing", picker_name="No State Thing")
+    registry = discover_plugins(tmp_path)
+    bus, notifications, canvas_document = _make_wired_bus(registry)
+    parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
+
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["No State Thing", parent.id])
+    )
+    assert node_id is not None
+
+    chat_data, reloaded = _round_trip_via_files(canvas_document, registry)
+
+    saved_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "no_state_plugin.thing")
+    assert saved_payload["title"] == "Greeting"
+    assert saved_payload["content"] == "hello from no_state_plugin"
+    assert "plugin_state" not in saved_payload
+
+    assert len(reloaded.nodes) == 2
+    plugin_node = next(n for n in reloaded.nodes.values() if n.kind == "no_state_plugin.thing")
+    assert plugin_node.title == "Greeting"
+    assert plugin_node.content == "hello from no_state_plugin"
+    assert plugin_node.state is None
+    reloaded_parent = next(n for n in reloaded.nodes.values() if n.id != plugin_node.id)
+    assert reloaded_parent.kind == "chat"
+    assert any(
+        e.source == reloaded_parent.id and e.target == plugin_node.id
+        for e in reloaded.edges.values()
+    )
+
+
+def test_plugin_node_with_real_state_round_trips_custom_fields_through_save_and_reload(tmp_path):
+    _write_plugin(
+        tmp_path, "stateful_plugin", py_body=_STATEFUL_PY_BODY, kind="widget",
+        picker_name="Stateful Widget",
+    )
+    registry = discover_plugins(tmp_path)
+    bus, notifications, canvas_document = _make_wired_bus(registry)
+    parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
+
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Stateful Widget", parent.id])
+    )
+    assert node_id is not None
+    # A real LIVE edit after creation, not just the factory's initial
+    # value - proves the round-trip reflects the node's actual current
+    # state, not merely what _make_tally-equivalent seeded it with.
+    canvas_document.nodes[node_id].state.clicks = 7
+    canvas_document.nodes[node_id].state.label = "edited"
+
+    chat_data, reloaded = _round_trip_via_files(canvas_document, registry)
+
+    saved_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "stateful_plugin.widget")
+    assert saved_payload["plugin_state"] == {"clicks": 7, "label": "edited"}
+
+    assert len(reloaded.nodes) == 2
+    plugin_node = next(n for n in reloaded.nodes.values() if n.kind == "stateful_plugin.widget")
+    assert plugin_node.title == "Widget"
+    assert plugin_node.state.clicks == 7
+    assert plugin_node.state.label == "edited"
+    reloaded_parent = next(n for n in reloaded.nodes.values() if n.id != plugin_node.id)
+    assert reloaded_parent.kind == "chat"
+    assert any(
+        e.source == reloaded_parent.id and e.target == plugin_node.id
+        for e in reloaded.edges.values()
+    )
+
+
+def test_plugin_node_whose_kind_is_no_longer_registered_is_dropped_not_crashed(tmp_path):
+    # A plugin removed/renamed between save and load - the same "unrecognized
+    # node_type -> skip, never crash" posture session_load.py already applies
+    # to every other kind (this module's own docstring documents 5 kinds
+    # R5-closeout deleted with the exact same tolerant behavior).
+    _write_plugin(tmp_path, "temporary_plugin", kind="thing", picker_name="Temporary Thing")
+    registry = discover_plugins(tmp_path)
+    bus, notifications, canvas_document = _make_wired_bus(registry)
+    parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Temporary Thing", parent.id])
+    )
+    assert node_id is not None
+
+    chat_data = build_chat_data(canvas_document, plugin_registry=registry)
+    notes_data = chat_data.pop("notes_data")
+    pins_data = chat_data.pop("pins_data")
+    empty_registry = discover_plugins(tmp_path / "does_not_exist")
+
+    doc2 = SceneDocument()
+    restore_chat_into_document(
+        doc2, {"data": chat_data}, notes_data, pins_data, plugin_registry=empty_registry,
+    )
+
+    assert not any(n.kind == "temporary_plugin.thing" for n in doc2.nodes.values())
+    # The parent node itself (a plain built-in "chat" node, unaffected by
+    # the missing plugin) must still be there - one dropped node is not a
+    # failed load.
+    assert any(n.kind == "chat" for n in doc2.nodes.values())
+
+
+def test_live_wire_scene_payload_includes_plugin_state_when_serializer_registered(tmp_path):
+    # ADR-014 stage 14.2's OTHER half - the live WS wire, not save/reload.
+    # register_plugins populates SceneDocument.plugin_node_serializers from
+    # the SAME registry _round_trip_via_files' save path reads its
+    # serialize hooks from - one function, two call sites.
+    _write_plugin(
+        tmp_path, "stateful_plugin", py_body=_STATEFUL_PY_BODY, kind="widget",
+        picker_name="Stateful Widget",
+    )
+    registry = discover_plugins(tmp_path)
+    bus, notifications, canvas_document = _make_wired_bus(registry)
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Stateful Widget", parent.id])
+    )
+
+    wire = canvas_document.scene_payload()
+    node_wire = next(n for n in wire["nodes"] if n["id"] == node_id)
+    # Coerced to str on the wire (SceneNodeRow.pluginState is dict[str, str]
+    # - see contracts/graphlink_scene_payload.py's own comment) even though
+    # `clicks` is a real int in memory and in the save file.
+    assert node_wire["pluginState"] == {"clicks": "3", "label": "initial"}
+
+    parent_wire = next(n for n in wire["nodes"] if n["id"] == parent.id)
+    assert parent_wire["pluginState"] == {}
+
+
+def test_live_wire_plugin_state_is_empty_for_a_plugin_kind_with_no_serializer(tmp_path):
+    _write_plugin(tmp_path, "no_state_plugin", kind="thing", picker_name="No State Thing")
+    registry = discover_plugins(tmp_path)
+    bus, notifications, canvas_document = _make_wired_bus(registry)
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["No State Thing", parent.id])
+    )
+
+    wire = canvas_document.scene_payload()
+    node_wire = next(n for n in wire["nodes"] if n["id"] == node_id)
+    assert node_wire["pluginState"] == {}
+
+
+def test_a_plugin_serializer_that_raises_degrades_to_empty_plugin_state_on_the_wire(tmp_path):
+    raising_body = textwrap.dedent("""\
+        from backend.plugin_sdk import HostContext, PluginNodeSeed
+
+
+        def _make(document, run_ctx, parent_id):
+            return PluginNodeSeed(title="Boom", content="")
+
+
+        def _serialize(node):
+            raise RuntimeError("this plugin's serializer is broken")
+
+
+        def register(host: HostContext) -> None:
+            host.register_node_kind("boom", _make, requires_parent=True, serialize=_serialize)
+            host.register_picker_entry(
+                node_kind="boom", name="Boom Thing", description="raises", category="More Plugins",
+            )
+    """)
+    _write_plugin(tmp_path, "raising_plugin", py_body=raising_body, kind="boom", picker_name="Boom Thing")
+    registry = discover_plugins(tmp_path)
+    bus, notifications, canvas_document = _make_wired_bus(registry)
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Boom Thing", parent.id])
+    )
+    assert node_id is not None
+
+    # Live wire: a raising serializer degrades to {}, never crashes the
+    # whole scene publish.
+    wire = canvas_document.scene_payload()
+    node_wire = next(n for n in wire["nodes"] if n["id"] == node_id)
+    assert node_wire["pluginState"] == {}
+
+    # Save file: same degrade-not-crash posture - the node's universal
+    # title/content still saves, just without plugin_state.
+    chat_data = build_chat_data(canvas_document, plugin_registry=registry)
+    saved_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "raising_plugin.boom")
+    assert saved_payload["title"] == "Boom"
+    assert "plugin_state" not in saved_payload
+
+
+# -- Integration coverage using the REAL shipped demo plugins ---------------
+#
+# The tests above prove the MECHANISM is generic against an arbitrary,
+# never-before-seen plugin. These two prove the actual shipped
+# plugins/hello_node/ and plugins/counter_node/ (real discover_plugins(),
+# no tmp_path override) round-trip correctly through the real default
+# discovery root - the production configuration, not just the test harness.
+
+
+def test_real_hello_node_plugin_round_trips_through_save_and_reload():
+    registry = discover_plugins()
+    bus, notifications, canvas_document = _make_wired_bus(registry)
+    parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
+
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Hello Node", parent.id])
+    )
+    assert node_id is not None
+
+    _chat_data, reloaded = _round_trip_via_files(canvas_document, registry)
+
+    plugin_node = next(n for n in reloaded.nodes.values() if n.kind == "hello_node.hello_note")
+    assert plugin_node.title == "Hello Node"
+    assert "hello_node" in plugin_node.content
+    assert plugin_node.state is None
+
+
+def test_real_counter_node_plugin_round_trips_its_custom_state_through_save_and_reload():
+    registry = discover_plugins()
+    bus, notifications, canvas_document = _make_wired_bus(registry)
+    parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
+
+    node_id = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Counter Node", parent.id])
+    )
+    assert node_id is not None
+    canvas_document.nodes[node_id].state.count = 42
+
+    _chat_data, reloaded = _round_trip_via_files(canvas_document, registry)
+
+    plugin_node = next(n for n in reloaded.nodes.values() if n.kind == "counter_node.tally")
+    assert plugin_node.title == "Counter"
+    assert plugin_node.state.count == 42
+    assert plugin_node.state.label == "from counter_node"

--- a/backend/tests/test_plugin_sdk.py
+++ b/backend/tests/test_plugin_sdk.py
@@ -1,0 +1,308 @@
+"""ADR-014 stage 14.1: Plugin SDK tests - manifest format, discovery, and
+the host API v1 (backend/plugin_sdk.py), plus the generic executePlugin
+fallback wired into backend/plugins.py.
+
+Every discovery test below uses a tmp_path-derived plugins_root, a FRESH
+key in discover_plugins' own module-level memoization cache
+(_REGISTRY_CACHE, keyed by resolved path) - this never touches the shared
+cache entry for the real repo plugins/ directory, and needs no
+conftest.py-style real-data-dir guard (discovery never reads/writes
+~/.graphlink)."""
+
+import asyncio
+import textwrap
+
+import pytest
+
+from backend.canvas import SceneDocument
+from backend.events import SessionBus
+from backend.notifications import NotificationState
+from backend.plugin_sdk import (
+    HostContext,
+    PluginLoadError,
+    PluginRegistrationError,
+    discover_plugins,
+)
+from backend.plugins import _PLUGINS, register_plugins
+
+
+def _write_plugin(
+    plugins_root,
+    plugin_id,
+    *,
+    id_field=None,
+    sdk_api_version=1,
+    entry_point="plugin:register",
+    kind="greet",
+    picker_name="Test Greet",
+    category="More Plugins",
+    py_body=None,
+    toml_body=None,
+    dir_name=None,
+):
+    """Writes one real plugin.toml + plugin.py under plugins_root/dir_name
+    (defaulting dir_name to plugin_id). id_field lets a test deliberately
+    write an [plugin].id that diverges from the directory name."""
+    plugin_dir = plugins_root / (dir_name or plugin_id)
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+
+    if toml_body is None:
+        toml_body = textwrap.dedent(f"""\
+            [plugin]
+            id = "{id_field if id_field is not None else plugin_id}"
+            name = "Test Plugin {plugin_id}"
+            version = "0.1.0"
+            sdk_api_version = {sdk_api_version}
+            entry_point = "{entry_point}"
+        """)
+    (plugin_dir / "plugin.toml").write_text(toml_body, encoding="utf-8")
+
+    if py_body is None:
+        py_body = textwrap.dedent(f"""\
+            from backend.canvas import SceneDocument
+            from backend.plugin_sdk import HostContext, PluginNodeSeed, PluginRunContext
+
+
+            def _make(document, run_ctx, parent_id):
+                return PluginNodeSeed(
+                    title="Greeting",
+                    content="hello from " + run_ctx.plugin_id,
+                )
+
+
+            def register(host: HostContext) -> None:
+                host.register_node_kind("{kind}", _make, requires_parent=True)
+                host.register_picker_entry(
+                    node_kind="{kind}",
+                    name="{picker_name}",
+                    description="a test plugin",
+                    category="{category}",
+                )
+        """)
+    (plugin_dir / "plugin.py").write_text(py_body, encoding="utf-8")
+    return plugin_dir
+
+
+# -- discovery: the happy path -----------------------------------------------
+
+
+def test_discover_plugins_finds_imports_and_populates_the_registry(tmp_path):
+    _write_plugin(tmp_path, "acme_greeter", kind="greet", picker_name="Acme Greeter")
+
+    registry = discover_plugins(tmp_path)
+
+    assert registry.load_errors == []
+    assert "acme_greeter.greet" in registry.node_kinds
+    assert registry.node_kinds["acme_greeter.greet"].plugin_id == "acme_greeter"
+    assert registry.node_kinds["acme_greeter.greet"].requires_parent is True
+    assert "Acme Greeter" in registry.picker_entries
+    entry = registry.picker_entries["Acme Greeter"]
+    assert entry.plugin_id == "acme_greeter"
+    assert entry.node_kind == "acme_greeter.greet"
+
+
+# -- malformed manifests: skipped, per-plugin, others unaffected ------------
+
+
+def test_malformed_manifest_missing_plugin_table_is_skipped_good_sibling_still_loads(tmp_path):
+    _write_plugin(
+        tmp_path, "broken_one", dir_name="broken_one",
+        toml_body="[frontend]\nview = \"generic\"\n",
+    )
+    _write_plugin(tmp_path, "good_one", kind="greet", picker_name="Good One Entry")
+
+    registry = discover_plugins(tmp_path)
+
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "broken_one"
+    assert isinstance(registry.load_errors[0], PluginLoadError)
+    assert "good_one.greet" in registry.node_kinds
+    assert "Good One Entry" in registry.picker_entries
+    assert not any(kind.startswith("broken_one.") for kind in registry.node_kinds)
+
+
+def test_malformed_manifest_id_mismatch_with_directory_name_is_skipped(tmp_path):
+    _write_plugin(tmp_path, "dir_name_one", id_field="a_totally_different_id")
+    _write_plugin(tmp_path, "good_two", kind="greet", picker_name="Good Two Entry")
+
+    registry = discover_plugins(tmp_path)
+
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "dir_name_one"
+    assert "good_two.greet" in registry.node_kinds
+    assert "Good Two Entry" in registry.picker_entries
+
+
+def test_malformed_manifest_sdk_api_version_out_of_range_is_skipped(tmp_path):
+    _write_plugin(tmp_path, "future_plugin", sdk_api_version=999)
+    _write_plugin(tmp_path, "good_three", kind="greet", picker_name="Good Three Entry")
+
+    registry = discover_plugins(tmp_path)
+
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "future_plugin"
+    assert "good_three.greet" in registry.node_kinds
+    assert "Good Three Entry" in registry.picker_entries
+
+
+# -- picker-name collisions: raised/recorded, never silently overwritten ---
+
+
+def test_picker_name_collision_with_a_builtin_name_is_recorded_not_silently_merged(tmp_path):
+    builtin_name = _PLUGINS[0][0]  # "System Prompt" today - any real built-in name works
+    _write_plugin(tmp_path, "colliding_plugin", kind="greet", picker_name=builtin_name)
+
+    registry = discover_plugins(tmp_path, builtin_names=frozenset(p[0] for p in _PLUGINS))
+
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "colliding_plugin"
+    assert builtin_name not in registry.picker_entries
+    assert "colliding_plugin.greet" not in registry.node_kinds
+
+
+def test_picker_name_collision_between_two_plugins_is_recorded_first_wins_not_overwritten(tmp_path):
+    # Directory names are chosen so sorted glob() ordering is deterministic:
+    # "plugin_a" is imported before "plugin_b".
+    _write_plugin(tmp_path, "plugin_a", dir_name="plugin_a", kind="greet", picker_name="Shared Name")
+    _write_plugin(tmp_path, "plugin_b", dir_name="plugin_b", kind="greet", picker_name="Shared Name")
+
+    registry = discover_plugins(tmp_path)
+
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "plugin_b"
+    assert registry.picker_entries["Shared Name"].plugin_id == "plugin_a"
+    assert "plugin_a.greet" in registry.node_kinds
+    assert "plugin_b.greet" not in registry.node_kinds
+
+
+# -- requires_parent=False: rejected at REGISTRATION time -------------------
+
+
+def test_requires_parent_false_raises_plugin_registration_error_at_registration_time():
+    host = HostContext("some_plugin")
+
+    def _factory(document, run_ctx, parent_id):
+        raise AssertionError("factory must never be called - registration itself must fail")
+
+    with pytest.raises(PluginRegistrationError):
+        host.register_node_kind("floating", _factory, requires_parent=False)
+    assert "some_plugin.floating" not in host._node_kinds
+
+
+# -- HostContext.register_intent(): declaration-time behavior only ----------
+#
+# ADR-014 stage 14.1 deviation (see backend/plugin_sdk.py's own module and
+# HostContext.register_intent docstrings): live SessionBus activation of a
+# plugin-declared intent is deferred - it collides with tests/
+# test_undo_classification_gate.py's hard-locked requirement that every
+# backend/ register_intent() call use a source-literal (topic, intent) pair,
+# which a dynamically plugin-declared name can never satisfy by construction.
+# The declaration API itself is still real and tested here.
+
+
+def test_host_context_register_intent_stores_a_real_spec():
+    host = HostContext("intent_plugin")
+    handler = lambda document, run_ctx, *args: None  # noqa: E731
+
+    host.register_intent("do_thing", handler, args_schema=None)
+
+    assert len(host._intents) == 1
+    spec = host._intents[0]
+    assert spec.plugin_id == "intent_plugin"
+    assert spec.name == "do_thing"
+    assert spec.handler is handler
+
+
+# -- discovery memoization ----------------------------------------------------
+
+
+def test_discover_plugins_is_memoized_by_resolved_path(tmp_path):
+    _write_plugin(tmp_path, "memo_plugin", kind="greet", picker_name="Memo Entry")
+
+    first = discover_plugins(tmp_path)
+    # Mutate the manifest on disk AFTER the first call - a second call that
+    # actually rescanned would either pick up the new picker name or blow up
+    # on the now-different sdk_api_version. A truly memoized call returns
+    # the exact same object, untouched by this mutation.
+    _write_plugin(tmp_path, "memo_plugin", kind="greet", picker_name="Mutated Entry Should Not Appear")
+
+    second = discover_plugins(tmp_path)
+
+    assert second is first
+    assert "Memo Entry" in second.picker_entries
+    assert "Mutated Entry Should Not Appear" not in second.picker_entries
+
+
+# -- end-to-end through register_plugins + execute_plugin -------------------
+
+
+def _make_wired_bus(plugin_registry):
+    bus = SessionBus("plugin-sdk-e2e-test")
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    canvas_document = SceneDocument()
+    bus.register_topic("scene", canvas_document.scene_payload)
+    register_plugins(bus, notifications, canvas_document, plugin_registry=plugin_registry)
+    return bus, notifications, canvas_document
+
+
+def test_execute_plugin_end_to_end_creates_a_real_node_with_content_and_parent_edge(tmp_path):
+    _write_plugin(tmp_path, "e2e_plugin", kind="thing", picker_name="E2E Thing")
+    registry = discover_plugins(tmp_path)
+
+    bus, notifications, canvas_document = _make_wired_bus(registry)
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["E2E Thing", parent.id])
+    )
+
+    assert result is not None
+    node = canvas_document.nodes[result]
+    assert node.kind == "e2e_plugin.thing"
+    assert node.content == "hello from e2e_plugin"
+    assert any(
+        e.source == parent.id and e.target == node.id for e in canvas_document.edges.values()
+    )
+    assert notifications.visible is False, "success is not a deferral - no notification fires"
+
+
+def test_execute_plugin_requires_a_valid_parent_for_a_discovered_plugin(tmp_path):
+    _write_plugin(tmp_path, "needs_parent_plugin", kind="thing", picker_name="Needs Parent Thing")
+    registry = discover_plugins(tmp_path)
+    bus, notifications, canvas_document = _make_wired_bus(registry)
+
+    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Needs Parent Thing"]))
+
+    assert result is None
+    assert notifications.visible is True
+    assert notifications.msg_type == "warning"
+    assert not any(n.kind == "needs_parent_plugin.thing" for n in canvas_document.nodes.values())
+
+
+# -- undo: a discovered plugin's node creation goes through the SAME -------
+# -- record_command/undo stack every built-in plugin already uses ----------
+
+
+def test_undo_reverts_a_plugin_created_node_and_its_parent_edge(tmp_path):
+    _write_plugin(tmp_path, "undo_plugin", kind="thing", picker_name="Undo Thing")
+    registry = discover_plugins(tmp_path)
+
+    bus, notifications, canvas_document = _make_wired_bus(registry)
+    parent = canvas_document.add_node(10, 20, "parent")
+
+    result = asyncio.run(
+        bus.dispatch_intent("app-plugins", "executePlugin", ["Undo Thing", parent.id])
+    )
+    assert result in canvas_document.nodes
+    assert canvas_document.can_undo()
+
+    canvas_document.undo()
+
+    assert result not in canvas_document.nodes
+    assert not any(
+        e.source == parent.id and e.target == result for e in canvas_document.edges.values()
+    )
+    # The parent itself must survive the undo - only the plugin's own
+    # command_type ("plugin:undo_plugin.thing") should have been reversed.
+    assert parent.id in canvas_document.nodes

--- a/backend/tests/test_plugin_sdk.py
+++ b/backend/tests/test_plugin_sdk.py
@@ -23,7 +23,7 @@ from backend.plugin_sdk import (
     PluginRegistrationError,
     discover_plugins,
 )
-from backend.plugins import _PLUGINS, register_plugins
+from backend.plugins import register_plugins
 from backend.session_load import restore_chat_into_document
 from backend.session_save import build_chat_data
 
@@ -150,16 +150,53 @@ def test_malformed_manifest_sdk_api_version_out_of_range_is_skipped(tmp_path):
 # -- picker-name collisions: raised/recorded, never silently overwritten ---
 
 
-def test_picker_name_collision_with_a_builtin_name_is_recorded_not_silently_merged(tmp_path):
-    builtin_name = _PLUGINS[0][0]  # "System Prompt" today - any real built-in name works
-    _write_plugin(tmp_path, "colliding_plugin", kind="greet", picker_name=builtin_name)
+def test_picker_name_collision_with_a_reserved_name_is_recorded_not_silently_merged(tmp_path):
+    # ADR-014 stage 14.3: the 8 pre-SDK built-ins are now real discovered
+    # plugins themselves (plugins/web_research/, plugins/gitlink/, ...), so
+    # backend/plugins.py's own register_plugins() no longer calls
+    # discover_plugins(builtin_names=...) with a real argument - collisions
+    # between a migrated built-in and a third-party plugin are now caught
+    # by the SAME picker_entries/builtin_actions collision check any two
+    # plugins are checked with (see the two tests below this one). The
+    # `builtin_names` mechanism itself stays real, generic SDK surface -
+    # exercised here directly with a synthetic reserved-name set, the way
+    # any host embedding this SDK could still reserve a name that has no
+    # registry entry of its own yet.
+    _write_plugin(tmp_path, "colliding_plugin", kind="greet", picker_name="Reserved Name")
 
-    registry = discover_plugins(tmp_path, builtin_names=frozenset(p[0] for p in _PLUGINS))
+    registry = discover_plugins(tmp_path, builtin_names=frozenset({"Reserved Name"}))
 
     assert len(registry.load_errors) == 1
     assert registry.load_errors[0].plugin_dir == "colliding_plugin"
-    assert builtin_name not in registry.picker_entries
+    assert "Reserved Name" not in registry.picker_entries
     assert "colliding_plugin.greet" not in registry.node_kinds
+
+
+def test_picker_name_collision_with_a_real_builtin_action_name_is_recorded_not_silently_merged(tmp_path):
+    # ADR-014 stage 14.3: a third-party plugin naming itself "Web Research"
+    # (a real migrated built-in's name, registered via
+    # register_builtin_plugin rather than register_picker_entry) must still
+    # be rejected - the two registration mechanisms share one flat name
+    # space. Directory name "aaa_colliding" sorts before "web_research" in
+    # glob() order, so this plugin is merged FIRST and the real
+    # plugins/web_research/ package collides against IT, proving the check
+    # is symmetric (either registration order loses to the other).
+    _write_plugin(tmp_path, "aaa_colliding", kind="greet", picker_name="Web Research")
+    # Copy the real web_research plugin's manifest/module into this same
+    # tmp_path root so discover_plugins() sees both in one scan.
+    import shutil
+
+    from backend.plugin_sdk import DEFAULT_PLUGINS_ROOT
+
+    shutil.copytree(DEFAULT_PLUGINS_ROOT / "web_research", tmp_path / "web_research")
+
+    registry = discover_plugins(tmp_path)
+
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "web_research"
+    assert registry.picker_entries["Web Research"].plugin_id == "aaa_colliding"
+    assert "aaa_colliding.greet" in registry.node_kinds
+    assert "Web Research" not in registry.builtin_actions
 
 
 def test_picker_name_collision_between_two_plugins_is_recorded_first_wins_not_overwritten(tmp_path):
@@ -213,6 +250,98 @@ def test_host_context_register_intent_stores_a_real_spec():
     assert spec.plugin_id == "intent_plugin"
     assert spec.name == "do_thing"
     assert spec.handler is handler
+
+
+# -- ADR-014 stage 14.3: HostContext.register_builtin_plugin() --------------
+#
+# The first-party migration escape hatch - see BuiltinActionSpec/
+# HostContext.register_builtin_plugin's own docstrings (backend/
+# plugin_sdk.py) for the full contract. Declaration-time behavior only
+# here; end-to-end dispatch through executePlugin is covered by the
+# per-built-in tests in backend/tests/test_plugins.py.
+
+
+def test_host_context_register_builtin_plugin_stores_a_real_spec():
+    host = HostContext("some_plugin")
+
+    def _handler(document, run_ctx, parent_node_id):
+        return "unused-in-this-test"
+
+    host.register_builtin_plugin(
+        name="Some Action", description="does a thing", category="More Plugins",
+        handler=_handler,
+    )
+
+    assert len(host._builtin_actions) == 1
+    spec = host._builtin_actions["Some Action"]
+    assert spec.plugin_id == "some_plugin"
+    assert spec.name == "Some Action"
+    assert spec.description == "does a thing"
+    assert spec.category == "More Plugins"
+    assert spec.handler is _handler
+
+
+def test_host_context_register_builtin_plugin_same_plugin_name_reuse_raises():
+    host = HostContext("some_plugin")
+    host.register_builtin_plugin(
+        name="Dup", description="d", category="More Plugins", handler=lambda d, r, p: None,
+    )
+
+    with pytest.raises(PluginRegistrationError):
+        host.register_builtin_plugin(
+            name="Dup", description="d2", category="More Plugins", handler=lambda d, r, p: None,
+        )
+
+
+def test_builtin_action_name_collision_between_two_plugins_is_recorded_first_wins(tmp_path):
+    # Two synthetic plugins each calling register_builtin_plugin (NOT
+    # register_picker_entry) with the same name - directory names chosen so
+    # sorted glob() ordering is deterministic.
+    py_body_a = "from backend.plugin_sdk import HostContext\n\n\ndef register(host: HostContext) -> None:\n    host.register_builtin_plugin(name='Shared Builtin', description='a', category='More Plugins', handler=lambda d, r, p: None)\n"
+    py_body_b = "from backend.plugin_sdk import HostContext\n\n\ndef register(host: HostContext) -> None:\n    host.register_builtin_plugin(name='Shared Builtin', description='b', category='More Plugins', handler=lambda d, r, p: None)\n"
+    _write_plugin(tmp_path, "plugin_a", dir_name="plugin_a", py_body=py_body_a, toml_body=None)
+    _write_plugin(tmp_path, "plugin_b", dir_name="plugin_b", py_body=py_body_b, toml_body=None)
+
+    registry = discover_plugins(tmp_path)
+
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "plugin_b"
+    assert registry.builtin_actions["Shared Builtin"].plugin_id == "plugin_a"
+
+
+def test_builtin_action_name_collision_with_a_picker_entry_name_is_recorded(tmp_path):
+    # A register_builtin_plugin name colliding against an ALREADY-merged
+    # register_picker_entry name (from a different plugin) must be
+    # rejected too - one flat name space across both mechanisms.
+    py_body_builtin = "from backend.plugin_sdk import HostContext\n\n\ndef register(host: HostContext) -> None:\n    host.register_builtin_plugin(name='Shared Name', description='b', category='More Plugins', handler=lambda d, r, p: None)\n"
+    _write_plugin(tmp_path, "plugin_a", dir_name="plugin_a", kind="greet", picker_name="Shared Name")
+    _write_plugin(tmp_path, "plugin_b", dir_name="plugin_b", py_body=py_body_builtin, toml_body=None)
+
+    registry = discover_plugins(tmp_path)
+
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "plugin_b"
+    assert registry.picker_entries["Shared Name"].plugin_id == "plugin_a"
+    assert "Shared Name" not in registry.builtin_actions
+
+
+def test_resolve_builtin_action_returns_none_for_unknown_name(tmp_path):
+    py_body = (
+        "from backend.plugin_sdk import HostContext\n\n\n"
+        "def register(host: HostContext) -> None:\n"
+        "    host.register_builtin_plugin(\n"
+        "        name='Real', description='d', category='More Plugins',\n"
+        "        handler=lambda d, r, p: None,\n"
+        "    )\n"
+    )
+    _write_plugin(tmp_path, "some_plugin", py_body=py_body, toml_body=None)
+
+    registry = discover_plugins(tmp_path)
+
+    resolved = registry.resolve_builtin_action("Real")
+    assert resolved is not None
+    assert resolved.plugin_id == "some_plugin"
+    assert registry.resolve_builtin_action("Nope") is None
 
 
 # -- discovery memoization ----------------------------------------------------

--- a/backend/tests/test_plugin_worker.py
+++ b/backend/tests/test_plugin_worker.py
@@ -1,0 +1,704 @@
+"""ADR-014 stage 14.5: out-of-process third-party plugin execution behind
+the host API + guard.
+
+Exit criterion this file proves, literally, with REAL subprocess execution
+(never mocked): "a third-party plugin cannot read secrets or exceed its
+scopes (test); tools flow to the registry." Sections below, each proving
+one load-bearing claim from the stage's own design:
+
+A. [runtime] manifest parsing - the opt-in table, fail-soft on an unknown
+   value, byte-identical default for every plugin that omits it.
+B. Discovery of an out-of-process plugin spawns a REAL worker subprocess,
+   collects its registrations via "get_registrations", and the resulting
+   picker entry appears in plugins_payload() exactly like an in-process
+   plugin's would.
+C. THE empirical secret-containment proof: a fake secret-shaped env var is
+   planted on the HOST test process, the shipped plugins/sandboxed_demo
+   plugin's node-creation is triggered, and the created node's content -
+   built entirely inside the WORKER subprocess - is asserted to contain
+   NEITHER the planted value NOR the env var's own name.
+D. The EXISTING 14.4 grant gate (SettingsManager.get_plugin_grants(),
+   backend/plugins.py's _execute_discovered_plugin) already covers
+   out-of-process plugins for free - proven with a real out-of-process
+   plugin, the same notification/no-node/no-command shape as 14.4's own
+   in-process denial tests.
+E. A worker subprocess crash (at registration time, and mid-call) or a
+   call that times out produces a clean, typed PluginWorkerError - never a
+   hang, never some other uncaught exception type.
+F. register_plugin_tools() registers a plugin's custom intent into a real
+   ToolRegistry, scoped from its manifest, denied pre-handler on
+   insufficient scopes (mirroring backend/tools.py's own scope-deny
+   tests), and reaches the plugin's real handler once both the tool's
+   scopes AND the install-time Settings grant are satisfied - proven for
+   BOTH an in-process and an out-of-process plugin's intent, since
+   PluginIntentSpec.handler is the same shape either way.
+G. backend/agents.py's builder_tool_registry() really wires
+   register_plugin_tools() in, using the real shipped plugins/ root.
+
+Every out-of-process test that spawns a worker closes it in a `finally`
+block (via registry.worker_clients.values() or a directly-constructed
+PluginWorkerClient) - the SAME "always close what you connect()ed" discipline
+backend/tests/test_mcp_client.py's own McpStdioClient tests already use.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import textwrap
+
+import pytest
+
+from backend.canvas import SceneDocument
+from backend.events import SessionBus
+from backend.notifications import NotificationState
+from backend.plugin_sdk import (
+    DEFAULT_PLUGINS_ROOT,
+    PluginRegistrationError,
+    PluginWorkerClient,
+    PluginWorkerError,
+    discover_plugins,
+)
+from backend.plugins import plugins_payload, register_plugin_tools, register_plugins
+from backend.providers.base import ToolCall
+from backend.tools import RunContext, ToolRegistry
+from graphlink_settings_store import SettingsManager
+
+
+def _close_workers(registry) -> None:
+    for client in registry.worker_clients.values():
+        client.close()
+
+
+def _write_out_of_process_plugin(
+    plugins_root, plugin_id, *, py_body, scopes_toml='[scopes]\ngrants = ["graph.mutate"]',
+):
+    """Writes one real out-of-process plugin.toml + plugin.py under
+    plugins_root/plugin_id - mirrors backend/tests/test_plugin_grants.py's
+    own _write_grant_test_plugin, plus the new [runtime] table."""
+    plugin_dir = plugins_root / plugin_id
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.toml").write_text(
+        textwrap.dedent(f"""\
+            [plugin]
+            id = "{plugin_id}"
+            name = "{plugin_id} Plugin"
+            version = "0.1.0"
+            sdk_api_version = 1
+            entry_point = "plugin:register"
+
+            [runtime]
+            isolation = "out-of-process"
+
+            {scopes_toml}
+        """),
+        encoding="utf-8",
+    )
+    (plugin_dir / "plugin.py").write_text(py_body, encoding="utf-8")
+    return plugin_dir
+
+
+_SIMPLE_NODE_PY_BODY = textwrap.dedent("""\
+    from backend.plugin_sdk import HostContext, PluginNodeSeed
+
+
+    def _make(document, run_ctx, parent_id):
+        parent = document.nodes[parent_id]
+        return PluginNodeSeed(title="OOP Node", content=f"branched from {parent.title}")
+
+
+    def register(host: HostContext) -> None:
+        host.register_node_kind("thing", _make, requires_parent=True)
+        host.register_picker_entry(
+            node_kind="thing", name="OOP Thing", description="d", category="More Plugins",
+        )
+""")
+
+
+def _wired_bus(registry, tmp_path, *, dirname="oop-store"):
+    settings_manager = SettingsManager(tmp_path / dirname / "session.dat")
+    notifications = NotificationState()
+    bus = SessionBus("plugin-worker-test")
+    bus.register_topic("notification", notifications.payload)
+    canvas_document = SceneDocument()
+    bus.register_topic("scene", canvas_document.scene_payload)
+    register_plugins(bus, notifications, canvas_document, settings_manager, plugin_registry=registry)
+    return bus, notifications, canvas_document, settings_manager
+
+
+# -- A: [runtime] manifest parsing -------------------------------------------
+
+
+def test_runtime_isolation_defaults_to_in_process_when_table_omitted():
+    from backend.plugin_sdk import _load_manifest
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / "noruntime"
+        plugin_dir.mkdir()
+        manifest_path = plugin_dir / "plugin.toml"
+        manifest_path.write_text(
+            textwrap.dedent("""\
+                [plugin]
+                id = "noruntime"
+                name = "No Runtime"
+                version = "0.1.0"
+                sdk_api_version = 1
+                entry_point = "plugin:register"
+            """),
+            encoding="utf-8",
+        )
+        manifest = _load_manifest(manifest_path, plugin_dir)
+        assert manifest.runtime_isolation == "in-process"
+
+
+def test_runtime_isolation_out_of_process_parses():
+    from backend.plugin_sdk import _load_manifest
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / "oopplugin"
+        plugin_dir.mkdir()
+        manifest_path = plugin_dir / "plugin.toml"
+        manifest_path.write_text(
+            textwrap.dedent("""\
+                [plugin]
+                id = "oopplugin"
+                name = "OOP Plugin"
+                version = "0.1.0"
+                sdk_api_version = 1
+                entry_point = "plugin:register"
+
+                [runtime]
+                isolation = "out-of-process"
+            """),
+            encoding="utf-8",
+        )
+        manifest = _load_manifest(manifest_path, plugin_dir)
+        assert manifest.runtime_isolation == "out-of-process"
+
+
+def test_unknown_runtime_isolation_error_raises_at_manifest_load_time_directly():
+    from backend.plugin_sdk import _load_manifest
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / "badruntime"
+        plugin_dir.mkdir()
+        manifest_path = plugin_dir / "plugin.toml"
+        manifest_path.write_text(
+            textwrap.dedent("""\
+                [plugin]
+                id = "badruntime"
+                name = "Bad Runtime"
+                version = "0.1.0"
+                sdk_api_version = 1
+                entry_point = "plugin:register"
+
+                [runtime]
+                isolation = "in-a-sandbox-somewhere"
+            """),
+            encoding="utf-8",
+        )
+        with pytest.raises(PluginRegistrationError, match="isolation"):
+            _load_manifest(manifest_path, plugin_dir)
+
+
+def test_unknown_runtime_isolation_is_rejected_at_discovery_fail_soft_per_plugin(tmp_path):
+    _write_out_of_process_plugin(
+        tmp_path / "plugins", "badruntime2", py_body=_SIMPLE_NODE_PY_BODY,
+    )
+    # Corrupt the freshly-written manifest's [runtime] table directly.
+    manifest_path = tmp_path / "plugins" / "badruntime2" / "plugin.toml"
+    manifest_path.write_text(
+        manifest_path.read_text(encoding="utf-8").replace(
+            'isolation = "out-of-process"', 'isolation = "teleported"'
+        ),
+        encoding="utf-8",
+    )
+    good_dir = tmp_path / "plugins" / "goodsibling"
+    good_dir.mkdir(parents=True)
+    (good_dir / "plugin.toml").write_text(
+        textwrap.dedent("""\
+            [plugin]
+            id = "goodsibling"
+            name = "Good Sibling"
+            version = "0.1.0"
+            sdk_api_version = 1
+            entry_point = "plugin:register"
+        """),
+        encoding="utf-8",
+    )
+    (good_dir / "plugin.py").write_text(
+        "from backend.plugin_sdk import HostContext\n\n\ndef register(host: HostContext) -> None:\n    pass\n",
+        encoding="utf-8",
+    )
+
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        assert len(registry.load_errors) == 1
+        assert registry.load_errors[0].plugin_dir == "badruntime2"
+        assert "badruntime2" not in registry.manifests
+        assert "goodsibling" in registry.manifests
+    finally:
+        _close_workers(registry)
+
+
+# -- B: discovery spawns a real worker + collects registrations -------------
+
+
+def test_discovery_of_an_out_of_process_plugin_spawns_a_real_worker_and_collects_registrations(tmp_path):
+    _write_out_of_process_plugin(tmp_path / "plugins", "oop_basic", py_body=_SIMPLE_NODE_PY_BODY)
+
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        assert registry.load_errors == []
+        assert "oop_basic" in registry.worker_clients
+        worker = registry.worker_clients["oop_basic"]
+        assert worker.is_connected is True
+        assert "oop_basic.thing" in registry.node_kinds
+        assert "OOP Thing" in registry.picker_entries
+        assert registry.picker_entries["OOP Thing"].plugin_id == "oop_basic"
+    finally:
+        _close_workers(registry)
+
+
+def test_out_of_process_plugins_picker_entry_appears_in_plugins_payload_like_an_in_process_ones_would(tmp_path):
+    _write_out_of_process_plugin(tmp_path / "plugins", "oop_payload", py_body=_SIMPLE_NODE_PY_BODY)
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        settings_manager = SettingsManager(tmp_path / "store" / "session.dat")
+        payload = plugins_payload(registry, settings_manager)
+        grants_row = next(r for r in payload["grants"] if r["pluginId"] == "oop_payload")
+        assert grants_row["scopes"] == ["graph.mutate"]
+        assert grants_row["granted"] is False
+
+        more_plugins = next(c for c in payload["categories"] if c["name"] == "More Plugins")
+        assert any(p["name"] == "OOP Thing" for p in more_plugins["plugins"])
+    finally:
+        _close_workers(registry)
+
+
+# -- C: THE empirical secret-containment proof -------------------------------
+
+
+def test_out_of_process_plugin_worker_cannot_see_a_planted_host_secret_env_var(tmp_path, monkeypatch):
+    """THE stage 14.5 exit criterion, proven empirically: plant
+    GRAPHLINK_OPENAI_API_KEY=fake-test-secret-value on the HOST test
+    process, discover a fresh copy of the REAL shipped
+    plugins/sandboxed_demo plugin (a fresh tmp_path copy, so the env var is
+    guaranteed to be set BEFORE this specific worker's Popen call, and this
+    test never touches the shared, memoized real-repo-root registry any
+    other test might have already populated), grant it, create its node,
+    and assert the WORKER's own reported view of its environment - which
+    crossed the RPC boundary as plain node content - contains neither the
+    secret's value nor its name."""
+    monkeypatch.setenv("GRAPHLINK_OPENAI_API_KEY", "fake-test-secret-value")
+
+    plugins_root = tmp_path / "plugins"
+    plugins_root.mkdir()
+    shutil.copytree(DEFAULT_PLUGINS_ROOT / "sandboxed_demo", plugins_root / "sandboxed_demo")
+
+    registry = discover_plugins(plugins_root)
+    try:
+        bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+        settings_manager.set_plugin_grant("sandboxed_demo", True)
+        parent = canvas_document.add_node(10, 20, "parent")
+
+        node_id = asyncio.run(
+            bus.dispatch_intent("app-plugins", "executePlugin", ["Sandboxed Env Probe", parent.id])
+        )
+
+        assert node_id is not None
+        node = canvas_document.nodes[node_id]
+        assert "fake-test-secret-value" not in node.content
+        assert "GRAPHLINK_OPENAI_API_KEY" not in node.content
+        # Sanity check the probe actually ran and reported SOMETHING (proves
+        # this isn't a vacuous pass from an empty/failed report) - PATH is
+        # allowlisted by graphlink_process_env.safe_subprocess_env() and
+        # every real Windows/dev environment has one.
+        assert "PATH=" in node.content or "Path=" in node.content
+    finally:
+        _close_workers(registry)
+
+
+# -- D: the EXISTING 14.4 grant gate already covers out-of-process plugins --
+
+
+def test_ungranted_out_of_process_plugin_denies_node_creation_same_shape_as_in_process(tmp_path):
+    _write_out_of_process_plugin(tmp_path / "plugins", "oop_deny", py_body=_SIMPLE_NODE_PY_BODY)
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+        parent = canvas_document.add_node(10, 20, "parent")
+
+        result = asyncio.run(
+            bus.dispatch_intent("app-plugins", "executePlugin", ["OOP Thing", parent.id])
+        )
+
+        assert result is None
+        assert notifications.visible is True
+        assert notifications.msg_type == "warning"
+        assert "approval" in notifications.message.lower()
+        assert len(canvas_document.nodes) == 1  # only the parent
+        assert canvas_document.can_undo() is False
+    finally:
+        _close_workers(registry)
+
+
+def test_granting_an_out_of_process_plugin_then_allows_node_creation_to_succeed(tmp_path):
+    _write_out_of_process_plugin(tmp_path / "plugins", "oop_allow", py_body=_SIMPLE_NODE_PY_BODY)
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+        parent = canvas_document.add_node(10, 20, "parent")
+
+        denied = asyncio.run(
+            bus.dispatch_intent("app-plugins", "executePlugin", ["OOP Thing", parent.id])
+        )
+        assert denied is None
+
+        settings_manager.set_plugin_grant("oop_allow", True)
+
+        created = asyncio.run(
+            bus.dispatch_intent("app-plugins", "executePlugin", ["OOP Thing", parent.id])
+        )
+        assert created is not None
+        node = canvas_document.nodes[created]
+        assert node.kind == "oop_allow.thing"
+        assert node.content == "branched from parent"
+        assert canvas_document.can_undo() is True
+    finally:
+        _close_workers(registry)
+
+
+# -- E: worker crash / malformed response is handled cleanly ----------------
+
+
+_CRASH_ON_REGISTER_PY_BODY = textwrap.dedent("""\
+    from backend.plugin_sdk import HostContext
+
+
+    def register(host: HostContext) -> None:
+        raise RuntimeError("this plugin's register() call always fails")
+""")
+
+
+def test_a_worker_that_crashes_during_register_produces_a_discovery_time_load_error_not_a_hang(tmp_path):
+    _write_out_of_process_plugin(
+        tmp_path / "plugins", "oop_crash_register", py_body=_CRASH_ON_REGISTER_PY_BODY,
+    )
+    good_dir = tmp_path / "plugins" / "oop_good_sibling"
+    _write_out_of_process_plugin(
+        tmp_path / "plugins", "oop_good_sibling", py_body=_SIMPLE_NODE_PY_BODY,
+    )
+
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        assert len(registry.load_errors) == 1
+        assert registry.load_errors[0].plugin_dir == "oop_crash_register"
+        assert "oop_crash_register" not in registry.manifests
+        # A crashed worker must never be left resident for a plugin that
+        # never finished loading.
+        assert "oop_crash_register" not in registry.worker_clients
+        # The sibling plugin's OWN worker is completely unaffected.
+        assert "oop_good_sibling" in registry.manifests
+        assert "oop_good_sibling" in registry.worker_clients
+    finally:
+        _close_workers(registry)
+
+
+_CRASH_MID_CALL_PY_BODY = textwrap.dedent("""\
+    import os
+
+    from backend.plugin_sdk import HostContext, PluginNodeSeed
+
+
+    def _make(document, run_ctx, parent_id):
+        os._exit(1)  # a genuine process crash - NOT a caught Exception
+
+
+    def register(host: HostContext) -> None:
+        host.register_node_kind("thing", _make, requires_parent=True)
+        host.register_picker_entry(
+            node_kind="thing", name="Crash Thing", description="d", category="More Plugins",
+        )
+""")
+
+
+def test_a_worker_that_crashes_mid_call_raises_a_clean_plugin_worker_error_not_a_hang(tmp_path):
+    plugin_dir = _write_out_of_process_plugin(
+        tmp_path / "plugins", "oop_crash_mid_call", py_body=_CRASH_MID_CALL_PY_BODY,
+    )
+    worker = PluginWorkerClient(plugin_id="oop_crash_mid_call", source_dir=plugin_dir, timeout=10.0)
+    try:
+        worker.connect()
+        response = worker.call("get_registrations", {})
+        assert response["node_kinds"] == [{"local_kind": "thing", "requires_parent": True}]
+
+        with pytest.raises(PluginWorkerError, match="closed its output unexpectedly"):
+            worker.call(
+                "invoke_factory",
+                {"kind": "thing", "parent_snapshot": {"id": "p1", "title": "Parent", "content": "", "kind": "chat"}},
+            )
+    finally:
+        worker.close()
+
+
+_SLOW_INTENT_PY_BODY = textwrap.dedent("""\
+    import time
+
+    from backend.plugin_sdk import HostContext
+
+
+    def _slow(document, run_ctx):
+        time.sleep(5)
+        return "too slow"
+
+
+    def register(host: HostContext) -> None:
+        host.register_intent("slow", _slow)
+""")
+
+
+def test_a_call_that_exceeds_the_configured_timeout_raises_a_clean_plugin_worker_error(tmp_path):
+    plugin_dir = _write_out_of_process_plugin(
+        tmp_path / "plugins", "oop_slow", py_body=_SLOW_INTENT_PY_BODY,
+    )
+    # Default timeout for connect + the fast "get_registrations" call
+    # (interpreter cold-start alone can take longer than a tight deadline on
+    # a loaded CI box) - `timeout` is a plain instance attribute, so it is
+    # deliberately tightened AFTER the worker is already up and responsive,
+    # isolating what this test actually wants to prove (a genuinely slow
+    # CALL times out cleanly) from unrelated process-startup variance.
+    worker = PluginWorkerClient(plugin_id="oop_slow", source_dir=plugin_dir)
+    try:
+        worker.connect()
+        worker.call("get_registrations", {})  # a fast call succeeds first
+        worker.timeout = 0.5
+
+        with pytest.raises(PluginWorkerError, match="timed out"):
+            worker.call("invoke_intent", {"name": "slow", "args": {}})
+    finally:
+        worker.close()
+
+
+def test_invoke_factory_with_an_unknown_kind_returns_a_clean_error_not_a_crash(tmp_path):
+    plugin_dir = _write_out_of_process_plugin(
+        tmp_path / "plugins", "oop_unknown_kind", py_body=_SIMPLE_NODE_PY_BODY,
+    )
+    worker = PluginWorkerClient(plugin_id="oop_unknown_kind", source_dir=plugin_dir)
+    try:
+        worker.connect()
+        worker.call("get_registrations", {})
+
+        with pytest.raises(PluginWorkerError, match="unknown node kind"):
+            worker.call(
+                "invoke_factory",
+                {"kind": "not_a_real_kind", "parent_snapshot": {"id": "p1", "title": "P", "content": "", "kind": "x"}},
+            )
+        # The worker itself is still alive and usable after a clean,
+        # caught, per-request error - one bad call does not take down the
+        # whole resident process.
+        assert worker.is_connected is True
+    finally:
+        worker.close()
+
+
+def test_calling_before_connect_raises_a_clean_plugin_worker_error(tmp_path):
+    plugin_dir = _write_out_of_process_plugin(
+        tmp_path / "plugins", "oop_not_connected", py_body=_SIMPLE_NODE_PY_BODY,
+    )
+    worker = PluginWorkerClient(plugin_id="oop_not_connected", source_dir=plugin_dir)
+    with pytest.raises(PluginWorkerError):
+        worker.call("get_registrations", {})
+
+
+def test_worker_client_close_is_idempotent(tmp_path):
+    plugin_dir = _write_out_of_process_plugin(
+        tmp_path / "plugins", "oop_close_twice", py_body=_SIMPLE_NODE_PY_BODY,
+    )
+    worker = PluginWorkerClient(plugin_id="oop_close_twice", source_dir=plugin_dir)
+    worker.connect()
+    worker.close()
+    worker.close()  # must not raise
+
+
+# -- F: register_plugin_tools() flows plugin intents to the ToolRegistry ----
+
+
+_INTENT_PY_BODY = textwrap.dedent("""\
+    from backend.plugin_sdk import HostContext
+
+
+    def _do_thing(document, run_ctx):
+        return f"did-the-thing:{run_ctx.plugin_id}"
+
+
+    def register(host: HostContext) -> None:
+        host.register_intent("do_thing", _do_thing)
+""")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_register_plugin_tools_registers_a_namespaced_tool_with_the_manifests_scopes(tmp_path):
+    _write_out_of_process_plugin(tmp_path / "plugins", "tool_plug", py_body=_INTENT_PY_BODY)
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        settings_manager = SettingsManager(tmp_path / "store" / "session.dat")
+        canvas_document = SceneDocument()
+        tool_registry = ToolRegistry()
+
+        registered = register_plugin_tools(tool_registry, registry, settings_manager, canvas_document)
+
+        assert registered == ("plugin:tool_plug:do_thing",)
+        assert tool_registry.scopes_for("plugin:tool_plug:do_thing") == frozenset({"graph.mutate"})
+    finally:
+        _close_workers(registry)
+
+
+def test_register_plugin_tools_denies_insufficient_scopes_before_the_handler_runs(tmp_path):
+    _write_out_of_process_plugin(tmp_path / "plugins", "tool_plug2", py_body=_INTENT_PY_BODY)
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        settings_manager = SettingsManager(tmp_path / "store" / "session.dat")
+        settings_manager.set_plugin_grant("tool_plug2", True)  # granted, but scope is still missing
+        canvas_document = SceneDocument()
+        tool_registry = ToolRegistry()
+        register_plugin_tools(tool_registry, registry, settings_manager, canvas_document)
+
+        prompted = []
+
+        async def request_approval(call):
+            prompted.append(call)
+            return True
+
+        ctx = RunContext(granted_scopes=frozenset(), request_approval=request_approval)  # no graph.mutate
+        call = ToolCall(id="1", name="plugin:tool_plug2:do_thing", arguments={})
+        result = _run(tool_registry.invoke(call, ctx))
+
+        assert result.is_error is True
+        assert "scope" in result.content.lower()
+        assert prompted == []  # denied before any approval prompt, let alone the handler
+    finally:
+        _close_workers(registry)
+
+
+def test_register_plugin_tools_with_sufficient_scopes_but_no_settings_grant_is_denied(tmp_path):
+    _write_out_of_process_plugin(tmp_path / "plugins", "tool_plug3", py_body=_INTENT_PY_BODY)
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        settings_manager = SettingsManager(tmp_path / "store" / "session.dat")  # never granted
+        canvas_document = SceneDocument()
+        tool_registry = ToolRegistry()
+        register_plugin_tools(tool_registry, registry, settings_manager, canvas_document)
+
+        async def request_approval(call):
+            return True
+
+        ctx = RunContext(granted_scopes=frozenset({"graph.mutate"}), request_approval=request_approval)
+        call = ToolCall(id="1", name="plugin:tool_plug3:do_thing", arguments={})
+        result = _run(tool_registry.invoke(call, ctx))
+
+        assert result.is_error is True
+        assert "approval" in result.content.lower()
+    finally:
+        _close_workers(registry)
+
+
+def test_register_plugin_tools_with_scopes_and_grant_reaches_the_out_of_process_plugins_real_handler(tmp_path):
+    """THE full round trip: ToolRegistry.invoke() -> the install-time-grant
+    re-check -> the RPC-backed wrapper closure -> the REAL out-of-process
+    plugin's own _do_thing, running inside its worker subprocess - and its
+    real string return value makes it all the way back as ToolResult.content."""
+    _write_out_of_process_plugin(tmp_path / "plugins", "tool_plug4", py_body=_INTENT_PY_BODY)
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        settings_manager = SettingsManager(tmp_path / "store" / "session.dat")
+        settings_manager.set_plugin_grant("tool_plug4", True)
+        canvas_document = SceneDocument()
+        tool_registry = ToolRegistry()
+        register_plugin_tools(tool_registry, registry, settings_manager, canvas_document)
+
+        prompted = []
+
+        async def request_approval(call):
+            prompted.append(call)
+            return True
+
+        ctx = RunContext(granted_scopes=frozenset({"graph.mutate"}), request_approval=request_approval)
+        call = ToolCall(id="1", name="plugin:tool_plug4:do_thing", arguments={})
+        result = _run(tool_registry.invoke(call, ctx))
+
+        assert result.is_error is False
+        assert result.content == "did-the-thing:tool_plug4"
+        assert len(prompted) == 1  # approval="always" - the approval callback WAS consulted
+    finally:
+        _close_workers(registry)
+
+
+def test_register_plugin_tools_works_for_an_in_process_plugins_intent_too(tmp_path):
+    """The SAME registry/handler machinery, for an IN-PROCESS plugin's
+    intent (no [runtime] table at all) - proves PluginIntentSpec.handler's
+    origin (direct function vs. RPC-backed wrapper) is genuinely opaque to
+    register_plugin_tools."""
+    plugin_dir = tmp_path / "plugins" / "inproc_tool_plug"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.toml").write_text(
+        textwrap.dedent("""\
+            [plugin]
+            id = "inproc_tool_plug"
+            name = "In-Process Tool Plug"
+            version = "0.1.0"
+            sdk_api_version = 1
+            entry_point = "plugin:register"
+
+            [scopes]
+            grants = ["graph.mutate"]
+        """),
+        encoding="utf-8",
+    )
+    (plugin_dir / "plugin.py").write_text(_INTENT_PY_BODY, encoding="utf-8")
+
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        assert "inproc_tool_plug" not in registry.worker_clients  # no worker for an in-process plugin
+        settings_manager = SettingsManager(tmp_path / "store" / "session.dat")
+        settings_manager.set_plugin_grant("inproc_tool_plug", True)
+        canvas_document = SceneDocument()
+        tool_registry = ToolRegistry()
+        register_plugin_tools(tool_registry, registry, settings_manager, canvas_document)
+
+        async def request_approval(call):
+            return True
+
+        ctx = RunContext(granted_scopes=frozenset({"graph.mutate"}), request_approval=request_approval)
+        call = ToolCall(id="1", name="plugin:inproc_tool_plug:do_thing", arguments={})
+        result = _run(tool_registry.invoke(call, ctx))
+
+        assert result.content == "did-the-thing:inproc_tool_plug"
+    finally:
+        _close_workers(registry)
+
+
+# -- G: backend/agents.py's builder_tool_registry() really wires it in ------
+
+
+def test_builder_tool_registry_includes_the_real_shipped_sandboxed_demo_plugin_tool(tmp_path):
+    from backend.agents import AgentDispatcher
+
+    settings_manager = SettingsManager(tmp_path / "session.dat")
+    dispatcher = AgentDispatcher(settings_manager)
+    document = SceneDocument()
+
+    registry = dispatcher.builder_tool_registry(document)
+
+    names = [spec.name for spec in registry.specs()]
+    assert "plugin:sandboxed_demo:ping" in names
+    assert registry.scopes_for("plugin:sandboxed_demo:ping") == frozenset({"graph.mutate"})

--- a/backend/tests/test_plugin_worker.py
+++ b/backend/tests/test_plugin_worker.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import asyncio
 import shutil
 import textwrap
+import time
 
 import pytest
 
@@ -61,6 +62,8 @@ from backend.plugin_sdk import (
 )
 from backend.plugins import plugins_payload, register_plugin_tools, register_plugins
 from backend.providers.base import ToolCall
+from backend.session_load import restore_chat_into_document
+from backend.session_save import build_chat_data
 from backend.tools import RunContext, ToolRegistry
 from graphlink_settings_store import SettingsManager
 
@@ -448,6 +451,74 @@ def test_a_worker_that_crashes_mid_call_raises_a_clean_plugin_worker_error_not_a
         worker.close()
 
 
+def test_second_call_on_an_already_dead_worker_raises_plugin_worker_error_not_a_hang(tmp_path):
+    """ADR-014 review-fix (finding 3): the FIRST call after a crash is
+    already proven clean by the test immediately above (the reader thread
+    detects the closed pipe mid-call). This test proves the SECOND call on
+    that now-confirmed-dead worker object is ALSO clean - before this fix,
+    nothing stopped that second call from reaching _write() and racing
+    whatever raw, platform-specific exception a write to a dead process's
+    stdin happens to produce (empirically OSError: [Errno 22] Invalid
+    argument on Windows - not caught by _write()'s prior, narrower
+    (BrokenPipeError, ValueError) except clause). call()'s own new
+    is_connected guard now fails this fast, with the documented type,
+    before ever reaching _write() at all."""
+    plugin_dir = _write_out_of_process_plugin(
+        tmp_path / "plugins", "oop_dead_second_call", py_body=_CRASH_MID_CALL_PY_BODY,
+    )
+    worker = PluginWorkerClient(plugin_id="oop_dead_second_call", source_dir=plugin_dir, timeout=10.0)
+    try:
+        worker.connect()
+        worker.call("get_registrations", {})
+        with pytest.raises(PluginWorkerError, match="closed its output unexpectedly"):
+            worker.call(
+                "invoke_factory",
+                {"kind": "thing", "parent_snapshot": {"id": "p1", "title": "Parent", "content": "", "kind": "chat"}},
+            )
+        # Wait for the OS to actually finish reaping the crashed process -
+        # the reader thread's EOF detection (what the call above already
+        # raised on) and the OS-level exit status are two independent
+        # signals that can land a beat apart.
+        deadline = time.monotonic() + 5.0
+        while worker._process.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert worker._process.poll() is not None, "worker process never actually exited"
+
+        with pytest.raises(PluginWorkerError, match="not connected"):
+            worker.call("get_registrations", {})
+    finally:
+        worker.close()
+
+
+def test_write_to_an_already_dead_worker_process_raises_plugin_worker_error_not_a_raw_oserror(tmp_path):
+    """ADR-014 review-fix (finding 3): a direct, low-level unit test of
+    _write()'s own except-clause widening - bypasses call()'s is_connected
+    guard entirely (calling _write() straight) to prove specifically that
+    writing to a dead process's stdin pipe now raises the documented
+    PluginWorkerError rather than a raw OSError escaping uncaught."""
+    plugin_dir = _write_out_of_process_plugin(
+        tmp_path / "plugins", "oop_dead_write", py_body=_CRASH_MID_CALL_PY_BODY,
+    )
+    worker = PluginWorkerClient(plugin_id="oop_dead_write", source_dir=plugin_dir, timeout=10.0)
+    try:
+        worker.connect()
+        worker.call("get_registrations", {})
+        with pytest.raises(PluginWorkerError, match="closed its output unexpectedly"):
+            worker.call(
+                "invoke_factory",
+                {"kind": "thing", "parent_snapshot": {"id": "p1", "title": "Parent", "content": "", "kind": "chat"}},
+            )
+        deadline = time.monotonic() + 5.0
+        while worker._process.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert worker._process.poll() is not None, "worker process never actually exited"
+
+        with pytest.raises(PluginWorkerError, match="not accepting input"):
+            worker._write({"jsonrpc": "2.0", "id": 999, "method": "noop", "params": {}})
+    finally:
+        worker.close()
+
+
 _SLOW_INTENT_PY_BODY = textwrap.dedent("""\
     import time
 
@@ -687,6 +758,51 @@ def test_register_plugin_tools_works_for_an_in_process_plugins_intent_too(tmp_pa
         _close_workers(registry)
 
 
+def test_register_plugin_tools_isolates_a_registration_failure_so_a_later_plugins_tools_still_register(tmp_path):
+    """ADR-014 review-fix (finding 1): register_plugin_tools now wraps each
+    spec's registration in its own try/except, mirroring
+    _register_configured_mcp_tools' own real per-server isolation (backend/
+    agents.py). BEFORE this fix, a single raising ToolRegistry.register()
+    call (e.g. two PluginIntentSpec entries resolving to the SAME
+    namespaced_name - impossible to construct today through HostContext.
+    register_intent's own new duplicate-name guard, see that guard's
+    dedicated test in test_plugin_sdk.py, but still reachable from a
+    hand-built PluginRegistry that bypasses HostContext entirely, exactly
+    as constructed here) would raise straight out of the `for` loop and
+    silently strip every plugin ENUMERATED AFTER the offender of its
+    Builder tools too - not just the offending one."""
+    from backend.plugin_sdk import PluginIntentSpec, PluginRegistry
+
+    registry = PluginRegistry()
+    registry.intents.append(
+        PluginIntentSpec(plugin_id="dup_plugin", name="run", handler=lambda d, r: "first")
+    )
+    registry.intents.append(
+        # A duplicate (plugin_id, name) pair - real discovery can never
+        # produce this anymore (HostContext.register_intent rejects it at
+        # declaration time), but a hand-built registry still can.
+        PluginIntentSpec(plugin_id="dup_plugin", name="run", handler=lambda d, r: "second")
+    )
+    registry.intents.append(
+        PluginIntentSpec(plugin_id="good_plugin", name="run", handler=lambda d, r: "good")
+    )
+
+    settings_manager = SettingsManager(tmp_path / "store" / "session.dat")
+    canvas_document = SceneDocument()
+    tool_registry = ToolRegistry()
+
+    registered = register_plugin_tools(tool_registry, registry, settings_manager, canvas_document)
+
+    # The offending plugin's FIRST registration succeeded (before the
+    # collision); its duplicate second entry was skipped (logged, not
+    # raised, not re-added to `registered`); the LATER, entirely unrelated
+    # plugin's tool still registered - this last assertion is the one that
+    # would have failed (or the whole call would have raised, uncaught, out
+    # of this test) before the per-item try/except existed.
+    assert registered == ("plugin:dup_plugin:run", "plugin:good_plugin:run")
+    assert tool_registry.scopes_for("plugin:good_plugin:run") is not None
+
+
 # -- G: backend/agents.py's builder_tool_registry() really wires it in ------
 
 
@@ -702,3 +818,175 @@ def test_builder_tool_registry_includes_the_real_shipped_sandboxed_demo_plugin_t
     names = [spec.name for spec in registry.specs()]
     assert "plugin:sandboxed_demo:ping" in names
     assert registry.scopes_for("plugin:sandboxed_demo:ping") == frozenset({"graph.mutate"})
+
+
+# -- H: discover_plugins() concurrent-first-caller race (finding 4) ---------
+
+_MARKER_ON_REGISTER_PY_BODY = textwrap.dedent("""\
+    from pathlib import Path
+
+    from backend.plugin_sdk import HostContext, PluginNodeSeed
+
+
+    def _make(document, run_ctx, parent_id):
+        return PluginNodeSeed(title="T", content="")
+
+
+    def register(host: HostContext) -> None:
+        # Appends one line every time THIS module's register() actually
+        # runs - which only happens once per real worker subprocess spawn
+        # (backend/plugin_worker.py imports this module and calls
+        # register() exactly once per process lifetime). Counting lines in
+        # this file after the race is how the test below proves how many
+        # DISTINCT worker subprocesses actually got spawned, without any
+        # in-memory state that could hide a real inter-process race.
+        marker = Path(__file__).parent / "spawn_marker.txt"
+        with marker.open("a", encoding="utf-8") as fh:
+            fh.write("spawned\\n")
+        host.register_node_kind("thing", _make, requires_parent=True)
+        host.register_picker_entry(
+            node_kind="thing", name="Race Thing", description="d", category="More Plugins",
+        )
+""")
+
+
+def test_discover_plugins_concurrent_first_callers_share_one_registry_and_spawn_one_worker(tmp_path):
+    """ADR-014 review-fix (finding 4): discover_plugins()'s check-then-scan-
+    then-set sequence now runs under a module-level threading.Lock -
+    empirically reproduced here with 2 REAL OS threads racing the SAME
+    never-before-seen plugins_root (a fresh tmp_path key, confirmed absent
+    from _REGISTRY_CACHE). BEFORE this fix, both threads could miss the
+    empty cache, each independently scan and spawn a REAL resident worker
+    subprocess for the out-of-process plugin below, and whichever thread's
+    `_REGISTRY_CACHE[resolved] = registry` write ran last would silently
+    orphan the loser's own live subprocess - discarded with a live PID and
+    no reference anywhere ever able to close() it.
+
+    Currently unreachable via any real production call path (backend/
+    agents.py, backend/plugins.py, backend/session_load.py, backend/
+    session_save.py all call discover_plugins() from synchronous code on
+    the event-loop thread, never from asyncio.to_thread or a second OS
+    thread) - this test is prevention against a future regression, proven
+    with a direct, deliberate 2-thread repro, not a claim this fires in
+    production today."""
+    import threading
+
+    plugins_root = tmp_path / "plugins"
+    _write_out_of_process_plugin(plugins_root, "race_plugin", py_body=_MARKER_ON_REGISTER_PY_BODY)
+
+    results: list = []
+    barrier = threading.Barrier(2)
+
+    def _discover():
+        barrier.wait(timeout=10)  # maximizes the chance both threads race the SAME empty cache
+        results.append(discover_plugins(plugins_root))
+
+    t1 = threading.Thread(target=_discover)
+    t2 = threading.Thread(target=_discover)
+    t1.start()
+    t2.start()
+    t1.join(timeout=30)
+    t2.join(timeout=30)
+
+    assert len(results) == 2
+    registry_a, registry_b = results
+    try:
+        # The SAME PluginRegistry object - not two independently-scanned
+        # registries that merely happen to compare equal.
+        assert registry_a is registry_b
+        assert "race_plugin" in registry_a.worker_clients
+
+        marker = plugins_root / "race_plugin" / "spawn_marker.txt"
+        assert marker.is_file(), "register() never ran at all"
+        spawn_count = marker.read_text(encoding="utf-8").count("spawned")
+        # Exactly ONE worker subprocess actually spawned and ran register()
+        # - the loser thread blocked on the lock and returned the winner's
+        # already-populated registry without scanning or spawning anything
+        # itself.
+        assert spawn_count == 1
+    finally:
+        _close_workers(registry_a)
+
+
+# -- I: out-of-process NodeState round-trip through save/reload (finding 5) -
+
+_STATEFUL_OOP_PY_BODY = textwrap.dedent("""\
+    from dataclasses import dataclass
+
+    from backend.plugin_sdk import HostContext, PluginNodeSeed
+
+
+    @dataclass
+    class WidgetState:
+        clicks: int = 0
+        label: str = ""
+
+
+    def _make(document, run_ctx, parent_id):
+        return PluginNodeSeed(
+            title="OOP Widget", content="", state=WidgetState(clicks=3, label="initial"),
+        )
+
+
+    def register(host: HostContext) -> None:
+        host.register_node_kind("widget", _make, requires_parent=True)
+        host.register_picker_entry(
+            node_kind="widget", name="OOP Widget", description="d", category="More Plugins",
+        )
+""")
+
+
+def test_out_of_process_plugin_node_state_round_trips_through_save_and_reload(tmp_path):
+    """ADR-014 review-fix (finding 5): the out-of-process NodeState
+    round-trip mechanism (backend/plugin_worker.py's _state_to_plain_dict,
+    backend/plugin_sdk.py's GenericPluginState/_out_of_process_state_
+    serialize/_out_of_process_state_deserialize) was real, but nothing
+    SHIPPED exercised it end to end - plugins/sandboxed_demo's only
+    factory never sets PluginNodeSeed.state. This is the missing coverage:
+    a real out-of-process test-fixture plugin with a real dataclass state
+    field (WidgetState, defined and instantiated entirely INSIDE the
+    worker subprocess), taken through the REAL worker subprocess -> save
+    -> reload cycle, and confirmed to restore correctly as a
+    GenericPluginState with the right `data` dict - not merely at the
+    live-node stage, but after a genuine file round-trip."""
+    from backend.plugin_sdk import GenericPluginState
+
+    _write_out_of_process_plugin(
+        tmp_path / "plugins", "oop_widget", py_body=_STATEFUL_OOP_PY_BODY,
+    )
+    registry = discover_plugins(tmp_path / "plugins")
+    try:
+        bus, notifications, canvas_document, settings_manager = _wired_bus(registry, tmp_path)
+        settings_manager.set_plugin_grant("oop_widget", True)
+        parent = canvas_document.add_chat_node(10, 20, "parent", is_user=False)
+
+        node_id = asyncio.run(
+            bus.dispatch_intent("app-plugins", "executePlugin", ["OOP Widget", parent.id])
+        )
+        assert node_id is not None
+        node = canvas_document.nodes[node_id]
+        assert node.kind == "oop_widget.widget"
+        # Real, out-of-process-produced GenericPluginState - WidgetState
+        # itself was constructed and serialized (dataclasses.asdict)
+        # entirely INSIDE the worker subprocess; the host only ever sees
+        # the resulting plain dict over the RPC boundary.
+        assert isinstance(node.state, GenericPluginState)
+        assert node.state.data == {"clicks": 3, "label": "initial"}
+
+        chat_data = build_chat_data(canvas_document, plugin_registry=registry)
+        notes_data = chat_data.pop("notes_data")
+        pins_data = chat_data.pop("pins_data")
+        saved_payload = next(n for n in chat_data["nodes"] if n["node_type"] == "oop_widget.widget")
+        assert saved_payload["plugin_state"] == {"clicks": 3, "label": "initial"}
+
+        doc2 = SceneDocument()
+        restore_chat_into_document(
+            doc2, {"data": chat_data}, notes_data, pins_data, plugin_registry=registry,
+        )
+
+        reloaded = next(n for n in doc2.nodes.values() if n.kind == "oop_widget.widget")
+        assert reloaded.title == "OOP Widget"
+        assert isinstance(reloaded.state, GenericPluginState)
+        assert reloaded.state.data == {"clicks": 3, "label": "initial"}
+    finally:
+        _close_workers(registry)

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -57,6 +57,30 @@ def test_get_plugin_categories_groups_in_category_order_and_skips_empty():
         assert category["plugins"]
 
 
+def test_get_plugin_categories_pins_the_original_curated_within_category_order_for_the_8_builtins():
+    # ADR-014 review-fix (finding 7): discover_plugins()'s sorted(glob(...))
+    # (backend/plugin_sdk.py) walks plugin DIRECTORIES alphabetically - an
+    # axis unrelated to the original hand-ordered _PLUGINS tuple literal
+    # (deleted by the stage 14.3 migration; recovered verbatim via
+    # `git show beb927b:backend/plugins.py`). Without _builtin_picker_
+    # sort_key (backend/plugins.py), Build & Execution silently reflowed to
+    # alphabetical-by-directory-name (Virtual Environment Runner's own dir
+    # is "code_sandbox", so it sorted ahead of Gitlink) instead of this
+    # curated sequence - a real, user-visible regression for a migration
+    # meant to be byte-faithful. Pinned here against the REAL shipped
+    # plugins/ root so a future directory rename/addition can't silently
+    # reintroduce the drift without failing a test.
+    grouped = get_plugin_categories(discover_plugins())
+    by_category = {category["name"]: [p["name"] for p in category["plugins"]] for category in grouped}
+
+    assert by_category["Branch Foundations"] == ["System Prompt", "Conversation Node"]
+    assert by_category["Reasoning & Research"] == ["Web Research"]
+    assert by_category["Build & Execution"] == [
+        "Gitlink", "Py-Coder", "Virtual Environment Runner", "HTML Renderer",
+    ]
+    assert by_category["Workflow & Drafting"] == ["Artifact / Drafter"]
+
+
 def test_get_plugin_categories_appends_more_plugins_only_if_uncategorized():
     # Real discovery includes plugins/hello_node/ and plugins/counter_node/,
     # both registered with the HostContext default category ("More

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -1,43 +1,77 @@
-"""Plugin picker topic tests (Qt-removal plan R2.5, extended R5.1)."""
+"""Plugin picker topic tests (Qt-removal plan R2.5, extended R5.1;
+migrated onto the ADR-014 Plugin SDK at stage 14.3 - see
+backend/tests/test_plugin_builtin_migration.py for the per-built-in
+name/description/category/command_type/undo pinning tests this migration
+added)."""
 
 import asyncio
 
 from backend.canvas import SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
-from backend.plugins import _CATEGORY_META, _PLUGINS, get_plugin_categories, plugins_payload, register_plugins
+from backend.plugin_sdk import discover_plugins
+from backend.plugins import get_plugin_categories, plugins_payload, register_plugins
+
+
+# ADR-014 stage 14.3: the 4 structural tests below used to call
+# get_plugin_categories()/plugins_payload() with NO plugin_registry
+# argument, relying on the (now-removed) hardcoded `_PLUGINS` list to
+# supply entries even with no real registry. Since the 8 built-ins are now
+# real discovered plugins themselves, there is no picker entry that exists
+# independent of a real registry anymore - these tests now pass the real
+# discovered registry (discover_plugins(), the production plugins/ root),
+# which also picks up plugins/hello_node/ and plugins/counter_node/ (both
+# registered under the HostContext default "More Plugins" category) - a
+# genuine, expected structural difference from the pre-migration synthetic
+# "just the hardcoded 8" listing, not a narrowing of intent.
 
 
 def test_get_plugin_categories_groups_in_category_order_and_skips_empty():
-    grouped = get_plugin_categories()
+    grouped = get_plugin_categories(discover_plugins())
     names = [category["name"] for category in grouped]
 
-    # "Validation & Delivery" has no plugins in _PLUGINS today, so the
-    # empty-category-skip rule drops it from the result entirely.
-    non_empty_meta_names = [
-        meta["name"]
-        for meta in _CATEGORY_META
-        if any(category_name == meta["name"] for _name, _description, category_name in _PLUGINS)
+    # "Validation & Delivery" has no plugins mapped to it in the real
+    # shipped plugin set today, so the empty-category-skip rule drops it
+    # from the result entirely. "More Plugins" is appended last for
+    # plugins/hello_node/'s and plugins/counter_node/'s uncategorized
+    # entries.
+    assert names == [
+        "Branch Foundations", "Reasoning & Research", "Build & Execution",
+        "Workflow & Drafting", "More Plugins",
     ]
-    assert names == non_empty_meta_names
     for category in grouped:
         assert category["plugins"]
 
 
 def test_get_plugin_categories_appends_more_plugins_only_if_uncategorized():
-    grouped = get_plugin_categories()
-    assert "More Plugins" not in [category["name"] for category in grouped]
+    # Real discovery includes plugins/hello_node/ and plugins/counter_node/,
+    # both registered with the HostContext default category ("More
+    # Plugins") - proves the catch-all activates for genuinely
+    # uncategorized entries.
+    grouped = get_plugin_categories(discover_plugins())
+    more_plugins = next(c for c in grouped if c["name"] == "More Plugins")
+    plugin_names = {p["name"] for p in more_plugins["plugins"]}
+    assert {"Hello Node", "Counter Node"} <= plugin_names
+
+    # When nothing is uncategorized (no registry at all -> zero entries),
+    # the catch-all must not appear.
+    grouped_empty = get_plugin_categories(None)
+    assert "More Plugins" not in [category["name"] for category in grouped_empty]
 
 
 def test_get_plugin_categories_covers_every_plugin_exactly_once():
-    grouped = get_plugin_categories()
+    registry = discover_plugins()
+    grouped = get_plugin_categories(registry)
     seen = [plugin["name"] for category in grouped for plugin in category["plugins"]]
-    assert sorted(seen) == sorted(name for name, _description, _category in _PLUGINS)
+    expected = {entry.name for entry in registry.picker_entries.values()} | {
+        spec.name for spec in registry.builtin_actions.values()
+    }
+    assert set(seen) == expected
     assert len(seen) == len(set(seen))
 
 
 def test_plugins_payload_shape_matches_generated_validator_shape():
-    payload = plugins_payload()
+    payload = plugins_payload(discover_plugins())
     assert set(payload) == {"categories"}
     for category in payload["categories"]:
         assert set(category) == {"name", "description", "plugins"}
@@ -85,32 +119,17 @@ def test_register_plugins_publishes_on_the_app_plugins_topic():
     assert recorder.messages[0]["payload"]["categories"]
 
 
-def test_execute_plugin_falls_through_to_the_generic_deferred_notice_for_an_unhandled_registered_name(monkeypatch):
-    # R7.5a closed the last 2 gaps (Conversation Node, HTML Renderer) - every
-    # _PLUGINS entry today has its own real branch, so the generic fallback
-    # at the bottom of execute_plugin has no live entry left to exercise
-    # through the real registry. It stays in place as the established growth
-    # path for the NEXT plugin added to _PLUGINS before its own branch lands
-    # (same state every plugin above was once in) - proven still-correct
-    # here by monkeypatching _PLUGINS into exactly that state for one call.
-    import backend.plugins as plugins_module
-
-    monkeypatch.setattr(
-        plugins_module,
-        "_PLUGINS",
-        plugins_module._PLUGINS + [("Future Plugin", "Not yet wired.", "Build & Execution")],
-    )
-    bus = SessionBus("plugins-exec-test")
-    notifications = NotificationState()
-    bus.register_topic("notification", notifications.payload)
-    register_plugins(bus, notifications, SceneDocument())
-
-    result = asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Future Plugin"]))
-
-    assert result is None
-    assert notifications.visible is True
-    assert notifications.msg_type == "info"
-    assert notifications.message == '"Future Plugin" node creation isn\'t available yet.'
+# ADR-014 stage 14.3: test_execute_plugin_falls_through_to_the_generic_
+# deferred_notice_for_an_unhandled_registered_name (formerly here) is
+# REMOVED, not just updated - it exercised a code path
+# (execute_plugin's `_PLUGINS`-membership-but-no-branch-yet "isn't
+# available yet" info notice) that no longer exists in any form.
+# `_PLUGINS` itself is gone: every name now either resolves to a real
+# `plugin_registry.builtin_actions`/`picker_entries` entry or hits the
+# generic "Unknown plugin" warning in _execute_discovered_plugin -
+# covered immediately below by
+# test_execute_plugin_shows_warning_notification_for_unknown_plugin. There
+# is no longer a third state ("a known name with no branch yet") to test.
 
 
 def test_execute_plugin_shows_warning_notification_for_unknown_plugin():
@@ -698,13 +717,18 @@ def test_execute_plugin_html_renderer_creates_a_real_html_node_with_empty_conten
     assert "scene" in recorder.topics_seen()
 
 
-def test_every_plugin_now_has_a_real_creation_branch():
-    # R7.5a closes the last 2 gaps - confirms explicitly (rather than
-    # letting the old parametrized non-regression test below silently
-    # collect zero cases) that every _PLUGINS entry has moved off the
-    # generic deferred notice.
+def test_every_builtin_now_has_a_real_builtin_action_registration():
+    # ADR-014 stage 14.3: R7.5a's old "every _PLUGINS entry has moved off
+    # the generic deferred notice" claim is now expressed differently -
+    # there is no more `_PLUGINS` list to compare against. Confirms
+    # instead that all 8 migrated built-ins are real
+    # `plugin_registry.builtin_actions` entries (the ADR-014 stage 14.3
+    # escape hatch), not `picker_entries` (the generic PluginNodeSeed
+    # path reserved for third-party plugins and the demo plugins).
     handled = {
         "Web Research", "Artifact / Drafter", "Gitlink", "Py-Coder", "Virtual Environment Runner",
         "System Prompt", "Conversation Node", "HTML Renderer",
     }
-    assert handled == {name for name, _description, _category in _PLUGINS}
+    registry = discover_plugins()
+    assert handled == set(registry.builtin_actions)
+    assert handled.isdisjoint(registry.picker_entries)

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -5,12 +5,26 @@ name/description/category/command_type/undo pinning tests this migration
 added)."""
 
 import asyncio
+import tempfile
+from pathlib import Path
 
 from backend.canvas import SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.plugin_sdk import discover_plugins
 from backend.plugins import get_plugin_categories, plugins_payload, register_plugins
+from graphlink_settings_store import SettingsManager
+
+
+def _fresh_settings_manager() -> SettingsManager:
+    # ADR-014 stage 14.4: register_plugins now requires a real SettingsManager
+    # (the deny-by-default plugin-grant store). A bare stdlib tempfile dir -
+    # explicitly sanctioned by conftest.py's own "tmp_path/TemporaryDirectory-
+    # derived override" guard docstring - avoids threading a pytest tmp_path
+    # fixture through every one of this file's test functions (every real
+    # dispatch below is a BUILT-IN plugin, never grant-gated, so nothing here
+    # actually needs the store to persist across calls).
+    return SettingsManager(Path(tempfile.mkdtemp()) / "session.dat")
 
 
 # ADR-014 stage 14.3: the 4 structural tests below used to call
@@ -71,12 +85,14 @@ def test_get_plugin_categories_covers_every_plugin_exactly_once():
 
 
 def test_plugins_payload_shape_matches_generated_validator_shape():
-    payload = plugins_payload(discover_plugins())
-    assert set(payload) == {"categories"}
+    payload = plugins_payload(discover_plugins(), _fresh_settings_manager())
+    assert set(payload) == {"categories", "grants"}
     for category in payload["categories"]:
         assert set(category) == {"name", "description", "plugins"}
         for plugin in category["plugins"]:
             assert set(plugin) == {"name", "description"}
+    for grant in payload["grants"]:
+        assert set(grant) == {"pluginId", "name", "scopes", "granted"}
 
 
 def test_plugins_never_imports_qt():
@@ -103,7 +119,7 @@ def test_plugins_never_imports_qt():
 def test_register_plugins_publishes_on_the_app_plugins_topic():
     bus = SessionBus("plugins-test")
     notifications = NotificationState()
-    register_plugins(bus, notifications, SceneDocument())
+    register_plugins(bus, notifications, SceneDocument(), _fresh_settings_manager())
 
     class Recorder:
         def __init__(self):
@@ -136,7 +152,7 @@ def test_execute_plugin_shows_warning_notification_for_unknown_plugin():
     bus = SessionBus("plugins-exec-unknown-test")
     notifications = NotificationState()
     bus.register_topic("notification", notifications.payload)
-    register_plugins(bus, notifications, SceneDocument())
+    register_plugins(bus, notifications, SceneDocument(), _fresh_settings_manager())
 
     asyncio.run(bus.dispatch_intent("app-plugins", "executePlugin", ["Not A Real Plugin"]))
     assert notifications.visible is True
@@ -153,7 +169,7 @@ def _make_plugins_bus():
     bus.register_topic("notification", notifications.payload)
     canvas_document = SceneDocument()
     bus.register_topic("scene", canvas_document.scene_payload)
-    register_plugins(bus, notifications, canvas_document)
+    register_plugins(bus, notifications, canvas_document, _fresh_settings_manager())
     return bus, notifications, canvas_document
 
 

--- a/backend/tests/test_pycoder_domain.py
+++ b/backend/tests/test_pycoder_domain.py
@@ -1,0 +1,533 @@
+"""ADR-014 H3: graphlink_plugins/pycoder/domain.py had zero direct unit
+tests - only indirect coverage via backend/tests/test_execution_guard.py
+(the Windows Job Object guard's wiring into PythonREPL.start()/stop(), plus
+its own crash-restart-leak and concurrent-stop-race regression pins) and
+backend/tests/test_process_env_allowlist.py (safe_subprocess_env()'s pure
+allowlist logic, unwired). Neither exercises PythonREPL's actual REPL
+behavior (real stdout, state persistence, error classification, EOF/crash
+handling) or any of the three LLM-calling Agent classes at all.
+
+This file deliberately does NOT re-test what test_execution_guard.py already
+covers (guard assign/close on start/stop, the crash-restart leak fix, the
+concurrent-stop lock, prepare_scratch_dir/touch_scratch_dir_usage wiring) -
+see that file for those. It covers:
+
+  - PythonREPL's own REPL semantics against REAL subprocesses (this repo's
+    established precedent for this class - see test_execution_guard.py's
+    own module docstring): real stdout, cross-call state persistence,
+    last_run_failed classification, the EOF-mid-read crash path (distinct
+    from test_execution_guard's kill-between-calls restart path), the
+    stdin-write-failure path, stop()/restart idempotency, and one true
+    end-to-end proof that the executed code's actual cwd is the scratch
+    directory (existing coverage only proves prepare_scratch_dir(cwd) was
+    *called*, never that Popen's cwd= really lands the child there) plus one
+    proving env=safe_subprocess_env() is really wired into the real Popen
+    call (existing coverage only proves the allowlist's own pure logic).
+
+  - PyCoderExecutionAgent / PyCoderRepairAgent / PyCoderAnalysisAgent: mocks
+    the api_provider.chat boundary (mirroring backend/tests/test_agents.py's
+    own `monkeypatch.setattr(api_provider, "chat", ...)` convention) and
+    exercises the real prompt-construction and response-parsing logic around
+    it - conversation-history JSON embedding, the is_final_attempt repair-
+    prompt branch, the ```python fenced-code extraction regex (and its
+    fallback to the raw response), and the original_prompt-present/absent
+    analysis-prompt branch.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import MagicMock
+
+import api_provider
+import graphlink_task_config as config
+from graphlink_plugins.pycoder.domain import (
+    PyCoderAnalysisAgent,
+    PyCoderExecutionAgent,
+    PyCoderRepairAgent,
+    PythonREPL,
+)
+
+
+# ============================================================================
+# PythonREPL - happy path, against real subprocesses
+# ============================================================================
+
+
+class TestPythonReplHappyPath:
+    def test_start_spawns_a_real_running_process(self):
+        repl = PythonREPL(repl_id="happy-start-test")
+        try:
+            repl.start()
+            assert repl.process is not None
+            assert repl.process.poll() is None, "the child should still be alive right after start()"
+        finally:
+            repl.stop()
+
+    def test_execute_returns_real_stdout(self):
+        repl = PythonREPL(repl_id="happy-stdout-test")
+        try:
+            result = repl.execute("print('hello from repl')")
+            assert result == "hello from repl"
+            assert repl.last_run_failed is False
+        finally:
+            repl.stop()
+
+    def test_execute_implicitly_starts_the_repl(self):
+        repl = PythonREPL(repl_id="happy-implicit-start-test")
+        assert repl.process is None
+        try:
+            repl.execute("1 + 1")
+            assert repl.process is not None
+        finally:
+            repl.stop()
+
+    def test_state_persists_across_execute_calls(self):
+        # The whole point of PythonREPL over subprocess.run: it's a
+        # persistent interpreter, not a fresh one per call.
+        repl = PythonREPL(repl_id="happy-state-test")
+        try:
+            repl.execute("x = 41")
+            result = repl.execute("print(x + 1)")
+            assert result == "42"
+        finally:
+            repl.stop()
+
+    def test_imports_persist_across_execute_calls(self):
+        repl = PythonREPL(repl_id="happy-import-persist-test")
+        try:
+            repl.execute("import math")
+            result = repl.execute("print(math.floor(3.7))")
+            assert result == "3"
+        finally:
+            repl.stop()
+
+    def test_last_run_failed_is_false_on_success(self):
+        repl = PythonREPL(repl_id="happy-success-flag-test")
+        try:
+            repl.execute("print('ok')")
+            assert repl.last_run_failed is False
+        finally:
+            repl.stop()
+
+    def test_last_run_failed_is_true_on_a_raised_exception(self):
+        repl = PythonREPL(repl_id="happy-error-flag-test")
+        try:
+            result = repl.execute("raise ValueError('boom')")
+            assert repl.last_run_failed is True
+            assert "ValueError" in result
+            assert "boom" in result
+        finally:
+            repl.stop()
+
+    def test_repl_survives_and_keeps_working_after_a_caught_exception(self):
+        # The wrapper script's exec() failing must not kill the REPL loop -
+        # only an uncaught process-level crash should.
+        repl = PythonREPL(repl_id="happy-recovery-test")
+        try:
+            repl.execute("raise KeyError('nope')")
+            assert repl.last_run_failed is True
+            result = repl.execute("print('still alive')")
+            assert result == "still alive"
+            assert repl.last_run_failed is False
+        finally:
+            repl.stop()
+
+    def test_output_containing_the_word_error_is_not_misclassified(self):
+        # Regression precedent named directly in PythonREPL's own docstring
+        # (audit finding B2): classification is structural (the boundary
+        # line), not a scan for English error keywords in stdout.
+        repl = PythonREPL(repl_id="happy-error-keyword-test")
+        try:
+            result = repl.execute("print('the operation failed gracefully')")
+            assert repl.last_run_failed is False
+            assert result == "the operation failed gracefully"
+        finally:
+            repl.stop()
+
+    def test_multiline_code_round_trips_through_base64(self):
+        repl = PythonREPL(repl_id="happy-multiline-test")
+        code = "\n".join([
+            "total = 0",
+            "for i in range(5):",
+            "    total += i",
+            "print(total)",
+        ])
+        try:
+            result = repl.execute(code)
+            assert result == "10"
+        finally:
+            repl.stop()
+
+    def test_unicode_code_and_output_round_trip_through_base64(self):
+        # Restricted to Latin-1-supplement characters (codepage-safe on
+        # Windows' default console codepage, e.g. cp1252) rather than
+        # broader Unicode (e.g. CJK or symbol characters) - see this
+        # module's own test run notes: the wrapper script's child process
+        # gets no explicit stdout encoding from PythonREPL.start() (no
+        # `encoding="utf-8"` on Popen, and safe_subprocess_env() allowlists
+        # LANG/LC_ALL for POSIX but nothing that forces UTF-8 I/O on
+        # Windows), so print()-ing a character outside the console's default
+        # codepage genuinely raises UnicodeEncodeError inside the child on
+        # this platform - a real, unfixed gap flagged separately, not a
+        # test-authoring mistake. This test still proves the base64 framing
+        # itself round-trips real non-ASCII bytes correctly.
+        repl = PythonREPL(repl_id="happy-unicode-test")
+        try:
+            result = repl.execute("print('café')")
+            assert result == "café"
+        finally:
+            repl.stop()
+
+    def test_stop_clears_process_and_guard(self):
+        repl = PythonREPL(repl_id="happy-stop-test")
+        repl.execute("1 + 1")
+        real_process = repl.process
+        repl.stop()
+        assert repl.process is None
+        assert repl.guard is None
+        # And the OS-level process is actually gone, not just detached.
+        assert real_process.poll() is not None, "the real subprocess must actually be dead after stop()"
+
+
+class TestPythonReplStopAndRestartIdempotency:
+    def test_stop_without_ever_starting_does_not_raise(self):
+        repl = PythonREPL(repl_id="idempotent-never-started-test")
+        repl.stop()  # must be a no-op, not an AttributeError
+        assert repl.process is None
+        assert repl.guard is None
+
+    def test_calling_stop_twice_in_a_row_does_not_raise(self):
+        repl = PythonREPL(repl_id="idempotent-double-stop-test")
+        repl.execute("1 + 1")
+        repl.stop()
+        repl.stop()  # second call: self.process is already None, must be a no-op
+        assert repl.process is None
+        assert repl.guard is None
+
+    def test_execute_after_stop_transparently_restarts(self):
+        repl = PythonREPL(repl_id="idempotent-restart-test")
+        try:
+            repl.execute("x = 1")
+            repl.stop()
+            assert repl.process is None
+            # A fresh process - and thus fresh state, since it's a new
+            # interpreter - not an error.
+            result = repl.execute("print('restarted')")
+            assert result == "restarted"
+            assert repl.process is not None
+        finally:
+            repl.stop()
+
+    def test_state_does_not_survive_a_stop_restart_cycle(self):
+        # Sibling of test_state_persists_across_execute_calls: proves state
+        # persistence is a property of the live process, not something
+        # PythonREPL fakes up some other way across a real restart.
+        repl = PythonREPL(repl_id="idempotent-state-reset-test")
+        try:
+            repl.execute("x = 99")
+            repl.stop()
+            result = repl.execute("print(x)")
+            assert repl.last_run_failed is True
+            assert "NameError" in result
+        finally:
+            repl.stop()
+
+
+class TestPythonReplCrashMidRead:
+    """The EOF-with-no-boundary-line branch (execute()'s `if not line: ...
+    self.stop(); break`) - distinct from test_execution_guard.py's
+    TestPythonReplRestartDoesNotLeakTheOldGuard, which kills the process
+    BETWEEN execute() calls (poll()-based restart at the top of execute()).
+    Here the process dies DURING the readline() loop of the call that
+    triggered it."""
+
+    def test_sys_exit_inside_executed_code_is_detected_as_a_crash(self):
+        # sys.exit() raises SystemExit, which is a BaseException, not an
+        # Exception - the wrapper script's `except Exception:` does not
+        # catch it, so it propagates and kills the whole wrapper process.
+        repl = PythonREPL(repl_id="crash-sysexit-test")
+        try:
+            repl.execute("import sys; sys.exit(1)")
+            assert repl.last_run_failed is True
+            # execute()'s EOF branch calls self.stop() itself.
+            assert repl.process is None
+        finally:
+            repl.stop()
+
+    def test_the_repl_auto_restarts_and_keeps_working_after_a_crash(self):
+        repl = PythonREPL(repl_id="crash-recovery-test")
+        try:
+            repl.execute("import os; os._exit(1)")
+            assert repl.last_run_failed is True
+            assert repl.process is None
+
+            result = repl.execute("print('back up')")
+            assert result == "back up"
+            assert repl.last_run_failed is False
+            assert repl.process is not None
+        finally:
+            repl.stop()
+
+
+class TestPythonReplStdinWriteFailure:
+    """The `except Exception as e: return f"Failed to send code to REPL:
+    {e}"` branch - mocks only the stdin file object on an otherwise real,
+    running process, to force a deterministic write failure without racing
+    a real pipe-closed timing window."""
+
+    def test_a_stdin_write_failure_is_reported_without_crashing(self):
+        repl = PythonREPL(repl_id="stdin-failure-test")
+        repl.start()
+        real_stdin = repl.process.stdin
+        try:
+            broken_stdin = MagicMock()
+            broken_stdin.write.side_effect = OSError("simulated broken pipe")
+            repl.process.stdin = broken_stdin
+
+            result = repl.execute("1 + 1")
+
+            assert "Failed to send code to REPL" in result
+            assert "simulated broken pipe" in result
+            assert repl.last_run_failed is True
+        finally:
+            repl.process.stdin = real_stdin
+            repl.stop()
+
+
+class TestPythonReplScratchDirIsolation:
+    """test_execution_guard.py's TestPycoderScratchDirWiring proves
+    prepare_scratch_dir(repl.cwd) is CALLED. These prove the isolation it
+    exists for actually holds end to end: the child's real working directory
+    is that scratch dir, and the restricted environment really reaches the
+    real Popen() call, not just safe_subprocess_env()'s own pure allowlist
+    logic (already covered by test_process_env_allowlist.py in isolation)."""
+
+    def test_executed_code_actually_runs_with_cwd_set_to_the_scratch_dir(self):
+        repl = PythonREPL(repl_id="cwd-isolation-test")
+        try:
+            repl.execute("open('marker.txt', 'w').write('hello from repl')")
+            marker = repl.cwd / "marker.txt"
+            assert marker.exists(), (
+                "a relative-path file write from executed code must land in "
+                "the REPL's own scratch dir, not the app's cwd"
+            )
+            assert marker.read_text(encoding="utf-8") == "hello from repl"
+        finally:
+            repl.stop()
+            marker_path = repl.cwd / "marker.txt"
+            if marker_path.exists():
+                marker_path.unlink()
+
+    def test_the_real_subprocess_environment_excludes_a_secret_shaped_variable(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-not-leak-into-repl")
+        repl = PythonREPL(repl_id="env-isolation-test")
+        try:
+            result = repl.execute("import os; print(os.environ.get('ANTHROPIC_API_KEY'))")
+            assert result.strip() == "None", (
+                "PythonREPL.start() must pass env=safe_subprocess_env() into "
+                "the real Popen() call, not inherit the parent's full "
+                "environment"
+            )
+        finally:
+            repl.stop()
+
+
+# ============================================================================
+# PyCoderExecutionAgent
+# ============================================================================
+
+
+def _capture_chat(monkeypatch, response_content="FAKE_RESPONSE"):
+    """Mirrors backend/tests/test_agents.py's own
+    `monkeypatch.setattr(api_provider, "chat", ...)` convention. Returns the
+    list of captured (task, messages, kwargs) calls."""
+    calls = []
+
+    def _fake_chat(task, messages, **kwargs):
+        calls.append({"task": task, "messages": messages, "kwargs": kwargs})
+        return {"message": {"content": response_content}}
+
+    monkeypatch.setattr(api_provider, "chat", _fake_chat)
+    return calls
+
+
+class TestPyCoderExecutionAgent:
+    def test_get_response_calls_chat_with_task_chat_and_system_plus_user_messages(self, monkeypatch):
+        calls = _capture_chat(monkeypatch)
+        agent = PyCoderExecutionAgent()
+
+        agent.get_response(conversation_history=[], user_prompt="sort a list")
+
+        assert len(calls) == 1
+        call = calls[0]
+        assert call["task"] == config.TASK_CHAT
+        assert [m["role"] for m in call["messages"]] == ["system", "user"]
+        assert "[TOOL:PYTHON]" in call["messages"][0]["content"]
+
+    def test_get_response_embeds_the_conversation_history_as_json(self, monkeypatch):
+        calls = _capture_chat(monkeypatch)
+        agent = PyCoderExecutionAgent()
+        history = [
+            {"role": "user", "content": "I have a list: 3, 1, 2."},
+            {"role": "assistant", "content": "Got it."},
+        ]
+
+        agent.get_response(conversation_history=history, user_prompt="sort it")
+
+        user_message = calls[0]["messages"][1]["content"]
+        assert json.dumps(history, indent=2) in user_message
+        assert "sort it" in user_message
+
+    def test_get_response_returns_the_chat_response_content(self, monkeypatch):
+        _capture_chat(monkeypatch, response_content="[TOOL:PYTHON]\nprint(1)\n[/TOOL]")
+        agent = PyCoderExecutionAgent()
+
+        result = agent.get_response(conversation_history=[], user_prompt="anything")
+
+        assert result == "[TOOL:PYTHON]\nprint(1)\n[/TOOL]"
+
+    def test_user_prompt_is_embedded_verbatim_in_the_final_prompt(self, monkeypatch):
+        calls = _capture_chat(monkeypatch)
+        agent = PyCoderExecutionAgent()
+
+        agent.get_response(conversation_history=[], user_prompt='what is 2 + 2?')
+
+        user_message = calls[0]["messages"][1]["content"]
+        assert 'Final User Prompt: "what is 2 + 2?"' in user_message
+
+
+# ============================================================================
+# PyCoderRepairAgent
+# ============================================================================
+
+
+class TestPyCoderRepairAgentPromptConstruction:
+    def test_default_call_builds_the_bug_fix_prompt_not_the_retry_prompt(self, monkeypatch):
+        calls = _capture_chat(monkeypatch)
+        agent = PyCoderRepairAgent()
+
+        agent.get_response(code="x = 1/0", error="ZeroDivisionError")
+
+        user_message = calls[0]["messages"][1]["content"]
+        assert "The following Python code produced an error" in user_message
+        assert "x = 1/0" in user_message
+        assert "ZeroDivisionError" in user_message
+        assert "Re-evaluate the original problem" not in user_message
+
+    def test_is_final_attempt_true_builds_the_retry_prompt_instead(self, monkeypatch):
+        calls = _capture_chat(monkeypatch)
+        agent = PyCoderRepairAgent()
+
+        agent.get_response(code="x = 1/0", error="ZeroDivisionError", is_final_attempt=True)
+
+        user_message = calls[0]["messages"][1]["content"]
+        assert "Re-evaluate the original problem" in user_message
+        assert "x = 1/0" in user_message
+        assert "ZeroDivisionError" in user_message
+        assert "The following Python code produced an error" not in user_message
+
+    def test_calls_chat_with_task_chat(self, monkeypatch):
+        calls = _capture_chat(monkeypatch)
+        agent = PyCoderRepairAgent()
+
+        agent.get_response(code="pass", error="none")
+
+        assert calls[0]["task"] == config.TASK_CHAT
+        assert [m["role"] for m in calls[0]["messages"]] == ["system", "user"]
+
+
+class TestPyCoderRepairAgentResponseParsing:
+    def test_extracts_code_from_a_single_fenced_python_block(self, monkeypatch):
+        _capture_chat(
+            monkeypatch,
+            response_content="Here is the fix:\n```python\nprint('fixed')\n```\nLet me know if that works.",
+        )
+        agent = PyCoderRepairAgent()
+
+        result = agent.get_response(code="broken", error="err")
+
+        assert result == "print('fixed')"
+
+    def test_falls_back_to_the_raw_stripped_response_when_unfenced(self, monkeypatch):
+        _capture_chat(monkeypatch, response_content="  print('no fence here')  ")
+        agent = PyCoderRepairAgent()
+
+        result = agent.get_response(code="broken", error="err")
+
+        assert result == "print('no fence here')"
+
+    def test_extracts_only_the_first_fenced_block_when_multiple_are_present(self):
+        # Direct regex-behavior test - pins the module's own extraction
+        # pattern (non-greedy .*? under re.DOTALL) independent of any
+        # provider mock.
+        response = (
+            "```python\nfirst_block()\n```\n"
+            "some commentary\n"
+            "```python\nsecond_block()\n```"
+        )
+        match = re.search(r"```python\n(.*?)\n```", response, re.DOTALL)
+        assert match is not None
+        assert match.group(1).strip() == "first_block()"
+
+    def test_multiline_fenced_code_is_preserved_verbatim(self, monkeypatch):
+        code_block = "def f(x):\n    return x + 1\n\nprint(f(41))"
+        _capture_chat(monkeypatch, response_content=f"```python\n{code_block}\n```")
+        agent = PyCoderRepairAgent()
+
+        result = agent.get_response(code="broken", error="err")
+
+        assert result == code_block
+
+
+# ============================================================================
+# PyCoderAnalysisAgent
+# ============================================================================
+
+
+class TestPyCoderAnalysisAgent:
+    def test_with_an_original_prompt_includes_it_and_calls_chat_task_chat(self, monkeypatch):
+        calls = _capture_chat(monkeypatch)
+        agent = PyCoderAnalysisAgent()
+
+        agent.get_response(original_prompt="what is the sum?", code="print(sum([1,2]))", code_output="3")
+
+        assert calls[0]["task"] == config.TASK_CHAT
+        user_message = calls[0]["messages"][1]["content"]
+        assert 'Original Prompt: "what is the sum?"' in user_message
+        assert "print(sum([1,2]))" in user_message
+        assert "3" in user_message
+        assert "Based on all the above" in user_message
+
+    def test_without_an_original_prompt_omits_the_original_prompt_label(self, monkeypatch):
+        calls = _capture_chat(monkeypatch)
+        agent = PyCoderAnalysisAgent()
+
+        agent.get_response(original_prompt=None, code="print('hi')", code_output="hi")
+
+        user_message = calls[0]["messages"][1]["content"]
+        assert "Original Prompt:" not in user_message
+        assert "Please analyze the following Python code" in user_message
+        assert "print('hi')" in user_message
+        assert "hi" in user_message
+
+    def test_an_empty_string_original_prompt_is_treated_as_absent(self, monkeypatch):
+        # `if original_prompt:` - an empty string is falsy, same branch as
+        # None, not the "Original Prompt:" branch.
+        calls = _capture_chat(monkeypatch)
+        agent = PyCoderAnalysisAgent()
+
+        agent.get_response(original_prompt="", code="print(1)", code_output="1")
+
+        user_message = calls[0]["messages"][1]["content"]
+        assert "Original Prompt:" not in user_message
+        assert "Please analyze the following Python code" in user_message
+
+    def test_returns_the_chat_response_content(self, monkeypatch):
+        _capture_chat(monkeypatch, response_content="This code prints hi.")
+        agent = PyCoderAnalysisAgent()
+
+        result = agent.get_response(original_prompt=None, code="print('hi')", code_output="hi")
+
+        assert result == "This code prints hi."

--- a/backend/tests/test_web_research_domain.py
+++ b/backend/tests/test_web_research_domain.py
@@ -1,0 +1,799 @@
+"""ADR-014 H3: graphlink_plugins/web_research/domain.py and service.py had
+ZERO direct unit tests. This file closes that gap for the CORE orchestration
+logic - domain.py's value/error contracts, and WebResearchService's own
+behavior (evidence selection, citation formatting, source aggregation, error
+handling) - using fake in-process implementations of ports.py's four
+Protocols (SearchProvider, DocumentFetcher, ContentExtractor, ResearchModel).
+No real network call is made anywhere in this file.
+
+Deliberately out of scope (covered elsewhere / by a different increment):
+  - providers.py, fetch_policy.py, crawl_etiquette.py (the network-fetching
+    layer: SSRF/IP-pinning, robots.txt, redirects, timeouts) - see
+    test_web_research_fetch_policy.py, test_web_research_crawl_etiquette.py,
+    test_web_research_providers_fetcher.py.
+  - WebResearchService._retain_documents / retain_to_knowledge wiring -
+    already has dedicated, thorough coverage in
+    test_web_research_retention.py; not re-covered here beyond incidental
+    exercise (every request built below defaults retain_to_knowledge=False).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graphlink_plugins.web_research.domain import (
+    CancellationToken,
+    FetchedDocument,
+    FetchedPayload,
+    ProgressEvent,
+    RequestCancelled,
+    ResearchCitation,
+    ResearchFailure,
+    ResearchLimits,
+    ResearchResult,
+    ResearchSource,
+    ResearchStage,
+    SearchResult,
+    SourceAssessment,
+    WebResearchRequest,
+)
+from graphlink_plugins.web_research.service import WebResearchService
+
+
+# ---------------------------------------------------------------------------
+# Fakes for the four ports.py Protocols. Kept intentionally simple (canned
+# results / scripted errors keyed by source_id) rather than MagicMock, so the
+# test bodies below stay readable - mirrors test_web_research_retention.py's
+# existing Fake* convention.
+# ---------------------------------------------------------------------------
+
+
+class FakeSearchProvider:
+    name = "fake"
+
+    def __init__(self, results, *, error=None):
+        self._results = list(results)
+        self._error = error
+        self.calls: list[str] = []
+
+    def search(self, query, *, limits, token):
+        self.calls.append(query)
+        if self._error is not None:
+            raise self._error
+        return list(self._results)
+
+
+class FakeFetcher:
+    def __init__(self, *, payloads=None, errors=None):
+        self._payloads = payloads or {}
+        self._errors = errors or {}
+        self.calls: list[str] = []
+
+    def fetch(self, result, *, limits, token):
+        self.calls.append(result.source_id)
+        if result.source_id in self._errors:
+            raise self._errors[result.source_id]
+        payload = self._payloads.get(result.source_id)
+        if payload is not None:
+            return payload
+        return FetchedPayload(
+            source_id=result.source_id,
+            requested_url=result.url,
+            final_url=result.url,
+            content_type="text/html",
+            body=b"<html>ignored - FakeExtractor supplies the real text</html>",
+        )
+
+
+class FakeExtractor:
+    def __init__(self, documents=None, *, errors=None):
+        self._documents = documents or {}
+        self._errors = errors or {}
+        self.calls: list[str] = []
+
+    def extract(self, payload, *, limits, token):
+        self.calls.append(payload.source_id)
+        if payload.source_id in self._errors:
+            raise self._errors[payload.source_id]
+        document = self._documents.get(payload.source_id)
+        if document is not None:
+            return document
+        return _document(payload.source_id, sections=("Default fake content.",), final_url=payload.final_url)
+
+
+class FakeModel:
+    def __init__(self, *, refined_query=None, assessments=None, answer="A synthesized answer [s1].", refine_error=None):
+        self._refined_query = refined_query
+        self._assessments = assessments or {}
+        self._answer = answer
+        self._refine_error = refine_error
+        self.refine_calls: list[tuple] = []
+        self.assess_calls: list[str] = []
+        self.summarize_calls: list[list[str]] = []
+
+    def refine_query(self, query, history, *, limits, token):
+        self.refine_calls.append((query, history))
+        if self._refine_error is not None:
+            raise self._refine_error
+        return self._refined_query if self._refined_query is not None else query
+
+    def assess_source(self, query, document, *, limits, token):
+        self.assess_calls.append(document.source_id)
+        return self._assessments.get(document.source_id, SourceAssessment(accepted=True))
+
+    def summarize(self, query, history, evidence, *, limits, token):
+        self.summarize_calls.append(list(evidence))
+        return self._answer
+
+
+# ---------------------------------------------------------------------------
+# Construction helpers.
+# ---------------------------------------------------------------------------
+
+
+def _search_result(source_id="s1", *, url=None, title=None, rank=0, snippet=""):
+    url = url or f"https://example.com/{source_id}"
+    return SearchResult(source_id=source_id, title=title or f"Title {source_id}", url=url, canonical_url=url, snippet=snippet, rank=rank, provider="fake")
+
+
+def _document(source_id, *, text="", sections=(), title="Doc", final_url=None, truncated=False, content_hash=""):
+    return FetchedDocument(
+        source_id=source_id,
+        title=title,
+        final_url=final_url or f"https://example.com/{source_id}",
+        content_type="text/html",
+        text=text,
+        sections=sections,
+        truncated=truncated,
+        content_hash=content_hash,
+    )
+
+
+def _request(*, query="widgets", history=None, limits=None, retain_to_knowledge=False, provider_snapshot=None, request_id="r1"):
+    return WebResearchRequest(
+        request_id=request_id,
+        node_id="n1",
+        chat_epoch=1,
+        original_query=query,
+        branch_history=history or [],
+        limits=limits or ResearchLimits(),
+        provider_snapshot=provider_snapshot or {},
+        retain_to_knowledge=retain_to_knowledge,
+    )
+
+
+def _service(*, search=None, fetcher=None, extractor=None, model=None):
+    return WebResearchService(
+        search_provider=search or FakeSearchProvider([_search_result("s1")]),
+        fetcher=fetcher or FakeFetcher(),
+        extractor=extractor or FakeExtractor({"s1": _document("s1", sections=("Widgets are great.",))}),
+        model=model or FakeModel(),
+    )
+
+
+# ===========================================================================
+# domain.py: value objects, error types, cancellation primitive
+# ===========================================================================
+
+
+class TestResearchLimitsValidation:
+    @pytest.mark.parametrize(
+        "field_name",
+        [
+            "max_search_results",
+            "max_sources",
+            "max_redirects",
+            "max_bytes_per_source",
+            "max_chars_per_source",
+            "max_chars_per_evidence_chunk",
+            "max_evidence_chars",
+            "max_evidence_tokens",
+            "max_query_chars",
+            "max_history_chars",
+        ],
+    )
+    def test_zero_value_raises_value_error(self, field_name):
+        with pytest.raises(ValueError, match=field_name):
+            ResearchLimits(**{field_name: 0})
+
+    @pytest.mark.parametrize("field_name", ["max_sources", "max_query_chars"])
+    def test_negative_value_raises_value_error(self, field_name):
+        with pytest.raises(ValueError, match=field_name):
+            ResearchLimits(**{field_name: -1})
+
+    def test_defaults_construct_without_error(self):
+        limits = ResearchLimits()
+        assert limits.max_sources == 4
+        assert limits.max_search_results == 8
+
+    def test_is_frozen(self):
+        limits = ResearchLimits()
+        with pytest.raises(Exception):  # dataclasses.FrozenInstanceError
+            limits.max_sources = 99
+
+
+class TestCancellationToken:
+    def test_starts_uncancelled(self):
+        token = CancellationToken()
+        assert token.cancelled is False
+        assert token.is_set() is False
+        token.raise_if_cancelled()  # must not raise
+
+    def test_cancel_flips_both_accessors(self):
+        token = CancellationToken()
+        token.cancel()
+        assert token.cancelled is True
+        assert token.is_set() is True
+
+    def test_raise_if_cancelled_raises_request_cancelled_once_cancelled(self):
+        token = CancellationToken()
+        token.cancel()
+        with pytest.raises(RequestCancelled):
+            token.raise_if_cancelled()
+
+    def test_request_cancelled_is_retryable(self):
+        assert RequestCancelled.retryable is True
+        assert RequestCancelled.code == "cancelled"
+
+
+class TestResearchFailure:
+    def test_defaults(self):
+        exc = ResearchFailure("oops")
+        assert exc.code == "research_failed"
+        assert exc.retryable is True
+        assert exc.source_id is None
+        assert str(exc) == "oops"
+
+    def test_custom_fields_are_stored_verbatim(self):
+        exc = ResearchFailure("bad", code="x", retryable=False, source_id="s1")
+        assert (exc.code, exc.retryable, exc.source_id) == ("x", False, "s1")
+
+
+class TestWebResearchRequestDefaults:
+    def test_retain_to_knowledge_defaults_to_false(self):
+        request = WebResearchRequest(request_id="r", node_id="n", chat_epoch=1, original_query="q")
+        assert request.retain_to_knowledge is False
+
+    def test_mutable_defaults_are_independent_between_instances(self):
+        a = WebResearchRequest(request_id="a", node_id="n", chat_epoch=1, original_query="q")
+        b = WebResearchRequest(request_id="b", node_id="n", chat_epoch=1, original_query="q")
+        a.branch_history.append({"role": "user"})
+        assert b.branch_history == []
+        assert isinstance(a.limits, ResearchLimits)
+
+
+class TestResearchSourceToDict:
+    def test_round_trips_every_field(self):
+        source = ResearchSource(
+            source_id="s1",
+            title="T",
+            url="https://x",
+            canonical_url="https://x",
+            snippet="snip",
+            rank=1,
+            provider="ddg",
+            final_url="https://y",
+            status="accepted",
+            error_code="",
+            error_message="",
+            truncated=True,
+            content_hash="abc",
+            citation_count=2,
+        )
+        assert source.to_dict() == {
+            "source_id": "s1",
+            "title": "T",
+            "url": "https://x",
+            "canonical_url": "https://x",
+            "snippet": "snip",
+            "rank": 1,
+            "provider": "ddg",
+            "final_url": "https://y",
+            "status": "accepted",
+            "error_code": "",
+            "error_message": "",
+            "truncated": True,
+            "content_hash": "abc",
+            "citation_count": 2,
+        }
+
+
+class TestResearchResultToDict:
+    def test_serializes_nested_sources_and_citations(self):
+        source = ResearchSource(source_id="s1", title="T", url="u", canonical_url="u", status="accepted")
+        citation = ResearchCitation(source_id="s1", marker="[s1]", claim_context="ctx")
+        result = ResearchResult(
+            request_id="r1",
+            original_query="q",
+            effective_query="q2",
+            answer_markdown="answer [s1]",
+            sources=[source],
+            citations=[citation],
+            warnings=["w1"],
+            provider_snapshot={"provider": "anthropic"},
+        )
+        d = result.to_dict()
+        assert d["request_id"] == "r1"
+        assert d["sources"] == [source.to_dict()]
+        assert d["citations"] == [{"source_id": "s1", "marker": "[s1]", "claim_context": "ctx"}]
+        assert d["warnings"] == ["w1"]
+        assert d["provider_snapshot"] == {"provider": "anthropic"}
+
+
+class TestResearchResultToLegacyDict:
+    def test_only_accepted_sources_are_included_preferring_final_url_over_url(self):
+        accepted_with_final = ResearchSource(source_id="s1", title="A", url="https://a", canonical_url="https://a", final_url="https://a-final", status="accepted")
+        accepted_no_final = ResearchSource(source_id="s2", title="B", url="https://b", canonical_url="https://b", final_url="", status="accepted")
+        rejected = ResearchSource(source_id="s3", title="C", url="https://c", canonical_url="https://c", status="rejected")
+        failed = ResearchSource(source_id="s4", title="D", url="https://d", canonical_url="https://d", status="failed")
+        result = ResearchResult(
+            request_id="r1",
+            original_query="q",
+            effective_query="q",
+            answer_markdown="answer",
+            sources=[accepted_with_final, accepted_no_final, rejected, failed],
+        )
+        legacy = result.to_legacy_dict()
+        assert legacy["sources"] == ["https://a-final", "https://b"]
+        assert legacy["summary"] == "answer"
+        assert legacy["query"] == "q"
+        assert legacy["research_result"] == result.to_dict()
+
+
+# ===========================================================================
+# WebResearchService: construction
+# ===========================================================================
+
+
+class TestServiceConstruction:
+    def test_defaults_to_the_real_adapter_classes_when_none_given(self):
+        from graphlink_plugins.web_research.providers import (
+            ApiResearchModel,
+            BeautifulSoupContentExtractor,
+            DuckDuckGoSearchProvider,
+            RequestsDocumentFetcher,
+        )
+
+        service = WebResearchService()
+        assert isinstance(service.search_provider, DuckDuckGoSearchProvider)
+        assert isinstance(service.fetcher, RequestsDocumentFetcher)
+        assert isinstance(service.extractor, BeautifulSoupContentExtractor)
+        assert isinstance(service.model, ApiResearchModel)
+
+    def test_explicit_overrides_are_used_verbatim_not_wrapped(self):
+        search = FakeSearchProvider([])
+        fetcher = FakeFetcher()
+        extractor = FakeExtractor()
+        model = FakeModel()
+        service = WebResearchService(search_provider=search, fetcher=fetcher, extractor=extractor, model=model)
+        assert service.search_provider is search
+        assert service.fetcher is fetcher
+        assert service.extractor is extractor
+        assert service.model is model
+
+
+# ===========================================================================
+# WebResearchService._emit
+# ===========================================================================
+
+
+class TestEmit:
+    def test_calls_the_callback_with_a_fully_populated_progress_event(self):
+        request = _request(request_id="req-1")
+        events: list[ProgressEvent] = []
+        WebResearchService._emit(request, events.append, ResearchStage.SEARCHING, "msg", 1, 2, "s1")
+        assert events == [ProgressEvent("req-1", ResearchStage.SEARCHING, "msg", 1, 2, "s1")]
+
+    def test_is_a_no_op_when_callback_is_none(self):
+        request = _request()
+        WebResearchService._emit(request, None, ResearchStage.SEARCHING, "msg")  # must not raise
+
+
+# ===========================================================================
+# WebResearchService._citation_markers
+# ===========================================================================
+
+
+class TestCitationMarkers:
+    def test_extracts_simple_markers(self):
+        assert WebResearchService._citation_markers("See [s1] and [s2].") == {"s1", "s2"}
+
+    def test_extracts_hyphenated_chunk_markers(self):
+        assert WebResearchService._citation_markers("Evidence [s1-ab12ef] here.") == {"s1-ab12ef"}
+
+    def test_is_case_insensitive_and_lowercases_the_result(self):
+        assert WebResearchService._citation_markers("[S1] and [S2-AB].") == {"s1", "s2-ab"}
+
+    def test_dedups_repeated_markers_into_a_set(self):
+        assert WebResearchService._citation_markers("[s1] blah [s1] blah") == {"s1"}
+
+    def test_no_markers_returns_an_empty_set(self):
+        assert WebResearchService._citation_markers("No citations here.") == set()
+
+    def test_ignores_bracketed_text_that_does_not_match_the_marker_shape(self):
+        assert WebResearchService._citation_markers("[not a marker] [source1] [s1]") == {"s1"}
+
+
+# ===========================================================================
+# WebResearchService._select_evidence
+# ===========================================================================
+
+
+class TestSelectEvidence:
+    def test_single_short_section_yields_one_chunk(self):
+        doc = _document("s1", sections=("Hello world.",))
+        chunks = WebResearchService._select_evidence([doc], ResearchLimits(), CancellationToken())
+        assert len(chunks) == 1
+        assert chunks[0].source_id == "s1"
+        assert chunks[0].chunk_id == "s1-0-0"
+        assert chunks[0].text == "Hello world."
+        assert chunks[0].token_count == max(1, len("Hello world.") // 4)
+
+    def test_multiple_sections_produce_multiple_chunks_indexed_in_the_chunk_id(self):
+        doc = _document("s1", sections=("First section.", "Second section."))
+        chunks = WebResearchService._select_evidence([doc], ResearchLimits(), CancellationToken())
+        assert [c.chunk_id for c in chunks] == ["s1-0-0", "s1-1-0"]
+        assert [c.text for c in chunks] == ["First section.", "Second section."]
+
+    def test_blank_and_whitespace_only_sections_are_skipped_but_index_still_reflects_position(self):
+        doc = _document("s1", sections=("", "   ", "Real content."))
+        chunks = WebResearchService._select_evidence([doc], ResearchLimits(), CancellationToken())
+        assert len(chunks) == 1
+        assert chunks[0].text == "Real content."
+        assert chunks[0].chunk_id == "s1-2-0"
+
+    def test_internal_whitespace_is_collapsed_to_single_spaces(self):
+        doc = _document("s1", sections=("Line one\n\n  with   extra   spaces.",))
+        chunks = WebResearchService._select_evidence([doc], ResearchLimits(), CancellationToken())
+        assert chunks[0].text == "Line one with extra spaces."
+
+    def test_falls_back_to_splitting_text_into_lines_when_sections_is_empty(self):
+        doc = _document("s1", text="Line A\nLine B", sections=())
+        chunks = WebResearchService._select_evidence([doc], ResearchLimits(), CancellationToken())
+        assert [c.text for c in chunks] == ["Line A", "Line B"]
+
+    def test_a_long_section_is_split_across_multiple_offset_chunks(self):
+        limits = ResearchLimits(max_chars_per_evidence_chunk=10, max_chars_per_source=1000)
+        doc = _document("s1", sections=("a" * 25,))
+        chunks = WebResearchService._select_evidence([doc], limits, CancellationToken())
+        assert [c.chunk_id for c in chunks] == ["s1-0-0", "s1-0-10", "s1-0-20"]
+        assert [len(c.text) for c in chunks] == [10, 10, 5]
+
+    def test_max_chars_per_source_caps_one_documents_total_but_the_next_document_gets_its_own_budget(self):
+        limits = ResearchLimits(max_chars_per_evidence_chunk=10, max_chars_per_source=15)
+        doc_a = _document("a", sections=("a" * 30,))
+        doc_b = _document("b", sections=("b" * 30,))
+        chunks = WebResearchService._select_evidence([doc_a, doc_b], limits, CancellationToken())
+        a_total = sum(len(c.text) for c in chunks if c.source_id == "a")
+        b_total = sum(len(c.text) for c in chunks if c.source_id == "b")
+        assert a_total == 15
+        assert b_total == 15
+
+    def test_max_evidence_chars_caps_the_total_across_all_documents(self):
+        limits = ResearchLimits(max_chars_per_evidence_chunk=1000, max_chars_per_source=1000, max_evidence_chars=12)
+        doc_a = _document("a", sections=("a" * 20,))
+        doc_b = _document("b", sections=("b" * 20,))
+        chunks = WebResearchService._select_evidence([doc_a, doc_b], limits, CancellationToken())
+        assert [c.source_id for c in chunks] == ["a"]
+        assert chunks[0].text == "a" * 8  # 12 - len("[a] ") == 8 chars of budget left
+
+    def test_max_evidence_tokens_bounds_a_pieces_length_to_four_chars_per_token(self):
+        limits = ResearchLimits(max_chars_per_evidence_chunk=1000, max_chars_per_source=1000, max_evidence_tokens=2)
+        doc = _document("a", sections=("a" * 40,))
+        chunks = WebResearchService._select_evidence([doc], limits, CancellationToken())
+        assert len(chunks) == 1
+        assert chunks[0].token_count <= 2
+        assert len(chunks[0].text) <= 8
+
+    def test_no_documents_yields_no_chunks(self):
+        assert WebResearchService._select_evidence([], ResearchLimits(), CancellationToken()) == []
+
+    def test_raises_request_cancelled_when_the_token_is_already_cancelled(self):
+        doc = _document("a", sections=("first",))
+        token = CancellationToken()
+        token.cancel()
+        with pytest.raises(RequestCancelled):
+            WebResearchService._select_evidence([doc], ResearchLimits(), token)
+
+
+# ===========================================================================
+# WebResearchService.run - query validation
+# ===========================================================================
+
+
+class TestRunQueryValidation:
+    def test_empty_query_raises_before_any_search_call(self):
+        search = FakeSearchProvider([_search_result("s1")])
+        service = _service(search=search)
+        with pytest.raises(ResearchFailure) as exc_info:
+            service.run(_request(query="   "))
+        assert exc_info.value.code == "empty_query"
+        assert exc_info.value.retryable is False
+        assert search.calls == []
+
+    def test_query_over_the_configured_limit_raises_query_too_long(self):
+        service = _service()
+        limits = ResearchLimits(max_query_chars=5)
+        with pytest.raises(ResearchFailure) as exc_info:
+            service.run(_request(query="a very long query", limits=limits))
+        assert exc_info.value.code == "query_too_long"
+        assert exc_info.value.retryable is False
+
+    def test_query_whitespace_is_collapsed_before_being_sent_to_search(self):
+        search = FakeSearchProvider([_search_result("s1")])
+        service = _service(search=search)
+        service.run(_request(query="  widgets   for   home  "))
+        assert search.calls == ["widgets for home"]
+
+
+# ===========================================================================
+# WebResearchService.run - search-stage failures
+# ===========================================================================
+
+
+class TestRunSearchFailures:
+    def test_a_research_failure_from_the_search_provider_propagates_unchanged(self):
+        boom = ResearchFailure("search down", code="custom_search_fail")
+        service = _service(search=FakeSearchProvider([], error=boom))
+        with pytest.raises(ResearchFailure) as exc_info:
+            service.run(_request())
+        assert exc_info.value is boom
+
+    def test_a_generic_exception_from_the_search_provider_is_wrapped_as_search_failed(self):
+        service = _service(search=FakeSearchProvider([], error=RuntimeError("timeout")))
+        with pytest.raises(ResearchFailure) as exc_info:
+            service.run(_request())
+        assert exc_info.value.code == "search_failed"
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+    def test_no_search_results_raises_no_search_results_and_is_not_retryable(self):
+        service = _service(search=FakeSearchProvider([]))
+        with pytest.raises(ResearchFailure) as exc_info:
+            service.run(_request())
+        assert exc_info.value.code == "no_search_results"
+        assert exc_info.value.retryable is False
+
+
+# ===========================================================================
+# WebResearchService.run - source selection / aggregation
+# ===========================================================================
+
+
+class TestRunSourceSelection:
+    def test_candidates_are_truncated_to_limits_max_sources(self):
+        results = [_search_result(f"s{i}") for i in range(1, 6)]
+        fetcher = FakeFetcher()
+        extractor = FakeExtractor({f"s{i}": _document(f"s{i}", sections=(f"Content {i}.",)) for i in range(1, 6)})
+        service = _service(search=FakeSearchProvider(results), fetcher=fetcher, extractor=extractor)
+        result = service.run(_request(limits=ResearchLimits(max_sources=2)))
+        assert len(result.sources) == 2
+        assert fetcher.calls == ["s1", "s2"]
+
+    def test_accepted_rejected_and_failed_sources_all_land_with_the_right_status(self):
+        results = [_search_result("accepted"), _search_result("rejected"), _search_result("failed")]
+        extractor = FakeExtractor(
+            {
+                "accepted": _document("accepted", sections=("Good content.",)),
+                "rejected": _document("rejected", sections=("Bad content.",)),
+            }
+        )
+        fetcher = FakeFetcher(errors={"failed": ResearchFailure("dead link", code="fetch_dead")})
+        model = FakeModel(assessments={"rejected": SourceAssessment(accepted=False, reason="off_topic")}, answer="Answer citing [accepted].")
+        service = _service(search=FakeSearchProvider(results), fetcher=fetcher, extractor=extractor, model=model)
+        result = service.run(_request())
+
+        by_id = {s.source_id: s for s in result.sources}
+        assert by_id["accepted"].status == "accepted"
+        assert by_id["rejected"].status == "rejected"
+        assert by_id["rejected"].error_code == "off_topic"
+        assert by_id["failed"].status == "failed"
+        assert by_id["failed"].error_code == "fetch_dead"
+        assert any("was not used" in w for w in result.warnings)
+        assert any("could not be used" in w for w in result.warnings)
+
+    def test_rejection_without_an_explicit_reason_defaults_error_code_to_source_rejected(self):
+        results = [_search_result("s1"), _search_result("s2")]
+        extractor = FakeExtractor(
+            {
+                "s1": _document("s1", sections=("Rejected content.",)),
+                "s2": _document("s2", sections=("Accepted content.",)),
+            }
+        )
+        model = FakeModel(assessments={"s1": SourceAssessment(accepted=False)}, answer="Answer [s2].")
+        service = _service(search=FakeSearchProvider(results), extractor=extractor, model=model)
+        result = service.run(_request())
+        by_id = {s.source_id: s for s in result.sources}
+        assert by_id["s1"].status == "rejected"
+        assert by_id["s1"].error_code == "source_rejected"
+
+    def test_a_payload_level_truncation_is_recorded_on_the_source_record(self):
+        # source.truncated is populated from the FETCH-stage payload (network
+        # byte-cap truncation), set right after fetch() returns.
+        payload = FetchedPayload(
+            source_id="s1", requested_url="https://example.com/s1", final_url="https://example.com/s1",
+            content_type="text/html", body=b"<html>hi</html>", truncated=True,
+        )
+        fetcher = FakeFetcher(payloads={"s1": payload})
+        extractor = FakeExtractor({"s1": _document("s1", sections=("Some content.",))})
+        service = _service(fetcher=fetcher, extractor=extractor)
+        result = service.run(_request())
+        assert result.sources[0].status == "accepted"
+        assert result.sources[0].truncated is True
+
+    def test_a_document_level_truncation_still_warns_and_still_accepts_even_though_it_never_updates_source_truncated(self):
+        # KNOWN GAP (flagged, not fixed here - out of this test file's
+        # remit): the "Source N was truncated..." warning is driven by
+        # document.truncated (the EXTRACT-stage/content-layer signal), but
+        # ResearchSource.truncated is only ever assigned once, right after
+        # fetch(), from payload.truncated (the FETCH-stage/network-layer
+        # signal) - see service.py's run(). It is never re-synced from
+        # document.truncated afterward, so a source whose *content* was cut
+        # short during extraction (this test's case) still reports
+        # truncated=False on the ResearchSource/to_dict() record, even
+        # though the warning text told the user it was truncated. This
+        # test pins the CURRENT (inconsistent) behavior rather than the
+        # arguably-more-correct one, since fixing it would mean editing
+        # service.py, which is out of scope for this test-only file.
+        extractor = FakeExtractor({"s1": _document("s1", sections=("Some content.",), truncated=True)})
+        service = _service(extractor=extractor)
+        result = service.run(_request())
+        assert result.sources[0].status == "accepted"
+        assert any("truncated" in w for w in result.warnings)
+        assert result.sources[0].truncated is False  # NOT True - see docstring above
+
+
+# ===========================================================================
+# WebResearchService.run - error handling
+# ===========================================================================
+
+
+class TestRunErrorHandling:
+    def test_a_non_cancelled_fetch_failure_marks_that_source_failed_but_the_run_continues(self):
+        results = [_search_result("bad"), _search_result("good")]
+        fetcher = FakeFetcher(errors={"bad": ResearchFailure("blocked", code="url_blocked_by_policy")})
+        extractor = FakeExtractor({"good": _document("good", sections=("Fine content.",))})
+        service = _service(search=FakeSearchProvider(results), fetcher=fetcher, extractor=extractor)
+        result = service.run(_request())
+        by_id = {s.source_id: s for s in result.sources}
+        assert by_id["bad"].status == "failed"
+        assert by_id["bad"].error_code == "url_blocked_by_policy"
+        assert by_id["good"].status == "accepted"
+
+    def test_a_cancelled_fetch_aborts_the_whole_run_instead_of_being_recorded_as_a_failed_source(self):
+        results = [_search_result("s1"), _search_result("s2")]
+        fetcher = FakeFetcher(errors={"s1": ResearchFailure("stop", code="cancelled")})
+        service = _service(search=FakeSearchProvider(results), fetcher=fetcher)
+        with pytest.raises(ResearchFailure) as exc_info:
+            service.run(_request())
+        assert exc_info.value.code == "cancelled"
+        assert fetcher.calls == ["s1"]  # s2 was never attempted - the run aborted immediately
+
+    def test_a_generic_exception_is_recorded_with_a_safe_message_not_the_raw_exception_text(self):
+        results = [_search_result("bad"), _search_result("good")]
+        extractor = FakeExtractor({"good": _document("good", sections=("Fine.",))}, errors={"bad": RuntimeError("raw internal detail")})
+        service = _service(search=FakeSearchProvider(results), extractor=extractor)
+        result = service.run(_request())
+        by_id = {s.source_id: s for s in result.sources}
+        assert by_id["bad"].status == "failed"
+        assert by_id["bad"].error_code == "source_failed"
+        assert by_id["bad"].error_message == "The source failed during research."
+        assert "raw internal detail" not in by_id["bad"].error_message
+
+    def test_no_usable_sources_raised_when_every_candidate_is_rejected_or_failed(self):
+        results = [_search_result("rej"), _search_result("fail")]
+        extractor = FakeExtractor({"rej": _document("rej", sections=("x",))})
+        fetcher = FakeFetcher(errors={"fail": ResearchFailure("dead", code="fetch_dead")})
+        model = FakeModel(assessments={"rej": SourceAssessment(accepted=False, reason="no")})
+        service = _service(search=FakeSearchProvider(results), fetcher=fetcher, extractor=extractor, model=model)
+        with pytest.raises(ResearchFailure) as exc_info:
+            service.run(_request())
+        assert exc_info.value.code == "no_usable_sources"
+        assert exc_info.value.retryable is True
+
+    def test_no_evidence_raised_when_accepted_documents_have_no_extractable_text(self):
+        extractor = FakeExtractor({"s1": _document("s1", sections=("   ", ""))})
+        service = _service(extractor=extractor)
+        with pytest.raises(ResearchFailure) as exc_info:
+            service.run(_request())
+        assert exc_info.value.code == "no_evidence"
+        assert exc_info.value.retryable is False
+
+    def test_cancellation_before_search_stops_before_any_search_call(self):
+        search = FakeSearchProvider([_search_result("s1")])
+        service = _service(search=search)
+        token = CancellationToken()
+        token.cancel()
+        with pytest.raises(RequestCancelled):
+            service.run(_request(), token=token)
+        assert search.calls == []
+
+
+# ===========================================================================
+# WebResearchService.run - citation formatting
+# ===========================================================================
+
+
+class TestRunCitationFormatting:
+    def test_citation_count_is_set_per_source_by_whether_the_answer_actually_used_its_marker(self):
+        results = [_search_result("s1"), _search_result("s2")]
+        extractor = FakeExtractor(
+            {
+                "s1": _document("s1", sections=("Content one.",)),
+                "s2": _document("s2", sections=("Content two.",)),
+            }
+        )
+        model = FakeModel(answer="Only cites [s1] here.")
+        service = _service(search=FakeSearchProvider(results), extractor=extractor, model=model)
+        result = service.run(_request())
+        by_id = {s.source_id: s for s in result.sources}
+        assert by_id["s1"].citation_count == 1
+        assert by_id["s2"].citation_count == 0
+        assert {c.source_id for c in result.citations} == {"s1", "s2"}
+        assert {c.marker for c in result.citations} == {"[s1]", "[s2]"}
+
+    def test_missing_citations_appends_a_sources_section_and_a_warning(self):
+        model = FakeModel(answer="An answer with no markers at all.")
+        service = _service(model=model)
+        result = service.run(_request())
+        assert "### Sources" in result.answer_markdown
+        assert "[s1]" in result.answer_markdown
+        assert any("did not emit inline citations" in w for w in result.warnings)
+
+    def test_citations_already_present_leave_the_answer_untouched(self):
+        model = FakeModel(answer="Cited answer [s1].")
+        service = _service(model=model)
+        result = service.run(_request())
+        assert result.answer_markdown == "Cited answer [s1]."
+        assert not any("did not emit inline citations" in w for w in result.warnings)
+
+    def test_rejected_sources_never_appear_in_the_citations_list(self):
+        results = [_search_result("s1"), _search_result("s2")]
+        extractor = FakeExtractor({"s1": _document("s1", sections=("Content.",))})
+        model = FakeModel(assessments={"s2": SourceAssessment(accepted=False, reason="off_topic")}, answer="[s1] cited.")
+        service = _service(search=FakeSearchProvider(results), extractor=extractor, model=model)
+        result = service.run(_request())
+        assert {c.source_id for c in result.citations} == {"s1"}
+
+
+# ===========================================================================
+# WebResearchService.run - result shape / progress events
+# ===========================================================================
+
+
+class TestRunResultShape:
+    def test_result_carries_request_id_normalized_query_effective_query_and_provider_snapshot(self):
+        request = WebResearchRequest(
+            request_id="req-42",
+            node_id="n1",
+            chat_epoch=1,
+            original_query="  widgets  ",
+            provider_snapshot={"provider": "anthropic"},
+        )
+        model = FakeModel(refined_query="widgets and gadgets")
+        service = _service(model=model)
+        result = service.run(request)
+        assert result.request_id == "req-42"
+        assert result.original_query == "widgets"
+        assert result.effective_query == "widgets and gadgets"
+        assert result.provider_snapshot == {"provider": "anthropic"}
+
+
+class TestRunProgressEvents:
+    def test_emits_stages_in_order_starting_preparing_and_ending_completed(self):
+        events: list[ProgressEvent] = []
+        service = _service()
+        service.run(_request(), progress=events.append)
+        stages = [e.stage for e in events]
+        assert stages[0] == ResearchStage.PREPARING
+        assert stages[-1] == ResearchStage.COMPLETED
+        assert ResearchStage.SEARCHING in stages
+        assert ResearchStage.FETCHING in stages
+        assert ResearchStage.EXTRACTING in stages
+        assert ResearchStage.VALIDATING in stages
+        assert ResearchStage.SYNTHESIZING in stages
+        assert all(e.request_id == "r1" for e in events)
+
+    def test_no_progress_callback_is_a_valid_no_op_call_shape(self):
+        service = _service()
+        result = service.run(_request())  # progress=None (the default)
+        assert result.answer_markdown  # the run still completes normally

--- a/backend/tests/test_web_research_providers_coverage.py
+++ b/backend/tests/test_web_research_providers_coverage.py
@@ -1,0 +1,888 @@
+"""Fills real coverage gaps in graphlink_plugins/web_research/providers.py
+left after test_web_research_providers_fetcher.py (ADR-004 stage 4.5's
+IP-pinning/robots/redirect-chain integration tests) and the dedicated
+fetch_policy.py/crawl_etiquette.py suites.
+
+fetch_policy.py and crawl_etiquette.py already have thorough direct unit
+coverage (SSRF/private-range/localhost validation, DNS-rebinding pinning,
+robots.txt parsing/caching/fail-open, Crawl-delay precedence/clamping) - see
+test_web_research_fetch_policy.py and test_web_research_crawl_etiquette.py.
+This file does not re-test those modules' own logic; the fake-resolver
+FetchPolicy instances constructed below exist only to reach the providers.py
+branches under test.
+
+What was genuinely untested before this file (confirmed by reading every
+existing web_research test file):
+
+- RequestsDocumentFetcher.fetch()'s content-type/content-length/streaming
+  byte-cap enforcement, redirect-limit/invalid-redirect handling, HTTP
+  error-status mapping, the requests-package-missing guard, and the
+  catch-all "fetch_failed" exception mapping - test_..._providers_fetcher.py
+  covers the pinning/robots/redirect-chain/timeout wiring but never
+  exercises these branches.
+- RequestsDocumentFetcher._fetch_robots_bytes() - previously only exercised
+  indirectly through fetch()'s own robots.txt lookup; never unit-tested on
+  its own (policy-rejection, request-exception, truncation, close()-on-error
+  paths).
+- BeautifulSoupContentExtractor - zero prior coverage of any kind. This is
+  the module's actual "response parsing" layer (HTML/JSON/plain-text
+  extraction, truncation, empty-source/dependency-missing/extract-failed
+  error mapping) and it had no direct tests at all.
+- The small helpers dependency_status() and source_id_for_url().
+- DuckDuckGoSearchProvider.search() - dependency-missing guard,
+  normalization/dedup, and provider-exception mapping.
+- ApiResearchModel - JSON/legacy-text response parsing and exception
+  fallbacks for refine_query/assess_source/summarize.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from graphlink_plugins.web_research import providers as providers_module
+from graphlink_plugins.web_research.crawl_etiquette import CrawlEtiquette
+from graphlink_plugins.web_research.domain import (
+    CancellationToken,
+    FetchedPayload,
+    RequestCancelled,
+    ResearchFailure,
+    ResearchLimits,
+    SearchResult,
+)
+from graphlink_plugins.web_research.fetch_policy import FetchPolicy
+from graphlink_plugins.web_research.providers import (
+    ApiResearchModel,
+    BeautifulSoupContentExtractor,
+    DuckDuckGoSearchProvider,
+    RequestsDocumentFetcher,
+    dependency_status,
+    source_id_for_url,
+)
+
+
+def _search_result(url="https://example.com/page"):
+    return SearchResult(source_id="s1-abc", title="Example", url=url, canonical_url=url)
+
+
+def _real_policy_with_fake_resolver(*addresses, **kwargs):
+    def resolver(host, port, type=None):
+        import socket
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (addr, port)) for addr in addresses]
+
+    return FetchPolicy(resolver=resolver, **kwargs)
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, content_type="text/html", body=b"<html>hi</html>", headers=None, location=None):
+        self.status_code = status_code
+        self._body = body
+        self.headers = dict(headers or {})
+        self.headers.setdefault("Content-Type", content_type)
+        if location:
+            self.headers["Location"] = location
+        self.closed = False
+
+    @property
+    def is_redirect(self):
+        return self.status_code in (301, 302, 303, 307, 308) and "Location" in self.headers
+
+    @property
+    def is_permanent_redirect(self):
+        return self.status_code in (301, 308) and "Location" in self.headers
+
+    def iter_content(self, chunk_size=16384):
+        for i in range(0, len(self._body), chunk_size):
+            yield self._body[i : i + chunk_size]
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeSession:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.trust_env = True
+        self.headers = {}
+        self.mounted = []
+        self.get_calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def mount(self, prefix, adapter):
+        self.mounted.append((prefix, adapter))
+
+    def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        if not self._responses:
+            raise AssertionError("no more scripted responses")
+        return self._responses.pop(0)
+
+
+@pytest.fixture
+def limits():
+    return ResearchLimits()
+
+
+@pytest.fixture
+def token():
+    return CancellationToken()
+
+
+def _patched_requests(fake_session):
+    """Context manager patching providers_module.requests so fetch() drives
+    the fake session instead of real sockets, matching the convention
+    established in test_web_research_providers_fetcher.py."""
+    return patch.object(providers_module, "requests")
+
+
+# ---------------------------------------------------------------------------
+# RequestsDocumentFetcher: content-type / content-length / streaming caps
+# ---------------------------------------------------------------------------
+
+
+class TestContentTypeAndSizeEnforcement:
+    def test_a_disallowed_content_type_is_rejected_before_any_body_is_kept(self, limits, token):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        etiquette = CrawlEtiquette(default_crawl_delay_seconds=0)
+        fake_session = _FakeSession(
+            [
+                _FakeResponse(status_code=404, body=b""),  # robots.txt
+                _FakeResponse(status_code=200, content_type="application/pdf", body=b"%PDF-1.4 ..."),
+            ]
+        )
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=etiquette)
+
+        with _patched_requests(fake_session) as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "unsupported_content_type"
+        assert exc_info.value.retryable is False
+
+    def test_a_content_length_header_over_the_limit_rejects_without_streaming_the_body(self, limits, token):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        etiquette = CrawlEtiquette(default_crawl_delay_seconds=0)
+        oversized = _FakeResponse(
+            status_code=200,
+            content_type="text/html",
+            body=b"<html>should never be read</html>",
+            headers={"Content-Length": str(limits.max_bytes_per_source + 1)},
+        )
+
+        def _iter_content_should_not_be_called(chunk_size=16384):
+            raise AssertionError("body must not be streamed once Content-Length exceeds the cap")
+
+        oversized.iter_content = _iter_content_should_not_be_called
+        fake_session = _FakeSession([_FakeResponse(status_code=404, body=b""), oversized])
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=etiquette)
+
+        with _patched_requests(fake_session) as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "source_too_large"
+        assert exc_info.value.retryable is False
+
+    def test_a_streamed_body_exceeding_the_cap_is_truncated_rather_than_rejected(self, limits, token):
+        # No Content-Length header this time - the cap must still be
+        # enforced by the chunked-read loop itself.
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        etiquette = CrawlEtiquette(default_crawl_delay_seconds=0)
+        tight_limits = ResearchLimits(max_bytes_per_source=10)
+        oversized_body = b"0123456789ABCDEF"  # 16 bytes > the 10-byte cap
+        fake_session = _FakeSession(
+            [
+                _FakeResponse(status_code=404, body=b""),
+                _FakeResponse(status_code=200, content_type="text/plain", body=oversized_body),
+            ]
+        )
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=etiquette)
+
+        with _patched_requests(fake_session) as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            result = fetcher.fetch(_search_result(), limits=tight_limits, token=token)
+
+        assert result.truncated is True
+        assert result.body == oversized_body[:10]
+
+    def test_the_smaller_of_policy_and_per_request_limits_wins(self, limits, token):
+        policy = _real_policy_with_fake_resolver("93.184.216.34", max_bytes=5)
+        etiquette = CrawlEtiquette(default_crawl_delay_seconds=0)
+        generous_limits = ResearchLimits(max_bytes_per_source=1_000_000)
+        body = b"0123456789"
+        fake_session = _FakeSession(
+            [
+                _FakeResponse(status_code=404, body=b""),
+                _FakeResponse(status_code=200, content_type="text/plain", body=body),
+            ]
+        )
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=etiquette)
+
+        with _patched_requests(fake_session) as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            result = fetcher.fetch(_search_result(), limits=generous_limits, token=token)
+
+        # policy.max_bytes=5 is tighter than the request's own 1,000,000 cap.
+        assert result.body == body[:5]
+        assert result.truncated is True
+
+    def test_a_body_under_the_cap_is_returned_whole_and_not_marked_truncated(self, limits, token):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        etiquette = CrawlEtiquette(default_crawl_delay_seconds=0)
+        body = b"short body"
+        fake_session = _FakeSession(
+            [
+                _FakeResponse(status_code=404, body=b""),
+                _FakeResponse(status_code=200, content_type="text/plain", body=body),
+            ]
+        )
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=etiquette)
+
+        with _patched_requests(fake_session) as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            result = fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert result.body == body
+        assert result.truncated is False
+
+
+# ---------------------------------------------------------------------------
+# RequestsDocumentFetcher: redirect-limit / invalid-redirect / HTTP errors
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectAndStatusHandling:
+    def test_exceeding_the_redirect_limit_raises_redirect_limit(self, limits, token):
+        policy = _real_policy_with_fake_resolver("93.184.216.34", max_redirects=1)
+        etiquette = CrawlEtiquette(default_crawl_delay_seconds=0)
+        # robots.txt (once - same origin throughout) + two redirect hops,
+        # the second of which exceeds max_redirects=1.
+        fake_session = _FakeSession(
+            [
+                _FakeResponse(status_code=404, body=b""),
+                _FakeResponse(status_code=302, location="https://example.com/hop2"),
+                _FakeResponse(status_code=302, location="https://example.com/hop3"),
+            ]
+        )
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=etiquette)
+
+        with _patched_requests(fake_session) as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "redirect_limit"
+
+    def test_a_redirect_status_with_no_location_header_is_rejected(self, limits, token):
+        # A distinct one-off subclass (never mutates the shared _FakeResponse
+        # class used by every other test in this file) that reports itself
+        # as a redirect without actually carrying a Location header.
+        class _RedirectWithNoLocation(_FakeResponse):
+            @property
+            def is_redirect(self):
+                return True
+
+            @property
+            def is_permanent_redirect(self):
+                return False
+
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        etiquette = CrawlEtiquette(default_crawl_delay_seconds=0)
+        broken_redirect = _RedirectWithNoLocation(status_code=302, body=b"")
+        broken_redirect.headers.pop("Location", None)
+        fake_session = _FakeSession([_FakeResponse(status_code=404, body=b""), broken_redirect])
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=etiquette)
+
+        with _patched_requests(fake_session) as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "invalid_redirect"
+
+    def test_an_http_error_status_is_mapped_to_fetch_http_error(self, limits, token):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        etiquette = CrawlEtiquette(default_crawl_delay_seconds=0)
+        fake_session = _FakeSession(
+            [
+                _FakeResponse(status_code=404, body=b""),
+                _FakeResponse(status_code=500, content_type="text/html", body=b"server error"),
+            ]
+        )
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=etiquette)
+
+        with _patched_requests(fake_session) as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "fetch_http_error"
+        assert "500" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# RequestsDocumentFetcher: dependency-missing guard + catch-all mapping
+# ---------------------------------------------------------------------------
+
+
+class TestDependencyMissingAndCatchAllErrorMapping:
+    def test_requests_unavailable_raises_a_non_retryable_dependency_failure(self, limits, token):
+        fetcher = RequestsDocumentFetcher()
+        with patch.object(providers_module, "REQUESTS_AVAILABLE", False):
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "fetch_dependency_missing"
+        assert exc_info.value.retryable is False
+        assert exc_info.value.source_id == "s1-abc"
+
+    def test_an_unexpected_non_research_exception_is_mapped_to_a_generic_fetch_failed(self, limits, token):
+        # A defect somewhere in the inner loop (not a ResearchFailure, not a
+        # requests.RequestException, not URLPolicyError) must still surface
+        # as a user-safe ResearchFailure rather than an unhandled traceback.
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        etiquette = CrawlEtiquette(default_crawl_delay_seconds=0)
+        broken_response = _FakeResponse(status_code=200, content_type="text/html")
+
+        def _boom(chunk_size=16384):
+            raise RuntimeError("unexpected parsing bug")
+
+        broken_response.iter_content = _boom
+        # One scripted response for the robots.txt lookup CrawlEtiquette.gate()
+        # performs first, then the broken one for the actual content GET.
+        fake_session = _FakeSession([_FakeResponse(status_code=404, body=b""), broken_response])
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=etiquette)
+
+        with _patched_requests(fake_session) as fake_requests_module:
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "fetch_failed"
+
+
+# ---------------------------------------------------------------------------
+# RequestsDocumentFetcher._fetch_robots_bytes - direct unit coverage
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRobotsBytesDirectly:
+    """_fetch_robots_bytes was previously only exercised indirectly, as a
+    side effect of fetch()'s own robots.txt lookup (always scripted as a
+    trivial 404 in the existing integration tests). These call it directly
+    to pin its own error-handling contract."""
+
+    def test_returns_none_when_the_robots_url_itself_fails_policy_validation(self):
+        # A private/loopback resolution for the robots.txt host must be
+        # rejected the same way the main content fetch would be.
+        policy = FetchPolicy(resolver=lambda host, port, type=None: [(2, 1, 6, "", ("127.0.0.1", port))])
+        fetcher = RequestsDocumentFetcher(policy=policy)
+
+        result = fetcher._fetch_robots_bytes("https://blocked.example/robots.txt", MagicMock())
+
+        assert result is None
+
+    def test_returns_none_on_a_request_exception(self):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fetcher = RequestsDocumentFetcher(policy=policy)
+
+        class _RequestException(Exception):
+            pass
+
+        fake_session = MagicMock()
+        fake_session.get.side_effect = _RequestException("network unreachable")
+
+        with patch.object(providers_module, "requests") as fake_requests_module:
+            fake_requests_module.RequestException = _RequestException
+            result = fetcher._fetch_robots_bytes("https://example.com/robots.txt", fake_session)
+
+        assert result is None
+
+    def test_returns_the_status_code_and_full_body_on_a_completed_response(self):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fetcher = RequestsDocumentFetcher(policy=policy)
+        response = _FakeResponse(status_code=200, body=b"User-agent: *\nDisallow: /private/\n")
+        fake_session = MagicMock()
+        fake_session.get.return_value = response
+
+        with patch.object(providers_module, "requests") as fake_requests_module:
+            fake_requests_module.RequestException = Exception
+            result = fetcher._fetch_robots_bytes("https://example.com/robots.txt", fake_session)
+
+        assert result == (200, b"User-agent: *\nDisallow: /private/\n")
+        assert response.closed is True
+
+    def test_returns_a_non_200_status_code_unmodified_alongside_whatever_body_it_sent(self):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fetcher = RequestsDocumentFetcher(policy=policy)
+        response = _FakeResponse(status_code=404, body=b"not found")
+        fake_session = MagicMock()
+        fake_session.get.return_value = response
+
+        with patch.object(providers_module, "requests") as fake_requests_module:
+            fake_requests_module.RequestException = Exception
+            result = fetcher._fetch_robots_bytes("https://example.com/robots.txt", fake_session)
+
+        assert result == (404, b"not found")
+
+    def test_the_body_is_truncated_to_the_robots_txt_byte_cap(self):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fetcher = RequestsDocumentFetcher(policy=policy)
+        oversized_body = b"x" * (RequestsDocumentFetcher.ROBOTS_TXT_MAX_BYTES + 500)
+        response = _FakeResponse(status_code=200, body=oversized_body)
+        fake_session = MagicMock()
+        fake_session.get.return_value = response
+
+        with patch.object(providers_module, "requests") as fake_requests_module:
+            fake_requests_module.RequestException = Exception
+            status_code, body = fetcher._fetch_robots_bytes("https://example.com/robots.txt", fake_session)
+
+        assert status_code == 200
+        assert len(body) == RequestsDocumentFetcher.ROBOTS_TXT_MAX_BYTES
+
+    def test_the_response_is_closed_even_when_reading_the_body_raises(self):
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fetcher = RequestsDocumentFetcher(policy=policy)
+        response = _FakeResponse(status_code=200, body=b"irrelevant")
+
+        class _RequestException(Exception):
+            pass
+
+        def _boom(chunk_size=8192):
+            raise _RequestException("connection reset mid-body")
+
+        response.iter_content = _boom
+        fake_session = MagicMock()
+        fake_session.get.return_value = response
+
+        with patch.object(providers_module, "requests") as fake_requests_module:
+            fake_requests_module.RequestException = _RequestException
+            result = fetcher._fetch_robots_bytes("https://example.com/robots.txt", fake_session)
+
+        assert result is None
+        assert response.closed is True
+
+
+# ---------------------------------------------------------------------------
+# BeautifulSoupContentExtractor - previously zero direct coverage
+# ---------------------------------------------------------------------------
+
+
+def _payload(content_type="text/html", body=b"<html><body><p>hi</p></body></html>", truncated=False, final_url="https://example.com/page"):
+    return FetchedPayload(
+        source_id="s1-abc",
+        requested_url=final_url,
+        final_url=final_url,
+        content_type=content_type,
+        body=body,
+        truncated=truncated,
+        status_code=200,
+        duration_ms=5,
+    )
+
+
+class TestBeautifulSoupContentExtractorHtml:
+    def test_extracts_title_and_readable_paragraph_text(self, limits, token):
+        html = b"<html><head><title>My Page</title></head><body><p>Hello world.</p></body></html>"
+        extractor = BeautifulSoupContentExtractor()
+
+        doc = extractor.extract(_payload(body=html), limits=limits, token=token)
+
+        assert doc.title == "My Page"
+        assert "Hello world." in doc.text
+        assert doc.sections == ("Hello world.",)
+        assert doc.source_id == "s1-abc"
+
+    def test_falls_back_to_the_hostname_when_there_is_no_title_tag(self, limits, token):
+        html = b"<html><body><p>No title here.</p></body></html>"
+        extractor = BeautifulSoupContentExtractor()
+
+        doc = extractor.extract(_payload(body=html, final_url="https://news.example/a"), limits=limits, token=token)
+
+        assert doc.title == "news.example"
+
+    def test_script_style_nav_and_footer_content_is_stripped(self, limits, token):
+        html = (
+            b"<html><body>"
+            b"<nav>Site nav</nav>"
+            b"<script>alert('x')</script>"
+            b"<style>.a{color:red}</style>"
+            b"<p>Real content.</p>"
+            b"<footer>Copyright 2026</footer>"
+            b"</body></html>"
+        )
+        extractor = BeautifulSoupContentExtractor()
+
+        doc = extractor.extract(_payload(body=html), limits=limits, token=token)
+
+        assert "Real content." in doc.text
+        assert "Site nav" not in doc.text
+        assert "alert" not in doc.text
+        assert "color:red" not in doc.text
+        assert "Copyright" not in doc.text
+
+    def test_extraction_prefers_the_main_or_article_element_when_present(self, limits, token):
+        html = (
+            b"<html><body>"
+            b"<nav><p>Nav link text</p></nav>"
+            b"<main><p>Main content only.</p></main>"
+            b"</body></html>"
+        )
+        extractor = BeautifulSoupContentExtractor()
+
+        doc = extractor.extract(_payload(body=html), limits=limits, token=token)
+
+        assert "Main content only." in doc.text
+        assert "Nav link text" not in doc.text
+
+    def test_text_is_truncated_to_max_chars_per_source_and_flagged(self, limits, token):
+        long_paragraph = "word " * 10_000
+        html = f"<html><body><p>{long_paragraph}</p></body></html>".encode("utf-8")
+        tight_limits = ResearchLimits(max_chars_per_source=100)
+        extractor = BeautifulSoupContentExtractor()
+
+        doc = extractor.extract(_payload(body=html), limits=tight_limits, token=token)
+
+        assert len(doc.text) <= 100
+        assert doc.truncated is True
+
+    def test_a_payload_already_marked_truncated_stays_truncated_even_if_the_text_fits(self, limits, token):
+        html = b"<html><body><p>short.</p></body></html>"
+        extractor = BeautifulSoupContentExtractor()
+
+        doc = extractor.extract(_payload(body=html, truncated=True), limits=limits, token=token)
+
+        assert doc.truncated is True
+
+    def test_content_hash_is_a_stable_sha256_of_the_final_text(self, limits, token):
+        html = b"<html><body><p>Deterministic content.</p></body></html>"
+        extractor = BeautifulSoupContentExtractor()
+
+        doc = extractor.extract(_payload(body=html), limits=limits, token=token)
+
+        assert doc.content_hash == hashlib.sha256(doc.text.encode("utf-8", errors="replace")).hexdigest()
+
+    def test_purely_whitespace_or_markup_only_html_raises_empty_source(self, limits, token):
+        html = b"<html><body><script>1</script><style>.a{}</style></body></html>"
+        extractor = BeautifulSoupContentExtractor()
+
+        with pytest.raises(ResearchFailure) as exc_info:
+            extractor.extract(_payload(body=html), limits=limits, token=token)
+
+        assert exc_info.value.code == "empty_source"
+        assert exc_info.value.retryable is False
+
+    def test_cancellation_is_honored_before_extraction_begins(self, limits, token):
+        token.cancel()
+        extractor = BeautifulSoupContentExtractor()
+
+        with pytest.raises(RequestCancelled):
+            extractor.extract(_payload(), limits=limits, token=token)
+
+    def test_beautifulsoup_unavailable_raises_a_non_retryable_dependency_failure(self, limits, token):
+        extractor = BeautifulSoupContentExtractor()
+        with patch.object(providers_module, "BEAUTIFULSOUP_AVAILABLE", False):
+            with pytest.raises(ResearchFailure) as exc_info:
+                extractor.extract(_payload(), limits=limits, token=token)
+
+        assert exc_info.value.code == "extract_dependency_missing"
+        assert exc_info.value.retryable is False
+
+    def test_an_unexpected_exception_during_extraction_is_mapped_to_extract_failed(self, limits, token):
+        extractor = BeautifulSoupContentExtractor()
+        with patch.object(providers_module, "BeautifulSoup", side_effect=RuntimeError("parser exploded")):
+            with pytest.raises(ResearchFailure) as exc_info:
+                extractor.extract(_payload(), limits=limits, token=token)
+
+        assert exc_info.value.code == "extract_failed"
+
+
+class TestBeautifulSoupContentExtractorJsonAndPlainText:
+    def test_valid_json_is_pretty_printed_and_titled_by_hostname(self, limits, token):
+        payload = _payload(content_type="application/json", body=b'{"b": 2, "a": 1}', final_url="https://api.example/data")
+        extractor = BeautifulSoupContentExtractor()
+
+        doc = extractor.extract(payload, limits=limits, token=token)
+
+        assert doc.title == "api.example"
+        parsed_back = json.loads(doc.text)
+        assert parsed_back == {"b": 2, "a": 1}
+
+    def test_malformed_json_falls_back_to_the_raw_decoded_text(self, limits, token):
+        payload = _payload(content_type="application/json", body=b"{not valid json", final_url="https://api.example/data")
+        extractor = BeautifulSoupContentExtractor()
+
+        doc = extractor.extract(payload, limits=limits, token=token)
+
+        assert "not valid json" in doc.text
+
+    def test_plain_text_content_is_split_into_line_sections(self, limits, token):
+        payload = _payload(content_type="text/plain", body=b"line one\nline two\n\nline three", final_url="https://text.example/f.txt")
+        extractor = BeautifulSoupContentExtractor()
+
+        doc = extractor.extract(payload, limits=limits, token=token)
+
+        assert doc.title == "text.example"
+        assert doc.sections == ("line one", "line two", "line three")
+
+
+# ---------------------------------------------------------------------------
+# dependency_status / source_id_for_url helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSmallHelpers:
+    def test_dependency_status_reports_all_three_optional_packages(self):
+        status = dependency_status()
+        assert set(status.keys()) == {"ddgs", "requests", "beautifulsoup4"}
+        assert all(isinstance(v, bool) for v in status.values())
+
+    def test_source_id_is_deterministic_for_the_same_url_and_rank(self):
+        first = source_id_for_url("https://example.com/a", rank=0)
+        second = source_id_for_url("https://example.com/a", rank=0)
+        assert first == second
+
+    def test_source_id_differs_for_different_urls(self):
+        a = source_id_for_url("https://example.com/a", rank=0)
+        b = source_id_for_url("https://example.com/b", rank=0)
+        assert a != b
+
+    def test_source_id_prefix_is_1_indexed_from_rank(self):
+        assert source_id_for_url("https://example.com/a", rank=0).startswith("s1-")
+        assert source_id_for_url("https://example.com/a", rank=4).startswith("s5-")
+
+    def test_source_id_canonicalizes_equivalent_urls_to_the_same_digest(self):
+        # https + default port 443 written explicitly vs. omitted - same
+        # canonical URL, so the same digest (mirrors DuckDuckGoSearchProvider's
+        # own dedup-by-canonical-url use of this function).
+        a = source_id_for_url("https://Example.com:443/path", rank=0)
+        b = source_id_for_url("https://example.com/path", rank=0)
+        assert a == b
+
+
+# ---------------------------------------------------------------------------
+# DuckDuckGoSearchProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDuckDuckGoSearchProvider:
+    def test_raises_a_non_retryable_failure_when_ddgs_is_unavailable(self, limits, token):
+        provider = DuckDuckGoSearchProvider()
+        with patch.object(providers_module, "DUCKDUCKGO_SEARCH_AVAILABLE", False):
+            with pytest.raises(ResearchFailure) as exc_info:
+                provider.search("query", limits=limits, token=token)
+
+        assert exc_info.value.code == "search_dependency_missing"
+        assert exc_info.value.retryable is False
+
+    def test_normalizes_results_and_dedupes_by_canonical_url(self, limits, token):
+        raw_results = [
+            {"href": "https://example.com/a", "title": "A", "body": "snippet a"},
+            {"href": "https://example.com/a#dup", "title": "A dup", "body": "snippet dup"},  # same canonical URL
+            {"href": "https://example.com/b", "title": "B", "body": "snippet b"},
+        ]
+        fake_ddgs = MagicMock()
+        fake_ddgs.__enter__.return_value = fake_ddgs
+        fake_ddgs.__exit__.return_value = False
+        fake_ddgs.text.return_value = raw_results
+        provider = DuckDuckGoSearchProvider()
+
+        with patch.object(providers_module, "DDGS", return_value=fake_ddgs):
+            results = provider.search("query", limits=limits, token=token)
+
+        assert [r.canonical_url for r in results] == ["https://example.com/a", "https://example.com/b"]
+        assert results[0].rank == 1
+        # Rank reflects the ORIGINAL raw-result index (enumerate() runs
+        # before the dedup check), not a sequential post-dedup count - the
+        # skipped duplicate at index 1 leaves a gap, so "b" (index 2) is
+        # rank 3, not rank 2.
+        assert results[1].rank == 3
+
+    def test_non_dict_raw_results_are_skipped(self, limits, token):
+        fake_ddgs = MagicMock()
+        fake_ddgs.__enter__.return_value = fake_ddgs
+        fake_ddgs.__exit__.return_value = False
+        fake_ddgs.text.return_value = ["not-a-dict", None, {"href": "https://example.com/a", "title": "A"}]
+        provider = DuckDuckGoSearchProvider()
+
+        with patch.object(providers_module, "DDGS", return_value=fake_ddgs):
+            results = provider.search("query", limits=limits, token=token)
+
+        assert len(results) == 1
+        assert results[0].canonical_url == "https://example.com/a"
+
+    def test_a_result_missing_a_title_falls_back_to_the_hostname(self, limits, token):
+        fake_ddgs = MagicMock()
+        fake_ddgs.__enter__.return_value = fake_ddgs
+        fake_ddgs.__exit__.return_value = False
+        fake_ddgs.text.return_value = [{"href": "https://news.example/a", "body": "snippet"}]
+        provider = DuckDuckGoSearchProvider()
+
+        with patch.object(providers_module, "DDGS", return_value=fake_ddgs):
+            results = provider.search("query", limits=limits, token=token)
+
+        assert results[0].title == "news.example"
+
+    def test_a_provider_side_exception_is_mapped_to_a_research_failure(self, limits, token):
+        fake_ddgs_cls = MagicMock(side_effect=RuntimeError("provider is down"))
+        provider = DuckDuckGoSearchProvider()
+
+        with patch.object(providers_module, "DDGS", fake_ddgs_cls):
+            with pytest.raises(ResearchFailure) as exc_info:
+                provider.search("query", limits=limits, token=token)
+
+        assert exc_info.value.code == "search_provider_unavailable"
+
+    def test_cancellation_is_honored_before_the_search_call(self, limits, token):
+        token.cancel()
+        provider = DuckDuckGoSearchProvider()
+
+        with pytest.raises(RequestCancelled):
+            provider.search("query", limits=limits, token=token)
+
+
+# ---------------------------------------------------------------------------
+# ApiResearchModel - JSON/legacy-text parsing + exception fallbacks
+# ---------------------------------------------------------------------------
+
+
+class TestApiResearchModelRefineQuery:
+    def test_returns_the_bare_query_without_calling_the_model_when_there_is_no_history(self, limits, token):
+        model = ApiResearchModel()
+        with patch.object(providers_module.api_provider, "chat") as fake_chat:
+            result = model.refine_query("  what is graphlink  ", [], limits=limits, token=token)
+
+        fake_chat.assert_not_called()
+        assert result == "what is graphlink"
+
+    def test_uses_the_models_rewritten_query_when_history_is_present(self, limits, token):
+        model = ApiResearchModel()
+        with patch.object(
+            providers_module.api_provider, "chat", return_value={"message": {"content": '"refined query"'}}
+        ):
+            result = model.refine_query("original", [{"role": "user", "content": "context"}], limits=limits, token=token)
+
+        assert result == "refined query"
+
+    def test_falls_back_to_the_original_query_when_the_model_call_raises(self, limits, token):
+        model = ApiResearchModel()
+        with patch.object(providers_module.api_provider, "chat", side_effect=RuntimeError("provider down")):
+            result = model.refine_query("original query", [{"role": "user", "content": "context"}], limits=limits, token=token)
+
+        assert result == "original query"
+
+    def test_falls_back_to_the_original_query_when_the_model_returns_blank(self, limits, token):
+        model = ApiResearchModel()
+        with patch.object(providers_module.api_provider, "chat", return_value={"message": {"content": "   "}}):
+            result = model.refine_query("original query", [{"role": "user", "content": "context"}], limits=limits, token=token)
+
+        assert result == "original query"
+
+
+class TestApiResearchModelAssessSource:
+    def _document(self, text="Some evidence text about the query."):
+        from graphlink_plugins.web_research.domain import FetchedDocument
+
+        return FetchedDocument(
+            source_id="s1-abc",
+            title="Title",
+            final_url="https://example.com/a",
+            content_type="text/html",
+            text=text,
+        )
+
+    def test_parses_a_valid_json_response_into_a_source_assessment(self, limits, token):
+        model = ApiResearchModel()
+        raw = json.dumps({"policy": "allow", "relevance": "high", "quality": "high", "reason": "on_topic"})
+        with patch.object(providers_module.api_provider, "chat", return_value={"message": {"content": raw}}):
+            assessment = model.assess_source("query", self._document(), limits=limits, token=token)
+
+        assert assessment.accepted is True
+        assert assessment.policy_status == "allow"
+        assert assessment.reason == "on_topic"
+
+    def test_a_block_policy_or_low_quality_is_not_accepted(self, limits, token):
+        model = ApiResearchModel()
+        raw = json.dumps({"policy": "allow", "relevance": "high", "quality": "low", "reason": "thin_content"})
+        with patch.object(providers_module.api_provider, "chat", return_value={"message": {"content": raw}}):
+            assessment = model.assess_source("query", self._document(), limits=limits, token=token)
+
+        assert assessment.accepted is False
+
+    def test_legacy_unsafe_text_response_is_treated_as_blocked(self, limits, token):
+        model = ApiResearchModel()
+        with patch.object(providers_module.api_provider, "chat", return_value={"message": {"content": "UNSAFE"}}):
+            assessment = model.assess_source("query", self._document(), limits=limits, token=token)
+
+        assert assessment.accepted is False
+        assert assessment.policy_status == "block"
+        assert assessment.reason == "model_blocked"
+
+    def test_legacy_safe_text_response_is_treated_as_allowed(self, limits, token):
+        model = ApiResearchModel()
+        with patch.object(providers_module.api_provider, "chat", return_value={"message": {"content": "SAFE"}}):
+            assessment = model.assess_source("query", self._document(), limits=limits, token=token)
+
+        assert assessment.accepted is True
+        assert assessment.policy_status == "allow"
+
+    def test_unparseable_non_legacy_text_is_treated_as_unknown_and_not_accepted(self, limits, token):
+        model = ApiResearchModel()
+        with patch.object(providers_module.api_provider, "chat", return_value={"message": {"content": "gibberish response"}}):
+            assessment = model.assess_source("query", self._document(), limits=limits, token=token)
+
+        assert assessment.accepted is False
+        assert assessment.reason == "invalid_model_output"
+
+    def test_a_model_call_exception_yields_a_not_accepted_unknown_assessment(self, limits, token):
+        model = ApiResearchModel()
+        with patch.object(providers_module.api_provider, "chat", side_effect=RuntimeError("boom")):
+            assessment = model.assess_source("query", self._document(), limits=limits, token=token)
+
+        assert assessment.accepted is False
+        assert assessment.reason == "validation_unavailable"
+
+
+class TestApiResearchModelSummarize:
+    def test_returns_the_models_answer_text(self, limits, token):
+        model = ApiResearchModel()
+        with patch.object(providers_module.api_provider, "chat", return_value={"message": {"content": "Final answer [s1]."}}):
+            answer = model.summarize("query", [], ["evidence chunk"], limits=limits, token=token)
+
+        assert answer == "Final answer [s1]."
+
+    def test_an_empty_answer_raises_a_research_failure(self, limits, token):
+        model = ApiResearchModel()
+        with patch.object(providers_module.api_provider, "chat", return_value={"message": {"content": "   "}}):
+            with pytest.raises(ResearchFailure) as exc_info:
+                model.summarize("query", [], ["evidence chunk"], limits=limits, token=token)
+
+        assert exc_info.value.code == "empty_summary"
+
+    def test_a_model_call_exception_is_wrapped_as_a_research_failure(self, limits, token):
+        model = ApiResearchModel()
+        with patch.object(providers_module.api_provider, "chat", side_effect=RuntimeError("provider down")):
+            with pytest.raises(ResearchFailure) as exc_info:
+                model.summarize("query", [], ["evidence chunk"], limits=limits, token=token)
+
+        assert exc_info.value.code == "summarization_failed"

--- a/contracts/graphlink_app_plugins_payload.py
+++ b/contracts/graphlink_app_plugins_payload.py
@@ -25,8 +25,28 @@ class AppPluginCategoryPayload:
 
 
 @dataclass
+class AppPluginGrantPayload:
+    """ADR-014 stage 14.4: one row per DISTINCT non-built-in discovered
+    plugin_id - see backend/plugins.py's own _plugin_grants_payload for the
+    exact "one row per plugin, not per picker entry, built-ins never
+    appear here" construction rule. `scopes` is the plugin's own
+    self-reported [scopes].grants manifest declaration (read-only in the
+    Settings UI, matching McpServerConfigPayload.scopes' own read-only
+    posture there); `granted` is the ONE thing a Settings checkbox actually
+    writes back, via the new setPluginGrant intent."""
+
+    pluginId: str
+    name: str
+    scopes: list[str]
+    granted: bool
+
+
+@dataclass
 class AppPluginsStatePayload:
     schemaVersion: int
     revision: int
     categories: list[AppPluginCategoryPayload]
+    # ADR-014 stage 14.4: the Settings > Plugins page's own data - see
+    # AppPluginGrantPayload's own docstring.
+    grants: list[AppPluginGrantPayload]
     minCompatibleSchemaVersion: int | None = None

--- a/contracts/graphlink_scene_payload.py
+++ b/contracts/graphlink_scene_payload.py
@@ -155,6 +155,23 @@ kind=="chat" rows whose turn actually invoked tools, defaulted `[]` for
 every other kind and for tool-less chat turns - same additive rule as
 everything above. See ToolInvocationRow's own docstring for why its
 `arguments` field is a JSON-encoded string, not a nested object.
+
+ADR-014 stage 14.2 adds `pluginState` (dict[str, str]): the Plugin SDK's
+generic live-wire fallback for a THIRD-PARTY plugin's own NodeState
+subclass fields - populated only for a plugin-registered node kind whose
+author opted into HostContext.register_node_kind(..., serialize=...)
+(backend/plugin_sdk.py), defaulted `{}` for every built-in kind and for
+any plugin kind that never opted in, same additive rule as everything
+above. dict[str, str], not a richer nested shape, for the SAME reason
+ResearchResultRow.providerSnapshot above is dict[str, str] rather than a
+bare dict - graphlink_wire_schema.py's generator has no `Any`/free-form-
+object construct, and a third-party plugin's own state shape is
+definitionally unknowable to this schema ahead of time. See backend/
+domain/graph.py's SceneDocument.plugin_node_serializers/_plugin_state_wire
+for the populating side. Not read by the frontend today (same "on the
+wire, not yet a rendered feature" posture `contentParts` above already
+established) - real dynamic frontend plugin rendering is stage 14.5's job,
+per ADR-014's own stage 14.1 scoping decision.
 """
 
 from __future__ import annotations
@@ -549,6 +566,10 @@ class SceneNodeRow:
     builderApprovalToolName: str = ""
     builderApprovalSummary: str = ""
     builderStatusDetail: str = ""
+    # ADR-014 stage 14.2: the Plugin SDK's generic live-wire fallback for a
+    # third-party plugin's own NodeState subclass fields - see this file's
+    # own module docstring for the full rationale.
+    pluginState: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -357,13 +357,14 @@ class SettingsManager:
         providers whose compute is free to the user) - see that commit's own
         CURRENT_SCHEMA_VERSION bump comment.
 
-        mcp_servers (ADR-007 stage 7.5) is grouped in here too even though
-        it was added later without its own CURRENT_SCHEMA_VERSION bump -
-        there is no version number to place it at. Since every migration in
-        this chain always runs on every load regardless of the file's own
-        declared version (see _load_state's own comment on why), attaching
-        it to the chain's current terminal function is the deliberate,
-        least-surprising home for it, not a guess."""
+        mcp_servers (ADR-007 stage 7.5) and plugin_grants (ADR-014 stage
+        14.4) are both grouped in here too even though neither was added
+        alongside its own CURRENT_SCHEMA_VERSION bump - there is no version
+        number to place either at. Since every migration in this chain
+        always runs on every load regardless of the file's own declared
+        version (see _load_state's own comment on why), attaching them to
+        the chain's current terminal function is the deliberate,
+        least-surprising home for them, not a guess."""
         if 'ollama_reasoning_level' not in state:
             # R8a: reasoning went from a 2-value Ollama/Llama.cpp bool
             # "mode" to a graded 4-value level shared by every provider -
@@ -394,6 +395,14 @@ class SettingsManager:
             # configured yet is the correct, safe starting point, not an
             # error.
             state['mcp_servers'] = []
+        if 'plugin_grants' not in state or not isinstance(state.get('plugin_grants'), dict):
+            # ADR-014 stage 14.4: install-time consent grants for discovered
+            # third-party plugins - same "no version number to place it at,
+            # attach it to the chain's current terminal function" posture as
+            # mcp_servers directly above. Absent -> {}, matching the
+            # initial-state default in _create_initial_state: a plugin_id
+            # with no entry here is NOT granted (deny-by-default).
+            state['plugin_grants'] = {}
         return state
 
     def _load_state(self):
@@ -547,6 +556,10 @@ class SettingsManager:
             # ADR-007 stage 7.5: MCP client configuration - see
             # get_mcp_servers/set_mcp_servers' own docstrings.
             "mcp_servers": [],
+            # ADR-014 stage 14.4: install-time consent grants for discovered
+            # third-party plugins - see get_plugin_grants/set_plugin_grant's
+            # own docstrings.
+            "plugin_grants": {},
         }
         self._save_state(state)
         return state
@@ -1213,6 +1226,46 @@ class SettingsManager:
                 "timeout": float(entry.get("timeout", 30.0) or 30.0),
             })
         self.state["mcp_servers"] = normalized
+        self._save_state()
+
+    def get_plugin_grants(self) -> dict:
+        """ADR-014 stage 14.4: install-time consent grants for discovered
+        THIRD-PARTY/demo-mechanism plugins - built-in plugins never consult
+        this at all (see backend/plugins.py's own _execute_discovered_plugin
+        for the enforcement point). Keyed by plugin_id -> bool. A plugin_id
+        with no entry here reads as NOT granted via the caller's own
+        `.get(plugin_id, False)` (this method does not synthesize that
+        default itself - it returns exactly what is persisted, same posture
+        as get_mcp_servers above returning exactly the persisted, validated
+        server list rather than padding in every possible name). Malformed
+        entries (a non-string key, an empty key) are dropped rather than
+        raised on, same fail-soft posture as every other collection getter
+        in this class."""
+        raw = self.state.get("plugin_grants", {})
+        if not isinstance(raw, dict):
+            return {}
+        grants = {}
+        for plugin_id, granted in raw.items():
+            key = str(plugin_id).strip()
+            if not key:
+                continue
+            grants[key] = bool(granted)
+        return grants
+
+    def set_plugin_grant(self, plugin_id: str, granted: bool) -> None:
+        """Sets ONE plugin's grant, leaving every other plugin's grant
+        untouched - deliberately NOT set_mcp_servers' whole-collection-
+        replace posture (that fits an add/remove/edit-a-server list editor;
+        this fits a single Settings checkbox toggling exactly one plugin's
+        consent at a time, ADR-014 stage 14.4's own "install-time consent"
+        model - decided once, ahead of time, per plugin, not a live per-call
+        approval prompt)."""
+        key = str(plugin_id or "").strip()
+        if not key:
+            return
+        grants = self.get_plugin_grants()
+        grants[key] = bool(granted)
+        self.state["plugin_grants"] = grants
         self._save_state()
 
     @staticmethod

--- a/plugins/artifact/plugin.py
+++ b/plugins/artifact/plugin.py
@@ -1,0 +1,44 @@
+"""ADR-014 stage 14.3: first-party migration of the pre-SDK "Artifact /
+Drafter" picker action. A byte-faithful relocation of backend/plugins.py's
+old hardcoded `if name == "Artifact / Drafter":` branch - same
+command_type string ("pluginArtifact"), same parent-validation warning
+text, same factory call (SceneDocument.add_artifact_node), same
+undo/parent-validation behavior. See plugins/web_research/plugin.py's own
+docstring for the shared register_builtin_plugin escape-hatch rationale."""
+
+from __future__ import annotations
+
+from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.plugin_sdk import HostContext, PluginRunContext
+
+
+def _execute(
+    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
+) -> "str | None":
+    if not parent_node_id or parent_node_id not in document.nodes:
+        run_ctx.notifications.show(
+            "Please select a valid node to branch from before adding an Artifact node.",
+            "warning",
+        )
+        return None
+    parent = document.nodes[parent_node_id]
+    node, _command = document.record_command(
+        "pluginArtifact", "user",
+        lambda: document.add_artifact_node(
+            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+        ),
+        node_ids=[parent_node_id],
+    )
+    return node.id
+
+
+def register(host: HostContext) -> None:
+    host.register_builtin_plugin(
+        name="Artifact / Drafter",
+        description=(
+            "A split-pane node for iteratively drafting and refining living documents "
+            "(Markdown)."
+        ),
+        category="Workflow & Drafting",
+        handler=_execute,
+    )

--- a/plugins/artifact/plugin.toml
+++ b/plugins/artifact/plugin.toml
@@ -1,0 +1,18 @@
+# plugins/artifact/plugin.toml
+#
+# ADR-014 stage 14.3: first-party migration of the pre-SDK "Artifact /
+# Drafter" built-in picker action - see plugins/web_research/plugin.toml's
+# own comment for the shared rationale (register_builtin_plugin, not
+# register_node_kind, to keep the already-shipped "artifact" kind string
+# unchanged).
+
+[plugin]
+id = "artifact"
+name = "Artifact / Drafter"
+version = "1.0.0"
+sdk_api_version = 1
+entry_point = "plugin:register"
+description = "A split-pane node for iteratively drafting and refining living documents (Markdown)."
+
+[frontend]
+view = "generic"

--- a/plugins/code_sandbox/plugin.py
+++ b/plugins/code_sandbox/plugin.py
@@ -1,0 +1,47 @@
+"""ADR-014 stage 14.3: first-party migration of the pre-SDK "Virtual
+Environment Runner" picker action. A byte-faithful relocation of
+backend/plugins.py's old hardcoded `if name == "Virtual Environment
+Runner":` branch - same command_type string ("pluginCodeSandbox"), same
+parent-validation warning text, same factory call
+(SceneDocument.add_code_sandbox_node), same undo/parent-validation
+behavior. See plugins/web_research/plugin.py's own docstring for the
+shared register_builtin_plugin escape-hatch rationale."""
+
+from __future__ import annotations
+
+from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.plugin_sdk import HostContext, PluginRunContext
+
+
+def _execute(
+    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
+) -> "str | None":
+    if not parent_node_id or parent_node_id not in document.nodes:
+        run_ctx.notifications.show(
+            "Please select a valid node to branch from before adding a Virtual "
+            "Environment Runner node.",
+            "warning",
+        )
+        return None
+    parent = document.nodes[parent_node_id]
+    node, _command = document.record_command(
+        "pluginCodeSandbox", "user",
+        lambda: document.add_code_sandbox_node(
+            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+        ),
+        node_ids=[parent_node_id],
+    )
+    return node.id
+
+
+def register(host: HostContext) -> None:
+    host.register_builtin_plugin(
+        name="Virtual Environment Runner",
+        description=(
+            "Runs Python inside an isolated virtualenv with your full user-account "
+            "privileges (isolates installed packages, not the operating system) and "
+            "lets you declare per-node requirements.txt dependencies."
+        ),
+        category="Build & Execution",
+        handler=_execute,
+    )

--- a/plugins/code_sandbox/plugin.toml
+++ b/plugins/code_sandbox/plugin.toml
@@ -1,0 +1,18 @@
+# plugins/code_sandbox/plugin.toml
+#
+# ADR-014 stage 14.3: first-party migration of the pre-SDK "Virtual
+# Environment Runner" built-in picker action - see
+# plugins/web_research/plugin.toml's own comment for the shared rationale
+# (register_builtin_plugin, not register_node_kind, to keep the
+# already-shipped "code_sandbox" kind string unchanged).
+
+[plugin]
+id = "code_sandbox"
+name = "Virtual Environment Runner"
+version = "1.0.0"
+sdk_api_version = 1
+entry_point = "plugin:register"
+description = "Runs Python inside an isolated virtualenv with your full user-account privileges (isolates installed packages, not the operating system) and lets you declare per-node requirements.txt dependencies."
+
+[frontend]
+view = "generic"

--- a/plugins/conversation_node/plugin.py
+++ b/plugins/conversation_node/plugin.py
@@ -1,0 +1,42 @@
+"""ADR-014 stage 14.3: first-party migration of the pre-SDK "Conversation
+Node" picker action. A byte-faithful relocation of backend/plugins.py's
+old hardcoded `if name == "Conversation Node":` branch - same
+command_type string ("pluginConversationNode"), same parent-validation
+warning text, same factory call (SceneDocument.add_conversation_node),
+same undo/parent-validation behavior. See plugins/web_research/plugin.py's
+own docstring for the shared register_builtin_plugin escape-hatch
+rationale."""
+
+from __future__ import annotations
+
+from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.plugin_sdk import HostContext, PluginRunContext
+
+
+def _execute(
+    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
+) -> "str | None":
+    if not parent_node_id or parent_node_id not in document.nodes:
+        run_ctx.notifications.show(
+            "Please select a valid node to branch from before adding a Conversation Node.",
+            "warning",
+        )
+        return None
+    parent = document.nodes[parent_node_id]
+    node, _command = document.record_command(
+        "pluginConversationNode", "user",
+        lambda: document.add_conversation_node(
+            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+        ),
+        node_ids=[parent_node_id],
+    )
+    return node.id
+
+
+def register(host: HostContext) -> None:
+    host.register_builtin_plugin(
+        name="Conversation Node",
+        description="Adds a node for a self-contained, linear chat conversation.",
+        category="Branch Foundations",
+        handler=_execute,
+    )

--- a/plugins/conversation_node/plugin.toml
+++ b/plugins/conversation_node/plugin.toml
@@ -1,0 +1,18 @@
+# plugins/conversation_node/plugin.toml
+#
+# ADR-014 stage 14.3: first-party migration of the pre-SDK "Conversation
+# Node" built-in picker action - see plugins/web_research/plugin.toml's
+# own comment for the shared rationale (register_builtin_plugin, not
+# register_node_kind, to keep the already-shipped "conversation" kind
+# string unchanged).
+
+[plugin]
+id = "conversation_node"
+name = "Conversation Node"
+version = "1.0.0"
+sdk_api_version = 1
+entry_point = "plugin:register"
+description = "Adds a node for a self-contained, linear chat conversation."
+
+[frontend]
+view = "generic"

--- a/plugins/counter_node/plugin.py
+++ b/plugins/counter_node/plugin.py
@@ -1,0 +1,83 @@
+"""Reference plugin proving ADR-014 stage 14.2's generic persistence
+mechanism end to end: a plugin's OWN NodeState subclass (CounterState below)
+attaches via PluginNodeSeed.state exactly like plugins/hello_node/ proved
+title/content do, but ALSO opts into HostContext.register_node_kind's
+serialize/deserialize hooks - so a save -> reload cycle provably restores
+`count`/`label`, not just the universal title/content fields every plugin
+kind gets for free.
+
+Adds ONE new kind, "tally" (namespaced to "counter_node.tally" - collision
+with any built-in kind is structurally impossible, same as hello_node's own
+"hello_note")."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from backend.canvas import SceneDocument
+from backend.domain.node_states import NodeState
+from backend.plugin_sdk import HostContext, PluginNodeSeed, PluginRunContext
+
+
+@dataclass
+class CounterState(NodeState):
+    """This plugin's own per-node state - a plain dataclass subclassing the
+    same NodeState marker every built-in per-kind state class subclasses
+    (backend/domain/node_states.py). Nothing beyond that inheritance is
+    required of a plugin's own state class."""
+
+    count: int = 0
+    label: str = ""
+
+
+def _make_tally(
+    document: SceneDocument, run_ctx: PluginRunContext, parent_id: str,
+) -> PluginNodeSeed:
+    parent = document.nodes[parent_id]
+    return PluginNodeSeed(
+        title="Counter",
+        content=f"A running tally branched from '{parent.title}'.",
+        state=CounterState(count=0, label=f"from {run_ctx.plugin_id}"),
+    )
+
+
+def _serialize_tally(node) -> dict:
+    """Called both by backend/domain/graph.py's _node_wire (the live WS
+    wire's pluginState field) and by backend/session_save.py (the
+    persisted save file's plugin_state field) - see HostContext.
+    register_node_kind's own docstring for the shared-hook contract. Must
+    tolerate `node.state` not (yet) being a CounterState instance - a node
+    of this kind freshly minted by _make_tally above always has one, but a
+    defensive isinstance check costs nothing and keeps this function honest
+    about its own precondition."""
+    state = node.state
+    if not isinstance(state, CounterState):
+        return {}
+    return {"count": state.count, "label": state.label}
+
+
+def _deserialize_tally(data: dict) -> CounterState | None:
+    """The save-side-only mirror of _serialize_tally above, called by
+    backend/session_load.py with whatever dict serialize() most recently
+    produced for this node."""
+    try:
+        count = int(data.get("count", 0))
+    except (TypeError, ValueError):
+        count = 0
+    return CounterState(count=count, label=str(data.get("label", "") or ""))
+
+
+def register(host: HostContext) -> None:
+    host.register_node_kind(
+        "tally", _make_tally, requires_parent=True,
+        serialize=_serialize_tally, deserialize=_deserialize_tally,
+    )
+    host.register_picker_entry(
+        node_kind="tally",
+        name="Counter Node",
+        description=(
+            "Adds a node with a real per-node counter - proves the "
+            "ADR-014 stage 14.2 generic persistence mechanism end to end."
+        ),
+        category="More Plugins",
+    )

--- a/plugins/counter_node/plugin.toml
+++ b/plugins/counter_node/plugin.toml
@@ -1,0 +1,19 @@
+# plugins/counter_node/plugin.toml
+#
+# ADR-014 stage 14.2's reference plugin for the generic persistence/
+# serialization mechanism - proves a plugin's OWN NodeState subclass (not
+# just title/content) round-trips through save/reload via
+# HostContext.register_node_kind(..., serialize=..., deserialize=...).
+# See plugins/hello_node/ for the "no custom state at all" baseline case
+# this plugin deliberately does NOT repeat.
+
+[plugin]
+id = "counter_node"
+name = "Counter Node Plugin"
+version = "0.1.0"
+sdk_api_version = 1
+entry_point = "plugin:register"
+description = "Reference plugin for ADR-014 stage 14.2 - a real NodeState subclass that round-trips through save/reload."
+
+[frontend]
+view = "generic"

--- a/plugins/counter_node/plugin.toml
+++ b/plugins/counter_node/plugin.toml
@@ -17,3 +17,9 @@ description = "Reference plugin for ADR-014 stage 14.2 - a real NodeState subcla
 
 [frontend]
 view = "generic"
+
+[scopes]
+# ADR-014 stage 14.4: this plugin creates a node (add_plugin_node), so it
+# declares graph.mutate - see plugins/hello_node/plugin.toml's own [scopes]
+# comment for the full "self-reported, not itself enforced" contract.
+grants = ["graph.mutate"]

--- a/plugins/gitlink/plugin.py
+++ b/plugins/gitlink/plugin.py
@@ -1,0 +1,44 @@
+"""ADR-014 stage 14.3: first-party migration of the pre-SDK "Gitlink"
+picker action. A byte-faithful relocation of backend/plugins.py's old
+hardcoded `if name == "Gitlink":` branch - same command_type string
+("pluginGitlink"), same parent-validation warning text, same factory call
+(SceneDocument.add_gitlink_node), same undo/parent-validation behavior.
+See plugins/web_research/plugin.py's own docstring for the shared
+register_builtin_plugin escape-hatch rationale."""
+
+from __future__ import annotations
+
+from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.plugin_sdk import HostContext, PluginRunContext
+
+
+def _execute(
+    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
+) -> "str | None":
+    if not parent_node_id or parent_node_id not in document.nodes:
+        run_ctx.notifications.show(
+            "Please select a valid node to branch from before adding a Gitlink node.",
+            "warning",
+        )
+        return None
+    parent = document.nodes[parent_node_id]
+    node, _command = document.record_command(
+        "pluginGitlink", "user",
+        lambda: document.add_gitlink_node(
+            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+        ),
+        node_ids=[parent_node_id],
+    )
+    return node.id
+
+
+def register(host: HostContext) -> None:
+    host.register_builtin_plugin(
+        name="Gitlink",
+        description=(
+            "Loads a GitHub repository into structured XML context, prepares "
+            "file-level changes, and only writes after explicit approval."
+        ),
+        category="Build & Execution",
+        handler=_execute,
+    )

--- a/plugins/gitlink/plugin.toml
+++ b/plugins/gitlink/plugin.toml
@@ -1,0 +1,18 @@
+# plugins/gitlink/plugin.toml
+#
+# ADR-014 stage 14.3: first-party migration of the pre-SDK "Gitlink"
+# built-in picker action - see plugins/web_research/plugin.toml's own
+# comment for the shared rationale (register_builtin_plugin, not
+# register_node_kind, to keep the already-shipped "gitlink" kind string
+# unchanged).
+
+[plugin]
+id = "gitlink"
+name = "Gitlink"
+version = "1.0.0"
+sdk_api_version = 1
+entry_point = "plugin:register"
+description = "Loads a GitHub repository into structured XML context, prepares file-level changes, and only writes after explicit approval."
+
+[frontend]
+view = "generic"

--- a/plugins/hello_node/plugin.py
+++ b/plugins/hello_node/plugin.py
@@ -1,0 +1,45 @@
+"""Reference plugin proving the ADR-014 stage 14.1 discovery loop end to
+end: manifest -> discovery -> HostContext.register_node_kind/
+register_picker_entry -> a working node kind, created via the existing
+executePlugin intent, undone via the existing undo stack, rendered by the
+existing generic placeholder-card fallback view. Adds ONE new kind,
+"hello_note" (namespaced to "hello_node.hello_note" - collision with any
+built-in kind, e.g. "note", is structurally impossible).
+
+No NodeState subclass (this demo's one string fits in content, which
+_node_wire already emits unconditionally for every kind) and no custom
+intent (creation alone is enough to prove the loop)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from backend.canvas import SceneDocument
+from backend.plugin_sdk import HostContext, PluginNodeSeed, PluginRunContext
+
+
+def _make_hello_note(
+    document: SceneDocument, run_ctx: PluginRunContext, parent_id: str,
+) -> PluginNodeSeed:
+    parent = document.nodes[parent_id]
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    return PluginNodeSeed(
+        title="Hello Node",
+        content=(
+            f"Created by plugin '{run_ctx.plugin_id}' at {stamp}, "
+            f"branched from '{parent.title}'."
+        ),
+    )
+
+
+def register(host: HostContext) -> None:
+    host.register_node_kind("hello_note", _make_hello_note, requires_parent=True)
+    host.register_picker_entry(
+        node_kind="hello_note",
+        name="Hello Node",
+        description=(
+            "Adds a trivial timestamped node - proves the ADR-014 SDK "
+            "discovery loop end to end."
+        ),
+        category="More Plugins",
+    )

--- a/plugins/hello_node/plugin.toml
+++ b/plugins/hello_node/plugin.toml
@@ -29,3 +29,11 @@ description = "Reference plugin for ADR-014 stage 14.1."   # optional, default "
 # renders via the existing generic placeholder-card fallback. Any other
 # value is a discovery-time error, not a silently-ignored no-op.
 view = "generic"
+
+[scopes]
+# ADR-014 stage 14.4: this plugin creates a node (add_plugin_node), so it
+# declares graph.mutate - a subset of backend.tools.KNOWN_SCOPES, validated
+# at discovery. Self-reported, not enforced by itself - the real gate is the
+# user's install-time grant in Settings > Plugins (SettingsManager.
+# get_plugin_grants/set_plugin_grant), deny-by-default until then.
+grants = ["graph.mutate"]

--- a/plugins/hello_node/plugin.toml
+++ b/plugins/hello_node/plugin.toml
@@ -1,0 +1,31 @@
+# plugins/hello_node/plugin.toml
+#
+# Only [plugin] is required. [frontend] is optional and reserved for stage
+# 14.5's real dynamic frontend loading - omitting it is equivalent to
+# view = "generic". No other tables exist yet.
+
+[plugin]
+id = "hello_node"                  # required. [a-z0-9_]+, MUST equal this
+                                    # file's parent directory name - checked
+                                    # at discovery.
+name = "Hello Node Plugin"         # required. Human-readable; logs/errors only.
+version = "0.1.0"                  # required. The plugin's OWN semver; informational only.
+sdk_api_version = 1                # required, int. Checked against
+                                    # plugin_sdk.SDK_API_VERSION /
+                                    # MIN_COMPATIBLE_SDK_API_VERSION - same
+                                    # schema_version/min_compatible shape
+                                    # SessionBus.register_topic already uses
+                                    # (backend/events.py). Outside range ->
+                                    # this ONE plugin is skipped and logged;
+                                    # every other plugin still loads.
+entry_point = "plugin:register"    # required. "<module>:<callable>", resolved
+                                    # relative to THIS plugin's own directory
+                                    # (never via sys.path), called once as
+                                    # register(host: HostContext) -> None.
+description = "Reference plugin for ADR-014 stage 14.1."   # optional, default "".
+
+[frontend]
+# Reserved for stage 14.5. "generic" is the ONLY legal value before 14.5:
+# renders via the existing generic placeholder-card fallback. Any other
+# value is a discovery-time error, not a silently-ignored no-op.
+view = "generic"

--- a/plugins/html_renderer/plugin.py
+++ b/plugins/html_renderer/plugin.py
@@ -1,0 +1,44 @@
+"""ADR-014 stage 14.3: first-party migration of the pre-SDK "HTML
+Renderer" picker action. A byte-faithful relocation of
+backend/plugins.py's old hardcoded `if name == "HTML Renderer":` branch -
+same command_type string ("pluginHtmlRenderer"), same parent-validation
+warning text, same factory call (SceneDocument.add_html_node, starting
+with empty html_content - the plugin picker has no field to source
+initial HTML from), same undo/parent-validation behavior. See
+plugins/web_research/plugin.py's own docstring for the shared
+register_builtin_plugin escape-hatch rationale."""
+
+from __future__ import annotations
+
+from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.plugin_sdk import HostContext, PluginRunContext
+
+
+def _execute(
+    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
+) -> "str | None":
+    if not parent_node_id or parent_node_id not in document.nodes:
+        run_ctx.notifications.show(
+            "Please select a valid node to branch from before adding an HTML "
+            "Renderer node.",
+            "warning",
+        )
+        return None
+    parent = document.nodes[parent_node_id]
+    node, _command = document.record_command(
+        "pluginHtmlRenderer", "user",
+        lambda: document.add_html_node(
+            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, "", parent_node_id
+        ),
+        node_ids=[parent_node_id],
+    )
+    return node.id
+
+
+def register(host: HostContext) -> None:
+    host.register_builtin_plugin(
+        name="HTML Renderer",
+        description="Adds a node to render HTML code from a parent node.",
+        category="Build & Execution",
+        handler=_execute,
+    )

--- a/plugins/html_renderer/plugin.toml
+++ b/plugins/html_renderer/plugin.toml
@@ -1,0 +1,18 @@
+# plugins/html_renderer/plugin.toml
+#
+# ADR-014 stage 14.3: first-party migration of the pre-SDK "HTML Renderer"
+# built-in picker action - see plugins/web_research/plugin.toml's own
+# comment for the shared rationale (register_builtin_plugin, not
+# register_node_kind, to keep the already-shipped "html" kind string
+# unchanged).
+
+[plugin]
+id = "html_renderer"
+name = "HTML Renderer"
+version = "1.0.0"
+sdk_api_version = 1
+entry_point = "plugin:register"
+description = "Adds a node to render HTML code from a parent node."
+
+[frontend]
+view = "generic"

--- a/plugins/pycoder/plugin.py
+++ b/plugins/pycoder/plugin.py
@@ -1,0 +1,41 @@
+"""ADR-014 stage 14.3: first-party migration of the pre-SDK "Py-Coder"
+picker action. A byte-faithful relocation of backend/plugins.py's old
+hardcoded `if name == "Py-Coder":` branch - same command_type string
+("pluginPyCoder"), same parent-validation warning text, same factory call
+(SceneDocument.add_pycoder_node), same undo/parent-validation behavior.
+See plugins/web_research/plugin.py's own docstring for the shared
+register_builtin_plugin escape-hatch rationale."""
+
+from __future__ import annotations
+
+from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.plugin_sdk import HostContext, PluginRunContext
+
+
+def _execute(
+    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
+) -> "str | None":
+    if not parent_node_id or parent_node_id not in document.nodes:
+        run_ctx.notifications.show(
+            "Please select a valid node to branch from before adding a Py-Coder node.",
+            "warning",
+        )
+        return None
+    parent = document.nodes[parent_node_id]
+    node, _command = document.record_command(
+        "pluginPyCoder", "user",
+        lambda: document.add_pycoder_node(
+            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+        ),
+        node_ids=[parent_node_id],
+    )
+    return node.id
+
+
+def register(host: HostContext) -> None:
+    host.register_builtin_plugin(
+        name="Py-Coder",
+        description="Opens a Python execution environment to run code and get AI analysis.",
+        category="Build & Execution",
+        handler=_execute,
+    )

--- a/plugins/pycoder/plugin.toml
+++ b/plugins/pycoder/plugin.toml
@@ -1,0 +1,18 @@
+# plugins/pycoder/plugin.toml
+#
+# ADR-014 stage 14.3: first-party migration of the pre-SDK "Py-Coder"
+# built-in picker action - see plugins/web_research/plugin.toml's own
+# comment for the shared rationale (register_builtin_plugin, not
+# register_node_kind, to keep the already-shipped "pycoder" kind string
+# unchanged).
+
+[plugin]
+id = "pycoder"
+name = "Py-Coder"
+version = "1.0.0"
+sdk_api_version = 1
+entry_point = "plugin:register"
+description = "Opens a Python execution environment to run code and get AI analysis."
+
+[frontend]
+view = "generic"

--- a/plugins/sandboxed_demo/plugin.py
+++ b/plugins/sandboxed_demo/plugin.py
@@ -1,0 +1,58 @@
+"""ADR-014 stage 14.5 reference plugin - proves [runtime] isolation =
+"out-of-process" end to end. This module's own code NEVER runs inside the
+host process - only inside the worker subprocess backend/plugin_worker.py
+spawns (`python -m backend.plugin_worker sandboxed_demo <this-dir>`). See
+that module's own docstring for the isolation property this buys, and
+backend/plugin_sdk.py's _discover_out_of_process_plugin for how the host
+side reconstructs this plugin's registrations without ever importing this
+file.
+
+_make_env_probe is deliberately introspective FOR TEST OBSERVABILITY ONLY -
+a real third-party plugin has no legitimate reason to read the FULL content
+of every visible environment variable and report it back to the host; this
+one does so on purpose, so backend/tests/test_plugin_worker.py can plant a
+fake secret-shaped env var on the HOST process (e.g.
+GRAPHLINK_OPENAI_API_KEY), trigger this plugin's node creation, and assert
+the created node's content - which crossed the RPC boundary from the
+WORKER's own os.environ, built by the host via graphlink_process_env.
+safe_subprocess_env()'s ALLOWLIST at Popen time, never inherited wholesale
+from the host - does NOT contain that secret's name or value. This is the
+real, empirical proof of the "a third-party plugin cannot read secrets"
+exit criterion, not an assertion about code structure alone."""
+
+from __future__ import annotations
+
+import os
+
+from backend.plugin_sdk import HostContext, PluginNodeSeed, PluginRunContext
+
+
+def _make_env_probe(document, run_ctx: PluginRunContext, parent_id: str) -> PluginNodeSeed:
+    parent = document.nodes[parent_id]
+    visible = sorted(f"{name}={value}" for name, value in os.environ.items())
+    return PluginNodeSeed(
+        title="Sandboxed Env Probe",
+        content=(
+            f"Ran out-of-process, branched from '{parent.title}'. "
+            f"Visible environment in this worker process: {' | '.join(visible)}"
+        ),
+    )
+
+
+def _ping(document, run_ctx: PluginRunContext):
+    return f"pong from {run_ctx.plugin_id}"
+
+
+def register(host: HostContext) -> None:
+    host.register_node_kind("env_probe", _make_env_probe, requires_parent=True)
+    host.register_picker_entry(
+        node_kind="env_probe",
+        name="Sandboxed Env Probe",
+        description=(
+            "Runs out-of-process and reports what it can see in its own "
+            "environment - proves the ADR-014 stage 14.5 secret-containment "
+            "boundary."
+        ),
+        category="More Plugins",
+    )
+    host.register_intent("ping", _ping)

--- a/plugins/sandboxed_demo/plugin.toml
+++ b/plugins/sandboxed_demo/plugin.toml
@@ -1,0 +1,36 @@
+# plugins/sandboxed_demo/plugin.toml
+#
+# ADR-014 stage 14.5's reference plugin - the FIRST (and, as of this stage,
+# only) real out-of-process plugin package. Proves [runtime] isolation =
+# "out-of-process" end to end: this plugin's own plugin.py NEVER runs
+# inside the host process - only inside the worker subprocess
+# backend/plugin_worker.py spawns. See plugins/hello_node/plugin.toml's own
+# header comment for what every other [plugin]/[frontend]/[scopes] field
+# means - unchanged here.
+
+[plugin]
+id = "sandboxed_demo"
+name = "Sandboxed Demo Plugin"
+version = "0.1.0"
+sdk_api_version = 1
+entry_point = "plugin:register"
+description = "ADR-014 stage 14.5 reference plugin - proves out-of-process isolation end to end."
+
+[frontend]
+view = "generic"
+
+[runtime]
+# ADR-014 stage 14.5's new table. "out-of-process" - discover_plugins()
+# never imports plugin.py into the host process at all; instead it spawns a
+# resident worker subprocess (python -m backend.plugin_worker) and talks to
+# it over a JSON-RPC stdio pipe. See backend/plugin_sdk.py's
+# _discover_out_of_process_plugin and backend/plugin_worker.py's own module
+# docstrings for the full mechanism.
+isolation = "out-of-process"
+
+[scopes]
+# This plugin creates a node (add_plugin_node, via the host's own
+# reconstruction of its declarations), so it declares graph.mutate - same
+# self-reported, not-itself-enforced contract as every other plugin's
+# [scopes] table (see plugins/hello_node/plugin.toml's own comment).
+grants = ["graph.mutate"]

--- a/plugins/system_prompt/plugin.py
+++ b/plugins/system_prompt/plugin.py
@@ -1,0 +1,76 @@
+"""ADR-014 stage 14.3: first-party migration of the pre-SDK "System Prompt"
+picker action. A byte-faithful relocation of backend/plugins.py's old
+hardcoded `if name == "System Prompt":` branch - the one built-in whose
+shape genuinely differs from the other 7 (a branch-point CHILD of
+parent_node_id, one MESSAGE_VERTICAL_SPACING below it):
+
+- Resolves parent_node_id's BRANCH ROOT (SceneDocument.get_branch_root),
+  the same parent-edge walk backend/agents.py's
+  _resolve_branch_system_prompt uses at send time - the note attaches to
+  that root, not to whichever node was actually selected.
+- A root can only ever have ONE effective system-prompt note
+  (_resolve_branch_system_prompt has no deterministic "which one wins"
+  rule for two at once) - reuses an existing one instead of creating a
+  silently-inert duplicate, returning its id with NO new node created.
+- The only branch that both creates AND connects in one record_command
+  call - and the edge direction is REVERSED from every other built-in's
+  root -> child edge: note -> root, the exact shape
+  _resolve_branch_system_prompt looks for.
+
+Same command_type string ("pluginSystemPrompt"), same parent-validation
+warning text, same dedup/reversed-edge/branch-root-walk logic as the
+branch it replaces. See plugins/web_research/plugin.py's own docstring for
+the shared register_builtin_plugin escape-hatch rationale."""
+
+from __future__ import annotations
+
+from backend.canvas import SceneDocument
+from backend.plugin_sdk import HostContext, PluginRunContext
+
+
+def _execute(
+    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
+) -> "str | None":
+    if not parent_node_id or parent_node_id not in document.nodes:
+        run_ctx.notifications.show(
+            "Please select a valid node to branch from before adding a System Prompt node.",
+            "warning",
+        )
+        return None
+    root = document.get_branch_root(parent_node_id)
+    existing = next(
+        (
+            document.nodes[edge.source]
+            for edge in document.edges.values()
+            if edge.target == root.id
+            and edge.source in document.nodes
+            and document.nodes[edge.source].kind == "note"
+            and document.nodes[edge.source].state.is_system_prompt
+        ),
+        None,
+    )
+    if existing is not None:
+        return existing.id
+
+    def _create_system_prompt_note():
+        created = document.add_note(root.x, root.y - 150, is_system_prompt=True)
+        document.connect(created.id, root.id)
+        return created
+
+    note, _command = document.record_command(
+        "pluginSystemPrompt", "user", _create_system_prompt_note,
+        node_ids=[root.id],
+    )
+    return note.id
+
+
+def register(host: HostContext) -> None:
+    host.register_builtin_plugin(
+        name="System Prompt",
+        description=(
+            "Adds a special node to override the default system prompt for a "
+            "conversation branch."
+        ),
+        category="Branch Foundations",
+        handler=_execute,
+    )

--- a/plugins/system_prompt/plugin.toml
+++ b/plugins/system_prompt/plugin.toml
@@ -1,0 +1,19 @@
+# plugins/system_prompt/plugin.toml
+#
+# ADR-014 stage 14.3: first-party migration of the pre-SDK "System Prompt"
+# built-in picker action - see plugins/web_research/plugin.toml's own
+# comment for the shared rationale (register_builtin_plugin, not
+# register_node_kind, to keep the already-shipped "note" kind string
+# unchanged - a System Prompt is a "note" node with is_system_prompt=True,
+# not a distinct kind of its own).
+
+[plugin]
+id = "system_prompt"
+name = "System Prompt"
+version = "1.0.0"
+sdk_api_version = 1
+entry_point = "plugin:register"
+description = "Adds a special node to override the default system prompt for a conversation branch."
+
+[frontend]
+view = "generic"

--- a/plugins/web_research/plugin.py
+++ b/plugins/web_research/plugin.py
@@ -1,0 +1,50 @@
+"""ADR-014 stage 14.3: first-party migration of the pre-SDK "Web Research"
+picker action. A byte-faithful relocation of backend/plugins.py's old
+hardcoded `if name == "Web Research":` branch - same command_type string
+("pluginWebResearch"), same parent-validation warning text, same factory
+call (SceneDocument.add_web_research_node), same undo/parent-validation
+behavior. Registered via HostContext.register_builtin_plugin, NOT
+register_node_kind/register_picker_entry: the "web_research" kind string
+is already baked into web_ui's NODE_TYPES map, the wire contract, and
+session_save.py/session_load.py's hand-written serializer - renaming it to
+a namespaced "web_research.web_research" via the generic PluginNodeSeed
+path would be an invasive, unnecessary breaking change. See
+HostContext.register_builtin_plugin's own docstring (backend/plugin_sdk.py)
+for the full escape-hatch rationale."""
+
+from __future__ import annotations
+
+from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.plugin_sdk import HostContext, PluginRunContext
+
+
+def _execute(
+    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
+) -> "str | None":
+    if not parent_node_id or parent_node_id not in document.nodes:
+        run_ctx.notifications.show(
+            "Please select a valid node to branch from before adding a Web Node.",
+            "warning",
+        )
+        return None
+    parent = document.nodes[parent_node_id]
+    node, _command = document.record_command(
+        "pluginWebResearch", "user",
+        lambda: document.add_web_research_node(
+            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+        ),
+        node_ids=[parent_node_id],
+    )
+    return node.id
+
+
+def register(host: HostContext) -> None:
+    host.register_builtin_plugin(
+        name="Web Research",
+        description=(
+            "Searches, retrieves, and summarizes cited web sources under a bounded "
+            "network policy."
+        ),
+        category="Reasoning & Research",
+        handler=_execute,
+    )

--- a/plugins/web_research/plugin.toml
+++ b/plugins/web_research/plugin.toml
@@ -1,0 +1,23 @@
+# plugins/web_research/plugin.toml
+#
+# ADR-014 stage 14.3: first-party migration of the pre-SDK "Web Research"
+# built-in picker action onto a real plugin package. Uses
+# HostContext.register_builtin_plugin (NOT register_node_kind/
+# register_picker_entry) - see plugins/web_research/plugin.py's own
+# docstring and HostContext.register_builtin_plugin's docstring
+# (backend/plugin_sdk.py) for why: the "web_research" kind string is
+# already baked into the frontend's NODE_TYPES map, the wire contract, and
+# session_save.py/session_load.py's hand-written serializer, so this
+# plugin reuses SceneDocument.add_web_research_node directly rather than
+# going through the generic, auto-namespaced PluginNodeSeed path.
+
+[plugin]
+id = "web_research"
+name = "Web Research"
+version = "1.0.0"
+sdk_api_version = 1
+entry_point = "plugin:register"
+description = "Searches, retrieves, and summarizes cited web sources under a bounded network policy."
+
+[frontend]
+view = "generic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,13 @@ dependencies = [
     "reportlab",
     "requests",
     "tiktoken",
+    # ADR-014 stage 14.1: backend/plugin_sdk.py parses plugin.toml via
+    # stdlib tomllib, which is only available from Python 3.11 onward -
+    # this repo's own requires-python floor is 3.10. tomli is the
+    # conditional fallback for that gap (CI/dev both already run 3.12+, so
+    # this branch is dead in practice today, but is real correctness for
+    # the declared support floor, not speculative).
+    'tomli; python_version < "3.11"',
 ]
 
 # llama-cpp-python is lazily imported (api_provider._load_llama_cpp_class) only when

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -178,6 +178,14 @@ _KNOWN_NON_NODE_FIELD_ACCESS_SHAPES = {
         # backend/tests/test_agents.py; failures[i].code there is that
         # object's own .code, e.g. "watchdog_timeout".
         {"root": "failures", "file": "test_agents.py"},
+        # ADR-014 stage 14.3's H3 test-coverage work: RequestCancelled/
+        # ResearchFailure (graphlink_plugins/web_research/domain.py) are
+        # exception classes with their OWN .code error-code string
+        # (e.g. "cancelled", "research_failed") - never a SceneNode -
+        # confined to backend/tests/test_web_research_domain.py, which
+        # exercises exactly these two classes directly.
+        {"root": "RequestCancelled", "file": "test_web_research_domain.py"},
+        {"root": "exc", "file": "test_web_research_domain.py"},
     ),
     "language": (),
     # PR6's "document" kind reuses byte_size/mime_type/duration_seconds,
@@ -191,9 +199,8 @@ _KNOWN_NON_NODE_FIELD_ACCESS_SHAPES = {
     ),
     "mime_type": ({"root": "staged", "file": None},),
     "duration_seconds": ({"root": "staged", "file": None},),
-    # PR7's "chat" kind reuses "provider" (never "model" - confirmed no
-    # non-SceneNode ".model" access exists anywhere in SCAN_DIRS), which
-    # collides with two wholly unrelated types: a ResearchSource's own
+    # PR7's "chat" kind reuses "provider", which collides with two wholly
+    # unrelated types: a ResearchSource's own
     # .provider (backend/canvas.py's _research_result_wire, iterating
     # result.sources) and a ModelDescriptor's own .provider (ADR-002 stage
     # 2.7 relocated this from backend/settings.py to
@@ -222,6 +229,12 @@ _KNOWN_NON_NODE_FIELD_ACCESS_SHAPES = {
         # model catalogs, so "catalog" never means anything else there.
         {"root": "catalog", "file": "test_model_routing.py"},
     ),
+    # ADR-014 stage 14.3's H3 test-coverage work: WebResearchService's own
+    # .model (its ApiResearchModel/FakeModel dependency, e.g.
+    # `service.model`) is never a SceneNode - confined to
+    # backend/tests/test_web_research_domain.py, which constructs and
+    # asserts against WebResearchService directly.
+    "model": ({"root": "service", "file": "test_web_research_domain.py"},),
 }
 
 

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -323,7 +323,7 @@ _EXPECTED_SCENE_NODE_WIRE_KEYS = sorted([
     "isDocked", "isFinalDeliverable", "isLocked", "isSummaryNote",
     "isSystemPrompt", "isUser", "itemIds", "kind", "language", "mimeType",
     "model", "overrideModelId", "overrideProvider",
-    "pendingRequestId", "previewLabel", "provider", "pycoderAnalysis",
+    "pendingRequestId", "pluginState", "previewLabel", "provider", "pycoderAnalysis",
     "pycoderAwaitingApproval", "pycoderCode", "pycoderError",
     "pycoderLastRunFailed", "pycoderMode", "pycoderOutput", "pycoderPrompt",
     "researchActiveSourceId", "researchCompleted", "researchError",

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -245,12 +245,14 @@ def test_the_scan_finds_the_real_population_of_registered_intents():
     # stage 8.3 added the "builder" topic's five run-lifecycle intents
     # plus scene's own setPlanSteps, 151 -> 153 when stage 8.6 added
     # builder's own listRecipes/saveRecipe pair, 153 -> 154 when
-    # ADR-012 stage 12.2 added app-settings' own setTheme, and 154 -> 157 when
+    # ADR-012 stage 12.2 added app-settings' own setTheme, 154 -> 157 when
     # ADR-012 stage 12.6 added scene's own loadSampleWorkspace plus
-    # app-settings' own setHasCompletedOnboarding/setMcpServers.
+    # app-settings' own setHasCompletedOnboarding/setMcpServers, and
+    # 157 -> 159 when ADR-014 stage 14.4 added app-plugins' own
+    # invokePluginIntent/setPluginGrant pair.
     real = _collect_real_registrations()
-    assert len(real) == 157, (
-        f"expected exactly 157 real registered intents, found {len(real)} - "
+    assert len(real) == 159, (
+        f"expected exactly 159 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -86,6 +86,9 @@ CLASSIFICATION: tuple[Classified, ...] = (
 
     # -- backend/plugins.py (app-plugins) ------------------------------------
     Classified("app-plugins", "executePlugin", "A", "content: creates a new node (Web Research/Gitlink/PyCoder/Sandbox/Artifact/System-Prompt note/Conversation/HTML) - every branch wraps its own pluginX command_type"),
+    # ADR-014 stage 14.4:
+    Classified("app-plugins", "invokePluginIntent", "B", "run-lifecycle: dispatches to a plugin's own custom intent handler defined outside backend/ (invisible to this same-file AST walk) - if that handler mutates the document it must call record_command itself, same posture as register_builtin_plugin's own escape-hatch handler"),
+    Classified("app-plugins", "setPluginGrant", "B", "preference: plugin install-time consent grant is settings-store configuration, not document content, same posture as setMcpServers"),
 
     # -- backend/api/intents_grid.py (grid-control) --------------------------
     Classified("grid-control", "setGridSize", "B", "preference: grid appearance"),

--- a/web_ui/src/app/canvas/SceneCanvas.pinSearchJump.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.pinSearchJump.test.tsx
@@ -144,6 +144,8 @@ function chatRow(id: string, x: number, y: number, title = id): SceneNodeRow {
   builderApprovalToolName: "",
   builderApprovalSummary: "",
   builderStatusDetail: "",
+  // ADR-014 stage 14.2
+  pluginState: {},
       }),
     ) as unknown as SceneNodeRow),
   };

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -154,6 +154,8 @@ function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
   builderApprovalToolName: "",
   builderApprovalSummary: "",
   builderStatusDetail: "",
+  // ADR-014 stage 14.2
+  pluginState: {},
     ...overrides,
   };
 }

--- a/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
@@ -151,6 +151,8 @@ function chatRow(id: string, x: number, y = 0): SceneNodeRow {
   builderApprovalToolName: "",
   builderApprovalSummary: "",
   builderStatusDetail: "",
+  // ADR-014 stage 14.2
+  pluginState: {},
       }),
     ) as unknown as SceneNodeRow),
   };

--- a/web_ui/src/app/canvas/renderCountGate.test.tsx
+++ b/web_ui/src/app/canvas/renderCountGate.test.tsx
@@ -162,6 +162,8 @@ function chatRow(id: string, x: number): SceneNodeRow {
         builderApprovalToolName: "",
         builderApprovalSummary: "",
         builderStatusDetail: "",
+        // ADR-014 stage 14.2
+        pluginState: {},
       }),
     ) as unknown as SceneNodeRow),
   };

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -199,6 +199,8 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         builderApprovalToolName: "",
         builderApprovalSummary: "",
         builderStatusDetail: "",
+        // ADR-014 stage 14.2
+        pluginState: {},
       },
     ],
     edges: [],

--- a/web_ui/src/app/chrome/PluginPicker.test.tsx
+++ b/web_ui/src/app/chrome/PluginPicker.test.tsx
@@ -25,6 +25,12 @@ const snapshot = {
       plugins: [{ name: "Py-Coder", description: "Python workspace." }],
     },
   ],
+  // ADR-014 stage 14.4: now a required field on the "app-plugins" contract
+  // (one row per distinct non-built-in plugin_id) - PluginPicker.tsx itself
+  // doesn't read it, but a snapshot missing it fails TOPIC_VALIDATORS
+  // validation and silently never updates state, matching every other
+  // required field already listed here.
+  grants: [],
 };
 
 function makeTransport() {

--- a/web_ui/src/app/chrome/PluginPicker.tsx
+++ b/web_ui/src/app/chrome/PluginPicker.tsx
@@ -26,6 +26,10 @@ const initialState: AppPluginsState = {
   minCompatibleSchemaVersion: 1,
   revision: 0,
   categories: [],
+  // ADR-014 stage 14.4: required by the "app-plugins" contract now, but
+  // unused here - the grants list only matters to SettingsDialog.tsx's own
+  // Plugins page (Settings > Plugins), not the picker itself.
+  grants: [],
 };
 
 export function PluginPicker({ transport, store }: { transport: WsTransport; store: SceneStore }) {

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -95,6 +95,10 @@ function makeTransport() {
     intents,
     push: (payload: Record<string, unknown>) => listeners.get("app-settings")?.(payload),
     pushExecutionLimits: (payload: Record<string, unknown>) => listeners.get("execution-limits")?.(payload),
+    // ADR-014 stage 14.4: the Plugins page reads a SECOND, independent
+    // subscription ("app-plugins", the same topic PluginPicker.tsx already
+    // reads) - separate from the dialog's own "app-settings" push above.
+    pushPlugins: (payload: Record<string, unknown>) => listeners.get("app-plugins")?.(payload),
   };
 }
 
@@ -180,6 +184,16 @@ async function goToMcpServers(
   await user.click(screen.getByText("open settings"));
   await user.click(screen.getByRole("button", { name: "MCP Servers" }));
   act(() => push({ ...snapshot, ...overrides, activeSection: "mcp servers" }));
+}
+
+async function goToPlugins(
+  user: ReturnType<typeof userEvent.setup>,
+  push: (payload: Record<string, unknown>) => void,
+  overrides: Record<string, unknown> = {},
+) {
+  await user.click(screen.getByText("open settings"));
+  await user.click(screen.getByRole("button", { name: "Plugins" }));
+  act(() => push({ ...snapshot, ...overrides, activeSection: "plugins" }));
 }
 
 // Settings' selects are CustomSelect.tsx (chrome/CustomSelect.tsx), not
@@ -1023,6 +1037,95 @@ describe("SettingsDialog", () => {
       await user.click(screen.getByRole("button", { name: "Remove fs" }));
 
       expect(intents).toContainEqual(["app-settings", "setMcpServers", [[gitServer]]]);
+    });
+  });
+
+  // ADR-014 stage 14.4: install-time consent for discovered third-party
+  // plugins. Reads a SEPARATE topic ("app-plugins", via pushPlugins) than
+  // every other section in this file - each test below pushes both the
+  // "app-settings" snapshot (to select the Plugins section) and, where
+  // needed, a distinct "app-plugins" snapshot carrying the new `grants`
+  // field, mirroring how the Resource Limits tests above push
+  // "execution-limits" independently of "app-settings".
+  describe("Plugins page", () => {
+    const helloGrant = { pluginId: "hello_node", name: "Hello Node", scopes: ["graph.mutate"], granted: false };
+    const counterGrant = {
+      pluginId: "counter_node",
+      name: "Counter Node",
+      scopes: ["graph.mutate", "graph.read"],
+      granted: true,
+    };
+
+    function pushGrants(pushPlugins: (payload: Record<string, unknown>) => void, grants: unknown[]) {
+      act(() =>
+        pushPlugins({ schemaVersion: 1, minCompatibleSchemaVersion: 1, revision: 1, categories: [], grants }),
+      );
+    }
+
+    it("navigating to Plugins fires setActiveSection with its own key", async () => {
+      const { user, push, intents } = setup();
+      await goToPlugins(user, push);
+
+      expect(intents).toContainEqual(["app-settings", "setActiveSection", ["plugins"]]);
+    });
+
+    it("renders sensibly before any app-plugins snapshot has arrived", async () => {
+      const { user, push } = setup();
+      await goToPlugins(user, push);
+
+      expect(screen.getByText("No third-party plugins need a grant right now.")).toBeInTheDocument();
+      expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+    });
+
+    it("an empty grants array renders sensibly - no crash, no phantom rows", async () => {
+      const { user, push, pushPlugins } = setup();
+      await goToPlugins(user, push);
+      pushGrants(pushPlugins, []);
+
+      expect(screen.getByText("No third-party plugins need a grant right now.")).toBeInTheDocument();
+      expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+    });
+
+    it("renders one row per grants entry with its name, declared scopes, and current granted state", async () => {
+      const { user, push, pushPlugins } = setup();
+      await goToPlugins(user, push);
+      pushGrants(pushPlugins, [helloGrant, counterGrant]);
+
+      expect(screen.getByText("Hello Node")).toBeInTheDocument();
+      expect(screen.getByText("graph.mutate")).toBeInTheDocument();
+      expect(screen.getByText("Counter Node")).toBeInTheDocument();
+      expect(screen.getByText("graph.mutate, graph.read")).toBeInTheDocument();
+
+      expect(screen.getByRole("checkbox", { name: "Granted: Hello Node" })).not.toBeChecked();
+      expect(screen.getByRole("checkbox", { name: "Granted: Counter Node" })).toBeChecked();
+    });
+
+    it("a plugin with no declared scopes shows a 'No declared scopes' placeholder, not an empty string", async () => {
+      const { user, push, pushPlugins } = setup();
+      await goToPlugins(user, push);
+      pushGrants(pushPlugins, [{ pluginId: "bare_plugin", name: "Bare Plugin", scopes: [], granted: false }]);
+
+      expect(screen.getByText("No declared scopes")).toBeInTheDocument();
+    });
+
+    it("checking an ungranted plugin's checkbox fires setPluginGrant with its pluginId and true", async () => {
+      const { user, push, pushPlugins, intents } = setup();
+      await goToPlugins(user, push);
+      pushGrants(pushPlugins, [helloGrant]);
+
+      await user.click(screen.getByRole("checkbox", { name: "Granted: Hello Node" }));
+
+      expect(intents).toContainEqual(["app-plugins", "setPluginGrant", ["hello_node", true]]);
+    });
+
+    it("unchecking an already-granted plugin's checkbox fires setPluginGrant with its pluginId and false", async () => {
+      const { user, push, pushPlugins, intents } = setup();
+      await goToPlugins(user, push);
+      pushGrants(pushPlugins, [counterGrant]);
+
+      await user.click(screen.getByRole("checkbox", { name: "Granted: Counter Node" }));
+
+      expect(intents).toContainEqual(["app-plugins", "setPluginGrant", ["counter_node", false]]);
     });
   });
 });

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { WsTransport } from "../../lib/ws/transport";
 import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
+import type { AppPluginGrant, AppPluginsState } from "../../lib/bridge-core/generated/app-plugins-state";
 import type { AppSettingsState, McpServerConfig } from "../../lib/bridge-core/generated/app-settings-state";
 import { useExecutionLimits } from "../canvas/ExecutionLimitsContext";
 import { Dialog, useOverlays } from "../overlays/overlays";
@@ -22,6 +23,7 @@ const SECTIONS = [
   "API Endpoint",
   "Integrations",
   "MCP Servers",
+  "Plugins",
   "Resource Limits",
 ] as const;
 type Section = (typeof SECTIONS)[number];
@@ -184,6 +186,19 @@ const initialState: AppSettingsState = {
   llamaCppNotice: "",
   // ADR-012 stage 12.6: mirrors SettingsManager.get_mcp_servers()'s own default.
   mcpServers: [],
+};
+
+const initialPluginsState: AppPluginsState = {
+  schemaVersion: 1,
+  minCompatibleSchemaVersion: 1,
+  revision: 0,
+  categories: [],
+  // ADR-014 stage 14.4: one entry per discovered NON-built-in plugin (see
+  // backend/plugins.py's plugin_registry.picker_entries/node_kinds split vs.
+  // builtin_actions, and AppPluginGrantPayload's own docstring in
+  // contracts/graphlink_app_plugins_payload.py for the "one row per
+  // distinct plugin_id" construction rule) - built-ins never appear here.
+  grants: [],
 };
 
 function sectionKey(section: Section): string {
@@ -1168,6 +1183,68 @@ function McpServersPage({ state, transport }: { state: AppSettingsState; transpo
   );
 }
 
+// ADR-014 stage 14.4: install-time consent for discovered THIRD-PARTY
+// plugins, mirroring McpServersPage's own minimalism immediately above -
+// one row per entry, a single checkbox, no per-scope editing UI (MCP
+// Servers itself has never had one for its own `scopes` field, so this
+// stays exactly that coarse). Built-in plugins (the 8 migrated in stage
+// 14.3) never appear in `grants` - backend/plugins.py only emits an entry
+// per distinct plugin_id reached through the generic, non-builtin_actions
+// discovery path - so this page can never gate anything that ships with
+// the app itself.
+//
+// Honesty note (carried over from the ADR-014 stage 14.4 design): checking
+// "Granted" here answers "did the user consent to this plugin acting at
+// all," not "is this specific mutation confined to some enforced boundary."
+// A plugin's declared scopes are a self-reported checklist the backend
+// records for its own self-documentation, not a sandboxed capability set -
+// real capability sandboxing is ADR-014 stage 14.5's job (out-of-process
+// execution). This page does not claim otherwise.
+function PluginsPage({ grants, transport }: { grants: AppPluginGrant[]; transport: WsTransport }) {
+  return (
+    <div className="settings-general-page">
+      <p className="settings-integrations-intro">
+        Discovered third-party plugins are not granted by default. A plugin listed here cannot create nodes or run
+        its intents until you check "Granted" for it - built-in plugins ship with the app and are never listed or
+        gated here.
+      </p>
+
+      <fieldset className="settings-fieldset">
+        <legend>Discovered Plugins</legend>
+        {grants.length === 0 && (
+          <p className="settings-update-status">No third-party plugins need a grant right now.</p>
+        )}
+        {grants.map((grant) => (
+          <div className="settings-mcp-server-row" key={grant.pluginId}>
+            <label className="settings-checkbox-row settings-mcp-server-toggle">
+              <input
+                type="checkbox"
+                aria-label={`Granted: ${grant.name}`}
+                checked={grant.granted}
+                onChange={(event) =>
+                  transport.fireIntent(
+                    "app-plugins",
+                    "setPluginGrant",
+                    [grant.pluginId, event.target.checked],
+                    undefined,
+                    true,
+                  )
+                }
+              />
+              <span className="settings-mcp-server-info">
+                <span className="settings-mcp-server-name">{grant.name}</span>
+                <span className="settings-mcp-server-command">
+                  {grant.scopes.length > 0 ? grant.scopes.join(", ") : "No declared scopes"}
+                </span>
+              </span>
+            </label>
+          </div>
+        ))}
+      </fieldset>
+    </div>
+  );
+}
+
 // ADR-012 stage 12.6: a read-only disclosure surface, not a settings page in
 // the usual sense - there is nothing here to edit (per ADR-005 §4, these
 // caps are a fixed, backend-computed fact, not a user-tunable preference),
@@ -1216,12 +1293,25 @@ function ResourceLimitsPage() {
 
 export function SettingsDialog({ transport }: { transport: WsTransport }) {
   const [state, setState] = useState<AppSettingsState>(initialState);
+  // ADR-014 stage 14.4: a second, independent subscription to "app-plugins"
+  // (the same topic PluginPicker.tsx already reads) - the grants list isn't
+  // part of "app-settings" (which this dialog otherwise reads exclusively),
+  // so this is a sibling subscription, not a repurposing of `state` above.
+  const [pluginsState, setPluginsState] = useState<AppPluginsState>(initialPluginsState);
 
   useEffect(() => {
     return transport.subscribe("app-settings", (payload) => {
       const validated = TOPIC_VALIDATORS["app-settings"](payload);
       if (validated.ok) setState(validated.value as AppSettingsState);
       else console.error("[app-settings] rejected snapshot:", validated.errors);
+    });
+  }, [transport]);
+
+  useEffect(() => {
+    return transport.subscribe("app-plugins", (payload) => {
+      const validated = TOPIC_VALIDATORS["app-plugins"](payload);
+      if (validated.ok) setPluginsState(validated.value as AppPluginsState);
+      else console.error("[app-plugins] rejected snapshot:", validated.errors);
     });
   }, [transport]);
 
@@ -1275,6 +1365,8 @@ export function SettingsDialog({ transport }: { transport: WsTransport }) {
             <LlamaCppPage state={state} transport={transport} />
           ) : activeSection === "MCP Servers" ? (
             <McpServersPage state={state} transport={transport} />
+          ) : activeSection === "Plugins" ? (
+            <PluginsPage grants={pluginsState.grants} transport={transport} />
           ) : activeSection === "Resource Limits" ? (
             <ResourceLimitsPage />
           ) : (

--- a/web_ui/src/lib/bridge-core/generated/app-plugins-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/app-plugins-state.schema.json
@@ -41,6 +41,36 @@
       },
       "type": "array"
     },
+    "grants": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "granted": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pluginId": {
+            "type": "string"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "pluginId",
+          "name",
+          "scopes",
+          "granted"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
     "minCompatibleSchemaVersion": {
       "type": "integer"
     },
@@ -54,7 +84,8 @@
   "required": [
     "schemaVersion",
     "revision",
-    "categories"
+    "categories",
+    "grants"
   ],
   "title": "AppPluginsState",
   "type": "object"

--- a/web_ui/src/lib/bridge-core/generated/app-plugins-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/app-plugins-state.ts
@@ -13,10 +13,18 @@ export interface AppPluginEntry {
   description: string;
 }
 
+export interface AppPluginGrant {
+  pluginId: string;
+  name: string;
+  scopes: string[];
+  granted: boolean;
+}
+
 export interface AppPluginsState {
   schemaVersion: number;
   revision: number;
   categories: AppPluginCategory[];
+  grants: AppPluginGrant[];
   minCompatibleSchemaVersion?: number | null;
 }
 
@@ -69,6 +77,31 @@ function checkAppPluginEntry(value: unknown, path: string, errors: string[]): vo
   }
 }
 
+function checkAppPluginGrant(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["pluginId"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.pluginId: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.pluginId` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["name"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.name: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.name` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["scopes"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.scopes: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.scopes` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "string") errors.push(`${path}.scopes` + `[${i}]` + ": expected string"); }); }
+  }
+  {
+    const fieldValue = value["granted"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.granted: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.granted` + ": expected boolean"); }
+  }
+}
+
 function checkAppPluginsState(value: unknown, path: string, errors: string[]): void {
   if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
   {
@@ -86,6 +119,12 @@ function checkAppPluginsState(value: unknown, path: string, errors: string[]): v
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.categories: missing required field`);
     else { if (!Array.isArray(fieldValue)) errors.push(`${path}.categories` + ": expected array");
     else (fieldValue as unknown[]).forEach((item, i) => { checkAppPluginCategory(item, `${path}.categories` + `[${i}]`, errors); }); }
+  }
+  {
+    const fieldValue = value["grants"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.grants: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.grants` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { checkAppPluginGrant(item, `${path}.grants` + `[${i}]`, errors); }); }
   }
   {
     const fieldValue = value["minCompatibleSchemaVersion"];

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -458,6 +458,12 @@
             },
             "type": "array"
           },
+          "pluginState": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "previewLabel": {
             "type": "string"
           },
@@ -775,7 +781,8 @@
           "builderAwaitingToolApproval",
           "builderApprovalToolName",
           "builderApprovalSummary",
-          "builderStatusDetail"
+          "builderStatusDetail",
+          "pluginState"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -111,6 +111,7 @@ export interface SceneNodeRow {
   builderApprovalToolName: string;
   builderApprovalSummary: string;
   builderStatusDetail: string;
+  pluginState: Record<string, string>;
 }
 
 export interface ConversationMessageRow {
@@ -777,6 +778,12 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["builderStatusDetail"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.builderStatusDetail: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.builderStatusDetail` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["pluginState"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.pluginState: missing required field`);
+    else { if (!isRecord(fieldValue)) errors.push(`${path}.pluginState` + ": expected object");
+    else Object.entries(fieldValue as Record<string, unknown>).forEach(([k, v]) => { if (typeof v !== "string") errors.push(`${path}.pluginState` + `[${JSON.stringify(k)}]` + ": expected string"); }); }
   }
 }
 


### PR DESCRIPTION
## Problem

`_PLUGINS` was an 8-tuple literal and `execute_plugin` a 190-line if-chain — adding one plugin meant editing 6+ core files, there was no manifest, no discovery, no capability model, no isolation, and a plugin ran in-process with full backend privileges and access to every API key. `graphlink_plugins/**` (the built-ins' domain logic) had zero tests.

## Change

Five stages, one branch:

- **14.1** — `plugin.toml` manifest + lazy/memoized discovery + `HostContext`/`PluginRunContext`/`PluginRegistry` (`backend/plugin_sdk.py`, new) + a generic `executePlugin` dispatch fallback + `plugins/hello_node/` reference plugin.
- **14.2** — generic node persistence: optional `serialize`/`deserialize` hooks on `register_node_kind`, a plugin-kind fallback in `session_save.py`/`session_load.py`, a new `pluginState` wire field added through the proper ADR-003 codegen process, `plugins/counter_node/` proving a real `NodeState` round-trip.
- **14.3** — migrated all 8 built-in plugin actions (System Prompt, Conversation Node, Web Research, Gitlink, Py-Coder, Virtual Environment Runner, HTML Renderer, Artifact/Drafter) off the hardcoded if-chain onto `plugins/<name>/` packages via a new `HostContext.register_builtin_plugin` escape hatch — deliberately un-namespaced, since these kinds already have full-fidelity frontend/wire/persistence support and namespacing them would be an invasive, unnecessary breaking rename. Added real test coverage for `graphlink_plugins/**`'s domain logic (`code_sandbox`, `pycoder`, `gitlink`, `web_research`).
- **14.4** — scope model + install-time consent: `plugin.toml` gains `[scopes]`; `SettingsManager.get_plugin_grants()`/`set_plugin_grant()` (persisted, mirroring the existing MCP-server settings pattern); a coarse deny-by-default grant gate checked before a discovered plugin's factory/intent/tool handler ever runs; a new Settings > Plugins UI page; resolved a deferred custom-intent/undo-classification-gate conflict via a second static `invokePluginIntent` intent that dispatches dynamically with a grant check ahead of the handler.
- **14.5** — out-of-process third-party execution: `backend/plugin_worker.py` (a subprocess entry point serving a host-initiated-only JSON-RPC loop over stdio, mirroring the existing MCP stdio client), spawned via the existing execution guard + an environment allowlist (the real secret-containment mechanism — verified empirically with a planted fake API-key env var), `plugins/sandboxed_demo/` reference plugin, plugin-declared intents now flow into the ADR-007 `ToolRegistry` for Builder-loop use.

A 6-dimension adversarial review after all 5 stages landed found and fixed 8 real issues, most notably: a duplicate plugin-intent name silently stripped every subsequently-loaded plugin's Builder tools, and revoking a plugin's grant didn't stop its `serialize`/`deserialize` code from continuing to run on every save/load/wire-broadcast.

Explicitly out of scope: real dynamic frontend JS loading (widening `[frontend].view` beyond `"generic"`) — a separate, large problem not required by any stage's exit criterion, left as a named, deliberate gap.

## Test plan

- [x] Full `pytest -q` from repo root: 2857 passed, 17 skipped, 6 failed (all 6 confirmed pre-existing/unrelated — a `pywebview` version mismatch and a flaky date-boundary backup-rotation test)
- [x] Full `npx vitest run` from `web_ui/`: passes (one flaky test under full-suite load confirmed unrelated, passes clean in isolation)
- [x] Empirical secret-containment proof: planted `GRAPHLINK_OPENAI_API_KEY` on the host process, triggered a real out-of-process plugin's node creation, confirmed the created node's content contains neither the secret's value nor its name
- [x] All 8 built-ins' picker display, node creation, undo, and within-category ordering pinned by parametrized tests against the pre-migration behavior
- [x] Real 2-thread repro proving a discovery-cache race, fixed with a lock and regression test
- [x] Grant-gate coverage: node creation, custom intents, and Builder-loop tool invocation all deny an ungranted plugin; revoking a grant now also stops `serialize`/`deserialize`