### PR TITLE
Build out the Builder: activity log, notifications, anchored placement, and a rebuilt launch dialog

### DIFF
--- a/backend/api/intents_builder.py
+++ b/backend/api/intents_builder.py
@@ -152,6 +152,31 @@ def register_builder_intents(
         await bus.publish("notification")
         return clean_name
 
+    async def delete_recipe(name):
+        """stage 8.7: rounds out the recipe lifecycle - saveRecipe already
+        creates one from a finished build, but nothing could ever remove
+        one. Mirrors save_recipe's own name-guard against built-ins and its
+        own settings.get_recipes()/set_recipes() replace-the-whole-list
+        posture."""
+        from backend.builder import BUILT_IN_RECIPES
+
+        clean_name = str(name or "").strip()
+        if any(r["name"] == clean_name for r in BUILT_IN_RECIPES):
+            notifications.show(f'"{clean_name}" is a built-in recipe - it cannot be deleted.', "warning")
+            await bus.publish("notification")
+            return False
+        settings = agent_dispatcher._settings_manager
+        existing = settings.get_recipes()
+        remaining = [r for r in existing if r["name"] != clean_name]
+        if len(remaining) == len(existing):
+            notifications.show(f'No saved recipe named "{clean_name}".', "info")
+            await bus.publish("notification")
+            return False
+        settings.set_recipes(remaining)
+        notifications.show(f'Deleted recipe "{clean_name}".', "info")
+        await bus.publish("notification")
+        return True
+
     async def start_execution(node_id):
         node = document.nodes.get(node_id)
         if node is None or not isinstance(node.state, PlanState):
@@ -202,4 +227,5 @@ def register_builder_intents(
     bus.register_intent("builder", "denyTool", deny_tool)
     bus.register_intent("builder", "listRecipes", list_recipes)
     bus.register_intent("builder", "saveRecipe", save_recipe)
+    bus.register_intent("builder", "deleteRecipe", delete_recipe)
     bus.register_intent("scene", "setPlanSteps", set_plan_steps)

--- a/backend/builder.py
+++ b/backend/builder.py
@@ -82,6 +82,14 @@ _APPROVAL_SUMMARY_CAP = 400
 # summaries are shown one at a time, activity rows are shown many at once.
 _ACTIVITY_CAP = 100
 _ACTIVITY_SUMMARY_CAP = 200
+# review-fix: a tool CALL's name has no upstream length validation - it is
+# whatever a provider's tool-call parsing extracted from the model's own
+# output verbatim (e.g. providers/ollama_provider.py's _extract_tool_calls),
+# so a malformed/hallucinating turn (most reachable with a local model) can
+# emit an arbitrarily large one. Every OTHER field this row stores is
+# capped; leaving `tool` uncapped would let exactly that turn defeat the
+# same wire/session-size bound the ring buffer and summary cap exist for.
+_ACTIVITY_TOOL_NAME_CAP = 80
 
 # stage 8.7: which terminal/pause statuses notify, and with what severity -
 # keyed by the exact status string _land() writes to builder_status.
@@ -409,7 +417,7 @@ def _log_activity(node, *, tool: str, summary: str, outcome: str, step_id: str, 
     from the front (oldest first) once the ring buffer's cap is exceeded."""
     activity = node.state.builder_activity
     activity.append({
-        "tool": tool,
+        "tool": _truncate(tool, _ACTIVITY_TOOL_NAME_CAP),
         "summary": summary,
         "outcome": outcome,
         "stepId": step_id,

--- a/backend/builder.py
+++ b/backend/builder.py
@@ -74,6 +74,19 @@ _AUTOPILOT_AUTO_SCOPES = frozenset({
 
 _APPROVAL_SUMMARY_CAP = 400
 
+# stage 8.7: the activity log's own caps. A build is bounded at 50 steps x
+# _STEP_TURN_CAP turns, so nothing else bounds how many rows a pathological
+# replan loop could otherwise append to a plan node's wire dict (a whole-
+# node diff per graph.py's take_dirty_patch_ops) - the ring buffer is the
+# backstop. The summary cap is tighter than approval's own 400: approval
+# summaries are shown one at a time, activity rows are shown many at once.
+_ACTIVITY_CAP = 100
+_ACTIVITY_SUMMARY_CAP = 200
+
+# stage 8.7: which terminal/pause statuses notify, and with what severity -
+# keyed by the exact status string _land() writes to builder_status.
+_LAND_NOTIFICATION_KINDS = {"done": "success", "failed": "error", "paused": "warning"}
+
 PLAN_SCHEMA = {
     "type": "object",
     "properties": {
@@ -368,11 +381,42 @@ def plan_steps_for_goal(goal: str, *, runtime=None, settings_manager=None) -> li
 
 # -- the executor loop -------------------------------------------------------
 
+def _truncate(text: str, cap: int) -> str:
+    return text if len(text) <= cap else text[:cap] + "…"
+
+
 def _approval_summary(call: ToolCall) -> str:
     args = json.dumps(call.arguments, sort_keys=True, ensure_ascii=False)
-    if len(args) > _APPROVAL_SUMMARY_CAP:
-        args = args[:_APPROVAL_SUMMARY_CAP] + "…"
-    return f"{call.name} {args}"
+    return f"{call.name} {_truncate(args, _APPROVAL_SUMMARY_CAP)}"
+
+
+def _activity_summary(call: ToolCall, result: ToolResult) -> str:
+    """What a build's activity row shows for one invoked call. An error
+    (a real failure OR an approval denial - invoke() returns denial as
+    ToolResult(is_error=True, content="...was denied approval.") and the
+    two are not otherwise distinguishable here) shows the tool's own
+    result text, since that already says exactly what happened. A success
+    shows the call's arguments instead - the result of, say,
+    graph.read_subgraph is the interesting part to the MODEL, not to a
+    human scanning what the build did."""
+    text = result.content if result.is_error else json.dumps(call.arguments, sort_keys=True, ensure_ascii=False)
+    return _truncate(text, _ACTIVITY_SUMMARY_CAP)
+
+
+def _log_activity(node, *, tool: str, summary: str, outcome: str, step_id: str, elapsed_ms: int) -> None:
+    """Appends one row to the plan node's activity log - see PlanState's
+    own docstring for why this is deliberately untouched by undo. Trims
+    from the front (oldest first) once the ring buffer's cap is exceeded."""
+    activity = node.state.builder_activity
+    activity.append({
+        "tool": tool,
+        "summary": summary,
+        "outcome": outcome,
+        "stepId": step_id,
+        "elapsedMs": elapsed_ms,
+    })
+    if len(activity) > _ACTIVITY_CAP:
+        del activity[: len(activity) - _ACTIVITY_CAP]
 
 
 def _rough_token_count(text: str) -> int:
@@ -532,6 +576,16 @@ async def run_build(
         if node.pending_request_id == request_id:
             node.pending_request_id = None
         await bus.publish("scene")
+        # stage 8.7: a build that lands while the user is elsewhere on the
+        # canvas (or the app is unfocused) must not announce nothing.
+        # "stopped" is excluded - the user just clicked Stop and is
+        # necessarily present, so a notification for an action they took
+        # themselves is noise. "interrupted" never reaches this function
+        # (it is a session_load-time normalization, not a run outcome).
+        kind = _LAND_NOTIFICATION_KINDS.get(status)
+        if kind is not None and notifications is not None and detail:
+            notifications.show(detail, kind)
+            await bus.publish("notification")
 
     node.state.builder_status = "running"
     node.state.builder_status_detail = ""
@@ -657,7 +711,16 @@ async def run_build(
                         else:
                             await _land("paused", breach + " Raise the budget and resume to continue.")
                         return
+                    call_started = time.monotonic()
                     result = await registry.invoke(call, ctx)
+                    # stage 8.7: every invoked call, including the four
+                    # in-band control tools - hiding those would make the
+                    # log lie about how many turns the build actually took.
+                    _log_activity(
+                        node, tool=call.name, summary=_activity_summary(call, result),
+                        outcome="error" if result.is_error else "ok",
+                        step_id=step["id"], elapsed_ms=max(0, round((time.monotonic() - call_started) * 1000)),
+                    )
                     messages.append({
                         "role": "tool", "tool_call_id": call.id,
                         "name": call.name, "content": result.content,
@@ -715,10 +778,10 @@ async def run_build(
         # the timeout path above so resume doesn't skip the in-flight step.
         if step is not None and step.get("status") == "running":
             step["status"] = "pending"
+        # _land("failed", ...) now sends this failure's own notification
+        # (see _LAND_NOTIFICATION_KINDS) - a second one here would be a
+        # duplicate banner for the same event.
         await _land("failed", f"Build failed: {exc} — resume to retry.")
-        if notifications is not None:
-            notifications.show(f"Build failed: {exc}", "error")
-            await bus.publish("notification")
 
 
 def _apply_replan(document, node, controls: BuilderControls, run_id: str) -> None:

--- a/backend/domain/commands.py
+++ b/backend/domain/commands.py
@@ -236,6 +236,31 @@ def _restore(live: dict, snapshot: dict) -> None:
                 restored.state.builder_awaiting_tool_approval = False
                 restored.state.builder_approval_tool_name = ""
                 restored.state.builder_approval_summary = ""
+            # review-fix (stage 8.7): builder_activity is documented as run
+            # TELEMETRY, not reversible document content (PlanState's own
+            # docstring: "deliberately left untouched by an undo, so the
+            # record of what happened survives reverting what happened") -
+            # unlike plan_steps, which genuinely IS reversible content
+            # (scene/setPlanSteps is A-classified for exactly that reason).
+            # A command recorded MID-RUN (builderReplan fires on every
+            # builder.replan call, not just once at the run's start)
+            # snapshots the node with whatever activity existed at THAT
+            # instant; restoring that snapshot verbatim would silently erase
+            # every row logged afterward the moment the command is inverted
+            # - the same phantom-state class of hazard pending_request_id's
+            # unconditional reset above already guards against, just for a
+            # different field. Carries the CURRENT node's activity log
+            # forward instead of trusting the snapshot's stale copy - `live`
+            # still holds the pre-restore node at this point, one line
+            # before it is replaced. A node that does not currently exist
+            # (this restore is recreating a deleted one) has no "current" to
+            # preserve, so the snapshot's own activity is used as-is - the
+            # only case where trusting the snapshot is correct.
+            current = live.get(key)
+            if isinstance(getattr(restored, "state", None), PlanState) and isinstance(
+                getattr(current, "state", None), PlanState,
+            ):
+                restored.state.builder_activity = current.state.builder_activity
             live[key] = restored
 
 

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -2346,6 +2346,19 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
                 ]
                 if isinstance(n.state, PlanState) else []
             ),
+            # ADR-008 stage 8.7: the run's own activity log - see PlanState's
+            # docstring for why this is untouched by undo.
+            "builderActivity": (
+                [
+                    {
+                        "tool": a["tool"], "summary": a["summary"],
+                        "outcome": a["outcome"], "stepId": a["stepId"],
+                        "elapsedMs": a["elapsedMs"],
+                    }
+                    for a in n.state.builder_activity
+                ]
+                if isinstance(n.state, PlanState) else []
+            ),
             "builderStatus": n.state.builder_status if isinstance(n.state, PlanState) else "",
             "builderMode": n.state.builder_mode if isinstance(n.state, PlanState) else "",
             "builderRunId": n.state.builder_run_id if isinstance(n.state, PlanState) else "",

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -774,6 +774,20 @@ class PlanState(NodeState):
     own precedent directly above: the wire layer owns the typed row
     (PlanStepRow in contracts/), the domain keeps the flexible shape.
 
+    `activity` (stage 8.7) items are plain dicts {"tool": str, "summary":
+    str, "outcome": "ok"|"error", "stepId": str, "elapsedMs": int} - one
+    row per tool the loop invoked, in call order, written by builder.py's
+    _log_activity at its single registry.invoke() choke point. This is the
+    build's own visible record of WHAT IT DID - distinct from undo (undo_run
+    reverts document MUTATIONS; a build's activity log is run telemetry and
+    is deliberately left untouched by an undo, so the record of what
+    happened survives reverting what happened) and distinct from a chat
+    node's tool_invocations (that field holds one TURN's calls for a
+    completed reply; this holds a whole BUILD's calls across every turn and
+    every step). A capped ring buffer (see builder.py's _ACTIVITY_CAP) -
+    a build is bounded at 50 steps x 8 turns, so nothing else bounds this
+    list's growth.
+
     `builder_status` is the loop's own state machine:
       draft -> planning -> awaiting_start -> running <-> awaiting_approval
       running -> paused (budget breach; resumable)
@@ -797,6 +811,7 @@ class PlanState(NodeState):
 
     plan_goal: str = ""
     plan_steps: list[dict[str, Any]] = field(default_factory=list)
+    builder_activity: list[dict[str, Any]] = field(default_factory=list)
     builder_status: str = "draft"
     builder_mode: str = "copilot"  # "copilot" | "autopilot"
     builder_run_id: str = ""

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -716,12 +716,21 @@ def _restore_plan_payload(payload: dict[str, Any]) -> SceneNode:
     activity = []
     for raw in payload.get("activity") or []:
         if isinstance(raw, dict) and raw.get("tool"):
+            # review-fix: elapsedMs is untrusted input from a saved file
+            # (hand-edited, or written by an older/different format) - a
+            # non-numeric value must degrade to 0, the same tolerance every
+            # other field on this row already gets via str(), not crash the
+            # whole session load the way a bare int() would.
+            try:
+                elapsed_ms = int(raw.get("elapsedMs", 0) or 0)
+            except (TypeError, ValueError):
+                elapsed_ms = 0
             activity.append({
                 "tool": str(raw.get("tool", "")),
                 "summary": str(raw.get("summary", "")),
                 "outcome": str(raw.get("outcome", "ok")),
                 "stepId": str(raw.get("stepId", "")),
-                "elapsedMs": int(raw.get("elapsedMs", 0) or 0),
+                "elapsedMs": elapsed_ms,
             })
     return SceneNode(
         id="", x=x, y=y,

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -713,6 +713,16 @@ def _restore_plan_payload(payload: dict[str, Any]) -> SceneNode:
                 "detail": str(raw.get("detail", "")),
             })
     mode = str(payload.get("builder_mode", "copilot") or "copilot")
+    activity = []
+    for raw in payload.get("activity") or []:
+        if isinstance(raw, dict) and raw.get("tool"):
+            activity.append({
+                "tool": str(raw.get("tool", "")),
+                "summary": str(raw.get("summary", "")),
+                "outcome": str(raw.get("outcome", "ok")),
+                "stepId": str(raw.get("stepId", "")),
+                "elapsedMs": int(raw.get("elapsedMs", 0) or 0),
+            })
     return SceneNode(
         id="", x=x, y=y,
         title=f"Build: {goal[:40]}" if goal else "Build",
@@ -721,6 +731,7 @@ def _restore_plan_payload(payload: dict[str, Any]) -> SceneNode:
         state=PlanState(
             plan_goal=goal,
             plan_steps=steps,
+            builder_activity=activity,
             builder_status=status,
             builder_mode=mode if mode in ("copilot", "autopilot") else "copilot",
             builder_run_id=str(payload.get("builder_run_id", "")),

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -403,6 +403,12 @@ def _serialize_plan_node(node: SceneNode) -> dict[str, Any]:
         "node_type": "plan",
         "goal": node.state.plan_goal,
         "steps": [dict(s) for s in node.state.plan_steps],
+        # stage 8.7: the run's activity log - persisted like every other
+        # PlanState field so it survives restart alongside the resume
+        # point, and (unlike the LIVE-run fields below) it describes past
+        # calls rather than an in-flight RunHandle, so nothing here needs
+        # load-time normalization.
+        "activity": [dict(a) for a in node.state.builder_activity],
         "builder_status": node.state.builder_status,
         "builder_mode": node.state.builder_mode,
         "builder_run_id": node.state.builder_run_id,

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -18,13 +18,16 @@ import time
 
 import api_provider
 from backend import builder as builder_module
+from backend import tools_graph as tools_graph_module
 from backend.builder import run_build
 from backend.domain.graph import SceneDocument
+from backend.domain.model import MESSAGE_VERTICAL_SPACING
+from backend.notifications import NotificationState
 from backend.providers.base import ToolCall
 from backend.run_lifecycle import RunRegistry
 from backend.tests.test_canvas import make_bus_with_dispatcher
 from backend.tools import ToolRegistry
-from backend.tools_graph import register_graph_tools, register_run_node_tool
+from backend.tools_graph import _place_child, register_graph_tools, register_run_node_tool
 from backend.builder import register_builder_control_tools
 
 
@@ -99,7 +102,7 @@ def seed_plan(document, steps, *, mode="copilot", **budgets):
     return node
 
 
-async def drive_build(document, dispatcher, registry, bus, node, *, approve=True, deny_first=False):
+async def drive_build(document, dispatcher, registry, bus, node, *, approve=True, deny_first=False, notifications=None):
     """Runs run_build while a driver coroutine plays the approving human.
     Returns (approvals_seen, denials_issued)."""
     cancel_event = threading.Event()
@@ -111,7 +114,7 @@ async def drive_build(document, dispatcher, registry, bus, node, *, approve=True
         try:
             await run_build(
                 document=document, dispatcher=dispatcher, registry=registry,
-                bus=bus, notifications=None, plan_node_id=node.id,
+                bus=bus, notifications=notifications, plan_node_id=node.id,
                 request_id=handle.request_id, handle=handle, cancel_event=cancel_event,
             )
         finally:
@@ -829,3 +832,251 @@ class TestReviewFixRegressions:
             "a transient provider fault must not permanently kill a build "
             "whose goal/checklist/spent budgets are still on the canvas"
         )
+
+
+class TestActivityLog:
+    """stage 8.7: the build's own visible record of what it did."""
+
+    def test_activity_rows_are_written_for_ok_and_error_calls_including_control_tools(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["one step"])
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [
+                call("c1", "graph.create_node", kind="note", content="x"),
+                # pycoder requires parent_id - this call errors.
+                call("c2", "graph.create_node", kind="pycoder"),
+            ]},
+            {"tool_calls": [call("c3", "builder.complete_step", summary="done")]},
+        ], [])
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node))
+
+        rows = node.state.builder_activity
+        tools = [r["tool"] for r in rows]
+        assert tools == ["graph.create_node", "graph.create_node", "builder.complete_step"], (
+            "every invoked call is logged in order, including the control tool"
+        )
+        assert rows[0]["outcome"] == "ok"
+        assert rows[1]["outcome"] == "error"
+        assert rows[2]["outcome"] == "ok"
+        assert all(r["stepId"] == "s1" for r in rows)
+        assert all(isinstance(r["elapsedMs"], int) and r["elapsedMs"] >= 0 for r in rows)
+
+    def test_a_denied_call_logs_as_error_with_the_denial_text(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["one step"])
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [call("c1", "graph.create_node", kind="note", content="first try")]},
+            {"tool_calls": [call("c2", "builder.complete_step", summary="ok, done without it")]},
+        ], [])
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node, deny_first=True))
+
+        rows = node.state.builder_activity
+        assert rows[0]["tool"] == "graph.create_node"
+        assert rows[0]["outcome"] == "error"
+        assert "denied" in rows[0]["summary"]
+
+    def test_activity_is_a_capped_ring_buffer(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        # autopilot: 120 graph.mutate calls with no approval round-trip each.
+        node = seed_plan(document, ["one step"], mode="autopilot", max_tokens=10_000_000, max_wall_seconds=10_000)
+        calls = [call(f"c{i}", "graph.create_node", kind="note", content=str(i)) for i in range(120)]
+        calls.append(call("cfinal", "builder.complete_step", summary="done"))
+        scripted_turns(monkeypatch, [{"tool_calls": calls}], [])
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node))
+
+        assert node.state.builder_status == "done"
+        assert len(node.state.builder_activity) == builder_module._ACTIVITY_CAP
+        # Oldest dropped first: the newest row logged is always last.
+        assert node.state.builder_activity[-1]["tool"] == "builder.complete_step"
+
+    def test_undo_run_leaves_the_activity_log_intact(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["one step"])
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [call("c1", "graph.create_node", kind="note", content="x")]},
+            {"tool_calls": [call("c2", "builder.complete_step", summary="done")]},
+        ], [])
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node))
+        logged = len(node.state.builder_activity)
+        assert logged > 0
+
+        document.undo_run(node.state.builder_run_id)
+
+        assert len(node.state.builder_activity) == logged, (
+            "activity is run telemetry, not document content - undo_run must not touch it"
+        )
+
+    def test_activity_round_trips_through_session_save_and_load(self):
+        from backend.session_load import _restore_plan_payload
+        from backend.session_save import _serialize_plan_node
+
+        document = SceneDocument()
+        node = document.add_plan_node(0, 0, "the goal")
+        node.state.builder_activity = [
+            {"tool": "graph.create_node", "summary": "{}", "outcome": "ok", "stepId": "s1", "elapsedMs": 42},
+        ]
+
+        restored = _restore_plan_payload(_serialize_plan_node(node))
+
+        assert restored.state.builder_activity == node.state.builder_activity
+
+
+class TestLandNotifications:
+    """stage 8.7: a build that lands while the user is elsewhere must not
+    announce nothing."""
+
+    def test_done_notifies_success(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["one step"])
+        notifications = NotificationState()
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [call("c1", "builder.finish_build", summary="all done")]},
+        ], [])
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node, notifications=notifications))
+
+        assert notifications.msg_type == "success"
+        assert notifications.message == "all done"
+
+    def test_paused_notifies_warning(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["one step"], max_tokens=1)
+        notifications = NotificationState()
+        scripted_turns(monkeypatch, [
+            {
+                "tool_calls": [call("c1", "graph.create_node", kind="note", content="x")],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 5},
+            },
+        ], [])
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node, notifications=notifications))
+
+        assert notifications.msg_type == "warning"
+        assert "budget" in notifications.message.lower()
+
+    def test_failed_notifies_error(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["a step"])
+        notifications = NotificationState()
+
+        def boom_turn(task, messages, tools=(), **kwargs):
+            raise RuntimeError("rate limited")
+
+        monkeypatch.setattr(api_provider, "chat_turn_with_tools", boom_turn)
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node, notifications=notifications))
+
+        assert notifications.msg_type == "error"
+        assert "rate limited" in notifications.message
+
+    def test_stopped_does_not_notify(self):
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["one step"])
+        notifications = NotificationState()
+        cancel_event = threading.Event()
+        cancel_event.set()  # pre-cancelled: the loop's own top-of-loop check fires first
+        handle = dispatcher._runs.claim("builder", node_id=node.id, cancel_event=cancel_event)
+
+        async def run():
+            try:
+                await run_build(
+                    document=document, dispatcher=dispatcher, registry=registry,
+                    bus=bus, notifications=notifications, plan_node_id=node.id,
+                    request_id=handle.request_id, handle=handle, cancel_event=cancel_event,
+                )
+            finally:
+                dispatcher._runs.release(handle.request_id)
+
+        asyncio.run(run())
+
+        assert node.state.builder_status == "stopped"
+        assert notifications.message == "", (
+            "Stop is user-initiated - a notification for an action the user just took is noise"
+        )
+
+
+class TestAnchoredPlacement:
+    """stage 8.7: a build's parentless creates land near its plan node
+    instead of scattering at the canvas origin."""
+
+    def test_a_parentless_create_anchors_near_the_plan_node(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["one step"])
+        node.x, node.y = 500.0, 300.0
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [call("c1", "graph.create_node", kind="note", content="x")]},
+            {"tool_calls": [call("c2", "builder.complete_step", summary="done")]},
+        ], [])
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node))
+
+        created = next(n for n in document.nodes.values() if n.kind == "note")
+        assert created.x == node.x
+        assert created.y == node.y + MESSAGE_VERTICAL_SPACING
+
+    def test_multiple_parentless_creates_fan_out_along_the_anchor_row(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["one step"])
+        node.x, node.y = 100.0, 100.0
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [
+                call("c1", "graph.create_node", kind="note", content="a"),
+                call("c2", "graph.create_node", kind="note", content="b"),
+            ]},
+            {"tool_calls": [call("c3", "builder.complete_step", summary="done")]},
+        ], [])
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node))
+
+        notes = sorted((n for n in document.nodes.values() if n.kind == "note"), key=lambda n: n.x)
+        assert len(notes) == 2
+        assert notes[0].x == node.x
+        assert notes[1].x == node.x + tools_graph_module._SIBLING_HORIZONTAL_SPACING
+        assert notes[0].y == notes[1].y == node.y + MESSAGE_VERTICAL_SPACING
+
+    def test_no_anchor_falls_back_to_the_origin_drop(self):
+        document = SceneDocument()
+        assert _place_child(document, None, None) == (80.0, 80.0)
+
+
+class TestDeleteRecipe:
+    def test_deletes_a_saved_recipe(self):
+        async def run():
+            bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+            source = document.add_plan_node(0, 0, "goal")
+            source.state.plan_steps = [{"id": "s1", "title": "step", "status": "done", "detail": ""}]
+            await bus.dispatch_intent("builder", "saveRecipe", [source.id, "My recipe"])
+
+            result = await bus.dispatch_intent("builder", "deleteRecipe", ["My recipe"])
+            assert result is True
+
+            listing = await bus.dispatch_intent("builder", "listRecipes", [])
+            names = [r["name"] for r in listing["recipes"]]
+            assert "My recipe" not in names
+            assert "Research and summarize" in names, "built-ins are untouched"
+
+        asyncio.run(run())
+
+    def test_refuses_to_delete_a_built_in(self):
+        async def run():
+            bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+            result = await bus.dispatch_intent("builder", "deleteRecipe", ["Research and summarize"])
+            assert result is False
+
+            listing = await bus.dispatch_intent("builder", "listRecipes", [])
+            names = [r["name"] for r in listing["recipes"]]
+            assert "Research and summarize" in names
+
+        asyncio.run(run())
+
+    def test_deleting_an_unknown_name_is_a_no_op_not_an_error(self):
+        async def run():
+            bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+            result = await bus.dispatch_intent("builder", "deleteRecipe", ["Nonexistent"])
+            assert result is False
+
+        asyncio.run(run())

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -1016,11 +1016,11 @@ class TestActivityLog:
         long_tool_name = "graph." + "x" * 200
         long_content = "y" * 500
 
