### PR TITLE
Fix critical and high-severity defects found by a repo audit

### DIFF
--- a/api_provider.py
+++ b/api_provider.py
@@ -27,6 +27,61 @@ from graphlink_audio import guess_audio_mime_type
 from graphlink_model_catalog import FALLBACK_ENABLED_TASKS, ModelDescriptor, ModelRef, ollama_descriptor, sort_descriptors
 
 
+# The ollama package ships its module-level helpers (ollama.chat/embed/list/
+# show) as bound methods of ONE module-level Client, and that client is built
+# with `timeout=None` - i.e. no socket timeout of any kind. Every other
+# provider in this file is bounded (the OpenAI/Anthropic SDKs default to
+# 600s; the hand-rolled Anthropic/Gemini REST calls pass explicit timeouts),
+# so Ollama was the one path that could block a worker thread FOREVER.
+#
+# Why that is worse than it sounds: a daemon that accepts the TCP connection
+# but never answers (a GPU hang or a stuck model load - a real, known Ollama
+# failure mode) parks the calling thread on a socket read that never
+# returns. Cancellation cannot help, because the cancel event is only polled
+# between streamed chunks / after the call returns, and the dispatch watchdog
+# (asyncio.wait_for) only stops WAITING - the worker keeps its
+# asyncio.to_thread pool slot. Enough of those and the shared executor is
+# exhausted and every to_thread in the app - including all settings
+# mutations - queues forever: the whole backend soft-hangs.
+#
+# Configured on the existing shared client rather than by constructing our
+# own: every call site keeps calling `ollama.chat(...)` exactly as before,
+# and the test suite's monkeypatching of those module attributes keeps
+# working. READ_TIMEOUT is deliberately generous and sits ABOVE the dispatch
+# watchdog, so this is a backstop against a genuinely wedged daemon, not
+# something that can cut a legitimately slow local generation short (for a
+# streaming call httpx applies it per-chunk-read, i.e. to the GAP between
+# tokens, not to the whole reply).
+_OLLAMA_CONNECT_TIMEOUT_SECONDS = 10.0
+_OLLAMA_READ_TIMEOUT_SECONDS = 600.0
+
+
+def _configure_ollama_client_timeout() -> None:
+    """Bound the shared ollama client's socket timeouts. Best-effort: this
+    reaches into the package's own internals (the bound method's __self__
+    and its httpx client), so a future ollama release that reshapes either
+    must degrade to the previous no-timeout behavior rather than breaking
+    import of this whole module."""
+    try:
+        import httpx
+
+        client = getattr(ollama.chat, "__self__", None)
+        inner = getattr(client, "_client", None)
+        if inner is None:
+            return
+        inner.timeout = httpx.Timeout(
+            connect=_OLLAMA_CONNECT_TIMEOUT_SECONDS,
+            read=_OLLAMA_READ_TIMEOUT_SECONDS,
+            write=60.0,
+            pool=_OLLAMA_CONNECT_TIMEOUT_SECONDS,
+        )
+    except Exception:  # pragma: no cover - defensive, see docstring
+        pass
+
+
+_configure_ollama_client_timeout()
+
+
 USE_API_MODE = False
 API_PROVIDER_TYPE = None
 API_CLIENT = None
@@ -63,6 +118,40 @@ LLAMA_CPP_SETTINGS = {
 }
 _LLAMA_CPP_CLIENT_CACHE = {}
 _LLAMA_CPP_CLIENT_LOCK = threading.RLock()
+
+# _LLAMA_CPP_CLIENT_LOCK above guards only the CACHE (lookup/creation). It
+# does NOT guard INFERENCE, and those are genuinely different critical
+# sections: one cached Llama instance is handed to every caller that resolves
+# to the same model, and llama-cpp-python's Llama is not thread-safe (it
+# carries mutable per-sequence state - n_tokens and the KV cache - and
+# releases the GIL inside llama_decode). RunRegistry.is_busy is per-kind
+# per-session, so a streaming chat reply and a chart/note generation in the
+# same session, or two sessions at once, legitimately run concurrently on
+# separate worker threads - and before this lock they could interleave two
+# generations on ONE native context, which corrupts output or dies in native
+# code and takes the whole backend process with it.
+#
+# A plain Lock, not an RLock, and deliberately so: a stream() generator holds
+# this across its whole consumption and releases it in a finally, which -
+# if the caller abandons the generator - runs during garbage collection,
+# potentially on a DIFFERENT thread. RLock refuses a release from any thread
+# but its owner (RuntimeError); a plain Lock permits it, which is exactly the
+# behavior this ownership pattern needs.
+_LLAMA_CPP_SHARED_INFERENCE_LOCK = threading.Lock()
+
+
+def llama_cpp_inference_lock(client):
+    """The inference lock for one cached Llama instance - see
+    _LLAMA_CPP_SHARED_INFERENCE_LOCK's own comment for why inference needs a
+    lock separate from the cache lock.
+
+    Per-CLIENT rather than global, so two different models (separate native
+    contexts, no shared state) still run concurrently; only calls sharing one
+    instance serialize. A client with no attached lock - a monkeypatched fake
+    in a test, or an instance built before this existed - falls back to the
+    module-wide lock, which is over-strict but never unsafe."""
+    lock = getattr(client, "_graphlink_inference_lock", None)
+    return lock if lock is not None else _LLAMA_CPP_SHARED_INFERENCE_LOCK
 
 # Guards the provider globals above. Mutators (initialize_api,
 # initialize_local_provider, set_task_model) write under this lock;
@@ -1529,7 +1618,23 @@ def anthropic_reasoning_kwargs(model_id: str, level: str, max_tokens: int) -> di
     if level == "off":
         return {}
     if _is_anthropic_effort_model(model_id):
-        return {"effort": level}
+        # NESTED under output_config, not top-level. Verified directly
+        # against the installed SDK (anthropic 0.116.0): messages.create has
+        # no `effort` parameter and no **kwargs, but does take
+        # `output_config`, whose OutputConfigParam declares
+        # effort: Literal["low","medium","high","xhigh","max"] | None - so
+        # the three levels passed here are already valid values, and only
+        # the nesting was ever wrong.
+        #
+        # A flat {"effort": level} was silently useless on BOTH paths, which
+        # is why nothing caught it: on the SDK path
+        # _filter_kwargs_for_callable keeps only names the callable actually
+        # declares, so the unknown key was dropped and the user's Low/Medium/
+        # High selection simply never reached a paid API call - no error, no
+        # signal; on the SDK-absent REST path the same key went out as a
+        # top-level body field, which the API rejects with a 400 on every
+        # request that has reasoning enabled.
+        return {"output_config": {"effort": level}}
     budget = _ANTHROPIC_BUDGET_TOKENS[level]
     result = {"thinking": {"type": "enabled", "budget_tokens": budget}}
     if max_tokens <= budget:
@@ -1922,6 +2027,16 @@ def _get_llama_cpp_client(task: str, settings: dict | None = None):
             ) from exc
 
         _configure_llama_cpp_chat_handler(client, active_settings)
+        # This instance's own inference lock, attached once at construction so
+        # every caller that later resolves to this same cached client
+        # serializes its generations against the same object - see
+        # llama_cpp_inference_lock's own docstring.
+        try:
+            client._graphlink_inference_lock = threading.Lock()
+        except Exception:
+            # An exotic Llama build that refuses attribute assignment falls
+            # back to the module-wide lock rather than losing the guard.
+            pass
         _LLAMA_CPP_CLIENT_CACHE[cache_key] = client
         return client
 

--- a/backend/api/intents_settings_api_provider.py
+++ b/backend/api/intents_settings_api_provider.py
@@ -36,7 +36,7 @@ from backend.api._settings_shared import (
 )
 from backend.events import SessionBus
 from backend.notifications import NotificationState
