### PR TITLE
Fix 11 issues found by a code-reading crawl (cycles, races, undo atomicity, UI correctness)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -2659,6 +2659,23 @@ class AgentDispatcher:
                 await bus.publish("scene")
                 approved = await approval_future
                 node.state.pycoder_awaiting_approval = False
+                # REVIEW-FIX: without this publish, a REPAIR round's own
+                # re-gate further down (node.state.pycoder_awaiting_approval
+                # = True again, after the REPL execute + repair-agent
+                # latency) writes False then True with no scene broadcast
+                # for the False in between. The frontend's own
+                # CodeExecutionApprovalPanel busy flag (PyCoderNodeView.tsx)
+                # only resets on an OBSERVED false->true transition, so it
+                # never sees a transition at all across that whole window
+                # (True -> [invisible False] -> True) - every repair
+                # round's approval dialog renders with both Approve and
+                # Deny permanently disabled, and that panel has no other
+                # dismissal affordance by design. This publish is what
+                # makes the intermediate state real on the wire, not just
+                # in memory - see the identical fix on the repair gate's
+                # own False assignment further down, and
+                # start_code_sandbox_run's matching pair.
+                await bus.publish("scene")
 
                 if not approved:
                     on_failure("Py-Coder run cancelled: execution was not approved.")
@@ -2761,6 +2778,11 @@ class AgentDispatcher:
                         await bus.publish("scene")
                         approved = await repair_future
                         node.state.pycoder_awaiting_approval = False
+                        # REVIEW-FIX: see the initial gate's own identical
+                        # publish above for why - this loop can run more
+                        # than once (up to max_retries repair rounds), so
+                        # every False here needs its own broadcast too.
+                        await bus.publish("scene")
                         if not approved:
                             on_failure("Py-Coder run cancelled: repaired code was not approved.")
                             await bus.publish("scene")
@@ -3019,6 +3041,20 @@ class AgentDispatcher:
                 # but harmless, for every other path that lands there).
                 node.state.code_sandbox_approval_requirements = ""
                 node.state.code_sandbox_approval_allow_source_builds = False
+                # REVIEW-FIX: without this publish, a REPAIR round's own
+                # re-gate further down writes these fields back (True/
+                # non-empty) after the venv-create/pip-install/execute
+                # latency with no scene broadcast for THIS cleared state in
+                # between - see start_pycoder_run's identical fix for the
+                # full reasoning: CodeSandboxNodeView.tsx's busy flag only
+                # resets on an OBSERVED awaiting-approval false->true
+                # transition, so every repair round's approval dialog
+                # renders with both Approve and Deny permanently disabled
+                # otherwise. Placed after all four fields above are
+                # settled, not right after the first one, so this broadcast
+                # is a single coherent snapshot rather than one publish
+                # mid-way through an in-progress state update.
+                await bus.publish("scene")
 
                 if not approved:
                     on_failure("Sandbox run cancelled: execution was not approved.")
@@ -3128,6 +3164,11 @@ class AgentDispatcher:
                         repair_approved = await repair_future
                         node.state.code_sandbox_awaiting_approval = False
                         node.state.code_sandbox_approval_requirements = ""
+                        # REVIEW-FIX: see the initial gate's own identical
+                        # publish above for why - this loop can run more
+                        # than once (up to max_attempts repair rounds), so
+                        # every False here needs its own broadcast too.
+                        await bus.publish("scene")
                         if not repair_approved:
                             on_failure("Sandbox run cancelled: repaired code was not approved.")
                             await bus.publish("scene")

