### PR TITLE
Fit frames and containers to their members' real rendered size

### DIFF
--- a/backend/api/intents_groups.py
+++ b/backend/api/intents_groups.py
@@ -120,7 +120,22 @@ def register_groups_intents(bus: SessionBus, document: SceneDocument) -> None:
         )
         await publish_scene()
 
+    async def report_node_sizes(sizes):
+        # The frontend's continuous "here is what these nodes actually
+        # render as" report - the only way this backend can learn a chat
+        # node's real height (see SceneDocument.measured_sizes's comment).
+        # Deliberately NOT a recorded command: an observation about
+        # rendering is not a user edit, and putting it in the undo stack
+        # would make Ctrl+Z replay layout noise.
+        triples = [(s[0], s[1], s[2]) for s in sizes]
+        # Republish ONLY when a group box actually moved. The client
+        # re-reports steady-state sizes routinely (any re-measure), and a
+        # scene snapshot per report would be pure churn.
+        if document.set_measured_node_sizes(triples):
+            await publish_scene()
+
     bus.register_intent("scene", "addNote", add_note)
+    bus.register_intent("scene", "reportNodeSizes", report_node_sizes)
     bus.register_intent("scene", "setNoteContent", set_note_content)
     bus.register_intent("scene", "createFrame", create_frame)
     bus.register_intent("scene", "createContainer", create_container)

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -111,6 +111,28 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
 
     nodes: dict[str, SceneNode] = field(default_factory=dict)
     edges: dict[str, SceneEdge] = field(default_factory=dict)
+    # node id -> (width, height): each node's ACTUAL rendered footprint in
+    # flow units, as last reported by the frontend (the reportNodeSizes
+    # intent -> set_measured_node_sizes). Only ids the client has measured
+    # appear here.
+    #
+    # This is the one piece of node geometry the backend cannot derive for
+    # itself - a chat node's height is whatever its markdown laid out to,
+    # which only the browser knows - and frame/container bounds math is the
+    # sole consumer (see _member_footprint in domain/groups.py for the
+    # measured -> intrinsic -> estimate fallback chain).
+    #
+    # Kept OFF SceneNode deliberately, in its own map rather than two more
+    # node fields: this is an observation about rendering, not document
+    # state. It is never persisted (session_save writes nodes, not this),
+    # never reaches the client (scene_payload emits node fields, and the
+    # client is where these came from), and never enters the undo stack -
+    # all three fall out structurally from living here instead of on the
+    # node, rather than depending on three separate places remembering to
+    # skip a field. tests/test_node_state_migration.py's ADR-002 gate locks
+    # SceneNode's own shape to its 14 core fields for closely related
+    # reasons.
+    measured_sizes: dict[str, tuple[float, float]] = field(default_factory=dict)
     pins: NavigationPinStore = field(default_factory=NavigationPinStore)
     grid: GridViewSettings = field(default_factory=GridViewSettings)
     snap_to_grid: bool = False

--- a/backend/domain/groups.py
+++ b/backend/domain/groups.py
@@ -34,14 +34,111 @@ from backend.domain.node_states import ContainerState, FrameState
 
 class GroupOps:
 
