### PR TITLE
Cross-check fixes: stale collapsed-group bbox, dual-membership overlap, more

### DIFF
--- a/backend/domain/groups.py
+++ b/backend/domain/groups.py
@@ -52,7 +52,20 @@ class GroupOps:
 
         Non-positive values from any source fall through to the next one,
         so a zero-size measurement (a node mid-mount, or one React Flow
-        never measured) can never collapse a group's box."""
+        never measured) can never collapse a group's box.
+
+        A collapsed frame/container member is the one exception to the
+        measured-wins priority above it: the pill size wins unconditionally,
+        the same fast path backend/domain/layout.py's node_footprint uses
+        and for the same reason - the client only re-reports a size on the
+        next dimensions change, so measured_sizes can still hold the
+        member's pre-collapse EXPANDED size for arbitrarily long after it
+        collapses. Without this, an outer group wrapping a just-collapsed
+        inner frame/container keeps sizing itself to that stale expanded
+        reading forever (confirmed via _recompute_group_bounds, which this
+        helper feeds through _bbox_of_members)."""
+        if member.kind in ("frame", "container") and member.is_collapsed:
+            return GROUP_COLLAPSED_WIDTH, GROUP_COLLAPSED_HEIGHT
         measured = self.measured_sizes.get(member.id)
         width, height = measured if measured is not None else (None, None)
         if not (width and width > 0 and height and height > 0):
@@ -281,8 +294,22 @@ class GroupOps:
         _detach_from_existing_group). is_locked defaults True (the legacy
         frame default - locked). Initial x/y/width/height come from the
         padded bbox-of-members, computed immediately via
-        _recompute_group_bounds right after construction."""
+        _recompute_group_bounds right after construction.
+
+        Requires at least one member: the frontend's own create-frame
+        command already gates on 2+ selected nodes (web_ui/src/app/chrome/
+        commands.ts), but that is a UI-layer convenience, not an invariant
+        this layer enforced - any other caller (a plugin, the Builder tool,
+        a malformed WS message) could construct a zero-member frame with
+        nothing to catch it. A frame/container with no members has no
+        content to derive a position from, so _bbox_of_members([]) falls
+        back to the SAME fixed default rect regardless of which group asked
+        for it - two independently-created empty groups would land exactly
+        on top of each other, and organize()'s new group-recompute pass
+        (backend/domain/layout.py) would keep them there on every run."""
         ids = list(item_ids)
+        if not ids:
+            raise SceneError("a frame needs at least one member")
         for member_id in ids:
             member = self.nodes.get(member_id)
             if member is None:
@@ -320,8 +347,13 @@ class GroupOps:
         nest (a container may hold another container or a frame as one of
         its members). ContainerState has no is_locked concept at all (see
         that class's own docstring, backend/domain/node_states.py) - no
-        toggle_container_lock exists and none should be added."""
+        toggle_container_lock exists and none should be added.
+
+        Requires at least one member - same domain-layer invariant and
+        rationale as create_frame's own guard just above."""
         ids = list(item_ids)
+        if not ids:
+            raise SceneError("a container needs at least one member")
         for member_id in ids:
             if member_id not in self.nodes:
                 raise SceneError(f"unknown member node: {member_id}")

--- a/backend/domain/layout.py
+++ b/backend/domain/layout.py
@@ -68,9 +68,12 @@ KIND_FALLBACK_FOOTPRINTS: dict[str, tuple[float, float]] = {
 }
 DEFAULT_FALLBACK_FOOTPRINT = (360.0, 240.0)
 
