### PR TITLE
Agent harness: user-directory workspaces behind a trust grant

### DIFF
--- a/backend/api/intents_harness.py
+++ b/backend/api/intents_harness.py
@@ -8,6 +8,12 @@ an ordinary Ctrl+Z-undoable command, the builder-plan precedent exactly.
 
 from __future__ import annotations
 
+import asyncio
+import os
+from pathlib import Path
+
+from backend import native_dialogs
+from backend.api._settings_shared import run_locked
 from backend.api._shared import make_publish_scene
 from backend.domain.graph import SceneDocument
 from backend.domain.node_states import HarnessState
@@ -94,6 +100,45 @@ def register_harness_intents(
     async def cancel(request_id):
         agent_dispatcher.cancel_harness(request_id)
 
+    async def pick_workspace(node_id):
+        """Bind this agent node to a real project directory. The pick IS
+        the consent (the gitlink local-root precedent): on success we add
+        the folder to the settings trust list AND set it as this node's
+        requested workspace. B-classified run-config, not document content -
+        a workspace binding is a run setting like the budget, and it also
+        writes the settings store, which is never an undo target."""
+        node = document.nodes.get(node_id)
+        if node is None or not isinstance(node.state, HarnessState):
+            return
+        directory = node.state.harness_workspace_path or os.path.expanduser("~")
+        try:
+            folder = await native_dialogs.pick_folder(directory=directory)
+        except Exception as exc:  # noqa: BLE001 - a local folder path, not a credential
+            notifications.show(f"Could not open the folder picker: {exc}", "error")
+            await bus.publish("notification")
+            return
+        if not folder:
+            return
+        resolved = str(Path(folder).resolve())
+        settings = agent_dispatcher._settings_manager
+        if settings is not None:
+            # The grant write goes through the same locked writer every
+            # other settings mutation uses (save_recipe's precedent), so it
+            # cannot land mid-write against a concurrent settings save.
+            await asyncio.to_thread(run_locked, lambda: settings.add_harness_trusted_dir(resolved))
+        node.state.harness_workspace_path = resolved
+        await publish_scene()
+
+    async def use_scratch(node_id):
+        """Unbind from the user directory, reverting to the managed scratch
+        workspace. Leaves the trust grant in place (revoking trust is a
+        settings concern, not a per-node one)."""
+        node = document.nodes.get(node_id)
+        if node is None or not isinstance(node.state, HarnessState):
+            return
+        node.state.harness_workspace_path = ""
+        await publish_scene()
+
     async def approve_tool(request_id):
         agent_dispatcher.approve_code_execution(request_id)
 
@@ -105,3 +150,5 @@ def register_harness_intents(
     bus.register_intent("harness", "cancel", cancel)
     bus.register_intent("harness", "approveTool", approve_tool)
     bus.register_intent("harness", "denyTool", deny_tool)
+    bus.register_intent("harness", "pickWorkspace", pick_workspace)
+    bus.register_intent("harness", "useScratch", use_scratch)

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -2566,6 +2566,12 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
             "harnessCompactions": (
                 n.state.harness_compactions if isinstance(n.state, HarnessState) else 0
             ),
+            "harnessWorkspacePath": (
+                n.state.harness_workspace_path if isinstance(n.state, HarnessState) else ""
+            ),
+            "harnessWorkspaceActive": (
+                n.state.harness_workspace_active if isinstance(n.state, HarnessState) else ""
+            ),
             "harnessMaxTurns": n.state.harness_max_turns if isinstance(n.state, HarnessState) else 0,
             "harnessSpentTurns": (
                 n.state.harness_spent_turns if isinstance(n.state, HarnessState) else 0

--- a/backend/domain/node_states.py
+++ b/backend/domain/node_states.py
@@ -902,6 +902,16 @@ class HarnessState(NodeState):
     harness_status_detail: str = ""
     harness_run_id: str = ""
     harness_workspace_id: str = ""
+    # The user directory this node is bound to work in, or "" for the
+    # managed scratch workspace (the default). A REQUEST, not a grant: it
+    # is honored at run time only if it is in the settings trust list (see
+    # backend/harness/workspace.bound_root); otherwise the run silently
+    # uses scratch. harness_workspace_active is the RESULT the last run
+    # actually bound - the resolved user dir when the trust check passed,
+    # else "" - so the UI can show "working in <dir>" vs "scratch" honestly
+    # rather than echoing the unverified request.
+    harness_workspace_path: str = ""
+    harness_workspace_active: str = ""
     harness_activity: list[dict[str, Any]] = field(default_factory=list)
     harness_max_turns: int = 16
     harness_spent_turns: int = 0

--- a/backend/harness/loop.py
+++ b/backend/harness/loop.py
@@ -37,7 +37,7 @@ import graphlink_task_config as config
 from backend.domain.node_states import HarnessState
 from backend.harness import context as context_module
 from backend.harness.transcript import append_compaction, append_message, load_messages
-from backend.harness.workspace import ensure_workspace
+from backend.harness.workspace import bound_root, ensure_workspace
 from backend.providers.base import CancelToken, ToolCall
 from backend.tools import (
     CODE_EXECUTE,
@@ -117,6 +117,9 @@ class HarnessRunContext(RunContext):
     run_id: str | None = None
     harness_node_id: str | None = None
     harness_workspace_id: str | None = None
+    # The run's ONE resolved confinement root (a Path), set at run start -
+    # a trusted user dir or the scratch dir. The tools confine against this.
+    harness_workspace_dir: object = None
     model_ref: object = None
     settings_manager: object = None
     runtime: object = None
@@ -269,7 +272,20 @@ async def run_harness(
     await bus.publish("scene")
 
     try:
-        workspace = ensure_workspace(node.state.harness_workspace_id)
+        # The transcript ALWAYS lives in the managed scratch dir - never
+        # written into a user's own project folder. The confinement root
+        # (and the AGENTS.md the prompt reads) is whatever the run bound:
+        # a trusted user directory, or that same scratch dir. bound_root is
+        # the trust gate - an untrusted/missing path silently falls back to
+        # scratch (see workspace.bound_root).
+        transcript_dir = ensure_workspace(node.state.harness_workspace_id)
+        root, is_user_dir = bound_root(
+            node.state.harness_workspace_id,
+            node.state.harness_workspace_path,
+            settings_manager=settings_manager,
+        )
+        ctx.harness_workspace_dir = root
+        node.state.harness_workspace_active = str(root) if is_user_dir else ""
 
         # ADR-021 stage 21.1 posture: offer only tools this run could
         # actually pass the scope gate with - anything else spends context
@@ -281,13 +297,13 @@ async def run_harness(
         # H3: built ONCE, here, and never rebuilt inside the loop - the
         # byte-stable prefix a provider's prompt cache keys on (see
         # backend/harness/context.py's own docstring).
-        system_prompt = context_module.build_system_prompt(workspace)
+        system_prompt = context_module.build_system_prompt(root)
         user_message = {"role": "user", "content": user_text}
-        append_message(workspace, user_message)
+        append_message(transcript_dir, user_message)
         # `history` deliberately excludes the system prompt: it lives
         # outside history so compaction structurally cannot touch it (and
         # so the cacheable prefix is the same object every turn).
-        history: list = [*load_messages(workspace), user_message]
+        history: list = [*load_messages(transcript_dir), user_message]
 
         turns = 0
         max_turns = max(1, int(node.state.harness_max_turns))
@@ -332,7 +348,7 @@ async def run_harness(
                     compacted = None
                 if compacted is not None:
                     history, _summary = compacted
-                    append_compaction(workspace, history[0]["content"])
+                    append_compaction(transcript_dir, history[0]["content"])
                     node.state.harness_compactions += 1
                     node.state.harness_context_tokens = context_module.history_tokens(history)
                     await bus.publish("scene")
@@ -358,7 +374,7 @@ async def run_harness(
                     {"id": c.id, "name": c.name, "arguments": c.arguments} for c in tool_calls
                 ]
             history.append(assistant_message)
-            append_message(workspace, assistant_message)
+            append_message(transcript_dir, assistant_message)
 
             if not tool_calls:
                 await _land("done", "Task complete.", reply=assistant_text)
@@ -377,7 +393,7 @@ async def run_harness(
                     "name": call.name, "content": result.content,
                 }
                 history.append(tool_message)
-                append_message(workspace, tool_message)
+                append_message(transcript_dir, tool_message)
                 await bus.publish("scene")
     except api_provider.RequestCancelledError:
         await _land("stopped", "Stopped by user.")

--- a/backend/harness/subagents.py
+++ b/backend/harness/subagents.py
@@ -87,7 +87,7 @@ SUBAGENT_SPAWN_SPEC = ToolSpec(
 async def run_subagent(
     *,
     registry: ToolRegistry,
-    workspace_id: str,
+    workspace_dir,
     task: str,
     model_ref=None,
     settings_manager=None,
@@ -97,9 +97,10 @@ async def run_subagent(
 ) -> str:
     """The child loop: a stripped-down run_harness that touches no node,
     no bus, and no transcript - it exists only to produce a string. Reads
-    the same workspace; keeps its whole conversation in local memory and
-    discards it when it returns. Blocking model calls run via to_thread,
-    exactly as the parent loop's do."""
+    the SAME bound root as its parent (scratch or trusted user dir - the
+    parent passes its resolved root as workspace_dir); keeps its whole
+    conversation in local memory and discards it when it returns. Blocking
+    model calls run via to_thread, exactly as the parent loop's do."""
     import api_provider
 
     async def _auto(_call: ToolCall) -> bool:
@@ -112,9 +113,9 @@ async def run_subagent(
         request_approval=_auto,
         cancel=CancelToken(cancel_event) if cancel_event is not None else None,
     )
-    # The duck-typed workspace channel the fs tools read (they look for
-    # ctx.harness_workspace_id); RunContext has no such field, so set it.
-    ctx.harness_workspace_id = workspace_id
+    # The duck-typed root channel the fs tools read (ctx.harness_workspace_dir),
+    # so the child confines to exactly its parent's root.
+    ctx.harness_workspace_dir = workspace_dir
 
     specs = tuple(
         spec for spec in registry.specs()
@@ -159,8 +160,17 @@ async def run_subagent(
 
 def register_subagent_tool(registry: ToolRegistry) -> None:
     async def spawn(call: ToolCall, ctx: RunContext) -> ToolResult:
-        workspace_id = getattr(ctx, "harness_workspace_id", None)
-        if not isinstance(workspace_id, str) or not workspace_id:
+        from pathlib import Path
+
+        from backend.harness.workspace import workspace_dir
+
+        # Inherit the parent's bound root: its resolved user/scratch dir if
+        # the loop set one, else recompute the scratch dir from the id.
+        root = getattr(ctx, "harness_workspace_dir", None)
+        if not isinstance(root, Path):
+            workspace_id = getattr(ctx, "harness_workspace_id", None)
+            root = workspace_dir(workspace_id) if isinstance(workspace_id, str) and workspace_id else None
+        if root is None:
             return ToolResult(content="No harness workspace is bound to this run.", is_error=True)
         task = str(call.arguments.get("task") or "").strip()
         if not task:
@@ -168,7 +178,7 @@ def register_subagent_tool(registry: ToolRegistry) -> None:
         try:
             summary = await run_subagent(
                 registry=registry,
-                workspace_id=workspace_id,
+                workspace_dir=root,
                 task=task,
                 model_ref=getattr(ctx, "model_ref", None),
                 settings_manager=getattr(ctx, "settings_manager", None),

--- a/backend/harness/tools_fs.py
+++ b/backend/harness/tools_fs.py
@@ -3,24 +3,26 @@ the fs.read scope with `auto` approval (the read-only posture every other
 auto tool in backend/tools.py's vocabulary already takes).
 
 Every handler resolves its path arguments through
-workspace.resolve_in_workspace - the single confinement choke point - and
-bounds its result before returning it (PLAN §2.3: results are capped at
-the boundary so no tool can flood the context; the same posture the MCP
-result caps and builder activity caps already establish).
+workspace.resolve_under_root against the run's ONE bound root - the single
+confinement choke point - and bounds its result before returning it (PLAN
+§2.3: results are capped at the boundary so no tool can flood the context;
+the same posture the MCP result caps and builder activity caps already
+establish).
 
-Handlers find their workspace via the duck-typed run context
-(ctx.harness_workspace_id) - the exact channel builder.py's control tools
-already read ctx.controls through: tools stay ordinary registry
-registrations with no special dispatch, and a context without the
-attribute (some non-harness run invoking them by mistake) degrades to an
-ordinary error ToolResult, never a crash.
+Handlers get that root from the duck-typed run context via _bound_root:
+the loop resolves the root once at run start (a managed scratch dir, or a
+trusted user directory) and sets ctx.harness_workspace_dir; a context with
+neither that nor a scratch id degrades to an ordinary error ToolResult,
+never a crash.
 """
 
 from __future__ import annotations
 
 import re
 
-from backend.harness.workspace import WorkspaceError, resolve_in_workspace, workspace_dir
+from pathlib import Path
+
+from backend.harness.workspace import WorkspaceError, resolve_under_root, workspace_dir
 from backend.providers.base import ToolCall, ToolSpec
 from backend.tools import FS_READ, FS_WRITE, RunContext, ToolRegistry, ToolResult
 
@@ -124,29 +126,37 @@ FS_GREP_SPEC = ToolSpec(
 )
 
 
-def _workspace_id_of(ctx: RunContext) -> str | None:
+def _bound_root(ctx: RunContext) -> Path | None:
+    """The run's ONE confinement root, off the context. The loop resolves
+    it once (scratch dir or trusted user dir) and sets harness_workspace_dir;
+    an older caller that set only harness_workspace_id still works, binding
+    that id's scratch dir. None means no workspace is bound at all."""
+    root = getattr(ctx, "harness_workspace_dir", None)
+    if isinstance(root, Path):
+        return root.resolve()
     workspace_id = getattr(ctx, "harness_workspace_id", None)
-    return workspace_id if isinstance(workspace_id, str) and workspace_id else None
+    if isinstance(workspace_id, str) and workspace_id:
+        return workspace_dir(workspace_id).resolve()
+    return None
 
 
-def _iter_workspace_files(workspace_id: str, pattern: str):
-    """Workspace-relative iteration; resolve_in_workspace re-checks every
-    yielded candidate so a glob cannot be a traversal primitive (Path.glob
-    itself refuses '..' segments, but the double-check keeps confinement a
-    single-choke-point property rather than a per-caller convention)."""
-    root = workspace_dir(workspace_id).resolve()
+def _iter_under_root(root: Path, pattern: str):
+    """Root-relative iteration; resolve_under_root re-checks every yielded
+    candidate so a glob cannot be a traversal primitive (Path.glob itself
+    refuses '..' segments, but the double-check keeps confinement a single-
+    choke-point property rather than a per-caller convention)."""
     for path in sorted(root.glob(pattern or "**/*")):
-        resolved = resolve_in_workspace(workspace_id, str(path))
+        resolved = resolve_under_root(root, str(path))
         yield resolved, resolved.relative_to(root).as_posix()
 
 
 def register_harness_fs_tools(registry: ToolRegistry) -> None:
     async def fs_read(call: ToolCall, ctx: RunContext) -> ToolResult:
-        workspace_id = _workspace_id_of(ctx)
-        if workspace_id is None:
+        root = _bound_root(ctx)
+        if root is None:
             return ToolResult(content="No harness workspace is bound to this run.", is_error=True)
         try:
-            target = resolve_in_workspace(workspace_id, str(call.arguments.get("path") or ""))
+            target = resolve_under_root(root, str(call.arguments.get("path") or ""))
         except WorkspaceError as exc:
             return ToolResult(content=str(exc), is_error=True)
         if not target.is_file():
@@ -172,14 +182,14 @@ def register_harness_fs_tools(registry: ToolRegistry) -> None:
         return ToolResult(content=header + body)
 
     async def fs_list(call: ToolCall, ctx: RunContext) -> ToolResult:
-        workspace_id = _workspace_id_of(ctx)
-        if workspace_id is None:
+        root = _bound_root(ctx)
+        if root is None:
             return ToolResult(content="No harness workspace is bound to this run.", is_error=True)
         pattern = str(call.arguments.get("pattern") or "**/*")
         entries: list[str] = []
         truncated = False
         try:
-            for resolved, relative in _iter_workspace_files(workspace_id, pattern):
+            for resolved, relative in _iter_under_root(root, pattern):
                 if len(entries) >= _LIST_CAP_ENTRIES:
                     truncated = True
                     break
@@ -192,8 +202,8 @@ def register_harness_fs_tools(registry: ToolRegistry) -> None:
         return ToolResult(content="\n".join(entries) + suffix)
 
     async def fs_grep(call: ToolCall, ctx: RunContext) -> ToolResult:
-        workspace_id = _workspace_id_of(ctx)
-        if workspace_id is None:
+        root = _bound_root(ctx)
+        if root is None:
             return ToolResult(content="No harness workspace is bound to this run.", is_error=True)
         raw_pattern = str(call.arguments.get("pattern") or "")
         if not raw_pattern:
@@ -208,7 +218,7 @@ def register_harness_fs_tools(registry: ToolRegistry) -> None:
         matches: list[str] = []
         skipped_large = 0
         try:
-            for resolved, relative in _iter_workspace_files(workspace_id, file_glob):
+            for resolved, relative in _iter_under_root(root, file_glob):
                 if len(matches) >= _GREP_CAP_MATCHES:
                     break
                 if not resolved.is_file():
@@ -241,8 +251,8 @@ def register_harness_fs_tools(registry: ToolRegistry) -> None:
         return ToolResult(content="\n".join(matches) + footer)
 
     async def fs_write(call: ToolCall, ctx: RunContext) -> ToolResult:
-        workspace_id = _workspace_id_of(ctx)
-        if workspace_id is None:
+        root = _bound_root(ctx)
+        if root is None:
             return ToolResult(content="No harness workspace is bound to this run.", is_error=True)
         content = call.arguments.get("content")
         if not isinstance(content, str):
@@ -253,10 +263,10 @@ def register_harness_fs_tools(registry: ToolRegistry) -> None:
                 is_error=True,
             )
         try:
-            target = resolve_in_workspace(workspace_id, str(call.arguments.get("path") or ""))
+            target = resolve_under_root(root, str(call.arguments.get("path") or ""))
         except WorkspaceError as exc:
             return ToolResult(content=str(exc), is_error=True)
-        if target == workspace_dir(workspace_id).resolve():
+        if target == root:
             return ToolResult(content="path names the workspace root, not a file.", is_error=True)
         try:
             target.parent.mkdir(parents=True, exist_ok=True)
@@ -266,8 +276,8 @@ def register_harness_fs_tools(registry: ToolRegistry) -> None:
         return ToolResult(content=f"Wrote {len(content)} characters to {call.arguments.get('path')}.")
 
     async def fs_edit(call: ToolCall, ctx: RunContext) -> ToolResult:
-        workspace_id = _workspace_id_of(ctx)
-        if workspace_id is None:
+        root = _bound_root(ctx)
+        if root is None:
             return ToolResult(content="No harness workspace is bound to this run.", is_error=True)
         old_string = call.arguments.get("old_string")
         new_string = call.arguments.get("new_string")
@@ -278,7 +288,7 @@ def register_harness_fs_tools(registry: ToolRegistry) -> None:
                 content=f"Replacement longer than {_WRITE_CAP_CHARS} characters.", is_error=True,
             )
         try:
-            target = resolve_in_workspace(workspace_id, str(call.arguments.get("path") or ""))
+            target = resolve_under_root(root, str(call.arguments.get("path") or ""))
         except WorkspaceError as exc:
             return ToolResult(content=str(exc), is_error=True)
         if not target.is_file():

--- a/backend/harness/tools_shell.py
+++ b/backend/harness/tools_shell.py
@@ -31,6 +31,8 @@ import subprocess
 import sys
 import time
 
+from pathlib import Path
+
 from api_provider import RequestCancelledError
 from backend.harness.workspace import WorkspaceError, ensure_workspace
 from backend.providers.base import ToolCall, ToolSpec
@@ -110,16 +112,25 @@ def _run_command(command: str, cwd, cancel_event) -> tuple[str, "int | None", st
 
 def register_harness_shell_tool(registry: ToolRegistry) -> None:
     async def shell_exec(call: ToolCall, ctx: RunContext) -> ToolResult:
-        workspace_id = getattr(ctx, "harness_workspace_id", None)
-        if not isinstance(workspace_id, str) or not workspace_id:
-            return ToolResult(content="No harness workspace is bound to this run.", is_error=True)
+        # The command runs with cwd = the run's bound root: the trusted
+        # user directory when one is bound (already ensured by the loop and
+        # carried on the context), else the managed scratch dir created
+        # here. A user dir is the person's own folder - never chmod'd or
+        # created by us.
+        bound = getattr(ctx, "harness_workspace_dir", None)
         command = str(call.arguments.get("command") or "").strip()
         if not command:
             return ToolResult(content="shell.exec needs a non-empty command.", is_error=True)
         if len(command) > _COMMAND_CAP_CHARS:
             return ToolResult(content=f"Command longer than {_COMMAND_CAP_CHARS} characters.", is_error=True)
         try:
-            workspace = ensure_workspace(workspace_id)
+            if isinstance(bound, Path):
+                workspace = bound
+            else:
+                workspace_id = getattr(ctx, "harness_workspace_id", None)
+                if not isinstance(workspace_id, str) or not workspace_id:
+                    return ToolResult(content="No harness workspace is bound to this run.", is_error=True)
+                workspace = ensure_workspace(workspace_id)
         except (WorkspaceError, OSError) as exc:
             return ToolResult(content=f"Could not prepare the workspace: {exc}", is_error=True)
 

--- a/backend/harness/workspace.py
+++ b/backend/harness/workspace.py
@@ -1,20 +1,34 @@
-"""Harness workspace binding (PLAN-2026-08-24 §3.2.5, H1: managed scratch
-roots only).
+"""Harness workspace binding (PLAN-2026-08-24 §3.2.5).
 
-A harness session binds to exactly one directory under
-graphlink_scratch_dirs.HARNESS_WORKSPACE_ROOT, keyed by the node's own
-durable harness_workspace_id (minted once at node creation - the
-pycoder_repl_id precedent: node ids are reassigned by array position on
-session reload, so they are not durable enough to name an on-disk
-directory). Creation goes through prepare_scratch_dir so the 0700 chmod
-and the private-root ownership check apply unchanged; ordinary use bumps
-the directory's own mtime via touch_scratch_dir_usage so the launch age
-sweep never mistakes an active workspace for an abandoned one.
+A harness run binds to exactly ONE root directory, resolved once at run
+start (backend/harness/loop.py) and carried on the run context. It is one
+of two kinds:
 
-Every path a tool touches resolves through resolve_in_workspace - the one
-confinement choke point. Confinement here is a correctness/UX layer over
-READ access (H1 ships read-only tools); the OS-level guard story for
-mutating tools is H2's, per the plan's permissions-vs-sandbox split.
+- a MANAGED scratch directory under graphlink_scratch_dirs.
+  HARNESS_WORKSPACE_ROOT, keyed by the node's durable harness_workspace_id
+  (the pycoder_repl_id precedent: node ids are reassigned by array
+  position on reload, so they cannot name an on-disk directory). Created
+  via prepare_scratch_dir so the 0700 chmod and private-root ownership
+  check apply; usage bumps its mtime so the launch age-sweep never treats
+  an active workspace as abandoned. This is the default.
+
+- a USER directory the person explicitly granted through the folder
+  picker (harness_workspace_path). This is real work in a real project
+  folder, so it is NOT chmod-restricted, NOT age-swept, and NOT deleted
+  when the node is deleted - it is the user's own directory, not scratch.
+
+THE TRUST GATE (bound_root) is the security boundary for the user-dir
+case: a node's harness_workspace_path is honored ONLY if that exact
+resolved path is in the settings trust list, checked at RUN time. A
+session file is untrusted input (hand-editable, importable), so a path
+that is not currently trusted on THIS install degrades to the node's
+scratch workspace rather than silently operating on a folder this user
+never granted. The grant is made by the person picking the folder in a
+native dialog (the pick IS the consent - the gitlink local-root
+precedent); nothing the model does can add a grant.
+
+Every path a tool touches resolves through resolve_under_root - the one
+confinement choke point - against whichever root the run bound.
 """
 
 from __future__ import annotations
@@ -36,7 +50,7 @@ class WorkspaceError(ValueError):
 
 
 def workspace_dir(workspace_id: str) -> Path:
-    """The deterministic on-disk directory for a workspace id - computable
+    """The deterministic scratch directory for a workspace id - computable
     from the raw id alone, the same recompute-don't-hold-a-reference shape
     remove_scratch_dir_for_id relies on for node-delete GC."""
     if not workspace_id:
@@ -48,28 +62,58 @@ def workspace_dir(workspace_id: str) -> Path:
 
 
 def ensure_workspace(workspace_id: str) -> Path:
-    """Create-or-reuse, with the shared permissioning applied; called at
-    run start (and by tests). Also refreshes the usage mtime - a run IS a
-    use, whether or not any tool ends up writing."""
+    """Create-or-reuse the managed scratch dir, with the shared
+    permissioning applied; called at run start (and by tests). Also
+    refreshes the usage mtime - a run IS a use, whether or not any tool
+    ends up writing."""
     path = workspace_dir(workspace_id)
     prepare_scratch_dir(path)
     touch_scratch_dir_usage(path)
     return path
 
 
-def resolve_in_workspace(workspace_id: str, raw_path: str) -> Path:
-    """The confinement choke point every fs tool routes through: interprets
-    `raw_path` (relative, or absolute-but-inside) against the workspace and
-    returns a fully resolved Path proven to live under it.
+def bound_root(
+    workspace_id: str,
+    workspace_path: str | None,
+    *,
+    settings_manager=None,
+) -> tuple[Path, bool]:
+    """Resolve a run's ONE bound root. Returns (root, is_user_dir).
+
+    A non-empty workspace_path is honored only when it passes the trust
+    gate: settings_manager.get_harness_trusted_dirs() must contain its
+    resolved absolute string AND it must still be an existing directory.
+    Any failure - untrusted, missing, gone, no settings manager - falls
+    back silently to the managed scratch workspace. This is the load-
+    bearing check: a session file naming a directory is a REQUEST, never a
+    grant."""
+    if workspace_path and settings_manager is not None:
+        try:
+            candidate = Path(workspace_path).resolve()
+        except OSError:
+            candidate = None
+        if candidate is not None and candidate.is_dir():
+            try:
+                trusted = set(settings_manager.get_harness_trusted_dirs())
+            except Exception:
+                trusted = set()
+            if str(candidate) in {str(Path(t).resolve()) for t in trusted if isinstance(t, str)}:
+                return candidate, True
+    return ensure_workspace(workspace_id), False
+
+
+def resolve_under_root(root: Path, raw_path: str) -> Path:
+    """The confinement choke point every fs/shell tool routes through:
+    interprets `raw_path` (relative, or absolute-but-inside) against
+    `root` and returns a fully resolved Path proven to live under it.
 
     resolve() (not a lexical prefix check) so both `..` traversal and a
-    symlink planted inside the workspace pointing out of it land on the
-    REAL target before the containment test - the same class of hostile-
-    disk input the scratch-root ownership check already treats as in-scope.
-    The workspace root itself resolves first for the comparison, so a
-    symlinked temp dir (macOS /tmp -> /private/tmp) never produces false
-    refusals."""
-    root = workspace_dir(workspace_id).resolve()
+    symlink planted inside the root pointing out of it land on the REAL
+    target before the containment test - the same class of hostile-disk
+    input the scratch-root ownership check already treats as in-scope. The
+    root itself resolves first for the comparison, so a symlinked temp dir
+    (macOS /tmp -> /private/tmp) never produces false refusals."""
+    root = root.resolve()
     candidate = Path(raw_path) if raw_path else Path(".")
     if not candidate.is_absolute():
         candidate = root / candidate
@@ -80,3 +124,10 @@ def resolve_in_workspace(workspace_id: str, raw_path: str) -> Path:
             "inside the workspace are accessible"
         )
     return resolved
+
+
+def resolve_in_workspace(workspace_id: str, raw_path: str) -> Path:
+    """Scratch-workspace confinement by id - the H1 signature, kept for
+    callers and tests that bind a scratch workspace directly. Delegates to
+    resolve_under_root against the id's scratch dir."""
+    return resolve_under_root(workspace_dir(workspace_id), raw_path)

--- a/backend/session_load.py
+++ b/backend/session_load.py
@@ -856,6 +856,7 @@ def _restore_harness_payload(payload: dict[str, Any]) -> SceneNode:
             ),
             harness_run_id=str(payload.get("harness_run_id", "")),
             harness_workspace_id=str(payload.get("workspace_id") or uuid.uuid4().hex[:12]),
+            harness_workspace_path=str(payload.get("workspace_path", "")),
             harness_activity=activity,
             harness_max_turns=_int("max_turns", 16),
             harness_spent_turns=_int("spent_turns", 0),

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -477,6 +477,11 @@ def _serialize_harness_node(node: SceneNode) -> dict[str, Any]:
         "status_detail": node.state.harness_status_detail,
         "harness_run_id": node.state.harness_run_id,
         "workspace_id": node.state.harness_workspace_id,
+        # The user-dir request persists (re-checked against trust on the
+        # next run); the resolved-active result does not - it is recomputed
+        # per run, and a stale "active" from a machine that trusted the dir
+        # must never imply trust on a machine that does not.
+        "workspace_path": node.state.harness_workspace_path,
         "activity": [dict(a) for a in node.state.harness_activity],
         "max_turns": node.state.harness_max_turns,
         "spent_turns": node.state.harness_spent_turns,

--- a/backend/tests/test_harness_subagents.py
+++ b/backend/tests/test_harness_subagents.py
@@ -74,7 +74,7 @@ def test_subagent_is_offered_only_read_tools_no_write_shell_or_spawn(workspace_r
         {"content": "", "tool_calls": [call("s1", "fs.read", path="a.txt")]},
         {"content": "a.txt contains findable content"},
     ])
-    answer = asyncio.run(run_subagent(registry=registry, workspace_id="ws1", task="what is in a.txt?"))
+    answer = asyncio.run(run_subagent(registry=registry, workspace_dir=ensure_workspace("ws1"), task="what is in a.txt?"))
     assert answer == "a.txt contains findable content"
     offered = set(seen[0])
     assert {"fs.read", "fs.list", "fs.grep"} <= offered
@@ -91,7 +91,7 @@ def test_a_write_attempt_by_the_subagent_is_denied_by_scope(workspace_root, monk
         {"content": "", "tool_calls": [call("s1", "fs.write", path="x.txt", content="nope")]},
         {"content": "I could not write; I can only read."},
     ])
-    answer = asyncio.run(run_subagent(registry=registry, workspace_id="ws1", task="try to write"))
+    answer = asyncio.run(run_subagent(registry=registry, workspace_dir=ensure_workspace("ws1"), task="try to write"))
     assert "only read" in answer
     assert not (ensure_workspace("ws1") / "x.txt").exists()
 
@@ -104,7 +104,7 @@ def test_turn_limit_returns_the_last_text_flagged(workspace_root, monkeypatch):
         {"content": "still looking", "tool_calls": [call("s2", "fs.list")]},
     ])
     answer = asyncio.run(
-        run_subagent(registry=registry, workspace_id="ws1", task="loop", max_turns=2)
+        run_subagent(registry=registry, workspace_dir=ensure_workspace("ws1"), task="loop", max_turns=2)
     )
     assert "turn limit" in answer
 

--- a/backend/tests/test_harness_user_dirs.py
+++ b/backend/tests/test_harness_user_dirs.py
@@ -1,0 +1,96 @@
+"""User-directory workspaces: the trust gate is the whole security story,
+so the tests concentrate there - a trusted dir binds, an untrusted request
+degrades to scratch, confinement holds against the user dir, and the
+transcript never lands inside it."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.harness import workspace as workspace_module
+from backend.harness.workspace import bound_root, ensure_workspace, resolve_under_root
+from backend.harness.tools_fs import register_harness_fs_tools
+from backend.providers.base import ToolCall
+from backend.tools import FS_READ, FS_WRITE, RunContext, ToolRegistry
+
+
+@pytest.fixture
+def workspace_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(workspace_module, "HARNESS_WORKSPACE_ROOT", tmp_path / "scratch")
+    return tmp_path
+
+
+class FakeSettings:
+    def __init__(self, trusted):
+        self._trusted = list(trusted)
+
+    def get_harness_trusted_dirs(self):
+        return list(self._trusted)
+
+
+def test_a_trusted_existing_dir_binds_as_a_user_dir(workspace_root, tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    settings = FakeSettings([str(project.resolve())])
+    root, is_user_dir = bound_root("ws1", str(project), settings_manager=settings)
+    assert is_user_dir and root == project.resolve()
+
+
+def test_an_untrusted_dir_silently_falls_back_to_scratch(workspace_root, tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    # The path is a real dir but NOT in the trust list: a session file's
+    # request must never be honored on trust it does not carry.
+    root, is_user_dir = bound_root("ws1", str(project), settings_manager=FakeSettings([]))
+    assert not is_user_dir
+    assert root == ensure_workspace("ws1")
+
+
+def test_a_trusted_but_now_missing_dir_falls_back_to_scratch(workspace_root, tmp_path):
+    gone = tmp_path / "gone"
+    settings = FakeSettings([str((tmp_path / "gone").resolve())])
+    root, is_user_dir = bound_root("ws1", str(gone), settings_manager=settings)
+    assert not is_user_dir and root == ensure_workspace("ws1")
+
+
+def test_no_path_or_no_settings_is_scratch(workspace_root):
+    assert bound_root("ws1", "", settings_manager=FakeSettings(["/anything"]))[1] is False
+    assert bound_root("ws1", "/some/dir", settings_manager=None)[1] is False
+
+
+def test_confinement_and_write_hold_against_a_user_dir(workspace_root, tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "readme.txt").write_text("hello from the project", encoding="utf-8")
+    registry = ToolRegistry()
+    register_harness_fs_tools(registry)
+
+    async def approve(_call):
+        return True
+
+    # A run bound to the user dir carries it as the resolved root.
+    ctx = RunContext(granted_scopes=frozenset({FS_READ, FS_WRITE}), request_approval=approve)
+    ctx.harness_workspace_dir = project.resolve()
+
+    async def go():
+        read = await registry.invoke(ToolCall(id="1", name="fs.read", arguments={"path": "readme.txt"}), ctx)
+        wrote = await registry.invoke(
+            ToolCall(id="2", name="fs.write", arguments={"path": "out.txt", "content": "written"}), ctx,
+        )
+        escape = await registry.invoke(
+            ToolCall(id="3", name="fs.read", arguments={"path": "../secret.txt"}), ctx,
+        )
+        return read, wrote, escape
+
+    read, wrote, escape = asyncio.run(go())
+    assert not read.is_error and "hello from the project" in read.content
+    assert not wrote.is_error and (project / "out.txt").read_text(encoding="utf-8") == "written"
+    assert escape.is_error and "outside" in escape.content
+
+
+def test_scratch_resolve_helper_still_confines(workspace_root):
+    ensure_workspace("ws1")
+    with pytest.raises(workspace_module.WorkspaceError):
+        resolve_under_root(workspace_module.workspace_dir("ws1"), "../elsewhere")

--- a/contracts/graphlink_scene_payload.py
+++ b/contracts/graphlink_scene_payload.py
@@ -617,6 +617,8 @@ class SceneNodeRow:
     harnessAwaitingApproval: bool = False
     harnessApprovalToolName: str = ""
     harnessApprovalSummary: str = ""
+    harnessWorkspacePath: str = ""
+    harnessWorkspaceActive: str = ""
     harnessMaxTurns: int = 0
     harnessSpentTurns: int = 0
     harnessSpentTokens: int = 0

--- a/tests/test_node_state_migration.py
+++ b/tests/test_node_state_migration.py
@@ -367,7 +367,7 @@ _EXPECTED_SCENE_NODE_WIRE_KEYS = sorted([
     "harnessRunId", "harnessActivity", "harnessMaxTurns", "harnessSpentTurns",
     "harnessSpentTokens", "harnessAwaitingApproval", "harnessApprovalToolName",
     "harnessApprovalSummary", "harnessContextTokens", "harnessMaxContextTokens",
-    "harnessCompactions",
+    "harnessCompactions", "harnessWorkspacePath", "harnessWorkspaceActive",
 ])
 
 

--- a/tests/test_undo_classification_gate.py
+++ b/tests/test_undo_classification_gate.py
@@ -267,8 +267,8 @@ def test_the_scan_finds_the_real_population_of_registered_intents():
     # rendered-size report, without which frame/container bounds fall back
     # to a flat 220x120 estimate per member and do not enclose them).
     real = _collect_real_registrations()
-    assert len(real) == 177, (
-        f"expected exactly 177 real registered intents, found {len(real)} - "
+    assert len(real) == 179, (
+        f"expected exactly 179 real registered intents, found {len(real)} - "
         "either the scan broke, or the app's registered-intent surface "
         "genuinely changed and tests/undo_classification.py's own count "
         "comment (and this assertion) need a deliberate update alongside it"

--- a/tests/undo_classification.py
+++ b/tests/undo_classification.py
@@ -267,6 +267,8 @@ CLASSIFICATION: tuple[Classified, ...] = (
     Classified("harness", "cancel", "B", "run-lifecycle: cancel"),
     Classified("harness", "approveTool", "B", "security: harness tool-call approval gate"),
     Classified("harness", "denyTool", "B", "security: harness tool-call approval gate"),
+    Classified("harness", "pickWorkspace", "B", "run-config: binds the node to a trusted user dir and writes the settings trust grant, not document content"),
+    Classified("harness", "useScratch", "B", "run-config: reverts the node to the scratch workspace"),
 
     # -- backend/api/intents_settings_general.py (app-settings) -------------
     Classified("app-settings", "setActiveSection", "B", "preference: which Settings page is open"),

--- a/web_ui/src/app/canvas/HarnessNodeView.test.tsx
+++ b/web_ui/src/app/canvas/HarnessNodeView.test.tsx
@@ -17,6 +17,8 @@ function makeData(overrides: Partial<HarnessNodeData> = {}): HarnessNodeData {
     harnessContextTokens: 0,
     harnessMaxContextTokens: 48000,
     harnessCompactions: 0,
+    harnessWorkspacePath: "",
+    harnessWorkspaceActive: "",
     harnessAwaitingApproval: false,
     harnessApprovalToolName: "",
     harnessApprovalSummary: "",
@@ -31,6 +33,8 @@ function makeData(overrides: Partial<HarnessNodeData> = {}): HarnessNodeData {
     onCancel: vi.fn(),
     onApproveTool: vi.fn(),
     onDenyTool: vi.fn(),
+    onPickWorkspace: vi.fn(),
+    onUseScratch: vi.fn(),
     ...overrides,
   };
 }
@@ -115,6 +119,48 @@ describe("HarnessNodeView", () => {
     expect(data.onApproveTool).toHaveBeenCalledTimes(1);
     await user.click(screen.getByRole("button", { name: "Deny" }));
     expect(data.onDenyTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers a folder picker on scratch, and a trusted-vs-pending state when bound", async () => {
+    const user = userEvent.setup();
+    const scratch = makeData({ harnessStatus: "done", pendingRequestId: null });
+    const { rerender } = renderHarness(scratch);
+    expect(screen.getByText("Scratch workspace")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Choose folder…" }));
+    expect(scratch.onPickWorkspace).toHaveBeenCalledTimes(1);
+
+    // Bound and trusted: the active dir matches the request, no warning.
+    rerender(
+      <ReactFlowProvider>
+        <HarnessNodeView
+          id="n1" type="harness"
+          data={makeData({
+            harnessStatus: "done", pendingRequestId: null,
+            harnessWorkspacePath: "C:/proj", harnessWorkspaceActive: "C:/proj",
+          })}
+          selected={false} isConnectable={false} positionAbsoluteX={0} positionAbsoluteY={0}
+          zIndex={0} dragging={false} deletable selectable draggable parentId={undefined}
+        />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByText(/C:\/proj/)).toBeInTheDocument();
+    expect(screen.queryByText(/not trusted/)).not.toBeInTheDocument();
+
+    // Bound but not trusted on this machine: pending warning shown.
+    rerender(
+      <ReactFlowProvider>
+        <HarnessNodeView
+          id="n1" type="harness"
+          data={makeData({
+            harnessStatus: "done", pendingRequestId: null,
+            harnessWorkspacePath: "C:/proj", harnessWorkspaceActive: "",
+          })}
+          selected={false} isConnectable={false} positionAbsoluteX={0} positionAbsoluteY={0}
+          zIndex={0} dragging={false} deletable selectable draggable parentId={undefined}
+        />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByText(/not trusted on this machine/)).toBeInTheDocument();
   });
 
   it("renders activity rows with error styling on failures", () => {

--- a/web_ui/src/app/canvas/HarnessNodeView.tsx
+++ b/web_ui/src/app/canvas/HarnessNodeView.tsx
@@ -37,6 +37,8 @@ export interface HarnessNodeData extends Record<string, unknown> {
   harnessContextTokens: number;
   harnessMaxContextTokens: number;
   harnessCompactions: number;
+  harnessWorkspacePath: string;
+  harnessWorkspaceActive: string;
   harnessMaxTurns: number;
   harnessSpentTurns: number;
   harnessSpentTokens: number;
@@ -48,6 +50,8 @@ export interface HarnessNodeData extends Record<string, unknown> {
   onCancel: () => void;
   onApproveTool: () => void;
   onDenyTool: () => void;
+  onPickWorkspace: () => void;
+  onUseScratch: () => void;
 }
 
 export type HarnessFlowNode = Node<HarnessNodeData, "harness">;
@@ -122,6 +126,47 @@ function HarnessNodeViewInner({ data, selected }: NodeProps<HarnessFlowNode>) {
           {data.harnessStatusDetail}
         </p>
       )}
+
+      {/* Workspace binding. harnessWorkspacePath is the REQUEST (what the
+          node asks for); a run only honors it if the folder is trusted, and
+          reports the truth in harnessWorkspaceActive. So a bound path with
+          no matching active dir after a run means the grant did not apply on
+          this machine - shown as pending rather than as if it were live. */}
+      <div className="harness-node-workspace">
+        {data.harnessWorkspacePath ? (
+          <>
+            <span
+              className="harness-node-workspace-dir"
+              title={data.harnessWorkspacePath}
+            >
+              📁 {data.harnessWorkspacePath}
+              {!running &&
+                data.harnessWorkspaceActive !== data.harnessWorkspacePath &&
+                " (not trusted on this machine — using scratch)"}
+            </span>
+            <button
+              type="button"
+              className="plan-node-button nodrag"
+              onClick={data.onUseScratch}
+              disabled={running}
+            >
+              Use scratch
+            </button>
+          </>
+        ) : (
+          <>
+            <span className="harness-node-workspace-dir">Scratch workspace</span>
+            <button
+              type="button"
+              className="plan-node-button nodrag"
+              onClick={data.onPickWorkspace}
+              disabled={running}
+            >
+              Choose folder…
+            </button>
+          </>
+        )}
+      </div>
 
       {data.harnessReply && (
         <div className="harness-node-reply nowheel nodrag">{data.harnessReply}</div>

--- a/web_ui/src/app/canvas/SceneCanvas.pinSearchJump.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.pinSearchJump.test.tsx
@@ -154,6 +154,8 @@ function chatRow(id: string, x: number, y: number, title = id): SceneNodeRow {
   harnessContextTokens: 0,
   harnessMaxContextTokens: 48000,
   harnessCompactions: 0,
+  harnessWorkspacePath: "",
+  harnessWorkspaceActive: "",
   harnessAwaitingApproval: false,
   harnessApprovalToolName: "",
   harnessApprovalSummary: "",

--- a/web_ui/src/app/canvas/SceneCanvas.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.test.tsx
@@ -166,6 +166,8 @@ function baseNode(overrides: Partial<SceneNodeRow> = {}): SceneNodeRow {
   harnessContextTokens: 0,
   harnessMaxContextTokens: 48000,
   harnessCompactions: 0,
+  harnessWorkspacePath: "",
+  harnessWorkspaceActive: "",
   harnessAwaitingApproval: false,
   harnessApprovalToolName: "",
   harnessApprovalSummary: "",

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -865,6 +865,8 @@ function makeHarnessFns(id: string, liveRef: { current: DispatcherLive }) {
       const { n, store } = liveRef.current;
       if (n.pendingRequestId) store.denyHarnessTool(n.pendingRequestId);
     },
+    onPickWorkspace: () => liveRef.current.store.pickHarnessWorkspace(id),
+    onUseScratch: () => liveRef.current.store.useHarnessScratch(id),
   };
 }
 
@@ -1531,6 +1533,8 @@ export function toFlowNodes(
           harnessContextTokens: n.harnessContextTokens,
           harnessMaxContextTokens: n.harnessMaxContextTokens,
           harnessCompactions: n.harnessCompactions,
+          harnessWorkspacePath: n.harnessWorkspacePath,
+          harnessWorkspaceActive: n.harnessWorkspaceActive,
           harnessAwaitingApproval: n.harnessAwaitingApproval,
           harnessApprovalToolName: n.harnessApprovalToolName,
           harnessApprovalSummary: n.harnessApprovalSummary,

--- a/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
@@ -199,6 +199,8 @@ function chatRow(id: string, x: number, y = 0): SceneNodeRow {
   harnessContextTokens: 0,
   harnessMaxContextTokens: 48000,
   harnessCompactions: 0,
+  harnessWorkspacePath: "",
+  harnessWorkspaceActive: "",
   harnessAwaitingApproval: false,
   harnessApprovalToolName: "",
   harnessApprovalSummary: "",

--- a/web_ui/src/app/canvas/renderCountGate.test.tsx
+++ b/web_ui/src/app/canvas/renderCountGate.test.tsx
@@ -172,6 +172,8 @@ function chatRow(id: string, x: number): SceneNodeRow {
         harnessContextTokens: 0,
         harnessMaxContextTokens: 48000,
         harnessCompactions: 0,
+        harnessWorkspacePath: "",
+        harnessWorkspaceActive: "",
         harnessAwaitingApproval: false,
         harnessApprovalToolName: "",
         harnessApprovalSummary: "",

--- a/web_ui/src/app/canvas/sceneStore.test.ts
+++ b/web_ui/src/app/canvas/sceneStore.test.ts
@@ -238,6 +238,8 @@ function validScenePayload(overrides: Record<string, unknown> = {}) {
         harnessContextTokens: 0,
         harnessMaxContextTokens: 48000,
         harnessCompactions: 0,
+        harnessWorkspacePath: "",
+        harnessWorkspaceActive: "",
         harnessAwaitingApproval: false,
         harnessApprovalToolName: "",
         harnessApprovalSummary: "",

--- a/web_ui/src/app/canvas/sceneStore.ts
+++ b/web_ui/src/app/canvas/sceneStore.ts
@@ -905,6 +905,14 @@ export class SceneStore {
     this.transport.fireIntent("harness", "denyTool", [requestId]);
   }
 
+  pickHarnessWorkspace(nodeId: string): void {
+    this.transport.fireIntent("harness", "pickWorkspace", [nodeId]);
+  }
+
+  useHarnessScratch(nodeId: string): void {
+    this.transport.fireIntent("harness", "useScratch", [nodeId]);
+  }
+
   // R5.2: real Artifact/Drafter plugin - sendArtifactMessage appends a real
   // user instruction AND triggers ArtifactAgent.get_response(current_artifact,
   // history) for an existing artifact node; cancelArtifactRequest targets it

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -7515,6 +7515,20 @@ mark.document-view-search-match-current {
   padding: 8px;
   background-color: var(--gl-surface-inset, var(--gl-surface-window));
 }
+.harness-node-workspace {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--gl-surface-text-muted);
+}
+.harness-node-workspace-dir {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .harness-node-composer { display: flex; align-items: flex-end; gap: 8px; }
 .harness-node-input {
   box-sizing: border-box;

--- a/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.schema.json
@@ -432,6 +432,12 @@
           "harnessStatusDetail": {
             "type": "string"
           },
+          "harnessWorkspaceActive": {
+            "type": "string"
+          },
+          "harnessWorkspacePath": {
+            "type": "string"
+          },
           "headerColor": {
             "type": "string"
           },
@@ -899,6 +905,8 @@
           "harnessAwaitingApproval",
           "harnessApprovalToolName",
           "harnessApprovalSummary",
+          "harnessWorkspacePath",
+          "harnessWorkspaceActive",
           "harnessMaxTurns",
           "harnessSpentTurns",
           "harnessSpentTokens",

--- a/web_ui/src/lib/bridge-core/generated/scene-state.ts
+++ b/web_ui/src/lib/bridge-core/generated/scene-state.ts
@@ -125,6 +125,8 @@ export interface SceneNodeRow {
   harnessAwaitingApproval: boolean;
   harnessApprovalToolName: string;
   harnessApprovalSummary: string;
+  harnessWorkspacePath: string;
+  harnessWorkspaceActive: string;
   harnessMaxTurns: number;
   harnessSpentTurns: number;
   harnessSpentTokens: number;
@@ -882,6 +884,16 @@ function checkSceneNodeRow(value: unknown, path: string, errors: string[]): void
     const fieldValue = value["harnessApprovalSummary"];
     if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.harnessApprovalSummary: missing required field`);
     else { if (typeof fieldValue !== "string") errors.push(`${path}.harnessApprovalSummary` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["harnessWorkspacePath"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.harnessWorkspacePath: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.harnessWorkspacePath` + ": expected string"); }
+  }
+  {
+    const fieldValue = value["harnessWorkspaceActive"];
+    if (fieldValue === undefined || fieldValue === null) errors.push(`${path}.harnessWorkspaceActive: missing required field`);
+    else { if (typeof fieldValue !== "string") errors.push(`${path}.harnessWorkspaceActive` + ": expected string"); }
   }
   {
     const fieldValue = value["harnessMaxTurns"];


### PR DESCRIPTION
## Problem

The agent could only ever work in a private scratch directory. Real use — "refactor this project", "run the tests in my repo" — means working in the user's own folder. That is a genuinely new security surface (a folder the agent writes to and runs shell in), so it ships as its own increment with the trust gate as the centerpiece.

## Change

- **The pick is the consent.** Choosing a folder in the native dialog (`harness/pickWorkspace`) adds it to a settings trust list (`add_harness_trusted_dir`, landed with H4) and sets it as the node's requested workspace. Nothing the model does can grant a directory.
- **The trust gate (`workspace.bound_root`) is the boundary.** A node's `harness_workspace_path` is a *request*, re-checked against the trust list **at every run**: an untrusted path — or one that has since been deleted, or a session imported from a machine that trusted it — silently falls back to scratch. Session files are untrusted input, so this is the load-bearing check. The node reports the resolved *active* dir separately from the request, so the UI shows "not trusted on this machine" rather than implying access it lacks.
- **Confinement refactored to root-based.** The run resolves its one bound root once (scratch or trusted user dir) and carries it on the context; every fs/shell tool confines through the single `resolve_under_root` choke point, and a subagent inherits its parent's exact root. The transcript **always** stays in the managed scratch dir — a project folder is never littered with harness bookkeeping.
- **UI:** the node shows its workspace with Choose folder / Use scratch controls; two new B-classified run-config intents.

## Test plan

Backend tests concentrate on the security-critical trust gate: a trusted existing dir binds, an untrusted request degrades to scratch, a trusted-but-missing dir degrades, no-path/no-settings is scratch, and confinement + write hold against a real user dir while `..` escape is refused. One UI test covers the picker and the trusted-vs-pending display. Full suites green: backend 3,072 passed / 19 skipped in 96s; frontend all passed; `npm run check` clean.