### PR TITLE
Redesign the app bar with a fixed three-column layout and grouped controls

### DIFF
--- a/web_ui/e2e/boot.spec.ts
+++ b/web_ui/e2e/boot.spec.ts
@@ -22,9 +22,16 @@ test("boots against the real backend and renders the canvas shell", async ({ pag
   await expect(page.getByTestId("scene-canvas")).toBeVisible();
   await expect(page.locator(".react-flow__viewport")).toBeVisible();
 
-  // The connection badge (connectionBadge.ts) reporting the real WS
-  // handshake's outcome, not just "the page loaded".
-  await expect(page.locator(".app-conn-open")).toHaveText("connected");
+  // The real WS handshake's outcome (App.tsx's data-connection-status),
+  // not just "the page loaded". gotoApp already waited on this exact
+  // attribute to reach "open" before returning, so this is a direct
+  // re-assertion of that same state rather than a race - the app bar and
+  // canvas checks above ran after that wait, and a WS drop between then and
+  // now is exactly the kind of regression this line exists to catch.
+  // connectionBadge.ts's own label text is NOT asserted here any more: it
+  // now renders only for a degraded connection (App.tsx), so "connected"
+  // has no visible text to check on the happy path this test exercises.
+  await expect(page.locator('.app-shell[data-connection-status="open"]')).toBeAttached();
 
   // A fresh session has zero nodes - SceneCanvas.tsx's own empty-state hint
   // is the honest "nothing broken, genuinely nothing here yet" signal for

--- a/web_ui/e2e/helpers.ts
+++ b/web_ui/e2e/helpers.ts
@@ -6,11 +6,16 @@ import { expect, type Page } from "@playwright/test";
  *
  * Two things every spec would otherwise have to repeat:
  *
- * 1. Wait for the REAL WS round-trip to complete (App.tsx's connection
- *    badge, `.app-conn-<status>`) before touching anything - a fresh
- *    `page.goto("/")` returns as soon as the SPA shell's static HTML/JS
- *    loads, well before the WsTransport handshake against the real backend
- *    (tests_e2e/run_backend.py) has actually completed.
+ * 1. Wait for the REAL WS round-trip to complete (App.tsx's
+ *    `data-connection-status` attribute on `.app-shell`) before touching
+ *    anything - a fresh `page.goto("/")` returns as soon as the SPA shell's
+ *    static HTML/JS loads, well before the WsTransport handshake against the
+ *    real backend (tests_e2e/run_backend.py) has actually completed. This
+ *    used to wait on the visible connection badge (`.app-conn-open`), which
+ *    stopped being a reliable signal once that badge became exception-only
+ *    (App.tsx renders nothing there for a healthy connection by design) -
+ *    the attribute is the same underlying signal without depending on
+ *    whatever the topbar currently chooses to show for it.
  * 2. Dismiss the first-run onboarding wizard (chrome/OnboardingDialog.tsx).
  *    Every E2E run boots against a BRAND NEW settings_state_file (see that
  *    script's own docstring on why - full isolation from a real user's
@@ -38,13 +43,13 @@ import { expect, type Page } from "@playwright/test";
  */
 export async function gotoApp(page: Page): Promise<void> {
   await page.goto("/");
-  await expect(page.locator(".app-conn-open")).toBeVisible();
+  await expect(page.locator('.app-shell[data-connection-status="open"]')).toBeAttached();
 
   // waitFor (not isVisible(), which resolves immediately either way) is
   // deliberate: the app-settings snapshot that decides whether onboarding
-  // auto-opens arrives asynchronously over the SAME WS connection
-  // app-conn-open just confirmed, so it can genuinely still be in flight at
-  // this exact line. A bare isVisible() check here would race it - "not
+  // auto-opens arrives asynchronously over the SAME WS connection the
+  // attribute above just confirmed, so it can genuinely still be in flight
+  // at this exact line. A bare isVisible() check here would race it - "not
   // visible yet" and "never opening" look identical at a single instant,
   // and picking the wrong one would leave the dialog to pop up mid-test
   // instead of being dismissed up front.

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -379,7 +379,18 @@ function App() {
     <OverlayProvider>
       <ReactFlowProvider>
         <GlobalShortcuts store={sceneStore} />
-        <div className="app-shell">
+        {/* data-connection-status: the real WS connection state, always
+            present regardless of whether the topbar renders any visual
+            indicator for it (see .app-topbar-status below - a healthy
+            connection now renders nothing there by design). The E2E suite's
+            shared boot helper (e2e/helpers.ts) waits on this attribute to
+            know the real backend round-trip has completed before touching
+            anything, which it can no longer do by waiting for a badge that
+            is often absent on purpose. Not a UI affordance - never styled,
+            never meant to be seen - so this stays a plain attribute rather
+            than a class, the same "invisible hook, not a rendered element"
+            posture as aria-live regions elsewhere in this file. */}
+        <div className="app-shell" data-connection-status={status}>
           {/* ADR-012 stage 12.3: the very first focusable element in the
               page, per the standard skip-link convention - invisible until
               it itself receives focus (Tab from anywhere before the canvas

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -400,12 +400,39 @@ function App() {
           <div aria-live="polite" role="status" className="visually-hidden">
             {announcement}
           </div>
+          {/* Three declared grid tracks - brand, toolbar, status - so the
+              regions of a permanently-visible bar have fixed homes and
+              cannot encroach on one another. See .app-topbar in styles.css
+              and AppBar.tsx's own layout contract. */}
           <header className="app-topbar">
-            <span className="app-title">Graphlink</span>
+            <div className="app-topbar-brand">
+              <svg aria-hidden="true" viewBox="0 0 24 24" className="app-brand-mark">
+                <circle cx="6" cy="7" r="2.6" />
+                <circle cx="18" cy="6" r="2.6" />
+                <circle cx="12" cy="17.5" r="2.6" />
+                <path d="M7.6 8.9 10.8 15M16.6 8.2 13.3 15M8.5 6.6h6.9" />
+              </svg>
+              <span className="app-title">Graphlink</span>
+            </div>
             <AppBar store={sceneStore} />
-            <span className={`app-conn app-conn-${status}`} title={`backend ${system.backendVersion ?? ""}`}>
-              {connectionBadgeLabel(status)}
-            </span>
+            {/* Exception-only: a healthy connection shows nothing at all.
+                A permanent "connected" badge reports the expected state on
+                every frame and carries no information. The degraded states
+                do carry information - "reconnecting" is the app's own
+                answer to "why did my click do nothing", since intents are
+                queued or refused while it shows (see connectionBadge.ts) -
+                so those still surface, and only those. */}
+            <div className="app-topbar-status">
+              {status !== "open" && (
+                <span
+                  className={`app-conn app-conn-${status}`}
+                  title={`backend ${system.backendVersion ?? ""}`}
+                >
+                  <span className="app-conn-dot" aria-hidden="true" />
+                  {connectionBadgeLabel(status)}
+                </span>
+              )}
+            </div>
           </header>
 
           <main className="app-canvas-region">

--- a/web_ui/src/app/chrome/AppBar.test.tsx
+++ b/web_ui/src/app/chrome/AppBar.test.tsx
@@ -197,19 +197,29 @@ describe("AppBar", () => {
       await user.click(screen.getByRole("button", { name: "More toolbar actions" }));
       const menu = screen.getByRole("dialog");
 
+      // Tiers live on the GROUP wrapper, not the individual button: the
+      // bar collapses whole clusters so related actions stay together at
+      // every width instead of leaving fragments behind (see AppBar.tsx).
+      // The contract this pins is unchanged though - an inline action and
+      // its overflow duplicate must always collapse at the same tier.
       const pairs: [string, string][] = [
-        ["Export PNG", "1"],
-        ["Pins", "2"],
+        ["Undo", "1"],
+        ["Redo", "1"],
+        ["Zoom In", "1"],
+        ["Zoom Out", "1"],
+        ["Reset", "1"],
+        ["Fit All", "1"],
         ["Organize", "2"],
-        ["View", "2"],
-        ["Plugins", "2"],
-        ["Zoom In", "3"],
-        ["Zoom Out", "3"],
-        ["Reset", "3"],
-        ["Fit All", "3"],
-        ["About", "1"],
-        ["Help", "1"],
-        ["Diagnostics", "1"],
+        ["Pins", "2"],
+        ["Export PNG", "2"],
+        ["View", "3"],
+        ["Plugins", "3"],
+        ["Global Search", "4"],
+        ["Knowledge", "4"],
+        ["Builder", "4"],
+        ["Diagnostics", "4"],
+        ["Help", "4"],
+        ["About", "4"],
       ];
       for (const [label, tier] of pairs) {
         // Every duplicated pair shares its exact label except Plugins (the
@@ -222,7 +232,7 @@ describe("AppBar", () => {
         const matches = screen.getAllByRole("button", { name: new RegExp(label) });
         const inline = matches.find((el) => !menu.contains(el));
         const overflowItem = matches.find((el) => menu.contains(el));
-        expect(inline).toHaveAttribute("data-tier", tier);
+        expect(inline?.closest(".appbar-group")).toHaveAttribute("data-tier", tier);
         expect(overflowItem).toHaveAttribute("data-tier", tier);
       }
 

--- a/web_ui/src/app/chrome/AppBar.tsx
+++ b/web_ui/src/app/chrome/AppBar.tsx
@@ -4,9 +4,35 @@ import { exportCanvasAsPng } from "../canvas/exportCanvasPng";
 import { motionDuration } from "../reducedMotion";
 import type { SceneStore } from "../canvas/sceneStore";
 import { Popover, useOverlays } from "../overlays/overlays";
+import { AppBarIcon, type AppBarIconName } from "./AppBarIcon";
 
 /**
  * The app bar (Qt-removal plan R2) - the toolbar island's SPA successor.
+ *
+ * LAYOUT CONTRACT. This bar is on screen at all times, so its geometry is
+ * fixed rather than emergent:
+ *
+ * - `.app-topbar` (styles.css) is a THREE-COLUMN GRID - brand, this
+ *   toolbar, connection status - so those three regions occupy declared
+ *   tracks and cannot encroach on one another. The previous layout was one
+ *   flex row in which the status badge sat outside the toolbar and relied
+ *   on `margin-left: auto` against a `flex: 1` sibling that had already
+ *   eaten the free space, which is why it ended up jammed against the last
+ *   button instead of anchored to the window edge.
+ * - The row has a FIXED height and every control a fixed height, so the bar
+ *   never changes size with its contents.
+ * - Related actions live in `.appbar-group` containers with uniform inner
+ *   spacing and a shared surface. Grouping is what carries the visual
+ *   organisation; the old bar was one undifferentiated run of twenty text
+ *   buttons separated by ad-hoc 1px rules.
+ *
+ * ICONS vs LABELS. Frequent, app-specific verbs (Library, Save, Organize,
+ * View, Plugins) keep text - they are the vocabulary of the product and
+ * nothing draws them unambiguously. Universally-recognised mechanics (undo,
+ * redo, the four viewport controls) and the utility surfaces on the right
+ * become icons with `title` + `aria-label` carrying the exact same wording
+ * they had as text, which is what keeps them findable by keyboard, by
+ * screen reader, and by every existing test.
  *
  * Intent routing, surface by surface, against the ToolbarBridge @Slot list:
  * - zoomIn/zoomOut/resetZoom/fitAll -> React Flow viewport ops (they were
@@ -26,65 +52,111 @@ import { Popover, useOverlays } from "../overlays/overlays";
  *
  * R8a (UI/UX issue list finding #8): the provider-mode <select> that used to
  * sit here was permanently `disabled`, held exactly one hardcoded option
- * ("Ollama (Local)"), and its onChange was a literal no-op - at the time,
- * there was no setProviderMode intent anywhere in backend/ for it to call.
- * Removed outright rather than left as a dead control.
+ * ("Ollama (Local)"), and its onChange was a literal no-op. Removed outright
+ * rather than left as a dead control. ADR-006 stage 6.5 later added a real
+ * setProviderMode intent and ADR-012 stage 12.6 wired it up - but NOT back
+ * into this toolbar: a cramped toolbar select is exactly what got removed,
+ * and Settings' own per-mode pages already give that switch a home
+ * co-located with the configuration it affects.
  *
- * ADR-006 stage 6.5 later added a real setProviderMode intent
- * (backend/api/intents_settings_general.py), and ADR-012 stage 12.6 wired
- * it up - but NOT back into this toolbar. A cramped toolbar select was
- * exactly what got removed above for being broken, and Settings' 3 per-mode
- * pages (Ollama/Llama.cpp/API Endpoint - SettingsDialog.tsx) already give a
- * user somewhere to configure whichever mode they're switching to; each
- * page's own "Use This Provider" action is the real switch trigger,
- * co-located with that mode's config instead of living in a second place
- * that would need to stay in sync with it.
- *
- * R8a (finding #5): below ~1120px window width this toolbar's 12 buttons
- * (13 with the now-removed select) had no shrink/wrap/overflow behavior at
- * all, so the low end of it - Settings, About, Help, the connection status
- * next to this component - ran off the right edge of the window, dragging a
- * horizontal scrollbar across the WHOLE document with it (the canvas and
- * composer went with it, off-screen).
- *
- * Fixed with a real overflow menu, not the audit's own "minimum stopgap"
- * (bare overflow-x: auto). `.appbar` gets `min-width: 0` (a flex item
- * otherwise floors at its content's min-content width - that is what forced
- * the overflow in the first place) and `container-type: inline-size`
- * (styles.css), so its own descendants can query how much room THIS
- * toolbar - not the window - actually has. Every collapsible button is
- * rendered TWICE: once inline, once as a duplicate inside the overflow
- * menu, tagged with the same data-tier either way. Pure CSS @container
- * rules (styles.css) decide which copy is visible at the current width, in
- * three tiers (least-used collapses first) - no ResizeObserver/width-
- * measurement JS anywhere; container queries are declarative, and this app
- * targets one Chromium engine (WebView2), so there is no compatibility
- * reason to reach for JS instead. Library, Save and Settings never
- * collapse - those three are exactly what the finding flagged as becoming
- * unreachable.
+ * R8a (finding #5): below a narrow width this toolbar's buttons had no
+ * shrink/wrap/overflow behavior at all, so its right end ran off the window
+ * edge, dragging a horizontal scrollbar across the WHOLE document with it.
+ * Fixed with a real overflow menu: `.appbar` declares `container-type:
+ * inline-size` (styles.css) so its descendants can query how much room THIS
+ * toolbar - not the window - actually has, and whole GROUPS collapse in
+ * tiers (least-used first). Collapsing by group rather than by button keeps
+ * related actions together at every width instead of leaving fragments of a
+ * cluster behind. Every collapsible action is rendered twice - once inline,
+ * once inside the overflow menu, tagged with the same data-tier - and pure
+ * CSS decides which copy is visible. No ResizeObserver or width measurement
+ * anywhere; container queries are declarative and this app targets one
+ * engine (WebView2).
  *
  * The overflow menu is the shared `Popover` (overlays.tsx), NOT `NodeMenu`
  * (canvas/NodeMenu.tsx) - tried first, reverted after live testing caught a
  * real bug: NodeMenu portals to document.body, and a portaled element is no
- * longer a DESCENDANT of `.appbar` in the DOM, so it falls OUTSIDE the
- * `@container appbar` scope entirely - every item in it would have silently
- * stayed hidden forever, regardless of width. `.appbar` therefore does NOT
- * get `overflow: hidden` either (the version that used NodeMenu needed it,
- * to stop tier-hidden buttons spilling past the toolbar mid-resize, and
- * could afford it because the portaled menu didn't live inside that box to
- * begin with); the horizontal-spill backstop instead lives one level up, on
- * `.app-topbar` (`overflow-x: hidden`, with `overflow-y: visible` so it
- * does not clip this dropdown, which extends below the header row by
- * design). `Popover`'s own light-dismiss (outside pointerdown) and the
- * OverlayProvider's single-open policy (opening Settings while this is open
- * correctly closes it, same as every other surface) both apply for free.
+ * longer a DESCENDANT of `.appbar`, so it falls OUTSIDE the `@container
+ * appbar` scope entirely and every item in it would have silently stayed
+ * hidden forever. `.appbar` therefore does NOT get `overflow: hidden`
+ * either; the horizontal-spill backstop is the tier breakpoints being
+ * correctly tuned, plus the grid track above that cannot be overrun.
  *
- * Both copies of a collapsible button call the exact same handler - the
- * handler is the single source of truth for BEHAVIOR, only the two bits of
- * JSX markup (label text) are duplicated, which is what stays in sync via
- * ordinary code review rather than an abstraction neither codebase
- * precedent nor this component's small, fixed button set actually needs.
+ * Both copies of a collapsible action call the exact same handler - the
+ * handler is the single source of truth for BEHAVIOR, only the label markup
+ * is duplicated.
  */
+
+/** Text button: an app verb, where the word is the affordance. */
+function BarButton({
+  label,
+  className,
+  title,
+  disabled,
+  trigger,
+  pressed,
+  onClick,
+}: {
+  label: string;
+  className: string;
+  title?: string;
+  disabled?: boolean;
+  trigger?: string;
+  pressed?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={className}
+      title={title}
+      disabled={disabled}
+      data-overlay-trigger={trigger}
+      aria-pressed={pressed}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}
+
+/**
+ * Icon button. `label` is the accessible name AND the tooltip, so an
+ * icon-only control is never nameless - it reads identically to the text
+ * button it replaced for anything that is not a pair of eyes.
+ */
+function BarIconButton({
+  icon,
+  label,
+  className,
+  disabled,
+  trigger,
+  pressed,
+  onClick,
+}: {
+  icon: AppBarIconName;
+  label: string;
+  className: string;
+  disabled?: boolean;
+  trigger?: string;
+  pressed?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`${className} appbar-btn-icon`}
+      title={label}
+      aria-label={label}
+      disabled={disabled}
+      data-overlay-trigger={trigger}
+      aria-pressed={pressed}
+      onClick={onClick}
+    >
+      <AppBarIcon name={icon} />
+    </button>
+  );
+}
 
 export function AppBar({ store }: { store: SceneStore }) {
   const overlays = useOverlays();
@@ -114,137 +186,128 @@ export function AppBar({ store }: { store: SceneStore }) {
   // Plain actions (Organize/Zoom/Fit/Export) never touch the overlay
   // registry at all, so their overflow copies close it explicitly.
   const closeOverflow = () => overlays.close();
+  const overflowItem = (surface: string) =>
+    "appbar-overflow-item" + (overlays.isOpen(surface) ? " checked" : "");
 
   return (
     <div className="appbar" role="toolbar" aria-label="Application bar">
-      <button
-        type="button"
-        className={chip("library")}
-        data-overlay-trigger="library"
-        aria-pressed={overlays.isOpen("library")}
-        onClick={() => overlays.toggle("library", "dialog")}
-      >
-        Library
-      </button>
-      <button type="button" className="appbar-btn" onClick={() => store.saveChat()}>
-        Save
-      </button>
+      {/* SESSION - the document itself. Never collapses: losing the way to
+          open or save your work at a narrow width is what finding #5 was
+          about in the first place. */}
+      <div className="appbar-group">
+        <BarButton
+          label="Library"
+          className={chip("library")}
+          trigger="library"
+          pressed={overlays.isOpen("library")}
+          onClick={() => overlays.toggle("library", "dialog")}
+        />
+        <BarButton label="Save" className="appbar-btn" onClick={() => store.saveChat()} />
+      </div>
 
-      <span className="appbar-separator appbar-tier" data-tier="2" />
-      <button
-        type="button"
-        className={chip("pins") + " appbar-tier"}
-        data-tier="2"
-        data-overlay-trigger="pins"
-        aria-pressed={overlays.isOpen("pins")}
-        title="Navigation pins"
-        onClick={() => overlays.toggle("pins", "popover")}
-      >
-        Pins
-      </button>
-      <button type="button" className="appbar-btn appbar-tier" data-tier="2" onClick={() => store.organizeNodes()}>
-        Organize
-      </button>
+      {/* HISTORY - keyboard equivalents exist (Ctrl+Z / Ctrl+Shift+Z), so
+          this is the first group to fold away. */}
+      <div className="appbar-group appbar-tier" data-tier="1">
+        <BarIconButton
+          icon="undo"
+          label="Undo"
+          className="appbar-btn"
+          disabled={!scene.canUndo}
+          onClick={() => store.undo()}
+        />
+        <BarIconButton
+          icon="redo"
+          label="Redo"
+          className="appbar-btn"
+          disabled={!scene.canRedo}
+          onClick={() => store.redo()}
+        />
+      </div>
 
-      <span className="appbar-separator appbar-tier" data-tier="1" />
-      <button
-        type="button"
-        className="appbar-btn appbar-tier"
-        data-tier="1"
-        disabled={!scene.canUndo}
-        title={scene.canUndo ? `Undo ${scene.undoLabel} (Ctrl+Z)` : "Nothing to undo"}
-        onClick={() => store.undo()}
-      >
-        Undo
-      </button>
-      <button
-        type="button"
-        className="appbar-btn appbar-tier"
-        data-tier="1"
-        disabled={!scene.canRedo}
-        title={scene.canRedo ? `Redo ${scene.redoLabel} (Ctrl+Shift+Z)` : "Nothing to redo"}
-        onClick={() => store.redo()}
-      >
-        Redo
-      </button>
+      {/* VIEWPORT - wheel and trackpad cover zooming, so these fold early
+          too. */}
+      <div className="appbar-group appbar-tier" data-tier="1">
+        <BarIconButton
+          icon="zoom-out"
+          label="Zoom Out"
+          className="appbar-btn"
+          onClick={() => zoomOut({ duration: motionDuration(150) })}
+        />
+        <BarIconButton
+          icon="zoom-in"
+          label="Zoom In"
+          className="appbar-btn"
+          onClick={() => zoomIn({ duration: motionDuration(150) })}
+        />
+        <BarIconButton icon="zoom-reset" label="Reset" className="appbar-btn" onClick={resetZoom} />
+        <BarIconButton
+          icon="fit"
+          label="Fit All"
+          className="appbar-btn"
+          onClick={() => fitView({ duration: motionDuration(200) })}
+        />
+      </div>
 
-      <span className="appbar-separator appbar-tier" data-tier="3" />
-      <button
-        type="button"
-        className="appbar-btn appbar-tier"
-        data-tier="3"
-        onClick={() => zoomIn({ duration: motionDuration(150) })}
-      >
-        Zoom In
-      </button>
-      <button
-        type="button"
-        className="appbar-btn appbar-tier"
-        data-tier="3"
-        onClick={() => zoomOut({ duration: motionDuration(150) })}
-      >
-        Zoom Out
-      </button>
-      <button type="button" className="appbar-btn appbar-tier" data-tier="3" onClick={resetZoom}>
-        Reset
-      </button>
-      <button
-        type="button"
-        className="appbar-btn appbar-tier"
-        data-tier="3"
-        onClick={() => fitView({ duration: motionDuration(200) })}
-      >
-        Fit All
-      </button>
+      {/* ARRANGE - acts on the graph's layout and landmarks. */}
+      <div className="appbar-group appbar-tier" data-tier="2">
+        <BarIconButton
+          icon="organize"
+          label="Organize"
+          className="appbar-btn"
+          onClick={() => store.organizeNodes()}
+        />
+        <BarIconButton
+          icon="pin"
+          label="Pins"
+          className={chip("pins")}
+          trigger="pins"
+          pressed={overlays.isOpen("pins")}
+          onClick={() => overlays.toggle("pins", "popover")}
+        />
+        <BarIconButton
+          icon="export"
+          label="Export PNG"
+          className="appbar-btn"
+          onClick={exportPng}
+        />
+      </div>
 
-      <span className="appbar-separator appbar-tier" data-tier="1" />
-      <button
-        type="button"
-        className="appbar-btn appbar-tier"
-        data-tier="1"
-        title="Export the whole canvas as a PNG image"
-        onClick={exportPng}
-      >
-        Export PNG
-      </button>
-
-      <span className="appbar-separator appbar-tier" data-tier="2" />
-      <button
-        type="button"
-        className={chip("view") + " appbar-tier"}
-        data-tier="2"
-        data-overlay-trigger="view"
-        aria-pressed={overlays.isOpen("view")}
-        onClick={() => overlays.toggle("view", "popover")}
-      >
-        View
-      </button>
-      <button
-        type="button"
-        className={chip("plugins") + " appbar-tier"}
-        data-tier="2"
-        data-overlay-trigger="plugins"
-        aria-pressed={overlays.isOpen("plugins")}
-        onClick={() => overlays.toggle("plugins", "popover")}
-      >
-        Plugins <span className="appbar-chevron">&#9662;</span>
-      </button>
+      {/* PANELS - canvas appearance and the plugin launcher. Text, because
+          both open a surface whose contents the word names. */}
+      <div className="appbar-group appbar-tier" data-tier="3">
+        <BarButton
+          label="View"
+          className={chip("view")}
+          trigger="view"
+          pressed={overlays.isOpen("view")}
+          onClick={() => overlays.toggle("view", "popover")}
+        />
+        <button
+          type="button"
+          className={chip("plugins")}
+          data-overlay-trigger="plugins"
+          aria-pressed={overlays.isOpen("plugins")}
+          onClick={() => overlays.toggle("plugins", "popover")}
+        >
+          Plugins <span className="appbar-chevron">&#9662;</span>
+        </button>
+      </div>
 
       <span className="appbar-spacer" />
 
-      {/* Tier-gated the same way as every collapsible button above: CSS
-          only shows this once at least one tier is hidden, so it never
-          appears as a "..." button opening an empty menu at full width. */}
+      {/* Tier-gated the same way as every collapsible group above: CSS only
+          shows this once at least one tier is hidden, so it never appears
+          as a menu button opening an empty menu at full width. */}
       <button
         type="button"
-        className={"appbar-btn appbar-overflow-trigger" + (overlays.isOpen("toolbar-overflow") ? " checked" : "")}
+        className={"appbar-btn appbar-btn-icon appbar-overflow-trigger" + (overlays.isOpen("toolbar-overflow") ? " checked" : "")}
         data-overlay-trigger="toolbar-overflow"
         aria-label="More toolbar actions"
         aria-haspopup="dialog"
         aria-expanded={overlays.isOpen("toolbar-overflow")}
         onClick={() => overlays.toggle("toolbar-overflow", "popover")}
       >
-        <span aria-hidden="true">&#8942;</span>
+        <AppBarIcon name="more" />
       </button>
       <Popover name="toolbar-overflow" label="More toolbar actions" className="appbar-overflow-menu">
         <button
@@ -252,20 +315,68 @@ export function AppBar({ store }: { store: SceneStore }) {
           className="appbar-overflow-item"
           data-tier="1"
           onClick={() => {
-            exportPng();
+            store.undo();
             closeOverflow();
           }}
+          disabled={!scene.canUndo}
         >
-          Export PNG
+          Undo
         </button>
         <button
           type="button"
-          className={"appbar-overflow-item" + (overlays.isOpen("pins") ? " checked" : "")}
-          data-tier="2"
-          aria-pressed={overlays.isOpen("pins")}
-          onClick={() => overlays.toggle("pins", "popover")}
+          className="appbar-overflow-item"
+          data-tier="1"
+          onClick={() => {
+            store.redo();
+            closeOverflow();
+          }}
+          disabled={!scene.canRedo}
         >
-          Pins
+          Redo
+        </button>
+        <button
+          type="button"
+          className="appbar-overflow-item"
+          data-tier="1"
+          onClick={() => {
+            zoomIn({ duration: motionDuration(150) });
+            closeOverflow();
+          }}
+        >
+          Zoom In
+        </button>
+        <button
+          type="button"
+          className="appbar-overflow-item"
+          data-tier="1"
+          onClick={() => {
+            zoomOut({ duration: motionDuration(150) });
+            closeOverflow();
+          }}
+        >
+          Zoom Out
+        </button>
+        <button
+          type="button"
+          className="appbar-overflow-item"
+          data-tier="1"
+          onClick={() => {
+            resetZoom();
+            closeOverflow();
+          }}
+        >
+          Reset
+        </button>
+        <button
+          type="button"
+          className="appbar-overflow-item"
+          data-tier="1"
+          onClick={() => {
+            fitView({ duration: motionDuration(200) });
+            closeOverflow();
+          }}
+        >
+          Fit All
         </button>
         <button
           type="button"
@@ -280,8 +391,28 @@ export function AppBar({ store }: { store: SceneStore }) {
         </button>
         <button
           type="button"
-          className={"appbar-overflow-item" + (overlays.isOpen("view") ? " checked" : "")}
+          className={overflowItem("pins")}
           data-tier="2"
+          aria-pressed={overlays.isOpen("pins")}
+          onClick={() => overlays.toggle("pins", "popover")}
+        >
+          Pins
+        </button>
+        <button
+          type="button"
+          className="appbar-overflow-item"
+          data-tier="2"
+          onClick={() => {
+            exportPng();
+            closeOverflow();
+          }}
+        >
+          Export PNG
+        </button>
+        <button
+          type="button"
+          className={overflowItem("view")}
+          data-tier="3"
           aria-pressed={overlays.isOpen("view")}
           onClick={() => overlays.toggle("view", "popover")}
         >
@@ -289,8 +420,8 @@ export function AppBar({ store }: { store: SceneStore }) {
         </button>
         <button
           type="button"
-          className={"appbar-overflow-item" + (overlays.isOpen("plugins") ? " checked" : "")}
-          data-tier="2"
+          className={overflowItem("plugins")}
+          data-tier="3"
           aria-pressed={overlays.isOpen("plugins")}
           onClick={() => overlays.toggle("plugins", "popover")}
         >
@@ -298,88 +429,8 @@ export function AppBar({ store }: { store: SceneStore }) {
         </button>
         <button
           type="button"
-          className="appbar-overflow-item"
-          data-tier="3"
-          onClick={() => {
-            zoomIn({ duration: motionDuration(150) });
-            closeOverflow();
-          }}
-        >
-          Zoom In
-        </button>
-        <button
-          type="button"
-          className="appbar-overflow-item"
-          data-tier="3"
-          onClick={() => {
-            zoomOut({ duration: motionDuration(150) });
-            closeOverflow();
-          }}
-        >
-          Zoom Out
-        </button>
-        <button
-          type="button"
-          className="appbar-overflow-item"
-          data-tier="3"
-          onClick={() => {
-            resetZoom();
-            closeOverflow();
-          }}
-        >
-          Reset
-        </button>
-        <button
-          type="button"
-          className="appbar-overflow-item"
-          data-tier="3"
-          onClick={() => {
-            fitView({ duration: motionDuration(200) });
-            closeOverflow();
-          }}
-        >
-          Fit All
-        </button>
-        <button
-          type="button"
-          className={"appbar-overflow-item" + (overlays.isOpen("about") ? " checked" : "")}
-          data-tier="1"
-          aria-pressed={overlays.isOpen("about")}
-          onClick={() => overlays.toggle("about", "dialog")}
-        >
-          About
-        </button>
-        <button
-          type="button"
-          className={"appbar-overflow-item" + (overlays.isOpen("help") ? " checked" : "")}
-          data-tier="1"
-          aria-pressed={overlays.isOpen("help")}
-          onClick={() => overlays.toggle("help", "dialog")}
-        >
-          Help
-        </button>
-        <button
-          type="button"
-          className={"appbar-overflow-item" + (overlays.isOpen("diagnostics") ? " checked" : "")}
-          data-tier="1"
-          aria-pressed={overlays.isOpen("diagnostics")}
-          onClick={() => overlays.toggle("diagnostics", "dialog")}
-        >
-          Diagnostics
-        </button>
-        <button
-          type="button"
-          className={"appbar-overflow-item" + (overlays.isOpen("knowledge") ? " checked" : "")}
-          data-tier="1"
-          aria-pressed={overlays.isOpen("knowledge")}
-          onClick={() => overlays.toggle("knowledge", "dialog")}
-        >
-          Knowledge
-        </button>
-        <button
-          type="button"
-          className={"appbar-overflow-item" + (overlays.isOpen("global-search") ? " checked" : "")}
-          data-tier="1"
+          className={overflowItem("global-search")}
+          data-tier="4"
           aria-pressed={overlays.isOpen("global-search")}
           onClick={() => overlays.toggle("global-search", "dialog")}
         >
@@ -387,84 +438,119 @@ export function AppBar({ store }: { store: SceneStore }) {
         </button>
         <button
           type="button"
-          className={"appbar-overflow-item" + (overlays.isOpen("builder-launch") ? " checked" : "")}
-          data-tier="1"
+          className={overflowItem("knowledge")}
+          data-tier="4"
+          aria-pressed={overlays.isOpen("knowledge")}
+          onClick={() => overlays.toggle("knowledge", "dialog")}
+        >
+          Knowledge
+        </button>
+        <button
+          type="button"
+          className={overflowItem("builder-launch")}
+          data-tier="4"
           aria-pressed={overlays.isOpen("builder-launch")}
           onClick={() => overlays.toggle("builder-launch", "dialog")}
         >
           Builder
         </button>
+        <button
+          type="button"
+          className={overflowItem("diagnostics")}
+          data-tier="4"
+          aria-pressed={overlays.isOpen("diagnostics")}
+          onClick={() => overlays.toggle("diagnostics", "dialog")}
+        >
+          Diagnostics
+        </button>
+        <button
+          type="button"
+          className={overflowItem("help")}
+          data-tier="4"
+          aria-pressed={overlays.isOpen("help")}
+          onClick={() => overlays.toggle("help", "dialog")}
+        >
+          Help
+        </button>
+        <button
+          type="button"
+          className={overflowItem("about")}
+          data-tier="4"
+          aria-pressed={overlays.isOpen("about")}
+          onClick={() => overlays.toggle("about", "dialog")}
+        >
+          About
+        </button>
       </Popover>
 
-      <button
-        type="button"
-        className={chip("settings")}
-        data-overlay-trigger="settings"
-        aria-pressed={overlays.isOpen("settings")}
-        onClick={() => overlays.toggle("settings", "dialog")}
-      >
-        Settings
-      </button>
-      <button
-        type="button"
-        className={chip("about") + " appbar-tier"}
-        data-tier="1"
-        data-overlay-trigger="about"
-        aria-pressed={overlays.isOpen("about")}
-        onClick={() => overlays.toggle("about", "dialog")}
-      >
-        About
-      </button>
-      <button
-        type="button"
-        className={chip("help") + " appbar-tier"}
-        data-tier="1"
-        data-overlay-trigger="help"
-        aria-pressed={overlays.isOpen("help")}
-        onClick={() => overlays.toggle("help", "dialog")}
-      >
-        Help
-      </button>
-      <button
-        type="button"
-        className={chip("diagnostics") + " appbar-tier"}
-        data-tier="1"
-        data-overlay-trigger="diagnostics"
-        aria-pressed={overlays.isOpen("diagnostics")}
-        onClick={() => overlays.toggle("diagnostics", "dialog")}
-      >
-        Diagnostics
-      </button>
-      <button
-        type="button"
-        className={chip("knowledge") + " appbar-tier"}
-        data-tier="1"
-        data-overlay-trigger="knowledge"
-        aria-pressed={overlays.isOpen("knowledge")}
-        onClick={() => overlays.toggle("knowledge", "dialog")}
-      >
-        Knowledge
-      </button>
-      <button
-        type="button"
-        className={chip("global-search") + " appbar-tier"}
-        data-tier="1"
-        data-overlay-trigger="global-search"
-        aria-pressed={overlays.isOpen("global-search")}
-        onClick={() => overlays.toggle("global-search", "dialog")}
-      >
-        Global Search
-      </button>
-      <button
-        type="button"
-        className={chip("builder-launch") + " appbar-tier"}
-        data-tier="1"
-        data-overlay-trigger="builder-launch"
-        aria-pressed={overlays.isOpen("builder-launch")}
-        onClick={() => overlays.toggle("builder-launch", "dialog")}
-      >
-        Builder
-      </button>
+      {/* WORKSPACE TOOLS - cross-cutting surfaces rather than canvas verbs.
+          Icon-only: the right end of a permanently-visible bar is where
+          density pays, and each carries its full name as tooltip and
+          accessible name. */}
+      <div className="appbar-group appbar-tier" data-tier="4">
+        <BarIconButton
+          icon="search"
+          label="Global Search"
+          className={chip("global-search")}
+          trigger="global-search"
+          pressed={overlays.isOpen("global-search")}
+          onClick={() => overlays.toggle("global-search", "dialog")}
+        />
+        <BarIconButton
+          icon="knowledge"
+          label="Knowledge"
+          className={chip("knowledge")}
+          trigger="knowledge"
+          pressed={overlays.isOpen("knowledge")}
+          onClick={() => overlays.toggle("knowledge", "dialog")}
+        />
+        <BarIconButton
+          icon="builder"
+          label="Builder"
+          className={chip("builder-launch")}
+          trigger="builder-launch"
+          pressed={overlays.isOpen("builder-launch")}
+          onClick={() => overlays.toggle("builder-launch", "dialog")}
+        />
+        <BarIconButton
+          icon="diagnostics"
+          label="Diagnostics"
+          className={chip("diagnostics")}
+          trigger="diagnostics"
+          pressed={overlays.isOpen("diagnostics")}
+          onClick={() => overlays.toggle("diagnostics", "dialog")}
+        />
+        <BarIconButton
+          icon="help"
+          label="Help"
+          className={chip("help")}
+          trigger="help"
+          pressed={overlays.isOpen("help")}
+          onClick={() => overlays.toggle("help", "dialog")}
+        />
+        <BarIconButton
+          icon="about"
+          label="About"
+          className={chip("about")}
+          trigger="about"
+          pressed={overlays.isOpen("about")}
+          onClick={() => overlays.toggle("about", "dialog")}
+        />
+      </div>
+
+      {/* SETTINGS stands alone at the end - the one destination that
+          configures the app rather than acting on the graph, and like
+          Library/Save it never collapses. */}
+      <div className="appbar-group">
+        <BarIconButton
+          icon="settings"
+          label="Settings"
+          className={chip("settings")}
+          trigger="settings"
+          pressed={overlays.isOpen("settings")}
+          onClick={() => overlays.toggle("settings", "dialog")}
+        />
+      </div>
     </div>
   );
 }

--- a/web_ui/src/app/chrome/AppBarIcon.tsx
+++ b/web_ui/src/app/chrome/AppBarIcon.tsx
@@ -1,0 +1,170 @@
+/**
+ * The app bar's icon set.
+ *
+ * Same convention as ChatLibraryDialog's own Icon component (24x24 view
+ * box, `className="icon"`, stroke inherited from the button's colour, no
+ * fills) so toolbar glyphs sit on the identical visual footing as the rest
+ * of the app's chrome rather than introducing a second icon language.
+ *
+ * Its own module rather than a local in AppBar.tsx: `react-refresh/
+ * only-export-components` flags a component file that exports more than
+ * components, and keeping the glyph table separate leaves AppBar.tsx as
+ * layout and behaviour only.
+ */
+
+export type AppBarIconName =
+  | "undo"
+  | "redo"
+  | "zoom-in"
+  | "zoom-out"
+  | "zoom-reset"
+  | "fit"
+  | "organize"
+  | "pin"
+  | "export"
+  | "search"
+  | "knowledge"
+  | "builder"
+  | "diagnostics"
+  | "settings"
+  | "help"
+  | "about"
+  | "more";
+
+export function AppBarIcon({ name }: { name: AppBarIconName }) {
+  switch (name) {
+    case "undo":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M4 9h10a5 5 0 0 1 0 10h-4" />
+          <path d="m4 9 4-4M4 9l4 4" />
+        </svg>
+      );
+    case "redo":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M20 9H10a5 5 0 0 0 0 10h4" />
+          <path d="m20 9-4-4M20 9l-4 4" />
+        </svg>
+      );
+    case "zoom-in":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <circle cx="10.5" cy="10.5" r="6.5" />
+          <path d="m20 20-4.8-4.8M10.5 7.5v6M7.5 10.5h6" />
+        </svg>
+      );
+    case "zoom-out":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <circle cx="10.5" cy="10.5" r="6.5" />
+          <path d="m20 20-4.8-4.8M7.5 10.5h6" />
+        </svg>
+      );
+    case "zoom-reset":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <circle cx="12" cy="12" r="7.5" />
+          <circle cx="12" cy="12" r="2" />
+        </svg>
+      );
+    case "fit":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M4 9V4h5M20 9V4h-5M4 15v5h5M20 15v5h-5" />
+        </svg>
+      );
+    case "organize":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <rect x="4" y="4" width="7" height="7" rx="1" />
+          <rect x="13" y="4" width="7" height="7" rx="1" />
+          <rect x="4" y="13" width="7" height="7" rx="1" />
+          <rect x="13" y="13" width="7" height="7" rx="1" />
+        </svg>
+      );
+    case "pin":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M9 4h6l-1 6 3 3H7l3-3Z" />
+          <path d="M12 13v7" />
+        </svg>
+      );
+    case "export":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M12 4v10" />
+          <path d="m8 10 4 4 4-4" />
+          <path d="M5 17v2a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2" />
+        </svg>
+      );
+    case "search":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <circle cx="10.5" cy="10.5" r="6.5" />
+          <path d="m20 20-4.8-4.8" />
+        </svg>
+      );
+    case "knowledge":
+      // An open book: two facing pages around a visible spine. The earlier
+      // single-outline version rendered as a plain rectangle at 15px.
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M12 6.5v13" />
+          <path d="M12 6.5C10.5 5 8.5 4.5 4 4.5v13c4.5 0 6.5.5 8 2" />
+          <path d="M12 6.5c1.5-1.5 3.5-2 8-2v13c-4.5 0-6.5.5-8 2" />
+        </svg>
+      );
+    case "builder":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M14 4a4 4 0 0 0-4 5l-6 6 3 3 6-6a4 4 0 0 0 5-4Z" />
+          <path d="m14.5 9.5 4 4" />
+        </svg>
+      );
+    case "diagnostics":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M3 12h4l2.5-6 5 12L17 12h4" />
+        </svg>
+      );
+    case "settings":
+      // Sliders rather than a cog: at a 15px render a cog's teeth collapse
+      // into radial strokes and read as a sun/brightness mark, which is
+      // exactly what this glyph was mistaken for. Sliders stay legible at
+      // this size and carry the same "adjust how this behaves" meaning.
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <path d="M4 7h8M17 7h3M4 12h11M20 12h0M4 17h5M14 17h6" />
+          <circle cx="14.5" cy="7" r="2.1" />
+          <circle cx="17.5" cy="12" r="2.1" />
+          <circle cx="11.5" cy="17" r="2.1" />
+        </svg>
+      );
+    case "help":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <circle cx="12" cy="12" r="8.5" />
+          <path d="M9.6 9.4a2.5 2.5 0 1 1 3.2 2.9c-.6.2-.9.7-.9 1.3v.4" />
+          <path d="M12 17.2v.01" />
+        </svg>
+      );
+    case "about":
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <circle cx="12" cy="12" r="8.5" />
+          <path d="M12 11v5.5" />
+          <path d="M12 7.8v.01" />
+        </svg>
+      );
+    case "more":
+    default:
+      return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+          <circle cx="12" cy="5.5" r="1.4" fill="currentColor" stroke="none" />
+          <circle cx="12" cy="12" r="1.4" fill="currentColor" stroke="none" />
+          <circle cx="12" cy="18.5" r="1.4" fill="currentColor" stroke="none" />
+        </svg>
+      );
+  }
+}

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -54,43 +54,6 @@ body,
   font-family: var(--gl-font-family);
 }
 
