### PR TITLE
Fix persistence and WebSocket state races

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -7,11 +7,13 @@ Serves three things:
 - / - the built SPA (static files), when a build directory exists
 
 Client -> server message kinds over /ws:
-  {"kind": "subscribe", "topics": ["system", ...]}      -> current snapshots
+  {"kind": "subscribe", "topics": ["system", ...],
+   "id": optional}                                        -> current snapshots
   {"kind": "intent", "topic": t, "intent": name,
    "args": [...], "id": optional}                        -> optional result
 Server -> client:
-  {"kind": "state", "topic": t, "payload": {...envelope...}}
+  {"kind": "state", "topic": t, "payload": {...envelope...},
+   "id": echoed when subscribe supplied one}
   {"kind": "result", "id": ..., "value": ...}            (only when id sent)
   {"kind": "error", "id": ..., "error": "..."}           (bad topic/intent)
 
@@ -299,15 +301,19 @@ def _evict_idle_session(bus: SessionBus) -> bool:
     this module, not the domain-agnostic event bus).
 
     Returns False (veto the eviction, try again next sweep) if a real
-    in-flight run is still active - a monotonic-time TTL is not a
-    substitute for actually knowing cancellation has finished. Otherwise
-    performs the same disconnect-time teardown ws_endpoint's own finally
-    block already does on a normal last-connection-drops path (cancel_all
-    + cancel_all_pending_approvals), plus the one thing that path never
-    had to do because it never applied to an ABANDONED session before this
-    stage: cancel the autosave task, so its closure stops holding the
-    whole SceneDocument alive via a strong reference nothing can ever
-    reach again once this session is gone from EventBus._sessions.
+    in-flight run or chat mutation is still active - a monotonic-time TTL is
+    not a substitute for actually knowing cancellation has finished. A chat
+    mutation includes autosave's pre-write read/backup awaits: cancelling its
+    task there would prevent the database write from ever starting, while the
+    old "guard active, so skip the final flush" branch discarded the only
+    remaining copy of the dirty document. Otherwise performs the same
+    disconnect-time teardown ws_endpoint's own finally block already does on
+    a normal last-connection-drops path (cancel_all +
+    cancel_all_pending_approvals), plus the one thing that path never had to
+    do because it never applied to an ABANDONED session before this stage:
+    cancel the autosave task, so its closure stops holding the whole
+    SceneDocument alive via a strong reference nothing can ever reach again
+    once this session is gone from EventBus._sessions.
     """
     try:
         context = get_session_context(bus)
@@ -317,6 +323,12 @@ def _evict_idle_session(bus: SessionBus) -> bool:
         # evict outright rather than getting stuck vetoing forever.
         return True
     if context.agent_dispatcher.has_in_flight_runs():
+        return False
+    mutation_guard = getattr(bus, "chat_mutation_guard", None)
+    if mutation_guard is not None and mutation_guard.get("active"):
+        # Do not cancel an autosave/user save/load/rename halfway through an
+        # await. The next sweep retries after the guard's finally block has
+        # released, at which point the normal dirty flush + teardown is safe.
         return False
     context.agent_dispatcher.cancel_all()
     context.agent_dispatcher.cancel_all_pending_approvals()
@@ -340,22 +352,12 @@ def _evict_idle_session(bus: SessionBus) -> bool:
     # register_chat_library actually ran for this bus (bus.chat_db_path
     # unset - e.g. several tests in this suite build a bare SessionBus/
     # SessionContext directly, without ever registering the chat library -
-    # means there is nothing to flush) and when no write is already in
-    # flight (mutation_guard active): a tick genuinely mid-write will
-    # still complete and record its own result correctly once
-    # autosave_task.cancel() below lets it finish (see
-    # test_evict_idle_session_releases_the_mutation_guard_when_cancelling_
-    # mid_write in backend/tests/test_session_lifecycle.py) - racing a
-    # SECOND write against it here would only risk an avoidable lost-race
-    # warning for no benefit.
+    # means there is nothing to flush). An active mutation already vetoed
+    # eviction above, so reaching this point guarantees this synchronous
+    # final flush cannot race an autosave/manual chat operation.
     chat_db_path = getattr(bus, "chat_db_path", None)
     last_saved = getattr(bus, "chat_save_state", None)
-    mutation_guard = getattr(bus, "chat_mutation_guard", None)
-    if (
-        chat_db_path is not None
-        and last_saved is not None
-        and not (mutation_guard is not None and mutation_guard.get("active"))
-    ):
+    if chat_db_path is not None and last_saved is not None:
         try:
             flush_dirty_session_before_teardown(chat_db_path, context.canvas_document, last_saved)
         except Exception:
@@ -729,7 +731,7 @@ async def _handle_message(session: SessionBus, websocket: WebSocket, message: di
         topics = message.get("topics") or session.topic_names()
         for topic in topics:
             try:
-                await session.send_snapshot(topic, websocket)
+                await session.send_snapshot(topic, websocket, request_id=msg_id)
             except UnknownTopicError:
                 await websocket.send_json(
                     {"kind": "error", "id": msg_id, "error": f"unknown topic: {topic}"}

--- a/backend/autosave.py
+++ b/backend/autosave.py
@@ -42,10 +42,10 @@ surface a real notification, since silently failing to protect the user's
 work would defeat the entire point of this feature.
 
 CONCURRENCY: shares the SAME mutation_guard dict backend/chat_library.py's
-own loadChat/saveChat/newChat intents already use (see that module's own
+own loadChat/saveChat/newChat/renameChat intents use (see that module's own
 docstring on _serialize_mutating_intent) - an autosave tick that fires while
-a manual load/save/new-chat is already in flight skips itself for this
-interval rather than racing it (there will be another tick along in
+a manual load/save/new-chat/rename is already in flight skips itself for
+this interval rather than racing it (there will be another tick along in
 `interval_seconds`, so skipping one is free; racing a manual operation is
 not).
 
@@ -66,13 +66,12 @@ a record of the prior reasoning, not silently deleted - see this session's
 own "no room for error, document mistakes rather than quietly editing"
 discipline.
 
-This task's own eventual cancellation (via task.cancel(), a cooperative
-request the same as everywhere else in this codebase) is safe here
-specifically because _guarded_tick's own try/finally already always
-leaves mutation_guard in a clean state on any exit path, cancellation
-included (asyncio.CancelledError propagates through a `finally`, same as
-any other exception) - there is no partial-claim state a cancelled tick
-could strand the guard in.
+Eviction cancels this task only after the mutation guard is inactive. That
+ordering is data-safety-critical: cancellation during autosave_tick's
+pre-write load/backup awaits could otherwise stop the only dirty copy before
+the database write begins. _guarded_tick's try/finally still guarantees the
+guard itself is released on cancellation or any other exit, but guard cleanup
+alone is not evidence that the user's pending write completed.
 """
 
 from __future__ import annotations

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -115,17 +115,13 @@ class ConcurrentSaveConflict(RuntimeError):
 CHATS_DB_SCHEMA_VERSION = 4
 
 
-# ADR-009 stage 9.2: `created_at`/rename_chat's own `updated_at` are written
-# via SQLite's inline `CURRENT_TIMESTAMP` (second resolution, no fractional
-# part) - the format every pre-9.2 row's timestamps are still in.
-# save_chat_atomically_row's own `now` (see that function's own docstring)
-# is now generated in PYTHON at microsecond resolution instead, specifically
-# so two writes issued in close succession (the exact optimistic-concurrency
-# scenario this stage exists for - two sessions racing a save) are NEVER
-# indistinguishable the way two same-second CURRENT_TIMESTAMP values would
-# be. Both formats are real, both must parse - _TIMESTAMP_DISPLAY_FORMATS is
-# tried in order (second-resolution first, since it's still the more common
-# case across created_at + every non-chat-save write).
+# ADR-009 stage 9.2: `created_at` and historical `updated_at` values use
+# SQLite's inline `CURRENT_TIMESTAMP` (second resolution, no fractional
+# part). Optimistic-concurrency writes from save_chat_atomically_row and
+# rename_chat generate `updated_at` in Python at microsecond resolution so
+# two back-to-back writes cannot share a token. Both formats are real and
+# must parse; try second-resolution first because every created_at and every
+# row last touched before this transition still uses it.
 _TIMESTAMP_DISPLAY_FORMATS = ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S.%f")
 
 
@@ -1109,12 +1105,47 @@ def get_all_chats(db_path: Path, notifications: NotificationState | None = None)
     ]
 
 
-def rename_chat(db_path: Path, chat_id: int, new_title: str) -> None:
+def rename_chat(
+    db_path: Path,
+    chat_id: int,
+    new_title: str,
+    *,
+    expected_updated_at: str | None = None,
+) -> str | None:
+    """Rename one graph and return the exact new optimistic-save token.
+
+    A rename of the graph currently open in a session participates in the
+    same optimistic-concurrency contract as a content save.  Without
+    returning the new ``updated_at`` value, the session keeps holding the
+    token from before its own rename and its next Save is rejected as though
+    some other window changed the graph.  ``expected_updated_at`` also keeps
+    token synchronization from weakening the existing lost-update guard: a
+    stale session may not rename a newer row and then adopt that row's fresh
+    token before overwriting its content.
+
+    ``None`` is returned for the existing blind-update call shape when the
+    graph no longer exists.  With an expected token, a missing row and a
+    stale row are intentionally the same concurrency conflict.
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        conn.execute(
-            "UPDATE graphs SET title = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
-            (new_title, chat_id),
-        )
+        if expected_updated_at is not None:
+            cursor = conn.execute(
+                "UPDATE graphs SET title = ?, updated_at = ? WHERE id = ? AND updated_at = ?",
+                (new_title, now, chat_id, expected_updated_at),
+            )
+            if cursor.rowcount == 0:
+                raise ConcurrentSaveConflict(
+                    f"chat {chat_id} was modified elsewhere since it was last loaded/saved "
+                    "in this session (expected updated_at "
+                    f"{expected_updated_at!r} did not match)"
+                )
+        else:
+            cursor = conn.execute(
+                "UPDATE graphs SET title = ?, updated_at = ? WHERE id = ?",
+                (new_title, now, chat_id),
+            )
+    return now if cursor.rowcount else None
 
 
 def delete_chat(db_path: Path, chat_id: int, *, knowledge_db_path: Path | None = None) -> None:
@@ -1511,8 +1542,8 @@ def save_chat_atomically_row(
 
     `now` is generated in PYTHON (datetime.now(timezone.utc), microsecond
     resolution) rather than via SQLite's own inline `CURRENT_TIMESTAMP`
-    function (this function's pre-9.2 behavior, and what rename_chat still
-    uses) - SECOND resolution alone is not fine-grained enough for a real
+    function (this function's pre-9.2 behavior) - SECOND resolution alone
+    is not fine-grained enough for a real
     optimistic-concurrency token: two writes issued within the same wall-
     clock second (verified directly - this is not a theoretical concern;
     it is exactly what a fast two-session race, including this stage's own
@@ -1525,8 +1556,7 @@ def save_chat_atomically_row(
     in the row, with no possibility of drift from a second, separate read-
     back after the write. See _TIMESTAMP_DISPLAY_FORMATS' own comment for
     how the display-formatting functions handle both this and the older,
-    second-resolution format that pre-9.2 rows and rename_chat's own writes
-    still use.
+    second-resolution format historical rows still use.
 
     ADR-020 stage 20.2: `workspace_id`, when given (not None), is written
     ONLY on the INSERT branch below - a resave of an EXISTING graph (the
@@ -1866,7 +1896,7 @@ def make_serialize_mutating_intent(
     notifications: NotificationState | None,
 ):
     """Factory for the reentrancy-guard decorator register_chat_library's