+        from backend.providers.base import ToolSpec
+        from backend.tools import GRAPH_READ, ToolResult
+
         async def oversized_handler(call, ctx):
             return ToolResult(content="ok")
-
-        from backend.providers.base import ToolSpec
-        from backend.tools import GRAPH_READ
 
         registry.register(
             ToolSpec(name=long_tool_name, description="d", input_schema={"type": "object"}),
@@ -1034,6 +1034,11 @@ class TestActivityLog:
         asyncio.run(drive_build(document, dispatcher, registry, bus, node))
 
         row = node.state.builder_activity[0]
+        # Pinned explicitly: an error result would ALSO produce a long,
+        # truncated summary (the error text embeds the oversized tool
+        # name), so without this the assertions below could pass for the
+        # wrong reason - the success path never actually being exercised.
+        assert row["outcome"] == "ok"
         # _truncate appends a trailing ellipsis character on top of the cap,
         # so the truncated length is cap + 1, not cap itself.
         assert len(row["tool"]) == builder_module._ACTIVITY_TOOL_NAME_CAP + 1

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -924,6 +924,123 @@ class TestActivityLog:
 
         assert restored.state.builder_activity == node.state.builder_activity
 
+    def test_session_load_drops_malformed_activity_entries_instead_of_crashing(self):
+        from backend.session_load import _restore_plan_payload
+
+        payload = {
+            "goal": "g",
+            "activity": [
+                {"tool": "graph.create_node", "summary": "ok row", "outcome": "ok", "stepId": "s1", "elapsedMs": 5},
+                "not a dict",
+                {"summary": "missing the tool key entirely"},
+                {"tool": "run_node", "summary": "s", "outcome": "ok", "stepId": "s1", "elapsedMs": "not a number"},
+            ],
+        }
+
+        restored = _restore_plan_payload(payload)
+
+        assert len(restored.state.builder_activity) == 2, (
+            "the non-dict entry and the entry missing 'tool' are dropped, "
+            "matching plan_steps' own malformed-entry tolerance"
+        )
+        assert restored.state.builder_activity[0]["tool"] == "graph.create_node"
+        assert restored.state.builder_activity[1]["elapsedMs"] == 0, (
+            "a non-numeric elapsedMs coerces to 0 rather than crashing session load"
+        )
+
+    def test_review_fix_undo_run_does_not_revert_activity_logged_after_a_mid_run_replan(self, monkeypatch):
+        """A command recorded mid-run (builderReplan fires on every
+        builder.replan call, not just once) snapshots the plan node with
+        whatever activity existed at that instant. Reverting that command -
+        via undo_run, which walks the whole run's commands - must not
+        silently erase rows logged afterward; see commands.py's own
+        review-fix in _restore for the mechanism."""
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["s1", "s2", "s3"])
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [call("c1", "builder.complete_step", summary="s1 done")]},
+            # The replan's own command snapshots the node right after this
+            # call's own activity row is appended.
+            {"tool_calls": [call("c2", "builder.replan", steps=["new s3"], reason="r")]},
+            # Everything below is logged AFTER that snapshot.
+            {"tool_calls": [call("c3", "graph.create_node", kind="note", content="after replan")]},
+            {"tool_calls": [call("c4", "builder.complete_step", summary="s2 done")]},
+            {"tool_calls": [call("c5", "builder.complete_step", summary="new s3 done")]},
+        ], [])
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node))
+
+        assert node.state.builder_status == "done"
+        activity_before_undo = list(node.state.builder_activity)
+        assert len(activity_before_undo) == 5, "one row per invoked call"
+
+        document.undo_run(node.state.builder_run_id)
+
+        assert node.state.builder_activity == activity_before_undo, (
+            "undo_run inverts the builderReplan command among the run's "
+            "others - its mid-run snapshot must not erase rows logged after it"
+        )
+
+    def test_activity_is_a_capped_ring_buffer_at_the_exact_boundary(self, monkeypatch):
+        """review-fix: the existing ring-buffer test only checks aggregate
+        length and the newest row after a large overshoot; this pins the
+        exact trim at the boundary - one run under the cap, one exactly at
+        it, one one-over - and which specific rows survive."""
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["one step"], mode="autopilot", max_tokens=10_000_000, max_wall_seconds=10_000)
+        # _ACTIVITY_CAP + 1 create_node calls, then complete_step - the cap
+        # is breached by exactly one row.
+        calls = [
+            call(f"c{i}", "graph.create_node", kind="note", content=str(i))
+            for i in range(builder_module._ACTIVITY_CAP + 1)
+        ]
+        calls.append(call("cfinal", "builder.complete_step", summary="done"))
+        scripted_turns(monkeypatch, [{"tool_calls": calls}], [])
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node))
+
+        activity = node.state.builder_activity
+        assert len(activity) == builder_module._ACTIVITY_CAP
+        # The trim runs after EVERY append that exceeds the cap, not once
+        # at the end: 101 create_node calls (content "0".."100") first push
+        # the log to 101 rows, dropping content "0"; the trailing
+        # complete_step then pushes it to 101 again, dropping content "1"
+        # too - "2" is the oldest of the two content rows to survive both
+        # trims.
+        assert activity[0]["summary"] == '{"content": "2", "kind": "note"}'
+        assert activity[-1]["tool"] == "builder.complete_step"
+
+    def test_activity_tool_name_and_summary_are_both_truncated_when_over_cap(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["one step"])
+        long_tool_name = "graph." + "x" * 200
+        long_content = "y" * 500
+
+        async def oversized_handler(call, ctx):
+            return ToolResult(content="ok")
+
+        from backend.providers.base import ToolSpec
+        from backend.tools import GRAPH_READ
+
+        registry.register(
+            ToolSpec(name=long_tool_name, description="d", input_schema={"type": "object"}),
+            oversized_handler, scopes={GRAPH_READ}, approval="auto",
+        )
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [call("c1", long_tool_name, content=long_content)]},
+            {"tool_calls": [call("c2", "builder.complete_step", summary="done")]},
+        ], [])
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node))
+
+        row = node.state.builder_activity[0]
+        # _truncate appends a trailing ellipsis character on top of the cap,
+        # so the truncated length is cap + 1, not cap itself.
+        assert len(row["tool"]) == builder_module._ACTIVITY_TOOL_NAME_CAP + 1
+        assert row["tool"].endswith("…")
+        assert len(row["summary"]) == builder_module._ACTIVITY_SUMMARY_CAP + 1
+        assert row["summary"].endswith("…")
+
 
 class TestLandNotifications:
     """stage 8.7: a build that lands while the user is elsewhere must not
@@ -1041,6 +1158,35 @@ class TestAnchoredPlacement:
     def test_no_anchor_falls_back_to_the_origin_drop(self):
         document = SceneDocument()
         assert _place_child(document, None, None) == (80.0, 80.0)
+
+    def test_review_fix_an_explicit_parent_id_equal_to_the_anchor_does_not_overlap_an_anchor_placed_sibling(self):
+        """The executor prompt tells the model the plan node's own id
+        (builder.py: "The plan node's id is {plan_node_id}."), and nothing
+        stops it passing that back as parent_id for a chat/code node -
+        which used to count siblings by EDGE (invisible to a note the
+        anchor branch placed with no edge at all), landing the two nodes on
+        top of each other. Both branches must now agree on the same row."""
+        document = SceneDocument()
+        plan = document.add_plan_node(200.0, 200.0, "goal")
+
+        x1, y1 = _place_child(document, None, plan.id)  # parentless -> anchor branch
+        document.add_note(x1, y1)
+        x2, y2 = _place_child(document, plan.id, plan.id)  # parent_id IS the anchor
+
+        assert (x2, y2) != (x1, y1), "must not collide with the anchor-placed sibling"
+        assert (x2, y2) == (x1 + tools_graph_module._SIBLING_HORIZONTAL_SPACING, y1)
+
+    def test_review_fix_a_real_parent_distinct_from_the_anchor_keeps_its_own_edge_based_counting(self):
+        """The unification fix must be scoped to parent_id == anchor_id
+        only - a normal parent (anything else) keeps exactly its prior,
+        unrelated-to-the-builder edge-based placement."""
+        document = SceneDocument()
+        plan = document.add_plan_node(0.0, 0.0, "goal")
+        parent = document.add_chat_node(500.0, 500.0, "p", True)
+
+        x, y = _place_child(document, parent.id, plan.id)
+
+        assert (x, y) == (parent.x, parent.y + MESSAGE_VERTICAL_SPACING)
 
 
 class TestDeleteRecipe:

--- a/backend/tools_graph.py
+++ b/backend/tools_graph.py
@@ -197,28 +197,43 @@ def _place_child(
 ) -> tuple[float, float]:
     """Parent-relative placement, model-free: directly below the parent,
     fanning right one slot per existing child so parallel children of the
