### PR TITLE
Fix medium-effort technical debt: shared-helper extractions and dedup

### DIFF
--- a/backend/agents.py
+++ b/backend/agents.py
@@ -657,25 +657,33 @@ class AgentDispatcher:
                 node.pending_request_id = None
             await bus.publish("scene")
 
-    def cancel_builder(self, request_id: str) -> None:
-        """Stop for the Builder: deny any parked approval first (cancel
-        means deny - the code_sandbox precedent), then the standard
-        release-on-cancel.
+    def _cancel_with_pending_approval_denied(self, request_id: str, kind: str) -> bool:
+        """Shared shape behind cancel_builder/cancel_harness/
+        cancel_code_sandbox: cancel means deny any parked approval FIRST
+        (before self._runs.cancel's own kind check below ever runs), then
+        the standard release-on-cancel.
 
-        The `handle.kind == "builder"` check is load-bearing, not defensive
+        The `handle.kind == kind` check is load-bearing, not defensive
         fluff: without it, a stale or foreign request_id belonging to a
-        DIFFERENT approval-gated kind (code_sandbox, harness) currently
-        parked mid-gate would have its approval_future wrongly resolved to
-        False here, before self._runs.cancel's own kind check below ever
-        runs - silently denying a human approval that was never meant for
-        this method at all."""
+        DIFFERENT approval-gated kind currently parked mid-gate would have
+        its approval_future wrongly resolved to False here - silently
+        denying a human approval that was never meant for this call at
+        all."""
         handle = self._runs.get(request_id)
         if (
-            handle is not None and handle.kind == "builder"
+            handle is not None and handle.kind == kind
             and handle.approval_future is not None and not handle.approval_future.done()
         ):
             handle.approval_future.set_result(False)
-        self._runs.cancel(request_id, kind="builder")
+        return self._runs.cancel(request_id, kind=kind)
+
+    def cancel_builder(self, request_id: str) -> None:
+        """Stop for the Builder: deny any parked approval first (cancel
+        means deny - the code_sandbox precedent), then the standard
+        release-on-cancel. See _cancel_with_pending_approval_denied for the
+        shared shape and its own docstring for why the kind check inside it
+        is load-bearing."""
+        self._cancel_with_pending_approval_denied(request_id, "builder")
 
     # -- PLAN-2026-08-24 H1: the agent harness -------------------------------
 
@@ -866,18 +874,10 @@ class AgentDispatcher:
     def cancel_harness(self, request_id: str) -> None:
         """Stop for a harness run: deny any parked approval first (cancel
         means deny - the code_sandbox/builder precedent), then the standard
-        release-on-cancel.
-
-        The `handle.kind == "harness"` check is load-bearing - see
-        cancel_builder's own docstring for the exact foreign-kind
-        approval-denial race this closes."""
-        handle = self._runs.get(request_id)
-        if (
-            handle is not None and handle.kind == "harness"
-            and handle.approval_future is not None and not handle.approval_future.done()
-        ):
-            handle.approval_future.set_result(False)
-        self._runs.cancel(request_id, kind="harness")
+        release-on-cancel. See _cancel_with_pending_approval_denied for the
+        shared shape - its own docstring covers the exact foreign-kind
+        approval-denial race the kind check inside it closes."""
+        self._cancel_with_pending_approval_denied(request_id, "harness")
 
     async def remove_code_sandbox_scratch_dir(self, sandbox_id: str) -> None:
         """ADR-005 stage 5.3: node-delete teardown for Execution Sandbox.
@@ -905,14 +905,9 @@ class AgentDispatcher:
         other dispatch surface (the checkpoint is a cancel_event check
         between stages, not a true mid-call interrupt) EXCEPT for the
         approval pause itself, which this DOES immediately and definitely
-        unblock by resolving approval_future."""
-        handle = self._runs.get(request_id)
-        if handle is None or handle.kind != "code_sandbox":
-            return False
-        future = handle.approval_future
-        if future is not None and not future.done():
-            future.set_result(False)
-        return self._runs.cancel(request_id, kind="code_sandbox")
+        unblock by resolving approval_future. See
+        _cancel_with_pending_approval_denied for the shared shape."""
+        return self._cancel_with_pending_approval_denied(request_id, "code_sandbox")
 
     def _resolve_approval(self, request_id: str, approved: bool) -> bool:
         """The shared approve/deny primitive backing approve_code_execution/
@@ -2141,128 +2136,144 @@ class AgentDispatcher:
     # why every Gitlink action - including these four - shares that one
     # field); it is set/cleared inline here rather than via a background task.
 
-    async def fetch_gitlink_repositories(self, *, bus: SessionBus, notifications_state, node) -> list[str]:
+    async def _run_gitlink_blocking_action(
+        self,
+        *,
+        bus: SessionBus,
+        notifications_state,
+        node,
+        action,
+        timeout: float,
+        timeout_message: str,
+        error_log_message: str,
+        error_notify_prefix: str,
+        default=None,
+    ):
+        """Shared skeleton behind the four PLAIN gitlink async methods below
+        (fetch_gitlink_repositories/load_gitlink_repo_tree/
+        import_gitlink_snapshot/build_gitlink_context) - see the comment
+        above `fetch_gitlink_repositories` for why these four (unlike
+        start_gitlink_run/start_gitlink_apply) claim node.pending_request_id
+        inline and are awaited directly by the caller, with no
+        RunRegistry/cancel_event involvement. `action` is a zero-arg async
+        callable doing the actual blocking work (already wrapped in
+        asyncio.to_thread by the caller, including any success-path
+        transform of the thread result); everything around it - the busy
+        marker claim/release, the "scene" publishes bracketing it, and the
+        timeout/exception -> notification handling - was identical across
+        all four before this extraction."""
         request_id = uuid.uuid4().hex
         node.pending_request_id = request_id
         await bus.publish("scene")
         try:
-            return await asyncio.wait_for(
-                asyncio.to_thread(_list_github_repositories, self._settings_manager),
-                timeout=GITLINK_REPO_LIST_TIMEOUT_SECONDS,
-            )
+            return await asyncio.wait_for(action(), timeout=timeout)
         except asyncio.TimeoutError:
-            notifications_state.show(
-                "Loading GitHub repositories stopped responding before the request completed. "
-                "Please try again.",
-                "error",
-            )
+            notifications_state.show(timeout_message, "error")
             await bus.publish("notification")
-            return []
+            return default
         except Exception as exc:
-            logger.exception("gitlink repository listing failed")
-            notifications_state.show(f"Failed to load GitHub repositories: {exc}", "error")
+            logger.exception(error_log_message)
+            notifications_state.show(f"{error_notify_prefix}: {exc}", "error")
             await bus.publish("notification")
-            return []
+            return default
         finally:
             node.pending_request_id = None
             await bus.publish("scene")
 
+    async def fetch_gitlink_repositories(self, *, bus: SessionBus, notifications_state, node) -> list[str]:
+        async def _action():
+            return await asyncio.to_thread(_list_github_repositories, self._settings_manager)
+
+        return await self._run_gitlink_blocking_action(
+            bus=bus,
+            notifications_state=notifications_state,
+            node=node,
+            action=_action,
+            timeout=GITLINK_REPO_LIST_TIMEOUT_SECONDS,
+            timeout_message=(
+                "Loading GitHub repositories stopped responding before the request completed. "
+                "Please try again."
+            ),
+            error_log_message="gitlink repository listing failed",
+            error_notify_prefix="Failed to load GitHub repositories",
+            default=[],
+        )
+
     async def load_gitlink_repo_tree(self, *, bus: SessionBus, notifications_state, node, repo: str, branch: str):
-        request_id = uuid.uuid4().hex
-        node.pending_request_id = request_id
-        await bus.publish("scene")
-        try:
-            return await asyncio.wait_for(
-                asyncio.to_thread(_load_gitlink_tree, self._settings_manager, repo, branch),
-                timeout=GITLINK_TREE_TIMEOUT_SECONDS,
-            )
-        except asyncio.TimeoutError:
-            notifications_state.show(
+        async def _action():
+            return await asyncio.to_thread(_load_gitlink_tree, self._settings_manager, repo, branch)
+
+        return await self._run_gitlink_blocking_action(
+            bus=bus,
+            notifications_state=notifications_state,
+            node=node,
+            action=_action,
+            timeout=GITLINK_TREE_TIMEOUT_SECONDS,
+            timeout_message=(
                 "Loading the repository file tree stopped responding before the request "
-                "completed. Please try again.",
-                "error",
-            )
-            await bus.publish("notification")
-            return None
-        except Exception as exc:
-            logger.exception("gitlink repo tree load failed")
-            notifications_state.show(f"Failed to load the repository file tree: {exc}", "error")
-            await bus.publish("notification")
-            return None
-        finally:
-            node.pending_request_id = None
-            await bus.publish("scene")
+                "completed. Please try again."
+            ),
+            error_log_message="gitlink repo tree load failed",
+            error_notify_prefix="Failed to load the repository file tree",
+            default=None,
+        )
 
     async def import_gitlink_snapshot(
         self, *, bus: SessionBus, notifications_state, node, repo: str, branch: str,
         local_root_hint: str, imported_root_hint: str,
     ):
-        request_id = uuid.uuid4().hex
-        node.pending_request_id = request_id
-        await bus.publish("scene")
-        try:
-            resolved_repo, resolved_branch, local_root_path = await asyncio.wait_for(
-                asyncio.to_thread(
-                    _ensure_gitlink_snapshot, self._settings_manager, repo, branch,
-                    local_root_hint, imported_root_hint,
-                ),
-                timeout=GITLINK_IMPORT_TIMEOUT_SECONDS,
+        async def _action():
+            resolved_repo, resolved_branch, local_root_path = await asyncio.to_thread(
+                _ensure_gitlink_snapshot, self._settings_manager, repo, branch,
+                local_root_hint, imported_root_hint,
             )
             return resolved_repo, resolved_branch, str(local_root_path)
-        except asyncio.TimeoutError:
-            notifications_state.show(
+
+        return await self._run_gitlink_blocking_action(
+            bus=bus,
+            notifications_state=notifications_state,
+            node=node,
+            action=_action,
+            timeout=GITLINK_IMPORT_TIMEOUT_SECONDS,
+            timeout_message=(
                 "Importing the repository snapshot stopped responding before the request "
-                "completed. Please try again.",
-                "error",
-            )
-            await bus.publish("notification")
-            return None
-        except Exception as exc:
-            logger.exception("gitlink snapshot import failed")
-            notifications_state.show(f"Failed to import the repository snapshot: {exc}", "error")
-            await bus.publish("notification")
-            return None
-        finally:
-            node.pending_request_id = None
-            await bus.publish("scene")
+                "completed. Please try again."
+            ),
+            error_log_message="gitlink snapshot import failed",
+            error_notify_prefix="Failed to import the repository snapshot",
+            default=None,
+        )
 
     async def build_gitlink_context(
         self, *, bus: SessionBus, notifications_state, node, scope_mode: str, selected_paths: list[str],
     ):
-        request_id = uuid.uuid4().hex
-        node.pending_request_id = request_id
-        await bus.publish("scene")
-        try:
-            return await asyncio.wait_for(
-                asyncio.to_thread(
-                    _build_gitlink_context_bundle,
-                    self._settings_manager,
-                    repo=node.state.gitlink_repo,
-                    branch=node.state.gitlink_branch,
-                    scope_mode=scope_mode,
-                    selected_paths=selected_paths,
-                    repo_file_paths=list(node.state.gitlink_repo_file_paths),
-                    local_root_hint=node.state.gitlink_local_root,
-                    imported_root_hint=node.state.gitlink_imported_root,
-                ),
-                timeout=GITLINK_CONTEXT_TIMEOUT_SECONDS,
+        async def _action():
+            return await asyncio.to_thread(
+                _build_gitlink_context_bundle,
+                self._settings_manager,
+                repo=node.state.gitlink_repo,
+                branch=node.state.gitlink_branch,
+                scope_mode=scope_mode,
+                selected_paths=selected_paths,
+                repo_file_paths=list(node.state.gitlink_repo_file_paths),
+                local_root_hint=node.state.gitlink_local_root,
+                imported_root_hint=node.state.gitlink_imported_root,
             )
-        except asyncio.TimeoutError:
-            notifications_state.show(
+
+        return await self._run_gitlink_blocking_action(
+            bus=bus,
+            notifications_state=notifications_state,
+            node=node,
+            action=_action,
+            timeout=GITLINK_CONTEXT_TIMEOUT_SECONDS,
+            timeout_message=(
                 "Building the repository context stopped responding before the request "
-                "completed. Please try again.",
-                "error",
-            )
-            await bus.publish("notification")
-            return None
-        except Exception as exc:
-            logger.exception("gitlink context build failed")
-            notifications_state.show(f"Failed to build the repository context: {exc}", "error")
-            await bus.publish("notification")
-            return None
-        finally:
-            node.pending_request_id = None
-            await bus.publish("scene")
+                "completed. Please try again."
+            ),
+            error_log_message="gitlink context build failed",
+            error_notify_prefix="Failed to build the repository context",
+            default=None,
+        )
 
     async def start_gitlink_run(
         self,

--- a/backend/api/_settings_shared.py
+++ b/backend/api/_settings_shared.py
@@ -28,6 +28,15 @@ would create the same cycle if left in backend/settings.py.
 backend/settings.py re-exports all six verbatim so composer.py's existing
 import keeps working unchanged.
 
+pick_scan_folder_and_run factors out the busy-guarded native folder-pick
+step behind Settings' two "Scan Folder..." buttons
+(intents_settings_ollama.py's pickOllamaScanFolder / intents_settings_
+llama_cpp.py's pickLlamaCppScanFolder) - identical control flow (busy
+pre-check, open the native dialog, map a raised exception or a cancelled
+dialog to a state update, otherwise hand the picked folder to the page's
+own scan runner), differing only in which SettingsSessionState fields each
+page uses and which manager getter seeds the dialog's starting directory.
+
 run_locked/locked_llama_cpp_settings/republish_composer_reasoning/
 redact_secret were private (leading-underscore) helpers before this split,
 each now crossing a real module boundary for the first time - renamed
@@ -46,14 +55,16 @@ unrenamed.
 from __future__ import annotations
 
 import asyncio
+import os
 import threading
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable
 
 import api_provider
 import graphlink_task_config as config
 from graphlink_settings_store import SettingsManager
 
+from backend import native_dialogs
 from backend.events import SessionBus
 
 # The six per-task model-assignment slots the API-provider page exposes,
@@ -241,6 +252,46 @@ async def apply_gemini_reasoning_level(manager: SettingsManager, level: str) -> 
 async def apply_openai_reasoning_level(manager: SettingsManager, level: str) -> None:
     await asyncio.to_thread(run_locked, manager.set_openai_reasoning_level, level)
     await asyncio.to_thread(api_provider.set_openai_reasoning_level, level)
+
+
+async def pick_scan_folder_and_run(
+    bus: SessionBus,
+    state: SettingsSessionState,
+    *,
+    status_field: str,
+    notice_field: str,
+    saved_scan_path: str,
+    run_scan: Callable[[str], Awaitable[None]],
+) -> None:
+    """Shared body of pickOllamaScanFolder/pickLlamaCppScanFolder: guard on
+    the page's own "already running" reentrancy flag, open the native
+    folder dialog seeded at `saved_scan_path` (or home), and hand the picked
+    folder to `run_scan`. A cancelled dialog is a quiet no-op (state goes
+    back to "idle"); a dialog-open failure reports an error - matches both
+    callers' pre-extraction behavior exactly.
+
+    `status_field`/`notice_field` name the two SettingsSessionState fields
+    this manages (getattr/setattr, since Ollama and Llama.cpp each have
+    their own distinct fields for this - `ollama_scan_status`/
+    `ollama_notice` vs `llama_scan_status`/`llama_notice` - not indirection
+    for its own sake)."""
+    if getattr(state, status_field) == "running":
+        return
+    setattr(state, status_field, "running")
+    await bus.publish("app-settings")
+    directory = saved_scan_path or os.path.expanduser("~")
+    try:
+        folder = await native_dialogs.pick_folder(directory=directory)
+    except Exception as exc:  # noqa: BLE001 - a local folder path, not a credential
+        setattr(state, status_field, "error")
+        setattr(state, notice_field, f"Could not open the folder picker: {exc}")
+        await bus.publish("app-settings")
+        return
+    if not folder:
+        setattr(state, status_field, "idle")
+        await bus.publish("app-settings")
+        return
+    await run_scan(folder)
 
 
 def redact_secret(text: str, secret: Any) -> str:

--- a/backend/api/_shared.py
+++ b/backend/api/_shared.py
@@ -22,11 +22,26 @@ counterpart, needed once backend/api/intents_grid.py's own
 register_grid_intents becomes the last consumer of register_canvas's
 former local `publish_grid` closure. Relocated verbatim from
 backend/canvas.py's former register_canvas (former lines 302-303).
+
+claim_busy_node_or_notify factors out the single-in-flight-run-per-node
+busy guard that backend/api/intents_gitlink.py's runGitlinkChangeSet and
+backend/api/intents_code_sandbox.py's runCodeSandbox each hand-wrote
+identically (down to the synchronous placeholder-claim-before-any-await
+race fix - see run_gitlink_change_set's own inline comment, still the
+canonical explanation, for exactly why that ordering matters). The two
+callers differ only in their busy/placeholder values and in what
+"start the run" means for their own node kind - everything else, including
+the SceneError recovery path, was copy-pasted.
 """
 
 from __future__ import annotations
 
+from typing import Any, Callable
+
+from backend.domain.graph import SceneDocument
+from backend.domain.model import SceneError
 from backend.events import SessionBus
+from backend.notifications import NotificationState
 
 
 def make_publish_scene(bus: SessionBus):
@@ -57,3 +72,47 @@ def make_publish_token_counter(bus: SessionBus):
             await bus.publish("token-counter")
 
     return publish_token_counter
+
+
+async def claim_busy_node_or_notify(
+    bus: SessionBus,
+    document: SceneDocument,
+    notifications: NotificationState,
+    node_id: str,
+    *,
+    busy_message: str,
+    placeholder: str,
+    start_run: Callable[[], Any],
+) -> Any | None:
+    """Shared busy-guard + synchronous placeholder-claim for node kinds that
+    allow only one in-flight run at a time (Gitlink's runGitlinkChangeSet,
+    Execution Sandbox's runCodeSandbox).
+
+    The busy pre-check and the placeholder claim happen in this same
+    synchronous stretch, before `start_run()` or any await - a second
+    concurrent call for the SAME node_id must never be able to pass the
+    pre-check during a later `await publish_scene()` gap. `start_run`'s own
+    dispatcher (the only real caller of the node's pending_request_id after
+    this point) recognizes this exact placeholder and overwrites it with the
+    real request_id, still synchronously.
+
+    Returns whatever `start_run()` returns on success, or None (after
+    already publishing a notification) if the node was busy, or if
+    `start_run()` raised SceneError (node deleted/wrong-kind concurrently
+    with the claim) - in which case the placeholder is cleared so it doesn't
+    linger on a node this call is giving up on."""
+    node_for_check = document.nodes.get(node_id)
+    if node_for_check is not None and node_for_check.pending_request_id:
+        notifications.show(busy_message, "info")
+        await bus.publish("notification")
+        return None
+    if node_for_check is not None:
+        node_for_check.pending_request_id = placeholder
+    try:
+        return start_run()
+    except SceneError:
+        if node_for_check is not None:
+            node_for_check.pending_request_id = None
+        notifications.show("This node no longer exists.", "warning")
+        await bus.publish("notification")
+        return None

--- a/backend/api/intents_branches.py
+++ b/backend/api/intents_branches.py
@@ -34,6 +34,41 @@ def register_branches_intents(
     # module-level import here.
     from backend.canvas import _format_branches_for_comparison
 
+    async def _dedupe_and_require_two_branches(node_ids, verb: str):
+        """Shared first step of compare_branches/synthesize_branches: de-dupe
+        the selected ids (preserving order) and require at least 2. `verb`
+        is the action word ("compare"/"synthesize") - the only thing that
+        differs between the two callers' equivalent checks. Returns the
+        de-duped ids, or None (after already publishing the notification)
+        when the caller should stop."""
+        ids = list(dict.fromkeys(str(i) for i in (node_ids or [])))  # de-dupe, preserve order
+        if len(ids) < 2:
+            notifications.show(f"Select at least 2 branches to {verb}.", "warning")
+            await bus.publish("notification")
+            return None
+        return ids
+
+    async def _resolve_chat_sources(ids, verb: str):
+        """Shared second step: resolve every id to a real chat node and
+        format each source's branch history for the agent. Returns
+        (sources, formatted_text), or None (after already publishing the
+        notification) if any id isn't a real chat node."""
+        sources = []
+        for node_id in ids:
+            node = document.nodes.get(node_id)
+            if node is None or node.kind != "chat":
+                notifications.show(f"Every selected node must be a real chat message to {verb}.", "warning")
+                await bus.publish("notification")
+                return None
+            sources.append(node)
+
+        branches = [
+            (f"Branch {index + 1}", document.chat_branch_history(node.id))
+            for index, node in enumerate(sources)
+        ]
+        formatted = _format_branches_for_comparison(branches)
+        return sources, formatted
+
     async def _generate_note_from_node(source_node_id, note_kind):
         """R8a: shared path for generateKeyTakeaway and generateExplainerNote.
 
@@ -133,26 +168,13 @@ def register_branches_intents(
         must supply 2+ real ids up front, the same "the frontend already
         gathered React Flow's own multi-selection" contract create_frame/
         create_container already use."""
-        ids = list(dict.fromkeys(str(i) for i in (node_ids or [])))  # de-dupe, preserve order
-        if len(ids) < 2:
-            notifications.show("Select at least 2 branches to compare.", "warning")
-            await bus.publish("notification")
+        ids = await _dedupe_and_require_two_branches(node_ids, "compare")
+        if ids is None:
             return None
-
-        sources = []
-        for node_id in ids:
-            node = document.nodes.get(node_id)
-            if node is None or node.kind != "chat":
-                notifications.show("Every selected node must be a real chat message to compare.", "warning")
-                await bus.publish("notification")
-                return None
-            sources.append(node)
-
-        branches = [
-            (f"Branch {index + 1}", document.chat_branch_history(node.id))
-            for index, node in enumerate(sources)
-        ]
-        formatted = _format_branches_for_comparison(branches)
+        resolved = await _resolve_chat_sources(ids, "compare")
+        if resolved is None:
+            return None
+        sources, formatted = resolved
 
         # Positioned beside the bottom-most source branch, the same
         # "offset to the side" convention _generate_note_from_node uses for
@@ -216,10 +238,8 @@ def register_branches_intents(
         composer_document.route() - the same route a plain send would
         actually use - onto the result node (see ChatState's own comment,
         backend/domain/node_states.py)."""
-        ids = list(dict.fromkeys(str(i) for i in (node_ids or [])))  # de-dupe, preserve order
-        if len(ids) < 2:
-            notifications.show("Select at least 2 branches to synthesize.", "warning")
-            await bus.publish("notification")
+        ids = await _dedupe_and_require_two_branches(node_ids, "synthesize")
+        if ids is None:
             return None
 
         clean_instructions = str(instructions or "").strip()
@@ -228,20 +248,10 @@ def register_branches_intents(
             await bus.publish("notification")
             return None
 
-        sources = []
-        for node_id in ids:
-            node = document.nodes.get(node_id)
-            if node is None or node.kind != "chat":
-                notifications.show("Every selected node must be a real chat message to synthesize.", "warning")
-                await bus.publish("notification")
-                return None
-            sources.append(node)
-
-        branches = [
-            (f"Branch {index + 1}", document.chat_branch_history(node.id))
-            for index, node in enumerate(sources)
-        ]
-        formatted = _format_branches_for_comparison(branches)
+        resolved = await _resolve_chat_sources(ids, "synthesize")
+        if resolved is None:
+            return None
+        sources, formatted = resolved
 
         parent = sources[0]
         route = composer_document.route()

--- a/backend/api/intents_code_sandbox.py
+++ b/backend/api/intents_code_sandbox.py
@@ -15,9 +15,8 @@ Sandbox still depends on them.
 from __future__ import annotations
 
 from backend.agents import _CODE_EXEC_RUN_CLAIM_PLACEHOLDER, AgentDispatcher
-from backend.api._shared import make_publish_scene
+from backend.api._shared import claim_busy_node_or_notify, make_publish_scene
 from backend.domain.graph import SceneDocument
-from backend.domain.model import SceneError
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 
@@ -44,22 +43,16 @@ def register_code_sandbox_intents(
 
     async def run_code_sandbox(node_id, input_text):
         # Same busy-claim-placeholder pattern as run_gitlink_change_set
-        # (backend/api/intents_gitlink.py) - see that function's own
-        # comment for the exact race this closes.
-        node_for_check = document.nodes.get(node_id)
-        if node_for_check is not None and node_for_check.pending_request_id:
-            notifications.show("Virtual Environment Runner is already busy for this node.", "info")
-            await bus.publish("notification")
-            return None
-        if node_for_check is not None:
-            node_for_check.pending_request_id = _CODE_EXEC_RUN_CLAIM_PLACEHOLDER
-        try:
-            node = document.start_code_sandbox_run(node_id, input_text)
-        except SceneError:
-            if node_for_check is not None:
-                node_for_check.pending_request_id = None
-            notifications.show("This node no longer exists.", "warning")
-            await bus.publish("notification")
+        # (backend/api/intents_gitlink.py) - shared via
+        # claim_busy_node_or_notify (backend/api/_shared.py), which owns
+        # the exact race that placeholder claim closes.
+        node = await claim_busy_node_or_notify(
+            bus, document, notifications, node_id,
+            busy_message="Virtual Environment Runner is already busy for this node.",
+            placeholder=_CODE_EXEC_RUN_CLAIM_PLACEHOLDER,
+            start_run=lambda: document.start_code_sandbox_run(node_id, input_text),
+        )
+        if node is None:
             return None
         await publish_scene()
 

--- a/backend/api/intents_gitlink.py
+++ b/backend/api/intents_gitlink.py
@@ -19,9 +19,8 @@ import os
 
 from backend import native_dialogs
 from backend.agents import _GITLINK_RUN_CLAIM_PLACEHOLDER, AgentDispatcher
-from backend.api._shared import make_publish_scene
+from backend.api._shared import claim_busy_node_or_notify, make_publish_scene
 from backend.domain.graph import SceneDocument
-from backend.domain.model import SceneError
 from backend.events import SessionBus
 from backend.notifications import NotificationState
 
@@ -136,32 +135,18 @@ def register_gitlink_intents(
         return document.fetch_gitlink_context_xml(node_id)
 
     async def run_gitlink_change_set(node_id, task_prompt):
-        node_for_check = document.nodes.get(node_id)
-        if node_for_check is not None and node_for_check.pending_request_id:
-            notifications.show("Gitlink is already busy for this node.", "info")
-            await bus.publish("notification")
-            return None
-        # R5.3 post-review FIX 4(b): claim the busy slot with a placeholder
-        # SYNCHRONOUSLY, in the same stretch as the busy pre-check just
-        # above - before document.start_gitlink_run or any await - so a
-        # second concurrent call for this SAME node_id can never pass that
-        # same pre-check during the `await publish_scene()` gap below.
-        # agent_dispatcher.start_gitlink_run (the ONLY caller of this dict
-        # entry for this node_id, invoked just below) recognizes this exact
-        # placeholder and overwrites it with the real request_id, still
-        # synchronously - see that method's own docstring.
-        if node_for_check is not None:
-            node_for_check.pending_request_id = _GITLINK_RUN_CLAIM_PLACEHOLDER
-        try:
-            node = document.start_gitlink_run(node_id, task_prompt)
-        except SceneError:
-            # Node deleted (or wrong-kind) concurrently with the claim above -
-            # the placeholder must not linger on a node this handler is
-            # about to give up on.
-            if node_for_check is not None:
-                node_for_check.pending_request_id = None
-            notifications.show("This node no longer exists.", "warning")
-            await bus.publish("notification")
+        # R5.3 post-review FIX 4(b) / R8b: the busy pre-check, synchronous
+        # placeholder claim, and SceneError recovery are shared with
+        # Execution Sandbox's runCodeSandbox - see claim_busy_node_or_notify's
+        # own docstring (backend/api/_shared.py) for exactly why the claim
+        # must land in the same synchronous stretch as the pre-check.
+        node = await claim_busy_node_or_notify(
+            bus, document, notifications, node_id,
+            busy_message="Gitlink is already busy for this node.",
+            placeholder=_GITLINK_RUN_CLAIM_PLACEHOLDER,
+            start_run=lambda: document.start_gitlink_run(node_id, task_prompt),
+        )
+        if node is None:
             return None
         await publish_scene()
 

--- a/backend/api/intents_settings_llama_cpp.py
+++ b/backend/api/intents_settings_llama_cpp.py
@@ -25,6 +25,7 @@ from backend.api._settings_shared import (
     SettingsSessionState,
     apply_llama_cpp_reasoning_level,
     locked_llama_cpp_settings,
+    pick_scan_folder_and_run,
     republish_composer_reasoning,
     run_locked,
 )
@@ -211,24 +212,15 @@ def register_settings_llama_cpp_intents(
         await _run_llama_cpp_scan(None)
 
     async def pick_llama_cpp_scan_folder():
-        if state.llama_scan_status == "running":
-            return
-        state.llama_scan_status = "running"
-        await bus.publish("app-settings")
-        directory = manager.get_llama_cpp_model_scan_path() or os.path.expanduser("~")
-        try:
-            # Same reentrancy-gate hazard fixed above for pick_ollama_scan_folder.
-            folder = await native_dialogs.pick_folder(directory=directory)
-        except Exception as exc:  # noqa: BLE001 - a local folder path, not a credential
-            state.llama_scan_status = "error"
-            state.llama_notice = f"Could not open the folder picker: {exc}"
-            await bus.publish("app-settings")
-            return
-        if not folder:
-            state.llama_scan_status = "idle"
-            await bus.publish("app-settings")
-            return
-        await _run_llama_cpp_scan(folder)
+        # R8b: same reentrancy-gate hazard fixed for pick_ollama_scan_folder
+        # (intents_settings_ollama.py) - both now share
+        # pick_scan_folder_and_run (backend/api/_settings_shared.py).
+        await pick_scan_folder_and_run(
+            bus, state,
+            status_field="llama_scan_status", notice_field="llama_notice",
+            saved_scan_path=manager.get_llama_cpp_model_scan_path(),
+            run_scan=_run_llama_cpp_scan,
+        )
 
     async def save_llama_cpp_settings():
         # Sequencing matches legacy's saveLlamaCppSettings() exactly:

--- a/backend/api/intents_settings_ollama.py
+++ b/backend/api/intents_settings_ollama.py
@@ -9,7 +9,6 @@ change.
 from __future__ import annotations
 
 import asyncio
-import os
 
 import ollama
 
@@ -17,12 +16,12 @@ import api_provider
 import graphlink_task_config as config
 from graphlink_model_catalog import AUTO_MODEL, INHERIT_MODEL
 
-from backend import native_dialogs
 from backend.api._settings_shared import (
     OLLAMA_TASK_KEYS,
     REASONING_LEVELS,
     SettingsSessionState,
     apply_ollama_reasoning_level,
+    pick_scan_folder_and_run,
     republish_composer_reasoning,
     run_locked,
 )
@@ -183,30 +182,21 @@ def register_settings_ollama_intents(
         # (blocking, potentially long-lived-until-the-user-decides) native
         # dialog opens, not after - two near-simultaneous clicks must not
         # both reach a native file-dialog call.
-        if state.ollama_scan_status == "running":
-            return
-        state.ollama_scan_status = "running"
-        await bus.publish("app-settings")
-        directory = manager.get_ollama_model_scan_path() or os.path.expanduser("~")
-        try:
-            # Adversarial-review finding: the native dialog call itself can
-            # raise (a per-platform GTK/COM/file-type-parsing failure inside
-            # pywebview's create_file_dialog - confirmed reachable via its
-            # own source, not theoretical). Uncaught, this would strand the
-            # reentrancy gate at "running" forever - the exact class of bug
-            # already fixed twice in this file for the SCAN/PERSIST steps,
-            # reintroduced here via the dialog call that precedes them.
-            folder = await native_dialogs.pick_folder(directory=directory)
-        except Exception as exc:  # noqa: BLE001 - a local folder path, not a credential
-            state.ollama_scan_status = "error"
-            state.ollama_notice = f"Could not open the folder picker: {exc}"
-            await bus.publish("app-settings")
-            return
-        if not folder:
-            state.ollama_scan_status = "idle"
-            await bus.publish("app-settings")
-            return
-        await _run_ollama_scan(folder)
+        #
+        # R8b: this guard/dialog/error-mapping sequence is shared with
+        # intents_settings_llama_cpp.py's own pickLlamaCppScanFolder - see
+        # pick_scan_folder_and_run's own docstring
+        # (backend/api/_settings_shared.py). The Adversarial-review finding
+        # that motivated the try/except here (the native dialog call itself
+        # can raise - a per-platform GTK/COM/file-type-parsing failure
+        # inside pywebview's create_file_dialog, confirmed reachable via its
+        # own source, not theoretical) now lives in that shared function.
+        await pick_scan_folder_and_run(
+            bus, state,
+            status_field="ollama_scan_status", notice_field="ollama_notice",
+            saved_scan_path=manager.get_ollama_model_scan_path(),
+            run_scan=_run_ollama_scan,
+        )
 
     async def pull_ollama_model(model_name: str):
         model_name = str(model_name).strip()

--- a/backend/plugin_sdk.py
+++ b/backend/plugin_sdk.py
@@ -397,6 +397,50 @@ class PluginIntentSpec:
 BuiltinActionHandler = Callable[[SceneDocument, PluginRunContext, "str | None"], "str | None"]
 
 
+def make_simple_child_node_handler(
+    *, command_type: str, warning_suffix: str, create: Callable[[SceneDocument, str], SceneNode],
+) -> BuiltinActionHandler:
+    """Factory for the one BuiltinActionHandler shape shared, byte-for-byte
+    apart from three call-site-specific values, by 6 of the 7 register_
+    builtin_plugin migrations (plugins/artifact, code_sandbox,
+    conversation_node, gitlink, html_renderer, web_research - every one
+    EXCEPT plugins/system_prompt, whose branch-root-walk/dedup/reversed-edge
+    shape is genuinely its own, per that plugin's own docstring): validate
+    parent_node_id against document.nodes, show a warning and return None if
+    it's missing/stale, otherwise run 'create' inside one record_command
+    call and return the created node's id.
+
+    'command_type' is the record_command command_type string (e.g.
+    "pluginArtifact"). 'warning_suffix' completes "Please select a valid
+    node to branch from before adding {warning_suffix}." - each call site's
+    original wording (e.g. "an Artifact node", "a Web Node") is preserved
+    verbatim, not derived from 'name', since at least one (Web Research's
+    "a Web Node") intentionally does not match its picker label. 'create' is
+    called as create(document, parent_node_id) INSIDE record_command's
+    zero-arg closure and must return the created SceneNode - callers close
+    over document.place_child(...)'s own kind string and any extra
+    positional args their add_*_node factory needs (e.g. html_renderer's
+    empty initial html_content)."""
+
+    def _execute(
+        document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
+    ) -> "str | None":
+        if not parent_node_id or parent_node_id not in document.nodes:
+            run_ctx.notifications.show(
+                f"Please select a valid node to branch from before adding {warning_suffix}.",
+                "warning",
+            )
+            return None
+        node, _command = document.record_command(
+            command_type, "user",
+            lambda: create(document, parent_node_id),
+            node_ids=[parent_node_id],
+        )
+        return node.id
+
+    return _execute
+
+
 @dataclass(frozen=True)
 class BuiltinActionSpec:
     plugin_id: str

--- a/backend/plugins.py
+++ b/backend/plugins.py
@@ -329,7 +329,7 @@ async def _execute_discovered_plugin(
         return None
     kind_spec, picker_entry = resolved
 
-    if not settings_manager.get_plugin_grants().get(kind_spec.plugin_id, False):
+    if not _is_plugin_granted(settings_manager, kind_spec.plugin_id):
         notifications.show(
             f'"{picker_entry.name}" needs your approval before it can create nodes - '
             f'grant it in Settings > Plugins.', "warning",
@@ -418,7 +418,7 @@ async def _invoke_discovered_plugin_intent(
         await bus.publish("notification")
         return None
 
-    if not settings_manager.get_plugin_grants().get(plugin_id, False):
+    if not _is_plugin_granted(settings_manager, plugin_id):
         notifications.show(
             f'"{plugin_id}" needs your approval before it can run this action - '
             f'grant it in Settings > Plugins.', "warning",
@@ -547,7 +547,7 @@ def _make_plugin_tool_handler(
     NotificationState through, for a plugin author who needs one."""
 
     async def _handler(call: ToolCall, ctx: RunContext) -> ToolResult:
-        if not settings_manager.get_plugin_grants().get(plugin_id, False):
+        if not _is_plugin_granted(settings_manager, plugin_id):
             return ToolResult(
                 content=f'Plugin "{plugin_id}" needs your approval in Settings > Plugins before '
                 f'this action can run.',
@@ -585,12 +585,25 @@ def _make_plugin_tool_handler(
     return _handler
 
 
+def _is_plugin_granted(settings_manager: SettingsManager, plugin_id: str) -> bool:
+    """The one grant-check predicate every install-time consent gate in this
+    module resolves to: _execute_discovered_plugin (node creation),
+    _invoke_discovered_plugin_intent, _make_plugin_tool_handler's Builder-
+    tool handler, and _grant_gated_serialize below all gate on this exact
+    settings_manager.get_plugin_grants().get(plugin_id, False) lookup -
+    previously each hand-rolled it inline instead of sharing one helper.
+    Checked fresh on every call (never cached), same as before this
+    extraction - a grant flip in Settings takes effect on the very next
+    check at any of those call sites."""
+    return bool(settings_manager.get_plugin_grants().get(plugin_id, False))
+
+
 def _grant_gated_serialize(plugin_id: str, serialize, settings_manager: SettingsManager):
     """ADR-014 review-fix: wraps a plugin's own HostContext.register_node_
     kind(..., serialize=...) hook so a revoked Settings > Plugins grant
     actually stops it from running, rather than merely hiding the plugin's
     PICKER entry while its serializer keeps firing on every scene publish
-    forever after. The SAME settings_manager.get_plugin_grants() check
+    forever after. The SAME _is_plugin_granted check
     _execute_discovered_plugin/_invoke_discovered_plugin_intent/
     register_plugin_tools' own handler already apply before calling into a
     plugin's code, extended to this fourth call site.
@@ -613,7 +626,7 @@ def _grant_gated_serialize(plugin_id: str, serialize, settings_manager: Settings
     session's live SceneDocument)."""
 
     def _serialize(node):
-        if not settings_manager.get_plugin_grants().get(plugin_id, False):
+        if not _is_plugin_granted(settings_manager, plugin_id):
             return None
         return serialize(node)
 

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1826,6 +1826,54 @@ def test_scan_llama_cpp_system_reports_truncated_scans(manager, monkeypatch):
     assert "stopped early" in payload["llamaCppNotice"]
 
 
+def test_pick_llama_cpp_scan_folder_scans_the_picked_folder(manager, monkeypatch):
+    # R8b: pickLlamaCppScanFolder now shares pick_scan_folder_and_run with
+    # pickOllamaScanFolder (see test_pick_ollama_scan_folder_scans_the_picked_folder
+    # above) - this covers the Llama.cpp-specific wiring (llama_scan_status/
+    # llama_notice, get_llama_cpp_model_scan_path) that had no direct
+    # intent-level test before the extraction.
+    async def _fake_pick_folder(directory=""):
+        return "C:/models/llama"
+
+    monkeypatch.setattr(native_dialogs, "pick_folder", _fake_pick_folder)
+    monkeypatch.setattr(
+        api_provider,
+        "scan_local_llama_cpp_models",
+        lambda scan_path: {
+            "models": ["C:/models/llama/a.gguf"], "scan_mode": "folder", "scan_path": scan_path,
+            "locations": [scan_path], "truncated": False,
+        },
+    )
+    bus = SessionBus("settings-pick-llama-cpp-scan-folder-test")
+    register_settings(bus, manager)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "pickLlamaCppScanFolder", []))
+
+    assert manager.get_llama_cpp_scanned_models() == ["C:/models/llama/a.gguf"]
+    payload = recorder.messages[-1]["payload"]
+    assert payload["llamaCppScanStatus"] == "done"
+
+
+def test_pick_llama_cpp_scan_folder_is_a_no_op_when_cancelled(manager, monkeypatch):
+    async def _fake_pick_folder(directory=""):
+        return None
+
+    calls = []
+    monkeypatch.setattr(native_dialogs, "pick_folder", _fake_pick_folder)
+    monkeypatch.setattr(api_provider, "scan_local_llama_cpp_models", lambda scan_path: calls.append(1) or {"models": []})
+    bus = SessionBus("settings-pick-llama-cpp-scan-folder-cancel-test")
+    register_settings(bus, manager)
+    recorder = Recorder()
+    bus.attach(recorder)
+
+    asyncio.run(bus.dispatch_intent("app-settings", "pickLlamaCppScanFolder", []))
+
+    assert calls == []
+    assert recorder.messages[-1]["payload"]["llamaCppScanStatus"] == "idle"
+
+
 def test_save_llama_cpp_settings_rejects_missing_chat_path(manager):
     bus = SessionBus("settings-llama-cpp-save-missing-chat-test")
     register_settings(bus, manager)

--- a/plugins/artifact/plugin.py
+++ b/plugins/artifact/plugin.py
@@ -4,31 +4,22 @@ old hardcoded `if name == "Artifact / Drafter":` branch - same
 command_type string ("pluginArtifact"), same parent-validation warning
 text, same factory call (SceneDocument.add_artifact_node), same
 undo/parent-validation behavior. See plugins/web_research/plugin.py's own
-docstring for the shared register_builtin_plugin escape-hatch rationale."""
+docstring for the shared register_builtin_plugin escape-hatch rationale.
+_execute itself is backend/plugin_sdk.py's make_simple_child_node_handler -
+see that factory's own docstring for the shared validate/record_command/
+return-id shape it replaces here."""
 
 from __future__ import annotations
 
-from backend.canvas import SceneDocument
-from backend.plugin_sdk import HostContext, PluginRunContext
+from backend.plugin_sdk import HostContext, make_simple_child_node_handler
 
-
-def _execute(
-    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
-) -> "str | None":
-    if not parent_node_id or parent_node_id not in document.nodes:
-        run_ctx.notifications.show(
-            "Please select a valid node to branch from before adding an Artifact node.",
-            "warning",
-        )
-        return None
-    node, _command = document.record_command(
-        "pluginArtifact", "user",
-        lambda: document.add_artifact_node(
-            *document.place_child(parent_node_id, "artifact"), parent_node_id
-        ),
-        node_ids=[parent_node_id],
-    )
-    return node.id
+_execute = make_simple_child_node_handler(
+    command_type="pluginArtifact",
+    warning_suffix="an Artifact node",
+    create=lambda document, parent_node_id: document.add_artifact_node(
+        *document.place_child(parent_node_id, "artifact"), parent_node_id
+    ),
+)
 
 
 def register(host: HostContext) -> None:

--- a/plugins/code_sandbox/plugin.py
+++ b/plugins/code_sandbox/plugin.py
@@ -5,32 +5,22 @@ Runner":` branch - same command_type string ("pluginCodeSandbox"), same
 parent-validation warning text, same factory call
 (SceneDocument.add_code_sandbox_node), same undo/parent-validation
 behavior. See plugins/web_research/plugin.py's own docstring for the
-shared register_builtin_plugin escape-hatch rationale."""
+shared register_builtin_plugin escape-hatch rationale. _execute itself is
+backend/plugin_sdk.py's make_simple_child_node_handler - see that
+factory's own docstring for the shared validate/record_command/
+return-id shape it replaces here."""
 
 from __future__ import annotations
 
-from backend.canvas import SceneDocument
-from backend.plugin_sdk import HostContext, PluginRunContext
+from backend.plugin_sdk import HostContext, make_simple_child_node_handler
 
-
-def _execute(
-    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
-) -> "str | None":
-    if not parent_node_id or parent_node_id not in document.nodes:
-        run_ctx.notifications.show(
-            "Please select a valid node to branch from before adding a Virtual "
-            "Environment Runner node.",
-            "warning",
-        )
-        return None
-    node, _command = document.record_command(
-        "pluginCodeSandbox", "user",
-        lambda: document.add_code_sandbox_node(
-            *document.place_child(parent_node_id, "code_sandbox"), parent_node_id
-        ),
-        node_ids=[parent_node_id],
-    )
-    return node.id
+_execute = make_simple_child_node_handler(
+    command_type="pluginCodeSandbox",
+    warning_suffix="a Virtual Environment Runner node",
+    create=lambda document, parent_node_id: document.add_code_sandbox_node(
+        *document.place_child(parent_node_id, "code_sandbox"), parent_node_id
+    ),
+)
 
 
 def register(host: HostContext) -> None:

--- a/plugins/conversation_node/plugin.py
+++ b/plugins/conversation_node/plugin.py
@@ -5,31 +5,21 @@ command_type string ("pluginConversationNode"), same parent-validation
 warning text, same factory call (SceneDocument.add_conversation_node),
 same undo/parent-validation behavior. See plugins/web_research/plugin.py's
 own docstring for the shared register_builtin_plugin escape-hatch
-rationale."""
+rationale. _execute itself is backend/plugin_sdk.py's
+make_simple_child_node_handler - see that factory's own docstring for the
+shared validate/record_command/return-id shape it replaces here."""
 
 from __future__ import annotations
 
-from backend.canvas import SceneDocument
-from backend.plugin_sdk import HostContext, PluginRunContext
+from backend.plugin_sdk import HostContext, make_simple_child_node_handler
 
-
-def _execute(
-    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
-) -> "str | None":
-    if not parent_node_id or parent_node_id not in document.nodes:
-        run_ctx.notifications.show(
-            "Please select a valid node to branch from before adding a Conversation Node.",
-            "warning",
-        )
-        return None
-    node, _command = document.record_command(
-        "pluginConversationNode", "user",
-        lambda: document.add_conversation_node(
-            *document.place_child(parent_node_id, "conversation"), parent_node_id
-        ),
-        node_ids=[parent_node_id],
-    )
-    return node.id
+_execute = make_simple_child_node_handler(
+    command_type="pluginConversationNode",
+    warning_suffix="a Conversation Node",
+    create=lambda document, parent_node_id: document.add_conversation_node(
+        *document.place_child(parent_node_id, "conversation"), parent_node_id
+    ),
+)
 
 
 def register(host: HostContext) -> None:

--- a/plugins/gitlink/plugin.py
+++ b/plugins/gitlink/plugin.py
@@ -4,31 +4,22 @@ hardcoded `if name == "Gitlink":` branch - same command_type string
 ("pluginGitlink"), same parent-validation warning text, same factory call
 (SceneDocument.add_gitlink_node), same undo/parent-validation behavior.
 See plugins/web_research/plugin.py's own docstring for the shared
-register_builtin_plugin escape-hatch rationale."""
+register_builtin_plugin escape-hatch rationale. _execute itself is
+backend/plugin_sdk.py's make_simple_child_node_handler - see that
+factory's own docstring for the shared validate/record_command/
+return-id shape it replaces here."""
 
 from __future__ import annotations
 
-from backend.canvas import SceneDocument
-from backend.plugin_sdk import HostContext, PluginRunContext
+from backend.plugin_sdk import HostContext, make_simple_child_node_handler
 
-
-def _execute(
-    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
-) -> "str | None":
-    if not parent_node_id or parent_node_id not in document.nodes:
-        run_ctx.notifications.show(
-            "Please select a valid node to branch from before adding a Gitlink node.",
-            "warning",
-        )
-        return None
-    node, _command = document.record_command(
-        "pluginGitlink", "user",
-        lambda: document.add_gitlink_node(
-            *document.place_child(parent_node_id, "gitlink"), parent_node_id
-        ),
-        node_ids=[parent_node_id],
-    )
-    return node.id
+_execute = make_simple_child_node_handler(
+    command_type="pluginGitlink",
+    warning_suffix="a Gitlink node",
+    create=lambda document, parent_node_id: document.add_gitlink_node(
+        *document.place_child(parent_node_id, "gitlink"), parent_node_id
+    ),
+)
 
 
 def register(host: HostContext) -> None:

--- a/plugins/html_renderer/plugin.py
+++ b/plugins/html_renderer/plugin.py
@@ -6,32 +6,22 @@ warning text, same factory call (SceneDocument.add_html_node, starting
 with empty html_content - the plugin picker has no field to source
 initial HTML from), same undo/parent-validation behavior. See
 plugins/web_research/plugin.py's own docstring for the shared
-register_builtin_plugin escape-hatch rationale."""
+register_builtin_plugin escape-hatch rationale. _execute itself is
+backend/plugin_sdk.py's make_simple_child_node_handler - see that
+factory's own docstring for the shared validate/record_command/
+return-id shape it replaces here."""
 
 from __future__ import annotations
 
-from backend.canvas import SceneDocument
-from backend.plugin_sdk import HostContext, PluginRunContext
+from backend.plugin_sdk import HostContext, make_simple_child_node_handler
 
-
-def _execute(
-    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
-) -> "str | None":
-    if not parent_node_id or parent_node_id not in document.nodes:
-        run_ctx.notifications.show(
-            "Please select a valid node to branch from before adding an HTML "
-            "Renderer node.",
-            "warning",
-        )
-        return None
-    node, _command = document.record_command(
-        "pluginHtmlRenderer", "user",
-        lambda: document.add_html_node(
-            *document.place_child(parent_node_id, "html"), "", parent_node_id
-        ),
-        node_ids=[parent_node_id],
-    )
-    return node.id
+_execute = make_simple_child_node_handler(
+    command_type="pluginHtmlRenderer",
+    warning_suffix="an HTML Renderer node",
+    create=lambda document, parent_node_id: document.add_html_node(
+        *document.place_child(parent_node_id, "html"), "", parent_node_id
+    ),
+)
 
 
 def register(host: HostContext) -> None:

--- a/plugins/web_research/plugin.py
+++ b/plugins/web_research/plugin.py
@@ -10,31 +10,22 @@ session_save.py/session_load.py's hand-written serializer - renaming it to
 a namespaced "web_research.web_research" via the generic PluginNodeSeed
 path would be an invasive, unnecessary breaking change. See
 HostContext.register_builtin_plugin's own docstring (backend/plugin_sdk.py)
-for the full escape-hatch rationale."""
+for the full escape-hatch rationale. _execute itself is
+backend/plugin_sdk.py's make_simple_child_node_handler - see that
+factory's own docstring for the shared validate/record_command/
+return-id shape it replaces here."""
 
 from __future__ import annotations
 
-from backend.canvas import SceneDocument
-from backend.plugin_sdk import HostContext, PluginRunContext
+from backend.plugin_sdk import HostContext, make_simple_child_node_handler
 
-
-def _execute(
-    document: SceneDocument, run_ctx: PluginRunContext, parent_node_id: "str | None",
-) -> "str | None":
-    if not parent_node_id or parent_node_id not in document.nodes:
-        run_ctx.notifications.show(
-            "Please select a valid node to branch from before adding a Web Node.",
-            "warning",
-        )
-        return None
-    node, _command = document.record_command(
-        "pluginWebResearch", "user",
-        lambda: document.add_web_research_node(
-            *document.place_child(parent_node_id, "web_research"), parent_node_id
-        ),
-        node_ids=[parent_node_id],
-    )
-    return node.id
+_execute = make_simple_child_node_handler(
+    command_type="pluginWebResearch",
+    warning_suffix="a Web Node",
+    create=lambda document, parent_node_id: document.add_web_research_node(
+        *document.place_child(parent_node_id, "web_research"), parent_node_id
+    ),
+)
 
 
 def register(host: HostContext) -> None:

--- a/web_ui/src/app/canvas/ChatNodeView.tsx
+++ b/web_ui/src/app/canvas/ChatNodeView.tsx
@@ -10,6 +10,7 @@ import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
 import { NodeShell } from "./NodeShell";
 import { useLodVisibility } from "./useLodVisibility";
+import { useStreamBuffer } from "./useStreamBuffer";
 
 /**
  * The chat node (Qt-removal plan R3.1/R3.2) - ChatNode's React successor:
@@ -817,85 +818,12 @@ export const ChatNodeView = memo(function ChatNodeView({
   const [contentExpanded, setContentExpanded] = useState(false);
   const [contentOverflows, setContentOverflows] = useState(false);
 
-  // ADR-006 stage 6.4: live Regenerate streaming - the exact
-  // subscription/reset pattern CodeSandboxNodeView's live terminal
-  // established (derived-state reset during render so a new request never
-  // shows the previous run's stale content, effect below left to do only
-  // transport synchronization; see that file's own comments for the full
-  // rationale).
-  const [streamedContent, setStreamedContent] = useState("");
-  const [subscribedRequestId, setSubscribedRequestId] = useState(data.pendingRequestId);
-  if (data.pendingRequestId !== subscribedRequestId) {
-    setSubscribedRequestId(data.pendingRequestId);
-    setStreamedContent("");
-  }
-
-  // ADR-011 stage 11.4: deltas accumulate into these refs (not React state)
-  // as they arrive - only the rAF-scheduled flush below ever calls
-  // setStreamedContent, so a fast burst of many small deltas within one
-  // frame re-parses markdown (NodeMarkdown's full unified/remark/rehype/
-  // KaTeX/highlight pipeline) at most once per frame, not once per delta.
-  // Every byte still lands in streamedContent, in order - only the RE-PARSE
-  // cadence changes, never the data: pendingBufferRef always holds the full,
-  // in-order text accumulated since the last flush, and flushStreamBuffer
-  // moves the whole thing into state atomically. pendingResetRef tracks
-  // whether the buffered text should REPLACE streamedContent at the next
-  // flush (a `reset` frame) rather than append to it, mirroring the
-  // original un-throttled `reset ? delta : current + delta` semantics
-  // exactly - just deferred to flush time instead of applied delta-by-delta.
-  const pendingBufferRef = useRef("");
-  const pendingResetRef = useRef(false);
-  const rafHandleRef = useRef<number | null>(null);
-
-  function flushStreamBuffer() {
-    if (rafHandleRef.current !== null) {
-      cancelAnimationFrame(rafHandleRef.current);
-      rafHandleRef.current = null;
-    }
-    const bufferedText = pendingBufferRef.current;
-    const shouldReset = pendingResetRef.current;
-    pendingBufferRef.current = "";
-    pendingResetRef.current = false;
-    if (!bufferedText && !shouldReset) return;
-    setStreamedContent((current) => (shouldReset ? bufferedText : current + bufferedText));
-  }
-
-  useEffect(() => {
-    const requestId = data.pendingRequestId;
-    if (!requestId) return;
-    const unsubscribe = data.subscribeStream(requestId, (delta, done, reset) => {
-      if (reset) {
-        pendingBufferRef.current = delta;
-        pendingResetRef.current = true;
-      } else {
-        pendingBufferRef.current += delta;
-      }
-      // Stream completion/reset flushes synchronously - the final chunk (or
-      // a fresh restart) shouldn't wait an extra frame, and this is also
-      // what guarantees a trailing chunk never gets stranded in the buffer
-      // past the last render.
-      if (done || reset) {
-        flushStreamBuffer();
-      } else if (rafHandleRef.current === null) {
-        rafHandleRef.current = requestAnimationFrame(flushStreamBuffer);
-      }
-    });
-    return () => {
-      unsubscribe();
-      // A requestId change (new run, or this run finished) makes any
-      // content still sitting in the buffer for the OLD request moot - the
-      // render-time subscribedRequestId reset above already clears
-      // streamedContent to "" for a new id, and data.content is the source
-      // of truth once pendingRequestId returns to null - but flush (rather
-      // than silently drop) here too, so no buffered byte is ever lost even
-      // in that narrow window.
-      flushStreamBuffer();
-    };
-    // data.subscribeStream is a fresh closure every render (see SceneCanvas's
-    // toFlowNodes) - depending on it would resubscribe on every unrelated
-    // re-render; data.pendingRequestId itself is the real re-subscribe key.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data.pendingRequestId]);
+  // ADR-006 stage 6.4 / ADR-011 stage 11.4: live Regenerate streaming,
+  // throttled to at most one markdown re-parse per animation frame - see
+  // useStreamBuffer's own doc comment for the full rationale (dedup: this
+  // was duplicated inline here and in ConversationNodeView until the tech-
+  // debt sweep extracted it).
+  const streamedContent = useStreamBuffer(data.pendingRequestId, data.subscribeStream);
 
   useEffect(() => {
     const contentEl = contentRef.current;

--- a/web_ui/src/app/canvas/ConversationNodeView.tsx
+++ b/web_ui/src/app/canvas/ConversationNodeView.tsx
@@ -1,5 +1,5 @@
 import type { Node, NodeProps } from "@xyflow/react";
-import { memo, useEffect, useRef, useState, type ReactNode } from "react";
+import { memo, useState, type ReactNode } from "react";
 import type { StreamListener } from "../../lib/ws/transport";
 import { CollapseToggleButton } from "./CollapseToggleButton";
 import type { MenuPosition } from "./menuPosition";
@@ -7,6 +7,7 @@ import { NodeMarkdown } from "./NodeMarkdown";
 import { NodeMenu } from "./NodeMenu";
 import { NodeShell } from "./NodeShell";
 import { useLodVisibility } from "./useLodVisibility";
+import { useStreamBuffer } from "./useStreamBuffer";
 
 /**
  * The conversation node (Qt-removal plan R3.25/R3.26) - ConversationNode's
@@ -383,81 +384,14 @@ function ConversationNodeViewImpl({ data, selected }: NodeProps<ConversationFlow
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const [draft, setDraft] = useState("");
 
-  // ADR-006 stage 6.4: live reply streaming - the exact subscription/reset
-  // pattern CodeSandboxNodeView's live terminal established (derived-state
-  // reset during render so a new request never shows the previous reply's
-  // stale content, effect below left to do only transport synchronization;
-  // see that file's own comments for the full rationale).
-  const [streamedReply, setStreamedReply] = useState("");
-  const [subscribedRequestId, setSubscribedRequestId] = useState(data.pendingRequestId);
-  if (data.pendingRequestId !== subscribedRequestId) {
-    setSubscribedRequestId(data.pendingRequestId);
-    setStreamedReply("");
-  }
-
-  // ADR-011 stage 11.4 (extended here 2026-08-12): deltas accumulate into
-  // refs and only a rAF-scheduled flush ever calls setStreamedReply, so a
-  // fast burst of small deltas re-parses markdown at most once per frame
-  // instead of once per token.
-  //
-  // Stage 11.4 originally landed this throttle in ChatNodeView ONLY. An audit
-  // found this view had been left on the raw per-delta setState even though
-  // it renders its streamed reply through the very same <NodeMarkdown>
-  // component - i.e. the full unified/remark/rehype/KaTeX/highlight pipeline
-  // ran on every single token, exactly the cost stage 11.4 exists to remove.
-  // (CodeSandboxNodeView also streams unthrottled but renders into a plain
-  // <pre>, so it has no parse cost to amortize and is deliberately left as
-  // is.) The mechanism below is ChatNodeView's, deliberately kept identical
-  // rather than re-derived - see its own comment for the full rationale on
-  // why pendingResetRef defers `reset` semantics to flush time instead of
-  // applying them delta-by-delta.
-  const pendingBufferRef = useRef("");
-  const pendingResetRef = useRef(false);
-  const rafHandleRef = useRef<number | null>(null);
-
-  function flushStreamBuffer() {
-    if (rafHandleRef.current !== null) {
-      cancelAnimationFrame(rafHandleRef.current);
-      rafHandleRef.current = null;
-    }
-    const bufferedText = pendingBufferRef.current;
-    const shouldReset = pendingResetRef.current;
-    pendingBufferRef.current = "";
-    pendingResetRef.current = false;
-    if (!bufferedText && !shouldReset) return;
-    setStreamedReply((current) => (shouldReset ? bufferedText : current + bufferedText));
-  }
-
-  useEffect(() => {
-    const requestId = data.pendingRequestId;
-    if (!requestId) return;
-    const unsubscribe = data.subscribeStream(requestId, (delta, done, reset) => {
-      if (reset) {
-        pendingBufferRef.current = delta;
-        pendingResetRef.current = true;
-      } else {
-        pendingBufferRef.current += delta;
-      }
-      // Completion/reset flushes synchronously: the final chunk shouldn't
-      // wait an extra frame, and this is what guarantees a trailing chunk is
-      // never stranded in the buffer past the last render.
-      if (done || reset) {
-        flushStreamBuffer();
-      } else if (rafHandleRef.current === null) {
-        rafHandleRef.current = requestAnimationFrame(flushStreamBuffer);
-      }
-    });
-    return () => {
-      unsubscribe();
-      // Flush rather than silently drop, so no buffered byte is lost in the
-      // narrow window where the request id changes mid-stream.
-      flushStreamBuffer();
-    };
-    // data.subscribeStream is a fresh closure every render (see SceneCanvas's
-    // toFlowNodes) - depending on it would resubscribe on every unrelated
-    // re-render; data.pendingRequestId itself is the real re-subscribe key.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data.pendingRequestId]);
+  // ADR-006 stage 6.4 / ADR-011 stage 11.4 (throttle extended here
+  // 2026-08-12): live reply streaming, throttled to at most one markdown
+  // re-parse per animation frame - see useStreamBuffer's own doc comment
+  // for the full rationale (dedup: this was duplicated inline here and in
+  // ChatNodeView until the tech-debt sweep extracted it). (CodeSandboxNodeView
+  // also streams unthrottled but renders into a plain <pre>, so it has no
+  // parse cost to amortize and is deliberately left as is.)
+  const streamedReply = useStreamBuffer(data.pendingRequestId, data.subscribeStream);
 
   function send() {
     const text = draft.trim();

--- a/web_ui/src/app/canvas/connections/ConnectionCanvas.test.tsx
+++ b/web_ui/src/app/canvas/connections/ConnectionCanvas.test.tsx
@@ -1,0 +1,346 @@
+import { Position, ReactFlowProvider, useStoreApi } from "@xyflow/react";
+import { act, render } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectionCanvas, type ConnectionSpec } from "./ConnectionCanvas";
+import { anchorPoint, connectionPath, type ConnectionPath, type HandleGeometry } from "./connectionGeometry";
+
+/**
+ * ConnectionCanvas draws by reading @xyflow/react's OWN internal store
+ * (nodeLookup/width/height/transform) every animation frame - there is no
+ * `nodes` prop to pass in. Writing directly into that store via useStoreApi()
+ * inside an effect, from a sibling rendered under the same <ReactFlowProvider>,
+ * is the established way this codebase drives it in tests (see the identical
+ * ZoomSetter idiom in ConversationNodeView.test.tsx / GitlinkNodeView.test.tsx
+ * / WebResearchNodeView.test.tsx / CodeSandboxNodeView.test.tsx) - real
+ * per-node measurement (ResizeObserver -> handleBounds) never happens under
+ * jsdom regardless (confirmed by SceneCanvas.virtualization.test.tsx's own
+ * recon: xyflow's updateNodeInternals hits `window.DOMMatrixReadOnly is not a
+ * constructor`), so this is also the only way to get handleBounds populated
+ * at all here.
+ */
+interface FakeInternalNode {
+  internals: {
+    positionAbsolute: { x: number; y: number };
+    handleBounds?: {
+      source?: Array<{ x: number; y: number; width: number; height: number; position: Position }> | null;
+      target?: Array<{ x: number; y: number; width: number; height: number; position: Position }> | null;
+    };
+  };
+}
+
+function StoreSetter({
+  nodes,
+  width = 800,
+  height = 600,
+  transform = [0, 0, 1],
+}: {
+  nodes: Record<string, FakeInternalNode>;
+  width?: number;
+  height?: number;
+  transform?: [number, number, number];
+}) {
+  const store = useStoreApi();
+  useEffect(() => {
+    store.setState({
+      width,
+      height,
+      transform,
+      nodeLookup: new Map(Object.entries(nodes)) as unknown as ReturnType<typeof store.getState>["nodeLookup"],
+    });
+  }, [store, nodes, width, height, transform]);
+  return null;
+}
+
+type ConnectionCanvasProps = React.ComponentProps<typeof ConnectionCanvas>;
+
+function renderConnectionCanvas(
+  props: Partial<ConnectionCanvasProps> = {},
+  storeProps: React.ComponentProps<typeof StoreSetter> = { nodes: {} },
+) {
+  const defaultProps: ConnectionCanvasProps = {
+    connections: [],
+    hoveredId: null,
+    selectedId: null,
+    fadeEnabled: false,
+    stroke: "#888888",
+    selectedStroke: "#0088ff",
+    fadedOpacity: 0.2,
+    ...props,
+  };
+  const utils = render(
+    <ReactFlowProvider>
+      <StoreSetter {...storeProps} />
+      <ConnectionCanvas {...defaultProps} />
+    </ReactFlowProvider>,
+  );
+  return { ...utils, canvas: utils.container.querySelector("canvas") as HTMLCanvasElement };
+}
+
+/** A minimal call-recording stand-in for CanvasRenderingContext2D - only the
+ * subset ConnectionCanvas actually calls needs a spy. `stroke()` snapshots
+ * the style properties in force at the moment it's called, since the
+ * component sets them as plain mutable properties right before tracing each
+ * connection (there's no other way to observe "what style applied to which
+ * connection" from outside). */
+function fakeCtx2D() {
+  const strokeCalls: Array<{ strokeStyle: unknown; lineWidth: number; globalAlpha: number }> = [];
+  const ctx = {
+    lineCap: "",
+    globalAlpha: 1,
+    strokeStyle: "",
+    lineWidth: 1,
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    bezierCurveTo: vi.fn(),
+    stroke: vi.fn(() => {
+      strokeCalls.push({ strokeStyle: ctx.strokeStyle, lineWidth: ctx.lineWidth, globalAlpha: ctx.globalAlpha });
+    }),
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, strokeCalls };
+}
+
+/** Advances exactly one animation frame under fake timers. */
+function tickFrame() {
+  act(() => {
+    vi.advanceTimersByTime(16);
+  });
+}
+
+const NODE_A: FakeInternalNode = {
+  internals: {
+    positionAbsolute: { x: 100, y: 100 },
+    handleBounds: { source: [{ x: 0, y: 40, width: 8, height: 8, position: Position.Bottom }], target: null },
+  },
+};
+const NODE_B: FakeInternalNode = {
+  internals: {
+    positionAbsolute: { x: 300, y: 300 },
+    handleBounds: { source: null, target: [{ x: 0, y: -8, width: 8, height: 8, position: Position.Top }] },
+  },
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("ConnectionCanvas rendering", () => {
+  it("renders a canvas that is purely presentational: not hit-testable, drawn behind everything, hidden from a11y", () => {
+    const { canvas } = renderConnectionCanvas();
+    expect(canvas).not.toBeNull();
+    expect(canvas.className).toBe("scene-connection-canvas");
+    expect(canvas.style.pointerEvents).toBe("none");
+    expect(canvas.style.zIndex).toBe("-1");
+    expect(canvas.getAttribute("aria-hidden")).toBe("true");
+  });
+});
+
+describe("ConnectionCanvas animation-frame loop", () => {
+  it("schedules exactly one frame and never reschedules once it finds no 2D context (jsdom's own default)", () => {
+    // No getContext mock here on purpose: jsdom's real HTMLCanvasElement
+    // returns null from getContext("2d") (confirmed empirically - jsdom's own
+    // virtual console also logs a harmless "Not implemented" notice for it,
+    // independent of any console.error mock), which is exactly the case this
+    // component's own module doc calls out by name.
+    const rafSpy = vi.spyOn(window, "requestAnimationFrame");
+
+    renderConnectionCanvas();
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+
+    tickFrame(); // fires the first frame; draw() finds ctx===null and returns false
+    expect(rafSpy).toHaveBeenCalledTimes(1); // not rescheduled
+  });
+
+  it("keeps rescheduling every frame while a 2D context is available, and cancels the pending frame on unmount", () => {
+    const { ctx } = fakeCtx2D();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx);
+    const rafSpy = vi.spyOn(window, "requestAnimationFrame");
+    const cafSpy = vi.spyOn(window, "cancelAnimationFrame");
+
+    const { unmount } = renderConnectionCanvas();
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+
+    tickFrame();
+    expect(rafSpy).toHaveBeenCalledTimes(2); // draw() succeeded -> loop reschedules
+    tickFrame();
+    expect(rafSpy).toHaveBeenCalledTimes(3);
+
+    const pendingHandle = rafSpy.mock.results[2]!.value;
+    unmount();
+    expect(cafSpy).toHaveBeenCalledWith(pendingHandle);
+  });
+});
+
+describe("ConnectionCanvas backing-store sizing", () => {
+  it("sizes the backing store to the store's width/height times devicePixelRatio, and sets CSS size in px", () => {
+    const { ctx } = fakeCtx2D();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx);
+    vi.spyOn(window, "devicePixelRatio", "get").mockReturnValue(2);
+
+    const { canvas } = renderConnectionCanvas({}, { nodes: {}, width: 400, height: 300 });
+    tickFrame();
+
+    expect(canvas.width).toBe(800); // 400 * 2
+    expect(canvas.height).toBe(600); // 300 * 2
+    expect(canvas.style.width).toBe("400px");
+    expect(canvas.style.height).toBe("300px");
+  });
+});
+
+describe("ConnectionCanvas geometry resolution", () => {
+  it("resolves each connection's geometry from the store's live node positions and handle bounds, and reports it via onGeometry", () => {
+    const { ctx } = fakeCtx2D();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx);
+    const onGeometry = vi.fn();
+
+    const curved: ConnectionSpec = { id: "curved", source: "a", target: "b", orthogonal: false };
+    const stepped: ConnectionSpec = { id: "stepped", source: "a", target: "b", orthogonal: true };
+
+    renderConnectionCanvas(
+      { connections: [curved, stepped], onGeometry },
+      { nodes: { a: NODE_A, b: NODE_B } },
+    );
+    tickFrame();
+
+    // Computed via the SAME real, independently-tested pure functions
+    // (connectionGeometry.test.ts), not hand-derived - this test is only
+    // pinning that ConnectionCanvas wires the store's raw node/handle data
+    // into them correctly, not re-deriving the geometry math itself.
+    const sourceHandle: HandleGeometry = { x: 0, y: 40, width: 8, height: 8, side: "bottom" };
+    const targetHandle: HandleGeometry = { x: 0, y: -8, width: 8, height: 8, side: "top" };
+    const from = anchorPoint(100, 100, sourceHandle);
+    const to = anchorPoint(300, 300, targetHandle);
+
+    expect(onGeometry).toHaveBeenCalledTimes(1);
+    const geometry = onGeometry.mock.calls[0]![0] as Map<string, ConnectionPath>;
+    expect(geometry.size).toBe(2);
+    expect(geometry.get("curved")).toEqual(connectionPath(from, "bottom", to, "top", false));
+    // Same endpoints, but orthogonal:true must reach connectionPath as true too.
+    expect(geometry.get("stepped")).toEqual(connectionPath(from, "bottom", to, "top", true));
+  });
+
+  it("falls back to 'bottom' when a handle's own position is missing, same default sideOf itself falls back to", () => {
+    const { ctx } = fakeCtx2D();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx);
+    const onGeometry = vi.fn();
+    const undocumentedPosition = undefined as unknown as Position;
+    const weird: FakeInternalNode = {
+      internals: {
+        positionAbsolute: { x: 0, y: 0 },
+        handleBounds: {
+          source: [{ x: 0, y: 0, width: 8, height: 8, position: undocumentedPosition }],
+          target: null,
+        },
+      },
+    };
+
+    renderConnectionCanvas(
+      { connections: [{ id: "conn1", source: "weird", target: "b", orthogonal: false }], onGeometry },
+      { nodes: { weird, b: NODE_B } },
+    );
+    tickFrame();
+
+    const geometry = onGeometry.mock.calls[0]![0] as Map<string, ConnectionPath>;
+    // bottom-side anchor: x = nodeX + handle.x + handle.width/2 = 0+0+4 = 4;
+    // y = nodeY + handle.y + handle.height = 0+0+8 = 8.
+    expect(geometry.get("conn1")!.source).toEqual({ x: 4, y: 8 });
+  });
+
+  it("skips a connection whose source or target id isn't in the store's nodeLookup, without throwing", () => {
+    const { ctx } = fakeCtx2D();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx);
+    const onGeometry = vi.fn();
+
+    renderConnectionCanvas(
+      {
+        connections: [
+          { id: "missing-target", source: "a", target: "ghost", orthogonal: false },
+          { id: "missing-source", source: "ghost", target: "b", orthogonal: false },
+        ],
+        onGeometry,
+      },
+      { nodes: { a: NODE_A, b: NODE_B } },
+    );
+    tickFrame();
+
+    expect(onGeometry.mock.calls[0]![0].size).toBe(0);
+  });
+
+  it("skips a connection whose endpoint node has no measured handle bounds yet", () => {
+    const { ctx } = fakeCtx2D();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx);
+    const onGeometry = vi.fn();
+    const unmeasured: FakeInternalNode = { internals: { positionAbsolute: { x: 0, y: 0 } } }; // no handleBounds
+
+    renderConnectionCanvas(
+      { connections: [{ id: "conn1", source: "a", target: "unmeasured", orthogonal: false }], onGeometry },
+      { nodes: { a: NODE_A, unmeasured } },
+    );
+    tickFrame();
+
+    expect(onGeometry.mock.calls[0]![0].size).toBe(0);
+  });
+});
+
+describe("ConnectionCanvas hover/selection/fade styling", () => {
+  it("draws selected heavier and in the selected colour, exempts only the hovered connection from fade-dimming, and resets alpha after", () => {
+    // Real, slightly non-obvious behaviour pinned here: the code's fade check
+    // is `spec.id !== hovered`, with no exemption for `selected` - a selected
+    // connection that ISN'T also the hovered one IS dimmed like any other
+    // when fading is on. This locks that actual behaviour down rather than
+    // the possibly-more-intuitive "selected is always exempt" one.
+    const { ctx, strokeCalls } = fakeCtx2D();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx);
+
+    renderConnectionCanvas(
+      {
+        connections: [
+          { id: "selected", source: "a", target: "b", orthogonal: false },
+          { id: "hovered", source: "a", target: "b", orthogonal: false },
+          { id: "plain", source: "a", target: "b", orthogonal: false },
+        ],
+        selectedId: "selected",
+        hoveredId: "hovered",
+        fadeEnabled: true,
+        stroke: "#888888",
+        selectedStroke: "#0088ff",
+        fadedOpacity: 0.15,
+      },
+      { nodes: { a: NODE_A, b: NODE_B }, transform: [0, 0, 2] },
+    );
+    tickFrame();
+
+    expect(strokeCalls).toEqual([
+      { strokeStyle: "#0088ff", lineWidth: 1.25, globalAlpha: 0.15 }, // selected: 2.5/zoom(2), still dimmed
+      { strokeStyle: "#888888", lineWidth: 0.75, globalAlpha: 1 }, // hovered: 1.5/zoom(2), exempt from dimming
+      { strokeStyle: "#888888", lineWidth: 0.75, globalAlpha: 0.15 }, // plain: dimmed
+    ]);
+    expect(ctx.globalAlpha).toBe(1); // reset after the loop, so it never leaks to the next consumer of ctx
+  });
+
+  it("draws every connection at full opacity, undimmed, when fading is disabled", () => {
+    const { ctx, strokeCalls } = fakeCtx2D();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(ctx);
+
+    renderConnectionCanvas(
+      {
+        connections: [{ id: "conn1", source: "a", target: "b", orthogonal: false }],
+        hoveredId: null,
+        fadeEnabled: false,
+        fadedOpacity: 0.15,
+      },
+      { nodes: { a: NODE_A, b: NODE_B } },
+    );
+    tickFrame();
+
+    expect(strokeCalls).toEqual([{ strokeStyle: "#888888", lineWidth: 1.5, globalAlpha: 1 }]);
+  });
+});

