### PR TITLE
Run the test suite in parallel: 10+ minutes to ~80 seconds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
       # version skew - see that test's own module docstring for the CI
       # failure that proved the shell-out approach unusable.
       - name: Install dev tooling (pytest, ruff, mypy - CI-only, not in the prod lockfile)
-        run: pip install --quiet pytest==9.1.1 pytest-cov==7.1.0 ruff==0.16.4 mypy==2.3.1
+        run: pip install --quiet pytest==9.1.1 pytest-cov==7.1.0 pytest-xdist==3.8.0 ruff==0.16.4 mypy==2.3.1
 
       - name: Compile check
         run: python -m compileall -q .
@@ -155,8 +155,8 @@ jobs:
       # own module docstring already asks for (stable timing, no
       # environmental noise) - coverage instrumentation is exactly the
       # kind of noise that docstring means.
-      - name: Run pytest (perf suite, uninstrumented - coverage tracing would corrupt its timing assertions)
-        run: python -m pytest -q backend/tests/perf
+      - name: Run pytest (perf suite, uninstrumented AND serial - coverage tracing and parallel sibling workers would both corrupt its timing assertions)
+        run: python -m pytest -q -n0 backend/tests/perf
 
       - name: pip-audit (known-vulnerability scan of the locked dependency set)
         run: pip install --quiet pip-audit==2.10.1 && python -m pip_audit -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ llamacpp = ["llama-cpp-python"]
 # (the prod lockfile). CI installs them ad hoc (see .github/workflows/ci.yml),
 # same pattern ruff already used before this stage; this extra exists so a
 # contributor gets the identical set via one `pip install -e .[dev]`.
-dev = ["pytest", "pytest-cov", "ruff", "mypy"]
+dev = ["pytest", "pytest-cov", "pytest-xdist", "ruff", "mypy"]
 
 [tool.pytest.ini_options]
 # ADR-015 stage 15.3: --strict-markers rejects a typo'd/unregistered
@@ -71,7 +71,16 @@ dev = ["pytest", "pytest-cov", "ruff", "mypy"]
 # differently). Chasing that surface to zero is a real, separate body of
 # work, not "add a filterwarnings policy" - see ADR-015 §2's own "no
 # big-bang cleanup" instruction for ruff, which applies equally here.
-addopts = "--strict-markers --strict-config"
+# -n auto --dist worksteal: the suite is parallel-safe (every test isolates
+# into tmp_path/monkeypatch) but ran single-process for its whole life -
+# 10+ minutes of wall clock on a 12-core machine. Parallel: ~80s locally,
+# and CI's 4-core runners get the same multiplier. worksteal (not the
+# default load) because the tail is a handful of 10s+ real-venv sandbox
+# tests that would otherwise strand one worker long after the rest drain.
+# Debugging escape hatch: append -n0 to run serial (breakpoints, -s, or
+# the perf suite - CI passes -n0 there explicitly, since its timing
+# assertions must not share a loaded machine with 11 sibling workers).
+addopts = "--strict-markers --strict-config -n auto --dist worksteal"
 filterwarnings = [
     "error::DeprecationWarning",
     "error::PendingDeprecationWarning",


### PR DESCRIPTION
## Problem

The backend suite (3,327 tests) runs single-process: 10+ minutes of wall clock locally on a 12-core machine, and the same serialization on every CI run. That is dead waiting time on every verify cycle, doubled whenever a fix needs a re-run, and it burns Actions minutes on every PR.

## Change

- `pytest-xdist` added to the dev extra and to CI's pinned tool install.
- `-n auto --dist worksteal` in `addopts`, so the plain `pytest -q` everyone already runs is parallel by default. `worksteal` because the tail is a handful of 10s+ real-venv code-sandbox security tests that would strand one worker under the default distribution.
- The CI perf step passes `-n0`: its timing assertions must not share a loaded machine with sibling workers — the same reasoning that already runs it uninstrumented for coverage.
- `-n0` is the documented serial escape hatch for breakpoint/`-s` debugging.

No test changes. The suite was already parallel-safe (tmp_path/monkeypatch isolation throughout); it just never ran that way.

## Test plan

- Two consecutive full parallel runs, both green: 3,327 passed / 20 skipped in 83.5s and 81.0s (was 619s serial on the same tree).
- Targeted invocation (`pytest -q backend/tests/test_harness.py`) picks up the parallel default and passes; `pytest -q -n0 backend/tests/perf` passes serial (8/8).
- pytest-cov aggregates across xdist workers, so CI's coverage floor is unaffected.