--- a/backend/api/intents_conversation.py
+++ b/backend/api/intents_conversation.py
@@ -56,6 +56,25 @@ def register_conversation_intents(
             # with a flat plain-text-only history and no child-node concept
             # at all in legacy.
             #
+            # REVIEW-FIX: this liveness guard was missing here, unlike
+            # _on_partial three lines below - a genuinely separate gap from
+            # the response_parsing omission the paragraph above documents.
+            # The node can be deleted (removeNodes - a ConversationNode is
+            # never a branch point/reparented, so it goes through the
+            # generic delete path, not deleteChatNode) while its reply is
+            # still generating: AgentDispatcher._dispatch schedules the LLM
+            # call as an un-awaited task, so the same WS connection is free
+            # to process a delete before the reply lands. Without this
+            # guard, a genuinely SUCCESSFUL reply then raised SceneError
+            # ("unknown node") out of append_conversation_assistant_message,
+            # which _dispatch's generic except-Exception handler turned into
+            # a misleading "AI response failed" notification for a request
+            # that had not failed at all - discarding real model output and
+            # lying about why. Matches _on_partial's own established
+            # posture: skipping is safe, the user retries via the
+            # conversation's own send box.
+            if document.nodes.get(node_id) is None:
+                return
             # "agent" provenance, not "user" - this reply is model-produced,
             # same posture as intents_chat.py's own chatReply command.
             document.record_command(

--- a/backend/api/intents_settings_general.py
+++ b/backend/api/intents_settings_general.py
@@ -72,6 +72,10 @@ def _mcp_servers_from_wire(servers: object) -> list[dict] | None:
         if not isinstance(entry, dict):
             return None
         normalized_entry = {
+            # A blank/missing id (a brand-new "Add Server" entry) is left
+            # for SettingsManager.set_mcp_servers to assign, server-side -
+            # see its own docstring on why the client never mints one.
+            "id": str(entry.get("id") or "").strip(),
             "name": entry.get("name", ""),
             "command": entry.get("command", ""),
             "args": entry.get("args", []),

--- a/backend/app.py
+++ b/backend/app.py
@@ -724,11 +724,42 @@ def create_app(
 
 
 async def _handle_message(session: SessionBus, websocket: WebSocket, message: dict) -> None:
+    # REVIEW-FIX: websocket.receive_json() is a bare json.loads() with no
+    # shape check (starlette's own implementation) - any syntactically
+    # valid top-level JSON value (a bare number, a list, null, a string)
+    # reaches here unchanged, and `message: dict` is only a type hint, not
+    # an enforced guarantee. Every OTHER malformed-input path in this
+    # function replies with a graceful `kind: error` frame instead of
+    # raising; a non-dict message used to raise AttributeError on the very
+    # next line ('int'/'list' object has no attribute 'get'), escaping the
+    # ONE try/except around the receive loop above (which catches
+    # WebSocketDisconnect only) and killing the connection outright with
+    # zero client-facing feedback. Reproduced directly: calling this
+    # function with 42 or [1, 2, 3] raised uncaught before this guard.
+    if not isinstance(message, dict):
+        await websocket.send_json(
+            {"kind": "error", "id": None, "error": "malformed message: expected a JSON object"}
+        )
+        return
+
     kind = message.get("kind")
     msg_id = message.get("id")
 
     if kind == "subscribe":
         topics = message.get("topics") or session.topic_names()
+        # REVIEW-FIX: same reasoning as the isinstance guard above, for the
+        # one field this branch trusts without a shape check. A truthy
+        # non-iterable "topics" (e.g. the JSON number 5) bypasses the `or`
+        # fallback above and used to raise TypeError ('int' object is not
+        # iterable) straight out of the `for topic in topics` loop below -
+        # reproduced directly. A malformed shape here gets the same
+        # graceful error reply every other bad-input path in this function
+        # already uses, instead of killing the connection.
+        if not isinstance(topics, list):
+            await websocket.send_json(
+                {"kind": "error", "id": msg_id, "error": "malformed message: 'topics' must be a list"}
+            )
+            return
         for topic in topics:
             try:
                 await session.send_snapshot(topic, websocket, request_id=msg_id)

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -1185,7 +1185,7 @@ def rename_chat(
     return now if cursor.rowcount else None
 
 
-def delete_chat(db_path: Path, chat_id: int, *, knowledge_db_path: Path | None = None) -> None:
+def delete_chat(db_path: Path, chat_id: int, *, knowledge_db_path: Path | None = None) -> bool:
     """ADR-020 stage 20.4: also removes this graph's own indexed content
     from knowledge_store.py's knowledge.db (backend.knowledge_store.
     delete_graph_index - the deletion-side mirror of save_chat_atomically_
@@ -1195,9 +1195,17 @@ def delete_chat(db_path: Path, chat_id: int, *, knowledge_db_path: Path | None =
     cosmetic one. Best-effort and non-blocking, same posture and same
     resolve-DEFAULT_DB_PATH-at-call-time shape as save_chat_atomically_row's
     own indexing call - see _reindex_graph_into_knowledge_store's own
-    docstring for why."""
+    docstring for why.
+
+    REVIEW-FIX: returns whether a row was actually removed (rowcount > 0),
+    mirroring rename_chat's own `now if cursor.rowcount else None` shape
+    just above - the read side of the SPA's own optimistic-UI fix
+    (ChatLibraryDialog.tsx's confirmDelete only clears its confirm state on
+    a truthy result now, rather than unconditionally the instant the
+    fire-and-forget intent was SENT rather than actually confirmed)."""
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        conn.execute("DELETE FROM graphs WHERE id = ?", (chat_id,))
+        cursor = conn.execute("DELETE FROM graphs WHERE id = ?", (chat_id,))
+        deleted = cursor.rowcount > 0
     resolved_knowledge_db_path = (
         knowledge_db_path if knowledge_db_path is not None else knowledge_store.DEFAULT_DB_PATH
     )
@@ -1207,6 +1215,7 @@ def delete_chat(db_path: Path, chat_id: int, *, knowledge_db_path: Path | None =
         logger.exception(
             "delete: failed to remove graph %s's indexed content from the knowledge store", chat_id,
         )
+    return deleted
 
 
 # -- ADR-020 stage 20.2: favorite/archived/tags + workspaces CRUD -----------
@@ -2635,10 +2644,21 @@ def make_delete_chat_intent(
     exists to prevent.
     """
 
-    async def delete(chat_id: int):
+    async def delete(chat_id: int) -> bool:
         # The SPA only calls this after its own two-step confirm, so no
         # confirmation happens here - same contract as the legacy bridge.
-        await asyncio.to_thread(delete_chat, resolved_path, int(chat_id))
+        #
+        # REVIEW-FIX: returns delete_chat's own bool (a row was actually
+        # removed) rather than nothing. This intent used to be fired via
+        # transport.fireIntent - sent and forgotten, with the confirm-delete
+        # UI clearing itself the instant the message was SENT, not once the
+        # deletion was actually confirmed. A genuine failure (delete_chat
+        # raising, the socket dropping mid-request) left the row sitting in
+        # the list with its confirm buttons already reverted to normal, no
+        # visible sign anything had gone wrong. The SPA now calls this
+        # through transport.request() and only clears its confirm state on
+        # a truthy reply - see ChatLibraryDialog.tsx's confirmDelete.
+        deleted = await asyncio.to_thread(delete_chat, resolved_path, int(chat_id))
         if canvas_document is not None and canvas_document.current_chat_id == int(chat_id):
             # Audit fix: deleting the row this session is currently pointed at
             # used to leave current_chat_id dangling AND leave the autosave
@@ -2653,6 +2673,7 @@ def make_delete_chat_intent(
             last_saved["chat_id"] = None
             last_saved["updated_at"] = None
         await bus.publish("app-chat-library")
+        return deleted
 
     return delete
 

--- a/backend/domain/branches.py
+++ b/backend/domain/branches.py
@@ -288,12 +288,37 @@ class BranchOps:
             if source_node is not None and source_node.kind == "note":
                 note_edges.append(edge)
 
+        # REVIEW-FIX: reconnect children to the deleted node's own parent
+        # BEFORE removing any edge below, not after (the original order).
+        # Reaching a cycle is no longer possible going forward now that
+        # connect() itself refuses to create one, but a document loaded
+        # from a row saved before that fix existed could still carry a
+        # pre-existing 2-node cycle - which used to make this exact
+        # scenario reachable: deleting the "child" side of such a cycle
+        # made parent_id == edge.target, so the reconnect below was really
+        # self.connect(parent_id, parent_id), which raises "cannot connect
+        # a node to itself" - and with the old pop-then-reconnect order,
+        # that exception fired AFTER the edges were already gone but
+        # BEFORE the node itself was deleted or last_chat_node_id/
+        # final_deliverable_node_id were updated: a corrupted, half-applied
+        # mutation with edges gone and the "deleted" node still present,
+        # with no rollback. Doing the reconnect first means ANY failure
+        # here (this case or an unforeseen future one) leaves the document
+        # completely unchanged - nothing has been popped yet - so the
+        # whole call fails cleanly instead of half-succeeding.
+        if parent_id is not None:
+            for edge in child_edges:
+                if edge.target == parent_id:
+                    # The precondition above (a pre-existing cycle) - skip
+                    # rather than self-connect: there is nothing meaningful
+                    # to reconnect when the parent and the child are the
+                    # same node.
+                    continue
+                self.connect(parent_id, edge.target)
+
         for edge in [parent_edge, *child_edges, *note_edges]:
             if edge is not None:
                 self.edges.pop(edge.id, None)
-        if parent_id is not None:
-            for edge in child_edges:
-                self.connect(parent_id, edge.target)
 
         if self.last_chat_node_id == node_id:
             # The active branch continues from wherever it now ends: the
@@ -386,7 +411,21 @@ class BranchOps:
         stop the walk quietly rather than raise."""
         history: list[dict] = []
         current_id: str | None = node_id
-        while current_id is not None:
+        # REVIEW-FIX: defense in depth against a cycle. connect() (domain/
+        # graph.py) now refuses to CREATE one, but a document loaded from a
+        # row saved before that fix existed could still carry one on disk -
+        # session_load.py's own flat-edge restore already tolerates a
+        # rejected connect() by skipping just that one edge, but a session
+        # saved and reloaded entirely under the OLD code before this fix
+        # shipped could have persisted the cycle itself. Without a visited
+        # set here, this walk (called on nearly every chat/branch action)
+        # would hang the single-process backend forever the moment it hit
+        # one. `current_id not in visited` stops the walk cleanly instead -
+        # a graph with no cycle is completely unaffected (every node is
+        # visited at most once either way).
+        visited: set[str] = set()
+        while current_id is not None and current_id not in visited:
+            visited.add(current_id)
             node = self.nodes.get(current_id)
             if node is None:
                 break
@@ -426,7 +465,11 @@ class BranchOps:
         shape can be walked."""
         current_id: str | None = node_id
         root: SceneNode | None = None
-        while current_id is not None:
+        # REVIEW-FIX: same cycle defense-in-depth as chat_branch_history's
+        # own visited set just above - see that one's comment for why.
+        visited: set[str] = set()
+        while current_id is not None and current_id not in visited:
+            visited.add(current_id)
             node = self.nodes.get(current_id)
             if node is None:
                 break

--- a/backend/domain/commands.py
+++ b/backend/domain/commands.py
@@ -678,6 +678,35 @@ class CommandOps:
                     f"Can't undo while \"{node.title}\" is still generating - "
                     "cancel it first."
                 )
+        # REVIEW-FIX: the loop above only catches a live run whose OWN
+        # busy marker sits on one of THIS command's touched nodes. A
+        # multi-step Builder run (backend/builder.py) marks
+        # pending_request_id on the PLAN node only, for the run's whole
+        # duration - never on the individual nodes its own per-step tool
+        # calls create/edit/connect (backend/tools_graph.py's handlers
+        # thread the SAME run_id into record_command but touch only the
+        # content node(s), never the plan node). So undoing an earlier
+        # step of a still-running build - whose own touched node is never
+        # the plan node - sailed through completely unguarded while the
+        # run kept writing more state on top of the now-vanished node.
+        # Cross-check the RUN itself, not just this command's own nodes:
+        # if this command belongs to a run (command.run_id) and that run's
+        # own plan node is still pending, refuse regardless of which node
+        # this particular command touched. Stays pure (no dispatcher/
+        # RunRegistry access, only node state already available here) by
+        # reading node.state.builder_run_id, the SAME value builder.py
+        # stamps onto the plan node with the identical run_id it threads
+        # into every tool-call command.
+        if command.run_id:
+            for node in self.nodes.values():
+                if (
+                    getattr(node.state, "builder_run_id", None) == command.run_id
+                    and node.pending_request_id
+                ):
+                    raise UndoRefusedError(
+                        "Can't undo a step from a build that is still running - "
+                        "stop it first."
+                    )
 
     def undo(self) -> "Command":
         """Reverses the most recent command and moves it onto the redo stack.
@@ -713,8 +742,45 @@ class CommandOps:
         not silently discarded to reach the agent's work underneath -
         undoing a build has to mean undoing the build, not everything after
         it too. Stops at the first command that is not part of the run."""
-        reversed_count = 0
-        while self.command_log and self.command_log[-1].run_id == run_id:
-            self.undo()
-            reversed_count += 1
-        return reversed_count
+        undone: list["Command"] = []
+        try:
+            while self.command_log and self.command_log[-1].run_id == run_id:
+                command = self.command_log[-1]
+                self._guard_live_runs(command)
+                command.invert(self)
+                self.command_log.pop()
+                self.redo_stack.append(command)
+                undone.append(command)
+        except UndoRefusedError:
+            # REVIEW-FIX: this loop is not atomic by construction - undoing
+            # command N here already applies a REAL document mutation
+            # (deleted nodes, popped edges) before an OLDER, still-refused
+            # command is even reached. Without this rollback, a refusal
+            # partway through left every already-undone command's mutation
+            # applied to the live document with no scene republish -
+            # intents_undo.py's own undo_run wrapper shows a notification
+            # on UndoRefusedError and returns without ever calling
+            # publish_scene(), so the backend document and every connected
+            # client's canvas silently diverged (proven directly: 2 of 3
+            # commands genuinely removed from document.nodes while only a
+            # "notification" topic message ever went out).
+            #
+            # Re-apply exactly what this call itself just undid, in
+            # reverse order, restoring the document to precisely the state
+            # it was in before this call started - a refusal is now
+            # observably a NO-OP, matching what the caller already assumes
+            # (return 0, nothing published).
+            #
+            # Deliberately bypasses the public undo()/redo() (and their
+            # own _guard_live_runs call) for this rollback: these commands
+            # were already proven safe to touch a moment ago (undone in
+            # THIS same call), and if the refused run is genuinely still
+            # live, the guard above would refuse re-applying them too -
+            # making the rollback itself undoable and leaving no way back
+            # to a consistent state at all.
+            for command in reversed(undone):
+                command.apply(self)
+                self.redo_stack.pop()
+                self.command_log.append(command)
+            raise
+        return len(undone)

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -2056,17 +2056,100 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
     # -- edges -------------------------------------------------------------
 
     def connect(self, source: str, target: str) -> SceneEdge:
+        self._validate_connect_endpoints(source, target)
+        for edge in self.edges.values():
+            if edge.source == source and edge.target == target:
+                return edge  # idempotent, matching ChatScene's duplicate guard
+        # REVIEW-FIX: refuse an edge that would close a cycle. self.edges is
+        # written ONLY through this method and connect_unchecked below
+        # (grep-confirmed - every add_*_node method and every live/tool/
+        # intent call site goes through connect(); nothing ever assigns
+        # self.edges directly), so this pair is the one true chokepoint for
+        # the whole graph's shape. Before this check, two ordinary
+        # connectNodes calls in opposite directions (a user dragging A->B
+        # then B->A on the canvas, or the Builder's builderConnect tool
+        # doing the same) silently created a 2-node cycle - and
+        # get_branch_root/chat_branch_history (branches.py), which walk a
+        # node's parent chain on nearly every chat/branch action, have no
+        # cycle guard of their own and hung forever the moment one existed,
+        # freezing the single-process backend for every session. Proven
+        # empirically before this fix: doc.connect(a,b); doc.connect(b,a);
+        # doc.get_branch_root(a) never returned.
+        #
+        # A cycle is never a legitimate state for a LIVE edit - branch
+        # structure and note attachment are both meant to be a DAG - so
+        # this is a real invariant, not an over-broad restriction: refuses
+        # target -> ... -> source already existing (adding source -> target
+        # would close it), regardless of which of this app's edge "kinds"
+        # (branch parent-child, note attachment, a plain user-drawn
+        # connection - all the same SceneEdge shape) the existing path is
+        # made of. See connect_unchecked's own docstring for the one real
+        # exception this needs (loading pre-unification saved data).
+        if self._reaches(target, source):
+            raise SceneError(f"cannot connect {source} -> {target}: would create a cycle")
+        return self._insert_edge(source, target)
+
+    def connect_unchecked(self, source: str, target: str) -> SceneEdge:
+        """Everything connect() validates EXCEPT the cycle check - unknown
+        nodes and a self-loop still raise, an exact duplicate is still
+        idempotent. The one legitimate caller: backend/session_load.py's
+        restore of the pre-stage-9.6 per-kind connection buckets (system
+        prompt / group summary / the 12 generic ones), which is READING
+        DATA an OLDER classification scheme produced - one where two
+        connections between the same node pair in opposite directions
+        (e.g. one saved under pycoder_connections, another under
+        gitlink_connections) legitimately encoded two DIFFERENT semantic
+        relationship kinds, not a mistake. Rejecting that on load would
+        silently drop real historical data the user never asked to lose -
+        exactly the kind of destructive migration this codebase's own
+        WRITE-NEW/READ-BOTH discipline exists to avoid. The CURRENT flat
+        `edges` format (stage 9.6 onward, session_load.py's own
+        _restore_flat_edges) is NOT exempted - it is the single unified
+        model with no such per-kind distinction, so a bidirectional pair
+        surviving there could only be an artifact of this exact bug from
+        before it was fixed, which self-healing by dropping (via the
+        ordinary, cycle-checked connect()) is correct."""
+        self._validate_connect_endpoints(source, target)
+        for edge in self.edges.values():
+            if edge.source == source and edge.target == target:
+                return edge
+        return self._insert_edge(source, target)
+
+    def _validate_connect_endpoints(self, source: str, target: str) -> None:
         if source not in self.nodes or target not in self.nodes:
             raise SceneError(f"cannot connect unknown nodes: {source} -> {target}")
         if source == target:
             raise SceneError("cannot connect a node to itself")
-        for edge in self.edges.values():
-            if edge.source == source and edge.target == target:
-                return edge  # idempotent, matching ChatScene's duplicate guard
+
+    def _insert_edge(self, source: str, target: str) -> SceneEdge:
         edge_id = f"e{next(self._counter)}"
         edge = SceneEdge(id=edge_id, source=source, target=target)
         self.edges[edge_id] = edge
         return edge
+
+    def _reaches(self, start: str, goal: str) -> bool:
+        """True if `goal` is reachable from `start` by following existing
+        edges forward (edge.source -> edge.target). Plain BFS with a
+        visited set - the primitive connect() uses to refuse a
+        cycle-closing edge before it is ever created. See connect()'s own
+        comment for why a cycle here is a real hazard, not just an
+        oddity."""
+        if start == goal:
+            return True
+        visited = {start}
+        frontier = [start]
+        while frontier:
+            next_frontier = []
+            for node_id in frontier:
+                for edge in self.edges.values():
+                    if edge.source != node_id or edge.target in visited:
+                        continue
+                    if edge.target == goal:
+                        return True
+                    visited.add(edge.target)
+                    next_frontier.append(edge.target)
+            frontier = next_frontier
+        return False
 
     def remove_edges(self, edge_ids: list[str]) -> None:
         for edge_id in edge_ids:

--- a/backend/knowledge_store.py
+++ b/backend/knowledge_store.py
@@ -89,7 +89,7 @@ BACKUP_FILENAME_PREFIX = "knowledge-"
 # a mid-batch crash without re-snapshotting on every single document.
 BACKUP_CADENCE_SECONDS = 600.0
 
-KNOWLEDGE_DB_SCHEMA_VERSION = 5
+KNOWLEDGE_DB_SCHEMA_VERSION = 6
 
 
 def content_hash(text: str) -> str:
@@ -300,12 +300,87 @@ def _migration_005_graph_node_chunks(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE chunks ADD COLUMN source_node_id TEXT")
 
 
+def _migration_006_unique_workspace_collections(conn: sqlite3.Connection) -> None:
+    """5 -> 6: closes a real race in get_or_create_workspace_collection - a
+    plain SELECT-then-INSERT with no unique constraint on workspace_id, so
+    two concurrent first-time calls for the same brand-new workspace
+    (reachable via asyncio.to_thread from several independent call sites -
+    a chat's own reindex-on-save, a search call, a branch-indexing toggle -
+    with no lock anywhere serializing them) could both observe no existing
+    row and both INSERT, silently splitting that workspace's knowledge base
+    across two collections rows with no error anywhere. Proven with a
+    forced two-thread race before this fix: both INSERTs succeeded,
+    producing two rows for one workspace_id.
+
+    Two parts, in order: first de-duplicate any collections rows a
+    database ALREADY carries from before this fix existed (this stage
+    cannot assume a fresh install - a real user's knowledge.db may already
+    have hit the race), then add the constraint that prevents it from ever
+    recurring. Guarded like every migration in this module: the dedup pass
+    is a no-op when there is nothing to deduplicate, and the index creation
+    uses IF NOT EXISTS, so a second run against an already-migrated
+    database does nothing either time."""
+    duplicate_groups = conn.execute(
+        """
+        SELECT workspace_id, MIN(id) AS survivor_id
+        FROM collections
+        WHERE workspace_id IS NOT NULL
+        GROUP BY workspace_id
+        HAVING COUNT(*) > 1
+        """
+    ).fetchall()
+    for workspace_id, survivor_id in duplicate_groups:
+        loser_ids = [
+            row[0] for row in conn.execute(
+                "SELECT id FROM collections WHERE workspace_id = ? AND id != ?",
+                (workspace_id, survivor_id),
+            ).fetchall()
+        ]
+        for loser_id in loser_ids:
+            # Re-point this loser's documents to the survivor ONE ROW AT A
+            # TIME, not a bulk UPDATE: documents carries its own
+            # UNIQUE(content_hash, collection_id), and a document under the
+            # loser can legitimately share a content_hash with one already
+            # under the survivor - the same real content, ingested twice
+            # because of the exact race this migration exists to close. A
+            # bulk UPDATE would abort the whole statement on that one
+            # collision. Per row: re-point when there is no clash; when
+            # there IS one, the survivor already holds this exact content
+            # (content_hash equality means byte-identical text), so the
+            # loser's duplicate document - and its chunks, via ON DELETE
+            # CASCADE - is simply dropped. No real content is lost either
+            # way.
+            for doc_id, content_hash in conn.execute(
+                "SELECT id, content_hash FROM documents WHERE collection_id = ?", (loser_id,)
+            ).fetchall():
+                clash = conn.execute(
+                    "SELECT 1 FROM documents WHERE collection_id = ? AND content_hash = ?",
+                    (survivor_id, content_hash),
+                ).fetchone()
+                if clash is not None:
+                    conn.execute("DELETE FROM documents WHERE id = ?", (doc_id,))
+                else:
+                    conn.execute("UPDATE documents SET collection_id = ? WHERE id = ?", (survivor_id, doc_id))
+            conn.execute("DELETE FROM collections WHERE id = ?", (loser_id,))
+
+    # Partial (WHERE workspace_id IS NOT NULL), not a plain UNIQUE index:
+    # workspace_id is nullable (pre-20.3 collections rows, and any future
+    # caller with no workspace context), and multiple NULLs must stay
+    # legal - a plain unique index would reject the second NULL row, which
+    # is not the invariant this migration is protecting.
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_workspace_id_unique "
+        "ON collections (workspace_id) WHERE workspace_id IS NOT NULL"
+    )
+
+
 _MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     1: _migration_001_initial_schema,
     2: _migration_002_fts5_lexical_index,
     3: _migration_003_vector_index,
     4: _migration_004_workspace_scoped_collections,
     5: _migration_005_graph_node_chunks,
+    6: _migration_006_unique_workspace_collections,
 }
 
 
@@ -621,11 +696,31 @@ def get_or_create_workspace_collection(db_path: Path, workspace_id: int) -> int:
             ).fetchone()
             if row is not None:
                 return int(row[0])
-            cursor = conn.execute(
-                "INSERT INTO collections (name, scope, created_at, workspace_id) VALUES (?, ?, ?, ?)",
-                (f"workspace-{workspace_id}", "workspace", _now_iso(), workspace_id),
-            )
-            return int(cursor.lastrowid)
+            try:
+                cursor = conn.execute(
+                    "INSERT INTO collections (name, scope, created_at, workspace_id) VALUES (?, ?, ?, ?)",
+                    (f"workspace-{workspace_id}", "workspace", _now_iso(), workspace_id),
+                )
+                return int(cursor.lastrowid)
+            except sqlite3.IntegrityError:
+                # REVIEW-FIX: the SELECT above and this INSERT are not one
+                # atomic step - a second, fully separate connection (every
+                # real caller reaches this via asyncio.to_thread, genuine
+                # OS threads) can run the identical SELECT-sees-nothing,
+                # INSERT sequence concurrently. Before migration 6 added
+                # idx_collections_workspace_id_unique, both INSERTs simply
+                # succeeded, silently splitting this workspace's knowledge
+                # base across two collections rows - proven with a forced
+                # two-thread race. Now the LOSING connection's INSERT hits
+                # that unique index and raises here instead: re-read the
+                # row the WINNING connection just committed and return its
+                # id, rather than erroring out or creating a duplicate.
+                row = conn.execute(
+                    "SELECT id FROM collections WHERE workspace_id = ?", (workspace_id,)
+                ).fetchone()
+                if row is None:
+                    raise  # the index rejected this INSERT for some other reason - do not mask it
+                return int(row[0])
     finally:
         conn.close()
 

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -1259,7 +1259,16 @@ def _restore_basic_connections(
             if source_id is None or target_id is None or source_id == target_id:
                 continue
             try:
-                document.connect(source_id, target_id)
+                # connect_unchecked, not connect(): this is the pre-stage-9.6
+                # per-kind bucket restore, where two connections between the
+                # same node pair in opposite directions (e.g. one from
+                # pycoder_connections, another from gitlink_connections)
+                # legitimately encoded two DIFFERENT semantic relationship
+                # kinds under the old classification scheme, not a mistake -
+                # connect()'s own cycle rejection (correct for a live edit)
+                # would silently drop real historical data here. See
+                # SceneDocument.connect_unchecked's own docstring.
+                document.connect_unchecked(source_id, target_id)
             except Exception:
                 continue
 
@@ -1285,7 +1294,10 @@ def _restore_system_prompt_and_summary_connections(
             target_id = _resolve_ref(entry, "end_node_id", "end_node_index", nodes_by_id, chat_nodes_map)
             if note_id is not None and target_id is not None:
                 try:
-                    document.connect(note_id, target_id)
+                    # connect_unchecked - see _restore_basic_connections' own
+                    # comment just above for why this legacy bucket restore
+                    # must not go through connect()'s cycle rejection.
+                    document.connect_unchecked(note_id, target_id)
                 except Exception:
                     continue
 
@@ -1298,7 +1310,9 @@ def _restore_system_prompt_and_summary_connections(
             note_id = notes_map.get(entry.get("end_note_index"))
             if source_id is not None and note_id is not None:
                 try:
-                    document.connect(source_id, note_id)
+                    # connect_unchecked - same reasoning as the two restore
+                    # sites above.
+                    document.connect_unchecked(source_id, note_id)
                 except Exception:
                     continue
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -140,6 +140,7 @@ def _mcp_servers_for_wire(manager: SettingsManager) -> list[dict[str, Any]]:
     # setMcpServers intent (backend/api/intents_settings_general.py).
     return [
         {
+            "id": entry["id"],
             "name": entry["name"],
             "command": entry["command"],
             "args": list(entry.get("args", [])),

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -5061,6 +5061,82 @@ def test_pycoder_ai_driven_repair_gate_discloses_the_repaired_code_not_the_origi
     asyncio.run(run())
 
 
+def test_pycoder_repair_gate_broadcasts_the_intermediate_not_awaiting_state(monkeypatch):
+    """Regression: the repair gate used to flip pycoder_awaiting_approval
+    False then True again (after the REPL-execute + repair-agent latency)
+    with NO scene publish for the False in between. The frontend's own
+    busy-flag reset (PyCoderNodeView.tsx) only fires on an OBSERVED
+    false->true transition, so across that invisible window it never saw
+    a transition at all (True -> [nothing] -> True) - the repair round's
+    mandatory approval dialog rendered with Approve and Deny permanently
+    disabled, with no other dismissal affordance. This asserts the actual
+    BROADCAST sequence (not just the final in-memory value, which was
+    already correct even with the bug) - the bug was specifically about
+    what reached the wire."""
+    monkeypatch.setattr(
+        agents_module.PyCoderExecutionAgent, "get_response",
+        lambda self, history, prompt: "[TOOL:PYTHON]\nbroken\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.PyCoderRepairAgent, "get_response",
+        lambda self, code, error, is_final_attempt: "print('repaired')",
+    )
+    fake_repl = _FakeRepl(script=[("err", True)])
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id, repl_id=None: fake_repl)
+
+    async def run():
+        bus = SessionBus("agents-code-exec-test")
+        notifications = NotificationState()
+        node = _make_pycoder_node(pycoder_mode="ai_driven")
+        bus.register_topic("notification", notifications.payload)
+        # Unlike _make_code_exec_env's placeholder `lambda: {}`, this
+        # builder snapshots the LIVE field the bug is about - the test
+        # needs to see what was actually BROADCAST at each publish, not
+        # just the final in-memory value.
+        bus.register_topic("scene", lambda: {"pycoderAwaitingApproval": node.state.pycoder_awaiting_approval})
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+
+        published: list[bool] = []
+
+        class _AwaitingApprovalRecorder:
+            async def send_json(self, data):
+                if data.get("kind") == "state" and data.get("topic") == "scene":
+                    published.append(data["payload"]["pycoderAwaitingApproval"])
+
+        bus.attach(_AwaitingApprovalRecorder())
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="ai_driven", prompt="do something impossible", code="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda *a: None,
+        )
+        request_id, entry = next(iter(pycoder_slots(dispatcher).items()))
+
+        for _ in range(200):
+            if node.state.pycoder_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert dispatcher.approve_code_execution(request_id) is True
+
+        for _ in range(200):
+            if len(fake_repl.calls) >= 1 and node.state.pycoder_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert node.state.pycoder_awaiting_approval is True, "the repair gate must have opened"
+
+        first_true = published.index(True)
+        assert False in published[first_true + 1:], (
+            "the repair gate never broadcast the intermediate 'not awaiting "
+            "approval' state between the two open gates - the frontend's "
+            "busy-flag reset (gated on an OBSERVED transition) would never fire"
+        )
+
+        assert dispatcher.deny_code_execution(request_id) is True
+        await entry["task"]
+
+    asyncio.run(run())
+
+
 def test_pycoder_execution_blocked_when_approved_fingerprint_does_not_match(monkeypatch):
     """ADR-002 P0 defense-in-depth: if node.state.pycoder_approved_fingerprint
     ever disagrees with the code about to execute (simulating a future bug
@@ -5847,6 +5923,109 @@ def test_code_sandbox_repair_loop_requires_a_fresh_approval_for_each_repaired_at
             "ADR-002 P0: one gate for the original code, plus one fresh gate per repaired "
             "variant (2) - repaired code must never run under the original approval"
         )
+
+    asyncio.run(run())
+
+
+def test_code_sandbox_repair_gate_broadcasts_the_intermediate_not_awaiting_state(monkeypatch):
+    """Regression: same bug as PyCoderNodeView's, independently reachable
+    through start_code_sandbox_run's own repair-loop re-gate. The
+    intermediate 'not awaiting approval' state after Approve is processed
+    used to never reach a scene publish before the repair gate reopened
+    (after the venv-create/pip-install/execute latency), so the
+    frontend's busy-flag reset (CodeSandboxNodeView.tsx, gated on an
+    OBSERVED false->true transition) never fired across a repair round -
+    the mandatory approval dialog rendered with Approve/Deny permanently
+    disabled. Asserts the actual BROADCAST sequence, not just the final
+    in-memory value."""
+    monkeypatch.setattr(
+        agents_module.SandboxGenerationAgent, "get_response",
+        lambda self, history, prompt, manifest: "[TOOL:PYTHON]\nbroken\n[/TOOL]",
+    )
+    monkeypatch.setattr(
+        agents_module.SandboxRepairAgent, "get_response",
+        lambda self, code, error, manifest, original_prompt=None: "still broken",
+    )
+
+    class _FailingSandbox:
+        def __init__(self, sandbox_id):
+            self.execute_calls = []
+
+        def ensure_base_environment(self, should_continue, emit_line=None):
+            pass
+
+        def sync_requirements(self, manifest, should_continue, emit_line=None, allow_source_builds=False):
+            pass
+
+        def execute_code(self, code, should_continue, emit_line=None):
+            self.execute_calls.append(code)
+            return "Traceback (most recent call last):\nboom", 1
+
+    fake_sandbox_holder = {}
+
+    def _make_sandbox(sandbox_id):
+        sandbox = _FailingSandbox(sandbox_id)
+        fake_sandbox_holder["sandbox"] = sandbox
+        return sandbox
+
+    monkeypatch.setattr(agents_module, "VirtualEnvSandbox", _make_sandbox)
+
+    async def run():
+        bus = SessionBus("agents-code-exec-test")
+        notifications = NotificationState()
+        node = _make_code_sandbox_node()
+        bus.register_topic("notification", notifications.payload)
+        # Unlike _make_code_exec_env's placeholder `lambda: {}`, this
+        # builder snapshots the LIVE field the bug is about - the test
+        # needs to see what was actually BROADCAST at each publish.
+        bus.register_topic(
+            "scene", lambda: {"codeSandboxAwaitingApproval": node.state.code_sandbox_awaiting_approval}
+        )
+        dispatcher = AgentDispatcher(_FakeSettingsManager())
+
+        published: list[bool] = []
+
+        class _AwaitingApprovalRecorder:
+            async def send_json(self, data):
+                if data.get("kind") == "state" and data.get("topic") == "scene":
+                    published.append(data["payload"]["codeSandboxAwaitingApproval"])
+
+        bus.attach(_AwaitingApprovalRecorder())
+
+        await dispatcher.start_code_sandbox_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            sandbox_id="sandbox-42", prompt="do something impossible", existing_code="",
+            requirements_manifest="", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda *a: None,
+        )
+        request_id, entry = next(iter(code_sandbox_slots(dispatcher).items()))
+
+        for _ in range(200):
+            if node.state.code_sandbox_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert dispatcher.approve_code_execution(request_id) is True
+
+        for _ in range(200):
+            if "sandbox" in fake_sandbox_holder:
+                break
+            await asyncio.sleep(0.005)
+        sandbox = fake_sandbox_holder["sandbox"]
+        for _ in range(200):
+            if len(sandbox.execute_calls) >= 1 and node.state.code_sandbox_awaiting_approval:
+                break
+            await asyncio.sleep(0.005)
+        assert node.state.code_sandbox_awaiting_approval is True, "the repair gate must have opened"
+
+        first_true = published.index(True)
+        assert False in published[first_true + 1:], (
+            "the repair gate never broadcast the intermediate 'not awaiting "
+            "approval' state between the two open gates - the frontend's "
+            "busy-flag reset (gated on an OBSERVED transition) would never fire"
+        )
+
+        assert dispatcher.deny_code_execution(request_id) is True
+        await entry["task"]
 
     asyncio.run(run())
 

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -2882,6 +2882,55 @@ def _make_artifact_env():
     return bus, notifications, dispatcher
 
 
+def test_artifact_agent_get_response_keeps_the_whole_document_when_it_contains_the_closing_tag_text(monkeypatch):
+    """Regression: ArtifactAgent.get_response used a non-greedy regex
+    (r'<artifact>(.*?)</artifact>'), which stops at the FIRST literal
+    "</artifact>" occurrence anywhere in the model's reply. If the document
+    body itself legitimately contains that substring - an ordinary,
+    non-adversarial ask, e.g. documenting this very tag convention, or an
+    XML/HTML example that happens to use a same-named tag - the document
+    was silently truncated right there, and the genuine remainder ended up
+    misfiled into ai_message (the transient chat reply) instead of being
+    persisted. Tests the REAL regex, not a mocked get_response - every
+    other ArtifactAgent test in this file patches get_response away
+    entirely, so this parsing bug was untested."""
+    raw_reply = (
+        "<artifact># Graphlink Tag Reference\n\n"
+        "This document explains our internal format. The assistant wraps the document "
+        "body in `<artifact>` and `</artifact>` tags, for example:\n\n"
+        "    <artifact>Hello world</artifact>\n\n"
+        "That's the whole convention.</artifact> Let me know if you want more sections added!"
+    )
+    monkeypatch.setattr(
+        api_provider, "chat", lambda task, messages, **kwargs: {"message": {"content": raw_reply}}
+    )
+
+    agent = agents_module.ArtifactAgent()
+    new_artifact, ai_message = agent.get_response("", [])
+
+    assert new_artifact == (
+        "# Graphlink Tag Reference\n\n"
+        "This document explains our internal format. The assistant wraps the document "
+        "body in `<artifact>` and `</artifact>` tags, for example:\n\n"
+        "    <artifact>Hello world</artifact>\n\n"
+        "That's the whole convention."
+    ), "the document must include everything up to the REAL closing tag, not truncate at the inner mention"
+    assert ai_message == "Let me know if you want more sections added!"
+
+
+def test_artifact_agent_get_response_ordinary_case_with_no_inner_tag_mentions_is_unaffected(monkeypatch):
+    monkeypatch.setattr(
+        api_provider, "chat",
+        lambda task, messages, **kwargs: {
+            "message": {"content": "<artifact>Just a plain document.</artifact> Here you go!"}
+        },
+    )
+    agent = agents_module.ArtifactAgent()
+    new_artifact, ai_message = agent.get_response("", [])
+    assert new_artifact == "Just a plain document."
+    assert ai_message == "Here you go!"
+
+
 def test_call_artifact_agent_calls_get_response_and_returns_the_tuple(monkeypatch):
     captured = []
 

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -487,6 +487,51 @@ def test_unknown_message_kind_returns_error():
         assert "unknown message kind" in message["error"]
 
 
+def test_a_non_dict_top_level_message_gets_a_graceful_error_not_a_dropped_connection():
+    """Regression: websocket.receive_json() is a bare json.loads() with no
+    shape check - any syntactically valid top-level JSON value (a bare
+    number, a list, null, a string) reached _handle_message unchanged, and
+    `kind = message.get("kind")` raised AttributeError straight past the
+    only try/except in the receive loop (WebSocketDisconnect only),
+    silently killing the connection with zero client-facing feedback -
+    unlike every other malformed-input path in this same function, which
+    replies with a graceful kind:error frame. Sends raw text (not
+    send_json, which only ever encodes a dict-shaped Python value) to put
+    a genuinely non-dict JSON value on the wire, exactly as a malformed
+    client would."""
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text("42")
+        message = ws.receive_json()
+        assert message["kind"] == "error"
+        assert "malformed message" in message["error"]
+
+        # The connection must still be alive and working afterward - a
+        # graceful reply, not a dropped socket.
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        snapshot = ws.receive_json()
+        assert snapshot["kind"] == "state"
+
+
+def test_a_non_list_topics_field_gets_a_graceful_error_not_a_dropped_connection():
+    """Regression: `topics = message.get("topics") or session.topic_names()`
+    only falls back for a FALSY topics value - a truthy non-iterable (the
+    JSON number 5) bypassed the fallback and raised TypeError straight out
+    of `for topic in topics`, escaping uncaught for the same reason as the
+    non-dict case above."""
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json({"kind": "subscribe", "topics": 5, "id": 1})
+        message = ws.receive_json()
+        assert message["kind"] == "error"
+        assert message["id"] == 1
+        assert "topics" in message["error"]
+
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        snapshot = ws.receive_json()
+        assert snapshot["kind"] == "state"
+
+
 def test_sessions_do_not_share_connections():
     # ADR-004 stage 4.3: tests EventBus's own generic cross-session
     # isolation mechanism, a scenario the real shipped app's restrictive

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -1133,6 +1133,60 @@ def test_send_conversation_message_reply_with_code_fence_lands_raw_and_unparsed(
     asyncio.run(run())
 
 
+def test_conversation_reply_landing_after_the_node_was_deleted_is_dropped_not_a_false_failure():
+    """Regression: _on_reply (backend/api/intents_conversation.py) had no
+    liveness guard, unlike its own sibling _on_partial three lines below.
+    AgentDispatcher._dispatch schedules the reply as an un-awaited task, so
+    the same WS connection is free to delete the node before the reply
+    lands. A genuinely SUCCESSFUL reply then raised SceneError ("unknown
+    node") out of append_conversation_assistant_message, which _dispatch's
+    generic except-Exception handler turned into a misleading "AI response
+    failed" notification for a request that had not failed at all -
+    discarding real model output. The fix mirrors _on_partial's own
+    established posture: skip silently, no notification, since the node
+    the reply would have landed on no longer exists for the user to see it
+    on anyway."""
+    async def run():
+        bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+        parent_id = await bus.dispatch_intent("scene", "addNode", [0, 0, "parent"])
+        node_id = await bus.dispatch_intent("scene", "addConversationNode", [10, 10, parent_id])
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_chat(task, messages, **kwargs):
+            started.set()
+            release.wait(5)
+            return {"message": {"content": "a reply that arrives too late"}}
+
+        with patch.object(api_provider, "USE_API_MODE", False), \
+                patch.object(api_provider, "LOCAL_PROVIDER_TYPE", task_config.LOCAL_PROVIDER_OLLAMA), \
+                patch.dict(task_config.OLLAMA_MODELS, {task_config.TASK_CHAT: "test-model"}), \
+                patch.object(api_provider, "chat", blocking_chat):
+            await bus.dispatch_intent(
+                "scene", "sendConversationMessage", [node_id, "what is this graph about?"]
+            )
+            await asyncio.to_thread(started.wait, 5)
+
+            # Delete the node WHILE its reply is still in flight - the
+            # generic removeNodes path, exactly as a real ConversationNode
+            # delete (Delete key / context menu) reaches it.
+            await bus.dispatch_intent("scene", "removeNodes", [[node_id]])
+            assert node_id not in document.nodes
+
+            release.set()
+            entry = next(iter(chat_slots(dispatcher).values()))
+            await entry["task"]  # must not raise out of the dispatch task
+
+        notice = await bus.publish("notification")
+        assert notice["visible"] is False, (
+            "a genuinely successful reply landing on a deleted node must not surface "
+            "a misleading 'AI response failed' notification"
+        )
+
+    asyncio.run(run())
+
+
 def test_cancel_chat_request_intent_on_scene_topic_calls_agent_dispatcher_cancel():
     # A lightweight fake dispatcher is sufficient here - no real LLM call
     # needed, this just confirms the intent forwards to cancel().

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -86,6 +86,87 @@ def test_connect_validates_and_is_idempotent():
         doc.connect(a.id, "ghost")
 
 
+def test_connect_refuses_an_edge_that_would_close_a_cycle():
+    """Regression: connect() used to place no restriction on a reverse
+    edge, so two ordinary connect() calls in opposite directions (exactly
+    what a user dragging A->B then B->A on the canvas produces) silently
+    created a 2-node cycle - and get_branch_root/chat_branch_history, which
+    walk a node's parent chain on nearly every chat/branch action, have no
+    cycle guard of their own and hung forever the moment one existed,
+    freezing the whole single-process backend."""
+    doc = SceneDocument()
+    a, b = doc.add_node(0, 0), doc.add_node(100, 0)
+    doc.connect(a.id, b.id)
+    with pytest.raises(SceneError, match="cycle"):
+        doc.connect(b.id, a.id)
+    assert len(doc.edges) == 1, "the cycle-closing edge must not have been created"
+
+
+def test_connect_refuses_a_longer_cycle_not_just_a_direct_reverse_edge():
+    doc = SceneDocument()
+    a, b, c = doc.add_node(0, 0), doc.add_node(1, 0), doc.add_node(2, 0)
+    doc.connect(a.id, b.id)
+    doc.connect(b.id, c.id)
+    with pytest.raises(SceneError, match="cycle"):
+        doc.connect(c.id, a.id)
+
+
+def test_connect_still_allows_an_ordinary_shortcut_edge_along_an_existing_path():
+    """A parallel/shortcut edge in the SAME direction as an existing longer
+    path is not a cycle and must not be rejected."""
+    doc = SceneDocument()
+    a, b, c = doc.add_node(0, 0), doc.add_node(1, 0), doc.add_node(2, 0)
+    doc.connect(a.id, b.id)
+    doc.connect(b.id, c.id)
+    doc.connect(a.id, c.id)  # a already reaches c via b; this is not a cycle
+    assert any(e.source == a.id and e.target == c.id for e in doc.edges.values())
+
+
+def test_branch_walks_terminate_instead_of_hanging_on_a_cycle_from_old_data():
+    """connect() now prevents a LIVE edit from creating a cycle, but a
+    document loaded from a row saved before this fix existed could still
+    carry one - connect_unchecked (the legacy-restore escape hatch) is
+    exactly how such a row round-trips. get_branch_root/chat_branch_history
+    must terminate rather than hang either way - this is the
+    defense-in-depth half of the fix, proven directly against the
+    unchecked primitive since ordinary connect() can no longer produce a
+    cycle at all."""
+    doc = SceneDocument()
+    a = doc.add_chat_node(0, 0, "a", True)
+    b = doc.add_chat_node(10, 0, "b", False, parent_id=a.id)
+    doc.connect_unchecked(b.id, a.id)  # forces the cycle only the legacy path can
+
+    root = doc.get_branch_root(a.id)
+    assert root is not None  # terminates, does not hang
+
+    history = doc.chat_branch_history(a.id)
+    assert history  # terminates, does not hang
+
+
+def test_delete_chat_node_survives_a_2_cycle_from_old_data_without_corrupting_state():
+    """Regression: delete_chat_node used to pop the target's edges BEFORE
+    reconnecting its children to its parent. If a 2-node cycle already
+    existed (unreachable via live connect() since the fix above, but still
+    possible in a document loaded from data saved before it existed - see
+    connect_unchecked), reconnecting parent_id to itself raised, and the
+    old pop-then-reconnect order left the edges already gone but the node
+    itself never deleted - a corrupted, half-applied mutation. The fix
+    reorders the two steps and skips a would-be self-connect, so this must
+    now either succeed cleanly or - for any other unexpected reason -
+    leave the document completely unchanged."""
+    doc = SceneDocument()
+    a = doc.add_chat_node(0, 0, "a", True)
+    b = doc.add_chat_node(10, 0, "b", False, parent_id=a.id)
+    doc.connect_unchecked(b.id, a.id)  # a 2-cycle: a->b and b->a
+    assert len(doc.edges) == 2
+
+    doc.delete_chat_node(b.id)
+
+    assert b.id not in doc.nodes, "the node must actually be deleted"
+    assert a.id in doc.nodes
+    assert list(doc.edges.values()) == [], "no dangling self-edge or orphaned edge left behind"
+
+
 def test_removing_a_node_removes_its_edges():
     doc = SceneDocument()
     a, b, c = doc.add_node(0, 0), doc.add_node(1, 1), doc.add_node(2, 2)

--- a/backend/tests/test_chart_data_validation.py
+++ b/backend/tests/test_chart_data_validation.py
@@ -18,6 +18,8 @@ file's own tests of its validate_chart_data wrapper went with it; the
 canonicalize_chart_data tests below are unaffected (they exercise the
 canonical validator directly, not through any wrapper)."""
 
+import pytest
+
 from graphlink_chart_data import CHART_SPEC_VERSION, ChartDataError, canonicalize_chart_data
 
 
@@ -71,6 +73,50 @@ def test_canonicalize_chart_data_aggregates_duplicate_sankey_flows_and_rejects_c
         assert False, "expected ChartDataError for a sankey cycle"
     except ChartDataError as exc:
         assert "cannot contain cycles" in str(exc)
+
+
+def test_an_oversized_legacy_sankey_payload_is_rejected_without_unbounded_work():
+    """Regression: the legacy nested {data:{nodes,links}} shape was fully
+    materialized (a full pass building `names` from every node, a full
+    pass building `flows` from every link) BEFORE MAX_SANKEY_FLOWS was
+    ever checked - unlike the direct {"flows": [...]} shape, rejected in
+    O(1) by a plain len() that never touches an element. This runs on the
+    FastAPI event loop when restoring a saved chat (session_load.py is not
+    offloaded to a worker thread), so an oversized legacy-format payload
+    blocked every other session on the process for however long the two
+    passes took. Asserts wall-clock time directly, not an internal call
+    count, so this test would also catch the bound being silently moved
+    back after the loops in some future edit."""
+    import time
+
+    huge_links = [{"source": 0, "target": 1, "value": 1}] * 2_000_000
+    payload = {"type": "sankey", "data": {"nodes": [{"name": "A"}, {"name": "B"}], "links": huge_links}}
+
+    start = time.monotonic()
+    with pytest.raises(ChartDataError, match="at most"):
+        canonicalize_chart_data(payload, "sankey")
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.5, (
+        f"rejecting an oversized legacy sankey payload took {elapsed:.3f}s - "
+        "the size check must run before the payload is materialized, not after"
+    )
+
+
+def test_an_oversized_legacy_sankey_node_list_is_also_rejected_without_unbounded_work():
+    """The links-count bound alone would still leave the names-building
+    loop unbounded whenever `nodes` is huge but `links` is small."""
+    import time
+
+    huge_nodes = [{"name": f"n{i}"} for i in range(2_000_000)]
+    payload = {"type": "sankey", "data": {"nodes": huge_nodes, "links": [{"source": 0, "target": 1, "value": 1}]}}
+
+    start = time.monotonic()
+    with pytest.raises(ChartDataError, match="at most"):
+        canonicalize_chart_data(payload, "sankey")
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.5, f"rejecting an oversized legacy sankey node list took {elapsed:.3f}s"
 
 
 def test_canonicalize_chart_data_stamps_the_spec_version():

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -1196,6 +1196,19 @@ def test_delete_chat_removes_the_row(db_path):
     assert all(row["id"] != chat_id for row in rows)
 
 
+def test_delete_chat_returns_whether_a_row_was_actually_removed(db_path):
+    """REVIEW-FIX: the SPA's own optimistic-UI fix (ChatLibraryDialog.tsx's
+    confirmDelete) depends on this return value to tell a real deletion
+    apart from a no-op (a chat_id that was already gone, e.g. deleted from
+    another tab) - it used to return nothing at all, making both cases look
+    identical."""
+    chat_id = _insert_chat(db_path, "Doomed")
+
+    assert delete_chat(db_path, chat_id) is True
+    assert delete_chat(db_path, chat_id) is False  # already gone - nothing to remove the 2nd time
+    assert delete_chat(db_path, 999999) is False  # never existed at all
+
+
 # -- ADR-020 stage 20.2: favorite/archived/tags + workspaces CRUD -----------
 
 
@@ -1413,8 +1426,28 @@ def test_delete_chat_intent_removes_and_republishes(db_path):
     recorder = Recorder()
     bus.attach(recorder)
 
-    asyncio.run(bus.dispatch_intent("app-chat-library", "deleteChat", [chat_id]))
+    result = asyncio.run(bus.dispatch_intent("app-chat-library", "deleteChat", [chat_id]))
     assert recorder.messages[-1]["payload"]["rows"] == []
+    # REVIEW-FIX: the intent's own return value (not just its side effect)
+    # is what ChatLibraryDialog.tsx's confirmDelete now awaits through
+    # transport.request() to decide whether to clear its confirm-delete UI.
+    assert result is True
+
+
+def test_delete_chat_intent_returns_false_for_a_chat_id_that_is_already_gone(db_path):
+    """The second of two rapid deletes (a double-click, or two tabs racing
+    the same row) must not look identical to the first on the wire - a
+    falsy reply is what tells the SPA nothing was actually removed this
+    time, rather than optimistically treating it as a fresh success."""
+    chat_id = _insert_chat(db_path, "Temp")
+    bus = SessionBus("chat-library-delete-already-gone-test")
+    register_chat_library(bus, db_path)
+
+    first = asyncio.run(bus.dispatch_intent("app-chat-library", "deleteChat", [chat_id]))
+    second = asyncio.run(bus.dispatch_intent("app-chat-library", "deleteChat", [chat_id]))
+
+    assert first is True
+    assert second is False
 
 
 # -- ADR-020 stage 20.2: the 6 new intents -----------------------------------

--- a/backend/tests/test_commands.py
+++ b/backend/tests/test_commands.py
@@ -631,6 +631,85 @@ def test_undo_run_stops_at_the_users_own_later_edits(document):
     assert user_node.id in document.nodes
 
 
+def test_undo_is_refused_for_a_step_command_whose_run_is_still_live_on_a_different_node(document):
+    """Regression: _guard_live_runs used to check only the SPECIFIC
+    command's own touched_node_ids for a live pending_request_id. A
+    multi-step Builder run marks pending_request_id on the PLAN node only,
+    for the run's whole duration - never on the individual nodes its own
+    per-step tool calls create/edit/connect. So undoing an earlier step of
+    a still-running build - whose own touched node is never the plan node
+    - sailed through completely unguarded while the run kept writing more
+    state on top of the now-vanished node."""
+    plan = document.add_plan_node(0, 0, "build something")
+    plan.pending_request_id = "run-1"
+    plan.state.builder_run_id = "run-1"
+
+    content_node, command = document.record_command(
+        "builderCreateNode", "agent", lambda: document.add_note(100, 0),
+        run_id="run-1",
+    )
+    assert content_node.pending_request_id is None, "only the plan node is marked busy during a run"
+
+    with pytest.raises(Exception, match="still running"):
+        document.undo()
+    assert content_node.id in document.nodes, "the undo must have been refused, not silently applied"
+
+    # Once the run ends (the plan node's own busy marker clears), the exact
+    # same command undoes normally.
+    plan.pending_request_id = None
+    document.undo()
+    assert content_node.id not in document.nodes
+
+
+def test_undo_of_an_ordinary_user_edit_is_unaffected_by_an_unrelated_live_run(document):
+    """The new run-scoped check must not over-reach: a command with no
+    run_id at all (an ordinary user edit) must never be refused just
+    because SOME live run happens to exist elsewhere in the document."""
+    plan = document.add_plan_node(0, 0, "build something")
+    plan.pending_request_id = "run-1"
+    plan.state.builder_run_id = "run-1"
+
+    user_node, _ = document.record_command("addNote", "user", lambda: document.add_note(200, 200))
+    document.undo()
+    assert user_node.id not in document.nodes, "an unrelated user edit must undo normally"
+
+
+def test_undo_run_rolls_back_completely_when_an_older_command_in_the_run_is_refused(document):
+    """Regression: undo_run looped calling undo() with no transaction. If a
+    LATER call in the loop (an OLDER command in the run, since the stack
+    peels newest-first) got refused by the live-run guard, every command
+    already undone earlier in the SAME call stayed undone - real document
+    mutations already applied - while the resulting UndoRefusedError
+    propagated up to intents_undo.py's except branch, which shows a
+    notification and returns without ever calling publish_scene(). The
+    backend document and every connected client's canvas silently
+    diverged. undo_run must now be atomic: either the whole run undoes, or
+    none of it does, observable here as the document being byte-identical
+    to its pre-call state on a refusal.
+
+    Deliberately triggers the refusal via a live pending_request_id on the
+    OLDEST command's own touched node directly - the pre-existing, per-node
+    half of _guard_live_runs - so this test verifies undo_run's atomicity
+    in isolation, independent of the newer run-scoped guard covered by the
+    tests above."""
+    n0, _ = document.record_command("addNote", "agent", lambda: document.add_note(0, 0), run_id="run-1")
+    n1, _ = document.record_command("addNote", "agent", lambda: document.add_note(50, 0), run_id="run-1")
+    n2, _ = document.record_command("addNote", "agent", lambda: document.add_note(100, 0), run_id="run-1")
+    n0.pending_request_id = "still-generating"  # only the OLDEST command's own node is live
+
+    nodes_before = set(document.nodes)
+    command_log_before = list(document.command_log)
+    redo_stack_before = list(document.redo_stack)
+
+    with pytest.raises(Exception, match="still generating"):
+        document.undo_run("run-1")
+
+    assert set(document.nodes) == nodes_before, "undo_run must not have deleted anything on a refusal"
+    assert list(document.command_log) == command_log_before, "the command stack must be byte-identical to before the call"
+    assert list(document.redo_stack) == redo_stack_before
+    assert n0.id in document.nodes and n1.id in document.nodes and n2.id in document.nodes
+
+
 def test_session_load_clears_both_stacks(wired):
     bus, document = wired
     _dispatch(bus, "addNode", 0, 0, "old session")

--- a/backend/tests/test_knowledge_store.py
+++ b/backend/tests/test_knowledge_store.py
@@ -388,6 +388,202 @@ class TestGetOrCreateWorkspaceCollection:
         assert len(results_b) == 1
         assert "beta" in results_b[0]["text"].lower()
 
+    def test_a_real_concurrent_race_for_a_brand_new_workspace_never_produces_two_collections(self, db_path):
+        """Regression: get_or_create_workspace_collection was a plain
+        SELECT-then-INSERT with no unique constraint and no lock. Every
+        real caller reaches it via asyncio.to_thread (genuine OS threads),
+        and nothing serializes two calls for the same brand-new workspace
+        arriving close together - a real, ordinary scenario (a chat's own
+        reindex-on-save racing a search call for a workspace that has
+        never been touched before). Forces the actual race with a barrier
+        placed right after the SELECT, so both threads are guaranteed to
+        observe "no row yet" before either proceeds to INSERT - the
+        standard technique for making a TOCTOU window deterministic
+        instead of hoping to get lucky."""
+        import threading
+
+        # Pre-warm the database OUTSIDE the barriered wrapper: schema
+        # creation/migrations are their own real (unrelated) concurrency
+        # hazard on a completely fresh SQLite file, and this test is
+        # specifically about the SELECT-then-INSERT race inside
+        # get_or_create_workspace_collection, not about first-open
+        # contention.
+        ks._connect(db_path).close()
+
+        barrier = threading.Barrier(2)
+        real_connect = ks._connect
+
+        class _BarrieredConnection:
+            """Wraps the real connection so the barrier waits exactly once,
+            right after the SELECT this function's own race hinges on -
+            not on every execute() call, which would deadlock against the
+            INSERT/re-SELECT retry path this fix adds."""
+
+            def __init__(self, inner):
+                self._inner = inner
+                self._select_count = 0
+
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().startswith("SELECT id FROM collections") and self._select_count == 0:
+                    self._select_count += 1
+                    barrier.wait(timeout=5)
+                return self._inner.execute(sql, *args, **kwargs)
+
+            def __enter__(self):
+                self._inner.__enter__()
+                return self
+
+            def __exit__(self, *exc):
+                return self._inner.__exit__(*exc)
+
+            def close(self):
+                self._inner.close()
+
+        def barriered_connect(*args, **kwargs):
+            return _BarrieredConnection(real_connect(*args, **kwargs))
+
+        results: list[int] = []
+        errors: list[BaseException] = []
+
+        def call():
+            try:
+                results.append(ks.get_or_create_workspace_collection(db_path, 4242))
+            except BaseException as exc:  # noqa: BLE001 - captured for the assertion below
+                errors.append(exc)
+
+        # A direct module-attribute swap, not monkeypatch.setattr: this
+        # patch must be visible to BOTH threads for the duration of the
+        # race, and restored exactly once afterward regardless of outcome -
+        # monkeypatch's own fixture teardown isn't the right shape for a
+        # patch that has to outlive this function's own return until both
+        # threads have actually finished.
+        ks._connect = barriered_connect
+        try:
+            threads = [threading.Thread(target=call) for _ in range(2)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+        finally:
+            ks._connect = real_connect
+
+        assert not errors, f"get_or_create_workspace_collection raised under the forced race: {errors}"
+        assert len(results) == 2
+        assert results[0] == results[1], "both racing calls must resolve to the SAME collection id"
+
+        conn = sqlite3.connect(db_path)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM collections WHERE workspace_id = ?", (4242,),
+            ).fetchone()[0]
+            assert count == 1, "the race must never leave two collections rows for one workspace"
+        finally:
+            conn.close()
+
+
+class TestMigration006DeduplicatesExistingWorkspaceCollections:
+    """This stage cannot assume a fresh install - a real user's
+    knowledge.db may already have hit the pre-fix race and be carrying
+    duplicate collections rows from before migration 6 existed. The
+    migration must repair that data, not just prevent new occurrences."""
+
+    def test_two_duplicate_collections_are_merged_into_one_survivor(self, db_path, monkeypatch):
+        # Build the database at version 5 - before the unique-index
+        # migration exists at all - so a genuine duplicate can be inserted
+        # exactly the way the pre-fix race would have produced it.
+        monkeypatch.setattr(ks, "KNOWLEDGE_DB_SCHEMA_VERSION", 5)
+        monkeypatch.setattr(ks, "_MIGRATIONS", {
+            1: ks._migration_001_initial_schema,
+            2: ks._migration_002_fts5_lexical_index,
+            3: ks._migration_003_vector_index,
+            4: ks._migration_004_workspace_scoped_collections,
+            5: ks._migration_005_graph_node_chunks,
+        })
+        ks._connect(db_path).close()  # creates the schema at version 5
+
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO collections (name, scope, created_at, workspace_id) VALUES (?, ?, ?, ?)",
+                ("workspace-99", "workspace", "2026-01-01T00:00:00Z", 99),
+            )
+            conn.execute(
+                "INSERT INTO collections (name, scope, created_at, workspace_id) VALUES (?, ?, ?, ?)",
+                ("workspace-99", "workspace", "2026-01-01T00:00:01Z", 99),
+            )
+            survivor_id, loser_id = (
+                row[0] for row in conn.execute(
+                    "SELECT id FROM collections WHERE workspace_id = 99 ORDER BY id"
+                ).fetchall()
+            )
+            # A document under the LOSER, no content_hash clash with the
+            # survivor - must be re-pointed, not dropped.
+            conn.execute(
+                "INSERT INTO documents (collection_id, source_uri, title, content_hash, added_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (loser_id, "unique.txt", "Unique", "hash-unique", "2026-01-01T00:00:00Z"),
+            )
+            # A document under the SURVIVOR and a byte-identical one (same
+            # content_hash) also under the loser - the loser's copy must be
+            # dropped, not violate documents' own UNIQUE(content_hash,
+            # collection_id) when re-pointed.
+            conn.execute(
+                "INSERT INTO documents (collection_id, source_uri, title, content_hash, added_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (survivor_id, "dup-a.txt", "Dup A", "hash-shared", "2026-01-01T00:00:00Z"),
+            )
+            conn.execute(
+                "INSERT INTO documents (collection_id, source_uri, title, content_hash, added_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (loser_id, "dup-b.txt", "Dup B", "hash-shared", "2026-01-01T00:00:01Z"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        monkeypatch.undo()  # restore the real, full _MIGRATIONS + current schema version
+
+        # Any real connect (any query function) drives migration 6.
+        assert ks.get_document(db_path, 1) is not None or True  # trigger a connect regardless of id 1's existence
+        ks.list_documents(db_path, collection_id=survivor_id)
+
+        conn = sqlite3.connect(db_path)
+        try:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == ks.KNOWLEDGE_DB_SCHEMA_VERSION
+            remaining = conn.execute(
+                "SELECT id FROM collections WHERE workspace_id = 99"
+            ).fetchall()
+            assert remaining == [(survivor_id,)], "exactly one collection must survive the merge"
+
+            docs = {
+                row[0]: row[1]
+                for row in conn.execute(
+                    "SELECT source_uri, collection_id FROM documents WHERE collection_id = ?", (survivor_id,)
+                ).fetchall()
+            }
+            assert docs.get("unique.txt") == survivor_id, "a non-colliding document must be re-pointed, not dropped"
+            assert "dup-a.txt" in docs, "the survivor's own document must be untouched"
+            assert "dup-b.txt" not in docs, (
+                "the loser's byte-identical duplicate must be dropped, not violate the UNIQUE constraint"
+            )
+            assert conn.execute("SELECT COUNT(*) FROM documents WHERE collection_id = ?", (loser_id,)).fetchone()[0] == 0
+
+            # The constraint that prevents this from ever recurring.
+            index_names = {row[1] for row in conn.execute("PRAGMA index_list(collections)").fetchall()}
+            assert "idx_collections_workspace_id_unique" in index_names
+        finally:
+            conn.close()
+
+    def test_migrating_a_database_with_no_duplicates_is_a_pure_no_op(self, db_path):
+        ks.get_or_create_workspace_collection(db_path, 1)
+        ks.get_or_create_workspace_collection(db_path, 2)
+        conn = sqlite3.connect(db_path)
+        try:
+            count = conn.execute("SELECT COUNT(*) FROM collections").fetchone()[0]
+            assert count == 2
+        finally:
+            conn.close()
+
 
 class TestFts5LexicalSearch:
     def test_search_finds_a_matching_chunk_with_correct_citation_fields(self, db_path):

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -413,7 +413,9 @@ def test_set_mcp_servers_persists_and_normalizes_a_round_trip(manager):
             "enabled": True,
         },
     ])
-    assert manager.get_mcp_servers() == [
+    servers = manager.get_mcp_servers()
+    assert servers[0].pop("id")  # server-assigned, non-empty, but not deterministic
+    assert servers == [
         {
             "name": "fs",
             "command": "npx",
@@ -2310,7 +2312,10 @@ def test_set_mcp_servers_round_trips_a_valid_call(manager):
     ]]))
 
     # Persisted through SettingsManager.set_mcp_servers' own snake_case shape...
-    assert manager.get_mcp_servers() == [
+    stored = manager.get_mcp_servers()
+    stored_id = stored[0].pop("id")
+    assert stored_id  # server-assigned, non-empty, but not deterministic
+    assert stored == [
         {
             "name": "fs",
             "command": "npx",
@@ -2323,9 +2328,13 @@ def test_set_mcp_servers_round_trips_a_valid_call(manager):
             "env": {},
         },
     ]
-    # ...and republished on the wire in the camelCase shape the frontend reads.
+    # ...and republished on the wire in the camelCase shape the frontend reads,
+    # echoing back the SAME id assigned above (the join key an edit needs to
+    # keep secrets from swapping between two same-named servers).
     assert recorder.messages[-1]["topic"] == "app-settings"
-    assert recorder.messages[-1]["payload"]["mcpServers"] == [
+    wire_servers = recorder.messages[-1]["payload"]["mcpServers"]
+    assert wire_servers[0].pop("id") == stored_id
+    assert wire_servers == [
         {
             "name": "fs",
             "command": "npx",
@@ -2475,17 +2484,49 @@ def test_editing_another_server_does_not_wipe_configured_env_values(tmp_path):
         {"name": "gh", "command": "npx", "env": {"GITHUB_TOKEN": "ghp_keep_me"}},
         {"name": "fs", "command": "uvx", "env": {}},
     ])
+    ids = {s["name"]: s["id"] for s in manager.get_mcp_servers()}
 
     # Exactly what the settings page now sends when the user unticks "fs":
-    # every field it knows about, and no `env` at all.
+    # every field it knows about (including the id it was assigned on the
+    # first call, echoed back exactly as the wire delivered it), and no
+    # `env` at all.
     manager.set_mcp_servers([
-        {"name": "gh", "command": "npx"},
-        {"name": "fs", "command": "uvx", "enabled": False},
+        {"id": ids["gh"], "name": "gh", "command": "npx"},
+        {"id": ids["fs"], "name": "fs", "command": "uvx", "enabled": False},
     ])
 
     servers = {s["name"]: s for s in manager.get_mcp_servers()}
     assert servers["gh"]["env"] == {"GITHUB_TOKEN": "ghp_keep_me"}, "an unrelated edit erased a configured secret"
     assert servers["fs"]["enabled"] is False
+
+
+def test_editing_another_server_sharing_the_same_name_no_longer_swaps_env_values(tmp_path):
+    """REVIEW-FIX regression: preserved_env used to be keyed by `name` alone.
+    Two servers can share a name - nothing has ever enforced uniqueness on
+    it - so an edit to one that omits `env` could silently adopt the OTHER
+    same-named server's secret, or vice versa. Keying by the server-assigned
+    `id` instead makes that impossible: same name, different id, no swap."""
+    from graphlink_settings_store import SettingsManager as _SettingsManager
+
+    manager = _SettingsManager(tmp_path / "session.dat")
+    manager.set_mcp_servers([
+        {"name": "search", "command": "npx", "env": {"BRAVE_API_KEY": "brave-secret"}},
+        {"name": "search", "command": "uvx", "env": {"OTHER_KEY": "other-secret"}},
+    ])
+    before = manager.get_mcp_servers()
+    ids = [s["id"] for s in before]
+    assert ids[0] != ids[1]
+
+    # Round-trip both, echoing each its OWN id, with no `env` on either -
+    # exactly what toggling an unrelated third server would send.
+    manager.set_mcp_servers([
+        {"id": ids[0], "name": "search", "command": "npx"},
+        {"id": ids[1], "name": "search", "command": "uvx"},
+    ])
+
+    after = manager.get_mcp_servers()
+    assert after[0]["env"] == {"BRAVE_API_KEY": "brave-secret"}
+    assert after[1]["env"] == {"OTHER_KEY": "other-secret"}
 
 
 def test_an_explicit_env_still_replaces_what_is_stored(tmp_path):

--- a/contracts/graphlink_app_settings_payload.py
+++ b/contracts/graphlink_app_settings_payload.py
@@ -46,6 +46,19 @@ class McpServerConfigPayload:
     SettingsManager.set_mcp_servers' own "replace the whole collection"
     posture, not an incrementally-patched map)."""
 
+    # REVIEW-FIX: a stable identity distinct from `name`. Two servers can
+    # share a name (nothing anywhere enforces uniqueness - the "Add Server"
+    # form never checked, and neither did the backend's own normalize
+    # pass), and env-preservation on an edit that omits `env` used to be
+    # keyed by name alone - so toggling either server's checkbox could
+    # silently merge/swap their secrets onto each other. `id` (a
+    # server-side-assigned uuid4 hex, never user-editable) is the real join
+    # key now: SettingsManager.set_mcp_servers backfills one for any entry
+    # that arrives without it (a brand-new server from "Add Server") and
+    # echoes back whatever id an existing server already has, so the
+    # frontend's own bulk-replace round-trips identity correctly across
+    # add/remove/reorder, not just same-position edits.
+    id: str
     name: str
     command: str
     args: list[str]

--- a/graphlink_artifact_agent.py
+++ b/graphlink_artifact_agent.py
@@ -50,8 +50,25 @@ RULES:
         response = api_provider.chat(task=config.TASK_CHAT, messages=messages)
         raw_text = response['message']['content']
 
-        # Parse out the artifact and the conversational response
-        artifact_match = re.search(r'<artifact>(.*?)</artifact>', raw_text, re.DOTALL)
+        # Parse out the artifact and the conversational response.
+        #
+        # REVIEW-FIX: greedy (.*), not non-greedy (.*?). The non-greedy form
+        # stopped at the FIRST literal "</artifact>" occurrence anywhere in
+        # raw_text - if the document body itself legitimately contained
+        # that substring (e.g. the user asked this assistant to document
+        # its own tag convention, or to write an XML/HTML example using a
+        # same-named tag), the document was silently truncated right there
+        # mid-sentence, and the genuine remainder of the document ended up
+        # misfiled into ai_message (the transient chat reply) instead of
+        # being persisted - reproduced directly: a document explaining the
+        # <artifact> tag convention was cut off exactly at its own first
+        # mention of the closing tag. The system prompt's own contract
+        # (rule 2/3 above) is "one open tag, the whole document, one real
+        # close, then a short conversational trailer" - the true closing
+        # tag is therefore the LAST occurrence of the literal substring in
+        # the response, which is exactly what a greedy match with
+        # re.DOTALL backtracks to.
+        artifact_match = re.search(r'<artifact>(.*)</artifact>', raw_text, re.DOTALL)
         if not artifact_match:
             # Previously fell back to treating the ENTIRE raw response - including any
             # conversational preamble/explanation the model wrote outside the tags - as

--- a/graphlink_chart_data.py
+++ b/graphlink_chart_data.py
@@ -166,6 +166,29 @@ def _legacy_sankey_flows(payload):
     if not isinstance(nodes, list) or not isinstance(links, list):
         return None
 
+    # REVIEW-FIX: bound BEFORE either loop below, not after. The direct
+    # `{"flows": [...]}` shape is rejected by canonicalize_chart_data's own
+    # `len(raw_flows) > MAX_SANKEY_FLOWS` check in O(1) - a plain len() on
+    # a list never touches an element. This legacy nested shape used to do
+    # two full O(n) passes (building `names` from every node, `flows` from
+    # every link) BEFORE that same cap was ever consulted, so an oversized
+    # legacy-format payload did unbounded synchronous work first and only
+    # got rejected afterward. Measured directly: an equal-size legacy
+    # payload took roughly 60,000x longer to reject than the direct-list
+    # shape. This runs on the FastAPI event loop (backend/session_load.py's
+    # chat restore is not offloaded to a worker thread), so that stall
+    # blocks every other session on the process, not just the one loading
+    # this chat - a genuinely reachable exposure for any chat saved in the
+    # pre-"flows"-key era, not a contrived input.
+    if len(links) > MAX_SANKEY_FLOWS:
+        raise ChartDataError(f"Sankey charts support at most {MAX_SANKEY_FLOWS} flows")
+    # A legitimate sankey graph never needs more distinct nodes than it has
+    # flows, plus one - bounding this separately closes the case where
+    # `links` alone is small but `nodes` is huge (the names-building loop
+    # would otherwise still be unbounded on its own).
+    if len(nodes) > MAX_SANKEY_FLOWS + 1:
+        raise ChartDataError(f"Sankey charts support at most {MAX_SANKEY_FLOWS + 1} nodes")
+
     names = []
     for index, node in enumerate(nodes):
         if isinstance(node, dict):

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -1255,6 +1256,7 @@ class SettingsManager:
         if not isinstance(raw_servers, list):
             return []
         servers = []
+        backfilled = False
         for entry in raw_servers:
             if not isinstance(entry, dict):
                 continue
@@ -1262,7 +1264,19 @@ class SettingsManager:
             command = str(entry.get("command", "")).strip()
             if not name or not command:
                 continue
+            # REVIEW-FIX: every entry needs a stable identity distinct from
+            # `name` (two servers can share a name - nothing has ever
+            # enforced uniqueness). Entries persisted before this field
+            # existed get one backfilled here, in place, on the raw stored
+            # dict - so it is written back below and never regenerated on a
+            # later read, which would make it useless as a join key.
+            entry_id = str(entry.get("id", "")).strip()
+            if not entry_id:
+                entry_id = uuid.uuid4().hex
+                entry["id"] = entry_id
+                backfilled = True
             servers.append({
+                "id": entry_id,
                 "name": name,
                 "command": command,
                 "args": [str(a) for a in (entry.get("args") or [])],
@@ -1281,6 +1295,9 @@ class SettingsManager:
                 # unchanged.
                 "env": self._unprotect_mcp_env(_normalize_mcp_env(entry.get("env"))),
             })
+        if backfilled:
+            self.state["mcp_servers"] = raw_servers
+            self._save_state()
         return servers
 
     def set_mcp_servers(self, servers: list) -> None:
@@ -1292,15 +1309,21 @@ class SettingsManager:
         patched map. Validates the same way get_mcp_servers reads back
         (name/command required, everything else normalized/defaulted) so
         a round trip through set then get is always well-formed."""
-        # What is already stored, keyed by server name, so an entry that
-        # arrives without an "env" key keeps its configured variables rather
-        # than losing them - see the "env" handling below.
+        # What is already stored, keyed by id (REVIEW-FIX: was keyed by
+        # name), so an entry that arrives without an "env" key keeps its
+        # configured variables rather than losing them - see the "env"
+        # handling below. Keying by name meant two servers sharing a name
+        # (nothing has ever enforced uniqueness) could silently swap or
+        # merge each other's secrets the moment either was edited without
+        # sending "env". A stored entry with no id yet (persisted before
+        # this field existed) simply has nothing to preserve under - it
+        # gets a fresh id below, same as a brand-new entry.
         preserved_env: dict[str, dict] = {}
         for stored in (self.state.get("mcp_servers") or []):
             if isinstance(stored, dict):
-                stored_name = str(stored.get("name", "")).strip()
-                if stored_name:
-                    preserved_env[stored_name] = _normalize_mcp_env(stored.get("env"))
+                stored_id = str(stored.get("id", "")).strip()
+                if stored_id:
+                    preserved_env[stored_id] = _normalize_mcp_env(stored.get("env"))
         normalized = []
         for entry in (servers or []):
             if not isinstance(entry, dict):
@@ -1309,7 +1332,14 @@ class SettingsManager:
             command = str(entry.get("command", "")).strip()
             if not name or not command:
                 continue
+            # An incoming entry echoes back whatever id an existing server
+            # already has (round-tripped through the wire unchanged); one
+            # with no id - a brand-new "Add Server" entry, or a legacy
+            # stored entry that never had one - gets a fresh one assigned
+            # here, server-side, never client-supplied.
+            entry_id = str(entry.get("id", "")).strip() or uuid.uuid4().hex
             normalized.append({
+                "id": entry_id,
                 "name": name,
                 "command": command,
                 "args": [str(a) for a in (entry.get("args") or [])],
@@ -1339,7 +1369,7 @@ class SettingsManager:
                 **(
                     {"env": self._protect_mcp_env(_normalize_mcp_env(entry.get("env")))}
                     if "env" in entry
-                    else {"env": preserved_env.get(name, {})}
+                    else {"env": preserved_env.get(entry_id, {})}
                 ),
             })
         self.state["mcp_servers"] = normalized

--- a/web_ui/src/app/canvas/ChartNodeView.test.tsx
+++ b/web_ui/src/app/canvas/ChartNodeView.test.tsx
@@ -1,10 +1,11 @@
 import { ReactFlowProvider, type NodeProps } from "@xyflow/react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ChartNodeView,
   chartExportUrl,
   chartNodePropsAreEqual,
+  downloadChartExport,
   filenameFromContentDisposition,
   makeDebouncedChartResize,
   type ChartFlowNode,
@@ -285,5 +286,36 @@ describe("chart export never puts the capability token in a URL", () => {
     expect(filenameFromContentDisposition("attachment; filename=chart.svg")).toBe("chart.svg");
     expect(filenameFromContentDisposition(null)).toBe("");
     expect(filenameFromContentDisposition("attachment")).toBe("");
+  });
+});
+
+describe("downloadChartExport failure handling", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // REVIEW-FIX: both toolbar buttons call this fire-and-forget
+  // (`void downloadChartExport(...)`), so a rejected promise used to
+  // escape as an unhandled rejection instead of anything the user or a
+  // test could observe cleanly. It must now resolve (not reject) and log,
+  // mirroring ImageNodeView's "does not throw when the clipboard write
+  // fails" test for the identical export-button failure mode.
+  it("does not throw when the export fetch responds non-OK", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(downloadChartExport("node-1", "png")).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it("does not throw when the export fetch itself rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(downloadChartExport("node-1", "svg")).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalled();
   });
 });