--- a/web_ui/src/app/canvas/connections/connectionGeometry.test.ts
+++ b/web_ui/src/app/canvas/connections/connectionGeometry.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  anchorPoint,
+  connectionPath,
+  isPointOnConnection,
+  traceConnection,
+  type ConnectionPath,
+  type HandleGeometry,
+} from "./connectionGeometry";
+
+// Direct unit coverage of connection geometry: where a link anchors to a
+// handle, the curve (or right-angle step) joining two anchors, and the
+// hit-test a pointer is checked against. Same "one test per documented
+// semantic, named so a regression fails loudly" posture as
+// smartGuides.test.ts (the sibling pure-geometry module this one is modelled
+// on) - every branch in anchorPoint's side switch, controlPoints' floor, and
+// isPointOnConnection's orthogonal-vs-curved routing gets its own case.
+
+function handle(overrides: Partial<HandleGeometry> = {}): HandleGeometry {
+  return { x: 0, y: 0, width: 8, height: 8, side: "bottom", ...overrides };
+}
+
+describe("anchorPoint", () => {
+  it("anchors to the outer rim, centred across the box, for a bottom-facing handle", () => {
+    const p = anchorPoint(100, 200, handle({ x: 10, y: 30, width: 8, height: 8, side: "bottom" }));
+    // x centred across the handle's own width; y at the handle's far (outer) edge.
+    expect(p).toEqual({ x: 114, y: 238 });
+  });
+
+  it("anchors to the outer rim, centred across the box, for a top-facing handle", () => {
+    const p = anchorPoint(100, 200, handle({ x: 10, y: 30, width: 8, height: 8, side: "top" }));
+    // x centred the same way; y stays at the handle's own (near) edge, unlike bottom.
+    expect(p).toEqual({ x: 114, y: 230 });
+  });
+
+  it("anchors to the outer rim, centred across the box, for a right-facing handle", () => {
+    const p = anchorPoint(0, 0, handle({ x: 5, y: 5, width: 10, height: 20, side: "right" }));
+    expect(p).toEqual({ x: 15, y: 15 }); // x + width; y centred by height
+  });
+
+  it("anchors to the outer rim, centred across the box, for a left-facing handle", () => {
+    const p = anchorPoint(0, 0, handle({ x: 5, y: 5, width: 10, height: 20, side: "left" }));
+    expect(p).toEqual({ x: 5, y: 15 }); // x untouched; y centred by height
+  });
+});
+
+describe("connectionPath", () => {
+  it("departs each anchor perpendicular to its own handle side, for a mostly-vertical span", () => {
+    // source is bottom-facing -> vertical=true -> span is |dy|=100, offset=max(50,20)=50.
+    const path = connectionPath({ x: 0, y: 0 }, "bottom", { x: 40, y: 100 }, "top", false);
+    expect(path.c1).toEqual({ x: 0, y: 50 });
+    expect(path.c2).toEqual({ x: 40, y: 50 });
+  });
+
+  it("departs each anchor perpendicular to its own handle side, for a mostly-horizontal span", () => {
+    // source is right-facing -> vertical=false -> span is |dx|=100, offset=50.
+    const path = connectionPath({ x: 0, y: 0 }, "right", { x: 100, y: 40 }, "left", false);
+    expect(path.c1).toEqual({ x: 50, y: 0 });
+    expect(path.c2).toEqual({ x: 50, y: 40 });
+  });
+
+  it("only the SOURCE side decides vertical-vs-horizontal, not the target's", () => {
+    // source is right-facing (horizontal) even though the target is top-facing;
+    // the offset must follow dx, not dy.
+    const path = connectionPath({ x: 0, y: 0 }, "right", { x: 100, y: 400 }, "top", false);
+    expect(path.c1).toEqual({ x: 50, y: 0 }); // pushed along x, from dx=100 -> offset 50
+    expect(path.c2).toEqual({ x: 100, y: 350 }); // pushed along y regardless (target is top-facing)
+  });
+
+  it("floors the control-point offset at 20, so a very short link stays curved rather than collapsing", () => {
+    const path = connectionPath({ x: 0, y: 0 }, "bottom", { x: 5, y: 5 }, "top", false);
+    // dy=5 -> 0.5*5=2.5, below the 20 floor.
+    expect(path.c1).toEqual({ x: 0, y: 20 });
+    expect(path.c2).toEqual({ x: 5, y: -15 });
+  });
+
+  it("computes midY as the exact midpoint between source.y and target.y", () => {
+    const path = connectionPath({ x: 0, y: 10 }, "bottom", { x: 0, y: 50 }, "top", false);
+    expect(path.midY).toBe(30);
+  });
+
+  it("passes the orthogonal flag straight through, both ways", () => {
+    expect(connectionPath({ x: 0, y: 0 }, "bottom", { x: 0, y: 0 }, "top", true).orthogonal).toBe(true);
+    expect(connectionPath({ x: 0, y: 0 }, "bottom", { x: 0, y: 0 }, "top", false).orthogonal).toBe(false);
+  });
+});
+
+describe("isPointOnConnection", () => {
+  // A curved path whose control points are chosen colinear with source/target,
+  // so the cubic bezier reduces to an exact straight line - lets the sampled
+  // hit-test be checked against known-exact math instead of an approximation.
+  const straightLine: ConnectionPath = {
+    source: { x: 0, y: 0 },
+    target: { x: 100, y: 0 },
+    c1: { x: 33, y: 0 },
+    c2: { x: 66, y: 0 },
+    orthogonal: false,
+    midY: 0,
+  };
+
+  it("finds a point exactly on a straight (colinear-control-point) curve", () => {
+    expect(isPointOnConnection(straightLine, { x: 50, y: 0 }, 1)).toBe(true);
+  });
+
+  it("misses a point well off the curve", () => {
+    expect(isPointOnConnection(straightLine, { x: 50, y: 50 }, 1)).toBe(false);
+  });
+
+  it("uses an inclusive <= tolerance boundary", () => {
+    expect(isPointOnConnection(straightLine, { x: 50, y: 5 }, 5)).toBe(true); // exactly at tolerance
+    expect(isPointOnConnection(straightLine, { x: 50, y: 5.01 }, 5)).toBe(false); // just past it
+  });
+
+  it("an orthogonal route is a genuinely different path from a straight line between the same endpoints", () => {
+    // Same source/target/midY for both; only the routing (and control points,
+    // irrelevant to the orthogonal branch) differ.
+    const corners = { source: { x: 0, y: 0 }, target: { x: 100, y: 100 }, midY: 50 };
+    const stepped: ConnectionPath = { ...corners, c1: { x: 0, y: 0 }, c2: { x: 0, y: 0 }, orthogonal: true };
+    const straight: ConnectionPath = { ...corners, c1: { x: 25, y: 25 }, c2: { x: 75, y: 75 }, orthogonal: false };
+    // (25, 25) sits exactly on the direct diagonal but is ~25px from every
+    // segment of the source->midY->target step (down, then across, then down).
+    expect(isPointOnConnection(straight, { x: 25, y: 25 }, 1)).toBe(true);
+    expect(isPointOnConnection(stepped, { x: 25, y: 25 }, 1)).toBe(false);
+  });
+
+  it("finds a point on each of the three orthogonal segments: down to midY, across, then down to target", () => {
+    const path: ConnectionPath = {
+      source: { x: 0, y: 0 },
+      target: { x: 100, y: 100 },
+      c1: { x: 0, y: 0 },
+      c2: { x: 0, y: 0 },
+      orthogonal: true,
+      midY: 50,
+    };
+    expect(isPointOnConnection(path, { x: 0, y: 25 }, 1)).toBe(true); // first vertical segment
+    expect(isPointOnConnection(path, { x: 50, y: 50 }, 1)).toBe(true); // horizontal segment
+    expect(isPointOnConnection(path, { x: 100, y: 75 }, 1)).toBe(true); // second vertical segment
+  });
+});
+
+describe("traceConnection", () => {
+  // A minimal call-recording stand-in for CanvasRenderingContext2D - traceConnection
+  // only ever calls the path-building subset, so only that subset needs a spy.
+  function fakeCtx() {
+    const calls: string[] = [];
+    const ctx = {
+      beginPath: vi.fn(() => calls.push("beginPath")),
+      moveTo: vi.fn((x: number, y: number) => calls.push(`moveTo ${x},${y}`)),
+      lineTo: vi.fn((x: number, y: number) => calls.push(`lineTo ${x},${y}`)),
+      bezierCurveTo: vi.fn((c1x: number, c1y: number, c2x: number, c2y: number, x: number, y: number) =>
+        calls.push(`bezierCurveTo ${c1x},${c1y},${c2x},${c2y},${x},${y}`),
+      ),
+      stroke: vi.fn(() => calls.push("stroke")),
+    };
+    return { ctx: ctx as unknown as CanvasRenderingContext2D, calls };
+  }
+
+  it("traces a single bezier curve for a non-orthogonal path", () => {
+    const { ctx, calls } = fakeCtx();
+    const path: ConnectionPath = {
+      source: { x: 0, y: 0 },
+      target: { x: 100, y: 50 },
+      c1: { x: 10, y: 0 },
+      c2: { x: 90, y: 50 },
+      orthogonal: false,
+      midY: 25,
+    };
+    traceConnection(ctx, path);
+    expect(calls).toEqual(["beginPath", "moveTo 0,0", "bezierCurveTo 10,0,90,50,100,50", "stroke"]);
+  });
+
+  it("traces a 3-segment right-angle step for an orthogonal path, and never calls bezierCurveTo", () => {
+    const { ctx, calls } = fakeCtx();
+    const path: ConnectionPath = {
+      source: { x: 0, y: 0 },
+      target: { x: 100, y: 100 },
+      c1: { x: 0, y: 0 },
+      c2: { x: 0, y: 0 },
+      orthogonal: true,
+      midY: 50,
+    };
+    traceConnection(ctx, path);
+    expect(calls).toEqual(["beginPath", "moveTo 0,0", "lineTo 0,50", "lineTo 100,50", "lineTo 100,100", "stroke"]);
+  });
+});

