### PR TITLE
Stop MCP servers inheriting the backend's environment; validate asset refs

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -482,7 +482,7 @@ class AgentDispatcher:
                 continue
             client = McpStdioClient(
                 command=config_entry.command, args=tuple(config_entry.args),
-                timeout=config_entry.timeout,
+                env=config_entry.env, timeout=config_entry.timeout,
             )
             try:
                 client.connect()

--- a/backend/api/intents_settings_general.py
+++ b/backend/api/intents_settings_general.py
@@ -80,6 +80,7 @@ def _mcp_servers_from_wire(servers: object) -> list[dict] | None:
             "enabled_tools": entry.get("enabledTools", []),
             "enabled": entry.get("enabled", True),
             "timeout": entry.get("timeout", 30.0),
+            "env": entry.get("env", {}),
         })
     return normalized
 

--- a/backend/asset_store.py
+++ b/backend/asset_store.py
@@ -35,6 +35,7 @@ poorly - the same convention git's own object store uses.
 from __future__ import annotations
 
 import hashlib
+import re
 import logging
 import os
 from pathlib import Path
@@ -56,6 +57,10 @@ _EXTENSION_BY_MIME = {
 def content_ref(data: bytes) -> str:
     """The SHA-256 hex digest that names these exact bytes."""
     return hashlib.sha256(data).hexdigest()
+
+
+# Exactly what content_ref produces, and the only shape _path_for accepts.
+_CONTENT_REF_RE = re.compile(r"[0-9a-f]{64}")
 
 
 def extension_for_mime(mime_type: str | None) -> str:
@@ -86,17 +91,27 @@ class AssetStore:
     def __init__(self, root: Path):
         self.root = Path(root)
 
-    def _path_for(self, ref: str) -> Path:
+    def _path_for(self, ref: str) -> Path | None:
+        """The on-disk path for a content ref, or None for anything that is
+        not one. A ref is a SHA-256 hex digest and nothing else - it is read
+        straight out of persisted chat rows and imported archives, i.e. data
+        this process did not necessarily write, so a crafted value like
+        "../../.ssh/id_rsa" must be rejected here, at the one place a ref
+        becomes a path, rather than trusted into `root / ref[:2] / ref`."""
+        if not _CONTENT_REF_RE.fullmatch(ref or ""):
+            return None
         return self.root / ref[:2] / ref
 
     def exists(self, ref: str) -> bool:
-        return self._path_for(ref).is_file()
+        target = self._path_for(ref)
+        return target is not None and target.is_file()
 
     def put(self, data: bytes) -> str:
         """Stores `data` and returns its ref. Idempotent: storing identical
         bytes twice writes once and returns the same ref both times."""
         ref = content_ref(data)
         target = self._path_for(ref)
+        assert target is not None  # content_ref always yields a valid ref
         if target.is_file():
             return ref
 
@@ -130,7 +145,7 @@ class AssetStore:
         and an import from a bundle whose assets were stripped is a
         legitimate, survivable state."""
         target = self._path_for(ref)
-        if not target.is_file():
+        if target is None or not target.is_file():
             return None
         try:
             return target.read_bytes()

--- a/backend/mcp_client.py
+++ b/backend/mcp_client.py
@@ -45,11 +45,12 @@ import queue
 import subprocess
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable
 
 from backend.providers.base import ToolSpec
 from backend.tools import RunContext, ToolResult
+from graphlink_process_env import safe_subprocess_env
 
 # The MCP spec's own date-versioned protocol string - the most recent
 # stable revision at the time this client was written. Sent verbatim in
@@ -97,6 +98,16 @@ class McpServerConfig:
     enabled_tools: frozenset[str] = frozenset()
     enabled: bool = True
     timeout: float = 30.0
+    # Extra environment variables for THIS server's process, layered on top
+    # of the safe allowlist base (graphlink_process_env.safe_subprocess_env)
+    # - the ONLY way a server receives anything beyond that base. A GitHub
+    # MCP server needs GITHUB_TOKEN, a Brave one BRAVE_API_KEY; the user
+    # names exactly the variable that server needs here, and nothing else
+    # crosses. Before this field existed the spawn inherited the backend's
+    # whole environment, so every such server silently received every
+    # provider key the user had configured as an env var - the exact leak
+    # safe_subprocess_env was written to close at every other spawn site.
+    env: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -108,6 +119,7 @@ class McpServerConfig:
             "enabled_tools": sorted(self.enabled_tools),
             "enabled": self.enabled,
             "timeout": self.timeout,
+            "env": dict(self.env),
         }
 
     @classmethod
@@ -121,7 +133,25 @@ class McpServerConfig:
             enabled_tools=frozenset(str(t) for t in (data.get("enabled_tools") or [])),
             enabled=bool(data.get("enabled", True)),
             timeout=float(data.get("timeout", 30.0) or 30.0),
+            env=_coerce_env(data.get("env")),
         )
+
+
+def _coerce_env(raw: object) -> dict[str, str]:
+    """A persisted/wire `env` value as a clean str->str dict. Tolerant of
+    the shapes a hand-edited session.dat or an older payload can carry
+    (missing, null, non-dict, non-string values) - a malformed env entry
+    degrades to "no extra variables", never to a failed config load that
+    would take the whole server list with it."""
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, str] = {}
+    for key, value in raw.items():
+        name = str(key).strip()
+        if not name or value is None:
+            continue
+        out[name] = str(value)
+    return out
 
 
 class McpStdioClient:
@@ -153,12 +183,21 @@ class McpStdioClient:
         if self._process is not None:
             return
         try:
+            # env= is ALWAYS passed and ALWAYS built from the allowlist base:
+            # Popen(env=None) inherits the backend's full os.environ, which
+            # carries every provider API key the user configured as an
+            # environment variable. An MCP server is third-party code the
+            # user chose to run - it gets PATH/TEMP/HOME-class plumbing plus
+            # exactly the variables its own config names, nothing else. Same
+            # posture as pycoder/code_sandbox/plugin_sdk's spawns.
+            spawn_env = safe_subprocess_env()
+            spawn_env.update(self.env or {})
             self._process = subprocess.Popen(
                 [self.command, *self.args],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                env=self.env,
+                env=spawn_env,
                 cwd=self.cwd,
                 text=True,
                 bufsize=1,

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -148,6 +148,7 @@ def _mcp_servers_for_wire(manager: SettingsManager) -> list[dict[str, Any]]:
             "enabledTools": list(entry.get("enabled_tools", [])),
             "enabled": bool(entry.get("enabled", True)),
             "timeout": float(entry.get("timeout", 30.0)),
+            "env": dict(entry.get("env") or {}),
         }
         for entry in manager.get_mcp_servers()
     ]

--- a/backend/tests/test_mcp_client.py
+++ b/backend/tests/test_mcp_client.py
@@ -65,10 +65,20 @@ _FAKE_FS_SERVER_SCRIPT = textwrap.dedent(r'''
                         },
                     },
                     {"name": "unlisted_tool", "description": "Not enabled.", "inputSchema": {"type": "object"}},
+                    {"name": "read_env", "description": "Reports which env vars this process sees.",
+                     "inputSchema": {"type": "object", "properties": {"names": {"type": "array"}}}},
                 ]},
             })
         elif method == "tools/call":
             params = request.get("params", {})
+            if params.get("name") == "read_env":
+                import os
+                names = (params.get("arguments") or {}).get("names", [])
+                seen = {n: os.environ.get(n) for n in names}
+                send({"jsonrpc": "2.0", "id": request_id, "result": {
+                    "content": [{"type": "text", "text": json.dumps(seen)}], "isError": False,
+                }})
+                continue
             path = (params.get("arguments") or {}).get("path", "")
             try:
                 with open(path, "r", encoding="utf-8") as f:
@@ -115,7 +125,7 @@ def test_list_tools_returns_normalized_toolspecs(fake_fs_server):
         client.connect()
         specs = client.list_tools()
         names = [spec.name for spec in specs]
-        assert names == ["read_file", "unlisted_tool"]
+        assert names == ["read_file", "unlisted_tool", "read_env"]
         read_file_spec = specs[0]
         assert read_file_spec.description == "Reads a file's contents."
         assert read_file_spec.input_schema == {
@@ -251,3 +261,54 @@ def test_an_out_of_scope_mcp_call_is_denied_pre_handler(fake_fs_server, tmp_path
         assert prompted == []  # denied before any approval prompt, let alone the handler
     finally:
         client.close()
+
+
+# -- environment isolation (the spawn must never inherit the backend's env) --
+
+
+def _env_seen_by_server(monkeypatch, tmp_path, *, config_env=None):
+    """Spawn the fake server with a canary secret in THIS process's
+    environment and ask the server which variables it can actually see."""
+    import json as _json
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-CANARY-must-not-cross")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-CANARY-must-not-cross")
+    script = tmp_path / "fake_server.py"
+    script.write_text(_FAKE_FS_SERVER_SCRIPT, encoding="utf-8")
+    client = McpStdioClient(command=sys.executable, args=(str(script),), env=config_env or {})
+    client.connect()
+    try:
+        result = client.call_tool("read_env", {
+            "names": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GITHUB_TOKEN", "PATH"],
+        })
+    finally:
+        client.close()
+    return _json.loads(result.content)
+
+
+def test_server_process_does_not_inherit_provider_keys_from_the_backend(monkeypatch, tmp_path):
+    """The leak this closes: Popen(env=None) handed every provider API key
+    the user had set as an environment variable to whatever third-party
+    MCP server they configured. A server sees the allowlist base plus its
+    OWN config env - nothing else."""
+    seen = _env_seen_by_server(monkeypatch, tmp_path)
+    assert seen["OPENAI_API_KEY"] is None
+    assert seen["ANTHROPIC_API_KEY"] is None
+    assert seen["PATH"]  # launchers like npx/uvx still resolve
+
+
+def test_server_receives_exactly_the_variables_its_own_config_names(monkeypatch, tmp_path):
+    seen = _env_seen_by_server(monkeypatch, tmp_path, config_env={"GITHUB_TOKEN": "ghp_for_this_server_only"})
+    assert seen["GITHUB_TOKEN"] == "ghp_for_this_server_only"
+    assert seen["OPENAI_API_KEY"] is None  # still nothing beyond base + own config
+
+
+def test_config_env_round_trips_and_tolerates_malformed_values():
+    cfg = McpServerConfig.from_dict({
+        "name": "gh", "command": "npx",
+        "env": {"GITHUB_TOKEN": "ghp_x", " ": "dropped-blank-name", "NULL": None, 7: 8},
+    })
+    assert cfg.env == {"GITHUB_TOKEN": "ghp_x", "7": "8"}
+    assert McpServerConfig.from_dict(cfg.to_dict()).env == cfg.env
+    # non-dict / missing degrade to "no extra variables", never a failed load
+    assert McpServerConfig.from_dict({"name": "a", "command": "b", "env": "oops"}).env == {}
+    assert McpServerConfig.from_dict({"name": "a", "command": "b"}).env == {}

--- a/backend/tests/test_session_format_adr009.py
+++ b/backend/tests/test_session_format_adr009.py
@@ -264,3 +264,22 @@ def test_the_legacy_buckets_are_still_written_for_older_readers():
     assert "connections" in chat_data
     assert chat_data["system_prompt_connections"], "system-prompt bucket stopped being written"
     assert chat_data["group_summary_connections"], "group-summary bucket stopped being written"
+
+
+# -- ref validation: a ref names content, it is never a path ---------------
+
+
+def test_store_rejects_a_ref_that_is_not_a_content_digest(tmp_path):
+    """A ref is read straight out of persisted rows and imported archives -
+    data this process did not necessarily write - so a crafted value must
+    never be trusted into `root / ref[:2] / ref`. Only a SHA-256 hex digest
+    (exactly what content_ref produces) resolves to a path at all."""
+    store = AssetStore(tmp_path / "assets")
+    (tmp_path / "secret.txt").write_bytes(b"TOP SECRET")
+    ref = store.put(b"real image bytes")
+    assert store.get(ref) == b"real image bytes"
+
+    for crafted in ("../secret.txt", "../../secret.txt", "..\secret.txt", "", "x", ref.upper()):
+        assert store.get(crafted) is None, crafted
+        assert store.exists(crafted) is False, crafted
+        assert store.verify(crafted) is False, crafted

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -423,6 +423,7 @@ def test_set_mcp_servers_persists_and_normalizes_a_round_trip(manager):
             "enabled_tools": ["read_file"],
             "enabled": True,
             "timeout": 30.0,
+            "env": {},
         },
     ]
 
@@ -2319,6 +2320,7 @@ def test_set_mcp_servers_round_trips_a_valid_call(manager):
             "enabled_tools": ["read_file"],
             "enabled": True,
             "timeout": 45.0,
+            "env": {},
         },
     ]
     # ...and republished on the wire in the camelCase shape the frontend reads.
@@ -2333,6 +2335,7 @@ def test_set_mcp_servers_round_trips_a_valid_call(manager):
             "enabledTools": ["read_file"],
             "enabled": True,
             "timeout": 45.0,
+            "env": {},
         },
     ]
 

--- a/contracts/graphlink_app_settings_payload.py
+++ b/contracts/graphlink_app_settings_payload.py
@@ -54,6 +54,9 @@ class McpServerConfigPayload:
     enabledTools: list[str]
     enabled: bool
     timeout: float
+    # Per-server environment variables (KEY -> value), layered on the safe
+    # allowlist base at spawn - see backend/mcp_client.py's McpServerConfig.
+    env: dict[str, str]
 
 
 @dataclass

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -22,6 +22,20 @@ def _is_llama_cpp_gguf_path(path_value) -> bool:
     return bool(normalized) and normalized.lower().endswith(".gguf")
 
 
+def _normalize_mcp_env(raw):
+    """One MCP server's `env` as a clean str->str dict - tolerant of the
+    shapes a hand-edited session.dat or an older payload can carry (missing,
+    null, non-dict, non-string values, blank names). Malformed degrades to
+    "no extra variables", never to a dropped server entry."""
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(key).strip(): str(value)
+        for key, value in raw.items()
+        if str(key).strip() and value is not None
+    }
+
+
 class SettingsManager:
     NOTIFICATION_TYPES = ("info", "success", "warning", "error")
     # R8a: the graded reasoning-effort vocabulary shared by all 5 providers'
@@ -1195,6 +1209,10 @@ class SettingsManager:
                 "enabled_tools": sorted({str(t) for t in (entry.get("enabled_tools") or [])}),
                 "enabled": bool(entry.get("enabled", True)),
                 "timeout": float(entry.get("timeout", 30.0) or 30.0),
+                # Absent on every entry persisted before the field existed -
+                # reads back as "no extra variables", the same default the
+                # write side stores.
+                "env": _normalize_mcp_env(entry.get("env")),
             })
         return servers
 
@@ -1224,6 +1242,13 @@ class SettingsManager:
                 "enabled_tools": sorted({str(t) for t in (entry.get("enabled_tools") or [])}),
                 "enabled": bool(entry.get("enabled", True)),
                 "timeout": float(entry.get("timeout", 30.0) or 30.0),
+                # Per-server environment variables - the only channel by
+                # which a server process receives anything beyond the safe
+                # allowlist base (see McpStdioClient.connect). Values are
+                # stored as given; they are the user's own secrets for a
+                # server the user chose to run, same posture as the API keys
+                # this store already holds.
+                "env": _normalize_mcp_env(entry.get("env")),
             })
         self.state["mcp_servers"] = normalized
         self._save_state()

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
-import { SettingsDialog } from "./SettingsDialog";
+import { SettingsDialog, parseEnvLines } from "./SettingsDialog";
 import { OverlayProvider, useOverlays } from "../overlays/overlays";
 import { ExecutionLimitsProvider } from "../canvas/ExecutionLimitsContext";
 import type { WsTransport } from "../../lib/ws/transport";
@@ -922,6 +922,7 @@ describe("SettingsDialog", () => {
       enabledTools: [],
       enabled: true,
       timeout: 30,
+      env: {},
     };
 
     it("navigating to MCP Servers fires setActiveSection with its own key", async () => {
@@ -997,6 +998,7 @@ describe("SettingsDialog", () => {
             enabledTools: [],
             enabled: true,
             timeout: 30,
+            env: {},
           },
         ]],
       ]);
@@ -1030,6 +1032,7 @@ describe("SettingsDialog", () => {
         enabledTools: [],
         enabled: true,
         timeout: 30,
+        env: {},
       };
       const { user, push, intents } = setup();
       await goToMcpServers(user, push, { mcpServers: [fsServer, gitServer] });
@@ -1127,5 +1130,26 @@ describe("SettingsDialog", () => {
 
       expect(intents).toContainEqual(["app-plugins", "setPluginGrant", ["counter_node", false]]);
     });
+  });
+});
+
+describe("parseEnvLines (MCP server env field)", () => {
+  it("parses KEY=value lines into a record", () => {
+    expect(parseEnvLines("GITHUB_TOKEN=ghp_abc\nBRAVE_API_KEY=brv")).toEqual({
+      GITHUB_TOKEN: "ghp_abc",
+      BRAVE_API_KEY: "brv",
+    });
+  });
+
+  it("splits on the FIRST '=' only, so a value can itself contain '=' (base64 tokens do)", () => {
+    expect(parseEnvLines("TOKEN=abc==")).toEqual({ TOKEN: "abc==" });
+  });
+
+  it("skips blank lines, lines without '=', and lines with an empty key", () => {
+    expect(parseEnvLines("\n\nnot-a-pair\n=orphan-value\n  \nOK=1\r\n")).toEqual({ OK: "1" });
+  });
+
+  it("trims whitespace around keys and values and tolerates CRLF", () => {
+    expect(parseEnvLines("  A = 1 \r\n B=2\r\n")).toEqual({ A: "1", B: "2" });
   });
 });

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -1065,10 +1065,27 @@ function LlamaCppPage({ state, transport }: { state: AppSettingsState; transport
 // _register_configured_mcp_tools only connects enabled servers lazily, when
 // the Builder registry is next built), so replaying it after a reconnect is
 // always safe.
+/** "KEY=value" lines -> env record. Blank lines and lines without "=" are
+ * skipped; the first "=" splits, so a value may itself contain "=" (base64
+ * tokens routinely do). Exported for direct unit testing. */
+export function parseEnvLines(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (!key) continue;
+    env[key] = line.slice(eq + 1).trim();
+  }
+  return env;
+}
+
 function McpServersPage({ state, transport }: { state: AppSettingsState; transport: WsTransport }) {
   const [draftName, setDraftName] = useState("");
   const [draftCommand, setDraftCommand] = useState("");
   const [draftArgs, setDraftArgs] = useState("");
+  const [draftEnv, setDraftEnv] = useState("");
 
   const updateServers = (next: McpServerConfig[]) => {
     transport.fireIntent("app-settings", "setMcpServers", [next], undefined, true);
@@ -1081,11 +1098,15 @@ function McpServersPage({ state, transport }: { state: AppSettingsState; transpo
     const args = draftArgs.trim() ? draftArgs.trim().split(/\s+/) : [];
     updateServers([
       ...state.mcpServers,
-      { name, command, args, scopes: [], approval: "always", enabledTools: [], enabled: true, timeout: 30 },
+      {
+        name, command, args, scopes: [], approval: "always", enabledTools: [], enabled: true, timeout: 30,
+        env: parseEnvLines(draftEnv),
+      },
     ]);
     setDraftName("");
     setDraftCommand("");
     setDraftArgs("");
+    setDraftEnv("");
   };
 
   return (
@@ -1122,6 +1143,14 @@ function McpServersPage({ state, transport }: { state: AppSettingsState; transpo
                   {server.command}
                   {server.args.length > 0 ? ` ${server.args.join(" ")}` : ""}
                 </span>
+                {/* Names only, never values - these are the user's own
+                    tokens for a server they chose to run, and a settings
+                    page is no place to echo a secret back. */}
+                {Object.keys(server.env ?? {}).length > 0 && (
+                  <span className="settings-mcp-server-command">
+                    env: {Object.keys(server.env).sort().join(", ")}
+                  </span>
+                )}
               </span>
             </label>
             <button
@@ -1167,6 +1196,21 @@ function McpServersPage({ state, transport }: { state: AppSettingsState; transpo
             value={draftArgs}
             onChange={(event) => setDraftArgs(event.target.value)}
           />
+        </label>
+        <label className="settings-field">
+          <span className="settings-field-label">Environment variables (optional, one KEY=value per line)</span>
+          <textarea
+            className="settings-select settings-mcp-env-input"
+            rows={3}
+            placeholder={"GITHUB_TOKEN=ghp_...\nBRAVE_API_KEY=..."}
+            value={draftEnv}
+            onChange={(event) => setDraftEnv(event.target.value)}
+            spellCheck={false}
+          />
+          <span className="settings-field-hint">
+            A server receives only these variables plus basic system plumbing (PATH, TEMP, HOME) - never this
+            app&apos;s own provider keys.
+          </span>
         </label>
         <div className="settings-button-row">
           <button

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
@@ -157,6 +157,12 @@
             },
             "type": "array"
           },
+          "env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "name": {
             "type": "string"
           },
@@ -178,7 +184,8 @@
           "approval",
           "enabledTools",
           "enabled",
-          "timeout"
+          "timeout",
+          "env"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
@@ -19,6 +19,7 @@ export interface McpServerConfig {
   enabledTools: string[];
   enabled: boolean;
   timeout: number;
+  env: Record<string, string>;
 }
 
 export interface AppSettingsState {
@@ -158,6 +159,12 @@ function checkMcpServerConfig(value: unknown, path: string, errors: string[]): v
     const fieldValue = value["timeout"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.timeout: missing required field`);
     else { if (typeof fieldValue !== "number") errors.push(`${path}.timeout` + ": expected number"); }
+  }
+  {
+    const fieldValue = value["env"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.env: missing required field`);
+    else { if (!isRecord(fieldValue)) errors.push(`${path}.env` + ": expected object");
+    else Object.entries(fieldValue as Record<string, unknown>).forEach(([k, v]) => { if (typeof v !== "string") errors.push(`${path}.env` + `[${JSON.stringify(k)}]` + ": expected string"); }); }
   }
 }
 


### PR DESCRIPTION
## Problem

Two findings from a code audit of the security boundaries.

**1. MCP servers received every secret in the backend's environment.** `backend/agents.py` constructed `McpStdioClient` with no `env`, so `mcp_client.py` spawned the server with `Popen(env=None)` — which inherits the full parent `os.environ`, including any provider API key the user had configured as an environment variable (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, …). An MCP server is third-party code the user chose to run. `graphlink_process_env.safe_subprocess_env` exists precisely to close this at every spawn site — pycoder, code_sandbox and plugin_sdk all use it — and this one site was missed.

**2. Asset refs were trusted into a filesystem path.** `asset_store.py` built `root / ref[:2] / ref` from a ref read straight out of persisted chat rows and imported `.graphlink` archives — data this process did not necessarily write. A crafted `../../x` read an arbitrary local file into an image node. Low impact (it only renders into the user's own UI), but a one-line hardening.

## Change

The MCP spawn now always builds its env from the allowlist base. Because there was no per-server env field, the only way a server like `github-mcp` got its own token before was through this exact leak — so the allowlist alone would have broken those servers. `McpServerConfig` gains an `env` dict, layered on top of the base: a server receives `PATH`/`TEMP`/`HOME`-class plumbing plus exactly the variables its own config names, nothing else. It is persisted through the settings store, carried on the wire (contract regenerated), and editable on the MCP Servers settings page as `KEY=value` lines. The settings row lists variable **names** only, never values.

A ref is a SHA-256 hex digest and nothing else; `_path_for` now rejects anything that is not one, at the single place a ref becomes a path.

## Test plan

- The MCP fake server gained a `read_env` tool; two new tests spawn it **for real** with canary provider keys in the parent environment and assert the keys do not cross, `PATH` does, and a config-named variable does. A round-trip test covers env persistence and malformed values.
- The asset store test plants a file outside the store and asserts traversal, empty, short and upper-case refs all resolve to nothing while a real ref still round-trips.
- Pre-existing exact-shape assertions and fixtures updated for the new field.
- Targeted suites green: settings, mcp_client, session format, workspace archive, contracts, architectural gates (**301 passed**); SettingsDialog frontend tests (**83 passed**); `tsc` and `eslint` clean on touched files; `contracts/codegen.py --check` passes.

## Also verified clean during the audit (no change needed)

Auth (per-launch token, constant-time compare, loopback bind, strict WS origin), path traversal on the SPA route / gitlink writes / scratch-dir removal / zip extraction, HTML-node iframe sandboxing, markdown without `rehype-raw`, intent-bus error containment, lossless save/load across all 17 node kinds and cross-kind edges, Gemini key placement, backup rotation scope.