### PR TITLE
ADR-020 stage 20.5: quick switcher + command-palette registration + workspace export

### DIFF
--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -52,6 +52,8 @@ logger = logging.getLogger(__name__)
 
 from backend import db_backup
 from backend import knowledge_store
+from backend import native_dialogs
+from backend import workspace_archive
 from backend.canvas import SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -2424,6 +2426,117 @@ class LoadGraphAndFocusNodeArgs:
     nodeId: str
 
 
+@dataclass
+class ExportWorkspaceArgs:
+    """ADR-020 stage 20.5. See register_chat_library's own export_workspace
+    closure for the full contract this backs."""
+
+    workspaceId: int
+
+
+def _safe_export_filename(name: str) -> str:
+    """Sanitizes a workspace name into a default `.graphlink` SAVE-dialog
+    filename - a cosmetic prefill, not a security boundary (the user's own
+    native OS dialog, not this string, decides the real write path - see
+    native_dialogs.pick_save_file's own docstring). Unlike backend/assets.
+    py's own _sanitize_chart_filename (which strips to ASCII because it
+    feeds an HTTP header), this keeps full Unicode letters/digits - a real
+    local filesystem filename has no such restriction - and only strips
+    characters a filesystem path genuinely cannot contain (path separators,
+    control characters, drive-letter colons) plus collapses whitespace to a
+    single underscore, matching that function's own collapse convention."""
+    text = str(name or "")
+    safe = "".join(ch for ch in text if ch.isalnum() or ch in (" ", "-", "_")).strip()
+    safe = re.sub(r"\s+", "_", safe)
+    return safe or "workspace"
+
+
+def make_export_workspace(bus: SessionBus, resolved_path: Path, notifications: NotificationState | None):
+    """Factory for register_chat_library's own exportWorkspace intent -
+    lifted out to a top-level function purely to keep register_chat_library
+    itself under ADR-002's 300-line registration-function cap (stage 2.7),
+    the same "one definition, kept under the cap" precedent make_serialize_
+    mutating_intent/make_load_chat/make_load_graph_and_focus_node already
+    established in this file.
+
+    ADR-020 stage 20.5: exports every graph in `workspace_id` as one
+    `.graphlink` archive - backend/workspace_archive.py's own export_archive,
+    ADR-009 stage 9.4's own primitive (format/scrub/atomic-publish already
+    built, tested, and simply never wired to a real intent until now - see
+    that module's own docstring).
+
+    Read-only against chats.db and never touches canvas_document, so - like
+    register_chat_library's own createWorkspace/renameWorkspace/
+    archiveWorkspace/setWorkspaceDefaultModel closures - this needs neither
+    _serialize_mutating_intent's reentrancy guard nor an app-chat-library
+    republish; nothing this function does changes what that topic's own
+    snapshot would report.
+
+    The native SAVE dialog (native_dialogs.pick_save_file) is what actually
+    decides the destination - a cancelled dialog is a silent no-op, the SAME
+    "no window/user-cancelled -> quiet return" contract pick_gitlink_local_
+    root already established for every other native-dialog-backed intent in
+    this app, not a special case invented here."""
+
+    async def export_workspace(workspace_id: int):
+        workspaces = await asyncio.to_thread(get_all_workspaces, resolved_path)
+        workspace = next((w for w in workspaces if int(w["id"]) == int(workspace_id)), None)
+        if workspace is None:
+            return
+
+        all_chats = await asyncio.to_thread(get_all_chats, resolved_path)
+        graph_ids = [int(row["id"]) for row in all_chats if int(row["workspaceId"]) == int(workspace_id)]
+        if not graph_ids:
+            if notifications is not None:
+                notifications.show(f'"{workspace["name"]}" has no graphs to export.', "warning")
+                await bus.publish("notification")
+            return
+
+        default_name = f"{_safe_export_filename(str(workspace['name']))}.graphlink"
+        try:
+            target = await native_dialogs.pick_save_file(
+                default_name, file_types=("Graphlink Archive (*.graphlink)",),
+            )
+        except Exception as exc:  # noqa: BLE001 - a local file path, not a credential
+            if notifications is not None:
+                notifications.show(f"Could not open the save dialog: {exc}", "error")
+                await bus.publish("notification")
+            return
+        if not target:
+            return
+
+        def _load_one(graph_id: int) -> dict[str, Any]:
+            row = load_chat_row(resolved_path, graph_id)
+            return {
+                "title": row["title"] if row else "Untitled",
+                "data": row["data"] if row else {},
+                "notes": load_notes_rows(resolved_path, graph_id),
+                "pins": load_pins_rows(resolved_path, graph_id),
+            }
+
+        def _do_export() -> Path:
+            chats = [_load_one(graph_id) for graph_id in graph_ids]
+            return workspace_archive.export_archive(Path(target), chats, live_assets=store_for(resolved_path))
+
+        try:
+            written = await asyncio.to_thread(_do_export)
+        except OSError as exc:
+            if notifications is not None:
+                notifications.show(f"Could not export workspace: {exc}", "error")
+                await bus.publish("notification")
+            return
+
+        if notifications is not None:
+            plural = "" if len(graph_ids) == 1 else "s"
+            notifications.show(
+                f'Exported {len(graph_ids)} graph{plural} from "{workspace["name"]}" to {written.name}.',
+                "success",
+            )
+            await bus.publish("notification")
+
+    return export_workspace
+
+
 def register_chat_library(
     bus: SessionBus,
     db_path: Path | None = None,
@@ -2675,6 +2788,8 @@ def register_chat_library(
         )
         await bus.publish("app-chat-library")
 
+    export_workspace = make_export_workspace(bus, resolved_path, notifications)
+
     bus.register_intent("app-chat-library", "renameChat", rename)
     bus.register_intent("app-chat-library", "deleteChat", delete)
     bus.register_intent("app-chat-library", "loadChat", _serialize_mutating_intent(load_chat))
@@ -2701,13 +2816,12 @@ def register_chat_library(
     bus.register_intent("app-chat-library", "setGraphTags", set_tags, args_schema=SetGraphTagsArgs)
     bus.register_intent("app-chat-library", "createWorkspace", create_ws, args_schema=CreateWorkspaceArgs)
     bus.register_intent("app-chat-library", "renameWorkspace", rename_ws, args_schema=RenameWorkspaceArgs)
-    bus.register_intent(
-        "app-chat-library", "archiveWorkspace", archive_ws, args_schema=ArchiveWorkspaceArgs,
-    )
+    bus.register_intent("app-chat-library", "archiveWorkspace", archive_ws, args_schema=ArchiveWorkspaceArgs)
     bus.register_intent(
         "app-chat-library", "setWorkspaceDefaultModel", set_workspace_default_model_intent,
         args_schema=SetWorkspaceDefaultModelArgs,
     )
+    bus.register_intent("app-chat-library", "exportWorkspace", export_workspace, args_schema=ExportWorkspaceArgs)
 
     if canvas_document is not None and autosave_interval_seconds is not None:
         # R6.6: local import - backend/autosave.py itself imports several

--- a/backend/native_dialogs.py
+++ b/backend/native_dialogs.py
@@ -65,3 +65,29 @@ async def pick_folder(directory: str = "") -> str | None:
         return None
     result = await asyncio.to_thread(window.create_file_dialog, webview.FileDialog.FOLDER, directory=directory)
     return result[0] if result else None
+
+
+async def pick_save_file(default_name: str, file_types: Sequence[str] = (), directory: str = "") -> str | None:
+    """Opens a native SAVE file dialog (ADR-020 stage 20.5's own workspace
+    export). Returns the chosen path, or None if no window exists or the
+    user cancelled.
+
+    Unlike pick_file/pick_folder above, pywebview's own SAVE dialog returns
+    a single string (or None on cancel), not a one-element tuple - OPEN's
+    and FOLDER's own tuple shape exists for their allow_multiple capability,
+    which a save dialog has no equivalent of (there is only ever one
+    destination path). `default_name` seeds the dialog's own filename field
+    (pywebview's `save_filename` kwarg) - matches pick_file's own
+    `directory` seeding precedent of not leaving a starting value to
+    whatever the OS defaults to."""
+    window = _active_window()
+    if window is None:
+        return None
+    result = await asyncio.to_thread(
+        window.create_file_dialog,
+        webview.FileDialog.SAVE,
+        directory=directory,
+        save_filename=default_name,
+        file_types=tuple(file_types),
+    )
+    return result or None

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -377,7 +377,7 @@ def test_junk_args_never_crash_or_disconnect_any_registered_intent():
         assert ws.receive_json()["kind"] == "result"
 
 
-def test_args_schema_is_scoped_to_exactly_the_known_14_intents():
+def test_args_schema_is_scoped_to_exactly_the_known_15_intents():
     # ADR-003 stage 3.2 review-fix: the fuzz sweep above proves every intent
     # replies safely, but it only checks message["kind"], not the error TEXT
     # - a schema-validation rejection and an unmigrated handler's own generic
@@ -395,9 +395,11 @@ def test_args_schema_is_scoped_to_exactly_the_known_14_intents():
     # createWorkspace/renameWorkspace/archiveWorkspace); ADR-020 stage 20.3
     # added 1 more on "app-chat-library" (setWorkspaceDefaultModel); ADR-020
     # stage 20.4 added 2 more (("app-chat-library", "loadGraphAndFocusNode")
-    # and ("globalSearch", "search")) - each a real, deliberate addition, not
-    # drift - a real intentional addition to this set updates it explicitly,
-    # the same discipline this test itself exists to enforce.
+    # and ("globalSearch", "search")); stage 20.5 added 1 more
+    # (("app-chat-library", "exportWorkspace")) - each a real, deliberate
+    # addition, not drift - a real intentional addition to this set updates
+    # it explicitly, the same discipline this test itself exists to
+    # enforce.
     client = make_client()
     with client.websocket_connect("/ws") as ws:
         ws.send_json({"kind": "subscribe", "topics": ["system"]})
@@ -423,6 +425,7 @@ def test_args_schema_is_scoped_to_exactly_the_known_14_intents():
             ("app-chat-library", "setWorkspaceDefaultModel"),
             ("app-chat-library", "loadGraphAndFocusNode"),
             ("globalSearch", "search"),
+            ("app-chat-library", "exportWorkspace"),
         }
 
 

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -18,6 +18,8 @@ import backend.autosave as autosave_module
 import backend.chat_library as chat_library_module
 import backend.db_backup as db_backup_module
 import backend.knowledge_store as knowledge_store_module
+import backend.native_dialogs as native_dialogs_module
+import backend.workspace_archive as workspace_archive_module
 from backend.api.intents_global_search import register_global_search_intents
 from backend.autosave import autosave_tick, register_autosave
 from backend.canvas import SceneDocument
@@ -3205,3 +3207,156 @@ class TestGlobalSearchAcrossWorkspaces:
         hit = result["results"][0]
         assert hit["sourceNodeId"] is None
         assert hit["graphId"] is None
+
+
+class TestExportWorkspaceIntent:
+    """ADR-020 stage 20.5: exportWorkspace - see register_chat_library's own
+    export_workspace closure for the full contract. native_dialogs.
+    pick_save_file is monkeypatched exactly like test_canvas.py's own
+    pickGitlinkLocalRoot tests monkeypatch pick_folder - a fake async
+    function, never a real OS dialog."""
+
+    def test_exports_only_the_target_workspaces_graphs_as_a_real_archive(self, db_path, tmp_path, monkeypatch):
+        get_all_chats(db_path)  # bootstraps a fully-migrated db (Default = workspace A)
+        workspace_a = get_all_workspaces(db_path)[0]
+        workspace_b = create_workspace(db_path, "Workspace B")
+
+        save_chat_atomically_row(
+            db_path, None, "Graph A", {"nodes": [
+                {"node_type": "chat", "id": "a1", "raw_content": "hi from A", "is_user": True},
+            ]}, [], [], workspace_id=workspace_a["id"],
+        )
+        save_chat_atomically_row(
+            db_path, None, "Graph B", {"nodes": [
+                {"node_type": "chat", "id": "b1", "raw_content": "hi from B", "is_user": True},
+            ]}, [], [], workspace_id=workspace_b["id"],
+        )
+
+        target = tmp_path / "export.graphlink"
+
+        async def _fake_pick_save_file(default_name, file_types=(), directory=""):
+            return str(target)
+
+        monkeypatch.setattr(native_dialogs_module, "pick_save_file", _fake_pick_save_file)
+        bus, _document, notifications = _bus_with_canvas(db_path)
+        asyncio.run(bus.dispatch_intent("app-chat-library", "exportWorkspace", [workspace_a["id"]]))
+
+        assert target.exists()
+        archive = workspace_archive_module.read_archive(target)
+        assert len(archive["chats"]) == 1
+        assert archive["chats"][0]["title"] == "Graph A"
+        assert notifications.visible and notifications.msg_type == "success"
+        assert '"Default"' in notifications.message  # the WORKSPACE name is quoted in the toast
+        assert "1 graph" in notifications.message
+
+    def test_seeds_the_dialog_with_a_sanitized_workspace_name(self, db_path, tmp_path, monkeypatch):
+        workspace = create_workspace(db_path, "Client / Project #1")
+        save_chat_atomically_row(
+            db_path, None, "G", {"nodes": [
+                {"node_type": "chat", "id": "n1", "raw_content": "hi", "is_user": True},
+            ]}, [], [], workspace_id=workspace["id"],
+        )
+        seen_names = []
+
+        async def _fake_pick_save_file(default_name, file_types=(), directory=""):
+            seen_names.append(default_name)
+            return str(tmp_path / "out.graphlink")
+
+        monkeypatch.setattr(native_dialogs_module, "pick_save_file", _fake_pick_save_file)
+        bus, _document, _notifications = _bus_with_canvas(db_path)
+        asyncio.run(bus.dispatch_intent("app-chat-library", "exportWorkspace", [workspace["id"]]))
+
+        assert seen_names == ["Client_Project_1.graphlink"]
+
+    def test_a_cancelled_dialog_is_a_silent_no_op(self, db_path, tmp_path, monkeypatch):
+        workspace = create_workspace(db_path, "Workspace")
+        save_chat_atomically_row(
+            db_path, None, "G", {"nodes": [
+                {"node_type": "chat", "id": "n1", "raw_content": "hi", "is_user": True},
+            ]}, [], [], workspace_id=workspace["id"],
+        )
+
+        async def _fake_pick_save_file(default_name, file_types=(), directory=""):
+            return None
+
+        monkeypatch.setattr(native_dialogs_module, "pick_save_file", _fake_pick_save_file)
+        bus, _document, notifications = _bus_with_canvas(db_path)
+        asyncio.run(bus.dispatch_intent("app-chat-library", "exportWorkspace", [workspace["id"]]))
+
+        assert notifications.visible is False
+
+    def test_an_empty_workspace_warns_without_ever_opening_the_dialog(self, db_path, monkeypatch):
+        workspace = create_workspace(db_path, "Empty Workspace")
+        dialog_calls = []
+
+        async def _fake_pick_save_file(default_name, file_types=(), directory=""):
+            dialog_calls.append(default_name)
+            return None
+
+        monkeypatch.setattr(native_dialogs_module, "pick_save_file", _fake_pick_save_file)
+        bus, _document, notifications = _bus_with_canvas(db_path)
+        asyncio.run(bus.dispatch_intent("app-chat-library", "exportWorkspace", [workspace["id"]]))
+
+        assert dialog_calls == []
+        assert notifications.visible and notifications.msg_type == "warning"
+
+    def test_an_unknown_workspace_id_is_a_silent_no_op(self, db_path, monkeypatch):
+        dialog_calls = []
+
+        async def _fake_pick_save_file(default_name, file_types=(), directory=""):
+            dialog_calls.append(default_name)
+            return None
+
+        monkeypatch.setattr(native_dialogs_module, "pick_save_file", _fake_pick_save_file)
+        bus, _document, notifications = _bus_with_canvas(db_path)
+        asyncio.run(bus.dispatch_intent("app-chat-library", "exportWorkspace", [999999]))
+
+        assert dialog_calls == []
+        assert notifications.visible is False
+
+    def test_a_dialog_failure_shows_an_error_notification(self, db_path, monkeypatch):
+        workspace = create_workspace(db_path, "Workspace")
+        save_chat_atomically_row(
+            db_path, None, "G", {"nodes": [
+                {"node_type": "chat", "id": "n1", "raw_content": "hi", "is_user": True},
+            ]}, [], [], workspace_id=workspace["id"],
+        )
+
+        async def _boom(default_name, file_types=(), directory=""):
+            raise OSError("no save dialog available")
+
+        monkeypatch.setattr(native_dialogs_module, "pick_save_file", _boom)
+        bus, _document, notifications = _bus_with_canvas(db_path)
+        asyncio.run(bus.dispatch_intent("app-chat-library", "exportWorkspace", [workspace["id"]]))
+
+        assert notifications.visible and notifications.msg_type == "error"
+
+    def test_two_different_workspaces_export_two_different_archives(self, db_path, tmp_path, monkeypatch):
+        # Regression guard: exportWorkspace must scope by workspace_id, not
+        # export every graph in chats.db regardless of workspace - the same
+        # "workspace filter actually filters" property TestGlobalSearchAcross
+        # Workspaces's own scoped-search test proves for search.
+        workspace_a = create_workspace(db_path, "A")
+        workspace_b = create_workspace(db_path, "B")
+        save_chat_atomically_row(
+            db_path, None, "Graph A1", {"nodes": []}, [], [], workspace_id=workspace_a["id"],
+        )
+        save_chat_atomically_row(
+            db_path, None, "Graph A2", {"nodes": []}, [], [], workspace_id=workspace_a["id"],
+        )
+        save_chat_atomically_row(
+            db_path, None, "Graph B1", {"nodes": []}, [], [], workspace_id=workspace_b["id"],
+        )
+
+        target = tmp_path / "a-only.graphlink"
+
+        async def _fake_pick_save_file(default_name, file_types=(), directory=""):
+            return str(target)
+
+        monkeypatch.setattr(native_dialogs_module, "pick_save_file", _fake_pick_save_file)
+        bus, _document, _notifications = _bus_with_canvas(db_path)
+        asyncio.run(bus.dispatch_intent("app-chat-library", "exportWorkspace", [workspace_a["id"]]))
+
+        archive = workspace_archive_module.read_archive(target)
+        titles = {chat["title"] for chat in archive["chats"]}
+        assert titles == {"Graph A1", "Graph A2"}

--- a/backend/tests/test_native_dialogs.py
+++ b/backend/tests/test_native_dialogs.py
@@ -94,6 +94,58 @@ def test_pick_folder_returns_none_when_the_user_cancels(monkeypatch):
     assert result is None
 
 
+def test_pick_save_file_returns_none_when_no_window_exists(monkeypatch):
+    monkeypatch.setattr(webview, "windows", [])
+
+    result = asyncio.run(native_dialogs.pick_save_file("Default.graphlink"))
+
+    assert result is None
+
+
+def test_pick_save_file_calls_save_dialog_with_default_name_and_returns_the_path(monkeypatch):
+    # Unlike pick_file/pick_folder's own tuple-wrapped return, a real
+    # pywebview SAVE dialog resolves to a plain string - see pick_save_file's
+    # own docstring for why.
+    fake = _FakeWindow(return_value="C:/exports/My Workspace.graphlink")
+    monkeypatch.setattr(webview, "windows", [fake])
+
+    result = asyncio.run(
+        native_dialogs.pick_save_file("My Workspace.graphlink", file_types=("Graphlink Archive (*.graphlink)",))
+    )
+
+    assert result == "C:/exports/My Workspace.graphlink"
+    assert fake.calls == [
+        {
+            "dialog_type": webview.FileDialog.SAVE,
+            "directory": "",
+            "allow_multiple": False,
+            "save_filename": "My Workspace.graphlink",
+            "file_types": ("Graphlink Archive (*.graphlink)",),
+        }
+    ]
+
+
+def test_pick_save_file_returns_none_when_the_user_cancels(monkeypatch):
+    fake = _FakeWindow(return_value=None)
+    monkeypatch.setattr(webview, "windows", [fake])
+
+    result = asyncio.run(native_dialogs.pick_save_file("Default.graphlink"))
+
+    assert result is None
+
+
+def test_pick_save_file_returns_none_when_the_dialog_resolves_to_an_empty_string(monkeypatch):
+    # Defensive: some pywebview builds resolve a cancelled SAVE dialog to ""
+    # rather than None - pick_save_file's own `result or None` must treat
+    # both the same way.
+    fake = _FakeWindow(return_value="")
+    monkeypatch.setattr(webview, "windows", [fake])
+
+    result = asyncio.run(native_dialogs.pick_save_file("Default.graphlink"))
+
+    assert result is None
+
+
 def test_uses_the_first_window_when_multiple_exist():
     # webview.windows can only ever grow (create_window appends, nothing
     # removes) - confirms the module reads index 0, not "the last one" or

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -253,12 +253,13 @@ def test_the_scan_finds_the_real_population_of_registered_intents():
     # stage 20.2 added app-chat-library's own setGraphFavorite/
     # setGraphArchived/setGraphTags/createWorkspace/renameWorkspace/
     # archiveWorkspace sextet, 165 -> 166 when ADR-020 stage 20.3 added
-    # app-chat-library's own setWorkspaceDefaultModel, and 166 -> 168 when
+    # app-chat-library's own setWorkspaceDefaultModel, 166 -> 168 when
     # ADR-020 stage 20.4 added app-chat-library's own loadGraphAndFocusNode
-    # plus the new "globalSearch" topic's own search intent.
+    # plus the new "globalSearch" topic's own search intent, and 168 -> 169
+    # when ADR-020 stage 20.5 added app-chat-library's own exportWorkspace.
     real = _collect_real_registrations()
-    assert len(real) == 168, (
-        f"expected exactly 168 real registered intents, found {len(real)} - "
+    assert len(real) == 169, (
+        f"expected exactly 169 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -307,4 +307,7 @@ CLASSIFICATION: tuple[Classified, ...] = (
 
     # -- backend/api/intents_global_search.py - ADR-020 stage 20.4 --
     Classified("globalSearch", "search", "B", "read-only: queries the FTS index across graphs/documents/workspaces, no document mutation"),
+
+    # -- backend/chat_library.py (app-chat-library) - ADR-020 stage 20.5 --
+    Classified("app-chat-library", "exportWorkspace", "B", "read-only: reads chats.db and writes an external .graphlink file, no document mutation"),
 )

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -32,6 +32,7 @@ import { ComposerStore } from "./chrome/composerStore";
 import { DiagnosticsDialog } from "./chrome/DiagnosticsDialog";
 import { GlobalSearchDialog } from "./chrome/GlobalSearchDialog";
 import { KnowledgeSearchDialog } from "./chrome/KnowledgeSearchDialog";
+import { QuickSwitcherDialog } from "./chrome/QuickSwitcherDialog";
 import { BuilderLaunchDialog } from "./chrome/BuilderLaunchDialog";
 import { NotificationBanner } from "./chrome/NotificationBanner";
 import { OnboardingDialog } from "./chrome/OnboardingDialog";
@@ -152,6 +153,8 @@ function GlobalShortcuts({ store }: { store: SceneStore }) {
           return overlays.toggle("palette", "dialog");
         case "toggle-search":
           return overlays.toggle("search", "popover");
+        case "toggle-quick-switcher":
+          return overlays.toggle("quick-switcher", "dialog");
         // ADR-010 stage 10.2: the backend owns the stack, so these are a
         // straight forward - the frontend never decides WHAT gets undone.
         // A refusal (nothing to undo, or a node still generating) comes
@@ -449,6 +452,7 @@ function App() {
                     />
                   </div>
                   <CommandPalette store={sceneStore} />
+                  <QuickSwitcherDialog transport={transport} />
                   <AboutDialog transport={transport} />
                   {/* ADR-012 stage 12.6: not lazy, unlike Help/Settings/
                       Library just below - it has to be mounted from the

--- a/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
@@ -104,6 +104,7 @@ function composerSnapshot(overrides: Record<string, unknown> = {}) {
 // push() defaults to "app-chat-library" so those calls stay unchanged.
 function makeTransport() {
   const intents: unknown[][] = [];
+  const resubscribes: string[] = [];
   const listeners = new Map<string, (payload: Record<string, unknown>) => void>();
   const transport = {
     subscribe: (topic: string, l: (payload: Record<string, unknown>) => void) => {
@@ -111,6 +112,13 @@ function makeTransport() {
       return () => {
         listeners.delete(topic);
       };
+    },
+    // ADR-020 stage 20.5: ChatLibraryDialog.tsx now calls this unconditionally
+    // right after subscribe() - see that file's own comment for why (a
+    // second, independent "app-chat-library" subscriber, QuickSwitcherDialog.
+    // tsx, can otherwise steal the one-time fresh-snapshot push).
+    resubscribe: (topic: string) => {
+      resubscribes.push(topic);
     },
     intent: (topic: string, intent: string, args: unknown[]) => {
       intents.push([topic, intent, args]);
@@ -124,6 +132,7 @@ function makeTransport() {
   return {
     transport,
     intents,
+    resubscribes,
     push: (payload: Record<string, unknown>, topic: string = "app-chat-library") => listeners.get(topic)?.(payload),
   };
 }
@@ -658,5 +667,46 @@ describe("ChatLibraryDialog", () => {
 
     await chooseCustomOption(user, 'Default model for "Default"', "No workspace default");
     expect(intents).toContainEqual(["app-chat-library", "setWorkspaceDefaultModel", [1, "", ""]]);
+  });
+
+  // -- ADR-020 stage 20.5: workspace export ----------------------------------
+
+  it("the gear panel's Export Workspace button fires exportWorkspace with the workspace id", async () => {
+    const { user, push, intents } = setup();
+    act(() => push(composerSnapshot(), "app-composer"));
+    act(() => push({ ...snapshot, workspaces: [workspace({ id: 1, name: "Default" }), workspace({ id: 2, name: "Work" })] }));
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Show default model settings for "Work"'));
+    await user.click(screen.getByRole("button", { name: "Export Workspace…" }));
+
+    expect(intents).toContainEqual(["app-chat-library", "exportWorkspace", [2]]);
+  });
+
+  it("names the target workspace in the export panel's own description", async () => {
+    const { user, push } = setup();
+    act(() => push(composerSnapshot(), "app-composer"));
+    act(() => push({ ...snapshot, workspaces: [workspace({ id: 1, name: "Client Alpha" })] }));
+    await user.click(screen.getByText("open library"));
+
+    await user.click(screen.getByLabelText('Show default model settings for "Client Alpha"'));
+
+    expect(screen.getByText(/Save every graph in "Client Alpha" as one \.graphlink file\./)).toBeInTheDocument();
+  });
+
+  it("regression: resubscribes to app-chat-library on mount, so a late subscribe still gets a fresh snapshot", () => {
+    // ADR-020 stage 20.5: in the real app this dialog is lazy-mounted
+    // (App.tsx's own LazySurface), so it is no longer guaranteed to be the
+    // FIRST subscriber to "app-chat-library" - QuickSwitcherDialog.tsx now
+    // also subscribes, eagerly, from app start. WsTransport.subscribe()
+    // only sends a real wire-level "subscribe" (and gets a fresh snapshot
+    // back) for a topic's first-ever listener - without this dialog's own
+    // resubscribe() call on mount, opening Library after the quick switcher
+    // had already claimed that slot left it stuck on empty initialState
+    // ("No saved chats yet" with a real, populated library) - confirmed via
+    // a live browser repro before this fix, not a hypothetical.
+    const { resubscribes } = setup();
+
+    expect(resubscribes).toContain("app-chat-library");
   });
 });

--- a/web_ui/src/app/chrome/ChatLibraryDialog.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.tsx
@@ -80,6 +80,11 @@ type BucketKey = "Today" | "Yesterday" | "Previous 7 Days" | "Previous 30 Days" 
 const BUCKET_ORDER: BucketKey[] = ["Today", "Yesterday", "Previous 7 Days", "Previous 30 Days", "Older"];
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+// ADR-020 stage 20.5: matches sceneStore.ts's/composerStore.ts's own
+// NATIVE_DIALOG_TIMEOUT_MS - exportWorkspace opens a native OS SAVE dialog
+// server-side and waits on the user, not the network.
+const NATIVE_DIALOG_TIMEOUT_MS = 5 * 60_000;
+
 function startOfLocalDay(date: Date): number {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
 }
@@ -259,11 +264,24 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
   const lastTriggerRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
-    return transport.subscribe("app-chat-library", (payload) => {
+    const unsubscribe = transport.subscribe("app-chat-library", (payload) => {
       const validated = TOPIC_VALIDATORS["app-chat-library"](payload);
       if (validated.ok) setState(validated.value as AppChatLibraryState);
       else console.error("[app-chat-library] rejected snapshot:", validated.errors);
     });
+    // ADR-020 stage 20.5: WsTransport.subscribe() only sends a real wire-
+    // level "subscribe" (and so only gets a fresh snapshot back) for the
+    // TOPIC's first-ever listener - a second, independent subscriber (this
+    // dialog is lazy-mounted, per App.tsx's own LazySurface, so it now
+    // often loses that race to QuickSwitcherDialog.tsx's own eager,
+    // always-mounted "app-chat-library" subscription) would otherwise sit
+    // on initialState - "No saved chats yet" even with a real, populated
+    // library - until some unrelated future mutation happens to republish
+    // the topic. resubscribe() forces that fresh snapshot unconditionally,
+    // the same recovery primitive sceneStore.ts's own "scene" topic
+    // handling already relies on for an analogous re-sync need.
+    transport.resubscribe("app-chat-library");
+    return unsubscribe;
   }, [transport]);
 
   // ADR-020 stage 20.3: see this file's own module docstring for why this
@@ -420,6 +438,17 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
   function setWorkspaceDefaultModel(workspaceId: number, modelId: string) {
     const provider = modelId === "" ? "" : composerState.route.provider;
     transport.fireIntent("app-chat-library", "setWorkspaceDefaultModel", [workspaceId, provider, modelId], undefined, true);
+  }
+
+  // ADR-020 stage 20.5: fire-and-forget from this component's own
+  // perspective (the native SAVE dialog + a success/cancelled/error
+  // notification is the entire feedback loop - see register_chat_library's
+  // own export_workspace closure) - NOT queueable (unlike setWorkspaceDefault
+  // Model above): a save dialog waiting on the user has nothing sensible to
+  // replay after a reconnect, the same "native-dialog intents don't queue"
+  // posture attachFile/pickGitlinkLocalRoot already established.
+  function exportWorkspace(workspaceId: number) {
+    transport.fireIntent("app-chat-library", "exportWorkspace", [workspaceId], NATIVE_DIALOG_TIMEOUT_MS);
   }
 
   function startCreateWorkspace() {
@@ -661,6 +690,19 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
                 ]}
                 onChange={(modelId) => setWorkspaceDefaultModel(expandedWorkspace.id, modelId)}
               />
+            </div>
+            <div className="settings-field">
+              <span className="settings-field-label">Export</span>
+              <p className="settings-update-status">
+                Save every graph in &quot;{expandedWorkspace.name}&quot; as one .graphlink file.
+              </p>
+              <button
+                type="button"
+                className="library-new-chat-button"
+                onClick={() => exportWorkspace(expandedWorkspace.id)}
+              >
+                Export Workspace…
+              </button>
             </div>
           </div>
         )}

--- a/web_ui/src/app/chrome/GlobalSearchDialog.test.tsx
+++ b/web_ui/src/app/chrome/GlobalSearchDialog.test.tsx
@@ -119,7 +119,7 @@ describe("GlobalSearchDialog", () => {
     await user.type(screen.getByPlaceholderText(/search every workspace/i), "secret phrase");
     await user.click(screen.getByRole("button", { name: "Search" }));
 
-    expect(intents).toContainEqual(["search", "globalSearch", ["secret phrase", 10]]);
+    expect(intents).toContainEqual(["globalSearch", "search", ["secret phrase", 10]]);
   });
 
   it('renders "N results found" with N matching the real result count', async () => {

--- a/web_ui/src/app/chrome/GlobalSearchDialog.tsx
+++ b/web_ui/src/app/chrome/GlobalSearchDialog.tsx
@@ -37,7 +37,7 @@ import { Dialog, useOverlays } from "../overlays/overlays";
  *
  * Wire contract note (frontend/backend built concurrently against ADR-020
  * stage 20.4's shared design doc, no live handshake): this file calls
- * transport.request("search", "globalSearch", [query, k]) and
+ * transport.request("globalSearch", "search", [query, k]) and
  * transport.request("app-chat-library", "loadGraphAndFocusNode",
  * [graphId, nodeId]) - the exact topic/intent names and result field names
  * (chunkId/documentId/documentTitle/sourceUri/text/offsetStart/offsetEnd,
@@ -180,7 +180,7 @@ export function GlobalSearchDialog({ transport }: { transport: WsTransport }) {
     setSearching(true);
     setError(null);
     transport
-      .request("search", "globalSearch", [trimmed, 10])
+      .request("globalSearch", "search", [trimmed, 10])
       .then((value) => {
         if (requestId !== latestRequestId.current) return; // a newer search has since been sent
         const payload = value as { results: GlobalSearchResult[] };

--- a/web_ui/src/app/chrome/QuickSwitcherDialog.test.tsx
+++ b/web_ui/src/app/chrome/QuickSwitcherDialog.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { QuickSwitcherDialog } from "./QuickSwitcherDialog";
+import { OverlayProvider, useOverlays } from "../overlays/overlays";
+import type { WsTransport } from "../../lib/ws/transport";
+
+/**
+ * ADR-020 stage 20.5. Mirrors two established precedents rather than
+ * inventing test shape:
+ * - GlobalSearchDialog.test.tsx's own makeTransport() (subscribe/fireIntent
+ *   double, no real WsTransport).
+ * - CommandPalette.test.tsx's own ArrowDown/Enter + scrollIntoView-stub
+ *   coverage, since this dialog shares that exact keyboard contract.
+ */
+
+function row(overrides: Record<string, unknown>) {
+  return {
+    id: 1,
+    title: "Untitled",
+    createdLabel: "Jan 01, 2026",
+    updatedLabel: "Jan 01, 2026",
+    createdAtIso: "2026-01-01T08:00:00",
+    updatedAtIso: "2026-01-01T08:00:00",
+    preview: "",
+    messageCount: 0,
+    workspaceId: 1,
+    favorite: false,
+    archived: false,
+    tags: [] as string[],
+    ...overrides,
+  };
+}
+
+function workspace(overrides: Record<string, unknown>) {
+  return { id: 1, name: "Default", icon: "", archived: false, defaultModelProvider: "", defaultModelId: "", ...overrides };
+}
+
+function makeTransport() {
+  const intents: unknown[][] = [];
+  const resubscribes: string[] = [];
+  const listeners = new Map<string, (payload: unknown) => void>();
+  const transport = {
+    subscribe: (topic: string, listener: (payload: unknown) => void) => {
+      listeners.set(topic, listener);
+      return () => listeners.delete(topic);
+    },
+    // ADR-020 stage 20.5: QuickSwitcherDialog.tsx calls this unconditionally
+    // right after subscribe() - see that file's own comment for why.
+    resubscribe: (topic: string) => {
+      resubscribes.push(topic);
+    },
+    intent: () => {},
+    fireIntent: (topic: string, intent: string, args: unknown[] = []) => {
+      intents.push([topic, intent, args]);
+    },
+  } as unknown as WsTransport;
+  return {
+    transport,
+    intents,
+    resubscribes,
+    push: (payload: Record<string, unknown>) => listeners.get("app-chat-library")?.(payload),
+  };
+}
+
+function OpenQuickSwitcherButton() {
+  const overlays = useOverlays();
+  return (
+    <button type="button" onClick={() => overlays.toggle("quick-switcher", "dialog")}>
+      open quick switcher
+    </button>
+  );
+}
+
+function setup() {
+  const user = userEvent.setup();
+  const fake = makeTransport();
+  render(
+    <OverlayProvider>
+      <OpenQuickSwitcherButton />
+      <QuickSwitcherDialog transport={fake.transport} />
+    </OverlayProvider>,
+  );
+  return { user, ...fake };
+}
+
+const SNAPSHOT = {
+  schemaVersion: 1,
+  minCompatibleSchemaVersion: 1,
+  revision: 1,
+  rows: [
+    row({ id: 1, title: "Recent Graph", workspaceId: 1, updatedLabel: "Today" }),
+    row({ id: 2, title: "Older Graph", workspaceId: 2, updatedLabel: "Yesterday" }),
+    row({ id: 3, title: "Archived Graph", workspaceId: 1, archived: true, updatedLabel: "Last week" }),
+  ],
+  workspaces: [workspace({ id: 1, name: "Default" }), workspace({ id: 2, name: "Work" })],
+  notice: null,
+};
+
+describe("QuickSwitcherDialog", () => {
+  it("is closed until the surface opens", () => {
+    setup();
+    expect(screen.queryByLabelText("Search graphs by title")).toBeNull();
+  });
+
+  it("shows non-archived graphs in the backend's own (recency) order when the query is blank", async () => {
+    const { user, push } = setup();
+    push(SNAPSHOT);
+    await user.click(screen.getByText("open quick switcher"));
+
+    const options = screen.getAllByRole("option");
+    expect(options.map((el) => el.textContent)).toEqual([
+      "Recent GraphDefault · Today",
+      "Older GraphWork · Yesterday",
+    ]);
+    expect(screen.queryByText("Archived Graph")).toBeNull();
+  });
+
+  it("fuzzy-filters by typed title text", async () => {
+    const { user, push } = setup();
+    push(SNAPSHOT);
+    await user.click(screen.getByText("open quick switcher"));
+
+    await user.type(screen.getByLabelText("Search graphs by title"), "older");
+
+    expect(screen.getByText("Older Graph")).toBeInTheDocument();
+    expect(screen.queryByText("Recent Graph")).toBeNull();
+  });
+
+  it("shows a 'no matching graphs' message when nothing matches", async () => {
+    const { user, push } = setup();
+    push(SNAPSHOT);
+    await user.click(screen.getByText("open quick switcher"));
+
+    await user.type(screen.getByLabelText("Search graphs by title"), "zzz-nonexistent");
+
+    expect(screen.getByText("No matching graphs")).toBeInTheDocument();
+  });
+
+  it("clicking a row fires loadChat with its id and closes the dialog", async () => {
+    const { user, push, intents } = setup();
+    push(SNAPSHOT);
+    await user.click(screen.getByText("open quick switcher"));
+
+    await user.click(screen.getByText("Older Graph"));
+
+    expect(intents).toContainEqual(["app-chat-library", "loadChat", [2]]);
+    expect(screen.queryByLabelText("Search graphs by title")).toBeNull();
+  });
+
+  it("ArrowDown/Enter selects and loads the highlighted graph", async () => {
+    const { user, push, intents } = setup();
+    push(SNAPSHOT);
+    await user.click(screen.getByText("open quick switcher"));
+
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(intents).toContainEqual(["app-chat-library", "loadChat", [2]]);
+    expect(screen.queryByLabelText("Search graphs by title")).toBeNull();
+  });
+
+  it("resets the query on each fresh open", async () => {
+    const { user, push } = setup();
+    push(SNAPSHOT);
+    await user.click(screen.getByText("open quick switcher"));
+    await user.type(screen.getByLabelText("Search graphs by title"), "older");
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByText("open quick switcher"));
+
+    expect(screen.getByLabelText("Search graphs by title")).toHaveValue("");
+    expect(screen.getByText("Recent Graph")).toBeInTheDocument();
+  });
+
+  it("regression: resubscribes to app-chat-library on mount, since it is eagerly mounted and would otherwise silently claim the topic's one-time fresh-snapshot slot from a later subscriber (ChatLibraryDialog.tsx)", () => {
+    const { resubscribes } = setup();
+
+    expect(resubscribes).toContain("app-chat-library");
+  });
+});

--- a/web_ui/src/app/chrome/QuickSwitcherDialog.tsx
+++ b/web_ui/src/app/chrome/QuickSwitcherDialog.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { AppChatLibraryState } from "../../lib/bridge-core/generated/app-chat-library-state";
+import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
+import type { WsTransport } from "../../lib/ws/transport";
+import { useOverlays } from "../overlays/overlays";
+import { fuzzyFilterAndSort } from "./quickSwitcherFuzzy";
+
+const initialState: AppChatLibraryState = { schemaVersion: 0, revision: 0, rows: [], workspaces: [] };
+
+/**
+ * ADR-020 stage 20.5: the quick switcher (`Ctrl+P`-class) - "recent graphs,
+ * fuzzy title match, jump," per this stage's own design doc note (ADR-020's
+ * own "4. A phrase in a node... is found and focused" section). A direct
+ * sibling of CommandPalette.tsx, not CommandPalette itself repurposed: same
+ * hand-rolled overlay-scrim + palette-shell/palette-search-input/palette-
+ * results/palette-result markup, same reset-on-open-transition pattern, same
+ * ArrowUp/ArrowDown/Enter keyboard contract - but the palette filters a
+ * fixed, in-memory PaletteCommand[] built fresh every render, while this
+ * filters a LIVE server-pushed list of graphs (this app's own "app-chat-
+ * library" topic, the same snapshot ChatLibraryDialog.tsx already renders
+ * as the real library UI) and its own action is loadChat, not command.run().
+ *
+ * Subscribes to "app-chat-library" independently of ChatLibraryDialog - see
+ * WsTransport.subscribe's own Set<listener>-per-topic shape: multiple
+ * independent subscribers to the same topic is the ordinary, supported
+ * case (ChatLibraryDialog is usually unmounted anyway, per App.tsx's own
+ * LazySurface - a lazy chrome dialog mounts only once its own overlay
+ * surface has genuinely been opened, so this component cannot assume
+ * ChatLibraryDialog's subscription is even alive to piggyback on).
+ *
+ * Archived graphs are excluded, matching ChatLibraryDialog's own default
+ * (non-archived) view - a quick "jump to a recent graph" surface has no use
+ * for a graph the user explicitly archived. `rows` already arrives sorted
+ * updated_at DESC (backend/chat_library.py's own get_all_chats), so a blank
+ * query - fuzzyFilterAndSort's own "empty query ties everything, stable
+ * sort" contract - shows the most-recently-touched graphs first with zero
+ * extra sorting here.
+ */
+export function QuickSwitcherDialog({ transport }: { transport: WsTransport }) {
+  const overlays = useOverlays();
+  const [state, setState] = useState<AppChatLibraryState>(initialState);
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const resultsRef = useRef<HTMLUListElement>(null);
+  const isOpen = overlays.isOpen("quick-switcher");
+
+  useEffect(() => {
+    const unsubscribe = transport.subscribe("app-chat-library", (payload) => {
+      const validated = TOPIC_VALIDATORS["app-chat-library"](payload);
+      if (validated.ok) setState(validated.value as AppChatLibraryState);
+      else console.error("[app-chat-library] rejected snapshot:", validated.errors);
+    });
+    // WsTransport.subscribe() only sends a real wire-level "subscribe" (and
+    // so only gets a fresh snapshot back) for a topic's first-ever listener
+    // - this component is mounted unconditionally (see App.tsx), so it
+    // would otherwise silently "steal" that first-subscriber slot from
+    // whichever chrome surface subscribes to "app-chat-library" next (e.g.
+    // ChatLibraryDialog.tsx's own lazy-mounted subscription - see that
+    // file's own identical resubscribe() call and comment for the
+    // observed failure this closes: "No saved chats yet" with a real,
+    // populated library). resubscribe() forces a fresh snapshot
+    // unconditionally, making this independent of subscribe ORDER between
+    // the two dialogs.
+    transport.resubscribe("app-chat-library");
+    return unsubscribe;
+  }, [transport]);
+
+  // Reset local state during render on the false->true transition - same
+  // "not in an effect" posture as CommandPalette.tsx's own wasOpen tracking.
+  const [wasOpen, setWasOpen] = useState(isOpen);
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen);
+    if (isOpen) {
+      setQuery("");
+      setSelectedIndex(0);
+    }
+  }
+
+  useEffect(() => {
+    if (isOpen) inputRef.current?.focus();
+  }, [isOpen]);
+
+  const workspaceNameById = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const workspace of state.workspaces) map.set(workspace.id, workspace.name);
+    return map;
+  }, [state.workspaces]);
+
+  const candidates = useMemo(() => state.rows.filter((row) => !row.archived), [state.rows]);
+  const filtered = useMemo(
+    () => fuzzyFilterAndSort(query, candidates, (row) => row.title),
+    [candidates, query],
+  );
+
+  const clampedIndex = Math.min(selectedIndex, Math.max(filtered.length - 1, 0));
+
+  useEffect(() => {
+    resultsRef.current?.querySelector('[aria-selected="true"]')?.scrollIntoView({ block: "nearest" });
+  }, [clampedIndex]);
+
+  if (!isOpen) return null;
+
+  function jumpTo(id: number) {
+    overlays.close();
+    transport.fireIntent("app-chat-library", "loadChat", [id]);
+  }
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, Math.max(filtered.length - 1, 0)));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const row = filtered[clampedIndex];
+      if (row) jumpTo(row.id);
+    }
+    // Escape is handled globally by the overlay system.
+  }
+
+  return (
+    <div className="overlay-scrim" onPointerDown={(e) => e.target === e.currentTarget && overlays.close()}>
+      <div role="dialog" aria-modal="true" aria-label="Quick switcher" className="palette-shell">
+        <input
+          ref={inputRef}
+          className="palette-search-input"
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setSelectedIndex(0);
+          }}
+          onKeyDown={onKeyDown}
+          placeholder="Jump to a graph…"
+          aria-label="Search graphs by title"
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <ul className="palette-results" role="listbox" aria-label="Graphs" ref={resultsRef}>
+          {filtered.length === 0 && <li className="palette-empty">No matching graphs</li>}
+          {filtered.map((row, index) => (
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+            <li
+              key={row.id}
+              role="option"
+              aria-selected={index === clampedIndex}
+              className={"palette-result" + (index === clampedIndex ? " selected" : "")}
+              onMouseEnter={() => setSelectedIndex(index)}
+              onClick={() => jumpTo(row.id)}
+            >
+              <span className="quick-switcher-result-title">{row.title}</span>
+              <span className="quick-switcher-result-meta">
+                {workspaceNameById.get(row.workspaceId) ?? "Default"} · {row.updatedLabel}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/web_ui/src/app/chrome/commands.ts
+++ b/web_ui/src/app/chrome/commands.ts
@@ -202,6 +202,18 @@ export function buildCommands(
       enabled: () => true,
     },
     {
+      // ADR-020 stage 20.5: the quick switcher - see QuickSwitcherDialog.tsx.
+      // Same registration shape as "open-global-search" above (ADR-012's own
+      // "register every new surface in the palette" rule) - its real
+      // trigger is Ctrl+P (chrome/shortcuts.ts), this is the discoverable
+      // palette twin, same posture as "open-library"'s own Ctrl+L twin.
+      id: "open-quick-switcher",
+      name: "Quick Switcher",
+      aliases: ["go to graph", "jump to graph", "recent graphs", "switch graph"],
+      run: () => overlays.open("quick-switcher", "dialog"),
+      enabled: () => true,
+    },
+    {
       // ADR-020 stage 20.4: search every workspace's graphs and knowledge
       // documents at once - see GlobalSearchDialog.tsx. Same registration
       // shape as "open-library"/"open-plugins" above (ADR-012's own

--- a/web_ui/src/app/chrome/quickSwitcherFuzzy.test.ts
+++ b/web_ui/src/app/chrome/quickSwitcherFuzzy.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { fuzzyFilterAndSort, fuzzyScore } from "./quickSwitcherFuzzy";
+
+describe("fuzzyScore", () => {
+  it("matches every query character in order, case-insensitively", () => {
+    expect(fuzzyScore("gql", "Global Query Log")).not.toBeNull();
+    expect(fuzzyScore("GQL", "global query log")).not.toBeNull();
+  });
+
+  it("returns null when a query character is missing entirely", () => {
+    expect(fuzzyScore("xyz", "Global Query Log")).toBeNull();
+  });
+
+  it("returns null when the query characters appear out of order", () => {
+    // "g" only occurs before "query" here - "qg" has no valid in-order
+    // subsequence match, unlike against "Global Query Log" (which has a
+    // SECOND "g", after "query", still leaving "qg" satisfiable there).
+    expect(fuzzyScore("qg", "Log Query")).toBeNull();
+  });
+
+  it("scores an empty query as 0 (matches everything, ties)", () => {
+    expect(fuzzyScore("", "anything")).toBe(0);
+  });
+
+  it("ranks a tighter (more contiguous) match ahead of a looser one", () => {
+    const tight = fuzzyScore("cat", "concatenate");
+    const loose = fuzzyScore("cat", "circus at twilight");
+    expect(tight).not.toBeNull();
+    expect(loose).not.toBeNull();
+    expect(tight as number).toBeLessThan(loose as number);
+  });
+
+  it("ranks a prefix match ahead of a non-prefix match regardless of span", () => {
+    const prefix = fuzzyScore("api", "API research notes for the quarter");
+    const nonPrefix = fuzzyScore("api", "Graph API");
+    expect(prefix).not.toBeNull();
+    expect(nonPrefix).not.toBeNull();
+    expect(prefix as number).toBeLessThan(nonPrefix as number);
+  });
+});
+
+describe("fuzzyFilterAndSort", () => {
+  const rows = [
+    { title: "Onboarding Notes" },
+    { title: "Q3 Planning" },
+    { title: "API Research" },
+    { title: "Quarterly API Review" },
+  ];
+
+  it("filters out non-matching items", () => {
+    const result = fuzzyFilterAndSort("api", rows, (r) => r.title);
+    expect(result.map((r) => r.title)).toEqual(["API Research", "Quarterly API Review"]);
+  });
+
+  it("ranks the prefix match first", () => {
+    const result = fuzzyFilterAndSort("api", rows, (r) => r.title);
+    expect(result[0].title).toBe("API Research");
+  });
+
+  it("preserves input order (a stable sort) when the query is blank", () => {
+    const result = fuzzyFilterAndSort("", rows, (r) => r.title);
+    expect(result.map((r) => r.title)).toEqual(rows.map((r) => r.title));
+  });
+
+  it("preserves input order when the query is only whitespace", () => {
+    const result = fuzzyFilterAndSort("   ", rows, (r) => r.title);
+    expect(result.map((r) => r.title)).toEqual(rows.map((r) => r.title));
+  });
+});

--- a/web_ui/src/app/chrome/quickSwitcherFuzzy.ts
+++ b/web_ui/src/app/chrome/quickSwitcherFuzzy.ts
@@ -1,0 +1,55 @@
+/**
+ * ADR-020 stage 20.5: the quick switcher's fuzzy title match - a plain,
+ * dependency-free subsequence matcher (every character of the query must
+ * appear in the target, in order, not necessarily contiguous - the same
+ * matching contract VS Code's/Sublime's own "Go to File" use), not a fuzzy-
+ * scoring library. Split out as a pure function so the matching/ranking
+ * logic is unit-testable without mounting QuickSwitcherDialog.tsx.
+ *
+ * Lower score = better match, so a plain ascending sort ranks the best
+ * match first: an exact-prefix match (score includes PREFIX_BONUS, a large
+ * negative offset) always outranks a non-prefix match regardless of span,
+ * and among same-prefix-ness matches a tighter span (query characters found
+ * closer together in the target) outranks a looser one.
+ */
+
+const PREFIX_BONUS = -1000;
+
+/** Null when `query`'s characters do not all appear, in order, in `target`.
+ * An empty query matches everything with score 0 - every candidate ties, so
+ * a stable sort leaves the caller's own input order (recency, here)
+ * untouched. */
+export function fuzzyScore(query: string, target: string): number | null {
+  const q = query.toLowerCase();
+  if (q.length === 0) return 0;
+  const t = target.toLowerCase();
+
+  let qi = 0;
+  let firstIndex = -1;
+  let lastIndex = -1;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      if (firstIndex === -1) firstIndex = ti;
+      lastIndex = ti;
+      qi++;
+    }
+  }
+  if (qi < q.length) return null;
+
+  const spread = lastIndex - firstIndex + 1 - q.length;
+  const prefixBonus = firstIndex === 0 ? PREFIX_BONUS : 0;
+  return prefixBonus + spread * 10 + firstIndex;
+}
+
+/** Filters `items` to those whose `text(item)` fuzzy-matches `query`, sorted
+ * best-match-first. `Array.prototype.sort` is a stable sort (guaranteed
+ * since ES2019), so a blank query - every item scores 0 and ties - preserves
+ * `items`' own input order rather than reshuffling it. */
+export function fuzzyFilterAndSort<T>(query: string, items: readonly T[], text: (item: T) => string): T[] {
+  const trimmed = query.trim();
+  return items
+    .map((item) => ({ item, score: fuzzyScore(trimmed, text(item)) }))
+    .filter((entry): entry is { item: T; score: number } => entry.score !== null)
+    .sort((a, b) => a.score - b.score)
+    .map((entry) => entry.item);
+}

--- a/web_ui/src/app/chrome/shortcuts.test.ts
+++ b/web_ui/src/app/chrome/shortcuts.test.ts
@@ -19,6 +19,7 @@ describe("resolveShortcut", () => {
     expect(resolveShortcut(key("k"))).toBe("toggle-palette");
     expect(resolveShortcut(key("f"))).toBe("toggle-search");
     expect(resolveShortcut(key("g"))).toBe("create-frame");
+    expect(resolveShortcut(key("p"))).toBe("toggle-quick-switcher");
     expect(resolveShortcut(key("ArrowUp"))).toBe("navigate-up");
     expect(resolveShortcut(key("ArrowDown"))).toBe("navigate-down");
     expect(resolveShortcut(key("ArrowLeft"))).toBe("navigate-left");
@@ -88,12 +89,16 @@ describe("isGatedWhileTyping", () => {
   // contract-tests, PLUS "compare-branches"/"synthesize-branches" (ADR-002
   // Workstream 1 - new shortcuts, not legacy ports, gated for the same
   // reason as their closest sibling create-frame/create-container - see
-  // shortcuts.ts's own comment). Mirrored here so a future edit to the set
-  // has to be deliberate rather than incidental.
+  // shortcuts.ts's own comment) PLUS "toggle-quick-switcher" (ADR-020 stage
+  // 20.5 - a new shortcut, gated for the same "jump to a different
+  // document" reason as toggle-library - see shortcuts.ts's own comment).
+  // Mirrored here so a future edit to the set has to be deliberate rather
+  // than incidental.
   const GATED: ShortcutId[] = [
     "new-chat",
     "toggle-library",
     "toggle-search",
+    "toggle-quick-switcher",
     "create-frame",
     "create-container",
     "compare-branches",
@@ -113,9 +118,9 @@ describe("isGatedWhileTyping", () => {
     expect(isGatedWhileTyping(id)).toBe(false);
   });
 
-  it("gates exactly the 9 legacy combinations plus compare-branches/synthesize-branches (11 total), no more and no fewer", () => {
+  it("gates exactly the 9 legacy combinations plus compare-branches/synthesize-branches/toggle-quick-switcher (12 total), no more and no fewer", () => {
     const all: ShortcutId[] = [...GATED, ...EXEMPT];
-    expect(all.filter(isGatedWhileTyping)).toHaveLength(11);
+    expect(all.filter(isGatedWhileTyping)).toHaveLength(12);
   });
 });
 

--- a/web_ui/src/app/chrome/shortcuts.ts
+++ b/web_ui/src/app/chrome/shortcuts.ts
@@ -27,6 +27,7 @@ export type ShortcutId =
   | "synthesize-branches"
   | "toggle-palette"
   | "toggle-search"
+  | "toggle-quick-switcher"
   | "navigate-up"
   | "navigate-down"
   | "navigate-left"
@@ -57,6 +58,13 @@ const GATED_WHILE_TYPING = new Set<ShortcutId>([
   "new-chat",
   "toggle-library",
   "toggle-search",
+  // ADR-020 stage 20.5: the quick switcher is a "jump to a different
+  // document" surface, same posture as toggle-library right above it, not
+  // Ctrl+K's own exempt "summon key, idempotent handler" posture (see this
+  // file's own module doc for why Save/palette are the deliberate
+  // exceptions) - Ctrl+P mid-sentence in the composer or a node's inline
+  // editor must stay a plain "p", not hijack the field to open a dialog.
+  "toggle-quick-switcher",
   "create-frame",
   "create-container",
   "compare-branches",
@@ -122,6 +130,15 @@ export function resolveShortcut(event: ShortcutKeyEvent): ShortcutId | null {
       return event.shiftKey ? null : "toggle-palette";
     case "f":
       return event.shiftKey ? null : "toggle-search";
+    // ADR-020 stage 20.5: Ctrl+P is a new binding (no legacy key to match,
+    // same posture as compare-branches/synthesize-branches above) - the
+    // conventional "quick open"/"go to file" key VS Code and Sublime both
+    // use, which is exactly what this surface is for a graph. The browser's
+    // own native Ctrl+P (print) is already suppressed the same way every
+    // other ctrl-matched binding here is - see onKeyDown's own
+    // event.preventDefault() in App.tsx's GlobalShortcuts.
+    case "p":
+      return event.shiftKey ? null : "toggle-quick-switcher";
     // Ctrl+G -> Frame, Ctrl+Shift+G -> Container: two distinct legacy
     // bindings (graphlink_window.py:312-313), not one with a modifier.
     case "g":

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -2659,6 +2659,21 @@ body,
   color: var(--gl-surface-text-muted);
 }
 
+/* ADR-020 stage 20.5: the quick switcher's two-line result rows - a plain
+   command name (CommandPalette.tsx's own .palette-result content) needs no
+   secondary line, but a graph needs its workspace/recency disambiguated
+   from every other graph sharing the same title. */
+.quick-switcher-result-title {
+  display: block;
+}
+
+.quick-switcher-result-meta {
+  display: block;
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--gl-surface-text-muted);
+}
+
 .app-search-layer {
   position: absolute;
   top: var(--gl-chrome-inset);


### PR DESCRIPTION
## Problem
ADR-020's last stage: no fast keyboard path to jump between graphs (only the full Chat Library dialog), and `backend/workspace_archive.py`'s `export_archive` (built and tested in ADR-009 stage 9.4) was never wired to a real intent - a workspace could not be exported as a `.graphlink` file.

## Change
- `QuickSwitcherDialog.tsx` (new): `Ctrl+P` quick switcher - fuzzy title match over the same `app-chat-library` rows the real library UI already renders (recency-sorted, archived excluded), Enter/click jumps straight to a graph via the existing `loadChat` intent. Registered in the command palette as "Quick Switcher".
- `quickSwitcherFuzzy.ts` (new): dependency-free subsequence fuzzy matcher/ranker backing the switcher.
- `backend/native_dialogs.py`: new `pick_save_file` (a native SAVE dialog - the missing counterpart to the existing OPEN/FOLDER pickers).
- `backend/chat_library.py`: new `exportWorkspace` intent wires the dormant `export_archive` primitive to a real backend action - resolves the workspace's graphs, opens the native save dialog, writes the archive, notifies success/cancelled/error.
- `ChatLibraryDialog.tsx`: "Export Workspace" action in each workspace's settings panel.

## Bugs found and fixed while building this
- `GlobalSearchDialog.tsx`'s `runSearch()` called `transport.request("search", "globalSearch", ...)` - topic and intent were swapped relative to the backend's actual registration (topic `globalSearch`, intent `search`). Global Search was silently failing against a real backend. Fixed, with the matching test assertion corrected.
- Live browser verification surfaced a real race: `WsTransport.subscribe()` only sends a wire-level `subscribe` (and so only gets a fresh snapshot back) for a topic's first-ever listener. The quick switcher's own eager, always-mounted `app-chat-library` subscription could silently claim that slot ahead of the chat library dialog's lazy-mounted one, leaving the library stuck on "No saved chats yet" with a real, populated library. Both dialogs now call `transport.resubscribe()` on mount to force a fresh snapshot regardless of subscribe order.

## Test plan
- [x] `python -m pytest -q` from repo root: 2978 passed, 17 skipped, 0 failed
- [x] `npx vitest run` (web_ui): 1909 passed, 0 failed
- [x] `npx tsc --noEmit`: clean
- [x] Live browser verification: `Ctrl+P` opens the switcher with real, recency-sorted data; fuzzy filter narrows correctly; Escape closes; reproduced the exact subscribe-order race pre-fix (Library dialog showed "No saved chats yet" with 45 real chats present) and confirmed it's gone post-fix; Export Workspace button renders with the correct per-workspace description