+    def _member_footprint(self, member: SceneNode) -> tuple[float, float]:
+        """One member's (width, height) for bbox purposes, best source first:
+
+        1. The frontend's reported `measured_sizes` entry - what the node
+           actually rendered as.
+           The only source that is right for a chat node, whose height is
+           whatever its markdown laid out to.
+        2. The kind's own intrinsic size, for the three kinds that really
+           carry one: a chart's chart_width/height and a nested frame/
+           container's group_width/height are authoritative geometry this
+           backend already owns, so they need no client round trip.
+        3. GROUP_MEMBER_DEFAULT_WIDTH/HEIGHT - a flat estimate, and the
+           reason this helper exists: applying it to EVERY member (the
+           behavior before measured sizes) is what made frames render
+           smaller than the nodes they were supposed to enclose.
+
+        Non-positive values from any source fall through to the next one,
+        so a zero-size measurement (a node mid-mount, or one React Flow
+        never measured) can never collapse a group's box."""
+        measured = self.measured_sizes.get(member.id)
+        width, height = measured if measured is not None else (None, None)
+        if not (width and width > 0 and height and height > 0):
+            # Accessed through member.state, never an alias: tests/
+            # test_node_state_migration.py's ADR-002 gate reads this
+            # statically and an intermediate local would read as a bare
+            # field access on the node itself.
+            if member.kind == "chart" and member.state is not None:
+                width, height = member.state.chart_width, member.state.chart_height
+            elif member.kind in ("frame", "container") and member.state is not None:
+                width, height = member.state.group_width, member.state.group_height
+        if not (width and width > 0):
+            width = GROUP_MEMBER_DEFAULT_WIDTH
+        if not (height and height > 0):
+            height = GROUP_MEMBER_DEFAULT_HEIGHT
+        return float(width), float(height)
+
+    def set_measured_node_sizes(self, sizes: list[tuple[str, float, float]]) -> bool:
+        """Record the frontend's rendered size for each (node_id, w, h),
+        then re-fit every group affected. Returns True if anything actually
+        changed, so the caller can skip republishing the scene for the
+        steady-state case where the client re-reports sizes it already sent.
+
+        Unknown ids and non-positive sizes are skipped rather than raising:
+        this is a continuous background report from a client whose node set
+        can legitimately be a few frames behind the document's own.
+
+        NOT a recorded command - see SceneDocument.measured_sizes's own
+        comment for why an observation about rendering is not an undoable
+        edit, and why it lives off the node entirely."""
+        touched: set[str] = set()
+        for node_id, width, height in sizes:
+            if node_id not in self.nodes:
+                continue
+            try:
+                new_size = (float(width), float(height))
+            except (TypeError, ValueError):
+                continue
+            if new_size[0] <= 0 or new_size[1] <= 0:
+                continue
+            if self.measured_sizes.get(node_id) == new_size:
+                continue
+            self.measured_sizes[node_id] = new_size
+            touched.add(node_id)
+        # Deleted nodes' entries would otherwise accumulate for the life of
+        # the session. Pruned here rather than in remove_nodes so this map
+        # stays entirely self-managing, and on a debounced path so the scan
+        # is never hot.
+        if len(self.measured_sizes) > len(self.nodes):
+            for stale_id in [i for i in self.measured_sizes if i not in self.nodes]:
+                del self.measured_sizes[stale_id]
+        if not touched:
+            return False
+        # A resized member can change the box of the group holding it, and
+        # of any group holding THAT group - so recompute outward until
+        # nothing moves, rather than one level deep. Bounded by nesting
+        # depth, which this model caps at container-holding-frame.
+        changed = False
+        for _ in range(4):
+            pass_changed = False
+            for group in self.nodes.values():
+                if group.kind not in ("frame", "container"):
+                    continue
+                if not any(member_id in touched for member_id in group.item_ids):
+                    continue
+                before = (group.x, group.y, group.state.group_width, group.state.group_height)
+                self._recompute_group_bounds(group.id)
+                after = (group.x, group.y, group.state.group_width, group.state.group_height)
+                if before != after:
+                    pass_changed = True
+                    touched.add(group.id)
+            if not pass_changed:
+                break
+            changed = True
+        # Only a moved GROUP box is worth a republish: measured_sizes
+        # itself never reaches the client (it came FROM there), so a size
+        # report that leaves every box where it was is a no-op on the wire.
+        return changed
+
     def _bbox_of_members(self, item_ids: list[str]) -> tuple[float, float, float, float]:
         """Compute the padded union rect (x, y, width, height) enclosing
-        every member id's ESTIMATED footprint - GROUP_MEMBER_DEFAULT_WIDTH/
-        HEIGHT, since no current SceneNode kind carries its own width/height
-        field (see that constant's own comment). Stale/unknown member ids
-        (a member deleted out from under a group between mutations) are
-        silently skipped, never raise - a bbox recompute must never crash on
-        a dangling id. Falls back to a small default rect anchored at the
+        every member id's real footprint - see _member_footprint for where
+        each member's size comes from. Stale/unknown member ids (a member
+        deleted out from under a group between mutations) are silently
+        skipped, never raise - a bbox recompute must never crash on a
+        dangling id. Falls back to a small default rect anchored at the
         origin when item_ids is empty or every id is stale, so callers
         (including resize_frame's own minimum-size clamp) always get a
         well-defined rect back."""
@@ -50,9 +147,10 @@ class GroupOps:
             member = self.nodes.get(member_id)
             if member is None:
                 continue
+            member_width, member_height = self._member_footprint(member)
             mx1, my1 = member.x, member.y
