### PR TITLE
Keep node cards and connection lines on the same compositing path

### DIFF
--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -403,6 +403,26 @@ body,
   font-size: var(--gl-node-font-size, 11px);
 }
 
+/* Dark-theme drag-lag fix: node cards move as GPU-composited layers (the
+   browser promotes them on its own once their transform changes every
+   frame of a drag), while the connection lines live in an SVG that gets
+   re-rasterized on the main thread. Those are two different routes to the
+   screen, and when they fall a frame out of step the connection visibly
+   trails or stutters against the node it is attached to. The 1.5px stroke
+   on a near-black background makes every misstep stark in dark mode; the
+   identical misstep is nearly invisible against the light theme, which is
+   why the artifact reads as dark-only. Declaring will-change on BOTH the
+   node wrappers and the connection layer makes the browser put them on the
+   same compositing path from the first frame, instead of flipping the
+   nodes onto a separate one mid-gesture. */
+.scene-canvas .react-flow__node {
+  will-change: transform;
+}
+
+.scene-canvas .react-flow__edges {
+  will-change: transform;
+}
+
 .scene-canvas .react-flow__edge-path {
   stroke: var(--gl-surface-border-strong, var(--gl-surface-text-muted));
   stroke-width: 1.5;


### PR DESCRIPTION
## Problem

While dragging a node, its connection line can visibly trail or stutter instead of staying pinned to the node. The problem was reported as dark-mode-only: switching the app to the light theme makes it disappear.

The two behaviors have one explanation. Node cards are moved by the graphics processor as independent layers - the browser quietly promotes them to that fast path once their position starts changing every frame. The connection lines live in a drawing layer that is redrawn on the main processor. Content traveling by two different routes to the screen can arrive a frame out of step, and when it does, the line lags the node it is attached to. A thin bright line on a near-black background makes each misstep obvious; the identical misstep on a white background is nearly invisible. Dark mode does not cause the problem - it reveals it. This is also why measurements of the page's internal layout kept reporting the line perfectly attached while the screen showed otherwise: the divergence happens after layout, at the final composition step.

## Change

One stylesheet addition: declare `will-change: transform` on both the node wrappers and the connection layer. This tells the browser up front to give both the same treatment, instead of promoting nodes to a separate path partway through a drag gesture. No behavior, markup, or code-path changes - the drawing pipeline is simply aligned from the first frame.

## Test plan

- [x] Production build succeeds with the change
- [ ] Verify in the desktop app, dark theme: drag a connected node slowly around the canvas and confirm the connection stays pinned to the node - this is the reporter's reproduction and requires visual confirmation on the affected machine