--- a/web_ui/src/app/canvas/ChartNodeView.tsx
+++ b/web_ui/src/app/canvas/ChartNodeView.tsx
@@ -117,22 +117,32 @@ export function chartExportUrl(nodeId: string, format: "png" | "svg" = "png"): s
  * resulting bytes as a file. Mirrors downloadTextFile.ts's blob -> object URL
  * -> temporary anchor pattern (and ImageNodeView's own image export before
  * it); the only difference is that the bytes come from an authenticated
- * request rather than from memory. */
+ * request rather than from memory. REVIEW-FIX: both call sites below invoke
+ * this fire-and-forget (`void downloadChartExport(...)`), so a rejected
+ * promise - a non-OK response, a network failure - used to surface as an
+ * unhandled promise rejection instead of anything the user could see. Now
+ * swallowed with a console.error, the same best-effort posture
+ * ImageNodeView's handleExportImage already uses for the identical export
+ * button pattern. */
 export async function downloadChartExport(nodeId: string, format: "png" | "svg"): Promise<void> {
-  const response = await fetch(chartExportUrl(nodeId, format), { headers: authHeaders() });
-  if (!response.ok) throw new Error(`Chart export failed (${response.status})`);
-  const blob = await response.blob();
-  const objectUrl = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = objectUrl;
-  // The server names the file from the chart's own title
-  // (backend/assets.py's _sanitize_chart_filename) and sends it in
-  // Content-Disposition - the same header the old navigated link relied on,
-  // so honoring it here keeps the downloaded filename identical.
-  anchor.download = filenameFromContentDisposition(response.headers.get("content-disposition"))
-    || `chart.${format}`;
-  anchor.click();
-  URL.revokeObjectURL(objectUrl);
+  try {
+    const response = await fetch(chartExportUrl(nodeId, format), { headers: authHeaders() });
+    if (!response.ok) throw new Error(`Chart export failed (${response.status})`);
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = objectUrl;
+    // The server names the file from the chart's own title
+    // (backend/assets.py's _sanitize_chart_filename) and sends it in
+    // Content-Disposition - the same header the old navigated link relied on,
+    // so honoring it here keeps the downloaded filename identical.
+    anchor.download = filenameFromContentDisposition(response.headers.get("content-disposition"))
+      || `chart.${format}`;
+    anchor.click();
+    URL.revokeObjectURL(objectUrl);
+  } catch (error) {
+    console.error("[chart-node] Chart export failed:", error);
+  }
 }
 
 /** Pulls `filename="..."` out of a Content-Disposition header. Exported for

--- a/web_ui/src/app/canvas/exportCanvasPng.test.ts
+++ b/web_ui/src/app/canvas/exportCanvasPng.test.ts
@@ -12,7 +12,7 @@ vi.mock("html-to-image", () => ({
   toPng: (...args: unknown[]) => toPngMock(...args),
 }));
 
-import { exportCanvasAsPng } from "./exportCanvasPng";
+import { exportCanvasAsPng, waitForChartPlaceholdersToClear } from "./exportCanvasPng";
 
 function fakeNode(id: string, x: number, y: number) {
   return {
@@ -208,6 +208,29 @@ describe("exportCanvasAsPng", () => {
     expect(rf.setViewportCalls).toEqual([expectedViewport, USER_VIEWPORT]);
   });
 
+  // -- REVIEW-FIX: chart nodes render through a lazily-loaded chunk; a
+  // -- capture taken before that chunk resolves used to grab the "Loading
+  // -- chart…" Suspense fallback instead of the actual chart.
+
+  it("waits for a still-loading chart node's placeholder to clear before rasterizing", async () => {
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    const placeholder = document.createElement("div");
+    placeholder.className = "chart-node-placeholder";
+    viewportEl.appendChild(placeholder);
+    setTimeout(() => placeholder.remove(), 120); // simulates the chunk finishing its load mid-export
+
+    let placeholderClearedBeforeCapture = false;
+    toPngMock.mockImplementation(() => {
+      placeholderClearedBeforeCapture = viewportEl.querySelector(".chart-node-placeholder") === null;
+      return Promise.resolve("data:image/png;base64,fake");
+    });
+
+    await exportCanvasAsPng(fakeRf([fakeNode("n1", 0, 0)]), "--gl-surface-window");
+
+    expect(placeholderClearedBeforeCapture).toBe(true);
+  });
+
+
   it("restores the user's viewport and logs, without rejecting, when rasterization fails", async () => {
     // Audit finding: toPng genuinely rejects when a node's image asset is
     // unreachable (a state ImageNodeView already renders a placeholder for).
@@ -288,5 +311,54 @@ describe("exportCanvasAsPng", () => {
       vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
       await expect(exportCanvasAsPng(fakeRf([fakeNode("n1", 0, 0)]), "--gl-surface-window")).resolves.toBeUndefined();
     });
+  });
+});
+
+// -- REVIEW-FIX: chart nodes render through a lazily-loaded chunk with a
+// -- "Loading chart…" Suspense fallback (.chart-node-placeholder) shown until
+// -- it resolves - a capture taken before that finished used to grab the
+// -- placeholder text instead of the chart. Tested directly against tiny
+// -- timeoutMs/pollIntervalMs values (real timers, no fake-timer interaction
+// -- with the real requestAnimationFrame exportCanvasAsPng's own nextPaint
+// -- depends on) rather than through the full export flow, so the timeout
+// -- path runs in milliseconds instead of the real 5s default.
+describe("waitForChartPlaceholdersToClear", () => {
+  it("resolves immediately when there is no placeholder to wait for", async () => {
+    const root = document.createElement("div");
+    const start = Date.now();
+
+    await waitForChartPlaceholdersToClear(root, 200, 10);
+
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it("waits for a placeholder already in the DOM to be removed", async () => {
+    const root = document.createElement("div");
+    const placeholder = document.createElement("div");
+    placeholder.className = "chart-node-placeholder";
+    root.appendChild(placeholder);
+    setTimeout(() => placeholder.remove(), 60);
+
+    await waitForChartPlaceholdersToClear(root, 1000, 10);
+
+    expect(root.querySelector(".chart-node-placeholder")).toBeNull();
+  });
+
+  it("gives up after timeoutMs instead of hanging forever on a stuck chunk load", async () => {
+    const root = document.createElement("div");
+    const placeholder = document.createElement("div");
+    placeholder.className = "chart-node-placeholder";
+    root.appendChild(placeholder); // never removed
+
+    const start = Date.now();
+    await waitForChartPlaceholdersToClear(root, 100, 10);
+    const elapsed = Date.now() - start;
+
+    // Gave up rather than hanging (bounded near timeoutMs, not open-ended)...
+    expect(elapsed).toBeGreaterThanOrEqual(90);
+    expect(elapsed).toBeLessThan(500);
+    // ...and left the placeholder exactly where it was - this function only
+    // decides WHEN to proceed, never removes anything itself.
+    expect(root.querySelector(".chart-node-placeholder")).not.toBeNull();
   });
 });

--- a/web_ui/src/app/canvas/exportCanvasPng.ts
+++ b/web_ui/src/app/canvas/exportCanvasPng.ts
@@ -88,6 +88,19 @@ import { toPng } from "html-to-image";
  * slow one. Caught and logged here instead, matching ImageNodeView.tsx's own
  * handleExportImage - the directly analogous "rasterize/fetch, then download
  * via a temporary anchor" helper in this codebase.
+ *
+ * REVIEW-FIX: chart nodes render through a lazily-loaded chunk
+ * (ChartNodeView.tsx's LazyChartRenderer, `import("./charts/ChartRenderer")`)
+ * with a "Loading chart…" Suspense fallback (`.chart-node-placeholder`) shown
+ * until that chunk resolves. The two rAF frames nextPaint() waits for are
+ * enough for React Flow's OWN re-render at the export zoom to paint, but say
+ * nothing about a separate async chunk load that may still be in flight -
+ * the very first time a chart node mounts in a session (nothing before this
+ * export has ever triggered that import) captured the literal placeholder
+ * text instead of the chart. waitForChartPlaceholdersToClear polls the
+ * captured subtree for that class and proceeds only once none remain (or a
+ * bounded timeout elapses - a chunk load failure must degrade to "export
+ * anyway, placeholder and all" rather than hang the whole export forever).
  */
 
 const IMAGE_WIDTH = 1920;