-    own loadChat/saveChat/newChat intents are registered through - see
+    own loadChat/saveChat/newChat/renameChat intents use - see
     register_chat_library's own docstring (right below its call site) for
     the full OWNERSHIP audit-fix story this implements. Lifted out to a
     top-level factory - matching _new_mutation_guard/_new_save_state/
@@ -1882,7 +1912,8 @@ def make_serialize_mutating_intent(
     it - every pre-20.4 intent this wraps (loadChat/saveChat/newChat) is
     fire-and-forget from the frontend (transport.fireIntent never inspects
     the resolved value), so this was a silent no-op difference for all
-    three, never previously worth fixing on its own. ADR-020 stage 20.4's
+    three, never previously worth fixing on its own. renameChat later joined
+    the same wrapper to protect its optimistic-token refresh. ADR-020 stage 20.4's
     own loadGraphAndFocusNode is the first REQUEST/REPLY intent wrapped
     through this same guard (it needs the SAME reentrancy protection
     loadChat/saveChat/newChat already get, since it also mutates
@@ -2537,6 +2568,68 @@ def make_export_workspace(bus: SessionBus, resolved_path: Path, notifications: N
     return export_workspace
 
 
+def make_rename_chat_intent(
+    bus: SessionBus,
+    resolved_path: Path,
+    canvas_document: SceneDocument | None,
+    notifications: NotificationState | None,
+    last_saved: dict[str, Any],
+):
+    """Build the rename intent without inflating the registration function.
+
+    Renaming the graph currently open in this session is part of the same
+    optimistic-concurrency contract as saving its content: the metadata write
+    must validate the token this session loaded and then replace it with the
+    exact timestamp written by the rename. The caller wraps this handler in
+    the shared chat-mutation guard, making the token update race-free against
+    this session's save/load/autosave operations.
+    """
+
+    async def rename(chat_id: int, new_title: str):
+        # Non-empty guard matches the legacy `if ok and new_title:` - an
+        # empty/whitespace title is ignored, no mutation, no error (the SPA
+        # disables Save for an empty draft anyway).
+        title = str(new_title or "").strip()
+        if not title:
+            return
+        resolved_chat_id = int(chat_id)
+        expected_updated_at: str | None = None
+        if (
+            canvas_document is not None
+            and canvas_document.current_chat_id == resolved_chat_id
+            and last_saved.get("chat_id") == resolved_chat_id
+        ):
+            expected_updated_at = last_saved.get("updated_at")
+        try:
+            new_updated_at = await asyncio.to_thread(
+                rename_chat,
+                resolved_path,
+                resolved_chat_id,
+                title,
+                expected_updated_at=expected_updated_at,
+            )
+        except ConcurrentSaveConflict:
+            logger.warning(
+                "renameChat: lost a save race for chat %r (session=%r) - not overwriting the newer title",
+                resolved_chat_id,
+                bus.session_id,
+            )
+            if notifications is not None:
+                notifications.show(LOST_RACE_MESSAGE_MANUAL, "warning")
+                await bus.publish("notification")
+            return
+        if (
+            new_updated_at is not None
+            and canvas_document is not None
+            and canvas_document.current_chat_id == resolved_chat_id
+            and last_saved.get("chat_id") == resolved_chat_id
+        ):
+            last_saved["updated_at"] = new_updated_at
+        await bus.publish("app-chat-library")
+
+    return rename
+
+
 def register_chat_library(
     bus: SessionBus,
     db_path: Path | None = None,
@@ -2567,9 +2660,10 @@ def register_chat_library(
 
     bus.register_topic("app-chat-library", lambda: chat_library_payload(resolved_path, notifications))
 
-    # Adversarial review finding: loadChat/saveChat/newChat all mutate the
-    # SAME canvas_document and each awaits at least one asyncio.to_thread DB
-    # call - an await point that yields control back to the event loop. A
+    # Adversarial review finding: loadChat/saveChat/newChat mutate the SAME
+    # canvas_document, while renameChat advances that document's optimistic
+    # save token; each awaits at least one asyncio.to_thread DB call - an
+    # await point that yields control back to the event loop. A
     # session can have MULTIPLE attached WS connections at once (every tab/
     # window that doesn't pass its own ?session= query param shares
     # session="default" - see backend/app.py's ws_endpoint), so two tabs
@@ -2577,8 +2671,8 @@ def register_chat_library(
     # silently overwrite or corrupt one another's work - there is no
     # per-window isolation here the way Qt's single-threaded-per-window
     # model gave legacy for free. This mutable flag - checked and set at
-    # entry, cleared in a finally - serializes all three against each
-    # other, the generalized (load/new included, not just save)
+    # entry, cleared in a finally - serializes all four against each other,
+    # the generalized (load/new/rename included, not just save)
     # counterpart of ChatSessionManager's own _is_saving reentrancy guard.
     #
     # OWNERSHIP (audit fix). The flag above was written when only a
@@ -2587,8 +2681,10 @@ def register_chat_library(
     # operations. R6.6 then had a BACKGROUND task claim the same flag, and the
     # asymmetry went unnoticed - an autosave tick that happened to be mid-write
     # made the user's own Save/Load/New Chat vanish, with a warning naming an
-    # operation they never started. A background convenience feature must never
-    # be able to beat the user to their own data.
+    # operation they never started. Rename now shares this guard as well: its
+    # metadata write advances the open graph's optimistic-save token, which
+    # must not race those operations. A background convenience feature must
+    # never be able to beat the user to their own data.
     #
     # So the guard now records WHO holds it, and the two directions differ:
     #   user arrives, autosave holds  -> wait briefly for the tick to finish,
@@ -2634,15 +2730,9 @@ def register_chat_library(
     # in _connect) serializes concurrent writers. The topic builder's read
     # stays on the loop - a few-row SELECT, negligible.
 
-    async def rename(chat_id: int, new_title: str):
-        # Non-empty guard matches the legacy `if ok and new_title:` - an
-        # empty/whitespace title is ignored, no mutation, no error (the SPA
-        # disables Save for an empty draft anyway).
-        title = str(new_title or "").strip()
-        if not title:
-            return
-        await asyncio.to_thread(rename_chat, resolved_path, int(chat_id), title)
-        await bus.publish("app-chat-library")
+    rename = make_rename_chat_intent(
+        bus, resolved_path, canvas_document, notifications, _last_saved,
+    )
 
     async def delete(chat_id: int):
         # The SPA only calls this after its own two-step confirm, so no
@@ -2726,11 +2816,10 @@ def register_chat_library(
     # asyncio.to_thread call into the matching CRUD function, then republish
     # "app-chat-library" so every attached window's list/switcher picks up
     # the change - the same pattern every existing intent on this topic
-    # already uses. None of these six go through _serialize_mutating_intent -
-    # unlike loadChat/saveChat/newChat, they never touch canvas_document
-    # (the live in-memory scene), only chats.db rows, so there is nothing
-    # here for that guard to serialize against; renameChat/deleteChat (the
-    # topic's two other pre-existing chats.db-only intents) are the same way.
+    # already uses. None of these six go through _serialize_mutating_intent:
+    # they mutate workspace/list metadata only. renameChat is deliberately
+    # different from these metadata helpers because renaming the open graph
+    # advances and refreshes its shared optimistic-save token.
 
     async def set_favorite(graph_id: int, favorite: bool):
         await asyncio.to_thread(set_graph_favorite, resolved_path, int(graph_id), bool(favorite))
@@ -2790,7 +2879,7 @@ def register_chat_library(
 
     export_workspace = make_export_workspace(bus, resolved_path, notifications)
 
-    bus.register_intent("app-chat-library", "renameChat", rename)
+    bus.register_intent("app-chat-library", "renameChat", _serialize_mutating_intent(rename))
     bus.register_intent("app-chat-library", "deleteChat", delete)
     bus.register_intent("app-chat-library", "loadChat", _serialize_mutating_intent(load_chat))
     bus.register_intent("app-chat-library", "saveChat", _serialize_mutating_intent(save_chat))

--- a/backend/events.py
+++ b/backend/events.py
@@ -318,8 +318,8 @@ class _BufferedConnection:
             return False
 
     def offer_superseding(self, message: dict[str, Any], topic: str) -> None:
-        """Enqueue a full snapshot, first PURGING every queued state/patch
-        frame for the same topic - and, unlike offer(), guaranteed to succeed.
+        """Enqueue a full snapshot, first purging disposable queued state for
+        the same topic - and, unlike offer(), guaranteed to succeed.
 
         CODE-REVIEW FIX. send_snapshot used to send directly on the socket,
         bypassing this queue, which caused two real problems for a buffered
@@ -332,39 +332,49 @@ class _BufferedConnection:
         snapshot arriving, so it never asks again: wedged until reconnect.
 
         Purging is correct because a snapshot strictly supersedes every
-        queued frame of its own topic: the snapshot carries the topic's
-        current revision R, every queued state/patch was enqueued at some
-        revision <= R, and a patch published AFTER this call lands behind the
-        snapshot with baseRevision R - chaining perfectly. Stream frames and
-        other topics' frames are NOT superseded and are kept, order
-        preserved. Everything here is synchronous (no awaits), so the
+        *uncorrelated* queued frame of its own topic: the snapshot carries the
+        topic's current revision R, every queued state/patch was enqueued at
+        some revision <= R, and a patch published AFTER this call lands behind
+        the snapshot with baseRevision R - chaining perfectly. A state frame
+        carrying an ``id`` is different: it resolves one explicit subscribe
+        request, so dropping it would strand that request's client callback.
+        Correlated states, stream frames, and other topics' frames are kept in
+        order. Everything here is synchronous (no awaits), so the
         purge-and-requeue cannot interleave with the writer task's get() in a
         way that reorders the kept frames.
 
-        The final drop-oldest loop covers the pathological remainder (a queue
-        still full of stream/other-topic frames): the snapshot's delivery
-        guarantee outranks a stale stream delta's."""
+        If the remainder still fills the bounded queue, an uncorrelated frame
+        is discarded before a correlated state. Only the pathological case
+        where every queued entry is itself correlated falls back to dropping
+        the oldest request; bounded memory remains a hard invariant."""
         kept: list[dict[str, Any]] = []
         while True:
             try:
                 queued = self.queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
-            if queued.get("topic") == topic and queued.get("kind") in ("state", "patch"):
+            is_correlated_state = queued.get("kind") == "state" and queued.get("id") is not None
+            if (
+                queued.get("topic") == topic
+                and queued.get("kind") in ("state", "patch")
+                and not is_correlated_state
+            ):
                 continue  # strictly older state for this topic - superseded
             kept.append(queued)
+        if self.queue.maxsize > 0 and len(kept) >= self.queue.maxsize:
+            drop_index = next(
+                (
+                    index
+                    for index, item in enumerate(kept)
+                    if not (item.get("kind") == "state" and item.get("id") is not None)
+                ),
+                0,
+            )
+            kept.pop(drop_index)
+            self.dropped += 1
         for item in kept:
             self.queue.put_nowait(item)  # capacity is guaranteed: only removals so far
-        while True:
-            try:
-                self.queue.put_nowait(message)
-                return
-            except asyncio.QueueFull:
-                try:
-                    self.queue.get_nowait()
-                    self.dropped += 1
-                except asyncio.QueueEmpty:  # pragma: no cover - unreachable
-                    return
+        self.queue.put_nowait(message)
 
 
 class SessionBus:
@@ -721,7 +731,13 @@ class SessionBus:
                 logger.warning("dropping dead connection on session %s", self.session_id)
                 self.detach(conn)
 
-    async def send_snapshot(self, topic: str, conn: Connection) -> None:
+    async def send_snapshot(
+        self,
+        topic: str,
+        conn: Connection,
+        *,
+        request_id: Any | None = None,
+    ) -> None:
         """Send the current state of one topic to one connection (the
         subscribe handshake - the successor of loadFinished -> publish()).
 
@@ -739,12 +755,19 @@ class SessionBus:
         SceneDocument.published_scene_payload for the full mechanism and a
         reproduction. Falling back to the live builder is correct for a
         topic with no baseline (every non-scene topic, all full-snapshot)
-        and for one that has not published yet (nothing can be behind)."""
+        and for one that has not published yet (nothing can be behind).
+
+        `request_id`, when supplied by an explicit client resubscribe, is
+        echoed on that one state envelope. It lets the client distinguish the
+        requested authority fence from an older broadcast already in the
+        buffered writer when the request was sent."""
         t = self._topics.get(topic)
         if t is None:
             raise UnknownTopicError(topic)
         payload = t.baseline_snapshot() or t.snapshot()
         message = {"kind": "state", "topic": topic, "payload": payload}
+        if request_id is not None:
+            message["id"] = request_id
         # CODE-REVIEW FIX: a BUFFERED connection's snapshot must go through
         # its queue, not directly onto the socket - a direct send OVERTAKES
         # any queued older frames, which then arrive after it with

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -1077,32 +1077,77 @@ def _restore_frames(
     return frames_map
 
 
-def _restore_containers(document: SceneDocument, containers_data: list, all_items_map: dict[int, str]) -> None:
+def _restore_containers(
+    document: SceneDocument,
+    containers_data: list,
+    all_items_map: dict[int, str],
+    container_base_index: int,
+) -> dict[int, str]:
     if not isinstance(containers_data, list):
-        return
-    for container_payload in containers_data:
-        if not isinstance(container_payload, dict):
-            continue
-        try:
-            # Pure positional membership, same posture as frames - "items"
-            # is required in legacy (KeyError if absent); tolerated-missing
-            # here instead of aborting the whole load.
+        return {}
+
+    # Containers occupy the tail of the serialized all-items index and may
+    # themselves be container members. Restore dependency-ready payloads
+    # first and add each new id to the same map immediately, so an outer
+    # container can resolve the inner container created earlier in this pass.
+    # The deferred loop also tolerates hand-edited/legacy payloads whose
+    # container order is not dependency-first. A cycle cannot be represented
+    # by the live model; if no pass makes progress, the unresolved payloads
+    # are left out instead of creating silently incomplete groups.
+    container_slots = set(range(container_base_index, container_base_index + len(containers_data)))
+    pending = [
+        (index, payload)
+        for index, payload in enumerate(containers_data)
+        if isinstance(payload, dict)
+    ]
+    containers_map: dict[int, str] = {}
+
+    while pending:
+        deferred: list[tuple[int, dict[str, Any]]] = []
+        made_progress = False
+        for index, container_payload in pending:
             item_indices = container_payload.get("items", [])
             item_indices = item_indices if isinstance(item_indices, list) else []
-            member_ids = [all_items_map[i] for i in item_indices if i in all_items_map]
-            if not member_ids:
+            try:
+                if any(i in container_slots and i not in all_items_map for i in item_indices):
+                    deferred.append((index, container_payload))
+                    continue
+            except (TypeError, ValueError):
+                # Preserve the loader's tolerant posture for malformed item
+                # lists: the creation block below will skip this payload.
+                pass
+
+            container = None
+            try:
+                member_ids = [all_items_map[i] for i in item_indices if i in all_items_map]
+                if not member_ids:
+                    continue
+                container = document.create_container(member_ids)
+                # "Container" matches deserialize_container's own restore-time
+                # default (data.get("title", "Container")) - NOT
+                # create_container's own fresh-creation default ("New
+                # Container"), a different code path with a different default.
+                document.set_group_label(container.id, str(container_payload.get("title", "") or "Container"))
+                document.set_group_color(
+                    container.id,
+                    container_payload.get("color"),
+                    container_payload.get("header_color"),
+                )
+                if bool(container_payload.get("is_collapsed", False)):
+                    document.toggle_group_collapsed(container.id)
+            except Exception:
                 continue
-            container = document.create_container(member_ids)
-            # "Container" matches deserialize_container's own restore-time
-            # default (data.get("title", "Container")) - NOT
-            # create_container's own fresh-creation default ("New
-            # Container"), a different code path with a different default.
-            document.set_group_label(container.id, str(container_payload.get("title", "") or "Container"))
-            document.set_group_color(container.id, container_payload.get("color"), container_payload.get("header_color"))
-            if bool(container_payload.get("is_collapsed", False)):
-                document.toggle_group_collapsed(container.id)
-        except Exception:
-            continue
+
+            serialized_index = container_base_index + index
+            containers_map[index] = container.id
+            all_items_map[serialized_index] = container.id
+            made_progress = True
+
+        if not made_progress:
+            break
+        pending = deferred
+
+    return containers_map
 
 
 # The 7 kinds every era has always had, plus 5 that only existed before
@@ -1417,6 +1462,7 @@ def _restore_chat_into_document(
     node_slot_count = len(node_payloads)
     note_slot_count = len(notes_data) if isinstance(notes_data, list) else 0
     chart_slot_count = len(chat_data.get("charts", [])) if isinstance(chat_data.get("charts"), list) else 0
+    frame_slot_count = len(chat_data.get("frames", [])) if isinstance(chat_data.get("frames"), list) else 0
 
     frame_source_map = dict(all_nodes_map)
     for chart_index, chart_new_id in charts_map.items():
@@ -1430,7 +1476,13 @@ def _restore_chat_into_document(
         all_items_map[node_slot_count + note_slot_count + chart_index] = chart_new_id
     for frame_index, frame_new_id in frames_map.items():
         all_items_map[node_slot_count + note_slot_count + chart_slot_count + frame_index] = frame_new_id
-    _restore_containers(document, chat_data.get("containers", []), all_items_map)
+    container_base_index = node_slot_count + note_slot_count + chart_slot_count + frame_slot_count
+    _restore_containers(
+        document,
+        chat_data.get("containers", []),
+        all_items_map,
+        container_base_index,
+    )
 
     # ADR-009 stage 9.6. A file written by this build carries a flat
     # `edges` list and it is authoritative; the legacy buckets are only

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -41,24 +41,14 @@ get_all_serializable_items/CHILD_LINK_NODE_TYPES/NODE_LIST_NAMES), plus
 5 plugin kinds (pycoder/code_sandbox/web/artifact/gitlink) R5-closeout later
 deleted the branches for.
 
-KNOWN, ALREADY-EXISTING GAP THIS FILE DELIBERATELY DOES NOT "FIX" (present
-in legacy itself, not introduced here): scene_index.py's own
-get_all_serializable_items positions containers LAST in the combined item-
-index space (nodes+notes+charts+frames+containers), and create_container's
-own docstring confirms a container CAN legitimately hold another container
-as a member - but legacy's OWN restore_chat builds all_items_map from only
-nodes+notes+charts+frames BEFORE its containers-deserialization loop runs,
-and never adds containers to that map afterward either. A session containing
-a container nested inside another container would therefore fail to
-resolve that one reference on load in BOTH the legacy Qt app AND this
-project's own backend/session_load.py (which faithfully ported this exact
-restore_chat behavior in R6.4, offsets included). This file's own
-_serialize_container mirrors get_all_serializable_items's item-index
-scheme exactly (containers ARE included, at the tail) for save-side
-fidelity with legacy's OWN serializer - the corresponding load-side gap is
-a pre-existing, shared limitation, not a regression this increment
-introduces, and is out of scope to fix here (it would be a session_load.py
-change, not a session_save.py one).
+NESTED CONTAINERS: scene_index.py's get_all_serializable_items positions
+containers LAST in the combined item-index space
+(nodes+notes+charts+frames+containers), and create_container legitimately
+allows a container to hold another container. _serialize_container mirrors
+that index scheme exactly. backend/session_load.py resolves the matching
+tail indices incrementally while restoring containers, including a deferred
+pass for payloads that are not dependency-ordered, so nested membership now
+round-trips instead of losing the outer group.
 
 DELIBERATE SIMPLIFICATION (documented, not silent): legacy's own title
 generation for a brand-new chat tries an LLM call first (title_generator.
@@ -832,10 +822,10 @@ def _build_chat_data(
     for i, n in enumerate(charts):
         frame_source_index[n.id] = node_slot_count + i
 
-    # "all items index" = nodes + notes + charts + frames (+ containers,
-    # tail - see this module's own docstring on the known, shared,
-    # already-existing nested-container load-side gap) - mirrors
-    # get_all_serializable_items exactly.
+    # "all items index" = nodes + notes + charts + frames + containers at
+    # the tail - mirrors get_all_serializable_items exactly. The loader adds
+    # restored container ids back at these same tail indices so nesting can
+    # resolve on the way in as well.
     all_items_index = dict(nodes_index)
     for i, n in enumerate(notes):
         all_items_index[n.id] = node_slot_count + i

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -103,6 +103,7 @@ def test_subscribe_delivers_system_snapshot_with_envelope():
         message = ws.receive_json()
         assert message["kind"] == "state"
         assert message["topic"] == "system"
+        assert "id" not in message
         payload = message["payload"]
         assert payload["app"] == "graphlink"
         assert payload["sessionId"] == "default"
@@ -118,6 +119,17 @@ def test_subscribe_delivers_system_snapshot_with_envelope():
         # A freshly-subscribed session that has published nothing is
         # therefore correctly at 0.
         assert payload["revision"] == 0
+
+
+def test_explicit_subscribe_id_is_echoed_only_on_its_snapshot():
+    client = make_client()
+    with client.websocket_connect("/ws?session=default") as ws:
+        ws.send_json({"kind": "subscribe", "topics": ["system"], "id": 91})
+        message = ws.receive_json()
+
+        assert message["kind"] == "state"
+        assert message["topic"] == "system"
+        assert message["id"] == 91
 
 
 def test_scene_subscribe_snapshot_is_pinned_at_schema_version_2():

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -1833,6 +1833,47 @@ def test_save_chat_intent_resave_updates_same_row_and_keeps_existing_title(db_pa
     assert len(row["data"]["nodes"]) == 2
 
 
+def test_rename_of_open_chat_refreshes_save_token_and_next_edit_persists(db_path, monkeypatch):
+    """A session's own rename must not look like an external edit later.
+
+    Before the regression fix, rename_chat bumped the row's ``updated_at``
+    while the session kept its pre-rename token. The next Save therefore
+    raised ConcurrentSaveConflict and silently left the new canvas edit only
+    in memory. The spy also proves rename now runs under the same user-owned
+    mutation guard as save/load/autosave, which makes updating the shared
+    token race-free within this session.
+    """
+    bus, document, notifications = _bus_with_canvas(db_path)
+    document.add_chat_node(0, 0, "hello world", is_user=True)
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+    chat_id = document.current_chat_id
+    old_token = bus.chat_save_state["updated_at"]
+
+    real_rename = chat_library_module.rename_chat
+    observed_guard_owners = []
+
+    def rename_while_observing_guard(*args, **kwargs):
+        observed_guard_owners.append(bus.chat_mutation_guard["owner"])
+        return real_rename(*args, **kwargs)
+
+    monkeypatch.setattr(chat_library_module, "rename_chat", rename_while_observing_guard)
+    asyncio.run(bus.dispatch_intent("app-chat-library", "renameChat", [chat_id, "Renamed"]))
+
+    renamed_row = load_chat_row(db_path, chat_id)
+    assert observed_guard_owners == [USER_OWNER]
+    assert renamed_row["title"] == "Renamed"
+    assert renamed_row["updated_at"] != old_token
+    assert bus.chat_save_state["updated_at"] == renamed_row["updated_at"]
+
+    added_note = document.add_note(20, 20)
+    document.set_note_content(added_note.id, "saved after rename")
+    asyncio.run(bus.dispatch_intent("app-chat-library", "saveChat", []))
+
+    assert notifications.visible and notifications.msg_type == "success"
+    assert load_chat_row(db_path, chat_id)["title"] == "Renamed"
+    assert [row["content"] for row in load_notes_rows(db_path, chat_id)] == ["saved after rename"]
+
+
 def test_save_chat_intent_falls_back_to_insert_when_current_row_was_deleted_elsewhere(db_path):
     bus, document, notifications = _bus_with_canvas(db_path)
     document.current_chat_id = 999  # a row that never existed / was deleted
@@ -2622,6 +2663,32 @@ class TestOptimisticConcurrency:
         row = load_chat_row(db_path, chat_id)
         assert row["data"] == {"nodes": ["v1-from-A"]}
         assert row["updated_at"] == second_updated_at
+
+    def test_rename_with_a_stale_token_does_not_adopt_the_newer_rows_version(self, db_path):
+        chat_id, original_updated_at = save_chat_atomically_row(
+            db_path, None, "Original title", {"nodes": ["v0"]}, [], [],
+        )
+        save_chat_atomically_row(
+            db_path,
+            chat_id,
+            "Original title",
+            {"nodes": ["newer content from another session"]},
+            [],
+            [],
+            expected_updated_at=original_updated_at,
+        )
+
+        with pytest.raises(ConcurrentSaveConflict):
+            rename_chat(
+                db_path,
+                chat_id,
+                "Stale session's rename",
+                expected_updated_at=original_updated_at,
+            )
+
+        row = load_chat_row(db_path, chat_id)
+        assert row["title"] == "Original title"
+        assert row["data"] == {"nodes": ["newer content from another session"]}
 
     def test_a_lost_race_does_not_touch_notes_or_pins_either(self, db_path):
         # The whole write must roll back atomically - not just the chats

--- a/backend/tests/test_publish_coalescing_and_backpressure.py
+++ b/backend/tests/test_publish_coalescing_and_backpressure.py
@@ -341,6 +341,37 @@ def test_the_purge_keeps_stream_frames_and_other_topics_untouched():
     asyncio.run(run())
 
 
+def test_correlated_snapshots_survive_same_topic_superseding_and_queue_pressure():
+    async def run():
+        document = SceneDocument()
+        bus = make_bus(document, send_queue_maxsize=3)
+        gated = GatedRecorder()
+        bus.attach(gated, buffered=True)
+        document.add_node(0, 0, "a")
+
+        await bus.publish("scene")  # writer owns this frame and blocks
+        await asyncio.sleep(0.01)
+        await bus.send_snapshot("scene", gated, request_id=101)
+        await bus.publish_stream(
+            topic="scene", request_id="stream-1", seq=0, delta="a", done=False
+        )
+        await bus.publish_stream(
+            topic="scene", request_id="stream-1", seq=1, delta="b", done=False
+        )
+        # The queue is full. This later snapshot may supersede ordinary scene
+        # state and preferentially discard a stream frame, but request 101
+        # still needs its own correlated response before request 102.
+        await bus.send_snapshot("scene", gated, request_id=102)
+
+        gated.gate.set()
+        await asyncio.sleep(0.05)
+
+        correlated_ids = [message.get("id") for message in gated.messages if "id" in message]
+        assert correlated_ids == [101, 102]
+
+    asyncio.run(run())
+
+
 def test_send_snapshot_to_an_unbuffered_connection_is_still_synchronous():
     async def run():
         document = SceneDocument()

--- a/backend/tests/test_session_lifecycle.py
+++ b/backend/tests/test_session_lifecycle.py
@@ -21,6 +21,8 @@ itself respects (see backend/events.py's own docstring for why):
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import threading
 import time
 
 import pytest
@@ -397,80 +399,66 @@ def test_evict_idle_session_proceeds_and_cancels_the_autosave_task_when_idle():
     asyncio.run(_run())
 
 
-def test_evict_idle_session_releases_the_mutation_guard_when_cancelling_mid_write():
-    """Adversarial-review finding: the test above only ever cancels a
-    stand-in coroutine that never touches backend/chat_library.py's shared
-    mutation_guard - it cannot detect a regression in _guarded_tick's own
-    try/finally guarantee. Before ADR-004 stage 4.3, register_autosave's
-    task was "deliberately never explicitly cancelled" (see
-    backend/autosave.py's own updated docstring), so cancelling a REAL
-    _guarded_tick while it holds the guard mid-write was purely
-    theoretical dead code; this stage makes it a genuine, reachable
-    production path (_evict_idle_session cancels a live session's
-    autosave_task any time eviction proceeds while a write happens to be
-    in flight) for the first time. This test drives that real path: a
-    real register_autosave-installed task, actually suspended mid-write
-    (inside asyncio.to_thread, not idling in the inter-tick sleep), then
-    cancelled via the real _evict_idle_session call.
+def test_evict_idle_session_vetoes_while_autosave_is_preparing_to_write(tmp_path, monkeypatch):
+    """Eviction must not cancel an autosave before its DB write starts.
+
+    The old implementation noticed the active mutation guard, skipped its
+    own final flush, and then cancelled the autosave task anyway. Cancelling
+    during the awaited backup below prevents autosave_tick from ever reaching
+    save_chat_atomically_row, so the dirty document disappeared with the
+    evicted session. Pausing immediately before the write reproduces that
+    exact data-loss window rather than the safer case where a worker thread
+    has already entered SQLite and continues after task cancellation.
     """
     import backend.autosave as autosave_mod
-    from backend.chat_library import _new_mutation_guard, _new_save_state
-    from backend.autosave import register_autosave
-    import tempfile
-    from pathlib import Path
+    from backend.chat_library import get_all_chats, load_chat_row, register_chat_library
 
     async def _run():
         bus = SessionBus("s1")
         context, _tmp = _real_session_context()
         attach_session_context(bus, context)
-        context.canvas_document.add_node(0, 0, "hello")
-        mutation_guard = _new_mutation_guard()
-        last_saved = _new_save_state()
-        write_entered = asyncio.Event()
-        loop = asyncio.get_running_loop()
+        notifications = NotificationState()
+        bus.register_topic("notification", notifications.payload)
+        backup_entered = threading.Event()
+        release_backup = threading.Event()
 
-        real_write = autosave_mod.save_chat_atomically_row
+        def paused_backup(*args, **kwargs):
+            backup_entered.set()
+            assert release_backup.wait(timeout=30), "test never released the pre-write backup"
 
-        def slow_write(*args, **kwargs):
-            loop.call_soon_threadsafe(write_entered.set)
-            time.sleep(0.3)
-            # ADR-009 stage 9.2: (chat_id, updated_at) - any truthy chat_id
-            # and a well-formed timestamp string; DB unused for this
-            # assertion, but the shape must match the real function's
-            # contract so autosave_tick's own unpacking doesn't itself
-            # raise (masking this test's actual assertion behind a
-            # swallowed TypeError in autosave_tick's own except Exception).
-            return 1, "2026-01-01 00:00:00"
-
-        state_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
-        db_path = Path(state_dir.name) / "chats.db"
-        autosave_mod.save_chat_atomically_row = slow_write
+        monkeypatch.setattr(autosave_mod, "_maybe_backup_before_write", paused_backup)
+        register_chat_library(
+            bus,
+            tmp_path / "chats.db",
+            context.canvas_document,
+            notifications,
+            autosave_interval_seconds=0.01,
+        )
+        context.canvas_document.add_chat_node(0, 0, "dirty unsaved content", is_user=True)
         try:
-            register_autosave(bus, db_path, context.canvas_document, None, mutation_guard, last_saved, interval_seconds=0.01)
-            await asyncio.wait_for(write_entered.wait(), timeout=2.0)
-            # The tick is now genuinely suspended mid-write, holding the guard.
-            assert mutation_guard["active"] is True
-            assert mutation_guard["owner"] == "autosave"
+            assert await asyncio.to_thread(backup_entered.wait, 2.0), "autosave never reached the pre-write await"
+            assert bus.chat_mutation_guard["active"] is True
+            assert bus.chat_mutation_guard["owner"] == "autosave"
+            assert get_all_chats(tmp_path / "chats.db") == []
 
             result = _evict_idle_session(bus)
-            assert result is True
+            assert result is False
+            assert not bus.autosave_task.done(), "a vetoed eviction must leave autosave running"
 
-            for _ in range(20):
-                if bus.autosave_task.done():
+            release_backup.set()
+            for _ in range(200):
+                if bus.chat_save_state["chat_id"] is not None:
                     break
-                await asyncio.sleep(0.05)
-            assert bus.autosave_task.done()
-
-            # The whole point: cancellation mid-write must still release
-            # the guard via _guarded_tick's finally block, or a future
-            # manual save/load/new-chat intent on some OTHER session
-            # reusing this same guard shape would hang or wrongly report
-            # "busy" forever.
-            assert mutation_guard["active"] is False
-            assert mutation_guard["owner"] is None
-            assert mutation_guard["released"].is_set() is True
+                await asyncio.sleep(0.01)
+            saved_chat_id = bus.chat_save_state["chat_id"]
+            assert saved_chat_id is not None, "autosave did not finish after eviction was deferred"
+            row = load_chat_row(tmp_path / "chats.db", saved_chat_id)
+            assert row["data"]["nodes"][0]["raw_content"] == "dirty unsaved content"
         finally:
-            autosave_mod.save_chat_atomically_row = real_write
+            release_backup.set()
+            bus.autosave_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await bus.autosave_task
 
     asyncio.run(_run())
 
@@ -607,14 +595,12 @@ def test_evict_idle_session_does_not_write_a_redundant_row_for_a_clean_session(t
     assert load_chat_row(db_path, rows[0]["id"])["updated_at"] == saved_updated_at
 
 
-def test_evict_idle_session_does_not_flush_while_a_write_is_genuinely_in_flight(tmp_path):
-    # If the mutation guard is already held (a tick or manual op mid-write),
-    # the flush must not race a SECOND write against it - autosave_task.
-    # cancel() below still lets any genuinely in-flight tick finish and
-    # record its own result correctly (see
-    # test_evict_idle_session_releases_the_mutation_guard_when_cancelling_
-    # mid_write above), so attempting a flush here would only risk an
-    # avoidable spurious lost-race warning for no real benefit.
+def test_evict_idle_session_vetoes_without_flushing_while_a_chat_mutation_is_active(tmp_path):
+    # If the mutation guard is already held (an autosave or manual operation
+    # mid-await), eviction must neither race a second flush nor cancel the
+    # operation holding the only dirty in-memory state. Returning False lets
+    # EventBus reconsider the session on its next sweep after the guard is
+    # released.
     from backend.chat_library import register_chat_library
 
     db_path = tmp_path / "chats.db"
@@ -639,5 +625,5 @@ def test_evict_idle_session_does_not_flush_while_a_write_is_genuinely_in_flight(
     finally:
         app_module.flush_dirty_session_before_teardown = real_flush
 
-    assert result is True
+    assert result is False
     assert flush_calls == [], "a flush must not be attempted while a write is already in flight"

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -512,6 +512,26 @@ def test_container_can_reference_a_frame_via_the_full_offset_chain():
     assert container.item_ids == [frame.id]
 
 
+def test_nested_containers_restore_when_outer_payload_precedes_inner_dependency():
+    document = _restore(
+        nodes=[_chat("leaf")],
+        containers=[
+            # Container slots start after the one regular-node slot. The
+            # outer payload is deliberately first but references slot 2,
+            # occupied by the inner payload below, so restoration requires
+            # the loader's deferred dependency pass rather than list order.
+            {"items": [2], "title": "Outer"},
+            {"items": [0], "title": "Inner"},
+        ],
+    )
+
+    leaf = next(node for node in document.nodes.values() if node.kind == "chat")
+    inner = next(node for node in document.nodes.values() if node.content == "Inner")
+    outer = next(node for node in document.nodes.values() if node.content == "Outer")
+    assert inner.item_ids == [leaf.id]
+    assert outer.item_ids == [inner.id]
+
+
 # -- basic connections (12 keys), system-prompt / group-summary -------------
 
 

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -353,6 +353,23 @@ def test_container_default_title_round_trips_through_content_field():
     assert chat_data["containers"][0]["title"] == "My Container"
 
 
+def test_nested_containers_preserve_both_groups_and_membership_on_round_trip():
+    doc = SceneDocument()
+    note = doc.add_note(10, 20)
+    inner = doc.create_container([note.id])
+    outer = doc.create_container([inner.id])
+    doc.set_group_label(inner.id, "Inner")
+    doc.set_group_label(outer.id, "Outer")
+
+    restored = _round_trip(doc)
+
+    restored_note = next(node for node in restored.nodes.values() if node.kind == "note")
+    restored_inner = next(node for node in restored.nodes.values() if node.content == "Inner")
+    restored_outer = next(node for node in restored.nodes.values() if node.content == "Outer")
+    assert restored_inner.item_ids == [restored_note.id]
+    assert restored_outer.item_ids == [restored_inner.id]
+
+
 # -- notes / pins / view state / tokens ------------------------------------
 
 

--- a/web_ui/src/app/chrome/composerStore.test.ts
+++ b/web_ui/src/app/chrome/composerStore.test.ts
@@ -9,6 +9,11 @@ type StreamListener = (delta: string, done: boolean, reset: boolean, seq: number
 function makeFakeTransport() {
   const listeners = new Map<string, StateListener>();
   const intents: Array<{ topic: string; intent: string; args: unknown[] }> = [];
+  const intentCallbacks: Array<{
+    onSettled?: () => void;
+    onOfflineCoalesced?: () => void;
+  }> = [];
+  const resubscribeListeners: StateListener[] = [];
   const streamListeners = new Map<string, StreamListener>();
   const streamUnsubFns = new Map<string, ReturnType<typeof vi.fn>>();
   const subscribeStream = vi.fn((requestId: string, listener: StreamListener) => {
@@ -33,12 +38,35 @@ function makeFakeTransport() {
     // path is exercised by transport.test.ts, not re-tested at every call
     // site) so this file's existing assertions don't need to distinguish
     // the two.
-    fireIntent: vi.fn((topic: string, intent: string, args: unknown[] = []) => {
+    fireIntent: vi.fn((
+      topic: string,
+      intent: string,
+      args: unknown[] = [],
+      _timeoutMs?: number,
+      _queueable?: boolean,
+      _offlineCoalesceKey?: string,
+      onSettled?: () => void,
+      onOfflineCoalesced?: () => void,
+    ) => {
       intents.push({ topic, intent, args });
+      intentCallbacks.push({ onSettled, onOfflineCoalesced });
+    }),
+    resubscribe: vi.fn((_topic: string, listener?: StateListener) => {
+      if (listener) resubscribeListeners.push(listener);
+      return true;
     }),
     subscribeStream,
   } as unknown as WsTransport;
-  return { transport, listeners, intents, subscribeStream, streamListeners, streamUnsubFns };
+  return {
+    transport,
+    listeners,
+    intents,
+    intentCallbacks,
+    resubscribeListeners,
+    subscribeStream,
+    streamListeners,
+    streamUnsubFns,
+  };
 }
 
 function validComposerPayload(overrides: Record<string, unknown> = {}) {
@@ -83,6 +111,117 @@ describe("ComposerStore", () => {
     listeners.get("app-composer")!(validComposerPayload());
     expect(seen).toHaveBeenCalledTimes(1);
     expect(store.getComposer().draft.text).toBe("hi");
+  });
+
+  it("keeps controlled typing optimistic and ignores stale draft echoes until the newest value is acknowledged", () => {
+    const { transport, listeners, intents, intentCallbacks, resubscribeListeners } =
+      makeFakeTransport();
+    const store = new ComposerStore(transport);
+    store.connect();
+    listeners.get("app-composer")!(validComposerPayload());
+    const seen = vi.fn();
+    store.subscribe(seen);
+
+    store.updateDraft("hia");
+    expect(store.getComposer().draft.text).toBe("hia");
+    expect(seen).toHaveBeenCalledTimes(1);
+
+    // Model a controlled input computing its next value from the immediately
+    // rendered store snapshot, before either WebSocket echo has arrived.
+    store.updateDraft(`${store.getComposer().draft.text}b`);
+    expect(store.getComposer().draft.text).toBe("hiab");
+    expect(intents.slice(-2)).toEqual([
+      { topic: "app-composer", intent: "updateDraft", args: ["hia"] },
+      { topic: "app-composer", intent: "updateDraft", args: ["hiab"] },
+    ]);
+
+    // The first intent's stale echo may still carry useful server-owned
+    // fields; merge those without rolling the newer local text backward.
+    listeners.get("app-composer")!(
+      validComposerPayload({
+        revision: 2,
+        draft: { id: "d1", text: "hia", contextMode: "branch", sendMode: "enter_to_send", restored: false },
+        request: { id: null, state: "idle", message: "updated", canSend: true, canCancel: false, canRetry: false },
+      }),
+    );
+    expect(store.getComposer().draft.text).toBe("hiab");
+    expect(store.getComposer().request.message).toBe("updated");
+    expect(store.getComposer().revision).toBe(2);
+
+    // Passive value equality is ambiguous, so authority returns only after
+    // both requests settle and their explicit follow-up snapshot arrives.
+    intentCallbacks[0].onSettled?.();
+    expect(resubscribeListeners).toHaveLength(0);
+    intentCallbacks[1].onSettled?.();
+    expect(resubscribeListeners).toHaveLength(1);
+    const authoritative = validComposerPayload({
+      revision: 3,
+      draft: { id: "d1", text: "hiab", contextMode: "branch", sendMode: "enter_to_send", restored: false },
+    });
+    resubscribeListeners.shift()!(authoritative);
+    listeners.get("app-composer")!(authoritative);
+
+    // Later server snapshots are authoritative again (for example, a
+    // successful send clearing the draft).
+    listeners.get("app-composer")!(
+      validComposerPayload({
+        revision: 4,
+        draft: { id: "d1", text: "", contextMode: "branch", sendMode: "enter_to_send", restored: false },
+      }),
+    );
+    expect(store.getComposer().draft.text).toBe("");
+  });
+
+  it("does not mistake an older equal-value echo for acknowledgement in an A-B-A edit", () => {
+    const { transport, listeners, intentCallbacks, resubscribeListeners } = makeFakeTransport();
+    const store = new ComposerStore(transport);
+    store.connect();
+    listeners.get("app-composer")!(validComposerPayload());
+
+    store.updateDraft("hia");
+    store.updateDraft("hiab");
+    store.updateDraft("hia");
+
+    for (const [revision, text] of [[2, "hia"], [3, "hiab"], [4, "hia"]] as const) {
+      listeners.get("app-composer")!(
+        validComposerPayload({
+          revision,
+          draft: { id: "d1", text, contextMode: "branch", sendMode: "enter_to_send", restored: false },
+        }),
+      );
+      expect(store.getComposer().draft.text).toBe("hia");
+    }
+
+    for (const callbacks of intentCallbacks.slice(-3)) callbacks.onSettled?.();
+    expect(resubscribeListeners).toHaveLength(1);
+    const authoritative = validComposerPayload({
+      revision: 5,
+      draft: { id: "d1", text: "hia", contextMode: "branch", sendMode: "enter_to_send", restored: false },
+    });
+    resubscribeListeners.shift()!(authoritative);
+    listeners.get("app-composer")!(authoritative);
+    listeners.get("app-composer")!(
+      validComposerPayload({
+        revision: 6,
+        draft: { id: "d1", text: "server value", contextMode: "branch", sendMode: "enter_to_send", restored: false },
+      }),
+    );
+    expect(store.getComposer().draft.text).toBe("server value");
+  });
+
+  it("retains optimistic text without looping when a correlated snapshot is malformed", () => {
+    const { transport, listeners, intentCallbacks, resubscribeListeners } = makeFakeTransport();
+    const store = new ComposerStore(transport);
+    store.connect();
+    listeners.get("app-composer")!(validComposerPayload());
+    store.updateDraft("local");
+    intentCallbacks.at(-1)!.onSettled?.();
+    expect(resubscribeListeners).toHaveLength(1);
+
+    resubscribeListeners.shift()!({ schemaVersion: 1 });
+
+    expect(resubscribeListeners).toHaveLength(0);
+    expect(store.getComposer().draft.text).toBe("local");
   });
 
   it("rejects a malformed snapshot and keeps the previous state", () => {

--- a/web_ui/src/app/chrome/composerStore.ts
+++ b/web_ui/src/app/chrome/composerStore.ts
@@ -10,6 +10,7 @@ import type { AppComposerState } from "../../lib/bridge-core/generated/app-compo
 import type { TokenCounterState } from "../../lib/bridge-core/generated/token-counter-state";
 import type { NotificationState } from "../../lib/bridge-core/generated/notification-state";
 import type { WsTransport } from "../../lib/ws/transport";
+import { COMPOSER_DRAFT_OFFLINE_COALESCE_KEY } from "../../lib/ws/transport";
 import { announce } from "../announcer";
 
 // ADR-003 stage 3.1 review-fix: a native OS file dialog waits on the user,
@@ -82,6 +83,15 @@ export class ComposerStore {
   private composer: AppComposerState = initialComposerState;
   private tokenCounter: TokenCounterState = initialTokenCounterState;
   private notification: NotificationState = initialNotificationState;
+  /** Local draft writes whose request has not reached a terminal result.
+   * Draft text stays optimistic until all writes settle and an explicitly
+   * requested snapshot confirms current server authority. Generations, not
+   * text equality, disambiguate valid A -> B -> A edit sequences. */
+  private readonly pendingDraftGenerations = new Set<number>();
+  private latestOptimisticDraft: { generation: number; text: string } | null = null;
+  private nextDraftGeneration = 1;
+  /** Generation fenced by the one explicit snapshot request in flight. */
+  private draftResyncGeneration: number | null = null;
   private streamText = "";
   private streamUnsub: (() => void) | null = null;
   private readonly listeners = new Set<Listener>();
@@ -106,13 +116,61 @@ export class ComposerStore {
       this.bind<AppComposerState>("app-composer", (v) => {
         const prevId = this.composer.request.id;
         const prevState = this.composer.request.state;
-        this.composer = v;
-        this.syncStream(prevId, v.request.id);
-        this.announceRequestStateChange(prevState, v.request.state);
+        let next = v;
+        const optimistic = this.latestOptimisticDraft?.text;
+        if (optimistic !== undefined) {
+          // Accept unrelated server-owned fields while holding the newest
+          // local text over stale/intermediate broadcasts. A value match is
+          // not an acknowledgement: the user may legitimately type A-B-A.
+          next = { ...v, draft: { ...v.draft, text: optimistic } };
+        }
+        this.composer = next;
+        this.syncStream(prevId, next.request.id);
+        this.announceRequestStateChange(prevState, next.request.state);
+        this.requestDraftResync();
       }),
       this.bind<TokenCounterState>("token-counter", (v) => (this.tokenCounter = v)),
       this.bind<NotificationState>("notification", (v) => (this.notification = v)),
     );
+  }
+
+  private onDraftSettled(generation: number): void {
+    this.pendingDraftGenerations.delete(generation);
+    this.requestDraftResync();
+  }
+
+  private requestDraftResync(): void {
+    if (
+      this.draftResyncGeneration !== null ||
+      this.pendingDraftGenerations.size > 0 ||
+      !this.latestOptimisticDraft
+    ) {
+      return;
+    }
+
+    const fenceGeneration = this.latestOptimisticDraft.generation;
+    this.draftResyncGeneration = fenceGeneration;
+    const sent = this.transport.resubscribe("app-composer", (payload) => {
+      const validated = TOPIC_VALIDATORS["app-composer"](payload);
+      this.draftResyncGeneration = null;
+      if (!validated.ok) return;
+      if (
+        this.pendingDraftGenerations.size > 0 ||
+        this.latestOptimisticDraft?.generation !== fenceGeneration
+      ) {
+        this.requestDraftResync();
+        return;
+      }
+      // WsTransport invokes this one-shot callback before ordinary topic
+      // listeners, so the same requested snapshot becomes authoritative.
+      this.latestOptimisticDraft = null;
+    });
+    if (!sent) this.draftResyncGeneration = null;
+  }
+
+  private onDraftCoalesced(generation: number): void {
+    this.pendingDraftGenerations.delete(generation);
+    this.requestDraftResync();
   }
 
   dispose(): void {
@@ -179,11 +237,27 @@ export class ComposerStore {
   // -- intents (backend/composer.py + notifications.py, 1:1) --------------
 
   updateDraft(text: string): void {
+    const generation = this.nextDraftGeneration++;
+    this.pendingDraftGenerations.add(generation);
+    this.latestOptimisticDraft = { generation, text };
+    if (this.composer.draft.text !== text) {
+      this.composer = { ...this.composer, draft: { ...this.composer.draft, text } };
+      this.emit();
+    }
     // ADR-003 stage 3.6: queueable - the single most textbook idempotent
     // last-write-wins case in the app; a keystroke autosave lost to a
     // dropped connection is the exact "vanishes silently" gap this stage
     // exists to close.
-    this.transport.fireIntent("app-composer", "updateDraft", [text], undefined, true);
+    this.transport.fireIntent(
+      "app-composer",
+      "updateDraft",
+      [text],
+      undefined,
+      true,
+      COMPOSER_DRAFT_OFFLINE_COALESCE_KEY,
+      () => this.onDraftSettled(generation),
+      () => this.onDraftCoalesced(generation),
+    );
   }
 
   selectModel(modelId: string): void {

--- a/web_ui/src/lib/ws/transport.test.ts
+++ b/web_ui/src/lib/ws/transport.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { WsRequestError, WsTimeoutError, WsTopicBlockedError, WsTransport, WsUnavailableError } from "./transport";
+import {
+  COMPOSER_DRAFT_OFFLINE_COALESCE_KEY,
+  WsRequestError,
+  WsTimeoutError,
+  WsTopicBlockedError,
+  WsTransport,
+  WsUnavailableError,
+} from "./transport";
 import { READER_SCHEMA_VERSION } from "../bridge-core/schemaVersion";
 
 // ADR-003 stage 3.5: every real `kind:"state"`/`kind:"patch"` frame carries
@@ -102,6 +109,56 @@ describe("WsTransport", () => {
     socket.receive({ kind: "state", topic: "a", payload: { schemaVersion: READER_SCHEMA_VERSION, x: 1 } });
     expect(a).toHaveLength(1);
     expect(b).toHaveLength(0);
+  });
+
+  it("replays the last compatible full snapshot to a late topic subscriber without another wire subscribe", () => {
+    const t = makeTransport();
+    const first: unknown[] = [];
+    const late: unknown[] = [];
+    t.subscribe("app-settings", (payload) => first.push(payload));
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    const snapshot = { schemaVersion: READER_SCHEMA_VERSION, revision: 7, theme: "dark" };
+    socket.receive({ kind: "state", topic: "app-settings", payload: snapshot });
+    const sentBeforeLateSubscribe = socket.sent.length;
+
+    t.subscribe("app-settings", (payload) => late.push(payload));
+
+    expect(first).toEqual([snapshot]);
+    expect(late).toEqual([snapshot]);
+    expect(socket.sent).toHaveLength(sentBeforeLateSubscribe);
+  });
+
+  it("never replays a patch as state and requests a fresh snapshot after a patch invalidates the cache", () => {
+    const t = makeTransport();
+    const patches: unknown[] = [];
+    const lateStates: unknown[] = [];
+    t.subscribe("scene", () => {});
+    t.subscribePatch("scene", (patch) => patches.push(patch));
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+    socket.receive({
+      kind: "state",
+      topic: "scene",
+      payload: { schemaVersion: READER_SCHEMA_VERSION, revision: 1, nodes: [] },
+    });
+    socket.receive({
+      kind: "patch",
+      topic: "scene",
+      schemaVersion: READER_SCHEMA_VERSION,
+      minCompatibleSchemaVersion: READER_SCHEMA_VERSION,
+      revision: 2,
+      baseRevision: 1,
+      ops: [{ op: "removeNode", id: "n1" }],
+    });
+
+    t.subscribe("scene", (payload) => lateStates.push(payload));
+
+    expect(patches).toEqual([{ revision: 2, baseRevision: 1, ops: [{ op: "removeNode", id: "n1" }] }]);
+    expect(lateStates).toEqual([]);
+    expect(socket.lastSent()).toEqual({ kind: "subscribe", topics: ["scene"] });
   });
 
   it("intent() is a silent no-op before the socket opens (bridge parity)", () => {
@@ -532,6 +589,64 @@ describe("WsTransport", () => {
     t.resubscribe("scene");
 
     expect(socket.lastSent()).toEqual({ kind: "subscribe", topics: ["scene"] });
+  });
+
+  it("matches an explicit snapshot fence by id and runs it before ordinary listeners", () => {
+    const t = makeTransport();
+    const order: string[] = [];
+    t.subscribe("app-composer", () => order.push("ordinary"));
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    socket.open();
+
+    expect(t.resubscribe("app-composer", () => order.push("fence"))).toBe(true);
+    const request = socket.lastSent();
+    expect(request).toMatchObject({ kind: "subscribe", topics: ["app-composer"], id: expect.any(Number) });
+
+    // A buffered broadcast from before the request is still an ordinary
+    // snapshot even if it arrives first; it must not release the fence.
+    socket.receive({
+      kind: "state",
+      topic: "app-composer",
+      payload: { schemaVersion: READER_SCHEMA_VERSION, revision: 1 },
+    });
+    socket.receive({
+      kind: "state",
+      topic: "app-composer",
+      id: request.id,
+      payload: { schemaVersion: READER_SCHEMA_VERSION, revision: 2 },
+    });
+
+    expect(order).toEqual(["ordinary", "fence", "ordinary"]);
+  });
+
+  it("reissues a pending correlated snapshot fence after reconnect", () => {
+    const t = makeTransport();
+    t.subscribe("app-composer", () => {});
+    t.connect();
+    const first = FakeSocket.instances[0];
+    first.open();
+    const fence = vi.fn();
+    t.resubscribe("app-composer", fence);
+    const request = first.lastSent();
+
+    first.onclose?.();
+    vi.advanceTimersByTime(10_000);
+    const reconnected = FakeSocket.instances[1];
+    reconnected.open();
+    expect(reconnected.sent.map((raw) => JSON.parse(raw))).toContainEqual({
+      kind: "subscribe",
+      topics: ["app-composer"],
+      id: request.id,
+    });
+
+    reconnected.receive({
+      kind: "state",
+      topic: "app-composer",
+      id: request.id,
+      payload: { schemaVersion: READER_SCHEMA_VERSION, revision: 3 },
+    });
+    expect(fence).toHaveBeenCalledOnce();
   });
 
   it("resubscribe() is a no-op while the socket is not open", () => {
@@ -1195,6 +1310,67 @@ describe("offline intent queue (ADR-003 stage 3.6)", () => {
       intent: "showError",
       args: ["1 change could not be sent while disconnected."],
     });
+  });
+
+  it("keeps the latest offline draft in a reserved coalesced slot after 50 ordinary writes", async () => {
+    const t = makeTransport();
+    t.connect();
+    const socket = FakeSocket.instances[0];
+    const firstSettled = vi.fn();
+    const firstCoalesced = vi.fn();
+    const secondSettled = vi.fn();
+    const secondCoalesced = vi.fn();
+    const latestSettled = vi.fn();
+
+    t.fireIntent(
+      "app-composer",
+      "updateDraft",
+      ["first"],
+      undefined,
+      true,
+      COMPOSER_DRAFT_OFFLINE_COALESCE_KEY,
+      firstSettled,
+      firstCoalesced,
+    );
+    for (let i = 0; i < 50; i++) {
+      t.fireIntent("scene", "moveNodes", [[{ id: `n${i}`, x: i, y: i }]], undefined, true);
+    }
+    t.fireIntent(
+      "app-composer",
+      "updateDraft",
+      ["second"],
+      undefined,
+      true,
+      COMPOSER_DRAFT_OFFLINE_COALESCE_KEY,
+      secondSettled,
+      secondCoalesced,
+    );
+    t.fireIntent(
+      "app-composer",
+      "updateDraft",
+      ["latest"],
+      undefined,
+      true,
+      COMPOSER_DRAFT_OFFLINE_COALESCE_KEY,
+      latestSettled,
+    );
+
+    expect(firstCoalesced).toHaveBeenCalledOnce();
+    expect(secondCoalesced).toHaveBeenCalledOnce();
+    expect(firstSettled).not.toHaveBeenCalled();
+    expect(secondSettled).not.toHaveBeenCalled();
+
+    socket.open();
+    const sent = socket.sent.map((raw) => JSON.parse(raw));
+    expect(sent.filter((message) => message.intent === "moveNodes")).toHaveLength(50);
+    const drafts = sent.filter((message) => message.intent === "updateDraft");
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].args).toEqual(["latest"]);
+    expect(sent).not.toContainEqual(expect.objectContaining({ intent: "showError" }));
+
+    socket.receive({ kind: "result", id: drafts[0].id, value: null });
+    await Promise.resolve();
+    expect(latestSettled).toHaveBeenCalledOnce();
   });
 
   it("status is 'reconnecting', not 'connecting', on every attempt after a real connection was lost", () => {

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -153,6 +153,15 @@ export type PatchListener = (patch: ScenePatch) => void;
  * with the current value on subscribe" contract - see onVersionRejection. */
 export type VersionRejectionListener = (rejection: BridgeRejection | null) => void;
 
+/** The one offline intent whose intermediate values are deliberately
+ * replaceable. This is exported rather than inferred from `queueable`: most
+ * queueable intents (node positions, settings, etc.) still preserve every
+ * accepted write in order, while a text draft is explicitly last-write-wins. */
+export const COMPOSER_DRAFT_OFFLINE_COALESCE_KEY = "app-composer/updateDraft";
+export type OfflineIntentCoalesceKey = typeof COMPOSER_DRAFT_OFFLINE_COALESCE_KEY;
+export type IntentSettledListener = () => void;
+export type OfflineIntentCoalescedListener = () => void;
+
 interface WsLike {
   send(data: string): void;
   close(): void;
@@ -196,6 +205,23 @@ export class WsTransport {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   private readonly stateListeners = new Map<string, Set<StateListener>>();
+  /** Last compatible full snapshot for each still-observed topic. Several
+   * dialogs subscribe lazily after an app-level store has already caused
+   * the server's one subscribe snapshot to arrive; replaying it gives those
+   * listeners the same current-state-on-subscribe contract as onStatus(). */
+  private readonly stateSnapshots = new Map<string, Record<string, unknown>>();
+  /** Deduplicates snapshot requests when multiple listeners mount before
+   * the first response. A patch invalidates stateSnapshots, after which a
+   * late state listener uses this set to request one fresh full snapshot. */
+  private readonly snapshotRequestsPending = new Set<string>();
+  /** Correlated one-shot callbacks for explicit resubscribe() requests.
+   * Topic-only "next state" matching is insufficient because a buffered
+   * broadcast can arrive after an intent result but before the requested
+   * snapshot; the echoed request id identifies the actual authority fence. */
+  private readonly resubscribeListeners = new Map<
+    number,
+    { topic: string; listener: StateListener }
+  >();
   private readonly statusListeners = new Set<StatusListener>();
   /** Keyed by requestId - stream deltas are addressed to a specific in-flight
    * request, not a topic. See handleMessage()'s "stream" branch. */
@@ -264,6 +290,9 @@ export class WsTransport {
     intent: string;
     args: unknown[];
     timeoutMs?: number;
+    coalesceKey?: OfflineIntentCoalesceKey;
+    onSettled?: IntentSettledListener;
+    onOfflineCoalesced?: OfflineIntentCoalescedListener;
   }> = [];
   private static readonly OFFLINE_QUEUE_MAX = 50;
 
@@ -308,11 +337,19 @@ export class WsTransport {
       const topics = [...new Set([...this.stateListeners.keys(), ...this.patchListeners.keys()])];
       if (topics.length > 0) {
         socket.send(JSON.stringify({ kind: "subscribe", topics }));
+        for (const topic of topics) this.snapshotRequestsPending.add(topic);
       }
       // ADR-003 stage 3.6: AFTER re-subscribing, so a replayed intent
       // (e.g. moveNodes) applies against fresh server state rather than
       // racing the subscribe message.
       this.flushOfflineQueue();
+      // A connection can close after an explicit snapshot request is sent
+      // but before its correlated response arrives. Reissue those fences
+      // after ordinary subscriptions and queued writes on the new socket.
+      for (const [id, request] of this.resubscribeListeners) {
+        socket.send(JSON.stringify({ kind: "subscribe", topics: [request.topic], id }));
+        this.snapshotRequestsPending.add(request.topic);
+      }
     };
     socket.onmessage = (event) => {
       if (this.socket !== socket) return;
@@ -324,6 +361,7 @@ export class WsTransport {
     socket.onclose = () => {
       if (this.socket !== socket) return;
       this.socket = null;
+      this.snapshotRequestsPending.clear();
       // ADR-003 stage 3.6 review-fix: the paused state has to cover the WHOLE
       // outage, not just an in-flight connect attempt. This used to publish
       // "closed" here and leave connect() - which only runs after a 500ms-4s
@@ -349,24 +387,34 @@ export class WsTransport {
     this.failAllPending(new WsUnavailableError("transport disposed"));
     this.socket?.close();
     this.socket = null;
+    this.snapshotRequestsPending.clear();
+    this.resubscribeListeners.clear();
   }
 
   getStatus(): ConnectionStatus {
     return this.status;
   }
 
-  /** Listen for a topic's snapshots. Subscribing while open sends the
-   * subscribe immediately so the current snapshot arrives. */
+  /** Listen for a topic's snapshots. A compatible full snapshot already
+   * received for another listener is replayed synchronously; otherwise an
+   * open socket requests one (deduplicated while that request is pending). */
   subscribe(topic: string, listener: StateListener): () => void {
     let set = this.stateListeners.get(topic);
-    const isNewTopic = !set;
     if (!set) {
       set = new Set();
       this.stateListeners.set(topic, set);
     }
     set.add(listener);
-    if (isNewTopic && this.status === "open" && this.socket) {
+    const snapshot = this.stateSnapshots.get(topic);
+    if (snapshot) {
+      listener(snapshot);
+    } else if (
+      this.status === "open" &&
+      this.socket &&
+      !this.snapshotRequestsPending.has(topic)
+    ) {
       this.socket.send(JSON.stringify({ kind: "subscribe", topics: [topic] }));
+      this.snapshotRequestsPending.add(topic);
     }
     return () => {
       set.delete(listener);
@@ -377,16 +425,27 @@ export class WsTransport {
 
   /** ADR-003 stage 3.4: re-request a topic's current full snapshot.
    *
-   * `subscribe()` above sends its subscribe message only for a topic's FIRST
-   * listener (the isNewTopic guard), so an already-subscribed topic has no
-   * way to ask for fresh state through it - this is that missing half, used
-   * by the scene store to self-heal after a detected patch gap. Silently
-   * no-ops while the socket is not open, matching intent()'s own
-   * pre-connect behavior: reconnecting re-subscribes every topic from
-   * scratch anyway, which resolves the gap by itself. */
-  resubscribe(topic: string): void {
-    if (this.status !== "open" || !this.socket) return;
-    this.socket.send(JSON.stringify({ kind: "subscribe", topics: [topic] }));
+   * `subscribe()` above replays a valid cached snapshot when one exists, so
+   * an already-subscribed consumer that knows its state is stale needs an
+   * explicit way to bypass that cache - this is that path, used by the scene
+   * store to self-heal after a detected patch gap. Silently no-ops while the
+   * socket is not open, matching intent()'s own pre-connect behavior:
+   * reconnecting re-subscribes every topic from scratch anyway, which
+   * resolves the gap by itself. */
+  resubscribe(topic: string, onSnapshot?: StateListener): boolean {
+    if (this.status !== "open" || !this.socket) return false;
+    let id: number | undefined;
+    if (onSnapshot) {
+      id = this.nextId++;
+      this.resubscribeListeners.set(id, { topic, listener: onSnapshot });
+    }
+    this.socket.send(JSON.stringify({
+      kind: "subscribe",
+      topics: [topic],
+      ...(id === undefined ? {} : { id }),
+    }));
+    this.snapshotRequestsPending.add(topic);
+    return true;
   }
 
   /** ADR-003 stage 3.4: listen for a topic's `kind:"patch"` deltas. Sends no
@@ -466,8 +525,8 @@ export class WsTransport {
     };
   }
 
-  /** ADR-003 stage 3.5 review-fix: drops `versionRejections`' cached entry
-   * for `topic` once nothing is listening to it via ANY of the three
+  /** Drops a topic's per-topic caches once nothing is listening to it via
+   * ANY of the three
    * per-topic registries - state, patch, or rejection. Keyed off all three
    * (not just versionRejectionListeners alone) deliberately: a topic can
    * still have live state/patch listeners with no rejection listener
@@ -486,6 +545,11 @@ export class WsTransport {
     if (this.patchListeners.has(topic)) return;
     if (this.versionRejectionListeners.has(topic)) return;
     this.versionRejections.delete(topic);
+    this.stateSnapshots.delete(topic);
+    this.snapshotRequestsPending.delete(topic);
+    for (const [id, request] of this.resubscribeListeners) {
+      if (request.topic === topic) this.resubscribeListeners.delete(id);
+    }
   }
 
   /** ADR-003 stage 3.5 review-fix: blocks intent()/request() (and so
@@ -605,7 +669,16 @@ export class WsTransport {
    * WsTopicBlockedError banner; while not open - where no banner can be
    * delivered at all - by being counted into the reconnect summary like any
    * other loss. */
-  fireIntent(topic: string, intent: string, args: unknown[] = [], timeoutMs?: number, queueable = false): void {
+  fireIntent(
+    topic: string,
+    intent: string,
+    args: unknown[] = [],
+    timeoutMs?: number,
+    queueable = false,
+    offlineCoalesceKey?: OfflineIntentCoalesceKey,
+    onSettled?: IntentSettledListener,
+    onOfflineCoalesced?: OfflineIntentCoalescedListener,
+  ): void {
     // ADR-003 stage 3.6 x stage 3.5 interaction: a blocked topic must NEVER
     // enter the offline queue. Blocking exists precisely because this client
     // cannot trust the state these args were computed against, so holding
@@ -624,28 +697,56 @@ export class WsTransport {
     // topics are refused, and being refused is reported like any other loss.
     if (this.status !== "open") {
       if (queueable && !this.blockedTopics.has(topic)) {
-        this.enqueueOffline(topic, intent, args, timeoutMs);
+        this.enqueueOffline(
+          topic,
+          intent,
+          args,
+          timeoutMs,
+          offlineCoalesceKey,
+          onSettled,
+          onOfflineCoalesced,
+        );
       } else {
         this.droppedWhileOffline += 1;
+        onSettled?.();
       }
       return;
     }
-    this.request(topic, intent, args, timeoutMs).catch((err) => {
-      // A disposed transport is real teardown (unmount, or StrictMode's
-      // dev-only dispose-then-remount check) - there is nothing left to
-      // recover into.
-      if (this.disposed) return;
-      if (err instanceof WsUnavailableError) {
-        // Was genuinely in flight (status was "open" when sent) and got cut
-        // off mid-request rather than refused up front - same fate as the
-        // not-open case above either way: recoverable data is queued,
-        // everything else is counted for the next reconnect's summary.
-        if (queueable) this.enqueueOffline(topic, intent, args, timeoutMs);
-        else this.droppedWhileOffline += 1;
-        return;
-      }
-      this.showErrorDeduped(String(err.message));
-    });
+    this.request(topic, intent, args, timeoutMs).then(
+      () => onSettled?.(),
+      (err) => {
+        // A disposed transport is real teardown (unmount, or StrictMode's
+        // dev-only dispose-then-remount check) - there is nothing left to
+        // recover into.
+        if (this.disposed) {
+          onSettled?.();
+          return;
+        }
+        if (err instanceof WsUnavailableError) {
+          // Was genuinely in flight (status was "open" when sent) and got cut
+          // off mid-request rather than refused up front - same fate as the
+          // not-open case above either way: recoverable data is queued,
+          // everything else is counted for the next reconnect's summary.
+          if (queueable) {
+            this.enqueueOffline(
+              topic,
+              intent,
+              args,
+              timeoutMs,
+              offlineCoalesceKey,
+              onSettled,
+              onOfflineCoalesced,
+            );
+          } else {
+            this.droppedWhileOffline += 1;
+            onSettled?.();
+          }
+          return;
+        }
+        this.showErrorDeduped(String(err.message));
+        onSettled?.();
+      },
+    );
   }
 
   /** ADR-003 stage 3.6: how many non-queueable intents were refused while
@@ -672,13 +773,56 @@ export class WsTransport {
    * droppedWhileOffline) rather than silently evicting an older,
    * already-accepted one: evicting silently would just move the
    * "vanishes with no signal" failure from the un-queued case onto the
-   * queued one. */
-  private enqueueOffline(topic: string, intent: string, args: unknown[], timeoutMs?: number): void {
-    if (this.offlineQueue.length >= WsTransport.OFFLINE_QUEUE_MAX) {
-      this.droppedWhileOffline += 1;
+   * queued one.
+   *
+   * The composer draft is the narrow exception: its call site supplies the
+   * explicit coalesce key above, so a newer queued value replaces the older
+   * value in place. One reserved entry lets that key survive even when all
+   * 50 ordinary slots are occupied; this keeps the queue bounded at 51 while
+   * never evicting an already-accepted non-draft operation. */
+  private enqueueOffline(
+    topic: string,
+    intent: string,
+    args: unknown[],
+    timeoutMs?: number,
+    offlineCoalesceKey?: OfflineIntentCoalesceKey,
+    onSettled?: IntentSettledListener,
+    onOfflineCoalesced?: OfflineIntentCoalescedListener,
+  ): void {
+    // Runtime-check the key's target as well as typing it narrowly. A future
+    // JavaScript caller must not gain replacement/reserved-slot semantics for
+    // an unrelated operation merely by copying this string.
+    const coalesceKey =
+      offlineCoalesceKey === COMPOSER_DRAFT_OFFLINE_COALESCE_KEY &&
+      topic === "app-composer" &&
+      intent === "updateDraft"
+        ? offlineCoalesceKey
+        : undefined;
+    const item = { topic, intent, args, timeoutMs, coalesceKey, onSettled, onOfflineCoalesced };
+    if (coalesceKey) {
+      const existing = this.offlineQueue.findIndex((queued) => queued.coalesceKey === coalesceKey);
+      if (existing >= 0) {
+        // Replace in place: latest draft wins without perturbing the replay
+        // order of any independent queueable intents around it.
+        this.offlineQueue[existing].onOfflineCoalesced?.();
+        this.offlineQueue[existing] = item;
+        return;
+      }
+      // This key owns one dedicated slot beyond the 50 ordinary entries, so
+      // a draft first edited after saturation is still recoverable.
+      this.offlineQueue.push(item);
       return;
     }
-    this.offlineQueue.push({ topic, intent, args, timeoutMs });
+    const ordinaryCount = this.offlineQueue.reduce(
+      (count, queued) => count + (queued.coalesceKey ? 0 : 1),
+      0,
+    );
+    if (ordinaryCount >= WsTransport.OFFLINE_QUEUE_MAX) {
+      this.droppedWhileOffline += 1;
+      onSettled?.();
+      return;
+    }
+    this.offlineQueue.push(item);
   }
 
   /** ADR-003 stage 3.6: replays every queued intent, in the order they were
@@ -698,7 +842,16 @@ export class WsTransport {
     if (this.offlineQueue.length > 0) {
       const queued = this.offlineQueue.splice(0, this.offlineQueue.length);
       for (const item of queued) {
-        this.fireIntent(item.topic, item.intent, item.args, item.timeoutMs, true);
+        this.fireIntent(
+          item.topic,
+          item.intent,
+          item.args,
+          item.timeoutMs,
+          true,
+          item.coalesceKey,
+          item.onSettled,
+          item.onOfflineCoalesced,
+        );
       }
     }
     if (this.droppedWhileOffline > 0) {
@@ -759,6 +912,7 @@ export class WsTransport {
     if (kind === "state") {
       const topic = message.topic as string;
       const payload = message.payload as Record<string, unknown>;
+      this.snapshotRequestsPending.delete(topic);
       // ADR-003 stage 3.5: the version envelope lives INSIDE payload for a
       // state frame (see _Topic._stamp on the backend) - checked and, on
       // rejection, dispatched to NOTHING below. A rejected payload is stale
@@ -767,7 +921,19 @@ export class WsTransport {
       // this stage exists to replace: at least the old frozen-UI failure
       // mode didn't also risk running shape validation against fields a
       // breaking version change may have renamed or removed.
-      if (!this.checkVersionAndMaybeReject(topic, payload)) return;
+      if (!this.checkVersionAndMaybeReject(topic, payload)) {
+        this.stateSnapshots.delete(topic);
+        return;
+      }
+      this.stateSnapshots.set(topic, payload);
+      const snapshotRequestId = message.id;
+      if (typeof snapshotRequestId === "number") {
+        const resubscribeRequest = this.resubscribeListeners.get(snapshotRequestId);
+        if (resubscribeRequest?.topic === topic) {
+          this.resubscribeListeners.delete(snapshotRequestId);
+          resubscribeRequest.listener(payload);
+        }
+      }
       const listeners = this.stateListeners.get(topic);
       if (listeners) {
         for (const listener of [...listeners]) listener(payload);
@@ -782,6 +948,11 @@ export class WsTransport {
       // configuration, not an anomaly - same posture as the stream branch
       // below, and deliberately unlike the unknown-kind fallback at the end.
       const topic = message.topic as string;
+      // A generic transport cannot safely apply arbitrary topic patches to
+      // a cached payload. Drop the now-stale full snapshot; a state listener
+      // that mounts later will request a fresh one, while this patch keeps
+      // routing only through subscribePatch as before.
+      this.stateSnapshots.delete(topic);
       // ADR-003 stage 3.5: unlike a state frame, the version envelope is at
       // the TOP LEVEL of a patch frame, a sibling of ops/revision (see
       // _publish_now's broadcast dict on the backend) - `message` itself is


### PR DESCRIPTION
## Summary

This bounded QA pass fixes five reproducible correctness issues across persistence and the WebSocket client:

- keep the open graph's optimistic-save token synchronized when it is renamed, and serialize rename with save/load/autosave mutations
- defer idle-session eviction while a chat mutation is active so an autosave cannot be cancelled before its database write begins
- restore nested containers by resolving serialized container dependencies and publishing restored container IDs into the item map
- keep composer drafts optimistic across stale/out-of-order server snapshots, including repeated-value edits, and coalesce offline draft updates with latest-write-wins semantics
- replay compatible full snapshots to late subscribers and correlate explicit resubscribe snapshots so buffered broadcasts cannot release an optimistic-state fence

## Root cause and impact

The persistence failures came from state that was valid in isolation but not coordinated across adjacent operations: rename advanced the database timestamp without advancing the session token, eviction treated an active mutation as a reason to skip the final flush but still cancelled its task, and the loader never added restored containers to the same tail-index map used by serialization. These paths could reject a user's next save, discard dirty state during teardown, or silently omit an outer nested container.

On the frontend, controlled composer text waited for server round trips and could be rolled backward by stale snapshots. A simple value match is not a safe acknowledgement because edits can legitimately follow A → B → A. The transport also lacked a current-state-on-subscribe contract for lazy consumers. The fix uses local draft generations, terminal request settlement, a correlated follow-up snapshot, bounded offline coalescing, and compatible full-snapshot caching.

The subscribe correlation field is optional and backward compatible: ordinary subscribe/state frames remain unchanged when no request ID is supplied. Correlated snapshots are preserved under buffered queue pressure.

## Validation

- `python -m pytest -q --ignore=backend/tests/perf` — **2,991 passed, 17 skipped**
- `python -m pytest -q backend/tests/perf` — **8 passed**
- `python -m compileall -q .`
- `python -m ruff check .`
- `python -m mypy` — **no issues**
- `npm run check` — schema drift check, typecheck, lint, **1,922 tests**, production build, and bundle budgets all passed
- focused composer/transport and correlated-backpressure regressions passed
- independent backend and frontend/protocol adversarial reviews found no remaining actionable regression

Lint reports the repository's existing Fast Refresh warnings only (0 errors).