-    same parent land side by side instead of stacked."""
-    if parent_id is not None and parent_id in document.nodes:
+    same parent land side by side instead of stacked.
+
+    review-fix (stage 8.7): the plan node can be reached by EITHER path -
+    as an explicit parent_id (the executor prompt tells the model the plan
+    node's own id, and nothing stops it passing that id back as parent_id
+    for a chat/code node) or as the implicit anchor for a parentless create.
+    The two branches below used to count siblings differently (edges vs.
+    position), so a parentless create landing via the anchor branch was
+    invisible to the parent branch's edge count and vice versa - two nodes
+    from the two different paths could land on the exact same coordinates.
+    `parent_id != anchor_id` routes that one specific case (parent_id IS the
+    anchor) into the position-based branch below, which sees every node in
+    the row regardless of which path placed it. A normal parent - anything
+    other than the anchor - is completely unaffected."""
+    if parent_id is not None and parent_id in document.nodes and parent_id != anchor_id:
         parent = document.nodes[parent_id]
         existing_children = sum(1 for e in document.edges.values() if e.source == parent_id)
         return (
             parent.x + existing_children * _SIBLING_HORIZONTAL_SPACING,
             parent.y + MESSAGE_VERTICAL_SPACING,
         )
-    if anchor_id is not None and anchor_id in document.nodes:
-        # stage 8.7: same fan-out shape as the parented branch above, but
-        # the anchor (a plan node) never gains an EDGE to what it builds -
+    reference_id = parent_id or anchor_id
+    if reference_id is not None and reference_id in document.nodes:
+        # The anchor (a plan node) never gains an EDGE to what it builds -
         # it is a placement reference only - so there is no edge count to
-        # read a sibling index off. A node already sitting on the anchor's
-        # own placement row is this same anchor's own earlier creation
-        # (nothing else places there), so counting THOSE stands in for
-        # "existing children" without needing a persisted counter.
-        anchor = document.nodes[anchor_id]
-        row_y = anchor.y + MESSAGE_VERTICAL_SPACING
+        # read a sibling index off. A node already sitting on the
+        # reference's own placement row is this same reference's own
+        # earlier creation (nothing else places there), so counting THOSE
+        # stands in for "existing children" without needing a persisted
+        # counter - and, per the docstring above, catches siblings placed
+        # via EITHER path.
+        reference = document.nodes[reference_id]
+        row_y = reference.y + MESSAGE_VERTICAL_SPACING
         row_siblings = sum(
-            1 for n in document.nodes.values() if n.x >= anchor.x and abs(n.y - row_y) < 1.0
+            1 for n in document.nodes.values() if n.x >= reference.x and abs(n.y - row_y) < 1.0
         )
-        return anchor.x + row_siblings * _SIBLING_HORIZONTAL_SPACING, row_y
+        return reference.x + row_siblings * _SIBLING_HORIZONTAL_SPACING, row_y
     # Free-floating with no anchor either (a bare RunContext, e.g. a future
     # non-builder caller): drop near the origin offset by node count so
     # repeated creations don't perfectly overlap.

--- a/backend/tools_graph.py
+++ b/backend/tools_graph.py
@@ -28,7 +28,10 @@ loop - so per-call stamping has no such window.
 Placement: the model never picks coordinates. New nodes land relative to
 their parent using the same MESSAGE_VERTICAL_SPACING convention
 send_message's own reply placement uses (backend/domain/model.py), with a
