### PR TITLE
ADR-020 stage 20.4: Global FTS search across graphs + documents, jump-to-node

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -100,6 +100,12 @@ from graphlink_plugins.code_sandbox.domain import (
 )
 from graphlink_scratch_dirs import EXECUTION_SANDBOX_ROOT, PYCODER_REPL_ROOT
 from graphlink_scratch_dirs import remove_scratch_dir_for_id
+# ADR-020 stage 20.3: the workspace-default rung of resolve_model_ref's
+# chain, wired into _resolve_model_ref_for_dispatch below - safe as a
+# top-level import (graphlink_model_catalog is dependency-free, see its own
+# ModelRef docstring; several other modules already import it this way,
+# e.g. api_provider.py).
+from graphlink_model_catalog import ModelRef, resolve_model_ref
 from graphlink_plugins.web_research.domain import (
     CancellationToken,
     ProgressEvent,
@@ -904,28 +910,66 @@ class AgentDispatcher:
             return ""
         return BASE_SYSTEM_PROMPT
 
-    def _resolve_model_ref_for_dispatch(self, canvas_document, node_id: str | None):
-        """ADR-018 stage 18.2: the node/branch-override rungs of
-        graphlink_model_catalog.resolve_model_ref, computed here (mirroring
-        _resolve_branch_system_prompt's own "only when canvas_document/
-        node_id are supplied" restriction) and returned already resolved.
-        auto/workspace-default (which need the unified catalog and the
-        session's task-keyed default) stay out of scope here - when neither
-        rung fires, this returns None and the caller passes no model_ref at
-        all, falling through to api_provider's existing task-keyed lookup
-        UNCHANGED (see _provider_for_model_ref's own docstring in
-        api_provider.py). Diagnostics-worthy (the "why this model" rung
-        name) is thrown away at this layer on purpose - stage 18.3's
-        explain-resolution intent recomputes it fresh from the SAME
-        SceneDocument state the UI can already read, rather than this
-        already-in-flight dispatch trying to smuggle it back out."""
+    def _resolve_model_ref_for_dispatch(
+        self, canvas_document, node_id: str | None, bus: "SessionBus | None" = None,
+    ):
+        """ADR-018 stage 18.2 + ADR-020 stage 20.3: the full node -> branch
+        -> workspace-default rungs of graphlink_model_catalog.resolve_
+        model_ref (graphlink_model_catalog.py:381-419), computed here
+        (mirroring _resolve_branch_system_prompt's own "only when
+        canvas_document/node_id are supplied" restriction) and returned
+        already resolved. auto (which needs the unified catalog and the
+        session's task-keyed default) stays OUT of scope here exactly like
+        before 20.3 - `catalog=()` below makes resolve_model_ref's own auto
+        rung come back empty whenever node/branch/workspace are ALL unset,
+        so this still returns None in exactly that case, falling through to
+        api_provider's existing task-keyed lookup UNCHANGED (see
+        _provider_for_model_ref's own docstring in api_provider.py).
+        Diagnostics-worthy (the "why this model" rung name) is thrown away
+        at this layer on purpose - stage 18.3's explain-resolution intent
+        recomputes it fresh from the SAME SceneDocument state the UI can
+        already read, rather than this already-in-flight dispatch trying to
+        smuggle it back out.
+
+        ADR-020 stage 20.3: `bus`, when supplied, is the one extra piece of
+        context needed to find `canvas_document.current_workspace_id`'s own
+        workspace row - via `bus.chat_db_path` (stashed by backend/
+        chat_library.py's register_chat_library; the SAME attribute backend/
+        app.py's own eviction-flush call site already reads via
+        `getattr(bus, "chat_db_path", None)`). Optional and defaulted to
+        None so this method's pre-20.3 test call sites (an AgentDispatcher/
+        SceneDocument pair with no real SessionBus at all) keep passing
+        unchanged - a None bus (or a bare test double with no chat_db_path
+        attribute) simply skips the workspace rung, exactly like the
+        pre-20.3 code path when canvas_document/node_id were absent."""
         if canvas_document is None or node_id is None:
             return None
         resolve_model_for_node = getattr(canvas_document, "resolve_model_for_node", None)
         if resolve_model_for_node is None:
             return None
         node_ref, branch_ref = resolve_model_for_node(node_id)
-        return node_ref or branch_ref
+
+        workspace_ref = None
+        chats_db_path = getattr(bus, "chat_db_path", None) if bus is not None else None
+        workspace_id = getattr(canvas_document, "current_workspace_id", None)
+        if chats_db_path is not None and workspace_id is not None:
+            # Local import - backend.chat_library imports backend.canvas,
+            # which imports THIS module (AgentDispatcher) at module level -
+            # a top-level import here would be circular. Mirrors this
+            # codebase's own established "deferred import to break a real
+            # cycle" precedent (e.g. backend/api/intents_web_research.py's
+            # own `from backend.canvas import _research_result_wire`).
+            from backend.chat_library import get_workspace_default_model
+
+            default = get_workspace_default_model(chats_db_path, workspace_id)
+            if default is not None:
+                provider, model_id = default
+                workspace_ref = ModelRef(provider, model_id)
+
+        resolved = resolve_model_ref(
+            config.TASK_CHAT, node_ref=node_ref, branch_ref=branch_ref, workspace_ref=workspace_ref, catalog=(),
+        )
+        return resolved.ref if resolved is not None else None
 
     def _resolve_branch_system_prompt(self, canvas_document, node_id: str | None) -> str | None:
         """R6.1 port of legacy graphlink_chat_agent.py's
@@ -1184,7 +1228,7 @@ class AgentDispatcher:
                 persona_text = override if override is not None else self.persona()
                 # ADR-018 stage 18.2: computed once, shared by both branches
                 # below, exactly like persona_text/override_kwargs above.
-                model_ref = self._resolve_model_ref_for_dispatch(canvas_document, node_id)
+                model_ref = self._resolve_model_ref_for_dispatch(canvas_document, node_id, bus=bus)
                 model_ref_kwargs = {"model_ref": model_ref} if model_ref is not None else {}
                 # ADR-018 stage 18.4: the auto-policy rung's own catalog/
                 # settings access lives in api_provider, not here (mirrors
@@ -1695,6 +1739,7 @@ class AgentDispatcher:
         on_progress,
         on_success,
         on_failure,
+        knowledge_collection_id: int = 0,
     ) -> None:
         """R5.1: the Web Research independent-slot counterpart to
         start_image_reply above - NOT a variant of _dispatch, since there is
@@ -1717,7 +1762,21 @@ class AgentDispatcher:
         ADR-002 stage 2.4e: migrated onto self._runs, using RunHandle.
         on_cancel (cancel_token.cancel, a plain bound-method callable) -
         the first surface to actually need it, since CancellationToken has
-        no cancel_event-compatible Event to pass instead."""
+        no cancel_event-compatible Event to pass instead.
+
+        ADR-020 stage 20.3: `knowledge_collection_id` (keyword-only,
+        default 0 - the pre-20.3 global/unscoped sentinel, backend/
+        knowledge_store.py's own module docstring) is threaded straight
+        through into WebResearchRequest.knowledge_collection_id, which
+        WebResearchService._retain_documents uses ONLY when the request's
+        own `retain_to_knowledge` is True - see that field's own docstring
+        for why retention is opt-in and off everywhere in production today.
+        The real caller (backend/api/intents_web_research.py's
+        run_web_research) resolves the calling session's current workspace
+        BEFORE calling this method, via backend/knowledge_store.py's own
+        get_or_create_workspace_collection - this method only carries the
+        already-resolved id, it never resolves one itself (same "caller
+        resolves, this method dispatches" split as every other kwarg here)."""
         if self._runs.is_busy("web_research"):
             notifications_state.show("A web research request is already running.", "info")
             await bus.publish("notification")
@@ -1736,6 +1795,7 @@ class AgentDispatcher:
             chat_epoch=0,
             original_query=query,
             branch_history=list(branch_history),
+            knowledge_collection_id=knowledge_collection_id,
         )
 
         async def _invoke(fn, *a):

--- a/backend/api/intents_global_search.py
+++ b/backend/api/intents_global_search.py
@@ -1,0 +1,118 @@
+"""ADR-020 stage 20.4: the "globalSearch" topic's one WS intent - full-text
+search across EVERY workspace's graphs AND real ingested documents at once,
+the backend half of "a phrase in a node of a closed graph in another
+workspace is found and focused" (this stage's own exit criterion).
+
+Read-only, same "just return a value" shape as backend/api/
+intents_knowledge.py's own `search` (that one is deliberately workspace-
+scoped - see its own _resolve_workspace_collection_id docstring; this one
+is deliberately NOT, by default - collection_id=None already means "no
+filter, search everything" to backend.knowledge_store.search_chunks/
+backend.knowledge_retrieval.hybrid_search, which is exactly the cross-
+workspace mechanism this stage needs, not a new one).
+
+Registered on its own "globalSearch" topic rather than folded into
+"knowledge" - a deliberately different, wider-scoped search surface (every
+workspace, not just the calling session's current one), matching this
+codebase's own established practice of one topic per distinct feature
+surface even when the underlying primitives overlap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from backend.events import SessionBus
+from backend.knowledge_retrieval import hybrid_search
+from backend.knowledge_store import DEFAULT_DB_PATH, get_or_create_workspace_collection
+
+_DEFAULT_K = 20
+_MAX_K = 50
+
+_GRAPH_SOURCE_URI_PREFIX = "graph:"
+
+
+@dataclass
+class GlobalSearchArgs:
+    """`workspaceId=None` (the default - a trailing optional positional arg,
+    same "a dataclass field with a default is correctly optional" shape
+    backend/events.py's own _validate_intent_args docstring already
+    documents) searches every workspace's corpus at once - the default,
+    exit-criterion-driving behavior. A real int scopes to exactly that
+    workspace's own knowledge collection, for the optional workspace-filter
+    affordance this stage's own design allows (not required for the exit
+    criterion, but cheap to support given collection_id already accepts
+    either shape)."""
+
+    query: str
+    k: int
+    workspaceId: int | None = None
+
+
+def _graph_id_from_source_uri(source_uri: str) -> int | None:
+    """Parses the synthetic `f"graph:{graph_id}"` scheme backend.
+    knowledge_store.reindex_graph_content writes back OUT into a real int -
+    the inverse of that function's own f-string. Returns None for anything
+    that isn't that exact scheme (a real ingested document's own
+    source_uri - a file path, `branch:{node_id}`, a web URL, ...) or a
+    graph id that somehow failed to parse as an int (defensive; never
+    actually produced by reindex_graph_content itself)."""
+    if not source_uri.startswith(_GRAPH_SOURCE_URI_PREFIX):
+        return None
+    try:
+        return int(source_uri[len(_GRAPH_SOURCE_URI_PREFIX):])
+    except ValueError:
+        return None
+
+
+def _format_global_search_results(results: list[dict]) -> list[dict]:
+    """Mirrors backend/api/intents_knowledge.py's own _format_search_results
+    field-for-field, PLUS `sourceNodeId`/`graphId` - what tells the
+    frontend which of the two jump actions a given result row needs
+    (loadGraphAndFocusNode for a graph/node hit, "knowledge"'s own document-
+    source_uri external-link for a real ingested-document hit): `chunks.
+    source_node_id IS NOT NULL` is a real node id (see backend.
+    knowledge_store's own migration "5"); `graphId` is derived from that
+    SAME row's own `source_uri` ONLY when source_node_id is present - never
+    computed independently, so a real document whose source_uri happens to
+    start with "graph:" (not producible by any real ingestion path today,
+    but not worth trusting blindly either) can never be misread as a graph
+    hit."""
+    formatted = []
+    for result in results:
+        source_node_id = result.get("source_node_id")
+        graph_id = _graph_id_from_source_uri(result["source_uri"]) if source_node_id is not None else None
+        formatted.append({
+            "chunkId": result["chunk_id"],
+            "documentId": result["document_id"],
+            "documentTitle": result["document_title"],
+            "sourceUri": result["source_uri"],
+            "text": result["text"],
+            "offsetStart": result["offset_start"],
+            "offsetEnd": result["offset_end"],
+            "sourceNodeId": source_node_id,
+            "graphId": graph_id,
+        })
+    return formatted
+
+
+def register_global_search_intents(bus: SessionBus) -> None:
+    async def search(query: str, k: int, workspace_id: int | None = None):
+        k = min(max(int(k or _DEFAULT_K), 1), _MAX_K)
+
+        # Same blocking-I/O concern as backend/api/intents_knowledge.py's
+        # own search() - real SQLite I/O (and, for the optional workspace
+        # filter, a real SELECT-or-INSERT), never called inline on the event
+        # loop.
+        def _search():
+            collection_id = (
+                get_or_create_workspace_collection(DEFAULT_DB_PATH, int(workspace_id))
+                if workspace_id is not None else None
+            )
+            return hybrid_search(DEFAULT_DB_PATH, query, k=k, collection_id=collection_id)
+
+        results = await asyncio.to_thread(_search)
+        return {"results": _format_global_search_results(results)}
+
+    bus.register_intent("globalSearch", "search", search, args_schema=GlobalSearchArgs)

--- a/backend/api/intents_knowledge.py
+++ b/backend/api/intents_knowledge.py
@@ -24,11 +24,36 @@ from backend.domain.graph import SceneDocument, SceneError
 from backend.events import SessionBus
 from backend.knowledge_ingest import IngestError, ingest_text
 from backend.knowledge_retrieval import hybrid_search
-from backend.knowledge_store import DEFAULT_DB_PATH
+from backend.knowledge_store import DEFAULT_DB_PATH, get_or_create_workspace_collection
 from backend.notifications import NotificationState
 
 _DEFAULT_K = 5
 _MAX_K = 25
+
+
+def _resolve_workspace_collection_id(document: SceneDocument) -> int:
+    """ADR-020 stage 20.3: every real ingestion/search call in this module
+    scopes to the CALLING SESSION's current workspace - see backend.
+    knowledge_store.get_or_create_workspace_collection's own docstring for
+    the one-collection-per-workspace, auto-created, invisible scoping
+    decision this implements. `document.current_workspace_id` is None for
+    a session that has not yet loaded/created any chat with a real
+    workspace context (see backend/domain/graph.py's own docstring on that
+    field) - falls back to `0`, the pre-20.3 "no collection assigned"
+    global sentinel (backend.knowledge_store's own module docstring), so a
+    fresh, never-loaded session keeps searching/ingesting into the same
+    undifferentiated pool every pre-20.3 build already used, rather than
+    raising or guessing at some arbitrary workspace.
+
+    Real blocking SQLite I/O (a SELECT, or an INSERT the very first time a
+    given workspace ever ingests/searches anything) - callers run this
+    inside asyncio.to_thread, never inline on the event loop, same posture
+    every other blocking-I/O call in this module already follows (see
+    search()'s own comment on hybrid_search)."""
+    workspace_id = document.current_workspace_id
+    if workspace_id is None:
+        return 0
+    return get_or_create_workspace_collection(DEFAULT_DB_PATH, workspace_id)
 
 
 def branch_history_to_text(history: list[dict]) -> str:
@@ -80,12 +105,22 @@ def register_knowledge_intents(
 
     async def search(query, k):
         k = min(max(int(k or _DEFAULT_K), 1), _MAX_K)
+
+        # ADR-020 stage 20.3: scoped to the calling session's current
+        # workspace - see _resolve_workspace_collection_id's own docstring.
+        # Resolution + search both happen inside the SAME to_thread hop
+        # (one thread-pool round trip, not two) since both are real
+        # blocking SQLite I/O against the SAME underlying database file.
+        def _search():
+            collection_id = _resolve_workspace_collection_id(document)
+            return hybrid_search(DEFAULT_DB_PATH, query, k=k, collection_id=collection_id)
+
         # Adversarial-review finding: hybrid_search() does real blocking
         # SQLite I/O (and, when an embedding provider is wired, a network
         # round-trip) - called inline, it would stall the whole event loop
         # for every other connection, unlike every other blocking-I/O
         # intent handler in this codebase (e.g. intents_settings_*.py).
-        results = await asyncio.to_thread(hybrid_search, DEFAULT_DB_PATH, query, k=k)
+        results = await asyncio.to_thread(_search)
         return {"results": _format_search_results(results)}
 
     async def set_chat_index_into_knowledge(node_id, enabled):
@@ -115,13 +150,21 @@ def register_knowledge_intents(
         if enabled:
             history = document.chat_branch_history(node_id)
             text = branch_history_to_text(history)
+
+            # ADR-020 stage 20.3: same workspace-scoping, same single-hop
+            # resolve-then-ingest shape as search() above.
+            def _ingest():
+                collection_id = _resolve_workspace_collection_id(document)
+                return ingest_text(
+                    text,
+                    source_uri=f"branch:{node_id}", title=f"Branch (node {node_id})",
+                    collection_id=collection_id,
+                )
+
             try:
                 # Same blocking-I/O concern as search() above - ingest_text()
                 # does real SQLite writes (chunk + embedding-cache rows).
-                await asyncio.to_thread(
-                    ingest_text, text,
-                    source_uri=f"branch:{node_id}", title=f"Branch (node {node_id})",
-                )
+                await asyncio.to_thread(_ingest)
             except IngestError as exc:
                 if notifications is not None:
                     notifications.show(str(exc), "error")

--- a/backend/api/intents_web_research.py
+++ b/backend/api/intents_web_research.py
@@ -10,11 +10,15 @@ node.
 
 from __future__ import annotations
 
+import asyncio
+
 from backend.agents import AgentDispatcher
 from backend.api._shared import make_publish_scene
 from backend.domain.graph import SceneDocument
 from backend.domain.model import SceneError
 from backend.events import SessionBus
+from backend.knowledge_store import DEFAULT_DB_PATH as KNOWLEDGE_DEFAULT_DB_PATH
+from backend.knowledge_store import get_or_create_workspace_collection
 from backend.notifications import NotificationState
 
 
@@ -75,6 +79,27 @@ def register_web_research_intents(
             document.fail_web_research_run(node_id, cancelled=cancelled, message=str(exc))
             await bus.publish("scene")
 
+        # ADR-020 stage 20.3: resolves the calling session's current
+        # workspace's own knowledge collection BEFORE dispatch, exactly
+        # like every other real ingestion call site in this ADR stage -
+        # cheap (a single indexed SELECT, or an INSERT the very first time
+        # this workspace ever retains anything) but still real blocking
+        # SQLite I/O, so it goes through asyncio.to_thread rather than
+        # running inline on the event loop, same posture as backend/api/
+        # intents_knowledge.py's own search()/set_chat_index_into_
+        # knowledge(). document.current_workspace_id is None for a session
+        # that has not yet loaded/created any chat with a real workspace
+        # context - falls back to 0, the pre-20.3 global/unscoped sentinel
+        # (backend/knowledge_store.py's own module docstring), matching
+        # every other real call site's identical fallback.
+        workspace_id = document.current_workspace_id
+        if workspace_id is None:
+            knowledge_collection_id = 0
+        else:
+            knowledge_collection_id = await asyncio.to_thread(
+                get_or_create_workspace_collection, KNOWLEDGE_DEFAULT_DB_PATH, workspace_id,
+            )
+
         await agent_dispatcher.start_web_research(
             bus=bus,
             notifications_state=notifications,
@@ -85,6 +110,7 @@ def register_web_research_intents(
             on_progress=_on_progress,
             on_success=_on_success,
             on_failure=_on_failure,
+            knowledge_collection_id=knowledge_collection_id,
         )
         return node_id
 

--- a/backend/autosave.py
+++ b/backend/autosave.py
@@ -207,6 +207,14 @@ async def autosave_tick(
         new_chat_id, new_updated_at = await asyncio.to_thread(
             save_chat_atomically_row, db_path, chat_id_for_save, title, chat_data, notes_data, pins_data,
             expected_updated_at=expected_updated_at,
+            # ADR-020 stage 20.2: an autosave tick can be the FIRST write of
+            # a session that started with an explicit New Chat -> pick-a-
+            # workspace, then never got around to a manual Save - see
+            # backend/chat_library.py's own save_chat closure for the
+            # identical reasoning (only consulted on save_chat_atomically_
+            # row's own INSERT branch; a resave of an existing graph ignores
+            # this value entirely).
+            workspace_id=canvas_document.current_workspace_id,
         )
     except ConcurrentSaveConflict:
         # ADR-009 stage 9.2 exit criterion: a lost autosave race must

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -262,6 +262,7 @@ from backend.api.intents_chat_image import register_chat_image_intents  # noqa: 
 from backend.api.intents_code_sandbox import register_code_sandbox_intents  # noqa: E402
 from backend.api.intents_conversation import register_conversation_intents  # noqa: E402
 from backend.api.intents_gitlink import register_gitlink_intents  # noqa: E402
+from backend.api.intents_global_search import register_global_search_intents  # noqa: E402
 from backend.api.intents_grid import register_grid_intents  # noqa: E402
 from backend.api.intents_groups import register_groups_intents  # noqa: E402
 from backend.api.intents_knowledge import register_knowledge_intents  # noqa: E402
@@ -373,6 +374,12 @@ def register_canvas(
     # own docstring.
     register_onboarding_intents(bus, document)
     register_knowledge_intents(bus, document, notifications)
+    # ADR-020 stage 20.4: global cross-workspace search - deliberately takes
+    # no `document` (unlike register_knowledge_intents immediately above,
+    # which scopes to the CALLING session's current workspace) - global
+    # search is workspace-agnostic by design (collection_id=None searches
+    # every workspace's corpus at once - see that module's own docstring).
+    register_global_search_intents(bus)
     register_model_routing_intents(bus, document)
     register_pins_intents(bus, document)
     register_view_intents(bus, document)

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -43,6 +43,7 @@ import re
 import sqlite3
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -101,8 +102,11 @@ class ConcurrentSaveConflict(RuntimeError):
 # handed. ADR-020 stage 20.1 adds version "2": the "chats" table (still
 # created under that name by migration "1" above, unchanged) is renamed to
 # "graphs" and gains a workspace_id column - see
-# _migration_002_workspaces_and_graphs's own docstring.
-CHATS_DB_SCHEMA_VERSION = 2
+# _migration_002_workspaces_and_graphs's own docstring. ADR-020 stage 20.2
+# adds version "3": graphs gains favorite/archived columns and a tags/
+# graph_tags pair - see _migration_003_tags_favorite_archive's own
+# docstring.
+CHATS_DB_SCHEMA_VERSION = 3
 
 
 # ADR-009 stage 9.2: `created_at`/rename_chat's own `updated_at` are written
@@ -691,18 +695,103 @@ def _migration_002_workspaces_and_graphs(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_graphs_workspace_id ON graphs (workspace_id)")
 
 
+def _migration_003_tags_favorite_archive(conn: sqlite3.Connection) -> None:
+    """ADR-020 stage 20.2, migration "3" (2 -> 3): adds the three pieces of
+    per-graph metadata the real Chat Library UI (workspace switcher, tag
+    chips, favorite/archive icon buttons) needs - `graphs.favorite`,
+    `graphs.archived`, and a `tags`/`graph_tags` join-table pair for a
+    many-to-many graph<->tag relationship. Runs inside run_sqlite_migrations'
+    own managed transaction (manual BEGIN/COMMIT/ROLLBACK around
+    isolation_level=None - see that function's docstring, and
+    _migration_001_initial_schema's own docstring above) - must not BEGIN,
+    COMMIT, or ROLLBACK anything itself.
+
+    Deliberately narrow, matching _migration_002_workspaces_and_graphs's own
+    "one small, narrowly-scoped, independently-testable migration step per
+    stage" precedent (see _MIGRATIONS' own comment below) - this migration
+    does not touch workspaces at all, and does not backfill any tag data
+    (every existing graph simply starts untagged/not-favorited/not-archived,
+    which is exactly what favorite/archived's own `DEFAULT 0` and an empty
+    tags table already give it for free).
+
+    FAVORITE/ARCHIVED COLUMNS: unlike migration "2"'s own `workspace_id`
+    (which needed a non-NULL DEFAULT computed at migration time, and so
+    could NOT also declare a REFERENCES clause - see that migration's own
+    docstring for the empirically-verified reason), `favorite`/`archived`
+    have no FK to declare in the first place - a plain `NOT NULL DEFAULT 0`
+    ALTER TABLE ADD COLUMN, guarded exactly like every other ALTER TABLE in
+    this file (PRAGMA table_info probe first, so a second run against an
+    already-migrated database is a pure no-op).
+
+    TAGS/GRAPH_TAGS AND REAL DECLARED FOREIGN KEYS (verified empirically
+    against this project's actual bundled SQLite - 3.50.4 - via a live
+    cascade-delete test, not assumed from documentation alone): CREATE TABLE
+    has no restriction against a REFERENCES clause combined with a NOT NULL
+    column the way ALTER TABLE ADD COLUMN does (migration "2"'s own
+    constraint above is specific to ADD COLUMN) - so graph_tags declares
+    real `REFERENCES graphs (id) ON DELETE CASCADE` / `REFERENCES tags (id)
+    ON DELETE CASCADE` FKs directly, unlike graphs.workspace_id's
+    intentionally-undeclared conceptual FK. This means delete_chat's own
+    "DELETE FROM graphs WHERE id = ?" (which already cascades into notes/
+    pins - see _migration_001_initial_schema's own docstring) now also
+    cascades into graph_tags for free, with no separate cleanup code needed
+    anywhere in this module - _connect() already issues `PRAGMA foreign_keys
+    = ON` on every connection, before any migration or query ever runs, so
+    this cascade is live the instant a graph row is deleted through this
+    module's normal delete_chat path.
+
+    `tags.name` is `UNIQUE COLLATE NOCASE`: two graphs tagging "Work" and
+    "work" share ONE tags row - the case-insensitive collapse the wire
+    contract's own `tags: list[str]` field docstring promises happens at
+    this constraint (backstopped by set_graph_tags' own server-side
+    normalization, which never trusts the client alone to have already
+    collapsed case) rather than needing a second, redundant application-level
+    uniqueness check.
+
+    Guarded exactly like every migration above: CREATE TABLE IF NOT EXISTS,
+    a PRAGMA table_info probe before each ALTER TABLE, CREATE INDEX IF NOT
+    EXISTS - a second run against an already-migrated database is a pure
+    no-op."""
+    graphs_columns = [info[1] for info in conn.execute("PRAGMA table_info(graphs)").fetchall()]
+    if "favorite" not in graphs_columns:
+        conn.execute("ALTER TABLE graphs ADD COLUMN favorite INTEGER NOT NULL DEFAULT 0")
+    if "archived" not in graphs_columns:
+        conn.execute("ALTER TABLE graphs ADD COLUMN archived INTEGER NOT NULL DEFAULT 0")
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tags (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE COLLATE NOCASE
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS graph_tags (
+            graph_id INTEGER NOT NULL REFERENCES graphs (id) ON DELETE CASCADE,
+            tag_id INTEGER NOT NULL REFERENCES tags (id) ON DELETE CASCADE,
+            PRIMARY KEY (graph_id, tag_id)
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_graph_tags_tag_id ON graph_tags (tag_id)")
+
+
 # Keyed by the version each function PRODUCES (migration "1" takes a
 # database from 0 -> 1), matching graphlink_migrations' own ordering
 # convention - see run_sqlite_migrations' docstring. ADR-020 stage 20.1
 # added step "2" (bumping CHATS_DB_SCHEMA_VERSION to 2) for the workspaces/
-# graphs schema change - add step "3" here (and bump CHATS_DB_SCHEMA_VERSION
-# to 3) for the next schema change; never renumber or replace step "1" or
-# step "2" now that both have shipped - each must stay exactly what it is
-# today so it keeps correctly upgrading every already-migrated real
-# database.
+# graphs schema change; stage 20.2 added step "3" (bumping
+# CHATS_DB_SCHEMA_VERSION to 3) for the tags/favorite/archive schema change -
+# add step "4" here (and bump CHATS_DB_SCHEMA_VERSION to 4) for the next
+# schema change; never renumber or replace step "1", "2", or "3" now that
+# all three have shipped - each must stay exactly what it is today so it
+# keeps correctly upgrading every already-migrated real database.
 _MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     1: _migration_001_initial_schema,
     2: _migration_002_workspaces_and_graphs,
+    3: _migration_003_tags_favorite_archive,
 }
 
 
@@ -724,11 +813,32 @@ def get_all_chats(db_path: Path, notifications: NotificationState | None = None)
     # closing() + the connection's own transaction context: sqlite3's
     # `with conn:` commits/rolls back but does NOT close the connection -
     # without closing() the handle would linger until garbage collection.
+    # ADR-020 stage 20.2: workspace_id/favorite/archived are plain columns on
+    # graphs, pulled in the same SELECT as everything else. tags is a
+    # separate query (a graph<->tag many-to-many via graph_tags) rather than
+    # a JOIN against the row SELECT above - a JOIN would multiply each
+    # multi-tagged graph's row once per tag, which this function would then
+    # have to de-duplicate back down anyway; one small second query plus an
+    # in-memory group-by is simpler and, for the corpus size this app
+    # targets (hundreds of graphs, a handful of tags each - see this ADR's
+    # own "send everything, filter locally" design note), not meaningfully
+    # more expensive. Ordered by tag name (COLLATE NOCASE, matching tags.name
+    # itself) so each graph's own tag list already arrives display-sorted -
+    # no second Python-side sort needed.
     with contextlib.closing(_connect(db_path, notifications=notifications)) as conn, conn:
         rows = conn.execute(
-            "SELECT id, title, created_at, updated_at, preview, message_count "
+            "SELECT id, title, created_at, updated_at, preview, message_count, "
+            "workspace_id, favorite, archived "
             "FROM graphs ORDER BY updated_at DESC"
         ).fetchall()
+        tag_rows = conn.execute(
+            "SELECT graph_tags.graph_id, tags.name FROM graph_tags "
+            "JOIN tags ON tags.id = graph_tags.tag_id "
+            "ORDER BY tags.name COLLATE NOCASE"
+        ).fetchall()
+    tags_by_graph_id: dict[int, list[str]] = {}
+    for graph_id, tag_name in tag_rows:
+        tags_by_graph_id.setdefault(int(graph_id), []).append(str(tag_name))
     return [
         {
             "id": int(row[0]),
@@ -739,6 +849,10 @@ def get_all_chats(db_path: Path, notifications: NotificationState | None = None)
             "updatedAtIso": _format_timestamp_iso(row[3]),
             "preview": str(row[4] or ""),
             "messageCount": int(row[5] or 0),
+            "workspaceId": int(row[6]),
+            "favorite": bool(row[7]),
+            "archived": bool(row[8]),
+            "tags": tags_by_graph_id.get(int(row[0]), []),
         }
         for row in rows
     ]
@@ -755,6 +869,155 @@ def rename_chat(db_path: Path, chat_id: int, new_title: str) -> None:
 def delete_chat(db_path: Path, chat_id: int) -> None:
     with contextlib.closing(_connect(db_path)) as conn, conn:
         conn.execute("DELETE FROM graphs WHERE id = ?", (chat_id,))
+
+
+# -- ADR-020 stage 20.2: favorite/archived/tags + workspaces CRUD -----------
+#
+# Deliberately mirror rename_chat/delete_chat's own shape immediately above
+# (explicit db_path param, one function per single-field mutation, no
+# updated_at bump) rather than a single generic "patch this graph" function -
+# each is triggered by one row's own dedicated action button/input in the
+# real UI (a star toggle, an archive toggle, a tag-edit commit), exactly like
+# rename/delete already are, not a bulk list editor (see
+# SettingsManager.set_plugin_grant's own docstring for the precedent this
+# follows: a single-item write path, not McpServersPage's whole-collection
+# replace, for a mutation scoped to one row's own control).
+#
+# NONE of favorite/archived/tags bump `updated_at` (unlike rename_chat above,
+# and unlike save_chat_atomically_row's real content writes) - these are
+# metadata toggles, not content edits, and get_all_chats orders by
+# `updated_at DESC`. Bumping it here would silently re-sort (and re-bucket
+# under a date-grouped UI's "Today" section) every chat a user merely starred
+# or archived, which reads as a bug, not a feature - the same "no
+# reason to disturb the list order" instinct chat_library.py's own audit-fix
+# history already established for loadChat/saveChat's own digest bookkeeping
+# (see _new_save_state's own docstring, point 1).
+
+
+def set_graph_favorite(db_path: Path, graph_id: int, favorite: bool) -> None:
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        conn.execute(
+            "UPDATE graphs SET favorite = ? WHERE id = ?",
+            (1 if favorite else 0, graph_id),
+        )
+
+
+def set_graph_archived(db_path: Path, graph_id: int, archived: bool) -> None:
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        conn.execute(
+            "UPDATE graphs SET archived = ? WHERE id = ?",
+            (1 if archived else 0, graph_id),
+        )
+
+
+def _normalize_tags(tags: list[str]) -> list[str]:
+    """Trim/drop-empty/case-insensitively-dedupe a raw tag list BEFORE it
+    ever reaches SQL - the server-side half of the wire contract's own
+    "don't trust the client alone" requirement (tags.name's own UNIQUE
+    COLLATE NOCASE constraint is the storage-level backstop; this is the
+    Python-level one, so a caller never even attempts a same-collation
+    INSERT that constraint would reject). First-seen casing wins on a
+    collision (["work", "Work"] -> ["work"]) - an arbitrary but deterministic
+    tie-break; which casing "wins" has no behavioral consequence since every
+    lookup and constraint downstream is already case-insensitive."""
+    seen: dict[str, str] = {}
+    for raw in tags:
+        trimmed = str(raw).strip()
+        if not trimmed:
+            continue
+        key = trimmed.casefold()
+        if key not in seen:
+            seen[key] = trimmed
+    return list(seen.values())
+
+
+def set_graph_tags(db_path: Path, graph_id: int, tags: list[str]) -> None:
+    """BULK REPLACE of graph_id's full tag set - not an add/remove delta, per
+    this stage's own wire contract for setGraphTags. Deletes every existing
+    graph_tags row for graph_id, then (re)creates exactly the normalized set:
+    `INSERT OR IGNORE` into tags is what makes a name collision against an
+    EXISTING tag (any casing, thanks to tags.name's own COLLATE NOCASE
+    constraint) a safe no-op instead of a raised IntegrityError, and the
+    follow-up SELECT resolves to whichever row - new or pre-existing - is now
+    the canonical one for that name.
+
+    Orphaned tags (a tags row no graph_tags row references anymore, after
+    this or a later delete_chat's own cascade) are deliberately left in the
+    tags table rather than swept here - a tag a user is actively mid-typing
+    across two different graphs in quick succession should not have its own
+    row vanish and get regenerated with a new id between those two calls,
+    and an unused tags row is cheap (a handful of bytes, no unbounded growth
+    given this app's own "hundreds of graphs" scale)."""
+    normalized = _normalize_tags(tags)
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        conn.execute("DELETE FROM graph_tags WHERE graph_id = ?", (graph_id,))
+        for tag_name in normalized:
+            conn.execute("INSERT OR IGNORE INTO tags (name) VALUES (?)", (tag_name,))
+            tag_row = conn.execute("SELECT id FROM tags WHERE name = ?", (tag_name,)).fetchone()
+            conn.execute(
+                "INSERT OR IGNORE INTO graph_tags (graph_id, tag_id) VALUES (?, ?)",
+                (graph_id, int(tag_row[0])),
+            )
+
+
+def get_all_workspaces(db_path: Path) -> list[dict[str, Any]]:
+    """Every workspace row (including archived ones - the same "backend
+    always sends everything, filtering is client-side" design this whole
+    stage's wire contract already uses for graphs/rows - see this module's
+    own get_all_chats). Ordered by id (creation order), matching
+    workspaces.id's own AUTOINCREMENT semantics - stable and predictable for
+    a switcher-tabs UI, unlike ordering by name (which would reshuffle tabs
+    as workspaces are renamed) or updated_at (workspaces have no such
+    column)."""
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        rows = conn.execute("SELECT id, name, icon, archived FROM workspaces ORDER BY id").fetchall()
+    return [
+        {"id": int(row[0]), "name": str(row[1]), "icon": str(row[2] or ""), "archived": bool(row[3])}
+        for row in rows
+    ]
+
+
+def create_workspace(db_path: Path, name: str) -> dict[str, Any] | None:
+    """Creates a new workspace. Returns the created row's shape (id, name,
+    icon, archived) on success, or None for an empty/whitespace-only name -
+    the caller (createWorkspace's own intent handler) treats a None return as
+    a rejected request: a notification is shown and the topic is NOT
+    republished, matching rename's own `if not title: return` no-mutation
+    convention immediately above rather than silently accepting a blank
+    workspace name."""
+    trimmed = str(name or "").strip()
+    if not trimmed:
+        return None
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        cursor = conn.execute("INSERT INTO workspaces (name) VALUES (?)", (trimmed,))
+        workspace_id = int(cursor.lastrowid)
+    return {"id": workspace_id, "name": trimmed, "icon": "", "archived": False}
+
+
+def rename_workspace(db_path: Path, workspace_id: int, name: str) -> None:
+    title = str(name or "").strip()
+    if not title:
+        return
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        conn.execute("UPDATE workspaces SET name = ? WHERE id = ?", (title, workspace_id))
+
+
+def archive_workspace(db_path: Path, workspace_id: int, archived: bool) -> None:
+    """Archiving/unarchiving a workspace touches ONLY the workspaces row -
+    its graphs are untouched (still `archived = 0` unless a graph was
+    separately archived via set_graph_archived above), matching this stage's
+    own design note that archiving a workspace must not archive or delete
+    the graphs inside it. A UI that hides archived workspaces from its
+    switcher tabs by default (this stage's own real ChatLibraryDialog does)
+    is a client-side filtering choice, not something this function needs to
+    know about - get_all_workspaces above always returns every workspace,
+    archived or not, same "send everything, filter locally" posture as
+    get_all_chats."""
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        conn.execute(
+            "UPDATE workspaces SET archived = ? WHERE id = ?",
+            (1 if archived else 0, workspace_id),
+        )
 
 
 def load_chat_row(db_path: Path, chat_id: int) -> dict[str, Any] | None:
@@ -844,6 +1107,7 @@ def save_chat_atomically_row(
     pins_data: list[dict[str, Any]],
     *,
     expected_updated_at: str | None = None,
+    workspace_id: int | None = None,
 ) -> tuple[int, str]:
     """Mirrors ChatDatabase.save_chat_atomically (database.py:271-315): ONE
     shared connection - UPDATE if `chat_id` is truthy, else INSERT (the
@@ -898,7 +1162,29 @@ def save_chat_atomically_row(
     back after the write. See _TIMESTAMP_DISPLAY_FORMATS' own comment for
     how the display-formatting functions handle both this and the older,
     second-resolution format that pre-9.2 rows and rename_chat's own writes
-    still use."""
+    still use.
+
+    ADR-020 stage 20.2: `workspace_id`, when given (not None), is written
+    ONLY on the INSERT branch below - a resave of an EXISTING graph (the
+    UPDATE branch) never touches which workspace it belongs to, no matter
+    what `workspace_id` a caller happens to pass; the parameter is silently
+    ignored there rather than accepted-but-unused, so a future caller cannot
+    be misled into believing this can move a graph between workspaces.
+    `workspace_id=None` (the default, and what every pre-20.2 caller and
+    test still passes) omits the column from the INSERT entirely, which
+    means the row falls back to `graphs.workspace_id`'s own schema-level
+    `DEFAULT` - the Default workspace's real id, fixed in place by
+    _migration_002_workspaces_and_graphs at the moment it ran - preserving
+    this function's exact pre-20.2 INSERT behavior byte-for-byte. Callers
+    that DO know which workspace a new graph belongs to (backend/
+    chat_library.py's own save_chat closure, reading
+    canvas_document.current_workspace_id - see that field's own docstring in
+    backend/domain/graph.py) are expected to have ALREADY validated the id
+    against a real, current workspace row before calling this - this
+    function trusts the value it is given rather than re-querying
+    workspaces here, matching save_chat_atomically_row's own long-standing
+    "the caller resolves titles/ids, this function only writes" division of
+    labor (see e.g. how `title` itself already arrives fully resolved)."""
     chat_data_json = json.dumps(chat_data)
     preview, message_count = _extract_preview_and_message_count(chat_data)
     with contextlib.closing(_connect(db_path)) as conn:
@@ -924,6 +1210,13 @@ def save_chat_atomically_row(
                         (title, chat_data_json, preview, message_count, now, chat_id),
                     )
                 resolved_chat_id = chat_id
+            elif workspace_id is not None:
+                cursor = conn.execute(
+                    "INSERT INTO graphs (title, data, preview, message_count, updated_at, workspace_id) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (title, chat_data_json, preview, message_count, now, workspace_id),
+                )
+                resolved_chat_id = cursor.lastrowid
             else:
                 cursor = conn.execute(
                     "INSERT INTO graphs (title, data, preview, message_count, updated_at) "
@@ -1234,6 +1527,12 @@ def make_serialize_mutating_intent(
 def chat_library_payload(db_path: Path, notifications: NotificationState | None = None) -> dict[str, Any]:
     try:
         rows = get_all_chats(db_path, notifications=notifications)
+        # ADR-020 stage 20.2: the workspace switcher's own data - fetched
+        # inside the SAME try/except as rows above (a corrupt/locked
+        # chats.db fails both queries the same way, and this stage's own
+        # wire contract has no separate "workspaces failed to load" notice
+        # distinct from "could not load saved chats").
+        workspaces = get_all_workspaces(db_path)
         notice = None
     except sqlite3.Error as exc:
         # Recoverable inline message, matching ChatLibraryBridge's own
@@ -1244,8 +1543,9 @@ def chat_library_payload(db_path: Path, notifications: NotificationState | None 
         # real lock/IO error) - a plain corruption has already self-healed
         # silently by the time get_all_chats would ever raise.
         rows = []
+        workspaces = []
         notice = f"Could not load saved chats: {exc}"
-    return {"rows": rows, "notice": notice}
+    return {"rows": rows, "notice": notice, "workspaces": workspaces}
 
 
 def make_load_chat(
@@ -1449,6 +1749,12 @@ def make_save_chat(
             new_chat_id, new_updated_at = await asyncio.to_thread(
                 save_chat_atomically_row, resolved_path, chat_id_for_save, title, chat_data, notes_data, pins_data,
                 expected_updated_at=expected_updated_at,
+                # ADR-020 stage 20.2: only meaningful on the INSERT branch
+                # (chat_id_for_save falsy) - see save_chat_atomically_row's
+                # own workspace_id docstring. canvas_document.current_
+                # workspace_id was already validated against a real
+                # workspace by new_chat() before it was ever set.
+                workspace_id=canvas_document.current_workspace_id,
             )
         except ConcurrentSaveConflict:
             # ADR-009 stage 9.2 exit criterion: a lost write race is
@@ -1481,6 +1787,59 @@ def make_save_chat(
             await bus.publish("notification")
 
     return save_chat
+
+
+# ADR-020 stage 20.2: args schemas for the 6 new intents on "app-chat-
+# library", matching the ADR-003 dataclass-args_schema convention already
+# established elsewhere in this codebase (backend/plugins.py's
+# ExecutePluginArgs/InvokePluginIntentArgs/SetPluginGrantArgs, backend/
+# notifications.py's ShowMessageArgs) - dataclass FIELD ORDER is the
+# positional mapping dispatch_intent validates a real request's args
+# against (see backend/events.py's _validate_intent_args). This topic's
+# five PRE-EXISTING intents (renameChat/deleteChat/loadChat/saveChat/
+# newChat, all registered with no args_schema at all - verified directly
+# against this file, not assumed) are deliberately left as-is: retrofitting
+# them is unrelated churn outside this stage's own scope, so only the
+# genuinely NEW intents below opt into ADR-003 validation.
+@dataclass
+class SetGraphFavoriteArgs:
+    graphId: int
+    favorite: bool
+
+
+@dataclass
+class SetGraphArchivedArgs:
+    graphId: int
+    archived: bool
+
+
+@dataclass
+class SetGraphTagsArgs:
+    """`tags` is the graph's FULL replacement tag set - a bulk replace, not
+    an add/remove delta. See set_graph_tags' own docstring."""
+
+    graphId: int
+    tags: list[str]
+
+
+@dataclass
+class CreateWorkspaceArgs:
+    name: str
+
+
+@dataclass
+class RenameWorkspaceArgs:
+    workspaceId: int
+    name: str
+
+
+@dataclass
+class ArchiveWorkspaceArgs:
+    """Archiving (or unarchiving) a workspace never touches its graphs -
+    see archive_workspace's own docstring."""
+
+    workspaceId: int
+    archived: bool
 
 
 def register_chat_library(
@@ -1616,7 +1975,7 @@ def register_chat_library(
         bus, resolved_path, canvas_document, notifications, _record_saved, _last_saved, settings_manager,
     )
 
-    async def new_chat():
+    async def new_chat(workspace_id: int | None = None):
         # R6.5: the backend counterpart of legacy's "start with an empty
         # scene" - there is no legacy method this ports 1:1 (Qt's
         # ChatSessionManager has no "new chat" concept at all; a fresh scene
@@ -1625,7 +1984,36 @@ def register_chat_library(
         # exactly like clear_for_load already does for a session LOAD.
         if canvas_document is None:
             return
+
+        # ADR-020 stage 20.2: resolve/validate the caller's requested
+        # workspace BEFORE clear_for_load() below (which itself resets
+        # current_workspace_id to None) - an invalid/unknown workspaceId
+        # (never existed, or since deleted - there is no deleteWorkspace
+        # intent yet, but a caller could still send a stale/bogus id) falls
+        # back to None here. None is exactly what save_chat_atomically_row's
+        # own workspace_id=None default already resolves to the Default
+        # workspace for, via graphs.workspace_id's own schema DEFAULT (see
+        # that function's own docstring) - so "omitted or invalid ->
+        # Default" is satisfied by ONE fallback path, not two. Every OTHER
+        # caller of newChat in the codebase (e.g. commands.ts's palette "new
+        # chat" command) keeps calling this with zero args, which is
+        # `workspace_id=None` here - byte-identical pre-20.2 behavior.
+        resolved_workspace_id: int | None = None
+        if workspace_id is not None:
+            try:
+                candidate_workspace_id = int(workspace_id)
+            except (TypeError, ValueError):
+                candidate_workspace_id = None
+            if candidate_workspace_id is not None:
+                existing_workspace_ids = {
+                    workspace["id"]
+                    for workspace in await asyncio.to_thread(get_all_workspaces, resolved_path)
+                }
+                if candidate_workspace_id in existing_workspace_ids:
+                    resolved_workspace_id = candidate_workspace_id
+
         canvas_document.clear_for_load()
+        canvas_document.current_workspace_id = resolved_workspace_id
         # clear_for_load drops current_chat_id, so the save state that
         # described the old document no longer describes anything.
         _last_saved["digest"] = None
@@ -1633,11 +2021,78 @@ def register_chat_library(
         _last_saved["updated_at"] = None
         await bus.publish("scene")
 
+    # -- ADR-020 stage 20.2: the 6 new intents -------------------------------
+    #
+    # Mirror rename/delete's own shape immediately above: a single
+    # asyncio.to_thread call into the matching CRUD function, then republish
+    # "app-chat-library" so every attached window's list/switcher picks up
+    # the change - the same pattern every existing intent on this topic
+    # already uses. None of these six go through _serialize_mutating_intent -
+    # unlike loadChat/saveChat/newChat, they never touch canvas_document
+    # (the live in-memory scene), only chats.db rows, so there is nothing
+    # here for that guard to serialize against; renameChat/deleteChat (the
+    # topic's two other pre-existing chats.db-only intents) are the same way.
+
+    async def set_favorite(graph_id: int, favorite: bool):
+        await asyncio.to_thread(set_graph_favorite, resolved_path, int(graph_id), bool(favorite))
+        await bus.publish("app-chat-library")
+
+    async def set_archived(graph_id: int, archived: bool):
+        await asyncio.to_thread(set_graph_archived, resolved_path, int(graph_id), bool(archived))
+        await bus.publish("app-chat-library")
+
+    async def set_tags(graph_id: int, tags: list[str]):
+        # Server-side trim/dedupe/case-collapse happens inside
+        # set_graph_tags itself (_normalize_tags) - never trusting the
+        # client's own list, matching this stage's own wire-contract
+        # requirement.
+        await asyncio.to_thread(set_graph_tags, resolved_path, int(graph_id), list(tags))
+        await bus.publish("app-chat-library")
+
+    async def create_ws(name: str):
+        # create_workspace's own empty/whitespace-only guard returns None
+        # without mutating anything - branching on that return value (rather
+        # than re-checking `name` here too) keeps the single source of
+        # truth for "what counts as a valid workspace name" in one place.
+        created = await asyncio.to_thread(create_workspace, resolved_path, name)
+        if created is None:
+            if notifications is not None:
+                notifications.show("Workspace name cannot be empty.", "warning")
+                await bus.publish("notification")
+            return
+        await bus.publish("app-chat-library")
+
+    async def rename_ws(workspace_id: int, name: str):
+        # Same non-empty guard as rename (renameChat) immediately above -
+        # an empty/whitespace name is ignored, no mutation, no error, no
+        # republish.
+        title = str(name or "").strip()
+        if not title:
+            return
+        await asyncio.to_thread(rename_workspace, resolved_path, int(workspace_id), title)
+        await bus.publish("app-chat-library")
+
+    async def archive_ws(workspace_id: int, archived: bool):
+        await asyncio.to_thread(archive_workspace, resolved_path, int(workspace_id), bool(archived))
+        await bus.publish("app-chat-library")
+
     bus.register_intent("app-chat-library", "renameChat", rename)
     bus.register_intent("app-chat-library", "deleteChat", delete)
     bus.register_intent("app-chat-library", "loadChat", _serialize_mutating_intent(load_chat))
     bus.register_intent("app-chat-library", "saveChat", _serialize_mutating_intent(save_chat))
     bus.register_intent("app-chat-library", "newChat", _serialize_mutating_intent(new_chat))
+    bus.register_intent(
+        "app-chat-library", "setGraphFavorite", set_favorite, args_schema=SetGraphFavoriteArgs,
+    )
+    bus.register_intent(
+        "app-chat-library", "setGraphArchived", set_archived, args_schema=SetGraphArchivedArgs,
+    )
+    bus.register_intent("app-chat-library", "setGraphTags", set_tags, args_schema=SetGraphTagsArgs)
+    bus.register_intent("app-chat-library", "createWorkspace", create_ws, args_schema=CreateWorkspaceArgs)
+    bus.register_intent("app-chat-library", "renameWorkspace", rename_ws, args_schema=RenameWorkspaceArgs)
+    bus.register_intent(
+        "app-chat-library", "archiveWorkspace", archive_ws, args_schema=ArchiveWorkspaceArgs,
+    )
 
     if canvas_document is not None and autosave_interval_seconds is not None:
         # R6.6: local import - backend/autosave.py itself imports several
@@ -1744,6 +2199,9 @@ def flush_dirty_session_before_teardown(
         new_chat_id, new_updated_at = save_chat_atomically_row(
             db_path, chat_id_for_save, title, chat_data, notes_data, pins_data,
             expected_updated_at=expected_updated_at,
+            # ADR-020 stage 20.2: same reasoning as make_save_chat's own
+            # save_chat closure - only consulted on the INSERT branch.
+            workspace_id=canvas_document.current_workspace_id,
         )
     except ConcurrentSaveConflict:
         logger.warning(

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -51,6 +51,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 from backend import db_backup
+from backend import knowledge_store
 from backend.canvas import SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -195,6 +196,187 @@ def _extract_preview_and_message_count(chat_data: dict[str, Any]) -> tuple[str, 
         text = str(last_content or "")
     preview = " ".join(text.split())[:_PREVIEW_MAX_CHARS]
     return preview, len(chat_nodes)
+
+
+def _flatten_content_part_text(content: Any) -> str:
+    """Shared by both raw_content (chat) and conversation_history entries
+    (conversation/chat/html) below - the SAME "text is either a plain
+    string, or a list of {"type","text"} content-part dicts, only the
+    text-type parts count" shape _extract_preview_and_message_count above
+    already established as this codebase's own precedent for raw_content
+    specifically; conversation_history messages (backend/domain/
+    content_codec.py's own _serialize_history, each `{"role", "content"}`)
+    use the identical shape for their own `content` field."""
+    if isinstance(content, list):
+        return " ".join(
+            str(part.get("text", "")) for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+    return str(content or "")
+
+
+def _flatten_conversation_history(history: Any) -> str:
+    """ADR-020 stage 20.4: mirrors backend/api/intents_knowledge.py's own
+    branch_history_to_text exactly (same "role: text" per-turn join) -
+    conversation nodes have no OTHER text-bearing field at all (see
+    backend/session_save.py's own _serialize_conversation_node: node_type/
+    conversation_history/is_collapsed, nothing else), so without this a
+    conversation node would be completely unindexable, not even findable
+    by a title (it has none - see _extract_node_index_text's own
+    docstring)."""
+    if not isinstance(history, list):
+        return ""
+    lines = []
+    for turn in history:
+        if not isinstance(turn, dict):
+            continue
+        text = _flatten_content_part_text(turn.get("content")).strip()
+        if text:
+            lines.append(f"{turn.get('role', 'user')}: {text}")
+    return "\n\n".join(lines)
+
+
+# ADR-020 stage 20.4: one dominant, obviously-text-shaped field per kind,
+# ground-truthed against backend/session_save.py's real _NODE_SERIALIZERS
+# (session_save.py:198-527) - the SAVED WIRE key each kind's own serializer
+# actually writes, not a guess at the live domain object's own attribute
+# name (which often differs - e.g. a "code" node's domain field is
+# node.state.code, but _serialize_code_node writes it out under the wire
+# key "code", while an "artifact" node's domain field is node.state.
+# artifact_content but _serialize_artifact_node writes it under the wire
+# key "content", the SAME key "document" nodes use for their own content).
+# NAMED, HONEST GAP: only each kind's single most obviously-dominant
+# prompt/instruction/body field is indexed here - pycoder/code_sandbox's
+# own code/output/analysis, gitlink's own context_xml/proposal_data, plan's
+# own steps, and web_research's own research_result body are NOT indexed,
+# per this stage's own explicit "a reasonable single text field is enough;
+# skip the rest" allowance for kinds with no one obvious whole-content
+# field. "chat" and "conversation" are handled separately, immediately
+# below this map (see _extract_node_index_text).
+_TEXT_FIELD_BY_NODE_TYPE = {
+    "code": "code",
+    "document": "content",
+    "artifact": "content",
+    "thinking": "thinking_text",
+    "html": "html_content",
+    "web_research": "query",
+    "gitlink": "task_prompt",
+    "pycoder": "prompt",
+    "code_sandbox": "prompt",
+    "plan": "goal",
+    "image": "prompt",
+}
+
+
+def _extract_node_index_text(node: dict[str, Any]) -> str:
+    """One indexable text string for a single node in chat_data["nodes"]
+    (the already-serialized wire shape - see _TEXT_FIELD_BY_NODE_TYPE's own
+    docstring for why this is grounded in session_save.py's real per-kind
+    serializers, not guessed). Concatenates the node's own "title" (only
+    "document" nodes and Plugin SDK nodes - backend/session_save.py's own
+    _serialize_plugin_node universal fields - carry one; every other
+    built-in kind has none, so title contributes nothing there, which is
+    fine: title is a bonus, not the only signal) with a best-effort
+    dominant body field:
+
+      chat: raw_content - a plain string, or a list of {"type","text"}
+        content parts - the SAME shape/handling
+        _extract_preview_and_message_count above already established.
+      conversation: its own conversation_history, flattened (see
+        _flatten_conversation_history's own docstring - this is the ONLY
+        text this kind has at all).
+      every kind in _TEXT_FIELD_BY_NODE_TYPE: that one field, verbatim.
+      anything else (a Plugin SDK node not in the map above): falls back
+        to the generic "content" field _serialize_plugin_node's own
+        universal fields always write.
+
+    Returns "" (title + body both empty/absent) for a node with nothing
+    worth indexing - the caller (_extract_indexable_node_chunks) skips
+    writing a chunk row for that node entirely rather than indexing an
+    empty string under a real chunk id."""
+    node_type = node.get("node_type")
+    title = node.get("title")
+    title_text = title.strip() if isinstance(title, str) else ""
+
+    if node_type == "chat":
+        body_text = _flatten_content_part_text(node.get("raw_content")).strip()
+    elif node_type == "conversation":
+        body_text = _flatten_conversation_history(node.get("conversation_history")).strip()
+    else:
+        field_name = _TEXT_FIELD_BY_NODE_TYPE.get(node_type, "content")
+        raw_value = node.get(field_name)
+        body_text = str(raw_value).strip() if isinstance(raw_value, str) else ""
+
+    return " ".join(part for part in (title_text, body_text) if part)
+
+
+def _extract_indexable_node_chunks(chat_data: dict[str, Any]) -> list[tuple[str, str]]:
+    """Walks chat_data["nodes"] (already-serialized, pre-json.dumps - the
+    SAME dict _extract_preview_and_message_count above reads from, at the
+    same save-time point) and returns `[(node_id, text), ...]` for every
+    node with real indexable content - the input backend/knowledge_store.
+    py's own reindex_graph_content turns into one chunks row per node.
+    Nodes with no id, or with _extract_node_index_text returning "" (see
+    that function's own docstring), are skipped outright - never written
+    as an empty chunk under a real id."""
+    chunks: list[tuple[str, str]] = []
+    for node in chat_data.get("nodes", []):
+        if not isinstance(node, dict):
+            continue
+        node_id = node.get("id")
+        if not isinstance(node_id, str) or not node_id:
+            continue
+        text = _extract_node_index_text(node)
+        if text:
+            chunks.append((node_id, text))
+    return chunks
+
+
+def _reindex_graph_into_knowledge_store(
+    graph_id: int,
+    workspace_id: int,
+    title: str,
+    chat_data: dict[str, Any],
+    knowledge_db_path: Path | None,
+) -> None:
+    """The one call site save_chat_atomically_row uses to keep this graph's
+    global-search index in step with what was just written to chats.db -
+    see that function's own docstring for exactly where this runs (after
+    the chats.db write has already committed).
+
+    `knowledge_db_path` resolves knowledge_store.DEFAULT_DB_PATH here, at
+    CALL time (a live module-attribute read via `knowledge_store.
+    DEFAULT_DB_PATH`, never a value captured at import time) when the
+    caller passes None - the same "resolve the real default only when
+    asked to, read fresh every call" idiom this module's own
+    register_chat_library already uses for chats.db's own DEFAULT_DB_PATH.
+    This is what lets backend/tests/conftest.py's own real-user-data guard
+    fixture safely redirect EVERY caller that omits this parameter to a
+    throwaway tmp path by monkeypatching knowledge_store.DEFAULT_DB_PATH
+    alone, with no changes needed to any of this suite's many pre-existing
+    save_chat_atomically_row call sites - see that fixture's own comment.
+
+    Best-effort: indexing failure is logged and swallowed, never raised -
+    the chats.db write this runs after is the correctness-critical one and
+    must never be rolled back or reported as failed over a SECONDARY
+    search-index write. A knowledge.db that is locked, mid corruption-
+    rescue, or otherwise briefly unavailable just means global search is
+    stale for this one graph until its next save, not a lost or corrupted
+    chat."""
+    resolved_knowledge_db_path = (
+        knowledge_db_path if knowledge_db_path is not None else knowledge_store.DEFAULT_DB_PATH
+    )
+    try:
+        node_chunks = _extract_indexable_node_chunks(chat_data)
+        knowledge_store.reindex_graph_content(
+            resolved_knowledge_db_path,
+            graph_id=graph_id, workspace_id=workspace_id, title=title, node_chunks=node_chunks,
+        )
+    except Exception:
+        logger.exception(
+            "save: failed to index graph %s into the knowledge store - global search may be stale",
+            graph_id,
+        )
 
 
 def _connect(
@@ -933,9 +1115,28 @@ def rename_chat(db_path: Path, chat_id: int, new_title: str) -> None:
         )
 
 
-def delete_chat(db_path: Path, chat_id: int) -> None:
+def delete_chat(db_path: Path, chat_id: int, *, knowledge_db_path: Path | None = None) -> None:
+    """ADR-020 stage 20.4: also removes this graph's own indexed content
+    from knowledge_store.py's knowledge.db (backend.knowledge_store.
+    delete_graph_index - the deletion-side mirror of save_chat_atomically_
+    row's own reindex_graph_content call) - a deleted graph's chunks would
+    otherwise linger as a real, jump-to-node-able global-search hit
+    pointing at a graph that no longer exists, a user-visible bug, not a
+    cosmetic one. Best-effort and non-blocking, same posture and same
+    resolve-DEFAULT_DB_PATH-at-call-time shape as save_chat_atomically_row's
+    own indexing call - see _reindex_graph_into_knowledge_store's own
+    docstring for why."""
     with contextlib.closing(_connect(db_path)) as conn, conn:
         conn.execute("DELETE FROM graphs WHERE id = ?", (chat_id,))
+    resolved_knowledge_db_path = (
+        knowledge_db_path if knowledge_db_path is not None else knowledge_store.DEFAULT_DB_PATH
+    )
+    try:
+        knowledge_store.delete_graph_index(resolved_knowledge_db_path, chat_id)
+    except Exception:
+        logger.exception(
+            "delete: failed to remove graph %s's indexed content from the knowledge store", chat_id,
+        )
 
 
 # -- ADR-020 stage 20.2: favorite/archived/tags + workspaces CRUD -----------
@@ -1268,6 +1469,7 @@ def save_chat_atomically_row(
     *,
     expected_updated_at: str | None = None,
     workspace_id: int | None = None,
+    knowledge_db_path: Path | None = None,
 ) -> tuple[int, str]:
     """Mirrors ChatDatabase.save_chat_atomically (database.py:271-315): ONE
     shared connection - UPDATE if `chat_id` is truthy, else INSERT (the
@@ -1344,7 +1546,19 @@ def save_chat_atomically_row(
     function trusts the value it is given rather than re-querying
     workspaces here, matching save_chat_atomically_row's own long-standing
     "the caller resolves titles/ids, this function only writes" division of
-    labor (see e.g. how `title` itself already arrives fully resolved)."""
+    labor (see e.g. how `title` itself already arrives fully resolved).
+
+    ADR-020 stage 20.4: after the chats.db write above has fully committed,
+    this graph's content is re-indexed into knowledge_store.py's own
+    knowledge.db for global search - see _reindex_graph_into_knowledge_
+    store's own docstring for the exact strategy (delete-then-reinsert,
+    since a graph is mutated and re-saved constantly, unlike an immutable-
+    once-ingested file) and why a failure there is logged and swallowed
+    rather than raised. `knowledge_db_path` defaults (None) to
+    knowledge_store.DEFAULT_DB_PATH, resolved at call time - see that
+    helper's own docstring for why this specific resolution shape is what
+    keeps every pre-existing test call site of this function safe from
+    accidentally touching the real ~/.graphlink/knowledge/knowledge.db."""
     chat_data_json = json.dumps(chat_data)
     preview, message_count = _extract_preview_and_message_count(chat_data)
     with contextlib.closing(_connect(db_path)) as conn:
@@ -1433,6 +1647,25 @@ def save_chat_atomically_row(
                     ),
                 )
 
+        # ADR-020 stage 20.4: runs AFTER the `with conn:` block above has
+        # committed (or, on a ConcurrentSaveConflict, never reached here at
+        # all - that exception propagates straight out of the `with conn:`
+        # block, so this line is unreachable for a lost write race, exactly
+        # as it should be: nothing was actually written, so nothing here
+        # needs re-indexing). One extra cheap read on the SAME still-open
+        # connection - graphs.workspace_id is always a real, non-NULL int
+        # for resolved_chat_id regardless of which branch above ran (the
+        # INSERT branches always populate it - explicitly when `workspace_id`
+        # was given, via the schema's own DEFAULT otherwise; the UPDATE
+        # branch never changes it - see this function's own workspace_id
+        # paragraph above), so this is never the graph's SOURCE of workspace
+        # truth, only a resolve-what-was-just-written convenience read.
+        resolved_workspace_id = conn.execute(
+            "SELECT workspace_id FROM graphs WHERE id = ?", (resolved_chat_id,)
+        ).fetchone()[0]
+        _reindex_graph_into_knowledge_store(
+            resolved_chat_id, int(resolved_workspace_id), title, chat_data, knowledge_db_path,
+        )
         return resolved_chat_id, now
 
 
@@ -1640,7 +1873,21 @@ def make_serialize_mutating_intent(
     register_chat_library itself under ADR-002's 300-line registration-
     function cap (stage 2.7). Captures nothing register_chat_library's own
     callers couldn't already reach via bus.chat_mutation_guard, which is
-    the SAME dict passed in here as mutation_in_progress."""
+    the SAME dict passed in here as mutation_in_progress.
+
+    ADR-020 stage 20.4: `wrapped` now RETURNS `handler`'s own return value
+    (see the `return await handler(...)` line below) rather than discarding
+    it - every pre-20.4 intent this wraps (loadChat/saveChat/newChat) is
+    fire-and-forget from the frontend (transport.fireIntent never inspects
+    the resolved value), so this was a silent no-op difference for all
+    three, never previously worth fixing on its own. ADR-020 stage 20.4's
+    own loadGraphAndFocusNode is the first REQUEST/REPLY intent wrapped
+    through this same guard (it needs the SAME reentrancy protection
+    loadChat/saveChat/newChat already get, since it also mutates
+    canvas_document via a real load) - without this fix, dispatch_intent
+    would resolve the frontend's transport.request(...) promise with `None`
+    on every successful call, silently breaking the one thing that makes
+    request/reply the right shape here (see that intent's own docstring)."""
 
     def _claim_guard(owner: str) -> None:
         mutation_in_progress["active"] = True
@@ -1675,7 +1922,7 @@ def make_serialize_mutating_intent(
 
             _claim_guard(USER_OWNER)
             try:
-                await handler(*args, **kwargs)
+                return await handler(*args, **kwargs)
             finally:
                 _release_guard()
 
@@ -1825,6 +2072,148 @@ def make_load_chat(
             await bus.publish("notification")
 
     return load_chat
+
+
+# backend/domain/graph.py's own register_restored_node - used ONLY by the
+# session loader - mints a BRAND NEW id for every node on EVERY restore and
+# permanently discards whatever "id" the saved payload carried (see that
+# function's own docstring: "Assigns a fresh id ... is overwritten here -
+# backend ids are a different namespace/format than legacy's uuid-based
+# persistent ids"). This is deliberate and permanent, not a gap: two
+# DIFFERENT saved graphs' own "id" values routinely collide (each graph's
+# session minted its own "n1, n2, ..." independently), so reusing a saved
+# id verbatim on restore could collide with an already-live node from
+# whatever this document is CURRENTLY holding.
+#
+# Consequence for make_load_graph_and_focus_node below: node_id (sourced
+# from a PAST save's own recorded id - see _extract_indexable_node_chunks)
+# can be looked up directly against canvas_document.nodes ONLY when no
+# restore has happened since that save (the FAST PATH - ids are stable for
+# the entire time one graph stays continuously loaded). The moment a fresh
+# restore runs (the graph was NOT already open), that comparison is
+# comparing two unrelated id namespaces and must not be attempted - see
+# that function's own RELOAD PATH comment for the ordinal-position-based
+# fix this uses instead.
+_NON_REGULAR_NODE_KINDS = frozenset({"note", "chart", "frame", "container"})
+
+
+def make_load_graph_and_focus_node(
+    resolved_path: Path, canvas_document: SceneDocument | None, load_chat: Callable[..., Any],
+):
+    """Factory for register_chat_library's own loadGraphAndFocusNode intent
+    (ADR-020 stage 20.4) - see make_load_chat's own docstring immediately
+    above for why this is a top-level factory rather than a closure defined
+    inline.
+
+    REQUEST/REPLY, not fire-and-forget, unlike loadChat itself (which this
+    reuses without duplicating - see below): the frontend's global-search
+    "jump to this node, even in a graph from another workspace" action
+    needs the target node's real x/y coordinates back in hand before it can
+    call useReactFlow().setCenter(...) - there is no "wait for the next
+    matching scene state" primitive anywhere in this codebase's own
+    transport.ts to build that some other way (only persistent subscribe*
+    helpers), and this stage deliberately does not invent one. Returning
+    the coordinates directly in the resolved reply means the frontend never
+    has to wait for or inspect the "scene" topic separately, and no race is
+    possible: the reply literally cannot resolve before the restore below
+    (when one runs) has fully landed in canvas_document.
+
+    REUSE, NOT DUPLICATION: does exactly what load_chat already does
+    (restore_chat_into_document, set current_chat_id/current_workspace_id,
+    bus.publish("scene"), the "Loaded ..." notification) by calling straight
+    through to the SAME `load_chat` closure register_chat_library's own
+    loadChat intent is built from - not a second, parallel restore
+    implementation. `load_chat` never returns a value (loadChat's own
+    fire-and-forget contract is unchanged - this does not alter that
+    function at all, only calls it), so this function does its own node
+    lookup afterward rather than threading anything back through it.
+
+    FAST PATH vs. RELOAD PATH - see _NON_REGULAR_NODE_KINDS' own comment
+    immediately above for the full "node ids are NOT stable across a
+    restore" reasoning this split exists to handle correctly:
+
+      FAST PATH: `graph_id` already equals canvas_document's own
+      current_chat_id (the target graph is already the one open, so NO
+      restore runs here) - node_id is looked up directly against the live
+      document. Correct because ids never change while a graph stays
+      continuously loaded, and also a cheap, correctness-neutral
+      optimization (skips a pointless full scene reload + notification).
+
+      RELOAD PATH: a different graph was open (or none was), so load_chat
+      runs a REAL restore, which mints entirely new ids for every node -
+      node_id (recorded by a PAST save) can never be compared against
+      those directly. Instead: the saved row is re-read (load_chat_row,
+      the exact same row load_chat itself just restored FROM), node_id's
+      ORDINAL POSITION is found within THAT row's own "nodes" array (the
+      exact array _extract_indexable_node_chunks walked to produce this id
+      in the first place - i.e. this is comparing node_id against the
+      SAME payload it came from, never against live ids), and that ordinal
+      is mapped onto the freshly-restored live document's own "regular"
+      nodes (backend/session_save.py's own build_chat_data writes "nodes"
+      from exactly this filtered, array-ordered set - _NON_REGULAR_NODE_
+      KINDS' own exclusion mirrors that filter without importing session_
+      save.py's private constants) in RESTORE order, which - since
+      session_load.py restores each "nodes" array entry in array order -
+      is the same order as the saved array. The Nth saved entry and the
+      Nth freshly-restored live node are therefore the same node.
+
+    Returns `{"x": ..., "y": ...}` (real floats) on success, or `None` when
+    the target graph could not be loaded (a stale search result pointing at
+    a since-deleted graph - load_chat already shows its own "could not be
+    found" notification for that case, so this function raises nothing
+    further), the target node's own saved id is no longer present in the
+    CURRENT saved row at all (deleted since the graph was last saved/
+    indexed), or the ordinal position it resolves to falls outside the
+    freshly-restored live node list (a node that failed to restore for an
+    unrelated reason shifted every later ordinal down by one - a rare,
+    honestly-accepted degraded case, not a crash) - every one of these is
+    the same honest "the world moved on since this was indexed" outcome, a
+    stale search result, not a bug."""
+
+    async def load_graph_and_focus_node(graph_id: int, node_id: str) -> dict[str, float] | None:
+        if canvas_document is None:
+            return None
+        graph_id = int(graph_id)
+        node_id = str(node_id)
+
+        if canvas_document.current_chat_id == graph_id:
+            # FAST PATH - see this factory's own docstring.
+            node = canvas_document.nodes.get(node_id)
+            return {"x": float(node.x), "y": float(node.y)} if node is not None else None
+
+        await load_chat(graph_id)
+        if canvas_document.current_chat_id != graph_id:
+            # load_chat's own row-not-found branch never adopts graph_id as
+            # current_chat_id - see that function's own docstring/body.
+            # Nothing further to do: it already showed its own "could not
+            # be found" notification.
+            return None
+
+        # RELOAD PATH - see this factory's own docstring for the full
+        # ordinal-position reasoning.
+        row = await asyncio.to_thread(load_chat_row, resolved_path, graph_id)
+        if row is None:
+            return None
+        saved_data = row.get("data")
+        saved_nodes = saved_data.get("nodes", []) if isinstance(saved_data, dict) else []
+        ordinal = next(
+            (index for index, saved_node in enumerate(saved_nodes)
+             if isinstance(saved_node, dict) and saved_node.get("id") == node_id),
+            None,
+        )
+        if ordinal is None:
+            return None
+
+        live_regular_nodes = [
+            live_node for live_node in canvas_document.nodes.values()
+            if live_node.kind not in _NON_REGULAR_NODE_KINDS
+        ]
+        if ordinal >= len(live_regular_nodes):
+            return None
+        node = live_regular_nodes[ordinal]
+        return {"x": float(node.x), "y": float(node.y)}
+
+    return load_graph_and_focus_node
 
 
 def make_save_chat(
@@ -2026,6 +2415,15 @@ class SetWorkspaceDefaultModelArgs:
     modelId: str
 
 
+@dataclass
+class LoadGraphAndFocusNodeArgs:
+    """ADR-020 stage 20.4. See make_load_graph_and_focus_node's own
+    docstring for the full request/reply contract this backs."""
+
+    graphId: int
+    nodeId: str
+
+
 def register_chat_library(
     bus: SessionBus,
     db_path: Path | None = None,
@@ -2155,6 +2553,10 @@ def register_chat_library(
     load_chat = make_load_chat(
         bus, resolved_path, canvas_document, notifications, _record_saved, _last_saved, settings_manager,
     )
+    # ADR-020 stage 20.4: built from the SAME `load_chat` closure just
+    # above, not a second restore implementation - see make_load_graph_
+    # and_focus_node's own docstring.
+    load_graph_and_focus_node = make_load_graph_and_focus_node(resolved_path, canvas_document, load_chat)
     save_chat = make_save_chat(
         bus, resolved_path, canvas_document, notifications, _record_saved, _last_saved, settings_manager,
     )
@@ -2278,6 +2680,18 @@ def register_chat_library(
     bus.register_intent("app-chat-library", "loadChat", _serialize_mutating_intent(load_chat))
     bus.register_intent("app-chat-library", "saveChat", _serialize_mutating_intent(save_chat))
     bus.register_intent("app-chat-library", "newChat", _serialize_mutating_intent(new_chat))
+    # ADR-020 stage 20.4: REQUEST/REPLY (the frontend uses transport.
+    # request(...), not fireIntent) - see make_load_graph_and_focus_node's
+    # own docstring for why this needs the SAME reentrancy guard loadChat/
+    # saveChat/newChat get (it also mutates canvas_document, via load_chat,
+    # on the non-fast-path) and why _serialize_mutating_intent's own recent
+    # "return the handler's result" fix (see that factory's own docstring)
+    # is what makes returning a real value through this wrapper work at all.
+    bus.register_intent(
+        "app-chat-library", "loadGraphAndFocusNode",
+        _serialize_mutating_intent(load_graph_and_focus_node),
+        args_schema=LoadGraphAndFocusNodeArgs,
+    )
     bus.register_intent(
         "app-chat-library", "setGraphFavorite", set_favorite, args_schema=SetGraphFavoriteArgs,
     )

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -105,8 +105,11 @@ class ConcurrentSaveConflict(RuntimeError):
 # _migration_002_workspaces_and_graphs's own docstring. ADR-020 stage 20.2
 # adds version "3": graphs gains favorite/archived columns and a tags/
 # graph_tags pair - see _migration_003_tags_favorite_archive's own
-# docstring.
-CHATS_DB_SCHEMA_VERSION = 3
+# docstring. ADR-020 stage 20.3 adds version "4": workspaces gains a
+# per-workspace default model pin and a (this stage deliberately leaves
+# unpopulated - see that migration's own docstring) knowledge-collection
+# mirror column - see _migration_004_workspace_defaults's own docstring.
+CHATS_DB_SCHEMA_VERSION = 4
 
 
 # ADR-009 stage 9.2: `created_at`/rename_chat's own `updated_at` are written
@@ -778,20 +781,84 @@ def _migration_003_tags_favorite_archive(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_graph_tags_tag_id ON graph_tags (tag_id)")
 
 
+def _migration_004_workspace_defaults(conn: sqlite3.Connection) -> None:
+    """ADR-020 stage 20.3, migration "4" (3 -> 4): gives each workspace its
+    own default model pin (the genuinely new "workspace default" rung of
+    graphlink_model_catalog.resolve_model_ref's chain - see backend/
+    agents.py's _resolve_model_ref_for_dispatch for the real caller this
+    stage finally wires up) plus a knowledge-collection mirror column. Runs
+    inside run_sqlite_migrations' own managed transaction (manual BEGIN/
+    COMMIT/ROLLBACK around isolation_level=None - see that function's
+    docstring, and _migration_001_initial_schema's own docstring above) -
+    must not BEGIN, COMMIT, or ROLLBACK anything itself.
+
+    DEFAULT_MODEL_PROVIDER/DEFAULT_MODEL_ID: `NOT NULL DEFAULT ''` (not
+    NULL-able) - EMPTY STRING is this pair's own "unset" sentinel, checked
+    by get_workspace_default_model below (`if not provider or not
+    model_id: return None`), never SQL NULL. This mirrors graphs.
+    workspace_id's own migration-2 precedent of a plain, undeclared-FK
+    column with a concrete default rather than a nullable one - the
+    resolver that reads these two columns (backend/agents.py's
+    _resolve_model_ref_for_dispatch) needs a value it can compare with a
+    cheap truthiness check on every dispatch, not a three-way NULL/empty/
+    set distinction it would have to special-case.
+
+    KNOWLEDGE_COLLECTION_ID: genuinely nullable (no DEFAULT at all) -
+    unlike the two columns above, NULL here is a real, meaningful "not yet
+    resolved" state, not conflated with any other value. SCOPING DECISION,
+    made explicit here per this stage's own design note (the ADR's own
+    "document this as deliberate, not incomplete"): this column is added
+    to the schema exactly as designed, but THIS STAGE never writes or
+    reads it from any real code path. The single source of truth for
+    "which knowledge_store.py collection belongs to this workspace" is
+    knowledge.db's own `collections.workspace_id` column, resolved via
+    backend/knowledge_store.py's get_or_create_workspace_collection - a
+    plain, cheap, idempotent SELECT-or-INSERT called fresh by every real
+    ingest/search call site (backend/api/intents_knowledge.py, graphlink_
+    plugins/web_research/service.py) on every use, self-healing by
+    construction (a workspace whose collection row is missing, was never
+    created, or was restored from an older knowledge.db backup simply gets
+    a fresh one - see that function's own docstring). A denormalized
+    mirror of that id living in THIS database (chats.db, a separate SQLite
+    file - no declared cross-database FK is possible) would only ever be
+    as fresh as whichever caller last bothered to write it back, and could
+    silently point at a since-restored-away collection id after a
+    knowledge.db corruption rescue; trusting it for real resolution would
+    be strictly WORSE than just asking knowledge.db directly, which is
+    already cheap enough to do unconditionally. The column exists so a
+    future stage that wants to expose/display "this workspace's own
+    knowledge collection" without opening a second database file has
+    somewhere to put that value - reserved, not (yet) wired to anything.
+
+    Guarded exactly like every migration above: a PRAGMA table_info probe
+    before each ALTER TABLE, so a second run against an already-migrated
+    database is a pure no-op."""
+    workspaces_columns = [info[1] for info in conn.execute("PRAGMA table_info(workspaces)").fetchall()]
+    if "default_model_provider" not in workspaces_columns:
+        conn.execute("ALTER TABLE workspaces ADD COLUMN default_model_provider TEXT NOT NULL DEFAULT ''")
+    if "default_model_id" not in workspaces_columns:
+        conn.execute("ALTER TABLE workspaces ADD COLUMN default_model_id TEXT NOT NULL DEFAULT ''")
+    if "knowledge_collection_id" not in workspaces_columns:
+        conn.execute("ALTER TABLE workspaces ADD COLUMN knowledge_collection_id INTEGER")
+
+
 # Keyed by the version each function PRODUCES (migration "1" takes a
 # database from 0 -> 1), matching graphlink_migrations' own ordering
 # convention - see run_sqlite_migrations' docstring. ADR-020 stage 20.1
 # added step "2" (bumping CHATS_DB_SCHEMA_VERSION to 2) for the workspaces/
 # graphs schema change; stage 20.2 added step "3" (bumping
-# CHATS_DB_SCHEMA_VERSION to 3) for the tags/favorite/archive schema change -
-# add step "4" here (and bump CHATS_DB_SCHEMA_VERSION to 4) for the next
-# schema change; never renumber or replace step "1", "2", or "3" now that
-# all three have shipped - each must stay exactly what it is today so it
-# keeps correctly upgrading every already-migrated real database.
+# CHATS_DB_SCHEMA_VERSION to 3) for the tags/favorite/archive schema change;
+# stage 20.3 added step "4" (bumping CHATS_DB_SCHEMA_VERSION to 4) for the
+# workspace-default-model/knowledge-collection-mirror schema change - add
+# step "5" here (and bump CHATS_DB_SCHEMA_VERSION to 5) for the next schema
+# change; never renumber or replace step "1" through "4" now that all four
+# have shipped - each must stay exactly what it is today so it keeps
+# correctly upgrading every already-migrated real database.
 _MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     1: _migration_001_initial_schema,
     2: _migration_002_workspaces_and_graphs,
     3: _migration_003_tags_favorite_archive,
+    4: _migration_004_workspace_defaults,
 }
 
 
@@ -968,30 +1035,106 @@ def get_all_workspaces(db_path: Path) -> list[dict[str, Any]]:
     workspaces.id's own AUTOINCREMENT semantics - stable and predictable for
     a switcher-tabs UI, unlike ordering by name (which would reshuffle tabs
     as workspaces are renamed) or updated_at (workspaces have no such
-    column)."""
+    column).
+
+    ADR-020 stage 20.3: `defaultModelProvider`/`defaultModelId` (both ''
+    when unset - see migration "4"'s own docstring) ride along on every row,
+    same "send everything, filter/render locally" posture as favorite/
+    archived/tags already have on get_all_chats' own rows."""
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        rows = conn.execute("SELECT id, name, icon, archived FROM workspaces ORDER BY id").fetchall()
+        rows = conn.execute(
+            "SELECT id, name, icon, archived, default_model_provider, default_model_id "
+            "FROM workspaces ORDER BY id"
+        ).fetchall()
     return [
-        {"id": int(row[0]), "name": str(row[1]), "icon": str(row[2] or ""), "archived": bool(row[3])}
+        {
+            "id": int(row[0]),
+            "name": str(row[1]),
+            "icon": str(row[2] or ""),
+            "archived": bool(row[3]),
+            "defaultModelProvider": str(row[4] or ""),
+            "defaultModelId": str(row[5] or ""),
+        }
         for row in rows
     ]
 
 
 def create_workspace(db_path: Path, name: str) -> dict[str, Any] | None:
     """Creates a new workspace. Returns the created row's shape (id, name,
-    icon, archived) on success, or None for an empty/whitespace-only name -
-    the caller (createWorkspace's own intent handler) treats a None return as
-    a rejected request: a notification is shown and the topic is NOT
-    republished, matching rename's own `if not title: return` no-mutation
-    convention immediately above rather than silently accepting a blank
-    workspace name."""
+    icon, archived, defaultModelProvider, defaultModelId) on success, or
+    None for an empty/whitespace-only name - the caller (createWorkspace's
+    own intent handler) treats a None return as a rejected request: a
+    notification is shown and the topic is NOT republished, matching
+    rename's own `if not title: return` no-mutation convention immediately
+    above rather than silently accepting a blank workspace name.
+
+    ADR-020 stage 20.3: a brand-new workspace always starts with no default
+    model pinned (empty strings, matching migration "4"'s own DEFAULT '' for
+    every pre-existing row) - a caller sets one afterward via
+    set_workspace_default_model, same "create first, configure after" shape
+    as rename_workspace/archive_workspace already establish for their own
+    fields."""
     trimmed = str(name or "").strip()
     if not trimmed:
         return None
     with contextlib.closing(_connect(db_path)) as conn, conn:
         cursor = conn.execute("INSERT INTO workspaces (name) VALUES (?)", (trimmed,))
         workspace_id = int(cursor.lastrowid)
-    return {"id": workspace_id, "name": trimmed, "icon": "", "archived": False}
+    return {
+        "id": workspace_id, "name": trimmed, "icon": "", "archived": False,
+        "defaultModelProvider": "", "defaultModelId": "",
+    }
+
+
+def get_workspace_default_model(db_path: Path, workspace_id: int) -> tuple[str, str] | None:
+    """ADR-020 stage 20.3: the workspace-default rung's own read path - the
+    real caller is backend/agents.py's _resolve_model_ref_for_dispatch,
+    which builds the actual graphlink_model_catalog.ModelRef itself (this
+    module deliberately does not import that root module just to construct
+    one - matching every other "this module returns plain data, the caller
+    builds domain types" split already established here, e.g. get_all_chats
+    returning plain dicts rather than SceneNode instances).
+
+    Returns (provider, model_id), or None when workspace_id does not exist
+    OR has no default set - EITHER column empty counts as "no default" (a
+    half-set pair, only reachable via a UI bug or a hand-edited row, is
+    treated exactly like a fully-unset one, never a confusing partial
+    resolution - see set_workspace_default_model's own docstring for the
+    write-side half of this same posture)."""
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        row = conn.execute(
+            "SELECT default_model_provider, default_model_id FROM workspaces WHERE id = ?",
+            (workspace_id,),
+        ).fetchone()
+    if row is None:
+        return None
+    provider = str(row[0] or "").strip()
+    model_id = str(row[1] or "").strip()
+    if not provider or not model_id:
+        return None
+    return provider, model_id
+
+
+def set_workspace_default_model(db_path: Path, workspace_id: int, provider: str, model_id: str) -> None:
+    """ADR-020 stage 20.3: sets (or, given ("", "") for both, CLEARS - see
+    migration "4"'s own docstring on empty-string being this pair's "unset"
+    sentinel) the workspace's own default model pin. Both fields write
+    together, mirroring backend/domain/branches.py's own set_model_override
+    "no partial value" posture for the node/branch-level pin this rung sits
+    directly below in graphlink_model_catalog.resolve_model_ref's chain -
+    trimmed independently rather than validated-as-a-pair, so a genuinely
+    partial write (one empty, one not - a UI bug, never something the real
+    ChatLibraryDialog picker can produce) resolves to "no default set"
+    (get_workspace_default_model's own either-empty-counts-as-unset check)
+    rather than a confusing half-set state, matching create_workspace's own
+    trim-not-reject posture for `name`."""
+    provider = str(provider or "").strip()
+    model_id = str(model_id or "").strip()
+    with contextlib.closing(_connect(db_path)) as conn, conn:
+        conn.execute(
+            "UPDATE workspaces SET default_model_provider = ?, default_model_id = ? WHERE id = ?",
+            (provider, model_id, workspace_id),
+        )
 
 
 def rename_workspace(db_path: Path, workspace_id: int, name: str) -> None:
@@ -1022,10 +1165,10 @@ def archive_workspace(db_path: Path, workspace_id: int, archived: bool) -> None:
 
 def load_chat_row(db_path: Path, chat_id: int) -> dict[str, Any] | None:
     """Mirrors ChatDatabase.load_chat, extended for ADR-009 stage 9.2:
-    {"title", "data", "updated_at"} with `data` already json.loads()'d, or
-    None if the id doesn't exist (a chat deleted from another window/
-    process between the library listing and this call - the caller shows a
-    real notice, not a crash).
+    {"title", "data", "updated_at", "workspace_id"} with `data` already
+    json.loads()'d, or None if the id doesn't exist (a chat deleted from
+    another window/process between the library listing and this call - the
+    caller shows a real notice, not a crash).
 
     `updated_at` (new in stage 9.2) is the value optimistic concurrency is
     built on: the caller that loads a chat is expected to carry THIS exact
@@ -1034,14 +1177,31 @@ def load_chat_row(db_path: Path, chat_id: int) -> dict[str, Any] | None:
     hand it back as save_chat_atomically_row's expected_updated_at when it
     later saves - never re-read moments before that save, which would
     trivially always match and defeat the whole point of detecting a race
-    against some OTHER writer that saved in between."""
+    against some OTHER writer that saved in between.
+
+    `workspace_id` (new in ADR-020 stage 20.3): every graphs row always
+    carries a real, non-NULL one (graphs.workspace_id's own schema DEFAULT,
+    set at INSERT time by save_chat_atomically_row/migration "2" - see
+    those functions' own docstrings), so this is never None for an
+    existing row. ADVERSARIAL-REVIEW FIX: pre-20.3, loadChat's own closure
+    (below) never read this column at all, so
+    canvas_document.current_workspace_id stayed at whatever newChat last
+    left it (usually None) even after loading a chat that plainly belongs
+    to some OTHER, real workspace - meaning THIS stage's own workspace-
+    default model rung (backend/agents.py's _resolve_model_ref_for_dispatch)
+    and workspace-scoped knowledge corpus (backend/api/intents_knowledge.py)
+    would have silently resolved against the WRONG workspace (or none at
+    all) for the single most common real flow, opening an existing chat and
+    continuing the conversation - not just a brand-new chat started via
+    newChat(workspaceId=...). Fixed here, at the one place every load
+    already reads this row, rather than only in the callers that needed it."""
     with contextlib.closing(_connect(db_path)) as conn, conn:
         row = conn.execute(
-            "SELECT title, data, updated_at FROM graphs WHERE id = ?", (chat_id,)
+            "SELECT title, data, updated_at, workspace_id FROM graphs WHERE id = ?", (chat_id,)
         ).fetchone()
     if row is None:
         return None
-    return {"title": row[0], "data": json.loads(row[1]), "updated_at": row[2]}
+    return {"title": row[0], "data": json.loads(row[1]), "updated_at": row[2], "workspace_id": row[3]}
 
 
 def load_notes_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
@@ -1597,6 +1757,17 @@ def make_load_chat(
             # one - the backend analog of ChatSessionManager.current_chat_id
             # being set from the load path, not just the save path.
             canvas_document.current_chat_id = int(chat_id)
+            # ADR-020 stage 20.3 adversarial-review fix: mirror the SAME
+            # "set from the load path, not just newChat" treatment onto
+            # current_workspace_id - see load_chat_row's own docstring for
+            # the real gap this closes (pre-fix, opening an existing chat
+            # left current_workspace_id wherever newChat last set it,
+            # usually None, so this stage's own workspace-scoped model/
+            # knowledge resolution would silently miss the workspace the
+            # loaded chat actually belongs to). row["workspace_id"] is
+            # always a real int for an existing row (graphs.workspace_id's
+            # own NOT NULL DEFAULT), never None.
+            canvas_document.current_workspace_id = row.get("workspace_id")
             # Audit fix: the document now matches this row exactly, so record
             # that. Without it the first tick after a load rewrote a
             # byte-identical row and bumped updated_at, re-sorting the Chat
@@ -1842,6 +2013,19 @@ class ArchiveWorkspaceArgs:
     archived: bool
 
 
+@dataclass
+class SetWorkspaceDefaultModelArgs:
+    """ADR-020 stage 20.3. `provider`/`modelId` both "" clears the
+    workspace's default (set_workspace_default_model's own "both empty ->
+    unset" contract) - the frontend's own picker sends both fields
+    together on every real change, same "no partial value" shape
+    set_model_override's own wire-side callers already follow."""
+
+    workspaceId: int
+    provider: str
+    modelId: str
+
+
 def register_chat_library(
     bus: SessionBus,
     db_path: Path | None = None,
@@ -2076,6 +2260,19 @@ def register_chat_library(
         await asyncio.to_thread(archive_workspace, resolved_path, int(workspace_id), bool(archived))
         await bus.publish("app-chat-library")
 
+    async def set_workspace_default_model_intent(workspace_id: int, provider: str, model_id: str):
+        # ADR-020 stage 20.3: same shape as every other single-field
+        # workspace mutation above - one asyncio.to_thread call into the
+        # matching CRUD function, then republish so the switcher's own
+        # settings affordance picks up the new value. Never touches
+        # canvas_document (only a chats.db row), so - like createWorkspace/
+        # renameWorkspace/archiveWorkspace above - it does not go through
+        # _serialize_mutating_intent.
+        await asyncio.to_thread(
+            set_workspace_default_model, resolved_path, int(workspace_id), str(provider), str(model_id),
+        )
+        await bus.publish("app-chat-library")
+
     bus.register_intent("app-chat-library", "renameChat", rename)
     bus.register_intent("app-chat-library", "deleteChat", delete)
     bus.register_intent("app-chat-library", "loadChat", _serialize_mutating_intent(load_chat))
@@ -2092,6 +2289,10 @@ def register_chat_library(
     bus.register_intent("app-chat-library", "renameWorkspace", rename_ws, args_schema=RenameWorkspaceArgs)
     bus.register_intent(
         "app-chat-library", "archiveWorkspace", archive_ws, args_schema=ArchiveWorkspaceArgs,
+    )
+    bus.register_intent(
+        "app-chat-library", "setWorkspaceDefaultModel", set_workspace_default_model_intent,
+        args_schema=SetWorkspaceDefaultModelArgs,
     )
 
     if canvas_document is not None and autosave_interval_seconds is not None:

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -17,7 +17,10 @@ Reads/writes the SAME real ~/.graphlink/chats.db file the legacy app uses
 (same "chats"/"notes"/"pins" table schemas, same queries, same migration
 ALTER TABLEs for older databases, same _format_timestamp display format moved
 verbatim from graphlink_chat_library_bridge.py) - list, rename, delete,
-load, save, and new are ALL genuinely real here as of R6.5.
+load, save, and new are ALL genuinely real here as of R6.5. ADR-020 stage
+20.1 renamed the "chats" table itself to "graphs" (see
+_migration_002_workspaces_and_graphs) - the .db FILENAME and every other
+table/query/function/topic/intent name below are unaffected.
 
 R6.5's save_chat_atomically_row mirrors ChatDatabase.save_chat_atomically
 exactly: ONE shared connection for the chats-row write (UPDATE if a
@@ -95,8 +98,11 @@ class ConcurrentSaveConflict(RuntimeError):
 # the full schema every _ensure_* probe used to (re)create piecemeal on
 # every connection - see _migration_001_initial_schema's own docstring for
 # exactly what that migration does and does not assume about the DB it's
-# handed.
-CHATS_DB_SCHEMA_VERSION = 1
+# handed. ADR-020 stage 20.1 adds version "2": the "chats" table (still
+# created under that name by migration "1" above, unchanged) is renamed to
+# "graphs" and gains a workspace_id column - see
+# _migration_002_workspaces_and_graphs's own docstring.
+CHATS_DB_SCHEMA_VERSION = 2
 
 
 # ADR-009 stage 9.2: `created_at`/rename_chat's own `updated_at` are written
@@ -587,15 +593,116 @@ def _migration_001_initial_schema(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_pins_chat_id ON pins (chat_id)")
 
 
+def _migration_002_workspaces_and_graphs(conn: sqlite3.Connection) -> None:
+    """ADR-020 stage 20.1, migration "2" (1 -> 2): introduces the workspace
+    organizing unit. Every existing chat becomes a graph in one backfilled
+    "Default" workspace - no data loss, no user action required. Runs
+    inside run_sqlite_migrations' own managed transaction (manual BEGIN/
+    COMMIT/ROLLBACK around isolation_level=None - see that function's
+    docstring, and _migration_001_initial_schema's own docstring above) -
+    must not BEGIN, COMMIT, or ROLLBACK anything itself.
+
+    Deliberately narrow, matching ADR-020 stage 20.1's own exit criterion
+    ("pre-migration chats.db loads identically; all chats in Default
+    workspace"): adds ONLY `workspaces` + `graphs.workspace_id`. Tags/
+    favorite/archive are stage 20.2's own migration, landing alongside the
+    UI that actually uses them - not bundled in here, matching this
+    module's own "one small, narrowly-scoped, independently-testable
+    migration step per stage, never one big migration for the whole ADR"
+    precedent (see _MIGRATIONS' own comment below).
+
+    Deliberately does NOT rename the on-disk .db FILE (stays chats.db) or
+    any Python function/WS-topic/intent name in this module - only the SQL
+    TABLE "chats" renames to "graphs". Every query below this point in the
+    module was updated to match (get_all_chats/rename_chat/delete_chat/
+    load_chat_row/save_chat_atomically_row's own SQL strings) - so this
+    module now reads a little oddly for one stage (Python functions named
+    "chat" querying a table named "graphs"). That is an intentional,
+    temporary, honest incremental-migration tradeoff: renaming the user-
+    facing API/UI surface to "graph"/"workspace" terminology belongs to
+    stage 20.2, which is doing the real UI rework anyway and can rename
+    topic/intents/dialog title as part of that same, already-UI-touching
+    change - not an oversight here.
+
+    TABLE RENAME AND FOREIGN KEYS (verified empirically against this
+    project's actual bundled SQLite - 3.50.4, `PRAGMA legacy_alter_table`
+    reads 0/off by default - not assumed from documentation alone): `ALTER
+    TABLE chats RENAME TO graphs` correctly rewrites notes/pins' own
+    `FOREIGN KEY (chat_id) REFERENCES chats (id)` declarations to point at
+    "graphs" automatically (confirmed via `PRAGMA foreign_key_list` on
+    notes/pins after the rename, and a live cascade-delete-through-the-
+    renamed-table check) - no separate fix-up of notes/pins is needed or
+    done here.
+
+    `workspace_id` deliberately carries a plain `NOT NULL DEFAULT
+    <default_workspace_id>` with NO `REFERENCES workspaces (id)` clause -
+    verified empirically that SQLite's `ALTER TABLE ... ADD COLUMN` rejects
+    a REFERENCES clause combined with a non-NULL DEFAULT ("Cannot add a
+    REFERENCES column with non-NULL default value" - raised as
+    sqlite3.OperationalError), which every pre-existing graph row here
+    needs (the column is NOT NULL, so there is no NULL-then-backfill
+    option once it's added). Same no-declared-FK shape as this module's own
+    sibling store, backend/knowledge_store.py's `documents.collection_id` -
+    a conceptual foreign key enforced by this codebase's own CRUD, not a
+    declared SQLite constraint.
+
+    Guarded exactly like _migration_001_initial_schema: CREATE TABLE IF NOT
+    EXISTS, a PRAGMA table_info probe before each ALTER TABLE, CREATE INDEX
+    IF NOT EXISTS - a second run against an already-migrated database (or a
+    database that reaches this migration having already been renamed to
+    "graphs" by some earlier run of this same function) is a pure no-op,
+    matching that function's own idempotency discipline."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS workspaces (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            icon TEXT NOT NULL DEFAULT '',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            archived INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+    existing_default = conn.execute("SELECT id FROM workspaces WHERE name = 'Default'").fetchone()
+    if existing_default is not None:
+        # A second run of this migration (already-migrated db reconnecting,
+        # or this exact function somehow invoked twice) - reuse the SAME
+        # Default workspace row rather than creating a duplicate.
+        default_workspace_id = int(existing_default[0])
+    else:
+        cursor = conn.execute("INSERT INTO workspaces (name) VALUES ('Default')")
+        default_workspace_id = int(cursor.lastrowid)
+
+    # "chats" still exists under its old name - a database at version 0/1
+    # that hasn't seen this migration yet (real user data, or the fresh-db
+    # case where migration "1" just created it moments ago in this SAME
+    # transaction). On an already-migrated database PRAGMA table_info
+    # returns [] here (nothing named "chats" anymore) and the rename is
+    # skipped, matching migration "1"'s own guarded-ALTER-TABLE idiom.
+    chats_columns = [info[1] for info in conn.execute("PRAGMA table_info(chats)").fetchall()]
+    if chats_columns:
+        conn.execute("ALTER TABLE chats RENAME TO graphs")
+
+    graphs_columns = [info[1] for info in conn.execute("PRAGMA table_info(graphs)").fetchall()]
+    if "workspace_id" not in graphs_columns:
+        conn.execute(
+            f"ALTER TABLE graphs ADD COLUMN workspace_id INTEGER NOT NULL DEFAULT {default_workspace_id}"
+        )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_graphs_workspace_id ON graphs (workspace_id)")
+
+
 # Keyed by the version each function PRODUCES (migration "1" takes a
 # database from 0 -> 1), matching graphlink_migrations' own ordering
-# convention - see run_sqlite_migrations' docstring. The stage 9.2 agent
-# building backups/corrupt-rescue on top of this: add step "2" here (and
-# bump CHATS_DB_SCHEMA_VERSION to 2) for any further schema change, never
-# renumber or replace step "1" - it must stay exactly what it is today so it
-# keeps correctly upgrading every already-migrated real database.
+# convention - see run_sqlite_migrations' docstring. ADR-020 stage 20.1
+# added step "2" (bumping CHATS_DB_SCHEMA_VERSION to 2) for the workspaces/
+# graphs schema change - add step "3" here (and bump CHATS_DB_SCHEMA_VERSION
+# to 3) for the next schema change; never renumber or replace step "1" or
+# step "2" now that both have shipped - each must stay exactly what it is
+# today so it keeps correctly upgrading every already-migrated real
+# database.
 _MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     1: _migration_001_initial_schema,
+    2: _migration_002_workspaces_and_graphs,
 }
 
 
@@ -620,7 +727,7 @@ def get_all_chats(db_path: Path, notifications: NotificationState | None = None)
     with contextlib.closing(_connect(db_path, notifications=notifications)) as conn, conn:
         rows = conn.execute(
             "SELECT id, title, created_at, updated_at, preview, message_count "
-            "FROM chats ORDER BY updated_at DESC"
+            "FROM graphs ORDER BY updated_at DESC"
         ).fetchall()
     return [
         {
@@ -640,14 +747,14 @@ def get_all_chats(db_path: Path, notifications: NotificationState | None = None)
 def rename_chat(db_path: Path, chat_id: int, new_title: str) -> None:
     with contextlib.closing(_connect(db_path)) as conn, conn:
         conn.execute(
-            "UPDATE chats SET title = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            "UPDATE graphs SET title = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
             (new_title, chat_id),
         )
 
 
 def delete_chat(db_path: Path, chat_id: int) -> None:
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        conn.execute("DELETE FROM chats WHERE id = ?", (chat_id,))
+        conn.execute("DELETE FROM graphs WHERE id = ?", (chat_id,))
 
 
 def load_chat_row(db_path: Path, chat_id: int) -> dict[str, Any] | None:
@@ -667,7 +774,7 @@ def load_chat_row(db_path: Path, chat_id: int) -> dict[str, Any] | None:
     against some OTHER writer that saved in between."""
     with contextlib.closing(_connect(db_path)) as conn, conn:
         row = conn.execute(
-            "SELECT title, data, updated_at FROM chats WHERE id = ?", (chat_id,)
+            "SELECT title, data, updated_at FROM graphs WHERE id = ?", (chat_id,)
         ).fetchone()
     if row is None:
         return None
@@ -800,7 +907,7 @@ def save_chat_atomically_row(
             if chat_id:
                 if expected_updated_at is not None:
                     cursor = conn.execute(
-                        "UPDATE chats SET title = ?, data = ?, preview = ?, message_count = ?, "
+                        "UPDATE graphs SET title = ?, data = ?, preview = ?, message_count = ?, "
                         "updated_at = ? WHERE id = ? AND updated_at = ?",
                         (title, chat_data_json, preview, message_count, now, chat_id, expected_updated_at),
                     )
@@ -812,14 +919,14 @@ def save_chat_atomically_row(
                         )
                 else:
                     conn.execute(
-                        "UPDATE chats SET title = ?, data = ?, preview = ?, message_count = ?, "
+                        "UPDATE graphs SET title = ?, data = ?, preview = ?, message_count = ?, "
                         "updated_at = ? WHERE id = ?",
                         (title, chat_data_json, preview, message_count, now, chat_id),
                     )
                 resolved_chat_id = chat_id
             else:
                 cursor = conn.execute(
-                    "INSERT INTO chats (title, data, preview, message_count, updated_at) "
+                    "INSERT INTO graphs (title, data, preview, message_count, updated_at) "
                     "VALUES (?, ?, ?, ?, ?)",
                     (title, chat_data_json, preview, message_count, now),
                 )

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -204,6 +204,25 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
     # New Chat confirm skips only when the canvas is empty AND there is no
     # current chat - a predicate the frontend cannot evaluate without it.
     current_chat_id: int | None = None
+    # ADR-020 stage 20.2: which workspace the NEXT save of this document
+    # should INSERT a brand-new graph row into, or None to fall back to the
+    # Default workspace (see save_chat_atomically_row's own workspace_id
+    # docstring in backend/chat_library.py for exactly how this is
+    # consumed). Set by the newChat intent's own optional workspaceId
+    # argument (backend/chat_library.py's new_chat closure, ALREADY
+    # validated against a real, current workspace row by that closure before
+    # it ever reaches here - this field trusts whatever it holds), left None
+    # for a session that never called newChat with an explicit workspace
+    # (every pre-20.2 caller, and the zero-arg newChat() every non-library
+    # caller like commands.ts's palette command still uses). Deliberately
+    # NOT consulted for an UPDATE of an EXISTING graph (current_chat_id
+    # truthy) - resaving a chat never moves it to a different workspace, no
+    # matter what this field holds; only a fresh INSERT reads it. Reset to
+    # None by clear_for_load below, same "fresh session default" list
+    # current_chat_id is already in - a freshly loaded OR freshly cleared
+    # scene has no pending workspace assignment of its own until the next
+    # newChat call sets one.
+    current_workspace_id: int | None = None
     # ADR-014 stage 14.2: the live-wire half of the Plugin SDK's generic
     # persistence seam - keyed by a plugin's ALREADY-namespaced node kind
     # (f"{plugin_id}.{kind}", HostContext.register_node_kind's own
@@ -441,6 +460,7 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
         self.scroll_y = 0.0
         self.total_session_tokens = 0
         self.current_chat_id = None
+        self.current_workspace_id = None
         # ADR-010 stage 10.1: undo history does NOT survive a session load.
         # Every command in it references node/edge ids from the document
         # being replaced, so inverting one afterward would resurrect a node

--- a/backend/knowledge_embeddings.py
+++ b/backend/knowledge_embeddings.py
@@ -174,6 +174,11 @@ def vector_search(
             "token_count": rows[i]["token_count"],
             "offset_start": rows[i]["offset_start"], "offset_end": rows[i]["offset_end"],
             "document_title": rows[i]["document_title"], "source_uri": rows[i]["source_uri"],
+            # ADR-020 stage 20.4: propagated straight through from
+            # list_embeddings_for_search's own row shape - see that
+            # function's own docstring for why a fused hybrid_search()
+            # result needs this even when found only via this vector path.
+            "source_node_id": rows[i]["source_node_id"],
             "score": float(similarities[i]),
         }
         for i in order

--- a/backend/knowledge_store.py
+++ b/backend/knowledge_store.py
@@ -70,6 +70,7 @@ from typing import Any, NamedTuple
 from backend import db_backup
 from backend.notifications import NotificationState
 from graphlink_migrations import run_sqlite_migrations
+from graphlink_token_estimator import TokenEstimator
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,7 @@ BACKUP_FILENAME_PREFIX = "knowledge-"
 # a mid-batch crash without re-snapshotting on every single document.
 BACKUP_CADENCE_SECONDS = 600.0
 
-KNOWLEDGE_DB_SCHEMA_VERSION = 4
+KNOWLEDGE_DB_SCHEMA_VERSION = 5
 
 
 def content_hash(text: str) -> str:
@@ -271,11 +272,40 @@ def _migration_004_workspace_scoped_collections(conn: sqlite3.Connection) -> Non
     conn.execute("CREATE INDEX IF NOT EXISTS idx_collections_workspace_id ON collections (workspace_id)")
 
 
+def _migration_005_graph_node_chunks(conn: sqlite3.Connection) -> None:
+    """4 -> 5 (ADR-020 stage 20.4): `chunks.source_node_id` - the column
+    that lets a search HIT be traced back to which node, inside which
+    graph, produced it. NULL for every chunk that predates this stage (a
+    real ingested document's chunk - backend.knowledge_ingest's own
+    add_document_with_chunks call path never sets it) and for every chunk
+    a real document ingest produces from here on too; populated ONLY by
+    backend/chat_library.py's own graph-reindexing path
+    (knowledge_store.reindex_graph_content, below), one row per node in a
+    saved chat graph.
+
+    `documents.source_uri` already uniquely identifies WHICH graph a chunk
+    came from (the synthetic `f"graph:{graph_id}"` scheme reindex_graph_
+    content writes - see that function's own docstring), so no analogous
+    "source_graph_id" column is needed on either table: the graph id is
+    always one `int(source_uri.removeprefix("graph:"))` away from a
+    document row already joined into every real query here (search_chunks,
+    below).
+
+    Guarded exactly like every migration in this module and its sibling
+    backend/chat_library.py: a PRAGMA table_info probe before the ALTER
+    TABLE, so a second run against an already-migrated database is a pure
+    no-op."""
+    chunks_columns = [info[1] for info in conn.execute("PRAGMA table_info(chunks)").fetchall()]
+    if "source_node_id" not in chunks_columns:
+        conn.execute("ALTER TABLE chunks ADD COLUMN source_node_id TEXT")
+
+
 _MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     1: _migration_001_initial_schema,
     2: _migration_002_fts5_lexical_index,
     3: _migration_003_vector_index,
     4: _migration_004_workspace_scoped_collections,
+    5: _migration_005_graph_node_chunks,
 }
 
 
@@ -613,6 +643,155 @@ def delete_document(db_path: Path, document_id: int) -> bool:
         conn.close()
 
 
+# -- graph node indexing (ADR-020 stage 20.4) --------------------------------
+#
+# One `documents` row per GRAPH (source_uri = f"graph:{graph_id}", a
+# synthetic scheme that can never collide with a real file/branch/web-
+# research source_uri - the CALLING code is what feeds `node_chunks`,
+# already normalized per-node text - see backend/chat_library.py's own
+# node-content normalization), one `chunks` row per NODE inside it. Unlike
+# add_document_with_chunks's content-hash idempotency (built for immutable-
+# once-ingested files), a graph is mutated and re-saved constantly - see
+# reindex_graph_content's own docstring for why this is delete-then-
+# reinsert on every call instead.
+
+
+def _graph_source_uri(graph_id: int) -> str:
+    return f"graph:{graph_id}"
+
+
+def reindex_graph_content(
+    db_path: Path,
+    *,
+    graph_id: int,
+    workspace_id: int,
+    title: str,
+    node_chunks: list[tuple[str, str]],
+    notifications: NotificationState | None = None,
+    last_saved: dict[str, Any] | None = None,
+) -> None:
+    """The graph re-indexing strategy this stage's own design settled on:
+    graphs are MUTABLE (unlike a real ingested file - this module's own
+    content-hash-idempotency docstring explicitly assumes immutable-once-
+    ingested content), so a content-hash idempotent-insert would never hit
+    (a graph's own content_hash changes on every save) and would just
+    accumulate one stale document+chunks row per save, forever. Instead:
+    DELETE every existing documents+chunks row for this graph (looked up by
+    `source_uri = f"graph:{graph_id}"`, never by content_hash), then INSERT
+    a fresh documents row + fresh chunks rows reflecting the graph's CURRENT
+    content - called on EVERY save, insert or resave alike (see backend/
+    chat_library.py's save_chat_atomically_row, this function's one real
+    caller). `chunks_fts`'s own DELETE trigger (migration "2") keeps the
+    FTS index in sync automatically when the old chunks rows are deleted
+    (ON DELETE CASCADE fires the child table's own triggers - see that
+    migration's own docstring, already verified empirically there); this
+    function never touches chunks_fts directly.
+
+    `node_chunks` is `[(node_id, text), ...]`, already normalized and
+    already filtered to non-empty text by the caller - this function trusts
+    what it is given, matching this module's own "the caller resolves
+    content, this function only writes" division of labor (see e.g. how
+    add_document_with_chunks already trusts its own `chunks` param). An
+    empty list (a graph with no indexable node content at all right now)
+    still runs the DELETE below - clearing any STALE prior index for this
+    same graph_id, which matters when a graph's last node with real content
+    was just removed or emptied - but skips the INSERT, since there is
+    nothing left to write a document row for.
+
+    `workspace_id` resolves this graph's real knowledge collection via
+    get_or_create_workspace_collection - called BEFORE this function's own
+    write transaction opens (not nested inside it), specifically so it
+    never has to wait out its own separate connection's write lock against
+    the one this function is about to open on the SAME db file (a nested
+    call here would self-contend under WAL's own single-writer rule until
+    busy_timeout expired).
+
+    `content_hash` is still populated (the schema's own NOT NULL) even
+    though this path deliberately never CONSULTS it for idempotency (unlike
+    add_document_with_chunks) - computed from `source_uri` PLUS the graph's
+    own concatenated node text, not the text alone: `documents` declares
+    `UNIQUE(content_hash, collection_id)`, and two DIFFERENT graphs in the
+    SAME workspace/collection with byte-identical node content (a real,
+    reachable case - e.g. two graphs both created from a duplicated
+    starting template) are deliberately NOT the same document the way two
+    real files with identical extracted text are (add_document_with_chunks'
+    own content-hash-idempotency docstring) - each graph is its own
+    document, tracked by its own unique source_uri, regardless of what its
+    nodes happen to say. Folding source_uri into the hash input keeps this
+    per-graph-unique by construction (empirically verified - see this
+    function's own test_two_different_graphs_do_not_collide test) rather
+    than colliding on the UNIQUE constraint the moment two graphs' content
+    happens to match."""
+    collection_id = get_or_create_workspace_collection(db_path, workspace_id)
+    source_uri = _graph_source_uri(graph_id)
+    estimator = TokenEstimator()
+
+    conn = _connect(db_path, notifications=notifications)
+    try:
+        with conn:
+            if last_saved is not None:
+                maybe_backup_before_write(db_path, last_saved)
+
+            existing_ids = [
+                row[0]
+                for row in conn.execute(
+                    "SELECT id FROM documents WHERE source_uri = ?", (source_uri,)
+                ).fetchall()
+            ]
+            for existing_id in existing_ids:
+                # ON DELETE CASCADE removes this document's own chunks rows,
+                # which fires chunks_fts' own AFTER DELETE trigger for each
+                # one - chunks_fts needs no direct touch here.
+                conn.execute("DELETE FROM documents WHERE id = ?", (existing_id,))
+
+            if not node_chunks:
+                return
+
+            full_text = "\n\n".join(text for _, text in node_chunks)
+            cursor = conn.execute(
+                "INSERT INTO documents (collection_id, source_uri, title, mime, content_hash, added_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    collection_id, source_uri, title, "text/graph",
+                    content_hash(f"{source_uri}\n{full_text}"), _now_iso(),
+                ),
+            )
+            document_id = cursor.lastrowid
+            conn.executemany(
+                "INSERT INTO chunks "
+                "(document_id, ordinal, text, token_count, offset_start, offset_end, source_node_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [
+                    (document_id, ordinal, text, estimator.count_tokens(text), 0, len(text), node_id)
+                    for ordinal, (node_id, text) in enumerate(node_chunks)
+                ],
+            )
+    finally:
+        conn.close()
+
+
+def delete_graph_index(db_path: Path, graph_id: int) -> bool:
+    """The deletion-side mirror of reindex_graph_content: removes this
+    graph's own documents+chunks rows (ON DELETE CASCADE + chunks_fts' own
+    DELETE trigger keep chunks/chunks_fts in sync, same as reindex_graph_
+    content's own DELETE above) - called from backend/chat_library.py's
+    delete_chat, so a deleted graph's content stops being a real, jump-to-
+    node-able global-search hit rather than lingering as an orphaned index
+    entry for a graph that no longer exists. Returns whether a row was
+    actually deleted - False for a graph with nothing indexed (never saved
+    with any indexable node content, or already deleted) is a normal
+    outcome, not an error - mirrors delete_document's own return contract."""
+    conn = _connect(db_path)
+    try:
+        with conn:
+            cursor = conn.execute(
+                "DELETE FROM documents WHERE source_uri = ?", (_graph_source_uri(graph_id),)
+            )
+            return cursor.rowcount > 0
+    finally:
+        conn.close()
+
+
 # -- embedding cache/index CRUD (ADR-017 stage 17.3) -------------------------
 #
 # Deliberately byte-blob level - no numpy import in this module. Packing a
@@ -682,12 +861,19 @@ def list_embeddings_for_search(
     directly - the same fields search_chunks() (FTS5) already returns,
     matching shapes so stage 17.4's fusion can treat both result lists
     uniformly. `vector` is the raw packed BLOB - unpacking is
-    knowledge_embeddings.vector_search's job, not this module's."""
+    knowledge_embeddings.vector_search's job, not this module's.
+
+    ADR-020 stage 20.4: also carries `source_node_id` (migration "5") - a
+    fused hybrid_search() result found ONLY via this vector path still
+    needs to be traceable back to its origin node the same way a
+    search_chunks() (FTS5) hit already is, so a graph-derived chunk that
+    happens to have been embedded is never mistaken for a real ingested-
+    document hit downstream."""
     conn = _connect(db_path)
     try:
         query = (
             "SELECT e.chunk_id, e.dim, e.vector, c.document_id, c.ordinal, c.text, c.token_count, "
-            "c.offset_start, c.offset_end, d.title, d.source_uri "
+            "c.offset_start, c.offset_end, d.title, d.source_uri, c.source_node_id "
             "FROM embeddings e "
             "JOIN chunks c ON c.id = e.chunk_id "
             "JOIN documents d ON d.id = c.document_id "
@@ -703,6 +889,7 @@ def list_embeddings_for_search(
                 "chunk_id": row[0], "dim": row[1], "vector": row[2], "document_id": row[3],
                 "ordinal": row[4], "text": row[5], "token_count": row[6], "offset_start": row[7],
                 "offset_end": row[8], "document_title": row[9], "source_uri": row[10],
+                "source_node_id": row[11],
             }
             for row in rows
         ]
@@ -743,6 +930,16 @@ def search_chunks(
     matching everything (an empty FTS5 MATCH string is itself invalid
     syntax, and "no terms" has no reasonable non-empty answer).
 
+    ADR-020 stage 20.4: also carries `source_node_id` (migration "5",
+    NULL for every real ingested-document chunk, a real node id for a
+    chunk backend.chat_library.reindex_graph_content wrote) - this is what
+    lets a caller (backend/api/intents_global_search.py's own result
+    formatter) tell a "graph/node" hit apart from a real document hit
+    without a second query: `document_id` -> `documents.source_uri` is
+    already joined into every row here, and a graph-sourced document's own
+    `source_uri` is always the synthetic `f"graph:{graph_id}"` scheme
+    reindex_graph_content writes.
+
     `k` bounds the result count outright, not a suggestion - a caller doing
     budget-aware selection still needs a hard upper bound on rows actually
     pulled from SQLite before it starts trimming by token budget."""
@@ -762,7 +959,7 @@ def search_chunks(
         rows = conn.execute(
             f"""
             SELECT c.id, c.document_id, c.ordinal, c.text, c.token_count, c.offset_start, c.offset_end,
-                   d.title, d.source_uri, bm25(chunks_fts) AS score
+                   d.title, d.source_uri, bm25(chunks_fts) AS score, c.source_node_id
             FROM chunks_fts
             JOIN chunks c ON c.id = chunks_fts.rowid
             JOIN documents d ON d.id = c.document_id
@@ -777,6 +974,7 @@ def search_chunks(
                 "chunk_id": row[0], "document_id": row[1], "ordinal": row[2], "text": row[3],
                 "token_count": row[4], "offset_start": row[5], "offset_end": row[6],
                 "document_title": row[7], "source_uri": row[8], "score": row[9],
+                "source_node_id": row[10],
             }
             for row in rows
         ]

--- a/backend/knowledge_store.py
+++ b/backend/knowledge_store.py
@@ -35,6 +35,23 @@ would not enforce what it looks like it enforces (SQL NULL is never equal
 to another NULL, so two unscoped documents with identical content would
 NOT collide), and `collections.id` is an AUTOINCREMENT primary key that
 never produces 0, so the sentinel can never collide with a real row.
+
+WORKSPACE-SCOPED KNOWLEDGE (ADR-020 stage 20.3) - SCOPING DECISION, made
+explicit here rather than left to be inferred: this stage gives every
+backend/chat_library.py workspace EXACTLY ONE collection (`collections.
+workspace_id`, migration "4" below), created lazily on first real ingest/
+search via get_or_create_workspace_collection - NOT a general, user-facing
+"create/rename/delete many named collections per workspace" feature. That
+larger surface (a collection browser, assigning documents to specific
+collections, etc.) is deliberately out of scope for this stage - the exit
+criterion this stage is built around is "two workspaces' corpora are
+separate", not "users can manage arbitrarily many collections" - and is
+left for a future stage to build only if it turns out to be needed. The
+pre-20.3 `collection_id=0` global/unscoped pool is untouched by this
+stage: every document ingested before this migration, and every document
+ingested by a caller with no real workspace context of its own (see e.g.
+backend/api/intents_knowledge.py's own None-workspace fallback), keeps
+landing there exactly as it always has.
 """
 
 from __future__ import annotations
@@ -71,7 +88,7 @@ BACKUP_FILENAME_PREFIX = "knowledge-"
 # a mid-batch crash without re-snapshotting on every single document.
 BACKUP_CADENCE_SECONDS = 600.0
 
-KNOWLEDGE_DB_SCHEMA_VERSION = 3
+KNOWLEDGE_DB_SCHEMA_VERSION = 4
 
 
 def content_hash(text: str) -> str:
@@ -219,10 +236,46 @@ def _migration_003_vector_index(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_embeddings_model_id ON embeddings (model_id)")
 
 
+def _migration_004_workspace_scoped_collections(conn: sqlite3.Connection) -> None:
+    """3 -> 4 (ADR-020 stage 20.3): `collections.workspace_id` - scopes each
+    collection (and, transitively, every document/chunk ingested into it)
+    to a real backend/chat_library.py `workspaces` row - a DIFFERENT SQLite
+    database file (chats.db, not this module's own knowledge.db), so no
+    declared SQL FOREIGN KEY is possible across the two; this is a
+    conceptual FK enforced by this codebase's own CRUD only, same posture
+    as backend/chat_library.py's own graphs.workspace_id -> workspaces.id
+    link (see that migration's own docstring for the identical empirically-
+    grounded reasoning about undeclared cross-store/ADD-COLUMN FKs).
+
+    NULL (not 0) is "no workspace assigned" here - deliberately NOT the
+    same sentinel as documents.collection_id's own `0` ("no collection
+    assigned" - this module's own docstring), which already means
+    something real and different: every document ingested before this
+    stage (and every one ingested by a caller that still has no workspace
+    context of its own - see backend/api/intents_knowledge.py's own
+    fallback) keeps landing in collection_id 0, the pre-20.3 global/
+    unscoped pool, completely untouched by this migration. A collections
+    row with workspace_id NULL is simply one this stage's own code never
+    produces (get_or_create_workspace_collection below always supplies a
+    real int) - nullable rather than defaulting to some sentinel int so a
+    later migration can tell "predates workspace-scoping" apart from
+    "deliberately global" without overloading one column for both.
+
+    Guarded exactly like every migration in this module and its sibling
+    backend/chat_library.py: a PRAGMA table_info probe before the ALTER
+    TABLE, so a second run against an already-migrated database is a pure
+    no-op."""
+    collections_columns = [info[1] for info in conn.execute("PRAGMA table_info(collections)").fetchall()]
+    if "workspace_id" not in collections_columns:
+        conn.execute("ALTER TABLE collections ADD COLUMN workspace_id INTEGER")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_collections_workspace_id ON collections (workspace_id)")
+
+
 _MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     1: _migration_001_initial_schema,
     2: _migration_002_fts5_lexical_index,
     3: _migration_003_vector_index,
+    4: _migration_004_workspace_scoped_collections,
 }
 
 
@@ -502,6 +555,47 @@ def list_chunks_for_document(db_path: Path, document_id: int) -> list[dict[str, 
             }
             for row in rows
         ]
+    finally:
+        conn.close()
+
+
+def get_or_create_workspace_collection(db_path: Path, workspace_id: int) -> int:
+    """ADR-020 stage 20.3: the ONE collection-creation code path this stage
+    builds - per the ADR's own scoping decision, every workspace gets
+    EXACTLY one collection, created lazily on first real use, never
+    surfaced as a separately manageable entity (no create_collection(name,
+    ...) API for users - see this module's own module docstring update for
+    the full reasoning). Idempotent by construction: a SELECT first, an
+    INSERT only on a genuine miss, so every real call site (backend/api/
+    intents_knowledge.py's search()/branch-indexing, graphlink_plugins/
+    web_research/service.py's retention) can simply call this on EVERY
+    real ingest/search for a workspace with no "did I already create this
+    workspace's collection" bookkeeping of its own to carry - and it is
+    self-healing: a workspace whose collection row is missing (never
+    created, or knowledge.db was restored from a backup that predates it)
+    just gets a fresh one on the very next call, rather than erroring.
+
+    `name`/`scope` are cosmetic only - nothing in this codebase's own UI
+    ever displays a collection by name (the ADR's own "invisible, not a
+    general collection-management UI" scoping decision) - `name` is a
+    stable, deterministic f"workspace-{workspace_id}" (useful only for a
+    human inspecting the raw .db file directly), `scope` reuses the
+    pre-20.3 column literally ("workspace") purely for that same manual-
+    inspection value; neither is read back by any real code path in this
+    codebase."""
+    conn = _connect(db_path)
+    try:
+        with conn:
+            row = conn.execute(
+                "SELECT id FROM collections WHERE workspace_id = ?", (workspace_id,)
+            ).fetchone()
+            if row is not None:
+                return int(row[0])
+            cursor = conn.execute(
+                "INSERT INTO collections (name, scope, created_at, workspace_id) VALUES (?, ?, ?, ?)",
+                (f"workspace-{workspace_id}", "workspace", _now_iso(), workspace_id),
+            )
+            return int(cursor.lastrowid)
     finally:
         conn.close()
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,7 +14,7 @@ _REAL_DATA_DIR = (Path.home() / ".graphlink").resolve()
 
 
 @pytest.fixture(autouse=True)
-def _never_touch_the_real_user_data_dir(monkeypatch):
+def _never_touch_the_real_user_data_dir(monkeypatch, tmp_path):
     """Hard-fail any test that opens the developer's REAL ~/.graphlink files.
 
     create_app() defaults settings_state_file/chat_db_path to
@@ -34,6 +34,33 @@ def _never_touch_the_real_user_data_dir(monkeypatch):
     test must pass a tmp_path/TemporaryDirectory-derived override - see
     test_assets.py's or test_http_trust_boundary.py's make_client helpers for
     the established shape.
+
+    ADR-020 stage 20.4: extended to cover backend.knowledge_store too (its
+    own `_connect`, the same shape as chat_library's) - backend/chat_library.
+    py's save_chat_atomically_row/delete_chat now write/delete through it
+    (indexing a saved graph's content for global search - see that
+    function's own docstring) on EVERY real call, not just ones a caller
+    opted into. Also REDIRECTS (not just guards) knowledge_store.
+    DEFAULT_DB_PATH to a throwaway tmp_path for the duration of every test:
+    this suite has 40+ pre-existing save_chat_atomically_row/delete_chat
+    call sites (this file, test_session_lifecycle.py, test_autosave.py) that
+    predate that indexing hook and pass no explicit knowledge_db_path
+    override, so without this redirect every one of them would immediately
+    start hard-failing against the guard above the moment it fires - exactly
+    the class of bug this fixture exists to make impossible, just reached
+    through a NEW call path this fixture's own pre-20.4 shape had no way to
+    anticipate. Safe to redirect the constant itself (rather than touching
+    each call site): backend/chat_library.py's own indexing hook reads
+    `knowledge_store.DEFAULT_DB_PATH` as a live module attribute at CALL
+    time (`from backend import knowledge_store` + `knowledge_store.
+    DEFAULT_DB_PATH`, never `from backend.knowledge_store import
+    DEFAULT_DB_PATH`, which would bind the value at IMPORT time instead and
+    never see this patch) - the same pattern backend/tests/
+    test_intents_knowledge.py's own module docstring already documents and
+    relies on for its own, unrelated monkeypatching of this exact constant.
+    A test that explicitly passes its own knowledge_db_path (or its own
+    explicit monkeypatch of this same constant, applied after this fixture
+    via ordinary fixture/setattr ordering) is unaffected either way.
     """
     def _guard(path, what):
         try:
@@ -49,6 +76,7 @@ def _never_touch_the_real_user_data_dir(monkeypatch):
 
     import graphlink_settings_store as settings_store
     from backend import chat_library
+    from backend import knowledge_store
 
     real_settings_init = settings_store.SettingsManager.__init__
 
@@ -65,8 +93,16 @@ def _never_touch_the_real_user_data_dir(monkeypatch):
         _guard(db_path, "chat_library._connect(db_path=...)")
         return real_connect(db_path, *args, **kwargs)
 
+    real_knowledge_connect = knowledge_store._connect
+
+    def guarded_knowledge_connect(db_path, *args, **kwargs):
+        _guard(db_path, "knowledge_store._connect(db_path=...)")
+        return real_knowledge_connect(db_path, *args, **kwargs)
+
     monkeypatch.setattr(settings_store.SettingsManager, "__init__", guarded_settings_init)
     monkeypatch.setattr(chat_library, "_connect", guarded_connect)
+    monkeypatch.setattr(knowledge_store, "_connect", guarded_knowledge_connect)
+    monkeypatch.setattr(knowledge_store, "DEFAULT_DB_PATH", tmp_path / "knowledge-test-default" / "knowledge.db")
     yield
 
 

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -717,6 +717,162 @@ def test_regenerate_response_also_resolves_the_branch_pinned_model_ref(monkeypat
     asyncio.run(run())
 
 
+# -- ADR-020 stage 20.3: the workspace-default model rung ---------------------
+#
+# The exit criterion's own "different default models" half, proven through
+# the REAL sendMessage -> _dispatch -> _resolve_model_ref_for_dispatch ->
+# graphlink_model_catalog.resolve_model_ref chain (never by calling
+# resolve_model_ref directly) - two workspaces, each with its own default
+# model pinned via the real backend/chat_library.py CRUD, a node/graph in
+# each with NO node/branch override, dispatch resolves to the correct
+# DIFFERENT model per workspace.
+
+
+def test_workspace_default_model_flows_through_real_dispatch_and_differs_per_workspace(monkeypatch, tmp_path):
+    import graphlink_model_catalog as mc
+    from backend import chat_library
+
+    _configure_fake_ollama_provider_only(monkeypatch)
+    captured = {}
+
+    def fake_stream(conversation_history, persona_text, cancel_event, on_chunk, **kwargs):
+        captured["model_ref"] = kwargs.get("model_ref")
+        on_chunk("a reply", False)
+        return "a reply"
+
+    monkeypatch.setattr(agents_module, "_call_chat_agent_stream", fake_stream)
+
+    db_path = tmp_path / "chats.db"
+    workspace_alpha = chat_library.create_workspace(db_path, "Alpha")
+    workspace_beta = chat_library.create_workspace(db_path, "Beta")
+    chat_library.set_workspace_default_model(db_path, workspace_alpha["id"], "Anthropic Claude", "claude-opus-5")
+    chat_library.set_workspace_default_model(db_path, workspace_beta["id"], "Ollama", "llama3")
+
+    async def dispatch_in_workspace(workspace_id):
+        bus = SessionBus(f"agents-workspace-model-test-{workspace_id}")
+        # Same attribute backend/chat_library.py's own register_chat_library
+        # stashes on a real session's bus - see _resolve_model_ref_for_
+        # dispatch's own docstring for why this is the one piece of extra
+        # context the workspace rung needs.
+        bus.chat_db_path = db_path
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+        document = register_canvas(bus, notifications, dispatcher, composer_document)
+        # Mirrors what loadChat/newChat's own current_workspace_id wiring
+        # sets on a real session (backend/chat_library.py) - deliberately
+        # NOT going through those intents here, so this test proves the
+        # dispatch-side wiring specifically, independent of the load/new-
+        # chat wiring already pinned by backend/tests/test_chat_library.py's
+        # own loadChat current_workspace_id tests.
+        document.current_workspace_id = workspace_id
+
+        root = document.add_chat_node(0, 0, "root message", True)
+        document.last_chat_node_id = root.id
+        # No node/branch override anywhere - this exact node/graph shape is
+        # the exit criterion's own "with no node/branch override" clause.
+
+        await bus.dispatch_intent("scene", "sendMessage", ["continue the conversation"])
+        entry = next(iter(chat_slots(dispatcher).values()))
+        await entry["task"]
+
+    asyncio.run(dispatch_in_workspace(workspace_alpha["id"]))
+    assert captured["model_ref"] == mc.ModelRef("Anthropic Claude", "claude-opus-5")
+
+    asyncio.run(dispatch_in_workspace(workspace_beta["id"]))
+    assert captured["model_ref"] == mc.ModelRef("Ollama", "llama3")
+
+
+def test_workspace_default_model_is_overridden_by_a_node_pin(monkeypatch, tmp_path):
+    # The chain's own precedence: node override beats workspace default even
+    # when a workspace default IS set - not a regression of ADR-018 stage
+    # 18.2's own node/branch rungs.
+    import graphlink_model_catalog as mc
+    from backend import chat_library
+
+    _configure_fake_ollama_provider_only(monkeypatch)
+    captured = {}
+
+    def fake_stream(conversation_history, persona_text, cancel_event, on_chunk, **kwargs):
+        captured["model_ref"] = kwargs.get("model_ref")
+        on_chunk("a reply", False)
+        return "a reply"
+
+    monkeypatch.setattr(agents_module, "_call_chat_agent_stream", fake_stream)
+
+    db_path = tmp_path / "chats.db"
+    workspace = chat_library.create_workspace(db_path, "Alpha")
+    chat_library.set_workspace_default_model(db_path, workspace["id"], "Anthropic Claude", "claude-opus-5")
+
+    async def run():
+        bus = SessionBus("agents-workspace-vs-node-override-test")
+        bus.chat_db_path = db_path
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+        document = register_canvas(bus, notifications, dispatcher, composer_document)
+        document.current_workspace_id = workspace["id"]
+
+        root = document.add_chat_node(0, 0, "root message", True)
+        document.last_chat_node_id = root.id
+        document.set_model_override(root.id, "Ollama", "llama3")
+
+        await bus.dispatch_intent("scene", "sendMessage", ["continue"])
+        entry = next(iter(chat_slots(dispatcher).values()))
+        await entry["task"]
+
+        assert captured["model_ref"] == mc.ModelRef("Ollama", "llama3")
+
+    asyncio.run(run())
+
+
+def test_workspace_default_model_is_absent_when_the_workspace_has_none_set(monkeypatch, tmp_path):
+    # A real workspace with NO default configured must behave exactly like
+    # pre-20.3: no model_ref kwarg at all, falling through to api_provider's
+    # own task-keyed lookup - not a workspace_ref of empty strings smuggled
+    # through as if it were real.
+    from backend import chat_library
+
+    _configure_fake_ollama_provider_only(monkeypatch)
+    captured = {"saw_model_ref_kwarg": "unset"}
+
+    def fake_stream(conversation_history, persona_text, cancel_event, on_chunk, **kwargs):
+        captured["saw_model_ref_kwarg"] = "model_ref" in kwargs
+        on_chunk("a reply", False)
+        return "a reply"
+
+    monkeypatch.setattr(agents_module, "_call_chat_agent_stream", fake_stream)
+
+    db_path = tmp_path / "chats.db"
+    workspace = chat_library.create_workspace(db_path, "NoDefault")
+
+    async def run():
+        bus = SessionBus("agents-workspace-no-default-test")
+        bus.chat_db_path = db_path
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+        document = register_canvas(bus, notifications, dispatcher, composer_document)
+        document.current_workspace_id = workspace["id"]
+
+        root = document.add_chat_node(0, 0, "root message", True)
+        document.last_chat_node_id = root.id
+
+        await bus.dispatch_intent("scene", "sendMessage", ["continue"])
+        entry = next(iter(chat_slots(dispatcher).values()))
+        await entry["task"]
+
+        assert captured["saw_model_ref_kwarg"] is False
+
+    asyncio.run(run())
+
+
 # -- ADR-006 stage 6.7: system-prompt wire shape at the api_provider seam -----
 #
 # These drive the REAL _call_chat_agent_stream -> ChatAgent -> ChatWorker

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -377,7 +377,7 @@ def test_junk_args_never_crash_or_disconnect_any_registered_intent():
         assert ws.receive_json()["kind"] == "result"
 
 
-def test_args_schema_is_scoped_to_exactly_the_known_5_intents():
+def test_args_schema_is_scoped_to_exactly_the_known_11_intents():
     # ADR-003 stage 3.2 review-fix: the fuzz sweep above proves every intent
     # replies safely, but it only checks message["kind"], not the error TEXT
     # - a schema-validation rejection and an unmigrated handler's own generic
@@ -390,9 +390,12 @@ def test_args_schema_is_scoped_to_exactly_the_known_5_intents():
     # fail the fuzz sweep. Originally the exact 3 intents ADR-003 stage 3.2's
     # own PR description claimed to have migrated (showInfo/showError/
     # executePlugin); ADR-014 stage 14.4 added 2 more
-    # (invokePluginIntent/setPluginGrant), both deliberately, not drift -
-    # a real intentional additions to this set updates it explicitly, the
-    # same discipline this test itself exists to enforce.
+    # (invokePluginIntent/setPluginGrant); ADR-020 stage 20.2 added 6 more on
+    # "app-chat-library" (setGraphFavorite/setGraphArchived/setGraphTags/
+    # createWorkspace/renameWorkspace/archiveWorkspace) - each a real,
+    # deliberate addition, not drift - a real intentional addition to this
+    # set updates it explicitly, the same discipline this test itself exists
+    # to enforce.
     client = make_client()
     with client.websocket_connect("/ws") as ws:
         ws.send_json({"kind": "subscribe", "topics": ["system"]})
@@ -409,6 +412,12 @@ def test_args_schema_is_scoped_to_exactly_the_known_5_intents():
             ("app-plugins", "executePlugin"),
             ("app-plugins", "invokePluginIntent"),
             ("app-plugins", "setPluginGrant"),
+            ("app-chat-library", "setGraphFavorite"),
+            ("app-chat-library", "setGraphArchived"),
+            ("app-chat-library", "setGraphTags"),
+            ("app-chat-library", "createWorkspace"),
+            ("app-chat-library", "renameWorkspace"),
+            ("app-chat-library", "archiveWorkspace"),
         }
 
 

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -377,7 +377,7 @@ def test_junk_args_never_crash_or_disconnect_any_registered_intent():
         assert ws.receive_json()["kind"] == "result"
 
 
-def test_args_schema_is_scoped_to_exactly_the_known_11_intents():
+def test_args_schema_is_scoped_to_exactly_the_known_12_intents():
     # ADR-003 stage 3.2 review-fix: the fuzz sweep above proves every intent
     # replies safely, but it only checks message["kind"], not the error TEXT
     # - a schema-validation rejection and an unmigrated handler's own generic
@@ -392,10 +392,11 @@ def test_args_schema_is_scoped_to_exactly_the_known_11_intents():
     # executePlugin); ADR-014 stage 14.4 added 2 more
     # (invokePluginIntent/setPluginGrant); ADR-020 stage 20.2 added 6 more on
     # "app-chat-library" (setGraphFavorite/setGraphArchived/setGraphTags/
-    # createWorkspace/renameWorkspace/archiveWorkspace) - each a real,
-    # deliberate addition, not drift - a real intentional addition to this
-    # set updates it explicitly, the same discipline this test itself exists
-    # to enforce.
+    # createWorkspace/renameWorkspace/archiveWorkspace); ADR-020 stage 20.3
+    # added 1 more on "app-chat-library" (setWorkspaceDefaultModel) - each a
+    # real, deliberate addition, not drift - a real intentional addition to
+    # this set updates it explicitly, the same discipline this test itself
+    # exists to enforce.
     client = make_client()
     with client.websocket_connect("/ws") as ws:
         ws.send_json({"kind": "subscribe", "topics": ["system"]})
@@ -418,6 +419,7 @@ def test_args_schema_is_scoped_to_exactly_the_known_11_intents():
             ("app-chat-library", "createWorkspace"),
             ("app-chat-library", "renameWorkspace"),
             ("app-chat-library", "archiveWorkspace"),
+            ("app-chat-library", "setWorkspaceDefaultModel"),
         }
 
 

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -377,7 +377,7 @@ def test_junk_args_never_crash_or_disconnect_any_registered_intent():
         assert ws.receive_json()["kind"] == "result"
 
 
-def test_args_schema_is_scoped_to_exactly_the_known_12_intents():
+def test_args_schema_is_scoped_to_exactly_the_known_14_intents():
     # ADR-003 stage 3.2 review-fix: the fuzz sweep above proves every intent
     # replies safely, but it only checks message["kind"], not the error TEXT
     # - a schema-validation rejection and an unmigrated handler's own generic
@@ -393,10 +393,11 @@ def test_args_schema_is_scoped_to_exactly_the_known_12_intents():
     # (invokePluginIntent/setPluginGrant); ADR-020 stage 20.2 added 6 more on
     # "app-chat-library" (setGraphFavorite/setGraphArchived/setGraphTags/
     # createWorkspace/renameWorkspace/archiveWorkspace); ADR-020 stage 20.3
-    # added 1 more on "app-chat-library" (setWorkspaceDefaultModel) - each a
-    # real, deliberate addition, not drift - a real intentional addition to
-    # this set updates it explicitly, the same discipline this test itself
-    # exists to enforce.
+    # added 1 more on "app-chat-library" (setWorkspaceDefaultModel); ADR-020
+    # stage 20.4 added 2 more (("app-chat-library", "loadGraphAndFocusNode")
+    # and ("globalSearch", "search")) - each a real, deliberate addition, not
+    # drift - a real intentional addition to this set updates it explicitly,
+    # the same discipline this test itself exists to enforce.
     client = make_client()
     with client.websocket_connect("/ws") as ws:
         ws.send_json({"kind": "subscribe", "topics": ["system"]})
@@ -420,6 +421,8 @@ def test_args_schema_is_scoped_to_exactly_the_known_12_intents():
             ("app-chat-library", "renameWorkspace"),
             ("app-chat-library", "archiveWorkspace"),
             ("app-chat-library", "setWorkspaceDefaultModel"),
+            ("app-chat-library", "loadGraphAndFocusNode"),
+            ("globalSearch", "search"),
         }
 
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -3383,6 +3383,69 @@ def test_run_web_research_intent_publishes_scene_and_calls_start_web_research_wi
         assert callable(call["on_progress"])
         assert callable(call["on_success"])
         assert callable(call["on_failure"])
+        # ADR-020 stage 20.3: no real workspace context on this document
+        # (current_workspace_id is None, the register_canvas-only default) -
+        # resolves to 0, the pre-20.3 global/unscoped sentinel, without
+        # touching knowledge.db at all.
+        assert call["knowledge_collection_id"] == 0
+
+    asyncio.run(run())
+
+
+def test_run_web_research_intent_resolves_the_calling_sessions_workspace_collection(monkeypatch, tmp_path):
+    # ADR-020 stage 20.3: when the document DOES carry a real workspace
+    # context (mirrors what loadChat/newChat's own current_workspace_id
+    # wiring sets on a real session), runWebResearch resolves that
+    # workspace's own knowledge_store.py collection BEFORE dispatching -
+    # proving the real intents_web_research.py wiring, not just the
+    # underlying get_or_create_workspace_collection function in isolation.
+    from backend import knowledge_store
+    from backend.api import intents_web_research as intents_web_research_module
+
+    knowledge_db_path = tmp_path / "knowledge.db"
+    monkeypatch.setattr(intents_web_research_module, "KNOWLEDGE_DEFAULT_DB_PATH", knowledge_db_path)
+
+    class _FakeDispatcher:
+        def __init__(self):
+            self.calls = []
+
+        async def start_web_research(self, **kwargs):
+            self.calls.append(kwargs)
+
+        def cancel_web_research(self, request_id):
+            return False
+
+        def is_web_research_busy(self):
+            return False
+
+    async def run():
+        bus = SessionBus("run-web-research-workspace-collection-test")
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        composer_document = ComposerDocument()
+        bus.register_topic("app-composer", composer_document.payload)
+        fake_dispatcher = _FakeDispatcher()
+        document = register_canvas(bus, notifications, fake_dispatcher, composer_document)
+        document.current_workspace_id = 99
+
+        root = await bus.dispatch_intent("scene", "addChatNode", [0, 0, "root question", True])
+        wr_node = document.add_web_research_node(0, 0, root)
+
+        await bus.dispatch_intent("scene", "runWebResearch", [wr_node.id, "what is this about?"])
+
+        assert len(fake_dispatcher.calls) == 1
+        expected_collection_id = knowledge_store.get_or_create_workspace_collection(knowledge_db_path, 99)
+        assert fake_dispatcher.calls[0]["knowledge_collection_id"] == expected_collection_id
+        # A real, non-zero row actually landed in knowledge.db, not a
+        # freshly-invented number this test happens to compute the same way.
+        conn = __import__("sqlite3").connect(knowledge_db_path)
+        try:
+            row = conn.execute(
+                "SELECT workspace_id FROM collections WHERE id = ?", (expected_collection_id,),
+            ).fetchone()
+            assert row == (99,)
+        finally:
+            conn.close()
 
     asyncio.run(run())
 

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -42,6 +42,7 @@ from backend.chat_library import (
     flush_dirty_session_before_teardown,
     get_all_chats,
     get_all_workspaces,
+    get_workspace_default_model,
     load_chat_row,
     load_notes_rows,
     load_pins_rows,
@@ -52,6 +53,7 @@ from backend.chat_library import (
     set_graph_archived,
     set_graph_favorite,
     set_graph_tags,
+    set_workspace_default_model,
 )
 from backend.events import IntentValidationError, SessionBus
 from backend.notifications import NotificationState
@@ -859,6 +861,235 @@ class TestMigration003AddsTagsFavoriteArchive:
             conn.close()
 
 
+def _create_migration_3_shaped_db(db_path) -> list[int]:
+    """ADR-020 stage 20.3's own analog of _create_migration_2_shaped_db
+    above: builds a chats.db in EXACTLY the shape a real, already-upgraded
+    (through ADR-020 stage 20.2) install has TODAY, right before this
+    stage's own migration "4" ever runs against it - workspaces + graphs
+    (favorite/archived, no default-model/knowledge-collection columns yet)
+    + tags/graph_tags + notes/pins, real rows in more than one workspace,
+    PRAGMA user_version explicitly left at 3.
+
+    Returns the inserted graph ids, in insertion order (mirrors
+    _create_migration_2_shaped_db's own two-Default-one-other split)."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE workspaces (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, "
+            "icon TEXT NOT NULL DEFAULT '', created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+            "archived INTEGER NOT NULL DEFAULT 0)"
+        )
+        default_id = conn.execute("INSERT INTO workspaces (name) VALUES ('Default')").lastrowid
+        other_id = conn.execute("INSERT INTO workspaces (name) VALUES ('Research')").lastrowid
+
+        conn.execute(
+            "CREATE TABLE graphs (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, "
+            "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+            "data TEXT NOT NULL, preview TEXT DEFAULT '', message_count INTEGER DEFAULT 0, "
+            f"workspace_id INTEGER NOT NULL DEFAULT {default_id}, "
+            "favorite INTEGER NOT NULL DEFAULT 0, archived INTEGER NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE notes (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id INTEGER NOT NULL, "
+            "content TEXT NOT NULL, position_x REAL NOT NULL, position_y REAL NOT NULL, width REAL NOT NULL, "
+            "height REAL NOT NULL, color TEXT NOT NULL, header_color TEXT, "
+            "is_system_prompt INTEGER DEFAULT 0, is_summary_note INTEGER DEFAULT 0, "
+            "FOREIGN KEY (chat_id) REFERENCES graphs (id) ON DELETE CASCADE)"
+        )
+        conn.execute(
+            "CREATE TABLE pins (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id INTEGER NOT NULL, "
+            "title TEXT NOT NULL, note TEXT, position_x REAL NOT NULL, position_y REAL NOT NULL, "
+            "pin_id TEXT, sort_order INTEGER DEFAULT 0, anchor_item_id TEXT, created_at TEXT, "
+            "FOREIGN KEY (chat_id) REFERENCES graphs (id) ON DELETE CASCADE)"
+        )
+        conn.execute(
+            "CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE COLLATE NOCASE)"
+        )
+        conn.execute(
+            "CREATE TABLE graph_tags (graph_id INTEGER NOT NULL REFERENCES graphs (id) ON DELETE CASCADE, "
+            "tag_id INTEGER NOT NULL REFERENCES tags (id) ON DELETE CASCADE, PRIMARY KEY (graph_id, tag_id))"
+        )
+        conn.execute("CREATE INDEX idx_notes_chat_id ON notes (chat_id)")
+        conn.execute("CREATE INDEX idx_pins_chat_id ON pins (chat_id)")
+        conn.execute("CREATE INDEX idx_graphs_workspace_id ON graphs (workspace_id)")
+        conn.execute("CREATE INDEX idx_graph_tags_tag_id ON graph_tags (tag_id)")
+
+        graph_ids = []
+        for title, workspace_id in (
+            ("First Graph", default_id),
+            ("Second Graph", default_id),
+            ("Third Graph", other_id),
+        ):
+            cursor = conn.execute(
+                "INSERT INTO graphs (title, data, workspace_id) VALUES (?, ?, ?)",
+                (title, json.dumps({"nodes": []}), workspace_id),
+            )
+            graph_ids.append(cursor.lastrowid)
+        conn.commit()
+
+        conn.execute("PRAGMA user_version = 3")
+        conn.commit()
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 3
+        return graph_ids
+    finally:
+        conn.close()
+
+
+class TestMigration004WorkspaceDefaults:
+    """ADR-020 stage 20.3's own fidelity proof, mirroring
+    TestMigration003AddsTagsFavoriteArchive above precisely: hand-build a
+    real migration-3-shaped chats.db, drive it through the REAL production
+    connect path (never a hand-called migration function), and assert
+    every original row survives byte-for-byte with the new columns landing
+    correctly around it."""
+
+    def test_existing_workspaces_get_empty_default_model_and_null_collection_id(self, db_path):
+        graph_ids = _create_migration_3_shaped_db(db_path)
+
+        rows = get_all_chats(db_path)
+        assert len(rows) == 3
+        assert {row["id"] for row in rows} == set(graph_ids)
+
+        workspaces = get_all_workspaces(db_path)
+        assert len(workspaces) == 2
+        for workspace in workspaces:
+            assert workspace["defaultModelProvider"] == ""
+            assert workspace["defaultModelId"] == ""
+        assert get_workspace_default_model(db_path, workspaces[0]["id"]) is None
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == CHATS_DB_SCHEMA_VERSION
+            workspaces_columns = {info[1] for info in conn.execute("PRAGMA table_info(workspaces)").fetchall()}
+            assert {"default_model_provider", "default_model_id", "knowledge_collection_id"} <= workspaces_columns
+
+            rows = conn.execute(
+                "SELECT default_model_provider, default_model_id, knowledge_collection_id FROM workspaces"
+            ).fetchall()
+            for provider, model_id, collection_id in rows:
+                assert provider == ""
+                assert model_id == ""
+                assert collection_id is None
+
+            # Deliberately narrow, matching this migration's own docstring:
+            # graphs/tags/graph_tags are completely untouched.
+            graph_titles = {row[0] for row in conn.execute("SELECT title FROM graphs").fetchall()}
+            assert graph_titles == {"First Graph", "Second Graph", "Third Graph"}
+        finally:
+            conn.close()
+
+    def test_fresh_database_lands_on_version_4_with_the_new_columns(self, db_path):
+        assert not db_path.exists()
+
+        rows = get_all_chats(db_path)
+
+        assert rows == []
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == CHATS_DB_SCHEMA_VERSION
+            workspaces_columns = {info[1] for info in conn.execute("PRAGMA table_info(workspaces)").fetchall()}
+            assert {"default_model_provider", "default_model_id", "knowledge_collection_id"} <= workspaces_columns
+            default_row = conn.execute(
+                "SELECT default_model_provider, default_model_id, knowledge_collection_id FROM workspaces"
+            ).fetchone()
+            assert default_row == ("", "", None)
+        finally:
+            conn.close()
+
+    def test_migration_is_idempotent_when_run_twice_in_a_row(self, db_path):
+        graph_ids = _create_migration_3_shaped_db(db_path)
+
+        get_all_chats(db_path)
+        rows_after_second_connect = get_all_chats(db_path)
+
+        assert {row["id"] for row in rows_after_second_connect} == set(graph_ids)
+        conn = sqlite3.connect(db_path)
+        try:
+            # A second run must not duplicate the new columns - the PRAGMA
+            # table_info probe itself proves no OperationalError ("duplicate
+            # column name") was raised by a naive re-ALTER.
+            workspaces_columns = [info[1] for info in conn.execute("PRAGMA table_info(workspaces)").fetchall()]
+            assert workspaces_columns.count("default_model_provider") == 1
+            assert workspaces_columns.count("default_model_id") == 1
+            assert workspaces_columns.count("knowledge_collection_id") == 1
+            assert conn.execute("SELECT COUNT(*) FROM workspaces").fetchone()[0] == 2
+        finally:
+            conn.close()
+
+
+class TestWorkspaceDefaultModelCrud:
+    def test_set_then_get_round_trips_the_pinned_model(self, db_path):
+        workspace = create_workspace(db_path, "Research")
+        assert get_workspace_default_model(db_path, workspace["id"]) is None
+
+        set_workspace_default_model(db_path, workspace["id"], "Anthropic Claude", "claude-opus-5")
+
+        assert get_workspace_default_model(db_path, workspace["id"]) == ("Anthropic Claude", "claude-opus-5")
+        rows = get_all_workspaces(db_path)
+        [row] = [r for r in rows if r["id"] == workspace["id"]]
+        assert row["defaultModelProvider"] == "Anthropic Claude"
+        assert row["defaultModelId"] == "claude-opus-5"
+
+    def test_setting_both_empty_clears_a_previously_set_default(self, db_path):
+        workspace = create_workspace(db_path, "Research")
+        set_workspace_default_model(db_path, workspace["id"], "Ollama", "llama3")
+        assert get_workspace_default_model(db_path, workspace["id"]) is not None
+
+        set_workspace_default_model(db_path, workspace["id"], "", "")
+
+        assert get_workspace_default_model(db_path, workspace["id"]) is None
+
+    def test_a_half_set_pair_is_treated_as_fully_unset(self, db_path):
+        workspace = create_workspace(db_path, "Research")
+        set_workspace_default_model(db_path, workspace["id"], "Anthropic Claude", "")
+        assert get_workspace_default_model(db_path, workspace["id"]) is None
+
+    def test_two_different_workspaces_hold_independent_defaults(self, db_path):
+        ws1 = create_workspace(db_path, "Research")
+        ws2 = create_workspace(db_path, "Personal")
+        set_workspace_default_model(db_path, ws1["id"], "Anthropic Claude", "claude-opus-5")
+        set_workspace_default_model(db_path, ws2["id"], "Ollama", "llama3")
+
+        assert get_workspace_default_model(db_path, ws1["id"]) == ("Anthropic Claude", "claude-opus-5")
+        assert get_workspace_default_model(db_path, ws2["id"]) == ("Ollama", "llama3")
+
+    def test_a_never_existed_workspace_id_returns_none(self, db_path):
+        get_all_chats(db_path)  # bootstraps a fresh, fully-migrated db
+        assert get_workspace_default_model(db_path, 999999) is None
+
+    def test_create_workspace_starts_with_no_default_model(self, db_path):
+        created = create_workspace(db_path, "Fresh")
+        assert created["defaultModelProvider"] == ""
+        assert created["defaultModelId"] == ""
+
+
+class TestSetWorkspaceDefaultModelIntent:
+    def test_intent_sets_the_default_and_republishes_the_topic(self, db_path):
+        bus, document, notifications = _bus_with_canvas(db_path)
+        workspace = create_workspace(db_path, "Research")
+
+        asyncio.run(bus.dispatch_intent(
+            "app-chat-library", "setWorkspaceDefaultModel", [workspace["id"], "Anthropic Claude", "claude-opus-5"],
+        ))
+
+        assert get_workspace_default_model(db_path, workspace["id"]) == ("Anthropic Claude", "claude-opus-5")
+        payload = chat_library_payload(db_path)
+        [row] = [w for w in payload["workspaces"] if w["id"] == workspace["id"]]
+        assert row["defaultModelProvider"] == "Anthropic Claude"
+        assert row["defaultModelId"] == "claude-opus-5"
+
+    def test_intent_with_both_empty_clears_it(self, db_path):
+        bus, document, notifications = _bus_with_canvas(db_path)
+        workspace = create_workspace(db_path, "Research")
+        set_workspace_default_model(db_path, workspace["id"], "Ollama", "llama3")
+
+        asyncio.run(bus.dispatch_intent(
+            "app-chat-library", "setWorkspaceDefaultModel", [workspace["id"], "", ""],
+        ))
+
+        assert get_workspace_default_model(db_path, workspace["id"]) is None
+
+
 def test_get_all_chats_reads_real_rows(db_path):
     first_id = _insert_chat(db_path, "First")
     second_id = _insert_chat(db_path, "Second")
@@ -1436,6 +1667,39 @@ def test_load_chat_intent_shows_an_error_notification_for_a_missing_chat(db_path
 
     assert document.nodes == {}
     assert notifications.visible and notifications.msg_type == "error"
+
+
+def test_load_chat_intent_sets_current_workspace_id_from_the_loaded_graphs_own_row(db_path):
+    """ADR-020 stage 20.3 adversarial-review fix (see load_chat_row's own
+    docstring): opening an EXISTING chat that belongs to some other, real
+    workspace must set canvas_document.current_workspace_id to THAT
+    workspace's id - not leave it at whatever newChat last set (usually
+    None) - because this stage's own workspace-scoped model/knowledge
+    resolution reads exactly this field on every dispatch/search. This is
+    the single most common real flow (open a saved chat, keep working), not
+    just a corner case of newChat(workspaceId=...)."""
+    get_all_chats(db_path)  # bootstraps a fresh, fully-migrated db (Default workspace seeded)
+    other_workspace = create_workspace(db_path, "Research")
+    chat_id, _ = save_chat_atomically_row(
+        db_path, None, "In Research", {"nodes": []}, [], [], workspace_id=other_workspace["id"],
+    )
+    bus, document, notifications = _bus_with_canvas(db_path)
+    assert document.current_workspace_id is None  # nothing loaded yet
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "loadChat", [chat_id]))
+
+    assert document.current_workspace_id == other_workspace["id"]
+
+
+def test_load_chat_intent_sets_current_workspace_id_to_default_for_a_default_workspace_chat(db_path):
+    get_all_chats(db_path)  # bootstraps a fresh, fully-migrated db (Default workspace seeded)
+    default_workspace_id = get_all_workspaces(db_path)[0]["id"]
+    chat_id, _ = save_chat_atomically_row(db_path, None, "In Default", {"nodes": []}, [], [])
+    bus, document, notifications = _bus_with_canvas(db_path)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "loadChat", [chat_id]))
+
+    assert document.current_workspace_id == default_workspace_id
 
 
 def test_load_chat_intent_restores_notes_and_pins_too(db_path):

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -33,19 +33,27 @@ from backend.chat_library import (
     _format_timestamp_iso,
     _maybe_backup_before_write,
     _new_save_state,
+    _normalize_tags,
     _resolve_seed_message,
+    archive_workspace,
     chat_library_payload,
+    create_workspace,
     delete_chat,
     flush_dirty_session_before_teardown,
     get_all_chats,
+    get_all_workspaces,
     load_chat_row,
     load_notes_rows,
     load_pins_rows,
     register_chat_library,
     rename_chat,
+    rename_workspace,
     save_chat_atomically_row,
+    set_graph_archived,
+    set_graph_favorite,
+    set_graph_tags,
 )
-from backend.events import SessionBus
+from backend.events import IntentValidationError, SessionBus
 from backend.notifications import NotificationState
 
 
@@ -473,8 +481,11 @@ def _create_migration_1_shaped_db(db_path) -> list[int]:
     version; this migration "2" test's own realistic starting point is "at
     1, about to go to 2", not "at 0, needs both steps" - that combined case
     is already covered by TestMigrationUpgradesAPreExistingRealShapedDatabase
-    above, which now also implicitly exercises 0 -> 1 -> 2 in one hop since
-    CHATS_DB_SCHEMA_VERSION is 2).
+    above, which now also implicitly exercises 0 -> 1 -> 2 -> 3 in one hop
+    since CHATS_DB_SCHEMA_VERSION is 3 (ADR-020 stage 20.2 added step "3" -
+    see _create_migration_2_shaped_db below for THIS migration's own "at 2,
+    about to go to 3" realistic starting point, one step further down the
+    same chain).
 
     Returns the three inserted chat ids, in insertion order."""
     conn = sqlite3.connect(db_path)
@@ -650,6 +661,204 @@ class TestMigration002IntroducesWorkspacesAndGraphs:
             conn.close()
 
 
+def _create_migration_2_shaped_db(db_path) -> list[int]:
+    """ADR-020 stage 20.2's own analog of _create_migration_1_shaped_db
+    above: builds a chats.db in EXACTLY the shape a real, already-upgraded
+    (ADR-020 stage 20.1) install has TODAY, right before this stage's own
+    migration "3" ever runs against it - workspaces + graphs (with
+    workspace_id, but no favorite/archived columns yet) + notes/pins, real
+    rows in more than one workspace, PRAGMA user_version explicitly left at
+    2 (a real post-20.1 database has already run migrations "1" and "2" and
+    stamped its version at 2 - this migration "3" test's own realistic
+    starting point, mirroring _create_migration_1_shaped_db's own "at 1,
+    about to go to 2" precedent one step further down the chain).
+
+    Returns the inserted graph ids, in insertion order (first two in the
+    Default workspace, the third in a second, explicitly-created workspace -
+    proving migration 3 touches every graph regardless of which workspace it
+    is already in)."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE workspaces (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, "
+            "icon TEXT NOT NULL DEFAULT '', created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+            "archived INTEGER NOT NULL DEFAULT 0)"
+        )
+        default_id = conn.execute("INSERT INTO workspaces (name) VALUES ('Default')").lastrowid
+        other_id = conn.execute("INSERT INTO workspaces (name) VALUES ('Research')").lastrowid
+
+        conn.execute(
+            "CREATE TABLE graphs (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, "
+            "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+            "data TEXT NOT NULL, preview TEXT DEFAULT '', message_count INTEGER DEFAULT 0, "
+            f"workspace_id INTEGER NOT NULL DEFAULT {default_id})"
+        )
+        conn.execute(
+            "CREATE TABLE notes (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id INTEGER NOT NULL, "
+            "content TEXT NOT NULL, position_x REAL NOT NULL, position_y REAL NOT NULL, width REAL NOT NULL, "
+            "height REAL NOT NULL, color TEXT NOT NULL, header_color TEXT, "
+            "is_system_prompt INTEGER DEFAULT 0, is_summary_note INTEGER DEFAULT 0, "
+            "FOREIGN KEY (chat_id) REFERENCES graphs (id) ON DELETE CASCADE)"
+        )
+        conn.execute(
+            "CREATE TABLE pins (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id INTEGER NOT NULL, "
+            "title TEXT NOT NULL, note TEXT, position_x REAL NOT NULL, position_y REAL NOT NULL, "
+            "pin_id TEXT, sort_order INTEGER DEFAULT 0, anchor_item_id TEXT, created_at TEXT, "
+            "FOREIGN KEY (chat_id) REFERENCES graphs (id) ON DELETE CASCADE)"
+        )
+        conn.execute("CREATE INDEX idx_notes_chat_id ON notes (chat_id)")
+        conn.execute("CREATE INDEX idx_pins_chat_id ON pins (chat_id)")
+        conn.execute("CREATE INDEX idx_graphs_workspace_id ON graphs (workspace_id)")
+
+        graph_ids = []
+        for title, workspace_id in (
+            ("First Graph", default_id),
+            ("Second Graph", default_id),
+            ("Third Graph", other_id),
+        ):
+            cursor = conn.execute(
+                "INSERT INTO graphs (title, data, workspace_id) VALUES (?, ?, ?)",
+                (title, json.dumps({"nodes": []}), workspace_id),
+            )
+            graph_ids.append(cursor.lastrowid)
+        conn.commit()
+
+        conn.execute("PRAGMA user_version = 2")
+        conn.commit()
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        return graph_ids
+    finally:
+        conn.close()
+
+
+class TestMigration003AddsTagsFavoriteArchive:
+    """ADR-020 stage 20.2's own fidelity proof, mirroring
+    TestMigration002IntroducesWorkspacesAndGraphs above precisely: hand-build
+    a real migration-2-shaped chats.db, drive it through the REAL production
+    connect path (never a hand-called migration function), and assert every
+    original row survives byte-for-byte with the new columns/tables landing
+    correctly around it."""
+
+    def test_existing_graphs_get_favorite_archive_defaults_and_no_tags(self, db_path):
+        graph_ids = _create_migration_2_shaped_db(db_path)
+
+        rows = get_all_chats(db_path)
+
+        assert len(rows) == 3
+        by_id = {row["id"]: row for row in rows}
+        for graph_id in graph_ids:
+            assert by_id[graph_id]["favorite"] is False
+            assert by_id[graph_id]["archived"] is False
+            assert by_id[graph_id]["tags"] == []
+        assert by_id[graph_ids[0]]["title"] == "First Graph"
+        assert by_id[graph_ids[2]]["title"] == "Third Graph"
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == CHATS_DB_SCHEMA_VERSION
+
+            graphs_columns = {info[1] for info in conn.execute("PRAGMA table_info(graphs)").fetchall()}
+            assert {"favorite", "archived"} <= graphs_columns
+
+            tags_columns = {info[1] for info in conn.execute("PRAGMA table_info(tags)").fetchall()}
+            assert tags_columns == {"id", "name"}
+
+            graph_tags_indexes = {row[1] for row in conn.execute("PRAGMA index_list(graph_tags)").fetchall()}
+            assert "idx_graph_tags_tag_id" in graph_tags_indexes
+
+            # Workspaces (migration 2's own table) are completely untouched -
+            # this migration is deliberately narrow, per its own docstring.
+            workspace_names = {
+                row[0] for row in conn.execute("SELECT name FROM workspaces").fetchall()
+            }
+            assert workspace_names == {"Default", "Research"}
+        finally:
+            conn.close()
+
+    def test_fresh_database_lands_on_version_3_with_favorite_archive_columns(self, db_path):
+        assert not db_path.exists()
+
+        rows = get_all_chats(db_path)
+
+        assert rows == []
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == CHATS_DB_SCHEMA_VERSION
+            graphs_columns = {info[1] for info in conn.execute("PRAGMA table_info(graphs)").fetchall()}
+            assert {"favorite", "archived"} <= graphs_columns
+            assert conn.execute("SELECT COUNT(*) FROM tags").fetchone()[0] == 0
+        finally:
+            conn.close()
+
+    def test_migration_is_idempotent_when_run_twice_in_a_row(self, db_path):
+        graph_ids = _create_migration_2_shaped_db(db_path)
+
+        get_all_chats(db_path)
+        rows_after_second_connect = get_all_chats(db_path)
+
+        assert {row["id"] for row in rows_after_second_connect} == set(graph_ids)
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("SELECT COUNT(*) FROM graphs").fetchone()[0] == 3
+            # A second run must not duplicate favorite/archived columns or
+            # re-create tags/graph_tags in a way that loses data - trivially
+            # true here since nothing has tagged anything yet, but the
+            # PRAGMA table_info probe itself proves no OperationalError
+            # ("duplicate column name") was raised by a naive re-ALTER.
+            graphs_columns = [info[1] for info in conn.execute("PRAGMA table_info(graphs)").fetchall()]
+            assert graphs_columns.count("favorite") == 1
+            assert graphs_columns.count("archived") == 1
+        finally:
+            conn.close()
+
+    def test_graph_tags_cascade_deletes_on_both_sides_real_sqlite_behavior(self, db_path):
+        """Empirically verifies (not assumed from documentation alone) that
+        graph_tags' own declared `ON DELETE CASCADE` FKs actually fire under
+        this project's real bundled SQLite, in BOTH directions: deleting the
+        graph side (delete_chat's own real production path) and deleting the
+        tag side (a raw DELETE, since no intent deletes a tags row directly
+        today - set_graph_tags deliberately leaves orphaned tags in place,
+        see its own docstring - but the declared FK must still cascade if
+        one ever is removed some other way)."""
+        get_all_chats(db_path)  # bootstraps a fresh, fully-migrated db
+        graph_id = save_chat_atomically_row(db_path, None, "Tagged", {"nodes": []}, [], [])[0]
+        set_graph_tags(db_path, graph_id, ["work", "urgent"])
+
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("PRAGMA foreign_keys = ON")
+            assert conn.execute("SELECT COUNT(*) FROM graph_tags").fetchone()[0] == 2
+
+            # Graph-side cascade: delete_chat's own real "DELETE FROM graphs"
+            # (via the production delete_chat function, not raw SQL) must
+            # remove both graph_tags rows.
+            delete_chat(db_path, graph_id)
+            assert conn.execute("SELECT COUNT(*) FROM graph_tags").fetchone()[0] == 0
+            # The tags rows THEMSELVES survive (orphaned, by design).
+            assert conn.execute("SELECT COUNT(*) FROM tags").fetchone()[0] == 2
+        finally:
+            conn.close()
+
+        # Tag-side cascade: re-tag a second graph, then delete the TAG row
+        # directly and confirm the join row disappears too.
+        second_graph_id = save_chat_atomically_row(db_path, None, "Also Tagged", {"nodes": []}, [], [])[0]
+        set_graph_tags(db_path, second_graph_id, ["work"])
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("PRAGMA foreign_keys = ON")
+            tag_id = conn.execute("SELECT id FROM tags WHERE name = 'work'").fetchone()[0]
+            assert conn.execute(
+                "SELECT COUNT(*) FROM graph_tags WHERE tag_id = ?", (tag_id,)
+            ).fetchone()[0] == 1
+            conn.execute("DELETE FROM tags WHERE id = ?", (tag_id,))
+            conn.commit()
+            assert conn.execute(
+                "SELECT COUNT(*) FROM graph_tags WHERE tag_id = ?", (tag_id,)
+            ).fetchone()[0] == 0
+        finally:
+            conn.close()
+
+
 def test_get_all_chats_reads_real_rows(db_path):
     first_id = _insert_chat(db_path, "First")
     second_id = _insert_chat(db_path, "Second")
@@ -661,6 +870,7 @@ def test_get_all_chats_reads_real_rows(db_path):
         assert set(row) == {
             "id", "title", "createdLabel", "updatedLabel",
             "createdAtIso", "updatedAtIso", "preview", "messageCount",
+            "workspaceId", "favorite", "archived", "tags",
         }
         assert row["updatedLabel"] == "Jan 02, 2026 11:30 AM"
         assert row["updatedAtIso"] == "2026-01-02T11:30:00"
@@ -668,6 +878,14 @@ def test_get_all_chats_reads_real_rows(db_path):
         # ALTER TABLE migration must still leave these rows valid.
         assert row["preview"] == ""
         assert row["messageCount"] == 0
+        # ADR-020 stage 20.2: a row that never went through migration 3's
+        # own default column values still lands on the same fresh-graph
+        # defaults - untagged, not favorited, not archived, in whichever
+        # workspace migration 2 backfilled it into (Default, here).
+        assert row["favorite"] is False
+        assert row["archived"] is False
+        assert row["tags"] == []
+        assert isinstance(row["workspaceId"], int)
 
 
 def test_format_timestamp_matches_legacy_display_format():
@@ -743,12 +961,158 @@ def test_delete_chat_removes_the_row(db_path):
     assert all(row["id"] != chat_id for row in rows)
 
 
+# -- ADR-020 stage 20.2: favorite/archived/tags + workspaces CRUD -----------
+
+
+def test_set_graph_favorite_round_trips(db_path):
+    chat_id = _insert_chat(db_path, "Star Me")
+    assert next(row for row in get_all_chats(db_path) if row["id"] == chat_id)["favorite"] is False
+
+    set_graph_favorite(db_path, chat_id, True)
+    assert next(row for row in get_all_chats(db_path) if row["id"] == chat_id)["favorite"] is True
+
+    set_graph_favorite(db_path, chat_id, False)
+    assert next(row for row in get_all_chats(db_path) if row["id"] == chat_id)["favorite"] is False
+
+
+def test_set_graph_favorite_does_not_bump_updated_at(db_path):
+    # A metadata toggle must never re-sort get_all_chats' own
+    # `ORDER BY updated_at DESC` - see set_graph_favorite's own docstring.
+    chat_id = _insert_chat(db_path, "Stable Order")
+    before = next(row for row in get_all_chats(db_path) if row["id"] == chat_id)["updatedAtIso"]
+    set_graph_favorite(db_path, chat_id, True)
+    after = next(row for row in get_all_chats(db_path) if row["id"] == chat_id)["updatedAtIso"]
+    assert before == after
+
+
+def test_set_graph_archived_round_trips(db_path):
+    chat_id = _insert_chat(db_path, "Archive Me")
+    assert next(row for row in get_all_chats(db_path) if row["id"] == chat_id)["archived"] is False
+
+    set_graph_archived(db_path, chat_id, True)
+    assert next(row for row in get_all_chats(db_path) if row["id"] == chat_id)["archived"] is True
+
+    set_graph_archived(db_path, chat_id, False)
+    assert next(row for row in get_all_chats(db_path) if row["id"] == chat_id)["archived"] is False
+
+
+def test_normalize_tags_trims_drops_empty_and_case_collapses():
+    assert _normalize_tags(["  Work  ", "urgent", "", "   ", "WORK", "work"]) == ["Work", "urgent"]
+    assert _normalize_tags([]) == []
+
+
+def test_set_graph_tags_round_trips_with_trim_dedupe_case_collapse(db_path):
+    chat_id = _insert_chat(db_path, "Tag Me")
+    set_graph_tags(db_path, chat_id, ["  Work  ", "Work", "urgent", "", "URGENT"])
+
+    row = next(row for row in get_all_chats(db_path) if row["id"] == chat_id)
+    assert row["tags"] == ["urgent", "Work"]  # display-sorted (COLLATE NOCASE): u < W
+
+
+def test_set_graph_tags_is_a_bulk_replace_not_a_delta(db_path):
+    chat_id = _insert_chat(db_path, "Retag Me")
+    set_graph_tags(db_path, chat_id, ["one", "two"])
+    set_graph_tags(db_path, chat_id, ["three"])
+
+    row = next(row for row in get_all_chats(db_path) if row["id"] == chat_id)
+    assert row["tags"] == ["three"]
+
+
+def test_set_graph_tags_clearing_to_empty_removes_all_tags(db_path):
+    chat_id = _insert_chat(db_path, "Untag Me")
+    set_graph_tags(db_path, chat_id, ["one"])
+    set_graph_tags(db_path, chat_id, [])
+
+    row = next(row for row in get_all_chats(db_path) if row["id"] == chat_id)
+    assert row["tags"] == []
+
+
+def test_set_graph_tags_shares_one_tags_row_across_graphs_case_insensitively(db_path):
+    first_id = _insert_chat(db_path, "First")
+    second_id = _insert_chat(db_path, "Second")
+    set_graph_tags(db_path, first_id, ["Work"])
+    set_graph_tags(db_path, second_id, ["work"])  # different casing
+
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM tags").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_get_all_workspaces_includes_the_seeded_default(db_path):
+    _insert_chat(db_path, "Bootstraps a fresh db")  # triggers migration
+    workspaces = get_all_workspaces(db_path)
+    assert len(workspaces) == 1
+    assert workspaces[0]["name"] == "Default"
+    assert workspaces[0]["archived"] is False
+
+
+def test_create_workspace_returns_the_new_row_and_persists(db_path):
+    _insert_chat(db_path, "Bootstraps a fresh db")
+    created = create_workspace(db_path, "Research")
+    assert created is not None
+    assert created["name"] == "Research"
+    assert created["archived"] is False
+
+    workspaces = get_all_workspaces(db_path)
+    names = {workspace["name"] for workspace in workspaces}
+    assert names == {"Default", "Research"}
+
+
+def test_create_workspace_rejects_empty_or_whitespace_only_name(db_path):
+    _insert_chat(db_path, "Bootstraps a fresh db")
+    assert create_workspace(db_path, "") is None
+    assert create_workspace(db_path, "   ") is None
+    assert len(get_all_workspaces(db_path)) == 1  # still just Default
+
+
+def test_rename_workspace_persists(db_path):
+    _insert_chat(db_path, "Bootstraps a fresh db")
+    created = create_workspace(db_path, "Old Name")
+    rename_workspace(db_path, created["id"], "New Name")
+
+    workspace = next(ws for ws in get_all_workspaces(db_path) if ws["id"] == created["id"])
+    assert workspace["name"] == "New Name"
+
+
+def test_rename_workspace_ignores_empty_name(db_path):
+    _insert_chat(db_path, "Bootstraps a fresh db")
+    created = create_workspace(db_path, "Keep Me")
+    rename_workspace(db_path, created["id"], "   ")
+
+    workspace = next(ws for ws in get_all_workspaces(db_path) if ws["id"] == created["id"])
+    assert workspace["name"] == "Keep Me"
+
+
+def test_archive_workspace_round_trips_and_does_not_touch_its_graphs(db_path):
+    chat_id = _insert_chat(db_path, "Bootstraps a fresh db")
+    default_workspace = get_all_workspaces(db_path)[0]
+
+    archive_workspace(db_path, default_workspace["id"], True)
+    workspace = next(ws for ws in get_all_workspaces(db_path) if ws["id"] == default_workspace["id"])
+    assert workspace["archived"] is True
+    # The graph inside it is completely unaffected.
+    graph_row = next(row for row in get_all_chats(db_path) if row["id"] == chat_id)
+    assert graph_row["archived"] is False
+    assert graph_row["workspaceId"] == default_workspace["id"]
+
+    archive_workspace(db_path, default_workspace["id"], False)
+    workspace = next(ws for ws in get_all_workspaces(db_path) if ws["id"] == default_workspace["id"])
+    assert workspace["archived"] is False
+
+
 def test_chat_library_payload_shape(db_path):
     _insert_chat(db_path, "A Chat")
     payload = chat_library_payload(db_path)
-    assert set(payload) == {"rows", "notice"}
+    assert set(payload) == {"rows", "notice", "workspaces"}
     assert payload["notice"] is None
     assert len(payload["rows"]) == 1
+    # ADR-020 stage 20.2: the Default workspace always exists (migration 2
+    # seeds it unconditionally) - one workspace row even for a db with no
+    # explicit workspace of its own ever created.
+    assert len(payload["workspaces"]) == 1
+    assert payload["workspaces"][0]["name"] == "Default"
 
 
 def test_chat_library_never_imports_qt():
@@ -816,6 +1180,115 @@ def test_delete_chat_intent_removes_and_republishes(db_path):
 
     asyncio.run(bus.dispatch_intent("app-chat-library", "deleteChat", [chat_id]))
     assert recorder.messages[-1]["payload"]["rows"] == []
+
+
+# -- ADR-020 stage 20.2: the 6 new intents -----------------------------------
+
+
+def test_set_graph_favorite_intent_fires_with_the_right_args_and_republishes(db_path):
+    chat_id = _insert_chat(db_path, "Star Via Intent")
+    bus = SessionBus("chat-library-set-favorite-test")
+    register_chat_library(bus, db_path)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "setGraphFavorite", [chat_id, True]))
+    row = next(row for row in recorder.messages[-1]["payload"]["rows"] if row["id"] == chat_id)
+    assert row["favorite"] is True
+
+
+def test_set_graph_favorite_intent_rejects_wrong_typed_args(db_path):
+    _insert_chat(db_path, "Whatever")
+    bus = SessionBus("chat-library-set-favorite-validation-test")
+    register_chat_library(bus, db_path)
+
+    with pytest.raises(IntentValidationError):
+        asyncio.run(bus.dispatch_intent("app-chat-library", "setGraphFavorite", ["not-an-int", True]))
+
+
+def test_set_graph_archived_intent_fires_with_the_right_args_and_republishes(db_path):
+    chat_id = _insert_chat(db_path, "Archive Via Intent")
+    bus = SessionBus("chat-library-set-archived-test")
+    register_chat_library(bus, db_path)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "setGraphArchived", [chat_id, True]))
+    row = next(row for row in recorder.messages[-1]["payload"]["rows"] if row["id"] == chat_id)
+    assert row["archived"] is True
+
+
+def test_set_graph_tags_intent_fires_with_the_right_args_and_republishes(db_path):
+    chat_id = _insert_chat(db_path, "Tag Via Intent")
+    bus = SessionBus("chat-library-set-tags-test")
+    register_chat_library(bus, db_path)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "setGraphTags", [chat_id, ["  Work  ", "work"]]))
+    row = next(row for row in recorder.messages[-1]["payload"]["rows"] if row["id"] == chat_id)
+    assert row["tags"] == ["Work"]
+
+
+def test_create_workspace_intent_publishes_the_new_workspace(db_path):
+    _insert_chat(db_path, "Bootstraps a fresh db")
+    bus = SessionBus("chat-library-create-workspace-test")
+    register_chat_library(bus, db_path)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "createWorkspace", ["Research"]))
+    names = {ws["name"] for ws in recorder.messages[-1]["payload"]["workspaces"]}
+    assert names == {"Default", "Research"}
+
+
+def test_create_workspace_intent_rejects_empty_name_with_a_notification(db_path):
+    _insert_chat(db_path, "Bootstraps a fresh db")
+    bus = SessionBus("chat-library-create-workspace-empty-test")
+    document = SceneDocument()
+    bus.register_topic("scene", document.scene_payload)
+    notifications = NotificationState()
+    bus.register_topic("notification", notifications.payload)
+    register_chat_library(bus, db_path, document, notifications, autosave_interval_seconds=None)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "createWorkspace", ["   "]))
+
+    # No new workspace was created, and no "app-chat-library" republish
+    # happened - only a notification.
+    assert len(get_all_workspaces(db_path)) == 1
+    notification_messages = [m for m in recorder.messages if m.get("topic") == "notification"]
+    assert notification_messages, "an empty workspace name must surface a real notification"
+    assert notification_messages[-1]["payload"]["message"] == "Workspace name cannot be empty."
+
+
+def test_rename_workspace_intent_fires_with_the_right_args_and_republishes(db_path):
+    _insert_chat(db_path, "Bootstraps a fresh db")
+    default_workspace_id = get_all_workspaces(db_path)[0]["id"]
+    bus = SessionBus("chat-library-rename-workspace-test")
+    register_chat_library(bus, db_path)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "renameWorkspace", [default_workspace_id, "Renamed"]))
+    names = {ws["name"] for ws in recorder.messages[-1]["payload"]["workspaces"]}
+    assert names == {"Renamed"}
+
+
+def test_archive_workspace_intent_fires_with_the_right_args_and_republishes(db_path):
+    _insert_chat(db_path, "Bootstraps a fresh db")
+    default_workspace_id = get_all_workspaces(db_path)[0]["id"]
+    bus = SessionBus("chat-library-archive-workspace-test")
+    register_chat_library(bus, db_path)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "archiveWorkspace", [default_workspace_id, True]))
+    workspace = next(
+        ws for ws in recorder.messages[-1]["payload"]["workspaces"] if ws["id"] == default_workspace_id
+    )
+    assert workspace["archived"] is True
 
 
 # -- R6.4: load_chat_row / load_notes_rows / load_pins_rows -----------------
@@ -1114,6 +1587,41 @@ def test_new_chat_intent_clears_canvas_and_resets_current_chat_id(db_path):
 
     assert document.nodes == {}
     assert document.current_chat_id is None
+    # ADR-020 stage 20.2: every OTHER caller of newChat (e.g. commands.ts's
+    # palette command) keeps calling with zero args - byte-identical
+    # pre-20.2 behavior, including current_workspace_id staying unset.
+    assert document.current_workspace_id is None
+
+
+def test_new_chat_intent_honors_an_explicit_valid_workspace_id(db_path):
+    _insert_chat(db_path, "Bootstraps a fresh db")
+    other_workspace = create_workspace(db_path, "Research")
+    bus, document, _ = _bus_with_canvas(db_path)
+
+    asyncio.run(bus.dispatch_intent("app-chat-library", "newChat", [other_workspace["id"]]))
+
+    assert document.current_workspace_id == other_workspace["id"]
+
+    # And the NEXT save actually lands the new graph in that workspace.
+    document.add_chat_node(0, 0, "hello", is_user=True)
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+    saved_row = next(row for row in get_all_chats(db_path) if row["id"] == document.current_chat_id)
+    assert saved_row["workspaceId"] == other_workspace["id"]
+
+
+def test_new_chat_intent_defaults_to_default_workspace_when_id_is_invalid(db_path):
+    _insert_chat(db_path, "Bootstraps a fresh db")
+    default_workspace_id = get_all_workspaces(db_path)[0]["id"]
+    bus, document, _ = _bus_with_canvas(db_path)
+
+    # A workspace id that has never existed.
+    asyncio.run(bus.dispatch_intent("app-chat-library", "newChat", [999999]))
+    assert document.current_workspace_id is None
+
+    document.add_chat_node(0, 0, "hello", is_user=True)
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+    saved_row = next(row for row in get_all_chats(db_path) if row["id"] == document.current_chat_id)
+    assert saved_row["workspaceId"] == default_workspace_id
 
 
 def test_two_concurrent_save_chat_calls_do_not_race_only_one_row_is_written(db_path):

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -460,6 +460,196 @@ class TestMigrationUpgradesAPreExistingRealShapedDatabase:
         assert rows_after_second_connect[0]["id"] == chat_id
 
 
+def _create_migration_1_shaped_db(db_path) -> list[int]:
+    """ADR-020 stage 20.1's own analog of _create_pre_migration_shaped_db
+    above: builds a chats.db in EXACTLY the shape a real, already-upgraded
+    (ADR-009 stage 9.1) install has TODAY, right before this stage's own
+    migration "2" ever runs against it - the full chats/notes/pins schema
+    (raw DDL, not this module's own functions, which already assume the
+    NEW post-migration-2 schema once chat_library.py has been edited),
+    several real chat rows (including notes AND pins on at least one of
+    them), and PRAGMA user_version explicitly left at 1 (not 0 - a real
+    post-9.1 database has already run migration "1" and stamped its
+    version; this migration "2" test's own realistic starting point is "at
+    1, about to go to 2", not "at 0, needs both steps" - that combined case
+    is already covered by TestMigrationUpgradesAPreExistingRealShapedDatabase
+    above, which now also implicitly exercises 0 -> 1 -> 2 in one hop since
+    CHATS_DB_SCHEMA_VERSION is 2).
+
+    Returns the three inserted chat ids, in insertion order."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE chats (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL, "
+            "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+            "data TEXT NOT NULL, preview TEXT DEFAULT '', message_count INTEGER DEFAULT 0)"
+        )
+        conn.execute(
+            "CREATE TABLE notes (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id INTEGER NOT NULL, "
+            "content TEXT NOT NULL, position_x REAL NOT NULL, position_y REAL NOT NULL, width REAL NOT NULL, "
+            "height REAL NOT NULL, color TEXT NOT NULL, header_color TEXT, "
+            "is_system_prompt INTEGER DEFAULT 0, is_summary_note INTEGER DEFAULT 0, "
+            "FOREIGN KEY (chat_id) REFERENCES chats (id) ON DELETE CASCADE)"
+        )
+        conn.execute(
+            "CREATE TABLE pins (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id INTEGER NOT NULL, "
+            "title TEXT NOT NULL, note TEXT, position_x REAL NOT NULL, position_y REAL NOT NULL, "
+            "pin_id TEXT, sort_order INTEGER DEFAULT 0, anchor_item_id TEXT, created_at TEXT, "
+            "FOREIGN KEY (chat_id) REFERENCES chats (id) ON DELETE CASCADE)"
+        )
+        conn.execute("CREATE INDEX idx_notes_chat_id ON notes (chat_id)")
+        conn.execute("CREATE INDEX idx_pins_chat_id ON pins (chat_id)")
+
+        chat_ids = []
+        for title, preview, count, created, updated in (
+            ("First Chat", "hi there", 1, "2026-01-01 09:00:00", "2026-01-01 09:05:00"),
+            ("Second Chat", "another one", 2, "2026-01-02 10:00:00", "2026-01-02 10:10:00"),
+            ("Third Chat", "the last one", 3, "2026-01-03 11:00:00", "2026-01-03 11:15:00"),
+        ):
+            cursor = conn.execute(
+                "INSERT INTO chats (title, data, created_at, updated_at, preview, message_count) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (title, json.dumps({"nodes": [{"node_type": "chat", "raw_content": preview}]}),
+                 created, updated, preview, count),
+            )
+            chat_ids.append(cursor.lastrowid)
+
+        # Notes and pins attached to the first chat only - mirrors
+        # _create_pre_migration_shaped_db's own "at least one" scope; the
+        # other two chats exercise the no-notes/no-pins case.
+        conn.execute(
+            "INSERT INTO notes (chat_id, content, position_x, position_y, width, height, color, "
+            "header_color, is_system_prompt, is_summary_note) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (chat_ids[0], "A migration-2 note", 1.0, 2.0, 100.0, 50.0, "#222222", None, 0, 0),
+        )
+        conn.execute(
+            "INSERT INTO pins (chat_id, title, note, position_x, position_y, pin_id, sort_order, "
+            "anchor_item_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (chat_ids[0], "A migration-2 pin", "", 5.0, 6.0, "pin-1", 0, None, "2026-01-01 00:00:00"),
+        )
+        conn.commit()
+
+        conn.execute("PRAGMA user_version = 1")
+        conn.commit()
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        return chat_ids
+    finally:
+        conn.close()
+
+
+class TestMigration002IntroducesWorkspacesAndGraphs:
+    """ADR-020 stage 20.1's own fidelity proof, mirroring
+    TestMigrationUpgradesAPreExistingRealShapedDatabase above precisely:
+    hand-build a real migration-1-shaped chats.db, drive it through the
+    REAL production connect path (never a hand-called migration function -
+    that would only prove the SQL, not the wiring), and assert every
+    original row survives byte-for-byte under its new home."""
+
+    def test_existing_chats_become_graphs_in_the_default_workspace(self, db_path):
+        chat_ids = _create_migration_1_shaped_db(db_path)
+
+        # The real, production connect path - any query function drives it,
+        # exactly like TestMigrationUpgradesAPreExistingRealShapedDatabase's
+        # own get_all_chats(db_path) call above.
+        rows = get_all_chats(db_path)
+
+        assert len(rows) == 3
+        assert {row["id"] for row in rows} == set(chat_ids)
+        by_id = {row["id"]: row for row in rows}
+        assert by_id[chat_ids[0]]["title"] == "First Chat"
+        assert by_id[chat_ids[0]]["preview"] == "hi there"
+        assert by_id[chat_ids[0]]["messageCount"] == 1
+        assert by_id[chat_ids[1]]["title"] == "Second Chat"
+        assert by_id[chat_ids[2]]["title"] == "Third Chat"
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == CHATS_DB_SCHEMA_VERSION
+
+            workspace_rows = conn.execute("SELECT id, name FROM workspaces").fetchall()
+            assert len(workspace_rows) == 1
+            default_workspace_id, default_workspace_name = workspace_rows[0]
+            assert default_workspace_name == "Default"
+
+            graph_workspace_ids = {
+                row[0] for row in conn.execute("SELECT workspace_id FROM graphs").fetchall()
+            }
+            assert graph_workspace_ids == {default_workspace_id}
+
+            graphs_indexes = {row[1] for row in conn.execute("PRAGMA index_list(graphs)").fetchall()}
+            assert "idx_graphs_workspace_id" in graphs_indexes
+
+            # The renamed table's own row identity/content is untouched -
+            # the rename is a pure schema-level operation, not a data copy.
+            graphs_rows = conn.execute(
+                "SELECT id, title, data, created_at, updated_at, preview, message_count FROM graphs "
+                "ORDER BY id"
+            ).fetchall()
+            assert [row[0] for row in graphs_rows] == chat_ids
+            assert graphs_rows[0][1] == "First Chat"
+            assert graphs_rows[0][2] == json.dumps({"nodes": [{"node_type": "chat", "raw_content": "hi there"}]})
+            assert graphs_rows[0][3] == "2026-01-01 09:00:00"
+            assert graphs_rows[0][4] == "2026-01-01 09:05:00"
+        finally:
+            conn.close()
+
+        # load_chat_row/load_notes_rows/load_pins_rows - unchanged Python
+        # behavior, now transparently reading through the renamed table.
+        chat_row = load_chat_row(db_path, chat_ids[0])
+        assert chat_row["title"] == "First Chat"
+        assert chat_row["data"] == {"nodes": [{"node_type": "chat", "raw_content": "hi there"}]}
+
+        notes = load_notes_rows(db_path, chat_ids[0])
+        assert len(notes) == 1 and notes[0]["content"] == "A migration-2 note"
+
+        pins = load_pins_rows(db_path, chat_ids[0])
+        assert len(pins) == 1 and pins[0]["title"] == "A migration-2 pin"
+
+        # The other two chats never had notes/pins - still true post-migration.
+        assert load_notes_rows(db_path, chat_ids[1]) == []
+        assert load_pins_rows(db_path, chat_ids[1]) == []
+
+    def test_fresh_database_lands_on_version_2_with_only_the_default_workspace(self, db_path):
+        # No pre-existing file at all - a fresh install. Must reach version
+        # 2 cleanly with the Default workspace seeded and zero graphs.
+        assert not db_path.exists()
+
+        rows = get_all_chats(db_path)
+
+        assert rows == []
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == CHATS_DB_SCHEMA_VERSION
+            workspace_rows = conn.execute("SELECT id, name FROM workspaces").fetchall()
+            assert len(workspace_rows) == 1
+            assert workspace_rows[0][1] == "Default"
+            assert conn.execute("SELECT COUNT(*) FROM graphs").fetchone()[0] == 0
+        finally:
+            conn.close()
+
+    def test_migration_is_idempotent_when_run_twice_in_a_row(self, db_path):
+        # Matches TestMigrationUpgradesAPreExistingRealShapedDatabase's own
+        # test_upgrade_is_safe_to_run_twice_in_a_row precedent: a second
+        # connect (already at target version 2) is a true no-op - no
+        # duplicate Default workspace, no data disturbance.
+        chat_ids = _create_migration_1_shaped_db(db_path)
+
+        get_all_chats(db_path)
+        rows_after_second_connect = get_all_chats(db_path)
+
+        assert {row["id"] for row in rows_after_second_connect} == set(chat_ids)
+
+        conn = sqlite3.connect(db_path)
+        try:
+            workspace_rows = conn.execute("SELECT id, name FROM workspaces").fetchall()
+            assert len(workspace_rows) == 1, (
+                f"expected exactly one Default workspace after two migration passes, got {workspace_rows}"
+            )
+            assert conn.execute("SELECT COUNT(*) FROM graphs").fetchone()[0] == 3
+        finally:
+            conn.close()
+
+
 def test_get_all_chats_reads_real_rows(db_path):
     first_id = _insert_chat(db_path, "First")
     second_id = _insert_chat(db_path, "Second")
@@ -1587,7 +1777,10 @@ class TestCorruptDbRescue:
         holder = sqlite3.connect(db_path, timeout=30)
         holder.execute("PRAGMA journal_mode=WAL")
         holder.execute("BEGIN IMMEDIATE")
-        holder.execute("UPDATE chats SET title = 'locked-write'")
+        # ADR-020 stage 20.1: the real save_chat_atomically_row call above
+        # already migrated this db to version 2, which renamed "chats" to
+        # "graphs" - this raw SQL must target the table's CURRENT real name.
+        holder.execute("UPDATE graphs SET title = 'locked-write'")
         try:
             # A short timeout so this test doesn't hang for 30s waiting out
             # the real busy_timeout - a fresh connect() with its own short

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -17,6 +17,8 @@ import pytest
 import backend.autosave as autosave_module
 import backend.chat_library as chat_library_module
 import backend.db_backup as db_backup_module
+import backend.knowledge_store as knowledge_store_module
+from backend.api.intents_global_search import register_global_search_intents
 from backend.autosave import autosave_tick, register_autosave
 from backend.canvas import SceneDocument
 from backend.chat_library import (
@@ -57,6 +59,7 @@ from backend.chat_library import (
 )
 from backend.events import IntentValidationError, SessionBus
 from backend.notifications import NotificationState
+from backend.session_save import build_chat_data
 
 
 @pytest.fixture
@@ -2740,3 +2743,465 @@ def test_concurrent_save_conflict_message_names_the_chat(db_path):
         save_chat_atomically_row(
             db_path, chat_id, "T", {"nodes": []}, [], [], expected_updated_at=updated_at,
         )
+
+
+# -- ADR-020 stage 20.4: global FTS search + cross-workspace jump-to-node ----
+
+
+@pytest.fixture
+def knowledge_db_path(tmp_path):
+    return tmp_path / "knowledge" / "knowledge.db"
+
+
+class TestExtractIndexableNodeChunks:
+    """Unit tests for chat_library.py's own node-content normalization -
+    _extract_node_index_text/_extract_indexable_node_chunks, the piece that
+    turns a saved chat_data["nodes"] list into `[(node_id, text), ...]` for
+    backend.knowledge_store.reindex_graph_content. Ground-truthed against
+    backend/session_save.py's real per-kind _NODE_SERIALIZERS field names
+    (session_save.py:198-527) - see _TEXT_FIELD_BY_NODE_TYPE's own
+    docstring for exactly why each field name below is what it is, not a
+    guess (e.g. "code" nodes use wire key "code", NOT "content")."""
+
+    def test_chat_node_plain_string_raw_content(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "chat", "id": "n1", "raw_content": "Hello there"}]}
+        )
+        assert chunks == [("n1", "Hello there")]
+
+    def test_chat_node_multimodal_list_raw_content_only_text_parts_contribute(self):
+        chunks = chat_library_module._extract_indexable_node_chunks({
+            "nodes": [{
+                "node_type": "chat", "id": "n1",
+                "raw_content": [
+                    {"type": "text", "text": "a real phrase"},
+                    {"type": "image_bytes", "data": "not text"},
+                ],
+            }],
+        })
+        assert chunks == [("n1", "a real phrase")]
+
+    def test_code_node_uses_the_code_field_not_content(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "code", "id": "n1", "code": "print('hi')", "language": "python"}]}
+        )
+        assert chunks == [("n1", "print('hi')")]
+
+    def test_document_node_uses_content_and_title(self):
+        chunks = chat_library_module._extract_indexable_node_chunks({
+            "nodes": [{"node_type": "document", "id": "n1", "title": "Spec", "content": "the body text"}],
+        })
+        assert chunks == [("n1", "Spec the body text")]
+
+    def test_artifact_node_uses_content(self):
+        chunks = chat_library_module._extract_indexable_node_chunks({
+            "nodes": [{
+                "node_type": "artifact", "id": "n1", "instruction": "build it", "content": "the artifact body",
+            }],
+        })
+        assert chunks == [("n1", "the artifact body")]
+
+    def test_thinking_node_uses_thinking_text(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "thinking", "id": "n1", "thinking_text": "reasoning here"}]}
+        )
+        assert chunks == [("n1", "reasoning here")]
+
+    def test_html_node_uses_html_content(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "html", "id": "n1", "html_content": "<p>hi</p>"}]}
+        )
+        assert chunks == [("n1", "<p>hi</p>")]
+
+    def test_conversation_node_flattens_its_own_history(self):
+        # conversation has NO other text-bearing field at all - see
+        # session_save.py's own _serialize_conversation_node - so this is
+        # the only way it is ever findable.
+        chunks = chat_library_module._extract_indexable_node_chunks({
+            "nodes": [{
+                "node_type": "conversation", "id": "n1",
+                "conversation_history": [
+                    {"role": "user", "content": "what is a widget"},
+                    {"role": "assistant", "content": "a small mechanical thing"},
+                ],
+            }],
+        })
+        assert chunks == [("n1", "user: what is a widget\n\nassistant: a small mechanical thing")]
+
+    def test_web_research_node_uses_query(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "web_research", "id": "n1", "query": "best hiking trails"}]}
+        )
+        assert chunks == [("n1", "best hiking trails")]
+
+    def test_gitlink_node_uses_task_prompt(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "gitlink", "id": "n1", "task_prompt": "refactor the widget module"}]}
+        )
+        assert chunks == [("n1", "refactor the widget module")]
+
+    def test_pycoder_node_uses_prompt_not_code(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "pycoder", "id": "n1", "prompt": "sort this list", "code": "x.sort()"}]}
+        )
+        assert chunks == [("n1", "sort this list")]
+
+    def test_code_sandbox_node_uses_prompt(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "code_sandbox", "id": "n1", "prompt": "install numpy and plot"}]}
+        )
+        assert chunks == [("n1", "install numpy and plot")]
+
+    def test_plan_node_uses_goal(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "plan", "id": "n1", "goal": "build a REST API"}]}
+        )
+        assert chunks == [("n1", "build a REST API")]
+
+    def test_image_node_uses_prompt(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "image", "id": "n1", "prompt": "a cat on a skateboard"}]}
+        )
+        assert chunks == [("n1", "a cat on a skateboard")]
+
+    def test_a_plugin_node_falls_back_to_the_universal_content_and_title_fields(self):
+        chunks = chat_library_module._extract_indexable_node_chunks({
+            "nodes": [{"node_type": "my_plugin.widget", "id": "n1", "title": "Widget", "content": "plugin body text"}],
+        })
+        assert chunks == [("n1", "Widget plugin body text")]
+
+    def test_a_node_with_no_id_is_skipped(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "code", "code": "no id on this node"}]}
+        )
+        assert chunks == []
+
+    def test_a_node_with_nothing_indexable_is_skipped_entirely(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": [{"node_type": "thinking", "id": "n1", "thinking_text": ""}]}
+        )
+        assert chunks == []
+
+    def test_non_dict_and_malformed_entries_in_nodes_do_not_crash(self):
+        chunks = chat_library_module._extract_indexable_node_chunks(
+            {"nodes": ["not-a-dict", {"node_type": "code", "id": "n1", "code": "ok"}, None]}
+        )
+        assert chunks == [("n1", "ok")]
+
+
+class TestSaveChatAtomicallyRowIndexesIntoKnowledgeStore:
+    """ADR-020 stage 20.4: save_chat_atomically_row's own knowledge-store
+    re-indexing hook (_reindex_graph_into_knowledge_store) - proven here
+    against the REAL save path, not backend.knowledge_store.
+    reindex_graph_content in isolation (backend/tests/test_knowledge_store.
+    py's own TestReindexGraphContent covers that primitive directly)."""
+
+    def test_a_save_makes_node_content_findable_via_search_chunks(self, db_path, knowledge_db_path):
+        chat_data = {"nodes": [
+            {"node_type": "chat", "id": "n1", "raw_content": "a phrase about narwhals", "is_user": True},
+        ]}
+        chat_id, _ = save_chat_atomically_row(
+            db_path, None, "Narwhal Graph", chat_data, [], [], knowledge_db_path=knowledge_db_path,
+        )
+        results = knowledge_store_module.search_chunks(knowledge_db_path, "narwhals")
+        assert len(results) == 1
+        assert results[0]["source_node_id"] == "n1"
+        assert results[0]["source_uri"] == f"graph:{chat_id}"
+        assert results[0]["document_title"] == "Narwhal Graph"
+
+    def test_resaving_with_changed_content_updates_the_index(self, db_path, knowledge_db_path):
+        chat_data_v0 = {"nodes": [
+            {"node_type": "chat", "id": "n1", "raw_content": "the old phrase", "is_user": True},
+        ]}
+        chat_id, _ = save_chat_atomically_row(
+            db_path, None, "T", chat_data_v0, [], [], knowledge_db_path=knowledge_db_path,
+        )
+        assert len(knowledge_store_module.search_chunks(knowledge_db_path, "old phrase")) == 1
+
+        chat_data_v1 = {"nodes": [
+            {"node_type": "chat", "id": "n1", "raw_content": "the new phrase", "is_user": True},
+        ]}
+        save_chat_atomically_row(
+            db_path, chat_id, "T", chat_data_v1, [], [], knowledge_db_path=knowledge_db_path,
+        )
+        assert knowledge_store_module.search_chunks(knowledge_db_path, "old phrase") == []
+        new_results = knowledge_store_module.search_chunks(knowledge_db_path, "new phrase")
+        assert len(new_results) == 1
+        assert new_results[0]["source_node_id"] == "n1"
+
+    def test_the_indexed_workspace_is_the_graphs_real_workspace_on_a_resave(self, db_path, knowledge_db_path):
+        # UPDATE branch: workspace_id is never re-passed on a resave (see
+        # save_chat_atomically_row's own docstring) - the reindex hook must
+        # still resolve the graph's REAL, already-assigned workspace, not
+        # silently fall back to some default/global collection.
+        get_all_chats(db_path)  # bootstraps a fully-migrated db
+        workspace = create_workspace(db_path, "Research")
+        chat_data = {"nodes": [
+            {"node_type": "chat", "id": "n1", "raw_content": "scoped phrase", "is_user": True},
+        ]}
+        chat_id, _ = save_chat_atomically_row(
+            db_path, None, "T", chat_data, [], [],
+            workspace_id=workspace["id"], knowledge_db_path=knowledge_db_path,
+        )
+        # Resave with NO workspace_id arg at all (the default, None).
+        save_chat_atomically_row(db_path, chat_id, "T", chat_data, [], [], knowledge_db_path=knowledge_db_path)
+
+        collection_id = knowledge_store_module.get_or_create_workspace_collection(knowledge_db_path, workspace["id"])
+        results = knowledge_store_module.search_chunks(knowledge_db_path, "scoped phrase", collection_id=collection_id)
+        assert len(results) == 1
+
+    def test_a_knowledge_store_failure_never_breaks_the_chats_db_save(self, db_path, knowledge_db_path, monkeypatch):
+        # Best-effort: a broken knowledge.db write must never take down the
+        # correctness-critical chats.db save with it.
+        def _boom(*args, **kwargs):
+            raise sqlite3.OperationalError("simulated knowledge.db failure")
+
+        monkeypatch.setattr(chat_library_module.knowledge_store, "reindex_graph_content", _boom)
+        chat_data = {"nodes": [{"node_type": "chat", "id": "n1", "raw_content": "hi", "is_user": True}]}
+        chat_id, _updated_at = save_chat_atomically_row(
+            db_path, None, "T", chat_data, [], [], knowledge_db_path=knowledge_db_path,
+        )
+        assert chat_id is not None
+        assert load_chat_row(db_path, chat_id)["data"] == chat_data
+
+
+class TestDeleteChatRemovesTheKnowledgeIndexToo:
+    def test_deleting_a_graph_removes_its_indexed_content(self, db_path, knowledge_db_path):
+        chat_data = {"nodes": [
+            {"node_type": "chat", "id": "n1", "raw_content": "a phrase about octopi", "is_user": True},
+        ]}
+        chat_id, _ = save_chat_atomically_row(
+            db_path, None, "T", chat_data, [], [], knowledge_db_path=knowledge_db_path,
+        )
+        assert len(knowledge_store_module.search_chunks(knowledge_db_path, "octopi")) == 1
+
+        delete_chat(db_path, chat_id, knowledge_db_path=knowledge_db_path)
+
+        assert knowledge_store_module.search_chunks(knowledge_db_path, "octopi") == []
+        assert get_all_chats(db_path) == []  # the chats.db row is gone too
+
+    def test_a_knowledge_store_failure_never_breaks_the_chats_db_delete(self, db_path, knowledge_db_path, monkeypatch):
+        chat_data = {"nodes": [{"node_type": "chat", "id": "n1", "raw_content": "hi", "is_user": True}]}
+        chat_id, _ = save_chat_atomically_row(
+            db_path, None, "T", chat_data, [], [], knowledge_db_path=knowledge_db_path,
+        )
+
+        def _boom(*args, **kwargs):
+            raise sqlite3.OperationalError("simulated knowledge.db failure")
+
+        monkeypatch.setattr(chat_library_module.knowledge_store, "delete_graph_index", _boom)
+        delete_chat(db_path, chat_id, knowledge_db_path=knowledge_db_path)  # must not raise
+        assert get_all_chats(db_path) == []
+
+
+class TestLoadGraphAndFocusNodeIntent:
+    """ADR-020 stage 20.4: the request/reply intent - see
+    make_load_graph_and_focus_node's own docstring for the full contract."""
+
+    def test_returns_the_real_node_coordinates_after_loading_a_different_graph(self, db_path):
+        # A REAL saved graph, built via a real live document/save cycle (so
+        # its own persisted "id" is a genuine, counter-minted SceneNode id,
+        # never a hand-typed guess) - then looked up against a COMPLETELY
+        # FRESH document/bus (a different SessionBus, own fresh id counter),
+        # exactly the real "jump into a graph THIS session has never loaded
+        # before" scenario - see make_load_graph_and_focus_node's own
+        # docstring for why the two documents' ids are never expected to
+        # match (RELOAD PATH: resolved by ordinal position, not by id).
+        seed_document = SceneDocument()
+        seed_node = seed_document.add_chat_node(123.5, 456.0, "hi", is_user=True)
+        seed_chat_data = build_chat_data(seed_document)
+        seed_notes = seed_chat_data.pop("notes_data", [])
+        seed_pins = seed_chat_data.pop("pins_data", [])
+        chat_id, _ = save_chat_atomically_row(db_path, None, "Target Graph", seed_chat_data, seed_notes, seed_pins)
+        saved_node_id = seed_node.id
+
+        bus, document, notifications = _bus_with_canvas(db_path)
+
+        result = asyncio.run(
+            bus.dispatch_intent("app-chat-library", "loadGraphAndFocusNode", [chat_id, saved_node_id])
+        )
+
+        assert result == {"x": 123.5, "y": 456.0}
+        assert document.current_chat_id == chat_id
+        assert len(document.nodes) == 1
+        live_node = next(iter(document.nodes.values()))
+        assert live_node.x == 123.5 and live_node.y == 456.0
+
+    def test_the_fast_path_skips_the_reload_when_already_on_the_target_graph(self, db_path):
+        # The SAVED id is deliberately irrelevant here (never compared
+        # against in the fast path) - only the LIVE id (captured after the
+        # real load, below) matters.
+        chat_data = {"nodes": [
+            {"node_type": "chat", "id": "irrelevant-saved-id", "raw_content": "hi", "is_user": True,
+             "position": {"x": 10.0, "y": 20.0}},
+        ]}
+        chat_id = _insert_chat(db_path, "Already Open", data=json.dumps(chat_data))
+        bus, document, notifications = _bus_with_canvas(db_path)
+        asyncio.run(bus.dispatch_intent("app-chat-library", "loadChat", [chat_id]))
+        assert notifications.visible
+        notifications.dismiss()  # reset so we can prove NO second "Loaded ..." notice fires
+        live_node_id = next(iter(document.nodes.values())).id
+
+        result = asyncio.run(
+            bus.dispatch_intent("app-chat-library", "loadGraphAndFocusNode", [chat_id, live_node_id])
+        )
+
+        assert result == {"x": 10.0, "y": 20.0}
+        assert notifications.visible is False, "the fast path must not reload (and re-notify) a graph already open"
+
+    def test_returns_none_for_a_stale_search_result_pointing_at_a_deleted_node(self, db_path):
+        chat_data = {"nodes": [
+            {"node_type": "chat", "id": "n1", "raw_content": "hi", "is_user": True, "position": {"x": 0, "y": 0}},
+        ]}
+        chat_id = _insert_chat(db_path, "Graph", data=json.dumps(chat_data))
+        bus, document, notifications = _bus_with_canvas(db_path)
+
+        result = asyncio.run(bus.dispatch_intent(
+            "app-chat-library", "loadGraphAndFocusNode", [chat_id, "node-that-no-longer-exists"],
+        ))
+
+        assert result is None
+        assert document.current_chat_id == chat_id  # the graph itself DID load successfully
+
+    def test_returns_none_for_a_stale_search_result_pointing_at_a_deleted_graph(self, db_path):
+        bus, document, notifications = _bus_with_canvas(db_path)
+
+        result = asyncio.run(bus.dispatch_intent("app-chat-library", "loadGraphAndFocusNode", [999999, "n1"]))
+
+        assert result is None
+        assert notifications.visible and notifications.msg_type == "error"
+
+
+class TestGlobalSearchAcrossWorkspaces:
+    """ADR-020 stage 20.4's own exit criterion, proven literally end to
+    end: two workspaces, a graph in each with distinct node content, a
+    search from global scope (collection_id=None) finds a phrase that
+    exists ONLY in workspace B's graph while the "current" session context
+    is workspace A, the search result correctly identifies the source
+    graph_id/node_id, and calling loadGraphAndFocusNode with that graph_id/
+    node_id returns the real node's real x/y coordinates - the full
+    backend chain, not just the FTS query in isolation."""
+
+    def test_a_phrase_in_a_closed_graph_in_another_workspace_is_found_and_focused(
+        self, db_path, knowledge_db_path, monkeypatch,
+    ):
+        import backend.api.intents_global_search as igs_module
+        # intents_global_search.py imports DEFAULT_DB_PATH BY NAME (the same
+        # shape backend/api/intents_knowledge.py already uses, and this
+        # exact test's own precedent - test_intents_knowledge.py's own
+        # module docstring on why this monkeypatch, not the module-level
+        # one, is what's needed for a NAME import).
+        monkeypatch.setattr(igs_module, "DEFAULT_DB_PATH", knowledge_db_path)
+
+        get_all_chats(db_path)  # bootstraps a fully-migrated db (Default = workspace A)
+        workspace_a = get_all_workspaces(db_path)[0]
+        workspace_b = create_workspace(db_path, "Workspace B")
+
+        graph_a_data = {"nodes": [
+            {"node_type": "chat", "id": "a1", "raw_content": "notes about apples", "is_user": True,
+             "position": {"x": 1.0, "y": 2.0}},
+        ]}
+        graph_a_id, _ = save_chat_atomically_row(
+            db_path, None, "Graph A", graph_a_data, [], [],
+            workspace_id=workspace_a["id"], knowledge_db_path=knowledge_db_path,
+        )
+
+        graph_b_data = {"nodes": [
+            {"node_type": "chat", "id": "b1", "raw_content": "a very unique phrase about zephyrsaurus",
+             "is_user": True, "position": {"x": 777.0, "y": 888.0}},
+        ]}
+        graph_b_id, _ = save_chat_atomically_row(
+            db_path, None, "Graph B", graph_b_data, [], [],
+            workspace_id=workspace_b["id"], knowledge_db_path=knowledge_db_path,
+        )
+
+        # The "current" session context is workspace A - it loaded Graph A
+        # (the graph the user is CURRENTLY looking at) and never opened
+        # Graph B at all.
+        bus, document, notifications = _bus_with_canvas(db_path)
+        register_global_search_intents(bus)
+        asyncio.run(bus.dispatch_intent("app-chat-library", "loadChat", [graph_a_id]))
+        assert document.current_chat_id == graph_a_id
+        assert document.current_workspace_id == workspace_a["id"]
+
+        # Global scope (no workspaceId filter) must find the phrase that
+        # exists ONLY in workspace B's graph.
+        search_result = asyncio.run(bus.dispatch_intent("globalSearch", "search", ["zephyrsaurus", 10]))
+        results = search_result["results"]
+        assert len(results) == 1
+        hit = results[0]
+        assert hit["graphId"] == graph_b_id
+        assert hit["sourceNodeId"] == "b1"
+        assert "zephyrsaurus" in hit["text"].lower()
+
+        # The SAME global search also finds Graph A's own exclusive phrase -
+        # proving this is a real cross-workspace search, not an accident of
+        # only one workspace's collection being queried.
+        apples_result = asyncio.run(bus.dispatch_intent("globalSearch", "search", ["apples", 10]))
+        assert len(apples_result["results"]) == 1
+        assert apples_result["results"][0]["graphId"] == graph_a_id
+        assert apples_result["results"][0]["sourceNodeId"] == "a1"
+
+        # The full chain: loadGraphAndFocusNode with the search result's OWN
+        # graph_id/node_id returns the real node's real x/y - while the
+        # session is STILL sitting on Graph A (a genuine cross-workspace
+        # jump, not a same-graph lookup).
+        focus_result = asyncio.run(bus.dispatch_intent(
+            "app-chat-library", "loadGraphAndFocusNode", [hit["graphId"], hit["sourceNodeId"]],
+        ))
+        assert focus_result == {"x": 777.0, "y": 888.0}
+        assert document.current_chat_id == graph_b_id  # the session really did switch graphs
+
+    def test_a_workspace_filter_scopes_the_search_to_one_workspace(self, db_path, knowledge_db_path, monkeypatch):
+        import backend.api.intents_global_search as igs_module
+        monkeypatch.setattr(igs_module, "DEFAULT_DB_PATH", knowledge_db_path)
+
+        get_all_chats(db_path)
+        workspace_a = get_all_workspaces(db_path)[0]
+        workspace_b = create_workspace(db_path, "Workspace B")
+
+        save_chat_atomically_row(
+            db_path, None, "Graph A", {"nodes": [
+                {"node_type": "chat", "id": "a1", "raw_content": "shared search term alpha", "is_user": True},
+            ]}, [], [], workspace_id=workspace_a["id"], knowledge_db_path=knowledge_db_path,
+        )
+        save_chat_atomically_row(
+            db_path, None, "Graph B", {"nodes": [
+                {"node_type": "chat", "id": "b1", "raw_content": "shared search term beta", "is_user": True},
+            ]}, [], [], workspace_id=workspace_b["id"], knowledge_db_path=knowledge_db_path,
+        )
+
+        bus, _document, _notifications = _bus_with_canvas(db_path)
+        register_global_search_intents(bus)
+
+        unscoped = asyncio.run(bus.dispatch_intent("globalSearch", "search", ["shared search term", 10]))
+        assert len(unscoped["results"]) == 2
+
+        scoped_to_b = asyncio.run(
+            bus.dispatch_intent("globalSearch", "search", ["shared search term", 10, workspace_b["id"]])
+        )
+        assert len(scoped_to_b["results"]) == 1
+        assert scoped_to_b["results"][0]["sourceNodeId"] == "b1"
+
+    def test_a_document_hit_carries_no_graph_id_or_source_node_id(self, db_path, knowledge_db_path, monkeypatch):
+        # A real ingested document (not a graph) must be distinguishable
+        # from a graph/node hit - sourceNodeId/graphId both None.
+        import backend.api.intents_global_search as igs_module
+        monkeypatch.setattr(igs_module, "DEFAULT_DB_PATH", knowledge_db_path)
+
+        from backend.knowledge_chunking import chunk_text
+
+        text = "A real ingested document about jackalopes."
+        knowledge_store_module.add_document_with_chunks(
+            knowledge_db_path, source_uri="notes.txt", title="Notes", mime="text/plain",
+            text=text, chunks=chunk_text(text, target_tokens=1000),
+        )
+
+        bus, _document, _notifications = _bus_with_canvas(db_path)
+        register_global_search_intents(bus)
+        result = asyncio.run(bus.dispatch_intent("globalSearch", "search", ["jackalopes", 10]))
+
+        assert len(result["results"]) == 1
+        hit = result["results"][0]
+        assert hit["sourceNodeId"] is None
+        assert hit["graphId"] is None

--- a/backend/tests/test_intents_knowledge.py
+++ b/backend/tests/test_intents_knowledge.py
@@ -126,3 +126,86 @@ class TestSetChatIndexIntoKnowledgeIntent:
         recorder.messages.clear()
         _run(bus.dispatch_intent("scene", "setChatIndexIntoKnowledge", [node_id, True]))
         assert "scene" in recorder.topics_seen()
+
+
+# -- ADR-020 stage 20.3: workspace-scoped knowledge corpus -------------------
+#
+# The exit criterion's own "different corpora" half, proven through the REAL
+# search()/setChatIndexIntoKnowledge intent call paths (backend/api/
+# intents_knowledge.py) - never by calling backend.knowledge_store's
+# get_or_create_workspace_collection or hybrid_search directly - so this
+# actually pins the WIRING (document.current_workspace_id -> collection
+# resolution -> collection_id-scoped store call), not just the underlying
+# pure functions those intents happen to call.
+
+
+class TestWorkspaceScopedKnowledgeCorpus:
+    def test_two_separate_sessions_in_two_workspaces_never_see_each_others_content(self, _isolated_knowledge_db):
+        # Two INDEPENDENT sessions/documents (not one document whose
+        # workspace id is merely mutated mid-test) - the closest analog to
+        # the real world, where two different browser tabs/windows each
+        # have their own chats open in different workspaces at once.
+        bus1, document1, _ = make_bus()
+        document1.current_workspace_id = 10
+        node1 = _run(bus1.dispatch_intent("scene", "addChatNode", [0, 0, "alpha team roadmap notes", True]))
+        _run(bus1.dispatch_intent("scene", "setChatIndexIntoKnowledge", [node1, True]))
+
+        bus2, document2, _ = make_bus()
+        document2.current_workspace_id = 20
+        node2 = _run(bus2.dispatch_intent("scene", "addChatNode", [0, 0, "beta team roadmap notes", True]))
+        _run(bus2.dispatch_intent("scene", "setChatIndexIntoKnowledge", [node2, True]))
+
+        # Each session's own search() call (real intent dispatch, not a
+        # direct hybrid_search() call) sees ONLY its own workspace's content.
+        results1 = _run(bus1.dispatch_intent("knowledge", "search", ["roadmap notes", 10]))
+        assert len(results1["results"]) == 1
+        assert "alpha" in results1["results"][0]["text"]
+
+        results2 = _run(bus2.dispatch_intent("knowledge", "search", ["roadmap notes", 10]))
+        assert len(results2["results"]) == 1
+        assert "beta" in results2["results"][0]["text"]
+
+        # Behind the scenes, two genuinely distinct collections.
+        collection1 = knowledge_store.get_or_create_workspace_collection(_isolated_knowledge_db, 10)
+        collection2 = knowledge_store.get_or_create_workspace_collection(_isolated_knowledge_db, 20)
+        assert collection1 != collection2
+        docs1 = knowledge_store.list_documents(_isolated_knowledge_db, collection_id=collection1)
+        docs2 = knowledge_store.list_documents(_isolated_knowledge_db, collection_id=collection2)
+        assert len(docs1) == 1 and len(docs2) == 1
+        assert docs1[0]["id"] != docs2[0]["id"]
+
+    def test_switching_the_same_sessions_workspace_switches_what_search_can_see(self, _isolated_knowledge_db):
+        bus, document, _ = make_bus()
+
+        document.current_workspace_id = 1
+        node_ws1 = _run(bus.dispatch_intent("scene", "addChatNode", [0, 0, "workspace one exclusive content", True]))
+        _run(bus.dispatch_intent("scene", "setChatIndexIntoKnowledge", [node_ws1, True]))
+
+        # Still in workspace 1: finds it.
+        found_in_ws1 = _run(bus.dispatch_intent("knowledge", "search", ["exclusive content", 5]))
+        assert len(found_in_ws1["results"]) == 1
+
+        # Mirrors what loadChat's own current_workspace_id fix (backend/
+        # chat_library.py) does when a session switches to a different
+        # graph/workspace - search() must immediately stop seeing workspace
+        # 1's content.
+        document.current_workspace_id = 2
+        found_in_ws2 = _run(bus.dispatch_intent("knowledge", "search", ["exclusive content", 5]))
+        assert found_in_ws2["results"] == []
+
+    def test_a_session_with_no_workspace_context_falls_back_to_the_pre_20_3_global_pool(self, _isolated_knowledge_db):
+        # document.current_workspace_id is None (the default - a session
+        # that never loaded/created a chat with a real workspace) - must
+        # resolve to collection_id=0, the pre-20.3 unscoped pool, not raise
+        # or silently pick some arbitrary workspace.
+        bus, document, _ = make_bus()
+        assert document.current_workspace_id is None
+
+        node_id = _run(bus.dispatch_intent("scene", "addChatNode", [0, 0, "unscoped content", True]))
+        _run(bus.dispatch_intent("scene", "setChatIndexIntoKnowledge", [node_id, True]))
+
+        docs = knowledge_store.list_documents(_isolated_knowledge_db, collection_id=0)
+        assert len(docs) == 1
+
+        results = _run(bus.dispatch_intent("knowledge", "search", ["unscoped content", 5]))
+        assert len(results["results"]) == 1

--- a/backend/tests/test_knowledge_store.py
+++ b/backend/tests/test_knowledge_store.py
@@ -273,6 +273,122 @@ class TestMigrationBackfill:
         assert results[0]["document_id"] == outcome.document_id
 
 
+class TestMigration004WorkspaceScopedCollections:
+    """ADR-020 stage 20.3, migration "4" (3 -> 4): collections.workspace_id.
+    Mirrors TestMigrationBackfill's own "simulate a real user upgrading in
+    place" shape - ingest against schema version 3 (no workspace_id column
+    yet), then let the module's own real target version (4) take over."""
+
+    def test_a_migration_from_3_to_4_adds_the_column_without_disturbing_existing_collections(
+        self, db_path, monkeypatch,
+    ):
+        monkeypatch.setattr(ks, "KNOWLEDGE_DB_SCHEMA_VERSION", 3)
+        monkeypatch.setattr(ks, "_MIGRATIONS", {
+            1: ks._migration_001_initial_schema,
+            2: ks._migration_002_fts5_lexical_index,
+            3: ks._migration_003_vector_index,
+        })
+        outcome = _ingest(db_path, text="Pre-existing content about giraffes.", collection_id=7)
+
+        monkeypatch.undo()
+        # The real, production connect path - any query function drives it.
+        assert ks.get_document(db_path, outcome.document_id) is not None
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == ks.KNOWLEDGE_DB_SCHEMA_VERSION
+            collections_columns = {info[1] for info in conn.execute("PRAGMA table_info(collections)").fetchall()}
+            assert "workspace_id" in collections_columns
+            # Pre-existing collection_id=7 documents are untouched - this
+            # migration adds a NEW nullable column, it never backfills or
+            # reinterprets the pre-20.3 collection_id=0-style sentinel.
+            row = conn.execute(
+                "SELECT collection_id FROM documents WHERE id = ?", (outcome.document_id,),
+            ).fetchone()
+            assert row[0] == 7
+        finally:
+            conn.close()
+
+    def test_fresh_database_lands_on_version_4_with_the_workspace_id_column(self, db_path):
+        outcome = _ingest(db_path, text="Fresh install content.")
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == ks.KNOWLEDGE_DB_SCHEMA_VERSION
+            collections_columns = {info[1] for info in conn.execute("PRAGMA table_info(collections)").fetchall()}
+            assert "workspace_id" in collections_columns
+        finally:
+            conn.close()
+        assert ks.get_document(db_path, outcome.document_id) is not None
+
+    def test_migration_is_idempotent_when_run_twice_in_a_row(self, db_path):
+        _ingest(db_path, text="First document.")
+        _ingest(db_path, text="A second, different document.")
+        conn = sqlite3.connect(db_path)
+        try:
+            columns = [info[1] for info in conn.execute("PRAGMA table_info(collections)").fetchall()]
+            assert columns.count("workspace_id") == 1
+        finally:
+            conn.close()
+
+
+class TestGetOrCreateWorkspaceCollection:
+    """ADR-020 stage 20.3's own scoping decision (see this module's own
+    module-docstring update): exactly ONE auto-created collection per
+    workspace, resolved idempotently - the mechanism the exit criterion's
+    own "two workspaces' corpora are separate" half rests on."""
+
+    def test_creates_a_new_collection_on_first_call_for_a_workspace(self, db_path):
+        collection_id = ks.get_or_create_workspace_collection(db_path, 42)
+        assert isinstance(collection_id, int)
+        conn = sqlite3.connect(db_path)
+        try:
+            row = conn.execute(
+                "SELECT workspace_id FROM collections WHERE id = ?", (collection_id,),
+            ).fetchone()
+            assert row == (42,)
+        finally:
+            conn.close()
+
+    def test_repeated_calls_for_the_same_workspace_return_the_same_id_not_a_new_row(self, db_path):
+        first = ks.get_or_create_workspace_collection(db_path, 5)
+        second = ks.get_or_create_workspace_collection(db_path, 5)
+        third = ks.get_or_create_workspace_collection(db_path, 5)
+        assert first == second == third
+        conn = sqlite3.connect(db_path)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM collections WHERE workspace_id = ?", (5,),
+            ).fetchone()[0]
+            assert count == 1
+        finally:
+            conn.close()
+
+    def test_two_different_workspaces_get_two_genuinely_different_collections(self, db_path):
+        collection_a = ks.get_or_create_workspace_collection(db_path, 1)
+        collection_b = ks.get_or_create_workspace_collection(db_path, 2)
+        assert collection_a != collection_b
+
+    def test_documents_ingested_into_different_workspace_collections_are_isolated(self, db_path):
+        collection_a = ks.get_or_create_workspace_collection(db_path, 100)
+        collection_b = ks.get_or_create_workspace_collection(db_path, 200)
+
+        _ingest(db_path, text="Alpha workspace exclusive content.", collection_id=collection_a)
+        _ingest(db_path, text="Beta workspace exclusive content.", collection_id=collection_b)
+
+        docs_a = ks.list_documents(db_path, collection_id=collection_a)
+        docs_b = ks.list_documents(db_path, collection_id=collection_b)
+        assert len(docs_a) == 1 and len(docs_b) == 1
+        assert docs_a[0]["id"] != docs_b[0]["id"]
+
+        results_a = ks.search_chunks(db_path, "exclusive content", collection_id=collection_a)
+        assert len(results_a) == 1
+        assert "alpha" in results_a[0]["text"].lower()
+
+        results_b = ks.search_chunks(db_path, "exclusive content", collection_id=collection_b)
+        assert len(results_b) == 1
+        assert "beta" in results_b[0]["text"].lower()
+
+
 class TestFts5LexicalSearch:
     def test_search_finds_a_matching_chunk_with_correct_citation_fields(self, db_path):
         text = "The quick brown fox jumps over the lazy dog."

--- a/backend/tests/test_knowledge_store.py
+++ b/backend/tests/test_knowledge_store.py
@@ -459,3 +459,179 @@ class TestFts5LexicalSearch:
         results = ks.search_chunks(db_path, "python")
         assert len(results) == 2
         assert results[0]["source_uri"] == "dense.txt"
+
+    def test_source_node_id_is_none_for_a_real_ingested_document_chunk(self, db_path):
+        _ingest(db_path, text="Content with no originating graph node at all.")
+        results = ks.search_chunks(db_path, "originating")
+        assert len(results) == 1
+        assert results[0]["source_node_id"] is None
+
+
+class TestMigration005GraphNodeChunks:
+    """ADR-020 stage 20.4, migration "5" (4 -> 5): chunks.source_node_id.
+    Mirrors TestMigration004WorkspaceScopedCollections's own "simulate a
+    real user upgrading in place" shape exactly - ingest against schema
+    version 4 (no source_node_id column yet), then let the module's own
+    real target version (5) take over on the next connect."""
+
+    def test_a_migration_from_4_to_5_adds_the_column_without_disturbing_existing_chunks(
+        self, db_path, monkeypatch,
+    ):
+        monkeypatch.setattr(ks, "KNOWLEDGE_DB_SCHEMA_VERSION", 4)
+        monkeypatch.setattr(ks, "_MIGRATIONS", {
+            1: ks._migration_001_initial_schema,
+            2: ks._migration_002_fts5_lexical_index,
+            3: ks._migration_003_vector_index,
+            4: ks._migration_004_workspace_scoped_collections,
+        })
+        outcome = _ingest(db_path, text="Pre-existing content about pangolins.")
+
+        monkeypatch.undo()
+        # The real, production connect path - any query function drives it.
+        assert ks.get_document(db_path, outcome.document_id) is not None
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == ks.KNOWLEDGE_DB_SCHEMA_VERSION
+            chunks_columns = {info[1] for info in conn.execute("PRAGMA table_info(chunks)").fetchall()}
+            assert "source_node_id" in chunks_columns
+            # The pre-existing chunk survives byte-for-byte, with the new
+            # column landing NULL (never backfilled to some sentinel) - a
+            # real ingested document's chunk is never a graph-node chunk.
+            row = conn.execute(
+                "SELECT text, source_node_id FROM chunks WHERE document_id = ?", (outcome.document_id,),
+            ).fetchone()
+            assert row[0] == "Pre-existing content about pangolins."
+            assert row[1] is None
+        finally:
+            conn.close()
+        # And it is still findable via search_chunks - the migration never
+        # disturbed chunks_fts either.
+        results = ks.search_chunks(db_path, "pangolins")
+        assert len(results) == 1
+        assert results[0]["source_node_id"] is None
+
+    def test_fresh_database_lands_on_version_5_with_the_source_node_id_column(self, db_path):
+        outcome = _ingest(db_path, text="Fresh install content, take two.")
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == ks.KNOWLEDGE_DB_SCHEMA_VERSION
+            chunks_columns = {info[1] for info in conn.execute("PRAGMA table_info(chunks)").fetchall()}
+            assert "source_node_id" in chunks_columns
+        finally:
+            conn.close()
+        assert ks.get_document(db_path, outcome.document_id) is not None
+
+    def test_migration_is_idempotent_when_run_twice_in_a_row(self, db_path):
+        _ingest(db_path, text="First document, second migration test.")
+        _ingest(db_path, text="A second, different document, same test.")
+        conn = sqlite3.connect(db_path)
+        try:
+            columns = [info[1] for info in conn.execute("PRAGMA table_info(chunks)").fetchall()]
+            assert columns.count("source_node_id") == 1
+        finally:
+            conn.close()
+
+
+class TestReindexGraphContent:
+    """ADR-020 stage 20.4: backend.knowledge_store.reindex_graph_content /
+    delete_graph_index - the FTS-index half of "a graph is saved, its node
+    content becomes searchable; re-saved, the index reflects the CURRENT
+    content; deleted, the index entry is gone too". backend/tests/
+    test_chat_library.py's own TestGlobalSearchAcrossWorkspaces covers the
+    full real save_chat_atomically_row-driven path end to end; these tests
+    exercise this module's own primitive directly and in isolation."""
+
+    def test_indexes_one_chunk_per_node_findable_by_content(self, db_path):
+        workspace_id = 1
+        ks.reindex_graph_content(
+            db_path, graph_id=42, workspace_id=workspace_id, title="My Graph",
+            node_chunks=[("node-a", "Alpha node about kangaroos."), ("node-b", "Beta node about wombats.")],
+        )
+        kangaroo_hits = ks.search_chunks(db_path, "kangaroos")
+        assert len(kangaroo_hits) == 1
+        assert kangaroo_hits[0]["source_node_id"] == "node-a"
+        assert kangaroo_hits[0]["source_uri"] == "graph:42"
+        assert kangaroo_hits[0]["document_title"] == "My Graph"
+
+        wombat_hits = ks.search_chunks(db_path, "wombats")
+        assert len(wombat_hits) == 1
+        assert wombat_hits[0]["source_node_id"] == "node-b"
+
+    def test_resaving_with_changed_content_makes_old_content_unfindable_and_new_content_findable(self, db_path):
+        ks.reindex_graph_content(
+            db_path, graph_id=7, workspace_id=1, title="Graph",
+            node_chunks=[("node-a", "The original phrase about penguins.")],
+        )
+        assert len(ks.search_chunks(db_path, "penguins")) == 1
+
+        ks.reindex_graph_content(
+            db_path, graph_id=7, workspace_id=1, title="Graph",
+            node_chunks=[("node-a", "The replacement phrase about dolphins.")],
+        )
+        assert ks.search_chunks(db_path, "penguins") == []
+        dolphin_hits = ks.search_chunks(db_path, "dolphins")
+        assert len(dolphin_hits) == 1
+        assert dolphin_hits[0]["source_node_id"] == "node-a"
+
+        # Exactly one documents row for this graph, never one per save -
+        # the delete-then-reinsert strategy never accumulates duplicates.
+        conn = sqlite3.connect(db_path)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM documents WHERE source_uri = ?", ("graph:7",),
+            ).fetchone()[0]
+            assert count == 1
+        finally:
+            conn.close()
+
+    def test_resaving_with_empty_node_chunks_clears_the_prior_index(self, db_path):
+        ks.reindex_graph_content(
+            db_path, graph_id=9, workspace_id=1, title="Graph",
+            node_chunks=[("node-a", "Content about octopuses.")],
+        )
+        assert len(ks.search_chunks(db_path, "octopuses")) == 1
+
+        ks.reindex_graph_content(db_path, graph_id=9, workspace_id=1, title="Graph", node_chunks=[])
+        assert ks.search_chunks(db_path, "octopuses") == []
+
+    def test_two_different_graphs_do_not_collide_even_with_identical_content(self, db_path):
+        # Different from add_document_with_chunks' own content-hash
+        # idempotency (this module's own module docstring) - two DIFFERENT
+        # graphs with byte-identical node text must remain two distinct,
+        # independently-searchable documents, never collapsed into one.
+        ks.reindex_graph_content(
+            db_path, graph_id=1, workspace_id=1, title="Graph One",
+            node_chunks=[("node-a", "Identical shared phrase about beavers.")],
+        )
+        ks.reindex_graph_content(
+            db_path, graph_id=2, workspace_id=1, title="Graph Two",
+            node_chunks=[("node-a", "Identical shared phrase about beavers.")],
+        )
+        results = ks.search_chunks(db_path, "beavers")
+        assert len(results) == 2
+        assert {r["source_uri"] for r in results} == {"graph:1", "graph:2"}
+
+    def test_reindexing_resolves_the_real_per_workspace_collection(self, db_path):
+        collection_id = ks.get_or_create_workspace_collection(db_path, 55)
+        ks.reindex_graph_content(
+            db_path, graph_id=3, workspace_id=55, title="Graph",
+            node_chunks=[("node-a", "Scoped content about lemurs.")],
+        )
+        scoped = ks.search_chunks(db_path, "lemurs", collection_id=collection_id)
+        assert len(scoped) == 1
+        other = ks.search_chunks(db_path, "lemurs", collection_id=ks.get_or_create_workspace_collection(db_path, 99))
+        assert other == []
+
+    def test_delete_graph_index_removes_the_chunk_and_returns_true(self, db_path):
+        ks.reindex_graph_content(
+            db_path, graph_id=11, workspace_id=1, title="Graph",
+            node_chunks=[("node-a", "Content about toucans.")],
+        )
+        assert len(ks.search_chunks(db_path, "toucans")) == 1
+
+        assert ks.delete_graph_index(db_path, 11) is True
+        assert ks.search_chunks(db_path, "toucans") == []
+
+    def test_delete_graph_index_on_a_graph_with_nothing_indexed_returns_false(self, db_path):
+        assert ks.delete_graph_index(db_path, 12345) is False

--- a/backend/tests/test_web_research_retention.py
+++ b/backend/tests/test_web_research_retention.py
@@ -82,10 +82,10 @@ def _service(document_text="Retained page content about widgets."):
     return service
 
 
-def _request(*, retain_to_knowledge=False):
+def _request(*, retain_to_knowledge=False, knowledge_collection_id=0):
     return WebResearchRequest(
         request_id="r1", node_id="n1", chat_epoch=1, original_query="widgets",
-        retain_to_knowledge=retain_to_knowledge,
+        retain_to_knowledge=retain_to_knowledge, knowledge_collection_id=knowledge_collection_id,
     )
 
 
@@ -113,6 +113,23 @@ class TestRetentionGating:
         with patch("backend.knowledge_ingest.ingest_text", side_effect=RuntimeError("disk full")):
             result = service.run(_request(retain_to_knowledge=True))
         assert result.answer_markdown  # the primary operation still succeeded
+
+    def test_the_requests_own_knowledge_collection_id_is_threaded_to_ingest_text(self):
+        # ADR-020 stage 20.3: the real fix for this module's own previously-
+        # hardcoded collection_id=0 - WebResearchRequest.knowledge_
+        # collection_id flows through run() -> _retain_documents() ->
+        # every ingest_text() call, not silently dropped along the way.
+        service = _service(document_text="Retained page content about widgets.")
+        with patch("backend.knowledge_ingest.ingest_text") as mock_ingest:
+            service.run(_request(retain_to_knowledge=True, knowledge_collection_id=77))
+        mock_ingest.assert_called_once()
+        assert mock_ingest.call_args.kwargs["collection_id"] == 77
+
+    def test_default_knowledge_collection_id_is_the_pre_20_3_unscoped_sentinel(self):
+        service = _service(document_text="Retained page content about widgets.")
+        with patch("backend.knowledge_ingest.ingest_text") as mock_ingest:
+            service.run(_request(retain_to_knowledge=True))
+        assert mock_ingest.call_args.kwargs["collection_id"] == 0
 
 
 class TestRetainDocumentsUnit:
@@ -147,3 +164,26 @@ class TestRetainDocumentsUnit:
         ) as mock_ingest:
             WebResearchService._retain_documents(documents, sources)
         assert mock_ingest.call_count == 2  # the second call still happened
+
+    def test_collection_id_defaults_to_the_unscoped_sentinel_when_omitted(self):
+        documents = [
+            FetchedDocument(source_id="a", title="A", final_url="https://a.example/", content_type="text/html", text="content a"),
+        ]
+        sources = [type("S", (), {"source_id": "a", "title": "A"})()]
+        with patch("backend.knowledge_ingest.ingest_text") as mock_ingest:
+            WebResearchService._retain_documents(documents, sources)
+        assert mock_ingest.call_args.kwargs["collection_id"] == 0
+
+    def test_collection_id_is_forwarded_to_every_document_in_the_batch(self):
+        documents = [
+            FetchedDocument(source_id="a", title="A", final_url="https://a.example/", content_type="text/html", text="content a"),
+            FetchedDocument(source_id="b", title="B", final_url="https://b.example/", content_type="text/html", text="content b"),
+        ]
+        sources = [
+            type("S", (), {"source_id": "a", "title": "A"})(),
+            type("S", (), {"source_id": "b", "title": "B"})(),
+        ]
+        with patch("backend.knowledge_ingest.ingest_text") as mock_ingest:
+            WebResearchService._retain_documents(documents, sources, 42)
+        assert mock_ingest.call_count == 2
+        assert all(c.kwargs["collection_id"] == 42 for c in mock_ingest.call_args_list)

--- a/contracts/graphlink_app_chat_library_payload.py
+++ b/contracts/graphlink_app_chat_library_payload.py
@@ -59,15 +59,15 @@ class AppWorkspaceRowPayload:
     graphlink_model_catalog.resolve_model_ref's node->branch->workspace->auto
     chain) - empty string on BOTH means "no workspace default set", matching
     workspaces.default_model_provider/default_model_id's own NOT NULL
-    DEFAULT '' column shape, not a null/omitted-field sentinel. Defaulted
-    to "" here (rather than left required) so this stage's frontend work can
-    land and typecheck against a real generated wire type ahead of the
-    concurrent backend stage 20.3 commit that populates get_all_workspaces
-    with real values and adds the corresponding DB columns + setWorkspaceDefaultModel
-    intent handler - the same "frontend commit lands referencing a topic the
-    backend hasn't wired a handler for yet, backend's own commit completes
-    it" sequencing stage 20.2's own two commits (5999fbf then 4bd1185) already
-    used for createWorkspace/renameWorkspace/archiveWorkspace."""
+    DEFAULT '' column shape (backend/chat_library.py's migration "4"), not
+    a null/omitted-field sentinel. `get_all_workspaces`/`create_workspace`
+    always send both explicitly (never omit them), matching this whole
+    topic's own "send everything" posture - the `= ""` defaults below exist
+    purely so a hand-built payload in a test doesn't need to spell out both
+    fields when it doesn't care about them, not because a real row is ever
+    missing them. Backend CRUD: get_workspace_default_model/
+    set_workspace_default_model; wire intent: setWorkspaceDefaultModel
+    (workspaceId, provider, modelId) on "app-chat-library"."""
 
     id: int
     name: str

--- a/contracts/graphlink_app_chat_library_payload.py
+++ b/contracts/graphlink_app_chat_library_payload.py
@@ -11,6 +11,16 @@ human display strings, not meant to be parsed back), preview (a one-line
 snippet of the last message, computed once at save time - see
 backend/chat_library.py's _extract_preview_and_message_count), and
 messageCount.
+
+ADR-020 stage 20.2 adds the real Chat Library UI's own data: each row now
+carries which workspace it belongs to (`workspaceId`) plus its favorite/
+archived flags and tag list, and the state payload gains a full
+`workspaces` list (the switcher's own tab data) alongside `rows` - see
+backend/chat_library.py's get_all_chats/get_all_workspaces for how each is
+built. `tags` is already-sorted (by tag name, case-insensitively),
+deduped, and case-normalized-for-display server-side (backend/
+chat_library.py's set_graph_tags/_normalize_tags) - the frontend renders it
+as-is rather than re-normalizing.
 """
 
 from __future__ import annotations
@@ -28,6 +38,26 @@ class AppChatLibraryRowPayload:
     updatedAtIso: str | None
     preview: str
     messageCount: int
+    # ADR-020 stage 20.2.
+    workspaceId: int
+    favorite: bool
+    archived: bool
+    tags: list[str]
+
+
+@dataclass
+class AppWorkspaceRowPayload:
+    """ADR-020 stage 20.2: one row per workspace, always sent regardless of
+    its own archived state (this whole topic's own "send everything, filter
+    locally" design - see backend/chat_library.py's get_all_workspaces) -
+    the real ChatLibraryDialog switcher hides archived workspaces from its
+    tabs by default, client-side, same as it already does for archived
+    graphs."""
+
+    id: int
+    name: str
+    icon: str
+    archived: bool
 
 
 @dataclass
@@ -35,5 +65,7 @@ class AppChatLibraryStatePayload:
     schemaVersion: int
     revision: int
     rows: list[AppChatLibraryRowPayload]
+    # ADR-020 stage 20.2: the workspace switcher's own data.
+    workspaces: list[AppWorkspaceRowPayload]
     notice: str | None = None
     minCompatibleSchemaVersion: int | None = None

--- a/contracts/graphlink_app_chat_library_payload.py
+++ b/contracts/graphlink_app_chat_library_payload.py
@@ -52,12 +52,29 @@ class AppWorkspaceRowPayload:
     locally" design - see backend/chat_library.py's get_all_workspaces) -
     the real ChatLibraryDialog switcher hides archived workspaces from its
     tabs by default, client-side, same as it already does for archived
-    graphs."""
+    graphs.
+
+    ADR-020 stage 20.3: defaultModelProvider/defaultModelId are this
+    workspace's own model-routing default (the new "workspace" rung in
+    graphlink_model_catalog.resolve_model_ref's node->branch->workspace->auto
+    chain) - empty string on BOTH means "no workspace default set", matching
+    workspaces.default_model_provider/default_model_id's own NOT NULL
+    DEFAULT '' column shape, not a null/omitted-field sentinel. Defaulted
+    to "" here (rather than left required) so this stage's frontend work can
+    land and typecheck against a real generated wire type ahead of the
+    concurrent backend stage 20.3 commit that populates get_all_workspaces
+    with real values and adds the corresponding DB columns + setWorkspaceDefaultModel
+    intent handler - the same "frontend commit lands referencing a topic the
+    backend hasn't wired a handler for yet, backend's own commit completes
+    it" sequencing stage 20.2's own two commits (5999fbf then 4bd1185) already
+    used for createWorkspace/renameWorkspace/archiveWorkspace."""
 
     id: int
     name: str
     icon: str
     archived: bool
+    defaultModelProvider: str = ""
+    defaultModelId: str = ""
 
 
 @dataclass

--- a/graphlink_plugins/web_research/domain.py
+++ b/graphlink_plugins/web_research/domain.py
@@ -122,6 +122,21 @@ class WebResearchRequest:
     # behavior - ADR-017 doc's own Context section - must stay the default,
     # not silently start persisting fetched pages to disk).
     retain_to_knowledge: bool = False
+    # ADR-020 stage 20.3: which backend/knowledge_store.py collection
+    # retained documents land in, when retain_to_knowledge is True - see
+    # that store's own get_or_create_workspace_collection docstring for the
+    # one-collection-per-workspace scoping this implements. 0 (the default,
+    # and what every pre-20.3 caller/test still passes) is the same "no
+    # collection assigned" global sentinel every other real ingestion call
+    # site in this codebase already falls back to when it has no workspace
+    # context of its own (see backend.knowledge_store's own module
+    # docstring) - a caller that DOES know the calling session's current
+    # workspace (backend/api/intents_web_research.py's run_web_research,
+    # the real production call site) resolves it BEFORE constructing this
+    # request and is expected to have done so already; this class only
+    # carries the already-resolved id, matching every other field here's
+    # own "plain, already-resolved data" shape.
+    knowledge_collection_id: int = 0
 
 
 @dataclass(frozen=True)

--- a/graphlink_plugins/web_research/service.py
+++ b/graphlink_plugins/web_research/service.py
@@ -84,7 +84,7 @@ class WebResearchService:
         return {marker.lower() for marker in re.findall(r"\[(s\d+(?:-[a-f0-9]+)?)\]", answer, flags=re.IGNORECASE)}
 
     @staticmethod
-    def _retain_documents(accepted_documents, source_records) -> None:
+    def _retain_documents(accepted_documents, source_records, collection_id: int = 0) -> None:
         """ADR-017 stage 17.5: opt-in retention of this run's accepted
         source documents into the local knowledge store - the ADR's own
         "Web Research fetches, summarizes, and discards; nothing is
@@ -96,7 +96,17 @@ class WebResearchService:
         real job (the synthesized answer), matching this codebase's own
         established "best-effort side write must never fail the primary
         operation" posture (e.g. backend.knowledge_store.maybe_backup_
-        before_write's identical swallow-and-log)."""
+        before_write's identical swallow-and-log).
+
+        ADR-020 stage 20.3: `collection_id` (default 0, the pre-20.3
+        global/unscoped sentinel) is the real fix for this method's own
+        previously-hardcoded collection_id=0 the ADR-020 audit flagged -
+        run() below forwards WebResearchRequest.knowledge_collection_id,
+        already resolved (via backend/knowledge_store.py's own
+        get_or_create_workspace_collection) by the real caller BEFORE this
+        method ever runs; this is purely already-resolved data passed
+        through to every ingest_text() call in the loop, same shape as
+        every other parameter here."""
         from backend.knowledge_ingest import ingest_text
 
         titles_by_id = {source.source_id: source.title for source in source_records}
@@ -107,6 +117,7 @@ class WebResearchService:
                     source_uri=document.final_url,
                     title=titles_by_id.get(document.source_id, document.final_url),
                     mime="text/html",
+                    collection_id=collection_id,
                 )
             except Exception:
                 logger.exception(
@@ -191,7 +202,7 @@ class WebResearchService:
             raise ResearchFailure("No usable source content could be retrieved.", code="no_usable_sources", retryable=True)
 
         if request.retain_to_knowledge:
-            self._retain_documents(accepted_documents, source_records)
+            self._retain_documents(accepted_documents, source_records, request.knowledge_collection_id)
 
         chunks = self._select_evidence(accepted_documents, request.limits, token)
         if not chunks:

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -252,10 +252,11 @@ def test_the_scan_finds_the_real_population_of_registered_intents():
     # invokePluginIntent/setPluginGrant pair, and 159 -> 165 when ADR-020
     # stage 20.2 added app-chat-library's own setGraphFavorite/
     # setGraphArchived/setGraphTags/createWorkspace/renameWorkspace/
-    # archiveWorkspace sextet.
+    # archiveWorkspace sextet, and 165 -> 166 when ADR-020 stage 20.3 added
+    # app-chat-library's own setWorkspaceDefaultModel.
     real = _collect_real_registrations()
-    assert len(real) == 165, (
-        f"expected exactly 165 real registered intents, found {len(real)} - "
+    assert len(real) == 166, (
+        f"expected exactly 166 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -249,10 +249,13 @@ def test_the_scan_finds_the_real_population_of_registered_intents():
     # ADR-012 stage 12.6 added scene's own loadSampleWorkspace plus
     # app-settings' own setHasCompletedOnboarding/setMcpServers, and
     # 157 -> 159 when ADR-014 stage 14.4 added app-plugins' own
-    # invokePluginIntent/setPluginGrant pair.
+    # invokePluginIntent/setPluginGrant pair, and 159 -> 165 when ADR-020
+    # stage 20.2 added app-chat-library's own setGraphFavorite/
+    # setGraphArchived/setGraphTags/createWorkspace/renameWorkspace/
+    # archiveWorkspace sextet.
     real = _collect_real_registrations()
-    assert len(real) == 159, (
-        f"expected exactly 159 real registered intents, found {len(real)} - "
+    assert len(real) == 165, (
+        f"expected exactly 165 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -252,11 +252,13 @@ def test_the_scan_finds_the_real_population_of_registered_intents():
     # invokePluginIntent/setPluginGrant pair, and 159 -> 165 when ADR-020
     # stage 20.2 added app-chat-library's own setGraphFavorite/
     # setGraphArchived/setGraphTags/createWorkspace/renameWorkspace/
-    # archiveWorkspace sextet, and 165 -> 166 when ADR-020 stage 20.3 added
-    # app-chat-library's own setWorkspaceDefaultModel.
+    # archiveWorkspace sextet, 165 -> 166 when ADR-020 stage 20.3 added
+    # app-chat-library's own setWorkspaceDefaultModel, and 166 -> 168 when
+    # ADR-020 stage 20.4 added app-chat-library's own loadGraphAndFocusNode
+    # plus the new "globalSearch" topic's own search intent.
     real = _collect_real_registrations()
-    assert len(real) == 166, (
-        f"expected exactly 166 real registered intents, found {len(real)} - "
+    assert len(real) == 168, (
+        f"expected exactly 168 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -95,6 +95,7 @@ CLASSIFICATION: tuple[Classified, ...] = (
     Classified("app-chat-library", "createWorkspace", "B", "whole-session: creates a new workspace organizing unit, not a document edit"),
     Classified("app-chat-library", "renameWorkspace", "B", "whole-session: renames a workspace, not a document edit"),
     Classified("app-chat-library", "archiveWorkspace", "B", "whole-session: archives a workspace (its graphs are untouched), not a document edit"),
+    Classified("app-chat-library", "setWorkspaceDefaultModel", "B", "whole-session: sets a workspace's own default-model pin, not a document edit"),
 
     # -- backend/plugins.py (app-plugins) ------------------------------------
     Classified("app-plugins", "executePlugin", "A", "content: creates a new node (Web Research/Gitlink/PyCoder/Sandbox/Artifact/System-Prompt note/Conversation/HTML) - every branch wraps its own pluginX command_type"),

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -96,6 +96,7 @@ CLASSIFICATION: tuple[Classified, ...] = (
     Classified("app-chat-library", "renameWorkspace", "B", "whole-session: renames a workspace, not a document edit"),
     Classified("app-chat-library", "archiveWorkspace", "B", "whole-session: archives a workspace (its graphs are untouched), not a document edit"),
     Classified("app-chat-library", "setWorkspaceDefaultModel", "B", "whole-session: sets a workspace's own default-model pin, not a document edit"),
+    Classified("app-chat-library", "loadGraphAndFocusNode", "B", "whole-session: load - same clear_for_load/command_log-clear shape as loadChat, just also replies with the focused node's coordinates"),
 
     # -- backend/plugins.py (app-plugins) ------------------------------------
     Classified("app-plugins", "executePlugin", "A", "content: creates a new node (Web Research/Gitlink/PyCoder/Sandbox/Artifact/System-Prompt note/Conversation/HTML) - every branch wraps its own pluginX command_type"),
@@ -303,4 +304,7 @@ CLASSIFICATION: tuple[Classified, ...] = (
     # -- backend/api/intents_knowledge.py (knowledge, scene) - ADR-017 stage 17.5 --
     Classified("knowledge", "search", "B", "read-only: queries the local knowledge store, no document mutation"),
     Classified("scene", "setChatIndexIntoKnowledge", "A", "content: branch-indexing opt-in is document state, same posture as setGroupColor"),
+
+    # -- backend/api/intents_global_search.py - ADR-020 stage 20.4 --
+    Classified("globalSearch", "search", "B", "read-only: queries the FTS index across graphs/documents/workspaces, no document mutation"),
 )

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -83,6 +83,18 @@ CLASSIFICATION: tuple[Classified, ...] = (
     Classified("app-chat-library", "loadChat", "B", "whole-session: load - clear_for_load already clears command_log/redo_stack"),
     Classified("app-chat-library", "saveChat", "B", "whole-session: persistence, not an in-document edit"),
     Classified("app-chat-library", "newChat", "B", "whole-session: new - clear_for_load already clears command_log/redo_stack"),
+    # ADR-020 stage 20.2: favorite/archived/tags/workspace mutations all
+    # write chats.db rows directly (backend/chat_library.py's own
+    # set_graph_favorite/set_graph_archived/set_graph_tags/create_workspace/
+    # rename_workspace/archive_workspace) - none of the six touch
+    # canvas_document (the live in-document scene) at all, same posture as
+    # renameChat/deleteChat immediately above.
+    Classified("app-chat-library", "setGraphFavorite", "B", "whole-session: favorites a saved session record, not the live document"),
+    Classified("app-chat-library", "setGraphArchived", "B", "whole-session: archives a saved session record, not the live document"),
+    Classified("app-chat-library", "setGraphTags", "B", "whole-session: replaces a saved session's tag set, not the live document"),
+    Classified("app-chat-library", "createWorkspace", "B", "whole-session: creates a new workspace organizing unit, not a document edit"),
+    Classified("app-chat-library", "renameWorkspace", "B", "whole-session: renames a workspace, not a document edit"),
+    Classified("app-chat-library", "archiveWorkspace", "B", "whole-session: archives a workspace (its graphs are untouched), not a document edit"),
 
     # -- backend/plugins.py (app-plugins) ------------------------------------
     Classified("app-plugins", "executePlugin", "A", "content: creates a new node (Web Research/Gitlink/PyCoder/Sandbox/Artifact/System-Prompt note/Conversation/HTML) - every branch wraps its own pluginX command_type"),

--- a/web_ui/scripts/check-bundle-size.mjs
+++ b/web_ui/scripts/check-bundle-size.mjs
@@ -43,7 +43,17 @@ const LARGEST_CHUNK_CEILING_BYTES = 815_000;
 // total, same rationale as the per-chunk ceiling above; still comfortably
 // looser than the per-chunk ceiling so a later stage adding one more small
 // lazy chunk doesn't trip this on its own.
-const TOTAL_JS_CEILING_BYTES = 1_355_000;
+//
+// ADR-020 stage 20.2 (real, deliberate growth, not absorbed silently): the
+// lazy-loaded ChatLibraryDialog chunk grew with the workspace switcher, tag
+// filter chips, favorite/archive icon buttons, and inline tag editing this
+// stage adds - measured total is now 1,356,069 bytes, which already exceeds
+// the prior ceiling on its own. Re-anchored to that new reality with the
+// same ~5% headroom the original ceiling used (1,356,069 * 1.05 ≈
+// 1,423,872, rounded down to a clean number) - this only ever moves the
+// ceiling down again in a later stage that shrinks the total, per this
+// file's own ratchet discipline above.
+const TOTAL_JS_CEILING_BYTES = 1_423_000;
 
 let entries;
 try {

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -30,6 +30,7 @@ import { CommandPalette } from "./chrome/CommandPalette";
 import { Composer } from "./chrome/Composer";
 import { ComposerStore } from "./chrome/composerStore";
 import { DiagnosticsDialog } from "./chrome/DiagnosticsDialog";
+import { GlobalSearchDialog } from "./chrome/GlobalSearchDialog";
 import { KnowledgeSearchDialog } from "./chrome/KnowledgeSearchDialog";
 import { BuilderLaunchDialog } from "./chrome/BuilderLaunchDialog";
 import { NotificationBanner } from "./chrome/NotificationBanner";
@@ -461,6 +462,7 @@ function App() {
                   </LazySurface>
                   <DiagnosticsDialog transport={transport} />
                   <KnowledgeSearchDialog transport={transport} />
+                  <GlobalSearchDialog transport={transport} />
                   <BuilderLaunchDialog transport={transport} />
                   <LazySurface overlayName="settings">
                     <SettingsDialog transport={transport} />

--- a/web_ui/src/app/chrome/AppBar.tsx
+++ b/web_ui/src/app/chrome/AppBar.tsx
@@ -378,6 +378,15 @@ export function AppBar({ store }: { store: SceneStore }) {
         </button>
         <button
           type="button"
+          className={"appbar-overflow-item" + (overlays.isOpen("global-search") ? " checked" : "")}
+          data-tier="1"
+          aria-pressed={overlays.isOpen("global-search")}
+          onClick={() => overlays.toggle("global-search", "dialog")}
+        >
+          Global Search
+        </button>
+        <button
+          type="button"
           className={"appbar-overflow-item" + (overlays.isOpen("builder-launch") ? " checked" : "")}
           data-tier="1"
           aria-pressed={overlays.isOpen("builder-launch")}
@@ -435,6 +444,16 @@ export function AppBar({ store }: { store: SceneStore }) {
         onClick={() => overlays.toggle("knowledge", "dialog")}
       >
         Knowledge
+      </button>
+      <button
+        type="button"
+        className={chip("global-search") + " appbar-tier"}
+        data-tier="1"
+        data-overlay-trigger="global-search"
+        aria-pressed={overlays.isOpen("global-search")}
+        onClick={() => overlays.toggle("global-search", "dialog")}
+      >
+        Global Search
       </button>
       <button
         type="button"

--- a/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
@@ -24,8 +24,11 @@ function row(overrides: Record<string, unknown>) {
   };
 }
 
+// ADR-020 stage 20.3: defaultModelProvider/defaultModelId default to "" -
+// matching AppWorkspaceRowPayload's own "empty string on both = no
+// workspace default set" wire contract, not an omitted/optional field.
 function workspace(overrides: Record<string, unknown>) {
-  return { id: 1, name: "Default", icon: "", archived: false, ...overrides };
+  return { id: 1, name: "Default", icon: "", archived: false, defaultModelProvider: "", defaultModelId: "", ...overrides };
 }
 
 const snapshot = {
@@ -54,14 +57,59 @@ const snapshot = {
   notice: null,
 };
 
+// ADR-020 stage 20.3: a minimal but real AppComposerState snapshot - the
+// workspace default-model picker reads route.modelOptions/route.provider
+// from this same "app-composer" topic Composer.tsx itself reads, per this
+// file's own module docstring.
+function composerSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1,
+    minCompatibleSchemaVersion: 1,
+    revision: 1,
+    draft: { id: "", text: "", contextMode: "branch", sendMode: "enter_to_send", restored: false },
+    context: { anchor: null, items: [], totalTokens: 0, reviewAvailable: false },
+    route: {
+      mode: "ollama",
+      provider: "Ollama (Local)",
+      modelId: "",
+      modelLabel: "",
+      modelOptions: [
+        { id: "llama3", label: "Llama 3" },
+        { id: "mistral", label: "Mistral" },
+      ],
+      reasoning: { level: "off", label: "Off", options: [] },
+      label: "Ollama (Local)",
+      available: true,
+      canChange: true,
+    },
+    request: { id: null, state: "idle", message: "", canSend: true, canCancel: false, canRetry: false },
+    capabilities: {
+      attachments: false,
+      contextReview: false,
+      routeSelection: false,
+      modelSelection: true,
+      reasoningSelection: true,
+      settingsShortcut: true,
+      cancellation: false,
+    },
+    ...overrides,
+  };
+}
+
+// ADR-020 stage 20.3: keyed by topic (not a single shared listener) - this
+// dialog now holds two independent subscriptions ("app-chat-library" and
+// "app-composer", see the module docstring on ChatLibraryDialog.tsx), so a
+// single-listener fake would have the SECOND subscribe() call silently
+// clobber the first, breaking every pre-existing push() call in this file.
+// push() defaults to "app-chat-library" so those calls stay unchanged.
 function makeTransport() {
   const intents: unknown[][] = [];
-  let listener: ((payload: Record<string, unknown>) => void) | null = null;
+  const listeners = new Map<string, (payload: Record<string, unknown>) => void>();
   const transport = {
-    subscribe: (_topic: string, l: (payload: Record<string, unknown>) => void) => {
-      listener = l;
+    subscribe: (topic: string, l: (payload: Record<string, unknown>) => void) => {
+      listeners.set(topic, l);
       return () => {
-        listener = null;
+        listeners.delete(topic);
       };
     },
     intent: (topic: string, intent: string, args: unknown[]) => {
@@ -76,8 +124,20 @@ function makeTransport() {
   return {
     transport,
     intents,
-    push: (payload: Record<string, unknown>) => listener?.(payload),
+    push: (payload: Record<string, unknown>, topic: string = "app-chat-library") => listeners.get(topic)?.(payload),
   };
+}
+
+// ADR-020 stage 20.3: identical helper to SettingsDialog.test.tsx's own -
+// CustomSelect's option panel portals to document.body asynchronously
+// after the trigger click, so the option lookup must be findBy, not getBy.
+async function chooseCustomOption(
+  user: ReturnType<typeof userEvent.setup>,
+  triggerName: string,
+  optionName: string,
+) {
+  await user.click(screen.getByRole("button", { name: triggerName }));
+  await user.click(await screen.findByRole("button", { name: optionName }));
 }
 
 function OpenLibraryButton() {
@@ -476,5 +536,127 @@ describe("ChatLibraryDialog", () => {
 
     expect(intents.filter((i) => i[1] === "setGraphTags")).toEqual([]);
     expect(screen.getByText("First Chat")).toBeInTheDocument();
+  });
+
+  // -- ADR-020 stage 20.3: workspace default-model settings -----------------
+
+  it("the gear settings icon is rendered only for real workspaces, not the 'All' tab", async () => {
+    const { user, push } = setup();
+    act(() => push({ ...snapshot, workspaces: [workspace({ id: 1, name: "Default" }), workspace({ id: 2, name: "Work" })] }));
+    await user.click(screen.getByText("open library"));
+
+    expect(screen.getByLabelText('Show default model settings for "Default"')).toBeInTheDocument();
+    expect(screen.getByLabelText('Show default model settings for "Work"')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Show default model settings for "All"')).toBeNull();
+  });
+
+  it("the gear icon reveals an inline panel (no new modal) showing 'no default set' when unset", async () => {
+    const { user, push } = setup();
+    act(() => push(composerSnapshot(), "app-composer"));
+    await user.click(screen.getByText("open library"));
+
+    expect(screen.queryByText(/Default model for/)).toBeNull();
+
+    await user.click(screen.getByLabelText('Show default model settings for "Default"'));
+
+    // Still the same dialog - no second <Dialog> mounted.
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    expect(screen.getByText('No default set - dispatch falls through to any node/branch pin, then the auto policy.')).toBeInTheDocument();
+  });
+
+  it("a workspace with a default already set shows its current provider/model instead of the unset message", async () => {
+    const { user, push } = setup();
+    act(() => push(composerSnapshot(), "app-composer"));
+    act(() =>
+      push({
+        ...snapshot,
+        workspaces: [workspace({ id: 1, name: "Default", defaultModelProvider: "Ollama (Local)", defaultModelId: "llama3" })],
+      }),
+    );
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Show default model settings for "Default"'));
+
+    expect(screen.getByText("Currently: Ollama (Local) / llama3")).toBeInTheDocument();
+  });
+
+  it("clicking the gear icon again hides the panel", async () => {
+    const { user, push } = setup();
+    act(() => push(composerSnapshot(), "app-composer"));
+    await user.click(screen.getByText("open library"));
+
+    const gear = screen.getByLabelText('Show default model settings for "Default"');
+    await user.click(gear);
+    expect(screen.getByText(/Default model for/)).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Hide default model settings for "Default"'));
+    expect(screen.queryByText(/Default model for/)).toBeNull();
+  });
+
+  it("choosing a model option fires setWorkspaceDefaultModel with the workspace id, the composer's active provider, and the chosen model id", async () => {
+    const { user, push, intents } = setup();
+    act(() => push(composerSnapshot(), "app-composer"));
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Show default model settings for "Default"'));
+    await chooseCustomOption(user, 'Default model for "Default"', "Mistral");
+
+    expect(intents).toContainEqual(["app-chat-library", "setWorkspaceDefaultModel", [1, "Ollama (Local)", "mistral"]]);
+  });
+
+  it("choosing 'No workspace default' fires setWorkspaceDefaultModel with empty provider and model id (clearing)", async () => {
+    const { user, push, intents } = setup();
+    act(() => push(composerSnapshot(), "app-composer"));
+    act(() =>
+      push({
+        ...snapshot,
+        workspaces: [workspace({ id: 1, name: "Default", defaultModelProvider: "Ollama (Local)", defaultModelId: "llama3" })],
+      }),
+    );
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Show default model settings for "Default"'));
+    await chooseCustomOption(user, 'Default model for "Default"', "No workspace default");
+
+    expect(intents).toContainEqual(["app-chat-library", "setWorkspaceDefaultModel", [1, "", ""]]);
+  });
+
+  it("a republish with the new value (live re-subscribe) updates the panel without closing/reopening the dialog", async () => {
+    const { user, push } = setup();
+    act(() => push(composerSnapshot(), "app-composer"));
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Show default model settings for "Default"'));
+    expect(screen.getByText('No default set - dispatch falls through to any node/branch pin, then the auto policy.')).toBeInTheDocument();
+
+    // Simulate the backend republishing after setWorkspaceDefaultModel commits.
+    act(() =>
+      push({
+        ...snapshot,
+        revision: 2,
+        workspaces: [workspace({ id: 1, name: "Default", defaultModelProvider: "Ollama (Local)", defaultModelId: "mistral" })],
+      }),
+    );
+
+    expect(screen.getByText("Currently: Ollama (Local) / mistral")).toBeInTheDocument();
+  });
+
+  it("when the active provider's catalog has no models, a placeholder message shows in place of options (clearing still works)", async () => {
+    const { user, push, intents } = setup();
+    act(() => push(composerSnapshot({ route: { ...composerSnapshot().route, modelOptions: [] } }), "app-composer"));
+    act(() =>
+      push({
+        ...snapshot,
+        workspaces: [workspace({ id: 1, name: "Default", defaultModelProvider: "Ollama (Local)", defaultModelId: "llama3" })],
+      }),
+    );
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Show default model settings for "Default"'));
+
+    expect(screen.getByText(/No models found for Ollama \(Local\)\. Run a scan on its Settings page\./)).toBeInTheDocument();
+
+    await chooseCustomOption(user, 'Default model for "Default"', "No workspace default");
+    expect(intents).toContainEqual(["app-chat-library", "setWorkspaceDefaultModel", [1, "", ""]]);
   });
 });

--- a/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
@@ -15,8 +15,17 @@ function row(overrides: Record<string, unknown>) {
     updatedAtIso: "2026-01-01T08:00:00",
     preview: "",
     messageCount: 0,
+    // ADR-020 stage 20.2.
+    workspaceId: 1,
+    favorite: false,
+    archived: false,
+    tags: [] as string[],
     ...overrides,
   };
+}
+
+function workspace(overrides: Record<string, unknown>) {
+  return { id: 1, name: "Default", icon: "", archived: false, ...overrides };
 }
 
 const snapshot = {
@@ -41,6 +50,7 @@ const snapshot = {
       updatedAtIso: "2026-01-14T08:00:00",
     }),
   ],
+  workspaces: [workspace({})],
   notice: null,
 };
 
@@ -123,7 +133,7 @@ describe("ChatLibraryDialog", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  it("New Chat dispatches the newChat intent and closes the dialog", async () => {
+  it("New Chat dispatches the newChat intent with no workspaceId while 'All' is selected, and closes the dialog", async () => {
     const { user, intents } = setup();
     await user.click(screen.getByText("open library"));
 
@@ -280,5 +290,191 @@ describe("ChatLibraryDialog", () => {
     await user.click(screen.getByText("open library"));
 
     expect(screen.getByText("Could not load saved chats: disk error")).toBeInTheDocument();
+  });
+
+  // -- ADR-020 stage 20.2: workspace switcher -------------------------------
+
+  it("workspace tabs: switching to a specific workspace filters the visible list to that workspace's graphs, 'All' shows every workspace", async () => {
+    const { user, push } = setup();
+    act(() =>
+      push({
+        ...snapshot,
+        workspaces: [workspace({ id: 1, name: "Default" }), workspace({ id: 2, name: "Work" })],
+        rows: [
+          row({ id: 1, title: "First Chat", workspaceId: 1 }),
+          row({ id: 2, title: "Second Chat", workspaceId: 2 }),
+        ],
+      }),
+    );
+    await user.click(screen.getByText("open library"));
+
+    // "All" is the default selection - both workspaces' graphs are visible.
+    expect(screen.getByText("First Chat")).toBeInTheDocument();
+    expect(screen.getByText("Second Chat")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Work" }));
+    expect(screen.queryByText("First Chat")).toBeNull();
+    expect(screen.getByText("Second Chat")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "All" }));
+    expect(screen.getByText("First Chat")).toBeInTheDocument();
+    expect(screen.getByText("Second Chat")).toBeInTheDocument();
+  });
+
+  it("New Chat passes the selected workspace's id once a specific workspace tab (not All) is active", async () => {
+    const { user, push, intents } = setup();
+    act(() => push({ ...snapshot, workspaces: [workspace({ id: 1, name: "Default" }), workspace({ id: 2, name: "Work" })] }));
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByRole("button", { name: "Work" }));
+    await user.click(screen.getByRole("button", { name: "New Chat" }));
+
+    expect(intents).toContainEqual(["app-chat-library", "newChat", [2]]);
+  });
+
+  it("the + Workspace affordance reveals an inline input; Enter commits createWorkspace with the trimmed name", async () => {
+    const { user, intents } = setup();
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByRole("button", { name: "+ Workspace" }));
+    const input = screen.getByLabelText("New workspace name");
+    await user.type(input, "  Research  {Enter}");
+
+    expect(intents).toContainEqual(["app-chat-library", "createWorkspace", ["Research"]]);
+  });
+
+  it("Escape while creating a workspace cancels without dispatching createWorkspace", async () => {
+    const { user, intents } = setup();
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByRole("button", { name: "+ Workspace" }));
+    await user.keyboard("{Escape}");
+
+    expect(intents.filter((i) => i[1] === "createWorkspace")).toEqual([]);
+    expect(screen.queryByLabelText("New workspace name")).toBeNull();
+  });
+
+  // -- ADR-020 stage 20.2: tag filter chips (AND semantics) -----------------
+
+  it("tag filter chips use AND semantics: a graph must carry every selected tag to remain visible", async () => {
+    const { user, push } = setup();
+    act(() =>
+      push({
+        ...snapshot,
+        rows: [
+          row({ id: 1, title: "Alpha", tags: ["work", "urgent"] }),
+          row({ id: 2, title: "Beta", tags: ["work"] }),
+          row({ id: 3, title: "Gamma", tags: ["urgent"] }),
+        ],
+      }),
+    );
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByRole("button", { name: "work" }));
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(screen.queryByText("Gamma")).toBeNull();
+
+    // Adding a second chip narrows further (AND, not OR) - only the row
+    // carrying BOTH selected tags remains.
+    await user.click(screen.getByRole("button", { name: "urgent" }));
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Beta")).toBeNull();
+    expect(screen.queryByText("Gamma")).toBeNull();
+  });
+
+  // -- ADR-020 stage 20.2: favorite / archive icon buttons ------------------
+
+  it("the star icon button fires setGraphFavorite with the toggled value", async () => {
+    const { user, intents } = setup();
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Add "First Chat" to favorites'));
+    expect(intents).toContainEqual(["app-chat-library", "setGraphFavorite", [1, true]]);
+  });
+
+  it("an already-favorited row's star button reads 'remove from favorites' and fires favorite:false", async () => {
+    const { user, push, intents } = setup();
+    act(() => push({ ...snapshot, rows: [row({ id: 1, title: "First Chat", favorite: true })] }));
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Remove "First Chat" from favorites'));
+    expect(intents).toContainEqual(["app-chat-library", "setGraphFavorite", [1, false]]);
+  });
+
+  it("the archive icon button fires setGraphArchived, and archived rows are hidden by default until the Archived toggle is switched on", async () => {
+    const { user, push, intents } = setup();
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Archive "First Chat"'));
+    expect(intents).toContainEqual(["app-chat-library", "setGraphArchived", [1, true]]);
+
+    // Simulate the backend republishing with the row now archived.
+    act(() => push({ ...snapshot, rows: [row({ id: 1, title: "First Chat", archived: true }), snapshot.rows[1]] }));
+    expect(screen.queryByText("First Chat")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Archived" }));
+    expect(screen.getByText("First Chat")).toBeInTheDocument();
+  });
+
+  it("the Archived toggle defaults off: archived rows are excluded from the list on first render", async () => {
+    const { user, push } = setup();
+    act(() =>
+      push({
+        ...snapshot,
+        rows: [row({ id: 1, title: "First Chat", archived: true }), row({ id: 2, title: "Second Chat", archived: false })],
+      }),
+    );
+    await user.click(screen.getByText("open library"));
+
+    expect(screen.queryByText("First Chat")).toBeNull();
+    expect(screen.getByText("Second Chat")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Archived" }));
+    expect(screen.getByText("First Chat")).toBeInTheDocument();
+  });
+
+  it("shows a distinct 'no matches' state for filters (not search), with a Clear filters action", async () => {
+    const { user, push } = setup();
+    act(() =>
+      push({
+        ...snapshot,
+        rows: [row({ id: 1, title: "First Chat", archived: true }), row({ id: 2, title: "Second Chat", archived: true })],
+      }),
+    );
+    await user.click(screen.getByText("open library"));
+
+    expect(screen.getByText("No chats match the current filters.")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Clear filters"));
+    expect(screen.getByText("First Chat")).toBeInTheDocument();
+  });
+
+  // -- ADR-020 stage 20.2: inline tag editing --------------------------------
+
+  it("tag editing: the tag icon opens an inline input pre-filled with the row's tags; Enter commits the trimmed/split list via setGraphTags", async () => {
+    const { user, push, intents } = setup();
+    act(() => push({ ...snapshot, rows: [row({ id: 1, title: "First Chat", tags: ["work", "urgent"] }), snapshot.rows[1]] }));
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Edit tags for "First Chat"'));
+    const input = screen.getByLabelText('Edit tags for "First Chat"') as HTMLInputElement;
+    expect(input.value).toBe("work, urgent");
+
+    await user.clear(input);
+    await user.type(input, "one, two{Enter}");
+
+    expect(intents).toContainEqual(["app-chat-library", "setGraphTags", [1, ["one", "two"]]]);
+  });
+
+  it("tag editing: Escape cancels without dispatching setGraphTags", async () => {
+    const { user, intents } = setup();
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Edit tags for "First Chat"'));
+    await user.keyboard("{Escape}");
+
+    expect(intents.filter((i) => i[1] === "setGraphTags")).toEqual([]);
+    expect(screen.getByText("First Chat")).toBeInTheDocument();
   });
 });

--- a/web_ui/src/app/chrome/ChatLibraryDialog.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { WsTransport } from "../../lib/ws/transport";
 import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
-import type { AppChatLibraryRow, AppChatLibraryState } from "../../lib/bridge-core/generated/app-chat-library-state";
+import type { AppChatLibraryRow, AppChatLibraryState, AppWorkspaceRow } from "../../lib/bridge-core/generated/app-chat-library-state";
 import { Dialog, useOverlays } from "../overlays/overlays";
 
 /**
@@ -21,6 +21,18 @@ import { Dialog, useOverlays } from "../overlays/overlays";
  * the composer island's exact "flat/borderless until interaction, one
  * filled accent element" language rather than inventing a new visual
  * system - see styles.css's own comment on the .library-* rules.
+ *
+ * ADR-020 stage 20.2 adds the real Chat Library UI on top of stage 20.1's
+ * workspaces/graphs schema: a workspace switcher (tabs mirroring
+ * ViewPopover.tsx's single-select preset-button idiom), tag filter chips
+ * (mirroring ViewPopover's multi-select toggle-chip filter section),
+ * favorite/archive icon buttons (added to the existing always-visible
+ * .library-row-actions row), and inline tag editing (the exact rename
+ * input-swap interaction pattern, applied to a different field). All
+ * filtering (workspace/tags/archived/search) is client-side, layered on
+ * top of the existing search-filter pipeline - the backend always sends
+ * every non-deleted graph across every workspace in one payload (see
+ * backend/chat_library.py's get_all_chats).
  */
 
 const initialState: AppChatLibraryState = {
@@ -28,6 +40,7 @@ const initialState: AppChatLibraryState = {
   minCompatibleSchemaVersion: 1,
   revision: 0,
   rows: [],
+  workspaces: [],
   notice: null,
 };
 
@@ -85,7 +98,11 @@ function groupRows(rows: AppChatLibraryRow[]): Array<{ key: BucketKey; rows: App
   }));
 }
 
-function Icon({ name }: { name: "search" | "pencil" | "trash" | "check" | "x" | "chat" }) {
+function Icon({
+  name,
+}: {
+  name: "search" | "pencil" | "trash" | "check" | "x" | "chat" | "star" | "star-filled" | "archive" | "tag";
+}) {
   switch (name) {
     case "search":
       return (
@@ -126,6 +143,41 @@ function Icon({ name }: { name: "search" | "pencil" | "trash" | "check" | "x" | 
           <path d="M4 5h16v11H8l-4 4Z" />
         </svg>
       );
+    // ADR-020 stage 20.2: same 10-point star polygon for both the outline
+    // and filled states (an un-favorited row shows the outline, a
+    // favorited one the filled variant) - only the `fill` differs, so the
+    // two always read as the exact same glyph, never a visually distinct
+    // "different icon" swap.
+    case "star":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M12 2.5 14.18 9.01 21.04 9.06 15.52 13.14 17.58 19.69 12 15.7 6.42 19.69 8.48 13.14 2.96 9.06 9.82 9.01Z" />
+        </svg>
+      );
+    case "star-filled":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path
+            d="M12 2.5 14.18 9.01 21.04 9.06 15.52 13.14 17.58 19.69 12 15.7 6.42 19.69 8.48 13.14 2.96 9.06 9.82 9.01Z"
+            fill="currentColor"
+          />
+        </svg>
+      );
+    case "archive":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M3 4.5h18v4H3Z" />
+          <path d="M4.5 8.5v10a1.5 1.5 0 0 0 1.5 1.5h12a1.5 1.5 0 0 0 1.5-1.5v-10" />
+          <path d="M9.5 12.5h5" />
+        </svg>
+      );
+    case "tag":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M20 13.5 12.5 21a1.5 1.5 0 0 1-2.12 0L3 13.6V5a1.5 1.5 0 0 1 1.5-1.5h8.6a1.5 1.5 0 0 1 1.06.44L20 10.4a1.5 1.5 0 0 1 0 2.12Z" />
+          <circle cx="8" cy="8.5" r="1.4" />
+        </svg>
+      );
   }
 }
 
@@ -136,8 +188,21 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
   const [renamingId, setRenamingId] = useState<number | null>(null);
   const [renameDraft, setRenameDraft] = useState("");
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<number | null>(null);
+  // ADR-020 stage 20.2: workspace switcher / tag filter / archived-toggle /
+  // inline tag-edit local UI state - none of this is scene state or
+  // persisted anywhere; it lives exactly like `query` above, dialog-local
+  // and reset whenever the dialog closes and reopens (a fresh mount).
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<number | null>(null);
+  const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
+  const [showArchived, setShowArchived] = useState(false);
+  const [isCreatingWorkspace, setIsCreatingWorkspace] = useState(false);
+  const [newWorkspaceDraft, setNewWorkspaceDraft] = useState("");
+  const [editingTagsId, setEditingTagsId] = useState<number | null>(null);
+  const [tagsDraft, setTagsDraft] = useState("");
   const renameRef = useRef<HTMLInputElement>(null);
   const deleteCancelRef = useRef<HTMLButtonElement>(null);
+  const newWorkspaceRef = useRef<HTMLInputElement>(null);
+  const tagsEditRef = useRef<HTMLInputElement>(null);
   const lastTriggerRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
@@ -159,21 +224,77 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
     if (confirmingDeleteId !== null) deleteCancelRef.current?.focus();
   }, [confirmingDeleteId]);
 
+  useEffect(() => {
+    if (isCreatingWorkspace) newWorkspaceRef.current?.focus();
+  }, [isCreatingWorkspace]);
+
+  useEffect(() => {
+    if (editingTagsId !== null) {
+      tagsEditRef.current?.focus();
+      tagsEditRef.current?.select();
+    }
+  }, [editingTagsId]);
+
   // A republish after delete/rename elsewhere can drop the row a pending
-  // confirm/rename targeted - reset-during-render on a revision change,
-  // same pattern CommandPalette uses for its own wasOpen tracking.
+  // confirm/rename/tag-edit targeted - reset-during-render on a revision
+  // change, same pattern CommandPalette uses for its own wasOpen tracking.
+  // ADR-020 stage 20.2: also resets selectedWorkspaceId if the workspace it
+  // pointed at just got archived (archiveWorkspace publishes this same
+  // topic) - staying selected on a now-hidden tab would otherwise strand
+  // the view on a permanently empty list with no visible way back.
+  const visibleWorkspaceIds = new Set(state.workspaces.filter((w) => !w.archived).map((w) => w.id));
   const [seenRevision, setSeenRevision] = useState(state.revision);
   if (seenRevision !== state.revision) {
     setSeenRevision(state.revision);
     setConfirmingDeleteId(null);
     setRenamingId(null);
+    setEditingTagsId(null);
+    if (selectedWorkspaceId !== null && !visibleWorkspaceIds.has(selectedWorkspaceId)) {
+      setSelectedWorkspaceId(null);
+    }
   }
+
+  // ADR-020 stage 20.2: workspace -> archived -> tags -> search, each stage
+  // narrowing the previous one - "empty selection means no filter" at every
+  // stage, matching sceneStore's own filterKinds/filterStatuses convention
+  // (see ViewPopover.tsx's FILTER section comment).
+  const workspaceRows = useMemo(() => {
+    if (selectedWorkspaceId === null) return state.rows;
+    return state.rows.filter((row) => row.workspaceId === selectedWorkspaceId);
+  }, [state.rows, selectedWorkspaceId]);
+
+  // Tag chips are scoped to the CURRENTLY VISIBLE workspace's graphs (not
+  // narrowed further by the archived toggle or the tag selection itself -
+  // narrowing by the very filter being rendered would make chips disappear
+  // as you select them).
+  const availableTags = useMemo(() => {
+    const names = new Set<string>();
+    for (const row of workspaceRows) for (const tag of row.tags) names.add(tag);
+    return [...names].sort((a, b) => a.localeCompare(b));
+  }, [workspaceRows]);
+
+  const archivedRows = useMemo(() => {
+    if (showArchived) return workspaceRows;
+    return workspaceRows.filter((row) => !row.archived);
+  }, [workspaceRows, showArchived]);
+
+  // AND semantics: a graph must carry EVERY selected tag, not just one of
+  // them. Chosen over OR because these chips read as successive narrowing
+  // facets of a single "tags" filter (click more chips -> fewer, more
+  // specific results) rather than a "match any of these labels" broadening
+  // filter - the opposite of what most users expect when they add a second
+  // active chip to an already-filtered list.
+  const tagRows = useMemo(() => {
+    if (selectedTags.size === 0) return archivedRows;
+    const required = [...selectedTags];
+    return archivedRows.filter((row) => required.every((tag) => row.tags.includes(tag)));
+  }, [archivedRows, selectedTags]);
 
   const filtered = useMemo(() => {
     const term = query.trim().toLowerCase();
-    if (!term) return state.rows;
-    return state.rows.filter((row) => `${row.title} ${row.preview}`.toLowerCase().includes(term));
-  }, [query, state.rows]);
+    if (!term) return tagRows;
+    return tagRows.filter((row) => `${row.title} ${row.preview}`.toLowerCase().includes(term));
+  }, [query, tagRows]);
 
   const groups = useMemo(() => groupRows(filtered), [filtered]);
 
@@ -183,8 +304,66 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
   }
 
   function newChat() {
-    transport.fireIntent("app-chat-library", "newChat", []);
+    // ADR-020 stage 20.2: newChat's new trailing workspaceId param is
+    // optional/backward-compatible - omitted here whenever "All" is
+    // selected (selectedWorkspaceId === null), which resolves server-side
+    // to the Default workspace exactly like every pre-20.2 caller (e.g.
+    // commands.ts's palette "new chat" command, unaffected by this change).
+    const args = selectedWorkspaceId === null ? [] : [selectedWorkspaceId];
+    transport.fireIntent("app-chat-library", "newChat", args);
     overlays.close();
+  }
+
+  function selectWorkspace(workspaceId: number | null) {
+    setSelectedWorkspaceId(workspaceId);
+    // Tags are scoped to the workspace they were chosen from - carrying a
+    // stale selection into a workspace that doesn't have that tag at all
+    // would silently filter to zero rows with no visible chip explaining
+    // why.
+    setSelectedTags(new Set());
+  }
+
+  function toggleTag(tag: string) {
+    setSelectedTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(tag)) next.delete(tag);
+      else next.add(tag);
+      return next;
+    });
+  }
+
+  function startCreateWorkspace() {
+    setIsCreatingWorkspace(true);
+    setNewWorkspaceDraft("");
+  }
+
+  function commitCreateWorkspace() {
+    const name = newWorkspaceDraft.trim();
+    if (!name) return;
+    transport.fireIntent("app-chat-library", "createWorkspace", [name]);
+    setIsCreatingWorkspace(false);
+  }
+
+  function cancelCreateWorkspace() {
+    setIsCreatingWorkspace(false);
+  }
+
+  function onNewWorkspaceKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitCreateWorkspace();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      cancelCreateWorkspace();
+    }
+  }
+
+  function toggleFavorite(row: AppChatLibraryRow) {
+    transport.fireIntent("app-chat-library", "setGraphFavorite", [row.id, !row.favorite]);
+  }
+
+  function toggleArchived(row: AppChatLibraryRow) {
+    transport.fireIntent("app-chat-library", "setGraphArchived", [row.id, !row.archived]);
   }
 
   function startRename(row: AppChatLibraryRow, trigger: HTMLButtonElement) {
@@ -192,6 +371,7 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
     setRenamingId(row.id);
     setRenameDraft(row.title);
     setConfirmingDeleteId(null);
+    setEditingTagsId(null);
   }
 
   function commitRename() {
@@ -217,10 +397,54 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
     }
   }
 
+  // ADR-020 stage 20.2: the exact startRename/commitRename/cancelRename/
+  // onRenameKeyDown shape immediately above, applied to `tags` instead of
+  // `title` - same input-swaps-the-row-primary-slot idiom, same Enter-
+  // commits/Escape-cancels contract. Draft is a plain comma-separated
+  // string (pre-filled from row.tags.join(", ")); commit splits on comma,
+  // trims each piece, and drops empties before firing setGraphTags - the
+  // server independently trims/dedupes/case-collapses too (see
+  // backend/chat_library.py's _normalize_tags), so this is a UX nicety for
+  // immediate feedback, not the only place that normalization happens.
+  function startTagEdit(row: AppChatLibraryRow, trigger: HTMLButtonElement) {
+    lastTriggerRef.current = trigger;
+    setEditingTagsId(row.id);
+    setTagsDraft(row.tags.join(", "));
+    setConfirmingDeleteId(null);
+    setRenamingId(null);
+  }
+
+  function commitTagEdit() {
+    if (editingTagsId === null) return;
+    const tags = tagsDraft
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+    transport.fireIntent("app-chat-library", "setGraphTags", [editingTagsId, tags], undefined, true);
+    setEditingTagsId(null);
+    lastTriggerRef.current?.focus();
+  }
+
+  function cancelTagEdit() {
+    setEditingTagsId(null);
+    lastTriggerRef.current?.focus();
+  }
+
+  function onTagEditKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitTagEdit();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      cancelTagEdit();
+    }
+  }
+
   function startDelete(row: AppChatLibraryRow, trigger: HTMLButtonElement) {
     lastTriggerRef.current = trigger;
     setConfirmingDeleteId(row.id);
     setRenamingId(null);
+    setEditingTagsId(null);
   }
 
   function confirmDelete() {
@@ -245,13 +469,61 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
     }
   }
 
+  function clearFilters() {
+    setSelectedTags(new Set());
+    setShowArchived(true);
+  }
+
   const total = state.rows.length;
   const resultsAnnouncement =
     total === 0 ? "" : filtered.length === 0 ? "No chats match" : `${filtered.length} results`;
+  const visibleWorkspaces = state.workspaces.filter((w) => !w.archived);
 
   return (
     <Dialog name="library" title="Chat Library" className="library-dialog">
       <div className="library-shell">
+        {visibleWorkspaces.length > 0 && (
+          <div className="library-workspace-tabs" role="group" aria-label="Workspaces">
+            <button
+              type="button"
+              className={"view-preset-btn" + (selectedWorkspaceId === null ? " active" : "")}
+              onClick={() => selectWorkspace(null)}
+            >
+              All
+            </button>
+            {visibleWorkspaces.map((workspace: AppWorkspaceRow) => (
+              <button
+                key={workspace.id}
+                type="button"
+                className={"view-preset-btn" + (selectedWorkspaceId === workspace.id ? " active" : "")}
+                onClick={() => selectWorkspace(workspace.id)}
+              >
+                {workspace.name}
+              </button>
+            ))}
+            {isCreatingWorkspace ? (
+              <div className="library-workspace-new-input-wrap">
+                <input
+                  ref={newWorkspaceRef}
+                  className="library-row-rename-input"
+                  type="text"
+                  value={newWorkspaceDraft}
+                  onChange={(event) => setNewWorkspaceDraft(event.target.value)}
+                  onKeyDown={onNewWorkspaceKeyDown}
+                  placeholder="Workspace name"
+                  aria-label="New workspace name"
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+              </div>
+            ) : (
+              <button type="button" className="library-new-chat-button" onClick={startCreateWorkspace}>
+                + Workspace
+              </button>
+            )}
+          </div>
+        )}
+
         <div className="library-header">
           {total > 0 && (
             <div className="library-search-wrap">
@@ -268,10 +540,38 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
               />
             </div>
           )}
+          {total > 0 && (
+            <button
+              type="button"
+              className={"view-preset-btn library-archived-toggle" + (showArchived ? " active" : "")}
+              aria-pressed={showArchived}
+              onClick={() => setShowArchived((prev) => !prev)}
+            >
+              Archived
+            </button>
+          )}
           <button type="button" className="library-new-chat-button" onClick={newChat}>
             New Chat
           </button>
         </div>
+
+        {availableTags.length > 0 && (
+          <div className="library-tag-filter-row">
+            <div className="view-row" role="group" aria-label="Filter by tag">
+              {availableTags.map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  className={"view-preset-btn" + (selectedTags.has(tag) ? " active" : "")}
+                  aria-pressed={selectedTags.has(tag)}
+                  onClick={() => toggleTag(tag)}
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="library-visually-hidden" role="status" aria-live="polite">
           {resultsAnnouncement}
@@ -293,12 +593,21 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
             </button>
           </div>
         ) : filtered.length === 0 ? (
-          <div className="library-search-empty">
-            <p>No chats match &quot;{query}&quot;.</p>
-            <button type="button" className="library-search-empty-clear" onClick={() => setQuery("")}>
-              Clear search
-            </button>
-          </div>
+          query.trim() ? (
+            <div className="library-search-empty">
+              <p>No chats match &quot;{query}&quot;.</p>
+              <button type="button" className="library-search-empty-clear" onClick={() => setQuery("")}>
+                Clear search
+              </button>
+            </div>
+          ) : (
+            <div className="library-search-empty">
+              <p>No chats match the current filters.</p>
+              <button type="button" className="library-search-empty-clear" onClick={clearFilters}>
+                Clear filters
+              </button>
+            </div>
+          )
         ) : (
           <div className="library-groups">
             {groups.map((group) => (
@@ -308,6 +617,7 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
                   {group.rows.map((row) => {
                     const isRenaming = renamingId === row.id;
                     const isConfirmingDelete = confirmingDeleteId === row.id;
+                    const isEditingTags = editingTagsId === row.id;
                     const messageWord = row.messageCount === 1 ? "message" : "messages";
                     return (
                       <li key={row.id} className="library-row">
@@ -325,6 +635,22 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
                               spellCheck={false}
                             />
                             <p className="library-row-preview hint">Enter to save · Esc to cancel</p>
+                          </div>
+                        ) : isEditingTags ? (
+                          <div className="library-row-primary">
+                            <input
+                              ref={tagsEditRef}
+                              className="library-row-rename-input"
+                              type="text"
+                              value={tagsDraft}
+                              onChange={(event) => setTagsDraft(event.target.value)}
+                              onKeyDown={onTagEditKeyDown}
+                              placeholder="tag-one, tag-two"
+                              aria-label={`Edit tags for "${row.title}"`}
+                              autoComplete="off"
+                              spellCheck={false}
+                            />
+                            <p className="library-row-preview hint">Comma-separated · Enter to save · Esc to cancel</p>
                           </div>
                         ) : (
                           <button
@@ -344,7 +670,7 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
                           </button>
                         )}
 
-                        {!isRenaming && !isConfirmingDelete && row.messageCount > 0 && (
+                        {!isRenaming && !isConfirmingDelete && !isEditingTags && row.messageCount > 0 && (
                           <span className="library-row-count">{row.messageCount}</span>
                         )}
 
@@ -364,6 +690,25 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
                               className="library-icon-button"
                               aria-label="Cancel rename"
                               onClick={cancelRename}
+                            >
+                              <Icon name="x" />
+                            </button>
+                          </div>
+                        ) : isEditingTags ? (
+                          <div className="library-row-actions">
+                            <button
+                              type="button"
+                              className="library-icon-button"
+                              aria-label={`Save tags for "${row.title}"`}
+                              onClick={commitTagEdit}
+                            >
+                              <Icon name="check" />
+                            </button>
+                            <button
+                              type="button"
+                              className="library-icon-button"
+                              aria-label="Cancel tag edit"
+                              onClick={cancelTagEdit}
                             >
                               <Icon name="x" />
                             </button>
@@ -393,6 +738,30 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
                           </div>
                         ) : (
                           <div className="library-row-actions">
+                            <button
+                              type="button"
+                              className="library-icon-button"
+                              aria-label={row.favorite ? `Remove "${row.title}" from favorites` : `Add "${row.title}" to favorites`}
+                              onClick={() => toggleFavorite(row)}
+                            >
+                              <Icon name={row.favorite ? "star-filled" : "star"} />
+                            </button>
+                            <button
+                              type="button"
+                              className="library-icon-button"
+                              aria-label={row.archived ? `Unarchive "${row.title}"` : `Archive "${row.title}"`}
+                              onClick={() => toggleArchived(row)}
+                            >
+                              <Icon name="archive" />
+                            </button>
+                            <button
+                              type="button"
+                              className="library-icon-button"
+                              aria-label={`Edit tags for "${row.title}"`}
+                              onClick={(event) => startTagEdit(row, event.currentTarget)}
+                            >
+                              <Icon name="tag" />
+                            </button>
                             <button
                               type="button"
                               className="library-icon-button"

--- a/web_ui/src/app/chrome/ChatLibraryDialog.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.tsx
@@ -2,7 +2,10 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { WsTransport } from "../../lib/ws/transport";
 import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
 import type { AppChatLibraryRow, AppChatLibraryState, AppWorkspaceRow } from "../../lib/bridge-core/generated/app-chat-library-state";
+import type { AppComposerState } from "../../lib/bridge-core/generated/app-composer-state";
 import { Dialog, useOverlays } from "../overlays/overlays";
+import { CustomSelect } from "./CustomSelect";
+import { initialComposerState } from "./composerStore";
 
 /**
  * The chat library dialog (Qt-removal plan R2.5e + R6.4 + R6.5, R8a full
@@ -33,6 +36,35 @@ import { Dialog, useOverlays } from "../overlays/overlays";
  * top of the existing search-filter pipeline - the backend always sends
  * every non-deleted graph across every workspace in one payload (see
  * backend/chat_library.py's get_all_chats).
+ *
+ * ADR-020 stage 20.3 adds a small settings affordance per REAL workspace
+ * tab (never "All", which isn't a real workspace row) - a gear icon that
+ * reveals an inline expansion below the tabs strip showing that
+ * workspace's current default model and a control to change it
+ * (workspace.defaultModelProvider/defaultModelId, "" on both meaning "no
+ * default set" - see contracts/graphlink_app_chat_library_payload.py's own
+ * docstring on AppWorkspaceRowPayload). The reveal itself follows this
+ * file's own established inline-expansion idiom (the same "click an icon,
+ * a panel opens in place, no new modal" shape as inline rename/tag-edit
+ * above), but the WIDGET inside it is CustomSelect.tsx (Settings' own
+ * "pick one value from a small catalog" control), not Composer.tsx's
+ * Popover-based ModelPicker - deliberately: CustomSelect's own module
+ * docstring documents exactly why it stays outside the useOverlays()
+ * registry (a Popover opening would flip the registry's openSurface away
+ * from "library", which THIS dialog's own <Dialog name="library"> would
+ * read as "I'm not open anymore" and unmount - the identical class of bug
+ * that docstring already names for Settings). The model catalog itself is
+ * NOT a second data-fetching path - this dialog adds a second, independent
+ * subscription to the existing "app-composer" topic (same dual-subscription
+ * shape SettingsDialog.tsx already uses for app-settings + app-plugins) and
+ * reads route.modelOptions/route.provider, the exact same fields Composer's
+ * own model picker renders from. Since this app has exactly one ACTIVE
+ * provider at a time (see SettingsDialog.tsx's own ProviderModeSwitch), a
+ * workspace default is "pick a model from the currently active provider's
+ * catalog" - the chosen option's id becomes defaultModelId and the
+ * currently active route.provider tags along as defaultModelProvider,
+ * mirroring how Composer's own selectModel(modelId) never takes a separate
+ * provider argument either.
  */
 
 const initialState: AppChatLibraryState = {
@@ -101,7 +133,7 @@ function groupRows(rows: AppChatLibraryRow[]): Array<{ key: BucketKey; rows: App
 function Icon({
   name,
 }: {
-  name: "search" | "pencil" | "trash" | "check" | "x" | "chat" | "star" | "star-filled" | "archive" | "tag";
+  name: "search" | "pencil" | "trash" | "check" | "x" | "chat" | "star" | "star-filled" | "archive" | "tag" | "gear";
 }) {
   switch (name) {
     case "search":
@@ -178,6 +210,16 @@ function Icon({
           <circle cx="8" cy="8.5" r="1.4" />
         </svg>
       );
+    // ADR-020 stage 20.3: a plain 8-spoke gear/settings glyph, same
+    // stroke-only construction (circle + straight paths) as every other
+    // icon in this component - not a filled Material-style cog.
+    case "gear":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <circle cx="12" cy="12" r="3.2" />
+          <path d="M12 3v3.2M12 17.8V21M21 12h-3.2M6.2 12H3M18.36 5.64l-2.26 2.26M7.9 16.1l-2.26 2.26M18.36 18.36l-2.26-2.26M7.9 7.9 5.64 5.64" />
+        </svg>
+      );
   }
 }
 
@@ -199,6 +241,17 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
   const [newWorkspaceDraft, setNewWorkspaceDraft] = useState("");
   const [editingTagsId, setEditingTagsId] = useState<number | null>(null);
   const [tagsDraft, setTagsDraft] = useState("");
+  // ADR-020 stage 20.3: which real workspace's gear-icon settings panel is
+  // currently expanded - dialog-local, same "not scene state, reset on
+  // remount" posture as every other piece of local UI state above.
+  const [workspaceSettingsId, setWorkspaceSettingsId] = useState<number | null>(null);
+  // ADR-020 stage 20.3: a second, independent subscription to "app-composer"
+  // (the same topic Composer.tsx/composerStore.ts already read) - this
+  // dialog reads route.modelOptions/route.provider from it for the
+  // workspace default-model picker, rather than opening a second
+  // data-fetching path. Mirrors SettingsDialog.tsx's own dual "app-settings"
+  // + "app-plugins" subscription shape.
+  const [composerState, setComposerState] = useState<AppComposerState>(initialComposerState);
   const renameRef = useRef<HTMLInputElement>(null);
   const deleteCancelRef = useRef<HTMLButtonElement>(null);
   const newWorkspaceRef = useRef<HTMLInputElement>(null);
@@ -210,6 +263,17 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
       const validated = TOPIC_VALIDATORS["app-chat-library"](payload);
       if (validated.ok) setState(validated.value as AppChatLibraryState);
       else console.error("[app-chat-library] rejected snapshot:", validated.errors);
+    });
+  }, [transport]);
+
+  // ADR-020 stage 20.3: see this file's own module docstring for why this
+  // second subscription reuses "app-composer" rather than opening a new
+  // data-fetching path.
+  useEffect(() => {
+    return transport.subscribe("app-composer", (payload) => {
+      const validated = TOPIC_VALIDATORS["app-composer"](payload);
+      if (validated.ok) setComposerState(validated.value as AppComposerState);
+      else console.error("[app-composer] rejected snapshot:", validated.errors);
     });
   }, [transport]);
 
@@ -251,6 +315,12 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
     setEditingTagsId(null);
     if (selectedWorkspaceId !== null && !visibleWorkspaceIds.has(selectedWorkspaceId)) {
       setSelectedWorkspaceId(null);
+    }
+    // ADR-020 stage 20.3: same "don't strand the panel on a now-hidden tab"
+    // guard selectedWorkspaceId already gets above - an archived workspace
+    // loses its own settings panel too, not just its selected-tab status.
+    if (workspaceSettingsId !== null && !visibleWorkspaceIds.has(workspaceSettingsId)) {
+      setWorkspaceSettingsId(null);
     }
   }
 
@@ -330,6 +400,26 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
       else next.add(tag);
       return next;
     });
+  }
+
+  // ADR-020 stage 20.3: toggles the SAME workspace's panel closed (matching
+  // startRename/startTagEdit's own "click again to close" absence - those
+  // two don't have a re-click-to-close affordance because Save/Cancel
+  // already close them, but a settings panel has no commit step, so the
+  // gear icon itself is the only open/close control it has).
+  function toggleWorkspaceSettings(workspaceId: number) {
+    setWorkspaceSettingsId((prev) => (prev === workspaceId ? null : workspaceId));
+  }
+
+  // ADR-020 stage 20.3: modelId === "" clears the workspace default (both
+  // wire fields go back to "", matching AppWorkspaceRowPayload's own "empty
+  // string on BOTH means unset" contract) - otherwise the CURRENTLY ACTIVE
+  // provider tags along with the chosen model id, the same implicit-
+  // provider posture Composer's own selectModel(modelId) already has (see
+  // this file's own module docstring).
+  function setWorkspaceDefaultModel(workspaceId: number, modelId: string) {
+    const provider = modelId === "" ? "" : composerState.route.provider;
+    transport.fireIntent("app-chat-library", "setWorkspaceDefaultModel", [workspaceId, provider, modelId], undefined, true);
   }
 
   function startCreateWorkspace() {
@@ -478,6 +568,9 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
   const resultsAnnouncement =
     total === 0 ? "" : filtered.length === 0 ? "No chats match" : `${filtered.length} results`;
   const visibleWorkspaces = state.workspaces.filter((w) => !w.archived);
+  // ADR-020 stage 20.3.
+  const expandedWorkspace = visibleWorkspaces.find((w) => w.id === workspaceSettingsId) ?? null;
+  const modelCatalogOptions = composerState.route.modelOptions;
 
   return (
     <Dialog name="library" title="Chat Library" className="library-dialog">
@@ -492,14 +585,27 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
               All
             </button>
             {visibleWorkspaces.map((workspace: AppWorkspaceRow) => (
-              <button
-                key={workspace.id}
-                type="button"
-                className={"view-preset-btn" + (selectedWorkspaceId === workspace.id ? " active" : "")}
-                onClick={() => selectWorkspace(workspace.id)}
-              >
-                {workspace.name}
-              </button>
+              // ADR-020 stage 20.3: wraps the tab + its gear icon so the two
+              // stay visually paired if .library-workspace-tabs's own
+              // flex-wrap ever breaks the row across lines.
+              <div key={workspace.id} className="library-workspace-tab-group">
+                <button
+                  type="button"
+                  className={"view-preset-btn" + (selectedWorkspaceId === workspace.id ? " active" : "")}
+                  onClick={() => selectWorkspace(workspace.id)}
+                >
+                  {workspace.name}
+                </button>
+                <button
+                  type="button"
+                  className="library-icon-button library-workspace-settings-button"
+                  aria-label={`${workspaceSettingsId === workspace.id ? "Hide" : "Show"} default model settings for "${workspace.name}"`}
+                  aria-expanded={workspaceSettingsId === workspace.id}
+                  onClick={() => toggleWorkspaceSettings(workspace.id)}
+                >
+                  <Icon name="gear" />
+                </button>
+              </div>
             ))}
             {isCreatingWorkspace ? (
               <div className="library-workspace-new-input-wrap">
@@ -521,6 +627,41 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
                 + Workspace
               </button>
             )}
+          </div>
+        )}
+
+        {expandedWorkspace && (
+          // ADR-020 stage 20.3: the inline-reveal itself - a plain block
+          // below the tabs strip, not a popover/modal (see this file's own
+          // module docstring for why CustomSelect, not Composer's Popover-
+          // based ModelPicker, is the widget inside it).
+          <div
+            className="library-workspace-settings-panel"
+            role="region"
+            aria-label={`Default model for "${expandedWorkspace.name}"`}
+          >
+            <div className="settings-field">
+              <span className="settings-field-label">Default model for &quot;{expandedWorkspace.name}&quot;</span>
+              <p className="settings-update-status">
+                {expandedWorkspace.defaultModelProvider && expandedWorkspace.defaultModelId
+                  ? `Currently: ${expandedWorkspace.defaultModelProvider} / ${expandedWorkspace.defaultModelId}`
+                  : "No default set - dispatch falls through to any node/branch pin, then the auto policy."}
+              </p>
+              {modelCatalogOptions.length === 0 ? (
+                <p className="settings-update-status">
+                  No models found for {composerState.route.provider}. Run a scan on its Settings page.
+                </p>
+              ) : null}
+              <CustomSelect
+                ariaLabel={`Default model for "${expandedWorkspace.name}"`}
+                value={expandedWorkspace.defaultModelId}
+                options={[
+                  { id: "", label: "No workspace default" },
+                  ...modelCatalogOptions.map((option) => ({ id: option.id, label: option.label })),
+                ]}
+                onChange={(modelId) => setWorkspaceDefaultModel(expandedWorkspace.id, modelId)}
+              />
+            </div>
           </div>
         )}
 

--- a/web_ui/src/app/chrome/GlobalSearchDialog.test.tsx
+++ b/web_ui/src/app/chrome/GlobalSearchDialog.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * ADR-020 stage 20.4. Mirrors two established precedents rather than
+ * inventing test shape:
+ * - KnowledgeSearchDialog.test.tsx's own makeTransport()/setup() (request()
+ *   is the one transport method this dialog calls, never fireIntent/intent)
+ *   and its monotonic-requestId stale-response-guard race.
+ * - SceneCanvas.pinSearchJump.test.tsx's own useReactFlow wrapping (every
+ *   real pan/zoom/getNodes export stays functional; only setCenter is
+ *   intercepted) for asserting the jump-to-node call's exact arguments.
+ */
+import { ReactFlowProvider, type useReactFlow as UseReactFlowType } from "@xyflow/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type SetCenterCall = [number, number, { zoom?: number; duration?: number } | undefined];
+const setCenterCalls: SetCenterCall[] = [];
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@xyflow/react")>();
+  return {
+    ...original,
+    useReactFlow: (...args: Parameters<typeof UseReactFlowType>) => {
+      const real = original.useReactFlow(...args);
+      return {
+        ...real,
+        setCenter: (x: number, y: number, options?: { zoom?: number; duration?: number }) => {
+          setCenterCalls.push([x, y, options]);
+          return real.setCenter(x, y, options);
+        },
+      };
+    },
+  };
+});
+
+import { GlobalSearchDialog } from "./GlobalSearchDialog";
+import { OverlayProvider, useOverlays } from "../overlays/overlays";
+import type { WsTransport } from "../../lib/ws/transport";
+
+// Matches KnowledgeSearchDialog.test.tsx's own makeTransport() shape exactly.
+function makeTransport() {
+  const intents: unknown[][] = [];
+  const request = vi.fn<(topic: string, intent: string, args?: unknown[]) => Promise<unknown>>();
+  const transport = {
+    subscribe: () => () => {},
+    intent: () => {},
+    fireIntent: () => {},
+    request: (topic: string, intent: string, args: unknown[] = []) => {
+      intents.push([topic, intent, args]);
+      return request(topic, intent, args);
+    },
+  } as unknown as WsTransport;
+  return { transport, intents, request };
+}
+
+function OpenGlobalSearchButton() {
+  const overlays = useOverlays();
+  return (
+    <button type="button" onClick={() => overlays.open("global-search", "dialog")}>
+      open global search
+    </button>
+  );
+}
+
+function DialogOpenProbe() {
+  const overlays = useOverlays();
+  return <span data-testid="open-surface">{overlays.isOpen("global-search") ? "open" : "closed"}</span>;
+}
+
+async function setup() {
+  const user = userEvent.setup();
+  const fake = makeTransport();
+  render(
+    <OverlayProvider>
+      <ReactFlowProvider>
+        <OpenGlobalSearchButton />
+        <DialogOpenProbe />
+        <GlobalSearchDialog transport={fake.transport} />
+      </ReactFlowProvider>
+    </OverlayProvider>,
+  );
+  await user.click(screen.getByRole("button", { name: "open global search" }));
+  return { user, ...fake };
+}
+
+const DOCUMENT_HIT = {
+  chunkId: 1,
+  documentId: 10,
+  documentTitle: "Fox Story",
+  sourceUri: "https://example.com/fox",
+  text: "The quick brown fox jumps over the lazy dog.",
+  offsetStart: 0,
+  offsetEnd: 45,
+  sourceNodeId: null,
+  graphId: null,
+};
+
+const GRAPH_HIT = {
+  chunkId: 2,
+  documentId: 11,
+  documentTitle: "Workspace B / Onboarding Notes",
+  sourceUri: "graph:42",
+  text: "The secret phrase lives only in this graph's node.",
+  offsetStart: 0,
+  offsetEnd: 51,
+  sourceNodeId: "node-9",
+  graphId: 42,
+};
+
+describe("GlobalSearchDialog", () => {
+  beforeEach(() => {
+    setCenterCalls.length = 0;
+  });
+
+  it("submitting a query requests search/globalSearch with the typed text and a default k", async () => {
+    const { user, intents, request } = await setup();
+    request.mockResolvedValueOnce({ results: [] });
+
+    await user.type(screen.getByPlaceholderText(/search every workspace/i), "secret phrase");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(intents).toContainEqual(["search", "globalSearch", ["secret phrase", 10]]);
+  });
+
+  it('renders "N results found" with N matching the real result count', async () => {
+    const { user, request } = await setup();
+    request.mockResolvedValueOnce({ results: [DOCUMENT_HIT, GRAPH_HIT] });
+
+    await user.type(screen.getByPlaceholderText(/search every workspace/i), "query");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(await screen.findByText("2 results found")).toBeInTheDocument();
+  });
+
+  it("shows an explicit empty state instead of a false zero-results count", async () => {
+    const { user, request } = await setup();
+    request.mockResolvedValueOnce({ results: [] });
+
+    await user.type(screen.getByPlaceholderText(/search every workspace/i), "nothing here");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(await screen.findByText("No results found")).toBeInTheDocument();
+  });
+
+  it("a document hit (sourceNodeId/graphId both null) keeps the Open source link, not a jump action", async () => {
+    const { user, request } = await setup();
+    request.mockResolvedValueOnce({ results: [DOCUMENT_HIT] });
+
+    await user.type(screen.getByPlaceholderText(/search every workspace/i), "query");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await user.click(await screen.findByText("Fox Story"));
+
+    const link = screen.getByRole("link", { name: "Open source" });
+    expect(link).toHaveAttribute("href", "https://example.com/fox");
+    expect(screen.queryByRole("button", { name: "Jump to node" })).not.toBeInTheDocument();
+  });
+
+  it("a graph/node hit shows a Jump to node action instead of Open source", async () => {
+    const { user, request } = await setup();
+    request.mockResolvedValueOnce({ results: [GRAPH_HIT] });
+
+    await user.type(screen.getByPlaceholderText(/search every workspace/i), "query");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await user.click(await screen.findByText("Workspace B / Onboarding Notes"));
+
+    expect(screen.getByRole("button", { name: "Jump to node" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Open source" })).not.toBeInTheDocument();
+  });
+
+  it("activating a graph/node hit fires loadGraphAndFocusNode with the right graphId/nodeId, then calls setCenter with the resolved coordinates and closes the dialog", async () => {
+    const { user, intents, request } = await setup();
+    request.mockResolvedValueOnce({ results: [GRAPH_HIT] });
+
+    await user.type(screen.getByPlaceholderText(/search every workspace/i), "query");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await user.click(await screen.findByText("Workspace B / Onboarding Notes"));
+
+    request.mockResolvedValueOnce({ x: 1234, y: -567 });
+    await user.click(screen.getByRole("button", { name: "Jump to node" }));
+
+    expect(intents).toContainEqual(["app-chat-library", "loadGraphAndFocusNode", [42, "node-9"]]);
+    expect(await screen.findByTestId("open-surface")).toHaveTextContent("closed");
+    expect(setCenterCalls).toHaveLength(1);
+    const [x, y, options] = setCenterCalls[0];
+    expect(x).toBe(1234);
+    expect(y).toBe(-567);
+    expect(options?.zoom).toBe(1);
+  });
+
+  it("a stale node (loadGraphAndFocusNode resolves null) shows an honest error and never calls setCenter", async () => {
+    const { user, request } = await setup();
+    request.mockResolvedValueOnce({ results: [GRAPH_HIT] });
+
+    await user.type(screen.getByPlaceholderText(/search every workspace/i), "query");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await user.click(await screen.findByText("Workspace B / Onboarding Notes"));
+
+    request.mockResolvedValueOnce(null);
+    await user.click(screen.getByRole("button", { name: "Jump to node" }));
+
+    expect(await screen.findByText("This node no longer exists in that graph.")).toBeInTheDocument();
+    expect(setCenterCalls).toHaveLength(0);
+  });
+
+  it("a failed global search shows an error instead of a silent empty state", async () => {
+    const { user, request } = await setup();
+    request.mockRejectedValueOnce(new Error("boom"));
+
+    await user.type(screen.getByPlaceholderText(/search every workspace/i), "query");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/search failed/i);
+  });
+
+  // Mirrors KnowledgeSearchDialog's own identical, already-adversarially-
+  // reviewed test: runSearch()'s `searching` early-return is what actually
+  // makes the monotonic-requestId guard below it unreachable in normal use
+  // (both the Search button and Enter share the same gated function, so a
+  // second dispatch while the first is still in flight is impossible to
+  // trigger through the UI, not merely discarded after the fact) - proven
+  // here the same way Knowledge proves it: a second Enter press while the
+  // first request is still pending fires no second transport.request call
+  // at all.
+  it("a second Enter press while a search is already in flight does not fire a duplicate request", async () => {
+    const { user, request } = await setup();
+    let resolveFirst: (value: unknown) => void = () => {};
+    request.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveFirst = resolve; }),
+    );
+
+    const input = screen.getByPlaceholderText(/search every workspace/i);
+    await user.type(input, "first query{Enter}");
+    expect(request).toHaveBeenCalledTimes(1);
+
+    await user.clear(input);
+    await user.type(input, "second query{Enter}");
+    expect(request).toHaveBeenCalledTimes(1);
+
+    resolveFirst({ results: [GRAPH_HIT] });
+    expect(await screen.findByText("Workspace B / Onboarding Notes")).toBeInTheDocument();
+  });
+});

--- a/web_ui/src/app/chrome/GlobalSearchDialog.tsx
+++ b/web_ui/src/app/chrome/GlobalSearchDialog.tsx
@@ -1,0 +1,244 @@
+import { useReactFlow } from "@xyflow/react";
+import { useRef, useState } from "react";
+import type { WsTransport } from "../../lib/ws/transport";
+import { motionDuration } from "../reducedMotion";
+import { Dialog, useOverlays } from "../overlays/overlays";
+
+/**
+ * ADR-020 stage 20.4: the "Global Search" dialog - search across every
+ * workspace's graphs AND every ingested knowledge document at once
+ * (backend's new "search"/"globalSearch" intent, backend.knowledge_store's
+ * real chunks_fts/chunks/documents underneath - collection_id=None, the
+ * same "no filter, search everything" mechanism search_chunks/hybrid_search
+ * already support, not a second cross-collection union built for this
+ * stage). A direct sibling of KnowledgeSearchDialog.tsx (ADR-017 stage
+ * 17.5) - same request/reply shape, same monotonic-requestId
+ * stale-response guard (a real adversarial-review-driven fix there, for
+ * exactly the same "a network round trip can resolve out of send order"
+ * race a global search hits too), same expand-a-card-for-the-cited-excerpt
+ * result-card interaction. This file does not invent a different
+ * result-list shape - see that component for the pattern this one mirrors.
+ *
+ * The one real difference: a hit can come from TWO kinds of source now,
+ * not one. A document hit (sourceNodeId/graphId both null - an ordinary
+ * ingested file or web-research page, same shape KnowledgeSearchDialog
+ * already renders) keeps that dialog's own "Open source" external-link
+ * behavior verbatim - KnowledgeSearchDialog.tsx itself is untouched by
+ * this stage. A graph/node hit (both non-null - knowledge_store's
+ * chunks.source_node_id column, this stage's own migration 5) instead gets
+ * a "Jump to node" action: transport.request(...) for the new
+ * loadGraphAndFocusNode intent resolves with the node's real {x, y} - the
+ * backend has already fully restored that graph into canvas_document by
+ * the time this promise resolves, so there is no separate "scene" topic
+ * race to wait out (see that intent's own backend docstring) - then
+ * useReactFlow().setCenter, the exact same call SearchOverlay.tsx's own
+ * jumpTo() already makes for an in-canvas match, just fed coordinates from
+ * the reply instead of a locally-computed one.
+ *
+ * Wire contract note (frontend/backend built concurrently against ADR-020
+ * stage 20.4's shared design doc, no live handshake): this file calls
+ * transport.request("search", "globalSearch", [query, k]) and
+ * transport.request("app-chat-library", "loadGraphAndFocusNode",
+ * [graphId, nodeId]) - the exact topic/intent names and result field names
+ * (chunkId/documentId/documentTitle/sourceUri/text/offsetStart/offsetEnd,
+ * plus this stage's own sourceNodeId/graphId) are this component's one
+ * real integration point with the backend half of this stage. Neither is
+ * backed by a codegen contract (like "knowledge"/"search" itself, this is
+ * a request/reply intent, not a persistent state topic - see
+ * KnowledgeSearchDialog.tsx's own identical posture), so there is nothing
+ * in web_ui/src/lib/bridge-core/generated/ to check against; if the
+ * backend half lands under different names, reconciling is a
+ * find-and-replace of the two string literals below, not a redesign.
+ */
+
+interface GlobalSearchResult {
+  chunkId: number;
+  documentId: number;
+  documentTitle: string;
+  sourceUri: string;
+  text: string;
+  offsetStart: number;
+  offsetEnd: number;
+  /** Non-null only for a graph-sourced chunk (knowledge_store's
+   * chunks.source_node_id, this stage's migration 5) - the node within
+   * that graph this hit came from. */
+  sourceNodeId: string | null;
+  /** Non-null only for a graph-sourced chunk - the graph (chat_id) that
+   * owns sourceNodeId, parsed server-side from documents.source_uri's own
+   * synthetic "graph:{id}" scheme. */
+  graphId: number | null;
+}
+
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function isGraphHit(
+  result: GlobalSearchResult,
+): result is GlobalSearchResult & { sourceNodeId: string; graphId: number } {
+  return result.sourceNodeId != null && result.graphId != null;
+}
+
+function GlobalSearchResultCard({ transport, result }: { transport: WsTransport; result: GlobalSearchResult }) {
+  const [expanded, setExpanded] = useState(false);
+  const [jumping, setJumping] = useState(false);
+  const [jumpError, setJumpError] = useState<string | null>(null);
+  const { setCenter } = useReactFlow();
+  const overlays = useOverlays();
+  const graphHit = isGraphHit(result);
+
+  function jumpToNode() {
+    if (!graphHit || jumping) return;
+    setJumping(true);
+    setJumpError(null);
+    transport
+      .request("app-chat-library", "loadGraphAndFocusNode", [result.graphId, result.sourceNodeId])
+      .then((value) => {
+        const position = value as { x: number; y: number } | null;
+        // A stale result: the graph was re-indexed since this node was
+        // deleted from it. Not an error - the search hit was real at
+        // index time, just no longer resolvable to a live location.
+        if (!position) {
+          setJumpError("This node no longer exists in that graph.");
+          return;
+        }
+        setCenter(position.x, position.y, { zoom: 1, duration: motionDuration(300) });
+        overlays.close();
+      })
+      .catch(() => setJumpError("Couldn't open that graph - see graphlink.log for details."))
+      .finally(() => setJumping(false));
+  }
+
+  return (
+    <li className="global-search-result-item">
+      <button
+        type="button"
+        className="global-search-result-header"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <span className="global-search-result-title">{result.documentTitle}</span>
+        <span className="global-search-result-kind">{graphHit ? "Graph" : "Document"}</span>
+        <span className="global-search-result-source">{result.sourceUri}</span>
+      </button>
+      {expanded && (
+        <div className="global-search-result-body">
+          <p className="global-search-result-excerpt">{result.text}</p>
+          <div className="global-search-result-footer">
+            <span className="global-search-result-offset">
+              Offset {result.offsetStart}–{result.offsetEnd}
+            </span>
+            {graphHit ? (
+              <button
+                type="button"
+                className="global-search-result-open-link"
+                onClick={jumpToNode}
+                disabled={jumping}
+              >
+                {jumping ? "Jumping…" : "Jump to node"}
+              </button>
+            ) : (
+              isHttpUrl(result.sourceUri) && (
+                <a
+                  className="global-search-result-open-link"
+                  href={result.sourceUri}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Open source
+                </a>
+              )
+            )}
+          </div>
+          {jumpError && (
+            <p className="global-search-jump-error" role="alert">
+              {jumpError}
+            </p>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
+export function GlobalSearchDialog({ transport }: { transport: WsTransport }) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<GlobalSearchResult[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Same monotonic-requestId stale-response guard as KnowledgeSearchDialog's
+  // own latestRequestId - see that component's comment for the full
+  // rationale. Checked before ever touching state in a resolved/rejected
+  // handler, so only the MOST RECENTLY SENT request's own response ever
+  // wins, regardless of network arrival order.
+  const latestRequestId = useRef(0);
+
+  function runSearch() {
+    const trimmed = query.trim();
+    if (!trimmed || searching) return;
+    const requestId = ++latestRequestId.current;
+    setSearching(true);
+    setError(null);
+    transport
+      .request("search", "globalSearch", [trimmed, 10])
+      .then((value) => {
+        if (requestId !== latestRequestId.current) return; // a newer search has since been sent
+        const payload = value as { results: GlobalSearchResult[] };
+        setResults(payload.results);
+      })
+      .catch(() => {
+        if (requestId !== latestRequestId.current) return;
+        setError("Search failed - see graphlink.log for details.");
+      })
+      .finally(() => {
+        if (requestId === latestRequestId.current) setSearching(false);
+      });
+  }
+
+  return (
+    <Dialog name="global-search" title="Global Search" className="global-search-dialog">
+      <div className="global-search-row">
+        <input
+          type="text"
+          className="global-search-input"
+          aria-label="Search every workspace"
+          placeholder="Search every workspace's graphs and knowledge base…"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") runSearch();
+          }}
+        />
+        <button
+          type="button"
+          className="global-search-button"
+          onClick={runSearch}
+          disabled={searching || !query.trim()}
+        >
+          {searching ? "Searching…" : "Search"}
+        </button>
+      </div>
+
+      {error && (
+        <p className="global-search-empty" role="alert">
+          {error}
+        </p>
+      )}
+
+      {results != null && !error && (
+        <>
+          <h2 className="global-search-section-title">
+            {results.length === 0
+              ? "No results found"
+              : `${results.length} result${results.length === 1 ? "" : "s"} found`}
+          </h2>
+          <ul className="global-search-result-list">
+            {results.map((result) => (
+              <GlobalSearchResultCard key={result.chunkId} transport={transport} result={result} />
+            ))}
+          </ul>
+        </>
+      )}
+    </Dialog>
+  );
+}

--- a/web_ui/src/app/chrome/commands.test.ts
+++ b/web_ui/src/app/chrome/commands.test.ts
@@ -95,6 +95,9 @@ describe("buildCommands", () => {
     expect(overlays.open).toHaveBeenCalledWith("settings", "dialog");
     commands.find((c) => c.id === "open-view")!.run();
     expect(overlays.open).toHaveBeenCalledWith("view", "popover");
+    // ADR-020 stage 20.4: the Global Search palette entry.
+    commands.find((c) => c.id === "open-global-search")!.run();
+    expect(overlays.open).toHaveBeenCalledWith("global-search", "dialog");
   });
 
   it("add-pin computes the viewport center and calls addPin", () => {

--- a/web_ui/src/app/chrome/commands.ts
+++ b/web_ui/src/app/chrome/commands.ts
@@ -202,6 +202,17 @@ export function buildCommands(
       enabled: () => true,
     },
     {
+      // ADR-020 stage 20.4: search every workspace's graphs and knowledge
+      // documents at once - see GlobalSearchDialog.tsx. Same registration
+      // shape as "open-library"/"open-plugins" above (ADR-012's own
+      // "register every new surface in the palette" rule).
+      id: "open-global-search",
+      name: "Open Global Search",
+      aliases: ["search everywhere", "search all workspaces", "find in graph"],
+      run: () => overlays.open("global-search", "dialog"),
+      enabled: () => true,
+    },
+    {
       // R6.1: plain, ungated - creates a blank note near the current
       // viewport center. Same center-of-viewport formula "add-pin" above
       // already uses; "Add System Prompt Note" is a DIFFERENT, existing

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -4485,6 +4485,53 @@ mark.document-view-search-match-current {
   opacity: 0.88;
 }
 
+/* -- ADR-020 stage 20.2: workspace switcher + tag filter chips --------
+   Both reuse .view-preset-btn/.view-row VERBATIM by className (that pair
+   is not scoped under .view-popover in this file's selectors - it is
+   already a globally-reusable pair, not a popover-local one) rather than
+   duplicating its padding/radius/font-size/color values under a new name -
+   see ViewPopover.tsx's own FILTER section for the identical multi-select
+   toggle-chip markup this dialog's tag row mirrors, and its grid-size
+   preset row for the single-select tab pattern the workspace row mirrors.
+   Only the ROW WRAPPERS below are new: .view-row/.overlay-popover's own
+   ambient 12px/14px padding is what every OTHER .view-row consumer relies
+   on for its horizontal gutter, and this dialog's .overlay-dialog-body is
+   padding:0 (see that rule above) - so each wrapper supplies its own
+   horizontal padding, matching .library-header's existing 20px gutter,
+   rather than .view-row silently touching the dialog's edges here. */
+
+.library-workspace-tabs {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--gl-surface-border);
+}
+
+/* Sizes the inline "new workspace" input to something reasonable for a
+   short name, the same way .view-popover's own `width: 250px` is an
+   arbitrary-but-intentional sizing choice for its content - the input
+   itself is .library-row-rename-input, reused verbatim (same idiom as the
+   per-row rename input this whole interaction is modeled on). */
+.library-workspace-new-input-wrap {
+  flex: 0 0 160px;
+}
+
+/* Prevents the Archived toggle chip (a .view-preset-btn dropped directly
+   into .library-header's flex row, next to the search box) from being
+   squeezed by .library-search-wrap's own `flex: 1` - .library-new-chat-
+   button already sets this for the same reason. */
+.library-archived-toggle {
+  flex-shrink: 0;
+}
+
+.library-tag-filter-row {
+  flex-shrink: 0;
+  padding: 10px 20px 0;
+}
+
 .library-visually-hidden {
   position: absolute;
   width: 1px;

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -4519,6 +4519,36 @@ mark.document-view-search-match-current {
   flex: 0 0 160px;
 }
 
+/* ADR-020 stage 20.3: pairs a workspace tab with its own gear/settings
+   icon button so the two move together if .library-workspace-tabs's own
+   flex-wrap ever breaks the row - a plain inline-flex wrapper, no border/
+   background of its own (both children keep their existing look). */
+.library-workspace-tab-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+/* Reuses .library-icon-button verbatim for size/hover/focus - this class
+   only exists so the gear button isn't accidentally swept up by a future
+   .library-icon-button-scoped selector that assumes every instance sits
+   inside .library-row-actions (this one doesn't). */
+.library-workspace-settings-button {
+  flex-shrink: 0;
+}
+
+/* The inline-reveal panel itself - a plain block below the tabs strip
+   (same "no popover, no modal" posture as .library-row-confirm above),
+   reusing .settings-field/.settings-field-label/.settings-update-status
+   verbatim from SettingsDialog's own pages rather than duplicating that
+   layout under a new name. */
+.library-workspace-settings-panel {
+  flex-shrink: 0;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--gl-surface-border);
+  background-color: var(--gl-surface-inset, var(--gl-surface-window));
+}
+
 /* Prevents the Archived toggle chip (a .view-preset-btn dropped directly
    into .library-header's flex row, next to the search box) from being
    squeezed by .library-search-wrap's own `flex: 1` - .library-new-chat-

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -3120,6 +3120,166 @@ body,
   color: var(--gl-surface-text-primary);
 }
 
+/* -- Global search dialog (ADR-020 stage 20.4) ------------------------------
+   A sibling of .knowledge-search-dialog just above, same rules renamed to
+   this dialog's own class prefix - see GlobalSearchDialog.tsx's own doc for
+   why this mirrors that pattern rather than inventing a new one. The only
+   addition is .global-search-result-kind, a small "Graph"/"Document" tag
+   distinguishing the two hit kinds this dialog (unlike Knowledge) can
+   return. */
+.global-search-dialog {
+  min-width: 480px;
+  max-width: min(640px, calc(100vw - 64px));
+  max-height: min(600px, calc(100vh - 96px));
+  overflow-y: auto;
+}
+
+.global-search-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.global-search-input {
+  flex: 1;
+  padding: 6px 10px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-surface-inset, var(--gl-surface-node-body));
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+}
+
+.global-search-button {
+  padding: 6px 14px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-neutral-button-hover);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.global-search-button:hover:not(:disabled) {
+  background-color: var(--gl-neutral-button-border);
+}
+
+.global-search-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.global-search-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--gl-surface-text-muted);
+}
+
+.global-search-section-title {
+  margin: 16px 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--gl-surface-text-muted);
+}
+
+.global-search-result-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.global-search-result-item {
+  border-radius: 6px;
+  background: var(--gl-surface-node-body);
+  border: 1px solid var(--gl-surface-border);
+}
+
+.global-search-result-header {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 8px 10px;
+  font-family: inherit;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.global-search-result-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--gl-surface-text-primary);
+}
+
+.global-search-result-kind {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--gl-surface-text-muted);
+}
+
+.global-search-result-source {
+  font-size: 11px;
+  color: var(--gl-surface-text-muted);
+  word-break: break-all;
+}
+
+.global-search-result-body {
+  padding: 0 10px 10px;
+}
+
+.global-search-result-excerpt {
+  margin: 0 0 8px;
+  padding: 8px;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--gl-surface-text-primary);
+  background-color: var(--gl-surface-inset, var(--gl-surface-node-body));
+  border-radius: 4px;
+}
+
+.global-search-result-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--gl-surface-text-muted);
+}
+
+.global-search-result-open-link {
+  color: var(--gl-surface-text-primary);
+  font-family: inherit;
+  font-size: 11px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.global-search-result-open-link:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.global-search-jump-error {
+  margin: 8px 0 0;
+  font-size: 11px;
+  color: var(--gl-semantic-status-error, var(--gl-surface-text-primary));
+}
+
 /* -- Document view panel (R8a follow-up) ------------------------------------
    Docked flush-left, border-right only - restores legacy's
    DocumentViewerPanel chrome (a permanent embedded QWidget, corner_radius=0,

--- a/web_ui/src/lib/bridge-core/generated/app-chat-library-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/app-chat-library-state.schema.json
@@ -15,11 +15,17 @@
       "items": {
         "additionalProperties": false,
         "properties": {
+          "archived": {
+            "type": "boolean"
+          },
           "createdAtIso": {
             "type": "string"
           },
           "createdLabel": {
             "type": "string"
+          },
+          "favorite": {
+            "type": "boolean"
           },
           "id": {
             "type": "integer"
@@ -30,6 +36,12 @@
           "preview": {
             "type": "string"
           },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "title": {
             "type": "string"
           },
@@ -38,6 +50,9 @@
           },
           "updatedLabel": {
             "type": "string"
+          },
+          "workspaceId": {
+            "type": "integer"
           }
         },
         "required": [
@@ -46,7 +61,11 @@
           "createdLabel",
           "updatedLabel",
           "preview",
-          "messageCount"
+          "messageCount",
+          "workspaceId",
+          "favorite",
+          "archived",
+          "tags"
         ],
         "type": "object"
       },
@@ -54,12 +73,40 @@
     },
     "schemaVersion": {
       "type": "integer"
+    },
+    "workspaces": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "archived": {
+            "type": "boolean"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "icon",
+          "archived"
+        ],
+        "type": "object"
+      },
+      "type": "array"
     }
   },
   "required": [
     "schemaVersion",
     "revision",
-    "rows"
+    "rows",
+    "workspaces"
   ],
   "title": "AppChatLibraryState",
   "type": "object"

--- a/web_ui/src/lib/bridge-core/generated/app-chat-library-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/app-chat-library-state.schema.json
@@ -81,6 +81,12 @@
           "archived": {
             "type": "boolean"
           },
+          "defaultModelId": {
+            "type": "string"
+          },
+          "defaultModelProvider": {
+            "type": "string"
+          },
           "icon": {
             "type": "string"
           },
@@ -95,7 +101,9 @@
           "id",
           "name",
           "icon",
-          "archived"
+          "archived",
+          "defaultModelProvider",
+          "defaultModelId"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/app-chat-library-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/app-chat-library-state.ts
@@ -11,12 +11,24 @@ export interface AppChatLibraryRow {
   updatedAtIso?: string | null;
   preview: string;
   messageCount: number;
+  workspaceId: number;
+  favorite: boolean;
+  archived: boolean;
+  tags: string[];
+}
+
+export interface AppWorkspaceRow {
+  id: number;
+  name: string;
+  icon: string;
+  archived: boolean;
 }
 
 export interface AppChatLibraryState {
   schemaVersion: number;
   revision: number;
   rows: AppChatLibraryRow[];
+  workspaces: AppWorkspaceRow[];
   notice?: string | null;
   minCompatibleSchemaVersion?: number | null;
 }
@@ -76,6 +88,51 @@ function checkAppChatLibraryRow(value: unknown, path: string, errors: string[]):
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.messageCount: missing required field`);
     else { if (typeof fieldValue !== "number") errors.push(`${path}.messageCount` + ": expected number"); }
   }
+  {
+    const fieldValue = value["workspaceId"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.workspaceId: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.workspaceId` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["favorite"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.favorite: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.favorite` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["archived"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.archived: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.archived` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["tags"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.tags: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.tags` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "string") errors.push(`${path}.tags` + `[${i}]` + ": expected string"); }); }
+  }
+}
+
+function checkAppWorkspaceRow(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["id"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.id: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.id` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["name"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.name: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.name` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["icon"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.icon: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.icon` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["archived"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.archived: missing required field`);
+    else { if (typeof fieldValue !== "boolean") errors.push(`${path}.archived` + ": expected boolean"); }
+  }
 }
 
 function checkAppChatLibraryState(value: unknown, path: string, errors: string[]): void {
@@ -95,6 +152,12 @@ function checkAppChatLibraryState(value: unknown, path: string, errors: string[]
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.rows: missing required field`);
     else { if (!Array.isArray(fieldValue)) errors.push(`${path}.rows` + ": expected array");
     else (fieldValue as unknown[]).forEach((item, i) => { checkAppChatLibraryRow(item, `${path}.rows` + `[${i}]`, errors); }); }
+  }
+  {
+    const fieldValue = value["workspaces"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.workspaces: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.workspaces` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { checkAppWorkspaceRow(item, `${path}.workspaces` + `[${i}]`, errors); }); }
   }
   {
     const fieldValue = value["notice"];

--- a/web_ui/src/lib/bridge-core/generated/app-chat-library-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/app-chat-library-state.ts
@@ -22,6 +22,8 @@ export interface AppWorkspaceRow {
   name: string;
   icon: string;
   archived: boolean;
+  defaultModelProvider: string;
+  defaultModelId: string;
 }
 
 export interface AppChatLibraryState {
@@ -132,6 +134,16 @@ function checkAppWorkspaceRow(value: unknown, path: string, errors: string[]): v
     const fieldValue = value["archived"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.archived: missing required field`);
     else { if (typeof fieldValue !== "boolean") errors.push(`${path}.archived` + ": expected boolean"); }
+  }
+  {
+    const fieldValue = value["defaultModelProvider"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.defaultModelProvider: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.defaultModelProvider` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["defaultModelId"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.defaultModelId: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.defaultModelId` + ": expected string"); }
   }
 }
 


### PR DESCRIPTION
## Problem
Search inside Graphlink was scoped to a single knowledge collection (ADR-017) or a single chat library (ADR-020 stages 20.1-20.3). There was no way to search across every workspace's graphs and ingested documents at once, or jump directly from a hit to the node that produced it.

## Change
- `backend/knowledge_store.py`: schema migration 4 -> 5 adds `chunks.source_node_id`. New `reindex_graph_content`/`delete_graph_index` index a saved graph's node text as searchable chunks, keyed by `source_uri = f"graph:{graph_id}"`, delete-then-reinsert on every save (graphs are mutable, unlike ingested files). `search_chunks` and `list_embeddings_for_search` now return `source_node_id` so a fused hybrid-search hit can be traced back to its node.
- `backend/chat_library.py`: wires graph reindexing into `save_chat_atomically_row`/`delete_chat`, and adds the `loadGraphAndFocusNode` REQUEST/REPLY intent (loads a graph and returns the focused node's coordinates).
- `backend/api/intents_global_search.py` (new): `globalSearch/search` intent, workspace-agnostic by design (`collection_id=None` searches every workspace's corpus).
- `web_ui`: Global Search dialog + jump-to-node wiring (stage 20.4 frontend, shipped in the prior commit on this branch).
- `backend/tests/conftest.py`: extends the real-user-data-dir guard to `knowledge_store._connect` and redirects `DEFAULT_DB_PATH` to `tmp_path`, since the new indexing hook now fires on every save/delete call site in the existing suite.
- `tests/undo_classification.py`: classifies both new intents as B (read-only / whole-session-load).
- `backend/tests/test_app_ws.py` + `tests/test_undo_classification_gate.py`: updated intent counts for the 2 new registered intents.

## Test plan
- [x] `python -m pytest -q` from repo root: 2962 passed, 17 skipped, 5 failed - all 5 failures are pre-existing and unrelated (`test_native_dialogs.py`, a local `pywebview` version mismatch on this machine; confirmed no files in this diff touch that module)
- [x] New backend coverage for `reindex_graph_content`/`delete_graph_index`/`loadGraphAndFocusNode`/`globalSearch.search` in `test_knowledge_store.py` and `test_chat_library.py`