-.app-topbar {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 14px;
-  background-color: var(--gl-surface-node-body);
-  border-bottom: 1px solid var(--gl-surface-border);
-}
-
-.app-title {
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.app-topbar-note {
-  font-size: 11px;
-  color: var(--gl-surface-text-muted);
-}
-
-.app-conn {
-  margin-left: auto;
-  font-size: 11px;
-  color: var(--gl-surface-text-muted);
-}
-
-.app-conn-open {
-  color: var(--gl-surface-text-primary);
-}
-
-/* ADR-003 stage 3.6: a real session existed and is currently paused, not
-   the muted/understated styling app-conn's base rule gives "connecting"
-   (first load, nothing was ever working) - warrants standing out the same
-   way .notification-error already does for "something needs attention". */
-.app-conn-reconnecting {
-  color: var(--gl-semantic-status-error, var(--gl-surface-text-primary));
-}
-
 /* ADR-003 stage 3.5: BridgeErrorState.tsx, first live wiring. Fills the
    canvas region it replaces (SceneCanvas.tsx renders this INSTEAD of
    CanvasInner, never alongside it) rather than floating as a small toast -
@@ -1445,125 +1408,256 @@ body,
   border-radius: 8px;
 }
 
-/* -- R2 app bar + overlay system ----------------------------------------- */
+/* -- R2 app bar + overlay system -----------------------------------------
+
+   LAYOUT CONTRACT. This bar is on screen at all times, so nothing about its
+   geometry is left to emerge from content. Three DECLARED grid tracks -
+   brand, toolbar, status - give each region a fixed home that the others
+   cannot encroach on. The previous layout was a single flex row in which
+   the status badge sat outside the toolbar and leaned on `margin-left:auto`
+   against a `flex: 1` sibling that had already consumed the free space, so
+   it ended up pressed against the last button rather than anchored to the
+   window edge.
+
+   The middle track is `minmax(0, 1fr)`: it is the only one allowed to
+   absorb or surrender space, and the `0` floor is what lets it shrink below
+   its content's intrinsic width so the toolbar's own container queries -
+   not the window - decide what collapses. Both outer tracks are `auto`,
+   i.e. exactly as wide as they need and never wider. */
 
 .app-topbar {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  /* Spacing lives on the regions, not as a column-gap: the status track is
+     empty whenever the connection is healthy, and a gap would still reserve
+     its gutter and push the toolbar off the right edge asymmetrically. */
+  column-gap: 0;
+  /* Fixed row height: the bar must not resize with its contents. */
+  height: 46px;
+  padding: 0 14px;
+  background-color: var(--gl-surface-node-body);
+  border-bottom: 1px solid var(--gl-surface-border);
+  /* Deliberately NO overflow-x here, despite that being the obvious
+     "stop the document spilling sideways" backstop. Per the overflow spec,
+     an overflow-x other than visible force-coerces overflow-y to auto on
+     the same element - and .appbar-overflow-menu is a descendant that
+     extends BELOW this row by design every time it opens, so it would be
+     clipped. The real backstop is the grid above (the middle track cannot
+     overrun its siblings) plus the tier breakpoints below. */
+}
+
+.app-topbar-brand {
+  display: flex;
+  align-items: center;
   gap: 8px;
-  /* R8a (UI/UX issue list finding #5): deliberately NO overflow-x: hidden
-     here, despite that being the obvious "stop the whole document from
-     spilling sideways" backstop. It was tried and reverted after review
-     caught it silently breaking the fix it was meant to protect: per the
-     CSS overflow spec, when overflow-x computes to anything other than
-     visible, a overflow-y of visible on the SAME element is force-coerced
-     to auto instead - it cannot stay visible, regardless of which value
-     was explicitly authored. .appbar-overflow-menu is a descendant of this
-     element (position: absolute, top: 100%, extending below this row by
-     design every time it opens) - an auto-coerced overflow-y here clips it
-     completely, confirmed live via getComputedStyle/elementFromPoint. There
-     is no ancestor position for a horizontal-only backstop that does not
-     have this exact problem, since the popover must stay inside .appbar's
-     @container subtree (see .appbar's own comment) and therefore inside
-     ANY ancestor between it and the document too. The real backstop is
-     therefore the tier breakpoints below being correctly margined instead
-     of a defensive CSS property: measured live, the four buttons that never
-     collapse (Library/Save/the overflow trigger/Settings) need ~207px, well
-     under the narrowest breakpoint's 420px floor. */
+  margin-right: 16px;
+  /* The brand never shrinks or wraps - it is the anchor the rest of the bar
+     is measured from. */
+  flex-shrink: 0;
+}
+
+.app-brand-mark {
+  width: 17px;
+  height: 17px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  color: var(--gl-surface-text-secondary);
+}
+
+.app-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+.app-topbar-note {
+  font-size: 11px;
+  color: var(--gl-surface-text-muted);
+}
+
+/* The status region: its own grid track, so it is anchored to the window's
+   right edge no matter how many buttons the toolbar is showing. */
+/* Empty whenever the connection is healthy - see App.tsx. :empty keeps it
+   from contributing any width or margin in that (normal) case, so the
+   toolbar's right edge lines up with the window padding exactly as the
+   brand does on the left. */
+.app-topbar-status {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-left: 16px;
+}
+
+.app-topbar-status:empty {
+  margin-left: 0;
+}
+
+/* Only ever rendered for a DEGRADED connection (App.tsx), so this is a
+   warning indicator rather than ambient status - it earns its space by
+   appearing exactly when something needs attention. */
+.app-conn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  padding: 0 10px;
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+  color: var(--gl-surface-text-muted);
+  background-color: var(--gl-surface-inset);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 999px;
+}
+
+.app-conn-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: currentColor;
+  flex-shrink: 0;
+}
+
+/* ADR-003 stage 3.6: a real session existed and is currently paused, not
+   the muted/understated styling app-conn's base rule gives "connecting"
+   (first load, nothing was ever working) - warrants standing out the same
+   way .notification-error already does for "something needs attention". */
+.app-conn-reconnecting {
+  color: var(--gl-semantic-status-error, var(--gl-surface-text-primary));
+  border-color: var(--gl-semantic-status-error, var(--gl-surface-border));
 }
 
 .appbar {
   display: flex;
   align-items: center;
-  gap: 4px;
-  flex: 1;
-  /* flex: 1 alone gives a flex item min-width: auto, i.e. it can never
-     shrink below the summed min-content width of its 12 buttons - that is
-     what forced .app-topbar wider than the window in the first place.
-     min-width: 0 lets it actually shrink. position: relative anchors
-     .appbar-overflow-menu (a Popover - overlays.tsx - which supplies no
-     positioning of its own; every other Popover consumer gets one from a
-     dedicated App.tsx wrapper div, which does not exist here). The
-     container-type/name pair is what the @container queries below key off -
-     deliberately NOT `overflow: hidden` here despite that being the more
-     obvious pairing: an overflow:hidden ancestor clips ANY descendant that
-     paints past its box regardless of the descendant's own position scheme,
-     and the overflow menu is exactly such a descendant every time it opens.
-     (NodeMenu.tsx - a portal - was tried here first specifically to dodge
-     that; it introduced a worse bug instead, see AppBar.tsx's own comment.) */
+  /* Space BETWEEN groups. Within a group the spacing is tighter (see
+     .appbar-group) - that difference is what makes the grouping legible
+     without needing a rule between every pair of buttons. */
+  gap: 10px;
+  /* Lets the middle grid track actually shrink; container-type/name is what
+     the @container queries at the bottom of this block key off. Deliberately
+     NOT `overflow: hidden` - an overflow:hidden ancestor clips ANY
+     descendant painting outside its box, and the overflow menu is exactly
+     such a descendant every time it opens. */
   min-width: 0;
   position: relative;
   container-type: inline-size;
   container-name: appbar;
 }
 
