### PR TITLE
Fix 34 issues found by a deeper, wider code-reading crawl (2 critical security bypasses, races, atomicity, UI correctness)

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -2560,7 +2560,22 @@ class AgentDispatcher:
         synchronous stretch as node.pending_request_id's own claim - same
         pattern as gitlink_run/gitlink_apply (stage 2.4f): node.pending_
         request_id remains the sole real busy guard, this registry claim
-        is pure task/cancel_event/approval_future bookkeeping."""
+        is task/cancel_event/approval_future bookkeeping.
+
+        REVIEW-FIX: ...plus `finalize` (see _finalize below), which used to
+        be omitted here. Without it, node.pending_request_id - the one
+        field runPyCoder's own busy pre-check and the frontend's spinner
+        both key off - was cleared ONLY by _run's own late `finally`, which
+        cannot run until the blocking repl.execute() call above actually
+        returns. RunRegistry.cancel() (cancel_pycoder, on every Cancel
+        click, node delete, and session disconnect) pops this handle and
+        frees is_busy("pycoder") immediately regardless, so a Cancel during
+        the EXECUTE stage used to leave the node showing busy - with zero
+        feedback - for up to PYCODER_EXECUTE_TIMEOUT_SECONDS after the run
+        was already gone from this registry. Every other cancellable kind
+        in this module either wires finalize (start_builder_run/_dispatch)
+        or gets near-instant natural cancellation anyway (code_sandbox's
+        should_continue() polling); this closes the one real gap."""
         if node.pending_request_id and node.pending_request_id != _CODE_EXEC_RUN_CLAIM_PLACEHOLDER:
             notifications_state.show("Py-Coder is already busy for this node.", "info")
             await bus.publish("notification")
@@ -2568,8 +2583,27 @@ class AgentDispatcher:
 
         cancel_event = threading.Event()
         approval_future: asyncio.Future = asyncio.get_running_loop().create_future()
+
+        async def _finalize() -> None:
+            """REVIEW-FIX: see this method's own docstring above - mirrors
+            start_builder_run's/_dispatch's identically-shaped _finalize.
+            Run by RunRegistry.cancel() the instant Cancel/Stop lands
+            (Cancel click, node delete, or session disconnect), well
+            before _run's own late `finally` can react to a blocking
+            repl.execute() call. `handle` is captured by reference to the
+            enclosing scope - safe even though this closure is defined
+            before `handle` itself is assigned below, since the body only
+            runs after claim() has returned."""
+            node.state.pycoder_awaiting_approval = False
+            node.state.pycoder_approved_fingerprint = None
+            node.state.pycoder_error = "Py-Coder execution cancelled."
+            if node.pending_request_id == handle.request_id:
+                node.pending_request_id = None
+            await bus.publish("scene")
+
         handle = self._runs.claim(
-            "pycoder", node_id=node_id, cancel_event=cancel_event, approval_future=approval_future
+            "pycoder", node_id=node_id, cancel_event=cancel_event,
+            approval_future=approval_future, finalize=_finalize,
         )
         request_id = handle.request_id
         node.pending_request_id = request_id

