### PR TITLE
Add on-canvas visual marker for navigation pins

### DIFF
--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -53,6 +53,7 @@ import { useCanvasFontVars } from "./useCanvasFontVars";
 import { useBranchFocus } from "./useBranchFocus";
 import { useViewportReporting } from "./useViewportReporting";
 import { useCanvasPan } from "./useCanvasPan";
+import { motionDuration } from "../reducedMotion";
 import { useNodeDragAndSizeSync } from "./useNodeDragAndSizeSync";
 
 /**
@@ -2548,7 +2549,25 @@ function CanvasInner({
   );
   const snapGrid = useMemo<[number, number]>(() => [grid.gridSize, grid.gridSize], [grid.gridSize]);
 
-  const { screenToFlowPosition } = reactFlow;
+  const { screenToFlowPosition, setCenter } = reactFlow;
+
+  // Navigation pins (R2.4/R6.3) render only in PinOverlay.tsx's own list -
+  // jump-to and rename/note editing, never a marker on the canvas itself.
+  // The legacy Qt app's pins WERE real QGraphicsItems living in the same
+  // scene as the nodes (NavigationPinsController.focus() called
+  // pin.setSelected(True) on one) - that half of the port was never
+  // carried forward. Same ViewportPortal technique the smart-guide lines
+  // below already use for exactly the same reason (children render inside
+  // the same CSS-transformed layer, in flow coordinates, panning/zooming
+  // for free). Click jumps to the pin, matching PinOverlay's own "Pin
+  // title" jump button (setCenter(pin.x, pin.y, ...)) exactly, so the two
+  // affordances behave identically.
+  const onJumpToPin = useCallback(
+    (pin: SceneState["pins"][number]) => {
+      setCenter(pin.x, pin.y, { zoom: 1, duration: motionDuration(300) });
+    },
+    [setCenter],
+  );
 
   // Factor-scaled canvas panning (the drag-speed setting's REAL job) plus
   // fade-connections hover - see the hook's own doc for why these two
@@ -2759,6 +2778,36 @@ function CanvasInner({
                       }
                 }
               />
+            ))}
+          </ViewportPortal>
+        )}
+        {/* R2.4/R6.3 fix: navigation pins had no on-canvas presence at all -
+            see this component's own doc comment on onJumpToPin above. One
+            marker per pin, anchored at its real scene (x, y) - the SAME
+            ViewportPortal technique as the smart-guide lines just above,
+            for the same "pan/zoom for free, flow coordinates" reason. The
+            marker's own tip (not its center) sits at (x, y), matching how
+            a map pin visually points AT a location rather than covering
+            it. pointerEvents stays enabled here (unlike the guide lines)
+            since a pin must be clickable to jump, mirroring PinOverlay's
+            own jump button. */}
+        {scene.pins.length > 0 && (
+          <ViewportPortal>
+            {scene.pins.map((pin) => (
+              <button
+                key={pin.id}
+                type="button"
+                className="scene-pin-marker"
+                style={{ position: "absolute", left: pin.x, top: pin.y }}
+                title={pin.note || pin.title}
+                aria-label={`Jump to pin ${pin.title}`}
+                onClick={() => onJumpToPin(pin)}
+              >
+                <svg aria-hidden="true" viewBox="0 0 24 24" className="scene-pin-marker-icon">
+                  <path d="M9 4h6l-1 6 3 3H7l3-3Z" />
+                  <path d="M12 13v7" />
+                </svg>
+              </button>
             ))}
           </ViewportPortal>
         )}

--- a/web_ui/src/app/styles.css
+++ b/web_ui/src/app/styles.css
@@ -429,6 +429,41 @@ body,
   background-color: var(--gl-neutral-button-hover);
 }
 
+/* R2.4/R6.3 fix: navigation pins had no on-canvas marker at all - see
+   SceneCanvas.tsx's own doc comment above the ViewportPortal that renders
+   these. left/top (set inline, per-pin, to its real scene x/y) mark where
+   the pin's TIP points, not the icon's own center - the translate below
+   shifts the icon up so the point of the glyph (x=12,y=20 of its own
+   24x24 viewBox, i.e. 50%/83.333%) lands exactly on that coordinate,
+   matching how a map pin visually points AT a location. Scales with
+   canvas zoom for free, same as every other ViewportPortal child. */
+.scene-pin-marker {
+  transform: translate(-50%, -83.333%);
+  display: flex;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background-color: var(--gl-surface-window);
+  box-shadow: var(--gl-shadow-1);
+  cursor: pointer;
+  z-index: 5;
+}
+
+.scene-pin-marker:hover {
+  background-color: var(--gl-neutral-button-hover);
+}
+
+.scene-pin-marker-icon {
+  width: 22px;
+  height: 22px;
+  padding: 3px;
+  fill: none;
+  stroke: var(--gl-surface-text-bright);
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 /* -- R3.1/R3.2 chat node --------------------------------------------------- */
 
 .chat-node {


### PR DESCRIPTION
## Problem
Navigation pins had no visual representation on the canvas itself. Clicking "Add Pin" only added an entry to the side-panel list (`PinOverlay.tsx`) - there was never an on-canvas marker at the pinned location. The legacy Qt app rendered pins as real `QGraphicsItem`s in the same scene as the nodes; that half of the functionality was never carried forward when the app was ported to the React SPA.

## Change
- `SceneCanvas.tsx`: renders one marker per pin via `ViewportPortal` (the same technique already used for smart-guide lines), anchored at the pin's real scene `(x, y)` so it pans/zooms with the canvas automatically. Reuses the existing pin glyph from `AppBarIcon.tsx`. Clicking a marker calls `setCenter` to jump to it, matching `PinOverlay`'s own jump-to button exactly.
- `styles.css`: adds `.scene-pin-marker` styling using the app's existing grayscale/high-contrast design tokens (`--gl-surface-window`, `--gl-surface-text-bright`, `--gl-shadow-1`) so the marker is visible in both themes without introducing any new raw color literal.

## Test plan
- [x] `npx tsc --noEmit` - clean
- [x] `npx vitest run` (full suite, web_ui/) - 2033/2033 passed
- [x] Verified via dev server: marker renders at correct scene coordinates, stays anchored across pan/zoom, click-to-jump works

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>