-            mx2 = member.x + GROUP_MEMBER_DEFAULT_WIDTH
-            my2 = member.y + GROUP_MEMBER_DEFAULT_HEIGHT
+            mx2 = member.x + member_width
+            my2 = member.y + member_height
             left = mx1 if left is None else min(left, mx1)
             top = my1 if top is None else min(top, my1)
             right = mx2 if right is None else max(right, mx2)

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -91,11 +91,14 @@ NOTE_AGENT_HEADER_COLOR = "#3f7dc9"
 # numbers reproduce). GROUP_PADDING applies to all 4 sides of the union rect;
 # GROUP_PADDING_TOP is the (larger) top-edge allowance instead of
 # GROUP_PADDING, leaving room for the header/label row every frame/container
-# renders. GROUP_MEMBER_DEFAULT_WIDTH/HEIGHT is the flat per-member footprint
-# estimate used when a member's own kind has no width/height field of its
-# own - true of every one of the 12 existing SceneNode kinds today (none
-# carries one), so this is always what is actually used in practice, not
-# just a defensive fallback. GROUP_COLLAPSED_WIDTH/HEIGHT is the fixed pill
+# renders. GROUP_MEMBER_DEFAULT_WIDTH/HEIGHT is the last-resort
+# per-member footprint estimate, used only for a member the frontend has
+# not measured yet (SceneDocument.measured_sizes) AND whose kind carries
+# no intrinsic size of its own -
+# see _member_footprint (backend/domain/groups.py) for the full fallback
+# chain. It used to be what EVERY member was measured by, which is
+# precisely why frames did not enclose their contents: no real rendered
+# node is 220x120 (a chat node alone is 422 wide and routinely 500+ tall). GROUP_COLLAPSED_WIDTH/HEIGHT is the fixed pill
 # size a frame/container shrinks to while is_collapsed.
 GROUP_PADDING = 40.0
 GROUP_PADDING_TOP = 50.0

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -19,6 +19,8 @@ from backend.canvas import (
     BRANCH_HORIZONTAL_SPACING,
     DRAG_FACTOR_MAX,
     DRAG_FACTOR_MIN,
+    GROUP_MEMBER_DEFAULT_HEIGHT,
+    GROUP_MEMBER_DEFAULT_WIDTH,
     MESSAGE_VERTICAL_SPACING,
     NOTE_AGENT_BODY_COLOR,
     NOTE_AGENT_HEADER_COLOR,
@@ -6018,6 +6020,107 @@ def test_create_frame_sets_correct_defaults_and_initial_bbox():
     assert frame.state.group_height == pytest.approx(510.0)
 
 
+# -- measured member sizes (frames that actually enclose their contents) ----
+
+
+def test_reported_sizes_grow_a_frame_to_enclose_its_real_members():
+    """The bug this whole mechanism exists for: every member used to be
+    measured as a flat 220x120, so a frame around real nodes (a chat node
+    is 422 wide and routinely 500+ tall) rendered smaller than its own
+    contents."""
+    doc = SceneDocument()
+    top = doc.add_chat_node(0, 0, "question", is_user=True)
+    bottom = doc.add_chat_node(0, 600, "reply", is_user=False, parent_id=top.id)
+    frame = doc.create_frame([top.id, bottom.id])
+    estimated = (frame.state.group_width, frame.state.group_height)
+
+    changed = doc.set_measured_node_sizes([(top.id, 422.0, 112.0), (bottom.id, 422.0, 525.0)])
+
+    assert changed is True
+    assert (frame.state.group_width, frame.state.group_height) != estimated
+    # Union of x:[0,422] and y:[0,112]+[600,1125], padded 40/50/40/40.
+    assert frame.x == pytest.approx(-40.0)
+    assert frame.y == pytest.approx(-50.0)
+    assert frame.state.group_width == pytest.approx(502.0)
+    assert frame.state.group_height == pytest.approx(1215.0)
+    for member, height in ((top, 112.0), (bottom, 525.0)):
+        assert member.x >= frame.x
+        assert member.y >= frame.y
+        assert member.x + 422.0 <= frame.x + frame.state.group_width
+        assert member.y + height <= frame.y + frame.state.group_height
+
+
+def test_reporting_unchanged_sizes_reports_no_change():
+    """The steady state - the client re-measures constantly, and a report
+    that moves nothing must not cost a scene republish."""
+    doc = SceneDocument()
+    member = doc.add_chat_node(0, 0, "hi", is_user=True)
+    doc.create_frame([member.id])
+    doc.set_measured_node_sizes([(member.id, 422.0, 300.0)])
+
+    assert doc.set_measured_node_sizes([(member.id, 422.0, 300.0)]) is False
+
+
+def test_measured_sizes_are_ignored_for_unknown_ids_and_non_positive_values():
+    """A continuous background report from a client whose node set can be a
+    few frames behind must never raise, and a zero-size measurement (a node
+    mid-mount) must never collapse a group's box."""
+    doc = SceneDocument()
+    member = doc.add_chat_node(0, 0, "hi", is_user=True)
+    frame = doc.create_frame([member.id])
+    doc.set_measured_node_sizes([(member.id, 422.0, 300.0)])
+    good = (frame.state.group_width, frame.state.group_height)
+
+    assert doc.set_measured_node_sizes([("nope", 100.0, 100.0)]) is False
+    assert doc.set_measured_node_sizes([(member.id, 0.0, 0.0)]) is False
+    assert doc.set_measured_node_sizes([(member.id, -5.0, 300.0)]) is False
+    assert (frame.state.group_width, frame.state.group_height) == good
+
+
+def test_chart_member_uses_its_own_size_without_being_measured():
+    """A chart carries authoritative geometry the backend already owns, so
+    it needs no client round trip to be enclosed correctly."""
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "q", is_user=True)
+    chart = doc.add_chart_node(
+        0, 0, parent.id, "bar", {"type": "bar", "title": "t", "labels": ["x"], "values": [1.0]},
+    )
+    frame = doc.create_frame([chart.id])
+
+    # ChartState's own defaults, not GROUP_MEMBER_DEFAULT_WIDTH/HEIGHT.
+    assert frame.state.group_width == pytest.approx(chart.state.chart_width + 80.0)
+    assert frame.state.group_height == pytest.approx(chart.state.chart_height + 90.0)
+
+
+def test_unmeasured_member_of_a_sizeless_kind_still_uses_the_estimate():
+    """The last-resort branch is still reachable and unchanged - a node the
+    client has not measured yet, whose kind carries no size of its own."""
+    doc = SceneDocument()
+    member = doc.add_node(0, 0)
+    frame = doc.create_frame([member.id])
+
+    assert frame.state.group_width == pytest.approx(GROUP_MEMBER_DEFAULT_WIDTH + 80.0)
+    assert frame.state.group_height == pytest.approx(GROUP_MEMBER_DEFAULT_HEIGHT + 90.0)
+
+
+def test_measured_size_change_propagates_to_a_container_holding_the_frame():
+    """A member resize has to reach the group holding its group, not just
+    the innermost one."""
+    doc = SceneDocument()
+    member = doc.add_chat_node(0, 0, "hi", is_user=True)
+    frame = doc.create_frame([member.id])
+    container = doc.create_container([frame.id])
+    before = (container.state.group_width, container.state.group_height)
+
+    doc.set_measured_node_sizes([(member.id, 422.0, 900.0)])
+
+    assert (container.state.group_width, container.state.group_height) != before
+    assert frame.x >= container.x
+    assert frame.y >= container.y
+    assert frame.x + frame.state.group_width <= container.x + container.state.group_width
+    assert frame.y + frame.state.group_height <= container.y + container.state.group_height
+
+
 def test_create_container_sets_correct_defaults():
     doc = SceneDocument()
     m1 = doc.add_node(0, 0)
