### PR TITLE
Restore a frame's saved position on session load

### DIFF
--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -1093,6 +1093,32 @@ def _restore_frames(
                 width_height = (float(size["width"]), float(size["height"]))
             if width_height is not None:
                 document.resize_frame(frame.id, width_height[0], width_height[1])
+            # The POSITION half of that same override, and for the identical
+            # reason. create_frame above placed this frame at its live
+            # bbox-of-members position, which _bbox_of_members derives from
+            # GROUP_MEMBER_DEFAULT_WIDTH/HEIGHT ESTIMATES (220x120,
+            # backend/domain/model.py) - no real rendered node is that size,
+            # so that placement is never where the user actually left the
+            # frame. Restoring the saved x/y through move_node (rather than
+            # assigning node.x/y directly) is what makes it STICK: move_node
+            # is the same call a live frame drag commits, and pinning
+            # group_manual_x/y is the only thing _recompute_group_bounds
+            # honors - a bare x/y assignment would be silently recomputed
+            # away by the very next member move. Union-with-live-content
+            # still applies exactly as it does for a drag, so a restored
+            # anchor can no more clip a member than a dragged one can.
+            # Ordered AFTER resize_frame (whose own trailing recompute
+            # re-centers on the member bbox) and BEFORE the collapse toggle
+            # below, so a collapsed frame's pill lands on the saved
+            # position too - that branch snaps the size and leaves x/y
+            # untouched.
+            position_xy = None
+            if isinstance(rect, dict) and "x" in rect and "y" in rect:
+                position_xy = (float(rect["x"]), float(rect["y"]))
+            elif isinstance(frame_payload.get("position"), dict):
+                position_xy = _position(frame_payload)
+            if position_xy is not None:
+                document.move_node(frame.id, position_xy[0], position_xy[1])
             if bool(frame_payload.get("is_collapsed", False)):
                 document.toggle_group_collapsed(frame.id)
         except Exception:

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -464,6 +464,83 @@ def test_frame_unlocked_flag_is_applied():
     assert frame.state.is_locked is False
 
 
+# Every frame payload below sits a single member at the origin, whose padded
+# estimated footprint is therefore (-40, -50) to (260, 210) - GROUP_PADDING 40
+# / GROUP_PADDING_TOP 50 around GROUP_MEMBER_DEFAULT_WIDTH/HEIGHT 220x120
+# (backend/domain/model.py). Saved rects here deliberately ENCLOSE that box,
+# which is the ordinary case: a real saved frame contains its own members. The
+# union test immediately below covers the case where it does not.
+
+
+def test_frame_position_is_restored_from_rect_as_a_manual_anchor():
+    """The saved rect's x/y is the frame's real position; create_frame's own
+    bbox-of-members placement (from 220x120 member ESTIMATES) is not. It
+    must land as a manual anchor, since that is the only form
+    _recompute_group_bounds preserves."""
+    document = _restore(
+        nodes=[_chat("a")],
+        frames=[{"items": [0], "note": "Moved", "position": {"x": -900, "y": -400},
+                 "rect": {"x": -900, "y": -400, "width": 1400, "height": 900}}],
+    )
+    frame = next(n for n in document.nodes.values() if n.kind == "frame")
+    assert (frame.state.group_manual_x, frame.state.group_manual_y) == (-900.0, -400.0)
+    assert (frame.x, frame.y) == (-900.0, -400.0)
+
+
+def test_frame_saved_rect_still_grows_to_enclose_a_member_outside_it():
+    """The restored anchor is UNIONED with live content, never substituted
+    for it - the same no-clip guarantee a live drag gets. Here the saved
+    rect starts below its own member (only reachable via a hand-edited or
+    cross-version payload), so the frame must grow up to re-enclose it
+    rather than restore a rect that visually cuts the member off."""
+    document = _restore(
+        nodes=[_chat("a")],
+        frames=[{"items": [0], "note": "Stale rect", "position": {"x": -500, "y": 250},
+                 "rect": {"x": -500, "y": 250, "width": 800, "height": 700}}],
+    )
+    frame = next(n for n in document.nodes.values() if n.kind == "frame")
+    member = document.nodes[frame.item_ids[0]]
+    assert frame.x <= member.x and frame.y <= member.y
+    assert frame.y == -50.0  # grown to the member's own padded top edge
+
+
+def test_frame_position_falls_back_to_the_position_key_when_rect_has_no_xy():
+    """The older "size"-only shape carries no rect x/y at all, but every era
+    of the payload has a top-level "position"."""
+    document = _restore(
+        nodes=[_chat("a")],
+        frames=[{"items": [0], "note": "Old shape", "position": {"x": -640, "y": -300},
+                 "size": {"width": 1000, "height": 800}}],
+    )
+    frame = next(n for n in document.nodes.values() if n.kind == "frame")
+    assert (frame.x, frame.y) == (-640.0, -300.0)
+
+
+def test_frame_with_no_position_information_keeps_its_computed_placement():
+    """Nothing to restore from - the bbox-of-members placement create_frame
+    already produced stands, and no anchor is invented for it."""
+    document = _restore(
+        nodes=[_chat("a")],
+        frames=[{"items": [0], "note": "No position"}],
+    )
+    frame = next(n for n in document.nodes.values() if n.kind == "frame")
+    assert frame.state.group_manual_x is None and frame.state.group_manual_y is None
+
+
+def test_collapsed_frame_restores_at_its_saved_position():
+    """The collapse branch of _recompute_group_bounds snaps the size and
+    leaves x/y alone, so the position must be restored before it runs."""
+    document = _restore(
+        nodes=[_chat("a")],
+        frames=[{"items": [0], "note": "Collapsed", "position": {"x": -500, "y": -400},
+                 "rect": {"x": -500, "y": -400, "width": 900, "height": 800},
+                 "is_collapsed": True}],
+    )
+    frame = next(n for n in document.nodes.values() if n.kind == "frame")
+    assert frame.is_collapsed is True
+    assert (frame.x, frame.y) == (-500.0, -400.0)
+
+
 # -- containers (nest frames/notes/charts, offset math) ----------------------
 
 

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -330,6 +330,52 @@ def test_frame_can_reference_a_chart_member_at_the_node_slot_count_offset():
     assert frame_payload["items"] == [0, node_slot_count]
 
 
+def test_frame_position_survives_a_save_load_round_trip():
+    """A frame the user dragged (and resized) must reload where they left
+    it. _serialize_frame has always written the full rect, but the loader
+    only ever read width/height back - so create_frame's own bbox-of-
+    members position (derived from GROUP_MEMBER_DEFAULT_WIDTH/HEIGHT
+    ESTIMATES, which no real rendered node matches) silently won, and every
+    reload teleported the frame. Members here are deliberately spaced far
+    wider than those 220x120 estimates, which is exactly when the drift is
+    visible rather than incidental."""
+    doc = SceneDocument()
+    a = doc.add_chat_node(0, 0, "question", is_user=True)
+    b = doc.add_chat_node(0, 600, "reply", is_user=False, parent_id=a.id)
+    frame = doc.create_frame([a.id, b.id])
+    doc.resize_frame(frame.id, 1072.0, 795.0)
+    doc.move_node(frame.id, -1170.0, 420.0)
+    expected = (frame.x, frame.y, frame.state.group_width, frame.state.group_height)
+
+    reloaded = _round_trip(doc)
+
+    restored = next(n for n in reloaded.nodes.values() if n.kind == "frame")
+    assert (restored.x, restored.y, restored.state.group_width, restored.state.group_height) == expected
+
+
+def test_reloaded_frame_keeps_its_position_when_a_member_later_moves():
+    """The position must be restored as a real manual ANCHOR (the same
+    thing move_node pins for a live drag), not just assigned to x/y: only
+    the anchor survives _recompute_group_bounds, which every later member
+    move triggers. Without it a reload looks correct until the user nudges
+    any member, at which point the frame jumps."""
+    doc = SceneDocument()
+    a = doc.add_chat_node(0, 0, "question", is_user=True)
+    b = doc.add_chat_node(0, 600, "reply", is_user=False, parent_id=a.id)
+    frame = doc.create_frame([a.id, b.id])
+    doc.resize_frame(frame.id, 1072.0, 795.0)
+    doc.move_node(frame.id, -1170.0, 420.0)
+
+    reloaded = _round_trip(doc)
+    restored = next(n for n in reloaded.nodes.values() if n.kind == "frame")
+    position_after_load = (restored.x, restored.y)
+    member_id = restored.item_ids[0]
+    member = reloaded.nodes[member_id]
+    reloaded.move_node(member_id, member.x + 5.0, member.y)
+
+    assert (restored.x, restored.y) == position_after_load
+
+
 def test_container_item_indices_reference_the_full_combined_offset_space():
     doc = SceneDocument()
     a = doc.add_chat_node(0, 0, "a", is_user=True)


### PR DESCRIPTION
## Problem

A frame the user dragged or resized reloads in the wrong place, with its members spilling outside the box.

`_serialize_frame` (backend/session_save.py) has always written the frame's full rect, but `_restore_frames` (backend/session_load.py) only ever read `width`/`height` back out of it. The position it used instead came from `create_frame`, which derives placement from `_bbox_of_members`' `GROUP_MEMBER_DEFAULT_WIDTH`/`HEIGHT` estimates (220x120) — a placeholder no real rendered node matches, since the domain layer never sees rendered sizes. Every reload therefore relocated the frame to the centre of an estimated bounding box.

Measured against a running backend: a frame saved at `(-1170, 420)` sized `1072x795` came back at `(-605, -285)`. Real chat nodes render 422px wide and up to ~600px tall, so members visibly escaped the frame.

## Change

Restore the saved `x`/`y` through `move_node` — the same call a live frame drag commits — falling back to the payload's top-level `position` key for older `size`-only payloads.

Going through `move_node` is what makes it stick: it pins `group_manual_x`/`group_manual_y`, the only position form `_recompute_group_bounds` preserves. Assigning `node.x`/`y` directly would be recomputed away by the next member move, so a reload would look correct until the user nudged anything.

The restored anchor is unioned with live content exactly as a dragged one is, so it can never clip a member. Ordered after `resize_frame` (whose trailing recompute re-centres on the member bbox) and before the collapse toggle, so a collapsed frame's pill also lands on the saved position.

Containers are deliberately untouched. They have no manual-anchor concept at all — `_recompute_group_bounds` gates that on `kind == "frame"` — so a container drag does not survive a member move even with no save/load involved. Their position not round-tripping is consistent with that live behaviour; giving them anchors would be a domain change, not a loader fix.

## Test plan

- Two round-trip tests in `test_session_save.py`: position survives save/load, and survives a later member move.
- Five loader tests in `test_session_load.py`: the rect `x`/`y` path, the legacy `position`-key fallback, payloads with no position at all, the collapsed case, and the union-still-encloses-a-stray-member guarantee.
- All five position tests fail before this change.
- Full suite from the repo root (`python -m pytest -q`): **3073 passed, 17 skipped**.
- Verified end to end in the real app: the demo workspace's two frames now load at exactly their saved rects with zero members spilling, with no client-side correction applied.