### PR TITLE
Stop gating nightly-perf on fixture_build_ms wall-clock noise

### DIFF
--- a/backend/tests/perf/check_baseline.py
+++ b/backend/tests/perf/check_baseline.py
@@ -10,21 +10,41 @@ committed" (used non-interactively, by the nightly workflow).
 
 Two metric classes, two tolerance profiles:
 
-- TIMING metrics (fixture_build_ms, payload_build_ms, serialize_ms,
-  publish_total_ms) are genuinely noisy wall-clock measurements - CPU
-  scheduling jitter, not just real code changes, moves these run to run.
-  ADR-019 section 4's own thresholds apply: >20% is a SOFT regression
-  (reported, fails the job), >=100% (2x) is called out as SEVERE in the
-  failure message specifically (the ADR's own "fails loudly" language).
-  Below MIN_TIMING_MS_FOR_PCT_CHECK, the baseline value itself is too
-  close to the timer's own resolution for a percentage to mean anything
-  (0.15ms -> 0.19ms is already +26% and is very plausibly pure noise) -
-  skipped from the pass/fail check entirely, just reported.
+- TIMING metrics (payload_build_ms, serialize_ms, publish_total_ms) are
+  genuinely noisy wall-clock measurements - CPU scheduling jitter, not
+  just real code changes, moves these run to run. ADR-019 section 4's own
+  thresholds apply: >20% is a SOFT regression (reported, fails the job),
+  >=100% (2x) is called out as SEVERE in the failure message specifically
+  (the ADR's own "fails loudly" language). Below
+  MIN_TIMING_MS_FOR_PCT_CHECK, the baseline value itself is too close to
+  the timer's own resolution for a percentage to mean anything (0.15ms ->
+  0.19ms is already +26% and is very plausibly pure noise) - skipped from
+  the pass/fail check entirely, just reported.
 - SIZE metrics (full_snapshot_kib, single_node_payload_kib) are
   deterministic byte counts from a fixed fixture - there is no timer
   jitter to account for, so any real drift beyond float-rounding IS a
   real code change (a wire field added/removed, a serialization tweak).
   Tighter thresholds than timing: >2% is worth a report, >10% fails.
+
+fixture_build_ms is measured and printed for visibility but deliberately
+NOT gated (REPORTED_ONLY_METRICS, not TIMING_METRICS): it times
+`workload.build()` - constructing the synthetic test fixture itself
+(measure_baselines.py's own `_measure`), which is test-harness overhead,
+not a real app code path, and isn't one of ADR-019 §2's budgeted rows
+(those are payload_build_ms/serialize_ms/publish_total_ms, all real
+publish-path work). Gating on it was a real incident, not a hypothetical:
+on 2026-08-24, `large`/`stress`'s fixture_build_ms swung +289%/+113% in a
+single run (8.75ms->34.0ms, 61.85ms->131.48ms) - both well above
+MIN_TIMING_MS_FOR_PCT_CHECK so not caught by that filter - while every
+genuinely budgeted metric in the SAME run stayed inside the 20% soft
+threshold. A git-log review of nightly-perf.yml's run history found this
+was the sole cause in 5 of the last 13 nightly runs: pure shared-runner
+scheduling noise on fixture construction (large object-allocation churn,
+no I/O, nothing the app's own code touches), gating nobody was
+triaging - exactly the "flaky perf gates get disabled and then nothing is
+enforced" failure mode ADR-019's own "Alternatives considered" section
+already named as the reason CI counting-assertions (not wall-clock) are
+the per-PR gate, applied here to the nightly wall-clock tier too.
 
 A failure here does not necessarily mean something got SLOWER - it just
 as often means baseline.json itself is stale and needs a deliberate,
@@ -44,7 +64,11 @@ from backend.tests.perf.measure_baselines import _measure
 
 BASELINE_PATH = Path(__file__).resolve().parent / "baseline.json"
 
-TIMING_METRICS = ("fixture_build_ms", "payload_build_ms", "serialize_ms", "publish_total_ms")
+TIMING_METRICS = ("payload_build_ms", "serialize_ms", "publish_total_ms")
+# Measured and printed, never gated - see this module's own docstring for
+# the 2026-08-24 incident that made this a deliberate exclusion, not an
+# oversight.
+REPORTED_ONLY_METRICS = ("fixture_build_ms",)
 SIZE_METRICS = ("full_snapshot_kib", "single_node_payload_kib")
 
 MIN_TIMING_MS_FOR_PCT_CHECK = 1.0
@@ -113,7 +137,7 @@ def main() -> int:
     print(f"{'workload':<10} {'metric':<22} {'baseline':>12} {'current':>12} {'change':>8}")
     for name, baseline in baseline_by_name.items():
         current = current_by_name[name]
-        for metric in (*TIMING_METRICS, *SIZE_METRICS):
+        for metric in (*REPORTED_ONLY_METRICS, *TIMING_METRICS, *SIZE_METRICS):
             base_val, cur_val = baseline[metric], current[metric]
             change = _pct_change(base_val, cur_val)
             print(f"{name:<10} {metric:<22} {base_val:>12} {cur_val:>12} {change:>+7.0%}")


### PR DESCRIPTION
## Problem

nightly-perf.yml has failed 5 of its last 13 runs. All 5 traced to the same cause: `fixture_build_ms` (time to construct the synthetic test fixture itself via `workload.build()`) swinging wildly on the shared Windows runner — most recently (2026-08-24) +289% on `large` and +113% on `stress` in a single run, both well above `MIN_TIMING_MS_FOR_PCT_CHECK` so not caught by the existing noise filter. In that same run, every metric that's actually part of ADR-019's budgeted rows (`payload_build_ms`, `serialize_ms`, `publish_total_ms`, wire sizes) stayed within threshold.

`fixture_build_ms` isn't one of ADR-019 §2's budgeted rows — it measures test-harness overhead (building the synthetic scene fixture), not a real app code path, so gating on it was checking noise, not signal.

## Change

`backend/tests/perf/check_baseline.py`: moved `fixture_build_ms` out of the gated `TIMING_METRICS` tuple into a new `REPORTED_ONLY_METRICS` tuple — still measured and printed every run for visibility, just no longer able to fail the job.

## Test plan

- [x] Ran `python -m backend.tests.perf.check_baseline` locally — `fixture_build_ms` no longer appears among reported failures, `payload_build_ms`/`serialize_ms`/`publish_total_ms` continue to be gated normally.
- [x] Confirmed via `gh run list --workflow=nightly-perf.yml` that this was the sole failure cause in the 5 recent failing runs before making the change.

Note: that same local run also surfaced real, deterministic wire-size drift (`full_snapshot_kib`/`single_node_payload_kib` up 13–19% across all workloads vs. the 2026-08-11 baseline) — unrelated to this fix and out of scope here; flagged separately, not touched by this PR.