@@ -6408,6 +6511,44 @@ def test_move_nodes_intent_publishes_the_scene_exactly_once_for_a_whole_group_dr
         )
         assert (document.nodes[m1_id].x, document.nodes[m1_id].y) == (20.0, 20.0)
         assert (document.nodes[m2_id].x, document.nodes[m2_id].y) == (320.0, 320.0)
+
+    asyncio.run(run())
+
+
+def test_report_node_sizes_intent_publishes_only_when_a_group_box_moves():
+    """The client re-measures constantly, so the intent must be silent for
+    a report that changes nothing - otherwise every settled re-measure
+    costs a full scene snapshot on the wire."""
+    async def run():
+        bus, document, recorder = make_bus()
+        m1_id = await bus.dispatch_intent("scene", "addNode", [0, 0])
+        frame_id = await bus.dispatch_intent("scene", "createFrame", [[m1_id]])
+
+        publishes_before = recorder.topics_seen().count("scene")
+        await bus.dispatch_intent("scene", "reportNodeSizes", [[[m1_id, 422.0, 600.0]]])
+        assert recorder.topics_seen().count("scene") - publishes_before == 1
+        assert document.nodes[frame_id].state.group_height == pytest.approx(690.0)
+
+        # Same sizes again: nothing moved, nothing published.
+        publishes_after_first = recorder.topics_seen().count("scene")
+        await bus.dispatch_intent("scene", "reportNodeSizes", [[[m1_id, 422.0, 600.0]]])
+        assert recorder.topics_seen().count("scene") == publishes_after_first
+
+    asyncio.run(run())
+
+
+def test_report_node_sizes_intent_is_not_undoable():
+    """An observation about rendering is not a user edit - it must not land
+    in the undo stack, or Ctrl+Z would replay layout noise."""
+    async def run():
+        bus, document, _recorder = make_bus()
+        m1_id = await bus.dispatch_intent("scene", "addNode", [0, 0])
+        await bus.dispatch_intent("scene", "createFrame", [[m1_id]])
+        undo_depth_before = len(document.command_log)
+
+        await bus.dispatch_intent("scene", "reportNodeSizes", [[[m1_id, 422.0, 600.0]]])
+
+        assert len(document.command_log) == undo_depth_before
 
     asyncio.run(run())
 

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -260,10 +260,13 @@ def test_the_scan_finds_the_real_population_of_registered_intents():
     # and 169 -> 170 when ADR-008 stage 8.7 added builder's own deleteRecipe,
     # and 170 -> 171 when ADR-021 stage 21.5 added scene/
     # setWebResearchRetainToKnowledge (the per-node knowledge-retention