--- a/backend/api/intents_builder.py
+++ b/backend/api/intents_builder.py
@@ -208,6 +208,29 @@ def register_builder_intents(
         agent_dispatcher.deny_code_execution(request_id)
 
     async def set_plan_steps(node_id, steps):
+        node = document.nodes.get(node_id)
+        # REVIEW-FIX: a live run_build holds `step = _current_step(node)`
+        # (backend/builder.py) as a direct reference into the OLD dict
+        # object living inside node.state.plan_steps, for the whole step -
+        # document.set_plan_steps always REPLACES the list with fresh dicts
+        # (graph.py), even for unchanged entries. Letting this intent land
+        # while the node is busy detaches run_build's own reference: its
+        # later `step["status"] = "done"` writes to an orphaned object, and
+        # the real (frozen, non-pending) row in plan_steps can never be
+        # touched again. Only run_build's own replan path re-resolves the
+        # reference after a replacement (builder.py's `_apply_replan`
+        # caller); this externally-triggered mutation has no such recovery,
+        # so it must be refused outright - mirrors undo/redo's own
+        # _guard_live_runs (backend/domain/commands.py) checking the same
+        # node.pending_request_id for the identical hazard class.
+        if node is not None and node.pending_request_id:
+            notifications.show(
+                f"Can't edit \"{node.title}\"'s steps while it is still running - "
+                "cancel or wait for it to finish.",
+                "info",
+            )
+            await bus.publish("notification")
+            return
         try:
             document.record_command(
                 "setPlanSteps", "user",

--- a/backend/api/intents_builder.py
+++ b/backend/api/intents_builder.py
@@ -16,6 +16,9 @@ itself along with everything the build made.
 
 from __future__ import annotations
 
+import asyncio
+
+from backend.api._settings_shared import run_locked
 from backend.api._shared import make_publish_scene
 from backend.domain.graph import SceneDocument, SceneError
 from backend.domain.node_states import PlanState
@@ -146,8 +149,27 @@ def register_builder_intents(
             await bus.publish("notification")
             return None
         settings = agent_dispatcher._settings_manager
-        existing = [r for r in settings.get_recipes() if r["name"] != clean_name]
-        settings.set_recipes(existing + [recipe_from_plan_node(node, clean_name)])
+        new_recipe = recipe_from_plan_node(node, clean_name)
+
+        def _persist() -> None:
+            existing = [r for r in settings.get_recipes() if r["name"] != clean_name]
+            settings.set_recipes(existing + [new_recipe])
+
+        # REVIEW-FIX: was an unlocked settings.get_recipes()/set_recipes()
+        # pair called directly on the event loop - every other settings-
+        # mutating intent in this codebase runs its SettingsManager writes
+        # through asyncio.to_thread(run_locked, ...) instead (backend/api/
+        # _settings_shared.py's own module docstring: _save_state's
+        # open()/json.dump()/fsync()/os.replace() sequence releases the GIL
+        # mid-write, so an unlocked writer here could land in the middle of
+        # another settings save's own write to the SAME state file).
+        # _save_state's except clause swallows the resulting IOError (logs
+        # and returns, never raises), so this used to report a successful
+        # save even when the disk write silently lost the change. The read
+        # and the write stay inside one run_locked closure rather than two
+        # separate to_thread calls, matching apply_ollama_chat_model's own
+        # "read-modify-write in a single locked section" precedent.
+        await asyncio.to_thread(run_locked, _persist)
         notifications.show(f'Saved recipe "{clean_name}".', "info")
         await bus.publish("notification")
         return clean_name
@@ -166,13 +188,22 @@ def register_builder_intents(
             await bus.publish("notification")
             return False
         settings = agent_dispatcher._settings_manager
-        existing = settings.get_recipes()
-        remaining = [r for r in existing if r["name"] != clean_name]
-        if len(remaining) == len(existing):
+        found = {"value": False}
+
+        def _persist() -> None:
+            existing = settings.get_recipes()
+            remaining = [r for r in existing if r["name"] != clean_name]
+            if len(remaining) != len(existing):
+                found["value"] = True
+                settings.set_recipes(remaining)
+
+        # REVIEW-FIX: same unlocked-write hazard save_recipe closed above -
+        # see its own comment for the full mechanism.
+        await asyncio.to_thread(run_locked, _persist)
+        if not found["value"]:
             notifications.show(f'No saved recipe named "{clean_name}".', "info")
             await bus.publish("notification")
             return False
-        settings.set_recipes(remaining)
         notifications.show(f'Deleted recipe "{clean_name}".', "info")
         await bus.publish("notification")
         return True

--- a/backend/app.py
+++ b/backend/app.py
@@ -24,6 +24,7 @@ intent - the acceptance round-trip. Real domain topics arrive per-phase
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
@@ -660,7 +661,29 @@ def create_app(
         session.attach(websocket, buffered=True)
         try:
             while True:
-                message = await websocket.receive_json()
+                # REVIEW-FIX: receive_json() is a bare json.loads() with no
+                # try/except of its own (starlette's own implementation) -
+                # a text frame that isn't syntactically valid JSON AT ALL
+                # (as opposed to valid-JSON-but-wrong-shape, which
+                # _handle_message's own guards below already handle
+                # gracefully) raised json.JSONDecodeError straight out of
+                # this await, past the only except clause here
+                # (WebSocketDisconnect only), and killed the connection
+                # outright with zero client-facing feedback - the same
+                # failure mode the non-dict/non-list REVIEW-FIXes in
+                # _handle_message already closed for their own trigger
+                # points, just left open at this earlier one. Caught here
+                # (inside the loop, not by the WebSocketDisconnect clause
+                # below) so a malformed frame gets the same graceful
+                # kind:error reply and the loop simply continues instead of
+                # tearing down the session.
+                try:
+                    message = await websocket.receive_json()
+                except json.JSONDecodeError:
+                    await websocket.send_json(
+                        {"kind": "error", "id": None, "error": "malformed message: invalid JSON"}
+                    )
+                    continue
                 await _handle_message(session, websocket, message)
         except WebSocketDisconnect:
             pass

--- a/backend/asset_store.py
+++ b/backend/asset_store.py
@@ -53,6 +53,15 @@ _EXTENSION_BY_MIME = {
     "image/svg+xml": "svg",
 }
 
+# Same set as _EXTENSION_BY_MIME's keys, exported so the asset-serving HTTP
+# route (backend/assets.py's get_asset) can validate a stored mime_type
+# against it before trusting the string into a response's Content-Type
+# header. Neither write path into document.image_assets (the addImageNode
+# WS intent, session_load._restore_image_payload) validates mime_type
+# before storing it, so the read side is the one place that can close the
+# gap regardless of how a bad value got stored.
+ALLOWED_IMAGE_MIME_TYPES = frozenset(_EXTENSION_BY_MIME)
+
 
 def content_ref(data: bytes) -> str:
     """The SHA-256 hex digest that names these exact bytes."""

--- a/backend/assets.py
+++ b/backend/assets.py
@@ -47,9 +47,18 @@ import re
 from fastapi import FastAPI, Response
 from fastapi.responses import JSONResponse
 
+from backend.asset_store import ALLOWED_IMAGE_MIME_TYPES
 from backend.events import EventBus, UnknownSessionError
 from backend.session_context import get_session_context
 from graphlink_chart_rendering import render_chart_png, render_chart_svg
+
+# Fallback Content-Type for a stored mime_type that is not one of this app's
+# own real image types (ALLOWED_IMAGE_MIME_TYPES). octet-stream rather than
+# an image/* guess: it tells every consumer (browser tab, <img> tag, future
+# download affordance) "do not try to render this as anything", which is
+# the whole point - the caller who wrote the bad mime_type also fully
+# controls the bytes behind it.
+_FALLBACK_MIME_TYPE = "application/octet-stream"
 
 # 3x the display resolution - mirrors legacy ChartItem.EXPORT_SCALE exactly.
 CHART_EXPORT_DPI_SCALE = 3.0
@@ -94,6 +103,13 @@ def register_assets(app: FastAPI, bus: EventBus) -> None:
         if asset is None:
             return JSONResponse({"error": "unknown asset"}, status_code=404)
         image_bytes, mime_type = asset
+        # Neither write path into document.image_assets (addImageNode's
+        # caller-supplied mime_type, session_load._restore_image_payload's
+        # payload-supplied mime_type) validates the string before storing
+        # it, so it is not trustworthy here - pass it through only if it is
+        # one of this app's own real image types.
+        if mime_type not in ALLOWED_IMAGE_MIME_TYPES:
+            mime_type = _FALLBACK_MIME_TYPE
         return Response(content=image_bytes, media_type=mime_type)
 
     @app.get("/api/assets/chart/{node_id}/export")

--- a/backend/builder.py
+++ b/backend/builder.py
@@ -603,32 +603,46 @@ async def run_build(
     node.pending_request_id = request_id
     await bus.publish("scene")
 
-    # ADR-021 stage 21.1: offer the model only tools this run could actually
-    # run. registry.specs() is deliberately unfiltered ("what exists" and
-    # "what this run may use" are independent questions - tools.py), but the
-    # Builder's grant set is FIXED (BUILDER_GRANTED_SCOPES), so any tool
-    # needing a scope outside it - an fs.read MCP server, say - can only ever
-    # be denied at invoke(). Offering it spends context on every turn to buy
-    # a guaranteed-failing call and a confused model. Filtered here rather
-    # than in the registry so the registry keeps its neutral contract.
-    specs = tuple(
-        spec for spec in registry.specs()
-        if (registry.scopes_for(spec.name) or frozenset()) <= BUILDER_GRANTED_SCOPES
-    )
-    system_prompt = resolve_prompt_text("builder-executor")
-    messages: list = [
-        {"role": "system", "content": system_prompt},
-        {
-            "role": "user",
-            "content": (
-                f"Goal:\n{node.state.plan_goal}\n\nCurrent plan:\n{_plan_digest(node)}\n\n"
-                f"The plan node's id is {plan_node_id}. Work the first pending step now."
-            ),
-        },
-    ]
-
     step: dict | None = None
     try:
+        # REVIEW-FIX: this setup (tool-spec filtering, prompt resolution,
+        # plan-digest formatting) used to sit BEFORE this try/except, in
+        # the same unguarded window the state-setting above already
+        # stamped builder_status="running"/pending_request_id=request_id
+        # into. An exception raised here used to escape run_build entirely -
+        # agents.py's own caller (start_builder_run's _run) wraps this call
+        # in only `finally: self._runs.release(request_id)`, no except - so
+        # the plan node was left stuck showing "running" forever with a
+        # pending_request_id no run backs anymore, and cancel_builder
+        # became a permanent silent no-op. Mirrors _run_builder_planning's
+        # own try/finally (backend/agents.py) around its equivalent setup
+        # window.
+        #
+        # ADR-021 stage 21.1: offer the model only tools this run could
+        # actually run. registry.specs() is deliberately unfiltered ("what
+        # exists" and "what this run may use" are independent questions -
+        # tools.py), but the Builder's grant set is FIXED
+        # (BUILDER_GRANTED_SCOPES), so any tool needing a scope outside it -
+        # an fs.read MCP server, say - can only ever be denied at invoke().
+        # Offering it spends context on every turn to buy a guaranteed-
+        # failing call and a confused model. Filtered here rather than in
+        # the registry so the registry keeps its neutral contract.
+        specs = tuple(
+            spec for spec in registry.specs()
+            if (registry.scopes_for(spec.name) or frozenset()) <= BUILDER_GRANTED_SCOPES
+        )
+        system_prompt = resolve_prompt_text("builder-executor")
+        messages: list = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": (
+                    f"Goal:\n{node.state.plan_goal}\n\nCurrent plan:\n{_plan_digest(node)}\n\n"
+                    f"The plan node's id is {plan_node_id}. Work the first pending step now."
+                ),
+            },
+        ]
+
         while True:
             if cancel_event.is_set():
                 raise api_provider.RequestCancelledError("stopped")

--- a/backend/builder.py
+++ b/backend/builder.py
@@ -65,11 +65,23 @@ BUILDER_GRANTED_SCOPES = frozenset({
 })
 
 # Autopilot's auto-approval set (design doc D5, user-confirmed 2026-08-09):
-# graph edits and code execution proceed unprompted (disclosed at launch;
-# ADR-005 resource caps still bound execution); net.fetch ALWAYS prompts -
-# the 8.5 exit criterion's "no network unless approved".
+# graph edits proceed unprompted; net.fetch ALWAYS prompts - the 8.5 exit
+# criterion's "no network unless approved".
+#
+# REVIEW-FIX: code.execute (run_node running a pycoder node) used to be in
+# this set too - "disclosed at launch" per the design doc - which let
+# Builder-authored Python run with zero human review whenever the model
+# steered itself into writing and then executing code in the same
+# autopilot run (e.g. off prompt-injected content it read via
+# graph.read_subgraph). Arbitrary code execution is a different risk class
+# than a graph edit (undoable, contained to the canvas) - it warrants the
+# same "always ask, even in autopilot" posture net.fetch already gets, not
+# a blanket auto-approve. Excluding it here is what forces run_node's
+# execute action through request_approval below regardless of mode; see
+# _approval_summary's own REVIEW-FIX for the matching visibility fix (the
+# prompt now shows the code, not just the call's arguments).
 _AUTOPILOT_AUTO_SCOPES = frozenset({
-    GRAPH_READ, GRAPH_MUTATE, CODE_EXECUTE, PROVIDER_CALL, KNOWLEDGE_READ,
+    GRAPH_READ, GRAPH_MUTATE, PROVIDER_CALL, KNOWLEDGE_READ,
 })
 
 _APPROVAL_SUMMARY_CAP = 400
@@ -395,7 +407,19 @@ def _truncate(text: str, cap: int) -> str:
     return text if len(text) <= cap else text[:cap] + "…"
 
 
-def _approval_summary(call: ToolCall) -> str:
+def _approval_summary(call: ToolCall, document) -> str:
+    """REVIEW-FIX: a run_node(action="execute") call's own arguments are
+    just {node_id, action} - the Python about to run lives on the TARGET
+    node's state, not in the call, so showing the arguments alone asks a
+    human to bless a black box (see run_node_pending_code's own doc for
+    why). Every other tool's arguments already say what will happen, so
+    they keep the plain JSON summary; only this one case substitutes the
+    code itself."""
+    from backend.tools_graph import run_node_pending_code
+
+    code = run_node_pending_code(document, call)
+    if code is not None:
+        return f"{call.name} will run this code:\n{_truncate(code, _APPROVAL_SUMMARY_CAP)}"
     args = json.dumps(call.arguments, sort_keys=True, ensure_ascii=False)
     return f"{call.name} {_truncate(args, _APPROVAL_SUMMARY_CAP)}"
 
@@ -520,7 +544,7 @@ async def run_build(
         handle.approval_future = future
         node.state.builder_awaiting_tool_approval = True
         node.state.builder_approval_tool_name = call.name
-        node.state.builder_approval_summary = _approval_summary(call)
+        node.state.builder_approval_summary = _approval_summary(call, document)
         await bus.publish("scene")
         try:
             approved = bool(await future)

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -2665,13 +2665,23 @@ def make_export_workspace(bus: SessionBus, resolved_path: Path, notifications: N
         if not target:
             return
 
+        # REVIEW-FIX: export used to hardcode {title, data, notes, pins} -
+        # tags/favorite/archived never rode along, even though they're
+        # already sitting in `all_chats` (fetched above to resolve
+        # graph_ids) rather than requiring a second DB round trip here.
+        chats_by_id = {int(row["id"]): row for row in all_chats}
+
         def _load_one(graph_id: int) -> dict[str, Any]:
             row = load_chat_row(resolved_path, graph_id)
+            meta = chats_by_id.get(graph_id, {})
             return {
                 "title": row["title"] if row else "Untitled",
                 "data": row["data"] if row else {},
                 "notes": load_notes_rows(resolved_path, graph_id),
                 "pins": load_pins_rows(resolved_path, graph_id),
+                "tags": list(meta.get("tags", [])),
+                "favorite": bool(meta.get("favorite", False)),
+                "archived": bool(meta.get("archived", False)),
             }
 
         def _do_export() -> Path:

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -2710,13 +2710,13 @@ def make_rename_chat_intent(
     this session's save/load/autosave operations.
     """
 
-    async def rename(chat_id: int, new_title: str):
+    async def rename(chat_id: int, new_title: str) -> str | None:
         # Non-empty guard matches the legacy `if ok and new_title:` - an
         # empty/whitespace title is ignored, no mutation, no error (the SPA
         # disables Save for an empty draft anyway).
         title = str(new_title or "").strip()
         if not title:
-            return
+            return None
         resolved_chat_id = int(chat_id)
         expected_updated_at: str | None = None
         if (
@@ -2742,7 +2742,7 @@ def make_rename_chat_intent(
             if notifications is not None:
                 notifications.show(LOST_RACE_MESSAGE_MANUAL, "warning")
                 await bus.publish("notification")
-            return
+            return None
         if (
             new_updated_at is not None
             and canvas_document is not None
@@ -2751,6 +2751,13 @@ def make_rename_chat_intent(
         ):
             last_saved["updated_at"] = new_updated_at
         await bus.publish("app-chat-library")
+        # REVIEW-FIX: returns rename_chat's own signal (None means the row
+        # no longer existed by the time the UPDATE ran) instead of always
+        # resolving to None - mirrors make_delete_chat_intent's delete()
+        # just above, which already returns delete_chat's own bool for the
+        # identical reason: a fire-and-forget caller has no way to tell a
+        # real rename apart from a silent no-op without this.
+        return new_updated_at
 
     return rename
 

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -1476,9 +1476,17 @@ def load_chat_row(db_path: Path, chat_id: int) -> dict[str, Any] | None:
     newChat(workspaceId=...). Fixed here, at the one place every load
     already reads this row, rather than only in the callers that needed it."""
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        row = conn.execute(
-            "SELECT title, data, updated_at, workspace_id FROM graphs WHERE id = ?", (chat_id,)
-        ).fetchone()
+        return _load_chat_row_from_conn(conn, chat_id)
+
+
+def _load_chat_row_from_conn(conn: sqlite3.Connection, chat_id: int) -> dict[str, Any] | None:
+    """The actual SELECT behind load_chat_row, split out so
+    load_chat_snapshot below can run it on a connection/transaction it
+    already owns instead of load_chat_row opening (and committing) its own -
+    see load_chat_snapshot's own REVIEW-FIX docstring for why."""
+    row = conn.execute(
+        "SELECT title, data, updated_at, workspace_id FROM graphs WHERE id = ?", (chat_id,)
+    ).fetchone()
     if row is None:
         return None
     return {"title": row[0], "data": json.loads(row[1]), "updated_at": row[2], "workspace_id": row[3]}
@@ -1489,14 +1497,20 @@ def load_notes_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
     SELECT column list; shape matches what backend/session_load.py's
     _restore_notes expects (nested "position"/"size" dicts)."""
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        rows = conn.execute(
-            """
-            SELECT content, position_x, position_y, width, height,
-                   color, header_color, is_system_prompt, is_summary_note, note_id
-            FROM notes WHERE chat_id = ?
-            """,
-            (chat_id,),
-        ).fetchall()
+        return _load_notes_rows_from_conn(conn, chat_id)
+
+
+def _load_notes_rows_from_conn(conn: sqlite3.Connection, chat_id: int) -> list[dict[str, Any]]:
+    """The actual SELECT behind load_notes_rows - see _load_chat_row_from_
+    conn's own docstring for why this is split out."""
+    rows = conn.execute(
+        """
+        SELECT content, position_x, position_y, width, height,
+               color, header_color, is_system_prompt, is_summary_note, note_id
+        FROM notes WHERE chat_id = ?
+        """,
+        (chat_id,),
+    ).fetchall()
     return [
         {
             "content": row[0],
@@ -1521,15 +1535,21 @@ def load_pins_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
     """Mirrors ChatDatabase.load_pins exactly, including its own
     sort_order-defaults-to-enumerate-index fallback for pre-migration rows."""
     with contextlib.closing(_connect(db_path)) as conn, conn:
-        rows = conn.execute(
-            """
-            SELECT pin_id, title, note, position_x, position_y,
-                   anchor_item_id, sort_order, created_at
-            FROM pins WHERE chat_id = ?
-            ORDER BY sort_order, id
-            """,
-            (chat_id,),
-        ).fetchall()
+        return _load_pins_rows_from_conn(conn, chat_id)
+
+
+def _load_pins_rows_from_conn(conn: sqlite3.Connection, chat_id: int) -> list[dict[str, Any]]:
+    """The actual SELECT behind load_pins_rows - see _load_chat_row_from_
+    conn's own docstring for why this is split out."""
+    rows = conn.execute(
+        """
+        SELECT pin_id, title, note, position_x, position_y,
+               anchor_item_id, sort_order, created_at
+        FROM pins WHERE chat_id = ?
+        ORDER BY sort_order, id
+        """,
+        (chat_id,),
+    ).fetchall()
     return [
         {
             "pin_id": row[0],
@@ -1542,6 +1562,40 @@ def load_pins_rows(db_path: Path, chat_id: int) -> list[dict[str, Any]]:
         }
         for index, row in enumerate(rows)
     ]
+
+
+def load_chat_snapshot(
+    db_path: Path, chat_id: int,
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]], list[dict[str, Any]]]:
+    """REVIEW-FIX: make_load_chat's loadChat intent used to read a chat's
+    row, notes, and pins through three independent connections/transactions
+    (load_chat_row, then load_notes_rows, then load_pins_rows), each on its
+    own asyncio.to_thread hop with a genuine event-loop yield in between - a
+    concurrent session's real save_chat_atomically_row call (a single
+    atomic delete-then-reinsert transaction) landing in one of those gaps
+    produced a torn read: part of what got restored reflecting the
+    pre-write state, part reflecting the post-write state. This function
+    gives all three reads ONE connection and ONE explicit transaction
+    instead, so they share a single WAL snapshot - the same consistency
+    guarantee save_chat_atomically_row's own single transaction already
+    gives its writes.
+
+    An explicit `BEGIN` is required here - a bare SELECT never opens an
+    implicit transaction under sqlite3's default legacy isolation_level
+    (only INSERT/UPDATE/DELETE/REPLACE do), so without it these three reads
+    would each still get their own independent autocommit snapshot even on
+    one shared connection, reproducing the exact bug this closes. See
+    graphlink_migrations.py's run_sqlite_migrations for the same fact
+    documented in detail for the DDL/PRAGMA case."""
+    with contextlib.closing(_connect(db_path)) as conn:
+        conn.execute("BEGIN")
+        try:
+            row = _load_chat_row_from_conn(conn, chat_id)
+            notes_rows = _load_notes_rows_from_conn(conn, chat_id)
+            pins_rows = _load_pins_rows_from_conn(conn, chat_id)
+        finally:
+            conn.commit()
+    return row, notes_rows, pins_rows
 
 
 def save_chat_atomically_row(
@@ -2087,15 +2141,18 @@ def make_load_chat(
         # them; a real running session always has both (see backend/app.py's
         # _configure_session ordering).
         try:
-            row = await asyncio.to_thread(load_chat_row, resolved_path, int(chat_id))
+            # REVIEW-FIX: row/notes/pins now come from ONE shared connection/
+            # transaction (load_chat_snapshot) instead of three independent
+            # ones - see that function's own docstring for the torn-read gap
+            # this closes (a concurrent session's save landing between two
+            # of the three separate reads used to combine pre-write and
+            # post-write state into a single restore).
+            row, notes_rows, pins_rows = await asyncio.to_thread(load_chat_snapshot, resolved_path, int(chat_id))
             if row is None:
                 if notifications is not None:
                     notifications.show("This chat could not be found. It may have already been deleted.", "error")
                     await bus.publish("notification")
                 return
-
-            notes_rows = await asyncio.to_thread(load_notes_rows, resolved_path, int(chat_id))
-            pins_rows = await asyncio.to_thread(load_pins_rows, resolved_path, int(chat_id))
 
             if canvas_document is None:
                 return

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -1662,11 +1662,24 @@ def save_chat_atomically_row(
                             f"{expected_updated_at!r} did not match)"
                         )
                 else:
-                    conn.execute(
+                    # REVIEW-FIX: the checked branch just above already
+                    # raises on rowcount == 0; this blind branch used to skip
+                    # that check entirely, so a concurrent delete_chat of
+                    # this exact row landed as a silent no-op UPDATE and the
+                    # unconditional workspace_id read-back below then blew up
+                    # with an unhandled TypeError (fetchone() on a gone row)
+                    # instead of the same clean ConcurrentSaveConflict every
+                    # caller already knows how to turn into LOST_RACE_MESSAGE.
+                    cursor = conn.execute(
                         "UPDATE graphs SET title = ?, data = ?, preview = ?, message_count = ?, "
                         "updated_at = ? WHERE id = ?",
                         (title, chat_data_json, preview, message_count, now, chat_id),
                     )
+                    if cursor.rowcount == 0:
+                        raise ConcurrentSaveConflict(
+                            f"chat {chat_id} no longer exists (it was likely deleted elsewhere "
+                            "since it was last loaded/saved in this session)"
+                        )
                 resolved_chat_id = chat_id
             elif workspace_id is not None:
                 cursor = conn.execute(
@@ -1737,11 +1750,13 @@ def save_chat_atomically_row(
                 )
 
         # ADR-020 stage 20.4: runs AFTER the `with conn:` block above has
-        # committed (or, on a ConcurrentSaveConflict, never reached here at
-        # all - that exception propagates straight out of the `with conn:`
-        # block, so this line is unreachable for a lost write race, exactly
-        # as it should be: nothing was actually written, so nothing here
-        # needs re-indexing). One extra cheap read on the SAME still-open
+        # committed (or, on a ConcurrentSaveConflict - raised by EITHER the
+        # checked or the blind UPDATE branch above on rowcount == 0, see
+        # REVIEW-FIX there - never reached here at all: that exception
+        # propagates straight out of the `with conn:` block, so this line is
+        # unreachable for a lost write race, exactly as it should be:
+        # nothing was actually written, so nothing here needs re-indexing).
+        # One extra cheap read on the SAME still-open
         # connection - graphs.workspace_id is always a real, non-NULL int
         # for resolved_chat_id regardless of which branch above ran (the
         # INSERT branches always populate it - explicitly when `workspace_id`

--- a/backend/domain/branches.py
+++ b/backend/domain/branches.py
@@ -289,32 +289,60 @@ class BranchOps:
                 note_edges.append(edge)
 
         # REVIEW-FIX: reconnect children to the deleted node's own parent
-        # BEFORE removing any edge below, not after (the original order).
-        # Reaching a cycle is no longer possible going forward now that
-        # connect() itself refuses to create one, but a document loaded
-        # from a row saved before that fix existed could still carry a
-        # pre-existing 2-node cycle - which used to make this exact
-        # scenario reachable: deleting the "child" side of such a cycle
-        # made parent_id == edge.target, so the reconnect below was really
-        # self.connect(parent_id, parent_id), which raises "cannot connect
-        # a node to itself" - and with the old pop-then-reconnect order,
-        # that exception fired AFTER the edges were already gone but
-        # BEFORE the node itself was deleted or last_chat_node_id/
-        # final_deliverable_node_id were updated: a corrupted, half-applied
-        # mutation with edges gone and the "deleted" node still present,
-        # with no rollback. Doing the reconnect first means ANY failure
-        # here (this case or an unforeseen future one) leaves the document
-        # completely unchanged - nothing has been popped yet - so the
-        # whole call fails cleanly instead of half-succeeding.
+        # BEFORE removing any edge below, not after (the original order) -
+        # and, as of this pass, check that EVERY child's reconnect will
+        # succeed before performing ANY of them, rather than one connect()
+        # per child interleaved with the loop.
+        #
+        # The reorder alone (reconnect-before-pop) already handles a
+        # pre-existing 2-node cycle where parent_id == edge.target (skipped
+        # just below rather than self-connected - see that comment), but it
+        # is NOT by itself atomic once node_id has 2+ children: connect()
+        # was being called once per child, sequentially, with no rollback
+        # around the loop. If child #1's reconnect succeeded (a real edge
+        # landed in self.edges) and child #2's reconnect then raised
+        # SceneError - reachable via a pre-existing MULTI-HOP legacy cycle,
+        # not just the direct 2-node case above, the same kind
+        # connect_unchecked still produces when session_load.py restores a
+        # pre-ADR-009-stage-9.6 per-kind connection-bucket save - the
+        # exception propagated with child #1's new edge already committed
+        # and node_id never deleted: a half-applied mutation, despite this
+        # comment previously (and wrongly) claiming that could no longer
+        # happen.
+        #
+        # Fixed by splitting "check" from "mutate" into two passes, the
+        # same discipline this session's undo_run fix (domain/commands.py)
+        # established for this same class of bug: the loop just below
+        # checks every child's reconnect with self._reaches BEFORE the
+        # second loop performs any connect() call at all. This is
+        # equivalent to checking each connect() as it would happen live,
+        # because connect() only ever ADDS an edge OUTGOING from
+        # parent_id, never one INCOMING to it - so nothing an earlier
+        # child's connect() call could do would change whether a LATER
+        # child's target can reach parent_id. Checking all of them against
+        # the graph exactly as it stood on entry to this method is
+        # therefore sound. A refusal here is now genuinely a no-op -
+        # nothing has been mutated yet - so the whole call fails cleanly
+        # instead of half-succeeding, for both the direct and the
+        # multi-hop cycle case.
         if parent_id is not None:
+            reconnect_targets = []
             for edge in child_edges:
                 if edge.target == parent_id:
-                    # The precondition above (a pre-existing cycle) - skip
-                    # rather than self-connect: there is nothing meaningful
-                    # to reconnect when the parent and the child are the
-                    # same node.
+                    # The direct-2-cycle precondition above - skip rather
+                    # than self-connect: there is nothing meaningful to
+                    # reconnect when the parent and the child are the same
+                    # node.
                     continue
-                self.connect(parent_id, edge.target)
+                reconnect_targets.append(edge.target)
+            for target in reconnect_targets:
+                if self._reaches(target, parent_id):
+                    raise SceneError(
+                        f"cannot delete {node_id}: reconnecting child {target} "
+                        f"to {parent_id} would create a cycle"
+                    )
+            for target in reconnect_targets:
+                self.connect(parent_id, target)
 
         for edge in [parent_edge, *child_edges, *note_edges]:
             if edge is not None:

--- a/backend/domain/commands.py
+++ b/backend/domain/commands.py
@@ -638,8 +638,28 @@ class CommandOps:
         outermost = self._composite_depth == 1
         try:
             yield
-        finally:
-            self._composite_depth -= 1
+        except BaseException:
+            # REVIEW-FIX: this block used to run its merge-and-push logic
+            # unconditionally from a `finally`, with no `except` at all - a
+            # mutator raising partway through the with-block (record_command's
+            # own AssertionError for an unanticipated deletion, or any
+            # exception from the wrapped domain call) still fell through to
+            # the same commit path, silently pushing whatever had been
+            # buffered SO FAR as if it were the complete action. That's a
+            # real, already-applied partial document mutation landing on the
+            # undo stack, while the caller's own exception handler has no
+            # reason to call publish_scene() for a group it believes never
+            # completed - the same live-document-diverges-from-clients shape
+            # undo_run's own REVIEW-FIX below already fixed for the reverse
+            # (undo) direction. Discard the buffered commands instead of
+            # merging/pushing them: a mid-block exception must mean the
+            # group never happened, matching what the caller already
+            # assumes when its own try/except catches this and never
+            # republishes.
+            if outermost:
+                self._composite_buffer.clear()
+            raise
+        else:
             if outermost:
                 buffered = list(self._composite_buffer)
                 self._composite_buffer.clear()
@@ -652,6 +672,8 @@ class CommandOps:
                 if merged is not None and not merged.is_noop:
                     self.redo_stack.clear()
                     self.command_log.append(merged)
+        finally:
+            self._composite_depth -= 1
 
     def can_undo(self) -> bool:
         return len(self.command_log) > 0

--- a/backend/domain/commands.py
+++ b/backend/domain/commands.py
@@ -687,17 +687,27 @@ class CommandOps:
     def redo_label(self) -> str:
         return self.redo_stack[-1].label if self.redo_stack else ""
 
-    def _guard_live_runs(self, command: "Command") -> None:
+    def _guard_live_runs(self, command: "Command", verb: str = "undo") -> None:
         """ADR-010 stage 10.4: refuse to undo/redo across a node with a live
         run. A node mid-generation has an in-flight agent writing to it;
         restoring a snapshot from before that run started would race the
         write and leave the node in a state neither the user nor the agent
-        asked for. The ADR's own guardrail - cancel first, then undo."""
+        asked for. The ADR's own guardrail - cancel first, then undo.
+
+        `verb` (REVIEW-FIX): the two UndoRefusedError messages below used to
+        be hard-coded with "undo" wording, so a refusal from redo() - which
+        calls this same guard - told the user "Can't undo..." for an action
+        they never asked to undo. intents_undo.py's redo handler passes
+        str(exc) straight to the notification banner (UndoRefusedError's own
+        docstring: shown "verbatim"), so the wrong verb reached the UI on
+        every refused redo. undo() and undo_run() keep the default "undo";
+        redo() passes "redo" so the same guard reads correctly from either
+        direction."""
         for node_id in command.touched_node_ids:
             node = self.nodes.get(node_id)
             if node is not None and node.pending_request_id:
                 raise UndoRefusedError(
-                    f"Can't undo while \"{node.title}\" is still generating - "
+                    f"Can't {verb} while \"{node.title}\" is still generating - "
                     "cancel it first."
                 )
         # REVIEW-FIX: the loop above only catches a live run whose OWN
@@ -726,7 +736,7 @@ class CommandOps:
                     and node.pending_request_id
                 ):
                     raise UndoRefusedError(
-                        "Can't undo a step from a build that is still running - "
+                        f"Can't {verb} a step from a build that is still running - "
                         "stop it first."
                     )
 
@@ -748,7 +758,7 @@ class CommandOps:
         if not self.redo_stack:
             raise UndoRefusedError("Nothing to redo.")
         command = self.redo_stack[-1]
-        self._guard_live_runs(command)
+        self._guard_live_runs(command, "redo")  # REVIEW-FIX: redo-appropriate wording
         command.apply(self)
         self.redo_stack.pop()
         self.command_log.append(command)

--- a/backend/knowledge_store.py
+++ b/backend/knowledge_store.py
@@ -583,11 +583,36 @@ def add_document_with_chunks(
             if last_saved is not None:
                 maybe_backup_before_write(db_path, last_saved)
 
-            cursor = conn.execute(
-                "INSERT INTO documents (collection_id, source_uri, title, mime, content_hash, added_at) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (collection_id, source_uri, title, mime, hash_value, _now_iso()),
-            )
+            try:
+                cursor = conn.execute(
+                    "INSERT INTO documents (collection_id, source_uri, title, mime, content_hash, added_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (collection_id, source_uri, title, mime, hash_value, _now_iso()),
+                )
+            except sqlite3.IntegrityError:
+                # REVIEW-FIX: the get_document_by_hash check above and this
+                # INSERT are not one atomic step - a second, fully separate
+                # connection (every real caller reaches this via
+                # asyncio.to_thread, genuine OS threads) can run the
+                # identical "no existing row" SELECT, then INSERT sequence
+                # concurrently for the same (content_hash, collection_id).
+                # Before this fix, the LOSING connection's INSERT hit the
+                # documents table's own UNIQUE(content_hash, collection_id)
+                # constraint and raised sqlite3.IntegrityError unhandled -
+                # this function's own docstring promises "always a no-op"
+                # for a content_hash that already exists, so an unhandled
+                # exception here broke that contract instead of the losing
+                # call simply returning the winner's already-committed
+                # document, same fix shape as get_or_create_workspace_
+                # collection's own identical race, above.
+                existing_id = get_document_by_hash(conn, content_hash_value=hash_value, collection_id=collection_id)
+                if existing_id is None:
+                    raise  # the constraint rejected this INSERT for some other reason - do not mask it
+                existing_count = conn.execute(
+                    "SELECT COUNT(*) FROM chunks WHERE document_id = ?", (existing_id,),
+                ).fetchone()[0]
+                return IngestOutcome(document_id=existing_id, chunk_count=existing_count, was_new=False)
+
             document_id = cursor.lastrowid
             conn.executemany(
                 "INSERT INTO chunks (document_id, ordinal, text, token_count, offset_start, offset_end) "

--- a/backend/knowledge_store.py
+++ b/backend/knowledge_store.py
@@ -816,17 +816,47 @@ def reindex_graph_content(
     per-graph-unique by construction (empirically verified - see this
     function's own test_two_different_graphs_do_not_collide test) rather
     than colliding on the UNIQUE constraint the moment two graphs' content
-    happens to match."""
+    happens to match.
+
+    REVIEW-FIX: the SELECT below and the DELETE/INSERT that follow it are
+    not one atomic step under a plain `with conn:` - Python's sqlite3
+    module only implicitly opens a transaction before INSERT/UPDATE/DELETE,
+    never before a bare SELECT, so the SELECT ran unlocked before this fix.
+    Two concurrent reindex_graph_content calls for the SAME graph_id
+    (reachable with no lock serializing them - see this function's own
+    calling-path docstring above) could both read the same pre-race
+    existing_ids and both INSERT a fresh documents row, leaving two rows
+    for one graph with no error raised - proven with a forced two-thread
+    race. Worse, a reindex racing a concurrent delete_graph_index call for
+    the same graph could read existing_ids BEFORE the delete's own DELETE
+    committed, then run its own (by-then-stale, no-op) DELETE and INSERT
+    AFTER the delete committed - silently resurrecting a just-deleted
+    graph's index entry that no future reindex will ever clean up, since
+    the graph no longer exists to trigger one.
+
+    `BEGIN IMMEDIATE` below acquires the write lock BEFORE the SELECT runs
+    (instead of leaving it deferred until the first DML), so the entire
+    SELECT-then-DELETE-then-INSERT sequence serializes against ANY other
+    writer on this db file - including delete_graph_index's own single
+    DELETE statement, which already atomically holds the write lock for
+    its own duration (no preceding SELECT of its own) and needs no change
+    of its own to be safe against this. Either the delete fully lands
+    first (this call's own SELECT then correctly sees no existing row and
+    the graph reappears with fresh content, no different from a normal
+    reindex-after-open-elsewhere race, not this bug) or this call fully
+    lands first (the later delete then correctly removes what was just
+    inserted) - the two can no longer straddle each other."""
     collection_id = get_or_create_workspace_collection(db_path, workspace_id)
     source_uri = _graph_source_uri(graph_id)
     estimator = TokenEstimator()
 
     conn = _connect(db_path, notifications=notifications)
     try:
-        with conn:
-            if last_saved is not None:
-                maybe_backup_before_write(db_path, last_saved)
+        if last_saved is not None:
+            maybe_backup_before_write(db_path, last_saved)
 
+        conn.execute("BEGIN IMMEDIATE")
+        try:
             existing_ids = [
                 row[0]
                 for row in conn.execute(
@@ -840,6 +870,7 @@ def reindex_graph_content(
                 conn.execute("DELETE FROM documents WHERE id = ?", (existing_id,))
 
             if not node_chunks:
+                conn.commit()
                 return
 
             full_text = "\n\n".join(text for _, text in node_chunks)
@@ -861,6 +892,10 @@ def reindex_graph_content(
                     for ordinal, (node_id, text) in enumerate(node_chunks)
                 ],
             )
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
     finally:
         conn.close()
 
@@ -875,7 +910,18 @@ def delete_graph_index(db_path: Path, graph_id: int) -> bool:
     entry for a graph that no longer exists. Returns whether a row was
     actually deleted - False for a graph with nothing indexed (never saved
     with any indexable node content, or already deleted) is a normal
-    outcome, not an error - mirrors delete_document's own return contract."""
+    outcome, not an error - mirrors delete_document's own return contract.
+
+    Needs no locking of its own against reindex_graph_content's race fix
+    (see that function's own REVIEW-FIX docstring): this DELETE is the
+    first and only statement in its transaction, so it already atomically
+    acquires the write lock the moment it runs - there is no preceding
+    SELECT here for a concurrent writer to interleave around. It was
+    reindex_graph_content's own SELECT-before-DELETE/INSERT that could run
+    unlocked ahead of this DELETE and later resurrect what this call just
+    removed; reindex_graph_content's own BEGIN IMMEDIATE closes that
+    window from its side, which is sufficient since SQLite allows only one
+    writer at a time on this db file."""
     conn = _connect(db_path)
     try:
         with conn:

--- a/backend/mcp_client.py
+++ b/backend/mcp_client.py
@@ -258,15 +258,31 @@ class McpStdioClient:
 
     def list_tools(self) -> tuple[ToolSpec, ...]:
         response = self._call("tools/list", {})
-        tools = response.get("tools", []) if isinstance(response, dict) else []
-        return tuple(
-            ToolSpec(
-                name=str(tool["name"]),
+        raw_tools = response.get("tools") if isinstance(response, dict) else None
+        if not isinstance(raw_tools, list):
+            raw_tools = []
+        specs: list[ToolSpec] = []
+        for tool in raw_tools:
+            # REVIEW-FIX: a spec-noncompliant server's tools/list response
+            # (a non-dict entry, a missing/null/blank "name") used to crash
+            # via an uncaught KeyError/TypeError - the only real caller
+            # (agents.py's _register_configured_mcp_tools) only catches
+            # (McpError, OSError), so this took down the WHOLE Builder tool
+            # registry for the session, every other configured server's
+            # tools included, not just this one's. Same "drop the bad
+            # entry, keep the rest" posture as graphlink_settings_store.py's
+            # get_mcp_servers for a malformed persisted server entry.
+            if not isinstance(tool, dict):
+                continue
+            name = tool.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            specs.append(ToolSpec(
+                name=name,
                 description=str(tool.get("description") or ""),
                 input_schema=tool.get("inputSchema") or {"type": "object"},
-            )
-            for tool in tools
-        )
+            ))
+        return tuple(specs)
 
     def call_tool(self, name: str, arguments: dict) -> ToolResult:
         response = self._call("tools/call", {"name": name, "arguments": dict(arguments or {})})

--- a/backend/mcp_client.py
+++ b/backend/mcp_client.py
@@ -183,6 +183,13 @@ class McpStdioClient:
         self._stderr_tail: "collections.deque[str]" = collections.deque(maxlen=200)
         self._responses: "queue.Queue[Any]" = queue.Queue()
         self._next_id = 0
+        # REVIEW-FIX: the id of the ONE request _call is currently waiting
+        # on (None when idle) - see _read_loop's own comment for why the
+        # reader thread checks this before queuing anything. Set/cleared
+        # only from within _call, always under _call_lock, matching this
+        # client's one-in-flight-request-at-a-time contract (see this
+        # class's own docstring).
+        self._pending_id: int | None = None
         self._write_lock = threading.Lock()
         self._call_lock = threading.Lock()
 
@@ -315,7 +322,22 @@ class McpStdioClient:
                     payload = json.loads(line)
                 except json.JSONDecodeError:
                     continue  # server-side logging on stdout, not JSON-RPC - skip
-                self._responses.put(payload)
+                # REVIEW-FIX: only queue a payload that answers the
+                # CURRENTLY in-flight request. Anything else - a legal MCP
+                # notification (no "id" at all; a server may send
+                # notifications/progress, notifications/message, etc. at
+                # any time, including while otherwise idle) or a stray/late
+                # response nothing is waiting on - used to be put() here
+                # unconditionally. Nothing ever drains self._responses
+                # between calls (the client sits idle/connected for most of
+                # a session), so a chatty/idle-notifying server grew this
+                # queue without bound for the client's whole lifetime.
+                # Dropping the non-matching payload here, rather than
+                # queuing then skipping past it in _call, is what actually
+                # bounds the queue.
+                pending_id = self._pending_id
+                if pending_id is not None and isinstance(payload, dict) and payload.get("id") == pending_id:
+                    self._responses.put(payload)
         finally:
             self._responses.put(_READER_CLOSED)
 
@@ -391,34 +413,45 @@ class McpStdioClient:
         with self._call_lock:
             self._next_id += 1
             request_id = self._next_id
-            self._write({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
-            deadline = time.monotonic() + self.timeout
-            while True:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    raise McpError(f"MCP server {self.command!r} timed out after {self.timeout}s calling {method!r}.")
-                try:
-                    payload = self._responses.get(timeout=remaining)
-                except queue.Empty:
-                    raise McpError(f"MCP server {self.command!r} timed out after {self.timeout}s calling {method!r}.")
-                if payload is _READER_CLOSED:
-                    stderr_tail = self._stderr_tail_text()
-                    raise McpError(
-                        f"MCP server {self.command!r} closed its output unexpectedly while calling {method!r}."
-                        + (f" stderr: {stderr_tail}" if stderr_tail.strip() else "")
-                    )
-                if not isinstance(payload, dict) or payload.get("id") != request_id:
-                    # A notification, or a response to a different in-flight
-                    # id - can't happen from THIS client (one call at a time
-                    # under _call_lock), but a server sending its own
-                    # unsolicited notification is legal MCP and must not be
-                    # mistaken for our response.
-                    continue
-                if "error" in payload:
-                    error = payload["error"]
-                    message_text = error.get("message", error) if isinstance(error, dict) else error
-                    raise McpError(f"{method} failed: {message_text}")
-                return payload.get("result", {}) or {}
+            # REVIEW-FIX: recorded so _read_loop can tell "the response to
+            # THIS call" apart from an unsolicited notification or a stray
+            # response nothing is waiting on - see that method's own
+            # comment. Cleared in `finally` no matter how the call ends
+            # (result, error, or timeout) so a late response that arrives
+            # after we've already given up is dropped by the reader too,
+            # not left for whatever happens to read the queue next.
+            self._pending_id = request_id
+            try:
+                self._write({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+                deadline = time.monotonic() + self.timeout
+                while True:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise McpError(f"MCP server {self.command!r} timed out after {self.timeout}s calling {method!r}.")
+                    try:
+                        payload = self._responses.get(timeout=remaining)
+                    except queue.Empty:
+                        raise McpError(f"MCP server {self.command!r} timed out after {self.timeout}s calling {method!r}.")
+                    if payload is _READER_CLOSED:
+                        stderr_tail = self._stderr_tail_text()
+                        raise McpError(
+                            f"MCP server {self.command!r} closed its output unexpectedly while calling {method!r}."
+                            + (f" stderr: {stderr_tail}" if stderr_tail.strip() else "")
+                        )
+                    if not isinstance(payload, dict) or payload.get("id") != request_id:
+                        # Defense in depth: _read_loop now only ever queues
+                        # a payload matching self._pending_id (== request_id
+                        # for this call's whole duration), so this should be
+                        # unreachable - kept as a safety net rather than an
+                        # invariant this method silently trusts.
+                        continue
+                    if "error" in payload:
+                        error = payload["error"]
+                        message_text = error.get("message", error) if isinstance(error, dict) else error
+                        raise McpError(f"{method} failed: {message_text}")
+                    return payload.get("result", {}) or {}
+            finally:
+                self._pending_id = None
 
 
 def register_mcp_server_tools(registry, client: McpStdioClient, config: McpServerConfig) -> tuple[str, ...]:

--- a/backend/mcp_client.py
+++ b/backend/mcp_client.py
@@ -329,12 +329,44 @@ class McpStdioClient:
         process = self._process
         if process is None or process.stdin is None:
             raise McpError(f"MCP server {self.command!r} is not connected.")
+        payload = json.dumps(message) + "\n"
         with self._write_lock:
-            try:
-                process.stdin.write(json.dumps(message) + "\n")
-                process.stdin.flush()
-            except (BrokenPipeError, ValueError) as exc:
-                raise McpError(f"MCP server {self.command!r} is not accepting input: {exc}") from exc
+            # REVIEW-FIX: stdin.write()/flush() are plain blocking file
+            # calls - Python gives no async/select-based way to bound them.
+            # A subprocess that stops draining its stdin (busy, wedged, or
+            # just an ordinarily-sized argument that fills the OS pipe
+            # buffer, a few KB on Windows) used to block this forever, and
+            # since _call() holds _call_lock for its whole body, every
+            # future call on this client deadlocked too - with no way to
+            # interrupt it (asyncio.to_thread cancellation doesn't touch the
+            # underlying blocked OS thread). The write is offloaded to a
+            # daemon helper thread and bounded with a join() timeout instead
+            # - mirrors _call's own read-side timeout against self.timeout.
+            # If it doesn't finish in time we raise rather than wait
+            # forever; the blocked syscall (and its thread) leaks, but a
+            # leaked thread beats a permanently deadlocked client.
+            outcome: list[BaseException] = []
+
+            def _blocking_write() -> None:
+                try:
+                    process.stdin.write(payload)
+                    process.stdin.flush()
+                except Exception as exc:  # re-raised on the caller's thread below
+                    outcome.append(exc)
+
+            writer = threading.Thread(target=_blocking_write, daemon=True)
+            writer.start()
+            writer.join(self.timeout)
+            if writer.is_alive():
+                raise McpError(
+                    f"MCP server {self.command!r} timed out after {self.timeout}s writing a "
+                    f"{message.get('method')!r} request - the process is not reading its stdin."
+                )
+            if outcome:
+                exc = outcome[0]
+                if isinstance(exc, (BrokenPipeError, ValueError)):
+                    raise McpError(f"MCP server {self.command!r} is not accepting input: {exc}") from exc
+                raise exc
 
     def _notify(self, method: str, params: dict) -> None:
         self._write({"jsonrpc": "2.0", "method": method, "params": params})

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -329,8 +329,17 @@ def _resolve_ref(
     the reference silently, matching legacy's own tolerance for a
     partially-resolvable payload)."""
     ref_id = payload.get(id_key)
-    if ref_id and ref_id in nodes_by_id:
-        return nodes_by_id[ref_id]
+    # REVIEW-FIX: ref_id comes straight from untrusted payload JSON and can
+    # legitimately be a list/dict (valid JSON, wrong shape) in a hand-edited
+    # or legacy save file - `x in dict`/`dict[x]` raise TypeError for an
+    # unhashable key, which would abort the ENTIRE chat load instead of just
+    # dropping this one reference. nodes_by_id is itself always populated
+    # with str(payload_id) keys (see the node-restore loop above), so
+    # str()-casting the lookup here is both crash-safe (str() is always
+    # hashable) and consistent with every other nodes_by_id lookup in this
+    # module (e.g. final_deliverable_node_id's identical str(...) guard).
+    if ref_id and str(ref_id) in nodes_by_id:
+        return nodes_by_id[str(ref_id)]
     ref_index = payload.get(index_key)
     if isinstance(ref_index, int) and ref_index in position_map:
         return position_map[ref_index]
@@ -1290,7 +1299,14 @@ def _restore_system_prompt_and_summary_connections(
         for entry in sp_entries:
             if not isinstance(entry, dict):
                 continue
-            note_id = notes_map.get(entry.get("start_note_index"))
+            # REVIEW-FIX: start_note_index is an untrusted payload value and
+            # can legitimately be a list/dict instead of the expected int -
+            # notes_map.get(x) raises TypeError for an unhashable x, which
+            # would abort the entire chat load. notes_map is int-keyed, so
+            # guard with the same isinstance(..., int) check _resolve_ref
+            # above already uses for its own index fallback.
+            start_note_index = entry.get("start_note_index")
+            note_id = notes_map.get(start_note_index) if isinstance(start_note_index, int) else None
             target_id = _resolve_ref(entry, "end_node_id", "end_node_index", nodes_by_id, chat_nodes_map)
             if note_id is not None and target_id is not None:
                 try:
@@ -1307,7 +1323,11 @@ def _restore_system_prompt_and_summary_connections(
             if not isinstance(entry, dict):
                 continue
             source_id = _resolve_ref(entry, "start_node_id", "start_node_index", nodes_by_id, chat_nodes_map)
-            note_id = notes_map.get(entry.get("end_note_index"))
+            # REVIEW-FIX: same unhashable-JSON-value risk as start_note_index
+            # above - guard end_note_index the same way before using it as a
+            # notes_map key.
+            end_note_index = entry.get("end_note_index")
+            note_id = notes_map.get(end_note_index) if isinstance(end_note_index, int) else None
             if source_id is not None and note_id is not None:
                 try:
                     # connect_unchecked - same reasoning as the two restore

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -982,9 +982,19 @@ def _restore_children(
             continue
         for position in range(max(len(child_ids), len(child_indices))):
             child_new_id = None
-            if position < len(child_ids) and child_ids[position] in nodes_by_id:
-                child_new_id = nodes_by_id[child_ids[position]]
-            elif position < len(child_indices):
+            # REVIEW-FIX: child_ids[position]/child_indices[position] come
+            # straight from untrusted payload JSON and can legitimately be a
+            # list/dict (valid JSON, wrong shape) instead of the expected
+            # scalar id/index - `x in dict`/`dict.get(x)` raise TypeError for
+            # an unhashable x, which would abort the entire chat load instead
+            # of skipping just this one child. nodes_by_id is always keyed by
+            # str(payload_id) (see _resolve_ref's identical str(...) guard),
+            # so str()-cast the id lookup; all_nodes_map is int-keyed, so
+            # isinstance-guard the index lookup the same way _resolve_ref
+            # guards its own index fallback.
+            if position < len(child_ids) and str(child_ids[position]) in nodes_by_id:
+                child_new_id = nodes_by_id[str(child_ids[position])]
+            elif position < len(child_indices) and isinstance(child_indices[position], int):
                 child_new_id = all_nodes_map.get(child_indices[position])
             if child_new_id is not None:
                 try:

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -6434,6 +6434,74 @@ def test_cancel_all_trips_a_pycoder_run_that_is_mid_execution_past_the_approval_
     asyncio.run(run())
 
 
+def test_cancel_pycoder_clears_pending_request_id_immediately_not_after_execute_returns(monkeypatch):
+    """REVIEW-FIX regression: start_pycoder_run's self._runs.claim() used
+    to omit `finalize`, unlike start_builder_run's/_dispatch's own claim()
+    calls. cancel_pycoder pops the registry handle (freeing is_busy(
+    "pycoder")) the INSTANT Cancel lands, but with no finalize wired,
+    nothing else observed that - node.pending_request_id (the sole real
+    busy guard runPyCoder's own pre-check reads, and what the frontend's
+    spinner keys off) stayed stuck pointing at the cancelled request until
+    _run's own late `finally` eventually ran, which cannot happen until
+    the blocking repl.execute() call actually returns - up to
+    PYCODER_EXECUTE_TIMEOUT_SECONDS later, since the REPL has no polling
+    hook. This asserts the busy guard clears WHILE still blocked inside
+    execute() (release is only set afterward), not merely once the task
+    eventually finishes - the same distinction test_cancel_all_trips_a_
+    pycoder_run_...'s own await-the-whole-task shape does not cover."""
+    started = threading.Event()
+    release = threading.Event()
+
+    class _BlockingRepl:
+        last_run_failed = False
+
+        def execute(self, code):
+            started.set()
+            release.wait(5)
+            return "output"
+
+    monkeypatch.setattr(AgentDispatcher, "get_pycoder_repl", lambda self, node_id, repl_id=None: _BlockingRepl())
+
+    async def run():
+        bus, notifications, dispatcher = _make_code_exec_env()
+        node = _make_pycoder_node(pycoder_mode="manual")
+
+        await dispatcher.start_pycoder_run(
+            bus=bus, notifications_state=notifications, node=node, node_id="n1",
+            mode="manual", prompt="", code="print(1)", conversation_history=[],
+            on_success=lambda *a: None, on_failure=lambda m: None,
+        )
+        request_id, entry = next(iter(pycoder_slots(dispatcher).items()))
+        await asyncio.to_thread(started.wait, 5)
+        assert node.pending_request_id == request_id, "sanity: busy before cancel"
+
+        # THE key action: Cancel, while still blocked inside repl.execute() -
+        # `release` is not set yet, so the orphaned task cannot have reached
+        # its own `finally` at any point below.
+        assert dispatcher.cancel_pycoder(request_id) is True
+        assert pycoder_slots(dispatcher) == {}, "the registry slot is freed immediately"
+
+        # finalize runs as a separately-scheduled task on this same loop
+        # (RunRegistry._schedule_finalize's run_coroutine_threadsafe) - give
+        # it a chance to actually execute before asserting on its effect.
+        for _ in range(50):
+            if node.pending_request_id is None:
+                break
+            await asyncio.sleep(0.01)
+
+        assert node.pending_request_id is None, (
+            "finalize must clear the busy guard the instant Cancel lands, "
+            "not wait for the orphaned execute() call to return"
+        )
+        assert node.state.pycoder_awaiting_approval is False
+        assert node.state.pycoder_error == "Py-Coder execution cancelled."
+
+        release.set()
+        await entry["task"]
+
+    asyncio.run(run())
+
+
 def test_cancel_code_sandbox_returns_false_for_an_unknown_request_id():
     dispatcher = AgentDispatcher(_FakeSettingsManager())
     assert dispatcher.cancel_code_sandbox("no-such-request") is False

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -513,6 +513,32 @@ def test_a_non_dict_top_level_message_gets_a_graceful_error_not_a_dropped_connec
         assert snapshot["kind"] == "state"
 
 
+def test_a_syntactically_invalid_json_frame_gets_a_graceful_error_not_a_dropped_connection():
+    """Regression: websocket.receive_json() is a bare json.loads() with no
+    try/except of its own (starlette's own implementation) - a text frame
+    that isn't syntactically valid JSON AT ALL (as opposed to
+    valid-JSON-but-wrong-shape, which the non-dict test above already
+    covers) raised json.JSONDecodeError straight out of that await, past
+    the only except clause around the receive loop (WebSocketDisconnect
+    only), and killed the connection outright with zero client-facing
+    feedback. Sends raw, deliberately unparseable text (not send_json,
+    which can only ever encode valid JSON) to put a genuinely malformed
+    frame on the wire, exactly as a garbling proxy or a truncated write
+    would."""
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text("{not valid json")
+        message = ws.receive_json()
+        assert message["kind"] == "error"
+        assert "malformed message" in message["error"]
+
+        # The connection must still be alive and working afterward - a
+        # graceful reply, not a dropped socket.
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        snapshot = ws.receive_json()
+        assert snapshot["kind"] == "state"
+
+
 def test_a_non_list_topics_field_gets_a_graceful_error_not_a_dropped_connection():
     """Regression: `topics = message.get("topics") or session.topic_names()`
     only falls back for a FALSY topics value - a truthy non-iterable (the

--- a/backend/tests/test_assets.py
+++ b/backend/tests/test_assets.py
@@ -74,6 +74,29 @@ def test_get_asset_respects_the_mime_type_it_was_stored_with():
     assert response.headers["content-type"] == "image/jpeg"
 
 
+def test_get_asset_falls_back_to_a_safe_content_type_for_a_non_image_mime_type():
+    # Regression: neither write path into document.image_assets (the
+    # addImageNode WS intent, session_load._restore_image_payload) validates
+    # mime_type before storing it, so a stored value like "text/html" used to
+    # be passed straight through as the response's Content-Type - letting a
+    # caller who fully controls the bytes also pick an arbitrary Content-Type
+    # for them. The read side (get_asset) is now the one place that closes
+    # this regardless of how the bad value got stored.
+    client = make_client()
+    bus = client.app.state.bus
+    document = get_session_context(bus.session("default")).canvas_document
+    parent = document.add_node(0, 0, "parent")
+    node = document.add_image_node(
+        0, 0, b"<script>alert(1)</script>", "prompt", parent.id, mime_type="text/html"
+    )
+
+    response = client.get(f"/api/assets/{node.state.image_asset_id}")
+
+    assert response.status_code == 200
+    assert response.content == b"<script>alert(1)</script>"
+    assert response.headers["content-type"] == "application/octet-stream"
+
+
 def test_get_asset_for_unknown_id_returns_404_json():
     client = make_client()
 

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -19,6 +19,7 @@ import time
 import api_provider
 from backend import builder as builder_module
 from backend import tools_graph as tools_graph_module
+from backend.api import intents_builder as intents_builder_module
 from backend.builder import run_build
 from backend.domain.graph import SceneDocument
 from backend.domain.model import MESSAGE_VERTICAL_SPACING
@@ -666,6 +667,52 @@ class TestBuilderIntents:
                 "builder", "saveRecipe", [source.id, "Research and summarize"],
             )
             assert result is None
+
+        asyncio.run(run())
+
+    def test_save_recipe_reads_and_writes_the_recipe_list_atomically_across_concurrent_calls(self, monkeypatch):
+        """Regression: save_recipe used to call settings.get_recipes() then
+        settings.set_recipes(...) directly on the event loop, with no lock
+        and no asyncio.to_thread - unlike every other settings-mutating
+        intent (backend/api/_settings_shared.py's own module docstring).
+        Mirrors test_settings.py's own run_locked atomicity regression
+        tests: patches intents_builder's own `run_locked` name binding to
+        inject a concurrent recipe write right where the real locked
+        section begins, then confirms this call's own read-modify-write
+        does not silently revert it."""
+        async def run():
+            bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+            manager = dispatcher._settings_manager
+            manager.set_recipes([{"name": "Existing", "goal": "g", "mode": "copilot", "steps": []}])
+            source = document.add_plan_node(0, 0, "goal")
+            source.state.plan_steps = [{"id": "s1", "title": "step", "status": "done", "detail": ""}]
+
+            real_run_locked = intents_builder_module.run_locked
+            injected = {"done": False}
+
+            def _run_locked_with_a_concurrent_write_in_the_window(mutation, *args):
+                if not injected["done"]:
+                    injected["done"] = True
+                    # A second connection's own recipe change lands and
+                    # commits, in full, right here - before this call's own
+                    # closure (the `mutation` argument) ever runs.
+                    manager.set_recipes([
+                        r for r in manager.get_recipes() if r["name"] != "Existing"
+                    ] + [{"name": "Concurrent", "goal": "g2", "mode": "copilot", "steps": []}])
+                return real_run_locked(mutation, *args)
+
+            monkeypatch.setattr(
+                intents_builder_module, "run_locked", _run_locked_with_a_concurrent_write_in_the_window,
+            )
+
+            await bus.dispatch_intent("builder", "saveRecipe", [source.id, "My recipe"])
+
+            assert injected["done"], "the concurrent write never ran - the test no longer exercises the window"
+            names = [r["name"] for r in manager.get_recipes()]
+            assert "My recipe" in names
+            # Must NOT be reverted - the concurrently-saved recipe must
+            # survive this call's own read-modify-write.
+            assert "Concurrent" in names
 
         asyncio.run(run())
 
@@ -1335,6 +1382,43 @@ class TestDeleteRecipe:
             names = [r["name"] for r in listing["recipes"]]
             assert "My recipe" not in names
             assert "Research and summarize" in names, "built-ins are untouched"
+
+        asyncio.run(run())
+
+    def test_delete_recipe_reads_and_writes_the_recipe_list_atomically_across_concurrent_calls(self, monkeypatch):
+        """Same run_locked atomicity regression as save_recipe's own test
+        above - delete_recipe used to call settings.get_recipes()/
+        set_recipes() directly on the event loop too, with no lock and no
+        asyncio.to_thread."""
+        async def run():
+            bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+            manager = dispatcher._settings_manager
+            manager.set_recipes([{"name": "My recipe", "goal": "g", "mode": "copilot", "steps": []}])
+
+            real_run_locked = intents_builder_module.run_locked
+            injected = {"done": False}
+
+            def _run_locked_with_a_concurrent_write_in_the_window(mutation, *args):
+                if not injected["done"]:
+                    injected["done"] = True
+                    manager.set_recipes(manager.get_recipes() + [
+                        {"name": "Concurrent", "goal": "g2", "mode": "copilot", "steps": []},
+                    ])
+                return real_run_locked(mutation, *args)
+
+            monkeypatch.setattr(
+                intents_builder_module, "run_locked", _run_locked_with_a_concurrent_write_in_the_window,
+            )
+
+            result = await bus.dispatch_intent("builder", "deleteRecipe", ["My recipe"])
+            assert result is True
+
+            assert injected["done"], "the concurrent write never ran - the test no longer exercises the window"
+            names = [r["name"] for r in manager.get_recipes()]
+            assert "My recipe" not in names
+            # Must NOT be reverted - the concurrently-saved recipe must
+            # survive this call's own read-modify-write.
+            assert "Concurrent" in names
 
         asyncio.run(run())
 

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -1006,6 +1006,32 @@ class TestReviewFixRegressions:
             "whose goal/checklist/spent budgets are still on the canvas"
         )
 
+    def test_a_setup_window_exception_lands_failed_instead_of_escaping(self, monkeypatch):
+        """Regression: the tool-spec filtering/prompt resolution/plan-digest
+        formatting between run_build's own busy-marker stamp (builder_status
+        ="running"/pending_request_id=request_id) and its try block used to
+        sit OUTSIDE any try/except. An exception raised there escaped
+        run_build entirely - agents.py's own caller wraps the call in only
+        `finally: self._runs.release(...)`, no except - leaving the plan
+        node stuck at "running" forever with a pending_request_id no run
+        backs anymore."""
+        document, dispatcher, registry, bus = make_harness()
+        node = seed_plan(document, ["a step"])
+
+        def boom_digest(node):
+            raise RuntimeError("boom during plan-digest formatting")
+
+        monkeypatch.setattr(builder_module, "_plan_digest", boom_digest)
+
+        asyncio.run(drive_build(document, dispatcher, registry, bus, node))
+
+        assert node.state.builder_status == "failed"
+        assert node.pending_request_id is None, (
+            "a setup-window exception must still clear pending_request_id, "
+            "or the plan node is stuck 'running' forever with cancel_builder "
+            "a permanent no-op"
+        )
+
 
 class TestActivityLog:
     """stage 8.7: the build's own visible record of what it did."""

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -546,6 +546,42 @@ class TestBuilderIntents:
 
         asyncio.run(run())
 
+    def test_set_plan_steps_refuses_while_the_node_has_a_live_run(self):
+        """A second tab (or the same tab in the WS-eventual-consistency
+        window right after a Resume click lands) can still fire
+        setPlanSteps while run_build is mid-step - PlanNodeView's own
+        canEditPlan gate is client-side only. document.set_plan_steps
+        always rebuilds plan_steps as fresh dict objects, even for entries
+        it leaves value-for-value unchanged - so letting this through would
+        detach run_build's own in-flight `step` reference (backend/
+        builder.py) from the live list even when the edit only touches a
+        DIFFERENT, still-pending step."""
+        async def run():
+            bus, document, recorder, dispatcher = make_bus_with_dispatcher()
+            node = document.add_plan_node(0, 0, "goal")
+            node.state.plan_steps = [
+                {"id": "s1", "title": "step one", "status": "running", "detail": ""},
+                {"id": "s2", "title": "step two", "status": "pending", "detail": ""},
+            ]
+            node.state.builder_status = "running"
+            node.pending_request_id = "req-1"
+            live_step = node.state.plan_steps[0]
+
+            await bus.dispatch_intent("scene", "setPlanSteps", [
+                node.id, [
+                    {"id": "s1", "title": "step one", "status": "running", "detail": ""},
+                    {"id": "s2", "title": "edited", "status": "pending", "detail": ""},
+                ],
+            ])
+
+            # Refused with a notification, not applied - the identity of
+            # the running step's dict must survive so run_build's own
+            # reference stays live.
+            assert node.state.plan_steps[0] is live_step
+            assert node.state.plan_steps[1]["title"] == "step two"
+
+        asyncio.run(run())
+
     def test_start_execution_refuses_a_non_resumable_status(self):
         async def run():
             bus, document, recorder, dispatcher = make_bus_with_dispatcher()

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -103,9 +103,12 @@ def seed_plan(document, steps, *, mode="copilot", **budgets):
     return node
 
 
-async def drive_build(document, dispatcher, registry, bus, node, *, approve=True, deny_first=False, notifications=None):
+async def drive_build(document, dispatcher, registry, bus, node, *, approve=True, deny_first=False, notifications=None, summaries=None):
     """Runs run_build while a driver coroutine plays the approving human.
-    Returns (approvals_seen, denials_issued)."""
+    Returns (approvals_seen, denials_issued). `summaries`, if passed, gets
+    each prompt's node.state.builder_approval_summary appended alongside
+    the matching approvals entry - opt-in so the existing two-tuple
+    callers are untouched."""
     cancel_event = threading.Event()
     handle = dispatcher._runs.claim("builder", node_id=node.id, cancel_event=cancel_event)
     approvals = []
@@ -130,6 +133,8 @@ async def drive_build(document, dispatcher, registry, bus, node, *, approve=True
             and not future.done()
         ):
             approvals.append(node.state.builder_approval_tool_name)
+            if summaries is not None:
+                summaries.append(node.state.builder_approval_summary)
             if deny_first and denials["count"] == 0:
                 denials["count"] += 1
                 future.set_result(False)
@@ -348,6 +353,71 @@ class TestAutopilotNetworkGate:
             "run_node registers graph.read only - the router must derive the "
             "research action's net.fetch scope or autopilot silently reaches "
             "the network"
+        )
+        assert node.state.builder_status == "done"
+
+
+class TestRunNodeExecuteApprovalGate:
+    """REVIEW-FIX regression: run_node(action="execute") on a pycoder node
+    used to bypass human review entirely - executing Builder-authored
+    Python straight through PythonREPL.execute() with no approval_future,
+    no pycoder_awaiting_approval, and (in autopilot, since code.execute
+    was in _AUTOPILOT_AUTO_SCOPES) no prompt at all. Mirrors
+    TestAutopilotNetworkGate's own shape for the identical class of gap,
+    now closed the same way: code.execute is no longer auto-approved, and
+    the prompt shown discloses the code itself (run_node_pending_code /
+    _approval_summary), not just the call's {node_id, action} arguments."""
+
+    def test_run_node_execute_prompts_in_autopilot_despite_the_registered_code_execute_scope(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        parent = document.add_chat_node(0, 0, "ctx", True)
+        pycoder = document.add_pycoder_node(0, 200, parent.id)
+        pycoder.state.pycoder_code = "print('should not run without review')"
+        node = seed_plan(document, ["run the code"], mode="autopilot")
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [call("c1", "run_node", node_id=pycoder.id)]},
+            {"tool_calls": [call("c2", "builder.complete_step", summary="done")]},
+        ], [])
+
+        approvals, denials = asyncio.run(
+            drive_build(document, dispatcher, registry, bus, node, deny_first=True)
+        )
+
+        assert approvals == ["run_node"], (
+            "code.execute must prompt even in autopilot - a Builder-written "
+            "pycoder node is arbitrary code execution, the same risk class "
+            "net.fetch already never auto-approves"
+        )
+        assert denials == 1
+        # Denied means invoke() never called the handler - LoopDispatcher.
+        # get_pycoder_repl raises if it's ever reached, so a passing build
+        # here (rather than an AssertionError bubbling out of the task) is
+        # itself proof the code never reached the REPL unapproved.
+        assert node.state.builder_status == "done"
+
+    def test_run_node_execute_approval_discloses_the_code_not_just_the_call_arguments(self, monkeypatch):
+        document, dispatcher, registry, bus = make_harness()
+        parent = document.add_chat_node(0, 0, "ctx", True)
+        pycoder = document.add_pycoder_node(0, 200, parent.id)
+        pycoder.state.pycoder_code = "import os\nos.system('echo hi')"
+        node = seed_plan(document, ["run the code"])  # copilot: already prompted pre-fix
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [call("c1", "run_node", node_id=pycoder.id)]},
+            {"tool_calls": [call("c2", "builder.complete_step", summary="done")]},
+        ], [])
+        summaries: list = []
+
+        approvals, denials = asyncio.run(
+            drive_build(document, dispatcher, registry, bus, node, deny_first=True, summaries=summaries)
+        )
+
+        assert approvals == ["run_node"]
+        assert len(summaries) == 1
+        # The old summary was just the call's own arguments - node_id/action,
+        # never the code. The fix must show the code that will actually run.
+        assert pycoder.state.pycoder_code in summaries[0]
+        assert summaries[0] == builder_module._approval_summary(
+            call("c1", "run_node", node_id=pycoder.id), document,
         )
         assert node.state.builder_status == "done"
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -186,7 +186,7 @@ def test_delete_chat_node_refuses_atomically_when_a_later_childs_reconnect_would
     doc = SceneDocument()
     p = doc.add_chat_node(0, 0, "p", True)
     d = doc.add_chat_node(1, 0, "d", False, parent_id=p.id)
-    c1 = doc.add_chat_node(2, 0, "c1", True, parent_id=d.id)
+    _c1 = doc.add_chat_node(2, 0, "c1", True, parent_id=d.id)
     c2 = doc.add_chat_node(2, 1, "c2", True, parent_id=d.id)
     x = doc.add_node(3, 0, "x")
     # A multi-hop legacy cycle only connect_unchecked can produce: c2 -> x

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -167,6 +167,50 @@ def test_delete_chat_node_survives_a_2_cycle_from_old_data_without_corrupting_st
     assert list(doc.edges.values()) == [], "no dangling self-edge or orphaned edge left behind"
 
 
+def test_delete_chat_node_refuses_atomically_when_a_later_childs_reconnect_would_close_a_multihop_cycle():
+    """Regression: the fix above (reorder reconnect-before-pop, skip a
+    direct 2-cycle self-connect) only covers a node with ONE child on a
+    2-node cycle. With 2+ children, the reconnect loop used to call
+    connect() once per child, sequentially, with no rollback around the
+    loop - if the FIRST child's reconnect succeeded (a real edge landed in
+    self.edges) and a LATER child's reconnect then raised SceneError
+    (reachable via a pre-existing MULTI-HOP legacy cycle - the kind
+    connect_unchecked still produces when session_load.py restores a
+    pre-ADR-009-stage-9.6 per-kind connection-bucket save, an entirely
+    ordinary old-saved-chat load), the exception propagated with the first
+    child's new edge already committed and the node never deleted: a
+    half-applied mutation from an ordinary Delete Message action. The fix
+    pre-flight-checks every child's reconnect before performing any of
+    them, so a refusal here must leave the document byte-identical to its
+    pre-delete-attempt state - not just "no crash." """
+    doc = SceneDocument()
+    p = doc.add_chat_node(0, 0, "p", True)
+    d = doc.add_chat_node(1, 0, "d", False, parent_id=p.id)
+    c1 = doc.add_chat_node(2, 0, "c1", True, parent_id=d.id)
+    c2 = doc.add_chat_node(2, 1, "c2", True, parent_id=d.id)
+    x = doc.add_node(3, 0, "x")
+    # A multi-hop legacy cycle only connect_unchecked can produce: c2 -> x
+    # -> p, combined with the ordinary p -> d -> c2 edges already in place,
+    # closes the loop p -> d -> c2 -> x -> p. Reconnecting c2 straight to p
+    # (what deleting d attempts, as the SECOND child processed since c1
+    # was added first) is exactly the edge that would close it - while
+    # reconnecting c1 (processed first) is perfectly fine on its own.
+    doc.connect_unchecked(c2.id, x.id)
+    doc.connect_unchecked(x.id, p.id)
+
+    nodes_before = set(doc.nodes)
+    edges_before = sorted((e.source, e.target) for e in doc.edges.values())
+
+    with pytest.raises(SceneError, match="cycle"):
+        doc.delete_chat_node(d.id)
+
+    assert set(doc.nodes) == nodes_before, "no node may be removed on refusal"
+    assert sorted((e.source, e.target) for e in doc.edges.values()) == edges_before, (
+        "no spurious edge (e.g. a p->c1 reconnect that succeeded before the "
+        "later c2 failure) may be left behind on refusal"
+    )
+
+
 def test_removing_a_node_removes_its_edges():
     doc = SceneDocument()
     a, b, c = doc.add_node(0, 0), doc.add_node(1, 1), doc.add_node(2, 2)

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -2764,6 +2764,28 @@ class TestOptimisticConcurrency:
         assert new_id == chat_id
         assert load_chat_row(db_path, chat_id)["data"] == {"nodes": ["v2-blind"]}
 
+    def test_blind_update_raises_cleanly_instead_of_crashing_when_the_row_was_deleted_concurrently(self, db_path):
+        # REVIEW-FIX regression: the blind-write branch (expected_updated_at
+        # =None, exercised just above) used to skip the rowcount check the
+        # checked branch right above it already has. A concurrent delete_
+        # chat of this exact row made the UPDATE affect zero rows and
+        # commit as a silent no-op, then this function crashed with an
+        # unhandled TypeError on its own post-commit workspace_id read-back
+        # (fetchone() on a now-gone row). This must now raise the SAME
+        # clean ConcurrentSaveConflict the checked branch already raises,
+        # so every caller's existing `except ConcurrentSaveConflict`
+        # handling (see the saveChat/autosave lost-race tests elsewhere in
+        # this class) covers this path too.
+        chat_id, _ = save_chat_atomically_row(db_path, None, "T", {"nodes": ["v0"]}, [], [])
+        delete_chat(db_path, chat_id)  # a concurrent session deletes it out from under this call
+
+        with pytest.raises(ConcurrentSaveConflict):
+            save_chat_atomically_row(db_path, chat_id, "T", {"nodes": ["v1-should-not-land"]}, [], [])
+
+        # Genuinely gone, not resurrected - matches the checked branch's own
+        # "nothing here is ever partially applied" guarantee.
+        assert load_chat_row(db_path, chat_id) is None
+
     def test_two_sessions_racing_through_the_real_saveChat_intent_surfaces_the_lost_race_notice(self, db_path):
         # End-to-end through the real register_chat_library wiring: two
         # SEPARATE sessions (separate SceneDocuments/buses, exactly like two

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -47,6 +47,7 @@ from backend.chat_library import (
     get_all_workspaces,
     get_workspace_default_model,
     load_chat_row,
+    load_chat_snapshot,
     load_notes_rows,
     load_pins_rows,
     register_chat_library,
@@ -1685,6 +1686,89 @@ def test_load_pins_rows_orders_by_sort_order_and_shape(db_path):
     assert [row["title"] for row in rows] == ["First", "Second"]
     assert rows[0]["position"] == {"x": 5.0, "y": 6.0}
     assert rows[0]["pin_id"] == "pin-a"
+
+
+# -- REVIEW-FIX: load_chat_snapshot - one shared connection/transaction for
+# -- the row/notes/pins reads make_load_chat's loadChat intent needs, closing
+# -- a torn-read gap the three independent load_chat_row/load_notes_rows/
+# -- load_pins_rows connections used to leave open (no existing test covered
+# -- this cross-call consistency at all before this fix).
+
+
+def test_load_chat_snapshot_reads_row_notes_and_pins_together(db_path):
+    chat_id = _insert_chat(db_path, "Snapshot", data=json.dumps({"nodes": []}))
+    _insert_note(db_path, chat_id, content="A note")
+    _insert_pin(db_path, chat_id, title="A pin")
+
+    row, notes_rows, pins_rows = load_chat_snapshot(db_path, chat_id)
+
+    assert row["title"] == "Snapshot"
+    assert len(notes_rows) == 1 and notes_rows[0]["content"] == "A note"
+    assert len(pins_rows) == 1 and pins_rows[0]["title"] == "A pin"
+
+
+def test_load_chat_snapshot_returns_none_row_and_empty_notes_pins_for_missing_id(db_path):
+    row, notes_rows, pins_rows = load_chat_snapshot(db_path, 999)
+    assert row is None
+    assert notes_rows == []
+    assert pins_rows == []
+
+
+def test_load_chat_snapshot_is_immune_to_a_concurrent_save_landing_mid_read(db_path, monkeypatch):
+    """Regression test for the torn-read finding: previously, load_chat_row/
+    load_notes_rows/load_pins_rows each opened and closed their OWN
+    connection, so a concurrent writer's real save_chat_atomically_row call
+    (a single atomic transaction) landing strictly BETWEEN two of those
+    three separate reads produced a torn combination - part of the pre-write
+    state, part of the post-write state. load_chat_snapshot now shares ONE
+    connection/transaction across all three reads, so the same concurrent
+    commit lands either entirely before or entirely after this call's own
+    WAL snapshot, never torn across it.
+
+    The race is simulated by monkeypatching the notes-read step to commit a
+    second, independent atomic save (via a fresh connection, standing in for
+    a different session) strictly between this call's row read (already
+    done by the time this runs) and its own notes/pins reads."""
+    chat_id, _ = save_chat_atomically_row(
+        db_path, None, "Before", {"nodes": []},
+        [{"content": "old note", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
+          "color": "#fff", "header_color": None, "is_system_prompt": False, "is_summary_note": False}],
+        [],
+    )
+
+    real_load_notes_rows_from_conn = chat_library_module._load_notes_rows_from_conn
+
+    def _load_notes_after_a_concurrent_save_lands(conn, cid):
+        # A different session's real, fully-committed atomic write - lands
+        # strictly between this call's already-done row read and this
+        # about-to-run notes read, exactly the gap the pre-fix three-
+        # separate-connections version left open.
+        save_chat_atomically_row(
+            db_path, chat_id, "After", {"nodes": []},
+            [{"content": "new note", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
+              "color": "#fff", "header_color": None, "is_system_prompt": False, "is_summary_note": False}],
+            [],
+        )
+        return real_load_notes_rows_from_conn(conn, cid)
+
+    monkeypatch.setattr(
+        chat_library_module, "_load_notes_rows_from_conn", _load_notes_after_a_concurrent_save_lands,
+    )
+
+    row, notes_rows, pins_rows = load_chat_snapshot(db_path, chat_id)
+
+    # This call's own snapshot was established at its FIRST read (the row
+    # itself), before the concurrent writer's commit - WAL's own snapshot
+    # isolation keeps that commit invisible for every read inside this same
+    # call, not just the first one.
+    assert row["title"] == "Before"
+    assert [n["content"] for n in notes_rows] == ["old note"]
+
+    # And the concurrent writer's commit really did land - a later, SEPARATE
+    # snapshot sees it, proving this isn't a stale cache masking the bug.
+    row_after, notes_after, _pins_after = load_chat_snapshot(db_path, chat_id)
+    assert row_after["title"] == "After"
+    assert [n["content"] for n in notes_after] == ["new note"]
 
 
 # -- R6.4: the loadChat intent -----------------------------------------------

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -3491,6 +3491,36 @@ class TestExportWorkspaceIntent:
         assert '"Default"' in notifications.message  # the WORKSPACE name is quoted in the toast
         assert "1 graph" in notifications.message
 
+    def test_export_includes_tags_favorite_and_archived(self, db_path, tmp_path, monkeypatch):
+        # REVIEW-FIX regression: export_workspace's per-chat payload used to
+        # be hardcoded to {title, data, notes, pins} - tags/favorite/
+        # archived never rode along even though get_all_chats (already
+        # fetched to resolve graph_ids) carries all three.
+        workspace = create_workspace(db_path, "Tagged Workspace")
+        chat_id, _ = save_chat_atomically_row(
+            db_path, None, "Tagged Graph", {"nodes": []}, [], [], workspace_id=workspace["id"],
+        )
+        set_graph_tags(db_path, chat_id, ["work", "urgent"])
+        set_graph_favorite(db_path, chat_id, True)
+        set_graph_archived(db_path, chat_id, True)
+
+        target = tmp_path / "tagged.graphlink"
+
+        async def _fake_pick_save_file(default_name, file_types=(), directory=""):
+            return str(target)
+
+        monkeypatch.setattr(native_dialogs_module, "pick_save_file", _fake_pick_save_file)
+        bus, _document, _notifications = _bus_with_canvas(db_path)
+        asyncio.run(bus.dispatch_intent("app-chat-library", "exportWorkspace", [workspace["id"]]))
+
+        archive = workspace_archive_module.read_archive(target)
+        chat = archive["chats"][0]
+        # get_all_chats returns each graph's tags already sorted (COLLATE
+        # NOCASE by tags.name) - see that function's own docstring.
+        assert chat["tags"] == ["urgent", "work"]
+        assert chat["favorite"] is True
+        assert chat["archived"] is True
+
     def test_seeds_the_dialog_with_a_sanitized_workspace_name(self, db_path, tmp_path, monkeypatch):
         workspace = create_workspace(db_path, "Client / Project #1")
         save_chat_atomically_row(

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -1419,6 +1419,41 @@ def test_rename_chat_intent_persists_and_republishes(db_path):
     assert recorder.messages[-1]["payload"]["rows"][0]["title"] == "After"
 
 
+def test_rename_chat_intent_returns_the_new_updated_at_on_success(db_path):
+    # REVIEW-FIX: rename_chat's own write already signals "the graph no
+    # longer exists" by returning None (see that function's own docstring),
+    # but make_rename_chat_intent's rename() used to discard that signal
+    # entirely and never return anything - always resolving to None
+    # regardless of whether the rename actually applied. Mirrors
+    # test_delete_chat_intent_removes_and_republishes's own assertion for
+    # make_delete_chat_intent's delete(), the identical shape.
+    chat_id = _insert_chat(db_path, "Before")
+    bus = SessionBus("chat-library-rename-returns-test")
+    register_chat_library(bus, db_path)
+
+    result = asyncio.run(bus.dispatch_intent("app-chat-library", "renameChat", [chat_id, "After"]))
+
+    assert result is not None
+    assert result == load_chat_row(db_path, chat_id)["updated_at"]
+
+
+def test_rename_chat_intent_returns_none_when_the_row_no_longer_exists(db_path):
+    """The rename-a-since-deleted-row race: two tabs of the same session (or
+    a queued/replayed intent) can reach renameChat after another tab's
+    deleteChat already removed the row. Pre-fix, this silently resolved to
+    None indistinguishably from a genuine success - now it's the SAME None
+    a genuine no-op title guard already returns, so a caller can finally
+    tell the two cases apart from a real success."""
+    chat_id = _insert_chat(db_path, "Temp")
+    bus = SessionBus("chat-library-rename-gone-test")
+    register_chat_library(bus, db_path)
+    asyncio.run(bus.dispatch_intent("app-chat-library", "deleteChat", [chat_id]))
+
+    result = asyncio.run(bus.dispatch_intent("app-chat-library", "renameChat", [chat_id, "Too Late"]))
+
+    assert result is None
+
+
 def test_delete_chat_intent_removes_and_republishes(db_path):
     chat_id = _insert_chat(db_path, "Temp")
     bus = SessionBus("chat-library-delete-test")

--- a/backend/tests/test_code_sandbox_only_binary.py
+++ b/backend/tests/test_code_sandbox_only_binary.py
@@ -441,3 +441,155 @@ class TestAllowSourceBuildsInstallsARealSourceOnlyPackage:
                 f"benign-source-pkg==0.0.1\n--no-index\n--find-links {find_links_dir.as_posix()}",
                 should_continue=lambda: True,
             )
+
+
+class TestDirectReferenceRequirementsBypassOnlyBinary:
+    """ADR-005 stage 5.5 round-3 review-fix: `--only-binary :all:` only
+    governs requirements pip resolves against an index/--find-links dir (the
+    ONLY shape every test above this class exercises). A direct-URL
+    reference (`pkg @ <url>`) or an editable/local-path install (`-e
+    <path>`) is never index-resolved at all, so pip still invokes THAT
+    reference's own PEP 517 build backend even with --only-binary :all: on
+    the command line - this class proves the bypass is real (negative
+    control, mirroring TestOnlyBinaryBlocksAHostileSdist's own "DOES execute
+    without the flag" control) and that sync_requirements now rejects it
+    before pip ever runs, using the identical hostile backend fixture as the
+    rest of this module."""
+
+    def test_a_direct_file_url_reference_still_executes_its_backend_even_with_only_binary(self, tmp_path):
+        # Negative control: replicates pip's ACTUAL pre-fix-equivalent
+        # invocation (--only-binary :all:, no requirements-line validation)
+        # directly against a hostile PEP 517 backend referenced by a direct
+        # file:// URL rather than an index/--find-links lookup. Proves the
+        # audit finding's mechanism, not just that sync_requirements now
+        # rejects the line - if pip's own behavior for direct references
+        # ever changes, this control (not just the rejection test below)
+        # would catch it.
+        marker = tmp_path / "marker.txt"
+        pkg_dir = tmp_path / "hostile_pkg_src"
+        pkg_dir.mkdir()
+        _write_hostile_backend(pkg_dir, marker)
+
+        venv_dir = tmp_path / "venv"
+        subprocess.run(
+            [sys.executable, "-m", "venv", str(venv_dir)],
+            check=True, capture_output=True, text=True, timeout=180,
+        )
+        python_exe = venv_dir / "Scripts" / "python.exe" if sys.platform == "win32" else venv_dir / "bin" / "python"
+        direct_url = pkg_dir.as_uri()
+
+        subprocess.run(
+            [
+                str(python_exe), "-m", "pip", "install", "--disable-pip-version-check",
+                "--only-binary", ":all:", "--no-input", f"hostile-pkg @ {direct_url}",
+            ],
+            capture_output=True, text=True, timeout=120,
+        )
+
+        assert marker.exists(), (
+            "test harness sanity check failed: a direct file:// reference "
+            "should still invoke the hostile backend even with "
+            "--only-binary :all: passed - if this assert fails, pip's own "
+            "behavior for direct references has changed and this finding "
+            "needs re-verification, not just this test suite"
+        )
+
+    def test_sync_requirements_rejects_a_direct_url_reference_before_pip_ever_runs(self, tmp_path):
+        marker = tmp_path / "marker.txt"
+        pkg_dir = tmp_path / "hostile_pkg_src"
+        pkg_dir.mkdir()
+        _write_hostile_backend(pkg_dir, marker)
+        direct_url = pkg_dir.as_uri()
+
+        sandbox = _make_sandbox_with_real_venv(tmp_path, "direct-url-block-test")
+
+        with pytest.raises(RuntimeError, match="Dependency installation blocked"):
+            sandbox.sync_requirements(
+                f"hostile-pkg @ {direct_url}",
+                should_continue=lambda: True,
+            )
+
+        assert not marker.exists(), (
+            "the hostile backend's build_wheel() hook executed - the new "
+            "direct-URL/editable check did not block it before pip ran"
+        )
+
+    def test_sync_requirements_rejects_an_editable_local_path_reference(self, tmp_path):
+        marker = tmp_path / "marker.txt"
+        pkg_dir = tmp_path / "hostile_pkg_src"
+        pkg_dir.mkdir()
+        _write_hostile_backend(pkg_dir, marker)
+
+        sandbox = _make_sandbox_with_real_venv(tmp_path, "editable-block-test")
+
+        with pytest.raises(RuntimeError, match="Dependency installation blocked"):
+            sandbox.sync_requirements(
+                f"-e {pkg_dir.as_posix()}",
+                should_continue=lambda: True,
+            )
+
+        assert not marker.exists(), (
+            "the hostile backend's build_wheel() hook executed - the new "
+            "editable-install check did not block it before pip ran"
+        )
+
+    def test_allow_source_builds_true_still_lets_a_direct_url_reference_reach_pip(self, tmp_path):
+        # Mirrors TestAllowSourceBuildsEscalation's own mirror-image style:
+        # the new check must not block the explicit opt-in - a direct
+        # reference under allow_source_builds=True reaches pip exactly as
+        # before, the backend runs (proven by the marker), and the hostile
+        # backend's own deliberate failure then surfaces as the ordinary
+        # pip-invocation "Dependency installation failed" error, not the new
+        # pre-check's "Dependency installation blocked" error.
+        marker = tmp_path / "marker.txt"
+        pkg_dir = tmp_path / "hostile_pkg_src"
+        pkg_dir.mkdir()
+        _write_hostile_backend(pkg_dir, marker)
+        direct_url = pkg_dir.as_uri()
+
+        sandbox = _make_sandbox_with_real_venv(tmp_path, "direct-url-escalation-test")
+
+        with pytest.raises(RuntimeError, match="Dependency installation failed"):
+            sandbox.sync_requirements(
+                f"hostile-pkg @ {direct_url}",
+                should_continue=lambda: True,
+                allow_source_builds=True,
+            )
+
+        assert marker.exists(), (
+            "allow_source_builds=True should have let pip attempt the "
+            "direct-URL install - the hostile backend's build_wheel() hook "
+            "never executed"
+        )
+
+    def test_an_ordinary_pinned_manifest_is_not_flagged_and_still_reaches_pip(self, tmp_path, monkeypatch):
+        # False-positive guard, in TestPipCommandIncludesTheFlags's own fast
+        # (non-subprocess-executing) style: an everyday manifest - including
+        # extras, environment markers, and the exact --no-index/--find-links
+        # option lines the real end-to-end tests above already use - must
+        # still reach pip unchanged.
+        sandbox = VirtualEnvSandbox("ordinary-requirement-test")
+        sandbox.base_dir = tmp_path
+        sandbox.requirements_file = tmp_path / "requirements.txt"
+        sandbox.requirements_hash_file = tmp_path / ".requirements.sha256"
+        sandbox.venv_dir = tmp_path / "venv"
+
+        captured_args = {}
+
+        def fake_run_subprocess(args, **kwargs):
+            captured_args["args"] = args
+            return "", 0
+
+        monkeypatch.setattr(sandbox, "_run_subprocess", fake_run_subprocess)
+
+        sandbox.sync_requirements(
+            "requests>=2.31,<3\n"
+            "numpy==1.26.0\n"
+            "pandas[excel]==2.2.0 ; python_version >= '3.9'\n"
+            "--no-index\n"
+            "--find-links ./local-wheels",
+            should_continue=lambda: True,
+        )
+
+        assert "args" in captured_args, "an ordinary manifest must still reach pip"
+        assert "--only-binary" in captured_args["args"]

--- a/backend/tests/test_commands.py
+++ b/backend/tests/test_commands.py
@@ -602,6 +602,54 @@ def test_a_composite_that_nets_out_to_nothing_is_not_logged(document):
     assert len(document.command_log) == 0
 
 
+def test_composite_discards_the_partial_buffer_on_a_mid_block_exception(document):
+    """REVIEW-FIX: composite()'s finally block used to merge and push
+    whatever had been buffered so far unconditionally, even when the
+    with-block raised partway through - silently committing a partial
+    group to the undo stack as if it were the whole action, with no
+    scene republish from the caller's own exception handler (which has
+    no reason to think the group ever completed). A mid-block exception
+    must now discard the buffer instead of committing it: only a clean
+    exit from the with-block pushes anything."""
+    node = document.add_note(0, 0)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with document.composite("multiMove", "user"):
+            document.record_command(
+                "moveNode", "user",
+                lambda: document.move_node(node.id, 10, 10), node_ids=[node.id],
+            )
+            raise RuntimeError("boom")
+
+    # The mutator itself already ran for real (the node did move) - that
+    # part is unavoidable and not what this fix addresses. What must NOT
+    # happen is the buffered moveNode landing on the undo stack as if the
+    # group had completed cleanly.
+    assert (document.nodes[node.id].x, document.nodes[node.id].y) == (10, 10)
+    assert len(document.command_log) == 0
+
+    # A later, unrelated composite must not see the discarded command leak
+    # in, and _composite_depth must have unwound back to 0 (not left stuck
+    # above 0, which would silently make every future composite non-
+    # outermost and never push anything at all). Two separate record_command
+    # calls forces the actual merge branch (a single one would pass through
+    # under its own original command_type), so a leftover moveNode from the
+    # discarded buffer would surface here as a 3rd merged member.
+    other_a = document.add_note(200, 0)
+    other_b = document.add_note(300, 0)
+    with document.composite("moveAgain", "user"):
+        document.record_command(
+            "moveNode", "user",
+            lambda: document.move_node(other_a.id, 20, 20), node_ids=[other_a.id],
+        )
+        document.record_command(
+            "moveNode", "user",
+            lambda: document.move_node(other_b.id, 30, 30), node_ids=[other_b.id],
+        )
+    assert len(document.command_log) == 1
+    assert document.command_log[-1].command_type == "moveAgain"
+
+
 def test_undo_run_reverses_a_whole_agent_build_in_one_action(document):
     """ADR-010 stage 10.5."""
     for index in range(3):

--- a/backend/tests/test_commands.py
+++ b/backend/tests/test_commands.py
@@ -15,7 +15,7 @@ import copy
 
 import pytest
 
-from backend.domain.commands import Command
+from backend.domain.commands import Command, UndoRefusedError
 from backend.domain.graph import SceneDocument
 from backend.domain.model import SceneNode
 
@@ -720,6 +720,56 @@ def test_undo_of_an_ordinary_user_edit_is_unaffected_by_an_unrelated_live_run(do
     user_node, _ = document.record_command("addNote", "user", lambda: document.add_note(200, 200))
     document.undo()
     assert user_node.id not in document.nodes, "an unrelated user edit must undo normally"
+
+
+def test_redo_refusal_message_says_redo_not_undo(document):
+    """REVIEW-FIX: _guard_live_runs' refusal message was hard-coded with
+    "undo" wording even though it is called identically from redo() -
+    intents_undo.py's redo handler passes str(exc) straight to the
+    notification banner shown to the user (UndoRefusedError's own
+    docstring: shown "verbatim"), so a refused redo used to tell the user
+    an undo had been blocked instead."""
+    node_id = document.add_note(0, 0).id
+    document.record_command(
+        "moveNode", "user", lambda: document.move_node(node_id, 10, 10), node_ids=[node_id],
+    )
+    document.undo()
+    assert document.can_redo()
+
+    # undo()'s invert() replaces the node object in document.nodes wholesale
+    # (see _restore) - the ORIGINAL `node` reference is now stale, so the
+    # live one has to be looked up fresh by id before mutating it.
+    document.nodes[node_id].pending_request_id = "req-live"
+    with pytest.raises(UndoRefusedError, match="Can't redo while") as exc_info:
+        document.redo()
+    assert "undo" not in str(exc_info.value)
+
+    document.nodes[node_id].pending_request_id = None
+    document.redo()
+    assert document.nodes[node_id].x == 10
+
+
+def test_redo_refusal_message_for_a_still_running_build_also_says_redo(document):
+    """Same fix, the run-scoped half of _guard_live_runs (the "step from a
+    build that is still running" message a still-live Builder run
+    triggers)."""
+    plan = document.add_plan_node(0, 0, "build something")
+    content_node, _command = document.record_command(
+        "builderCreateNode", "agent", lambda: document.add_note(100, 0),
+        run_id="run-1",
+    )
+    document.undo()
+    assert document.can_redo()
+
+    plan.pending_request_id = "run-1"
+    plan.state.builder_run_id = "run-1"
+    with pytest.raises(UndoRefusedError, match="Can't redo a step") as exc_info:
+        document.redo()
+    assert "undo" not in str(exc_info.value)
+
+    plan.pending_request_id = None
+    document.redo()
+    assert content_node.id in document.nodes
 
 
 def test_undo_run_rolls_back_completely_when_an_older_command_in_the_run_is_refused(document):

--- a/backend/tests/test_gitlink_domain.py
+++ b/backend/tests/test_gitlink_domain.py
@@ -742,6 +742,34 @@ def test_default_import_root_replaces_slashes_in_repo_and_branch():
     assert ".graphlink" in parts and "gitlink_repos" in parts
 
 
+def test_default_import_root_sanitizes_backslash_traversal_segments():
+    # On Windows, pathlib re-parses "\\" as a real separator once a string
+    # is joined into a Path - a repo value with a backslash-encoded ".."
+    # segment (e.g. pasted from a Windows path) must not be able to escape
+    # ~/.graphlink/gitlink_repos/ the way "/"-only sanitization allowed.
+    sandbox_root = Path.home() / ".graphlink" / "gitlink_repos"
+
+    escaped = default_import_root(
+        "a/xyz\\..\\..\\..\\AppData\\Local\\Temp\\evil", "marker"
+    )
+
+    # Exactly two path components (repo, branch) directly under the
+    # sandbox root - if the backslash segments had been reinterpreted as
+    # traversal, this would resolve to a shallower/different location, not
+    # a clean two-level path still rooted at gitlink_repos/.
+    relative_parts = escaped.relative_to(sandbox_root).parts
+    assert len(relative_parts) == 2
+    assert relative_parts[1] == "marker"
+
+
+def test_default_import_root_rejects_literal_dotdot_segment():
+    # Defense in depth: even a repo/branch value that sanitizes to the
+    # literal segment ".." (no slash or backslash to replace) must not be
+    # able to walk the resolved path back out of the sandbox root.
+    with pytest.raises(RuntimeError, match="escaped the local sandbox root"):
+        default_import_root("..", "marker")
+
+
 def test_scan_local_repo_paths_raises_when_root_missing(tmp_path):
     missing = tmp_path / "does-not-exist"
     with pytest.raises(RuntimeError, match="does not exist"):

--- a/backend/tests/test_knowledge_store.py
+++ b/backend/tests/test_knowledge_store.py
@@ -831,3 +831,228 @@ class TestReindexGraphContent:
 
     def test_delete_graph_index_on_a_graph_with_nothing_indexed_returns_false(self, db_path):
         assert ks.delete_graph_index(db_path, 12345) is False
+
+    def test_a_real_concurrent_race_reindexing_the_same_graph_never_produces_two_documents(self, db_path):
+        """Regression: reindex_graph_content's own existing-row lookup and
+        its own DELETE+INSERT were not one atomic step - two concurrent
+        reindexes of the SAME graph_id (reachable via asyncio.to_thread,
+        backend/chat_library.py's own post-commit reindex step with no
+        lock serializing two saves of the same chat from two sessions/
+        windows) could both read the same pre-race existing_ids and both
+        INSERT a fresh documents row, leaving two rows for one graph.
+
+        Forces the race by synchronizing both threads' own attempts to
+        acquire the write lock with a barrier, so they genuinely contend
+        for the SAME SQLite lock at the same instant - the same technique
+        TestGetOrCreateWorkspaceCollection's own identical race uses,
+        adapted to this fix's own lock-acquisition point (BEGIN IMMEDIATE)
+        rather than the SELECT that follows it: with the fix in place, a
+        losing thread's own SELECT is never even reachable until it
+        already holds the write lock, so barriering the SELECT itself
+        would deadlock the loser against the winner it is waiting on."""
+        import threading
+
+        collection_id = ks.get_or_create_workspace_collection(db_path, 1)
+
+        barrier = threading.Barrier(2)
+        real_connect = ks._connect
+
+        class _BarrieredConnection:
+            def __init__(self, inner):
+                self._inner = inner
+                self._waited = False
+
+            def execute(self, sql, *args, **kwargs):
+                if not self._waited and sql.strip() == "BEGIN IMMEDIATE":
+                    self._waited = True
+                    barrier.wait(timeout=5)
+                return self._inner.execute(sql, *args, **kwargs)
+
+            def executemany(self, sql, *args, **kwargs):
+                return self._inner.executemany(sql, *args, **kwargs)
+
+            def commit(self):
+                return self._inner.commit()
+
+            def rollback(self):
+                return self._inner.rollback()
+
+            def __enter__(self):
+                self._inner.__enter__()
+                return self
+
+            def __exit__(self, *exc):
+                return self._inner.__exit__(*exc)
+
+            def close(self):
+                self._inner.close()
+
+        def barriered_connect(*args, **kwargs):
+            return _BarrieredConnection(real_connect(*args, **kwargs))
+
+        errors: list[BaseException] = []
+
+        def call(node_text):
+            try:
+                ks.reindex_graph_content(
+                    db_path, graph_id=777, workspace_id=1, title="Racing Graph",
+                    node_chunks=[("node-a", node_text)],
+                )
+            except BaseException as exc:  # noqa: BLE001 - captured for the assertion below
+                errors.append(exc)
+
+        ks._connect = barriered_connect
+        try:
+            threads = [
+                threading.Thread(target=call, args=("Content from thread A about narwhals.",)),
+                threading.Thread(target=call, args=("Content from thread B about narwhals.",)),
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+        finally:
+            ks._connect = real_connect
+
+        assert not errors, f"reindex_graph_content raised under the forced race: {errors}"
+
+        conn = sqlite3.connect(db_path)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM documents WHERE source_uri = ?", ("graph:777",),
+            ).fetchone()[0]
+            assert count == 1, "the race must never leave two documents rows for one graph"
+            chunk_count = conn.execute(
+                "SELECT COUNT(*) FROM chunks c JOIN documents d ON d.id = c.document_id "
+                "WHERE d.source_uri = ?", ("graph:777",),
+            ).fetchone()[0]
+            assert chunk_count == 1, "the surviving document must carry exactly its own one node's chunk"
+        finally:
+            conn.close()
+
+        assert collection_id == ks.get_or_create_workspace_collection(db_path, 1)
+
+    def test_a_real_concurrent_delete_never_gets_silently_undone_by_an_in_flight_reindex(self, db_path):
+        """Regression: reindex_graph_content's existing-row SELECT could,
+        before this fix, run BEFORE a concurrent delete_graph_index call
+        for the same graph committed its DELETE, so reindex's own later
+        DELETE (targeting the by-then-already-gone row) was a harmless
+        no-op while its INSERT still ran - silently resurrecting a graph
+        that delete_graph_index had just, apparently successfully, removed.
+        Unlike the duplicate-documents race above, this is NOT self-healing:
+        the graph no longer exists in chat_library.py, so no future
+        reindex_graph_content call would ever come along to clean up the
+        resurrected row.
+
+        Forces the exact interleaving: seed one real existing document row
+        for the graph, then start a reindex of the SAME graph and pause it
+        (via a barrier) right after it has already re-read that stale
+        existing row but BEFORE its own DELETE executes - the precise
+        window the bug lived in - while a concurrent delete_graph_index
+        call is, at the very same instant, also trying to remove that same
+        row. Before this fix this reproduced two documents rows briefly
+        colliding into a resurrection; with the fix, reindex's own BEGIN
+        IMMEDIATE means it is already holding the write lock by the time
+        it reaches this window, so delete_graph_index's own DELETE simply
+        blocks until reindex's whole SELECT-DELETE-INSERT sequence commits,
+        then correctly removes what reindex just wrote - the two can never
+        straddle each other, so the graph ends up consistently gone."""
+        import threading
+
+        ks.reindex_graph_content(
+            db_path, graph_id=888, workspace_id=1, title="Doomed Graph",
+            node_chunks=[("node-a", "Content about pangolins, soon to be deleted.")],
+        )
+        assert len(ks.search_chunks(db_path, "pangolins")) == 1
+
+        barrier = threading.Barrier(2)
+        real_connect = ks._connect
+
+        class _BarrieredConnection:
+            """Barriers reindex's own per-row DELETE (its stale-read window
+            reading the SAME target document as the concurrent delete) and
+            delete_graph_index's own DELETE against the SAME barrier, so
+            both connections genuinely contend for the write lock at the
+            same instant - reindex already holds it (from its own BEGIN
+            IMMEDIATE, executed before this point), delete_graph_index does
+            not yet (this is the first statement on its own connection)."""
+
+            def __init__(self, inner):
+                self._inner = inner
+                self._waited = False
+
+            def execute(self, sql, *args, **kwargs):
+                target = sql.strip() in (
+                    "DELETE FROM documents WHERE id = ?",
+                    "DELETE FROM documents WHERE source_uri = ?",
+                )
+                if not self._waited and target:
+                    self._waited = True
+                    barrier.wait(timeout=5)
+                return self._inner.execute(sql, *args, **kwargs)
+
+            def executemany(self, sql, *args, **kwargs):
+                return self._inner.executemany(sql, *args, **kwargs)
+
+            def commit(self):
+                return self._inner.commit()
+
+            def rollback(self):
+                return self._inner.rollback()
+
+            def __enter__(self):
+                self._inner.__enter__()
+                return self
+
+            def __exit__(self, *exc):
+                return self._inner.__exit__(*exc)
+
+            def close(self):
+                self._inner.close()
+
+        def barriered_connect(*args, **kwargs):
+            return _BarrieredConnection(real_connect(*args, **kwargs))
+
+        errors: list[BaseException] = []
+        delete_results: list[bool] = []
+
+        def reindex_call():
+            try:
+                ks.reindex_graph_content(
+                    db_path, graph_id=888, workspace_id=1, title="Doomed Graph",
+                    node_chunks=[("node-a", "Fresh content about pangolins, racing the delete.")],
+                )
+            except BaseException as exc:  # noqa: BLE001 - captured for the assertion below
+                errors.append(exc)
+
+        def delete_call():
+            try:
+                delete_results.append(ks.delete_graph_index(db_path, 888))
+            except BaseException as exc:  # noqa: BLE001 - captured for the assertion below
+                errors.append(exc)
+
+        ks._connect = barriered_connect
+        try:
+            threads = [threading.Thread(target=reindex_call), threading.Thread(target=delete_call)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+        finally:
+            ks._connect = real_connect
+
+        assert not errors, f"reindex_graph_content/delete_graph_index raised under the forced race: {errors}"
+        assert delete_results == [True], "the delete must observe (and remove) a real row, not silently no-op"
+
+        conn = sqlite3.connect(db_path)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM documents WHERE source_uri = ?", ("graph:888",),
+            ).fetchone()[0]
+            assert count == 0, (
+                "a delete racing an in-flight reindex of the same graph must never leave a "
+                "resurrected document row behind"
+            )
+        finally:
+            conn.close()
+        assert ks.search_chunks(db_path, "pangolins") == []

--- a/backend/tests/test_knowledge_store.py
+++ b/backend/tests/test_knowledge_store.py
@@ -99,6 +99,102 @@ class TestIdempotency:
         assert first.document_id != second.document_id
         assert second.was_new is True
 
+    def test_a_real_concurrent_race_ingesting_identical_content_never_raises_and_stays_a_no_op(self, db_path):
+        """Regression: add_document_with_chunks' own get_document_by_hash
+        idempotency check and its own INSERT were not one atomic step - two
+        concurrent ingests of the SAME (content_hash, collection_id)
+        (reachable via asyncio.to_thread, e.g. backend/api/
+        intents_knowledge.py's setChatIndexIntoKnowledge firing twice for
+        the same node with no reentrancy guard covering this intent) could
+        both observe "no existing row" and both attempt the INSERT; the
+        documents table's own UNIQUE(content_hash, collection_id) then made
+        the LOSING thread's INSERT raise sqlite3.IntegrityError unhandled,
+        breaking this function's own documented "always an idempotent
+        no-op" contract instead of the losing call simply returning the
+        winner's already-committed document. Forces the race with a
+        barrier placed right after the SELECT, the exact same technique as
+        TestGetOrCreateWorkspaceCollection's own identical race, below."""
+        import threading
+
+        ks._connect(db_path).close()
+
+        text = "Identical content ingested by two threads at once."
+        chunks = _chunks_for(text)
+
+        barrier = threading.Barrier(2)
+        real_connect = ks._connect
+
+        class _BarrieredConnection:
+            """Wraps the real connection so the barrier waits exactly once,
+            right after the SELECT this function's own race hinges on -
+            not on every execute() call, which would deadlock against the
+            INSERT/re-SELECT retry path this fix adds."""
+
+            def __init__(self, inner):
+                self._inner = inner
+                self._select_count = 0
+
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().startswith("SELECT id FROM documents WHERE content_hash") and self._select_count == 0:
+                    self._select_count += 1
+                    barrier.wait(timeout=5)
+                return self._inner.execute(sql, *args, **kwargs)
+
+            def executemany(self, sql, *args, **kwargs):
+                return self._inner.executemany(sql, *args, **kwargs)
+
+            def __enter__(self):
+                self._inner.__enter__()
+                return self
+
+            def __exit__(self, *exc):
+                return self._inner.__exit__(*exc)
+
+            def close(self):
+                self._inner.close()
+
+        def barriered_connect(*args, **kwargs):
+            return _BarrieredConnection(real_connect(*args, **kwargs))
+
+        results: list = []
+        errors: list[BaseException] = []
+
+        def call():
+            try:
+                results.append(ks.add_document_with_chunks(
+                    db_path, source_uri="racing-doc.txt", title="Doc", mime="text/plain",
+                    text=text, chunks=chunks,
+                ))
+            except BaseException as exc:  # noqa: BLE001 - captured for the assertion below
+                errors.append(exc)
+
+        # A direct module-attribute swap, not monkeypatch.setattr: this
+        # patch must be visible to BOTH threads for the duration of the
+        # race, and restored exactly once afterward regardless of outcome.
+        ks._connect = barriered_connect
+        try:
+            threads = [threading.Thread(target=call) for _ in range(2)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+        finally:
+            ks._connect = real_connect
+
+        assert not errors, f"add_document_with_chunks raised under the forced race: {errors}"
+        assert len(results) == 2
+        assert results[0].document_id == results[1].document_id, "both racing calls must resolve to the SAME document"
+        assert results[0].was_new != results[1].was_new, "exactly one of the two calls actually inserted the row"
+
+        conn = sqlite3.connect(db_path)
+        try:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM documents WHERE content_hash = ?", (ks.content_hash(text),),
+            ).fetchone()[0]
+            assert count == 1, "the race must never leave two documents rows for one content_hash"
+        finally:
+            conn.close()
+
 
 # -- CRUD ---------------------------------------------------------------------
 

--- a/backend/tests/test_mcp_client.py
+++ b/backend/tests/test_mcp_client.py
@@ -448,3 +448,108 @@ def test_a_stdin_write_that_the_server_never_drains_raises_instead_of_hanging_fo
         assert elapsed < 2.5, f"write timeout did not bound the call - took {elapsed:.1f}s"
     finally:
         client.close()
+
+
+# -- a malformed tools/list response must not crash the whole registry ------
+
+
+_MALFORMED_TOOLS_SERVER_SCRIPT = textwrap.dedent(r'''
+    import json
+    import sys
+
+    def send(message):
+        sys.stdout.write(json.dumps(message) + "\n")
+        sys.stdout.flush()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        request = json.loads(line)
+        method = request.get("method")
+        request_id = request.get("id")
+        if method == "initialize":
+            send({"jsonrpc": "2.0", "id": request_id, "result": {
+                "protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                "serverInfo": {"name": "buggy", "version": "0.0.1"},
+            }})
+        elif method == "notifications/initialized":
+            pass
+        elif method == "tools/list":
+            send({
+                "jsonrpc": "2.0", "id": request_id,
+                "result": {"tools": [
+                    {"name": "good_tool", "description": "the only well-formed entry",
+                     "inputSchema": {"type": "object"}},
+                    {"description": "missing the required name field entirely"},
+                    "not_even_a_dict",
+                    {"name": None, "description": "a null name"},
+                    {"name": "", "description": "a blank name"},
+                ]},
+            })
+        else:
+            send({"jsonrpc": "2.0", "id": request_id,
+                  "error": {"code": -32601, "message": "unknown method"}})
+''')
+
+
+def test_list_tools_skips_malformed_entries_instead_of_crashing(tmp_path):
+    """Regression: list_tools() indexed tool["name"] with no shape
+    validation, so a single malformed entry (missing "name", a non-dict
+    entry, a null/blank name) raised KeyError/TypeError uncaught by the
+    only real caller - crashing the WHOLE Builder tool registry (every
+    other configured server's tools too) for the session. Malformed
+    entries must be skipped, not raised on - same "drop the bad entry, keep
+    the rest" posture as graphlink_settings_store.py's get_mcp_servers."""
+    script = tmp_path / "malformed_tools_server.py"
+    script.write_text(_MALFORMED_TOOLS_SERVER_SCRIPT, encoding="utf-8")
+    client = McpStdioClient(command=sys.executable, args=(str(script),))
+    try:
+        client.connect()
+        specs = client.list_tools()  # must not raise
+        assert [spec.name for spec in specs] == ["good_tool"]
+    finally:
+        client.close()
+
+
+_NULL_TOOLS_SERVER_SCRIPT = textwrap.dedent(r'''
+    import json
+    import sys
+
+    def send(message):
+        sys.stdout.write(json.dumps(message) + "\n")
+        sys.stdout.flush()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        request = json.loads(line)
+        method = request.get("method")
+        request_id = request.get("id")
+        if method == "initialize":
+            send({"jsonrpc": "2.0", "id": request_id, "result": {
+                "protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                "serverInfo": {"name": "buggy", "version": "0.0.1"},
+            }})
+        elif method == "notifications/initialized":
+            pass
+        elif method == "tools/list":
+            send({"jsonrpc": "2.0", "id": request_id, "result": {"tools": None}})
+        else:
+            send({"jsonrpc": "2.0", "id": request_id,
+                  "error": {"code": -32601, "message": "unknown method"}})
+''')
+
+
+def test_list_tools_tolerates_a_non_list_tools_field(tmp_path):
+    """A `"tools": null` response (or any non-list shape) must degrade to
+    "no tools", not raise - same tolerance as a malformed individual entry."""
+    script = tmp_path / "null_tools_server.py"
+    script.write_text(_NULL_TOOLS_SERVER_SCRIPT, encoding="utf-8")
+    client = McpStdioClient(command=sys.executable, args=(str(script),))
+    try:
+        client.connect()
+        assert client.list_tools() == ()
+    finally:
+        client.close()

--- a/backend/tests/test_mcp_client.py
+++ b/backend/tests/test_mcp_client.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import textwrap
+import time
 
 import pytest
 
@@ -372,5 +373,78 @@ def test_a_server_flooding_stderr_does_not_deadlock_the_client(tmp_path):
         result = client.call_tool("anything", {})
         assert result.content == "ok"
         assert result.is_error is False
+    finally:
+        client.close()
+
+
+# -- stdin write must not hang forever (the write-side deadlock) ------------
+
+
+_DEAF_SERVER_SCRIPT = textwrap.dedent(r'''
+    import json
+    import sys
+    import time
+
+    def send(message):
+        sys.stdout.write(json.dumps(message) + "\n")
+        sys.stdout.flush()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        request = json.loads(line)
+        method = request.get("method")
+        request_id = request.get("id")
+        if method == "initialize":
+            send({"jsonrpc": "2.0", "id": request_id, "result": {
+                "protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                "serverInfo": {"name": "deaf", "version": "0.0.1"},
+            }})
+            # Stop reading stdin entirely from here on - simulates a server
+            # that is busy/wedged and never drains its stdin again. The
+            # sleep sits inside the loop body, so control never returns to
+            # `for line in sys.stdin` to pull the next request. Bounded
+            # (not e.g. a full minute) so client.close() - which itself
+            # waits for the leaked writer thread's blocked write() to
+            # finally unblock once this process resumes reading - doesn't
+            # make the test itself slow; it just needs to comfortably
+            # outlast the client's own 1s write timeout below.
+            time.sleep(3)
+        else:
+            send({"jsonrpc": "2.0", "id": request_id,
+                  "error": {"code": -32601, "message": "unreachable - stdin is not read again"}})
+''')
+
+
+def test_a_stdin_write_that_the_server_never_drains_raises_instead_of_hanging_forever(tmp_path):
+    """Regression: _write() had no timeout on process.stdin.write()/flush().
+    A subprocess that stops draining its stdin blocks that write forever
+    while _call_lock is held, deadlocking every future call to this client
+    - with nothing anywhere that ever unblocks it short of killing the
+    process. Here the fake server answers the handshake and then never
+    reads stdin again; the client's next call carries an argument large
+    enough to fill the OS pipe buffer, so the write blocks. Bounded by the
+    fix's write-side timeout, the call must raise a clear McpError well
+    within a few seconds instead of hanging."""
+    script = tmp_path / "deaf_server.py"
+    script.write_text(_DEAF_SERVER_SCRIPT, encoding="utf-8")
+    client = McpStdioClient(command=sys.executable, args=(str(script),), timeout=1.0)
+    client.connect()
+    try:
+        # Comfortably larger than any OS pipe buffer (a few KB on Windows,
+        # tens of KB on Linux) - see the stderr-flood test above for the
+        # same reasoning on the read side.
+        big_argument = "x" * (4 * 1024 * 1024)
+        started = time.monotonic()
+        with pytest.raises(McpError, match="timed out"):
+            client.call_tool("anything", {"payload": big_argument})
+        elapsed = time.monotonic() - started
+        # The fake server first resumes draining stdin at the 3s mark (see
+        # its own comment) - well past self.timeout=1.0s. A tight bound
+        # here (not e.g. 10s) is deliberate: it's what actually proves the
+        # write was cut off by ITS OWN timeout rather than merely finishing
+        # whenever the server eventually got around to reading it.
+        assert elapsed < 2.5, f"write timeout did not bound the call - took {elapsed:.1f}s"
     finally:
         client.close()

--- a/backend/tests/test_mcp_client.py
+++ b/backend/tests/test_mcp_client.py
@@ -450,6 +450,77 @@ def test_a_stdin_write_that_the_server_never_drains_raises_instead_of_hanging_fo
         client.close()
 
 
+# -- idle notifications must not accumulate in the response queue -----------
+
+
+_NOTIFICATION_FLOOD_SERVER_SCRIPT = textwrap.dedent(r'''
+    import json
+    import sys
+
+    def send(message):
+        sys.stdout.write(json.dumps(message) + "\n")
+        sys.stdout.flush()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        request = json.loads(line)
+        method = request.get("method")
+        request_id = request.get("id")
+        if method == "initialize":
+            send({"jsonrpc": "2.0", "id": request_id, "result": {
+                "protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                "serverInfo": {"name": "noisy", "version": "0.0.1"},
+            }})
+        elif method == "notifications/initialized":
+            pass
+        elif method == "tools/call":
+            send({"jsonrpc": "2.0", "id": request_id, "result": {
+                "content": [{"type": "text", "text": "ok"}], "isError": False,
+            }})
+            # Legal MCP: a server may send notifications at any time, not
+            # just as a reply to a request. This floods a batch of them
+            # immediately after answering, while the client sits idle with
+            # no request in flight - the exact pattern a long-running
+            # progress/log-notifying server produces.
+            for i in range(300):
+                send({"jsonrpc": "2.0", "method": "notifications/message", "params": {"i": i}})
+        else:
+            send({"jsonrpc": "2.0", "id": request_id,
+                  "error": {"code": -32601, "message": "unknown method"}})
+''')
+
+
+def test_idle_notifications_do_not_accumulate_in_the_response_queue(tmp_path):
+    """Regression: the reader thread queued EVERY parsed stdout line
+    unconditionally, including legal MCP notifications a server sends while
+    otherwise idle (no request in flight) - nothing ever drains those
+    between calls, so self._responses grew without bound for the client's
+    whole lifetime. Here the fake server floods 300 notifications right
+    after answering a normal call; they must be dropped, not queued."""
+    script = tmp_path / "noisy_notifications_server.py"
+    script.write_text(_NOTIFICATION_FLOOD_SERVER_SCRIPT, encoding="utf-8")
+    client = McpStdioClient(command=sys.executable, args=(str(script),))
+    try:
+        client.connect()
+        result = client.call_tool("noisy", {})
+        assert result.content == "ok"
+
+        # The reader thread drains the flood off stdout concurrently with
+        # this assertion - give it a bounded window to catch up.
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and client._responses.qsize() > 0:
+            time.sleep(0.05)
+
+        assert client._responses.qsize() == 0, (
+            "idle notifications must be dropped, not queued forever - "
+            f"found {client._responses.qsize()} still queued"
+        )
+    finally:
+        client.close()
+
+
 # -- a malformed tools/list response must not crash the whole registry ------
 
 

--- a/backend/tests/test_run_node_tool.py
+++ b/backend/tests/test_run_node_tool.py
@@ -178,6 +178,30 @@ class TestRunChat:
 
         assert result.is_error
 
+    def test_node_deleted_while_the_reply_was_in_flight_is_a_clean_no_op(self, monkeypatch):
+        """REVIEW-FIX regression: an ordinary user can delete the chat node
+        run_node is replying to while _call_chat_agent (the await below) is
+        still in flight - remove_nodes has no special-casing for a chat
+        node just because it has a pending run_node request. add_chat_node
+        raises SceneError for a missing parent by design; uncaught, that
+        used to propagate out of handler() into ToolRegistry.invoke's
+        generic except Exception, discarding the reply as a confusing
+        internal exception instead of a clean tool error."""
+        document, dispatcher, registry = make_setup()
+        root = document.add_chat_node(0, 0, "what is 6*7?", True)
+
+        def _reply_then_delete(history, persona, cancel, **kwargs):
+            document.remove_nodes([root.id])
+            return "It is 42."
+
+        monkeypatch.setattr(agents_module, "_call_chat_agent", _reply_then_delete)
+
+        result = run_node(registry, make_ctx(), root.id)
+
+        assert result.is_error
+        assert "no longer exists" in result.content
+        assert not any(n.content == "It is 42." for n in document.nodes.values())
+
 
 class TestRunChart:
     def test_generates_a_chart_node_from_the_source_content(self, monkeypatch):
@@ -255,6 +279,27 @@ class TestRunChart:
         result = run_node(registry, make_ctx(), source.id, action="chart", chart_type="bar")
 
         assert result.is_error
+        assert not any(n.kind == "chart" for n in document.nodes.values())
+
+    def test_node_deleted_while_the_chart_was_in_flight_is_a_clean_no_op(self, monkeypatch):
+        """REVIEW-FIX regression: same missing-node race as TestRunChat's
+        identical test above - a concurrent delete of `source` while
+        _call_chart_agent (the await) is still running used to surface as
+        an uncaught SceneError from add_chart_node instead of a clean tool
+        error, since a chart with no source node has nothing to attach to."""
+        document, dispatcher, registry = make_setup()
+        source = document.add_chat_node(0, 0, "sales: Q1 10, Q2 20, Q3 15", False)
+
+        def _chart_then_delete(text, chart_type, cancel_event=None):
+            document.remove_nodes([source.id])
+            return {"labels": ["Q1", "Q2", "Q3"], "values": [10, 20, 15]}
+
+        monkeypatch.setattr(agents_module, "_call_chart_agent", _chart_then_delete)
+
+        result = run_node(registry, make_ctx(), source.id, action="chart", chart_type="bar")
+
+        assert result.is_error
+        assert "no longer exists" in result.content
         assert not any(n.kind == "chart" for n in document.nodes.values())
 
 
@@ -366,6 +411,57 @@ class TestRunResearch:
 
         assert result.is_error
         assert node.state.research_error
+
+    def test_node_deleted_mid_research_still_returns_the_completed_answer(self, monkeypatch):
+        """REVIEW-FIX regression: unlike chat/chart above (which CREATE a
+        new child node and so have nothing to land once the parent is
+        gone), a completed research answer is already fully formed here -
+        complete_web_research_run raises SceneError for a missing node by
+        design, but the model should still get the answer it already paid
+        for, mirroring _run_pycoder's own posture (complete_pycoder_run's
+        silent no-op for a deleted node)."""
+        from graphlink_plugins.web_research import service as wr_service
+        from graphlink_plugins.web_research.domain import ResearchResult
+
+        document, dispatcher, registry = make_setup()
+        node = self._seed_research(document)
+
+        def fake_run(self, request, *, token=None, progress=None):
+            document.remove_nodes([node.id])
+            return ResearchResult(
+                request_id=request.request_id, original_query=request.original_query,
+                effective_query=request.original_query, answer_markdown="Solar output doubled.",
+            )
+
+        monkeypatch.setattr(wr_service.WebResearchService, "run", fake_run)
+
+        result = run_node(registry, make_ctx(scopes=ALL_SCOPES | frozenset({"net.fetch"})), node.id)
+
+        assert not result.is_error
+        assert "doubled" in json.loads(result.content)["answer"]
+        assert node.id not in document.nodes
+
+    def test_node_deleted_mid_research_failure_is_still_a_clean_tool_error(self, monkeypatch):
+        """REVIEW-FIX regression: the failure-landing counterpart of the
+        success-path test above - fail_web_research_run also raises
+        SceneError for a missing node by design; a concurrent delete must
+        not turn an ordinary research failure into an uncaught exception."""
+        from graphlink_plugins.web_research import service as wr_service
+        from graphlink_plugins.web_research.domain import ResearchFailure
+
+        document, dispatcher, registry = make_setup()
+        node = self._seed_research(document)
+
+        def fake_run(self, request, *, token=None, progress=None):
+            document.remove_nodes([node.id])
+            raise ResearchFailure("No sources could be fetched.", code="no_sources")
+
+        monkeypatch.setattr(wr_service.WebResearchService, "run", fake_run)
+
+        result = run_node(registry, make_ctx(scopes=ALL_SCOPES | frozenset({"net.fetch"})), node.id)
+
+        assert result.is_error
+        assert "No sources" in result.content
 
     def test_research_requires_the_net_fetch_scope(self):
         document, dispatcher, registry = make_setup()

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -670,6 +670,36 @@ def test_group_summary_connection_chat_to_note():
     assert any(e.source == chat.id and e.target == note.id for e in document.edges.values())
 
 
+def test_malformed_connection_id_is_skipped_without_aborting_the_rest_of_the_load():
+    # A hand-edited/imported save with a non-scalar start_node_id (valid
+    # JSON, wrong shape) must not raise TypeError out of _resolve_ref and
+    # abort the whole load - only that one malformed entry is dropped, the
+    # next (well-formed) entry in the same list still restores.
+    document = _restore(
+        nodes=[_chat("a"), _chat("b"), _chat("c")],
+        connections=[
+            {"start_node_id": ["nested", "list"], "end_node_id": "b"},
+            {"start_node_index": 0, "end_node_index": 2},
+        ],
+    )
+    a, b, c = list(document.nodes.values())
+    assert len(document.edges) == 1
+    assert any(e.source == a.id and e.target == c.id for e in document.edges.values())
+
+
+def test_malformed_system_prompt_note_index_is_skipped_without_aborting_the_load():
+    # start_note_index/end_note_index are also untrusted payload values fed
+    # straight into notes_map.get() - a dict there (valid JSON, wrong shape)
+    # must not raise TypeError and abort the load either.
+    document = _restore(
+        nodes=[_chat("only-chat")],
+        notes=[{"content": "sp", "position": {"x": 0, "y": 0}, "size": {"width": 1, "height": 1},
+                "color": "#fff", "header_color": None, "is_system_prompt": True}],
+        system_prompt_connections=[{"start_note_index": {"nested": True}, "end_node_index": 0}],
+    )
+    assert not document.edges
+
+
 # -- pins / view state / tokens ------------------------------------------
 
 

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -347,6 +347,42 @@ def test_children_ids_are_id_preferred_over_children_indices():
     assert not any(e.source == root.id and e.target == wrong_child.id for e in document.edges.values())
 
 
+def test_malformed_child_id_is_skipped_without_aborting_the_rest_of_the_load():
+    # A hand-edited/imported save with a non-scalar children_ids entry
+    # (valid JSON, wrong shape) must not raise TypeError and abort the
+    # whole load - only that one malformed child is dropped, a well-formed
+    # sibling entry at another position still resolves.
+    document = _restore(nodes=[
+        {"node_type": "chat", "id": "root", "raw_content": "root", "is_user": True,
+         "position": {"x": 0, "y": 0}, "children_ids": [["nested", "list"], "child-b"]},
+        {"node_type": "chat", "id": "child-a", "raw_content": "child-a", "is_user": False,
+         "position": {"x": 0, "y": 100}},
+        {"node_type": "chat", "id": "child-b", "raw_content": "child-b", "is_user": False,
+         "position": {"x": 0, "y": 200}},
+    ])
+    root = next(n for n in document.nodes.values() if n.content == "root")
+    child_b = next(n for n in document.nodes.values() if n.content == "child-b")
+    assert len(document.edges) == 1
+    assert any(e.source == root.id and e.target == child_b.id for e in document.edges.values())
+
+
+def test_malformed_child_index_is_skipped_without_aborting_the_rest_of_the_load():
+    # Same tolerance, but for a non-scalar children_indices entry (a dict)
+    # instead of children_ids.
+    document = _restore(nodes=[
+        {"node_type": "chat", "id": "root", "raw_content": "root", "is_user": True,
+         "position": {"x": 0, "y": 0}, "children_indices": [{"nested": True}, 2]},
+        {"node_type": "chat", "id": "unused", "raw_content": "unused", "is_user": False,
+         "position": {"x": 0, "y": 100}},
+        {"node_type": "chat", "id": "child", "raw_content": "child", "is_user": False,
+         "position": {"x": 0, "y": 200}},
+    ])
+    root = next(n for n in document.nodes.values() if n.content == "root")
+    child = next(n for n in document.nodes.values() if n.content == "child")
+    assert len(document.edges) == 1
+    assert any(e.source == root.id and e.target == child.id for e in document.edges.values())
+
+
 # -- notes --------------------------------------------------------------
 
 

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -263,6 +263,37 @@ def test_an_old_settings_file_without_schema_version_is_backfilled(tmp_path):
     assert json.loads(state_file.read_text(encoding="utf-8"))["schema_version"] == SettingsManager.CURRENT_SCHEMA_VERSION
 
 
+@pytest.mark.parametrize(
+    "corrupt_schema_version",
+    [None, "not-a-version", [1], {"major": 1}, True],
+)
+def test_a_non_numeric_schema_version_is_backfilled_not_crashed_on(tmp_path, corrupt_schema_version):
+    # REVIEW-FIX regression: none of the dict migrations touch
+    # 'schema_version' itself, so a syntactically-valid-JSON but non-numeric
+    # value (a disk-level bit flip, or a hand-edited session.dat - a
+    # scenario this exact code region's own comments already anticipate)
+    # passed straight through to the `<` comparison, which raised an
+    # uncaught TypeError and took down SettingsManager.__init__ - and the
+    # whole app at boot - with no self-heal path. A non-numeric value must
+    # be treated the same as a missing one: backfilled to
+    # CURRENT_SCHEMA_VERSION, not a crash. (True is included even though it
+    # is technically an int subclass - it isn't a real version number
+    # either.)
+    import json
+
+    state_file = tmp_path / "session.dat"
+    state_file.write_text(
+        json.dumps({"schema_version": corrupt_schema_version, "show_token_counter": True}),
+        encoding="utf-8",
+    )
+
+    manager = SettingsManager(state_file)  # must not raise
+
+    assert manager.get_schema_version() == SettingsManager.CURRENT_SCHEMA_VERSION
+    manager.set_show_token_counter(False)  # persists the now-backfilled state
+    assert json.loads(state_file.read_text(encoding="utf-8"))["schema_version"] == SettingsManager.CURRENT_SCHEMA_VERSION
+
+
 # -- ADR-009 stage 9.1: scattered `if 'field' not in state` backfills refactored
 # -- into an explicit, ordered migration chain (graphlink_migrations.
 # -- run_dict_migrations). These are before/after equivalence tests: loading an

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -448,6 +448,36 @@ def test_set_mcp_servers_drops_an_entry_missing_a_name_or_command(manager):
     assert [entry["name"] for entry in manager.get_mcp_servers()] == ["valid"]
 
 
+def test_set_mcp_servers_tolerates_a_non_numeric_timeout_on_one_entry(manager):
+    # REVIEW-FIX regression: a non-numeric truthy "timeout" used to raise
+    # ValueError out of float() for THIS entry, aborting the whole
+    # bulk-replace call and discarding "git"'s valid edit too - contrary to
+    # this method's own docstring ("everything else normalized/defaulted").
+    manager.set_mcp_servers([
+        {"name": "fs", "command": "npx", "timeout": "not-a-number"},
+        {"name": "git", "command": "uvx"},
+    ])
+    servers = manager.get_mcp_servers()
+    assert [entry["name"] for entry in servers] == ["fs", "git"]
+    # The malformed value is coerced to the same default a missing timeout
+    # gets, not dropped or left malformed.
+    assert servers[0]["timeout"] == 30.0
+    assert servers[1]["timeout"] == 30.0
+
+
+def test_set_mcp_servers_tolerates_non_iterable_args_on_one_entry(manager):
+    # REVIEW-FIX regression: a non-iterable "args" (e.g. an int) used to
+    # raise TypeError out of the list comprehension for THIS entry, aborting
+    # the whole bulk-replace call and discarding "git"'s valid edit too.
+    manager.set_mcp_servers([
+        {"name": "fs", "command": "npx", "args": 42},
+        {"name": "git", "command": "uvx"},
+    ])
+    servers = manager.get_mcp_servers()
+    assert [entry["name"] for entry in servers] == ["fs", "git"]
+    assert servers[0]["args"] == []
+
+
 def test_get_mcp_servers_tolerates_a_malformed_entry_on_disk_without_dropping_the_rest(tmp_path):
     import json
 
@@ -2358,6 +2388,23 @@ def test_set_mcp_servers_is_a_bulk_replace_not_a_merge(manager):
     asyncio.run(bus.dispatch_intent("app-settings", "setMcpServers", [[{"name": "git", "command": "uvx"}]]))
 
     assert [entry["name"] for entry in manager.get_mcp_servers()] == ["git"]
+
+
+def test_set_mcp_servers_intent_tolerates_a_malformed_timeout_on_one_entry(manager):
+    # REVIEW-FIX regression, end-to-end through the intent: setMcpServers'
+    # own docstring (intents_settings_general.py) explicitly defers per-
+    # entry field validation to SettingsManager.set_mcp_servers - so a
+    # malformed timeout on one entry in an otherwise-valid multi-server
+    # payload must not lose every other server's edit in the same save.
+    bus = SessionBus("settings-set-mcp-servers-malformed-timeout-test")
+    register_settings(bus, manager)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setMcpServers", [[
+        {"name": "fs", "command": "npx", "timeout": "not-a-number"},
+        {"name": "git", "command": "uvx"},
+    ]]))
+
+    assert [entry["name"] for entry in manager.get_mcp_servers()] == ["fs", "git"]
 
 
 def test_set_mcp_servers_rejects_a_non_list_payload_without_persisting(manager):

--- a/backend/tests/test_workspace_archive.py
+++ b/backend/tests/test_workspace_archive.py
@@ -33,12 +33,15 @@ SECRET = "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789"
 HOME_PATH = r"C:\Users\ada\Documents\private.xlsx"
 
 
-def _chat(title="Trip planning", *, data=None, notes=None, pins=None):
+def _chat(title="Trip planning", *, data=None, notes=None, pins=None, tags=None, favorite=False, archived=False):
     return {
         "title": title,
         "data": data if data is not None else {"nodes": [{"content": "hello"}]},
         "notes": notes or [],
         "pins": pins or [],
+        "tags": tags or [],
+        "favorite": favorite,
+        "archived": archived,
     }
 
 
@@ -82,6 +85,46 @@ def test_a_chat_round_trips_through_export_and_import(tmp_path):
     assert len(chats) == 1
     assert chats[0]["title"] == "Trip planning"
     assert chats[0]["data"]["nodes"][0]["content"] == "keep me"
+
+
+# REVIEW-FIX: tags/favorite/archived used to be dropped entirely on export -
+# export_archive's payload was hardcoded to {title, data, notes, pins}, with
+# no field anywhere in the format for these three to travel through. See
+# backend/chat_library.py's make_export_workspace._load_one for where the
+# real export path now sources them from (get_all_chats, not load_chat_row/
+# load_notes_rows/load_pins_rows).
+
+
+def test_tags_favorite_and_archived_round_trip_through_export_and_import(tmp_path):
+    archive = tmp_path / "out.graphlink"
+    export_archive(archive, [_chat(tags=["work", "urgent"], favorite=True, archived=True)])
+
+    chats = import_archive(archive)
+
+    assert len(chats) == 1
+    assert chats[0]["tags"] == ["work", "urgent"]
+    assert chats[0]["favorite"] is True
+    assert chats[0]["archived"] is True
+
+
+def test_an_older_archive_without_tags_favorite_archived_defaults_them_back_rather_than_crashing(tmp_path):
+    # Simulates an archive written before this fix existed: its chat entry
+    # is exactly the old {title, data, notes, pins} shape, with no tags/
+    # favorite/archived keys at all - import_archive must default them
+    # rather than KeyError or crash.
+    archive = tmp_path / "pre_fix.graphlink"
+    old_shaped_chat = {"title": "Old Export", "data": {"nodes": []}, "notes": [], "pins": []}
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("manifest.json", json.dumps({"formatVersion": FORMAT_VERSION}))
+        zf.writestr("chats/0.json", json.dumps(old_shaped_chat))
+
+    chats = import_archive(archive)
+
+    assert len(chats) == 1
+    assert chats[0]["title"] == "Old Export"
+    assert chats[0]["tags"] == []
+    assert chats[0]["favorite"] is False
+    assert chats[0]["archived"] is False
 
 
 def test_assets_round_trip_into_a_DIFFERENT_store_the_second_machine_case(tmp_path):

--- a/backend/tools_graph.py
+++ b/backend/tools_graph.py
@@ -894,6 +894,20 @@ def make_run_node_handler(document: SceneDocument, dispatcher):
             ),
             timeout=_agents_const("WATCHDOG_TIMEOUT_SECONDS"),
         )
+        # REVIEW-FIX: an ordinary user can delete node_id while the await
+        # above was in flight (remove_nodes has no special-casing for a
+        # chat node just because run_node has a pending request on it - see
+        # run_node_pending_code's own neighbourhood for the analogous
+        # pycoder case). add_chat_node below raises SceneError for a
+        # missing parent BY DESIGN (its own docstring) - uncaught, that
+        # would propagate out of handler() into ToolRegistry.invoke's
+        # generic `except Exception`, discarding a reply the model already
+        # paid for. Land it as a clean, expected tool error instead - the
+        # same graceful-no-op posture fail_pycoder_run's own silent no-op
+        # and intents_web_research.py's `if node_id not in document.nodes:
+        # return` already give the sibling cases of this identical race.
+        if node_id not in document.nodes:
+            return _error(f"Node {node_id!r} no longer exists - the reply was discarded.")
         x, y = _place_child(document, node_id)
 
         def mutator():
@@ -962,7 +976,19 @@ def make_run_node_handler(document: SceneDocument, dispatcher):
                 timeout=_agents_const("WEB_RESEARCH_WATCHDOG_TIMEOUT_SECONDS"),
             )
         except ResearchFailure as exc:
-            document.fail_web_research_run(node_id, cancelled=token.cancelled, message=str(exc))
+            # REVIEW-FIX: node_id can be gone by the time this lands (a
+            # concurrent user delete - remove_nodes does not special-case a
+            # web_research node just because a run_node call has it
+            # pending). fail_web_research_run raises SceneError for a
+            # missing node BY DESIGN (its own docstring says the caller
+            # must check liveness first) - guard it here rather than
+            # letting that propagate out as an uncaught exception; the
+            # _error result below still reaches the model either way,
+            # mirroring _on_failure's own `if node_id not in document.
+            # nodes: return` in the dedicated WS intent (intents_web_
+            # research.py) for this identical race.
+            if node_id in document.nodes:
+                document.fail_web_research_run(node_id, cancelled=token.cancelled, message=str(exc))
             return _error(f"Research failed: {exc}")
         except RequestCancelled:
             # review-fix: this is a DIFFERENT class from api_provider's own
@@ -975,18 +1001,34 @@ def make_run_node_handler(document: SceneDocument, dispatcher):
             # landed, leaving it wedged mid-run. Land it properly, then
             # re-raise as the type invoke() DOES special-case so Stop is
             # honored immediately instead of only at the loop's next
-            # cancel_event checkpoint.
-            document.fail_web_research_run(node_id, cancelled=True, message="Web research was cancelled.")
+            # cancel_event checkpoint. REVIEW-FIX: guarded for the same
+            # missing-node race as the ResearchFailure branch above - the
+            # re-raise must still happen unconditionally so Stop is
+            # honored, only the landing call is conditional.
+            if node_id in document.nodes:
+                document.fail_web_research_run(node_id, cancelled=True, message="Web research was cancelled.")
             raise RequestCancelledError("Web research was cancelled.")
         except asyncio.TimeoutError:
             token.cancel()
-            document.fail_web_research_run(
-                node_id, cancelled=False, message="Research timed out.",
-            )
+            # REVIEW-FIX: same missing-node race as the ResearchFailure
+            # branch above.
+            if node_id in document.nodes:
+                document.fail_web_research_run(
+                    node_id, cancelled=False, message="Research timed out.",
+                )
             return _error(f"Research on node {node_id!r} timed out.")
         finally:
             watcher.cancel()
-        document.complete_web_research_run(node_id, _research_result_wire(result))
+        # REVIEW-FIX: same missing-node race as the ResearchFailure branch
+        # above, on the success path. Unlike the chat/chart branches below
+        # (which CREATE a new node parented on node_id and so have nothing
+        # useful to return if that parent is gone), the research answer
+        # itself is already fully formed here - mirror _run_pycoder's own
+        # posture (complete_pycoder_run's silent no-op) rather than
+        # discarding a completed result the model already paid for: skip
+        # the landing call but still return it.
+        if node_id in document.nodes:
+            document.complete_web_research_run(node_id, _research_result_wire(result))
         return ToolResult(content=json.dumps({
             "node_id": node_id,
             "answer": result.answer_markdown[:_RUN_OUTPUT_EXCERPT_CHARS],
@@ -1030,6 +1072,16 @@ def make_run_node_handler(document: SceneDocument, dispatcher):
             chart_data = canonicalize_chart_data(parsed, chart_type)
         except ChartDataError as exc:
             return _error(f"Chart generation produced invalid data: {exc}")
+        # REVIEW-FIX: node_id can be gone by the time this lands (same
+        # concurrent-delete race as _run_chat's own identical guard above -
+        # remove_nodes does not special-case a chat/note/document/code node
+        # just because run_node has it pending). add_chart_node below
+        # raises SceneError for a missing parent BY DESIGN - a chart with
+        # no source node to attach to is not a node this call can create at
+        # all, so there is nothing useful to land; fail cleanly instead of
+        # letting that SceneError propagate out of handler() uncaught.
+        if node_id not in document.nodes:
+            return _error(f"Node {node_id!r} no longer exists - the chart was discarded.")
         x, y = _place_child(document, node_id)
         chart_node, _command = document.record_command(
             "builderRunChart", "agent",

--- a/backend/tools_graph.py
+++ b/backend/tools_graph.py
@@ -242,6 +242,29 @@ def run_node_effective_scope(document: SceneDocument, call: ToolCall) -> str | N
     return _RUN_NODE_ACTION_SCOPES.get(action)
 
 
+def run_node_pending_code(document: SceneDocument, call: ToolCall) -> str | None:
+    """REVIEW-FIX: the code a run_node(action="execute") call is about to
+    hand to PythonREPL.execute() - or None if `call` is not such a call.
+    Exists so the approval prompt shown to a human (builder.py's
+    _approval_summary) can disclose the CODE, not just the call's own
+    arguments ({"node_id": ..., "action": "execute"}). The code itself
+    lives on the TARGET node's state (set by an earlier, separately-
+    approved graph.set_node_content call), not in this call - a human
+    approving from arguments alone would be blessing a black box, unlike
+    every other run_node action where the arguments already say what will
+    happen. Mirrors run_node_effective_scope's "derive what the call will
+    actually do before it's invoked" shape."""
+    if call.name != "run_node":
+        return None
+    node = document.nodes.get(str(call.arguments.get("node_id") or ""))
+    if node is None or node.kind != "pycoder":
+        return None
+    action = str(call.arguments.get("action") or "") or _RUN_NODE_DEFAULT_ACTIONS.get(node.kind, "")
+    if action != "execute":
+        return None
+    return node.state.pycoder_code
+
+
 def _run_id_of(ctx: RunContext) -> str | None:
     """The builder's BuilderRunContext carries run_id; a bare RunContext
     (tests, a future non-builder caller) does not - unstamped is the
@@ -692,7 +715,8 @@ RUN_NODE_SPEC = ToolSpec(
     description=(
         "Run a node's action and return its result. Actions: execute (a "
         "pycoder node's default - runs its current code in its Python REPL; "
-        "requires the code.execute scope), reply (a chat node's default - "
+        "requires the code.execute scope; always prompts for human "
+        "approval showing the code, even in autopilot), reply (a chat "
         "generates an assistant reply as a new child node from its branch "
         "history; requires provider.call), chart (explicit action on any "
         "content node - chat/note/document/code - generates a chart node "
@@ -760,7 +784,22 @@ def make_run_node_handler(document: SceneDocument, dispatcher):
     re-entering the fire-and-forget AgentDispatcher surfaces themselves:
     those claim their own busy kinds, wire callbacks to intents, and offer
     no awaitable completion; this runs inline under the BUILDER's run and
-    cancel event instead (the design doc's D9)."""
+    cancel event instead (the design doc's D9).
+
+    REVIEW-FIX: the execute action does NOT reuse start_pycoder_run's own
+    dedicated approval_future/pycoder_awaiting_approval gate (that surface
+    is fire-and-forget, as above) - it relies entirely on run_node's own
+    registry-level approval ("once", registered below) instead. That gate
+    used to be silently satisfied in autopilot (code.execute was in
+    builder.py's _AUTOPILOT_AUTO_SCOPES) and, in copilot, disclosed only
+    the call's own arguments (node_id/action, not the code) - the code
+    lives on the target node's state, written by an earlier, separately-
+    approved graph.set_node_content call the human may not connect to
+    this one. Fixed at the source: _AUTOPILOT_AUTO_SCOPES no longer
+    auto-approves code.execute (builder.py), and _approval_summary there
+    now shows the actual code for this call via run_node_pending_code
+    above - so BOTH modes now require a human to see and approve the
+    code immediately before it runs, not just the tool-call shape."""
 
     async def handler(call: ToolCall, ctx: RunContext) -> ToolResult:
         from backend import agents as _agents  # late import + late binding (test seam)

--- a/backend/workspace_archive.py
+++ b/backend/workspace_archive.py
@@ -3,7 +3,11 @@
 FORMAT. A plain zip, deliberately readable without this app:
 
     manifest.json              format version, app version, export time, index
-    chats/<n>.json             one chat: {title, data, notes, pins}
+    chats/<n>.json             one chat: {title, data, notes, pins, tags,
+                                favorite, archived} - the last three are
+                                REVIEW-FIX additions (older archives simply
+                                lack them; import_archive defaults them back
+                                to empty/false rather than requiring them)
     assets/<ref>.<ext>         binary assets, real files, content-addressed
 
 Chats are JSON and assets are files precisely because the point is
@@ -121,9 +125,12 @@ def export_archive(
 ) -> Path:
     """Writes `chats` to `archive_path` as a `.graphlink` archive.
 
-    Each entry in `chats` is {"title", "data", "notes", "pins"} - the exact
-    shape backend/chat_library.py's own load_chat_row/load_notes_rows/
-    load_pins_rows already return, so the caller does no reshaping.
+    Each entry in `chats` is {"title", "data", "notes", "pins", "tags",
+    "favorite", "archived"} - the exact shape backend/chat_library.py's own
+    make_export_workspace._load_one already builds (title/data/notes/pins
+    from load_chat_row/load_notes_rows/load_pins_rows, tags/favorite/
+    archived from get_all_chats - see that closure's own REVIEW-FIX
+    comment), so the caller does no reshaping.
 
     Every payload is scrubbed on the way in. Assets are copied out of
     `live_assets` as real files; a ref the store has never seen is skipped
@@ -143,6 +150,16 @@ def export_archive(
                     "data": scrub(chat.get("data") or {}),
                     "notes": scrub(chat.get("notes") or []),
                     "pins": scrub(chat.get("pins") or []),
+                    # REVIEW-FIX: tags/favorite/archived used to be dropped
+                    # entirely on export, with no field in this format for
+                    # them to ever travel through - see this module's own
+                    # docstring FORMAT section. scrub() is applied to tags
+                    # the same as any other user-authored text; favorite/
+                    # archived are plain bools, which scrub() already passes
+                    # through non-string scalars untouched.
+                    "tags": scrub(chat.get("tags") or []),
+                    "favorite": bool(chat.get("favorite", False)),
+                    "archived": bool(chat.get("archived", False)),
                 }
                 member = f"{CHATS_PREFIX}{position}.json"
                 archive.writestr(member, json.dumps(payload, indent=2))
@@ -250,7 +267,13 @@ def import_archive(archive_path: Path, target_assets: AssetStore | None = None) 
     than stored under a name that lies about its contents. Returns the
     chat payloads for the caller to write; this module never touches the
     database itself, which keeps the "what does importing mean" decision
-    (new rows? merge? replace?) where it belongs."""
+    (new rows? merge? replace?) where it belongs.
+
+    REVIEW-FIX: tags/favorite/archived are defaulted here (empty list/
+    False) rather than left absent - an archive written before export_
+    archive carried these fields simply never has them, and a caller
+    reading `chat["tags"]` off an older archive's entry should not have to
+    special-case a KeyError to stay backward-compatible."""
     parsed = read_archive(archive_path)
 
     if target_assets is not None:
@@ -263,4 +286,9 @@ def import_archive(archive_path: Path, target_assets: AssetStore | None = None) 
                 continue
             target_assets.put(data)
 
-    return parsed["chats"]
+    chats = parsed["chats"]
+    for chat in chats:
+        chat.setdefault("tags", [])
+        chat.setdefault("favorite", False)
+        chat.setdefault("archived", False)
+    return chats

--- a/graphlink_plugins/code_sandbox/domain.py
+++ b/graphlink_plugins/code_sandbox/domain.py
@@ -84,6 +84,87 @@ def _normalize_requirements(requirements_text):
     return "\n".join(lines).strip()
 
 
+# ADR-005 stage 5.5 round-3 review-fix: requirements-file option lines that
+# are NOT package specifiers - they legitimately carry their own paths/URLs
+# (--find-links, --index-url, ...) and must never be run through the
+# direct-reference check below, or every real end-to-end test in
+# test_code_sandbox_only_binary.py that uses `--find-links <path>` would
+# start failing alongside the actually-dangerous lines.
+_PIP_OPTION_LINE_PREFIXES = (
+    "-i", "--index-url",
+    "--extra-index-url",
+    "--no-index",
+    "-c", "--constraint",
+    "-r", "--requirement",
+    "-f", "--find-links",
+    "--no-binary",
+    "--only-binary",
+    "--prefer-binary",
+    "--require-hashes",
+    "--pre",
+    "--trusted-host",
+    "--use-feature",
+    "--global-option",
+    "--install-option",
+    "--config-settings",
+    "--hash",
+    "--no-deps",
+    "--no-build-isolation",
+)
+
+
+def _direct_reference_requirement_lines(normalized_requirements):
+    """Returns the requirements-file lines that name a package by direct
+    URL/VCS reference (`pkg @ <url>`, a bare `git+.../https://...` line),
+    editable install (`-e`/`--editable`), or bare local path, rather than an
+    ordinary index-resolved name.
+
+    THIS is the category `--only-binary :all:` (sync_requirements, below)
+    does NOT cover: none of these forms are ever resolved against an index,
+    so pip's index-only "no wheel published -> refuse" restriction never
+    even applies to them - pip downloads/reads the reference directly and
+    still runs ITS OWN PEP 517 build backend to produce a wheel. Verified
+    empirically against real pip (see test_code_sandbox_only_binary.py's
+    TestDirectReferenceRequirementsBypassOnlyBinary, mirroring this file's
+    own hostile-sdist proof for the plain-name case) that a `pkg @
+    file:///...` line reaches and executes a hostile build_wheel() hook
+    with --only-binary :all: on the command line, exactly as if the flag
+    were absent.
+
+    Deliberately a denylist of dangerous SHAPES, not an allowlist of a full
+    PEP 508 grammar - ordinary requirement lines (name, extras, version
+    specifiers, environment markers) never contain '@', '://', '/', or
+    '\\\\', so this stays conservative without needing to parse PEP 508
+    itself. A trailing '\\' line-continuation marker is stripped before the
+    path-character check so a routine multi-line hashed requirement
+    (`pkg==1.0 \\` / `    --hash=...`) is not mistaken for a Windows path.
+    """
+    unsafe_lines = []
+    for raw_line in normalized_requirements.split("\n"):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        line = re.split(r"\s+#", line, maxsplit=1)[0].strip()
+        if not line:
+            continue
+        if line.endswith("\\"):
+            line = line[:-1].rstrip()
+        if not line:
+            continue
+        if line.startswith(("-e", "--editable")):
+            unsafe_lines.append(raw_line.strip())
+            continue
+        if line.startswith(_PIP_OPTION_LINE_PREFIXES):
+            continue
+        if line.startswith("-"):
+            # An option this function does not special-case either way -
+            # not a package specifier, so it is not this check's concern.
+            continue
+        if "@" in line or "://" in line or "/" in line or "\\" in line:
+            unsafe_lines.append(raw_line.strip())
+    return unsafe_lines
+
+
 def _extract_python_block(response_text):
     tool_match = re.search(r"\[TOOL:PYTHON\](.*?)\[/TOOL\]", response_text, re.DOTALL)
     if tool_match:
@@ -346,6 +427,28 @@ class VirtualEnvSandbox:
 
     def sync_requirements(self, requirements_manifest, should_continue, emit_line=None, allow_source_builds=False):
         normalized = _normalize_requirements(requirements_manifest)
+        # ADR-005 stage 5.5 round-3 review-fix: checked unconditionally,
+        # ahead of even the cache short-circuit below - --only-binary :all:
+        # (further down this method) has NO effect on a direct-URL/editable/
+        # local-path requirement line (see _direct_reference_requirement_
+        # lines's own docstring for why), so those lines must never reach
+        # pip at all while the human has left source builds off, regardless
+        # of which branch of this method would otherwise run. Raising here,
+        # before the manifest hash is even computed against the cache, means
+        # a dangerous manifest can never become "the cached one" either.
+        if not allow_source_builds:
+            unsafe_lines = _direct_reference_requirement_lines(normalized)
+            if unsafe_lines:
+                offending = "\n".join(f"  {line}" for line in unsafe_lines)
+                raise RuntimeError(
+                    "Dependency installation blocked: the requirements list "
+                    "contains a direct URL, editable (-e), or local-path "
+                    "reference. Pip builds that reference using its own "
+                    "code regardless of --only-binary :all:, so this cannot "
+                    "be installed without explicitly allowing source "
+                    "builds. Enable \"Allow source builds\" to install it, "
+                    "or remove the line(s) below:\n" + offending
+                )
         manifest_hash = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
         previous_hash = self.requirements_hash_file.read_text(encoding="utf-8").strip() if self.requirements_hash_file.exists() else ""
 

--- a/graphlink_plugins/gitlink/repository.py
+++ b/graphlink_plugins/gitlink/repository.py
@@ -55,9 +55,33 @@ MAX_MANIFEST_ENTRIES = 1200
 
 
 def default_import_root(repo_name, branch_name):
-    safe_repo = repo_name.replace("/", "__")
-    safe_branch = branch_name.replace("/", "__")
-    return Path.home() / ".graphlink" / "gitlink_repos" / safe_repo / safe_branch
+    # Sanitizing only "/" left backslash-embedded ".." segments untouched -
+    # on Windows, pathlib re-parses "\\" as a real separator once the
+    # sanitized string is joined into a Path, so a repo/branch value such as
+    # "a/xyz\\..\\..\\..\\AppData\\Local\\Temp\\evil\\marker" turned back
+    # into literal ".." path components after the join and escaped the
+    # ~/.graphlink/gitlink_repos/ sandbox. Sanitizing "\\" the same way "/"
+    # already is collapses any embedded separator so a single repo/branch
+    # value can never reintroduce path components.
+    safe_repo = repo_name.replace("/", "__").replace("\\", "__")
+    safe_branch = branch_name.replace("/", "__").replace("\\", "__")
+
+    sandbox_root = Path.home() / ".graphlink" / "gitlink_repos"
+    candidate = sandbox_root / safe_repo / safe_branch
+
+    # Defense in depth, mirroring agent.py's _safe_local_target pattern
+    # (resolve, then verify the result is actually inside the intended
+    # root) rather than trusting sanitization alone to cover every case -
+    # e.g. a repo/branch value that is itself the literal segment "..".
+    # The containment check runs against resolved copies so any lexical
+    # ".." is normalized away for the comparison; the *returned* path is
+    # left unresolved so it is not silently rewritten to match the on-disk
+    # casing of any directory that happens to already exist there.
+    resolved_sandbox = sandbox_root.resolve()
+    resolved_candidate = candidate.resolve()
+    if resolved_candidate != resolved_sandbox and resolved_sandbox not in resolved_candidate.parents:
+        raise RuntimeError("Resolved Gitlink import path escaped the local sandbox root.")
+    return candidate
 
 
 def scan_local_repo_paths(local_root):

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -1338,16 +1338,36 @@ class SettingsManager:
             # stored entry that never had one - gets a fresh one assigned
             # here, server-side, never client-supplied.
             entry_id = str(entry.get("id", "")).strip() or uuid.uuid4().hex
+            # REVIEW-FIX: this method's own docstring above promises "name/
+            # command required, everything else normalized/defaulted" - but
+            # "args" and "timeout" were previously built with no guard at
+            # all: a non-iterable "args" (e.g. an int) raised TypeError out
+            # of the list comprehension, and a non-numeric truthy "timeout"
+            # (e.g. a string) raised ValueError out of float(). Either
+            # exception propagated straight out of set_mcp_servers, aborting
+            # the WHOLE bulk-replace and discarding every OTHER server's
+            # valid edit in the same call - not just the one malformed
+            # field on this one entry. Falling back to the same defaults
+            # get_mcp_servers/this method already use for a missing value
+            # keeps this entry (and every entry after it) instead.
+            try:
+                entry_args = [str(a) for a in (entry.get("args") or [])]
+            except TypeError:
+                entry_args = []
+            try:
+                entry_timeout = float(entry.get("timeout", 30.0) or 30.0)
+            except (TypeError, ValueError):
+                entry_timeout = 30.0
             normalized.append({
                 "id": entry_id,
                 "name": name,
                 "command": command,
-                "args": [str(a) for a in (entry.get("args") or [])],
+                "args": entry_args,
                 "scopes": sorted({str(s) for s in (entry.get("scopes") or [])}),
                 "approval": str(entry.get("approval") or "always"),
                 "enabled_tools": sorted({str(t) for t in (entry.get("enabled_tools") or [])}),
                 "enabled": bool(entry.get("enabled", True)),
-                "timeout": float(entry.get("timeout", 30.0) or 30.0),
+                "timeout": entry_timeout,
                 # Per-server environment variables - the only channel by
                 # which a server process receives anything beyond the safe
                 # allowlist base (see McpStdioClient.connect). These are real

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -513,8 +513,29 @@ class SettingsManager:
         # CURRENT_SCHEMA_VERSION.
         if 'schema_version' not in migrated_state:
             migrated_state['schema_version'] = self.CURRENT_SCHEMA_VERSION
-        elif migrated_state.get('schema_version', 0) < self.CURRENT_SCHEMA_VERSION:
-            migrated_state['schema_version'] = self.CURRENT_SCHEMA_VERSION
+        else:
+            _stored_schema_version = migrated_state.get('schema_version')
+            # REVIEW-FIX: none of the migrations above touch 'schema_version'
+            # itself, so a syntactically-valid-JSON but non-numeric value
+            # here (null, a string, a list, a dict - from disk-level
+            # corruption or the hand-edited session.dat this exact region's
+            # comments above already anticipate) passes straight through
+            # untouched. The `<` comparison this used to run directly raised
+            # an uncaught TypeError for any such value, escaping _load_state
+            # and taking down SettingsManager.__init__ - and the whole app
+            # at boot, on every single launch - with no self-heal path (the
+            # JSONDecodeError/UnicodeDecodeError/IOError handler above only
+            # catches parse-level failures, not this). bool is excluded even
+            # though it is technically an int subclass: a stray True/False
+            # here is exactly the kind of "not really a version number"
+            # value this guard exists to catch. Treating a non-numeric value
+            # the same as a missing one - landing on CURRENT_SCHEMA_VERSION -
+            # routes it through the same backfill posture as a file that
+            # never had the field at all, instead of crashing.
+            if not isinstance(_stored_schema_version, (int, float)) or isinstance(_stored_schema_version, bool):
+                migrated_state['schema_version'] = self.CURRENT_SCHEMA_VERSION
+            elif _stored_schema_version < self.CURRENT_SCHEMA_VERSION:
+                migrated_state['schema_version'] = self.CURRENT_SCHEMA_VERSION
 
         # Save immediately only if this load actually changed something -
         # the refactored equivalent of the old per-field state_changed flag

--- a/web_ui/src/app/canvas/GitlinkNodeView.test.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.test.tsx
@@ -278,6 +278,51 @@ describe("GitlinkNodeView", () => {
     expect(data.onBrowseLocalRoot).toHaveBeenCalledOnce();
   });
 
+  it("Browse picking a new folder resyncs the Local root draft, and a later blur commits the NEW value (regression: stale draft used to revert the just-picked folder)", async () => {
+    const user = userEvent.setup();
+    const { data, rerenderWithData } = renderGitlinkNodeWithRerender({
+      gitlinkLocalRoot: "",
+    });
+
+    // Simulates the Browse flow: onBrowseLocalRoot -> the native picker ->
+    // a fresh scene snapshot carrying the newly-picked folder as a new
+    // gitlinkLocalRoot prop. The field itself was never touched/focused by
+    // the user here, mirroring a brand-new node where Browse is the first
+    // thing clicked.
+    rerenderWithData({ ...data, gitlinkLocalRoot: "C:/repos/picked-folder" });
+
+    const input = screen.getByRole("textbox", { name: "Local root" });
+    await waitFor(() => expect(input).toHaveValue("C:/repos/picked-folder"));
+
+    // Without the resync, commitLocalRoot() on blur would still read the
+    // stale pre-Browse draft ("") and send that back to the server,
+    // silently reverting the folder the user just picked.
+    await user.click(input);
+    await user.click(document.body);
+    expect(data.onSetLocalRoot).toHaveBeenCalledWith("C:/repos/picked-folder");
+  });
+
+  it("does not clobber in-progress typing in the Local root field when an unrelated prop update arrives while it is focused", async () => {
+    const user = userEvent.setup();
+    const { data, rerenderWithData } = renderGitlinkNodeWithRerender({
+      gitlinkLocalRoot: "C:/repos/original",
+    });
+
+    const input = screen.getByRole("textbox", { name: "Local root" }) as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, "-edit");
+    expect(input.value).toBe("C:/repos/original-edit");
+
+    // An unrelated scene push (not the user's own Browse pick, not a
+    // commit) changes the prop while the field is still focused - the
+    // resync must skip it rather than stomp what the user is mid-typing.
+    rerenderWithData({ ...data, gitlinkLocalRoot: "C:/repos/somewhere-else" });
+    expect(input.value).toBe("C:/repos/original-edit");
+
+    await user.click(document.body);
+    expect(data.onSetLocalRoot).toHaveBeenCalledWith("C:/repos/original-edit");
+  });
+
   it("Import Repo Snapshot uses the current repo/branch draft field values", async () => {
     const user = userEvent.setup();
     const data = renderGitlinkNode();
@@ -783,7 +828,11 @@ describe("GitlinkNodeView React.memo comparator (ADR-011 stage 11.1)", () => {
         </ReactFlowProvider>
       </OverlayProvider>,
     );
-    expect(lodVisibilityCalls.count).toBe(2);
+    // One render for the prop change itself, plus a second, chained render
+    // from the localRootDraft resync effect's setLocalRootDraft() call (see
+    // the Browse-resync regression test above) - the field is not focused
+    // here, so the effect always fires this second render.
+    expect(lodVisibilityCalls.count).toBe(3);
   });
 
   it("re-renders when a callback prop is rebound to a new closure (e.g. onDelete)", () => {

--- a/web_ui/src/app/canvas/GitlinkNodeView.tsx
+++ b/web_ui/src/app/canvas/GitlinkNodeView.tsx
@@ -212,6 +212,34 @@ function GitlinkNodeViewImpl({ id, data, selected }: NodeProps<GitlinkFlowNode>)
       setSelectedPaths([]);
     }
   }, [data.gitlinkRepo, data.gitlinkBranch]);
+
+  // R5.3 post-review FIX 9: localRootDraft is, by the module doc's general
+  // policy, seeded once and never resynced - but Browse
+  // (data.onBrowseLocalRoot -> the native folder picker -> a fresh
+  // data.gitlinkLocalRoot prop pushed down through a new scene snapshot) is
+  // an externally-driven update that lands well after mount, and
+  // commitLocalRoot() always reads the local draft closure, never the prop
+  // itself. Without a resync, the very next blur of this field (clicking
+  // Build Context, the task-prompt textarea, anything else in the tab)
+  // silently sent the STALE pre-Browse value back to the server, reverting
+  // the folder the user just picked. Mirrors repoBranchRef's shape
+  // immediately above (a ref tracks the last-seen prop value; the effect
+  // only fires on an ACTUAL prop change, never on a bare re-render) but
+  // additionally skips the resync while the input is focused, so an
+  // unrelated scene push mid-type never clobbers what the user is actively
+  // typing - only a change that lands while the field is NOT being edited
+  // (exactly the Browse case) updates the draft.
+  const localRootRef = useRef(data.gitlinkLocalRoot);
+  const localRootFocusedRef = useRef(false);
+  useEffect(() => {
+    if (localRootRef.current !== data.gitlinkLocalRoot) {
+      localRootRef.current = data.gitlinkLocalRoot;
+      if (!localRootFocusedRef.current) {
+        setLocalRootDraft(data.gitlinkLocalRoot);
+      }
+    }
+  }, [data.gitlinkLocalRoot]);
+
   const [repoOptions, setRepoOptions] = useState<string[] | null>(null);
   const [repoOptionsLoading, setRepoOptionsLoading] = useState(false);
   const [repoOptionsError, setRepoOptionsError] = useState<string | null>(null);
@@ -454,7 +482,13 @@ function GitlinkNodeViewImpl({ id, data, selected }: NodeProps<GitlinkFlowNode>)
                     className="gitlink-node-input"
                     value={localRootDraft}
                     onChange={(event) => setLocalRootDraft(event.target.value)}
-                    onBlur={commitLocalRoot}
+                    onFocus={() => {
+                      localRootFocusedRef.current = true;
+                    }}
+                    onBlur={() => {
+                      localRootFocusedRef.current = false;
+                      commitLocalRoot();
+                    }}
                     onKeyDown={(event) => {
                       if (event.key === "Enter") {
                         event.preventDefault();

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -2505,6 +2505,19 @@ function CanvasInner({
   }, [
     scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus, focusAcceptedPaths,
     getComposerRoute, filterKinds, filterStatuses,
+    // REVIEW-FIX: a scene publish that lands while draggingRef.current is
+    // true bails out of this effect ABOVE and is discarded entirely, not
+    // queued - and draggingRef is a plain ref, so nothing here re-ran when
+    // dragging actually ended, permanently losing that snapshot unless some
+    // LATER, unrelated publish happened to change `scene` again. dragActive
+    // is reactive state that flips false in the exact same onNodesChange
+    // branch that clears draggingRef.current (see its own doc above), so
+    // listing it here is what makes this effect reconsider "should I sync
+    // now" the instant a drag gesture ends, using whichever `scene` this
+    // render already holds - not a special replay of whatever arrived
+    // mid-drag, just the ordinary reconciliation this effect always does,
+    // finally allowed to run once dragging stops.
+    dragActive,
   ]);
 
   // ADR-012 stage 12.3: Shift+F10 / the ContextMenu key opens a node's menu

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -2621,24 +2621,54 @@ function CanvasInner({
   // diffed against what was last sent, so a settled canvas reports nothing.
   const nodeSizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reportedSizesRef = useRef<Map<string, string>>(new Map());
+  // REVIEW-FIX: which node ids were unmeasurable as of the last flush - a
+  // node genuinely unmounted under onlyRenderVisibleElements (off-viewport)
+  // has no DOM to measure, so measuredNodeSize returns null for it and
+  // collectChangedNodeSizes correctly skips it rather than reporting a
+  // false zero. If that node's content grows while it sits off-viewport
+  // (e.g. a streaming member inside a frame), the growth produces no
+  // dimensions change at all until the node remounts - so the backend's
+  // frame/container bbox keeps computing against the member's last known
+  // (smaller) size, and the member can render visibly outside its frame's
+  // box for a moment once it scrolls back in. Tracked here so onNodesChange
+  // below can recognise exactly that "remount of a previously-unmeasurable
+  // node" transition and flush its real size immediately instead of behind
+  // the standard debounce, which exists to coalesce a busy streaming
+  // node's continuous resizes - not to delay a one-off catch-up report that
+  // is already late by definition. Rebuilt wholesale on every flush (below)
+  // rather than mutated incrementally, so it always reflects that flush's
+  // own measurements.
+  const unmeasurableIdsRef = useRef<Set<string>>(new Set());
   useEffect(
     () => () => {
       if (nodeSizeTimerRef.current) clearTimeout(nodeSizeTimerRef.current);
     },
     [],
   );
+  // The actual measure-diff-send pass, factored out so it can run either
+  // debounced (reportNodeSizesSoon, the common streaming-resize case) or
+  // immediately (the remount catch-up case in onNodesChange below).
+  const flushNodeSizes = useCallback(() => {
+    const currentlyUnmeasurable = new Set<string>();
+    const changed = collectChangedNodeSizes(
+      nodesRef.current.map((n) => n.id),
+      (id) => {
+        const size = measuredNodeSize(reactFlow, id);
+        if (size === null) currentlyUnmeasurable.add(id);
+        return size;
+      },
+      reportedSizesRef.current,
+    );
+    unmeasurableIdsRef.current = currentlyUnmeasurable;
+    store.reportNodeSizes(changed);
+  }, [reactFlow, store]);
   const reportNodeSizesSoon = useCallback(() => {
     if (nodeSizeTimerRef.current) clearTimeout(nodeSizeTimerRef.current);
     nodeSizeTimerRef.current = setTimeout(() => {
       nodeSizeTimerRef.current = null;
-      const changed = collectChangedNodeSizes(
-        nodesRef.current.map((n) => n.id),
-        (id) => measuredNodeSize(reactFlow, id),
-        reportedSizesRef.current,
-      );
-      store.reportNodeSizes(changed);
+      flushNodeSizes();
     }, NODE_SIZE_REPORT_DEBOUNCE_MS);
-  }, [reactFlow, store]);
+  }, [flushNodeSizes]);
 
 
   /**
@@ -2782,7 +2812,32 @@ function CanvasInner({
       // for reporting sizes back to the backend's group-bounds math. Only
       // schedules the debounced flush; the flush itself re-reads every
       // node and sends just the diffs.
-      if (changes.some((change) => change.type === "dimensions")) reportNodeSizesSoon();
+      //
+      // REVIEW-FIX: if any measured id was unmeasurable as of the last
+      // flush (unmeasurableIdsRef, populated by flushNodeSizes), this is a
+      // node that just remounted after being off-viewport - see that ref's
+      // own doc for why its content may have grown while unmounted, with
+      // no dimensions change able to fire during that whole window. That
+      // catch-up is flushed immediately, bypassing the debounce meant for
+      // coalescing an actively-streaming node's continuous resizes - a
+      // remount is a discrete one-off event, not a flurry, so there is no
+      // reason to make the frame's now-stale bbox wait out a debounce
+      // window it was never the cause of. Any pending debounced flush is
+      // cleared first so it doesn't fire again a moment later.
+      if (changes.some((change) => change.type === "dimensions")) {
+        const remountedFromUnmeasurable = changes.some(
+          (change) => change.type === "dimensions" && unmeasurableIdsRef.current.has(change.id),
+        );
+        if (remountedFromUnmeasurable) {
+          if (nodeSizeTimerRef.current) {
+            clearTimeout(nodeSizeTimerRef.current);
+            nodeSizeTimerRef.current = null;
+          }
+          flushNodeSizes();
+        } else {
+          reportNodeSizesSoon();
+        }
+      }
 
       for (const change of changes) {
         if (change.type !== "position") continue;
@@ -2853,7 +2908,7 @@ function CanvasInner({
       // eslint-disable-next-line react-hooks/immutability
       nodesRef.current = applyNodeChanges(changes, currentNodes);
     },
-    [store, reportNodeSizesSoon],
+    [store, reportNodeSizesSoon, flushNodeSizes],
   );
 
   const onConnect = useCallback(

--- a/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
@@ -95,6 +95,7 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 
 import { SceneCanvas } from "./SceneCanvas";
 import { SceneStore, initialSceneState } from "./sceneStore";
+import { NODE_SIZE_REPORT_DEBOUNCE_MS } from "./canvasConstants";
 import type { WsTransport } from "../../lib/ws/transport";
 import type { SceneNodeRow, SceneState } from "../../lib/bridge-core/generated/scene-state";
 
@@ -118,7 +119,7 @@ function makeWiredStore() {
   } as unknown as WsTransport;
   const store = new SceneStore(transport);
   store.connect();
-  return { store, stateListeners };
+  return { store, stateListeners, transport };
 }
 
 // Minimal fixture - only the fields toFlowNodes actually branches on need
@@ -187,7 +188,7 @@ function chatRow(id: string, x: number, y = 0): SceneNodeRow {
 }
 
 function mount() {
-  const { store, stateListeners } = makeWiredStore();
+  const { store, stateListeners, transport } = makeWiredStore();
   capturedProps = [];
   capturedStoreApi = null;
   render(
@@ -196,7 +197,7 @@ function mount() {
       <StoreApiProbe />
     </ReactFlowProvider>,
   );
-  return { store, stateListeners };
+  return { store, stateListeners, transport };
 }
 
 function publish(stateListeners: Map<string, StateListener>, scene: Partial<SceneState>) {
@@ -387,6 +388,97 @@ describe("SceneCanvas <ReactFlow> wiring (ADR-011 stages 11.2/11.3)", () => {
         "b",
         "c",
       ]);
+    });
+  });
+
+  // REVIEW-FIX (round 3): a frame/container member that is off-viewport
+  // (unmounted under onlyRenderVisibleElements) is genuinely unmeasurable -
+  // its content can grow while unmounted with no dimensions change able to
+  // fire at all, so the backend's frame bbox keeps computing against the
+  // member's last known (smaller) size. See flushNodeSizes/
+  // unmeasurableIdsRef's own doc in SceneCanvas.tsx. That gap self-heals
+  // once the member remounts and gets measured for real - but only if the
+  // resulting report is not itself made to wait out the standard debounce,
+  // which exists to coalesce a busy streaming node's continuous resizes,
+  // not to delay a one-off catch-up that is already late by definition.
+  describe("node-size remount catch-up (REVIEW-FIX round 3, frame bounds staying stale)", () => {
+    function fakeMeasuredElement(width: number, height: number): HTMLElement {
+      const el = document.createElement("div");
+      Object.defineProperty(el, "offsetWidth", { value: width, configurable: true });
+      Object.defineProperty(el, "offsetHeight", { value: height, configurable: true });
+      return el;
+    }
+
+    it("reports a node's real size IMMEDIATELY once it remounts measurable, having been unmeasurable at the last flush - not on the next debounce tick", () => {
+      vi.useFakeTimers();
+      try {
+        const { stateListeners, transport } = mount();
+        publish(stateListeners, { nodes: [chatRow("n0", 0)], edges: [] });
+
+        const querySelectorSpy = vi.spyOn(document, "querySelector").mockReturnValue(null);
+        const dimensionsChange = [
+          { id: "n0", type: "dimensions", dimensions: { width: 0, height: 0 }, resizing: false },
+        ] as unknown as NodeChange[];
+
+        // n0 is off-viewport (unmounted) right now - the resize-observer
+        // signal that still reaches onNodesChange finds nothing measurable
+        // (measuredNodeSize's DOM fallback returns null, mocked above).
+        act(() => lastProps().onNodesChange(dimensionsChange));
+        expect(transport.fireIntent).not.toHaveBeenCalledWith(
+          "scene", "reportNodeSizes", expect.anything(), undefined, true,
+        );
+
+        // The standard debounce elapses. flushNodeSizes runs, finds n0
+        // still unmeasurable (nothing to report), but now KNOWS that.
+        act(() => vi.advanceTimersByTime(NODE_SIZE_REPORT_DEBOUNCE_MS));
+        expect(transport.fireIntent).not.toHaveBeenCalledWith(
+          "scene", "reportNodeSizes", expect.anything(), undefined, true,
+        );
+
+        // n0 remounts (back on-viewport) at its real, now-larger size -
+        // content grew the whole time it sat unmounted and unmeasurable.
+        querySelectorSpy.mockReturnValue(fakeMeasuredElement(600, 480));
+        act(() => lastProps().onNodesChange(dimensionsChange));
+
+        // Reported WITHOUT advancing the timer at all - the catch-up
+        // bypassed the debounce instead of waiting out another full cycle.
+        expect(transport.fireIntent).toHaveBeenCalledWith(
+          "scene", "reportNodeSizes", [[["n0", 600, 480]]], undefined, true,
+        );
+
+        querySelectorSpy.mockRestore();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("still debounces an ordinary resize of an already-measurable node (no remount involved)", () => {
+      vi.useFakeTimers();
+      try {
+        const { stateListeners, transport } = mount();
+        publish(stateListeners, { nodes: [chatRow("n0", 0)], edges: [] });
+
+        const querySelectorSpy = vi.spyOn(document, "querySelector").mockReturnValue(fakeMeasuredElement(400, 300));
+        const dimensionsChange = [
+          { id: "n0", type: "dimensions", dimensions: { width: 400, height: 300 }, resizing: true },
+        ] as unknown as NodeChange[];
+
+        act(() => lastProps().onNodesChange(dimensionsChange));
+        // Not reported yet - n0 was never recorded as unmeasurable, so this
+        // is the ordinary debounced path, same as before this fix.
+        expect(transport.fireIntent).not.toHaveBeenCalledWith(
+          "scene", "reportNodeSizes", expect.anything(), undefined, true,
+        );
+
+        act(() => vi.advanceTimersByTime(NODE_SIZE_REPORT_DEBOUNCE_MS));
+        expect(transport.fireIntent).toHaveBeenCalledWith(
+          "scene", "reportNodeSizes", [[["n0", 400, 300]]], undefined, true,
+        );
+
+        querySelectorSpy.mockRestore();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
@@ -36,6 +36,7 @@
  */
 import { ReactFlowProvider, useStoreApi, type Edge, type NodeChange } from "@xyflow/react";
 import { act, render } from "@testing-library/react";
+import { useEffect } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 type CapturedProps = {
@@ -67,9 +68,18 @@ let capturedMiddleware: ((changes: NodeChange[]) => NodeChange[]) | null = null;
 // only way to observe what the scene-sync effect actually committed - this
 // probe captures the API handle once at mount, then the test polls
 // `.getState().nodes` imperatively, same posture as capturedMiddleware.
-let capturedStoreApi: ReturnType<typeof useStoreApi> | null = null;
+const capturedStoreApiRef: { current: ReturnType<typeof useStoreApi> | null } = { current: null };
 function StoreApiProbe() {
-  capturedStoreApi = useStoreApi();
+  const api = useStoreApi();
+  // Mutating capturedStoreApiRef during render itself is a lint error
+  // (react-hooks/immutability - a module-level object isn't a real ref the
+  // linter can special-case, even named like one) - deferring to an effect
+  // is the rule's own suggested fix, and works fine here since the tests
+  // below only read capturedStoreApiRef.current AFTER act()/render() have
+  // already flushed effects.
+  useEffect(() => {
+    capturedStoreApiRef.current = api;
+  });
   return null;
 }
 
@@ -190,7 +200,7 @@ function chatRow(id: string, x: number, y = 0): SceneNodeRow {
 function mount() {
   const { store, stateListeners, transport } = makeWiredStore();
   capturedProps = [];
-  capturedStoreApi = null;
+  capturedStoreApiRef.current = null;
   render(
     <ReactFlowProvider>
       <SceneCanvas store={store} onOpenDocumentView={() => {}} />
@@ -353,7 +363,7 @@ describe("SceneCanvas <ReactFlow> wiring (ADR-011 stages 11.2/11.3)", () => {
     it("applies the latest scene snapshot the moment dragging ends, even though it arrived mid-drag and nothing publishes again afterward", () => {
       const { stateListeners } = mount();
       publish(stateListeners, { nodes: [chatRow("a", 0), chatRow("b", 200)], edges: [] });
-      expect(capturedStoreApi!.getState().nodes.map((n: { id: string }) => n.id).sort()).toEqual(["a", "b"]);
+      expect(capturedStoreApiRef.current!.getState().nodes.map((n: { id: string }) => n.id).sort()).toEqual(["a", "b"]);
 
       // Production's real sequence: React Flow runs the registered
       // middleware inside its own update first, then hands the CORRECTED
@@ -376,14 +386,14 @@ describe("SceneCanvas <ReactFlow> wiring (ADR-011 stages 11.2/11.3)", () => {
         nodes: [chatRow("a", 0), chatRow("b", 200), chatRow("c", 400)],
         edges: [],
       });
-      expect(capturedStoreApi!.getState().nodes.map((n: { id: string }) => n.id).sort()).toEqual(["a", "b"]);
+      expect(capturedStoreApiRef.current!.getState().nodes.map((n: { id: string }) => n.id).sort()).toEqual(["a", "b"]);
 
       // Drag ends. No further scene publish EVER arrives after this point -
       // the only thing that can surface "c" now is the drag-end transition
       // itself.
       drag({ id: "a", dragging: false, position: { x: 10, y: 0 } });
 
-      expect(capturedStoreApi!.getState().nodes.map((n: { id: string }) => n.id).sort()).toEqual([
+      expect(capturedStoreApiRef.current!.getState().nodes.map((n: { id: string }) => n.id).sort()).toEqual([
         "a",
         "b",
         "c",

--- a/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
@@ -34,7 +34,7 @@
  * and correctly suspends it for an export, which is the actual surface this
  * app owns.
  */
-import { ReactFlowProvider, type Edge, type NodeChange } from "@xyflow/react";
+import { ReactFlowProvider, useStoreApi, type Edge, type NodeChange } from "@xyflow/react";
 import { act, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -57,6 +57,21 @@ let capturedProps: CapturedProps[] = [];
 // without a working xyflow measurement pipeline underneath, exactly as this
 // file already drives the captured props directly.
 let capturedMiddleware: ((changes: NodeChange[]) => NodeChange[]) | null = null;
+
+// REVIEW-FIX (round 3): the scene-sync effect writes straight into React
+// Flow's OWN internal store (storeApi.getState().setNodes(...)), never
+// through a `nodes` prop <ReactFlow> would otherwise receive - production
+// passes `defaultNodes` (uncontrolled), so CapturedProps.nodes above is
+// never actually populated. Reading that store directly (via the same
+// useStoreApi hook CanvasInner itself calls, left un-mocked below) is the
+// only way to observe what the scene-sync effect actually committed - this
+// probe captures the API handle once at mount, then the test polls
+// `.getState().nodes` imperatively, same posture as capturedMiddleware.
+let capturedStoreApi: ReturnType<typeof useStoreApi> | null = null;
+function StoreApiProbe() {
+  capturedStoreApi = useStoreApi();
+  return null;
+}
 
 vi.mock("@xyflow/react", async (importOriginal) => {
   const original = await importOriginal<typeof import("@xyflow/react")>();
@@ -174,9 +189,11 @@ function chatRow(id: string, x: number, y = 0): SceneNodeRow {
 function mount() {
   const { store, stateListeners } = makeWiredStore();
   capturedProps = [];
+  capturedStoreApi = null;
   render(
     <ReactFlowProvider>
       <SceneCanvas store={store} onOpenDocumentView={() => {}} />
+      <StoreApiProbe />
     </ReactFlowProvider>,
   );
   return { store, stateListeners };
@@ -318,6 +335,58 @@ describe("SceneCanvas <ReactFlow> wiring (ADR-011 stages 11.2/11.3)", () => {
 
       expect(querySelectorSpy).not.toHaveBeenCalled();
       querySelectorSpy.mockRestore();
+    });
+  });
+
+  // REVIEW-FIX (round 3): the scene-sync effect (SceneCanvas.tsx, just above
+  // dragActive's own dependency-array entry) used to bail out permanently on
+  // any scene publish that landed while draggingRef.current was true - the
+  // guard skipped the rebuild ENTIRELY rather than queuing it, and
+  // draggingRef is a plain ref, so nothing re-ran the effect once dragging
+  // actually ended. A publish that happened to be the LAST one before
+  // release stayed lost forever unless some later, unrelated publish
+  // changed `scene` again. Fixed by adding `dragActive` (reactive state
+  // that already flips false in the same onNodesChange branch that clears
+  // draggingRef.current) to the effect's dependency array.
+  describe("scene-sync catch-up once a drag ends (REVIEW-FIX round 3)", () => {
+    it("applies the latest scene snapshot the moment dragging ends, even though it arrived mid-drag and nothing publishes again afterward", () => {
+      const { stateListeners } = mount();
+      publish(stateListeners, { nodes: [chatRow("a", 0), chatRow("b", 200)], edges: [] });
+      expect(capturedStoreApi!.getState().nodes.map((n: { id: string }) => n.id).sort()).toEqual(["a", "b"]);
+
+      // Production's real sequence: React Flow runs the registered
+      // middleware inside its own update first, then hands the CORRECTED
+      // changes to onNodesChange - same helper as the smart-guide tests
+      // above.
+      const drag = (change: Partial<NodeChange> & { id: string }) =>
+        act(() => {
+          const raw = [{ type: "position", ...change } as NodeChange];
+          lastProps().onNodesChange(capturedMiddleware ? capturedMiddleware(raw) : raw);
+        });
+
+      // Start dragging "a".
+      drag({ id: "a", dragging: true, position: { x: 10, y: 0 } });
+
+      // A backend scene publish lands WHILE the drag is in flight - e.g. an
+      // unrelated node's streaming reply finishing mid-drag. The store must
+      // still show only the pre-drag nodes: the sync effect saw
+      // draggingRef.current === true and skipped the rebuild.
+      publish(stateListeners, {
+        nodes: [chatRow("a", 0), chatRow("b", 200), chatRow("c", 400)],
+        edges: [],
+      });
+      expect(capturedStoreApi!.getState().nodes.map((n: { id: string }) => n.id).sort()).toEqual(["a", "b"]);
+
+      // Drag ends. No further scene publish EVER arrives after this point -
+      // the only thing that can surface "c" now is the drag-end transition
+      // itself.
+      drag({ id: "a", dragging: false, position: { x: 10, y: 0 } });
+
+      expect(capturedStoreApi!.getState().nodes.map((n: { id: string }) => n.id).sort()).toEqual([
+        "a",
+        "b",
+        "c",
+      ]);
     });
   });
 });

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -7,7 +7,21 @@ type StateListener = (payload: Record<string, unknown>) => void;
 type PatchListener = (patch: ScenePatch) => void;
 type VersionRejectionListener = (rejection: BridgeRejection | null) => void;
 
-function makeFakeTransport() {
+// REVIEW-FIX: fireIntent's optional 7th arg (onSettled) is now read by
+// sendMessage (see sceneStore.ts's own comment on that call site) to defer
+// clearing the staged reply/synthesize target until the request has
+// actually settled, rather than synchronously before it's even sent.
+// Defaulting to a synchronous onSettled(true) here keeps every existing
+// `expect(intents/state).toEqual(...)` assertion in this file working
+// unchanged - they all still observe the post-clear state immediately after
+// calling the store method, exactly as before. A test that specifically
+// needs to exercise the "not yet settled" or "settled as a failure" window
+// (see the reply-target tests below) opts out via
+// `{ autoSettleFireIntent: false }` and drives the captured
+// `fireIntentSettlers` callbacks itself.
+function makeFakeTransport(opts: { autoSettleFireIntent?: boolean } = {}) {
+  const autoSettleFireIntent = opts.autoSettleFireIntent ?? true;
+  const fireIntentSettlers: Array<(succeeded: boolean) => void> = [];
   const listeners = new Map<string, StateListener>();
   const patchListeners = new Map<string, PatchListener>();
   // ADR-003 stage 3.5: mirrors the real WsTransport's own map - kept
@@ -43,9 +57,22 @@ function makeFakeTransport() {
     // error-recovery path is exercised by transport.test.ts, not re-tested
     // at every one of this file's call sites) so none of this file's many
     // existing `expect(intents).toEqual([...])` assertions needed to change.
-    fireIntent: vi.fn((topic: string, intent: string, args: unknown[] = []) => {
-      intents.push({ topic, intent, args });
-    }),
+    fireIntent: vi.fn(
+      (
+        topic: string,
+        intent: string,
+        args: unknown[] = [],
+        _timeoutMs?: number,
+        _queueable?: boolean,
+        _offlineCoalesceKey?: unknown,
+        onSettled?: (succeeded: boolean) => void,
+      ) => {
+        intents.push({ topic, intent, args });
+        if (!onSettled) return;
+        if (autoSettleFireIntent) onSettled(true);
+        else fireIntentSettlers.push(onSettled);
+      },
+    ),
     request: requestImpl,
     // ADR-003 stage 3.4: the scene topic's delta channel. Kept in its own
     // map (mirroring the real WsTransport's own parallel registry) so a
@@ -85,6 +112,7 @@ function makeFakeTransport() {
     requests,
     requestImpl,
     requestResults,
+    fireIntentSettlers,
   };
 }
 
@@ -1484,6 +1512,54 @@ describe("SceneStore", () => {
     ]);
   });
 
+  // REVIEW-FIX regression coverage: this used to clear replyTargetNodeId
+  // synchronously in the same stack frame as firing the intent, before the
+  // request had any chance to settle. Proves the clear now waits for
+  // onSettled instead of racing ahead of it.
+  it("sendMessage does NOT clear the reply target until the send actually settles", () => {
+    const { transport, intents, fireIntentSettlers } = makeFakeTransport({
+      autoSettleFireIntent: false,
+    });
+    const store = new SceneStore(transport);
+    store.setReplyTargetNodeId("n-root");
+
+    store.sendMessage("branching off root");
+    expect(intents).toEqual([
+      { topic: "scene", intent: "sendMessage", args: ["branching off root", "n-root"] },
+    ]);
+    // Still pending - the send has not settled yet, so the staged target
+    // must still be in effect (a retry right now should still branch).
+    expect(store.getReplyTargetNodeId()).toBe("n-root");
+
+    fireIntentSettlers[0](true);
+    expect(store.getReplyTargetNodeId()).toBeNull();
+  });
+
+  // REVIEW-FIX regression coverage: a failed/dropped send must NOT silently
+  // discard the user's staged branch target - they should be able to retry
+  // with it still in effect instead of the retry silently landing as an
+  // ordinary continuation of the current tip.
+  it("sendMessage leaves the reply target in place when the send settles as a failure", () => {
+    const { transport, intents, fireIntentSettlers } = makeFakeTransport({
+      autoSettleFireIntent: false,
+    });
+    const store = new SceneStore(transport);
+    store.setReplyTargetNodeId("n-root");
+
+    store.sendMessage("branching off root");
+    fireIntentSettlers[0](false);
+    expect(store.getReplyTargetNodeId()).toBe("n-root");
+
+    // A retry now must still carry the (still-staged) branch target, not
+    // silently fall through to an ordinary continuation.
+    store.sendMessage("branching off root, retried");
+    expect(intents[1]).toEqual({
+      topic: "scene",
+      intent: "sendMessage",
+      args: ["branching off root, retried", "n-root"],
+    });
+  });
+
   // -- ADR-002 Workstream 1: "Synthesize Branches" ---------------------------
 
   it("setSynthesizeTargetNodeIds/getSynthesizeTargetNodeIds update state, notify listeners, and clear any pending reply target", () => {
@@ -1551,6 +1627,25 @@ describe("SceneStore", () => {
       { topic: "scene", intent: "synthesizeBranches", args: [["n1", "n2"], "merge the best of both"] },
       { topic: "scene", intent: "sendMessage", args: ["a normal follow-up"] },
     ]);
+  });
+
+  // REVIEW-FIX regression coverage: same optimistic-clear-before-confirm bug
+  // as the reply-target case above, for the synthesize-target branch.
+  it("sendMessage leaves the synthesize target in place until settled, and keeps it on failure", () => {
+    const { transport, fireIntentSettlers } = makeFakeTransport({ autoSettleFireIntent: false });
+    const store = new SceneStore(transport);
+    store.setSynthesizeTargetNodeIds(["n1", "n2"]);
+
+    store.sendMessage("merge the best of both");
+    // Not yet settled - still staged.
+    expect(store.getSynthesizeTargetNodeIds()).toEqual(["n1", "n2"]);
+
+    fireIntentSettlers[0](false);
+    // Settled as a failure - must NOT be silently discarded.
+    expect(store.getSynthesizeTargetNodeIds()).toEqual(["n1", "n2"]);
+
+    fireIntentSettlers[0](true);
+    expect(store.getSynthesizeTargetNodeIds()).toBeNull();
   });
 
   it("sendMessage prefers a pending synthesize target over a pending reply target (the two are already mutually exclusive, but this proves the check order)", () => {

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -1077,15 +1077,42 @@ export class SceneStore {
   sendMessage(text: string): void {
     const synthesizeNodeIds = this.synthesizeTargetNodeIds;
     if (synthesizeNodeIds !== null) {
-      this.transport.fireIntent("scene", "synthesizeBranches", [synthesizeNodeIds, text]);
-      this.setSynthesizeTargetNodeIds(null);
+      // REVIEW-FIX: this used to clear the staged synthesize-target selection
+      // synchronously, in the same stack frame as firing the intent - before
+      // the request had any chance to succeed or fail. fireIntent's own send
+      // is always async (a WS send cannot settle synchronously), so the
+      // clear was provably racing ahead of any real signal. Deferred to
+      // onSettled and gated on success: a failed/dropped send (e.g. offline,
+      // since this intent is deliberately non-queueable - synthesizing
+      // branches creates new data, so it must not be replayed) leaves the
+      // staged selection in place so the user can retry it, instead of
+      // silently losing it.
+      this.transport.fireIntent(
+        "scene",
+        "synthesizeBranches",
+        [synthesizeNodeIds, text],
+        undefined,
+        false,
+        undefined,
+        (succeeded) => {
+          if (succeeded) this.setSynthesizeTargetNodeIds(null);
+        },
+      );
       return;
     }
     const branchFromNodeId = this.replyTargetNodeId;
     const args: unknown[] = [text];
     if (branchFromNodeId !== null) args.push(branchFromNodeId);
-    this.transport.fireIntent("scene", "sendMessage", args);
-    if (branchFromNodeId !== null) this.setReplyTargetNodeId(null);
+    // REVIEW-FIX: same optimistic-clear-before-confirm bug as above, for the
+    // "Branch from here" reply target. Cleared only once the send has
+    // actually settled successfully, so a failure leaves the staged branch
+    // target in effect for a retry rather than silently dropping it (a
+    // retry sent with no branch_from_node_id falls through to the current
+    // tip server-side - see backend/branches.py's send_message - silently
+    // misplacing the message the user meant to branch).
+    this.transport.fireIntent("scene", "sendMessage", args, undefined, false, undefined, (succeeded) => {
+      if (succeeded && branchFromNodeId !== null) this.setReplyTargetNodeId(null);
+    });
   }
 
   moveNode(id: string, x: number, y: number): void {

--- a/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.test.tsx
@@ -346,6 +346,62 @@ describe("ChatLibraryDialog", () => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
+  // -- REVIEW-FIX: commitRename used to fire-and-forget via fireIntent and
+  // -- clear renamingId the instant the message was SENT, not once the
+  // -- rename was actually confirmed - the same fix confirmDelete already
+  // -- got below, applied here since renameChat's own intent now returns a
+  // -- real success/failure signal (null when the row is gone) instead of
+  // -- always resolving to undefined.
+
+  it("a confirmed rename that actually applies closes the rename input", async () => {
+    const { user, request } = setup();
+    await user.click(screen.getByText("open library"));
+    request.mockResolvedValueOnce("2026-01-16 09:00:00.000000");
+
+    await user.click(screen.getByLabelText('Rename "First Chat"'));
+    const input = screen.getByLabelText('Rename "First Chat"') as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, "Renamed Title");
+    await user.click(screen.getByLabelText('Save "First Chat"'));
+
+    // Back to the normal (non-renaming) row action - the pencil button, not
+    // the input, now carries this label.
+    await screen.findByRole("button", { name: 'Rename "First Chat"' });
+    expect(screen.queryByRole("textbox", { name: 'Rename "First Chat"' })).toBeNull();
+  });
+
+  it("a resolved-but-falsy rename (the row was already gone) leaves the rename input in place rather than optimistically closing it", async () => {
+    const { user, request } = setup();
+    await user.click(screen.getByText("open library"));
+    request.mockResolvedValueOnce(null);
+
+    await user.click(screen.getByLabelText('Rename "First Chat"'));
+    const input = screen.getByLabelText('Rename "First Chat"') as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, "Renamed Title");
+    await user.click(screen.getByLabelText('Save "First Chat"'));
+    await vi.waitFor(() => expect(request).toHaveBeenCalled());
+
+    expect(screen.getByRole("textbox", { name: 'Rename "First Chat"' })).toBeInTheDocument();
+  });
+
+  it("a rejected rename request leaves the rename input in place and logs, without throwing", async () => {
+    const { user, request } = setup();
+    await user.click(screen.getByText("open library"));
+    request.mockRejectedValueOnce(new Error("socket dropped"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await user.click(screen.getByLabelText('Rename "First Chat"'));
+    const input = screen.getByLabelText('Rename "First Chat"') as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, "Renamed Title");
+    await user.click(screen.getByLabelText('Save "First Chat"'));
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
+
+    expect(screen.getByRole("textbox", { name: 'Rename "First Chat"' })).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
   it("deleting a row: trash opens an inline scoped confirm, confirming dispatches deleteChat for THAT row only", async () => {
     const { user, intents } = setup();
     await user.click(screen.getByText("open library"));

--- a/web_ui/src/app/chrome/ChatLibraryDialog.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.tsx
@@ -493,12 +493,27 @@ export function ChatLibraryDialog({ transport }: { transport: WsTransport }) {
     setEditingTagsId(null);
   }
 
+  // REVIEW-FIX: this used to fire-and-forget via transport.fireIntent and
+  // clear renamingId the instant the message was SENT, not once the rename
+  // was actually confirmed - backend's renameChat intent already signals a
+  // no-op (the row was deleted elsewhere, or a lost optimistic-concurrency
+  // race) by resolving to `null`, but nothing here ever looked at it, so the
+  // rename input closed itself over a rename that silently never happened.
+  // Same transport.request()-then-check shape as confirmDelete just below.
   function commitRename() {
     const title = renameDraft.trim();
     if (renamingId === null || !title) return;
-    transport.fireIntent("app-chat-library", "renameChat", [renamingId, title], undefined, true);
-    setRenamingId(null);
-    lastTriggerRef.current?.focus();
+    const chatId = renamingId;
+    transport
+      .request("app-chat-library", "renameChat", [chatId, title])
+      .then((newUpdatedAt) => {
+        if (!newUpdatedAt) return;
+        setRenamingId((current) => (current === chatId ? null : current));
+        lastTriggerRef.current?.focus();
+      })
+      .catch((error) => {
+        console.error("[chat-library] Rename failed:", error);
+      });
   }
 
   function cancelRename() {

--- a/web_ui/src/app/chrome/composerStore.ts
+++ b/web_ui/src/app/chrome/composerStore.ts
@@ -151,8 +151,17 @@ export class ComposerStore {
     const fenceGeneration = this.latestOptimisticDraft.generation;
     this.draftResyncGeneration = fenceGeneration;
     const sent = this.transport.resubscribe("app-composer", (payload) => {
-      const validated = TOPIC_VALIDATORS["app-composer"](payload);
       this.draftResyncGeneration = null;
+      // REVIEW-FIX (resubscribe-callback-dropped-on-version-rejection): null
+      // means the correlated reply failed schema-version negotiation - there
+      // is no snapshot to resync from and no useful retry to attempt right
+      // here (the version skew, not a stale read, is the actual problem).
+      // Clearing the fence above is still the important part: without it,
+      // this callback previously never ran at all on a rejection, leaving
+      // draftResyncGeneration stuck non-null and every future resync request
+      // a permanent no-op for the rest of this store's life.
+      if (payload === null) return;
+      const validated = TOPIC_VALIDATORS["app-composer"](payload);
       if (!validated.ok) return;
       if (
         this.pendingDraftGenerations.size > 0 ||

--- a/web_ui/src/lib/ws/queueableClassificationGuard.test.ts
+++ b/web_ui/src/lib/ws/queueableClassificationGuard.test.ts
@@ -39,14 +39,62 @@ const APP_SRC = join(HERE, "..", "..", "app");
 
 const NON_IDEMPOTENT_PREFIXES = ["toggle"];
 
-/** Captures one whole fireIntent(...) statement, up to the `)` that is
- * followed by `;`. Tolerates the multi-line formatting prettier gives the
- * longer call sites (moveNodes) and nested parens inside the args array
- * (`positions.map((p) => [...])`), neither of which puts `);` inside itself. */
-const FIRE_INTENT_RE = /fireIntent\(([\s\S]{0,500}?)\)\s*;/g;
 const INTENT_NAME_RE = /"[^"]*"\s*,\s*"([^"]+)"/;
 /** The 5th positional arg. Trailing comma is prettier's, for multi-line calls. */
 const QUEUEABLE_RE = /,\s*true\s*,?\s*$/;
+
+/** REVIEW-FIX: this used to be a single lazy regex,
+ * `/fireIntent\(([\s\S]{0,500}?)\)\s*;/g`, that captured up to the first `)`
+ * followed by a literal `;`. That has two independent blind spots, both
+ * confirmed against this repo's real files:
+ *
+ * 1. A comment that merely mentions `fireIntent(` with no real call behind
+ *    it (e.g. sceneStore.ts's own Gitlink section doc, "transport.fireIntent
+ *    ()/intent() are ...") still matches the literal text `fireIntent(`. The
+ *    lazy capture then has nothing of its own to stop on and keeps growing
+ *    until the NEXT `);` anywhere later in the file - which is a real call
+ *    site's own closing paren - swallowing that whole real call into one
+ *    garbage match and silently dropping it from the collected set.
+ * 2. A `fireIntent(...)` call written as a JSX inline arrow-function body
+ *    (`onChange={(id) => transport.fireIntent(...)}`) ends in `)}`, never
+ *    `);`. The old regex could never terminate on that call's own closing
+ *    paren at all, so it kept scanning past it looking for a `;` - which,
+ *    combined with blind spot 1, is how 22 of SettingsDialog.tsx's 33 real
+ *    call sites went uncollected.
+ *
+ * Fixed by not relying on a terminator character at all: walk forward from
+ * each `fireIntent(` occurrence counting paren depth (skipping over string
+ * literals, so a `)` inside a quoted arg can't look like the call's own
+ * close) until depth returns to zero. That closing paren is unambiguously
+ * the call's own, regardless of what follows it - `;`, `)}`, or nothing. A
+ * bare mention like `fireIntent()` in a comment still matches the call
+ * syntax, but now captures an empty body between its own open/close parens
+ * instead of swallowing everything up to some unrelated later call, so
+ * INTENT_NAME_RE correctly rejects it as not a real call site. */
+const CALL_START_RE = /fireIntent\(/g;
+
+function extractFireIntentArgLists(source: string): string[] {
+  const argLists: string[] = [];
+  for (const start of source.matchAll(CALL_START_RE)) {
+    const bodyStart = start.index + start[0].length;
+    let depth = 1;
+    let quote: string | null = null;
+    let i = bodyStart;
+    for (; i < source.length && depth > 0; i++) {
+      const ch = source[i];
+      if (quote) {
+        if (ch === "\\") i++;
+        else if (ch === quote) quote = null;
+        continue;
+      }
+      if (ch === '"' || ch === "'" || ch === "`") quote = ch;
+      else if (ch === "(") depth++;
+      else if (ch === ")") depth--;
+    }
+    argLists.push(source.slice(bodyStart, i - 1));
+  }
+  return argLists;
+}
 
 interface CallSite {
   file: string;
@@ -62,8 +110,7 @@ function collectFireIntentCallSites(): CallSite[] {
   const sites: CallSite[] = [];
   for (const file of files) {
     const source = readFileSync(file, "utf8");
-    for (const match of source.matchAll(FIRE_INTENT_RE)) {
-      const args = match[1];
+    for (const args of extractFireIntentArgLists(source)) {
       const name = INTENT_NAME_RE.exec(args);
       if (!name) continue;
       sites.push({ file, intent: name[1], queueable: QUEUEABLE_RE.test(args) });
@@ -90,5 +137,46 @@ describe("queueable intent classification (ADR-003 stage 3.6)", () => {
       .map((s) => `${s.intent} (${s.file})`);
 
     expect(offenders).toEqual([]);
+  });
+
+  // REVIEW-FIX regression coverage: the old lazy `fireIntent\(...\)\s*;`
+  // regex latched onto sceneStore.ts's own Gitlink-section doc comment
+  // ("transport.fireIntent()/intent() are ...", no real call behind it) and
+  // grew its capture past the real loadGitlinkRepoTree call site's own
+  // arguments until it hit the NEXT literal `);` in the file - which was
+  // that same call's closing paren - swallowing the whole thing into one
+  // garbage match. loadGitlinkRepoTree never appeared as its own collected
+  // site, so it had zero coverage under the "never queueable toggle*"
+  // assertion above (moot for it specifically, but the general hole is what
+  // matters: any call site downstream of such a comment was equally
+  // invisible). This asserts it is now found, on its own, exactly once.
+  it("collects loadGitlinkRepoTree as its own call site, not swallowed by a nearby comment", () => {
+    const sites = collectFireIntentCallSites().filter(
+      (s) => s.intent === "loadGitlinkRepoTree",
+    );
+    expect(sites).toHaveLength(1);
+    expect(sites[0].file.replace(/\\/g, "/")).toMatch(/canvas\/sceneStore\.ts$/);
+    expect(sites[0].queueable).toBe(false);
+  });
+
+  // REVIEW-FIX regression coverage: every fireIntent call in
+  // SettingsDialog.tsx is a JSX inline arrow-function body ending in `)}`,
+  // never `);` - a shape the old regex's required trailing `;` could never
+  // match at all, independent of the comment-latching issue above. That
+  // silently dropped 22 of the file's 33 real call sites. This pins the
+  // full count (verified by hand against the file: 33 `fireIntent(`
+  // occurrences, all real calls, no bare mentions in comments) so a future
+  // regression that drops any of them fails loudly instead of the guard's
+  // other assertions just quietly evaluating fewer sites.
+  it("collects every real fireIntent call site in SettingsDialog.tsx, including JSX arrow-body calls", () => {
+    const sites = collectFireIntentCallSites().filter((s) =>
+      s.file.replace(/\\/g, "/").endsWith("chrome/SettingsDialog.tsx"),
+    );
+    expect(sites).toHaveLength(33);
+    // Spot-check a few of the specific call sites that were among the 22
+    // previously hidden by the `)}` JSX-arrow-body gap.
+    for (const intent of ["setTheme", "setLlamaCppNCtx", "pullOllamaModel", "setActiveSection"]) {
+      expect(sites.some((s) => s.intent === intent)).toBe(true);
+    }
   });
 });

--- a/web_ui/src/lib/ws/transport.test.ts
+++ b/web_ui/src/lib/ws/transport.test.ts
@@ -463,6 +463,50 @@ describe("WsTransport", () => {
     expect(t.getStatus()).toBe("open");
   });
 
+  // REVIEW-FIX (dispose-then-connect-requeues-inflight-queueable-intent):
+  // fireIntent()'s rejection handler used to gate its "disposed transport,
+  // nothing to recover into" branch on the live `this.disposed` boolean -
+  // but that check runs in the MICROTASK scheduled by dispose()'s own
+  // synchronous failAllPending() call, and connect() (see the StrictMode
+  // test above) resets `this.disposed` back to false SYNCHRONOUSLY. Calling
+  // dispose() immediately followed by connect() - exactly React 18
+  // StrictMode's dev-mode double-invoke on the same memoized transport -
+  // meant the early return never fired, and a queueable intent that was
+  // genuinely killed by dispose() got silently re-queued and replayed on
+  // the NEW connection: a second application of an already-sent mutating
+  // intent.
+  it("REVIEW-FIX: a queueable intent in flight when dispose() is immediately followed by connect() is dropped, not requeued onto the new connection", async () => {
+    const t = makeTransport();
+    t.connect();
+    const first = FakeSocket.instances[0];
+    first.open();
+
+    t.fireIntent("scene", "moveNodes", [[{ id: "n1", x: 1, y: 2 }]], undefined, true);
+    expect(first.sent).toHaveLength(1); // sent normally while open, now in flight
+
+    // StrictMode's synchronous dispose-then-remount: connect() re-arms the
+    // transport (this.disposed back to false) in the SAME tick dispose()
+    // set it true, before the rejection microtask below ever runs.
+    t.dispose();
+    t.connect();
+    const second = FakeSocket.instances[1];
+
+    // A real WebSocket's onopen fires asynchronously, well after this
+    // synchronous dispose()/connect() pair - giving the rejection handler's
+    // microtask (scheduled by dispose()'s own synchronous failAllPending())
+    // time to run BEFORE the new socket ever opens and flushes the offline
+    // queue. Flushing the microtask queue here before open() matters: with
+    // the bug, this is exactly when the intent gets silently re-queued.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    second.open();
+
+    expect(second.sent.map((raw) => JSON.parse(raw))).not.toContainEqual(
+      expect.objectContaining({ intent: "moveNodes" }),
+    );
+  });
+
   it("a truly unrecognized kind still logs the existing 'unknown message kind' error (contrast with stream's silent drop)", () => {
     const t = makeTransport();
     t.connect();

--- a/web_ui/src/lib/ws/transport.test.ts
+++ b/web_ui/src/lib/ws/transport.test.ts
@@ -1014,6 +1014,46 @@ describe("WsTransport", () => {
       expect(sceneRejections.at(-1)).toBeNull();
       expect(gridRejections.at(-1)).toMatchObject({ kind: "version" });
     });
+
+    // REVIEW-FIX (resubscribe-callback-dropped-on-version-rejection): the
+    // "state" branch used to `return` on a version-rejected frame before
+    // ever reaching the resubscribeListeners lookup/invoke/delete block, so
+    // a correlated resubscribe() fence was never invoked and its entry
+    // leaked for the topic's remaining lifetime - composerStore's
+    // requestDraftResync() is the real caller left permanently stuck this
+    // way, since its own re-entrancy fence is cleared ONLY inside that
+    // callback.
+    it("REVIEW-FIX: a version-incompatible reply to a correlated resubscribe() fence still invokes it (with null) instead of leaking the entry", () => {
+      const t = makeTransport();
+      t.connect();
+      const socket = FakeSocket.instances[0];
+      socket.open();
+      t.subscribe("app-composer", () => {});
+      const fence = vi.fn();
+
+      expect(t.resubscribe("app-composer", fence)).toBe(true);
+      const request = socket.lastSent();
+
+      socket.receive({
+        kind: "state",
+        topic: "app-composer",
+        id: request.id,
+        payload: { schemaVersion: 2, minCompatibleSchemaVersion: 99, revision: 1 },
+      });
+
+      expect(fence).toHaveBeenCalledOnce();
+      expect(fence).toHaveBeenCalledWith(null);
+
+      // The entry is deleted, not merely invoked - a stray repeat frame with
+      // the same id must not double-fire an already-settled fence.
+      socket.receive({
+        kind: "state",
+        topic: "app-composer",
+        id: request.id,
+        payload: { schemaVersion: READER_SCHEMA_VERSION, revision: 2 },
+      });
+      expect(fence).toHaveBeenCalledOnce();
+    });
   });
 
   // ADR-003 stage 3.5 review-fix: closes a real gap a 4-lens adversarial

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -159,7 +159,18 @@ export type VersionRejectionListener = (rejection: BridgeRejection | null) => vo
  * accepted write in order, while a text draft is explicitly last-write-wins. */
 export const COMPOSER_DRAFT_OFFLINE_COALESCE_KEY = "app-composer/updateDraft";
 export type OfflineIntentCoalesceKey = typeof COMPOSER_DRAFT_OFFLINE_COALESCE_KEY;
-export type IntentSettledListener = () => void;
+/** REVIEW-FIX: `succeeded` distinguishes the one path where the intent was
+ * actually accepted by the backend (the request Promise resolved) from
+ * every other way an intent can reach a terminal state without ever being
+ * queued for replay - refused while offline, cut off mid-flight and
+ * non-queueable, torn down via dispose, or rejected with a genuine
+ * server-side error. Existing zero-arg listeners (e.g. composerStore's
+ * onDraftSettled) stay valid without changes - they just ignore the extra
+ * argument - since composerStore's own resync-on-settle logic already
+ * re-derives truth from the server regardless of outcome. A caller that
+ * DOES care about the distinction (sendMessage's staged reply-target
+ * clearing, sceneStore.ts) can now branch on it instead of guessing. */
+export type IntentSettledListener = (succeeded: boolean) => void;
 export type OfflineIntentCoalescedListener = () => void;
 
 interface WsLike {
@@ -708,18 +719,18 @@ export class WsTransport {
         );
       } else {
         this.droppedWhileOffline += 1;
-        onSettled?.();
+        onSettled?.(false);
       }
       return;
     }
     this.request(topic, intent, args, timeoutMs).then(
-      () => onSettled?.(),
+      () => onSettled?.(true),
       (err) => {
         // A disposed transport is real teardown (unmount, or StrictMode's
         // dev-only dispose-then-remount check) - there is nothing left to
         // recover into.
         if (this.disposed) {
-          onSettled?.();
+          onSettled?.(false);
           return;
         }
         if (err instanceof WsUnavailableError) {
@@ -739,12 +750,12 @@ export class WsTransport {
             );
           } else {
             this.droppedWhileOffline += 1;
-            onSettled?.();
+            onSettled?.(false);
           }
           return;
         }
         this.showErrorDeduped(String(err.message));
-        onSettled?.();
+        onSettled?.(false);
       },
     );
   }
@@ -819,7 +830,7 @@ export class WsTransport {
     );
     if (ordinaryCount >= WsTransport.OFFLINE_QUEUE_MAX) {
       this.droppedWhileOffline += 1;
-      onSettled?.();
+      onSettled?.(false);
       return;
     }
     this.offlineQueue.push(item);

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -223,6 +223,20 @@ export class WsTransport {
   private socket: WsLike | null = null;
   private status: ConnectionStatus = "closed";
   private disposed = false;
+  /** REVIEW-FIX (dispose-then-connect-requeues-inflight-queueable-intent):
+   * incremented every dispose() call, never reset - unlike `disposed` itself,
+   * which connect() always resets to false (see connect()'s own doc: it must
+   * always re-arm a disposed transport for React 18 StrictMode's synchronous
+   * dispose-then-remount cycle). fireIntent()'s rejection handler runs as a
+   * MICROTASK scheduled by dispose()'s own synchronous failAllPending() call
+   * - if connect() runs synchronously right after dispose(), exactly as
+   * StrictMode does, `this.disposed` is already back to false by the time
+   * that microtask runs, so a check against the live boolean can no longer
+   * tell "this rejection was caused by a dispose()" from "this transport has
+   * never been disposed". Comparing against an epoch captured at the moment
+   * the request was fired (see fireIntent()) survives that reset, because
+   * this field is only ever incremented, never rolled back. */
+  private disposeEpoch = 0;
   private attempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -405,6 +419,7 @@ export class WsTransport {
 
   dispose(): void {
     this.disposed = true;
+    this.disposeEpoch += 1;
     if (this.reconnectTimer !== null) clearTimeout(this.reconnectTimer);
     this.failAllPending(new WsUnavailableError("transport disposed"));
     this.socket?.close();
@@ -734,13 +749,24 @@ export class WsTransport {
       }
       return;
     }
+    // REVIEW-FIX (dispose-then-connect-requeues-inflight-queueable-intent):
+    // captured before the request is even sent, so a dispose() anywhere
+    // during this request's lifetime is still detected below even if a
+    // synchronous connect() has already reset `this.disposed` back to false
+    // by the time the rejection handler runs - see disposeEpoch's own doc.
+    const epochAtFire = this.disposeEpoch;
     this.request(topic, intent, args, timeoutMs).then(
       () => onSettled?.(true),
       (err) => {
         // A disposed transport is real teardown (unmount, or StrictMode's
         // dev-only dispose-then-remount check) - there is nothing left to
         // recover into.
-        if (this.disposed) {
+        //
+        // REVIEW-FIX (dispose-then-connect-requeues-inflight-queueable-intent):
+        // compares the epoch captured at fire time, not the current (mutable,
+        // possibly already-reset-by-connect()) `this.disposed` boolean - see
+        // disposeEpoch's own doc for why the live flag is unreliable here.
+        if (this.disposeEpoch !== epochAtFire) {
           onSettled?.(false);
           return;
         }

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -123,6 +123,17 @@ export type StateListener = (payload: Record<string, unknown>) => void;
 export type StatusListener = (status: ConnectionStatus) => void;
 export type StreamListener = (delta: string, done: boolean, reset: boolean, seq: number) => void;
 
+/** REVIEW-FIX (resubscribe-callback-dropped-on-version-rejection): the
+ * one-shot fence callback resubscribe() takes needs to be told when its
+ * correlated reply failed schema-version negotiation, not just handed a
+ * value on success - `payload` is null in exactly that case, the real
+ * payload otherwise. Deliberately a distinct type from StateListener
+ * (whose subscribe()/onStatus()-style contract never has anything to
+ * report but a value) rather than widening that shared type for every
+ * ordinary consumer that isn't the resubscribe fence - see
+ * handleMessage()'s "state" branch and resubscribe()'s own doc. */
+export type ResubscribeListener = (payload: Record<string, unknown> | null) => void;
+
 /** ADR-003 stage 3.4: one node-scoped delta from a `kind:"patch"` frame.
  * Deliberately typed loosely (`Record<string, unknown>` for the node/edge
  * bodies) - the transport's job is routing, not validating. Nothing here
@@ -231,7 +242,7 @@ export class WsTransport {
    * snapshot; the echoed request id identifies the actual authority fence. */
   private readonly resubscribeListeners = new Map<
     number,
-    { topic: string; listener: StateListener }
+    { topic: string; listener: ResubscribeListener }
   >();
   private readonly statusListeners = new Set<StatusListener>();
   /** Keyed by requestId - stream deltas are addressed to a specific in-flight
@@ -443,7 +454,7 @@ export class WsTransport {
    * socket is not open, matching intent()'s own pre-connect behavior:
    * reconnecting re-subscribes every topic from scratch anyway, which
    * resolves the gap by itself. */
-  resubscribe(topic: string, onSnapshot?: StateListener): boolean {
+  resubscribe(topic: string, onSnapshot?: ResubscribeListener): boolean {
     if (this.status !== "open" || !this.socket) return false;
     let id: number | undefined;
     if (onSnapshot) {
@@ -924,6 +935,16 @@ export class WsTransport {
       const topic = message.topic as string;
       const payload = message.payload as Record<string, unknown>;
       this.snapshotRequestsPending.delete(topic);
+      // REVIEW-FIX (resubscribe-callback-dropped-on-version-rejection): the
+      // correlated fence lookup now happens BEFORE the version check below,
+      // rather than after it, so it is still reachable on a rejection - see
+      // that branch for why.
+      const snapshotRequestId = message.id;
+      let resubscribeRequest: { topic: string; listener: ResubscribeListener } | undefined;
+      if (typeof snapshotRequestId === "number") {
+        const candidate = this.resubscribeListeners.get(snapshotRequestId);
+        if (candidate?.topic === topic) resubscribeRequest = candidate;
+      }
       // ADR-003 stage 3.5: the version envelope lives INSIDE payload for a
       // state frame (see _Topic._stamp on the backend) - checked and, on
       // rejection, dispatched to NOTHING below. A rejected payload is stale
@@ -932,18 +953,30 @@ export class WsTransport {
       // this stage exists to replace: at least the old frozen-UI failure
       // mode didn't also risk running shape validation against fields a
       // breaking version change may have renamed or removed.
+      //
+      // REVIEW-FIX (resubscribe-callback-dropped-on-version-rejection): "NOTHING
+      // below" used to include the correlated resubscribeListeners fence -
+      // this used to `return` before ever reaching its lookup/invoke/delete
+      // block. That fence is a one-shot callback some caller (composerStore's
+      // requestDraftResync, the real load-bearing case) is blocked on via its
+      // own re-entrancy guard; resubscribeListeners has no timeout-based
+      // cleanup the way pending (request()'s map) does, so leaving the entry
+      // un-invoked left both the entry and the caller's guard stuck for the
+      // topic's remaining lifetime. The fence is still invoked and deleted on
+      // rejection - with `null` rather than the withheld payload, so the
+      // caller can tell this was a rejection, not a snapshot it can trust.
       if (!this.checkVersionAndMaybeReject(topic, payload)) {
         this.stateSnapshots.delete(topic);
+        if (resubscribeRequest) {
+          this.resubscribeListeners.delete(snapshotRequestId as number);
+          resubscribeRequest.listener(null);
+        }
         return;
       }
       this.stateSnapshots.set(topic, payload);
-      const snapshotRequestId = message.id;
-      if (typeof snapshotRequestId === "number") {
-        const resubscribeRequest = this.resubscribeListeners.get(snapshotRequestId);
-        if (resubscribeRequest?.topic === topic) {
-          this.resubscribeListeners.delete(snapshotRequestId);
-          resubscribeRequest.listener(payload);
-        }
+      if (resubscribeRequest) {
+        this.resubscribeListeners.delete(snapshotRequestId as number);
+        resubscribeRequest.listener(payload);
       }
       const listeners = this.stateListeners.get(topic);
       if (listeners) {


### PR DESCRIPTION
## Problem

A second, deeper and wider fan-out crawl over territory not covered by the previous audit (PR #343) - 20 finder agents covering Builder orchestration, Py-Coder/Code Sandbox execution, MCP client internals, session restore/save, chat library, knowledge store, undo/redo, WS lifecycle, migrations, path-traversal security, and the remaining frontend stores/node views. 35 findings surfaced; each was independently re-derived and voted on by 3 adversarial skeptics per finding (majority rule), landing at 34 confirmed, 1 refuted. Every fix below is revert-verified: reverting just the fix makes its own new regression test fail for the documented reason.

## Changes

**Critical security**
- The Builder's `run_node` tool could execute a Py-Coder node's code directly through the REPL, completely bypassing the dedicated human-approval gate - in autopilot mode with zero review, in copilot mode showing only opaque JSON instead of the actual code. Both modes now require a human to see and approve the real code before it runs.
- Code Sandbox's `--only-binary :all:` defense against arbitrary code execution via a hostile package's PEP 517 build backend didn't cover pip's direct-URL/editable requirement syntax (`pkg @ file:///...`, `-e <path>`) - those lines are now blocked unless source builds are explicitly allowed.
- MCP client `_write()` had no timeout on the subprocess stdin write - a stuck server permanently deadlocked every future call to that client while holding the call lock.

**Builder / Py-Coder / MCP client**
- `setPlanSteps` had no guard against a concurrently-running build, letting a second tab or a WS-eventual-consistency window detach an in-flight step's dict reference from the live plan, permanently freezing that step at "running".
- `run_build`'s setup window (tool-spec filtering, prompt resolution, plan-digest formatting) sat outside its own try/finally, so a setup-time exception left the plan node stuck "running" forever with no live run backing it.
- Builder recipe save/delete bypassed the settings-write lock every other settings mutation uses, causing real reproduced concurrent-write corruption against any other settings save.
- `run_node`'s reply/research/chart actions had no liveness re-check after their async call, so a concurrent node delete crashed the run instead of degrading gracefully like the pycoder action already does.
- Cancelling a Py-Coder run gave no observable feedback and left the node stuck "busy" for up to 4 minutes - Cancel now actually clears it immediately.
- A malformed MCP `tools/list` response (missing/null fields) crashed the *entire* Builder tool registry for the session instead of just skipping the bad entry; an unbounded response queue from idle MCP notifications is now bounded.

**Data races and atomicity**
- `reindex_graph_content`'s unlocked SELECT let two concurrent graph saves duplicate a document row, or resurrect a just-deleted graph's search index entry; both closed with an explicit `BEGIN IMMEDIATE`.
- `add_document_with_chunks`'s idempotency check could still raise `IntegrityError` under a race instead of the documented no-op; fixed with the same catch-and-re-read pattern already used elsewhere in this file.
- `delete_chat_node`'s children-reconnect loop could commit a spurious edge before raising on a later child (a legacy multi-hop cycle); it's now a genuine check-then-mutate two-pass operation.
- `composite()`'s finally block committed a partial command group even when the block raised partway through; a mid-block exception now discards the buffer instead.
- Two malformed-JSON-payload crashes in `session_load.py`'s legacy connection-bucket restore could abort an entire chat load over one bad entry.
- `save_chat_atomically_row`'s blind-write branch could crash with an unhandled `TypeError` on a concurrent delete instead of the clean lost-race message its checked sibling already gives.
- `loadChat` read a chat's row/notes/pins through three independent connections with real await points between them, producing a torn read under a concurrent save; now one shared transaction.

**Other correctness**
- A non-JSON WS text frame killed the connection with an uncaught exception instead of a graceful error reply.
- A corrupted `schema_version` in `session.dat` crashed the whole app at boot with no self-heal path.
- One malformed MCP server field (a bad timeout/args value) discarded every other server's valid edit in the same bulk save.
- `renameChat`'s own "row no longer exists" signal was silently discarded by both the intent handler and the SPA, which closed its rename UI regardless of outcome - same class of bug already fixed for delete.
- Workspace export silently dropped every chat's tags/favorite/archived flags.
- A backslash-encoded path could escape Gitlink's local sandbox root on Windows; now sanitized and defense-in-depth checked.
- Gitlink's Local Root field went stale after Browse picked a new folder, silently reverting the pick on the next blur.
- Redo's refusal message said "Can't undo" even when a live run blocked a redo.
- A stored asset's `mime_type` was served as-is with no allowlist, letting a caller make the asset route return an arbitrary Content-Type.

**Frontend canvas and transport**
- A backend scene publish landing mid-drag was silently discarded and never re-applied once the drag ended, permanently freezing that node until an unrelated future update happened to flush it.
- A frame member that grew off-viewport now reports its new size immediately on remount instead of waiting for the next unrelated debounce tick.
- `sendMessage` cleared the staged reply-target/branch selection before the request had any chance to fail, silently losing it on a failed send.
- A version-rejected `resubscribe()` reply never invoked its correlated callback, permanently wedging `composerStore`'s draft-resync fence.
- A StrictMode dispose-then-connect cycle could silently replay an already-sent queueable intent onto the new connection - a real second application of a mutating intent.
- The queueable-intent classification guard's own regex silently dropped real `fireIntent` call sites (comments with a stray `fireIntent(` substring, and every JSX-inline-arrow call site in SettingsDialog.tsx) - fixed the regex itself, restoring the guard's actual coverage.

## Test plan
- [x] `python -m pytest -q` from repo root: 3169 passed, 17 skipped, 0 failed
- [x] `npm run check` in `web_ui/` (schema drift, typecheck, lint, 1998 tests, build, bundle-size gate): all clean
- [x] Every fix has a dedicated regression test, and every regression test was confirmed to fail against the pre-fix code before the fix was restored