### PR TITLE
Fix the 3 confirmed-high findings from the debt audit

### DIFF
--- a/backend/domain/commands.py
+++ b/backend/domain/commands.py
@@ -79,7 +79,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, Iterable, TypeVar
 
-from backend.domain.node_states import PlanState
+from backend.domain.node_states import HarnessState, PlanState
 
 if TYPE_CHECKING:
     from backend.domain.model import SceneEdge, SceneNode
@@ -236,6 +236,29 @@ def _restore(live: dict, snapshot: dict) -> None:
                 restored.state.builder_awaiting_tool_approval = False
                 restored.state.builder_approval_tool_name = ""
                 restored.state.builder_approval_summary = ""
+            # Technical-debt audit finding: HarnessState's own docstring
+            # documents the IDENTICAL "non-terminal status describes a
+            # RunHandle that cannot survive a restart" contract as
+            # PlanState's builder_status (session_load.py's own load-time
+            # normalization already treats them the same way), but this
+            # PlanState-only branch was never mirrored for harness nodes -
+            # so undoing/redoing an unrelated edit made while a harness
+            # agent was running restored a snapshotted "running" status
+            # forever, with pending_request_id already cleared above and
+            # therefore no live run left that could ever advance it past
+            # that state. Same _guard_live_runs guarantee applies: a REAL
+            # run on this node would already have refused the undo/redo,
+            # so any snapshotted "running" reaching here is provably stale.
+            if isinstance(getattr(restored, "state", None), HarnessState) and restored.state.harness_status == "running":
+                restored.state.harness_status = "interrupted"
+                restored.state.harness_status_detail = (
+                    "Restored from undo/redo history - resume to continue."
+                )
+                restored.state.harness_awaiting_approval = False
+                restored.state.harness_approval_tool_name = ""
+                restored.state.harness_approval_summary = ""
+                restored.state.harness_awaiting_question = False
+                restored.state.harness_question = ""
             # review-fix (stage 8.7): builder_activity is documented as run
             # TELEMETRY, not reversible document content (PlanState's own
             # docstring: "deliberately left untouched by an undo, so the
@@ -255,12 +278,17 @@ def _restore(live: dict, snapshot: dict) -> None:
             # before it is replaced. A node that does not currently exist
             # (this restore is recreating a deleted one) has no "current" to
             # preserve, so the snapshot's own activity is used as-is - the
-            # only case where trusting the snapshot is correct.
+            # only case where trusting the snapshot is correct. Mirrored
+            # below for HarnessState.harness_activity, same rationale.
             current = live.get(key)
             if isinstance(getattr(restored, "state", None), PlanState) and isinstance(
                 getattr(current, "state", None), PlanState,
             ):
                 restored.state.builder_activity = current.state.builder_activity
+            if isinstance(getattr(restored, "state", None), HarnessState) and isinstance(
+                getattr(current, "state", None), HarnessState,
+            ):
+                restored.state.harness_activity = current.state.harness_activity
             live[key] = restored
 
 

--- a/backend/session_save.py
+++ b/backend/session_save.py
@@ -118,19 +118,28 @@ _ACTIVE_SAVE_ASSET_STORE: contextvars.ContextVar = contextvars.ContextVar(
     "graphlink_active_save_asset_store", default=None
 )
 
-# The 12 "regular" node kinds - everything that is NOT note/frame/container/
+# The 13 "regular" node kinds - everything that is NOT note/frame/container/
 # chart. Mirrors scene_index.py's own NODE_LIST_NAMES (7 kinds, the current,
-# post-R5-closeout surviving set) PLUS the 5 kinds R5-closeout deleted from
+# post-R5-closeout surviving set) PLUS the 6 kinds R5-closeout deleted from
 # the legacy app's own lists but which this backend still fully supports
 # (see this module's own docstring: a NEW-app save containing one of these
-# 5 will simply have that one node silently skipped if ever loaded back into
+# 6 will simply have that one node silently skipped if ever loaded back into
 # the CURRENT legacy app, matching legacy's own tolerant unrecognized-
 # node_type behavior - not a regression, since the legacy app's own load
-# path already lost the ability to restore these 5 kinds when R5-closeout
+# path already lost the ability to restore these 6 kinds when R5-closeout
 # deleted their deserializer branches).
+#
+# "harness" (PLAN-2026-08-24) was missing from this tuple entirely until a
+# technical-debt audit caught it: _serialize_harness_node/_restore_harness_
+# payload (both below/in session_load.py) were fully implemented and wired
+# into their own dispatch tables from the day the feature shipped, but
+# `all_nodes` (below) never included a harness node in the first place - so
+# every harness node a user created was silently dropped on the very next
+# autosave or manual Save, with no error anywhere. Restoring it here is the
+# entire fix; both serializer and restorer already existed and are correct.
 _REGULAR_KINDS = (
     "chat", "code", "document", "image", "thinking", "conversation", "html",
-    "web_research", "artifact", "gitlink", "code_sandbox", "plan",
+    "web_research", "artifact", "gitlink", "code_sandbox", "plan", "harness",
 )
 
 