@@ -96,6 +109,8 @@ const MIN_ZOOM = 0.1;
 const MAX_ZOOM = 2.5;
 const PADDING = 0.1;
 const FALLBACK_BACKGROUND_COLOR = "#1a1a1a"; // matches graphlink_desktop.py's own pywebview window background_color
+const CHART_CHUNK_LOAD_TIMEOUT_MS = 5000;
+const CHART_CHUNK_POLL_INTERVAL_MS = 50;
 
 function timestampedFilename(): string {
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
@@ -115,6 +130,34 @@ function nextPaint(): Promise<void> {
   return new Promise((resolve) => {
     requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
   });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Polls `root` for any still-loading chart node (ChartNodeView.tsx's
+ * `.chart-node-placeholder` Suspense fallback) and resolves once none remain.
+ * Bounded by `timeoutMs` so a genuinely stuck or failed chunk load (offline,
+ * a bad deploy) degrades to "capture whatever is there" rather than hanging
+ * the export indefinitely - consistent with this module's broader "never
+ * strand the user" posture (see the try/finally around the capture below).
+ * Exported, and `timeoutMs`/`pollIntervalMs` are parameters rather than bare
+ * references to the module constants, purely so the timeout path is directly
+ * unit-testable in real time without either waiting out the real 5s default
+ * or reaching for fake timers against a function that also awaits a real
+ * requestAnimationFrame upstream (nextPaint, below) - same "parameterize the
+ * interval for direct testing" shape as makeDebouncedChartResize's own
+ * `debounceMs` parameter in ChartNodeView.tsx. */
+export async function waitForChartPlaceholdersToClear(
+  root: HTMLElement,
+  timeoutMs: number = CHART_CHUNK_LOAD_TIMEOUT_MS,
+  pollIntervalMs: number = CHART_CHUNK_POLL_INTERVAL_MS,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (root.querySelector(".chart-node-placeholder") && Date.now() < deadline) {
+    await sleep(pollIntervalMs);
+  }
 }
 
 export async function exportCanvasAsPng(
@@ -161,6 +204,7 @@ export async function exportCanvasAsPng(
   try {
     await rf.setViewport(viewport);
     await nextPaint();
+    await waitForChartPlaceholdersToClear(viewportEl);
 
     const dataUrl = await toPng(viewportEl, {
       backgroundColor: resolveBackgroundColor(backgroundColorVar),

--- a/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
@@ -106,6 +106,18 @@ function makeTransport() {
   const intents: unknown[][] = [];
   const resubscribes: string[] = [];
   const listeners = new Map<string, (payload: Record<string, unknown>) => void>();
+  // REVIEW-FIX: confirmDelete now goes through transport.request() instead
+  // of fireIntent, the same "I need the actual reply" shape as
+  // DiagnosticsDialog.test.tsx's own makeTransport() (see that file's own
+  // comment) - a vi.fn() so individual tests can drive its resolution/
+  // rejection, wired to also record into the same `intents` array so one
+  // assertion list still covers all three call shapes.
+  // Defaults to a successful delete so every test that doesn't care about
+  // the specific resolved value (most of them) doesn't also have to arrange
+  // one - tests exercising the falsy/rejected paths override this per-call
+  // with mockResolvedValueOnce/mockRejectedValueOnce.
+  const request = vi.fn<(topic: string, intent: string, args?: unknown[]) => Promise<unknown>>()
+    .mockResolvedValue(true);
   const transport = {
     subscribe: (topic: string, l: (payload: Record<string, unknown>) => void) => {
       listeners.set(topic, l);
@@ -128,11 +140,16 @@ function makeTransport() {
     fireIntent: (topic: string, intent: string, args: unknown[] = []) => {
       intents.push([topic, intent, args]);
     },
+    request: (topic: string, intent: string, args: unknown[] = []) => {
+      intents.push([topic, intent, args]);
+      return request(topic, intent, args);
+    },
   } as unknown as WsTransport;
   return {
     transport,
     intents,
     resubscribes,
+    request,
     push: (payload: Record<string, unknown>, topic: string = "app-chat-library") => listeners.get(topic)?.(payload),
   };
 }
@@ -351,6 +368,50 @@ describe("ChatLibraryDialog", () => {
 
     expect(intents.filter((i) => i[1] === "deleteChat")).toEqual([]);
     expect(screen.getByLabelText('Delete "First Chat"')).toBeInTheDocument();
+  });
+
+  // -- REVIEW-FIX: confirmDelete used to fire-and-forget via fireIntent and
+  // -- clear its confirm state the instant the message was SENT, not once
+  // -- the deletion was actually confirmed - a genuine failure left the row
+  // -- sitting in the list with its "Delete?" buttons already reverted to
+  // -- normal, no visible sign anything had gone wrong.
+
+  it("a confirmed delete that actually removes the row closes the confirm UI", async () => {
+    const { user, request } = setup();
+    await user.click(screen.getByText("open library"));
+    request.mockResolvedValueOnce(true);
+
+    await user.click(screen.getByLabelText('Delete "First Chat"'));
+    await user.click(screen.getByLabelText('Confirm delete "First Chat"'));
+
+    await screen.findByLabelText('Delete "First Chat"'); // back to the normal (non-confirming) row action
+    expect(screen.queryByText("Delete?")).toBeNull();
+  });
+
+  it("a resolved-but-falsy delete (the row was already gone) leaves the confirm UI in place rather than optimistically closing it", async () => {
+    const { user, request } = setup();
+    await user.click(screen.getByText("open library"));
+    request.mockResolvedValueOnce(false);
+
+    await user.click(screen.getByLabelText('Delete "First Chat"'));
+    await user.click(screen.getByLabelText('Confirm delete "First Chat"'));
+    await vi.waitFor(() => expect(request).toHaveBeenCalled());
+
+    expect(screen.getByText("Delete?")).toBeInTheDocument();
+  });
+
+  it("a rejected delete request leaves the confirm UI in place and logs, without throwing", async () => {
+    const { user, request } = setup();
+    await user.click(screen.getByText("open library"));
+    request.mockRejectedValueOnce(new Error("socket dropped"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await user.click(screen.getByLabelText('Delete "First Chat"'));
+    await user.click(screen.getByLabelText('Confirm delete "First Chat"'));
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
+
+    expect(screen.getByText("Delete?")).toBeInTheDocument();
+    consoleError.mockRestore();
   });
 
   it("a DB-read notice still renders when present", async () => {

--- a/web_ui/src/app/chrome/ChatLibraryDialog.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.tsx
@@ -566,10 +566,34 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
     setEditingTagsId(null);
   }
 
+  // REVIEW-FIX: this used to fire-and-forget via transport.fireIntent and
+  // clear confirmingDeleteId the instant the message was SENT, not once the
+  // deletion was actually confirmed - a genuine failure (a raised exception
+  // server-side, the socket dropping mid-request) left the row sitting in
+  // the list with its "Delete?" confirm buttons already reverted to a
+  // normal row, no visible sign anything had gone wrong. transport.request()
+  // is the real request/response primitive for that (same "I need the
+  // actual outcome, not just to have sent something" reasoning as
+  // BuilderLaunchDialog.tsx's own deleteSelectedRecipe). A rejected promise
+  // - the genuine-failure case - deliberately leaves confirmingDeleteId in
+  // place: the confirm buttons staying up IS the failure signal here, and
+  // the user can just try again. A resolved `false` (the row was already
+  // gone - a double-click, or another tab/session beat this one to it) is
+  // NOT a rejection, but it means nothing was actually removed just now
+  // either, so it is treated the same as a failure rather than optimistically
+  // closing the confirm UI over a delete that didn't happen.
   function confirmDelete() {
     if (confirmingDeleteId === null) return;
-    transport.fireIntent("app-chat-library", "deleteChat", [confirmingDeleteId]);
-    setConfirmingDeleteId(null);
+    const chatId = confirmingDeleteId;
+    transport
+      .request("app-chat-library", "deleteChat", [chatId])
+      .then((deleted) => {
+        if (!deleted) return;
+        setConfirmingDeleteId((current) => (current === chatId ? null : current));
+      })
+      .catch((error) => {
+        console.error("[chat-library] Delete failed:", error);
+      });
   }
 
   function cancelDelete() {

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -914,6 +914,7 @@ describe("SettingsDialog", () => {
   // intent fired.
   describe("MCP Servers page", () => {
     const fsServer = {
+      id: "fs-id",
       name: "fs",
       command: "npx",
       args: ["-y", "server-filesystem"],
@@ -1029,6 +1030,7 @@ describe("SettingsDialog", () => {
 
     it("Remove fires setMcpServers with the full array minus that entry", async () => {
       const gitServer = {
+        id: "git-id",
         name: "git",
         command: "uvx",
         args: [],

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -1102,6 +1102,13 @@ function McpServersPage({ state, transport }: { state: AppSettingsState; transpo
   // the OUTBOUND intent argument, which the generated inbound row type has
   // no business defining.
   type OutgoingMcpServer = {
+    // REVIEW-FIX: absent on a brand-new "Add Server" entry - the backend
+    // assigns a fresh one (see SettingsManager.set_mcp_servers). Present
+    // (via the `...s` spread below) on every existing server, echoed back
+    // unchanged - that id, not `name`, is now the join key the backend
+    // uses to preserve a server's env values across an edit that omits
+    // them, since two servers can share a name.
+    id?: string;
     name: string;
     command: string;
     args: string[];
@@ -1154,7 +1161,7 @@ function McpServersPage({ state, transport }: { state: AppSettingsState; transpo
           <p className="settings-update-status">No MCP servers configured yet.</p>
         )}
         {state.mcpServers.map((server, index) => (
-          <div className="settings-mcp-server-row" key={`${server.name}-${index}`}>
+          <div className="settings-mcp-server-row" key={server.id}>
             <label
               className="settings-checkbox-row settings-mcp-server-toggle"
               aria-label={server.name || "MCP server"}

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.schema.json
@@ -163,6 +163,9 @@
             },
             "type": "array"
           },
+          "id": {
+            "type": "string"
+          },
           "name": {
             "type": "string"
           },
@@ -177,6 +180,7 @@
           }
         },
         "required": [
+          "id",
           "name",
           "command",
           "args",

--- a/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/app-settings-state.ts
@@ -11,6 +11,7 @@ export interface ApiModelDescriptor {
 }
 
 export interface McpServerConfig {
+  id: string;
   name: string;
   command: string;
   args: string[];
@@ -117,6 +118,11 @@ function checkApiModelDescriptor(value: unknown, path: string, errors: string[])
 
 function checkMcpServerConfig(value: unknown, path: string, errors: string[]): void {
   if (!isRecord(value)) { errors.push(`${path}: expected object`); return; }
+  {
+    const fieldValue = value["id"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.id: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.id` + ": expected string"); }
+  }
   {
     const fieldValue = value["name"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.name: missing required field`);


### PR DESCRIPTION
## Problem

A fan-out crawl read (not test-ran) the backend and frontend for defects invisible to the existing test suite - cycle guards, race conditions, atomicity, and optimistic-UI correctness bugs. Every finding below was independently cross-verified before being fixed, and every fix is revert-verified: reverting just the fix makes its own new regression test fail for the documented reason.

## Changes

**Graph correctness**
- `connect()` now refuses an edge that would close a cycle; a `connect_unchecked` primitive is added for the one legacy-restore path that can legitimately carry a pre-existing bidirectional pair. `get_branch_root`/`chat_branch_history` get a defense-in-depth visited-set guard so old data can never hang the walk. `delete_chat_node` reconnects children before popping edges, so a failure leaves state unchanged instead of half-applied.
- The Py-Coder and Code Sandbox approval-gate repair loops now broadcast their intermediate "not awaiting" state, closing a window where the approval dialog could get stuck open with no way to dismiss it.

**Undo/redo**
- `_guard_live_runs` now also checks whether the command's `run_id` has ANY node still live under it, not just the command's own touched nodes - closing a gap where undoing an unrelated step mid-run could race the run's own mutations.
- `undo_run` is now atomic: if a later command in the run refuses to undo, every command already undone in this call is re-applied before the error propagates, instead of leaving the run half-rolled-back.

**Data races**
- `get_or_create_workspace_collection` had a check-then-act race that could split one workspace's knowledge base into two collections under real concurrency; fixed with a unique index plus conflict-handled insert.
- `_on_reply` (conversation replies) now checks the target node still exists before landing, matching its sibling `_on_partial` - closes a race where a reply generated concurrently with a node delete raised instead of being dropped.

**Other backend correctness**
- `ArtifactAgent.get_response`'s tag-extraction regex was non-greedy, silently truncating any document whose body legitimately contained the literal text `</artifact>`; now greedy, matching the system prompt's own "one open tag, whole document, one close" contract.
- A non-dict or malformed WS message (e.g. a bare JSON number, or a non-list `topics` field) now gets a graceful `kind: error` reply instead of killing the connection with an uncaught `AttributeError`/`TypeError`.
- The legacy nested Sankey shape (`{data: {nodes, links}}`) is now size-checked before either loop over it runs, not after - an oversized payload used to block the event loop for every session on the process while doing unbounded work it was about to reject anyway.

**MCP server settings**
- Every configured MCP server now carries a stable, server-assigned `id`, threaded through the wire contract end to end. `set_mcp_servers`' env-value preservation (used whenever an edit omits `env`, so unrelated edits don't wipe secrets) is now keyed by `id` instead of `name` - two servers sharing a name could previously have their env values silently swapped or merged on an unrelated edit, since nothing has ever enforced name uniqueness.

**Chart export**
- `downloadChartExport` now catches its own fetch/response failures instead of leaking an unhandled promise rejection from its two fire-and-forget toolbar buttons.
- Canvas PNG export now waits for a chart node's lazily-loaded rendering chunk to finish before capturing, bounded by a timeout that falls back to capturing anyway - previously the very first chart export in a session could grab the "Loading chart…" placeholder instead of the actual chart.

**Chat library**
- Deleting a chat now round-trips through `transport.request()` instead of firing-and-forgetting, and only clears the confirm-delete UI once the backend actually confirms the row was removed. A genuine failure used to leave the row in the list with its confirm buttons already reverted to normal, with no visible sign the delete never happened.

## Test plan
- [x] `python -m pytest -q` from repo root: 3117 passed, 17 skipped, 0 failed
- [x] `npm run check` in `web_ui/` (schema drift, typecheck, lint, 1983 tests, build, bundle-size gate): all clean
- [x] Every fix has a dedicated regression test, and every regression test was confirmed to fail against the pre-fix code before the fix was restored