-from graphlink_settings_store import SettingsManager
+from graphlink_settings_store import KEEP_EXISTING_SECRET, SettingsManager
 
 
 def register_settings_api_provider_intents(
@@ -256,9 +256,21 @@ def register_settings_api_provider_intents(
             # writing inside the same locked critical section makes this
             # atomic with respect to every other run_locked-guarded
             # mutation.
-            openai_key = api_key if provider == config.API_PROVIDER_OPENAI else manager.get_openai_key()
-            anthropic_key = api_key if provider == config.API_PROVIDER_ANTHROPIC else manager.get_anthropic_key()
-            gemini_key = api_key if provider == config.API_PROVIDER_GEMINI else manager.get_gemini_key()
+            #
+            # Follow-up fix: the two providers NOT being saved are no longer
+            # read back and rewritten at all - they are handed
+            # KEEP_EXISTING_SECRET, which set_api_settings leaves untouched on
+            # disk. Reading them was itself the hazard: get_*_key() returns ""
+            # both for "no key set" AND for "stored blob failed to decrypt",
+            # so a transient DPAPI failure while saving one provider silently
+            # re-encrypted "" over the other two's still-recoverable blobs and
+            # destroyed them. Not reading them removes the failure mode rather
+            # than trying to detect it after the fact - and it keeps the
+            # atomicity the comment above describes, since there is now
+            # nothing about the siblings to race on.
+            openai_key = api_key if provider == config.API_PROVIDER_OPENAI else KEEP_EXISTING_SECRET
+            anthropic_key = api_key if provider == config.API_PROVIDER_ANTHROPIC else KEEP_EXISTING_SECRET
+            gemini_key = api_key if provider == config.API_PROVIDER_GEMINI else KEEP_EXISTING_SECRET
             manager.set_api_settings(provider, base_url, openai_key, anthropic_key, gemini_key)
             manager.set_api_models(normalized_models, provider)
             for task, model_id in normalized_models.items():

--- a/backend/api/intents_settings_general.py
+++ b/backend/api/intents_settings_general.py
@@ -71,7 +71,7 @@ def _mcp_servers_from_wire(servers: object) -> list[dict] | None:
     for entry in servers:
         if not isinstance(entry, dict):
             return None
-        normalized.append({
+        normalized_entry = {
             "name": entry.get("name", ""),
             "command": entry.get("command", ""),
             "args": entry.get("args", []),
@@ -80,8 +80,19 @@ def _mcp_servers_from_wire(servers: object) -> list[dict] | None:
             "enabled_tools": entry.get("enabledTools", []),
             "enabled": entry.get("enabled", True),
             "timeout": entry.get("timeout", 30.0),
-            "env": entry.get("env", {}),
-        })
+        }
+        # "env" is forwarded ONLY when the client actually sent one, and the
+        # absence is meaningful rather than a default: the settings payload
+        # deliberately no longer carries env VALUES back to the client (see
+        # backend/settings.py's _mcp_servers_for_wire), so an edit that
+        # merely toggles or removes some other server echoes the whole list
+        # WITHOUT them. Defaulting to {} here would make that ordinary edit
+        # silently erase every configured variable on every server.
+        # SettingsManager.set_mcp_servers reads the missing key as "keep what
+        # is stored for this server".
+        if "env" in entry:
+            normalized_entry["env"] = entry.get("env") or {}
+        normalized.append(normalized_entry)
     return normalized
 
 

--- a/backend/autosave.py
+++ b/backend/autosave.py
@@ -137,14 +137,37 @@ async def autosave_tick(
         chat_data = build_chat_data(
             canvas_document, asset_store=store_for(db_path), settings_manager=settings_manager,
         )
-    except Exception:
+    except Exception as exc:
         logger.exception("autosave: failed to build chat data for session %r", bus.session_id)
+        # LOUD ON FAILURE (see this module's own docstring) - this branch used
+        # to log and return silently, every tick, forever. The most likely way
+        # to reach it is AssetStore.put() raising OSError because the assets
+        # directory is unwritable or the disk is full, which is precisely the
+        # moment the user most needs to know autosave has stopped protecting
+        # their work. The manual Save path already notifies for the same
+        # failure; this one now matches it.
+        if notifications is not None:
+            notifications.show(f"Autosave failed: {exc}", "error")
+            await bus.publish("notification")
         return
 
     notes_data = chat_data.pop("notes_data", [])
     pins_data = chat_data.pop("pins_data", [])
 
-    digest = _content_digest(chat_data, notes_data, pins_data)
+    try:
+        digest = _content_digest(chat_data, notes_data, pins_data)
+    except Exception as exc:
+        # _content_digest json.dumps(..., sort_keys=True) the payload, which
+        # raises on a dict with mixed-type keys - a shape a plugin's own
+        # serialize hook can produce and that session_save's json validation
+        # accepts (it does not require sort-ability). Escaping here would kill
+        # this tick outside every try below, so the guard belongs here too,
+        # and it reports rather than dying quietly.
+        logger.exception("autosave: failed to digest chat data for session %r", bus.session_id)
+        if notifications is not None:
+            notifications.show(f"Autosave failed: {exc}", "error")
+            await bus.publish("notification")
+        return
     if digest == last_saved["digest"] and canvas_document.current_chat_id == last_saved["chat_id"]:
         # Both halves matter. Content alone is not enough: chats.db is shared
         # mutable state, and a row that vanished underneath this session (the

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -2616,6 +2616,47 @@ def make_export_workspace(bus: SessionBus, resolved_path: Path, notifications: N
     return export_workspace
 
 
+def make_delete_chat_intent(
+    bus: SessionBus,
+    resolved_path: Path,
+    canvas_document: SceneDocument | None,
+    last_saved: dict[str, Any],
+):
+    """Build the delete intent without inflating the registration function -
+    same extraction the rename/load/save/export intents below already use.
+
+    The caller wraps this in the shared chat-mutation guard, exactly like
+    every other mutating intent on this topic. That matters rather than being
+    cosmetic symmetry: this handler writes canvas_document.current_chat_id
+    and last_saved, the same two cells a completing save/autosave writes, so
+    an unguarded delete racing an in-flight save could leave the session
+    pointed at a deleted row while the digest still claimed "already saved" -
+    which is the silent no-autosave state the fix inside the handler itself
+    exists to prevent.
+    """
+
+    async def delete(chat_id: int):
+        # The SPA only calls this after its own two-step confirm, so no
+        # confirmation happens here - same contract as the legacy bridge.
+        await asyncio.to_thread(delete_chat, resolved_path, int(chat_id))
+        if canvas_document is not None and canvas_document.current_chat_id == int(chat_id):
+            # Audit fix: deleting the row this session is currently pointed at
+            # used to leave current_chat_id dangling AND leave the autosave
+            # digest looking "already saved", so a user who deleted their open
+            # chat and kept working silently had no autosave protection at all
+            # until they happened to edit the canvas. Dropping both makes the
+            # next tick treat this as an unsaved session and INSERT a fresh
+            # row - the same thing a manual Save already does here (save_chat's
+            # own existing_row-is-None fallback).
+            canvas_document.current_chat_id = None
+            last_saved["digest"] = None
+            last_saved["chat_id"] = None
+            last_saved["updated_at"] = None
+        await bus.publish("app-chat-library")
+
+    return delete
+
+
 def make_rename_chat_intent(
     bus: SessionBus,
     resolved_path: Path,
@@ -2782,24 +2823,7 @@ def register_chat_library(
         bus, resolved_path, canvas_document, notifications, _last_saved,
     )
 
-    async def delete(chat_id: int):
-        # The SPA only calls this after its own two-step confirm, so no
-        # confirmation happens here - same contract as the legacy bridge.
-        await asyncio.to_thread(delete_chat, resolved_path, int(chat_id))
-        if canvas_document is not None and canvas_document.current_chat_id == int(chat_id):
-            # Audit fix: deleting the row this session is currently pointed at
-            # used to leave current_chat_id dangling AND leave the autosave
-            # digest looking "already saved", so a user who deleted their open
-            # chat and kept working silently had no autosave protection at all
-            # until they happened to edit the canvas. Dropping both makes the
-            # next tick treat this as an unsaved session and INSERT a fresh
-            # row - the same thing a manual Save already does here (save_chat's
-            # own existing_row-is-None fallback).
-            canvas_document.current_chat_id = None
-            _last_saved["digest"] = None
-            _last_saved["chat_id"] = None
-            _last_saved["updated_at"] = None
-        await bus.publish("app-chat-library")
+    delete = make_delete_chat_intent(bus, resolved_path, canvas_document, _last_saved)
 
     load_chat = make_load_chat(
         bus, resolved_path, canvas_document, notifications, _record_saved, _last_saved, settings_manager,

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -2928,7 +2928,18 @@ def register_chat_library(
     export_workspace = make_export_workspace(bus, resolved_path, notifications)
 
     bus.register_intent("app-chat-library", "renameChat", _serialize_mutating_intent(rename))
-    bus.register_intent("app-chat-library", "deleteChat", delete)
+    # Serialized like every other mutating intent here. It was the one
+    # exception, and that was a real hazard rather than an oversight with no
+    # consequence: delete mutates canvas_document.current_chat_id and
+    # _last_saved, the same two cells an in-flight save/autosave writes when
+    # it completes. Interleaved - delete lands while a save for the very row
+    # being deleted is still inside save_chat_atomically_row's post-commit
+    # knowledge reindex - delete's continuation clears both cells, then the
+    # save's continuation repopulates them, leaving the session pointed at a
+    # deleted row with a digest claiming "already saved". That is exactly the
+    # silent-no-autosave state the audit fix inside delete() above was written
+    # to prevent, reachable by racing it rather than by the path it guarded.
+    bus.register_intent("app-chat-library", "deleteChat", _serialize_mutating_intent(delete))
     bus.register_intent("app-chat-library", "loadChat", _serialize_mutating_intent(load_chat))
     bus.register_intent("app-chat-library", "saveChat", _serialize_mutating_intent(save_chat))
     bus.register_intent("app-chat-library", "newChat", _serialize_mutating_intent(new_chat))

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -112,7 +112,10 @@ class ConcurrentSaveConflict(RuntimeError):
 # per-workspace default model pin and a (this stage deliberately leaves
 # unpopulated - see that migration's own docstring) knowledge-collection
 # mirror column - see _migration_004_workspace_defaults's own docstring.
-CHATS_DB_SCHEMA_VERSION = 4
+# The note-edge fix adds version "5": the notes table gains a note_id
+# column so note-endpoint edges survive a save/load round-trip - see
+# _migration_005_note_ids's own docstring.
+CHATS_DB_SCHEMA_VERSION = 5
 
 
 # ADR-009 stage 9.2: `created_at` and historical `updated_at` values use
@@ -1022,6 +1025,36 @@ def _migration_004_workspace_defaults(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE workspaces ADD COLUMN knowledge_collection_id INTEGER")
 
 
+def _migration_005_note_ids(conn: sqlite3.Connection) -> None:
+    """Migration "5" (4 -> 5): give the notes table a `note_id` column that
+    persists each note's save-time payload id (SceneNode.id).
+
+    THE DATA LOSS THIS CLOSES. Since stage 9.6 the flat `edges` list is the
+    authoritative edge record, and it references every endpoint by its
+    save-time payload id. Node ids round-trip via the `data` blob and chart
+    ids via their own in-blob id, but a NOTE's id was written only into the
+    `notes` table, which had no column for it - so load_notes_rows returned
+    notes with no id, backend/session_load.py's flat-edge pass could not
+    resolve any note endpoint, and EVERY note connection (a System Prompt
+    note attached to a chat, a chat->summary note, a user-drawn note link)
+    was silently dropped on load and then written back gone on the next
+    save. Persisting the id here is what lets those edges round-trip, the
+    same way pins already persist pin_id.
+
+    Nullable TEXT with no default: a pre-existing row keeps NULL, which
+    load_notes_rows surfaces as "" (falsy) - identical to the old "no id"
+    behaviour for that one legacy row (its note edges were already lost on
+    the save that predated this fix; nothing here can resurrect them), while
+    every row written from now on carries a real id and round-trips. Runs
+    inside run_sqlite_migrations' own managed transaction - must not BEGIN/
+    COMMIT/ROLLBACK itself - and is guarded by a PRAGMA table_info probe so a
+    second run against an already-migrated database is a pure no-op, exactly
+    like every migration above."""
+    notes_columns = [info[1] for info in conn.execute("PRAGMA table_info(notes)").fetchall()]
+    if "note_id" not in notes_columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN note_id TEXT")
+
+
 # Keyed by the version each function PRODUCES (migration "1" takes a
 # database from 0 -> 1), matching graphlink_migrations' own ordering
 # convention - see run_sqlite_migrations' docstring. ADR-020 stage 20.1
@@ -1030,15 +1063,19 @@ def _migration_004_workspace_defaults(conn: sqlite3.Connection) -> None:
 # CHATS_DB_SCHEMA_VERSION to 3) for the tags/favorite/archive schema change;
 # stage 20.3 added step "4" (bumping CHATS_DB_SCHEMA_VERSION to 4) for the
 # workspace-default-model/knowledge-collection-mirror schema change - add
-# step "5" here (and bump CHATS_DB_SCHEMA_VERSION to 5) for the next schema
-# change; never renumber or replace step "1" through "4" now that all four
-# have shipped - each must stay exactly what it is today so it keeps
-# correctly upgrading every already-migrated real database.
+# step "5" (bumping CHATS_DB_SCHEMA_VERSION to 5) for the notes.note_id
+# column that lets note-endpoint edges round-trip - see
+# _migration_005_note_ids's own docstring - add step "6" here (and bump
+# CHATS_DB_SCHEMA_VERSION to 6) for the next schema change; never renumber
+# or replace step "1" through "5" now that all five have shipped - each must
+# stay exactly what it is today so it keeps correctly upgrading every
+# already-migrated real database.
 _MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     1: _migration_001_initial_schema,
     2: _migration_002_workspaces_and_graphs,
     3: _migration_003_tags_favorite_archive,
     4: _migration_004_workspace_defaults,
+    5: _migration_005_note_ids,
 }
 
 
@@ -1446,7 +1483,7 @@ def load_notes_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
         rows = conn.execute(
             """
             SELECT content, position_x, position_y, width, height,
-                   color, header_color, is_system_prompt, is_summary_note
+                   color, header_color, is_system_prompt, is_summary_note, note_id
             FROM notes WHERE chat_id = ?
             """,
             (chat_id,),
@@ -1460,6 +1497,12 @@ def load_notes_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
             "header_color": row[6],
             "is_system_prompt": bool(row[7]),
             "is_summary_note": bool(row[8]),
+            # The save-time payload id, restored so backend/session_load.py's
+            # flat-edge pass can map a note endpoint back to its new node id.
+            # Only present (truthy) for rows written after the note-edge fix;
+            # a NULL from a pre-fix row stays absent, harmless to the loader's
+            # own `if note_payload.get("id")` guard.
+            "id": row[9] or "",
         }
         for row in rows
     ]
@@ -1639,8 +1682,9 @@ def save_chat_atomically_row(
                     """
                     INSERT INTO notes (
                         chat_id, content, position_x, position_y,
-                        width, height, color, header_color, is_system_prompt, is_summary_note
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        width, height, color, header_color, is_system_prompt, is_summary_note,
+                        note_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         resolved_chat_id,
@@ -1653,6 +1697,10 @@ def save_chat_atomically_row(
                         note.get("header_color"),
                         1 if note.get("is_system_prompt") else 0,
                         1 if note.get("is_summary_note") else 0,
+                        # The note's save-time payload id, so flat-edge restore
+                        # can resolve note endpoints on load - see _ensure_schema's
+                        # note_id column comment for the data-loss this closes.
+                        str(note.get("id") or "") or None,
                     ),
                 )
 

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -37,6 +37,23 @@ class ImageState(NodeState):
     itself)."""
 
     image_asset_id: str = ""
+    # The content-addressed asset_ref this node was SAVED with, kept only
+    # when its bytes could not be read back at load time (the file is
+    # missing, or the read raised - an antivirus lock on Windows is enough).
+    #
+    # Without it that ref was gone the moment the load finished: the node
+    # restored with no image_asset_id, so the next save saw no bytes, took
+    # the inline branch and wrote `image_bytes: ""`, erasing the only
+    # pointer to an asset file that is still sitting on disk. A transient,
+    # fully recoverable read failure became permanent picture loss on the
+    # next autosave tick. Carrying the ref lets the save write it straight
+    # back out, so the row keeps pointing at the asset and a later load -
+    # once whatever held the file lets go - resolves it normally.
+    #
+    # Never surfaced on the wire (SceneDocument's node payload publishes
+    # imageAssetId only); this is save/load bookkeeping, not UI state.
+    unresolved_asset_ref: str = ""
+    unresolved_asset_mime_type: str = ""
 
 
 @dataclass

--- a/backend/mcp_client.py
+++ b/backend/mcp_client.py
@@ -40,6 +40,7 @@ by a finished settings panel.
 from __future__ import annotations
 
 import asyncio
+import collections
 import json
 import queue
 import subprocess
@@ -170,6 +171,16 @@ class McpStdioClient:
         self.timeout = timeout
         self._process: subprocess.Popen | None = None
         self._reader_thread: threading.Thread | None = None
+        self._stderr_thread: threading.Thread | None = None
+        # A bounded tail of the server's stderr, drained continuously by its
+        # own thread. Without a dedicated drainer, a server that writes more
+        # than the OS pipe buffer (~4 KiB on Windows, measured) to stderr
+        # before we read it BLOCKS on its own stderr write - and since we
+        # never read stderr except after stdout already closed, its stdout
+        # response never arrives and _call hangs until the timeout on EVERY
+        # request. A ring buffer keeps the diagnostic tail close() and the
+        # unexpected-close path want, without unbounded memory growth.
+        self._stderr_tail: "collections.deque[str]" = collections.deque(maxlen=200)
         self._responses: "queue.Queue[Any]" = queue.Queue()
         self._next_id = 0
         self._write_lock = threading.Lock()
@@ -207,6 +218,11 @@ class McpStdioClient:
 
         self._reader_thread = threading.Thread(target=self._read_loop, daemon=True)
         self._reader_thread.start()
+        # Drain stderr continuously (see _stderr_tail's own comment): a
+        # server that fills the stderr pipe buffer would otherwise block on
+        # its own stderr write and never send its stdout response.
+        self._stderr_thread = threading.Thread(target=self._drain_stderr, daemon=True)
+        self._stderr_thread.start()
 
         try:
             response = self._call("initialize", {
@@ -287,6 +303,28 @@ class McpStdioClient:
         finally:
             self._responses.put(_READER_CLOSED)
 
+    def _drain_stderr(self) -> None:
+        """Continuously read the server's stderr into a bounded ring buffer.
+        Its whole job is to keep the stderr pipe from filling and blocking
+        the server's own writes - see _stderr_tail's own comment. Runs for
+        the life of the process; ends when stderr reaches EOF."""
+        process = self._process
+        if process is None or process.stderr is None:
+            return
+        try:
+            for line in process.stderr:
+                self._stderr_tail.append(line)
+        except (ValueError, OSError):
+            # stderr closed out from under us (close() race) - nothing left
+            # to drain.
+            pass
+
+    def _stderr_tail_text(self, limit: int = 2000) -> str:
+        """The most recent stderr output, newest-bounded to `limit` chars -
+        for the unexpected-close diagnostic. Reads the ring buffer the
+        drainer thread fills, never the raw pipe (which the drainer owns)."""
+        return "".join(self._stderr_tail)[-limit:]
+
     def _write(self, message: dict) -> None:
         process = self._process
         if process is None or process.stdin is None:
@@ -316,9 +354,7 @@ class McpStdioClient:
                 except queue.Empty:
                     raise McpError(f"MCP server {self.command!r} timed out after {self.timeout}s calling {method!r}.")
                 if payload is _READER_CLOSED:
-                    stderr_tail = ""
-                    if self._process is not None and self._process.stderr is not None:
-                        stderr_tail = self._process.stderr.read(2000)
+                    stderr_tail = self._stderr_tail_text()
                     raise McpError(
                         f"MCP server {self.command!r} closed its output unexpectedly while calling {method!r}."
                         + (f" stderr: {stderr_tail}" if stderr_tail.strip() else "")

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -103,6 +103,7 @@ not part of this repo)."""
 
 from __future__ import annotations
 
+import collections
 import importlib.util
 import json
 import logging
@@ -806,6 +807,16 @@ class PluginWorkerClient:
         self._process: subprocess.Popen | None = None
         self._guard = None
         self._reader_thread: threading.Thread | None = None
+        self._stderr_thread: threading.Thread | None = None
+        # A bounded tail of the worker's stderr, drained continuously by its
+        # own thread. Without a dedicated drainer, a worker that writes more
+        # than the OS pipe buffer (~4 KiB on Windows, measured) to stderr
+        # before we read it blocks on its own stderr write - and since stderr
+        # is only ever read after stdout already closed, its stdout response
+        # never arrives and call() hangs until the timeout on every request.
+        # A traceback from an uncaught exception in plugin code is easily
+        # that large. Mirrors McpStdioClient's own stderr drainer.
+        self._stderr_tail: "collections.deque[str]" = collections.deque(maxlen=200)
         self._responses: "queue.Queue[Any]" = queue.Queue()
         self._next_id = 0
         self._write_lock = threading.Lock()
@@ -852,6 +863,11 @@ class PluginWorkerClient:
         self._guard.assign(self._process.pid)
         self._reader_thread = threading.Thread(target=self._read_loop, daemon=True)
         self._reader_thread.start()
+        # Drain stderr continuously (see _stderr_tail's own comment): a
+        # worker that fills the stderr pipe buffer would otherwise block on
+        # its own stderr write and never send its stdout response.
+        self._stderr_thread = threading.Thread(target=self._drain_stderr, daemon=True)
+        self._stderr_thread.start()
 
     def close(self) -> None:
         process = self._process
@@ -921,9 +937,7 @@ class PluginWorkerClient:
                         f"calling {method!r}."
                     )
                 if payload is _WORKER_READER_CLOSED:
-                    stderr_tail = ""
-                    if self._process is not None and self._process.stderr is not None:
-                        stderr_tail = self._process.stderr.read(2000)
+                    stderr_tail = self._stderr_tail_text()
                     raise PluginWorkerError(
                         f'Plugin worker "{self.plugin_id}" closed its output unexpectedly '
                         f"while calling {method!r}."
@@ -959,6 +973,28 @@ class PluginWorkerClient:
                 self._responses.put(payload)
         finally:
             self._responses.put(_WORKER_READER_CLOSED)
+
+    def _drain_stderr(self) -> None:
+        """Continuously read the worker's stderr into a bounded ring buffer,
+        so a worker writing a large traceback to stderr can't fill the pipe
+        and block its own stdout response - see _stderr_tail's own comment.
+        Runs for the life of the process; ends at stderr EOF."""
+        process = self._process
+        if process is None or process.stderr is None:
+            return
+        try:
+            for line in process.stderr:
+                self._stderr_tail.append(line)
+        except (ValueError, OSError):
+            # stderr closed out from under us (close() race) - nothing left
+            # to drain.
+            pass
+
+    def _stderr_tail_text(self, limit: int = 2000) -> str:
+        """The most recent stderr output, bounded to `limit` chars, for the
+        unexpected-close diagnostic. Reads the ring buffer the drainer
+        thread fills, never the raw pipe (which the drainer owns)."""
+        return "".join(self._stderr_tail)[-limit:]
 
     def _write(self, message: dict) -> None:
         process = self._process

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -176,6 +176,19 @@ KNOWN_RUNTIME_ISOLATION = frozenset({"in-process", "out-of-process"})
 
 _ID_PATTERN = re.compile(r"[a-z0-9_]+")
 
+# Both halves of an entry_point ("<module>:<callable>"). The module half is
+# interpolated straight into a filesystem path - `plugin_dir / f"{module}.py"`
+# in _import_entry_module - and that file is then EXECUTED, so it has to be a
+# bare module name and nothing else. Validating only the ":" split (all this
+# used to do) let a manifest say `entry_point = "../../../evil:register"`,
+# which resolves and executes a .py file OUTSIDE the plugin's own directory,
+# in the host process. A single path separator, drive letter, or ".." is the
+# whole exploit, so the allowlist is deliberately narrow: a leading letter or
+# underscore followed by word characters, which is what every real plugin
+# already uses ("plugin"). The callable half must likewise be a plain Python
+# identifier - it is fed to getattr on the imported module.
+_ENTRY_POINT_PART_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
 
 class PluginRegistrationError(Exception):
     """Raised for one plugin's own malformed manifest, bad register() call,
@@ -1216,6 +1229,19 @@ def _load_manifest(manifest_path: Path, plugin_dir: Path) -> PluginManifest:
         raise PluginRegistrationError(
             f'{manifest_path}: [plugin].entry_point must be "<module>:<callable>", got '
             f"{entry_point!r}"
+        )
+    # Both halves must be plain identifiers - see _ENTRY_POINT_PART_PATTERN's
+    # own comment for the path-traversal-into-code-execution this blocks.
+    if not _ENTRY_POINT_PART_PATTERN.fullmatch(module_name):
+        raise PluginRegistrationError(
+            f"{manifest_path}: [plugin].entry_point module {module_name!r} must be a plain "
+            "module name (letters, digits and underscores) - it names a file inside this "
+            "plugin's own directory, never a path"
+        )
+    if not _ENTRY_POINT_PART_PATTERN.fullmatch(fn_name):
+        raise PluginRegistrationError(
+            f"{manifest_path}: [plugin].entry_point callable {fn_name!r} must be a plain "
+            "Python identifier"
         )
 
     frontend_table = raw.get("frontend", {})

--- a/backend/providers/llama_cpp_provider.py
+++ b/backend/providers/llama_cpp_provider.py
@@ -28,6 +28,7 @@ from api_provider import (
     _prepare_llama_cpp_kwargs,
     _prepare_llama_cpp_messages,
     _raise_if_cancelled,
+    llama_cpp_inference_lock,
     llama_cpp_supports_reasoning,
 )
 from backend.providers.base import (
@@ -77,7 +78,12 @@ class LlamaCppProvider:
             client.create_chat_completion,
             _prepare_llama_cpp_kwargs(kwargs, self.settings),
         )
-        response = client.create_chat_completion(messages=llama_messages, **llama_kwargs)
+        # Serialized against every other generation on this same cached Llama
+        # instance - it is one native context with mutable KV state, and two
+        # concurrent decodes corrupt output or crash the process. See
+        # api_provider.llama_cpp_inference_lock.
+        with llama_cpp_inference_lock(client):
+            response = client.create_chat_completion(messages=llama_messages, **llama_kwargs)
         _raise_if_cancelled(cancel.event)
         # ADR-006 stage 6.8: llama.cpp's blocking response carries an
         # OpenAI-shaped usage dict; captured on a side attribute for
@@ -106,43 +112,57 @@ class LlamaCppProvider:
         # wrapped/faked create_chat_completion without a spelled-out `stream`
         # parameter silently degrade this into a blocking call.
         llama_kwargs.pop("stream", None)
-        chunks = client.create_chat_completion(
-            messages=llama_messages, stream=True, **llama_kwargs
-        )
 
         content_parts: list[str] = []
         reasoning_parts: list[str] = []
+        # Held across the ENTIRE stream, not just the call that opens it: a
+        # llama.cpp generation advances its one native context incrementally
+        # as chunks are pulled, so releasing after the opening call would let
+        # a second decode interleave mid-reply on the same KV cache. Released
+        # in the outer finally below - which is precisely why this must be a
+        # plain Lock: if a caller abandons this generator, that finally runs
+        # during generator finalization, possibly on another thread, and an
+        # RLock would refuse the release. See api_provider's own
+        # llama_cpp_inference_lock.
+        inference_lock = llama_cpp_inference_lock(client)
+        inference_lock.acquire()
         try:
-            for chunk in chunks:
-                # Cooperative-only cancellation: no live HTTP stream to close
-                # (inference runs in-process); the finally below still closes
-                # the generator so the shared cached client is never left
-                # with a partially-consumed completion.
-                _raise_if_cancelled(cancel.event)
+            chunks = client.create_chat_completion(
+                messages=llama_messages, stream=True, **llama_kwargs
+            )
+            try:
+                for chunk in chunks:
+                    # Cooperative-only cancellation: no live HTTP stream to close
+                    # (inference runs in-process); the finally below still closes
+                    # the generator so the shared cached client is never left
+                    # with a partially-consumed completion.
+                    _raise_if_cancelled(cancel.event)
 
-                choices = _extract_response_field(chunk, "choices", []) or []
-                if not choices:
-                    continue
-                delta = _extract_response_field(choices[0], "delta", {}) or {}
-                delta_content = _extract_response_field(delta, "content") or ""
-                if delta_content:
-                    content_parts.append(delta_content)
-                    yield ProviderEvent("text", delta_content)
-                # The same wide net _extract_llama_cpp_text casts for
-                # thinking output, at the delta level.
-                delta_reasoning = (
-                    _extract_response_field(delta, "reasoning")
-                    or _extract_response_field(delta, "reasoning_content")
-                    or _extract_response_field(delta, "thinking")
-                    or ""
-                )
-                if delta_reasoning:
-                    reasoning_parts.append(delta_reasoning)
-                    yield ProviderEvent("reasoning", delta_reasoning)
+                    choices = _extract_response_field(chunk, "choices", []) or []
+                    if not choices:
+                        continue
+                    delta = _extract_response_field(choices[0], "delta", {}) or {}
+                    delta_content = _extract_response_field(delta, "content") or ""
+                    if delta_content:
+                        content_parts.append(delta_content)
+                        yield ProviderEvent("text", delta_content)
+                    # The same wide net _extract_llama_cpp_text casts for
+                    # thinking output, at the delta level.
+                    delta_reasoning = (
+                        _extract_response_field(delta, "reasoning")
+                        or _extract_response_field(delta, "reasoning_content")
+                        or _extract_response_field(delta, "thinking")
+                        or ""
+                    )
+                    if delta_reasoning:
+                        reasoning_parts.append(delta_reasoning)
+                        yield ProviderEvent("reasoning", delta_reasoning)
+            finally:
+                close = getattr(chunks, "close", None)
+                if callable(close):
+                    close()
         finally:
-            close = getattr(chunks, "close", None)
-            if callable(close):
-                close()
+            inference_lock.release()
 
         # Streamed and blocking paths compose through the SAME extraction:
         # a synthetic blocking-shaped response through _extract_llama_cpp_text

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -182,6 +182,7 @@ literal values for the same concept):
 from __future__ import annotations
 
 import contextvars
+import logging
 import re
 import uuid
 from typing import Any
@@ -208,6 +209,8 @@ from backend.plugin_sdk import NodeKindSpec, PluginRegistry, discover_plugins
 from graphlink_chart_data import ChartDataError, canonicalize_chart_data
 from graphlink_navigation_pins import NavigationPinRecord
 from graphlink_settings_store import SettingsManager
+
+logger = logging.getLogger(__name__)
 
 # ADR-009 stage 9.5: the asset store in effect for the CURRENT restore.
 #
@@ -477,9 +480,17 @@ def _restore_image_payload(payload: dict[str, Any], document: SceneDocument) -> 
         if stored is not None:
             image_bytes = stored
             mime_type = str(payload.get("mime_type") or "image/png")
-        # A ref the store has never seen degrades to "this image does not
-        # render", never to "this chat will not load" - the conversation is
-        # worth far more than one of its pictures.
+        else:
+            # A ref the store has never seen degrades to "this image does not
+            # render", never to "this chat will not load" - the conversation is
+            # worth far more than one of its pictures. But the ref itself is
+            # REMEMBERED (see ImageState.unresolved_asset_ref): the read may
+            # have failed transiently while the asset file is still perfectly
+            # present, and dropping the ref here is what used to let the very
+            # next save overwrite it with an empty inline payload and lose the
+            # picture for good.
+            node.state.unresolved_asset_ref = asset_ref
+            node.state.unresolved_asset_mime_type = str(payload.get("mime_type") or "image/png")
 
     if not image_bytes:
         raw_b64 = payload.get("image_bytes")
@@ -897,8 +908,24 @@ def _restore_node(
                 try:
                     plugin_node = _restore_plugin_payload(payload, kind_spec, settings_manager)
                 except Exception:
+                    logger.exception(
+                        "session load: plugin node of kind %r failed to restore - skipping it", node_type,
+                    )
                     return None, None
                 return document.register_restored_node(plugin_node), None
+        # A saved node whose kind nothing currently registers. It is left out
+        # of the restored document (rendering an unknown kind is a frontend
+        # decision this layer cannot make), but it is NOT silently forgotten:
+        # the row on disk still holds it - session_save._is_plugin_kind keeps
+        # writing any plugin-namespaced node back out - so fixing or
+        # reinstalling the plugin and reloading brings it back. Logged
+        # because, before this, a plugin that failed discovery made its
+        # nodes disappear from the canvas with zero signal anywhere.
+        if node_type:
+            logger.warning(
+                "session load: no restorer registered for node kind %r - the node stays in the "
+                "saved row but is not on this canvas (a plugin that failed to load?)", node_type,
+            )
         return None, None
 
     parent_new_id: str | None = None

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -133,6 +133,26 @@ _REGULAR_KINDS = (
     "web_research", "artifact", "gitlink", "pycoder", "code_sandbox", "plan",
 )
 
+
+def _is_plugin_kind(kind: str) -> bool:
+    """True for a Plugin SDK node kind, recognized by its namespacing alone
+    (f"{plugin_id}.{kind}" - backend/plugin_sdk.py's HostContext.
+    register_node_kind) rather than by membership in the CURRENT registry.
+
+    That distinction is the whole point. `all_nodes` used to include a
+    plugin node only when this save's own registry still recognized its
+    kind, so a plugin that failed discovery at save time - an import error,
+    an out-of-process worker that could not spawn, a directory renamed;
+    discover_plugins swallows any of those per plugin - silently EXCLUDED
+    every one of its live nodes from the written row, destroying them on the
+    next autosave. It also made _serialize_plugin_node's own documented
+    kind_spec-is-None branch ("this function itself never drops a node
+    outright") unreachable dead code. A node that is sitting in the live
+    document gets written out, whether or not the code that created it
+    happens to be loadable this second; no built-in kind contains a dot, so
+    this can never capture one."""
+    return "." in kind
+
 # Mirrors backend/session_load.py's own _PARENT_CONTENT_INDEX_KINDS /
 # _PARENT_NODE_INDEX_KINDS split exactly - every regular kind except "chat"
 # requires exactly one incoming edge (its structural parent), keyed to one
@@ -280,6 +300,20 @@ def _serialize_image_node(
             "node_type": "image",
             "asset_ref": asset_store.put(image_bytes),
             "mime_type": mime_type,
+            "prompt": node.content,
+        }
+    # No bytes in hand, but this node was loaded from a row that named an
+    # asset_ref we could not read at the time - write that ref straight back
+    # out rather than replacing it with an empty inline payload. See
+    # ImageState.unresolved_asset_ref: the asset file is very often still on
+    # disk, and erasing the only pointer to it is what turned a transient
+    # read failure into permanent loss on the next autosave.
+    unresolved_ref = getattr(node.state, "unresolved_asset_ref", "")
+    if not image_bytes and unresolved_ref:
+        return {
+            "node_type": "image",
+            "asset_ref": unresolved_ref,
+            "mime_type": getattr(node.state, "unresolved_asset_mime_type", "") or "image/png",
             "prompt": node.content,
         }
     return {
@@ -809,7 +843,7 @@ def _build_chat_data(
     plugin_kinds = plugin_registry.node_kinds
     all_nodes = [
         n for n in document.nodes.values()
-        if n.kind in _REGULAR_KINDS or n.kind in plugin_kinds
+        if n.kind in _REGULAR_KINDS or n.kind in plugin_kinds or _is_plugin_kind(n.kind)
     ]
     notes = [n for n in document.nodes.values() if n.kind == "note"]
     charts = [n for n in document.nodes.values() if n.kind == "chart"]

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -148,7 +148,16 @@ def _mcp_servers_for_wire(manager: SettingsManager) -> list[dict[str, Any]]:
             "enabledTools": list(entry.get("enabled_tools", [])),
             "enabled": bool(entry.get("enabled", True)),
             "timeout": float(entry.get("timeout", 30.0)),
-            "env": dict(entry.get("env") or {}),
+            # NAMES ONLY, never values. These are real user secrets (a
+            # GITHUB_TOKEN for a GitHub MCP server, a BRAVE_API_KEY for a
+            # search one), and this payload is republished to every
+            # subscribed client on every settings change - shipping the
+            # values here contradicted the write-only posture this module
+            # already documents for the API keys and the GitHub token right
+            # above. The Settings page only ever displayed the names anyway;
+            # it now receives only what it displays, and a value the user
+            # wants to change is retyped, exactly like an API key.
+            "envKeys": sorted(str(k) for k in (entry.get("env") or {})),
         }
         for entry in manager.get_mcp_servers()
     ]

--- a/backend/tests/test_api_provider_reasoning.py
+++ b/backend/tests/test_api_provider_reasoning.py
@@ -7,6 +7,8 @@ covered here are pure (no network/SDK calls, no module-global state), so
 they're unit-tested directly rather than only through those indirect paths.
 """
 
+import pytest
+
 import api_provider
 
 
@@ -105,7 +107,24 @@ def test_anthropic_reasoning_kwargs_does_not_bump_max_tokens_when_already_large_
 
 def test_anthropic_reasoning_kwargs_uses_effort_for_opus_4_7_and_later():
     result = api_provider.anthropic_reasoning_kwargs("claude-opus-4-7", "high", 4096)
-    assert result == {"effort": "high"}
+    # Nested under output_config, which is the parameter the API and the SDK
+    # actually take - a flat {"effort": ...} was dropped by the SDK kwarg
+    # filter (reasoning silently ignored) and 400'd on the REST fallback.
+    assert result == {"output_config": {"effort": "high"}}
+
+
+def test_anthropic_effort_kwargs_survive_the_sdk_kwarg_filter():
+    """The regression guard that the shape assertion above cannot give on its
+    own: _filter_kwargs_for_callable keeps only parameters the callable really
+    declares, so a wrongly-named reasoning kwarg is silently discarded on the
+    way to a paid API call. Asserting it SURVIVES the filter is what actually
+    proves the user's Low/Medium/High selection reaches the model."""
+    anthropic = pytest.importorskip("anthropic")
+
+    built = api_provider.anthropic_reasoning_kwargs("claude-opus-4-7", "high", 4096)
+    create = anthropic.Anthropic(api_key="not-a-real-key").messages.create
+
+    assert api_provider._filter_kwargs_for_callable(create, built) == built
 
 
 def test_anthropic_reasoning_kwargs_effort_model_detection_is_forward_looking():

--- a/backend/tests/test_backend_secrets_at_rest.py
+++ b/backend/tests/test_backend_secrets_at_rest.py
@@ -571,3 +571,69 @@ class TestTmpFileIsChmoddedBeforeContentIsWritten:
 
         assert observed_sizes_at_tmp_chmod_time
         assert all(size == 0 for size in observed_sizes_at_tmp_chmod_time)
+
+
+class TestSavingOneProviderNeverDestroysTheOthersKeys:
+    """Regression: saving ONE provider's API key used to be able to wipe the
+    other two permanently.
+
+    saveApiConfiguration read the two providers it was NOT saving back with
+    get_*_key() and handed the results straight to set_api_settings. But
+    get_*_key() returns "" for a stored blob that fails to DECRYPT just as it
+    does for a key that was never set - so a transient DPAPI failure at that
+    moment re-encrypted "" over two still-recoverable blobs and destroyed
+    them, silently, with no way back. The siblings are now passed
+    KEEP_EXISTING_SECRET and never read or rewritten at all.
+    """
+
+    @staticmethod
+    def _toggle(monkeypatch, up=True):
+        state = {"up": up}
+        real_call = graphlink_secrets._dpapi_call
+
+        def toggling_call(data, encrypt):
+            if not state["up"]:
+                return None
+            return real_call(data, encrypt)
+
+        monkeypatch.setattr(graphlink_secrets, "_dpapi_call", toggling_call)
+        return state
+
+    def test_a_sibling_key_survives_a_save_made_while_dpapi_is_failing(self, tmp_path, monkeypatch):
+        from graphlink_settings_store import KEEP_EXISTING_SECRET
+
+        dpapi = self._toggle(monkeypatch, up=True)
+        state_file = tmp_path / "session.dat"
+        manager = SettingsManager(state_file)
+
+        # Both providers configured while DPAPI is healthy.
+        manager.set_api_settings("OpenAI-Compatible", "https://x/v1", "sk-openai-real", "sk-ant-real", "")
+        stored_before = json.loads(state_file.read_text(encoding="utf-8"))["openai_api_key"]
+        assert stored_before  # something real is on disk for the sibling
+
+        # DPAPI goes down, and the user saves ONLY the Anthropic key. The
+        # OpenAI blob must be left exactly as it is rather than overwritten
+        # with the "" a failed decrypt would have produced.
+        dpapi["up"] = False
+        manager.set_api_settings(
+            "Anthropic", "https://x/v1", KEEP_EXISTING_SECRET, "sk-ant-new", KEEP_EXISTING_SECRET
+        )
+
+        stored_after = json.loads(state_file.read_text(encoding="utf-8"))["openai_api_key"]
+        assert stored_after == stored_before, "saving one provider destroyed another provider's key"
+
+        # ...and once DPAPI recovers, the untouched blob still decrypts.
+        dpapi["up"] = True
+        assert SettingsManager(state_file).get_openai_key() == "sk-openai-real"
+
+    def test_an_explicit_empty_string_still_clears_a_key(self, tmp_path, monkeypatch):
+        """The sentinel must not make clearing impossible - "" is still a
+        real, honored instruction to remove the key."""
+        self._toggle(monkeypatch, up=True)
+        state_file = tmp_path / "session.dat"
+        manager = SettingsManager(state_file)
+        manager.set_api_settings("OpenAI-Compatible", "https://x/v1", "sk-openai-real", "", "")
+        assert manager.get_openai_key() == "sk-openai-real"
+
+        manager.set_api_settings("OpenAI-Compatible", "https://x/v1", "", "", "")
+        assert SettingsManager(state_file).get_openai_key() == ""

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -1602,6 +1602,9 @@ def test_load_notes_rows_shape_matches_session_load_expectations(db_path):
     assert rows[0] == {
         "content": "A note", "position": {"x": 1.0, "y": 2.0}, "size": {"width": 100.0, "height": 50.0},
         "color": "#111111", "header_color": None, "is_system_prompt": True, "is_summary_note": False,
+        # note-edge fix: the payload id round-trips too; "" for a row (like this
+        # test helper's) that predates / omits the note_id column.
+        "id": "",
     }
 
 

--- a/backend/tests/test_mcp_client.py
+++ b/backend/tests/test_mcp_client.py
@@ -312,3 +312,65 @@ def test_config_env_round_trips_and_tolerates_malformed_values():
     # non-dict / missing degrade to "no extra variables", never a failed load
     assert McpServerConfig.from_dict({"name": "a", "command": "b", "env": "oops"}).env == {}
     assert McpServerConfig.from_dict({"name": "a", "command": "b"}).env == {}
+
+
+# -- stderr must not deadlock the client (the pipe-buffer wedge) --------------
+
+
+_STDERR_FLOOD_SERVER_SCRIPT = textwrap.dedent(r'''
+    import json
+    import sys
+
+    def send(message):
+        sys.stdout.write(json.dumps(message) + "\n")
+        sys.stdout.flush()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        request = json.loads(line)
+        method = request.get("method")
+        request_id = request.get("id")
+        if method == "initialize":
+            send({"jsonrpc": "2.0", "id": request_id, "result": {
+                "protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                "serverInfo": {"name": "noisy", "version": "0.0.1"},
+            }})
+        elif method == "notifications/initialized":
+            pass
+        elif method == "tools/call":
+            # Flood stderr well past any OS pipe buffer (~4 KiB on Windows,
+            # ~64 KiB on Linux) BEFORE sending the stdout response. Without a
+            # client-side stderr drainer this write blocks on a full pipe and
+            # the response below is never sent - the client's _call() then
+            # hangs until its timeout.
+            sys.stderr.write("x" * (512 * 1024))
+            sys.stderr.flush()
+            send({"jsonrpc": "2.0", "id": request_id, "result": {
+                "content": [{"type": "text", "text": "ok"}], "isError": False,
+            }})
+        else:
+            send({"jsonrpc": "2.0", "id": request_id,
+                  "error": {"code": -32601, "message": "unknown method"}})
+''')
+
+
+def test_a_server_flooding_stderr_does_not_deadlock_the_client(tmp_path):
+    """Regression: stderr was read only once, on unexpected close, so a
+    server writing more than the OS pipe buffer to stderr before answering
+    blocked on its own stderr write and never sent its stdout response - so
+    every call() hung until the timeout. A dedicated drainer thread keeps
+    the pipe empty so the response still arrives. The generous timeout here
+    is a backstop: with the fix this returns in well under a second; without
+    it, the call never returns and the timeout is what fails the test."""
+    script = tmp_path / "noisy_stderr_server.py"
+    script.write_text(_STDERR_FLOOD_SERVER_SCRIPT, encoding="utf-8")
+    client = McpStdioClient(command=sys.executable, args=(str(script),), timeout=20.0)
+    client.connect()
+    try:
+        result = client.call_tool("anything", {})
+        assert result.content == "ok"
+        assert result.is_error is False
+    finally:
+        client.close()

--- a/backend/tests/test_session_format_adr009.py
+++ b/backend/tests/test_session_format_adr009.py
@@ -283,3 +283,62 @@ def test_store_rejects_a_ref_that_is_not_a_content_digest(tmp_path):
         assert store.get(crafted) is None, crafted
         assert store.exists(crafted) is False, crafted
         assert store.verify(crafted) is False, crafted
+
+
+# -- note edges survive a real DB round-trip (not just the in-memory one) --
+
+
+def test_note_edges_survive_a_full_db_round_trip(tmp_path):
+    """Regression for the note-edge data-loss bug.
+
+    The existing round-trip tests feed notes_data (payload ids intact)
+    straight into restore_chat_into_document, which HIDES the defect: on the
+    real path notes_data is written to the `notes` DB TABLE and read back by
+    load_notes_rows, and that table had no column for the note's payload id.
+    So the flat `edges` list (authoritative since stage 9.6) could not
+    resolve any note endpoint on load, and every note connection - a System
+    Prompt note attached to a chat, a chat->summary note, a user-drawn note
+    link - was silently dropped, then written back gone on the next save.
+
+    This test therefore drives the REAL save/load path through the SQLite
+    row + notes table, the one place the id was being stripped."""
+    from backend.chat_library import (
+        load_chat_row,
+        load_notes_rows,
+        load_pins_rows,
+        save_chat_atomically_row,
+    )
+
+    db_path = tmp_path / "chats.db"
+
+    doc = SceneDocument()
+    chat = doc.add_chat_node(0, 0, "hello", is_user=True)
+    note = doc.add_note(0, -120, is_system_prompt=True)
+    doc.set_note_content(note.id, "You are a helpful assistant.")
+    doc.connect(note.id, chat.id)  # the system-prompt note -> chat edge
+    assert _has_edge(doc, note.id, chat.id)
+
+    chat_data = build_chat_data(doc)
+    notes_data = chat_data.pop("notes_data")
+    pins_data = chat_data.pop("pins_data")
+    assert notes_data, "precondition: the doc has a note to persist"
+
+    chat_id, _ = save_chat_atomically_row(db_path, None, "t", chat_data, notes_data, pins_data)
+
+    # Reload EXACTLY as chat_library.loadChat does - from the DB, through the
+    # notes table, not from the in-memory notes_data above.
+    row = load_chat_row(db_path, chat_id)
+    restored = SceneDocument()
+    restore_chat_into_document(
+        restored,
+        row,
+        load_notes_rows(db_path, chat_id),
+        load_pins_rows(db_path, chat_id),
+    )
+
+    restored_notes = [n for n in restored.nodes.values() if n.kind == "note"]
+    restored_chats = [n for n in restored.nodes.values() if n.kind == "chat"]
+    assert len(restored_notes) == 1 and len(restored_chats) == 1
+    assert _has_edge(restored, restored_notes[0].id, restored_chats[0].id), (
+        "the system-prompt note lost its connection to the chat across a DB round-trip"
+    )

--- a/backend/tests/test_session_format_adr009.py
+++ b/backend/tests/test_session_format_adr009.py
@@ -342,3 +342,50 @@ def test_note_edges_survive_a_full_db_round_trip(tmp_path):
     assert _has_edge(restored, restored_notes[0].id, restored_chats[0].id), (
         "the system-prompt note lost its connection to the chat across a DB round-trip"
     )
+
+
+def test_an_unreadable_asset_ref_is_preserved_rather_than_erased(tmp_path):
+    """Regression: a TRANSIENT asset-read failure used to become permanent
+    picture loss on the very next save.
+
+    AssetStore.get() returns None both for "never stored" and for any OSError
+    on read (an antivirus lock on Windows is enough). The image node then
+    restored with no asset id, so the next save saw no bytes, fell through to
+    the inline branch and wrote image_bytes:"" - erasing the only pointer to
+    an asset file that was still sitting on disk the whole time. The ref is
+    now carried across the round-trip so the row keeps pointing at it."""
+    store = AssetStore(tmp_path / "assets")
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "draw me a cat", is_user=True)
+    doc.add_image_node(0, 120, PNG, "a cat", parent.id, mime_type="image/png")
+
+    saved = build_chat_data(doc, asset_store=store)
+    image_payload = next(
+        n for n in saved["nodes"] if n.get("node_type") == "image"
+    )
+    original_ref = image_payload["asset_ref"]
+    assert original_ref
+
+    # Reload while the store cannot produce the bytes (the transient failure).
+    class _UnreadableStore:
+        def get(self, ref):
+            return None
+
+        def put(self, data):  # pragma: no cover - not reached in this test
+            return content_ref(data)
+
+    notes_data = saved.pop("notes_data")
+    pins_data = saved.pop("pins_data")
+    reloaded = SceneDocument()
+    restore_chat_into_document(
+        reloaded, {"data": saved}, notes_data, pins_data, asset_store=_UnreadableStore()
+    )
+
+    # Now save again, exactly as an autosave tick would.
+    resaved = build_chat_data(reloaded, asset_store=store)
+    resaved_image = next(n for n in resaved["nodes"] if n.get("node_type") == "image")
+
+    assert resaved_image.get("asset_ref") == original_ref, (
+        "a transient asset-read failure erased the image's asset_ref on the next save"
+    )
+    assert not resaved_image.get("image_bytes")

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -15,7 +15,7 @@ import backend.api.intents_settings_ollama as intents_settings_ollama_module
 from backend import native_dialogs
 from backend.events import SessionBus
 from backend.notifications import NotificationState
-from backend.settings import register_settings, settings_payload
+from backend.settings import _mcp_servers_for_wire, register_settings, settings_payload
 
 
 @pytest.fixture
@@ -2335,7 +2335,8 @@ def test_set_mcp_servers_round_trips_a_valid_call(manager):
             "enabledTools": ["read_file"],
             "enabled": True,
             "timeout": 45.0,
-            "env": {},
+            # Names only - env VALUES are write-only on this wire now.
+            "envKeys": [],
         },
     ]
 
@@ -2425,3 +2426,78 @@ def test_set_recipes_replaces_the_whole_list(manager):
     manager.set_recipes([{"name": "one", "goal": "g"}])
     manager.set_recipes([{"name": "two", "goal": "g"}])
     assert [r["name"] for r in manager.get_recipes()] == ["two"]
+
+
+# -- MCP env values are secrets: encrypted at rest, never on the wire --------
+
+
+def test_mcp_env_values_are_encrypted_at_rest_and_never_sent_on_the_wire(tmp_path):
+    """The regression this closes: per-server `env` was introduced to stop MCP
+    servers inheriting the backend's whole environment, but the values it
+    holds - a GITHUB_TOKEN, a BRAVE_API_KEY - were written to session.dat as
+    plaintext JSON AND republished in every app-settings payload, while the
+    API keys sitting beside them were encrypted and write-only."""
+    import json as _json
+
+    from graphlink_settings_store import SettingsManager as _SettingsManager
+
+    state_file = tmp_path / "session.dat"
+    manager = _SettingsManager(state_file)
+    manager.set_mcp_servers([
+        {"name": "gh", "command": "npx", "env": {"GITHUB_TOKEN": "ghp_super_secret_value"}},
+    ])
+
+    # 1. Not readable as plaintext in the settings file.
+    on_disk = state_file.read_text(encoding="utf-8")
+    assert "ghp_super_secret_value" not in on_disk, "MCP env value stored in plaintext"
+    # The NAME is fine - it is not the secret, and Settings lists it.
+    assert "GITHUB_TOKEN" in on_disk
+
+    # 2. The spawn path still gets the real value back.
+    servers = manager.get_mcp_servers()
+    assert servers[0]["env"] == {"GITHUB_TOKEN": "ghp_super_secret_value"}
+
+    # 3. The wire payload carries the name and NOT the value.
+    wire = _mcp_servers_for_wire(manager)
+    assert wire[0]["envKeys"] == ["GITHUB_TOKEN"]
+    assert "env" not in wire[0]
+    assert "ghp_super_secret_value" not in _json.dumps(wire)
+
+
+def test_editing_another_server_does_not_wipe_configured_env_values(tmp_path):
+    """Because the wire no longer echoes env values back, an ordinary edit -
+    toggling one server's checkbox - sends the whole list WITHOUT them. That
+    must mean "leave them alone", not "clear them"."""
+    from graphlink_settings_store import SettingsManager as _SettingsManager
+
+    manager = _SettingsManager(tmp_path / "session.dat")
+    manager.set_mcp_servers([
+        {"name": "gh", "command": "npx", "env": {"GITHUB_TOKEN": "ghp_keep_me"}},
+        {"name": "fs", "command": "uvx", "env": {}},
+    ])
+
+    # Exactly what the settings page now sends when the user unticks "fs":
+    # every field it knows about, and no `env` at all.
+    manager.set_mcp_servers([
+        {"name": "gh", "command": "npx"},
+        {"name": "fs", "command": "uvx", "enabled": False},
+    ])
+
+    servers = {s["name"]: s for s in manager.get_mcp_servers()}
+    assert servers["gh"]["env"] == {"GITHUB_TOKEN": "ghp_keep_me"}, "an unrelated edit erased a configured secret"
+    assert servers["fs"]["enabled"] is False
+
+
+def test_an_explicit_env_still_replaces_what_is_stored(tmp_path):
+    """The preservation rule must not make env impossible to change or clear:
+    an entry that DOES carry `env` is authoritative for that server."""
+    from graphlink_settings_store import SettingsManager as _SettingsManager
+
+    manager = _SettingsManager(tmp_path / "session.dat")
+    manager.set_mcp_servers([{"name": "gh", "command": "npx", "env": {"OLD": "1"}}])
+
+    manager.set_mcp_servers([{"name": "gh", "command": "npx", "env": {"NEW": "2"}}])
+    assert manager.get_mcp_servers()[0]["env"] == {"NEW": "2"}
+
+    manager.set_mcp_servers([{"name": "gh", "command": "npx", "env": {}}])
+    assert manager.get_mcp_servers()[0]["env"] == {}

--- a/contracts/graphlink_app_settings_payload.py
+++ b/contracts/graphlink_app_settings_payload.py
@@ -54,9 +54,14 @@ class McpServerConfigPayload:
     enabledTools: list[str]
     enabled: bool
     timeout: float
-    # Per-server environment variables (KEY -> value), layered on the safe
-    # allowlist base at spawn - see backend/mcp_client.py's McpServerConfig.
-    env: dict[str, str]
+    # The NAMES of this server's configured environment variables, never
+    # their values - those are real user secrets (a GITHUB_TOKEN, a
+    # BRAVE_API_KEY), they are encrypted at rest, and they are write-only on
+    # this wire for the same reason apiKeyConfigured is a bool rather than a
+    # key: this payload is republished to every subscribed client on every
+    # settings change. The Settings page lists these names; changing a value
+    # means retyping it. See backend/settings.py's _mcp_servers_for_wire.
+    envKeys: list[str]
 
 
 @dataclass

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -1273,8 +1273,13 @@ class SettingsManager:
                 "timeout": float(entry.get("timeout", 30.0) or 30.0),
                 # Absent on every entry persisted before the field existed -
                 # reads back as "no extra variables", the same default the
-                # write side stores.
-                "env": _normalize_mcp_env(entry.get("env")),
+                # write side stores. Decrypted here (values are encrypted at
+                # rest by _protect_mcp_env) so the ONLY consumer that needs
+                # the real values - the MCP server spawn in backend/agents.py
+                # - gets them, while the settings wire payload never carries
+                # them at all. Legacy plaintext entries pass through
+                # unchanged.
+                "env": self._unprotect_mcp_env(_normalize_mcp_env(entry.get("env"))),
             })
         return servers
 
@@ -1287,6 +1292,15 @@ class SettingsManager:
         patched map. Validates the same way get_mcp_servers reads back
         (name/command required, everything else normalized/defaulted) so
         a round trip through set then get is always well-formed."""
+        # What is already stored, keyed by server name, so an entry that
+        # arrives without an "env" key keeps its configured variables rather
+        # than losing them - see the "env" handling below.
+        preserved_env: dict[str, dict] = {}
+        for stored in (self.state.get("mcp_servers") or []):
+            if isinstance(stored, dict):
+                stored_name = str(stored.get("name", "")).strip()
+                if stored_name:
+                    preserved_env[stored_name] = _normalize_mcp_env(stored.get("env"))
         normalized = []
         for entry in (servers or []):
             if not isinstance(entry, dict):
@@ -1306,14 +1320,45 @@ class SettingsManager:
                 "timeout": float(entry.get("timeout", 30.0) or 30.0),
                 # Per-server environment variables - the only channel by
                 # which a server process receives anything beyond the safe
-                # allowlist base (see McpStdioClient.connect). Values are
-                # stored as given; they are the user's own secrets for a
-                # server the user chose to run, same posture as the API keys
-                # this store already holds.
-                "env": _normalize_mcp_env(entry.get("env")),
+                # allowlist base (see McpStdioClient.connect). These are real
+                # user secrets (a GITHUB_TOKEN, a BRAVE_API_KEY), so each
+                # VALUE is encrypted at rest exactly like the API keys this
+                # store already holds - an earlier version of this comment
+                # claimed the "same posture as the API keys" while in fact
+                # writing them as plaintext JSON. Names stay in the clear:
+                # the Settings page lists them, and a variable name is not
+                # the secret.
+                #
+                # An entry that carries no "env" key at all means "leave
+                # whatever is stored for this server alone" - the wire
+                # deliberately never sends these values back (see
+                # backend/settings.py's _mcp_servers_for_wire), so a
+                # bulk-replace triggered by toggling one server's checkbox
+                # would otherwise wipe every configured variable it could
+                # not see.
+                **(
+                    {"env": self._protect_mcp_env(_normalize_mcp_env(entry.get("env")))}
+                    if "env" in entry
+                    else {"env": preserved_env.get(name, {})}
+                ),
             })
         self.state["mcp_servers"] = normalized
         self._save_state()
+
+    def _protect_mcp_env(self, env: dict) -> dict:
+        """Encrypt each env VALUE at rest, leaving names readable. Mirrors
+        _protect_and_track's use of graphlink_secrets.protect for the
+        top-level API keys, including its plaintext fallback when DPAPI is
+        unavailable (see graphlink_secrets' own docstring - refusing to save
+        would be worse than saving what this platform can protect)."""
+        return {str(key): graphlink_secrets.protect(str(value)) for key, value in (env or {}).items()}
+
+    def _unprotect_mcp_env(self, env: dict) -> dict:
+        """The read side of _protect_mcp_env. Legacy plaintext values (written
+        before env was encrypted) come back unchanged - graphlink_secrets.
+        unprotect passes through anything without the "dpapi:" prefix, the
+        same way the top-level secrets migrated."""
+        return {str(key): graphlink_secrets.unprotect(str(value)) for key, value in (env or {}).items()}
 
     def get_plugin_grants(self) -> dict:
         """ADR-014 stage 14.4: install-time consent grants for discovered

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -17,6 +17,40 @@ from graphlink_model_catalog import (
 logger = logging.getLogger(__name__)
 
 
+class _KeepExistingSecret:
+    """Type of the KEEP_EXISTING_SECRET sentinel below - a class only so it
+    has a readable repr in a traceback or a debugger."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<KEEP_EXISTING_SECRET>"
+
+
+# Pass this instead of a value to set_api_settings to mean "leave whatever is
+# already stored for this field exactly as it is".
+#
+# THE DATA LOSS THIS EXISTS TO PREVENT. Saving ONE provider's key used to
+# round-trip the other two through decrypt-then-re-encrypt: the caller read
+# them back with get_*_key() and handed the results straight to
+# set_api_settings. But get_*_key() returns "" whenever DPAPI decryption
+# FAILS, not only when no key is set - deliberately, on the read side - so a
+# transient CryptUnprotectData failure (a temporary-profile logon, an
+# unavailable master key on a domain machine, resource exhaustion; anything
+# graphlink_secrets' own blanket except turns into None) at the moment the
+# user saved their Anthropic key silently destroyed the still-recoverable
+# OpenAI and Gemini blobs, with no warning at the time and no way back. The
+# plaintext-migration path was hardened against exactly this hazard - it
+# never touches an undecryptable blob - and this sentinel closes the same
+# hole on the save path, by never reading those siblings at all rather than
+# by trying to tell a failed decrypt apart from an empty one after the fact.
+#
+# An explicit "" still clears a key, so a user genuinely emptying the field
+# is unaffected: the two intents are now distinguishable instead of collapsed
+# into the same empty string.
+KEEP_EXISTING_SECRET = _KeepExistingSecret()
+
+
 def _is_llama_cpp_gguf_path(path_value) -> bool:
     normalized = str(path_value or "").strip()
     return bool(normalized) and normalized.lower().endswith(".gguf")
@@ -423,9 +457,24 @@ class SettingsManager:
         if not self.state_file.exists():
             return self._create_initial_state()
         try:
-            with open(self.state_file, 'r') as f:
+            # encoding is explicit: this file is written as UTF-8 (_save_state
+            # opens for write with the same default text mode on the machine
+            # that produced it), but reading it back through the LOCALE codec
+            # made byte-level corruption fatal in a way the corrupt-file
+            # rescue below was written to prevent. Disk corruption that lands
+            # a byte the locale codec rejects (0x81/0x8D/0x9D under cp1252,
+            # far more under a CJK codepage) raises UnicodeDecodeError - a
+            # ValueError, caught by NEITHER handler here - and that escapes
+            # SettingsManager.__init__, which is constructed unguarded at boot
+            # (backend/app.py's create_app, and earlier still in
+            # graphlink_desktop.main). The app then fails to launch on every
+            # single start until the user finds and deletes the file by hand.
+            # UnicodeDecodeError is caught below for exactly that reason: a
+            # corrupt settings file must be backed up and replaced, never a
+            # permanent boot failure.
+            with open(self.state_file, 'r', encoding='utf-8') as f:
                 raw_state = json.load(f)
-        except (json.JSONDecodeError, IOError) as e:
+        except (json.JSONDecodeError, UnicodeDecodeError, IOError) as e:
             self._backup_corrupt_state_file(e)
             return self._create_initial_state()
 
@@ -643,7 +692,12 @@ class SettingsManager:
         data_to_save = state_data if state_data else self.state
         tmp_path = self.state_file.with_name(self.state_file.name + ".tmp")
         try:
-            with open(tmp_path, 'w') as f:
+            # encoding is explicit to match _load_state's own explicit utf-8
+            # read. json.dump defaults to ensure_ascii=True, so what actually
+            # lands here is pure ASCII either way and every previously-written
+            # file stays readable - this just removes the latent dependency on
+            # whatever locale codec the host happens to default to.
+            with open(tmp_path, 'w', encoding='utf-8') as f:
                 # ADR-004 stage 4.4 (adversarial-review fix): chmod the temp
                 # file immediately after opening it, BEFORE writing any
                 # content - chmod'ing only after fsync left a window where a
@@ -1113,9 +1167,17 @@ class SettingsManager:
     ):
         self.state["api_provider"] = provider
         self.state["api_base_url"] = base_url
-        self.state["openai_api_key"] = self._protect_and_track(openai_key)
-        self.state["anthropic_api_key"] = self._protect_and_track(anthropic_key)
-        self.state["gemini_api_key"] = self._protect_and_track(gemini_key)
+        # KEEP_EXISTING_SECRET leaves the stored value untouched - no decrypt,
+        # no re-encrypt, no write. See that sentinel's own comment for the
+        # sibling-key destruction this prevents; an ordinary "" still clears.
+        for state_key, value in (
+            ("openai_api_key", openai_key),
+            ("anthropic_api_key", anthropic_key),
+            ("gemini_api_key", gemini_key),
+        ):
+            if value is KEEP_EXISTING_SECRET:
+                continue
+            self.state[state_key] = self._protect_and_track(value)
         self._save_state()
 
     def set_api_models(self, models_dict: dict, provider: str | None = None):

--- a/web_ui/src/app/canvas/ChartNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChartNodeView.test.tsx
@@ -5,6 +5,7 @@ import {
   ChartNodeView,
   chartExportUrl,
   chartNodePropsAreEqual,
+  filenameFromContentDisposition,
   makeDebouncedChartResize,
   type ChartFlowNode,
 } from "./ChartNodeView";
@@ -91,14 +92,18 @@ describe("ChartNodeView", () => {
     expect(button).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("the Export PNG/SVG links point at the dedicated export endpoint for this node's id", () => {
+  it("Export PNG/SVG are buttons, never navigated links that could leak the token", () => {
+    // They used to be <a target="_blank"> carrying ?token=<capability token>.
+    // In the WebView2 shell that opens in the OS default browser, putting a
+    // live token into another browser's history/address bar. Asserting they
+    // are BUTTONS (and that no link with these names exists) is what keeps
+    // that from being reintroduced.
     renderChartNode({}, "chart-42");
-    const pngLink = screen.getByRole("link", { name: "Export PNG" });
-    expect(pngLink).toHaveAttribute("href", "/api/assets/chart/chart-42/export?session=default&fmt=png");
-    expect(pngLink).toHaveAttribute("target", "_blank");
-    const svgLink = screen.getByRole("link", { name: "Export SVG" });
-    expect(svgLink).toHaveAttribute("href", "/api/assets/chart/chart-42/export?session=default&fmt=svg");
-    expect(svgLink).toHaveAttribute("target", "_blank");
+
+    expect(screen.getByRole("button", { name: "Export PNG" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export SVG" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Export PNG" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Export SVG" })).toBeNull();
   });
 });
 
@@ -264,5 +269,21 @@ describe("ChartNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
     );
     expect(root.className).not.toBe("CORRUPTED");
     expect(root.className).toContain("selected");
+  });
+});
+
+describe("chart export never puts the capability token in a URL", () => {
+  it("chartExportUrl carries no token query parameter", () => {
+    // The token lives in location.hash; withAuthToken() used to append it
+    // here. Anything user-visible or navigable must not carry it.
+    expect(chartExportUrl("node-1", "png")).not.toContain("token");
+    expect(chartExportUrl("node-1", "svg")).not.toContain("token");
+  });
+
+  it("filenameFromContentDisposition honors the server's own filename", () => {
+    expect(filenameFromContentDisposition('attachment; filename="Q4_Revenue.png"')).toBe("Q4_Revenue.png");
+    expect(filenameFromContentDisposition("attachment; filename=chart.svg")).toBe("chart.svg");
+    expect(filenameFromContentDisposition(null)).toBe("");
+    expect(filenameFromContentDisposition("attachment")).toBe("");
   });
 });

--- a/web_ui/src/app/canvas/ChartNodeView.tsx
+++ b/web_ui/src/app/canvas/ChartNodeView.tsx
@@ -1,7 +1,7 @@
 import { NodeResizer, type Node, type NodeProps } from "@xyflow/react";
 import { lazy, memo, Suspense, useEffect, useRef } from "react";
 import type { ChartDataRow } from "../../lib/bridge-core/generated/scene-state";
-import { withAuthToken } from "../../lib/auth/token";
+import { authHeaders } from "../../lib/auth/token";
 import {
   CHART_MAX_HEIGHT,
   CHART_MAX_WIDTH,
@@ -67,7 +67,9 @@ const LazyChartRenderer = lazy(() => import("./charts/ChartRenderer"));
  *
  * Export/PNG and Export/SVG both hit the same dedicated export endpoint (a
  * real matplotlib re-render server-side - PNG at 3x resolution, SVG as
- * vector - not anything this renderer draws), opened directly in a new tab.
+ * vector - not anything this renderer draws), fetched with the capability
+ * token in a header and saved from a blob. They are buttons rather than
+ * new-tab links precisely because of that token - see chartExportUrl.
  * That stays server-side deliberately: a downloadable, print-quality
  * raster/vector asset is a different job than "draw this interactively."
  * ADR-013 stage 13.4 moved that render off the event loop
@@ -95,9 +97,51 @@ export type ChartFlowNode = Node<ChartNodeData, "chart">;
  * assumption everywhere else (see lib/ws/transport.ts's own defaultWsUrl
  * default parameter). */
 export function chartExportUrl(nodeId: string, format: "png" | "svg" = "png"): string {
-  // ADR-004 stage 4.1: this one is a plain <a href> the user clicks, so it
-  // has no way to carry a header either - same query-param treatment.
-  return withAuthToken(`/api/assets/chart/${nodeId}/export?session=default&fmt=${format}`);
+  // Deliberately NO token in this URL. It used to be withAuthToken(...) and
+  // to be used as an <a href target="_blank">, which leaked the live
+  // capability token off the machine: in the pywebview/WebView2 shell a
+  // target=_blank click raises NewWindowRequested, whose default handler
+  // opens the fully-resolved URL in the OS default browser - so the token
+  // landed in that browser's address bar, history and download manager, and
+  // was copyable straight out of the link's context menu. A synced browser
+  // history uploads it. That token authorizes every /api intent, including
+  // the code-execution approval gate, so this was the one place the "the
+  // token never leaves this window" property (see lib/auth/token.ts) broke.
+  //
+  // The fetch below sends it as an Authorization HEADER instead, and the
+  // bytes are saved from a blob - nothing user-visible carries the secret.
+  return `/api/assets/chart/${nodeId}/export?session=default&fmt=${format}`;
+}
+
+/** Fetches a chart export with the capability token in a header and saves the
+ * resulting bytes as a file. Mirrors downloadTextFile.ts's blob -> object URL
+ * -> temporary anchor pattern (and ImageNodeView's own image export before
+ * it); the only difference is that the bytes come from an authenticated
+ * request rather than from memory. */
+export async function downloadChartExport(nodeId: string, format: "png" | "svg"): Promise<void> {
+  const response = await fetch(chartExportUrl(nodeId, format), { headers: authHeaders() });
+  if (!response.ok) throw new Error(`Chart export failed (${response.status})`);
+  const blob = await response.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  // The server names the file from the chart's own title
+  // (backend/assets.py's _sanitize_chart_filename) and sends it in
+  // Content-Disposition - the same header the old navigated link relied on,
+  // so honoring it here keeps the downloaded filename identical.
+  anchor.download = filenameFromContentDisposition(response.headers.get("content-disposition"))
+    || `chart.${format}`;
+  anchor.click();
+  URL.revokeObjectURL(objectUrl);
+}
+
+/** Pulls `filename="..."` out of a Content-Disposition header. Exported for
+ * direct unit testing. Returns "" when the header is absent or unparseable,
+ * letting the caller fall back to its own default. */
+export function filenameFromContentDisposition(header: string | null): string {
+  if (!header) return "";
+  const match = /filename\s*=\s*"([^"]+)"/i.exec(header) ?? /filename\s*=\s*([^;]+)/i.exec(header);
+  return match ? match[1].trim() : "";
 }
 
 function chartTypeBadgeLabel(chartType: string): string {
@@ -220,22 +264,23 @@ export const ChartNodeView = memo(function ChartNodeView({
         >
           {data.chartAspectLocked ? "Unlock Aspect" : "Lock Aspect"}
         </button>
-        <a
+        {/* Buttons, not <a target="_blank"> links: the export request has to
+            carry the capability token, and a navigated link would hand it to
+            the OS default browser - see chartExportUrl's own comment. */}
+        <button
+          type="button"
           className="chart-node-btn chart-node-export-link"
-          href={chartExportUrl(id, "png")}
-          target="_blank"
-          rel="noreferrer"
+          onClick={() => { void downloadChartExport(id, "png"); }}
         >
           Export PNG
-        </a>
-        <a
+        </button>
+        <button
+          type="button"
           className="chart-node-btn chart-node-export-link"
-          href={chartExportUrl(id, "svg")}
-          target="_blank"
-          rel="noreferrer"
+          onClick={() => { void downloadChartExport(id, "svg"); }}
         >
           Export SVG
-        </a>
+        </button>
       </div>
     </NodeShell>
   );

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -922,7 +922,7 @@ describe("SettingsDialog", () => {
       enabledTools: [],
       enabled: true,
       timeout: 30,
-      env: {},
+      envKeys: [],
     };
 
     it("navigating to MCP Servers fires setActiveSection with its own key", async () => {
@@ -998,6 +998,11 @@ describe("SettingsDialog", () => {
             enabledTools: [],
             enabled: true,
             timeout: 30,
+            // The add path is the one place env VALUES go out (the user just
+            // typed them); every other edit omits `env` entirely so the
+            // backend keeps what is stored. Empty here because this test
+            // typed no variables.
+            envKeys: [],
             env: {},
           },
         ]],
@@ -1032,7 +1037,7 @@ describe("SettingsDialog", () => {
         enabledTools: [],
         enabled: true,
         timeout: 30,
-        env: {},
+        envKeys: [],
       };
       const { user, push, intents } = setup();
       await goToMcpServers(user, push, { mcpServers: [fsServer, gitServer] });

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -1087,7 +1087,34 @@ function McpServersPage({ state, transport }: { state: AppSettingsState; transpo
   const [draftArgs, setDraftArgs] = useState("");
   const [draftEnv, setDraftEnv] = useState("");
 
-  const updateServers = (next: McpServerConfig[]) => {
+  // What setMcpServers SENDS, which is genuinely not the same shape the
+  // app-settings state carries back. env values are write-only on this wire
+  // (see the contract's own McpServerConfigPayload.envKeys): the state we
+  // render has names only, while an outgoing entry MAY carry real values
+  // when the user just typed them. A missing `env` means "keep whatever is
+  // stored for this server", which is what lets toggling or removing one
+  // server leave every other server's variables untouched.
+  //
+  // Spelled out in full rather than written as `McpServerConfig & { env?: }`
+  // deliberately: intersecting a generated wire type is the ADR-003 C9
+  // anti-pattern (see lib/bridge-core/wireTypeCastGuard.test.ts) - it tells
+  // TypeScript a wire field exists on the author's word. This type describes
+  // the OUTBOUND intent argument, which the generated inbound row type has
+  // no business defining.
+  type OutgoingMcpServer = {
+    name: string;
+    command: string;
+    args: string[];
+    scopes: string[];
+    approval: string;
+    enabledTools: string[];
+    enabled: boolean;
+    timeout: number;
+    envKeys: string[];
+    env?: Record<string, string>;
+  };
+
+  const updateServers = (next: OutgoingMcpServer[]) => {
     transport.fireIntent("app-settings", "setMcpServers", [next], undefined, true);
   };
 
@@ -1096,11 +1123,15 @@ function McpServersPage({ state, transport }: { state: AppSettingsState; transpo
     const command = draftCommand.trim();
     if (!name || !command) return;
     const args = draftArgs.trim() ? draftArgs.trim().split(/\s+/) : [];
+    const env = parseEnvLines(draftEnv);
     updateServers([
       ...state.mcpServers,
       {
         name, command, args, scopes: [], approval: "always", enabledTools: [], enabled: true, timeout: 30,
-        env: parseEnvLines(draftEnv),
+        // The one place values are sent: the user just typed them. envKeys
+        // keeps the entry the same shape the rest of the list has.
+        envKeys: Object.keys(env).sort(),
+        env,
       },
     ]);
     setDraftName("");
@@ -1146,9 +1177,9 @@ function McpServersPage({ state, transport }: { state: AppSettingsState; transpo
                 {/* Names only, never values - these are the user's own
                     tokens for a server they chose to run, and a settings
                     page is no place to echo a secret back. */}
-                {Object.keys(server.env ?? {}).length > 0 && (
+                {(server.envKeys ?? []).length > 0 && (
                   <span className="settings-mcp-server-command">
-                    env: {Object.keys(server.env).sort().join(", ")}
+                    env: {[...server.envKeys].sort().join(", ")}
                   </span>
                 )}
               </span>

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import type { WsTransport } from "../../lib/ws/transport";
 import { TOPIC_VALIDATORS } from "../../lib/api-contract/topics";
 import type { AppPluginGrant, AppPluginsState } from "../../lib/bridge-core/generated/app-plugins-state";
-import type { AppSettingsState, McpServerConfig } from "../../lib/bridge-core/generated/app-settings-state";
+import type { AppSettingsState } from "../../lib/bridge-core/generated/app-settings-state";
 import { useExecutionLimits } from "../canvas/ExecutionLimitsContext";
 import { Dialog, useOverlays } from "../overlays/overlays";
 import { CustomSelect } from "./CustomSelect";

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
@@ -157,11 +157,11 @@
             },
             "type": "array"
           },
-          "env": {
-            "additionalProperties": {
+          "envKeys": {
+            "items": {
               "type": "string"
             },
-            "type": "object"
+            "type": "array"
           },
           "name": {
             "type": "string"
@@ -185,7 +185,7 @@
           "enabledTools",
           "enabled",
           "timeout",
-          "env"
+          "envKeys"
         ],
         "type": "object"
       },

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
@@ -19,7 +19,7 @@ export interface McpServerConfig {
   enabledTools: string[];
   enabled: boolean;
   timeout: number;
-  env: Record<string, string>;
+  envKeys: string[];
 }
 
 export interface AppSettingsState {
@@ -161,10 +161,10 @@ function checkMcpServerConfig(value: unknown, path: string, errors: string[]): v
     else { if (typeof fieldValue !== "number") errors.push(`${path}.timeout` + ": expected number"); }
   }
   {
-    const fieldValue = value["env"];
-    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.env: missing required field`);
-    else { if (!isRecord(fieldValue)) errors.push(`${path}.env` + ": expected object");
-    else Object.entries(fieldValue as Record<string, unknown>).forEach(([k, v]) => { if (typeof v !== "string") errors.push(`${path}.env` + `[${JSON.stringify(k)}]` + ": expected string"); }); }
+    const fieldValue = value["envKeys"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.envKeys: missing required field`);
+    else { if (!Array.isArray(fieldValue)) errors.push(`${path}.envKeys` + ": expected array");
+    else (fieldValue as unknown[]).forEach((item, i) => { if (typeof item !== "string") errors.push(`${path}.envKeys` + `[${i}]` + ": expected string"); }); }
   }
 }
 


### PR DESCRIPTION
## Problem

A read-the-code audit of the repo (not a test run - the suite was green for
every one of these) found a set of defects that silently lose user data, hang
the backend, or move secrets somewhere they should never go. The most serious
one was invisible to the test suite because the test bypassed the exact code
path that was broken.

**Data loss**
- Every note connection was dropped on reload. The flat `edges` list references
  endpoints by save-time id, but a note's id was written only into the `notes`
  table, which had no column for it - so a System Prompt note silently stopped
  applying after a reload, and the next save made it permanent. The existing
  round-trip test fed notes straight into the restore function, bypassing the
  table that was stripping the id.
- A plugin that failed discovery at save time excluded every one of its live
  nodes from the written row; the next autosave destroyed them.
- A transient asset-read failure (an AV lock is enough) erased an image's
  `asset_ref` on the next save, orphaning a file still on disk.
- `deleteChat` was the only mutating intent not serialized against the others,
  so racing an in-flight save left the session pointed at a deleted row with a
  digest claiming "already saved" - silently no autosave.
- Saving one provider's API key could permanently destroy the other two:
  `get_*_key()` returns `""` for a blob that fails to *decrypt* exactly as it
  does for one never set, so a transient DPAPI failure re-encrypted `""` over
  two recoverable blobs.
- Autosave's two earliest failure points logged and returned silently,
  breaking its own "loud on failure" contract when the disk is full.

**Hangs and crashes**
- Ollama had no timeout of any kind (`timeout=None`), so a wedged daemon parked
  a worker thread forever. Cancellation cannot help and the watchdog only stops
  waiting, so enough of them exhaust the shared executor and the whole backend
  soft-hangs.
- The MCP client and plugin worker read only stdout; a child writing >4 KiB to
  stderr before replying blocks on its own write and wedges that server until
  restart. One uncaught traceback is enough.
- llama.cpp handed one cached, non-thread-safe `Llama` to concurrent runs -
  interleaved decodes on one native context corrupt output or crash the process.

**Secrets and trust boundaries**
- MCP per-server `env` values were stored as plaintext and broadcast in every
  `app-settings` payload, while the API keys beside them were encrypted and
  write-only.
- The chart Export links carried the capability token in a `target="_blank"`
  href; in the WebView2 shell that hands it to the OS default browser, where it
  lands in history and is copyable. That token authorizes every `/api` intent,
  including the code-execution approval gate.
- A plugin's `entry_point` was validated only for its `":"` split, so a manifest
  could name `"../../../evil:register"` and get a file outside the plugin
  directory executed in the host process.
- Anthropic reasoning effort was sent as a flat `{"effort": ...}`; the SDK has
  no such parameter, so the kwarg filter dropped it and the user's selection
  never reached a paid API call, while the REST fallback 400'd.

## Change

Three commits, each self-contained:

1. **Persist note ids; drain subprocess stderr** - migration 5 adds
   `notes.note_id`; both subprocess clients drain stderr on a dedicated thread
   into a bounded ring buffer.
2. **Bound Ollama, serialize llama.cpp, stop silent data loss** - real socket
   timeouts on the shared Ollama client; a per-instance inference lock; a
   `KEEP_EXISTING_SECRET` sentinel so sibling keys are never read or rewritten;
   `entry_point` identifier validation; `deleteChat` serialized; plugin nodes
   preserved on save; asset refs preserved; `output_config` nesting for effort;
   autosave notifies on failure.
3. **Stop MCP env secrets and the capability token leaking** - env values
   encrypted at rest and reduced to `envKeys` on the wire, with "absent means
   keep stored" so an unrelated edit cannot wipe them; chart export fetched with
   an Authorization header and saved from a blob.

## Test plan

- `python -m pytest -q` from the repo root: **3094 passed, 17 skipped**.
- `npm run check` in `web_ui/`: schema check, typecheck, lint (0 errors),
  **1974 tests passed**, build and bundle-size all clean.
- New regression tests are **revert-verified** - each fails against the old code
  and passes with the fix:
  - the note->chat edge is missing after a real DB round-trip (21s MCP timeout
    for the stderr deadlock),
  - the sibling API key's DPAPI blob is destroyed,
  - the image's `asset_ref` comes back `None`,
  - the MCP token is written to `session.dat` in plaintext and appears in the
    wire payload,
  - the Anthropic effort kwarg is dropped by the SDK filter.
- Migration 5 is guarded by a `PRAGMA table_info` probe, so re-running it is a
  no-op; pre-fix rows read back as before.

## Not included

Deliberately left out, with reasons rather than silently dropped:

- **Restoring plugin nodes whose plugin failed to load.** Save now keeps them
  and load logs instead of dropping silently, so the data survives on disk and
  a fixed plugin brings them back - but rendering an unknown node kind is a
  frontend decision I did not want to make blind.
- **In-process plugin code executing at discovery, before any grant check.**
  Real, but changing when plugin code runs is an architectural call for the
  ADR-014 trust model, not a drive-by fix.
- Remaining medium/low findings (approval bound to `request_id` rather than the
  open gate, Gitlink read helpers blocking the WS loop, unbounded worker stdout,
  no CSP on the app document, `loadChat`/`newChat` losing up to 30s of unsaved
  edits) are catalogued and can follow.
