### PR TITLE
Add a Demo section to the README linking the YouTube walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,13 @@ It is built with a Python (FastAPI) backend and a Vite/React/TypeScript single-p
 
 > Graphlink is the second generation of the **Graphite** project, renamed to avoid collision with unrelated software. The rename is complete: modules, folders, and the UI all use the `graphlink` name.
 
+## Demo
+
+[![Watch the Graphlink demo](assets/screenshots/canvas-branching.png)](https://www.youtube.com/watch?v=16v0our6ZoI)
+
 ## Table of Contents
 
+- [Demo](#demo)
 - [Features](#features)
 - [Screenshots](#screenshots)
 - [The Builder](#the-builder)


### PR DESCRIPTION
## Problem

The README describes Graphlink's features in bullet form, but there's no faster way for a new visitor to see what the app actually looks like in motion.

## Change

Adds a **Demo** section right after the intro paragraph, before the Table of Contents: a clickable screenshot thumbnail linking to the YouTube walkthrough (branching canvas, Document View, and the Builder). Table of Contents updated to include the new section.

## Test plan

- [x] Rendered the README locally to confirm the link and image render correctly
- [x] Confirmed the linked video is public and playable