--- a/web_ui/src/app/canvas/useStreamBuffer.ts
+++ b/web_ui/src/app/canvas/useStreamBuffer.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from "react";
+import type { StreamListener } from "../../lib/ws/transport";
+
+/** Dedup (tech-debt sweep, cross-check against ChatNodeView/ConversationNodeView):
+ * both views independently implemented the exact same rAF-throttled stream-
+ * buffer accumulator for their live-streaming assistant reply (ADR-006 stage
+ * 6.4's subscribeStream/pendingRequestId pairing, throttled per ADR-011 stage
+ * 11.4 so a fast burst of deltas within one frame re-parses markdown at most
+ * once per frame instead of once per delta). The two copies were
+ * byte-for-byte identical apart from the returned state's local name
+ * (streamedContent vs streamedReply) - this hook is a pure extraction of
+ * that shared logic, zero behavior change, matching this codebase's existing
+ * small-shared-hook convention (see useLodVisibility.ts alongside this file).
+ *
+ * Deltas accumulate into refs (not React state) as they arrive - only the
+ * rAF-scheduled flush ever calls setState, so a burst of many small deltas
+ * within one frame updates the returned string at most once per frame. Every
+ * byte still lands in the result, in order; only the re-render cadence
+ * changes. pendingBufferRef always holds the full, in-order text accumulated
+ * since the last flush, and flushStreamBuffer moves the whole thing into
+ * state atomically. pendingResetRef tracks whether the buffered text should
+ * REPLACE the accumulated text at the next flush (a `reset` frame) rather
+ * than append to it, mirroring the original un-throttled
+ * `reset ? delta : current + delta` semantics exactly - just deferred to
+ * flush time instead of applied delta-by-delta.
+ *
+ * Returns "" whenever requestId is null, and re-seeds to "" the moment
+ * requestId changes to a new id (derived-state reset during render, so a new
+ * request never shows the previous run's stale text before its effect has a
+ * chance to run). subscribeStream is expected to be a fresh closure every
+ * render (see SceneCanvas's toFlowNodes) - only requestId itself is the
+ * effect's re-subscribe key, matching both call sites' own prior
+ * eslint-disable-line reasoning for react-hooks/exhaustive-deps. */
+export function useStreamBuffer(
+  requestId: string | null,
+  subscribeStream: (requestId: string, listener: StreamListener) => () => void,
+): string {
+  const [streamedText, setStreamedText] = useState("");
+  const [subscribedRequestId, setSubscribedRequestId] = useState(requestId);
+  if (requestId !== subscribedRequestId) {
+    setSubscribedRequestId(requestId);
+    setStreamedText("");
+  }
+
+  const pendingBufferRef = useRef("");
+  const pendingResetRef = useRef(false);
+  const rafHandleRef = useRef<number | null>(null);
+
+  function flushStreamBuffer() {
+    if (rafHandleRef.current !== null) {
+      cancelAnimationFrame(rafHandleRef.current);
+      rafHandleRef.current = null;
+    }
+    const bufferedText = pendingBufferRef.current;
+    const shouldReset = pendingResetRef.current;
+    pendingBufferRef.current = "";
+    pendingResetRef.current = false;
+    if (!bufferedText && !shouldReset) return;
+    setStreamedText((current) => (shouldReset ? bufferedText : current + bufferedText));
+  }
+
+  useEffect(() => {
+    if (!requestId) return;
+    const unsubscribe = subscribeStream(requestId, (delta, done, reset) => {
+      if (reset) {
+        pendingBufferRef.current = delta;
+        pendingResetRef.current = true;
+      } else {
+        pendingBufferRef.current += delta;
+      }
+      // Stream completion/reset flushes synchronously - the final chunk (or
+      // a fresh restart) shouldn't wait an extra frame, and this is also
+      // what guarantees a trailing chunk never gets stranded in the buffer
+      // past the last render.
+      if (done || reset) {
+        flushStreamBuffer();
+      } else if (rafHandleRef.current === null) {
+        rafHandleRef.current = requestAnimationFrame(flushStreamBuffer);
+      }
+    });
+    return () => {
+      unsubscribe();
+      // A requestId change (new run, or this run finished) makes any content
+      // still sitting in the buffer for the OLD request moot - the
+      // render-time subscribedRequestId reset above already clears
+      // streamedText to "" for a new id - but flush (rather than silently
+      // drop) here too, so no buffered byte is ever lost even in that narrow
+      // window.
+      flushStreamBuffer();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [requestId]);
+
+  return streamedText;
+}

--- a/web_ui/src/app/chrome/AppBarIcon.tsx
+++ b/web_ui/src/app/chrome/AppBarIcon.tsx
@@ -12,6 +12,8 @@
  * layout and behaviour only.
  */
 
+import { SearchIcon } from "./SearchIcon";
+
 export type AppBarIconName =
   | "undo"
   | "redo"
@@ -100,12 +102,7 @@ export function AppBarIcon({ name }: { name: AppBarIconName }) {
         </svg>
       );
     case "search":
-      return (
-        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
-          <circle cx="10.5" cy="10.5" r="6.5" />
-          <path d="m20 20-4.8-4.8" />
-        </svg>
-      );
+      return <SearchIcon />;
     case "knowledge":
       // An open book: two facing pages around a visible spine. The earlier
       // single-outline version rendered as a plain rectangle at 15px.

--- a/web_ui/src/app/chrome/BuilderLaunchDialog.test.tsx
+++ b/web_ui/src/app/chrome/BuilderLaunchDialog.test.tsx
@@ -35,26 +35,11 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 
 import { BuilderLaunchDialog } from "./BuilderLaunchDialog";
 import { OverlayProvider, useOverlays } from "../overlays/overlays";
-import type { WsTransport } from "../../lib/ws/transport";
-
-function makeTransport() {
-  const intents: unknown[][] = [];
-  const request = vi.fn<(topic: string, intent: string, args?: unknown[]) => Promise<unknown>>();
-  const transport = {
-    subscribe: () => () => {},
-    intent: () => {},
-    fireIntent: () => {},
-    request: (topic: string, intent: string, args: unknown[] = []) => {
-      intents.push([topic, intent, args]);
-      return request(topic, intent, args);
-    },
-  } as unknown as WsTransport;
-  return { transport, intents, request };
-}
+import { makeRequestOnlyTransport as makeTransport } from "../../lib/ws/transport.testUtils";
 
 // Only getScene() is exercised (reading the newly-created node's position
 // for the post-launch setCenter call) - a minimal fake, the same posture
-// makeTransport() takes for WsTransport above.
+// makeRequestOnlyTransport() takes for WsTransport.
 function makeStore(nodes: Array<{ id: string; x: number; y: number }> = []) {
   return {
     getScene: () => ({ nodes }),

--- a/web_ui/src/app/chrome/ChatLibraryDialog.tsx
+++ b/web_ui/src/app/chrome/ChatLibraryDialog.tsx
@@ -5,6 +5,7 @@ import type { AppChatLibraryRow, AppChatLibraryState, AppWorkspaceRow } from "..
 import type { AppComposerState } from "../../lib/bridge-core/generated/app-composer-state";
 import { Dialog, useOverlays } from "../overlays/overlays";
 import { CustomSelect } from "./CustomSelect";
+import { SearchIcon } from "./SearchIcon";
 import { initialComposerState } from "./composerStore";
 
 /**
@@ -142,12 +143,7 @@ function Icon({
 }) {
   switch (name) {
     case "search":
-      return (
-        <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
-          <circle cx="10.5" cy="10.5" r="6.5" />
-          <path d="m20 20-4.8-4.8" />
-        </svg>
-      );
+      return <SearchIcon />;
     case "pencil":
       return (
         <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">

--- a/web_ui/src/app/chrome/GlobalSearchDialog.test.tsx
+++ b/web_ui/src/app/chrome/GlobalSearchDialog.test.tsx
@@ -35,23 +35,7 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 
 import { GlobalSearchDialog } from "./GlobalSearchDialog";
 import { OverlayProvider, useOverlays } from "../overlays/overlays";
-import type { WsTransport } from "../../lib/ws/transport";
-
-// Matches KnowledgeSearchDialog.test.tsx's own makeTransport() shape exactly.
-function makeTransport() {
-  const intents: unknown[][] = [];
-  const request = vi.fn<(topic: string, intent: string, args?: unknown[]) => Promise<unknown>>();
-  const transport = {
-    subscribe: () => () => {},
-    intent: () => {},
-    fireIntent: () => {},
-    request: (topic: string, intent: string, args: unknown[] = []) => {
-      intents.push([topic, intent, args]);
-      return request(topic, intent, args);
-    },
-  } as unknown as WsTransport;
-  return { transport, intents, request };
-}
+import { makeRequestOnlyTransport as makeTransport } from "../../lib/ws/transport.testUtils";
 
 function OpenGlobalSearchButton() {
   const overlays = useOverlays();

--- a/web_ui/src/app/chrome/KnowledgeSearchDialog.test.tsx
+++ b/web_ui/src/app/chrome/KnowledgeSearchDialog.test.tsx
@@ -1,27 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { KnowledgeSearchDialog } from "./KnowledgeSearchDialog";
 import { OverlayProvider, useOverlays } from "../overlays/overlays";
-import type { WsTransport } from "../../lib/ws/transport";
-
-// Matches DiagnosticsDialog.test.tsx's own makeTransport() shape exactly -
-// KnowledgeSearchDialog only ever calls transport.request() (the "I need
-// the actual return value" primitive), never fireIntent/intent.
-function makeTransport() {
-  const intents: unknown[][] = [];
-  const request = vi.fn<(topic: string, intent: string, args?: unknown[]) => Promise<unknown>>();
-  const transport = {
-    subscribe: () => () => {},
-    intent: () => {},
-    fireIntent: () => {},
-    request: (topic: string, intent: string, args: unknown[] = []) => {
-      intents.push([topic, intent, args]);
-      return request(topic, intent, args);
-    },
-  } as unknown as WsTransport;
-  return { transport, intents, request };
-}
+import { makeRequestOnlyTransport as makeTransport } from "../../lib/ws/transport.testUtils";
 
 function OpenKnowledgeButton() {
   const overlays = useOverlays();

--- a/web_ui/src/app/chrome/SearchIcon.tsx
+++ b/web_ui/src/app/chrome/SearchIcon.tsx
@@ -1,0 +1,17 @@
+/**
+ * The magnifying-glass glyph - shared by AppBarIcon.tsx's "search" case and
+ * ChatLibraryDialog.tsx's own local Icon component, which previously each
+ * hand-rolled an identical `<svg>` (same viewBox, same circle+path). Pulled
+ * into its own module rather than folded into either dialog's icon set: it
+ * is the one glyph both sets actually need to render pixel-identically
+ * (search's own AppBar toolbar button and the library's inline search
+ * field), while the rest of each set is specific to its own surface.
+ */
+export function SearchIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="icon">
+      <circle cx="10.5" cy="10.5" r="6.5" />
+      <path d="m20 20-4.8-4.8" />
+    </svg>
+  );
+}

--- a/web_ui/src/lib/ws/transport.testUtils.ts
+++ b/web_ui/src/lib/ws/transport.testUtils.ts
@@ -1,0 +1,31 @@
+import { vi } from "vitest";
+import type { WsTransport } from "./transport";
+
+/**
+ * Shared fake for dialogs that only ever call transport.request() (never
+ * fireIntent/intent) - subscribe/intent/fireIntent are no-ops. Extracted
+ * from BuilderLaunchDialog.test.tsx, GlobalSearchDialog.test.tsx, and
+ * KnowledgeSearchDialog.test.tsx, which each defined this exact shape
+ * independently (their own comments already called out matching one
+ * another "exactly" - this makes that explicit instead of leaving three
+ * copies to drift).
+ *
+ * request() both records into `intents` (for call-shape assertions) and
+ * forwards to the returned `request` vi.fn(), so a test can drive its
+ * resolution/rejection with mockResolvedValueOnce/mockRejectedValueOnce/
+ * mockImplementation.
+ */
+export function makeRequestOnlyTransport() {
+  const intents: unknown[][] = [];
+  const request = vi.fn<(topic: string, intent: string, args?: unknown[]) => Promise<unknown>>();
+  const transport = {
+    subscribe: () => () => {},
+    intent: () => {},
+    fireIntent: () => {},
+    request: (topic: string, intent: string, args: unknown[] = []) => {
+      intents.push([topic, intent, args]);
+      return request(topic, intent, args);
+    },
+  } as unknown as WsTransport;
+  return { transport, intents, request };
+}

--- a/web_ui/src/lib/ws/transport.ts
+++ b/web_ui/src/lib/ws/transport.ts
@@ -372,8 +372,7 @@ export class WsTransport {
       // pairing a load-bearing invariant with nothing enforcing it.
       const topics = [...new Set([...this.stateListeners.keys(), ...this.patchListeners.keys()])];
       if (topics.length > 0) {
-        socket.send(JSON.stringify({ kind: "subscribe", topics }));
-        for (const topic of topics) this.snapshotRequestsPending.add(topic);
+        this.sendSubscribe(socket, topics);
       }
       // ADR-003 stage 3.6: AFTER re-subscribing, so a replayed intent
       // (e.g. moveNodes) applies against fresh server state rather than
@@ -383,8 +382,7 @@ export class WsTransport {
       // but before its correlated response arrives. Reissue those fences
       // after ordinary subscriptions and queued writes on the new socket.
       for (const [id, request] of this.resubscribeListeners) {
-        socket.send(JSON.stringify({ kind: "subscribe", topics: [request.topic], id }));
-        this.snapshotRequestsPending.add(request.topic);
+        this.sendSubscribe(socket, [request.topic], id);
       }
     };
     socket.onmessage = (event) => {
@@ -450,8 +448,7 @@ export class WsTransport {
       this.socket &&
       !this.snapshotRequestsPending.has(topic)
     ) {
-      this.socket.send(JSON.stringify({ kind: "subscribe", topics: [topic] }));
-      this.snapshotRequestsPending.add(topic);
+      this.sendSubscribe(this.socket, [topic]);
     }
     return () => {
       set.delete(listener);
@@ -476,12 +473,7 @@ export class WsTransport {
       id = this.nextId++;
       this.resubscribeListeners.set(id, { topic, listener: onSnapshot });
     }
-    this.socket.send(JSON.stringify({
-      kind: "subscribe",
-      topics: [topic],
-      ...(id === undefined ? {} : { id }),
-    }));
-    this.snapshotRequestsPending.add(topic);
+    this.sendSubscribe(this.socket, [topic], id);
     return true;
   }
 
@@ -616,7 +608,7 @@ export class WsTransport {
   intent(topic: string, intent: string, args: unknown[] = []): void {
     if (this.blockedTopics.has(topic)) return;
     if (this.status !== "open" || !this.socket) return;
-    this.socket.send(JSON.stringify({ kind: "intent", topic, intent, args }));
+    this.sendIntent(this.socket, topic, intent, args);
   }
 
   /** Intent with a reply (result or error), for request/response flows.
@@ -643,7 +635,7 @@ export class WsTransport {
         reject(new WsTimeoutError(`request timed out: ${topic}/${intent}`));
       }, timeoutMs ?? this.requestTimeout);
       this.pending.set(id, { resolve, reject, timer });
-      socket.send(JSON.stringify({ kind: "intent", topic, intent, args, id }));
+      this.sendIntent(socket, topic, intent, args, id);
     });
   }
 
@@ -913,16 +905,22 @@ export class WsTransport {
       // mean two outages inside the 3s window that each lost one change
       // report "1 change..." once and swallow the second - under-reporting
       // real data loss, which is precisely what this stage exists to stop.
-      this.intent(
-        "notification",
-        "showError",
-        [
-          n === 1
-            ? "1 change could not be sent while disconnected."
-            : `${n} changes could not be sent while disconnected.`,
-        ],
+      this.notifyError(
+        n === 1
+          ? "1 change could not be sent while disconnected."
+          : `${n} changes could not be sent while disconnected.`,
       );
     }
+  }
+
+  /** The one destination every client-surfaced error message goes through:
+   * the server-authoritative "notification"/"showError" intent (see
+   * fireIntent()'s own doc for why this reuses that channel rather than a
+   * second, client-local notification UI). Both call sites - the offline-
+   * queue summary above and showErrorDeduped below - used to spell out
+   * `this.intent("notification", "showError", [message])` themselves. */
+  private notifyError(message: string): void {
+    this.intent("notification", "showError", [message]);
   }
 
   /** ADR-003 stage 3.1 review-fix: the last showError message this transport
@@ -943,10 +941,31 @@ export class WsTransport {
       return;
     }
     this.lastShowError = { message, at: now };
-    this.intent("notification", "showError", [message]);
+    this.notifyError(message);
   }
 
   // -- internals ---------------------------------------------------------
+
+  /** Sends a `kind:"subscribe"` frame for one or more topics and marks each
+   * one as awaiting its snapshot. The single place that builds this frame -
+   * onopen's reconnect resubscribe-all, its resubscribeListeners fence
+   * replay, subscribe()'s own on-demand request, and resubscribe() itself
+   * each used to spell out an equivalent `socket.send(JSON.stringify({
+   * kind: "subscribe", ... }))` plus its own `snapshotRequestsPending.add`
+   * bookkeeping. `id` is omitted from the frame when undefined (JSON.stringify
+   * already drops an `undefined`-valued property on its own). */
+  private sendSubscribe(socket: WsLike, topics: string[], id?: number): void {
+    socket.send(JSON.stringify({ kind: "subscribe", topics, id }));
+    for (const topic of topics) this.snapshotRequestsPending.add(topic);
+  }
+
+  /** Sends a `kind:"intent"` frame - intent()'s fire-and-forget send and
+   * request()'s id-correlated send used to each spell out their own
+   * equivalent `socket.send(JSON.stringify({ kind: "intent", ... }))`. `id`
+   * is omitted from the frame when undefined, same as sendSubscribe above. */
+  private sendIntent(socket: WsLike, topic: string, intent: string, args: unknown[], id?: number): void {
+    socket.send(JSON.stringify({ kind: "intent", topic, intent, args, id }));
+  }
 
   private handleMessage(raw: string): void {
     let message: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Third batch from the technical-debt audit - the medium-effort duplication/refactor findings (following #360's high-severity fixes and #361's mechanical batch). About a third of the ~19 named items turned out to be false positives on re-verification (already-correct intentional separation, or a "14+ files" claim that was actually 3) - documented below rather than forced through.

### Backend
- `plugin_sdk.py`: extracted `make_simple_child_node_handler()` for the 6 `plugin.py` files (artifact, code_sandbox, conversation_node, gitlink, html_renderer, web_research) sharing an identical child-node-creation shape. `system_prompt`'s plugin is genuinely different (branch-root walk) and was left alone.
- `plugins.py`: extracted `_is_plugin_granted()` for 4 hand-duplicated grant checks.
- `agents.py`: extracted `_run_gitlink_blocking_action()` for 4 gitlink methods' identical claim/run/notify/release wrapper, and `_cancel_with_pending_approval_denied()` for 3 `cancel_*` methods' shared approval-denial step. The other `cancel_*` methods were already correct one-line `RunRegistry` delegations.
- `backend/api/`: `pick_scan_folder_and_run()` (`_settings_shared.py`), two branch-comparison helpers (`intents_branches.py`), and `claim_busy_node_or_notify()` (`_shared.py`, shared by `intents_gitlink.py`/`intents_code_sandbox.py`).

### Frontend
- `useStreamBuffer.ts`: the byte-identical stream-buffer logic `ChatNodeView.tsx` and `ConversationNodeView.tsx` each hand-rolled.
- `SearchIcon.tsx`: one genuinely duplicated icon between `AppBarIcon.tsx` and `ChatLibraryDialog.tsx` - every other icon in each set is legitimately distinct and was left alone.
- `transport.testUtils.ts`'s `makeRequestOnlyTransport()`: the 3 test files with a byte-identical mock transport. 9 other similarly-shaped mocks were confirmed genuinely different (different subscribe/resubscribe/intent shapes per what each dialog under test needs) and left alone.
- Added real test coverage for `connections/ConnectionCanvas.tsx` and `connectionGeometry.ts`, which had none.
- Deduped 6 hardcoded wire-frame literal call sites in `transport.ts` into `sendSubscribe()`/`sendIntent()`/`notifyError()`.

### Investigated and correctly left alone
- `node_states.py`'s per-kind dataclasses - no real field overlap, incremental migration is by design.
- `layout.py`/`groups.py`'s footprint calculations - intentionally different fallback precision, documented on both sides.
- `graph.py`/`branches.py`'s two BFS traversals - different jobs (reachability check vs. subtree collection).
- `HarnessLaunchDialog` vs. `BuilderLaunchDialog` - deliberate, documented scope difference (no recipes/oversight modes).
- `QuickSwitcherDialog`/`CommandPalette` - an acknowledged sibling relationship, not accidental drift.
- A frontend vitest coverage gate - investigated (measured 70-86% depending on the metric), deliberately not added. Forcing a floor through now would just make CI red for pre-existing gaps rather than closing them; flagging as a real, separate follow-up.

## Test plan
- [x] Full backend suite from the repo root (`python -m pytest -q`): 3072 passed, 19 skipped, 2 failed. Both failures are pre-existing and unrelated - confirmed by reproducing them with every change in this PR stashed: a Hypothesis input-generation health-check flake in `mutation_tests/test_chart_data_properties.py`, and a tight 2.0s timing assertion in `test_providers.py` this machine's current load can't reliably meet. Neither touches a file this PR modifies.
- [x] Full frontend check (`npm run check`): schema-drift check, typecheck, lint, vitest, build, and bundle-size check all passed.