-    # opt-in that finally makes ADR-017's retention path reachable).
+    # opt-in that finally makes ADR-017's retention path reachable), and
+    # 171 -> 172 when scene/reportNodeSizes was added (the frontend's own
+    # rendered-size report, without which frame/container bounds fall back
+    # to a flat 220x120 estimate per member and do not enclose them).
     real = _collect_real_registrations()
-    assert len(real) == 171, (
-        f"expected exactly 171 real registered intents, found {len(real)} - "
+    assert len(real) == 172, (
+        f"expected exactly 172 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -117,6 +117,12 @@ CLASSIFICATION: tuple[Classified, ...] = (
     Classified("scene", "setSmartGuides", "B", "preference: canvas behavior toggle"),
     Classified("scene", "setDragFactor", "B", "preference: drag sensitivity"),
     Classified("scene", "setViewState", "B", "view-state: zoom/scroll position"),
+    Classified(
+        "scene", "reportNodeSizes", "B",
+        "render-observation: the client reporting what nodes actually laid out to, "
+        "so group bounds can enclose them - not a user action, and replaying layout "
+        "noise through Ctrl+Z would be meaningless",
+    ),
     Classified("scene", "organizeNodes", "A", "content: auto-layout repositions every node - one Ctrl+Z restores them all"),
     Classified("scene", "setFontFamily", "B", "preference: canvas-appearance font"),
     Classified("scene", "setFontSize", "B", "preference: canvas-appearance font"),

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -15,6 +15,7 @@ import {
   groupDragKindOf,
   handleSelectionChange,
   isOrthogonalEligible,
+  collectChangedNodeSizes,
   makeDebouncedViewportReport,
   SceneCanvas,
   toFlowEdges,
@@ -2186,6 +2187,67 @@ describe("toFlowNodes (R6.3 html node splitter state)", () => {
     const flowNodes = toFlowNodes(scene, store);
     const htmlFlowNode = flowNodes.find((n) => n.id === "html-1");
     expect((htmlFlowNode!.data as { htmlSplitterState: number | null }).htmlSplitterState).toBeNull();
+  });
+});
+
+describe("collectChangedNodeSizes (node-size reporting for group bounds)", () => {
+  const sized = (sizes: Record<string, { width: number; height: number } | null>) =>
+    (id: string) => sizes[id] ?? null;
+
+  it("reports every measurable node the first time it is seen", () => {
+    const last = new Map<string, string>();
+    const changed = collectChangedNodeSizes(
+      ["a", "b"],
+      sized({ a: { width: 422, height: 112 }, b: { width: 680, height: 500 } }),
+      last,
+    );
+    expect(changed).toEqual([
+      ["a", 422, 112],
+      ["b", 680, 500],
+    ]);
+  });
+
+  it("reports nothing on a re-measure that produced identical sizes - the steady state costs no intent at all", () => {
+    const last = new Map<string, string>();
+    const measure = sized({ a: { width: 422, height: 112 } });
+    collectChangedNodeSizes(["a"], measure, last);
+
+    expect(collectChangedNodeSizes(["a"], measure, last)).toEqual([]);
+  });
+
+  it("reports only the node whose size actually moved", () => {
+    const last = new Map<string, string>();
+    collectChangedNodeSizes(
+      ["a", "b"],
+      sized({ a: { width: 422, height: 112 }, b: { width: 422, height: 300 } }),
+      last,
+    );
+
+    const changed = collectChangedNodeSizes(
+      ["a", "b"],
+      sized({ a: { width: 422, height: 112 }, b: { width: 422, height: 900 } }),
+      last,
+    );
+    expect(changed).toEqual([["b", 422, 900]]);
+  });
+
+  it("skips an unmeasurable node rather than reporting it as zero - an off-viewport node is unmounted, not shrunk", () => {
+    const last = new Map<string, string>();
+    collectChangedNodeSizes(["a"], sized({ a: { width: 422, height: 112 } }), last);
+
+    expect(collectChangedNodeSizes(["a"], sized({ a: null }), last)).toEqual([]);
+    // The last known size is retained, so scrolling back does not re-report.
+    expect(collectChangedNodeSizes(["a"], sized({ a: { width: 422, height: 112 } }), last)).toEqual([]);
+  });
+
+  it("skips non-positive measurements - a node mid-mount must never collapse its group's box", () => {
+    const last = new Map<string, string>();
+    const changed = collectChangedNodeSizes(
+      ["a", "b"],
+      sized({ a: { width: 0, height: 0 }, b: { width: 422, height: 0 } }),
+      last,
+    );
+    expect(changed).toEqual([]);
   });
 });
 

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -2466,32 +2466,6 @@ function CanvasInner({
     },
     [],
   );
-  // Node-size reporting: the backend fits frames/containers around their
-  // members but cannot measure a rendered node itself, so the canvas tells
-  // it what it actually laid out. Debounced for the same reason onMove is
-  // (a streaming reply re-measures its node on nearly every token) and
-  // diffed against what was last sent, so a settled canvas reports nothing.
-  const nodeSizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const reportedSizesRef = useRef<Map<string, string>>(new Map());
-  useEffect(
-    () => () => {
-      if (nodeSizeTimerRef.current) clearTimeout(nodeSizeTimerRef.current);
-    },
-    [],
-  );
-  const reportNodeSizesSoon = useCallback(() => {
-    if (nodeSizeTimerRef.current) clearTimeout(nodeSizeTimerRef.current);
-    nodeSizeTimerRef.current = setTimeout(() => {
-      nodeSizeTimerRef.current = null;
-      const changed = collectChangedNodeSizes(
-        nodesRef.current.map((n) => n.id),
-        (id) => measuredNodeSize(reactFlow, id),
-        reportedSizesRef.current,
-      );
-      store.reportNodeSizes(changed);
-    }, NODE_SIZE_REPORT_DEBOUNCE_MS);
-  }, [reactFlow, store]);
-
   const onMove: OnMove = useCallback(
     (_event, viewport) => {
       makeDebouncedViewportReport(viewportTimerRef, (zoomFactor, scrollX, scrollY) =>
@@ -2627,6 +2601,32 @@ function CanvasInner({
   // React Flow's own store update, where a setState call would be a
   // render-phase update.
   const pendingGuidesRef = useRef<GuideLine[]>([]);
+  // Node-size reporting: the backend fits frames/containers around their
+  // members but cannot measure a rendered node itself, so the canvas tells
+  // it what it actually laid out. Debounced for the same reason onMove is
+  // (a streaming reply re-measures its node on nearly every token) and
+  // diffed against what was last sent, so a settled canvas reports nothing.
+  const nodeSizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reportedSizesRef = useRef<Map<string, string>>(new Map());
+  useEffect(
+    () => () => {
+      if (nodeSizeTimerRef.current) clearTimeout(nodeSizeTimerRef.current);
+    },
+    [],
+  );
+  const reportNodeSizesSoon = useCallback(() => {
+    if (nodeSizeTimerRef.current) clearTimeout(nodeSizeTimerRef.current);
+    nodeSizeTimerRef.current = setTimeout(() => {
+      nodeSizeTimerRef.current = null;
+      const changed = collectChangedNodeSizes(
+        nodesRef.current.map((n) => n.id),
+        (id) => measuredNodeSize(reactFlow, id),
+        reportedSizesRef.current,
+      );
+      store.reportNodeSizes(changed);
+    }, NODE_SIZE_REPORT_DEBOUNCE_MS);
+  }, [reactFlow, store]);
+
 
   /**
    * DRAG-SYNC REBUILD: the drag-position corrections this canvas applies -

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -42,6 +42,7 @@ import { PlanNodeView, type PlanFlowNode, type PlanStepData } from "./PlanNodeVi
 import {
   GROUP_FALLBACK_HEIGHT,
   GROUP_FALLBACK_WIDTH,
+  NODE_SIZE_REPORT_DEBOUNCE_MS,
   VIEWPORT_REPORT_DEBOUNCE_MS,
 } from "./canvasConstants";
 import { handleKeyboardContextMenu } from "./keyboardContextMenu";
@@ -2211,6 +2212,43 @@ export function makeDebouncedViewportReport(
   };
 }
 
+/**
+ * The diff half of node-size reporting: given the ids currently on canvas,
+ * return only those whose rendered size differs from what was last sent,
+ * updating `lastReported` in place as it goes.
+ *
+ * Diffing is what makes this cheap enough to run on every re-measure. A
+ * streaming reply re-measures its node constantly but its WIDTH never
+ * moves and its height stops changing the moment the text settles, so the
+ * steady state is an empty array and no intent at all.
+ *
+ * Nodes that cannot be measured are SKIPPED, never reported as zero: with
+ * `onlyRenderVisibleElements` on, an off-viewport node is genuinely
+ * unmounted and unmeasurable, and the backend's last known size for it is
+ * better than a zero that would collapse its group's box. For the same
+ * reason this never removes ids from `lastReported` - a node that scrolls
+ * away and back has not changed size, so it should not re-report.
+ *
+ * Exported for direct unit testing, same posture as makeDebouncedViewport-
+ * Report/toFlowNodes above.
+ */
+export function collectChangedNodeSizes(
+  ids: string[],
+  measure: (id: string) => { width: number; height: number } | null,
+  lastReported: Map<string, string>,
+): Array<[string, number, number]> {
+  const changed: Array<[string, number, number]> = [];
+  for (const id of ids) {
+    const size = measure(id);
+    if (size === null || size.width <= 0 || size.height <= 0) continue;
+    const key = `${size.width}x${size.height}`;
+    if (lastReported.get(id) === key) continue;
+    lastReported.set(id, key);
+    changed.push([id, size.width, size.height]);
+  }
+  return changed;
+}
+
 // R8a: reads a real design-token value at render time rather than
 // hardcoding a hex literal - needed anywhere a color has to be a plain JS
 // string (an SVG-attribute-producing prop like MiniMap's nodeColor/
@@ -2428,6 +2466,32 @@ function CanvasInner({
     },
     [],
   );
+  // Node-size reporting: the backend fits frames/containers around their
+  // members but cannot measure a rendered node itself, so the canvas tells
+  // it what it actually laid out. Debounced for the same reason onMove is
+  // (a streaming reply re-measures its node on nearly every token) and
+  // diffed against what was last sent, so a settled canvas reports nothing.
+  const nodeSizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reportedSizesRef = useRef<Map<string, string>>(new Map());
+  useEffect(
+    () => () => {
+      if (nodeSizeTimerRef.current) clearTimeout(nodeSizeTimerRef.current);
+    },
+    [],
+  );
+  const reportNodeSizesSoon = useCallback(() => {
+    if (nodeSizeTimerRef.current) clearTimeout(nodeSizeTimerRef.current);
+    nodeSizeTimerRef.current = setTimeout(() => {
+      nodeSizeTimerRef.current = null;
+      const changed = collectChangedNodeSizes(
+        nodesRef.current.map((n) => n.id),
+        (id) => measuredNodeSize(reactFlow, id),
+        reportedSizesRef.current,
+      );
+      store.reportNodeSizes(changed);
+    }, NODE_SIZE_REPORT_DEBOUNCE_MS);
+  }, [reactFlow, store]);
+
   const onMove: OnMove = useCallback(
     (_event, viewport) => {
       makeDebouncedViewportReport(viewportTimerRef, (zoomFactor, scrollX, scrollY) =>
@@ -2701,6 +2765,11 @@ function CanvasInner({
       const settledMoveIntents: Array<{ id: string; x: number; y: number }> = [];
       let sawDragging = false;
       let sawDragEnd = false;
+      // React Flow's own "this node was (re)measured" signal - the trigger
+      // for reporting sizes back to the backend's group-bounds math. Only
+      // schedules the debounced flush; the flush itself re-reads every
+      // node and sends just the diffs.
+      if (changes.some((change) => change.type === "dimensions")) reportNodeSizesSoon();
 
       for (const change of changes) {
         if (change.type !== "position") continue;
@@ -2771,7 +2840,7 @@ function CanvasInner({
       // eslint-disable-next-line react-hooks/immutability
       nodesRef.current = applyNodeChanges(changes, currentNodes);
     },
-    [store],
+    [store, reportNodeSizesSoon],
   );
 
   const onConnect = useCallback(

--- a/web_ui/src/app/canvas/canvasConstants.ts
+++ b/web_ui/src/app/canvas/canvasConstants.ts
@@ -60,6 +60,15 @@ export const VIEWPORT_REPORT_DEBOUNCE_MS = 250;
 export const HTML_SPLITTER_REPORT_DEBOUNCE_MS = 200;
 export const CHAT_SCROLL_REPORT_DEBOUNCE_MS = 200;
 
+/** How long node re-measurements settle before being reported to the
+ * backend (reportNodeSizes), which needs them to fit a frame/container
+ * around its members - the backend cannot compute a chat node's rendered
+ * height for itself. Same debounce posture as the three above, but the
+ * burst it guards is different in kind: a streaming reply re-measures its
+ * node on nearly every token, so this is the difference between one report
+ * per settled layout and hundreds per reply. */
+export const NODE_SIZE_REPORT_DEBOUNCE_MS = 200;
+
 /** R6.3: HTML view node splitter-position scaffolding. Legacy's own
  * splitter_state (graphlink_html_view.py's QSplitter) was a deliberate scope
  * cut back in R3.17/R3.18 (see HtmlNodeView.tsx/styles.css's own now-

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -1113,6 +1113,18 @@ export class SceneStore {
     );
   }
 
+  // The backend owns all frame/container bounds math but cannot measure a
+  // node's rendered height itself, so the canvas reports what it actually
+  // laid out (SceneCanvas's own dimension-change handler, debounced and
+  // diffed - only genuinely changed sizes reach here). Queueable and
+  // idempotent last-write-wins for the same reason moveNodes is: a size
+  // report is a statement about the present, so a stale queued one is
+  // harmlessly superseded by the next.
+  reportNodeSizes(sizes: Array<[string, number, number]>): void {
+    if (sizes.length === 0) return;
+    this.transport.fireIntent("scene", "reportNodeSizes", [sizes], undefined, true);
+  }
+
   removeNodes(ids: string[]): void {
     if (ids.length > 0) this.transport.fireIntent("scene", "removeNodes", [ids]);
   }


### PR DESCRIPTION
## Problem

A frame rendered smaller than the nodes it was supposed to enclose — members visibly hung outside their own group box.

`_bbox_of_members` (backend/domain/groups.py) measured every member as a flat 220x120 (`GROUP_MEMBER_DEFAULT_WIDTH`/`HEIGHT`). No real node is that size: a chat node is 422 wide and routinely 500+ tall. The padded union rect was therefore always too small.

The backend cannot derive the true size itself — a chat node's height is whatever its markdown lays out to, which only the browser knows.

## Change

The canvas reports what it actually rendered. React Flow's `dimensions` changes schedule a debounced flush that diffs measured sizes against the last report and sends only what moved (`reportNodeSizes`), so a settled canvas costs nothing on the wire and a streaming reply reports once per settled layout instead of once per token.

`_member_footprint` consumes it with a **measured → intrinsic → estimate** chain. A chart's own `chart_width`/`height` and a nested group's `group_width`/`height` are authoritative geometry this backend already owns and need no client round trip; the flat estimate survives only as the last resort for an unmeasured node whose kind carries no size of its own. Non-positive measurements fall through rather than collapsing a box, so a node mid-mount — or one unmounted by `onlyRenderVisibleElements` — can never shrink its group.

Sizes live in `SceneDocument.measured_sizes`, not on `SceneNode`. This is an observation about rendering, not document state: keeping it off the node means it is structurally excluded from persistence, from `scene_payload`, and from the undo stack, rather than depending on three separate places remembering to skip a field — and it leaves ADR-002's locked 14-field `SceneNode` shape intact. The intent is classified **B (not undoable)** for the same reason: replaying layout noise through Ctrl+Z is meaningless. Republishing is gated on a group box actually moving.

## Test plan

- **Backend (8):** real-size enclosure, steady-state no-op, unknown ids and non-positive values, chart intrinsic size, the surviving estimate path, nested container propagation, plus two intent-level tests (publishes exactly once; never enters the undo stack).
- **Frontend (5):** the diffing helper — first-sight reporting, identical re-measure reports nothing, only the changed node is sent, unmeasurable nodes skipped rather than zeroed, non-positive values skipped.
- Targeted suites green: `test_canvas` 459, session load/save + commands + patch protocol + tools_graph 251, architectural gates 38, frontend helper 5. `tsc --noEmit` clean.
- Verified directly: a frame around two chat nodes went from 300x810 (members outside the box) to 502x1215 with both fully enclosed.