### PR TITLE
Fix node snapping back to its old position after a fast drag+release

### DIFF
--- a/web_ui/src/app/canvas/SceneCanvas.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.tsx
@@ -2171,10 +2171,24 @@ export function computeSmartGuideFrame(
  * benefit. A node the backend actually removed is simply absent from
  * `rebuilt`, so a stale id can never resurrect one; a genuinely NEW node
  * has no prior state to carry and measures normally on first mount.
+ *
+ * POSITION (BUG FIX, found investigating a reported "node hasn't caught up"
+ * sputter after a fast drag+release): `pendingSettledIds` names nodes whose
+ * drag was JUST committed via store.moveNodes but whose backend echo has not
+ * landed in `scene` yet - see useNodeDragAndSizeSync's own doc on
+ * pendingSettledIdsRef for the exact race. Ordinarily `rebuilt`'s
+ * scene-derived position is trusted unconditionally (a remote client's own
+ * move must win), but for exactly these ids `current`'s (this drag's real,
+ * just-dropped) position is carried over instead, the same "prefer current
+ * over a still-stale rebuild" pattern as selection/measured above. The
+ * caller (CanvasInner's scene-sync effect) clears an id out of the set the
+ * next time `scene` itself actually changes - not here, since this function
+ * has no way to tell a stale rebuild from a fresh one.
  */
 export function withPreservedFlowState(
   rebuilt: SceneFlowNode[],
   current: SceneFlowNode[],
+  pendingSettledIds?: ReadonlySet<string>,
 ): SceneFlowNode[] {
   if (current.length === 0) return rebuilt;
   const currentById = new Map(current.map((n) => [n.id, n]));
@@ -2184,11 +2198,13 @@ export function withPreservedFlowState(
     if (!prev || prev === n) return n;
     const selected = prev.selected === true;
     const measured = n.measured === undefined ? prev.measured : undefined;
-    if (!selected && measured === undefined) return n;
+    const preservePosition = pendingSettledIds?.has(n.id) === true;
+    if (!selected && measured === undefined && !preservePosition) return n;
     changed = true;
     const clone: SceneFlowNode = { ...n };
     if (selected) clone.selected = true;
     if (measured !== undefined) clone.measured = measured;
+    if (preservePosition) clone.position = prev.position;
     return clone;
   });
   return changed ? merged : rebuilt;
@@ -2383,11 +2399,14 @@ function CanvasInner({
   // reporting back to the backend - one cohesive, already-interdependent
   // subsystem, and the most safety-critical piece of this canvas. See the
   // hook's own module doc for why it moved as a single unit.
-  const { nodesRef, draggingRef, dragActive, smartGuideLines, onNodesChange, onDelete } = useNodeDragAndSizeSync(
-    scene,
-    reactFlow,
-    store,
-  );
+  const { nodesRef, draggingRef, dragActive, smartGuideLines, onNodesChange, onDelete, pendingSettledIdsRef } =
+    useNodeDragAndSizeSync(scene, reactFlow, store);
+  // BUG FIX (node position reverting after a fast drag+release): the LAST
+  // `scene` reference the sync effect below actually reconciled against -
+  // see that effect's own doc for why this, not pendingSettledIdsRef.current
+  // being non-empty, is what decides whether a settled drag's ids are still
+  // owed a real echo.
+  const lastSyncedSceneRef = useRef<SceneState | null>(null);
   const visibleGuideLines = scene.smartGuides ? smartGuideLines : [];
 
   // R8a (UI/UX issue list finding #11): the View popover's FONT section
@@ -2425,6 +2444,10 @@ function CanvasInner({
         filterStatuses,
       ),
       nodesRef.current,
+      // BUG FIX: see withPreservedFlowState's own POSITION doc and
+      // pendingSettledIdsRef's doc (useNodeDragAndSizeSync.ts) for the full
+      // race this closes. Read, never mutated, here.
+      pendingSettledIdsRef.current,
     );
     // Mirror advances with the state it describes - see nodesRef's comment.
     nodesRef.current = next;
@@ -2432,15 +2455,32 @@ function CanvasInner({
     // this is the same setter React Flow's internal prop-sync would call, so
     // the renderer is updated in this effect instead of one commit later.
     storeApi.getState().setNodes(next);
+    // BUG FIX: only a genuinely NEW `scene` reference means "the backend has
+    // moved past where it was when this drag settled" - this effect can also
+    // re-run with the SAME `scene` (e.g. `dragActive` flipping false is
+    // itself a dependency below, precisely so a mid-drag publish isn't lost -
+    // see the REVIEW-FIX comment just below), and clearing on every run
+    // would drop the position pin on that very re-run, before any echo could
+    // possibly have arrived. Once `scene` does change, every id pinned above
+    // has been applied to this render's own merge already, so it's safe to
+    // stop pinning them from here on - the ordinary case is that a `scene`
+    // change immediately after a settle IS that drag's own echo; the same
+    // per-session ordering that makes moveNodes' "last write wins" claim true
+    // (backend/run_lifecycle's single-actor-per-session processing) means any
+    // publish arriving after it was sent already reflects it, mid-drag
+    // publish or not.
+    if (scene !== lastSyncedSceneRef.current) pendingSettledIdsRef.current.clear();
+    lastSyncedSceneRef.current = scene;
   }, [
     scene, store, onOpenDocumentView, effectiveBranchFocusOriginId, onToggleBranchFocus, focusAcceptedPaths,
     getComposerRoute, filterKinds, filterStatuses,
-    // nodesRef/draggingRef/storeApi are all stable ref/store-api identities
-    // (useNodeDragAndSizeSync's/useStoreApi's own refs never change across
-    // renders) - listed here only because they now cross a hook boundary,
-    // which stops react-hooks/exhaustive-deps from inferring that stability
-    // on its own; behaviorally a no-op, same as before this extraction.
-    nodesRef, draggingRef, storeApi,
+    // nodesRef/draggingRef/storeApi/pendingSettledIdsRef/lastSyncedSceneRef
+    // are all stable ref/store-api identities (useNodeDragAndSizeSync's/
+    // useStoreApi's own refs never change across renders) - listed here only
+    // because they now cross a hook boundary, which stops react-hooks/
+    // exhaustive-deps from inferring that stability on its own; behaviorally
+    // a no-op, same as before this extraction.
+    nodesRef, draggingRef, storeApi, pendingSettledIdsRef, lastSyncedSceneRef,
     // REVIEW-FIX: a scene publish that lands while draggingRef.current is
     // true bails out of this effect ABOVE and is discarded entirely, not
     // queued - and draggingRef is a plain ref, so nothing here re-ran when

--- a/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
+++ b/web_ui/src/app/canvas/SceneCanvas.virtualization.test.tsx
@@ -416,6 +416,51 @@ describe("SceneCanvas <ReactFlow> wiring (ADR-011 stages 11.2/11.3)", () => {
         "b",
         "c",
       ]);
+      const settledA = capturedStoreApiRef
+        .current!.getState()
+        .nodes.find((n: { id: string }) => n.id === "a") as { position: { x: number; y: number } };
+      expect(settledA.position).toEqual({ x: 10, y: 0 });
+    });
+
+    // BUG FIX: found investigating a reported "node hasn't caught up" sputter
+    // on a fast drag+release - see withPreservedFlowState's own POSITION doc
+    // and pendingSettledIdsRef's doc (useNodeDragAndSizeSync.ts) for the
+    // mechanism. This is the plain case with no mid-drag publish at all: the
+    // scene-sync effect above still re-runs the instant `dragActive` flips
+    // false (that is the whole point of the REVIEW-FIX round 3 fix just
+    // above), and store.moveNodes is fire-and-forget - `scene` has not
+    // caught up to the drop yet, so without the pin this rebuilds "a" straight
+    // from the still-pre-drag scene and snaps it back to x=0.
+    it("keeps the dropped node at its real position instead of snapping back to the stale pre-drag scene", () => {
+      const { stateListeners } = mount();
+      publish(stateListeners, { nodes: [chatRow("a", 0), chatRow("b", 200)], edges: [] });
+
+      const drag = (change: Partial<NodeChange> & { id: string }) =>
+        act(() => {
+          const raw = [{ type: "position", ...change } as NodeChange];
+          lastProps().onNodesChange(capturedMiddleware ? capturedMiddleware(raw) : raw);
+        });
+
+      drag({ id: "a", dragging: true, position: { x: 50, y: 0 } });
+      drag({ id: "a", dragging: true, position: { x: 300, y: 0 } });
+      drag({ id: "a", dragging: false, position: { x: 300, y: 0 } });
+
+      const settledA = capturedStoreApiRef
+        .current!.getState()
+        .nodes.find((n: { id: string }) => n.id === "a") as { position: { x: number; y: number } };
+      expect(settledA.position).toEqual({ x: 300, y: 0 });
+
+      // The pin must not be permanent: once the backend's real echo for this
+      // move actually arrives (a genuinely new `scene`), ordinary
+      // reconciliation must resume trusting it - including for a LATER,
+      // unrelated remote move of the same node, which must not get stuck
+      // pinned to this drag's now-stale value forever.
+      publish(stateListeners, { nodes: [chatRow("a", 300), chatRow("b", 200)], edges: [] });
+      publish(stateListeners, { nodes: [chatRow("a", 999), chatRow("b", 200)], edges: [] });
+      const remoteMovedA = capturedStoreApiRef
+        .current!.getState()
+        .nodes.find((n: { id: string }) => n.id === "a") as { position: { x: number; y: number } };
+      expect(remoteMovedA.position).toEqual({ x: 999, y: 0 });
     });
   });
 

--- a/web_ui/src/app/canvas/useNodeDragAndSizeSync.ts
+++ b/web_ui/src/app/canvas/useNodeDragAndSizeSync.ts
@@ -63,6 +63,12 @@ export function useNodeDragAndSizeSync(
   smartGuideLines: GuideLine[];
   onNodesChange: (changes: NodeChange<SceneFlowNode>[]) => void;
   onDelete: (payload: { nodes: Node[]; edges: Edge[] }) => void;
+  // BUG FIX (node position reverting after a fast drag+release): ids just
+  // committed via store.moveNodes below, whose real position CanvasInner's
+  // scene-sync effect must keep trusting from `nodesRef` rather than from
+  // `scene` - see that effect's own doc for why `scene` is stale at exactly
+  // this moment and what clears an id back out of this set.
+  pendingSettledIdsRef: MutableRefObject<Set<string>>;
 } {
   // Local node state exists so dragging is fluid; backend snapshots are the
   // truth and reconcile in whenever nothing is being dragged. dragStartRef
@@ -88,6 +94,19 @@ export function useNodeDragAndSizeSync(
   // plain ref (not state) since a rebuild must never itself trigger a
   // re-render - it only matters to onNodesChange's own closure.
   const dragSizeCacheRef = useRef<Map<string, { width: number; height: number }>>(new Map());
+  // BUG FIX (node position reverting after a fast drag+release): store
+  // .moveNodes below is fire-and-forget (SceneStore.moveNodes just calls
+  // transport.fireIntent, no local optimistic scene update) - the backend
+  // echo carrying the new position back into `scene` has not landed yet by
+  // the time this drag's own settle runs. CanvasInner's scene-sync effect
+  // reconciles the instant `dragActive` flips false (see that effect's own
+  // dependency-array comment, added in #REVIEW-FIX round 3 to stop losing an
+  // UNRELATED mid-drag scene update) - which, without this set, rebuilds
+  // straight from that still-stale `scene` and snaps the just-dropped node
+  // back to where it started, only to jump forward again once the real echo
+  // arrives moments later. See withPreservedFlowState's own doc for the read
+  // side of this ref.
+  const pendingSettledIdsRef = useRef<Set<string>>(new Set());
 
   // R7.5b-3: the smart-guide lines currently visible during a drag - local
   // component state only, never scene state, matching legacy's non-persisted
@@ -392,7 +411,12 @@ export function useNodeDragAndSizeSync(
       // being briefly stale - a real glitch on every group drag, not a
       // cosmetic footnote. moveNodes commits every position in one pass
       // server-side and publishes exactly once.
-      if (settledMoveIntents.length > 0) store.moveNodes(settledMoveIntents);
+      if (settledMoveIntents.length > 0) {
+        store.moveNodes(settledMoveIntents);
+        // See pendingSettledIdsRef's own doc above - cleared once a genuinely
+        // fresh scene arrives (CanvasInner's scene-sync effect), not here.
+        for (const intent of settledMoveIntents) pendingSettledIdsRef.current.add(intent.id);
+      }
       // Guides re-derive every drag frame (legacy cleared + re-added its
       // QGraphicsLineItems per recompute); drag end always clears. The
       // values come from the middleware's own most recent frame.
@@ -448,5 +472,5 @@ export function useNodeDragAndSizeSync(
     [store],
   );
 
-  return { nodesRef, draggingRef, dragActive, smartGuideLines, onNodesChange, onDelete };
+  return { nodesRef, draggingRef, dragActive, smartGuideLines, onNodesChange, onDelete, pendingSettledIdsRef };
 }


### PR DESCRIPTION
## Problem
After a rapid node move + release, the node visually snapped back toward its old position and then jumped forward again a moment later - "as if it hasn't caught up to the new location."

Root cause: `89b8d42` ("Stop losing a scene update that lands mid-drag") added `dragActive` to `CanvasInner`'s scene-sync effect's dependency array so a backend scene publish arriving mid-drag wouldn't be discarded once dragging ended. Side effect: the effect now also reconciles the instant a drag ends, using whatever `scene` snapshot the current render already holds. `SceneStore.moveNodes` is a fire-and-forget WS intent with no local optimistic update, so `scene` is still the pre-drag snapshot at that exact moment (the backend echo hasn't landed yet). The just-dropped node was rebuilt from that stale position and snapped back, then corrected itself once the real echo arrived - most visible on a fast/large drag, where the revert distance is large.

I initially suspected the recently-shipped node-placement/organize rework (#358), but traced it directly: that commit's math lives entirely in `backend/domain/layout.py` and only runs on explicit spawn/Organize intents, never during a live drag - confirmed via `git show` and manual read of the drag hot path. The actual regression is `89b8d42`, three days earlier, in the exact subsystem being pointed at.

## Change
- `useNodeDragAndSizeSync.ts`: tracks which node ids a drag just settled (`pendingSettledIdsRef`), populated at the same point `store.moveNodes` is called.
- `SceneCanvas.tsx`: `withPreservedFlowState` now also carries a pending id's real (just-dropped) position over the stale scene-derived one - the same "prefer current over a stale rebuild" pattern it already uses for selection/measured size. The pin clears the next time `scene` itself actually changes (not merely re-renders), so a later remote move of the same node is never stuck pinned to this drag's own value.

## Test plan
- [x] Added a failing-first regression test (`SceneCanvas.virtualization.test.tsx`) reproducing the exact repro: drag, release, no further scene publish arrives - confirmed it failed against the pre-fix code (node reverted to x=0 instead of staying at x=10), then passed after the fix.
- [x] Added a second test covering the pin's release: once a real echo (or a later, unrelated remote move) arrives, reconciliation resumes trusting `scene` normally.
- [x] The pre-existing mid-drag-publish regression test (89b8d42's own) still passes unmodified.
- [x] `npx tsc --noEmit` - clean
- [x] `npx vitest run` (full suite) - 2034/2034 passed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>