### PR TITLE
ADR-015 stage 15.3: ruff (scoped) + pytest filterwarnings + dead Qt config cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,12 @@ concurrency:
 
 jobs:
   python-tests:
-    name: Python tests (offscreen)
+    # ADR-015 stage 15.3: was "Python tests (offscreen)" - a Qt-removal-era
+    # name for a job that no longer runs anything Qt-related (the offscreen
+    # QT_QPA_PLATFORM setting it referred to is gone, see pyproject.toml's
+    # own [tool.pytest.ini_options]). Windows-pinned for DPAPI, not Qt - see
+    # this file's own module comment above.
+    name: Python checks (Windows, DPAPI)
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
@@ -74,6 +79,9 @@ jobs:
 
       - name: Compile check
         run: python -m compileall -q .
+
+      - name: ruff (scoped rule set - see pyproject.toml's own [tool.ruff])
+        run: pip install --quiet ruff && python -m ruff check .
 
       - name: Run pytest
         run: python -m pytest -q

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -61,7 +61,6 @@ from __future__ import annotations
 import asyncio
 import difflib
 import inspect
-import json
 import logging
 import re
 import threading
@@ -108,7 +107,6 @@ from graphlink_scratch_dirs import remove_scratch_dir_for_id
 from graphlink_model_catalog import ModelRef, resolve_model_ref
 from graphlink_plugins.web_research.domain import (
     CancellationToken,
-    ProgressEvent,
     RequestCancelled,
     ResearchFailure,
     WebResearchRequest,

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -55,7 +55,6 @@ from backend.domain.commands import CommandOps
 from backend.domain.content_codec import _content_codec
 from backend.domain.groups import GroupOps
 from backend.domain.model import (
-    BRANCH_HORIZONTAL_SPACING,
     CHART_MAX_HEIGHT,
     CHART_MAX_WIDTH,
     CHART_MIN_HEIGHT,
@@ -68,20 +67,12 @@ from backend.domain.model import (
     FONT_SIZE_MAX,
     FONT_SIZE_MIN,
     GRID_COLOR_PRESETS,
-    GROUP_COLLAPSED_HEIGHT,
-    GROUP_COLLAPSED_WIDTH,
-    GROUP_INELIGIBLE_FRAME_MEMBER_KINDS,
-    GROUP_MEMBER_DEFAULT_HEIGHT,
-    GROUP_MEMBER_DEFAULT_WIDTH,
-    GROUP_PADDING,
-    GROUP_PADDING_TOP,
     HTML_TITLE_PREVIEW_LENGTH,
     IMAGE_TITLE_PREVIEW_LENGTH,
     MESSAGE_VERTICAL_SPACING,
     ORGANIZE_SPACING_X,
     ORGANIZE_SPACING_Y,
     SceneEdge,
-    SceneEmptyPromptError,
     SceneError,
     SceneNode,
     THINKING_TITLE_PREVIEW_LENGTH,

--- a/backend/plugin_worker.py
+++ b/backend/plugin_worker.py
@@ -159,7 +159,10 @@ def _state_to_plain_dict(state) -> "dict | None":
 
 
 def main() -> None:
-    plugin_id = sys.argv[1]
+    # argv[1] (plugin_id) is part of this module's own CLI contract (see the
+    # module docstring's `<plugin_id> <source_dir>`, matching plugin_sdk.py's
+    # own subprocess.Popen call) but never consulted here - manifest.id below
+    # is the authoritative identity HostContext uses, not whatever argv claims.
     source_dir = Path(sys.argv[2])
     manifest_path = source_dir / MANIFEST_FILENAME
     manifest = _load_manifest(manifest_path, source_dir)

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -818,8 +818,6 @@ def _build_chat_data(
 
     nodes_index = {n.id: i for i, n in enumerate(all_nodes)}
     notes_index = {n.id: i for i, n in enumerate(notes)}
-    charts_index = {n.id: i for i, n in enumerate(charts)}
-    frames_index = {n.id: i for i, n in enumerate(frames)}
     kind_by_id = {n.id: n.kind for n in document.nodes.values()}
 
     node_slot_count = len(all_nodes)

--- a/backend/tests/perf/graph_factory.py
+++ b/backend/tests/perf/graph_factory.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from backend.canvas import SceneDocument, SceneNode
+from backend.canvas import SceneDocument
 
 _LOREM = (
     "The quick brown fox jumps over the lazy dog while considering the "

--- a/backend/tests/perf/test_loop_watchdog.py
+++ b/backend/tests/perf/test_loop_watchdog.py
@@ -117,9 +117,9 @@ def _representative_operations(doc):
 
 def test_no_representative_operation_blocks_the_loop_beyond_the_ci_ceiling():
     # asyncio.run() in a sync test, not @pytest.mark.asyncio - pytest-asyncio
-    # is not one of this repo's dependencies (dev deps are pytest+pytest-env
-    # only, see pyproject.toml), and every other async-touching test here
-    # already uses this same convention (test_event_bus.py et al.).
+    # is not one of this repo's dependencies (see pyproject.toml's own `dev`
+    # extra), and every other async-touching test here already uses this
+    # same convention (test_event_bus.py et al.).
     async def _run() -> float:
         doc = build_graph(node_count=500, content_bytes=1200, chart_count=10, image_count=0, extra_edges=200)
         runs = []

--- a/backend/tests/test_backend_secrets_at_rest.py
+++ b/backend/tests/test_backend_secrets_at_rest.py
@@ -166,7 +166,7 @@ class TestLegacyPlaintextMigration:
 
     def test_migration_does_not_rewrite_when_nothing_needs_migrating(self, tmp_path):
         state_file = tmp_path / "session.dat"
-        manager = SettingsManager(state_file)  # fresh defaults, all secrets empty
+        SettingsManager(state_file)  # fresh defaults, all secrets empty
         mtime_after_first_load = state_file.stat().st_mtime_ns
 
         SettingsManager(state_file)  # second load - nothing to migrate

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -15,7 +15,6 @@ import asyncio
 import threading
 import time
 
-import pytest
 
 import api_provider
 from backend import builder as builder_module
@@ -435,8 +434,6 @@ class TestStop:
     def test_cancel_frees_the_slot_immediately_and_finalize_lands_stopped(self, monkeypatch):
         document, dispatcher, registry, bus = make_harness()
         node = seed_plan(document, ["one step"])
-        started = asyncio.Event()
-        release = asyncio.Event()
 
         def slow_turn(task, messages, tools=(), **kwargs):
             asyncio.get_event_loop_policy()  # no-op; runs in a worker thread

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -5241,7 +5241,7 @@ def test_remove_nodes_disposes_the_repl_for_every_deleted_pycoder_node():
         other_node = document.add_gitlink_node(0, 0, parent.id)
         # Populate a REPL for this node id, so there is something real to
         # tear down.
-        repl = dispatcher.get_pycoder_repl(pycoder_node.id, pycoder_node.state.pycoder_repl_id)
+        dispatcher.get_pycoder_repl(pycoder_node.id, pycoder_node.state.pycoder_repl_id)
         assert pycoder_node.id in dispatcher._pycoder_repls
 
         await bus.dispatch_intent("scene", "removeNodes", [[pycoder_node.id, other_node.id]])

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -43,7 +43,6 @@ from backend.chat_library import (
     chat_library_payload,
     create_workspace,
     delete_chat,
-    flush_dirty_session_before_teardown,
     get_all_chats,
     get_all_workspaces,
     get_workspace_default_model,
@@ -1784,7 +1783,7 @@ def test_fallback_title_matches_legacy_regex_and_truncation():
 def test_resolve_seed_message_uses_last_chat_node_content():
     document = SceneDocument()
     document.add_chat_node(0, 0, "first message", is_user=True)
-    ai = document.add_chat_node(0, 100, "second message", is_user=False)
+    document.add_chat_node(0, 100, "second message", is_user=False)
     assert _resolve_seed_message(document) == "second message"
 
 
@@ -2346,7 +2345,6 @@ class TestBackupBeforeWrite:
         # module doesn't currently guard against, and not what THIS test
         # is trying to pin down).
         counter = {"n": 0}
-        real_timestamp_now = db_backup_module._timestamp_now
 
         def fake_timestamp_now():
             counter["n"] += 1

--- a/backend/tests/test_commands.py
+++ b/backend/tests/test_commands.py
@@ -17,7 +17,7 @@ import pytest
 
 from backend.domain.commands import Command
 from backend.domain.graph import SceneDocument
-from backend.domain.model import SceneEdge, SceneNode
+from backend.domain.model import SceneNode
 
 
 # -- layer 1: Command.apply()/invert() against synthetic state --------------
@@ -633,7 +633,7 @@ def test_undo_run_stops_at_the_users_own_later_edits(document):
 
 def test_session_load_clears_both_stacks(wired):
     bus, document = wired
-    node_id = _dispatch(bus, "addNode", 0, 0, "old session")
+    _dispatch(bus, "addNode", 0, 0, "old session")
     _dispatch(bus, "undo")
     assert len(document.redo_stack) == 1
 

--- a/backend/tests/test_crash_recovery_notice.py
+++ b/backend/tests/test_crash_recovery_notice.py
@@ -18,8 +18,6 @@ from backend.crash_recovery import CRASH_NOTICE_MESSAGE
 
 # R7.2: api_provider/graphlink_task_config sit at the repo root, a sibling
 # of backend/ - already importable, no ordering constraint.
-import api_provider
-import graphlink_task_config as config
 
 
 def _client(previous_run_crashed: bool) -> TestClient:

--- a/backend/tests/test_db_backup.py
+++ b/backend/tests/test_db_backup.py
@@ -156,7 +156,6 @@ def test_take_backup_is_wal_safe_against_a_live_writer_holding_a_transaction(db_
 
 
 def test_take_backup_chmods_the_backup_to_0600(db_path):
-    import os
     import stat
     import sys
 

--- a/backend/tests/test_execution_guard.py
+++ b/backend/tests/test_execution_guard.py
@@ -18,11 +18,9 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-import tempfile
 import threading
 import time
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -478,7 +476,6 @@ class TestFailOpenFallbackPaths:
 
     def test_set_information_job_object_failure_falls_back_and_closes_the_handle(self, monkeypatch):
         closed_handles = []
-        real_create = guard_module._kernel32.CreateJobObjectW
         real_close = guard_module._kernel32.CloseHandle
 
         def recording_close(handle):

--- a/backend/tests/test_execution_guard_posix.py
+++ b/backend/tests/test_execution_guard_posix.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 import contextlib
 import importlib.util
-import os
 import pathlib
 import subprocess
 import sys

--- a/backend/tests/test_gitlink_domain.py
+++ b/backend/tests/test_gitlink_domain.py
@@ -46,7 +46,6 @@ import api_provider
 import graphlink_task_config as config
 from graphlink_plugins.common import github_client as github_client_module
 from graphlink_plugins.common.github_client import GitHubRestClient
-from graphlink_plugins.gitlink import agent as agent_module
 from graphlink_plugins.gitlink import repository as repository_module
 from graphlink_plugins.gitlink.agent import (
     GitlinkAgent,

--- a/backend/tests/test_knowledge_retrieval.py
+++ b/backend/tests/test_knowledge_retrieval.py
@@ -8,7 +8,6 @@ untrusted."
 
 from __future__ import annotations
 
-import pytest
 
 from backend.knowledge_chunking import chunk_text
 from backend.knowledge_embeddings import embed_pending_chunks

--- a/backend/tests/test_ollama_capability_cache.py
+++ b/backend/tests/test_ollama_capability_cache.py
@@ -90,7 +90,7 @@ def test_a_transient_probe_failure_is_not_cached_so_the_next_call_retries(monkey
     as crawl_etiquette's robots.txt fix."""
     monkeypatch.setattr(api_provider, "_OLLAMA_CAPABILITY_CACHE", {})
 
-    with patch("api_provider.ollama.show", side_effect=ConnectionError("daemon unreachable")) as mock_show:
+    with patch("api_provider.ollama.show", side_effect=ConnectionError("daemon unreachable")):
         first = api_provider._get_ollama_capabilities("model-a")
 
     assert first is None

--- a/backend/tests/test_plugin_grants.py
+++ b/backend/tests/test_plugin_grants.py
@@ -38,7 +38,6 @@ from backend.canvas import SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.plugin_sdk import (
-    HostContext,
     PluginRegistrationError,
     discover_plugins,
 )
@@ -719,7 +718,7 @@ def test_set_plugin_grant_intent_persists_and_republishes_the_app_plugins_topic(
     recorder = Recorder()
     bus.attach(recorder)
 
-    result = asyncio.run(
+    asyncio.run(
         bus.dispatch_intent("app-plugins", "setPluginGrant", ["livegrant", True])
     )
 

--- a/backend/tests/test_plugin_worker.py
+++ b/backend/tests/test_plugin_worker.py
@@ -394,7 +394,6 @@ def test_a_worker_that_crashes_during_register_produces_a_discovery_time_load_er
     _write_out_of_process_plugin(
         tmp_path / "plugins", "oop_crash_register", py_body=_CRASH_ON_REGISTER_PY_BODY,
     )
-    good_dir = tmp_path / "plugins" / "oop_good_sibling"
     _write_out_of_process_plugin(
         tmp_path / "plugins", "oop_good_sibling", py_body=_SIMPLE_NODE_PY_BODY,
     )

--- a/backend/tests/test_providers.py
+++ b/backend/tests/test_providers.py
@@ -881,7 +881,6 @@ def test_llama_cpp_rejects_media_up_front_with_the_actionable_message():
 def test_chat_routes_every_api_provider_through_its_provider_class(monkeypatch):
     """Seam-wiring for the three API-mode branches - the same not-just-
     behavior-parity proof the Ollama port got."""
-    import types
 
     calls = []
     for module_name, class_name in [
@@ -1510,7 +1509,6 @@ def test_anthropic_sse_reader_parses_data_lines_and_always_closes(monkeypatch):
     lines and blank separators are skipped, each data: line parses to its
     event dict, the request body carries \"stream\": true, and the response is
     closed even when the consumer abandons the generator mid-stream."""
-    import io
     import json as json_module
 
     class FakeHTTPResponse:

--- a/backend/tests/test_session_lifecycle.py
+++ b/backend/tests/test_session_lifecycle.py
@@ -187,7 +187,18 @@ def test_the_background_eviction_loop_survives_a_sweep_that_raises():
         session.idle_since -= 10_000
         assert bus._eviction_task is not None, "session() must have lazily started the real background loop"
 
-        await asyncio.sleep(0.15)
+        # A fixed sleep here (the original approach) bakes in "N intervals
+        # elapse within this exact wall-clock window" - true on an idle
+        # machine, but not under a full-suite run where scheduling delay can
+        # eat into the margin (Windows' own ~15 ms timer granularity doesn't
+        # help at a 20 ms interval - see test_loop_watchdog.py's module
+        # docstring). Polling to a generous deadline instead keeps the happy
+        # path just as fast (~60 ms nominal) while tolerating arbitrary
+        # scheduling delay before it actually fails.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 2.0
+        while calls["n"] < 3 and loop.time() < deadline:
+            await asyncio.sleep(0.01)
 
         assert calls["n"] >= 3, "the loop must keep calling the sweep on every interval, not stop after the first failure"
         assert not bus._eviction_task.done(), "one bad sweep must never end the free-running loop"

--- a/backend/tests/test_session_lifecycle.py
+++ b/backend/tests/test_session_lifecycle.py
@@ -30,7 +30,7 @@ from fastapi.testclient import TestClient
 from backend.app import create_app, _evict_idle_session
 from backend.events import DEFAULT_SESSION_ID, EventBus, SessionBus, UnknownSessionError
 from backend.notifications import NotificationState
-from backend.session_context import SessionContext, attach_session_context, get_session_context
+from backend.session_context import SessionContext, attach_session_context
 
 
 # -- layer 1: EventBus.session() issuance restriction ------------------------

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -529,7 +529,7 @@ def test_basic_connection_resolves_by_id_when_index_is_wrong():
         nodes=[_chat("a"), _chat("b")],
         content_connections=[{"start_node_index": 99, "start_node_id": "a", "end_node_index": 99, "end_node_id": "b"}],
     )
-    a = next(n for n in document.nodes.values() if n.content == "hi")
+    next(n for n in document.nodes.values() if n.content == "hi")
     assert len(document.edges) == 1
 
 

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -175,7 +175,7 @@ def test_gitlink_node_packs_repo_state_and_proposal_data():
 def test_image_node_encodes_bytes_from_image_assets_store():
     doc = SceneDocument()
     parent = doc.add_chat_node(0, 0, "p", is_user=False)
-    node = doc.add_image_node(10, 10, b"fake-png-bytes", "a prompt", parent.id)
+    doc.add_image_node(10, 10, b"fake-png-bytes", "a prompt", parent.id)
     chat_data = build_chat_data(doc)
     payload = next(n for n in chat_data["nodes"] if n["node_type"] == "image")
     import base64
@@ -287,7 +287,7 @@ def test_chat_to_note_edge_becomes_group_summary_connection():
 def test_chart_parent_edge_is_captured_on_the_charts_own_payload():
     doc = SceneDocument()
     parent = doc.add_chat_node(0, 0, "p", is_user=False)
-    chart = doc.add_chart_node(10, 10, parent.id, "bar", {"type": "bar", "title": "t", "labels": ["a"], "values": [1.0]})
+    doc.add_chart_node(10, 10, parent.id, "bar", {"type": "bar", "title": "t", "labels": ["a"], "values": [1.0]})
     chat_data = build_chat_data(doc)
     assert len(chat_data["charts"]) == 1
     assert chat_data["charts"][0]["parent_node_id"] == parent.id
@@ -487,7 +487,7 @@ def test_chat_node_serializes_a_model_override_pin():
 
 def test_chat_node_with_no_model_override_serializes_empty_strings():
     doc = SceneDocument()
-    root = doc.add_chat_node(0, 0, "root", True)
+    doc.add_chat_node(0, 0, "root", True)
 
     payload = next(p for p in build_chat_data(doc)["nodes"] if p.get("raw_content") == "root")
     assert payload["override_provider"] == ""

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -4,7 +4,6 @@ import asyncio
 
 import ollama
 import pytest
-import webview
 from graphlink_settings_store import SettingsManager
 
 import api_provider
@@ -377,7 +376,7 @@ def test_migration_chain_is_a_no_op_on_an_already_current_freshly_created_file(t
     # against a dict _create_initial_state() already fully populated must
     # change nothing at all, not even incidentally.
     state_file = tmp_path / "session.dat"
-    first = SettingsManager(state_file)  # creates the file fresh
+    SettingsManager(state_file)  # creates the file fresh
     on_disk_after_create = state_file.read_text(encoding="utf-8")
 
     SettingsManager(state_file)  # second load - every migration is a no-op

--- a/backend/tests/test_tool_calling.py
+++ b/backend/tests/test_tool_calling.py
@@ -18,7 +18,6 @@ import json
 import types
 from unittest.mock import patch
 
-import pytest
 
 import api_provider
 import graphlink_task_config as config

--- a/backend/tests/test_tools_knowledge.py
+++ b/backend/tests/test_tools_knowledge.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 import json
 
-import pytest
 
 from backend.knowledge_chunking import chunk_text
 from backend.knowledge_store import add_document_with_chunks
@@ -72,7 +71,7 @@ class TestRegistration:
 class TestInvocation:
     def test_a_real_search_round_trips_through_invoke_with_correct_citation_fields(self, tmp_path):
         db_path = tmp_path / "knowledge.db"
-        outcome = _ingest(db_path)
+        _ingest(db_path)
         registry = _registry(db_path)
 
         result = _run(

--- a/backend/tests/test_web_research_providers_coverage.py
+++ b/backend/tests/test_web_research_providers_coverage.py
@@ -42,7 +42,6 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-import requests
 
 from graphlink_plugins.web_research import providers as providers_module
 from graphlink_plugins.web_research.crawl_etiquette import CrawlEtiquette

--- a/backend/tests/test_web_research_retention.py
+++ b/backend/tests/test_web_research_retention.py
@@ -15,12 +15,10 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import pytest
 
 from graphlink_plugins.web_research.domain import (
     FetchedDocument,
     FetchedPayload,
-    ResearchLimits,
     SearchResult,
     SourceAssessment,
     WebResearchRequest,

--- a/backend/tests/test_workspace_archive.py
+++ b/backend/tests/test_workspace_archive.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import json
 import zipfile
-from pathlib import Path
 
 import pytest
 

--- a/contracts/codegen.py
+++ b/contracts/codegen.py
@@ -303,7 +303,7 @@ def _validator_for(name: str, fields: dict[str, Any]) -> str:
         access = f'value[{json.dumps(field_name)}]'
         field_path = "`${path}." + field_name + "`"
         check = _ts_check_expr(annotation, value_expr="fieldValue", path_expr=field_path)
-        body.append(f"  {{")
+        body.append("  {")
         body.append(f"    const fieldValue = {access};")
         if optional:
             body.append(f"    if (fieldValue !== undefined && fieldValue !== null) {{ {check} }}")

--- a/graphlink_desktop.py
+++ b/graphlink_desktop.py
@@ -35,6 +35,15 @@ import threading
 import time
 import urllib.request
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # ADR-015 stage 15.3: _start_backend/_shutdown_backend's own annotations
+    # reference uvicorn, but both import it LOCALLY (deferred, function-scope)
+    # to keep this module importable without uvicorn eagerly loaded - this
+    # TYPE_CHECKING-only import satisfies static analysis (ruff's F821,
+    # mypy) without changing that runtime behavior at all.
+    import uvicorn
 
 REPO_ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(REPO_ROOT))

--- a/graphlink_plugins/web_research/providers.py
+++ b/graphlink_plugins/web_research/providers.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import socket
 import time
-from datetime import datetime, timezone
 from typing import Sequence
 from urllib.parse import urljoin, urlsplit
 
@@ -489,7 +487,7 @@ class ApiResearchModel:
             quality = str(parsed.get("quality", "low")).lower()
             accepted = policy == "allow" and relevance == "high" and quality != "low"
             return SourceAssessment(accepted, policy, relevance, quality, str(parsed.get("reason", ""))[:200])
-        except Exception as exc:
+        except Exception:
             return SourceAssessment(False, "unknown", "unknown", "low", "validation_unavailable")
 
     def summarize(self, query: str, history: Sequence[dict], evidence: Sequence[str], *, limits: ResearchLimits, token: CancellationToken) -> str:

--- a/graphlink_plugins/web_research/service.py
+++ b/graphlink_plugins/web_research/service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Sequence
 
 from .domain import (
     CancellationToken,
@@ -15,7 +14,6 @@ from .domain import (
     ResearchResult,
     ResearchSource,
     ResearchStage,
-    SearchResult,
     WebResearchRequest,
 )
 from .ports import ContentExtractor, DocumentFetcher, ResearchModel, SearchProvider
@@ -192,7 +190,7 @@ class WebResearchService:
                 source.error_code = exc.code
                 source.error_message = str(exc)
                 warnings.append(f"Source {index} could not be used ({exc.code}).")
-            except Exception as exc:
+            except Exception:
                 source.status = "failed"
                 source.error_code = "source_failed"
                 source.error_message = "The source failed during research."

--- a/graphlink_secrets.py
+++ b/graphlink_secrets.py
@@ -22,7 +22,6 @@ Design tradeoffs, chosen deliberately:
 """
 
 import base64
-import ctypes
 import sys
 
 _DPAPI_PREFIX = "dpapi:"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,15 +48,33 @@ dependencies = [
 # for newer Python versions, so requiring it would break installs for most users.
 [project.optional-dependencies]
 llamacpp = ["llama-cpp-python"]
-dev = ["pytest", "pytest-env"]
+dev = ["pytest"]
 
-# The suite constructs real QGraphicsObject/QWidget-based nodes and must run
-# without a display server (CI runners, this pytest-env setting). QApplication
-# picks its platform plugin at construction time from this env var, so it must
-# be set before conftest.py's QApplication([]) - pytest-env applies env changes
-# before test collection/session start, which is early enough.
 [tool.pytest.ini_options]
-env = ["QT_QPA_PLATFORM=offscreen"]
+# ADR-015 stage 15.3: --strict-markers rejects a typo'd/unregistered
+# @pytest.mark.X outright rather than silently no-op'ing it; --strict-config
+# does the same for an unrecognized ini option. filterwarnings promotes the
+# three "an API is going away" classes to hard failures - the actual signal
+# a pytest warnings policy exists to catch (a dependency bump silently
+# breaking at the next major version) - rather than a blanket "error" on
+# every warning category. A blanket policy also promotes ResourceWarning,
+# and this codebase has a real, PRE-EXISTING, wide surface of those
+# (subprocess Popen pipes across pycoder REPLs and out-of-process plugin
+# workers, tempdirs, sockets - closed by GC rather than explicitly, each a
+# distinct message shape pytest's unraisable-exception hook wraps
+# differently). Chasing that surface to zero is a real, separate body of
+# work, not "add a filterwarnings policy" - see ADR-015 §2's own "no
+# big-bang cleanup" instruction for ruff, which applies equally here.
+addopts = "--strict-markers --strict-config"
+filterwarnings = [
+    "error::DeprecationWarning",
+    "error::PendingDeprecationWarning",
+    "error::FutureWarning",
+    # stdlib's own asyncio.get_event_loop_policy() deprecation (3.14 slates
+    # removal) - backend/tests/test_builder.py's one call is a documented
+    # no-op probe (see that test's own comment), not a real usage to migrate.
+    "ignore:'asyncio.get_event_loop_policy' is deprecated.*:DeprecationWarning",
+]
 # Hang diagnosis. pytest's built-in faulthandler dumps a full traceback of
 # every thread if any single test runs longer than this, naming the exact
 # test and line it is stuck on. Zero new dependencies (stdlib faulthandler,
@@ -139,3 +157,29 @@ include = [
 
 [tool.setuptools.dynamic]
 version = { attr = "graphlink_version.APP_VERSION" }
+
+# ADR-015 stage 15.3: a scoped starting rule set, not a big-bang cleanup (the
+# ADR's own explicit instruction) - F (pyflakes: undefined names, unused
+# imports, bad call arity) and E9 (pycodestyle syntax errors) are the class
+# compileall cannot catch and this stage exists to close; E/W (the rest of
+# pycodestyle - line length, whitespace style) are deliberately deferred to a
+# later ratchet rather than reformatting this entire codebase's existing
+# comment-heavy style in one pass. Ratchet up (more rule categories, fewer
+# ignores) in a later stage, never down.
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+exclude = ["graphlink_app", "web_ui"]
+
+[tool.ruff.lint]
+select = ["E9", "F"]
+
+[tool.ruff.lint.per-file-ignores]
+# backend/canvas.py's own docstring: it deliberately re-imports every
+# backend.domain name "back for its own use, so every existing `from
+# backend.canvas import X` consumer... keeps working unchanged" - a
+# compatibility facade from the ADR-002 stage 2.2 domain-package split, not
+# dead code. F401 (unused import) can't distinguish a re-export facade from
+# an actual leftover, so it's ignored for exactly this one file rather than
+# scattering 43 individual noqa comments across the import block.
+"backend/canvas.py" = ["F401"]

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,6 @@ Pillow
 pygments
 pypdf
 pytest
-pytest-env
 pyspellchecker
 python-docx
 reportlab

--- a/requirements.txt
+++ b/requirements.txt
@@ -1322,12 +1322,6 @@ pyspellchecker==0.9.0 \
 pytest==9.1.1 \
     --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \
     --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
-    # via
-    #   -r requirements.in
-    #   pytest-env
-pytest-env==1.6.0 \
-    --hash=sha256:1e7f8a62215e5885835daaed694de8657c908505b964ec8097a7ce77b403d9a3 \
-    --hash=sha256:ac02d6fba16af54d61e311dd70a3c61024a4e966881ea844affc3c8f0bf207d3
     # via -r requirements.in
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
@@ -1337,10 +1331,6 @@ python-docx==1.2.0 \
     --hash=sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7 \
     --hash=sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce
     # via -r requirements.in
-python-dotenv==1.2.2 \
-    --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \
-    --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
-    # via pytest-env
 pythonnet==3.1.0 \
     --hash=sha256:698dd88edc198819ad63b624a6ebe76208c7b46e4fe13626f65e484f0358d6ba \
     --hash=sha256:7b34c382905d10a371509ffafd64cae0416305c28817738a9cd138336f4e9991 \

--- a/tests/test_no_qt_anywhere.py
+++ b/tests/test_no_qt_anywhere.py
@@ -22,7 +22,6 @@ web_ui/, or the desktop entry point may ever import Qt, pin or no pin.
 
 from __future__ import annotations
 
-import importlib.util
 import json
 import re
 from pathlib import Path


### PR DESCRIPTION
## Problem

Two gaps in the quality-gate setup: nothing catches unused imports/undefined names/bad call arity (`python -m compileall` only checks syntax), and pytest has no `filterwarnings` policy, so a dependency's deprecation notice can silently start failing at the next major version with no warning. Separately, `pytest-env`/`QT_QPA_PLATFORM=offscreen` is a Qt-removal-era leftover with nothing left to configure.

## Change

- Add a scoped `ruff` CI step: `E9` (syntax errors) + `F` (pyflakes - unused imports/names, undefined names, bad call arity), not a full reformat. One `per-file-ignores` exception for `backend/canvas.py`, whose own docstring documents it as a deliberate domain-package re-export facade (every `from backend.canvas import X` consumer depends on it) - not dead code, and `--fix` would have broken it.
- Fix the ~30 real F401/F841 findings ruff turned up elsewhere (unused imports/locals).
- Add `--strict-markers --strict-config` and a `filterwarnings` policy to pytest, promoting `DeprecationWarning`/`PendingDeprecationWarning`/`FutureWarning` to hard failures. Deliberately scoped rather than a blanket `error`: this codebase has a real, pre-existing `ResourceWarning` surface (subprocess pipes, tempdirs, sockets left to GC across pycoder REPLs and out-of-process plugin workers) that a blanket policy would also promote, and closing that is separate work.
- Remove the dead `QT_QPA_PLATFORM=offscreen` env setting and `pytest-env` dependency - Qt was fully removed at the R7.6b cutover, so this had nothing left to do.
- `graphlink_desktop.py`: add a `TYPE_CHECKING`-only `uvicorn` import so ruff/mypy can resolve the type annotation on functions that import it locally at runtime (no behavior change).

## Test plan

- [x] `python -m pytest -q` from repo root: 2978 passed, 17 skipped (run twice to rule out flakiness)
- [x] `python -m compileall -q .`: clean
- [x] `python -m ruff check .`: clean