### PR TITLE
Keep off-screen culling paused while dragging

### DIFF
--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -2294,6 +2294,22 @@ function CanvasInner({
   const [smartGuideLines, setSmartGuideLines] = useState<GuideLine[]>([]);
   const visibleGuideLines = scene.smartGuides ? smartGuideLines : [];
 
+  // True for exactly the duration of an active node-drag gesture, mirrored
+  // from onNodesChange's own dragging/drag-end changes (state, unlike
+  // draggingRef, because it must re-render <ReactFlow> with a different
+  // onlyRenderVisibleElements value below). Why it exists: with
+  // off-viewport culling active, React Flow removes any node whose rect
+  // leaves the viewport - INCLUDING the node currently being dragged.
+  // Measured on a real scene: dragging a connected node across the
+  // viewport boundary unmounted it mid-gesture for 49 straight frames (the
+  // node simply vanished under the cursor) while its edge stayed rendered,
+  // pointing at nothing. Auto-pan during a drag makes this worse: every
+  // node the pan pushes across the boundary pops in or out mid-gesture.
+  // Suspending culling for the duration of the drag (same suspension
+  // mechanism exportInProgress already uses) keeps everything mounted while
+  // anything is moving; culling resumes the moment the drag ends.
+  const [dragActive, setDragActive] = useState(false);
+
   // R8a (UI/UX issue list finding #11): the View popover's FONT section
   // (family/size/color) already round-trips real intents into scene state -
   // nothing ever consumed them. Written as CSS custom properties on the
@@ -2598,6 +2614,11 @@ function CanvasInner({
       } else if (sawDragEnd) {
         setSmartGuideLines((current) => (current.length === 0 ? current : []));
       }
+      // Suspend off-viewport culling while a drag is in flight - see
+      // dragActive's own doc comment above. Same-value setState calls
+      // (every frame after the first) bail out without a re-render.
+      if (sawDragging) setDragActive(true);
+      else if (sawDragEnd) setDragActive(false);
       setNodes((current) => applyNodeChanges([...scaled, ...memberChanges], current));
     },
     [nodes, scene.dragFactor, scene.smartGuides, reactFlow, store],
@@ -2735,7 +2756,7 @@ function CanvasInner({
          *   via exportInProgress above, which that module now sets for the
          *   capture's duration.
          */
-        onlyRenderVisibleElements={!exportInProgress}
+        onlyRenderVisibleElements={!exportInProgress && !dragActive}
       >
         <Background
           variant={GRID_VARIANTS[grid.gridStyle] ?? BackgroundVariant.Dots}


### PR DESCRIPTION
## Problem

The canvas saves work by only rendering nodes that are currently inside the visible area. That optimization stayed active during drag gestures. When a drag makes the view follow the pointer, nodes and connections near the edge of the screen cross in and out of the visible area mid-gesture, and the renderer was removing and re-inserting them while everything was moving. On a crowded canvas this showed up as nodes and connections popping in and out during a drag - measured at over a hundred consecutive frames with a node and its connection missing during one drag that panned the view.

## Change

A flag now tracks each drag gesture from its first movement to its release, and the only-render-visible optimization is paused while the flag is set - the same suspension mechanism the image-export path already uses. Culling resumes as soon as the drag ends, so the savings on large scenes are unchanged except during the gesture itself.

## Test plan

- [x] Full frontend check passes: schema check, type check, lint (0 errors), 1927/1927 tests, production build, bundle-size check
- [x] Scripted-drag measurement in headless Chromium, before and after: with the fix, zero frames during a boundary-crossing drag had the dragged node or its connection unrendered, and connection endpoints stayed within 8 pixels of the node's connection point on every frame - including with the processor throttled sixfold to simulate a heavily loaded machine