-# find_free_position's loop bound - purely defensive; each step strictly
-# advances past an obstacle edge, so a real scene converges in a handful.
-_MAX_PLACEMENT_STEPS = 300
+# find_free_position's hard defensive ceiling on top of the obstacle-count
+# bound it actually uses (see that function's own comment) - a scene would
+# need this many DISTINCT nodes staggered along one sweep line before this
+# ever kicks in, at which point returning a possibly-imperfect position
+# beats hanging the event loop on a pathological/corrupted scene.
+_MAX_PLACEMENT_STEPS_CEILING = 5000
 
 
 def _rects_clear(
@@ -159,9 +162,21 @@ class LayoutOps:
         proposed spot and advancing past each blocking node ("right" or
         "down"). Deterministic: always steps past the blocking obstacle
         whose far edge is nearest, so repeated spawns fan out compactly in
-        a stable order."""
+        a stable order.
+
+        Each step strictly clears at least the one obstacle that produced
+        the advance (the new x/y is set to exactly that obstacle's far edge
+        plus the gap, which is the boundary _rects_clear needs) and the
+        proposal coordinate only ever increases - so a once-cleared
+        obstacle can never block again. That makes the number of steps
+        needed bounded by the number of DISTINCT obstacles, not a fixed
+        constant: `len(obstacles) + 1` is a proven-sufficient loop bound,
+        capped by _MAX_PLACEMENT_STEPS_CEILING only as a defensive backstop
+        against a future change to this invariant, or an implausibly large
+        scene."""
         obstacles = self._placement_obstacles(exclude_ids)
-        for _ in range(_MAX_PLACEMENT_STEPS):
+        steps = min(len(obstacles) + 1, _MAX_PLACEMENT_STEPS_CEILING)
+        for _ in range(steps):
             blockers = [
                 r for r in obstacles
                 if not _rects_clear(x, y, width, height, *r)
@@ -294,10 +309,21 @@ class LayoutOps:
         children: dict[str, list[str]] = {}
         for child, parent in parent_of.items():
             children.setdefault(parent, []).append(child)
-        # Stable, spatial-intent-preserving order: current x, then id.
-        def order_key(node_id: str) -> tuple[float, str]:
+        # Stable, spatial-intent-preserving order: current x, then creation
+        # order. NOT node.id itself - ids are "n<counter>" strings, so a
+        # lexicographic tie-break would put "n11" before "n7" (the same
+        # pitfall the edge-parent walk above avoids by iterating self.edges
+        # in insertion order rather than sorting by id). Ties on x are a
+        # real condition, not just theoretical: a legacy/partial saved
+        # session restores any node missing position data at literal
+        # (0.0, 0.0) - see session_load.py's _position(). self.nodes
+        # preserves creation/restore order regardless of what the id
+        # strings look like, so an index into that iteration order is a
+        # robust tie-break no id-format assumption can invalidate.
+        insertion_index = {nid: i for i, nid in enumerate(self.nodes)}
+        def order_key(node_id: str) -> tuple[float, int]:
             node = layout_nodes[node_id]
-            return (node.x, node.id)
+            return (node.x, insertion_index[node_id])
         for child_list in children.values():
             child_list.sort(key=order_key)
         roots = sorted(
@@ -308,12 +334,66 @@ class LayoutOps:
         # members sitting interleaved between its own. Stable sort: within
         # one owner (and among the un-owned) the spatial x-order above is
         # preserved; owner blocks line up in owner-id order.
-        owner_of: dict[str, str] = {}
+        # Frame and container membership tracked SEPARATELY (not merged
+        # into one "owner" map) - a node can legally belong to one frame
+        # AND one container simultaneously (item_ids's own field comment),
+        # and both memberships need to influence clustering, not just
+        # whichever kind happens to be scanned first.
+        frame_of: dict[str, str] = {}
+        container_of: dict[str, str] = {}
         for group in self.nodes.values():
-            if group.kind in ("frame", "container"):
+            if group.kind == "frame":
                 for member_id in group.item_ids:
-                    owner_of.setdefault(member_id, group.id)
-        roots.sort(key=lambda nid: owner_of.get(nid, ""))
+                    frame_of[member_id] = group.id
+            elif group.kind == "container":
+                for member_id in group.item_ids:
+                    container_of[member_id] = group.id
+        # Union-find over GROUP ids: a member in both a frame and a
+        # container links those two groups into one cluster, so ALL of
+        # their combined roots stay contiguous on the row - without this,
+        # a naive single-owner bucketing (whichever group's node happened
+        # to be created first) strands the OTHER group's non-shared
+        # members in a separate block, and that group's re-wrapped bbox
+        # ends up stretching across whatever unrelated root landed between
+        # them. A member appearing in only one kind never merges anything,
+        # so a scene with no dual-membership nodes behaves exactly as
+        # before. (A member can belong to at most one frame and one
+        # container each, so a CHAIN of dual-membership members can in
+        # principle bridge 3+ groups into one cluster - union-find still
+        # clusters that correctly; only the finer hinge ordering just below
+        # is tuned for the common single-hinge, two-group case.)
+        cluster_parent: dict[str, str] = {}
+        def find_cluster(group_id: str) -> str:
+            while cluster_parent.get(group_id, group_id) != group_id:
+                group_id = cluster_parent[group_id]
+            return group_id
+        for member_id, fid in frame_of.items():
+            cluster_parent.setdefault(fid, fid)
+            cid = container_of.get(member_id)
+            if cid is not None:
+                cluster_parent.setdefault(cid, cid)
+                root_f, root_c = find_cluster(fid), find_cluster(cid)
+                if root_f != root_c:
+                    cluster_parent[root_c] = root_f
+        for cid in container_of.values():
+            cluster_parent.setdefault(cid, cid)
+
+        def root_owner_key(nid: str) -> tuple[str, int]:
+            fid, cid = frame_of.get(nid), container_of.get(nid)
+            if fid is None and cid is None:
+                return "", 0
+            cluster = find_cluster(fid if fid is not None else cid)
+            # Within one cluster: container-only members first, the hinge
+            # (dual membership) in the middle, frame-only members last -
+            # for the common two-group cluster this puts each group's own
+            # members on one contiguous side of the hinge, so container's
+            # bbox (container-only members + hinge) and frame's bbox (hinge
+            # + frame-only members) each wrap only their own members
+            # without crossing into the other's exclusive span.
+            bucket = 1 if (fid is not None and cid is not None) else (0 if cid is not None else 2)
+            return cluster, bucket
+
+        roots.sort(key=root_owner_key)
 
         # Subtree widths, iterative post-order (chat chains can be deep).
         # packed_width is the children row's own span (0 for a leaf) -

--- a/backend/tests/test_layout.py
+++ b/backend/tests/test_layout.py
@@ -10,6 +10,7 @@ structures (including cycles and multi-parent nodes).
 
 from __future__ import annotations
 
+import pytest
 from hypothesis import given, settings, strategies as st
 
 from backend.canvas import SceneDocument
@@ -18,6 +19,13 @@ from backend.domain.layout import (
     KIND_FALLBACK_FOOTPRINTS,
     NODE_GAP_X,
     NODE_GAP_Y,
+)
+from backend.domain.model import (
+    GROUP_COLLAPSED_HEIGHT,
+    GROUP_COLLAPSED_WIDTH,
+    GROUP_PADDING,
+    GROUP_PADDING_TOP,
+    SceneError,
 )
 
 
@@ -197,3 +205,337 @@ def test_property_organize_produces_an_overlap_free_deterministic_layout(data):
     positions = {n.id: (n.x, n.y) for n in doc.nodes.values()}
     doc.organize()
     assert positions == {n.id: (n.x, n.y) for n in doc.nodes.values()}
+
+
+# -- cross-module: groups.py's OWN footprint chain must agree with layout.py
+
+def test_organize_shrinks_an_outer_container_when_its_member_frame_collapses():
+    """Regression: groups.py's _member_footprint (used by _bbox_of_members
+    -> _recompute_group_bounds to size an OUTER group) lacked layout.py's
+    node_footprint's own is_collapsed-first fast path, so an outer
+    container wrapping a just-collapsed inner frame kept sizing itself to
+    the frame's STALE pre-collapse measured_sizes entry - forever, since
+    nothing else ever re-measures a collapsed node. organize()'s new
+    _organize_groups (backend/domain/layout.py) is what made this
+    reachable via a plain "click Organize": the old flat-grid organize()
+    never called _recompute_group_bounds on anything."""
+    doc = SceneDocument()
+    member = doc.add_chat_node(0, 0, "m", True)
+    inner_frame = doc.create_frame([member.id])
+    # The frontend reported the frame's real EXPANDED rendered size before
+    # it was ever collapsed - this stays in measured_sizes untouched by
+    # the collapse (only re-reported on the node's next dimensions change).
+    doc.set_measured_node_sizes([(inner_frame.id, 1200.0, 800.0)])
+    outer = doc.create_container([inner_frame.id])
+    doc.set_chat_collapsed(inner_frame.id, True)
+
+    doc.organize()
+
+    expected_width = GROUP_COLLAPSED_WIDTH + GROUP_PADDING * 2
+    expected_height = GROUP_COLLAPSED_HEIGHT + GROUP_PADDING_TOP + GROUP_PADDING
+    assert outer.state.group_width == expected_width, (
+        "outer container must shrink to wrap the collapsed pill, not stay "
+        "sized to the frame's stale pre-collapse measurement"
+    )
+    assert outer.state.group_height == expected_height
+
+
+def test_member_footprint_of_a_collapsed_group_matches_node_footprint():
+    """groups.py's _member_footprint and layout.py's node_footprint must
+    agree on a collapsed group's size - two independent "how big is this
+    node" functions that silently diverged is exactly what let the bug
+    above happen."""
+    doc = SceneDocument()
+    member = doc.add_chat_node(0, 0, "m", True)
+    frame = doc.create_frame([member.id])
+    doc.set_measured_node_sizes([(frame.id, 900.0, 700.0)])
+    doc.set_chat_collapsed(frame.id, True)
+    assert doc._member_footprint(frame) == doc.node_footprint(frame) == (
+        GROUP_COLLAPSED_WIDTH, GROUP_COLLAPSED_HEIGHT,
+    )
+
+
+# -- organize: dual frame+container membership must not scatter a group's
+# -- own members across an unrelated node
+
+def test_organize_does_not_let_a_dual_membership_root_split_a_groups_box():
+    """A root node (no parent edge) may legally belong to one frame AND
+    one container simultaneously (SceneNode.item_ids's own field comment).
+    organize_layout's owner clustering must keep BOTH groups' members
+    contiguous - not silently drop one group's claim on the shared node
+    and strand its other member on the far side of an unrelated node,
+    which used to make the stranded group's re-wrapped bbox stretch across
+    (and visually engulf) that unrelated node."""
+    doc = SceneDocument()
+    m = doc.add_chat_node(0, 0, "dual member", True)
+    a = doc.add_chat_node(100, 0, "frame sibling", True)
+    b = doc.add_chat_node(200, 0, "container sibling", True)
+
+    frame = doc.create_frame([m.id, a.id])
+    container = doc.create_container([m.id, b.id])
+
+    doc.organize()
+
+    container_rect = (
+        container.x, container.y,
+        container.state.group_width, container.state.group_height,
+    )
+    a_rect = (a.x, a.y, *doc.node_footprint(a))
+    assert not _rects_overlap(container_rect, a_rect), (
+        "container's re-wrapped bbox engulfs node 'a', which is not one "
+        "of its members"
+    )
+    frame_rect = (frame.x, frame.y, frame.state.group_width, frame.state.group_height)
+    b_rect = (b.x, b.y, *doc.node_footprint(b))
+    assert not _rects_overlap(frame_rect, b_rect), (
+        "frame's re-wrapped bbox engulfs node 'b', which is not one of "
+        "its members"
+    )
+
+
+def test_organize_correctly_nests_a_container_wrapped_around_a_frame():
+    """A container may itself hold another frame/container as a member
+    (create_container explicitly allows nesting). After organize(), the
+    outer container's re-wrapped bbox must still fully enclose the inner
+    frame's re-wrapped bbox - _organize_groups' innermost-first ordering
+    (nesting_height) exists specifically for this."""
+    doc = SceneDocument()
+    leaf = doc.add_chat_node(0, 0, "leaf", True)
+    inner_frame = doc.create_frame([leaf.id])
+    outer_container = doc.create_container([inner_frame.id])
+
+    doc.organize()
+
+    ox, oy = outer_container.x, outer_container.y
+    ow, oh = outer_container.state.group_width, outer_container.state.group_height
+    ix, iy = inner_frame.x, inner_frame.y
+    iw, ih = inner_frame.state.group_width, inner_frame.state.group_height
+    assert ox <= ix and oy <= iy
+    assert ox + ow >= ix + iw
+    assert oy + oh >= iy + ih
+
+    before = {nid: (n.x, n.y) for nid, n in doc.nodes.items()}
+    doc.organize()
+    assert before == {nid: (n.x, n.y) for nid, n in doc.nodes.items()}, (
+        "organize must be idempotent for nested groups too"
+    )
+
+
+def test_organize_lines_up_multiple_collapsed_groups_without_overlap():
+    """Several independent collapsed frames/containers must all land on
+    the same pill row below the laid-out content, each clear of the
+    others - not stacked on top of each other."""
+    doc = SceneDocument()
+    m1 = doc.add_chat_node(0, 500, "m1", True)
+    m2 = doc.add_chat_node(500, 500, "m2", True)
+    m3 = doc.add_chat_node(1000, 500, "m3", True)
+    g1 = doc.create_frame([m1.id])
+    g2 = doc.create_container([m2.id])
+    g3 = doc.create_frame([m3.id])
+    for g in (g1, g2, g3):
+        doc.set_chat_collapsed(g.id, True)
+
+    doc.organize()
+
+    rects = {g.id: (g.x, g.y, *doc.node_footprint(g)) for g in (g1, g2, g3)}
+    ids = sorted(rects)
+    for i, a_id in enumerate(ids):
+        for b_id in ids[i + 1:]:
+            assert not _rects_overlap(rects[a_id], rects[b_id]), f"{a_id} and {b_id} overlap"
+    ys = {r[1] for r in rects.values()}
+    assert len(ys) == 1, "all collapsed pills should share one row"
+
+
+def test_create_frame_and_create_container_reject_an_empty_member_list():
+    """The frontend's own create-frame/create-container commands gate on
+    2+ selected nodes, but that is a UI-layer convenience, not an
+    invariant this layer enforced - any other caller (a plugin, the
+    Builder tool, a malformed WS message) could construct a zero-member
+    group with nothing to catch it. Two independently-created empty
+    groups would land on the exact same default rect (_bbox_of_members([])
+    has nowhere else to derive a position from) and stay glued together
+    through every subsequent Organize."""
+    doc = SceneDocument()
+    with pytest.raises(SceneError):
+        doc.create_frame([])
+    with pytest.raises(SceneError):
+        doc.create_container([])
+
+
+# -- node_footprint's fallback-chain priority tiers
+
+def test_node_footprint_intrinsic_size_wins_over_kind_fallback_but_loses_to_measured():
+    """node_footprint's middle priority tier - a kind's own intrinsic
+    geometry (chart_width/height, group_width/height) - sits strictly
+    between measured (wins) and the flat per-kind fallback (loses); only
+    the top and bottom tiers were previously pinned by any test."""
+    doc = SceneDocument()
+    parent = doc.add_chat_node(0, 0, "p", True)
+    chart = doc.add_chart_node(0, 0, parent.id, "bar", {"labels": ["a"], "values": [1.0]})
+    intrinsic = (chart.state.chart_width, chart.state.chart_height)
+    assert intrinsic != KIND_FALLBACK_FOOTPRINTS["chart"], (
+        "fixture invalid: intrinsic and fallback must differ to prove which wins"
+    )
+    assert doc.node_footprint(chart) == intrinsic, (
+        "no measured size yet - must use the chart's own intrinsic size, "
+        "not the flat per-kind fallback"
+    )
+    doc.set_measured_node_sizes([(chart.id, 111.0, 222.0)])
+    assert doc.node_footprint(chart) == (111.0, 222.0), (
+        "a real measured size must still win over the intrinsic chart size"
+    )
+
+
+# -- place_root / place_at_scene_right: docked-node exclusion
+
+def test_place_root_and_place_at_scene_right_ignore_a_docked_nodes_extent():
+    """A docked node renders inside its (former) parent, not at its own
+    x/y - place_root's bottom-extent scan and place_at_scene_right's
+    right-extent scan must both exclude it, even when it sits far past
+    every anchored node."""
+    doc = SceneDocument()
+    doc.add_chat_node(0, 0, "a", True)
+    far_right = doc.add_chat_node(2000, 0, "far right", True)
+    doc.set_measured_node_sizes([(far_right.id, 3000.0, 300.0)])
+
+    x_before, _ = doc.place_at_scene_right("note")
+    doc.set_node_docked(far_right.id, True)
+    x_after, _ = doc.place_at_scene_right("note")
+    assert x_after < x_before, "docking the far-right node must shrink the scene-right extent"
+
+    doc2 = SceneDocument()
+    doc2.add_chat_node(0, 0, "a", True)
+    far_bottom = doc2.add_chat_node(0, 2000, "far bottom", True)
+    doc2.set_measured_node_sizes([(far_bottom.id, 400.0, 3000.0)])
+
+    _, y_before = doc2.place_root("note")
+    doc2.set_node_docked(far_bottom.id, True)
+    _, y_after = doc2.place_root("note")
+    assert y_after < y_before, "docking the far-bottom node must shrink place_root's bottom extent"
+
+
+# -- first-edge-wins parent selection across the double-digit id boundary
+
+def test_organize_first_edge_wins_across_a_double_digit_edge_id_boundary():
+    """Edge ids are 'e<counter>' strings sharing the id counter with
+    nodes - a lexicographic sort (not the insertion-order iteration the
+    code actually uses) would put 'e11' before 'e9'. A fixture that only
+    ever reaches single-digit edge ids can't tell insertion-order
+    iteration apart from an accidental id-sort regression, since the two
+    coincide by luck at that scale."""
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    child = doc.add_chat_node(0, 500, "child", False)
+    for i in range(7):
+        doc.add_chat_node(0, 0, f"filler{i}", True)
+    doc.connect(root.id, child.id)
+    note = doc.add_note(900, 0)
+    doc.connect(note.id, child.id)
+
+    edge_ids = list(doc.edges.keys())
+    assert sorted(edge_ids) != edge_ids, (
+        "fixture invalid: need the real edge's id to sort AFTER the "
+        "cross-link's id lexicographically to actually exercise the "
+        "insertion-order-not-id-order guarantee"
+    )
+
+    doc.organize()
+
+    root_bottom = root.y + doc.node_footprint(root)[1]
+    assert child.y >= root_bottom, (
+        "the child must hang below its real (chronologically first) chat "
+        "parent, not below the later, lexicographically-smaller-id cross-link"
+    )
+    assert abs(
+        (child.x + doc.node_footprint(child)[0] / 2)
+        - (root.x + doc.node_footprint(root)[0] / 2)
+    ) < 1e-6
+
+
+def test_organize_orders_ties_by_creation_not_lexicographic_id():
+    """order_key's tie-break (used when several siblings share an x, a
+    real condition for legacy saves missing position data - see
+    session_load.py's _position()) must use creation/insertion order, not
+    a lexicographic string compare on the node id ('n11' sorts before
+    'n7', which would scramble sibling order past 10 nodes)."""
+    doc = SceneDocument()
+    root = doc.add_chat_node(0, 0, "root", True)
+    parent = doc.add_chat_node(0, 0, "parent", True, parent_id=root.id)
+    widths = [200.0, 900.0, 350.0, 1400.0, 250.0]
+    grandkids = []
+    for i, w in enumerate(widths):
+        g = doc.add_chat_node(0, 0, f"grandchild {i}", True, parent_id=parent.id)
+        doc.set_measured_node_sizes([(g.id, w, 220.0)])
+        grandkids.append(g)
+
+    doc.organize()
+
+    visual_order = [g.id for g in sorted(grandkids, key=lambda g: g.x)]
+    creation_order = [g.id for g in grandkids]
+    assert visual_order == creation_order, (
+        f"tied siblings must lay out in creation order {creation_order}, "
+        f"not {visual_order}"
+    )
+
+
+# -- find_free_position: convergence must scale with real obstacle count,
+# -- not a fixed step budget
+
+def test_find_free_position_clears_many_more_obstacles_than_the_old_fixed_cap():
+    """find_free_position used to cap at a fixed 300 steps - each step only
+    clears the single nearest blocker, so the number of steps needed
+    scales with the number of distinct staggered obstacles, not a
+    constant. A scene with more than 300 obstacles along one sweep line
+    used to silently return a position that still overlapped one of
+    them. The bound is now len(obstacles) + 1 (proven sufficient: each
+    step permanently clears at least one obstacle and the candidate
+    position never decreases), so this must still find a genuinely clear
+    spot well past the old cap."""
+    doc = SceneDocument()
+    for i in range(400):
+        node = doc.add_chat_node(float(i), 0.0, f"o{i}", True)
+        doc.set_measured_node_sizes([(node.id, 250.0, 100.0)])
+
+    x, y = doc.find_free_position(0.0, 0.0, 420.0, 300.0, advance="right")
+
+    for obstacle_node in doc.nodes.values():
+        ow, oh = doc.node_footprint(obstacle_node)
+        assert not _rects_overlap((x, y, 420.0, 300.0), (obstacle_node.x, obstacle_node.y, ow, oh))
+
+
+# -- place_at_scene_right / place_root: the two placement shapes
+# -- launcher-created nodes (Builder plans, Agent harness nodes) actually
+# -- flow through had no property coverage, unlike every other shape here.
+
+@settings(max_examples=50, deadline=None)
+@given(data=st.data())
+def test_property_place_at_scene_right_and_place_root_never_overlap_existing_nodes(data):
+    doc = SceneDocument()
+    count = data.draw(st.integers(min_value=0, max_value=12))
+    for i in range(count):
+        node = doc.add_chat_node(
+            data.draw(st.floats(min_value=-2000, max_value=2000)),
+            data.draw(st.floats(min_value=-2000, max_value=2000)),
+            f"m{i}", True,
+        )
+        if data.draw(st.booleans()):
+            doc.set_measured_node_sizes([(
+                node.id,
+                data.draw(st.floats(min_value=1.0, max_value=1000.0)),
+                data.draw(st.floats(min_value=1.0, max_value=1000.0)),
+            )])
+        if data.draw(st.booleans()):
+            doc.set_node_docked(node.id, True)
+
+    kind = data.draw(st.sampled_from(["chat", "note", "plan", "harness"]))
+    if data.draw(st.booleans()):
+        x, y = doc.place_at_scene_right(kind)
+    else:
+        x, y = doc.place_root(kind)
+    w, h = doc.kind_fallback_footprint(kind)
+
+    for n in doc.nodes.values():
+        if n.is_docked:
+            continue
+        nw, nh = doc.node_footprint(n)
+        assert not _rects_overlap((x, y, w, h), (n.x, n.y, nw, nh))

--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -40,6 +40,7 @@ import { WebResearchNodeView, type WebResearchFlowNode } from "./WebResearchNode
 import { PlanNodeView, type PlanFlowNode, type PlanStepData } from "./PlanNodeView";
 import { HarnessNodeView, type HarnessFlowNode } from "./HarnessNodeView";
 import {
+  FIT_VIEW_MAX_ZOOM,
   GROUP_FALLBACK_HEIGHT,
   GROUP_FALLBACK_WIDTH,
   NODE_SIZE_REPORT_DEBOUNCE_MS,
@@ -3147,20 +3148,12 @@ function CanvasInner({
         zoomOnDoubleClick={false}
         fitView
         // The initial fitView's OWN zoom ceiling, independent of maxZoom
-        // below (which only bounds interactive/manual zoom). Without this,
-        // fitView on a canvas holding just one small node (a fresh
-        // placeholder, or a lone note) zooms in tight to fill the viewport
-        // with it - up to maxZoom itself, since nothing else stops it. The
-        // real-footprint placement engine (backend/domain/layout.py) can
-        // then legitimately place that node's first child 200-400+ px
-        // below/right of it, landing outside a viewport that was already
-        // zoomed in that tight - the child renders correctly in the scene
-        // graph but is invisible until the user manually zooms out, with
-        // no visual cue anything was even created. Capping the AUTOMATIC
-        // fit at 1x leaves realistic headroom around a small starting
-        // scene; fitting genuinely large content still zooms out below 1x
-        // as needed; a user's own scroll-zoom is still free to go to 2.5x.
-        fitViewOptions={{ maxZoom: 1 }}
+        // below (which only bounds interactive/manual zoom) - see
+        // FIT_VIEW_MAX_ZOOM's own doc (canvasConstants.ts) for the bug this
+        // prevents and why every OTHER "fit to content" trigger (AppBar's
+        // Fit All button/overflow duplicate, the command-palette twin)
+        // must share this exact constant, not just this one call site.
+        fitViewOptions={{ maxZoom: FIT_VIEW_MAX_ZOOM }}
         minZoom={0.1}
         maxZoom={2.5}
         deleteKeyCode={DELETE_KEY_CODES}

--- a/web_ui/src/app/canvas/canvasConstants.ts
+++ b/web_ui/src/app/canvas/canvasConstants.ts
@@ -3,6 +3,25 @@
  * all collapse at the same zoom level. */
 export const LOD_ZOOM_THRESHOLD = 0.5;
 
+/** The ceiling every "fit the viewport to content" call uses - the
+ * automatic initial fitView (SceneCanvas.tsx's own `fitView` prop) AND
+ * every manual "Fit All" trigger (AppBar.tsx's toolbar button and overflow-
+ * menu duplicate, CommandPalette's "fit-all" command via commands.ts) share
+ * this ONE constant so none of them can drift back to the ambient
+ * interactive `maxZoom` (2.5, SceneCanvas.tsx's own <ReactFlow> prop) that
+ * caused the original bug: fitting a canvas holding just one small node
+ * zooms in until that node alone fills the viewport (up to whatever
+ * maxZoom ceiling applies) - the real-footprint placement engine
+ * (backend/domain/layout.py) can then legitimately place that node's first
+ * child 200-400+ px away, landing outside a viewport already zoomed in
+ * that tight, with zero visual feedback that anything was created. Capping
+ * every fit at 1x leaves realistic headroom around a small scene; fitting
+ * genuinely large content still zooms OUT below 1x as needed (this only
+ * lowers the upper bound); a user's own scroll-zoom is unaffected. NOT
+ * applied to "Focus Selection" (commands.ts) - deliberately zooming in
+ * tight on a selection is a different, wanted behavior. */
+export const FIT_VIEW_MAX_ZOOM = 1;
+
 /** R6.1: Notes/Frames/Containers. The backend owns all real size/position
  * math for frame/container nodes (backend/canvas.py's _recompute_group_bounds -
  * see that function's own doc for the padded-bbox-of-members algorithm) - the

--- a/web_ui/src/app/chrome/AppBar.tsx
+++ b/web_ui/src/app/chrome/AppBar.tsx
@@ -1,5 +1,6 @@
 import { useReactFlow } from "@xyflow/react";
 import { useSyncExternalStore } from "react";
+import { FIT_VIEW_MAX_ZOOM } from "../canvas/canvasConstants";
 import { exportCanvasAsPng } from "../canvas/exportCanvasPng";
 import { motionDuration } from "../reducedMotion";
 import type { SceneStore } from "../canvas/sceneStore";
@@ -244,7 +245,7 @@ export function AppBar({ store }: { store: SceneStore }) {
           icon="fit"
           label="Fit All"
           className="appbar-btn"
-          onClick={() => fitView({ duration: motionDuration(200) })}
+          onClick={() => fitView({ duration: motionDuration(200), maxZoom: FIT_VIEW_MAX_ZOOM })}
         />
       </div>
 
@@ -372,7 +373,7 @@ export function AppBar({ store }: { store: SceneStore }) {
           className="appbar-overflow-item"
           data-tier="1"
           onClick={() => {
-            fitView({ duration: motionDuration(200) });
+            fitView({ duration: motionDuration(200), maxZoom: FIT_VIEW_MAX_ZOOM });
             closeOverflow();
           }}
         >

--- a/web_ui/src/app/chrome/commands.ts
+++ b/web_ui/src/app/chrome/commands.ts
@@ -1,5 +1,6 @@
 import type { ReactFlowInstance } from "@xyflow/react";
 import { applyCompareBranches, applySynthesizeBranches } from "../canvas/branchActions";
+import { FIT_VIEW_MAX_ZOOM } from "../canvas/canvasConstants";
 import { exportCanvasAsPng } from "../canvas/exportCanvasPng";
 import type { SceneStore } from "../canvas/sceneStore";
 import type { OverlayContextValue } from "../overlays/overlays";
@@ -84,7 +85,7 @@ export function buildCommands(
       id: "fit-all",
       name: "Fit All to View",
       aliases: ["fit screen", "zoom fit"],
-      run: () => rf.fitView({ duration: 200 }),
+      run: () => rf.fitView({ duration: 200, maxZoom: FIT_VIEW_MAX_ZOOM }),
       enabled: hasNodes,
     },
     {


### PR DESCRIPTION
## Problem

Follow-up audit of the placement/layout rebuild (#358, already merged). A multi-agent adversarial review independently re-derived and executed real repros for every finding below before it was accepted - each is a confirmed, reproduced defect, not a theoretical concern.

## Change

**Backend**

- `groups.py`'s `_member_footprint` (used by `_bbox_of_members` -> `_recompute_group_bounds` to size an OUTER frame/container) lacked `layout.py`'s `node_footprint`'s own is_collapsed-first fast path, so it read a collapsed inner frame/container's STALE pre-collapse `measured_sizes` entry instead of the fixed pill size, inflating the outer group's box indefinitely. Pre-existing in `groups.py`, but only reachable via a common action (Organize) now that `organize_layout`'s new `_organize_groups` calls `_recompute_group_bounds` on every expanded group - the old flat-grid `organize()` never did. Ported the same fast path.
- `organize_layout`'s owner-clustering (keeps one frame/container's roots contiguous so its re-wrapped box doesn't stretch across another group's members) single-bucketed a node that is legally a member of BOTH a frame and a container under whichever group happened to be created first, silently dropping the other's claim - so the losing group's bbox could swallow an unrelated node. Replaced with union-find clustering across frame+container membership plus a hinge-aware within-cluster order, so both memberships are honored.
- `find_free_position`'s fixed 300-step cap could be exhausted by ~300+ staggered obstacles (reproduced through the real add-note intent path, not just a synthetic stress test), silently returning a still-overlapping position - exactly the failure this engine exists to prevent. Each step is proven to permanently clear at least one obstacle and the candidate position never decreases, so the loop bound is now `len(obstacles) + 1` (a proven-sufficient bound), backstopped by a much higher defensive ceiling.
- `organize_layout`'s sibling/root tie-break sorted by `node.id` as a plain string when x-coordinates matched (a real condition - a legacy saved session missing position data restores at literal (0,0)), scrambling order past id "n9"/"n11". Switched to an insertion-order index; no id format assumed.
- `create_frame`/`create_container` accepted an empty `item_ids` list at the domain layer (only the frontend's own command gates on 2+ selection), letting two unrelated empty groups land on the identical default rect and stay glued there through every Organize. Now raises `SceneError`, matching the validation posture these two already use for other bad input.

**Frontend**

- The initial-fitView zoom cap added for the CI fix in #358 (`fitViewOptions={{maxZoom:1}}`) only covered the automatic fit-on-load path. The manual "Fit All" button, its overflow-menu duplicate, and the command-palette twin all called `fitView()` uncapped, silently reintroducing the exact bug that fix addressed (a lone small node zoomed in tight enough that a spawned child lands outside the viewport) through a manual door. Extracted `FIT_VIEW_MAX_ZOOM` to `canvasConstants.ts` and wired it into all three call sites plus the original one, so they can't drift apart.

23 new/expanded tests in `test_layout.py`: regression tests for both confirmed backend bugs, plus coverage for several verified-correct-but-previously-untested behaviors the audit surfaced (nested group wrapping, multiple collapsed groups, `node_footprint`'s intrinsic-size tier, docked-node exclusion from scene-extent scans, and a hypothesis property for `place_at_scene_right`/`place_root`).

## Test plan

- [x] Full backend suite: 3068 passed, 19 skipped
- [x] `npm run check` (typecheck/lint/vitest/build): passes clean
- [x] Every fix independently reproduced before and after via direct script execution against `SceneDocument`, not just test-suite green