--- a/backend/tests/test_commands.py
+++ b/backend/tests/test_commands.py
@@ -1106,3 +1106,37 @@ def test_undo_never_resurrects_a_snapshotted_run_owned_builder_status():
     assert document.nodes[node.id].state.builder_status == "interrupted", (
         "redo must not resurrect it either"
     )
+
+
+def test_undo_never_resurrects_a_snapshotted_run_owned_harness_status():
+    """Technical-debt audit finding: HarnessState's own docstring documents
+    the IDENTICAL "non-terminal status describes a RunHandle that cannot
+    survive a restart" contract as PlanState.builder_status above, but the
+    _restore normalization was PlanState-only until this fix - so an
+    ordinary, unrelated edit (e.g. dragging the node) recorded while a
+    harness agent was running left the SAME phantom-status hazard: undo
+    resurrected "running" forever, with no live run behind it and no
+    button (Stop only fires if pending_request_id is set, and that is
+    already correctly cleared) that could ever advance it."""
+    document = SceneDocument()
+    node = document.add_harness_node(0, 0, "goal", max_turns=5)
+    node.state.harness_status = "running"  # mid-run when this command was recorded
+
+    document.record_command(
+        "moveNode", "user", lambda: document.move_node(node.id, 50, 50),
+        node_ids=[node.id],
+    )
+    node.state.harness_status = "done"  # the run landed for real after recording
+
+    command = document.command_log[-1]
+    command.invert(document)
+    assert document.nodes[node.id].x == 0.0
+    assert document.nodes[node.id].state.harness_status == "interrupted", (
+        "undo must not resurrect a run-owned status no live run backs"
+    )
+
+    command.apply(document)
+    assert document.nodes[node.id].x == 50.0
+    assert document.nodes[node.id].state.harness_status == "interrupted", (
+        "redo must not resurrect it either"
+    )

--- a/backend/tests/test_session_save.py
+++ b/backend/tests/test_session_save.py
@@ -74,6 +74,26 @@ def test_web_node_kind_translates_to_legacy_web_node_type():
     assert web_payload is not None
 
 
+def test_harness_node_survives_a_real_save_load_round_trip():
+    # Technical-debt audit finding: "harness" was never added to
+    # _REGULAR_KINDS, so every harness node was silently dropped from
+    # `all_nodes` and never appeared in the saved payload at all - not a
+    # missing field, the entire node. _serialize_harness_node/
+    # _restore_harness_payload were both already correct; they were simply
+    # never reached. Uses the real round trip, not a hand-built payload,
+    # as the strongest possible signal.
+    doc = SceneDocument()
+    doc.add_harness_node(0, 0, "investigate the flaky test", max_turns=9)
+
+    doc2 = _round_trip(doc)
+
+    restored = [n for n in doc2.nodes.values() if n.kind == "harness"]
+    assert len(restored) == 1, "the harness node must survive save/load, not vanish"
+    node = restored[0]
+    assert node.state.harness_goal == "investigate the flaky test"
+    assert node.state.harness_max_turns == 9
+
+
 def test_code_sandbox_sandbox_id_survives_a_real_save_load_round_trip():
     # ADR-005 stage 5.3 (review-fix): the whole point of
     # code_sandbox_sandbox_id - a scratch-dir key stable ACROSS a reload -


### PR DESCRIPTION
## Problem

Two silent, real bugs and one god-file, all confirmed by independent re-verification in the technical debt audit.

## Change

- **`session_save.py`**: `"harness"` was never added to `_REGULAR_KINDS`, so every harness node was silently dropped from every saved session - the whole node, not a field. The serializer and restorer were both already correct and fully wired; they were simply never reached.
- **`domain/commands.py`**: the undo/redo `_restore()` helper had a PlanState-only fix for a "phantom run status" hazard that was never mirrored onto `HarnessState`, despite its docstring documenting the identical contract. Undoing an unrelated edit made while a harness agent was running left the node permanently "Running" with a dead Stop button.
- **`api_provider.py`**'s god-file finding (4,322 lines, 8 unrelated concerns, ~60 importers) is confirmed but deliberately deferred to its own dedicated branch - it's a large, high-risk decomposition of the single most-imported file in the app.

## Test plan

- [x] New save/load round-trip regression test for harness nodes
- [x] New undo/redo regression test mirroring the existing PlanState one, for HarnessState
- [x] Full backend suite: 3069 passed, 19 skipped (one pre-existing, unrelated flaky mutation test, confirmed passing in isolation)