-horizontal fan-out for siblings so parallel children don't stack.
+horizontal fan-out for siblings so parallel children don't stack. A
+parentless create (stage 8.7) instead anchors near the run's plan node, if
+one exists, so a build's output lands where the user just looked rather
+than at the canvas origin - see _place_child's own doc.
 """
 
 from __future__ import annotations
@@ -178,21 +181,49 @@ def _run_id_of(ctx: RunContext) -> str | None:
     return getattr(ctx, "run_id", None)
 
 
-def _place_child(document: SceneDocument, parent_id: str | None) -> tuple[float, float]:
+def _anchor_id_of(ctx: RunContext) -> str | None:
+    """stage 8.7: BuilderRunContext already carries plan_node_id (builder.py)
+    for run attribution - reused here as a PLACEMENT reference, not graph
+    parentage, so a build's parentless creates (a note, a from-scratch
+    chat/code node) land near the plan node the user just launched instead
+    of scattered near the canvas origin. Same duck-typed degradation as
+    _run_id_of: a bare RunContext has none, and placement falls through to
+    the origin-drop fallback exactly as before this existed."""
+    return getattr(ctx, "plan_node_id", None)
+
+
+def _place_child(
+    document: SceneDocument, parent_id: str | None, anchor_id: str | None = None,
+) -> tuple[float, float]:
     """Parent-relative placement, model-free: directly below the parent,
     fanning right one slot per existing child so parallel children of the
     same parent land side by side instead of stacked."""
-    if parent_id is None or parent_id not in document.nodes:
-        # Free-floating (note, parentless chat/code): drop near the origin
-        # offset by node count so repeated creations don't perfectly overlap.
-        n = len(document.nodes)
-        return 80.0 + (n % 5) * 40.0, 80.0 + (n % 7) * 40.0
-    parent = document.nodes[parent_id]
-    existing_children = sum(1 for e in document.edges.values() if e.source == parent_id)
-    return (
-        parent.x + existing_children * _SIBLING_HORIZONTAL_SPACING,
-        parent.y + MESSAGE_VERTICAL_SPACING,
-    )
+    if parent_id is not None and parent_id in document.nodes:
+        parent = document.nodes[parent_id]
+        existing_children = sum(1 for e in document.edges.values() if e.source == parent_id)
+        return (
+            parent.x + existing_children * _SIBLING_HORIZONTAL_SPACING,
+            parent.y + MESSAGE_VERTICAL_SPACING,
+        )
+    if anchor_id is not None and anchor_id in document.nodes:
+        # stage 8.7: same fan-out shape as the parented branch above, but
+        # the anchor (a plan node) never gains an EDGE to what it builds -
+        # it is a placement reference only - so there is no edge count to
+        # read a sibling index off. A node already sitting on the anchor's
+        # own placement row is this same anchor's own earlier creation
+        # (nothing else places there), so counting THOSE stands in for
+        # "existing children" without needing a persisted counter.
+        anchor = document.nodes[anchor_id]
+        row_y = anchor.y + MESSAGE_VERTICAL_SPACING
+        row_siblings = sum(
+            1 for n in document.nodes.values() if n.x >= anchor.x and abs(n.y - row_y) < 1.0
+        )
+        return anchor.x + row_siblings * _SIBLING_HORIZONTAL_SPACING, row_y
+    # Free-floating with no anchor either (a bare RunContext, e.g. a future
+    # non-builder caller): drop near the origin offset by node count so
+    # repeated creations don't perfectly overlap.
+    n = len(document.nodes)
+    return 80.0 + (n % 5) * 40.0, 80.0 + (n % 7) * 40.0
 
 
 def _error(message: str) -> ToolResult:
@@ -215,7 +246,7 @@ def make_create_node_handler(document: SceneDocument):
         if kind == "document" and not title:
             return _error("kind 'document' requires a title.")
 
-        x, y = _place_child(document, parent_id)
+        x, y = _place_child(document, parent_id, _anchor_id_of(ctx))
         run_id = _run_id_of(ctx)
 
         def mutator():

--- a/contracts/graphlink_scene_payload.py
+++ b/contracts/graphlink_scene_payload.py
@@ -293,6 +293,21 @@ class PlanStepRow:
 
 
 @dataclass
+class BuilderActivityRow:
+    """ADR-008 stage 8.7: one row of a Builder run's activity log - the
+    typed wire shape of PlanState.builder_activity's own {"tool","summary",
+    "outcome","stepId","elapsedMs"} dicts (backend/domain/node_states.py).
+    outcome is "ok"|"error" - pinned as a plain string for the same
+    additive-evolution reason PlanStepRow's own status is."""
+
+    tool: str
+    summary: str
+    outcome: str = "ok"
+    stepId: str = ""
+    elapsedMs: int = 0
+
+
+@dataclass
 class ChartFlowRow:
     """One Sankey flow - the shape canonicalize_chart_data() (graphlink_
     chart_data.py) always builds every item of its "flows" list from, for
@@ -553,6 +568,7 @@ class SceneNodeRow:
     # contract these fields serialize.
     planGoal: str = ""
     planSteps: list["PlanStepRow"] = field(default_factory=list)
+    builderActivity: list["BuilderActivityRow"] = field(default_factory=list)
     builderStatus: str = ""
     builderMode: str = ""
     builderRunId: str = ""

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -110,7 +110,7 @@ MIGRATED_KIND_FIELDS = {
     # candidates - goal/steps/mode/run_id - collide with Command.run_id
     # and friends all over the command layer).
     "plan": [
-        "plan_goal", "plan_steps", "builder_status", "builder_mode",
+        "plan_goal", "plan_steps", "builder_activity", "builder_status", "builder_mode",
         "builder_run_id", "builder_max_steps", "builder_max_tokens",
         "builder_max_wall_seconds", "builder_spent_steps",
         "builder_spent_tokens", "builder_spent_wall_seconds",
@@ -343,9 +343,10 @@ _EXPECTED_SCENE_NODE_WIRE_KEYS = sorted([
     "completionTokens", "promptTokens",
     "researchResult", "researchStage", "researchTotal", "responseIncomplete",
     "synthesisInstructions", "title", "toolCalls", "x", "y",
-    # ADR-008 stage 8.3: the Builder plan node's 15 fields.
-    "planGoal", "planSteps", "builderStatus", "builderMode", "builderRunId",
-    "builderMaxSteps", "builderMaxTokens", "builderMaxWallSeconds",
+    # ADR-008 stage 8.3: the Builder plan node's 15 fields, +1 (builderActivity)
+    # when stage 8.7 added the run's own activity log.
+    "planGoal", "planSteps", "builderActivity", "builderStatus", "builderMode",
+    "builderRunId", "builderMaxSteps", "builderMaxTokens", "builderMaxWallSeconds",
     "builderSpentSteps", "builderSpentTokens", "builderSpentWallSeconds",
     "builderAwaitingToolApproval", "builderApprovalToolName",
     "builderApprovalSummary", "builderStatusDetail",

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -255,11 +255,12 @@ def test_the_scan_finds_the_real_population_of_registered_intents():
     # archiveWorkspace sextet, 165 -> 166 when ADR-020 stage 20.3 added
     # app-chat-library's own setWorkspaceDefaultModel, 166 -> 168 when
     # ADR-020 stage 20.4 added app-chat-library's own loadGraphAndFocusNode
-    # plus the new "globalSearch" topic's own search intent, and 168 -> 169
-    # when ADR-020 stage 20.5 added app-chat-library's own exportWorkspace.
+    # plus the new "globalSearch" topic's own search intent, 168 -> 169
+    # when ADR-020 stage 20.5 added app-chat-library's own exportWorkspace,
+    # and 169 -> 170 when ADR-008 stage 8.7 added builder's own deleteRecipe.
     real = _collect_real_registrations()
-    assert len(real) == 169, (
-        f"expected exactly 169 real registered intents, found {len(real)} - "
+    assert len(real) == 170, (
+        f"expected exactly 170 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -248,6 +248,7 @@ CLASSIFICATION: tuple[Classified, ...] = (
     Classified("builder", "denyTool", "B", "security: builder tool-call approval gate"),
     Classified("builder", "listRecipes", "B", "read-only: returns the recipe list"),
     Classified("builder", "saveRecipe", "B", "preference: writes the settings store's recipe list, not document state"),
+    Classified("builder", "deleteRecipe", "B", "preference: writes the settings store's recipe list, not document state - same posture as saveRecipe"),
     Classified("scene", "setPlanSteps", "A", "content: the plan checklist is document state"),
 
     # -- backend/api/intents_settings_general.py (app-settings) -------------

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -505,7 +505,7 @@ function App() {
                   <DiagnosticsDialog transport={transport} />
                   <KnowledgeSearchDialog transport={transport} />
                   <GlobalSearchDialog transport={transport} />
-                  <BuilderLaunchDialog transport={transport} />
+                  <BuilderLaunchDialog transport={transport} store={sceneStore} />
                   <LazySurface overlayName="settings">
                     <SettingsDialog transport={transport} />
                   </LazySurface>

--- a/web_ui/src/app/canvas/PlanNodeView.test.tsx
+++ b/web_ui/src/app/canvas/PlanNodeView.test.tsx
@@ -15,6 +15,7 @@ function makeData(overrides: Partial<PlanNodeData> = {}): PlanNodeData {
       { id: "s2", title: "Write summary", status: "running", detail: "" },
       { id: "s3", title: "Chart it", status: "pending", detail: "" },
     ],
+    builderActivity: [],
     builderStatus: "running",
     builderMode: "copilot",
     builderRunId: "run-1",
@@ -182,5 +183,56 @@ describe("PlanNodeView", () => {
 
     expect(screen.getByRole("alert")).toHaveTextContent("the model aborted");
     expect(screen.getByText("autopilot")).toBeInTheDocument();
+  });
+
+  describe("activity log", () => {
+    it("stays hidden entirely when the build has no activity yet", () => {
+      renderPlan(makeData({ builderActivity: [] }));
+      expect(screen.queryByText(/activity entr/)).not.toBeInTheDocument();
+    });
+
+    it("shows the count, error count, and every row's tool/summary/elapsed - collapsed by default", () => {
+      const data = makeData({
+        builderActivity: [
+          { tool: "graph.create_node", summary: '{"kind":"note"}', outcome: "ok", stepId: "s1", elapsedMs: 12 },
+          {
+            tool: "graph.create_node",
+            summary: "Tool call 'graph.create_node' was denied approval.",
+            outcome: "error", stepId: "s1", elapsedMs: 0,
+          },
+        ],
+      });
+      renderPlan(data);
+
+      const summary = screen.getByText("2 activity entries · 1 error");
+      const details = summary.closest("details");
+      expect(details).not.toHaveAttribute("open");
+      expect(screen.getAllByText("graph.create_node")).toHaveLength(2);
+      expect(screen.getByText('{"kind":"note"}')).toBeInTheDocument();
+      expect(screen.getByText(/was denied approval/)).toBeInTheDocument();
+      expect(screen.getByText("12ms")).toBeInTheDocument();
+    });
+
+    it("tints an error row distinctly from an ok row", () => {
+      renderPlan(makeData({
+        builderActivity: [
+          { tool: "graph.create_node", summary: "ok call", outcome: "ok", stepId: "s1", elapsedMs: 5 },
+          { tool: "run_node", summary: "boom", outcome: "error", stepId: "s1", elapsedMs: 3 },
+        ],
+      }));
+
+      expect(screen.getByText("ok call").closest(".chat-node-tool-invocation")).not.toHaveClass("error");
+      expect(screen.getByText("boom").closest(".chat-node-tool-invocation")).toHaveClass("error");
+    });
+
+    it("singular-cases one entry and omits the error count when nothing failed", () => {
+      renderPlan(makeData({
+        builderActivity: [
+          { tool: "builder.complete_step", summary: "{}", outcome: "ok", stepId: "s1", elapsedMs: 1 },
+        ],
+      }));
+      expect(screen.getByText("1 activity entry")).toBeInTheDocument();
+      expect(screen.queryByText(/error/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/web_ui/src/app/canvas/PlanNodeView.test.tsx
+++ b/web_ui/src/app/canvas/PlanNodeView.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ReactFlowProvider } from "@xyflow/react";
@@ -43,8 +44,8 @@ function makeData(overrides: Partial<PlanNodeData> = {}): PlanNodeData {
   };
 }
 
-function renderPlan(data: PlanNodeData) {
-  return render(
+function planElement(data: PlanNodeData) {
+  return (
     <ReactFlowProvider>
       <PlanNodeView
         id="n1"
@@ -61,8 +62,19 @@ function renderPlan(data: PlanNodeData) {
         draggable
         parentId={undefined}
       />
-    </ReactFlowProvider>,
+    </ReactFlowProvider>
   );
+}
+
+function renderPlan(data: PlanNodeData) {
+  return render(planElement(data));
+}
+
+// ReactFlowProvider remounting on every rerender would reset internal state
+// unrelated to this test - reusing the exact same element shape as
+// renderPlan keeps rerender() a like-for-like prop update instead.
+function rerenderPlan(rerender: (ui: ReactElement) => void, data: PlanNodeData) {
+  rerender(planElement(data));
 }
 
 describe("PlanNodeView", () => {
@@ -233,6 +245,35 @@ describe("PlanNodeView", () => {
       }));
       expect(screen.getByText("1 activity entry")).toBeInTheDocument();
       expect(screen.queryByText(/error/)).not.toBeInTheDocument();
+    });
+
+    it("review-fix: only auto-scrolls while running AND the disclosure is open - not collapsed, not landed", () => {
+      const scrollToSpy = vi.fn();
+      const originalScrollTo = Element.prototype.scrollTo;
+      Element.prototype.scrollTo = scrollToSpy;
+      const row = (n: number) => ({ tool: `tool-${n}`, summary: "{}", outcome: "ok", stepId: "s1", elapsedMs: n });
+
+      try {
+        const { rerender } = renderPlan(makeData({ builderStatus: "running", builderActivity: [row(1)] }));
+        const details = document.querySelector(".plan-node-activity") as HTMLDetailsElement;
+        expect(details.open).toBe(false); // collapsed by default
+
+        rerenderPlan(rerender, makeData({ builderStatus: "running", builderActivity: [row(1), row(2)] }));
+        expect(scrollToSpy).not.toHaveBeenCalled(); // still collapsed - must not scroll a hidden panel
+
+        details.open = true; // the same native toggle a real click on <summary> performs
+        rerenderPlan(rerender, makeData({ builderStatus: "running", builderActivity: [row(1), row(2), row(3)] }));
+        expect(scrollToSpy).toHaveBeenCalledTimes(1); // running + open - follows the newest row
+
+        scrollToSpy.mockClear();
+        rerenderPlan(rerender, makeData({
+          builderStatus: "done", pendingRequestId: null,
+          builderActivity: [row(1), row(2), row(3), row(4)],
+        }));
+        expect(scrollToSpy).not.toHaveBeenCalled(); // landed - stops following, doesn't yank a spot the user scrolled to
+      } finally {
+        Element.prototype.scrollTo = originalScrollTo;
+      }
     });
   });
 });

--- a/web_ui/src/app/canvas/PlanNodeView.tsx
+++ b/web_ui/src/app/canvas/PlanNodeView.tsx
@@ -27,9 +27,18 @@ export interface PlanStepData {
   detail: string;
 }
 
+export interface BuilderActivityRowData {
+  tool: string;
+  summary: string;
+  outcome: string;
+  stepId: string;
+  elapsedMs: number;
+}
+
 export interface PlanNodeData extends Record<string, unknown> {
   planGoal: string;
   planSteps: PlanStepData[];
+  builderActivity: BuilderActivityRowData[];
   builderStatus: string;
   builderMode: string;
   builderRunId: string;
@@ -96,6 +105,21 @@ function PlanNodeViewInner({ data, selected }: NodeProps<PlanFlowNode>) {
   const resumable = RESUMABLE.has(data.builderStatus);
   const startLabel = data.builderStatus === "awaiting_start" ? "Start build" : "Resume";
   const denyButtonRef = useRef<HTMLButtonElement>(null);
+  const activityDetailsRef = useRef<HTMLDetailsElement>(null);
+  const activityListRef = useRef<HTMLDivElement>(null);
+  const activityErrorCount = data.builderActivity.filter((row) => row.outcome !== "ok").length;
+
+  // Keeps the log pinned to its newest row while the build is actively
+  // producing more of them - only while the disclosure is actually open
+  // (a native <details>'s own `open` attribute IS the expand/collapse
+  // state here, so no separate React state exists to gate this on) and
+  // only while running, so a landed build's log stops moving under the
+  // user once there is nothing left to follow.
+  useEffect(() => {
+    if (running && activityDetailsRef.current?.open) {
+      activityListRef.current?.scrollTo({ top: activityListRef.current.scrollHeight });
+    }
+  }, [data.builderActivity, running]);
 
   // The tool-approval panel mounts fresh each time the Builder pauses for
   // approval (see the block-level comment above); Deny is the safe default,
@@ -165,6 +189,40 @@ function PlanNodeViewInner({ data, selected }: NodeProps<PlanFlowNode>) {
           Time {data.builderSpentWallSeconds}s/{data.builderMaxWallSeconds}s
         </span>
       </div>
+
+      {/* stage 8.7: the build's own visible record of what it did - real
+          backend state (PlanState.builder_activity), not a debug aid.
+          Reuses ChatNodeView's own "an assistant turn's tool calls,
+          disclosed" pattern (.chat-node-tool-invocations) rather than a
+          parallel widget, since the content is the same shape (a tool
+          name, an outcome, one block of detail text) - just scoped to a
+          whole BUILD instead of one turn, and potentially many more rows,
+          which is the one thing that needs its own scrollable container. */}
+      {data.builderActivity.length > 0 && (
+        <details className="chat-node-tool-invocations plan-node-activity" ref={activityDetailsRef}>
+          <summary>
+            {data.builderActivity.length === 1
+              ? "1 activity entry"
+              : `${data.builderActivity.length} activity entries`}
+            {activityErrorCount > 0 &&
+              ` · ${activityErrorCount} error${activityErrorCount === 1 ? "" : "s"}`}
+          </summary>
+          <div className="plan-node-activity-list nowheel nodrag" ref={activityListRef}>
+            {data.builderActivity.map((row, index) => (
+              <div
+                key={index}
+                className={`chat-node-tool-invocation${row.outcome !== "ok" ? " error" : ""}`}
+              >
+                <div className="chat-node-tool-invocation-name">
+                  {row.tool}
+                  <span className="plan-node-activity-elapsed">{row.elapsedMs}ms</span>
+                </div>
+                <pre className="chat-node-tool-invocation-arguments">{row.summary}</pre>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
 
       {data.builderAwaitingToolApproval && (
         <div className="plan-node-approval" role="group" aria-label="Builder tool approval">

--- a/web_ui/src/app/canvas/SceneCanvas.pinSearchJump.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.pinSearchJump.test.tsx
@@ -131,6 +131,7 @@ function chatRow(id: string, x: number, y: number, title = id): SceneNodeRow {
         indexIntoKnowledge: false,
   planGoal: "",
   planSteps: [],
+  builderActivity: [],
   builderStatus: "",
   builderMode: "",
   builderRunId: "",

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -141,6 +141,7 @@ function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
     indexIntoKnowledge: false,
   planGoal: "",
   planSteps: [],
+  builderActivity: [],
   builderStatus: "",
   builderMode: "",
   builderRunId: "",

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -1439,6 +1439,7 @@ export function toFlowNodes(
         data: {
           planGoal: n.planGoal,
           planSteps: n.planSteps,
+          builderActivity: n.builderActivity,
           builderStatus: n.builderStatus,
           builderMode: n.builderMode,
           builderRunId: n.builderRunId,

--- a/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
@@ -150,6 +150,7 @@ function chatRow(id: string, x: number, y = 0): SceneNodeRow {
         indexIntoKnowledge: false,
   planGoal: "",
   planSteps: [],
+  builderActivity: [],
   builderStatus: "",
   builderMode: "",
   builderRunId: "",

--- a/web_ui/src/app/canvas/renderCountGate.test.tsx
+++ b/web_ui/src/app/canvas/renderCountGate.test.tsx
@@ -149,6 +149,7 @@ function chatRow(id: string, x: number): SceneNodeRow {
         indexIntoKnowledge: false, // ADR-017 stage 17.5
         planGoal: "",
         planSteps: [],
+  builderActivity: [],
         builderStatus: "",
         builderMode: "",
         builderRunId: "",

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -186,6 +186,7 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         indexIntoKnowledge: false,
         planGoal: "",
         planSteps: [],
+        builderActivity: [],
         builderStatus: "",
         builderMode: "",
         builderRunId: "",

--- a/web_ui/src/app/chrome/BuilderLaunchDialog.test.tsx
+++ b/web_ui/src/app/chrome/BuilderLaunchDialog.test.tsx
@@ -1,6 +1,38 @@
+/**
+ * stage 8.7 rebuild. Mirrors GlobalSearchDialog.test.tsx's own useReactFlow
+ * wrapping (every real pan/zoom export stays functional; only setCenter is
+ * intercepted) for asserting the post-launch focus call's exact arguments,
+ * and CustomSelect.test.tsx's own "click the trigger by its ariaLabel, then
+ * click the option by its label" interaction shape for the recipe picker -
+ * userEvent.selectOptions no longer applies now that this is not a native
+ * <select>.
+ */
+import { ReactFlowProvider, type useReactFlow as UseReactFlowType } from "@xyflow/react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SceneStore } from "../canvas/sceneStore";
+
+type SetCenterCall = [number, number, { zoom?: number; duration?: number } | undefined];
+const setCenterCalls: SetCenterCall[] = [];
+
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@xyflow/react")>();
+  return {
+    ...original,
+    useReactFlow: (...args: Parameters<typeof UseReactFlowType>) => {
+      const real = original.useReactFlow(...args);
+      return {
+        ...real,
+        setCenter: (x: number, y: number, options?: { zoom?: number; duration?: number }) => {
+          setCenterCalls.push([x, y, options]);
+          return real.setCenter(x, y, options);
+        },
+      };
+    },
+  };
+});
+
 import { BuilderLaunchDialog } from "./BuilderLaunchDialog";
 import { OverlayProvider, useOverlays } from "../overlays/overlays";
 import type { WsTransport } from "../../lib/ws/transport";
@@ -20,6 +52,15 @@ function makeTransport() {
   return { transport, intents, request };
 }
 
+// Only getScene() is exercised (reading the newly-created node's position
+// for the post-launch setCenter call) - a minimal fake, the same posture
+// makeTransport() takes for WsTransport above.
+function makeStore(nodes: Array<{ id: string; x: number; y: number }> = []) {
+  return {
+    getScene: () => ({ nodes }),
+  } as unknown as SceneStore;
+}
+
 function OpenBuilderButton() {
   const overlays = useOverlays();
   return (
@@ -29,30 +70,44 @@ function OpenBuilderButton() {
   );
 }
 
-async function setup(startResult: unknown = "n42", recipes: unknown[] = []) {
+async function setup(startResult: unknown = "n42", recipes: unknown[] = [], nodes: Array<{ id: string; x: number; y: number }> = []) {
   const user = userEvent.setup();
   const fake = makeTransport();
+  const store = makeStore(nodes);
   // The dialog fires listRecipes on open - dispatch by intent so each
   // test's start-result expectation is never consumed by the list call.
   fake.request.mockImplementation((topic: string, intent: string) =>
     intent === "listRecipes"
       ? Promise.resolve({ recipes })
-      : startResult instanceof Error
-        ? Promise.reject(startResult)
-        : Promise.resolve(startResult),
+      : intent === "deleteRecipe"
+        ? Promise.resolve(true)
+        : startResult instanceof Error
+          ? Promise.reject(startResult)
+          : Promise.resolve(startResult),
   );
   render(
     <OverlayProvider>
-      <OpenBuilderButton />
-      <BuilderLaunchDialog transport={fake.transport} />
+      <ReactFlowProvider>
+        <OpenBuilderButton />
+        <BuilderLaunchDialog transport={fake.transport} store={store} />
+      </ReactFlowProvider>
     </OverlayProvider>,
   );
   await user.click(screen.getByRole("button", { name: "open builder" }));
   return { user, ...fake };
 }
 
+async function pickRecipe(user: ReturnType<typeof userEvent.setup>, name: string) {
+  await user.click(screen.getByRole("button", { name: "Recipe" }));
+  await user.click(screen.getByRole("button", { name: new RegExp("^" + name) }));
+}
+
 describe("BuilderLaunchDialog", () => {
-  it("submits the goal with mode and default budgets through builder/start", async () => {
+  beforeEach(() => {
+    setCenterCalls.length = 0;
+  });
+
+  it("submits the goal with mode and default (Standard) budgets through builder/start", async () => {
     const { user, intents } = await setup();
 
     await user.type(screen.getByLabelText(/what should the builder construct/i), "chart solar trends");
@@ -65,12 +120,10 @@ describe("BuilderLaunchDialog", () => {
 
   it("selecting a recipe enables launch without a typed goal and passes the name", async () => {
     const { user, intents } = await setup("n9", [
-      { name: "Research and summarize", description: "d", builtIn: true },
+      { name: "Research and summarize", description: "d", steps: [], mode: "copilot", builtIn: true },
     ]);
 
-    await user.selectOptions(
-      screen.getByLabelText("Recipe"), "Research and summarize",
-    );
+    await pickRecipe(user, "Research and summarize");
     await user.click(screen.getByRole("button", { name: "Start from recipe" }));
 
     expect(intents).toContainEqual([
@@ -107,16 +160,88 @@ describe("BuilderLaunchDialog", () => {
     expect(copilot.closest("label")).not.toHaveClass("selected");
   });
 
-  it("shows the selected recipe's own description", async () => {
+  it("shows the selected recipe's own description and step list", async () => {
     const { user } = await setup("n9", [
-      { name: "Research and summarize", description: "Researches a topic, then writes a summary.", builtIn: true },
+      {
+        name: "Research and summarize",
+        description: "Researches a topic, then writes a summary.",
+        steps: ["Create a web research node", "Write the summary note"],
+        mode: "copilot",
+        builtIn: true,
+      },
     ]);
 
-    await user.selectOptions(screen.getByLabelText("Recipe"), "Research and summarize");
+    await pickRecipe(user, "Research and summarize");
 
     expect(
       await screen.findByText("Researches a topic, then writes a summary."),
     ).toBeInTheDocument();
+    expect(screen.getByText("Create a web research node")).toBeInTheDocument();
+    expect(screen.getByText("Write the summary note")).toBeInTheDocument();
+  });
+
+  it("offers to delete a saved (non-built-in) recipe, and refreshes the list on success", async () => {
+    const { user, intents, request } = await setup("n9", [
+      { name: "My recipe", description: "d", steps: ["one"], mode: "copilot", builtIn: false },
+    ]);
+
+    await pickRecipe(user, "My recipe");
+    expect(screen.getByRole("button", { name: "Delete this recipe" })).toBeInTheDocument();
+
+    request.mockImplementation((topic: string, intent: string) =>
+      intent === "listRecipes" ? Promise.resolve({ recipes: [] }) : Promise.resolve(true),
+    );
+    await user.click(screen.getByRole("button", { name: "Delete this recipe" }));
+
+    expect(intents).toContainEqual(["builder", "deleteRecipe", ["My recipe"]]);
+    // The list is re-fetched and the selection clears back to from-scratch.
+    expect(await screen.findByText("Describe a build yourself, or pick a saved recipe.")).toBeInTheDocument();
+  });
+
+  it("hides the delete affordance for a built-in recipe", async () => {
+    const { user } = await setup("n9", [
+      { name: "Research and summarize", description: "d", steps: [], mode: "copilot", builtIn: true },
+    ]);
+
+    await pickRecipe(user, "Research and summarize");
+
+    expect(screen.queryByRole("button", { name: "Delete this recipe" })).not.toBeInTheDocument();
+  });
+
+  it("defaults to the Standard budget preset, and a preset click updates the submitted budgets", async () => {
+    const { user, intents } = await setup();
+
+    expect(screen.getByRole("button", { name: "Standard" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText(/12 steps · 150k tokens · 15 min/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Quick" }));
+    expect(screen.getByRole("button", { name: "Quick" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Standard" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByText(/6 steps · 50k tokens · 5 min/)).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/what should the builder construct/i), "goal");
+    await user.click(screen.getByRole("button", { name: "Plan the build" }));
+
+    expect(intents).toContainEqual(["builder", "start", ["goal", "copilot", 6, 50_000, 300, null]]);
+  });
+
+  it("clamps an out-of-range Advanced max-steps value on blur rather than silently reverting a typed 0", async () => {
+    const { user, intents } = await setup();
+
+    await user.click(screen.getByText("Advanced"));
+    const stepsInput = screen.getByLabelText("Max steps");
+    await user.clear(stepsInput);
+    await user.type(stepsInput, "0");
+    // Mid-typing, the raw value is preserved (not silently coerced back to
+    // the default the moment the field reads 0 or empty).
+    expect(stepsInput).toHaveValue(0);
+    await user.tab(); // blur
+
+    expect(stepsInput).toHaveValue(1); // clamped to MIN_STEPS, not reverted to 12
+
+    await user.type(screen.getByLabelText(/what should the builder construct/i), "goal");
+    await user.click(screen.getByRole("button", { name: "Plan the build" }));
+    expect(intents).toContainEqual(["builder", "start", ["goal", "copilot", 1, 150_000, 900, null]]);
   });
 
   it("a null start result (backend refused) shows an error instead of closing", async () => {
@@ -126,10 +251,11 @@ describe("BuilderLaunchDialog", () => {
     await user.click(screen.getByRole("button", { name: "Plan the build" }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(/could not start/i);
+    expect(setCenterCalls).toHaveLength(0);
   });
 
-  it("a successful start closes the dialog", async () => {
-    const { user } = await setup("n7");
+  it("a successful start closes the dialog and centers the viewport on the new plan node", async () => {
+    const { user } = await setup("n7", [], [{ id: "n7", x: 300, y: 200 }]);
 
     await user.type(screen.getByLabelText(/what should the builder construct/i), "goal");
     await user.click(screen.getByRole("button", { name: "Plan the build" }));
@@ -138,5 +264,10 @@ describe("BuilderLaunchDialog", () => {
       await screen.findByRole("button", { name: "open builder" }),
     ).toBeInTheDocument();
     expect(screen.queryByLabelText(/what should the builder construct/i)).not.toBeInTheDocument();
+
+    expect(setCenterCalls).toHaveLength(1);
+    const [x, y] = setCenterCalls[0];
+    expect(x).toBe(300 + 180);
+    expect(y).toBe(200 + 90);
   });
 });

--- a/web_ui/src/app/chrome/BuilderLaunchDialog.test.tsx
+++ b/web_ui/src/app/chrome/BuilderLaunchDialog.test.tsx
@@ -208,6 +208,70 @@ describe("BuilderLaunchDialog", () => {
     expect(screen.queryByRole("button", { name: "Delete this recipe" })).not.toBeInTheDocument();
   });
 
+  it("review-fix: shows a disabled 'Deleting…' state while the delete request is in flight", async () => {
+    const { user, request } = await setup("n9", [
+      { name: "My recipe", description: "d", steps: ["one"], mode: "copilot", builtIn: false },
+    ]);
+    await pickRecipe(user, "My recipe");
+
+    let resolveDelete: (value: unknown) => void = () => {};
+    request.mockImplementation((topic: string, intent: string) => {
+      if (intent === "deleteRecipe") return new Promise((resolve) => { resolveDelete = resolve; });
+      return Promise.resolve({ recipes: [] });
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete this recipe" }));
+
+    const deletingButton = await screen.findByRole("button", { name: "Deleting…" });
+    expect(deletingButton).toBeDisabled();
+
+    resolveDelete(true);
+    await screen.findByText("Describe a build yourself, or pick a saved recipe.");
+  });
+
+  it("review-fix: deleteRecipe resolving false leaves the selection and recipe list untouched", async () => {
+    const { user, intents, request } = await setup("n9", [
+      { name: "My recipe", description: "d", steps: ["one"], mode: "copilot", builtIn: false },
+    ]);
+    await pickRecipe(user, "My recipe");
+
+    request.mockImplementation((topic: string, intent: string) =>
+      intent === "deleteRecipe" ? Promise.resolve(false) : Promise.resolve({ recipes: [] }),
+    );
+    await user.click(screen.getByRole("button", { name: "Delete this recipe" }));
+
+    // Give the (rejected-by-backend) promise chain a tick to settle.
+    await screen.findByRole("button", { name: "Delete this recipe" });
+    expect(screen.queryByText("Describe a build yourself, or pick a saved recipe.")).not.toBeInTheDocument();
+    expect(intents.filter(([, intent]) => intent === "listRecipes")).toHaveLength(1); // only the on-open fetch
+  });
+
+  it("review-fix: a rejected deleteRecipe call surfaces an error instead of silently clearing the selection", async () => {
+    const { user, request } = await setup("n9", [
+      { name: "My recipe", description: "d", steps: ["one"], mode: "copilot", builtIn: false },
+    ]);
+    await pickRecipe(user, "My recipe");
+
+    request.mockImplementation((topic: string, intent: string) =>
+      intent === "deleteRecipe" ? Promise.reject(new Error("network down")) : Promise.resolve({ recipes: [] }),
+    );
+    await user.click(screen.getByRole("button", { name: "Delete this recipe" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/could not be deleted/i);
+    expect(screen.getByRole("button", { name: "Delete this recipe" })).toBeInTheDocument();
+  });
+
+  it("a recipe with an empty step list shows its description but no step list", async () => {
+    const { user } = await setup("n9", [
+      { name: "Bare recipe", description: "just a goal, no steps", steps: [], mode: "copilot", builtIn: true },
+    ]);
+
+    await pickRecipe(user, "Bare recipe");
+
+    expect(await screen.findByText("just a goal, no steps")).toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+
   it("defaults to the Standard budget preset, and a preset click updates the submitted budgets", async () => {
     const { user, intents } = await setup();
 
@@ -223,6 +287,28 @@ describe("BuilderLaunchDialog", () => {
     await user.click(screen.getByRole("button", { name: "Plan the build" }));
 
     expect(intents).toContainEqual(["builder", "start", ["goal", "copilot", 6, 50_000, 300, null]]);
+  });
+
+  it("review-fix: a hand-dirtied Advanced field clears every preset's highlight, and a later preset click overwrites all three fields", async () => {
+    const { user } = await setup();
+
+    await user.click(screen.getByText("Advanced"));
+    const stepsInput = screen.getByLabelText("Max steps");
+    await user.clear(stepsInput);
+    await user.type(stepsInput, "30");
+    await user.tab(); // blur - 30 is within [1,50], commits unclamped
+
+    // 30/150000/900 matches no preset combination - none should read active.
+    for (const label of ["Quick", "Standard", "Extended"]) {
+      expect(screen.getByRole("button", { name: label })).toHaveAttribute("aria-pressed", "false");
+    }
+
+    await user.click(screen.getByRole("button", { name: "Extended" }));
+
+    expect(screen.getByRole("button", { name: "Extended" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("Max steps")).toHaveValue(25);
+    expect(screen.getByLabelText("Max tokens")).toHaveValue(400_000);
+    expect(screen.getByLabelText("Max seconds")).toHaveValue(1_800);
   });
 
   it("clamps an out-of-range Advanced max-steps value on blur rather than silently reverting a typed 0", async () => {

--- a/web_ui/src/app/chrome/BuilderLaunchDialog.tsx
+++ b/web_ui/src/app/chrome/BuilderLaunchDialog.tsx
@@ -1,41 +1,93 @@
 import { useEffect, useRef, useState } from "react";
+import { useReactFlow } from "@xyflow/react";
 import type { WsTransport } from "../../lib/ws/transport";
+import type { SceneStore } from "../canvas/sceneStore";
+import { motionDuration } from "../reducedMotion";
 import { Dialog, useOverlays } from "../overlays/overlays";
+import { CustomSelect } from "./CustomSelect";
 
 /**
- * ADR-008 stage 8.3: the Builder's launcher - goal, oversight mode, and
+ * ADR-008 stage 8.3/8.7: the Builder's launcher - goal, oversight mode, and
  * the three hard budgets, submitted through `builder/start` (a
  * value-returning intent: it answers with the new plan node's id, so
  * transport.request(), the DiagnosticsDialog/KnowledgeSearchDialog
- * precedent, not fireIntent). On success the dialog closes and the plan
- * node - the visible, editable checklist - takes over on the canvas.
+ * precedent, not fireIntent). On success the dialog closes, the viewport
+ * centers on the new plan node (stage 8.7 - it previously landed wherever
+ * the scene's own extent happened to place it, off-screen as often as not),
+ * and the plan node - the visible, editable checklist - takes over on the
+ * canvas.
  *
  * Autopilot is a per-run, disclosed choice (the ADR's own decision #3):
  * selecting it surfaces the disclosure sentence inline, before launch -
  * graph edits and code execution will proceed WITHOUT per-step approval
  * (resource caps still apply); network access always still asks.
+ *
+ * stage 8.7 rebuild: this was the last dialog in the app still using a bare
+ * `<select>` (CustomSelect exists precisely to retire that - see its own
+ * module doc) and three unlabelled-scale number spinners with no sense of
+ * what they cost. Now: CustomSelect for the recipe picker, a live preview
+ * of a selected recipe's own steps (the payload always carried them -
+ * nothing rendered them), named budget TIERS with a plain-language summary
+ * line in place of raw numbers, and the exact numbers moved behind an
+ * "Advanced" disclosure for whoever wants them. Recipe deletion (builder/
+ * deleteRecipe) rounds out the lifecycle saveRecipe started.
  */
 
 const DEFAULT_MAX_STEPS = 12;
 const DEFAULT_MAX_TOKENS = 150_000;
 const DEFAULT_MAX_WALL_SECONDS = 900;
 
+// Mirrors intents_builder.py's own _MIN/_MAX_*_BUDGET constants exactly -
+// the backend clamps to these regardless, but the field should visually
+// settle on the value it is actually about to submit.
+const MIN_STEPS = 1;
+const MAX_STEPS = 50;
+const MIN_TOKENS = 1_000;
+const MAX_TOKENS = 2_000_000;
+const MIN_WALL_SECONDS = 30;
+const MAX_WALL_SECONDS = 7_200;
+
+// Named tiers in place of three bare numbers - "150000 tokens" means
+// nothing on its own sight-read; a tier name plus a plain-language budget
+// line does. Standard matches the launcher's own prior hardcoded defaults
+// exactly, so an existing habit of "just launch" is unaffected.
+const BUDGET_PRESETS = [
+  { id: "quick", label: "Quick", maxSteps: 6, maxTokens: 50_000, maxWallSeconds: 300 },
+  { id: "standard", label: "Standard", maxSteps: DEFAULT_MAX_STEPS, maxTokens: DEFAULT_MAX_TOKENS, maxWallSeconds: DEFAULT_MAX_WALL_SECONDS },
+  { id: "extended", label: "Extended", maxSteps: 25, maxTokens: 400_000, maxWallSeconds: 1_800 },
+] as const;
+
+function clamp(value: number, low: number, high: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(Math.max(value, low), high);
+}
+
+function formatBudgetLine(steps: number, tokens: number, seconds: number): string {
+  const minutes = Math.max(1, Math.round(seconds / 60));
+  return `${steps} step${steps === 1 ? "" : "s"} · ${Math.round(tokens / 1000).toLocaleString()}k tokens · ${minutes} min`;
+}
+
 interface RecipeRow {
   name: string;
   description: string;
+  goal: string;
+  steps: string[];
+  mode: "copilot" | "autopilot";
   builtIn: boolean;
 }
 
-export function BuilderLaunchDialog({ transport }: { transport: WsTransport }) {
+export function BuilderLaunchDialog({ transport, store }: { transport: WsTransport; store: SceneStore }) {
   const overlays = useOverlays();
+  const reactFlow = useReactFlow();
   const [goal, setGoal] = useState("");
   const [mode, setMode] = useState<"copilot" | "autopilot">("copilot");
-  const [maxSteps, setMaxSteps] = useState(DEFAULT_MAX_STEPS);
-  const [maxTokens, setMaxTokens] = useState(DEFAULT_MAX_TOKENS);
-  const [maxWallSeconds, setMaxWallSeconds] = useState(DEFAULT_MAX_WALL_SECONDS);
+  const [maxSteps, setMaxSteps] = useState<number>(DEFAULT_MAX_STEPS);
+  const [maxTokens, setMaxTokens] = useState<number>(DEFAULT_MAX_TOKENS);
+  const [maxWallSeconds, setMaxWallSeconds] = useState<number>(DEFAULT_MAX_WALL_SECONDS);
   const [recipes, setRecipes] = useState<RecipeRow[]>([]);
   const [recipe, setRecipe] = useState("");
   const [starting, setStarting] = useState(false);
+  const [deletingRecipe, setDeletingRecipe] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const latestRequestId = useRef(0);
   const open = overlays.isOpen("builder-launch");
@@ -73,6 +125,18 @@ export function BuilderLaunchDialog({ transport }: { transport: WsTransport }) {
         if (nodeId != null) {
           setGoal("");
           overlays.close();
+          // The launcher has no canvas anchor of its own, so the plan node
+          // can land anywhere the scene's own extent happens to place it -
+          // often off the current viewport entirely. intents_builder.start()
+          // already awaited publish_scene() before answering with this id,
+          // so the node's position is already in the store by the time this
+          // callback fires. Center is approximate (the node's real rendered
+          // size isn't known until React Flow measures it) - this only
+          // needs to bring it into view, not frame it exactly.
+          const node = store.getScene().nodes.find((n) => n.id === nodeId);
+          if (node) {
+            reactFlow.setCenter(node.x + 180, node.y + 90, { duration: motionDuration(300) });
+          }
         } else {
           setError("The build could not start - see the notification for details.");
         }
@@ -86,34 +150,81 @@ export function BuilderLaunchDialog({ transport }: { transport: WsTransport }) {
       });
   }
 
-  // The selected recipe's own description - listRecipes has always
-  // returned it, but nothing ever rendered it, so the picker gave no clue
-  // what a recipe actually builds until after launching it.
+  function deleteSelectedRecipe() {
+    if (!recipe || deletingRecipe) return;
+    setDeletingRecipe(true);
+    transport
+      .request("builder", "deleteRecipe", [recipe])
+      .then(() => transport.request("builder", "listRecipes", []))
+      .then((value) => {
+        const payload = value as { recipes: RecipeRow[] };
+        setRecipes(payload.recipes ?? []);
+        setRecipe("");
+      })
+      .finally(() => setDeletingRecipe(false));
+  }
+
+  // The selected recipe's own description AND steps - listRecipes has
+  // always returned both, but nothing ever rendered either, so the picker
+  // gave no clue what a recipe actually builds until after launching it.
   const selectedRecipe = recipes.find((r) => r.name === recipe) ?? null;
+  const selectedPresetId =
+    BUDGET_PRESETS.find(
+      (preset) =>
+        preset.maxSteps === maxSteps &&
+        preset.maxTokens === maxTokens &&
+        preset.maxWallSeconds === maxWallSeconds,
+    )?.id ?? null;
 
   return (
     <Dialog name="builder-launch" title="Builder" className="builder-launch-dialog">
       <div className="builder-launch-field">
-        <label className="builder-launch-label" htmlFor="builder-recipe">
-          Recipe
-        </label>
-        <select
-          id="builder-recipe"
-          className="builder-launch-select"
+        {/* A plain heading, not a <label>: CustomSelect is not a native
+            form control with an id to associate via htmlFor, and it
+            already carries its own accessible name via ariaLabel below -
+            the same "visible section text + CustomSelect's own ariaLabel,
+            no separate <label>" shape ViewPopover's font-family picker
+            uses. */}
+        <p className="builder-launch-label">Recipe</p>
+        <CustomSelect
           value={recipe}
-          onChange={(event) => setRecipe(event.target.value)}
-        >
-          <option value="">Start from scratch</option>
-          {recipes.map((r) => (
-            <option key={r.name} value={r.name}>
-              {r.name}
-              {r.builtIn ? " (built-in)" : ""}
-            </option>
-          ))}
-        </select>
-        <p className="builder-launch-hint">
-          {selectedRecipe?.description || "Describe a build yourself, or pick a saved recipe."}
-        </p>
+          options={[
+            { id: "", label: "Start from scratch" },
+            ...recipes.map((r) => ({
+              id: r.name,
+              label: r.builtIn ? `${r.name} (built-in)` : r.name,
+              description: r.description || undefined,
+            })),
+          ]}
+          onChange={setRecipe}
+          ariaLabel="Recipe"
+        />
+        {selectedRecipe ? (
+          <div className="builder-launch-recipe-preview">
+            {selectedRecipe.description && (
+              <p className="builder-launch-hint">{selectedRecipe.description}</p>
+            )}
+            {selectedRecipe.steps.length > 0 && (
+              <ol className="builder-launch-recipe-steps">
+                {selectedRecipe.steps.map((title, index) => (
+                  <li key={index}>{title}</li>
+                ))}
+              </ol>
+            )}
+            {!selectedRecipe.builtIn && (
+              <button
+                type="button"
+                className="builder-launch-delete-recipe"
+                onClick={deleteSelectedRecipe}
+                disabled={deletingRecipe}
+              >
+                {deletingRecipe ? "Deleting…" : "Delete this recipe"}
+              </button>
+            )}
+          </div>
+        ) : (
+          <p className="builder-launch-hint">Describe a build yourself, or pick a saved recipe.</p>
+        )}
       </div>
 
       <div className="builder-launch-field">
@@ -169,41 +280,76 @@ export function BuilderLaunchDialog({ transport }: { transport: WsTransport }) {
       <fieldset className="builder-launch-fieldset">
         <legend>Budgets</legend>
         <p className="builder-launch-hint">Hard limits - a breach pauses the build.</p>
-        <div className="builder-launch-budgets">
-          <label className="builder-launch-budget">
-            <span className="builder-launch-budget-label">Max steps</span>
-            <input
-              className="builder-launch-number"
-              type="number"
-              min={1}
-              max={50}
-              value={maxSteps}
-              onChange={(event) => setMaxSteps(Number(event.target.value) || DEFAULT_MAX_STEPS)}
-            />
-          </label>
-          <label className="builder-launch-budget">
-            <span className="builder-launch-budget-label">Max tokens</span>
-            <input
-              className="builder-launch-number"
-              type="number"
-              min={1000}
-              step={10_000}
-              value={maxTokens}
-              onChange={(event) => setMaxTokens(Number(event.target.value) || DEFAULT_MAX_TOKENS)}
-            />
-          </label>
-          <label className="builder-launch-budget">
-            <span className="builder-launch-budget-label">Max seconds</span>
-            <input
-              className="builder-launch-number"
-              type="number"
-              min={30}
-              step={60}
-              value={maxWallSeconds}
-              onChange={(event) => setMaxWallSeconds(Number(event.target.value) || DEFAULT_MAX_WALL_SECONDS)}
-            />
-          </label>
+        <div className="view-segment" role="group" aria-label="Budget preset">
+          {BUDGET_PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              className={"view-segment-btn" + (selectedPresetId === preset.id ? " active" : "")}
+              aria-pressed={selectedPresetId === preset.id}
+              onClick={() => {
+                setMaxSteps(preset.maxSteps);
+                setMaxTokens(preset.maxTokens);
+                setMaxWallSeconds(preset.maxWallSeconds);
+              }}
+            >
+              {preset.label}
+            </button>
+          ))}
         </div>
+        <p className="builder-launch-hint">{formatBudgetLine(maxSteps, maxTokens, maxWallSeconds)}</p>
+
+        <details className="builder-launch-advanced">
+          <summary>Advanced</summary>
+          <div className="builder-launch-budgets">
+            <label className="builder-launch-budget">
+              <span className="builder-launch-budget-label">Max steps</span>
+              <input
+                className="builder-launch-number"
+                type="number"
+                min={MIN_STEPS}
+                max={MAX_STEPS}
+                value={maxSteps}
+                onChange={(event) => setMaxSteps(Number(event.target.value))}
+                onBlur={(event) =>
+                  setMaxSteps(clamp(Number(event.target.value), MIN_STEPS, MAX_STEPS, DEFAULT_MAX_STEPS))
+                }
+              />
+            </label>
+            <label className="builder-launch-budget">
+              <span className="builder-launch-budget-label">Max tokens</span>
+              <input
+                className="builder-launch-number"
+                type="number"
+                min={MIN_TOKENS}
+                max={MAX_TOKENS}
+                step={10_000}
+                value={maxTokens}
+                onChange={(event) => setMaxTokens(Number(event.target.value))}
+                onBlur={(event) =>
+                  setMaxTokens(clamp(Number(event.target.value), MIN_TOKENS, MAX_TOKENS, DEFAULT_MAX_TOKENS))
+                }
+              />
+            </label>
+            <label className="builder-launch-budget">
+              <span className="builder-launch-budget-label">Max seconds</span>
+              <input
+                className="builder-launch-number"
+                type="number"
+                min={MIN_WALL_SECONDS}
+                max={MAX_WALL_SECONDS}
+                step={60}
+                value={maxWallSeconds}
+                onChange={(event) => setMaxWallSeconds(Number(event.target.value))}
+                onBlur={(event) =>
+                  setMaxWallSeconds(
+                    clamp(Number(event.target.value), MIN_WALL_SECONDS, MAX_WALL_SECONDS, DEFAULT_MAX_WALL_SECONDS),
+                  )
+                }
+              />
+            </label>
+          </div>
+        </details>
       </fieldset>
 
       {error && (

--- a/web_ui/src/app/chrome/BuilderLaunchDialog.tsx
+++ b/web_ui/src/app/chrome/BuilderLaunchDialog.tsx
@@ -155,11 +155,21 @@ export function BuilderLaunchDialog({ transport, store }: { transport: WsTranspo
     setDeletingRecipe(true);
     transport
       .request("builder", "deleteRecipe", [recipe])
-      .then(() => transport.request("builder", "listRecipes", []))
-      .then((value) => {
-        const payload = value as { recipes: RecipeRow[] };
-        setRecipes(payload.recipes ?? []);
-        setRecipe("");
+      .then((deleted) => {
+        // A resolved `false` (unknown name, or a refused built-in) is NOT a
+        // rejected promise - deleteRecipe's own backend already surfaced
+        // why via its own notification (backend/api/intents_builder.py).
+        // Refreshing the list and clearing the selection here regardless
+        // would silently claim success on a call that changed nothing.
+        if (!deleted) return;
+        return transport.request("builder", "listRecipes", []).then((value) => {
+          const payload = value as { recipes: RecipeRow[] };
+          setRecipes(payload.recipes ?? []);
+          setRecipe("");
+        });
+      })
+      .catch(() => {
+        setError("The recipe could not be deleted - see graphlink.log for details.");
       })
       .finally(() => setDeletingRecipe(false));
   }

--- a/web_ui/src/app/chrome/OnboardingDialog.tsx
+++ b/web_ui/src/app/chrome/OnboardingDialog.tsx
@@ -122,7 +122,9 @@ export function OnboardingDialog({ transport, store }: { transport: WsTransport;
         <div className="onboarding-step">
           <p>
             Graphlink is a visual AI workspace: every message becomes a node on a canvas, and you can branch a
-            conversation from any earlier node instead of only ever continuing the last one.
+            conversation from any earlier node instead of only ever continuing the last one. When a task needs more
+            than one step, the Builder can plan and construct a whole branch for you, supervised at whatever level
+            you choose.
           </p>
           <p>This short wizard checks your provider and offers a small sample workspace, then gets out of the way.</p>
         </div>

--- a/web_ui/src/app/chrome/help-data/sections.ts
+++ b/web_ui/src/app/chrome/help-data/sections.ts
@@ -330,6 +330,54 @@ export const HELP_SECTIONS: HelpSection[] = [
     ]
   },
   {
+    "name": "Builder",
+    "description": "An agent that plans a checklist for a goal, then constructs it on the canvas one supervised step at a time - the same tools you could use by hand, run for you.",
+    "subsections": [
+      {
+        "title": "How a Build Works",
+        "items": [
+          {
+            "action": "Goal, Plan, Build",
+            "description": "Give the Builder a goal, or pick a saved recipe, and it drafts a short checklist first. The plan is a real node on the canvas - review it, edit it if you want, and only then start the build."
+          },
+          {
+            "action": "What It Can Build",
+            "description": "Create and edit chat, note, code, document, and web research nodes; execute Python; generate charts and assistant replies from a node's content; run web research and search your knowledge base - the same actions available to you, driven for you."
+          },
+          {
+            "action": "Oversight: Co-pilot vs. Autopilot",
+            "description": "Co-pilot asks you to approve every mutating step. Autopilot runs to completion within its budgets, creating and editing nodes and executing code without asking - network access still asks every time, in either mode."
+          },
+          {
+            "action": "Budgets Are Hard Limits",
+            "description": "Steps, tokens, and time are capped before a build starts. A budget breach pauses the build with its state intact rather than losing progress - raise the limit and resume to pick up exactly where it stopped."
+          }
+        ]
+      },
+      {
+        "title": "The Plan Node",
+        "items": [
+          {
+            "action": "Watch It Build",
+            "description": "The plan node shows each step's status live, plus an expandable activity log of every tool call the build made and whether it succeeded."
+          },
+          {
+            "action": "Pause, Stop, and Resume",
+            "description": "A build can be stopped at any time. A paused, stopped, or failed build resumes from exactly where it left off - even after restarting the app, since the plan node itself is the resume point."
+          },
+          {
+            "action": "Undo a Build",
+            "description": "Once a build finishes or stops, Undo Build reverts everything it did in one action, the same as undoing any other change."
+          },
+          {
+            "action": "Save and Reuse Recipes",
+            "description": "Turn a finished build's plan into a reusable recipe from its own node's Save as Recipe action. A saved recipe can be deleted from the launcher when you no longer need it - built-in recipes cannot be removed."
+          }
+        ]
+      }
+    ]
+  },
+  {
     "name": "Settings & Models",
     "description": "How runtime modes, providers, model routing, and quality-of-life settings shape the behavior of the application.",
     "subsections": [

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -7351,6 +7351,25 @@ mark.document-view-search-match-current {
   color: var(--gl-surface-text-muted);
   flex-wrap: wrap;
 }
+
+/* stage 8.7: the activity log. .chat-node-tool-invocations already supplies
+   the disclosure surface's border/padding/summary styling and its per-row
+   .chat-node-tool-invocation(.error)/-name/-arguments treatment - this adds
+   only what a build's log needs beyond one turn's handful of calls: a
+   bounded, independently-scrollable list (up to 100 rows) and an elapsed-
+   time readout per row. */
+.plan-node-activity-list {
+  max-height: 160px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.plan-node-activity-elapsed {
+  float: right;
+  font-weight: 400;
+  color: var(--gl-surface-text-muted);
+}
 .plan-node-approval {
   border: 1px solid var(--gl-semantic-status-warning);
   border-radius: 6px;

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -7365,8 +7365,19 @@ mark.document-view-search-match-current {
   flex-direction: column;
 }
 
+/* review-fix: flexbox rather than float, matching the "label + trailing
+   value" idiom used everywhere else in the app (ViewPopover's own
+   .view-field-row and 20+ others) - the only float in this stylesheet
+   otherwise. Scoped to this activity section specifically (not a bare
+   .chat-node-tool-invocation-name override) so ChatNodeView's own use of
+   that class, which has no trailing value to align, is unaffected. */
+.plan-node-activity .chat-node-tool-invocation-name {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .plan-node-activity-elapsed {
-  float: right;
   font-weight: 400;
   color: var(--gl-surface-text-muted);
 }

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -7425,10 +7425,10 @@ mark.document-view-search-match-current {
 .builder-launch-label { font-size: 13px; font-weight: 600; }
 .builder-launch-hint { margin: 0; font-size: 11px; color: var(--gl-surface-text-muted); }
 
-/* One shared control box for all three input kinds - the number inputs
-   previously had no styling at all beyond a width, so they rendered as
-   stark default-white browser fields inside a dark dialog. */
-.builder-launch-select,
+/* stage 8.7: the recipe picker is CustomSelect now (its own component owns
+   its styling) - this shared control box is what remains for the goal
+   textarea and the Advanced number fields. Previously also styled the bare
+   <select> this replaced. */
 .builder-launch-goal,
 .builder-launch-number {
   box-sizing: border-box;
@@ -7443,12 +7443,58 @@ mark.document-view-search-match-current {
 }
 .builder-launch-goal { resize: vertical; min-height: 72px; line-height: 1.45; }
 
-.builder-launch-select:focus-visible,
 .builder-launch-goal:focus-visible,
 .builder-launch-number:focus-visible {
   outline: 2px solid var(--gl-focus-ring);
   outline-offset: 1px;
 }
+
+/* stage 8.7: a selected recipe's own steps, previewed before launch - the
+   payload always carried them (listRecipes), nothing ever rendered them.
+   A plain ordered list rather than .plan-node-steps: that list's per-step
+   status markers/classes describe a LIVE run, and nothing here has run
+   yet - this is a preview of what WILL happen, not a status board. */
+.builder-launch-recipe-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.builder-launch-recipe-steps {
+  margin: 0;
+  padding-left: 20px;
+  font-size: 12px;
+  color: var(--gl-surface-text-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.builder-launch-delete-recipe {
+  align-self: flex-start;
+  font-size: 11px;
+  font-family: inherit;
+  padding: 4px 8px;
+  color: var(--gl-surface-text-muted);
+  background: transparent;
+  border: 1px solid var(--gl-surface-border);
+  border-radius: 5px;
+  cursor: pointer;
+}
+.builder-launch-delete-recipe:hover:not(:disabled) {
+  color: var(--gl-semantic-status-error);
+  border-color: var(--gl-semantic-status-error);
+}
+.builder-launch-delete-recipe:disabled { opacity: 0.5; cursor: default; }
+
+/* Same disclosure posture as .plan-node-activity/.chat-node-tool-invocations
+   - a native <details>, cursor-pointer bold summary - here hiding the exact
+   numeric fields behind the named presets above, for whoever wants them. */
+.builder-launch-advanced summary {
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--gl-surface-text-secondary);
+}
+.builder-launch-advanced[open] summary { margin-bottom: 8px; }
 
 .builder-launch-fieldset {
   display: flex;

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -65,6 +65,37 @@
           "branchStatus": {
             "type": "string"
           },
+          "builderActivity": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "elapsedMs": {
+                  "type": "integer"
+                },
+                "outcome": {
+                  "type": "string"
+                },
+                "stepId": {
+                  "type": "string"
+                },
+                "summary": {
+                  "type": "string"
+                },
+                "tool": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "tool",
+                "summary",
+                "outcome",
+                "stepId",
+                "elapsedMs"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
           "builderApprovalSummary": {
             "type": "string"
           },
@@ -769,6 +800,7 @@
           "indexIntoKnowledge",
           "planGoal",
           "planSteps",
+          "builderActivity",
           "builderStatus",
           "builderMode",
           "builderRunId",

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -98,6 +98,7 @@ export interface SceneNodeRow {
   indexIntoKnowledge: boolean;
   planGoal: string;
   planSteps: PlanStepRow[];
+  builderActivity: BuilderActivityRow[];
   builderStatus: string;
   builderMode: string;
   builderRunId: string;
@@ -192,6 +193,14 @@ export interface PlanStepRow {
   title: string;
   status: string;
   detail: string;
+}
+
+export interface BuilderActivityRow {
+  tool: string;
+  summary: string;
+  outcome: string;
+  stepId: string;
+  elapsedMs: number;
 }
 
 export interface SceneEdgeRow {
@@ -715,6 +724,12 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     else (fieldValue as unknown[]).forEach((item, i) => { checkPlanStepRow(item, `${path}.planSteps` + `[${i}]`, errors); }); }
   }
   {
+    const fieldValue = value["builderActivity"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.builderActivity: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.builderActivity` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { checkBuilderActivityRow(item, `${path}.builderActivity` + `[${i}]`, errors); }); }
+  }
+  {
     const fieldValue = value["builderStatus"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.builderStatus: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.builderStatus` + ": expected string"); }
@@ -1082,6 +1097,35 @@ function checkPlanStepRow(value: unknown, path: string, errors: string[]): void 
     const fieldValue = value["detail"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.detail: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.detail` + ": expected string"); }
+  }
+}
+
+function checkBuilderActivityRow(value: unknown, path: string, errors: string[]): void {
+  if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["tool"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.tool: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.tool` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["summary"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.summary: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.summary` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["outcome"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.outcome: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.outcome` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["stepId"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.stepId: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.stepId` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["elapsedMs"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.elapsedMs: missing required field`);
+    else { if (typeof fieldValue !== "number") errors.push(`${path}.elapsedMs` + ": expected number"); }
   }
 }
 


### PR DESCRIPTION
## Problem

The Builder's engine (planning, budgets, approval routing, undo, resume) is substantial, but its surface was a prototype: builds had no visible activity log, a landed build announced nothing unless the user happened to be looking, output could land anywhere on the canvas, the launch dialog was the last surface in the app using a bare native `<select>` with an input bug in its budget fields, and the feature was undocumented anywhere in the app.

## Change

- **Activity log**: every tool call a build makes is recorded on the plan node - tool name, outcome, timing - in a capped ring buffer, rendered as a collapsible disclosure. Deliberately untouched by undo: it's run telemetry, not document content.
- **Completion notifications**: a build landing done, paused, or failed now shows a banner, so a build finishing off-screen isn't silent.
- **Anchored placement**: a build's new nodes land near its plan node instead of scattering at the canvas origin; launching a build centers the viewport on it.
- **Launch dialog rebuild**: the recipe picker is now the app's own CustomSelect; selecting a recipe previews its steps before launch; budgets are named presets (Quick / Standard / Extended) with the exact numbers behind an Advanced disclosure that clamps on blur (fixing a bug where typing `0`, or clearing a field to retype it, silently reverted to the default); a saved recipe can now be deleted.
- **Documentation**: a full Builder section in Help, one sentence in Onboarding.
- **Review-fix pass**: an adversarial review surfaced 13 findings, all fixed - most notably, undo could silently erase activity rows logged after a mid-run replan (the replan's own snapshot-based undo command was restoring the whole node wholesale); a build's parentless creates and an explicit `parent_id` equal to the plan node's own id used two different sibling-counting mechanisms and could overlap. Also fixed: an uncapped tool-call name field, a delete-recipe flow that ignored whether the delete actually succeeded, and a stray CSS float.

## Test plan

- [x] Full backend suite: 3020 passed, 17 skipped
- [x] Full frontend suite: 1944 passed, zero lint errors, build and bundle size clean
- [x] Every commit verified against a real running backend (a scripted provider driving an actual build through the real WS/document/wire path, including the copilot approval gate) before being committed - activity log content, completion notification, and anchored placement all confirmed against the real DOM and real node coordinates
- [x] The clamp-on-blur budget fix verified with genuine keyboard input (typed `0`, tabbed away, confirmed it settles on the clamped minimum)
- [x] Regression tests added for both correctness fixes found in review (undo-preserves-activity, placement overlap), plus the other 11 findings