+/* A cluster of related actions on one shared surface. Uniform inner
+   spacing and a single rounded container is what carries this bar's visual
+   organisation; the run of twenty text buttons this replaced used ad-hoc
+   1px rules and identical spacing everywhere, so nothing read as related
+   to anything else. */
+.appbar-group {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  background-color: var(--gl-surface-inset);
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
 .appbar-btn {
+  /* Fixed height on every control, so the row's own height is a constant
+     and never a function of which buttons happen to be showing. */
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
   font-size: 11px;
   font-weight: 600;
   font-family: inherit;
-  padding: 5px 10px;
-  color: var(--gl-surface-text-primary);
+  color: var(--gl-surface-text-secondary);
   background: transparent;
   border: 1px solid transparent;
   border-radius: 6px;
   cursor: pointer;
   white-space: nowrap;
+  transition:
+    background-color var(--gl-motion-fast) var(--gl-motion-ease),
+    color var(--gl-motion-fast) var(--gl-motion-ease);
+}
+
+/* Square footprint for icon-only controls, so a row of them is evenly
+   rhythmic rather than varying with glyph width. */
+.appbar-btn-icon {
+  width: 28px;
+  padding: 0;
+  justify-content: center;
+}
+
+.appbar-btn .icon {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .appbar-btn:hover:enabled {
   background-color: var(--gl-neutral-button-hover);
+  color: var(--gl-surface-text-primary);
+}
+
+.appbar-btn:focus-visible {
+  outline: 2px solid var(--gl-focus-ring);
+  outline-offset: -1px;
 }
 
 .appbar-btn:disabled {
-  opacity: 0.45;
+  opacity: 0.35;
   cursor: default;
 }
 
+/* Open-surface state. The filled treatment is reserved for this one meaning
+   across the whole bar, so "this panel is open" is never confusable with
+   hover or focus. */
 .appbar-btn-checkable.checked {
   background-color: var(--gl-neutral-button-background);
   border-color: var(--gl-neutral-button-border);
-}
-
-.appbar-separator {
-  width: 1px;
-  height: 18px;
-  margin: 0 4px;
-  background-color: var(--gl-surface-border);
+  color: var(--gl-surface-text-bright);
 }
 
 .appbar-spacer {
   flex: 1;
+  /* A real minimum, so the two clusters can never meet even at the
+     narrowest width the tiers allow. */
+  min-width: 12px;
 }
 
 .appbar-chevron {
   font-size: 9px;
+  opacity: 0.75;
 }
 
-/* R8a (finding #5): the overflow trigger + its menu. Hidden by default;
-   the container-query block below reveals the trigger once ANY tier has
-   collapsed, and reveals each overflow-menu item once ITS OWN tier has
-   collapsed - the item's data-tier is the same value used inline, so the
-   two stay in lockstep without any JS wiring them together. */
+/* The overflow trigger. Hidden by default; the container-query block below
+   reveals it once ANY tier has collapsed, and reveals each menu item once
+   ITS OWN tier has collapsed - the item's data-tier is the same value used
+   on the inline group, so the two stay in lockstep with no JS. */
 .appbar-overflow-trigger {
   display: none;
-  padding: 5px 8px;
-  font-size: 14px;
-  line-height: 1;
+  flex-shrink: 0;
 }
 
 /* .overlay-popover (the base class Popover always applies alongside this
-   one) already supplies background-color/border/box-shadow and a default
-   position/sizing - only what's genuinely DIFFERENT for a button-list menu
-   is overridden here (tighter padding/min-width/radius, matching node
-   context menus' own convention, plus a height cap this list can actually
-   need and the base class doesn't have). Position is the one property
-   .overlay-popover never sets for ANY consumer - View/Plugins/Pins get
-   theirs from a dedicated wrapper div in App.tsx; this one has no such
-   wrapper, so it's set directly here, anchored to .appbar's own right edge
-   (position: relative on .appbar above) rather than precisely under the
-   trigger button a few buttons to its left - the same "close, not
-   pixel-precise" anchoring posture every other toolbar popover in this app
-   already has (finding BAD-UX #27, a separate, pre-existing issue this does
-   not attempt to fix). z-index matches node context menus - the highest
-   ordinary-content tier below the modal/approval tiers. */
+   one) already supplies background/border/shadow and default sizing - only
+   what is genuinely different for a button-list menu is overridden here.
+   Position is the one property .overlay-popover never sets for any
+   consumer: View/Plugins/Pins get theirs from a dedicated wrapper div in
+   App.tsx, and this one has none, so it is anchored here to .appbar's own
+   right edge (position: relative on .appbar above). */
 .appbar-overflow-menu {
   position: absolute;
   top: 100%;
@@ -1573,7 +1667,7 @@ body,
   display: flex;
   flex-direction: column;
   gap: 2px;
-  min-width: 170px;
+  min-width: 180px;
   padding: 6px;
   border-radius: 8px;
   max-height: calc(100vh - 16px);
@@ -1595,33 +1689,34 @@ body,
   cursor: pointer;
 }
 
-.appbar-overflow-item:hover {
+.appbar-overflow-item:hover:enabled {
   background-color: var(--gl-neutral-button-hover);
 }
 
-/* Mirrors .appbar-btn-checkable.checked (the inline chips' own real-open-
-   state styling) - a separate rule rather than sharing that class, since
-   .appbar-overflow-item already needs its own base rule (full-width,
-   left-aligned, tier-gated display) incompatible with .appbar-btn's. Note
-   this can never actually render true in practice: OverlayProvider is
-   single-open, so by the time any of Pins/View/Plugins/About/Help becomes
-   the open surface, "toolbar-overflow" has already stopped being it, and
-   this whole menu has unmounted. Kept anyway for the same reason the inline
-   copy has it - matching what the component's own contract (real state, not
-   latched clicks) promises, not for an effect anyone will currently see. */
+.appbar-overflow-item:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+/* Mirrors .appbar-btn-checkable.checked for the menu copies. Note this can
+   never actually render true in practice: OverlayProvider is single-open,
+   so by the time any of Pins/View/Plugins/About/Help becomes the open
+   surface, "toolbar-overflow" has stopped being it and this menu has
+   unmounted. Kept anyway so both copies of a control state the same
+   contract. */
 .appbar-overflow-item.checked {
   background-color: var(--gl-neutral-button-background);
   border-color: var(--gl-neutral-button-border);
 }
 
-/* Breakpoints are tuned against this toolbar's own real button widths -
-   verified live by resizing the running app, not guessed. Tier 1 (About/
-   Help/Export PNG - least-frequently-used) collapses first; tier 3 (the
-   four zoom/fit controls, which have keyboard/wheel equivalents elsewhere)
-   collapses last, right before the floor of Library/Save/Settings, which
-   never collapse - those three are exactly what finding #5 flagged as
-   becoming unreachable, so they are the one tier that does not exist. */
-@container appbar (max-width: 820px) {
+/* Tiers collapse whole GROUPS, not individual buttons, so a cluster is
+   never left as a fragment of itself. Order is by how recoverable the
+   actions are elsewhere: history and viewport first (both have keyboard
+   and wheel equivalents), then arrange, then the panels, then the
+   workspace-tools cluster. Session (Library/Save) and Settings have no
+   tier at all - those are exactly what finding #5 flagged as becoming
+   unreachable, so they never collapse. */
+@container appbar (max-width: 900px) {
   .appbar-overflow-trigger {
     display: inline-flex;
     align-items: center;
@@ -1635,7 +1730,7 @@ body,
   }
 }
 
-@container appbar (max-width: 620px) {
+@container appbar (max-width: 720px) {
   .appbar-tier[data-tier="2"] {
     display: none;
   }
@@ -1644,11 +1739,20 @@ body,
   }
 }
 
-@container appbar (max-width: 420px) {
+@container appbar (max-width: 560px) {
   .appbar-tier[data-tier="3"] {
     display: none;
   }
   .appbar-overflow-item[data-tier="3"] {
+    display: block;
+  }
+}
+
+@container appbar (max-width: 400px) {
+  .appbar-tier[data-tier="4"] {
+    display: none;
+  }
+  .appbar-overflow-item[data-tier="4"] {
     display: block;
   }
 }


### PR DESCRIPTION
## Problem

The top bar was carried over from the Qt port as a single unbroken flex row of buttons with no visual grouping. The connection-status badge stayed anchored to the window edge only by consuming whatever space was left over from a sibling flex item; at narrow widths, or once enough buttons were present, it ended up pressed against the last toolbar button instead of the window edge. Below a threshold width the toolbar had no shrink or overflow behavior at all, causing horizontal scroll across the entire document.

## Change

- **Layout.** The header is now a three-column CSS grid - brand, toolbar, connection status - so each region occupies a declared track and cannot encroach on the others.
- **Grouping.** Toolbar actions are organized into labeled clusters (Session, History, Viewport, Arrange, Panels, Workspace Tools, Settings), each with consistent internal spacing and a shared surface, replacing the undifferentiated run of buttons.
- **Icons vs. labels.** Frequent, app-specific actions (Library, Save, Organize, View, Plugins) keep text labels. Universally recognizable actions (undo/redo, the four zoom controls, the workspace-tools cluster) become icon buttons, each carrying its full wording as both tooltip and accessible name.
- **Overflow behavior.** The existing container-query overflow mechanism now collapses whole groups instead of individual buttons, so a cluster of related actions is never left as a partial fragment at in-between widths. Global Search, which previously had no overflow-menu counterpart, now has one - it would otherwise have become unreachable once its tier collapsed.
- **Connection status.** The indicator now only renders when the connection is degraded. A permanently visible "connected" badge reports the expected state on every frame with no informational value; the reconnecting state carries real information (intents are queued or refused while it shows), so that state alone is surfaced.

## Test plan

- [x] Full frontend check passes: schema, types, lint (0 errors), 1930/1930 tests, production build, bundle size
- [x] Geometry verified across six viewport widths (560px-1600px): zero region overlap, constant 47px row height, uniform 26px control height, no document horizontal overflow at any width
- [x] Two icon glyphs (Settings, Knowledge) were redrawn after an initial render proved ambiguous at 15px