### PR TITLE
Rebuild node placement: measured-footprint engine + size-aware organize

### DIFF
--- a/backend/api/intents_branches.py
+++ b/backend/api/intents_branches.py
@@ -15,10 +15,8 @@ from backend.agents import AgentDispatcher
 from backend.composer import ComposerDocument
 from backend.domain.graph import SceneDocument
 from backend.domain.model import (
-    MESSAGE_VERTICAL_SPACING,
     NOTE_AGENT_BODY_COLOR,
     NOTE_AGENT_HEADER_COLOR,
-    NOTE_AGENT_X_OFFSET,
 )
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -36,13 +34,16 @@ def register_branches_intents(
     # module-level import here.
     from backend.canvas import _format_branches_for_comparison
 
-    async def _generate_note_from_node(source_node_id, note_kind, x_offset, y_offset):
+    async def _generate_note_from_node(source_node_id, note_kind):
         """R8a: shared path for generateKeyTakeaway and generateExplainerNote.
 
         Both take one chat node, run its text through an agent, and drop the
-        result into a new note beside it - identical except for the agent and
-        the note's offset, so they share one implementation rather than two
-        that can drift.
+        result into a new note beside it - identical except for the agent,
+        so they share one implementation rather than two that can drift.
+        Placement is place_child(prefer="right"): beside the source node's
+        real right edge, fanning down past earlier notes, so a takeaway and
+        an explainer generated from the same node never land on top of each
+        other.
 
         Source text is the node's OWN content, not the branch history that
         generate_chart uses: legacy's takeaway/explainer passed a single
@@ -78,7 +79,8 @@ def register_branches_intents(
             # node. Agent provenance, per stage 10.5's eventual "undo this
             # build".
             def _create_agent_note():
-                created = document.add_note(source.x + x_offset, source.y + y_offset)
+                nx, ny = document.place_child(source.id, "note", prefer="right")
+                created = document.add_note(nx, ny)
                 document.set_note_content(created.id, text)
                 # Legacy tinted these notes "Mid Gray" with an info-coloured
                 # header. Both values come from the frontend's own palette
@@ -112,13 +114,10 @@ def register_branches_intents(
         return result_holder.get("node_id")
 
     async def generate_key_takeaway(source_node_id):
-        return await _generate_note_from_node(source_node_id, "takeaway", NOTE_AGENT_X_OFFSET, 0)
+        return await _generate_note_from_node(source_node_id, "takeaway")
 
     async def generate_explainer_note(source_node_id):
-        # Offset vertically as well as horizontally so a takeaway and an
-        # explainer generated from the same node don't land on top of each
-        # other - the same 100px stagger legacy used.
-        return await _generate_note_from_node(source_node_id, "explainer", NOTE_AGENT_X_OFFSET, 100)
+        return await _generate_note_from_node(source_node_id, "explainer")
 
     async def compare_branches(node_ids):
         """ADR-002 Workstream 1 ("Compare Branches") - the second sequenced
@@ -155,12 +154,11 @@ def register_branches_intents(
         ]
         formatted = _format_branches_for_comparison(branches)
 
-        # Positioned below-and-right of the source branches, the same
+        # Positioned beside the bottom-most source branch, the same
         # "offset to the side" convention _generate_note_from_node uses for
-        # a single source - averaged/maxed across all sources here since
-        # there's more than one.
-        avg_x = sum(node.x for node in sources) / len(sources)
-        max_y = max(node.y for node in sources)
+        # a single source - anchored to the deepest source since there's
+        # more than one.
+        anchor = max(sources, key=lambda node: (node.y, node.id))
 
         result_holder: dict[str, str] = {}
 
@@ -172,7 +170,8 @@ def register_branches_intents(
             # One command for the whole comparison note - see
             # _generate_note_from_node's own equivalent block above.
             def _create_comparison_note():
-                created = document.add_note(avg_x + NOTE_AGENT_X_OFFSET, max_y)
+                nx, ny = document.place_child(anchor.id, "note", prefer="right")
+                created = document.add_note(nx, ny)
                 document.set_note_content(created.id, text)
                 document.set_group_color(created.id, NOTE_AGENT_BODY_COLOR, NOTE_AGENT_HEADER_COLOR)
                 document.mark_branch_comparison_note(created.id, ids)
@@ -245,8 +244,6 @@ def register_branches_intents(
         formatted = _format_branches_for_comparison(branches)
 
         parent = sources[0]
-        avg_x = sum(node.x for node in sources) / len(sources)
-        max_y = max(node.y for node in sources)
         route = composer_document.route()
 
         result_holder: dict[str, str] = {}
@@ -263,9 +260,8 @@ def register_branches_intents(
             # it correctly on undo is part of stage 10.2's stack work, where
             # the cursor semantics actually live.
             def _create_synthesis_node():
-                created = document.add_chat_node(
-                    avg_x, max_y + MESSAGE_VERTICAL_SPACING, text, False, parent_id=parent.id,
-                )
+                sx, sy = document.place_child(parent.id, "chat")
+                created = document.add_chat_node(sx, sy, text, False, parent_id=parent.id)
                 document.mark_branch_synthesis(
                     created.id, ids, clean_instructions, route.get("provider"), route.get("modelLabel"),
                 )

--- a/backend/api/intents_builder.py
+++ b/backend/api/intents_builder.py
@@ -43,14 +43,11 @@ _RESUMABLE_STATUSES = ("awaiting_start", "paused", "interrupted", "failed")
 
 
 def _place_plan_node(document: SceneDocument) -> tuple[float, float]:
-    """Right of the current scene's extent - the launcher has no canvas
-    anchor, and stacking new plans on (0,0) over existing work would be
-    worse than a simple fan to the right."""
-    if not document.nodes:
-        return 120.0, 120.0
-    max_x = max(n.x for n in document.nodes.values())
-    min_y = min(n.y for n in document.nodes.values())
-    return max_x + 420.0, max(min_y, 120.0)
+    """Right of the current scene's real extent (x + measured width, not
+    just max x) - the launcher has no canvas anchor, and stacking new
+    plans on (0,0) over existing work would be worse than a fan to the
+    right. See place_at_scene_right (backend/domain/layout.py)."""
+    return document.place_at_scene_right("plan")
 
 
 def register_builder_intents(

--- a/backend/api/intents_chart.py
+++ b/backend/api/intents_chart.py
@@ -23,7 +23,6 @@ from graphlink_chart_data import ChartDataError, canonicalize_chart_data, SUPPOR
 from backend.agents import AgentDispatcher
 from backend.api._shared import make_publish_scene
 from backend.domain.graph import SceneDocument
-from backend.domain.model import MESSAGE_VERTICAL_SPACING
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 
@@ -59,7 +58,6 @@ def register_chart_intents(
             await bus.publish("notification")
             return None
 
-        parent = document.nodes[parent_node_id]
         branch_history = document.chat_branch_history(parent_node_id)
         source_text = _chart_source_text(branch_history)
 
@@ -102,8 +100,7 @@ def register_chart_intents(
             node, _command = document.record_command(
                 "generateChart", "agent",
                 lambda: document.add_chart_node(
-                    parent.x + MESSAGE_VERTICAL_SPACING,
-                    parent.y,
+                    *document.place_child(parent_node_id, "chart", prefer="right"),
                     parent_node_id,
                     normalized_chart_type,
                     chart_data,

--- a/backend/api/intents_chat.py
+++ b/backend/api/intents_chat.py
@@ -34,12 +34,7 @@ from backend.agents import AgentDispatcher
 from backend.api._shared import make_publish_scene, make_publish_token_counter
 from backend.composer import ComposerDocument
 from backend.domain.graph import SceneDocument
-from backend.domain.model import MESSAGE_VERTICAL_SPACING, SceneError
-
-# ADR-021 stage 21.5: two document attachments on one message fan out
-# sideways instead of stacking, the same convention tools_graph.py's own
-# sibling placement uses for a builder's parallel children.
-DOCUMENT_ATTACHMENT_HORIZONTAL_SPACING = 360
+from backend.domain.model import SceneError
 
 
 def _merge_staged_attachments(text: str, staged: list) -> "tuple[str, list | None]":
@@ -98,12 +93,17 @@ def _promote_document_attachments(document: SceneDocument, node, staged: list) -
         attachment for attachment in staged
         if attachment.kind == "document" and attachment.extracted_text is not None
     ]
-    for index, attachment in enumerate(promotable):
+    for attachment in promotable:
+        # place_child resolves collisions against already-landed siblings,
+        # so two attachments on one message fan out sideways instead of
+        # stacking (ADR-021 stage 21.5's requirement, now via the shared
+        # placement engine instead of a local index offset).
+        ax, ay = document.place_child(node.id, "document")
         document.record_command(
             "addDocumentNode", "user",
-            lambda attachment=attachment, index=index: document.add_document_node(
-                node.x + index * DOCUMENT_ATTACHMENT_HORIZONTAL_SPACING,
-                node.y + MESSAGE_VERTICAL_SPACING,
+            lambda attachment=attachment, ax=ax, ay=ay: document.add_document_node(
+                ax,
+                ay,
                 attachment.name,
                 attachment.extracted_text or "",
                 "document",
@@ -151,19 +151,19 @@ def _build_reply_nodes(document, parent_node, placeholder_text, parsed_parts):
     parsed reply calls for, returning the reply node. Wrapped by ONE
     record_command at each call site, so a single undo reverses the whole
     reply rather than peeling off one child per Ctrl+Z."""
-    ax, ay = parent_node.x, parent_node.y + MESSAGE_VERTICAL_SPACING
+    ax, ay = document.place_child(parent_node.id, "chat")
     ai = document.add_chat_node(ax, ay, placeholder_text, False, parent_id=parent_node.id)
+    # Thinking children hang off the reply's left flank, code children off
+    # its right - the legacy left/right convention, but via place_child so
+    # each lands clear of the reply's real footprint and of its own earlier
+    # siblings instead of at a fixed 160px offset.
     for part in parsed_parts:
         if part["type"] == "thinking":
-            document.add_thinking_node(
-                ax - MESSAGE_VERTICAL_SPACING, ay + MESSAGE_VERTICAL_SPACING,
-                part["content"], parent_id=ai.id,
-            )
+            tx, ty = document.place_child(ai.id, "thinking", prefer="left")
+            document.add_thinking_node(tx, ty, part["content"], parent_id=ai.id)
         elif part["type"] == "code":
-            document.add_code_node(
-                ax + MESSAGE_VERTICAL_SPACING, ay + MESSAGE_VERTICAL_SPACING,
-                part["content"], part["language"], parent_id=ai.id,
-            )
+            cx, cy = document.place_child(ai.id, "code", prefer="right")
+            document.add_code_node(cx, cy, part["content"], part["language"], parent_id=ai.id)
     return ai
 
 
@@ -192,17 +192,15 @@ def _regenerate_in_place(document, node_to_regenerate, reply_text):
     node_to_regenerate.state.prompt_tokens = None
     node_to_regenerate.state.completion_tokens = None
 
-    bx, by = node_to_regenerate.x, node_to_regenerate.y
+    # Same left/right flank convention as _build_reply_nodes above.
     for part in parsed_parts:
         if part["type"] == "thinking":
-            document.add_thinking_node(
-                bx - MESSAGE_VERTICAL_SPACING, by + MESSAGE_VERTICAL_SPACING,
-                part["content"], parent_id=node_to_regenerate.id,
-            )
+            tx, ty = document.place_child(node_to_regenerate.id, "thinking", prefer="left")
+            document.add_thinking_node(tx, ty, part["content"], parent_id=node_to_regenerate.id)
         elif part["type"] == "code":
+            cx, cy = document.place_child(node_to_regenerate.id, "code", prefer="right")
             document.add_code_node(
-                bx + MESSAGE_VERTICAL_SPACING, by + MESSAGE_VERTICAL_SPACING,
-                part["content"], part["language"], parent_id=node_to_regenerate.id,
+                cx, cy, part["content"], part["language"], parent_id=node_to_regenerate.id,
             )
 
 
@@ -215,7 +213,7 @@ def _land_partial_reply_node(document, parent_node, partial_text):
     match the complete path (_build_reply_nodes) exactly. Module-level for
     the same 300-line-cap reason as its two siblings above."""
     def _commit():
-        ax, ay = parent_node.x, parent_node.y + MESSAGE_VERTICAL_SPACING
+        ax, ay = document.place_child(parent_node.id, "chat")
         ai = document.add_chat_node(ax, ay, partial_text, False, parent_id=parent_node.id)
         ai.state.response_incomplete = True
         return ai

--- a/backend/api/intents_groups.py
+++ b/backend/api/intents_groups.py
@@ -24,10 +24,15 @@ def register_groups_intents(bus: SessionBus, document: SceneDocument) -> None:
     # can close, per that ADR's own Consequences section ("Every new
     # mutating intent ... must produce a command").
     async def add_note(x, y, is_system_prompt=False, is_summary_note=False):
+        # The palette's "Add Note" always sends the viewport center, so a
+        # second note would land exactly on the first - collision-resolve
+        # the requested spot (a no-op when it is already clear).
+        width, height = document.kind_fallback_footprint("note")
+        nx, ny = document.find_free_position(float(x), float(y), width, height)
         node, _command = document.record_command(
             "addNote", "user",
             lambda: document.add_note(
-                x, y, is_system_prompt=is_system_prompt, is_summary_note=is_summary_note,
+                nx, ny, is_system_prompt=is_system_prompt, is_summary_note=is_summary_note,
             ),
         )
         await publish_scene()

--- a/backend/api/intents_harness.py
+++ b/backend/api/intents_harness.py
@@ -29,13 +29,10 @@ _MESSAGE_CAP = 20_000
 
 
 def _place_harness_node(document: SceneDocument) -> tuple[float, float]:
-    """Right of the current scene's extent - the builder-plan placement
-    exactly (no canvas anchor exists for a fresh agent either)."""
-    if not document.nodes:
-        return 120.0, 120.0
-    max_x = max(n.x for n in document.nodes.values())
-    min_y = min(n.y for n in document.nodes.values())
-    return max_x + 420.0, max(min_y, 120.0)
+    """Right of the current scene's real extent - the builder-plan
+    placement exactly (no canvas anchor exists for a fresh agent either).
+    See place_at_scene_right (backend/domain/layout.py)."""
+    return document.place_at_scene_right("harness")
 
 
 def register_harness_intents(

--- a/backend/canvas.py
+++ b/backend/canvas.py
@@ -47,7 +47,6 @@ from backend.token_counter import TokenCounterState
 from backend.domain.content_codec import _content_codec
 from backend.domain.graph import SceneDocument
 from backend.domain.model import (
-    BRANCH_HORIZONTAL_SPACING,
     CHART_MAX_HEIGHT,
     CHART_MAX_WIDTH,
     CHART_MIN_HEIGHT,
@@ -73,12 +72,8 @@ from backend.domain.model import (
     GROUP_PADDING_TOP,
     HTML_TITLE_PREVIEW_LENGTH,
     IMAGE_TITLE_PREVIEW_LENGTH,
-    MESSAGE_VERTICAL_SPACING,
     NOTE_AGENT_BODY_COLOR,
     NOTE_AGENT_HEADER_COLOR,
-    NOTE_AGENT_X_OFFSET,
-    ORGANIZE_SPACING_X,
-    ORGANIZE_SPACING_Y,
     SceneEdge,
     SceneEmptyPromptError,
     SceneError,

--- a/backend/domain/branches.py
+++ b/backend/domain/branches.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 from typing import Any
 
 from backend.domain.model import (
-    BRANCH_HORIZONTAL_SPACING,
-    MESSAGE_VERTICAL_SPACING,
     SceneEdge,
     SceneEmptyPromptError,
     SceneError,
@@ -373,10 +371,11 @@ class BranchOps:
     ) -> SceneNode:
         """The Composer's real Send action (R3.3): create a real user
         ChatNode continuing the current branch (last_chat_node_id), or
-        start a fresh root if none exists yet. Positioning is a simple
-        deterministic stack, not the legacy find_branch_position packing
-        algorithm - real auto-layout is a later refinement; "Organize
-        Nodes" already exists as a fallback.
+        start a fresh root if none exists yet. Positioning goes through
+        place_child/place_root (backend/domain/layout.py): below the
+        parent's real measured bottom edge, fanning right past any
+        occupied slot - the rebuilt equivalent of the legacy
+        find_branch_position packing.
 
         R8a: content_parts carries real attachments (image/audio) staged in
         the composer - optional, additive, threaded straight to
@@ -394,11 +393,11 @@ class BranchOps:
         already uses for an unknown id.
 
         When branching onto a parent that already has one or more chat-kind
-        children (a genuine divergence, not a fresh continuation), the new
-        sibling fans out horizontally by BRANCH_HORIZONTAL_SPACING per
-        existing child instead of landing on the exact same (x, y) as an
-        existing branch - which would render as one node silently hiding
-        another.
+        children (a genuine divergence, not a fresh continuation),
+        place_child's collision resolution fans the new sibling right past
+        the existing children instead of landing on the exact same (x, y)
+        as an existing branch - which would render as one node silently
+        hiding another.
 
         last_chat_node_id is updated to the new node afterward exactly as
         an ordinary send would be, override or not - so the branch just
@@ -406,22 +405,14 @@ class BranchOps:
         the same continue-from-here behavior as always."""
         if branch_from_node_id is not None and branch_from_node_id in self.nodes:
             parent_id: str | None = branch_from_node_id
-            parent = self.nodes[parent_id]
-            sibling_count = sum(
-                1
-                for e in self.edges.values()
-                if e.source == parent_id and (target := self.nodes.get(e.target)) is not None and target.kind == "chat"
-            )
-            x, y = parent.x + sibling_count * BRANCH_HORIZONTAL_SPACING, parent.y + MESSAGE_VERTICAL_SPACING
         else:
             parent_id = self.last_chat_node_id
-            if parent_id is not None and parent_id in self.nodes:
-                parent = self.nodes[parent_id]
-                x, y = parent.x, parent.y + MESSAGE_VERTICAL_SPACING
-            else:
+            if parent_id is not None and parent_id not in self.nodes:
                 parent_id = None
-                chat_node_count = sum(1 for n in self.nodes.values() if n.kind == "chat")
-                x, y = 0.0, chat_node_count * MESSAGE_VERTICAL_SPACING
+        if parent_id is not None:
+            x, y = self.place_child(parent_id, "chat")
+        else:
+            x, y = self.place_root("chat")
         node = self.add_chat_node(x, y, text, True, parent_id=parent_id, content_parts=content_parts)
         self.last_chat_node_id = node.id
         return node

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -54,6 +54,7 @@ from backend.domain.branches import BranchOps
 from backend.domain.commands import CommandOps
 from backend.domain.content_codec import _content_codec
 from backend.domain.groups import GroupOps
+from backend.domain.layout import LayoutOps
 from backend.domain.model import (
     CHART_MAX_HEIGHT,
     CHART_MAX_WIDTH,
@@ -69,9 +70,6 @@ from backend.domain.model import (
     GRID_COLOR_PRESETS,
     HTML_TITLE_PREVIEW_LENGTH,
     IMAGE_TITLE_PREVIEW_LENGTH,
-    MESSAGE_VERTICAL_SPACING,
-    ORGANIZE_SPACING_X,
-    ORGANIZE_SPACING_Y,
     SceneEdge,
     SceneError,
     SceneNode,
@@ -105,7 +103,7 @@ def _estimate_tokens(text: str) -> int:
 
 
 @dataclass
-class SceneDocument(BranchOps, GroupOps, CommandOps):
+class SceneDocument(BranchOps, GroupOps, LayoutOps, CommandOps):
     """The canvas document for one session. Plain data + invariants; the
     R6 serializer will read/write exactly this shape."""
 
@@ -1758,9 +1756,9 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
         (content=prompt, parent_id=<the new ChatNode's id>) - built entirely
         from the existing add_chat_node/add_image_node primitives, zero new
         mutation-in-place logic, matching this feature's create-new-nodes
-        scope decision. Positions via the same MESSAGE_VERTICAL_SPACING
-        offset convention send_message/regenerate_response's own new-child
-        placement already uses. last_chat_node_id is DELIBERATELY untouched
+        scope decision. Positions via place_child (backend/domain/layout.py),
+        the same collision-resolved placement send_message/regenerate_
+        response's own new-child placement uses. last_chat_node_id is DELIBERATELY untouched
         - mirrors legacy: handle_image_response never assigns
         self.current_node either, since image generation is side content,
         not a branch-continuation point (same posture as
@@ -1772,11 +1770,11 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
         parent = self.nodes.get(parent_chat_node_id)
         if parent is None:
             raise SceneError(f"unknown parent node: {parent_chat_node_id}")
-        ax, ay = parent.x, parent.y + MESSAGE_VERTICAL_SPACING
+        ax, ay = self.place_child(parent_chat_node_id, "chat")
         chat_node = self.add_chat_node(
             ax, ay, f'Generated image for prompt: "{prompt}"', False, parent_id=parent_chat_node_id,
         )
-        ix, iy = ax, ay + MESSAGE_VERTICAL_SPACING
+        ix, iy = self.place_child(chat_node.id, "image")
         image_node = self.add_image_node(ix, iy, image_bytes, prompt, chat_node.id, mime_type=mime_type)
         return chat_node, image_node
 
@@ -2095,14 +2093,9 @@ class SceneDocument(BranchOps, GroupOps, CommandOps):
         self.total_session_tokens += _estimate_tokens(str(text))
 
     def organize(self) -> None:
-        """Tidy layout: nodes into a near-square grid, stable id order."""
-        ordered = sorted(self.nodes.values(), key=lambda n: n.id)
-        if not ordered:
-            return
-        columns = max(1, math.ceil(math.sqrt(len(ordered))))
-        for index, node in enumerate(ordered):
-            node.x = float((index % columns) * ORGANIZE_SPACING_X)
-            node.y = float((index // columns) * ORGANIZE_SPACING_Y)
+        """Tidy layout: size-aware layered tree layout - see LayoutOps
+        .organize_layout (backend/domain/layout.py) for the algorithm."""
+        self.organize_layout()
 
     # -- snapshots ---------------------------------------------------------
 

--- a/backend/domain/graph.py
+++ b/backend/domain/graph.py
@@ -36,7 +36,6 @@ from collections import deque
 import itertools
 import json
 import logging
-import math
 import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable

--- a/backend/domain/layout.py
+++ b/backend/domain/layout.py
@@ -1,0 +1,378 @@
+"""LayoutOps - node placement and scene layout math for SceneDocument.
+
+The Qt canvas had find_branch_position packing and a size-aware organize;
+neither survived the Qt removal, so every spawn site degenerated to a
+fixed offset (parent.y + 160) that lands new nodes on top of their parent
+- a chat node routinely renders 500+ px tall - and organize() was a
+size-blind 260x180 grid. This module is the rebuilt placement engine:
+
+- node_footprint(): one node's (width, height), best source first -
+  the frontend's reported rendered size (measured_sizes), then the kind's
+  own intrinsic geometry (chart/frame/container), then a per-kind
+  fallback estimate. Same chain as groups.py's _member_footprint, but
+  with realistic per-kind fallbacks (the flat 220x120 group default is
+  far too small for placement: a chat node alone is 422 wide).
+- find_free_position(): deterministic collision resolution - a proposed
+  rect advances past whatever occupied rect it overlaps until clear.
+- place_child()/place_root()/place_at_scene_right(): the three placement
+  shapes every spawn site needs. All spawn coordinates flow through
+  these; no caller does its own offset math any more.
+- organize_layout(): the size-aware replacement for the placeholder grid
+  - a layered tree layout (children below parents, subtrees packed side
+  by side by real width), disconnected trees side by side, frames and
+  containers re-wrapped around their members afterwards.
+
+Domain-pure (imports only sibling domain modules), mixed into
+SceneDocument exactly like BranchOps/GroupOps/CommandOps.
+"""
+
+from __future__ import annotations
+
+from backend.domain.model import (
+    GROUP_COLLAPSED_HEIGHT,
+    GROUP_COLLAPSED_WIDTH,
+    SceneNode,
+)
+
+# Clearance between neighbouring nodes. Horizontal is a little wider than
+# vertical so sibling fans read as distinct columns; both are large enough
+# that edge routing has room to breathe between cards.
+NODE_GAP_X = 80.0
+NODE_GAP_Y = 70.0
+# organize(): gap between two disconnected trees' bounding boxes - wider
+# than the in-tree gaps so separate conversations read as separate islands.
+COMPONENT_GAP = 200.0
+
+# Fallback footprints per kind, used only until the frontend reports the
+# node's real rendered size (reportNodeSizes -> measured_sizes). Widths
+# track the fixed CSS widths where one exists (.chat-node is 420px, etc.);
+# heights are typical-render estimates - placement only needs them to be
+# in the right ballpark, and the next report replaces them with truth.
+KIND_FALLBACK_FOOTPRINTS: dict[str, tuple[float, float]] = {
+    "chat": (422.0, 360.0),
+    "conversation": (440.0, 420.0),
+    "code": (480.0, 360.0),
+    "thinking": (420.0, 260.0),
+    "html": (480.0, 400.0),
+    "image": (420.0, 420.0),
+    "document": (380.0, 240.0),
+    "note": (280.0, 200.0),
+    "web_research": (440.0, 380.0),
+    "artifact": (440.0, 380.0),
+    "gitlink": (440.0, 380.0),
+    "code_sandbox": (480.0, 420.0),
+    "plan": (440.0, 420.0),
+    "harness": (440.0, 420.0),
+    "chart": (600.0, 440.0),
+    "placeholder": (220.0, 120.0),
+}
+DEFAULT_FALLBACK_FOOTPRINT = (360.0, 240.0)
+
+# find_free_position's loop bound - purely defensive; each step strictly
+# advances past an obstacle edge, so a real scene converges in a handful.
+_MAX_PLACEMENT_STEPS = 300
+
+
+def _rects_clear(
+    ax: float, ay: float, aw: float, ah: float,
+    bx: float, by: float, bw: float, bh: float,
+) -> bool:
+    """True when the two rects are separated by at least the standard
+    clearance on one axis - overlap *or* near-touching both count as a
+    collision, so placement never produces visually-glued cards."""
+    return (
+        ax + aw + NODE_GAP_X <= bx
+        or bx + bw + NODE_GAP_X <= ax
+        or ay + ah + NODE_GAP_Y <= by
+        or by + bh + NODE_GAP_Y <= ay
+    )
+
+
+class LayoutOps:
+    """Placement/layout mixin for SceneDocument (same pattern as GroupOps).
+    Reads self.nodes / self.edges / self.measured_sizes."""
+
+    # -- footprints --------------------------------------------------------
+
+    def node_footprint(self, node: SceneNode) -> tuple[float, float]:
+        """One node's (width, height) for placement purposes: measured ->
+        intrinsic -> per-kind fallback. Non-positive values from any source
+        fall through, same posture as groups.py's _member_footprint."""
+        measured = self.measured_sizes.get(node.id)
+        width, height = measured if measured is not None else (None, None)
+        if not (width and width > 0 and height and height > 0):
+            if node.kind == "chart" and node.state is not None:
+                width, height = node.state.chart_width, node.state.chart_height
+            elif node.kind in ("frame", "container") and node.state is not None:
+                if node.is_collapsed:
+                    width, height = GROUP_COLLAPSED_WIDTH, GROUP_COLLAPSED_HEIGHT
+                else:
+                    width, height = node.state.group_width, node.state.group_height
+        if not (width and width > 0) or not (height and height > 0):
+            fw, fh = KIND_FALLBACK_FOOTPRINTS.get(node.kind, DEFAULT_FALLBACK_FOOTPRINT)
+            width = width if (width and width > 0) else fw
+            height = height if (height and height > 0) else fh
+        return float(width), float(height)
+
+    def kind_fallback_footprint(self, kind: str) -> tuple[float, float]:
+        """The pre-creation footprint estimate for a node that does not
+        exist yet (place_child sizes the child before add_*_node runs)."""
+        return KIND_FALLBACK_FOOTPRINTS.get(kind, DEFAULT_FALLBACK_FOOTPRINT)
+
+    def _placement_obstacles(
+        self, exclude_ids: frozenset[str] | set[str] = frozenset(),
+    ) -> list[tuple[float, float, float, float]]:
+        """Every rect a new node must not land on: all nodes except docked
+        ones (they render inside their parent, not at their own x/y) and
+        expanded frames/containers - a group's box is derived from its
+        members and auto-grows, so its MEMBERS are the real obstacles;
+        treating the whole group rect as solid would shove a reply to a
+        framed node clear outside its own frame. A collapsed group is a
+        fixed pill with no visible members, so it stays an obstacle."""
+        rects = []
+        for node in self.nodes.values():
+            if node.is_docked or node.id in exclude_ids:
+                continue
+            if node.kind in ("frame", "container") and not node.is_collapsed:
+                continue
+            w, h = self.node_footprint(node)
+            rects.append((node.x, node.y, w, h))
+        return rects
+
+    # -- collision resolution ----------------------------------------------
+
+    def find_free_position(
+        self,
+        x: float,
+        y: float,
+        width: float,
+        height: float,
+        *,
+        advance: str = "right",
+        exclude_ids: frozenset[str] | set[str] = frozenset(),
+    ) -> tuple[float, float]:
+        """First clear (x, y) for a width x height rect, starting at the
+        proposed spot and advancing past each blocking node ("right" or
+        "down"). Deterministic: always steps past the blocking obstacle
+        whose far edge is nearest, so repeated spawns fan out compactly in
+        a stable order."""
+        obstacles = self._placement_obstacles(exclude_ids)
+        for _ in range(_MAX_PLACEMENT_STEPS):
+            blockers = [
+                r for r in obstacles
+                if not _rects_clear(x, y, width, height, *r)
+            ]
+            if not blockers:
+                break
+            if advance == "down":
+                edge = min(r[1] + r[3] for r in blockers)
+                y = max(edge + NODE_GAP_Y, y + 1.0)
+            else:
+                edge = min(r[0] + r[2] for r in blockers)
+                x = max(edge + NODE_GAP_X, x + 1.0)
+        return x, y
+
+    # -- placement shapes ---------------------------------------------------
+
+    def place_child(
+        self, parent_id: str | None, kind: str, *, prefer: str = "below",
+    ) -> tuple[float, float]:
+        """Where a new `kind` node spawned from parent_id should land:
+
+        - "below": directly under the parent's real bottom edge; if that
+          slot is taken (an earlier sibling), fan right until clear.
+        - "right": beside the parent's real right edge; fan down.
+        - "left": beside the parent's left edge; fan down.
+        - "above": directly over the parent's top edge; fan right.
+
+        The parent's *measured* footprint drives the offset, so a tall
+        reply pushes its children fully clear instead of the old fixed
+        160px that buried them inside the parent card. Falls back to
+        place_root when parent_id is missing/unknown."""
+        parent = self.nodes.get(parent_id) if parent_id else None
+        if parent is None:
+            return self.place_root(kind)
+        pw, ph = self.node_footprint(parent)
+        cw, ch = self.kind_fallback_footprint(kind)
+        if prefer == "right":
+            x, y = parent.x + pw + NODE_GAP_X, parent.y
+            return self.find_free_position(x, y, cw, ch, advance="down")
+        if prefer == "left":
+            x, y = parent.x - NODE_GAP_X - cw, parent.y
+            return self.find_free_position(x, y, cw, ch, advance="down")
+        if prefer == "above":
+            x, y = parent.x, parent.y - NODE_GAP_Y - ch
+            return self.find_free_position(x, y, cw, ch, advance="right")
+        x, y = parent.x, parent.y + ph + NODE_GAP_Y
+        return self.find_free_position(x, y, cw, ch, advance="right")
+
+    def place_root(self, kind: str) -> tuple[float, float]:
+        """Where a fresh parentless node lands: below the scene's current
+        content, aligned with its left edge (origin for an empty scene),
+        collision-resolved rightward like any other spawn."""
+        cw, ch = self.kind_fallback_footprint(kind)
+        anchored = [n for n in self.nodes.values() if not n.is_docked]
+        if not anchored:
+            return 0.0, 0.0
+        min_x = min(n.x for n in anchored)
+        bottom = max(n.y + self.node_footprint(n)[1] for n in anchored)
+        return self.find_free_position(min_x, bottom + NODE_GAP_Y, cw, ch, advance="right")
+
+    def place_at_scene_right(self, kind: str) -> tuple[float, float]:
+        """Where a launcher-created node with no canvas anchor (a Builder
+        plan, an Agent harness) lands: clear of the scene's right edge -
+        the real right edge (x + width), not just max x, so it can never
+        overlap the widest existing node."""
+        cw, ch = self.kind_fallback_footprint(kind)
+        anchored = [n for n in self.nodes.values() if not n.is_docked]
+        if not anchored:
+            return 120.0, 120.0
+        right = max(n.x + self.node_footprint(n)[0] for n in anchored)
+        top = max(min(n.y for n in anchored), 120.0)
+        return self.find_free_position(right + NODE_GAP_X, top, cw, ch, advance="down")
+
+    # -- organize -----------------------------------------------------------
+
+    def organize_layout(self) -> None:
+        """Size-aware tidy layout - the rebuilt Organize Nodes.
+
+        Nodes form a forest via edges (first edge in id order wins as a
+        node's structural parent; a link that would close a cycle is
+        skipped). Each tree lays out top-down: a child row sits below the
+        parent's real bottom edge, and sibling subtrees pack side by side
+        by their real subtree widths - so nothing can overlap, whatever
+        each node measured. Disconnected trees line up left to right.
+
+        Frames/containers are not laid out as tree nodes: their geometry
+        is derived from their members, so after members move each group is
+        re-wrapped via _recompute_group_bounds (stale manual frame anchors
+        are cleared first - organize is an explicit whole-scene re-layout,
+        so a pinned position from before it is meaningless). Collapsed
+        group pills keep no member bbox to wrap, so they line up in a row
+        below everything else. Docked nodes ride along at their parent's
+        position (invisible while docked; sane if later undocked)."""
+        group_kinds = ("frame", "container")
+        layout_nodes = {
+            n.id: n for n in self.nodes.values()
+            if n.kind not in group_kinds and not n.is_docked
+        }
+        if not layout_nodes:
+            self._organize_groups()
+            return
+
+        parent_of: dict[str, str] = {}
+        for edge in sorted(self.edges.values(), key=lambda e: e.id):
+            source, target = edge.source, edge.target
+            if (
+                source == target
+                or source not in layout_nodes
+                or target not in layout_nodes
+                or target in parent_of
+            ):
+                continue
+            # Refuse a link that would close a cycle under the links
+            # assigned so far (walk source's ancestry looking for target).
+            ancestor: str | None = source
+            seen: set[str] = set()
+            while ancestor is not None and ancestor not in seen:
+                seen.add(ancestor)
+                ancestor = parent_of.get(ancestor)
+            if target in seen:
+                continue
+            parent_of[target] = source
+
+        children: dict[str, list[str]] = {}
+        for child, parent in parent_of.items():
+            children.setdefault(parent, []).append(child)
+        # Stable, spatial-intent-preserving order: current x, then id.
+        def order_key(node_id: str) -> tuple[float, str]:
+            node = layout_nodes[node_id]
+            return (node.x, node.id)
+        for child_list in children.values():
+            child_list.sort(key=order_key)
+        roots = sorted(
+            (nid for nid in layout_nodes if nid not in parent_of), key=order_key,
+        )
+
+        # Subtree widths, iterative post-order (chat chains can be deep).
+        footprints = {nid: self.node_footprint(n) for nid, n in layout_nodes.items()}
+        subtree_width: dict[str, float] = {}
+        stack: list[tuple[str, bool]] = [(r, False) for r in reversed(roots)]
+        while stack:
+            node_id, expanded = stack.pop()
+            kids = children.get(node_id, [])
+            if not expanded and kids:
+                stack.append((node_id, True))
+                stack.extend((k, False) for k in reversed(kids))
+                continue
+            own = footprints[node_id][0]
+            if kids:
+                packed = sum(subtree_width[k] for k in kids) + NODE_GAP_X * (len(kids) - 1)
+                subtree_width[node_id] = max(own, packed)
+            else:
+                subtree_width[node_id] = own
+
+        # Assign positions, iterative pre-order: each node centred over its
+        # own subtree span, children on a row below its real bottom edge.
+        cursor_x = 0.0
+        assign: list[tuple[str, float, float]] = []
+        for root in roots:
+            assign.append((root, cursor_x, 0.0))
+            cursor_x += subtree_width[root] + COMPONENT_GAP
+        while assign:
+            node_id, left, y = assign.pop()
+            node = layout_nodes[node_id]
+            width, height = footprints[node_id]
+            node.x = left + (subtree_width[node_id] - width) / 2.0
+            node.y = y
+            child_left = left + (subtree_width[node_id] - (
+                sum(subtree_width[k] for k in children.get(node_id, []))
+                + NODE_GAP_X * max(len(children.get(node_id, [])) - 1, 0)
+            )) / 2.0
+            for kid in children.get(node_id, []):
+                assign.append((kid, child_left, y + height + NODE_GAP_Y))
+                child_left += subtree_width[kid] + NODE_GAP_X
+
+        # Docked nodes ride along at their parent's spot.
+        for node in self.nodes.values():
+            if not node.is_docked:
+                continue
+            parent_edge = next(
+                (e for e in self.edges.values() if e.target == node.id), None,
+            )
+            if parent_edge is not None and parent_edge.source in self.nodes:
+                parent = self.nodes[parent_edge.source]
+                node.x, node.y = parent.x, parent.y
+
+        self._organize_groups()
+
+    def _organize_groups(self) -> None:
+        """Post-layout group pass: re-wrap every expanded frame/container
+        around its members' new positions; line collapsed pills up in a
+        row below the laid-out content."""
+        groups = [n for n in self.nodes.values() if n.kind in ("frame", "container")]
+        expanded = [g for g in groups if not g.is_collapsed]
+        collapsed = [g for g in groups if g.is_collapsed]
+        for group in expanded:
+            state = group.state
+            if state is not None:
+                for attr in (
+                    "group_manual_x", "group_manual_y",
+                    "group_manual_width", "group_manual_height",
+                ):
+                    if hasattr(state, attr):
+                        setattr(state, attr, None)
+            self._recompute_group_bounds(group.id)
+        if not collapsed:
+            return
+        others = [n for n in self.nodes.values() if not n.is_docked and n not in collapsed]
+        if others:
+            left = min(n.x for n in others)
+            bottom = max(n.y + self.node_footprint(n)[1] for n in others)
+        else:
+            left, bottom = 0.0, -GROUP_COLLAPSED_HEIGHT - COMPONENT_GAP
+        x = left
+        y = bottom + COMPONENT_GAP
+        for group in sorted(collapsed, key=lambda g: g.id):
+            group.x, group.y = x, y
+            x += GROUP_COLLAPSED_WIDTH + NODE_GAP_X

--- a/backend/domain/layout.py
+++ b/backend/domain/layout.py
@@ -98,16 +98,20 @@ class LayoutOps:
         """One node's (width, height) for placement purposes: measured ->
         intrinsic -> per-kind fallback. Non-positive values from any source
         fall through, same posture as groups.py's _member_footprint."""
+        if node.kind in ("frame", "container") and node.is_collapsed:
+            # The pill size wins over a measured entry: the measurement may
+            # be the EXPANDED box from before the collapse (the client only
+            # re-reports on the next dimensions change), and a stale
+            # 1200px-wide "obstacle" would shove every subsequent spawn
+            # past a phantom rect.
+            return GROUP_COLLAPSED_WIDTH, GROUP_COLLAPSED_HEIGHT
         measured = self.measured_sizes.get(node.id)
         width, height = measured if measured is not None else (None, None)
         if not (width and width > 0 and height and height > 0):
             if node.kind == "chart" and node.state is not None:
                 width, height = node.state.chart_width, node.state.chart_height
             elif node.kind in ("frame", "container") and node.state is not None:
-                if node.is_collapsed:
-                    width, height = GROUP_COLLAPSED_WIDTH, GROUP_COLLAPSED_HEIGHT
-                else:
-                    width, height = node.state.group_width, node.state.group_height
+                width, height = node.state.group_width, node.state.group_height
         if not (width and width > 0) or not (height and height > 0):
             fw, fh = KIND_FALLBACK_FOOTPRINTS.get(node.kind, DEFAULT_FALLBACK_FOOTPRINT)
             width = width if (width and width > 0) else fw
@@ -261,7 +265,13 @@ class LayoutOps:
             return
 
         parent_of: dict[str, str] = {}
-        for edge in sorted(self.edges.values(), key=lambda e: e.id):
+        # Insertion order, NOT sorted by id: edge ids are "e<counter>"
+        # strings, so a lexicographic sort puts e10 before e9 and a
+        # later-added cross-link could steal a node's structural parent
+        # from its real creation edge. self.edges preserves creation order
+        # (and a loaded session restores edges in saved order), which is
+        # exactly the "first edge wins" rule wanted here.
+        for edge in self.edges.values():
             source, target = edge.source, edge.target
             if (
                 source == target
@@ -293,10 +303,25 @@ class LayoutOps:
         roots = sorted(
             (nid for nid in layout_nodes if nid not in parent_of), key=order_key,
         )
+        # Keep roots that belong to the same frame/container adjacent, so a
+        # re-wrapped group's box does not stretch across another group's
+        # members sitting interleaved between its own. Stable sort: within
+        # one owner (and among the un-owned) the spatial x-order above is
+        # preserved; owner blocks line up in owner-id order.
+        owner_of: dict[str, str] = {}
+        for group in self.nodes.values():
+            if group.kind in ("frame", "container"):
+                for member_id in group.item_ids:
+                    owner_of.setdefault(member_id, group.id)
+        roots.sort(key=lambda nid: owner_of.get(nid, ""))
 
         # Subtree widths, iterative post-order (chat chains can be deep).
+        # packed_width is the children row's own span (0 for a leaf) -
+        # remembered so the assign pass below centres over the same number
+        # instead of re-deriving it.
         footprints = {nid: self.node_footprint(n) for nid, n in layout_nodes.items()}
         subtree_width: dict[str, float] = {}
+        packed_width: dict[str, float] = {}
         stack: list[tuple[str, bool]] = [(r, False) for r in reversed(roots)]
         while stack:
             node_id, expanded = stack.pop()
@@ -305,12 +330,12 @@ class LayoutOps:
                 stack.append((node_id, True))
                 stack.extend((k, False) for k in reversed(kids))
                 continue
-            own = footprints[node_id][0]
-            if kids:
-                packed = sum(subtree_width[k] for k in kids) + NODE_GAP_X * (len(kids) - 1)
-                subtree_width[node_id] = max(own, packed)
-            else:
-                subtree_width[node_id] = own
+            packed = (
+                sum(subtree_width[k] for k in kids) + NODE_GAP_X * (len(kids) - 1)
+                if kids else 0.0
+            )
+            packed_width[node_id] = packed
+            subtree_width[node_id] = max(footprints[node_id][0], packed)
 
         # Assign positions, iterative pre-order: each node centred over its
         # own subtree span, children on a row below its real bottom edge.
@@ -325,10 +350,7 @@ class LayoutOps:
             width, height = footprints[node_id]
             node.x = left + (subtree_width[node_id] - width) / 2.0
             node.y = y
-            child_left = left + (subtree_width[node_id] - (
-                sum(subtree_width[k] for k in children.get(node_id, []))
-                + NODE_GAP_X * max(len(children.get(node_id, [])) - 1, 0)
-            )) / 2.0
+            child_left = left + (subtree_width[node_id] - packed_width[node_id]) / 2.0
             for kid in children.get(node_id, []):
                 assign.append((kid, child_left, y + height + NODE_GAP_Y))
                 child_left += subtree_width[kid] + NODE_GAP_X
@@ -347,13 +369,54 @@ class LayoutOps:
         self._organize_groups()
 
     def _organize_groups(self) -> None:
-        """Post-layout group pass: re-wrap every expanded frame/container
-        around its members' new positions; line collapsed pills up in a
-        row below the laid-out content."""
+        """Post-layout group pass: line collapsed pills up in a row below
+        the laid-out content, then re-wrap every expanded frame/container
+        around its members' new positions - pills first, so a container
+        holding a collapsed pill wraps the pill's final spot, and
+        innermost groups first, so an outer container unions its inner
+        group's re-wrapped rect rather than a stale pre-organize one
+        (containers can legitimately nest - see create_container)."""
         groups = [n for n in self.nodes.values() if n.kind in ("frame", "container")]
         expanded = [g for g in groups if not g.is_collapsed]
         collapsed = [g for g in groups if g.is_collapsed]
-        for group in expanded:
+
+        if collapsed:
+            collapsed_set = {g.id for g in collapsed}
+            others = [
+                n for n in self.nodes.values()
+                if not n.is_docked and n.id not in collapsed_set
+            ]
+            if others:
+                left = min(n.x for n in others)
+                bottom = max(n.y + self.node_footprint(n)[1] for n in others)
+            else:
+                left, bottom = 0.0, -GROUP_COLLAPSED_HEIGHT - COMPONENT_GAP
+            x = left
+            y = bottom + COMPONENT_GAP
+            for group in sorted(collapsed, key=lambda g: g.id):
+                group.x, group.y = x, y
+                x += self.node_footprint(group)[0] + NODE_GAP_X
+
+        # Innermost-first: a group's nesting height is 1 + the tallest
+        # height among its member groups (0 when it holds no group).
+        height_cache: dict[str, int] = {}
+
+        def nesting_height(group_id: str, trail: frozenset[str] = frozenset()) -> int:
+            if group_id in height_cache:
+                return height_cache[group_id]
+            if group_id in trail:  # membership cycles cannot happen; belt and braces
+                return 0
+            group = self.nodes[group_id]
+            member_heights = [
+                nesting_height(member_id, trail | {group_id})
+                for member_id in group.item_ids
+                if (member := self.nodes.get(member_id)) is not None
+                and member.kind in ("frame", "container")
+            ]
+            height_cache[group_id] = 1 + max(member_heights, default=0) if member_heights else 0
+            return height_cache[group_id]
+
+        for group in sorted(expanded, key=lambda g: (nesting_height(g.id), g.id)):
             state = group.state
             if state is not None:
                 for attr in (
@@ -363,16 +426,3 @@ class LayoutOps:
                     if hasattr(state, attr):
                         setattr(state, attr, None)
             self._recompute_group_bounds(group.id)
-        if not collapsed:
-            return
-        others = [n for n in self.nodes.values() if not n.is_docked and n not in collapsed]
-        if others:
-            left = min(n.x for n in others)
-            bottom = max(n.y + self.node_footprint(n)[1] for n in others)
-        else:
-            left, bottom = 0.0, -GROUP_COLLAPSED_HEIGHT - COMPONENT_GAP
-        x = left
-        y = bottom + COMPONENT_GAP
-        for group in sorted(collapsed, key=lambda g: g.id):
-            group.x, group.y = x, y
-            x += GROUP_COLLAPSED_WIDTH + NODE_GAP_X

--- a/backend/domain/model.py
+++ b/backend/domain/model.py
@@ -52,33 +52,18 @@ FONT_COLOR_PRESETS = [
 FONT_SIZE_MIN = 8
 FONT_SIZE_MAX = 16
 
-# Organize: the R2 tidy-layout for placeholder nodes (the Qt organize used
-# node-size-aware packing; that returns with real nodes in R3).
-ORGANIZE_SPACING_X = 260
-ORGANIZE_SPACING_Y = 180
+# All spawn placement and the Organize layout live in
+# backend/domain/layout.py (LayoutOps) - the fixed-offset spacing constants
+# that used to sit here (ORGANIZE_SPACING_X/Y, MESSAGE_VERTICAL_SPACING,
+# BRANCH_HORIZONTAL_SPACING, NOTE_AGENT_X_OFFSET) were size-blind stopgaps
+# from the Qt removal and are retired; placement now uses each node's real
+# measured footprint plus collision resolution.
 
-# R3.3: the Composer's Send action stacks each new message below its parent
-# by this much - a simple deterministic layout, not the legacy
-# find_branch_position packing algorithm (a later refinement).
-MESSAGE_VERTICAL_SPACING = 160
-
-# ADR-002 Workstream 1: how far apart real branch siblings (2+ chat-kind
-# children of the same parent, from "Branch from here") fan out
-# horizontally, so a genuine divergence doesn't render as two nodes stacked
-# exactly on top of each other. 460px clears a chat node's own current CSS
-# width (420px, styles.css's .chat-node) with room to spare, same "clears
-# the node's width, not just MESSAGE_VERTICAL_SPACING" reasoning the Key
-# Takeaway/Explainer Note offset just below already uses.
-BRANCH_HORIZONTAL_SPACING = 460
-
-# R8a: where a generated Key Takeaway / Explainer Note lands relative to its
-# source chat node, and how it is tinted. 400px clears a chat node's own
-# width (~292px) with room to spare, matching the legacy offset. The colours
+# R8a: how a generated Key Takeaway / Explainer Note is tinted. The colours
 # are hex because the backend never resolves colour NAMES (see SceneNode's
 # own comment) - these two are the frontend palette's "Mid Gray" body and
 # "Blue" header, the closest surviving equivalents to legacy's Mid Gray +
 # status_info pairing (there is no status_info token in the new stack).
-NOTE_AGENT_X_OFFSET = 400
 NOTE_AGENT_BODY_COLOR = "#7a7a7a"
 NOTE_AGENT_HEADER_COLOR = "#3f7dc9"
 

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -42,7 +42,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
-from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.canvas import SceneDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 from backend.plugin_sdk import (
@@ -344,13 +344,13 @@ async def _execute_discovered_plugin(
         )
         await bus.publish("notification")
         return None
-    parent = canvas_document.nodes[parent_node_id]
     run_ctx = PluginRunContext(plugin_id=kind_spec.plugin_id, notifications=notifications)
 
     def _mutator():
         seed = kind_spec.factory(canvas_document, run_ctx, parent_node_id)
+        x, y = canvas_document.place_child(parent_node_id, kind_spec.kind)
         return canvas_document.add_plugin_node(
-            kind_spec.kind, parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id,
+            kind_spec.kind, x, y, parent_node_id,
             title=seed.title, content=seed.content, state=seed.state,
         )
 

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -22,7 +22,7 @@ from backend import tools_graph as tools_graph_module
 from backend.api import intents_builder as intents_builder_module
 from backend.builder import run_build
 from backend.domain.graph import SceneDocument
-from backend.domain.model import MESSAGE_VERTICAL_SPACING
+from backend.domain.layout import NODE_GAP_X, NODE_GAP_Y
 from backend.notifications import NotificationState
 from backend.providers.base import ToolCall
 from backend.run_lifecycle import RunRegistry
@@ -1446,7 +1446,7 @@ class TestAnchoredPlacement:
 
         created = next(n for n in document.nodes.values() if n.kind == "note")
         assert created.x == node.x
-        assert created.y == node.y + MESSAGE_VERTICAL_SPACING
+        assert created.y == node.y + document.node_footprint(node)[1] + NODE_GAP_Y
 
     def test_multiple_parentless_creates_fan_out_along_the_anchor_row(self, monkeypatch):
         document, dispatcher, registry, bus = make_harness()
@@ -1465,12 +1465,12 @@ class TestAnchoredPlacement:
         notes = sorted((n for n in document.nodes.values() if n.kind == "note"), key=lambda n: n.x)
         assert len(notes) == 2
         assert notes[0].x == node.x
-        assert notes[1].x == node.x + tools_graph_module._SIBLING_HORIZONTAL_SPACING
-        assert notes[0].y == notes[1].y == node.y + MESSAGE_VERTICAL_SPACING
+        assert notes[1].x >= notes[0].x + document.node_footprint(notes[0])[0] + NODE_GAP_X
+        assert notes[0].y == notes[1].y == node.y + document.node_footprint(node)[1] + NODE_GAP_Y
 
     def test_no_anchor_falls_back_to_the_origin_drop(self):
         document = SceneDocument()
-        assert _place_child(document, None, None) == (80.0, 80.0)
+        assert _place_child(document, None, None) == (0.0, 0.0)
 
     def test_review_fix_an_explicit_parent_id_equal_to_the_anchor_does_not_overlap_an_anchor_placed_sibling(self):
         """The executor prompt tells the model the plan node's own id
@@ -1487,7 +1487,9 @@ class TestAnchoredPlacement:
         x2, y2 = _place_child(document, plan.id, plan.id)  # parent_id IS the anchor
 
         assert (x2, y2) != (x1, y1), "must not collide with the anchor-placed sibling"
-        assert (x2, y2) == (x1 + tools_graph_module._SIBLING_HORIZONTAL_SPACING, y1)
+        note = next(n for n in document.nodes.values() if n.kind == "note")
+        assert y2 == y1
+        assert x2 >= x1 + document.node_footprint(note)[0] + NODE_GAP_X
 
     def test_review_fix_a_real_parent_distinct_from_the_anchor_keeps_its_own_edge_based_counting(self):
         """The unification fix must be scoped to parent_id == anchor_id
@@ -1499,7 +1501,7 @@ class TestAnchoredPlacement:
 
         x, y = _place_child(document, parent.id, plan.id)
 
-        assert (x, y) == (parent.x, parent.y + MESSAGE_VERTICAL_SPACING)
+        assert (x, y) == (parent.x, parent.y + document.node_footprint(parent)[1] + NODE_GAP_Y)
 
 
 class TestDeleteRecipe:

--- a/backend/tests/test_builder.py
+++ b/backend/tests/test_builder.py
@@ -18,7 +18,6 @@ import time
 
 import api_provider
 from backend import builder as builder_module
-from backend import tools_graph as tools_graph_module
 from backend.api import intents_builder as intents_builder_module
 from backend.builder import run_build
 from backend.domain.graph import SceneDocument

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -16,15 +16,12 @@ import pytest
 import backend.agents as agents_module
 from backend.agents import AgentDispatcher
 from backend.canvas import (
-    BRANCH_HORIZONTAL_SPACING,
     DRAG_FACTOR_MAX,
     DRAG_FACTOR_MIN,
     GROUP_MEMBER_DEFAULT_HEIGHT,
     GROUP_MEMBER_DEFAULT_WIDTH,
-    MESSAGE_VERTICAL_SPACING,
     NOTE_AGENT_BODY_COLOR,
     NOTE_AGENT_HEADER_COLOR,
-    NOTE_AGENT_X_OFFSET,
     SceneDocument,
     SceneEmptyPromptError,
     SceneError,
@@ -36,6 +33,7 @@ from backend.canvas import (
 )
 from backend import native_dialogs
 from backend.attachments import StagedAttachment
+from backend.domain.layout import NODE_GAP_X, NODE_GAP_Y
 from backend.composer import ComposerDocument
 from backend.events import SessionBus
 from backend.notifications import NotificationState
@@ -956,9 +954,11 @@ def test_send_message_branch_from_node_id_fans_out_siblings_so_they_do_not_overl
     first_reply = doc.send_message("first reply", branch_from_node_id=root.id)
     second_reply = doc.send_message("second reply", branch_from_node_id=root.id)
 
-    assert first_reply.y == second_reply.y == root.y + MESSAGE_VERTICAL_SPACING
+    root_w, root_h = doc.node_footprint(root)
+    assert first_reply.y == second_reply.y == root.y + root_h + NODE_GAP_Y
     assert first_reply.x == root.x
-    assert second_reply.x == root.x + BRANCH_HORIZONTAL_SPACING
+    # The second sibling fans right past the first one's full footprint.
+    assert second_reply.x >= first_reply.x + doc.node_footprint(first_reply)[0]
     assert first_reply.x != second_reply.x, "two real siblings must never render at the exact same position"
 
 
@@ -975,7 +975,7 @@ def test_send_message_branch_from_node_id_fan_out_ignores_non_chat_children():
     assert first_reply.x == root.x, "non-chat children must not shift the first real branch's fan-out index"
 
     second_reply = doc.send_message("second real branch", branch_from_node_id=root.id)
-    assert second_reply.x == root.x + BRANCH_HORIZONTAL_SPACING
+    assert second_reply.x >= first_reply.x + doc.node_footprint(first_reply)[0]
 
 
 def test_send_message_branch_from_node_id_unknown_id_falls_back_to_last_chat_node_id():
@@ -2374,19 +2374,57 @@ def test_font_intents_use_bridge_slot_names_and_bound_values():
     asyncio.run(run())
 
 
-def test_organize_arranges_nodes_in_a_stable_grid():
+def test_organize_lines_up_disconnected_nodes_without_overlap():
     async def run():
         bus, document, _ = make_bus()
         for i in range(5):
             await bus.dispatch_intent("scene", "addNode", [500 - i * 37, i * 91])
         await bus.dispatch_intent("scene", "organizeNodes", [])
-        positions = {n.id: (n.x, n.y) for n in document.nodes.values()}
-        # 5 nodes -> 3 columns; stable id order fills rows left-to-right.
-        assert positions["n0"] == (0.0, 0.0)
-        assert positions["n1"] == (260.0, 0.0)
-        assert positions["n2"] == (520.0, 0.0)
-        assert positions["n3"] == (0.0, 180.0)
-        assert positions["n4"] == (260.0, 180.0)
+        nodes = sorted(document.nodes.values(), key=lambda n: n.x)
+        # Disconnected nodes are separate components: one shared top row,
+        # ordered by their pre-organize x (n4 was leftmost, n0 rightmost),
+        # each clear of its neighbour's real footprint.
+        assert [n.id for n in nodes] == ["n4", "n3", "n2", "n1", "n0"]
+        assert all(n.y == 0.0 for n in nodes)
+        for left, right in zip(nodes, nodes[1:]):
+            assert right.x >= left.x + document.node_footprint(left)[0]
+
+    asyncio.run(run())
+
+
+def test_organize_is_deterministic_and_stacks_children_below_parents():
+    async def run():
+        bus, document, _ = make_bus()
+        root = document.add_chat_node(300, 900, "root", True)
+        first = document.add_chat_node(280, 100, "first child", False, parent_id=root.id)
+        second = document.add_chat_node(310, 120, "second child", False, parent_id=root.id)
+        stray = document.add_note(305, 905)
+        await bus.dispatch_intent("scene", "organizeNodes", [])
+
+        # Children sit strictly below the root's real bottom edge, packed
+        # side by side without overlap; the disconnected note lands in its
+        # own component, clear of the tree.
+        root_bottom = root.y + document.node_footprint(root)[1]
+        assert first.y >= root_bottom and second.y >= root_bottom
+        left, right = sorted((first, second), key=lambda n: n.x)
+        assert right.x >= left.x + document.node_footprint(left)[0]
+
+        rects = {
+            n.id: (n.x, n.y, *document.node_footprint(n))
+            for n in (root, first, second, stray)
+        }
+        for a_id, (ax, ay, aw, ah) in rects.items():
+            for b_id, (bx, by, bw, bh) in rects.items():
+                if a_id < b_id:
+                    assert (
+                        ax + aw <= bx or bx + bw <= ax or ay + ah <= by or by + bh <= ay
+                    ), f"{a_id} and {b_id} overlap after organize"
+
+        first_positions = {n.id: (n.x, n.y) for n in document.nodes.values()}
+        await bus.dispatch_intent("scene", "organizeNodes", [])
+        assert first_positions == {n.id: (n.x, n.y) for n in document.nodes.values()}, (
+            "organize must be deterministic - a second run may not move anything"
+        )
 
     asyncio.run(run())
 
@@ -6306,8 +6344,9 @@ def test_generate_key_takeaway_creates_a_tinted_note_beside_the_source_node(monk
         note = document.nodes[new_ids.pop()]
         assert note.kind == "note"
         assert note.content == "Key Takeaway\n\nMain Points:\n• it works"
-        # Offset to the RIGHT of the source, clearing the chat node's width.
-        assert (note.x, note.y) == (100 + NOTE_AGENT_X_OFFSET, 200)
+        # Offset to the RIGHT of the source, clearing the chat node's real
+        # footprint width plus the standard gap.
+        assert (note.x, note.y) == (100 + document.node_footprint(chat)[0] + NODE_GAP_X, 200)
         assert note.color == NOTE_AGENT_BODY_COLOR
         assert note.header_color == NOTE_AGENT_HEADER_COLOR
         assert recorder.topics_seen().count("scene") > scene_publishes_before
@@ -6478,11 +6517,12 @@ def test_compare_branches_creates_a_note_linked_to_all_sources(monkeypatch):
         assert note.item_ids == [first.id, second.id]
         assert note.color == NOTE_AGENT_BODY_COLOR
         assert note.header_color == NOTE_AGENT_HEADER_COLOR
-        # Positioned below-and-between the two sources, offset to the side -
-        # same "clears the source's width" convention as the single-node
-        # note agents.
-        assert note.x == (first.x + second.x) / 2 + NOTE_AGENT_X_OFFSET
-        assert note.y == max(first.y, second.y)
+        # Positioned beside the bottom-most source, offset to the side -
+        # same "clears the source's real width" convention as the
+        # single-node note agents.
+        anchor = max((first, second), key=lambda n: (n.y, n.id))
+        assert note.x >= anchor.x + document.node_footprint(anchor)[0]
+        assert note.y == anchor.y
         assert recorder.topics_seen().count("scene") > scene_publishes_before
 
     asyncio.run(run())
@@ -6618,9 +6658,9 @@ def test_synthesize_branches_creates_a_chat_node_continuing_from_the_first_sourc
         parent_edge = document._branch_parent_edge(node.id)
         assert parent_edge is not None
         assert parent_edge.source == first.id
-        # Positioned below every source, averaged across all of them.
-        assert node.x == (first.x + second.x) / 2
-        assert node.y == max(first.y, second.y) + MESSAGE_VERTICAL_SPACING
+        # Positioned below its parent's (the first source's) real bottom
+        # edge - collision-resolved, so it lands clear of every source.
+        assert node.y >= first.y + document.node_footprint(first)[1]
         assert document.last_chat_node_id == node.id
         assert recorder.topics_seen().count("scene") > scene_publishes_before
 

--- a/backend/tests/test_canvas.py
+++ b/backend/tests/test_canvas.py
@@ -963,9 +963,11 @@ def test_send_message_branch_from_node_id_fans_out_siblings_so_they_do_not_overl
 
 
 def test_send_message_branch_from_node_id_fan_out_ignores_non_chat_children():
-    """A docked/generated non-chat child (thinking, code, a generated note)
-    under the same parent must never count toward the fan-out index - only
-    real conversational branches are genuine "siblings" for this purpose."""
+    """Placement is geometric now, not index-counting: a non-chat child
+    (thinking, code) sitting AT the parent's own position does not occupy
+    the below-parent slot, so the first real branch still lands directly
+    under the parent - and a genuinely blocking child would shift it by
+    collision, which is the intended contract."""
     doc = SceneDocument()
     root = doc.send_message("root message")
     doc.add_thinking_node(root.x, root.y, "some reasoning", parent_id=root.id)

--- a/backend/tests/test_layout.py
+++ b/backend/tests/test_layout.py
@@ -1,0 +1,169 @@
+"""LayoutOps (backend/domain/layout.py): spawn placement + organize.
+
+Unit tests pin the placement shapes (below/right/left/above, footprint
+fallback chain, scene-edge placement); the hypothesis properties pin the
+two invariants the whole module exists for - a spawned child never lands
+on an existing node, and organize() always produces an overlap-free,
+deterministic layout - across arbitrary scene shapes, sizes, and edge
+structures (including cycles and multi-parent nodes).
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings, strategies as st
+
+from backend.canvas import SceneDocument
+from backend.domain.layout import (
+    DEFAULT_FALLBACK_FOOTPRINT,
+    KIND_FALLBACK_FOOTPRINTS,
+    NODE_GAP_X,
+    NODE_GAP_Y,
+)
+
+
+def _rects_overlap(a, b) -> bool:
+    ax, ay, aw, ah = a
+    bx, by, bw, bh = b
+    return not (ax + aw <= bx or bx + bw <= ax or ay + ah <= by or by + bh <= ay)
+
+
+def _assert_no_overlaps(doc: SceneDocument, *, skip_kinds=("frame", "container")):
+    rects = {
+        n.id: (n.x, n.y, *doc.node_footprint(n))
+        for n in doc.nodes.values()
+        if n.kind not in skip_kinds and not n.is_docked
+    }
+    ids = sorted(rects)
+    for i, a in enumerate(ids):
+        for b in ids[i + 1:]:
+            assert not _rects_overlap(rects[a], rects[b]), f"{a} and {b} overlap"
+
+
+# -- footprints -------------------------------------------------------------
+
+def test_footprint_prefers_the_frontend_measured_size():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "hi", True)
+    assert doc.node_footprint(node) == KIND_FALLBACK_FOOTPRINTS["chat"]
+    doc.set_measured_node_sizes([(node.id, 500.0, 750.0)])
+    assert doc.node_footprint(node) == (500.0, 750.0)
+
+
+def test_footprint_falls_back_per_kind_then_to_the_generic_default():
+    doc = SceneDocument()
+    note = doc.add_note(0, 0)
+    assert doc.node_footprint(note) == KIND_FALLBACK_FOOTPRINTS["note"]
+    node = doc.add_node(0, 0, "x")
+    node.kind = "some-unknown-kind"
+    assert doc.node_footprint(node) == DEFAULT_FALLBACK_FOOTPRINT
+
+
+# -- place_child ------------------------------------------------------------
+
+def test_place_child_lands_below_the_parents_real_measured_bottom_edge():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(100, 50, "a very tall reply", False)
+    doc.set_measured_node_sizes([(parent.id, 422.0, 900.0)])
+    x, y = doc.place_child(parent.id, "chat")
+    assert (x, y) == (100.0, 50.0 + 900.0 + NODE_GAP_Y), (
+        "the old fixed 160px offset buried children inside a tall parent"
+    )
+
+
+def test_place_child_fans_a_second_sibling_right_past_the_first():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "root", True)
+    first = doc.add_chat_node(*doc.place_child(parent.id, "chat"), "a", False, parent_id=parent.id)
+    second = doc.add_chat_node(*doc.place_child(parent.id, "chat"), "b", False, parent_id=parent.id)
+    assert first.y == second.y
+    assert second.x >= first.x + doc.node_footprint(first)[0] + NODE_GAP_X
+    _assert_no_overlaps(doc)
+
+
+def test_place_child_right_left_and_above_clear_the_parents_footprint():
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "root", True)
+    doc.set_measured_node_sizes([(parent.id, 600.0, 400.0)])
+    rx, ry = doc.place_child(parent.id, "note", prefer="right")
+    assert (rx, ry) == (600.0 + NODE_GAP_X, 0.0)
+    lx, _ly = doc.place_child(parent.id, "thinking", prefer="left")
+    assert lx == -NODE_GAP_X - KIND_FALLBACK_FOOTPRINTS["thinking"][0]
+    _ax, ay = doc.place_child(parent.id, "note", prefer="above")
+    assert ay == -NODE_GAP_Y - KIND_FALLBACK_FOOTPRINTS["note"][1]
+
+
+def test_place_child_with_unknown_parent_falls_back_to_place_root():
+    doc = SceneDocument()
+    existing = doc.add_chat_node(0, 0, "x", True)
+    x, y = doc.place_child("nope", "chat")
+    assert y >= existing.y + doc.node_footprint(existing)[1]
+
+
+def test_place_at_scene_right_clears_the_widest_nodes_real_edge():
+    doc = SceneDocument()
+    node = doc.add_chat_node(0, 0, "wide", True)
+    doc.set_measured_node_sizes([(node.id, 1500.0, 300.0)])
+    x, _y = doc.place_at_scene_right("plan")
+    assert x >= 1500.0 + NODE_GAP_X, (
+        "max-x placement ignored width and could land on a wide node"
+    )
+
+
+# -- properties -------------------------------------------------------------
+
+@settings(max_examples=50, deadline=None)
+@given(
+    heights=st.lists(st.floats(min_value=1.0, max_value=1200.0), min_size=1, max_size=12),
+    branch=st.lists(st.booleans(), min_size=0, max_size=11),
+)
+def test_property_spawned_chat_nodes_never_overlap(heights, branch):
+    """Grow a conversation with arbitrary measured reply heights, randomly
+    continuing the tip or branching from the root - no two nodes may ever
+    overlap, whatever their real rendered sizes."""
+    doc = SceneDocument()
+    root = doc.send_message("root")
+    doc.set_measured_node_sizes([(root.id, 422.0, heights[0])])
+    for index, height in enumerate(heights[1:]):
+        from_root = index < len(branch) and branch[index]
+        node = doc.send_message(
+            f"m{index}", branch_from_node_id=root.id if from_root else None,
+        )
+        doc.set_measured_node_sizes([(node.id, 422.0, height)])
+    _assert_no_overlaps(doc)
+
+
+@settings(max_examples=50, deadline=None)
+@given(data=st.data())
+def test_property_organize_produces_an_overlap_free_deterministic_layout(data):
+    """Any scene shape - random positions, random measured sizes, random
+    edges (cycles and multi-parent included) - must organize into a layout
+    with no overlapping nodes, and a second organize must be a no-op."""
+    doc = SceneDocument()
+    count = data.draw(st.integers(min_value=1, max_value=15))
+    nodes = []
+    for i in range(count):
+        node = doc.add_chat_node(
+            data.draw(st.floats(min_value=-2000, max_value=2000)),
+            data.draw(st.floats(min_value=-2000, max_value=2000)),
+            f"m{i}", True,
+        )
+        if data.draw(st.booleans()):
+            doc.set_measured_node_sizes([(
+                node.id,
+                data.draw(st.floats(min_value=1.0, max_value=1000.0)),
+                data.draw(st.floats(min_value=1.0, max_value=1000.0)),
+            )])
+        nodes.append(node)
+    edge_count = data.draw(st.integers(min_value=0, max_value=count * 2))
+    for _ in range(edge_count):
+        source = data.draw(st.sampled_from(nodes))
+        target = data.draw(st.sampled_from(nodes))
+        if source.id != target.id and not doc._reaches(target.id, source.id):
+            doc.connect(source.id, target.id)
+
+    doc.organize()
+    _assert_no_overlaps(doc)
+
+    positions = {n.id: (n.x, n.y) for n in doc.nodes.values()}
+    doc.organize()
+    assert positions == {n.id: (n.x, n.y) for n in doc.nodes.values()}

--- a/backend/tests/test_layout.py
+++ b/backend/tests/test_layout.py
@@ -109,6 +109,36 @@ def test_place_at_scene_right_clears_the_widest_nodes_real_edge():
     )
 
 
+def test_organize_keeps_the_creation_edge_as_structural_parent():
+    """A node's FIRST edge (its creation edge, in insertion order - never a
+    lexicographic id sort, where e10 < e9) stays its structural parent; a
+    later cross-link (e.g. a note attached to the same node) must not steal
+    the subtree."""
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    child = doc.add_chat_node(0, 500, "child", False, parent_id=root.id)
+    note = doc.add_note(900, 0)
+    doc.connect(note.id, child.id)
+
+    doc.organize()
+
+    assert child.y >= root.y + doc.node_footprint(root)[1], (
+        "the child must hang below its chat parent, not below the later-linked note"
+    )
+    assert abs((child.x + doc.node_footprint(child)[0] / 2)
+               - (root.x + doc.node_footprint(root)[0] / 2)) < 1e-6
+
+
+def test_footprint_of_a_collapsed_group_is_the_pill_not_a_stale_measurement():
+    doc = SceneDocument()
+    member = doc.add_chat_node(0, 0, "m", True)
+    frame = doc.create_frame([member.id])
+    doc.set_measured_node_sizes([(frame.id, 1200.0, 800.0)])
+    doc.set_chat_collapsed(frame.id, True)
+    from backend.domain.model import GROUP_COLLAPSED_HEIGHT, GROUP_COLLAPSED_WIDTH
+    assert doc.node_footprint(frame) == (GROUP_COLLAPSED_WIDTH, GROUP_COLLAPSED_HEIGHT)
+
+
 # -- properties -------------------------------------------------------------
 
 @settings(max_examples=50, deadline=None)

--- a/backend/tests/test_plugins.py
+++ b/backend/tests/test_plugins.py
@@ -519,10 +519,10 @@ def test_execute_plugin_system_prompt_creates_a_note_attached_to_the_branch_root
     note = canvas_document.nodes[result]
     assert note.kind == "note"
     assert note.state.is_system_prompt is True
-    # Positioned above the ROOT (not `mid`), roughly matching legacy's
-    # "200px above" placement.
+    # Positioned above the ROOT (not `mid`), clear of the root's top edge
+    # by the note's own footprint plus the standard gap.
     assert note.x == root.x
-    assert note.y == root.y - 150
+    assert note.y + canvas_document.node_footprint(note)[1] <= root.y
     # note -> root, the exact direction _resolve_branch_system_prompt looks
     # for - NOT root -> note (the child plugins' own direction) and NOT
     # note -> mid (the selected node, not the resolved root).

--- a/backend/tools_graph.py
+++ b/backend/tools_graph.py
@@ -25,13 +25,13 @@ user commands into the builder's undo entry. Every handler's
 record_command call is one synchronous stretch - atomic w.r.t. the event
 loop - so per-call stamping has no such window.
 
-Placement: the model never picks coordinates. New nodes land relative to
-their parent using the same MESSAGE_VERTICAL_SPACING convention
-send_message's own reply placement uses (backend/domain/model.py), with a
-horizontal fan-out for siblings so parallel children don't stack. A
-parentless create (stage 8.7) instead anchors near the run's plan node, if
-one exists, so a build's output lands where the user just looked rather
-than at the canvas origin - see _place_child's own doc.
+Placement: the model never picks coordinates. New nodes land via
+SceneDocument.place_child (backend/domain/layout.py) - the same
+collision-resolved, measured-footprint placement every other spawn path
+uses, which fans parallel children of one parent side by side instead of
+stacking them. A parentless create (stage 8.7) instead anchors near the
+run's plan node, if one exists, so a build's output lands where the user
+just looked rather than at the canvas origin - see _place_child's own doc.
 """
 
 from __future__ import annotations
@@ -41,7 +41,6 @@ import json
 from typing import Any
 
 from backend.domain.graph import SceneDocument, SceneError
-from backend.domain.model import MESSAGE_VERTICAL_SPACING
 from graphlink_scratch_dirs import HARNESS_WORKSPACE_ROOT, remove_scratch_dir_for_id
 from backend.domain.node_states import (
     ArtifactState,
@@ -51,11 +50,6 @@ from backend.domain.node_states import (
 )
 from backend.providers.base import ToolCall, ToolSpec
 from backend.tools import GRAPH_MUTATE, GRAPH_READ, RunContext, ToolRegistry, ToolResult
-
-# Sibling fan-out: the second/third/... child of the same parent shifts right
-# so a builder creating parallel children produces a readable fan, not a
-# stack. Value matches the vertical rhythm rather than inventing a new one.
-_SIBLING_HORIZONTAL_SPACING = 360
 
 # read_subgraph excerpt cap: full content stays on the node (the canvas is
 # the artifact); the tool result feeds the MODEL, where an unbounded excerpt
@@ -286,52 +280,22 @@ def _anchor_id_of(ctx: RunContext) -> str | None:
 
 
 def _place_child(
-    document: SceneDocument, parent_id: str | None, anchor_id: str | None = None,
+    document: SceneDocument,
+    parent_id: str | None,
+    anchor_id: str | None = None,
+    kind: str = "chat",
 ) -> tuple[float, float]:
-    """Parent-relative placement, model-free: directly below the parent,
-    fanning right one slot per existing child so parallel children of the
-    same parent land side by side instead of stacked.
-
-    review-fix (stage 8.7): the plan node can be reached by EITHER path -
-    as an explicit parent_id (the executor prompt tells the model the plan
-    node's own id, and nothing stops it passing that id back as parent_id
-    for a chat/code node) or as the implicit anchor for a parentless create.
-    The two branches below used to count siblings differently (edges vs.
-    position), so a parentless create landing via the anchor branch was
-    invisible to the parent branch's edge count and vice versa - two nodes
-    from the two different paths could land on the exact same coordinates.
-    `parent_id != anchor_id` routes that one specific case (parent_id IS the
-    anchor) into the position-based branch below, which sees every node in
-    the row regardless of which path placed it. A normal parent - anything
-    other than the anchor - is completely unaffected."""
-    if parent_id is not None and parent_id in document.nodes and parent_id != anchor_id:
-        parent = document.nodes[parent_id]
-        existing_children = sum(1 for e in document.edges.values() if e.source == parent_id)
-        return (
-            parent.x + existing_children * _SIBLING_HORIZONTAL_SPACING,
-            parent.y + MESSAGE_VERTICAL_SPACING,
-        )
-    reference_id = parent_id or anchor_id
-    if reference_id is not None and reference_id in document.nodes:
-        # The anchor (a plan node) never gains an EDGE to what it builds -
-        # it is a placement reference only - so there is no edge count to
-        # read a sibling index off. A node already sitting on the
-        # reference's own placement row is this same reference's own
-        # earlier creation (nothing else places there), so counting THOSE
-        # stands in for "existing children" without needing a persisted
-        # counter - and, per the docstring above, catches siblings placed
-        # via EITHER path.
-        reference = document.nodes[reference_id]
-        row_y = reference.y + MESSAGE_VERTICAL_SPACING
-        row_siblings = sum(
-            1 for n in document.nodes.values() if n.x >= reference.x and abs(n.y - row_y) < 1.0
-        )
-        return reference.x + row_siblings * _SIBLING_HORIZONTAL_SPACING, row_y
-    # Free-floating with no anchor either (a bare RunContext, e.g. a future
-    # non-builder caller): drop near the origin offset by node count so
-    # repeated creations don't perfectly overlap.
-    n = len(document.nodes)
-    return 80.0 + (n % 5) * 40.0, 80.0 + (n % 7) * 40.0
+    """Parent-relative placement, model-free, via SceneDocument.place_child
+    (backend/domain/layout.py): directly below the reference node's real
+    measured bottom edge, fanning right past any occupied slot - so
+    parallel children of the same parent land side by side regardless of
+    which path (explicit parent_id or the stage-8.7 plan-node anchor)
+    placed the earlier ones; collision resolution sees actual node rects,
+    not a per-path sibling counter. A parentless create with no anchor
+    either (a bare RunContext, e.g. a future non-builder caller) falls
+    through to place_root's below-the-scene drop."""
+    reference_id = parent_id if parent_id in document.nodes else anchor_id
+    return document.place_child(reference_id, kind)
 
 
 def _error(message: str) -> ToolResult:
@@ -354,7 +318,7 @@ def make_create_node_handler(document: SceneDocument):
         if kind == "document" and not title:
             return _error("kind 'document' requires a title.")
 
-        x, y = _place_child(document, parent_id, _anchor_id_of(ctx))
+        x, y = _place_child(document, parent_id, _anchor_id_of(ctx), kind)
         run_id = _run_id_of(ctx)
 
         def mutator():

--- a/backend/tools_graph.py
+++ b/backend/tools_graph.py
@@ -988,7 +988,7 @@ def make_run_node_handler(document: SceneDocument, dispatcher):
         # letting that SceneError propagate out of handler() uncaught.
         if node_id not in document.nodes:
             return _error(f"Node {node_id!r} no longer exists - the chart was discarded.")
-        x, y = _place_child(document, node_id)
+        x, y = _place_child(document, node_id, kind="chart")
         chart_node, _command = document.record_command(
             "builderRunChart", "agent",
             lambda: document.add_chart_node(x, y, node_id, chart_type, chart_data),

--- a/plugins/artifact/plugin.py
+++ b/plugins/artifact/plugin.py
@@ -8,7 +8,7 @@ docstring for the shared register_builtin_plugin escape-hatch rationale."""
 
 from __future__ import annotations
 
-from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.canvas import SceneDocument
 from backend.plugin_sdk import HostContext, PluginRunContext
 
 
@@ -21,11 +21,10 @@ def _execute(
             "warning",
         )
         return None
-    parent = document.nodes[parent_node_id]
     node, _command = document.record_command(
         "pluginArtifact", "user",
         lambda: document.add_artifact_node(
-            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            *document.place_child(parent_node_id, "artifact"), parent_node_id
         ),
         node_ids=[parent_node_id],
     )

--- a/plugins/code_sandbox/plugin.py
+++ b/plugins/code_sandbox/plugin.py
@@ -9,7 +9,7 @@ shared register_builtin_plugin escape-hatch rationale."""
 
 from __future__ import annotations
 
-from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.canvas import SceneDocument
 from backend.plugin_sdk import HostContext, PluginRunContext
 
 
@@ -23,11 +23,10 @@ def _execute(
             "warning",
         )
         return None
-    parent = document.nodes[parent_node_id]
     node, _command = document.record_command(
         "pluginCodeSandbox", "user",
         lambda: document.add_code_sandbox_node(
-            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            *document.place_child(parent_node_id, "code_sandbox"), parent_node_id
         ),
         node_ids=[parent_node_id],
     )

--- a/plugins/conversation_node/plugin.py
+++ b/plugins/conversation_node/plugin.py
@@ -9,7 +9,7 @@ rationale."""
 
 from __future__ import annotations
 
-from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.canvas import SceneDocument
 from backend.plugin_sdk import HostContext, PluginRunContext
 
 
@@ -22,11 +22,10 @@ def _execute(
             "warning",
         )
         return None
-    parent = document.nodes[parent_node_id]
     node, _command = document.record_command(
         "pluginConversationNode", "user",
         lambda: document.add_conversation_node(
-            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            *document.place_child(parent_node_id, "conversation"), parent_node_id
         ),
         node_ids=[parent_node_id],
     )

--- a/plugins/gitlink/plugin.py
+++ b/plugins/gitlink/plugin.py
@@ -8,7 +8,7 @@ register_builtin_plugin escape-hatch rationale."""
 
 from __future__ import annotations
 
-from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.canvas import SceneDocument
 from backend.plugin_sdk import HostContext, PluginRunContext
 
 
@@ -21,11 +21,10 @@ def _execute(
             "warning",
         )
         return None
-    parent = document.nodes[parent_node_id]
     node, _command = document.record_command(
         "pluginGitlink", "user",
         lambda: document.add_gitlink_node(
-            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            *document.place_child(parent_node_id, "gitlink"), parent_node_id
         ),
         node_ids=[parent_node_id],
     )

--- a/plugins/html_renderer/plugin.py
+++ b/plugins/html_renderer/plugin.py
@@ -10,7 +10,7 @@ register_builtin_plugin escape-hatch rationale."""
 
 from __future__ import annotations
 
-from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.canvas import SceneDocument
 from backend.plugin_sdk import HostContext, PluginRunContext
 
 
@@ -24,11 +24,10 @@ def _execute(
             "warning",
         )
         return None
-    parent = document.nodes[parent_node_id]
     node, _command = document.record_command(
         "pluginHtmlRenderer", "user",
         lambda: document.add_html_node(
-            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, "", parent_node_id
+            *document.place_child(parent_node_id, "html"), "", parent_node_id
         ),
         node_ids=[parent_node_id],
     )

--- a/plugins/system_prompt/plugin.py
+++ b/plugins/system_prompt/plugin.py
@@ -1,8 +1,8 @@
 """ADR-014 stage 14.3: first-party migration of the pre-SDK "System Prompt"
 picker action. A byte-faithful relocation of backend/plugins.py's old
 hardcoded `if name == "System Prompt":` branch - the one built-in whose
-shape genuinely differs from the other 7 (a branch-point CHILD of
-parent_node_id, one MESSAGE_VERTICAL_SPACING below it):
+shape genuinely differs from the other 7 (a note placed ABOVE the branch
+root, not a child fanned below the selected node):
 
 - Resolves parent_node_id's BRANCH ROOT (SceneDocument.get_branch_root),
   the same parent-edge walk backend/agents.py's
@@ -53,7 +53,8 @@ def _execute(
         return existing.id
 
     def _create_system_prompt_note():
-        created = document.add_note(root.x, root.y - 150, is_system_prompt=True)
+        nx, ny = document.place_child(root.id, "note", prefer="above")
+        created = document.add_note(nx, ny, is_system_prompt=True)
         document.connect(created.id, root.id)
         return created
 

--- a/plugins/web_research/plugin.py
+++ b/plugins/web_research/plugin.py
@@ -14,7 +14,7 @@ for the full escape-hatch rationale."""
 
 from __future__ import annotations
 
-from backend.canvas import MESSAGE_VERTICAL_SPACING, SceneDocument
+from backend.canvas import SceneDocument
 from backend.plugin_sdk import HostContext, PluginRunContext
 
 
@@ -27,11 +27,10 @@ def _execute(
             "warning",
         )
         return None
-    parent = document.nodes[parent_node_id]
     node, _command = document.record_command(
         "pluginWebResearch", "user",
         lambda: document.add_web_research_node(
-            parent.x, parent.y + MESSAGE_VERTICAL_SPACING, parent_node_id
+            *document.place_child(parent_node_id, "web_research"), parent_node_id
         ),
         node_ids=[parent_node_id],
     )

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -3146,6 +3146,21 @@ function CanvasInner({
         // RF's default dblclick-zoom would consume it before it ever bubbles.
         zoomOnDoubleClick={false}
         fitView
+        // The initial fitView's OWN zoom ceiling, independent of maxZoom
+        // below (which only bounds interactive/manual zoom). Without this,
+        // fitView on a canvas holding just one small node (a fresh
+        // placeholder, or a lone note) zooms in tight to fill the viewport
+        // with it - up to maxZoom itself, since nothing else stops it. The
+        // real-footprint placement engine (backend/domain/layout.py) can
+        // then legitimately place that node's first child 200-400+ px
+        // below/right of it, landing outside a viewport that was already
+        // zoomed in that tight - the child renders correctly in the scene
+        // graph but is invisible until the user manually zooms out, with
+        // no visual cue anything was even created. Capping the AUTOMATIC
+        // fit at 1x leaves realistic headroom around a small starting
+        // scene; fitting genuinely large content still zooms out below 1x
+        // as needed; a user's own scroll-zoom is still free to go to 2.5x.
+        fitViewOptions={{ maxZoom: 1 }}
         minZoom={0.1}
         maxZoom={2.5}
         deleteKeyCode={DELETE_KEY_CODES}


### PR DESCRIPTION
## Problem

The Qt canvas's `find_branch_position` packing and its size-aware organize never survived the Qt removal. Every spawn site degenerated to a fixed 160px-below-parent offset while real chat nodes render 500+px tall, so new nodes routinely landed on top of their parents and each other, and Organize was a size-blind 260x180 grid (a chat node alone is 422px wide). The backend already receives every node's real rendered size via `reportNodeSizes` but never used it for placement.

## Change

`backend/domain/layout.py` is a new placement engine, mixed into `SceneDocument` like the other domain ops:

- **`node_footprint()`** - measured (frontend-reported) → intrinsic (chart/group geometry) → per-kind fallback size chain; a collapsed group always reports its pill size.
- **`find_free_position()`** - deterministic collision resolution: a proposed rect advances past whatever it overlaps until clear, with standard gaps.
- **`place_child()` / `place_root()` / `place_at_scene_right()`** - the three placement shapes (below/right/left/above orientations), all sized by the parent's real footprint.
- **`organize_layout()`** - size-aware layered tree layout: children below their parent's real bottom edge, sibling subtrees packed side by side by real subtree width, disconnected trees as separate islands, same-frame members kept adjacent, frames/containers re-wrapped innermost-first afterwards, collapsed pills lined up below.

Every spawn site routes through the engine: composer send/branch/synthesize, replies plus thinking/code children, regenerate, generated images, document-attachment promotion, note agents (takeaway/explainer/compare), charts, builder tool creates, plan/harness launchers, and all eight builtin plugins. The retired fixed-offset constants (`MESSAGE_VERTICAL_SPACING`, `BRANCH_HORIZONTAL_SPACING`, `NOTE_AGENT_X_OFFSET`, `ORGANIZE_SPACING_X/Y`) are deleted.

Structural parent selection during organize follows edge insertion order (edge ids are `e<counter>` strings, so a lexicographic sort would put e10 before e9).

## Test plan

- New `backend/tests/test_layout.py`: unit tests for the placement shapes and footprint chain, plus two hypothesis properties - spawned nodes never overlap for arbitrary measured sizes, and organize always yields an overlap-free, deterministic layout for arbitrary scenes (cycles and multi-parent edges included).
- Regression tests: first-edge-wins parent selection, collapsed-pill footprint.
- Updated placement assertions in `test_canvas.py` / `test_builder.py` / `test_plugins.py` to the footprint-based contract.
- Full suite: 3056 passed, 19 skipped.
- Verified live against the dev server: composer sends land clear of existing content and Organize produces an overlap-free parent/child layout on the sample workspace.